### PR TITLE
numpy req fix - 0.1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to Some kind of Versioning
 ### Added
 - Initial features pending documentation
 
+## [0.1.7.2] - 2025-08-7
+### Fixed 
+- Numpy requirement in base install
+
+
 ## [0.1.7.1] - 2025-08-7
 ### Fixed 
 - Chatbook import logging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tldw_chatbook"
-version = "0.1.7.1"
+version = "0.1.7.2"
 authors = [
   { name="Robert Musser", email="contact@rmusser.net" },
 ]

--- a/tldw_chatbook/Audio/recording_service.py
+++ b/tldw_chatbook/Audio/recording_service.py
@@ -16,14 +16,15 @@ from pathlib import Path
 from contextlib import contextmanager
 from loguru import logger
 
-# Try to import numpy as required dependency for audio functionality
+# Try to import numpy as optional dependency for audio functionality
 try:
     import numpy as np
     NUMPY_AVAILABLE = True
 except ImportError:
+    np = None
     NUMPY_AVAILABLE = False
-    logger.error("NumPy not available. Audio recording functionality is disabled.")
-    logger.error("To enable audio features, install numpy: pip install numpy")
+    logger.warning("NumPy not available. Audio recording will use fallback methods.")
+    logger.info("For better performance, install numpy: pip install numpy")
 
 # Try to import audio backends
 PYAUDIO_AVAILABLE = False
@@ -346,8 +347,16 @@ class AudioRecordingService:
                 logger.warning(f"Sounddevice status: {status}")
             
             if self.is_recording:
-                # Convert float32 to int16 (numpy is required)
-                audio_data = (indata * 32767).astype(np.int16).tobytes()
+                # Convert float32 to int16
+                if NUMPY_AVAILABLE and np is not None:
+                    audio_data = (indata * 32767).astype(np.int16).tobytes()
+                else:
+                    # Fallback: manual conversion
+                    import struct
+                    audio_data = b''.join(
+                        struct.pack('h', int(min(32767, max(-32768, sample * 32767))))
+                        for sample in indata.flatten()
+                    )
                 self._process_audio_chunk(audio_data)
         
         try:
@@ -471,9 +480,20 @@ class AudioRecordingService:
             for chunk in recent_chunks:
                 self.audio_queue.put(chunk)
             
-            # Calculate RMS (numpy is required)
-            audio_data = np.frombuffer(b''.join(recent_chunks), dtype=np.int16)
-            rms = np.sqrt(np.mean(audio_data**2))
+            # Calculate RMS
+            combined_audio = b''.join(recent_chunks)
+            if NUMPY_AVAILABLE and np is not None:
+                audio_data = np.frombuffer(combined_audio, dtype=np.int16)
+                rms = np.sqrt(np.mean(audio_data**2))
+            else:
+                # Fallback: manual RMS calculation
+                import struct
+                samples = struct.unpack(f'{len(combined_audio)//2}h', combined_audio)
+                if samples:
+                    sum_squares = sum(s * s for s in samples)
+                    rms = (sum_squares / len(samples)) ** 0.5
+                else:
+                    rms = 0
             
             # Normalize (16-bit max is 32767)
             level = min(1.0, rms / 32767.0)

--- a/tldw_chatbook/Audio/recording_service.py
+++ b/tldw_chatbook/Audio/recording_service.py
@@ -353,9 +353,10 @@ class AudioRecordingService:
                 else:
                     # Fallback: manual conversion
                     import struct
+                    samples = struct.unpack(f'{frames * self.channels}f', indata.tobytes())
                     audio_data = b''.join(
                         struct.pack('h', int(min(32767, max(-32768, sample * 32767))))
-                        for sample in indata.flatten()
+                        for sample in samples
                     )
                 self._process_audio_chunk(audio_data)
         


### PR DESCRIPTION
Gemini:

I've updated the audio processing modules to make numpy an optional dependency rather than a strict requirement. This change ensures that the application can still perform core audio functionalities, such as audio level monitoring and data conversion, even if numpy is not installed, by falling back to pure Python implementations. This improves the flexibility and robustness of the audio components.
Highlights
```
    Optional NumPy Dependency: I've made numpy an optional dependency for audio processing, allowing the application to run without it.
    Audio Level Calculation Fallback: I've implemented a pure Python fallback for calculating audio RMS levels in dictation_service_lazy.py when numpy is unavailable.
    Audio Data Conversion Fallback: I've added a pure Python fallback for converting float32 audio data to int16 in recording_service.py.
    RMS Calculation Fallback in Recording Service: I've provided a pure Python fallback for RMS calculation in recording_service.py when numpy is not present.
```