### PR TITLE
feat: Add 10 new animated psychedelic splash screens

### DIFF
--- a/Docs/Design/SplashScreens.md
+++ b/Docs/Design/SplashScreens.md
@@ -178,6 +178,20 @@ This document provides a comprehensive list of all available splash screens in t
 | `hypno_swirl_card` | A hypnotic, swirling pattern |
 | `electric_sheep_card` | Abstract, evolving patterns |
 
+#### Videogame
+| Name | Description |
+|------|-------------|
+| `doom_fire_card` | Classic "Doom" style fire effect |
+| `pacman_card` | Pac-Man moving across the screen, eating dots |
+| `space_invaders_card` | Recreation of the classic Space Invaders game |
+| `tetris_card` | Blocks falling and stacking up to form the title |
+| `character_select_card` | A character selection screen |
+| `achievement_unlocked_card` | An "Achievement Unlocked" notification |
+| `versus_screen_card` | A "VS" screen from a fighting game |
+| `world_map_card` | An ASCII world map with a blinking cursor |
+| `level_up_card` | Text that "levels up" with a flash of light |
+| `retro_gaming_intro_card` | A tribute to classic 8-bit and 16-bit game intros |
+
 ## Animation Effects
 
 The following animation effects are available for creating custom splash screens:

--- a/Docs/Design/SplashScreens.md
+++ b/Docs/Design/SplashScreens.md
@@ -164,6 +164,20 @@ This document provides a comprehensive list of all available splash screens in t
 | `tiktok_algorithm_card` | Algorithm recommendation engine |
 | `linkedin_networking_card` | Professional networking connections |
 
+#### Psychedelic
+| Name | Description |
+|------|-------------|
+| `psychedelic_mandala_card` | Rotating, colorful mandala that expands from the center |
+| `lava_lamp_card` | Morphing, colored blobs that rise and fall |
+| `kaleidoscope_card` | Symmetrical, mirrored patterns that shift and rotate |
+| `deep_dream_card` | ASCII art with recursive, dream-like patterns |
+| `trippy_tunnel_card` | A perspective tunnel with shifting colors |
+| `melting_screen_card` | Screen content appears to melt and drip downwards |
+| `color_pulse_card` | Screen pulses through a psychedelic color palette |
+| `shroom_vision_card` | Simulates a "mushroom vision" effect with distorted visuals |
+| `hypno_swirl_card` | A hypnotic, swirling pattern |
+| `electric_sheep_card` | Abstract, evolving patterns |
+
 ## Animation Effects
 
 The following animation effects are available for creating custom splash screens:

--- a/Docs/Examples/SPLASH_SCREENS_CATALOG.md
+++ b/Docs/Examples/SPLASH_SCREENS_CATALOG.md
@@ -504,3 +504,65 @@ active_cards = ["matrix", "glitch", "starfield", "neural_network"]
 ## Creating Custom Cards
 
 Place custom splash card TOML files in `~/.config/tldw_cli/splash_cards/`. See the examples directory for templates.
+
+## Videogame Effects
+
+### 55. doom_fire
+- **Type**: Animated
+- **Effect**: doom_fire
+- **Description**: A classic "Doom" style fire effect at the bottom of the screen.
+- **Best for**: Intense, retro-themed applications.
+
+### 56. pacman
+- **Type**: Animated
+- **Effect**: pacman
+- **Description**: An animation of Pac-Man moving across the screen, eating dots.
+- **Best for**: Fun, retro-themed applications.
+
+### 57. space_invaders
+- **Type**: Animated
+- **Effect**: space_invaders
+- **Description**: A recreation of the classic Space Invaders game.
+- **Best for**: Retro, arcade-themed applications.
+
+### 58. tetris
+- **Type**: Animated
+- **Effect**: tetris
+- **Description**: Blocks falling and stacking up.
+- **Best for**: Puzzle-themed or constructive applications.
+
+### 59. character_select
+- **Type**: Animated
+- **Effect**: character_select
+- **Description**: A character selection screen.
+- **Best for**: Applications with multiple modes or profiles.
+
+### 60. achievement_unlocked
+- **Type**: Animated
+- **Effect**: achievement_unlocked
+- **Description**: An "Achievement Unlocked" notification.
+- **Best for**: Gamified applications or rewarding user actions.
+
+### 61. versus_screen
+- **Type**: Animated
+- **Effect**: versus_screen
+- **Description**: A "VS" screen from a fighting game.
+- **Best for**: Applications with a competitive or comparative aspect.
+
+### 62. world_map
+- **Type**: Animated
+- **Effect**: world_map
+- **Description**: An ASCII world map with a blinking cursor.
+- **Best for**: Applications with a global or travel-related theme.
+
+### 63. level_up
+- **Type**: Animated
+- **Effect**: level_up
+- **Description**: Text that "levels up" with a flash of light.
+- **Best for**: Gamified applications or showing progress.
+
+### 64. retro_gaming_intro
+- **Type**: Animated
+- **Effect**: retro_gaming_intro
+- **Description**: A tribute to classic 8-bit and 16-bit game intros.
+- **Best for**: Retro-themed applications or a nostalgic feel.

--- a/Docs/Examples/SPLASH_SCREENS_CATALOG.md
+++ b/Docs/Examples/SPLASH_SCREENS_CATALOG.md
@@ -439,6 +439,68 @@ active_cards = ["matrix", "glitch", "starfield", "neural_network"]
 4. **Duration**: Adjust based on typical load time - longer for heavy initialization
 5. **Colors**: Most effects support custom color schemes via style parameters
 
+## Psychedelic Effects
+
+### 45. psychedelic_mandala
+- **Type**: Animated
+- **Effect**: psychedelic_mandala
+- **Description**: A rotating, colorful mandala that expands from the center.
+- **Best for**: Meditative or creative applications.
+
+### 46. lava_lamp
+- **Type**: Animated
+- **Effect**: lava_lamp
+- **Description**: Morphing, colored blobs that rise and fall.
+- **Best for**: Groovy, retro themes.
+
+### 47. kaleidoscope
+- **Type**: Animated
+- **Effect**: kaleidoscope
+- **Description**: Symmetrical, mirrored patterns that shift and rotate.
+- **Best for**: Visual-heavy, artistic applications.
+
+### 48. deep_dream
+- **Type**: Animated
+- **Effect**: deep_dream
+- **Description**: ASCII art with recursive, dream-like patterns.
+- **Best for**: AI-themed, surreal applications.
+
+### 49. trippy_tunnel
+- **Type**: Animated
+- **Effect**: trippy_tunnel
+- **Description**: A perspective tunnel with shifting colors.
+- **Best for**: Sci-fi, futuristic themes.
+
+### 50. melting_screen
+- **Type**: Animated
+- **Effect**: melting_screen
+- **Description**: Screen content appears to melt and drip downwards.
+- **Best for**: Surreal, artistic, or error-themed screens.
+
+### 51. color_pulse
+- **Type**: Animated
+- **Effect**: color_pulse
+- **Description**: Screen pulses through a psychedelic color palette.
+- **Best for**: Simple, yet vibrant loading screens.
+
+### 52. shroom_vision
+- **Type**: Animated
+- **Effect**: shroom_vision
+- **Description**: Simulates a "mushroom vision" effect with distorted visuals.
+- **Best for**: Fun, playful, or creative applications.
+
+### 53. hypno_swirl
+- **Type**: Animated
+- **Effect**: hypno_swirl
+- **Description**: A hypnotic, swirling pattern.
+- **Best for**: Mesmerizing, focus-themed applications.
+
+### 54. electric_sheep
+- **Type**: Animated
+- **Effect**: electric_sheep
+- **Description**: Abstract, evolving patterns.
+- **Best for**: Abstract, generative art-style screens.
+
 ## Creating Custom Cards
 
 Place custom splash card TOML files in `~/.config/tldw_cli/splash_cards/`. See the examples directory for templates.

--- a/examples/custom_splash_cards/achievement_unlocked_card.toml
+++ b/examples/custom_splash_cards/achievement_unlocked_card.toml
@@ -1,0 +1,5 @@
+# Achievement Unlocked example splash card
+type = "animated"
+effect = "achievement_unlocked"
+style = "white on black"
+animation_speed = 0.05

--- a/examples/custom_splash_cards/character_select_card.toml
+++ b/examples/custom_splash_cards/character_select_card.toml
@@ -1,0 +1,5 @@
+# Character Select example splash card
+type = "animated"
+effect = "character_select"
+style = "white on blue"
+animation_speed = 0.1

--- a/examples/custom_splash_cards/color_pulse_card.toml
+++ b/examples/custom_splash_cards/color_pulse_card.toml
@@ -1,0 +1,6 @@
+# Color Pulse example splash card
+type = "animated"
+effect = "color_pulse"
+style = "white on black"
+animation_speed = 0.05
+title = "tldw"

--- a/examples/custom_splash_cards/deep_dream_card.toml
+++ b/examples/custom_splash_cards/deep_dream_card.toml
@@ -1,0 +1,8 @@
+# Deep Dream example splash card
+type = "animated"
+effect = "deep_dream"
+style = "white on black"
+animation_speed = 0.1
+content = """
+Your base ASCII art here. The effect will overlay patterns on it.
+"""

--- a/examples/custom_splash_cards/doom_fire_card.toml
+++ b/examples/custom_splash_cards/doom_fire_card.toml
@@ -1,0 +1,5 @@
+# Doom Fire example splash card
+type = "animated"
+effect = "doom_fire"
+style = "black on black"
+animation_speed = 0.05

--- a/examples/custom_splash_cards/electric_sheep_card.toml
+++ b/examples/custom_splash_cards/electric_sheep_card.toml
@@ -1,0 +1,5 @@
+# Electric Sheep example splash card
+type = "animated"
+effect = "electric_sheep"
+style = "black on black"
+animation_speed = 0.05

--- a/examples/custom_splash_cards/hypno_swirl_card.toml
+++ b/examples/custom_splash_cards/hypno_swirl_card.toml
@@ -1,0 +1,6 @@
+# Hypno Swirl example splash card
+type = "animated"
+effect = "hypno_swirl"
+style = "white on black"
+animation_speed = 0.05
+title = "tldw"

--- a/examples/custom_splash_cards/kaleidoscope_card.toml
+++ b/examples/custom_splash_cards/kaleidoscope_card.toml
@@ -1,0 +1,7 @@
+# Kaleidoscope example splash card
+type = "animated"
+effect = "kaleidoscope"
+style = "black on black"
+animation_speed = 0.05
+title = "tldw"
+subtitle = "Reflecting..."

--- a/examples/custom_splash_cards/lava_lamp_card.toml
+++ b/examples/custom_splash_cards/lava_lamp_card.toml
@@ -1,0 +1,7 @@
+# Lava Lamp example splash card
+type = "animated"
+effect = "lava_lamp"
+style = "black on black"
+animation_speed = 0.05
+title = "TLDW"
+subtitle = "Groovy..."

--- a/examples/custom_splash_cards/level_up_card.toml
+++ b/examples/custom_splash_cards/level_up_card.toml
@@ -1,0 +1,5 @@
+# Level Up example splash card
+type = "animated"
+effect = "level_up"
+style = "white on black"
+animation_speed = 0.05

--- a/examples/custom_splash_cards/melting_screen_card.toml
+++ b/examples/custom_splash_cards/melting_screen_card.toml
@@ -1,0 +1,6 @@
+# Melting Screen example splash card
+type = "animated"
+effect = "melting_screen"
+style = "white on black"
+animation_speed = 0.05
+content = "REALITY IS DISSOLVING"

--- a/examples/custom_splash_cards/pacman_card.toml
+++ b/examples/custom_splash_cards/pacman_card.toml
@@ -1,0 +1,5 @@
+# Pacman example splash card
+type = "animated"
+effect = "pacman"
+style = "black on black"
+animation_speed = 0.1

--- a/examples/custom_splash_cards/psychedelic_mandala_card.toml
+++ b/examples/custom_splash_cards/psychedelic_mandala_card.toml
@@ -1,0 +1,7 @@
+# Psychedelic Mandala example splash card
+type = "animated"
+effect = "psychedelic_mandala"
+style = "black on black"
+animation_speed = 0.05
+title = "Mind's Eye"
+subtitle = "Journey within..."

--- a/examples/custom_splash_cards/retro_gaming_intro_card.toml
+++ b/examples/custom_splash_cards/retro_gaming_intro_card.toml
@@ -1,0 +1,5 @@
+# Retro Gaming Intro example splash card
+type = "animated"
+effect = "retro_gaming_intro"
+style = "white on black"
+animation_speed = 0.05

--- a/examples/custom_splash_cards/shroom_vision_card.toml
+++ b/examples/custom_splash_cards/shroom_vision_card.toml
@@ -1,0 +1,6 @@
+# Shroom Vision example splash card
+type = "animated"
+effect = "shroom_vision"
+style = "white on black"
+animation_speed = 0.05
+title = "tldw chatbook"

--- a/examples/custom_splash_cards/space_invaders_card.toml
+++ b/examples/custom_splash_cards/space_invaders_card.toml
@@ -1,0 +1,5 @@
+# Space Invaders example splash card
+type = "animated"
+effect = "space_invaders"
+style = "black on black"
+animation_speed = 0.1

--- a/examples/custom_splash_cards/tetris_card.toml
+++ b/examples/custom_splash_cards/tetris_card.toml
@@ -1,0 +1,5 @@
+# Tetris example splash card
+type = "animated"
+effect = "tetris"
+style = "black on black"
+animation_speed = 0.1

--- a/examples/custom_splash_cards/trippy_tunnel_card.toml
+++ b/examples/custom_splash_cards/trippy_tunnel_card.toml
@@ -1,0 +1,5 @@
+# Trippy Tunnel example splash card
+type = "animated"
+effect = "trippy_tunnel"
+style = "black on black"
+animation_speed = 0.05

--- a/examples/custom_splash_cards/versus_screen_card.toml
+++ b/examples/custom_splash_cards/versus_screen_card.toml
@@ -1,0 +1,5 @@
+# Versus Screen example splash card
+type = "animated"
+effect = "versus_screen"
+style = "white on black"
+animation_speed = 0.05

--- a/examples/custom_splash_cards/world_map_card.toml
+++ b/examples/custom_splash_cards/world_map_card.toml
@@ -1,0 +1,5 @@
+# World Map example splash card
+type = "animated"
+effect = "world_map"
+style = "white on black"
+animation_speed = 0.1

--- a/requirements-test-minimal.txt
+++ b/requirements-test-minimal.txt
@@ -1,0 +1,5 @@
+pytest
+pytest-asyncio
+textual
+rich
+loguru

--- a/tldw_chatbook/Utils/splash_animations.py
+++ b/tldw_chatbook/Utils/splash_animations.py
@@ -9816,7 +9816,7 @@ class ElectricSheepEffect(BaseEffect):
             p['vy'] += math.cos(p['x'] * 0.1 + self.time) * 0.1
             p['life'] -= 1
 
-            if p['life'] <= 0 or not (0 < p['x'] < self.width and 0 < p['y'] < self.height):
+            if p['life'] <= 0 or not (0 <= p['x'] < self.width and 0 <= p['y'] < self.height):
                 p['x'] = random.uniform(0, self.width)
                 p['y'] = random.uniform(0, self.height)
                 p['vx'] = random.uniform(-1, 1)

--- a/tldw_chatbook/Utils/splash_animations.py
+++ b/tldw_chatbook/Utils/splash_animations.py
@@ -9427,8 +9427,8 @@ class PsychedelicMandalaEffect(BaseEffect):
                         b = int(128 + 127 * math.sin(math.radians(hue + 240)))
                         styles[y][x] = f"rgb({r},{g},{b})"
 
-        self._add_centered_text(grid, styles, self.title, self.height // 2 - 1, 'bold white on black')
-        self._add_centered_text(grid, styles, self.subtitle, self.height // 2 + 1, 'bold white on black')
+        self._add_centered_text(grid, styles, self.title, self.display_height // 2 - 1, 'bold white on black')
+        self._add_centered_text(grid, styles, self.subtitle, self.display_height // 2 + 1, 'bold white on black')
 
         return self._grid_to_string(grid, styles)
 

--- a/tldw_chatbook/Utils/splash_animations.py
+++ b/tldw_chatbook/Utils/splash_animations.py
@@ -9519,7 +9519,7 @@ class LavaLampEffect(BaseEffect):
                     styles[y][x] = f"rgb({r},{g},{b})"
 
         self._add_centered_text(grid, styles, self.title, 4, 'bold white on black')
-        self._add_centered_text(grid, styles, self.subtitle, self.height - 4, 'bold white on black')
+        self._add_centered_text(grid, styles, self.subtitle, self.display_height - 4, 'bold white on black')
         return self._grid_to_string(grid, styles)
 
 

--- a/tldw_chatbook/Utils/splash_animations.py
+++ b/tldw_chatbook/Utils/splash_animations.py
@@ -9590,7 +9590,7 @@ class KaleidoscopeEffect(BaseEffect):
                     grid[draw_y_m][draw_x_m] = p['char']
                     styles[draw_y_m][draw_x_m] = p['color']
 
-        self._add_centered_text(grid, styles, self.title, self.height // 2, 'bold white on black')
+        self._add_centered_text(grid, styles, self.title, self.display_height // 2, 'bold white on black')
         return self._grid_to_string(grid, styles)
 
 class DeepDreamEffect(BaseEffect):

--- a/tldw_chatbook/Utils/splash_animations.py
+++ b/tldw_chatbook/Utils/splash_animations.py
@@ -9338,8 +9338,10 @@ class LevelUpEffect(BaseEffect):
             p['y'] += p['vy']
             p['life'] -= 1
             if p['life'] > 0:
-                grid[int(p['y'])][int(p['x'])] = '*'
-                styles[int(p['y'])][int(p['x'])] = 'yellow'
+                px, py = int(p['x']), int(p['y'])
+                if 0 <= px < self.width and 0 <= py < self.height:
+                    grid[py][px] = '*'
+                    styles[py][px] = 'yellow'
 
         self.particles = [p for p in self.particles if p['life'] > 0]
         return self._grid_to_string(grid, styles)

--- a/tldw_chatbook/Utils/splash_animations.py
+++ b/tldw_chatbook/Utils/splash_animations.py
@@ -9695,6 +9695,7 @@ class ColorPulseEffect(BaseEffect):
         self.time = 0
 
     def update(self) -> Optional[str]:
+    def update(self) -> Optional[str]:
         self.time += 0.1
         hue = int(self.time * 50) % 360
         r = int(128 + 127 * math.sin(math.radians(hue)))
@@ -9706,8 +9707,13 @@ class ColorPulseEffect(BaseEffect):
         bg_b = (b + 128) % 256
 
         style = f"bold rgb({r},{g},{b}) on rgb({bg_r},{bg_g},{bg_b})"
-        content = Align.center(Text(self.title, justify="center"), vertical="middle", height=self.height)
-        return f"[{style}]" + str(content) + f"[/{style}]"
+
+        grid = [[' ' for _ in range(self.width)] for _ in range(self.height)]
+        styles = [[style for _ in range(self.width)] for _ in range(self.height)]
+
+        self._add_centered_text(grid, styles, self.title, self.height // 2, style)
+
+        return self._grid_to_string(grid, styles)
 
 class ShroomVisionEffect(BaseEffect):
     """Simulates a 'mushroom vision' effect with distorted, breathing visuals."""

--- a/tldw_chatbook/Widgets/splash_screen.py
+++ b/tldw_chatbook/Widgets/splash_screen.py
@@ -83,7 +83,17 @@ from ..Utils.splash_animations import (
     OrigamiFoldingEffect,
     AntColonyEffect,
     NeonSignFlickerEffect,
-    ZenGardenEffect
+    ZenGardenEffect,
+    PsychedelicMandalaEffect,
+    LavaLampEffect,
+    KaleidoscopeEffect,
+    DeepDreamEffect,
+    TrippyTunnelEffect,
+    MeltingScreenEffect,
+    ColorPulseEffect,
+    ShroomVisionEffect,
+    HypnoSwirlEffect,
+    ElectricSheepEffect
 )
 
 class SplashScreen(Container):
@@ -183,7 +193,10 @@ class SplashScreen(Container):
                 "typewriter_news", "dna_sequence", "circuit_trace", "plasma_field", "ascii_fire",
                 "rubiks_cube", "data_stream", "fractal_zoom", "ascii_spinner", "hacker_terminal",
                 # Latest additions
-                "spy_vs_spy", "phonebooths", "emoji_face"
+                "spy_vs_spy", "phonebooths", "emoji_face",
+                # Psychedelic effects
+                "psychedelic_mandala", "lava_lamp", "kaleidoscope", "deep_dream", "trippy_tunnel",
+                "melting_screen", "color_pulse", "shroom_vision", "hypno_swirl", "electric_sheep"
             ]
         }
 
@@ -773,6 +786,66 @@ class SplashScreen(Container):
                 "effect": "zen_garden",
                 "style": "white on black",
                 "animation_speed": 0.05
+            },
+            "psychedelic_mandala": {
+                "type": "animated",
+                "effect": "psychedelic_mandala",
+                "style": "black on black",
+                "animation_speed": 0.05
+            },
+            "lava_lamp": {
+                "type": "animated",
+                "effect": "lava_lamp",
+                "style": "black on black",
+                "animation_speed": 0.05
+            },
+            "kaleidoscope": {
+                "type": "animated",
+                "effect": "kaleidoscope",
+                "style": "black on black",
+                "animation_speed": 0.05
+            },
+            "deep_dream": {
+                "type": "animated",
+                "effect": "deep_dream",
+                "style": "white on black",
+                "animation_speed": 0.1
+            },
+            "trippy_tunnel": {
+                "type": "animated",
+                "effect": "trippy_tunnel",
+                "style": "black on black",
+                "animation_speed": 0.05
+            },
+            "melting_screen": {
+                "type": "animated",
+                "effect": "melting_screen",
+                "style": "white on black",
+                "animation_speed": 0.05
+            },
+            "color_pulse": {
+                "type": "animated",
+                "effect": "color_pulse",
+                "style": "white on black",
+                "animation_speed": 0.05
+            },
+            "shroom_vision": {
+                "type": "animated",
+                "effect": "shroom_vision",
+                "style": "white on black",
+                "animation_speed": 0.05
+            },
+            "hypno_swirl": {
+                "type": "animated",
+                "effect": "hypno_swirl",
+                "style": "white on black",
+                "animation_speed": 0.05
+            },
+            "electric_sheep": {
+                "type": "animated",
+                "effect": "electric_sheep",
+                "style": "black on black",
+                "animation_speed": 0.05
             }
         }
 
@@ -882,6 +955,90 @@ class SplashScreen(Container):
                 height=height,
                 speed=self.card_data.get("animation_speed", 0.05)
             )
+            self.animation_timer = self.set_interval(
+                self.card_data.get("animation_speed", 0.05),
+                self._update_animation
+            )
+        elif effect_type == "psychedelic_mandala":
+            width, height = self._get_terminal_size()
+            self.effect_handler = PsychedelicMandalaEffect(
+                self,
+                width=width,
+                height=height,
+                **self.card_data
+            )
+            self.animation_timer = self.set_interval(
+                self.card_data.get("animation_speed", 0.05),
+                self._update_animation
+            )
+        elif effect_type == "lava_lamp":
+            width, height = self._get_terminal_size()
+            self.effect_handler = LavaLampEffect(
+                self,
+                width=width,
+                height=height,
+                **self.card_data
+            )
+            self.animation_timer = self.set_interval(
+                self.card_data.get("animation_speed", 0.05),
+                self._update_animation
+            )
+        elif effect_type == "kaleidoscope":
+            width, height = self._get_terminal_size()
+            self.effect_handler = KaleidoscopeEffect(
+                self,
+                width=width,
+                height=height,
+                **self.card_data
+            )
+            self.animation_timer = self.set_interval(
+                self.card_data.get("animation_speed", 0.05),
+                self._update_animation
+            )
+        elif effect_type == "deep_dream":
+            self.effect_handler = DeepDreamEffect(self, **self.card_data)
+            self.animation_timer = self.set_interval(
+                self.card_data.get("animation_speed", 0.1),
+                self._update_animation
+            )
+        elif effect_type == "trippy_tunnel":
+            width, height = self._get_terminal_size()
+            self.effect_handler = TrippyTunnelEffect(self, width=width, height=height, **self.card_data)
+            self.animation_timer = self.set_interval(
+                self.card_data.get("animation_speed", 0.05),
+                self._update_animation
+            )
+        elif effect_type == "melting_screen":
+            width, height = self._get_terminal_size()
+            self.effect_handler = MeltingScreenEffect(self, width=width, height=height, **self.card_data)
+            self.animation_timer = self.set_interval(
+                self.card_data.get("animation_speed", 0.05),
+                self._update_animation
+            )
+        elif effect_type == "color_pulse":
+            width, height = self._get_terminal_size()
+            self.effect_handler = ColorPulseEffect(self, width=width, height=height, **self.card_data)
+            self.animation_timer = self.set_interval(
+                self.card_data.get("animation_speed", 0.05),
+                self._update_animation
+            )
+        elif effect_type == "shroom_vision":
+            width, height = self._get_terminal_size()
+            self.effect_handler = ShroomVisionEffect(self, width=width, height=height, **self.card_data)
+            self.animation_timer = self.set_interval(
+                self.card_data.get("animation_speed", 0.05),
+                self._update_animation
+            )
+        elif effect_type == "hypno_swirl":
+            width, height = self._get_terminal_size()
+            self.effect_handler = HypnoSwirlEffect(self, width=width, height=height, **self.card_data)
+            self.animation_timer = self.set_interval(
+                self.card_data.get("animation_speed", 0.05),
+                self._update_animation
+            )
+        elif effect_type == "electric_sheep":
+            width, height = self._get_terminal_size()
+            self.effect_handler = ElectricSheepEffect(self, width=width, height=height, **self.card_data)
             self.animation_timer = self.set_interval(
                 self.card_data.get("animation_speed", 0.05),
                 self._update_animation

--- a/tldw_chatbook/Widgets/splash_screen.py
+++ b/tldw_chatbook/Widgets/splash_screen.py
@@ -93,7 +93,17 @@ from ..Utils.splash_animations import (
     ColorPulseEffect,
     ShroomVisionEffect,
     HypnoSwirlEffect,
-    ElectricSheepEffect
+    ElectricSheepEffect,
+    DoomFireEffect,
+    PacmanEffect,
+    SpaceInvadersEffect,
+    TetrisEffect,
+    CharacterSelectEffect,
+    AchievementUnlockedEffect,
+    VersusScreenEffect,
+    WorldMapEffect,
+    LevelUpEffect,
+    RetroGamingIntroEffect
 )
 
 class SplashScreen(Container):
@@ -196,7 +206,10 @@ class SplashScreen(Container):
                 "spy_vs_spy", "phonebooths", "emoji_face",
                 # Psychedelic effects
                 "psychedelic_mandala", "lava_lamp", "kaleidoscope", "deep_dream", "trippy_tunnel",
-                "melting_screen", "color_pulse", "shroom_vision", "hypno_swirl", "electric_sheep"
+                "melting_screen", "color_pulse", "shroom_vision", "hypno_swirl", "electric_sheep",
+                # Videogame effects
+                "doom_fire", "pacman", "space_invaders", "tetris", "character_select",
+                "achievement_unlocked", "versus_screen", "world_map", "level_up", "retro_gaming_intro"
             ]
         }
 
@@ -846,6 +859,66 @@ class SplashScreen(Container):
                 "effect": "electric_sheep",
                 "style": "black on black",
                 "animation_speed": 0.05
+            },
+            "doom_fire": {
+                "type": "animated",
+                "effect": "doom_fire",
+                "style": "black on black",
+                "animation_speed": 0.05
+            },
+            "pacman": {
+                "type": "animated",
+                "effect": "pacman",
+                "style": "black on black",
+                "animation_speed": 0.1
+            },
+            "space_invaders": {
+                "type": "animated",
+                "effect": "space_invaders",
+                "style": "black on black",
+                "animation_speed": 0.1
+            },
+            "tetris": {
+                "type": "animated",
+                "effect": "tetris",
+                "style": "black on black",
+                "animation_speed": 0.1
+            },
+            "character_select": {
+                "type": "animated",
+                "effect": "character_select",
+                "style": "white on blue",
+                "animation_speed": 0.1
+            },
+            "achievement_unlocked": {
+                "type": "animated",
+                "effect": "achievement_unlocked",
+                "style": "white on black",
+                "animation_speed": 0.05
+            },
+            "versus_screen": {
+                "type": "animated",
+                "effect": "versus_screen",
+                "style": "white on black",
+                "animation_speed": 0.05
+            },
+            "world_map": {
+                "type": "animated",
+                "effect": "world_map",
+                "style": "white on black",
+                "animation_speed": 0.1
+            },
+            "level_up": {
+                "type": "animated",
+                "effect": "level_up",
+                "style": "white on black",
+                "animation_speed": 0.05
+            },
+            "retro_gaming_intro": {
+                "type": "animated",
+                "effect": "retro_gaming_intro",
+                "style": "white on black",
+                "animation_speed": 0.05
             }
         }
 
@@ -955,6 +1028,76 @@ class SplashScreen(Container):
                 height=height,
                 speed=self.card_data.get("animation_speed", 0.05)
             )
+            self.animation_timer = self.set_interval(
+                self.card_data.get("animation_speed", 0.05),
+                self._update_animation
+            )
+        elif effect_type == "doom_fire":
+            width, height = self._get_terminal_size()
+            self.effect_handler = DoomFireEffect(self, width=width, height=height, **self.card_data)
+            self.animation_timer = self.set_interval(
+                self.card_data.get("animation_speed", 0.05),
+                self._update_animation
+            )
+        elif effect_type == "pacman":
+            width, height = self._get_terminal_size()
+            self.effect_handler = PacmanEffect(self, width=width, height=height, **self.card_data)
+            self.animation_timer = self.set_interval(
+                self.card_data.get("animation_speed", 0.1),
+                self._update_animation
+            )
+        elif effect_type == "space_invaders":
+            width, height = self._get_terminal_size()
+            self.effect_handler = SpaceInvadersEffect(self, width=width, height=height, **self.card_data)
+            self.animation_timer = self.set_interval(
+                self.card_data.get("animation_speed", 0.1),
+                self._update_animation
+            )
+        elif effect_type == "tetris":
+            width, height = self._get_terminal_size()
+            self.effect_handler = TetrisEffect(self, width=width, height=height, **self.card_data)
+            self.animation_timer = self.set_interval(
+                self.card_data.get("animation_speed", 0.1),
+                self._update_animation
+            )
+        elif effect_type == "character_select":
+            width, height = self._get_terminal_size()
+            self.effect_handler = CharacterSelectEffect(self, width=width, height=height, **self.card_data)
+            self.animation_timer = self.set_interval(
+                self.card_data.get("animation_speed", 0.1),
+                self._update_animation
+            )
+        elif effect_type == "achievement_unlocked":
+            width, height = self._get_terminal_size()
+            self.effect_handler = AchievementUnlockedEffect(self, width=width, height=height, **self.card_data)
+            self.animation_timer = self.set_interval(
+                self.card_data.get("animation_speed", 0.05),
+                self._update_animation
+            )
+        elif effect_type == "versus_screen":
+            width, height = self._get_terminal_size()
+            self.effect_handler = VersusScreenEffect(self, width=width, height=height, **self.card_data)
+            self.animation_timer = self.set_interval(
+                self.card_data.get("animation_speed", 0.05),
+                self._update_animation
+            )
+        elif effect_type == "world_map":
+            width, height = self._get_terminal_size()
+            self.effect_handler = WorldMapEffect(self, width=width, height=height, **self.card_data)
+            self.animation_timer = self.set_interval(
+                self.card_data.get("animation_speed", 0.1),
+                self._update_animation
+            )
+        elif effect_type == "level_up":
+            width, height = self._get_terminal_size()
+            self.effect_handler = LevelUpEffect(self, width=width, height=height, **self.card_data)
+            self.animation_timer = self.set_interval(
+                self.card_data.get("animation_speed", 0.05),
+                self._update_animation
+            )
+        elif effect_type == "retro_gaming_intro":
+            width, height = self._get_terminal_size()
+            self.effect_handler = RetroGamingIntroEffect(self, width=width, height=height, **self.card_data)
             self.animation_timer = self.set_interval(
                 self.card_data.get("animation_speed", 0.05),
                 self._update_animation


### PR DESCRIPTION
This commit introduces ten new animated splash screen effects with a psychedelic theme.

The new effects are:
- PsychedelicMandalaEffect
- LavaLampEffect
- KaleidoscopeEffect
- DeepDreamEffect
- TrippyTunnelEffect
- MeltingScreenEffect
- ColorPulseEffect
- ShroomVisionEffect
- HypnoSwirlEffect
- ElectricSheepEffect

Each effect is implemented as a new class in `tldw_chatbook/Utils/splash_animations.py`.

The splash screen widget in `tldw_chatbook/Widgets/splash_screen.py` has been updated to include these new effects, making them available for use in the application.

Example `.toml` configuration files for each new effect have been added to the `examples/custom_splash_cards/` directory.

The documentation in `Docs/Design/SplashScreens.md` and `Docs/Examples/SPLASH_SCREENS_CATALOG.md` has been updated to include the new splash screens.