### PR TITLE
Add fun metrics tracking screen

### DIFF
--- a/Tests/Screens/test_metrics_screen.py
+++ b/Tests/Screens/test_metrics_screen.py
@@ -1,0 +1,37 @@
+# Tests/Screens/test_metrics_screen.py
+#
+# Pytest unit tests for the MetricsScreen class.
+#
+# Imports
+import pytest
+
+########################################################################################################################
+#
+# Test Functions
+#
+########################################################################################################################
+
+def test_metrics_screen_loads_data():
+    """
+    Placeholder test to ensure the test file is set up.
+    This should be expanded to actually test data loading and display.
+    """
+    # TODO: Mock METRICS_LOG_PATH and its content.
+    # TODO: Instantiate MetricsScreen.
+    # TODO: Trigger on_mount or directly call load_metrics.
+    # TODO: Assert that self.metrics is populated as expected.
+    # TODO: Assert that compose() renders the correct labels.
+    logging.info("Placeholder test for MetricsScreen data loading executed.")
+    pass
+
+# TODO: Add more comprehensive tests for MetricsScreen, including:
+#   - Test with missing metrics file.
+#   - Test with empty metrics file.
+#   - Test with malformed lines in metrics file.
+#   - Test UI rendering of metrics (mocking Label widgets if necessary).
+
+########################################################################################################################
+#
+# End of test_metrics_screen.py
+#
+########################################################################################################################

--- a/tldw_app/Constants.py
+++ b/tldw_app/Constants.py
@@ -14,13 +14,14 @@
 # --- Constants ---
 TAB_CHAT = "chat"
 TAB_CONV_CHAR = "conversations_characters"
-TAB_NOTES = "notes"
 TAB_MEDIA = "media"
+TAB_METRICS = "metrics"
+TAB_NOTES = "notes"
 TAB_SEARCH = "search"
 TAB_INGEST = "ingest"
-TAB_STATS = "stats"
 TAB_LOGS = "logs"
-ALL_TABS = [TAB_CHAT, TAB_CONV_CHAR, TAB_NOTES, TAB_MEDIA, TAB_SEARCH, TAB_INGEST, TAB_LOGS, TAB_STATS]
+TAB_STATS = "stats"
+ALL_TABS = [TAB_CHAT, TAB_CONV_CHAR, TAB_INGEST, TAB_LOGS, TAB_MEDIA, TAB_METRICS, TAB_NOTES, TAB_SEARCH, TAB_STATS]
 
 
 

--- a/tldw_app/Screens/Metrics_Screen.py
+++ b/tldw_app/Screens/Metrics_Screen.py
@@ -1,0 +1,101 @@
+# Metrics_Screen.py
+#
+# Description: Screen for displaying metrics.
+#
+# Imports
+import logging
+from pathlib import Path
+from textual.widgets import Static, Label
+from textual.containers import VerticalScroll
+
+########################################################################################################################
+#
+# Metrics Screen Class
+#
+########################################################################################################################
+
+METRICS_LOG_PATH = Path("/tmp/app_metrics.log")
+
+class MetricsScreen(Static):
+    """
+    A screen to display application metrics from a log file.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.metrics: dict[str, str] = {}
+        logging.info("MetricsScreen initialized. Log path: %s", METRICS_LOG_PATH)
+
+    def on_mount(self):
+        """Load metrics when the screen is mounted."""
+        logging.info("MetricsScreen on_mount: Calling load_metrics.")
+        self.load_metrics()
+        # After loading, we need to recompose or update the display.
+        # Textual handles reactive updates well, but for initial load like this,
+        # we might need to explicitly tell it to refresh if compose relies on data
+        # that wasn't ready at the initial compose call.
+        # However, since on_mount happens before the first paint after adding to DOM,
+        # the compose method called subsequently should have the data.
+        # If not, we might need self.refresh() or re-query and update.
+
+    def load_metrics(self):
+        """
+        Loads metrics from the predefined log file.
+        Parses key-value pairs and updates self.metrics.
+        Handles FileNotFoundError and parsing errors.
+        """
+        logging.info("Attempting to load metrics from: %s", METRICS_LOG_PATH)
+        self.metrics = {}  # Reset metrics before loading
+
+        try:
+            with open(METRICS_LOG_PATH, "r", encoding="utf-8") as f:
+                for i, line in enumerate(f):
+                    line = line.strip()
+                    if not line or line.startswith("#"):  # Skip empty lines and comments
+                        continue
+                    try:
+                        key, value = line.split("=", 1)
+                        self.metrics[key.strip()] = value.strip()
+                    except ValueError:
+                        logging.warning(
+                            "MetricsScreen: Malformed line #%d in %s: '%s'. Skipping.",
+                            i + 1, METRICS_LOG_PATH, line
+                        )
+            logging.info("Successfully loaded %d metrics.", len(self.metrics))
+            if not self.metrics:
+                logging.info("Metrics file was empty or contained no valid data.")
+                self.metrics = {"info": "Metrics file is empty or contains no valid data."}
+
+        except FileNotFoundError:
+            logging.error("MetricsScreen: Log file not found at %s.", METRICS_LOG_PATH)
+            self.metrics = {"error": f"Metrics log file not found: {METRICS_LOG_PATH.name}"}
+        except Exception as e:
+            logging.exception("MetricsScreen: An unexpected error occurred while loading metrics.")
+            self.metrics = {"error": f"An unexpected error occurred: {e}"}
+
+    def compose(self):
+        """Create child widgets for the screen based on loaded metrics."""
+        logging.info("MetricsScreen composing. Current metrics: %s", self.metrics)
+        with VerticalScroll(id="metrics-container"):
+            if not self.metrics: # Should not happen if load_metrics sets a message for empty/error
+                logging.warning("MetricsScreen compose: self.metrics is unexpectedly empty at compose time.")
+                yield Label("No metrics loaded or an error occurred. Check logs.")
+            elif "error" in self.metrics:
+                yield Label(f"[bold red]Error loading metrics:[/]\n{self.metrics['error']}")
+            elif "info" in self.metrics: # For specific info like "file empty"
+                 yield Label(f"[italic]{self.metrics['info']}[/]")
+            elif not self.metrics: # Truly empty after load_metrics somehow (fallback)
+                 yield Label("No metrics available.")
+            else:
+                yield Label("[b u]Application Metrics[/b u]\n")
+                for key, value in self.metrics.items():
+                    # Simple formatting for now
+                    display_key = key.replace("_", " ").capitalize()
+                    yield Label(f"[b]{display_key}:[/b] {value}")
+        logging.info("MetricsScreen compose finished.")
+
+########################################################################################################################
+#
+# End of Metrics_Screen.py
+#
+########################################################################################################################

--- a/tldw_app/app.py
+++ b/tldw_app/app.py
@@ -36,7 +36,7 @@ from textual.css.query import QueryError  # For specific error handling
 #
 # --- Local API library Imports ---
 from tldw_app.Chat.Chat_Functions import chat
-from tldw_app.Constants import ALL_TABS, TAB_CONV_CHAR, TAB_CHAT, TAB_LOGS, TAB_NOTES, css_content
+from tldw_app.Constants import ALL_TABS, TAB_CONV_CHAR, TAB_CHAT, TAB_LOGS, TAB_NOTES, TAB_METRICS, css_content
 from tldw_app.Logging_Config import RichLogHandler
 from tldw_app.Utils.Emoji_Handling import get_char, EMOJI_TITLE_BRAIN, FALLBACK_TITLE_BRAIN, EMOJI_TITLE_NOTE, \
     FALLBACK_TITLE_NOTE, EMOJI_TITLE_SEARCH, FALLBACK_TITLE_SEARCH, EMOJI_SIDEBAR_TOGGLE, FALLBACK_SIDEBAR_TOGGLE, \
@@ -53,6 +53,7 @@ from .config import (
     API_MODELS_BY_PROVIDER,
     LOCAL_PROVIDERS
 )
+from .Screens.Metrics_Screen import MetricsScreen
 from .Character_Chat import Character_Chat_Lib as ccl
 from .Notes.Notes_Library import NotesInteropService
 from .DB.ChaChaNotes_DB import CharactersRAGDBError, ConflictError
@@ -526,9 +527,13 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
                 yield RichLog(id="app-log-display", wrap=True, highlight=True, markup=True, auto_scroll=True)
                 yield Button("Copy All Logs to Clipboard", id="copy-logs-button", classes="logs-action-button")
 
+            # --- Metrics Tab Window ---
+            with Container(id=f"{TAB_METRICS}-window", classes="window"):
+                yield MetricsScreen()
+
             # --- Other Placeholder Windows ---
             for tab_id in ALL_TABS:
-                if tab_id not in [TAB_CHAT, TAB_CONV_CHAR, TAB_LOGS, TAB_NOTES]:  # Updated to TAB_CONV_CHAR
+                if tab_id not in [TAB_CHAT, TAB_CONV_CHAR, TAB_LOGS, TAB_NOTES, TAB_METRICS]:
                     with Container(id=f"{tab_id}-window", classes="window placeholder-window"):
                         yield Static(f"{tab_id.replace('_', ' ').capitalize()} Window Placeholder")
                         yield Button("Coming Soon", id=f"{tab_id}-placeholder-button", disabled=True)

--- a/tldw_app/css/tldw_cli.tcss
+++ b/tldw_app/css/tldw_cli.tcss
@@ -360,3 +360,55 @@ Collapsible > .collapsible--header {
     align: center middle; /* Aligns buttons horizontally if Horizontal container */
                            /* If this itself is a Vertical container, this might not do much */
 }
+
+/* --- Metrics Screen Styling --- */
+MetricsScreen {
+    padding: 1 2; /* Add some padding around the screen content */
+    /* layout: vertical; /* MetricsScreen is a Static, VerticalScroll handles layout */
+    /* align: center top; /* If needed, but VerticalScroll might handle this */
+}
+
+#metrics-container {
+    padding: 1;
+    /* border: round $primary-lighten-2; /* Optional: a subtle border */
+    /* background: $surface; /* Optional: a slightly different background */
+}
+
+/* Styling for individual metric labels within MetricsScreen */
+MetricsScreen Label {
+    width: 100%;
+    margin-bottom: 1; /* Space between metric items */
+    padding: 1;       /* Padding inside each label's box */
+    background: $panel-lighten-1; /* A slightly lighter background for each item */
+    border: round $primary-darken-1; /* Border for each item */
+    /* Textual CSS doesn't allow direct styling of parts of a Label's text (like key vs value) */
+    /* The Python code uses [b] for keys, which Rich Text handles. */
+}
+
+/* Style for the title label: "Application Metrics" */
+/* This targets the first Label directly inside the VerticalScroll with ID metrics-container */
+#metrics-container > Label:first-child {
+    text-style: bold underline;
+    align: center middle;
+    padding: 1 0 2 0; /* More padding below the title */
+    background: $transparent; /* No specific background for the title itself */
+    border: none; /* No border for the title itself */
+    margin-bottom: 2; /* Extra space after the title */
+}
+
+/* Style for error messages within MetricsScreen */
+/* These require the Python code to add the respective class to the Label widget */
+MetricsScreen Label.-error-message {
+    color: $error; /* Text color for errors */
+    background: $error-background 20%; /* Background for error messages, e.g., light red */
+    /* border: round $error; /* Optional: border for error messages */
+    text-style: bold;
+}
+
+/* Style for info messages (e.g. "file empty") within MetricsScreen */
+MetricsScreen Label.-info-message {
+    color: $text-muted; /* Or another color that indicates information */
+    background: $panel; /* A more subdued background, or $transparent */
+    /* border: round $primary-lighten-1; /* Optional: border for info messages */
+    text-style: italic;
+}


### PR DESCRIPTION
This commit introduces a new metrics tracking screen under the 'metrics' tab.

The screen displays key-value metrics loaded from a hardcoded log file (`/tmp/app_metrics.log`).

Key changes:
- Added `TAB_METRICS` constant and updated `ALL_TABS`.
- Created `tldw_app/Screens/Metrics_Screen.py` with logic for loading and displaying metrics.
- Integrated the new screen into `tldw_app/app.py`.
- Added basic CSS styling for the metrics screen in `tldw_app/css/tldw_cli.tcss`.
- Created a placeholder test file `Tests/Screens/test_metrics_screen.py`.