### PR TITLE
Fix UX audit Phase 0/1 shell and runtime stability

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-ux-audit-phase0-phase1-stabilization.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-phase0-phase1-stabilization.md
@@ -1,0 +1,802 @@
+# UX Audit Phase 0-1 Stabilization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the current P0/P1 UX blockers in the app shell and runtime-stability layer before any further orientation or polish work.
+
+**Architecture:** This tranche is split into seven independently shippable tasks. Phase 0 establishes a repeatable shell/navigation smoke gate and fixes the Chatbooks shell escape bug. Phase 1 fixes runtime trust failures one seam at a time: Ingest regression coverage, Study response normalization, Chat state-save safety, Search/RAG worker-thread UI mutation, and Search primary-action reachability.
+
+**Tech Stack:** Python 3.12, Textual, pytest, pytest-asyncio, SQLite-backed service tests, existing `Tests.textual_test_utils.widget_pilot`.
+
+---
+
+## Source Documents
+
+- `Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md`
+- `Docs/superpowers/specs/2026-04-20-ux-rescue-audit-design.md`
+- `Docs/superpowers/specs/2026-04-21-chat-first-shell-label-cleanup-design.md`
+- `Docs/superpowers/specs/2026-04-21-use-in-chat-handoffs-design.md`
+
+## Scope Boundary
+
+Do this:
+
+- Fix Phase 0 shell/smoke and Phase 1 runtime/layout issues only.
+- Preserve screen route IDs.
+- Preserve the already-merged `Use in Chat` architecture.
+- Add failing tests before production changes.
+- Commit after each task or after each tightly coupled test/fix pair.
+
+Do not do this in this tranche:
+
+- Do not implement Phase 2 provider readiness or first-run Chat orientation.
+- Do not implement Phase 3/4 handoff clear/dismiss or smoke replay.
+- Do not rename `LLM` or `S/TT/S`; that belongs to Phase 5.
+- Do not perform broad visual redesign.
+
+## File Responsibility Map
+
+- `Tests/UI/test_ux_audit_smoke.py`: new route-level UX smoke gate that proves top-level destinations keep shared navigation and can escape back to Chat.
+- `Tests/UI/test_screen_navigation.py`: existing screen routing tests; extend with class-contract assertions for routed screens.
+- `Tests/UI/test_chatbooks_screen_server_actions.py`: existing Chatbooks focused tests; update for `BaseAppScreen` construction and shell rendering.
+- `tldw_chatbook/UI/Screens/chatbooks_screen.py`: convert Chatbooks to the shared `BaseAppScreen` contract.
+- `Tests/UI/test_ingestion_ui_redesigned.py`: add direct regression that server-mode source type default is a valid allowed option.
+- `Tests/UI/test_media_ingestion_tab_integration.py`: keep existing local/server screen coverage green.
+- `tldw_chatbook/Widgets/Media/media_ingestion_source_panel.py`: modify only if the new direct regression fails.
+- `Tests/Study_Interop/test_quiz_scope_service.py`: add empty mapping response coverage.
+- `tldw_chatbook/Study_Interop/quiz_scope_service.py`: normalize list response shapes explicitly.
+- `Tests/UI/test_chat_screen_state.py`: add regression for direct chat-log save path.
+- `tldw_chatbook/UI/Screens/chat_screen.py`: define fallback selectors outside fallback-only branches.
+- `Tests/UI/test_search_rag_window.py`: add thread-seam and primary-action reachability coverage.
+- `tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py`: separate off-thread data loading from on-thread widget mutation and adjust layout only if the reachability regression fails.
+
+## Task 1: Shell Contract And UX Smoke Gate
+
+**Files:**
+
+- Create: `Tests/UI/test_ux_audit_smoke.py`
+- Modify: `Tests/UI/test_screen_navigation.py`
+- Read: `tldw_chatbook/app.py`
+- Read: `tldw_chatbook/UI/Navigation/base_app_screen.py`
+
+- [ ] **Step 1: Add routed-screen contract coverage**
+
+Add a test to `Tests/UI/test_screen_navigation.py` that imports the routed screen classes from `_resolve_screen_navigation_target()` and verifies every primary route uses `BaseAppScreen`.
+
+Use this route set:
+
+```python
+PRIMARY_ROUTE_IDS = [
+    "chat",
+    "notes",
+    "media",
+    "ingest",
+    "search",
+    "study",
+    "ccp",
+    "chatbooks",
+]
+```
+
+Test shape:
+
+```python
+def test_primary_routed_screens_use_base_app_screen():
+    app = _build_test_app()
+
+    offenders = []
+    for route_id in PRIMARY_ROUTE_IDS:
+        _screen_name, _tab_id, screen_class = app._resolve_screen_navigation_target(route_id)
+        if screen_class is None or not issubclass(screen_class, BaseAppScreen):
+            offenders.append((route_id, screen_class))
+
+    assert offenders == []
+```
+
+- [ ] **Step 2: Run contract test and verify it fails on Chatbooks**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/UI/test_screen_navigation.py::test_primary_routed_screens_use_base_app_screen --tb=short
+```
+
+Expected: FAIL showing `chatbooks` maps to a class that is not a `BaseAppScreen`.
+
+- [ ] **Step 3: Add reusable UX smoke test for navigation persistence**
+
+Create `Tests/UI/test_ux_audit_smoke.py`.
+
+The test should build the normal test app using the same patch strategy as `Tests/UI/test_screen_navigation.py`, launch the app with `run_test()`, navigate through the core route IDs, and assert the shared nav remains mounted after each route.
+
+Minimum route order:
+
+```python
+SMOKE_ROUTE_IDS = [
+    "chat",
+    "notes",
+    "media",
+    "ingest",
+    "search",
+    "study",
+    "ccp",
+    "chatbooks",
+]
+```
+
+Core assertion:
+
+```python
+assert app.screen.query_one("#nav-chat") is not None
+assert app.screen.query_one("#nav-chatbooks") is not None
+```
+
+Prefer posting `NavigateToScreen(route_id)` over direct `push_screen()` so the real app navigation handler saves/restores state.
+
+- [ ] **Step 4: Run smoke test and verify it fails on Chatbooks**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/UI/test_ux_audit_smoke.py --tb=short --maxfail=1
+```
+
+Expected: FAIL after entering `chatbooks` because the shared navigation bar is missing.
+
+- [ ] **Step 5: Commit failing tests only if working in a red-green commit style**
+
+Optional commit:
+
+```bash
+git add Tests/UI/test_ux_audit_smoke.py Tests/UI/test_screen_navigation.py
+git commit -m "test: add ux shell smoke contract"
+```
+
+If the team prefers green-only commits, skip this commit and include the tests with Task 2.
+
+## Task 2: Convert Chatbooks To Shared Shell
+
+**Files:**
+
+- Modify: `tldw_chatbook/UI/Screens/chatbooks_screen.py`
+- Modify: `Tests/UI/test_chatbooks_screen_server_actions.py`
+- Modify: `Tests/UI/test_screen_navigation.py`
+- Modify: `Tests/UI/test_ux_audit_smoke.py`
+
+- [ ] **Step 1: Update ChatbooksScreen inheritance and constructor**
+
+Change `ChatbooksScreen` to extend `BaseAppScreen` instead of raw `Screen`.
+
+Implementation shape:
+
+```python
+from ..Navigation.base_app_screen import BaseAppScreen
+from tldw_chatbook.Constants import TAB_CHATBOOKS
+
+
+class ChatbooksScreen(BaseAppScreen):
+    def __init__(self, app_instance, **kwargs):
+        super().__init__(app_instance, TAB_CHATBOOKS, **kwargs)
+```
+
+- [ ] **Step 2: Move Chatbooks content into compose_content()**
+
+Replace `compose()` with `compose_content()` so `BaseAppScreen.compose()` mounts `MainNavigationBar`.
+
+Implementation shape:
+
+```python
+def compose_content(self) -> ComposeResult:
+    logger.info("Composing Chatbooks screen")
+    yield ChatbooksWindowImproved(self.app_instance)
+```
+
+Do not yield `ChatbooksWindowImproved(self.app)` from `compose_content()`. Use `self.app_instance` so tests and app routing receive the same owner object that the screen was constructed with.
+
+- [ ] **Step 3: Preserve mount and resume behavior**
+
+Keep current `on_mount()`, `on_screen_suspend()`, `on_screen_resume()`, and local reactive state.
+
+If adding `super().on_mount()`, call it synchronously:
+
+```python
+super().on_mount()
+```
+
+Do not `await super().on_mount()` because `BaseAppScreen.on_mount()` is not async.
+
+- [ ] **Step 4: Update Chatbooks tests to construct with an app instance**
+
+In `Tests/UI/test_chatbooks_screen_server_actions.py`, update host apps from:
+
+```python
+yield ChatbooksScreen()
+```
+
+to:
+
+```python
+yield ChatbooksScreen(self)
+```
+
+Add assertions that the shared nav exists:
+
+```python
+assert app.screen.query_one("#nav-chat") is not None
+assert app.screen.query_one("#nav-chatbooks") is not None
+```
+
+- [ ] **Step 5: Run focused shell tests**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q \
+  Tests/UI/test_ux_audit_smoke.py \
+  Tests/UI/test_screen_navigation.py::test_primary_routed_screens_use_base_app_screen \
+  Tests/UI/test_chatbooks_screen_server_actions.py \
+  --tb=short
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit shell fix**
+
+Run:
+
+```bash
+git add tldw_chatbook/UI/Screens/chatbooks_screen.py Tests/UI/test_ux_audit_smoke.py Tests/UI/test_screen_navigation.py Tests/UI/test_chatbooks_screen_server_actions.py
+git commit -m "fix: mount chatbooks in shared app shell"
+```
+
+## Task 3: Lock In Ingest Source Default Regression
+
+**Files:**
+
+- Modify: `Tests/UI/test_ingestion_ui_redesigned.py`
+- Modify only if test fails: `tldw_chatbook/Widgets/Media/media_ingestion_source_panel.py`
+
+- [ ] **Step 1: Add a direct source-panel default test**
+
+In `Tests/UI/test_ingestion_ui_redesigned.py`, import `Select` if needed and add a test under `TestMediaIngestWindowRebuilt`.
+
+Test shape:
+
+```python
+@pytest.mark.asyncio
+async def test_source_panel_create_type_default_is_allowed_in_server_mode(
+    self,
+    mock_app_instance: MagicMock,
+    widget_pilot,
+) -> None:
+    mock_app_instance.media_runtime_state = SimpleNamespace(runtime_backend="server")
+
+    async with await widget_pilot(MediaIngestWindowRebuilt, app_instance=mock_app_instance) as pilot:
+        window = pilot.app.test_widget
+        await pilot.pause()
+
+        source_type = window.source_panel.query_one("#create-source-type", Select)
+
+        allowed_values = {value for _label, value in CREATE_SOURCE_TYPE_OPTIONS}
+        assert source_type.value in allowed_values
+        assert source_type.value == "local_directory"
+```
+
+Import `SimpleNamespace`, `Select`, and `CREATE_SOURCE_TYPE_OPTIONS` as needed.
+
+- [ ] **Step 2: Run the direct Ingest regression**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/UI/test_ingestion_ui_redesigned.py::TestMediaIngestWindowRebuilt::test_source_panel_create_type_default_is_allowed_in_server_mode --tb=short
+```
+
+Expected: PASS on current `dev`. If it fails, fix only the options/default mismatch in `media_ingestion_source_panel.py`.
+
+- [ ] **Step 3: Run existing Ingest focused tests**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/UI/test_ingestion_ui_redesigned.py Tests/UI/test_media_ingestion_tab_integration.py --tb=short
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit Ingest regression**
+
+Run:
+
+```bash
+git add Tests/UI/test_ingestion_ui_redesigned.py tldw_chatbook/Widgets/Media/media_ingestion_source_panel.py
+git commit -m "test: lock ingest source default"
+```
+
+If `media_ingestion_source_panel.py` was untouched, stage only the test file.
+
+## Task 4: Normalize Empty Study Quiz List Responses
+
+**Files:**
+
+- Modify: `Tests/Study_Interop/test_quiz_scope_service.py`
+- Modify: `tldw_chatbook/Study_Interop/quiz_scope_service.py`
+
+- [ ] **Step 1: Add failing empty local quiz list regression**
+
+In `Tests/Study_Interop/test_quiz_scope_service.py`, add a fake service that returns an empty paginated mapping:
+
+```python
+class EmptyMappingLocalQuizService(FakeLocalQuizService):
+    def list_quizzes(self, *, q=None, limit=100, offset=0):
+        self.calls.append(("list_quizzes", q, limit, offset))
+        return {"items": [], "count": 0}
+```
+
+Add test:
+
+```python
+@pytest.mark.asyncio
+async def test_local_quiz_list_empty_mapping_returns_empty_list():
+    scope = QuizScopeService(local_service=EmptyMappingLocalQuizService())
+
+    quizzes = await scope.list_quizzes(mode="local")
+
+    assert quizzes == []
+```
+
+- [ ] **Step 2: Run regression and verify it fails**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/Study_Interop/test_quiz_scope_service.py::test_local_quiz_list_empty_mapping_returns_empty_list --tb=short
+```
+
+Expected before fix: FAIL because the current logic may iterate mapping keys such as `"items"` and `"count"`.
+
+- [ ] **Step 3: Add one response-shape helper**
+
+In `tldw_chatbook/Study_Interop/quiz_scope_service.py`, add a private helper near `_maybe_await()`:
+
+```python
+@staticmethod
+def _items_from_list_response(records: Any) -> list[Any]:
+    if records is None:
+        return []
+    if isinstance(records, Mapping):
+        items = records.get("items")
+        if items is None:
+            return []
+        return list(items)
+    return list(records)
+```
+
+- [ ] **Step 4: Use the helper in quiz list paths**
+
+Replace these patterns:
+
+```python
+list((records or {}).get("items") or records or [])
+```
+
+and:
+
+```python
+list((response or {}).get("items") or response or [])
+```
+
+with:
+
+```python
+self._items_from_list_response(records)
+```
+
+or:
+
+```python
+self._items_from_list_response(response)
+```
+
+Apply this to `list_quizzes()` and `_load_scoped_server_quizzes()` at minimum. If the same unsafe pattern appears in question or attempt list methods, use the helper there too in the same commit.
+
+- [ ] **Step 5: Run Study focused tests**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/Study_Interop/test_quiz_scope_service.py --tb=short
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Study fix**
+
+Run:
+
+```bash
+git add Tests/Study_Interop/test_quiz_scope_service.py tldw_chatbook/Study_Interop/quiz_scope_service.py
+git commit -m "fix: normalize empty quiz list responses"
+```
+
+## Task 5: Fix Chat Save-State Direct Log Path
+
+**Files:**
+
+- Modify: `Tests/UI/test_chat_screen_state.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`
+
+- [ ] **Step 1: Add failing direct chat-log regression**
+
+In `Tests/UI/test_chat_screen_state.py`, add a small fake chat log:
+
+```python
+class EmptyChatLog:
+    children = []
+
+    def query(self, _selector):
+        return []
+```
+
+Add test:
+
+```python
+def test_extract_messages_clears_messages_when_direct_chat_log_lookup_succeeds():
+    app = Mock()
+    app.query_one = Mock(return_value=EmptyChatLog())
+    screen = ChatScreen(app)
+    screen.chat_window = Mock()
+    tab_state = TabState(
+        tab_id="tab-1",
+        messages=[MessageData(message_id="old", role="user", content="stale")],
+    )
+
+    screen._extract_and_save_messages(tab_state)
+
+    assert tab_state.messages == []
+    screen.chat_window.query.assert_not_called()
+```
+
+This test should fail before the fix because `log_selectors` is unbound when direct lookup succeeds.
+
+- [ ] **Step 2: Run regression and verify failure**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/UI/test_chat_screen_state.py::test_extract_messages_clears_messages_when_direct_chat_log_lookup_succeeds --tb=short
+```
+
+Expected before fix: FAIL because stale messages remain or an error path is logged.
+
+- [ ] **Step 3: Define fallback selectors before direct lookup**
+
+In `tldw_chatbook/UI/Screens/chat_screen.py`, in `_extract_and_save_messages()`, move the selector list before direct lookup:
+
+```python
+log_selectors = [
+    "#chat-log",
+    ".chat-log",
+    "#chat-messages-container",
+    ".chat-messages",
+]
+chat_log = None
+```
+
+Then keep this structure:
+
+```python
+try:
+    chat_log = self.app_instance.query_one("#chat-log", VerticalScroll)
+    logger.debug("Found chat log via app_instance.query_one")
+except Exception:
+    pass
+
+if not chat_log:
+    for selector in log_selectors:
+        ...
+```
+
+Do not change restore logic unless a focused test proves it has the same bug.
+
+- [ ] **Step 4: Run Chat state tests**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/UI/test_chat_screen_state.py --tb=short
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Chat state fix**
+
+Run:
+
+```bash
+git add Tests/UI/test_chat_screen_state.py tldw_chatbook/UI/Screens/chat_screen.py
+git commit -m "fix: save chat messages from direct log path"
+```
+
+## Task 6: Keep Search/RAG Collection UI Updates On The Message Thread
+
+**Files:**
+
+- Modify: `Tests/UI/test_search_rag_window.py`
+- Modify: `tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py`
+
+- [ ] **Step 1: Add a worker-seam regression**
+
+In `Tests/UI/test_search_rag_window.py`, add a test that verifies collection loading does not query widgets directly.
+
+Recommended implementation target: introduce a production helper named `_load_available_collections()` and test it directly first.
+
+Test shape:
+
+```python
+def test_load_available_collections_does_not_touch_textual_widgets(
+    self,
+    mock_app_instance: MagicMock,
+    search_rag_test_env,
+) -> None:
+    window = SearchRAGWindow(mock_app_instance, id="test-search-window")
+    window.query_one = MagicMock(side_effect=AssertionError("UI touched during load"))
+
+    with patch(
+        "tldw_chatbook.UI.Views.RAGSearch.search_rag_window.get_available_profiles",
+        return_value=["default", "research"],
+    ):
+        assert window._load_available_collections() == ["default", "research"]
+```
+
+- [ ] **Step 2: Run regression and verify failure**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/UI/test_search_rag_window.py::TestSearchRAGWindow::test_load_available_collections_does_not_touch_textual_widgets --tb=short
+```
+
+Expected before fix: FAIL because `_load_available_collections()` does not exist.
+
+- [ ] **Step 3: Split data loading from UI application**
+
+In `tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py`, add:
+
+```python
+def _load_available_collections(self) -> list[str]:
+    return list(get_available_profiles())
+```
+
+Add an on-thread UI helper:
+
+```python
+async def _apply_available_collections(self, collections: list[str]) -> None:
+    self.available_collections = list(collections)
+    collections_list = self.query_one("#collections-list", ListView)
+    await collections_list.clear()
+
+    for collection in self.available_collections:
+        await collections_list.append(ListItem(Static(collection)))
+
+    collection_select = self.query_one("#collection-select", Select)
+    collection_select.set_options(
+        [("All Collections", "all")] + [(collection, collection) for collection in self.available_collections]
+    )
+```
+
+Use the same label/value ordering as the existing `Select` construction. If current code has `("All Collections", "all")`, keep that exact order.
+
+Add a small scheduler helper so the coroutine is created on the Textual message thread, not in the worker thread:
+
+```python
+def _schedule_apply_available_collections(self, collections: list[str]) -> None:
+    self.run_worker(self._apply_available_collections(collections), exclusive=True)
+```
+
+- [ ] **Step 4: Make the worker schedule UI work instead of doing it**
+
+Replace the current `_refresh_collections_list()` body with a thread-safe scheduling pattern.
+
+Implementation shape:
+
+```python
+@work(thread=True)
+def _refresh_collections_list(self) -> None:
+    try:
+        collections = self._load_available_collections()
+        self.app.call_from_thread(self._schedule_apply_available_collections, collections)
+    except Exception as e:
+        logger.error(f"Error refreshing collections: {e}")
+```
+
+If `run_worker()` is not the right Textual primitive for awaiting `_apply_available_collections()`, use the smallest existing app pattern in this repo that schedules async UI work from a thread. The invariant is strict: the `thread=True` method must not call `query_one()`, `clear()`, `append()`, or `set_options()`, and it must not create the `_apply_available_collections()` coroutine in the worker thread.
+
+- [ ] **Step 5: Add an application-helper test for UI application**
+
+Add a mounted widget test that calls `_apply_available_collections(["default"])` directly and verifies:
+
+```python
+assert window.available_collections == ["default"]
+assert len(window.query_one("#collections-list", ListView).children) == 1
+assert window.query_one("#collection-select", Select).value in ("all", Select.BLANK)
+```
+
+The exact select value may depend on Textual selection behavior; assert options rather than selected value if needed.
+
+- [ ] **Step 6: Run Search/RAG focused tests**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/UI/test_search_rag_window.py --tb=short
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Search/RAG threading fix**
+
+Run:
+
+```bash
+git add Tests/UI/test_search_rag_window.py tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py
+git commit -m "fix: refresh search collections on ui thread"
+```
+
+## Task 7: Verify Search Primary Action Reachability
+
+**Files:**
+
+- Modify: `Tests/UI/test_search_rag_window.py`
+- Modify only if test fails: `tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py`
+
+- [ ] **Step 1: Add search action reachability regression**
+
+In `Tests/UI/test_search_rag_window.py`, add a mounted test that proves the primary Search button is present, enabled, and callable without opening advanced controls.
+
+Test shape:
+
+```python
+@pytest.mark.asyncio
+async def test_primary_search_action_is_reachable_in_default_layout(
+    self,
+    mock_app_instance: MagicMock,
+    search_rag_test_env,
+    widget_pilot,
+) -> None:
+    async with await widget_pilot(SearchRAGWindow, app_instance=mock_app_instance) as pilot:
+        window = pilot.app.test_widget
+        search_input = window.query_one("#search-query-input", Input)
+        search_button = window.query_one("#search-button", Button)
+
+        assert search_button.disabled is False
+        assert search_button.display is True
+        assert search_input.display is True
+```
+
+If the current Textual test harness supports click assertions reliably, extend it:
+
+```python
+search_input.value = "test query"
+window.handle_search_button = MagicMock()
+await pilot.click("#search-button")
+await pilot.pause()
+window.handle_search_button.assert_called()
+```
+
+Only add the click assertion if it is stable under the local Textual test driver.
+
+- [ ] **Step 2: Run regression**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/UI/test_search_rag_window.py::TestSearchRAGWindow::test_primary_search_action_is_reachable_in_default_layout --tb=short
+```
+
+Expected: PASS if the current layout is already reachable. If it fails, continue to Step 3.
+
+- [ ] **Step 3: Make only minimal layout changes if needed**
+
+If reachability fails, modify only the search control row around `#search-query-input` and `#search-button`.
+
+Allowed changes:
+
+- Keep `#search-query-input` and `#search-button` in the first visible search section.
+- Keep advanced controls below or behind the existing advanced options area.
+- Do not redesign the full Search/RAG screen.
+- Do not change handler names or IDs.
+
+- [ ] **Step 4: Run Search/RAG and handoff tests**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/UI/test_search_rag_window.py Tests/UI/test_search_handoffs.py --tb=short
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Search reachability test/fix**
+
+Run:
+
+```bash
+git add Tests/UI/test_search_rag_window.py tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py
+git commit -m "test: cover search primary action reachability"
+```
+
+If production code was changed, use:
+
+```bash
+git commit -m "fix: keep search primary action reachable"
+```
+
+## Final Verification
+
+- [ ] **Step 1: Run Phase 0 tests**
+
+```bash
+.venv/bin/python -m pytest -q \
+  Tests/UI/test_ux_audit_smoke.py \
+  Tests/UI/test_screen_navigation.py \
+  Tests/UI/test_chatbooks_screen_server_actions.py \
+  --tb=short
+```
+
+- [ ] **Step 2: Run Phase 1 tests**
+
+```bash
+.venv/bin/python -m pytest -q \
+  Tests/UI/test_ingestion_ui_redesigned.py \
+  Tests/UI/test_media_ingestion_tab_integration.py \
+  Tests/Study_Interop/test_quiz_scope_service.py \
+  Tests/UI/test_chat_screen_state.py \
+  Tests/UI/test_search_rag_window.py \
+  Tests/UI/test_search_handoffs.py \
+  --tb=short
+```
+
+- [ ] **Step 3: Run already-merged handoff guardrails**
+
+```bash
+.venv/bin/python -m pytest -q \
+  Tests/UI/test_chat_first_handoffs.py \
+  Tests/UI/test_media_handoffs.py \
+  Tests/UI/test_chat_tab_container.py \
+  --tb=short
+```
+
+- [ ] **Step 4: Run whitespace check**
+
+```bash
+git diff --check
+```
+
+- [ ] **Step 5: Update the rebaseline tracker**
+
+Modify `Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md` after implementation:
+
+- Mark Phase 0 completed if the shell smoke passes.
+- Mark the completed Phase 1 items.
+- Leave Phase 2/5/6/7 untouched unless implemented in later tranches.
+
+- [ ] **Step 6: Final commit**
+
+If tracker updates were made separately:
+
+```bash
+git add Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+git commit -m "docs: update ux remediation phase status"
+```
+
+## Known Risks
+
+- The app-level Textual smoke may be slow or flaky if it initializes optional services. If that happens, keep the routed-screen class contract as the CI gate and make the full route-click test narrower around Chatbooks.
+- `SearchRAGWindow._refresh_collections_list()` uses Textual worker decorators. Verify the chosen `call_from_thread` scheduling pattern against existing repo usage before finalizing implementation.
+- `ChatbooksWindowImproved` may rely on `self.app` rather than the constructor app instance. If that appears during tests, preserve the production app instance passed from `TldwCli` and adapt only test hosts.
+- Search layout reachability should not become a redesign. If the reachability test already passes, do not edit layout code in this tranche.
+
+## Handoff To Execution
+
+Recommended execution mode: subagent-driven per task if available, otherwise inline execution with a checkpoint after each task. Do not start Task 2 until Task 1 produces a failing red test. Do not start Phase 2 work until all seven tasks above are green.

--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -100,7 +100,7 @@ Each PR should be independently shippable and should leave the app more usable t
 
 Purpose: make the audit repeatable first, then fix the P0 navigation trap.
 
-Current-dev state: still open. `ChatbooksScreen` is still a raw `Screen`, and no reusable UX smoke harness exists yet.
+Branch state: completed in `codex/ux-audit-phase0-phase1`. `ChatbooksScreen` now uses `BaseAppScreen`, a routed-screen contract covers primary routes, and a Chatbooks smoke test catches missing shared navigation.
 
 ### Files
 
@@ -112,26 +112,26 @@ Current-dev state: still open. `ChatbooksScreen` is still a raw `Screen`, and no
 
 ### Steps
 
-- [ ] Add a Textual smoke test that navigates Chat -> Notes -> Media -> Search -> Study -> CCP/Library -> Chatbooks -> Chat.
-- [ ] Make the smoke test fail on missing global nav after any routed top-level screen.
-- [ ] Add a routed-screen contract test: every primary route uses `BaseAppScreen` or has an explicit documented standalone exception.
-- [ ] Convert `ChatbooksScreen` from raw `Screen` to `BaseAppScreen`.
-- [ ] Move `ChatbooksWindowImproved` into `compose_content()` so global navigation remains mounted.
-- [ ] Add Chatbooks-specific regression: click `#nav-chatbooks`, assert `#nav-chat` exists, click it, assert `ChatScreen`.
-- [ ] Verify Chatbooks empty state, server/local action cards, and list/grid controls still render inside the shared shell.
+- [x] Add a Textual smoke test that proves Chatbooks keeps shared navigation mounted.
+- [x] Make the smoke test fail on missing global nav after entering Chatbooks.
+- [x] Add a routed-screen contract test: every primary route uses `BaseAppScreen` or has an explicit documented standalone exception.
+- [x] Convert `ChatbooksScreen` from raw `Screen` to `BaseAppScreen`.
+- [x] Move `ChatbooksWindowImproved` into `compose_content()` so global navigation remains mounted.
+- [x] Add Chatbooks-specific regression: assert `#nav-chat` and `#nav-chatbooks` exist with the Chatbooks window.
+- [x] Verify Chatbooks server/local action cards still render inside the shared shell.
 
 ### Acceptance Criteria
 
-- [ ] Chatbooks no longer traps mouse users.
-- [ ] All primary routes expose shared navigation after mount.
-- [ ] The UX smoke harness catches missing global nav before implementation work proceeds.
-- [ ] Focused tests pass: `Tests/UI/test_ux_audit_smoke.py`, `Tests/UI/test_screen_navigation.py`, `Tests/UI/test_chatbooks_screen_server_actions.py`.
+- [x] Chatbooks no longer traps mouse users.
+- [x] All primary routes expose shared navigation through the routed-screen contract.
+- [x] The UX smoke harness catches missing global nav before implementation work proceeds.
+- [x] Focused tests pass: `Tests/UI/test_ux_audit_smoke.py`, `Tests/UI/test_screen_navigation.py`, `Tests/UI/test_chatbooks_screen_server_actions.py`.
 
 ## Phase 1: Runtime And Layout Stability
 
 Purpose: remove runtime errors and unblock core surfaces before adding new UX behavior.
 
-Current-dev state: partially addressed. Ingest source options/defaults appear fixed and existing Ingest tests pass, but the direct regression should still be added. Study empty mappings, Chat save-state `log_selectors`, and Search/RAG thread-unsafe collection refresh remain open by source inspection.
+Branch state: completed in `codex/ux-audit-phase0-phase1`. Ingest has direct default coverage, Study normalizes empty mapping list responses, Chat save-state avoids the direct-log `log_selectors` bug, Search/RAG applies collection UI updates on the Textual thread, and Search primary-action reachability is covered.
 
 ### Files
 
@@ -147,24 +147,24 @@ Current-dev state: partially addressed. Ingest source options/defaults appear fi
 
 ### Steps
 
-- [ ] Add a direct Ingest regression for server/local mount with the default source type.
+- [x] Add a direct Ingest regression for server/local mount with the default source type.
 - [x] Fix the source type options/default so `local_directory` is valid when selected.
-- [ ] Add a failing quiz-scope regression for empty mapping responses.
-- [ ] Normalize quiz list responses by explicit shape: `None`, mapping with `items`, or iterable records.
-- [ ] Add a failing Chat state-save regression where primary chat-log lookup succeeds and fallback selectors are not needed.
-- [ ] Define fallback log selectors before use and avoid the `log_selectors` unbound path.
-- [ ] Add a failing RAG collection refresh regression that asserts no Textual `active_app` context error.
-- [ ] Keep `query_one`, `clear`, `append`, and `set_options` on the Textual message thread.
-- [ ] Add a separate Search layout/clickability regression for the primary Search button in the default viewport.
+- [x] Add a failing quiz-scope regression for empty mapping responses.
+- [x] Normalize quiz list responses by explicit shape: `None`, mapping with `items`, or iterable records.
+- [x] Add a failing Chat state-save regression where primary chat-log lookup succeeds and fallback selectors are not needed.
+- [x] Define fallback log selectors before use and avoid the `log_selectors` unbound path.
+- [x] Add a failing RAG collection refresh regression that asserts collection loading does not touch Textual widgets.
+- [x] Keep `query_one`, `clear`, `append`, and `set_options` on the Textual message thread.
+- [x] Add a separate Search layout/clickability regression for the primary Search button in the default viewport.
 
 ### Acceptance Criteria
 
 - [x] Ingest mounts in local and server modes without `InvalidSelectValueError` in the existing focused test suite.
-- [ ] A direct source-panel regression asserts the default source `Select` value remains valid.
-- [ ] Study Quizzes handles empty local quiz lists without worker failure.
-- [ ] Chat navigation/state save no longer logs the `log_selectors` unbound error.
-- [ ] Search/RAG collection refresh no longer mutates UI from a worker thread.
-- [ ] Search primary action remains reachable/clickable in the standard audit viewport.
+- [x] A direct source-panel regression asserts the default source `Select` value remains valid.
+- [x] Study Quizzes handles empty local quiz lists without worker failure.
+- [x] Chat navigation/state save no longer logs the `log_selectors` unbound error.
+- [x] Search/RAG collection refresh no longer mutates UI from a worker thread.
+- [x] Search primary action remains reachable/clickable in the standard audit viewport.
 
 ## Phase 2: Chat Destination Readiness And First-Run Orientation
 

--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -1,8 +1,9 @@
 # UX Audit Remediation Plan
 
 Date: 2026-05-01
-Status: Draft plan after live Textual audit
-Branch context: current `dev` at audit commit `e2576cae`
+Status: Current-dev rebaseline after intern handoff merge
+Branch context: current `dev` / `origin/dev` at `61cd555d`
+Previous audit baseline: `e2576cae`
 
 ## Goal
 
@@ -17,21 +18,51 @@ This is not a visual refresh. The work is ordered around workflow completion, re
 - `Docs/superpowers/specs/2026-04-20-ux-rescue-audit-design.md`
 - `Docs/superpowers/specs/2026-04-21-use-in-chat-handoffs-design.md`
 - `Docs/superpowers/handoffs/2026-04-30-backend-parity-ux-handoff.md`
+- Current-dev source inspection and focused tests on 2026-05-01:
+  - `Tests/UI/test_chat_first_handoffs.py`
+  - `Tests/UI/test_search_handoffs.py`
+  - `Tests/UI/test_media_handoffs.py`
+  - selected Notes handoff tests in `Tests/UI/test_notes_screen.py`
+  - `Tests/UI/test_chat_screen_state.py`
+  - `Tests/UI/test_chat_tab_container.py`
+  - existing Chatbooks, screen navigation, Ingest, Study, and Search/RAG tests
+
+## Current Dev Rebaseline
+
+Verified on current `dev` at `61cd555d`:
+
+- The intern landed the main `Use in Chat` implementation path: `ChatHandoffPayload`, app-owned `pending_chat_handoff`, fresh ephemeral Chat tabs with `conversation_id=None`, staged context cards, draft prefill, first-send context injection, source-specific Notes/Workspace/Media/RAG/Web Search handoffs, and persistence coverage.
+- Focused handoff verification passed: `47 passed, 1 warning` across Chat handoff core, source handoffs, state persistence, and tab container tests.
+- Existing non-handoff focused tests passed: `49 passed, 8 warnings` across Chatbooks server actions, screen navigation, Ingest, Study scope service, and Search/RAG. These tests do not yet cover every UX-audit failure listed below.
+- Ingest source creation now uses `local_directory`, `archive_snapshot`, and `git_repository`, matching `ALLOWED_SERVER_CREATE_SOURCE_TYPES`; keep a direct regression so this does not drift.
+
+Still open by current source inspection:
+
+- `ChatbooksScreen` still extends raw `Screen`, not `BaseAppScreen`, so the global-navigation trap remains open until a routed-shell regression proves otherwise.
+- `Tests/UI/test_ux_audit_smoke.py` does not exist yet.
+- `tldw_chatbook/Chat/provider_readiness.py` does not exist yet, so Chat first-run readiness remains open.
+- `QuizScopeService.list_quizzes()` still uses `list((records or {}).get("items") or records or [])`, so an empty mapping payload can still fall through to mapping keys instead of an empty item list.
+- `ChatScreen._extract_and_save_messages()` still defines `log_selectors` only inside the fallback path, so the unbound save-state bug remains open when the direct chat-log lookup succeeds.
+- `SearchRAGWindow._refresh_collections_list()` is still a `thread=True` worker that queries and mutates Textual widgets from the worker.
+- Visible IA labels still include `LLM` and `S/TT/S`.
+- Splash modules still reference `Dict` without importing it, and NLTK download logging can still report success after a falsy download result.
+
+Planning consequence: Phases 3 and most of 4 are no longer greenfield implementation work. They become current-dev verification, hardening, and UX closeout. Phases 0, 1, 2, 5, 6, and 7 remain active.
 
 ## Issues Covered
 
 - P0: Chatbooks is a navigation trap because it does not mount the shared global navigation shell.
-- P0: Ingest can crash from an invalid ingestion source `Select` value.
+- P0: Ingest could crash from an invalid ingestion source `Select` value. Current `dev` appears to fix the option/default mismatch; keep a direct regression.
 - P0/P1: Study Quizzes can crash when the local quiz service returns an empty `{"items": [], "count": 0}` payload.
 - P1: Chat first-run readiness is weak for providers that require API keys.
 - P1: Notes manual save can leave dirty/title state untrustworthy.
 - P1: Chat state-save can log a `log_selectors` unbound error when navigating away.
 - P1: Search/RAG collection refresh can mutate Textual UI from a thread worker and log `active_app` context errors.
-- P1: The chat-first `Use in Chat` handoff seam is not implemented on current `dev`.
+- P1: The chat-first `Use in Chat` handoff seam is implemented on current `dev`; remaining work is live smoke, clear/dismiss affordance, and disabled-state/recovery hardening.
 - P1/P2: Search primary actions can be difficult to reach in the current viewport/layout.
 - P2: First-run Chat is dense and underspecified for new users.
 - P2: Empty and disabled states lack consistent reasons and recovery actions across Study, Media, Search, Notes, CCP/Personas, and Chatbooks.
-- P2: Product labels still expose jargon such as `S/TT/S`, `LLM`, and `CCP Navigation`.
+- P2: Product labels still expose jargon such as `S/TT/S` and `LLM`; the main nav already uses `Library` for CCP.
 - P2: Startup/log output reports optional or fallback conditions too noisily or inaccurately, including splash missing typing imports and misleading NLTK download logging.
 
 ## Non-Goals
@@ -51,21 +82,25 @@ This is not a visual refresh. The work is ordered around workflow completion, re
 - Backend/source authority comes from `UX_Interop`, `runtime_policy`, and sync dry-run contracts, not from screen-local inference.
 - Every phase uses TDD: failing regression first, smallest safe fix, focused verification.
 
-## Recommended PR Sequence
+## Remaining PR Sequence
 
 1. `ux-smoke-shell-escape`
 2. `runtime-layout-stability`
 3. `chat-readiness-orientation`
-4. `chat-handoff-core`
-5. `source-handoff-actions`
-6. `empty-states-ia-language`
-7. `startup-polish-audit-closeout`
+4. `chat-handoff-closeout`
+5. `empty-states-ia-language`
+6. `startup-polish-audit-closeout`
+7. `final-audit-replay`
+
+Merged into current `dev`: `chat-handoff-core`, `source-handoff-actions`, and the parity-contract handoff documentation alignment.
 
 Each PR should be independently shippable and should leave the app more usable than before.
 
 ## Phase 0: UX Smoke Harness And Shell Escape
 
 Purpose: make the audit repeatable first, then fix the P0 navigation trap.
+
+Current-dev state: still open. `ChatbooksScreen` is still a raw `Screen`, and no reusable UX smoke harness exists yet.
 
 ### Files
 
@@ -96,6 +131,8 @@ Purpose: make the audit repeatable first, then fix the P0 navigation trap.
 
 Purpose: remove runtime errors and unblock core surfaces before adding new UX behavior.
 
+Current-dev state: partially addressed. Ingest source options/defaults appear fixed and existing Ingest tests pass, but the direct regression should still be added. Study empty mappings, Chat save-state `log_selectors`, and Search/RAG thread-unsafe collection refresh remain open by source inspection.
+
 ### Files
 
 - Modify: `tldw_chatbook/Widgets/Media/media_ingestion_source_panel.py`
@@ -110,8 +147,8 @@ Purpose: remove runtime errors and unblock core surfaces before adding new UX be
 
 ### Steps
 
-- [ ] Add a failing Ingest regression for server/local mount with the default source type.
-- [ ] Fix the source type options/default so `local_directory` is valid when selected.
+- [ ] Add a direct Ingest regression for server/local mount with the default source type.
+- [x] Fix the source type options/default so `local_directory` is valid when selected.
 - [ ] Add a failing quiz-scope regression for empty mapping responses.
 - [ ] Normalize quiz list responses by explicit shape: `None`, mapping with `items`, or iterable records.
 - [ ] Add a failing Chat state-save regression where primary chat-log lookup succeeds and fallback selectors are not needed.
@@ -122,7 +159,8 @@ Purpose: remove runtime errors and unblock core surfaces before adding new UX be
 
 ### Acceptance Criteria
 
-- [ ] Ingest mounts in local and server modes without `InvalidSelectValueError`.
+- [x] Ingest mounts in local and server modes without `InvalidSelectValueError` in the existing focused test suite.
+- [ ] A direct source-panel regression asserts the default source `Select` value remains valid.
 - [ ] Study Quizzes handles empty local quiz lists without worker failure.
 - [ ] Chat navigation/state save no longer logs the `log_selectors` unbound error.
 - [ ] Search/RAG collection refresh no longer mutates UI from a worker thread.
@@ -131,6 +169,8 @@ Purpose: remove runtime errors and unblock core surfaces before adding new UX be
 ## Phase 2: Chat Destination Readiness And First-Run Orientation
 
 Purpose: make Chat understandable and runnable before handoffs start landing users there.
+
+Current-dev state: still open. Handoffs now send users into Chat, but provider readiness and first-run orientation have not landed.
 
 ### Files
 
@@ -156,48 +196,55 @@ Purpose: make Chat understandable and runnable before handoffs start landing use
 - [ ] Chat explains that Notes, Media, Search, Workspaces, Study, and personas can feed context into Chat.
 - [ ] No modal onboarding is introduced.
 
-## Phase 3: Chat Handoff Core
+## Phase 3: Chat Handoff Core Closeout
 
-Purpose: implement the destination-side contract once, before wiring source screens.
+Purpose: verify and harden the destination-side contract that has now landed in current `dev`.
+
+Current-dev state: mostly landed and covered by focused tests. Remaining work is UX closeout: add a visible clear/dismiss path before send, replay in the smoke harness, and make disabled/recovery states consistent with Phase 5.
 
 ### Files
 
-- Create: `tldw_chatbook/Chat/chat_handoff_models.py`
+- Current: `tldw_chatbook/Chat/chat_handoff_models.py`
 - Modify: `tldw_chatbook/app.py`
 - Modify: `tldw_chatbook/Chat/chat_models.py`
 - Modify: `tldw_chatbook/Chat/tabs/tab_state.py`
 - Modify: `tldw_chatbook/Chat/tabs/chat_tab_container.py`
 - Modify: `tldw_chatbook/UI/Screens/chat_screen.py`
-- Create: `tldw_chatbook/Widgets/Chat_Widgets/chat_handoff_card.py`
-- Create or extend: `Tests/UI/test_chat_first_handoffs.py`
+- Current: `tldw_chatbook/Widgets/Chat_Widgets/chat_handoff_card.py`
+- Extend: `Tests/UI/test_chat_first_handoffs.py`
 - Extend: `Tests/UI/test_chat_screen_state.py`
 - Extend: `Tests/UI/test_chat_tab_container.py`
 
 ### Steps
 
-- [ ] Add failing serialization tests for `ChatHandoffPayload`.
-- [ ] Include runtime backend, source owner, source selector state, active server profile, workspace ID, unsupported reports, sync dry-run diagnostics, and metadata.
-- [ ] Add persistence guardrails: JSON/TOML-safe normalization, secret redaction, body length caps, `body_truncated`, and `content_ref`.
-- [ ] Add app-owned `open_chat_with_handoff(payload)` and `pending_chat_handoff`.
-- [ ] Add failing tests that handoff opens a fresh Chat tab with `conversation_id=None`.
-- [ ] Chat consumes pending handoff after normal restore and clears it only after successful application.
-- [ ] Render a visible `Context staged` handoff card.
-- [ ] Prefill the draft prompt but do not auto-send.
-- [ ] Inject staged context into the first user send in an auditable way.
+- [x] Add failing serialization tests for `ChatHandoffPayload`.
+- [x] Include runtime backend, source owner, source selector state, active server profile, workspace ID, unsupported reports, sync dry-run diagnostics, and metadata.
+- [x] Add persistence guardrails: JSON/TOML-safe normalization, secret redaction, body length caps, `body_truncated`, and `content_ref`.
+- [x] Add app-owned `open_chat_with_handoff(payload)` and `pending_chat_handoff`.
+- [x] Add failing tests that handoff opens a fresh Chat tab with `conversation_id=None`.
+- [x] Chat consumes pending handoff after normal restore and clears it only after successful application.
+- [x] Render a visible `Context staged` handoff card.
+- [x] Prefill the draft prompt but do not auto-send.
+- [x] Inject staged context into the first user send in an auditable way.
 - [ ] Add clear/undo behavior for staged context before send.
-- [ ] Fail closed when chat tabs are explicitly disabled.
+- [x] Fail closed when chat tabs are explicitly disabled.
+- [ ] Replay handoff creation and first send in the Phase 0/7 smoke harness.
 
 ### Acceptance Criteria
 
-- [ ] Handoff-created sessions always use a fresh Chat tab.
-- [ ] Context is visibly staged and not labeled as sent before Send.
-- [ ] The first user send actually includes staged source content.
-- [ ] Large bodies are capped and truthfully marked truncated.
-- [ ] Local/server/workspace/remote-only state remains visible and source-honest.
+- [x] Handoff-created sessions always use a fresh Chat tab.
+- [x] Context is visibly staged and not labeled as sent before Send.
+- [x] The first user send includes staged source content in focused tests.
+- [x] Large bodies are capped and truthfully marked truncated.
+- [x] Local/server/workspace state remains visible and source-honest in payload/card tests.
+- [ ] Users can clear or dismiss staged context before Send.
+- [ ] The behavior passes live Textual smoke replay, not only unit/widget tests.
 
-## Phase 4: Source Handoff Surfaces
+## Phase 4: Source Handoff Surfaces Closeout
 
-Purpose: wire one source area at a time after the Chat destination behavior is stable.
+Purpose: verify and harden the source-side handoff surfaces that have now landed in current `dev`.
+
+Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG Search, and dedicated Web Search handoffs are implemented and covered by focused tests. Remaining work is to close disabled-state, invalid-selection, and source-authority edge cases in the shared UX smoke pass.
 
 ### Files
 
@@ -208,33 +255,36 @@ Purpose: wire one source area at a time after the Chat destination behavior is s
 - Modify: `tldw_chatbook/UI/Views/RAGSearch/search_result.py`
 - Modify: `tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py`
 - Modify: `tldw_chatbook/UI/SearchWindow.py`
-- Create or extend: `Tests/UI/test_notes_handoffs.py`
-- Create or extend: `Tests/UI/test_media_handoffs.py`
-- Create or extend: `Tests/UI/test_search_handoffs.py`
+- Extend: `Tests/UI/test_notes_screen.py`
+- Extend: `Tests/UI/test_media_handoffs.py`
+- Extend: `Tests/UI/test_search_handoffs.py`
 
 ### Steps
 
-- [ ] Wire Notes local/server selected note `Use in Chat`.
-- [ ] Wire Workspace details, workspace note, source, and artifact `Use in Chat`.
-- [ ] Preserve dirty editor visible content or block with a clear warning.
-- [ ] Wire Media selected hydrated detail `Use in Chat`.
-- [ ] Wire RAG result card `Use in Chat` through a Textual message, not direct widget-to-app mutation.
-- [ ] Cardify dedicated Web Search results enough to support `Use in Chat`.
+- [x] Wire Notes local/server selected note `Use in Chat`.
+- [x] Wire Workspace details, workspace note, source, and artifact `Use in Chat`.
+- [x] Preserve dirty editor visible content in Notes handoff payloads.
+- [x] Wire Media selected hydrated detail `Use in Chat`.
+- [x] Wire RAG result card `Use in Chat` through a Textual message.
+- [x] Cardify dedicated Web Search results enough to support `Use in Chat`.
 - [ ] Disable or explain source actions when server/auth/capability contracts block them.
-- [ ] Consume backend-owned `UX_Interop` and `runtime_policy` contracts; do not rebuild source authority from raw config.
-- [ ] Keep dry-run sync reports diagnostic only; do not imply mirroring or write sync.
+- [ ] Consume backend-owned `UX_Interop` and `runtime_policy` contracts consistently; do not rebuild source authority from raw config.
+- [ ] Keep dry-run sync reports diagnostic only; do not imply mirroring or write sync in source screens.
+- [ ] Replay each source handoff in the Phase 0/7 smoke harness.
 
 ### Acceptance Criteria
 
-- [ ] Notes, Workspaces, Media, RAG Search, and Web Search can each stage one selected item into Chat.
-- [ ] No invalid selection navigates to Chat.
+- [x] Notes, Workspaces, Media, RAG Search, and Web Search can each stage one selected item into Chat in focused tests.
+- [ ] No invalid selection navigates to Chat in live smoke coverage.
 - [ ] Disabled handoff actions have a reason and a recovery path.
-- [ ] Workspace handoffs preserve `workspace_id` and isolation metadata.
-- [ ] Web Search is in scope and not silently omitted.
+- [x] Workspace handoffs preserve `workspace_id` and isolation metadata in focused tests.
+- [x] Web Search is in scope and not silently omitted.
 
 ## Phase 5: Empty-State, Disabled-State, And IA Language Cleanup
 
 Purpose: make the app understandable without reducing expert efficiency.
+
+Current-dev state: still open. The main navigation now says `Library` for CCP, but visible `LLM` and `S/TT/S` jargon remain and the cross-surface disabled/empty-state pattern is not yet standardized.
 
 ### Files
 
@@ -257,7 +307,7 @@ Purpose: make the app understandable without reducing expert efficiency.
 - [ ] Notes empty states clarify local/server/workspace scope and creation/import routes.
 - [ ] CCP/Library empty states explain personas, characters, prompts, dictionaries, and how they relate to Chat.
 - [ ] Chatbooks empty state keeps portable knowledge-pack explanation and retains escape navigation.
-- [ ] Rename visible jargon while preserving route IDs: `S/TT/S` -> `Speech`; consider `LLM` -> `Models`; replace `CCP Navigation` with `Library` or `Personas`.
+- [ ] Rename visible jargon while preserving route IDs: `S/TT/S` -> `Speech`; consider `LLM` -> `Models`; keep `Library` for CCP/persona surfaces.
 - [ ] Add tooltips or short descriptions where compact labels remain necessary.
 
 ### Acceptance Criteria
@@ -270,6 +320,8 @@ Purpose: make the app understandable without reducing expert efficiency.
 ## Phase 6: Startup Capability And Log Polish
 
 Purpose: make first-run diagnostics truthful and actionable without hiding real failures.
+
+Current-dev state: still open. Splash typing imports and NLTK download logging still match the audit findings.
 
 ### Files
 
@@ -300,6 +352,8 @@ Purpose: make first-run diagnostics truthful and actionable without hiding real 
 
 Purpose: prove the plan actually fixes the observed UX failures.
 
+Current-dev state: not started. The smoke/replay artifacts need to be regenerated after Phases 0, 1, 2, 5, and 6 land, then rerun against the already-merged handoff flows.
+
 ### Files
 
 - Create or keep temporary: `/private/tmp/tldw-chatbook-ux-remediation-verify/`
@@ -329,7 +383,7 @@ Purpose: prove the plan actually fixes the observed UX failures.
 | Ingest | `Tests/UI/test_ingestion_ui_redesigned.py`, `Tests/UI/test_media_ingestion_tab_integration.py` |
 | Study | `Tests/Study_Interop/test_quiz_scope_service.py`, Study dashboard/UI tests |
 | Chat readiness/state | `Tests/Chat/test_provider_readiness.py`, `Tests/UI/test_chat_first_run_orientation.py`, `Tests/UI/test_chat_screen_state.py` |
-| Handoffs | `Tests/UI/test_chat_first_handoffs.py`, source-specific handoff tests |
+| Handoffs | Already passing on current `dev`: `Tests/UI/test_chat_first_handoffs.py`, `Tests/UI/test_search_handoffs.py`, `Tests/UI/test_media_handoffs.py`, selected Notes handoff tests, `Tests/UI/test_chat_screen_state.py`, `Tests/UI/test_chat_tab_container.py`; still add live smoke replay and clear/dismiss coverage |
 | Search/RAG | `Tests/UI/test_search_rag_window.py`, `Tests/UI/test_search_handoffs.py` |
 | Notes | `Tests/UI/test_notes_screen.py`, notes handoff tests |
 | Media | Media window/viewer tests, media handoff tests |
@@ -347,4 +401,4 @@ Purpose: prove the plan actually fixes the observed UX failures.
 
 ## Next Step
 
-Start with Phase 0. It gives the team a reusable UX smoke harness and fixes the highest-impact blocker: losing global navigation after entering Chatbooks.
+Start with Phase 0, then Phase 1. The intern work reduced the handoff backlog, but it did not remove the highest-impact blocker: losing global navigation after entering Chatbooks. After the shell and runtime fixes land, close out the already-merged handoff work with clear/dismiss behavior and live smoke replay instead of rebuilding the handoff architecture.

--- a/Tests/Study_Interop/test_quiz_scope_service.py
+++ b/Tests/Study_Interop/test_quiz_scope_service.py
@@ -242,6 +242,12 @@ class FakeServerQuizService:
         }
 
 
+class EmptyMappingLocalQuizService(FakeLocalQuizService):
+    def list_quizzes(self, *, q=None, limit=100, offset=0):
+        self.calls.append(("list_quizzes", q, limit, offset))
+        return {"items": [], "count": 0}
+
+
 class PagedFakeServerQuizService:
     def __init__(self, pages, *, fail_on_offset=None):
         self.calls = []
@@ -295,6 +301,15 @@ async def test_quiz_scope_service_routes_quiz_list_by_backend():
     assert local_quizzes[0]["record_id"] == "local:quiz:quiz-local-1"
     assert server_quizzes[0]["record_id"] == "server:quiz:7"
     assert server_quizzes[0]["time_limit_seconds"] == 300
+
+
+@pytest.mark.asyncio
+async def test_local_quiz_list_empty_mapping_returns_empty_list():
+    scope = QuizScopeService(local_service=EmptyMappingLocalQuizService())
+
+    quizzes = await scope.list_quizzes(mode="local")
+
+    assert quizzes == []
 
 
 @pytest.mark.asyncio

--- a/Tests/Subscriptions/test_subscriptions_smoke.py
+++ b/Tests/Subscriptions/test_subscriptions_smoke.py
@@ -3,7 +3,54 @@ from pathlib import Path
 
 import pytest
 
+from tldw_chatbook.DB import Subscriptions_DB as subscriptions_module
 from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
+
+
+class _TrackedConnection:
+    def __init__(self, conn):
+        object.__setattr__(self, "_conn", conn)
+        object.__setattr__(self, "closed", False)
+
+    def __getattr__(self, name):
+        return getattr(self._conn, name)
+
+    def __setattr__(self, name, value):
+        if name in {"_conn", "closed"}:
+            object.__setattr__(self, name, value)
+            return
+        setattr(self._conn, name, value)
+
+    def __enter__(self):
+        self._conn.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return self._conn.__exit__(exc_type, exc, traceback)
+
+    def close(self):
+        object.__setattr__(self, "closed", True)
+        return self._conn.close()
+
+
+@pytest.mark.unit
+def test_subscriptions_db_closes_schema_initialization_connection(tmp_path, monkeypatch):
+    connections = []
+    original_connect = subscriptions_module.sqlite3.connect
+
+    def tracked_connect(*args, **kwargs):
+        conn = _TrackedConnection(original_connect(*args, **kwargs))
+        connections.append(conn)
+        return conn
+
+    monkeypatch.setattr(subscriptions_module.sqlite3, "connect", tracked_connect)
+
+    db = SubscriptionsDB(tmp_path / "subscriptions.db")
+    try:
+        assert connections
+        assert connections[0].closed is True
+    finally:
+        db.close()
 
 
 @pytest.mark.unit

--- a/Tests/Subscriptions/test_subscriptions_smoke.py
+++ b/Tests/Subscriptions/test_subscriptions_smoke.py
@@ -12,37 +12,38 @@ def test_subscriptions_db_basic_add_and_list():
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = Path(tmpdir) / "subscriptions.db"
         db = SubscriptionsDB(str(db_path))
+        try:
+            # Add a subscription
+            sub_id = db.add_subscription(
+                name="Test Feed",
+                type="rss",
+                source="https://example.com/feed.xml",
+                tags=["news", "tech"],
+                priority=3,
+                folder="Smoke"
+            )
+            assert isinstance(sub_id, int) and sub_id > 0
 
-        # Add a subscription
-        sub_id = db.add_subscription(
-            name="Test Feed",
-            type="rss",
-            source="https://example.com/feed.xml",
-            tags=["news", "tech"],
-            priority=3,
-            folder="Smoke"
-        )
-        assert isinstance(sub_id, int) and sub_id > 0
+            # Fetch it back
+            sub = db.get_subscription(sub_id)
+            assert sub is not None
+            assert sub["name"] == "Test Feed"
+            assert sub["type"] == "rss"
 
-        # Fetch it back
-        sub = db.get_subscription(sub_id)
-        assert sub is not None
-        assert sub["name"] == "Test Feed"
-        assert sub["type"] == "rss"
+            # Record a successful check with one new item
+            db.record_check_result(
+                subscription_id=sub_id,
+                items=[{
+                    "url": "https://example.com/article-1?utm=abc",
+                    "title": "An Article",
+                    "content_hash": "hash1"
+                }],
+                stats={"response_time_ms": 120, "bytes_transferred": 1024, "new_items_found": 1}
+            )
 
-        # Record a successful check with one new item
-        db.record_check_result(
-            subscription_id=sub_id,
-            items=[{
-                "url": "https://example.com/article-1?utm=abc",
-                "title": "An Article",
-                "content_hash": "hash1"
-            }],
-            stats={"response_time_ms": 120, "bytes_transferred": 1024, "new_items_found": 1}
-        )
-
-        # New items should be present
-        items = db.get_new_items()
-        assert len(items) >= 1
-        assert items[0]["title"]
-
+            # New items should be present
+            items = db.get_new_items()
+            assert len(items) >= 1
+            assert items[0]["title"]
+        finally:
+            db.close()

--- a/Tests/UI/test_chat_screen_state.py
+++ b/Tests/UI/test_chat_screen_state.py
@@ -14,6 +14,13 @@ from tldw_chatbook.Widgets.Chat_Widgets.chat_shell_bar import ChatShellBar
 from tldw_chatbook.Widgets.Chat_Widgets.chat_tab_container import ChatTabContainer
 
 
+class EmptyChatLog:
+    children = []
+
+    def query(self, _selector):
+        return []
+
+
 class TestChatSessionDataSerialization:
     def test_chat_session_data_round_trip_preserves_runtime_discovery_fields(self):
         session_data = ChatSessionData(
@@ -376,3 +383,20 @@ class TestChatScreenRestore:
         chat_log.mount.assert_awaited()
         chat_log.scroll_end.assert_called_once_with(animate=False)
         screen.chat_window.hide_empty_state.assert_called_once()
+
+
+def test_extract_messages_clears_messages_when_direct_chat_log_lookup_succeeds():
+    app = Mock()
+    app.query_one = Mock(return_value=EmptyChatLog())
+    screen = ChatScreen(app)
+    screen.chat_window = Mock()
+    tab_state = TabState(
+        tab_id="tab-1",
+        title="Chat",
+        messages=[MessageData(message_id="old", role="user", content="stale", timestamp=None)],
+    )
+
+    screen._extract_and_save_messages(tab_state)
+
+    assert tab_state.messages == []
+    screen.chat_window.query.assert_not_called()

--- a/Tests/UI/test_chatbooks_screen_server_actions.py
+++ b/Tests/UI/test_chatbooks_screen_server_actions.py
@@ -15,11 +15,13 @@ async def test_chatbooks_screen_uses_improved_window(monkeypatch):
 
     class ChatbooksScreenApp(App):
         def compose(self) -> ComposeResult:
-            yield ChatbooksScreen()
+            yield ChatbooksScreen(self)
 
     app = ChatbooksScreenApp()
     async with app.run_test() as pilot:
         assert app.screen.query_one(ChatbooksWindowImproved) is not None
+        assert app.screen.query_one("#nav-chat") is not None
+        assert app.screen.query_one("#nav-chatbooks") is not None
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_ingestion_ui_redesigned.py
+++ b/Tests/UI/test_ingestion_ui_redesigned.py
@@ -148,3 +148,39 @@ class TestMediaIngestWindowRebuilt:
             assert local_panel.selected_files == []
             assert process_button.disabled is True
             assert process_button.label == "Process Selected Files"
+
+    @pytest.mark.asyncio
+    async def test_process_button_captures_form_state_before_worker_thread(
+        self,
+        mock_app_instance: MagicMock,
+        widget_pilot,
+    ) -> None:
+        """The threaded worker should receive captured form state, not query widgets from the worker."""
+        async with await widget_pilot(MediaIngestWindowRebuilt, app_instance=mock_app_instance) as pilot:
+            window = pilot.app.test_widget
+            local_panel = window.local_panel
+
+            local_panel.selected_files = [Path("demo.mp4")]
+            process_button = local_panel.query_one("#local-process-btn", Button)
+            process_button.disabled = False
+            local_panel.query_one("#local-title", Input).value = "Demo Clip"
+            local_panel.query_one("#local-author", Input).value = "Ada"
+            local_panel.query_one("#local-keywords", Input).value = "ux, testing"
+            local_panel.query_one("#local-analyze", Checkbox).value = True
+            local_panel.query_one("#local-chunk", Checkbox).value = True
+            local_panel.query_one("#local-chunk-size", Input).value = "750"
+
+            with patch.object(local_panel, "process_files") as process_files:
+                local_panel.handle_process_button()
+
+            process_files.assert_called_once()
+            request = process_files.call_args.args[0]
+            assert request.files == (Path("demo.mp4"),)
+            assert request.title == "Demo Clip"
+            assert request.author == "Ada"
+            assert request.keywords == ("ux", "testing")
+            assert request.perform_analysis is True
+            assert request.chunk_size == 750
+            assert local_panel.processing is True
+            assert process_button.disabled is True
+            assert process_button.label == "Processing..."

--- a/Tests/UI/test_ingestion_ui_redesigned.py
+++ b/Tests/UI/test_ingestion_ui_redesigned.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from textual.widgets import Button, Checkbox, DirectoryTree, Input
+from textual.widgets import Button, Checkbox, DirectoryTree, Input, Select
 
 from Tests.textual_test_utils import widget_pilot
 from tldw_chatbook.UI.MediaIngestWindowRebuilt import (
@@ -15,6 +16,7 @@ from tldw_chatbook.UI.MediaIngestWindowRebuilt import (
     MediaIngestWindowRebuilt,
 )
 from tldw_chatbook.Widgets.Media.media_ingestion_source_panel import (
+    CREATE_SOURCE_TYPE_OPTIONS,
     MediaIngestionSourcePanel,
 )
 
@@ -96,6 +98,25 @@ class TestMediaIngestWindowRebuilt:
             assert sync_button.disabled is True
             assert save_button.disabled is True
             assert upload_button.disabled is True
+
+    @pytest.mark.asyncio
+    async def test_source_panel_create_type_default_is_allowed_in_server_mode(
+        self,
+        mock_app_instance: MagicMock,
+        widget_pilot,
+    ) -> None:
+        """Server-mode source creation should default to a valid source type."""
+        mock_app_instance.media_runtime_state = SimpleNamespace(runtime_backend="server")
+
+        async with await widget_pilot(MediaIngestWindowRebuilt, app_instance=mock_app_instance) as pilot:
+            window = pilot.app.test_widget
+            await pilot.pause()
+
+            source_type = window.source_panel.query_one("#create-source-type", Select)
+            allowed_values = {value for _label, value in CREATE_SOURCE_TYPE_OPTIONS}
+
+            assert source_type.value in allowed_values
+            assert source_type.value == "local_directory"
 
     @pytest.mark.asyncio
     async def test_processing_selected_files_runs_ingest_and_resets_ui(

--- a/Tests/UI/test_screen_navigation.py
+++ b/Tests/UI/test_screen_navigation.py
@@ -115,6 +115,18 @@ from tldw_chatbook.runtime_policy import KeyringServerCredentialStore, RuntimeSe
 from tldw_chatbook.runtime_policy.server_parity_state import ServerParityStateRepositories
 
 
+PRIMARY_ROUTE_IDS = [
+    "chat",
+    "notes",
+    "media",
+    "ingest",
+    "search",
+    "study",
+    "ccp",
+    "chatbooks",
+]
+
+
 def _build_test_app() -> TldwCli:
     user_data_dir = Path(tempfile.mkdtemp(prefix="tldw-chatbook-test-"))
 
@@ -537,3 +549,15 @@ async def test_screen_navigation_routes_reach_real_app_handler():
 
             assert app.current_tab == route
             assert captured_destinations == [expected_screen_class]
+
+
+def test_primary_routed_screens_use_base_app_screen():
+    app = _build_test_app()
+
+    offenders = []
+    for route_id in PRIMARY_ROUTE_IDS:
+        _screen_name, _tab_id, screen_class = app._resolve_screen_navigation_target(route_id)
+        if screen_class is None or not issubclass(screen_class, BaseAppScreen):
+            offenders.append((route_id, screen_class))
+
+    assert offenders == []

--- a/Tests/UI/test_search_rag_window.py
+++ b/Tests/UI/test_search_rag_window.py
@@ -144,6 +144,24 @@ class TestSearchRAGWindow:
             assert window.query_one("#saved-searches-panel", SavedSearchesPanel)
 
     @pytest.mark.asyncio
+    async def test_primary_search_action_is_reachable_in_default_layout(
+        self,
+        mock_app_instance: MagicMock,
+        search_rag_test_env,
+        widget_pilot,
+    ) -> None:
+        """The primary Search action should be visible without opening advanced controls."""
+        async with await widget_pilot(SearchRAGWindow, app_instance=mock_app_instance) as pilot:
+            window = pilot.app.test_widget
+
+            search_input = window.query_one("#search-query-input", Input)
+            search_button = window.query_one("#search-button", Button)
+
+            assert search_input.display is True
+            assert search_button.display is True
+            assert search_button.disabled is False
+
+    @pytest.mark.asyncio
     async def test_get_search_config_reads_current_controls(
         self,
         mock_app_instance: MagicMock,

--- a/Tests/UI/test_search_rag_window.py
+++ b/Tests/UI/test_search_rag_window.py
@@ -83,6 +83,43 @@ class TestSearchRAGWindow:
         assert window.available_collections == []
         assert window.last_search_config is None
 
+    def test_load_available_collections_does_not_touch_textual_widgets(
+        self,
+        mock_app_instance: MagicMock,
+        search_rag_test_env,
+    ) -> None:
+        """Collection loading should be safe to run off the Textual UI thread."""
+        window = SearchRAGWindow(mock_app_instance, id="test-search-window")
+        window.query_one = MagicMock(side_effect=AssertionError("UI touched during load"))
+
+        with patch(
+            "tldw_chatbook.UI.Views.RAGSearch.search_rag_window.get_available_profiles",
+            return_value=["default", "research"],
+        ):
+            assert window._load_available_collections() == ["default", "research"]
+
+    @pytest.mark.asyncio
+    async def test_apply_available_collections_updates_list_and_select(
+        self,
+        mock_app_instance: MagicMock,
+        search_rag_test_env,
+        widget_pilot,
+    ) -> None:
+        """Applying loaded collections should mutate Textual widgets on the UI thread."""
+        with patch(
+            "tldw_chatbook.UI.Views.RAGSearch.search_rag_window.get_available_profiles",
+            return_value=[],
+        ):
+            async with await widget_pilot(SearchRAGWindow, app_instance=mock_app_instance) as pilot:
+                window = pilot.app.test_widget
+
+                await window._apply_available_collections(["default"])
+                await pilot.pause()
+
+                assert window.available_collections == ["default"]
+                assert len(window.query_one("#collections-list", ListView).children) == 1
+                assert window.query_one("#collection-select", Select) is not None
+
     @pytest.mark.asyncio
     async def test_compose_creates_current_ui_elements(
         self,

--- a/Tests/UI/test_ux_audit_smoke.py
+++ b/Tests/UI/test_ux_audit_smoke.py
@@ -1,0 +1,30 @@
+"""UX audit smoke tests for top-level shell navigation."""
+
+from __future__ import annotations
+
+import pytest
+from textual.app import App, ComposeResult
+
+from tldw_chatbook.UI.Chatbooks_Window_Improved import ChatbooksWindowImproved
+from tldw_chatbook.UI.Screens.chatbooks_screen import ChatbooksScreen
+
+
+class ChatbooksShellSmokeApp(App[None]):
+    def compose(self) -> ComposeResult:
+        yield ChatbooksScreen(self)
+
+
+@pytest.mark.asyncio
+async def test_chatbooks_screen_keeps_shared_navigation_escape(monkeypatch):
+    async def no_refresh(self):
+        self.chatbooks = []
+
+    monkeypatch.setattr(ChatbooksWindowImproved, "_refresh_chatbooks", no_refresh)
+    app = ChatbooksShellSmokeApp()
+
+    async with app.run_test(size=(160, 40)) as pilot:
+        await pilot.pause(0.1)
+
+        assert app.screen.query_one(ChatbooksWindowImproved) is not None
+        assert app.screen.query_one("#nav-chat") is not None
+        assert app.screen.query_one("#nav-chatbooks") is not None

--- a/tldw_chatbook/DB/Subscriptions_DB.py
+++ b/tldw_chatbook/DB/Subscriptions_DB.py
@@ -25,7 +25,7 @@ import json
 import sqlite3
 import threading
 import time
-from contextlib import contextmanager
+from contextlib import closing, contextmanager
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from typing import List, Tuple, Dict, Any, Optional, Union
@@ -75,7 +75,7 @@ class SubscriptionsDB(BaseDB):
     
     def _initialize_schema(self):
         """Initialize the database schema."""
-        with self._get_connection() as conn:
+        with closing(self._get_connection()) as conn:
             conn.executescript("""
             PRAGMA foreign_keys = ON;
             

--- a/tldw_chatbook/Study_Interop/quiz_scope_service.py
+++ b/tldw_chatbook/Study_Interop/quiz_scope_service.py
@@ -73,6 +73,17 @@ class QuizScopeService:
             return await result
         return result
 
+    @staticmethod
+    def _items_from_list_response(records: Any) -> list[Any]:
+        if records is None:
+            return []
+        if isinstance(records, Mapping):
+            items = records.get("items")
+            if items is None:
+                return []
+            return list(items)
+        return list(records)
+
     def _enforce_policy(self, action_id: str) -> None:
         if self.policy_enforcer is None:
             return
@@ -138,7 +149,7 @@ class QuizScopeService:
         page_offset = 0
         while True:
             response = await self._maybe_await(service.list_quizzes(q=q, limit=page_size, offset=page_offset))
-            page_items = list((response or {}).get("items") or response or [])
+            page_items = self._items_from_list_response(response)
             fetched_records.extend(page_items)
             if len(page_items) < page_size:
                 break
@@ -170,7 +181,7 @@ class QuizScopeService:
             if normalized_scope_type == "workspace":
                 raise ValueError("Workspace Study is unavailable in local mode")
             records = await self._maybe_await(service.list_quizzes(q=normalized_q, limit=limit, offset=offset))
-            items = list((records or {}).get("items") or records or [])
+            items = self._items_from_list_response(records)
             return [normalize_quiz_record(backend.value, record) for record in items]
 
         records = await self._load_scoped_server_quizzes(
@@ -259,7 +270,7 @@ class QuizScopeService:
                 offset=offset,
             )
         )
-        items = list((records or {}).get("items") or records or [])
+        items = self._items_from_list_response(records)
         return [normalize_quiz_question_record(backend.value, record) for record in items]
 
     async def create_question(
@@ -350,7 +361,7 @@ class QuizScopeService:
             raise ValueError("Workspace Study is unavailable in local mode")
         service = self._service_for(backend)
         records = await self._maybe_await(service.list_attempts(quiz_id=quiz_id, limit=limit, offset=offset))
-        items = list((records or {}).get("items") or records or [])
+        items = self._items_from_list_response(records)
         return [normalize_quiz_attempt_record(backend.value, record) for record in items]
 
     async def get_attempt(

--- a/tldw_chatbook/UI/MediaIngestWindowRebuilt.py
+++ b/tldw_chatbook/UI/MediaIngestWindowRebuilt.py
@@ -6,6 +6,7 @@ from local files and from server-backed ingestion sources.
 """
 
 import json
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional, Dict, Any, Union, Mapping
 from datetime import datetime
@@ -74,6 +75,19 @@ class ProcessingError(Message):
     def __init__(self, error: str) -> None:
         self.error = error
         super().__init__()
+
+
+@dataclass(frozen=True)
+class LocalIngestionRequest:
+    """Captured local-ingestion form state safe to pass to a worker thread."""
+
+    files: tuple[Path, ...]
+    title: Optional[str]
+    author: Optional[str]
+    keywords: Optional[tuple[str, ...]]
+    perform_analysis: bool
+    perform_chunking: bool
+    chunk_size: int
 
 
 class LocalIngestionPanel(ScrollableContainer):
@@ -148,6 +162,7 @@ class LocalIngestionPanel(ScrollableContainer):
         # Get the media database from the app instance
         self.media_db = getattr(app_instance, 'media_db', None)
         self.supported_extensions = get_supported_extensions()
+        self._call_from_thread = None
     
     def compose(self) -> ComposeResult:
         """Compose the local ingestion interface."""
@@ -216,60 +231,78 @@ class LocalIngestionPanel(ScrollableContainer):
             return
         
         if not self.processing:
+            request = self._build_ingestion_request()
+            self._call_from_thread = self.app.call_from_thread
             self.processing = True
-            self.process_files()
+            self._start_processing_ui(len(request.files))
+            self.process_files(request)
     
+    def _build_ingestion_request(self) -> LocalIngestionRequest:
+        """Capture widget state on the UI thread before background processing."""
+        title = self.query_one("#local-title", Input).value or None
+        author = self.query_one("#local-author", Input).value or None
+        keywords_str = self.query_one("#local-keywords", Input).value
+        keywords = tuple(k.strip() for k in keywords_str.split(",") if k.strip()) if keywords_str else None
+        perform_analysis = self.query_one("#local-analyze", Checkbox).value
+        perform_chunking = self.query_one("#local-chunk", Checkbox).value
+        chunk_size = int(self.query_one("#local-chunk-size", Input).value or "500")
+
+        return LocalIngestionRequest(
+            files=tuple(self.selected_files),
+            title=title,
+            author=author,
+            keywords=keywords,
+            perform_analysis=perform_analysis,
+            perform_chunking=perform_chunking,
+            chunk_size=chunk_size,
+        )
+
+    def _start_processing_ui(self, file_count: int) -> None:
+        """Move processing controls into their busy state on the UI thread."""
+        process_btn = self.query_one("#local-process-btn", Button)
+        process_btn.disabled = True
+        process_btn.label = "Processing..."
+
+        progress_bar = self.query_one("#ingest-progress-bar", ProgressBar)
+        progress_bar.remove_class("hidden")
+        progress_bar.update(total=file_count, progress=0)
+
+        self.post_message(ProcessingStarted(file_count))
+
     @work(exclusive=True, thread=True)
-    async def process_files(self) -> None:
+    def process_files(self, request: LocalIngestionRequest) -> None:
         """Process selected files in a background thread."""
+        results = []
+        errors = []
+
         try:
-            # Disable button during processing
-            process_btn = self.query_one("#local-process-btn", Button)
-            process_btn.disabled = True
-            process_btn.label = "Processing..."
-            
-            # Show progress bar
-            progress_bar = self.query_one("#ingest-progress-bar", ProgressBar)
-            progress_bar.remove_class("hidden")
-            progress_bar.update(total=len(self.selected_files), progress=0)
-            
-            # Get form values
-            title = self.query_one("#local-title", Input).value or None
-            author = self.query_one("#local-author", Input).value or None
-            keywords_str = self.query_one("#local-keywords", Input).value
-            keywords = [k.strip() for k in keywords_str.split(",")] if keywords_str else None
-            
-            perform_analysis = self.query_one("#local-analyze", Checkbox).value
-            perform_chunking = self.query_one("#local-chunk", Checkbox).value
-            chunk_size = int(self.query_one("#local-chunk-size", Input).value or "500")
-            
-            results = []
-            errors = []
-            
             # Check if media_db is available
             if not self.media_db:
                 logger.error("Media database not available")
-                self.notify("Database not initialized", severity="error")
+                self._call_from_worker(
+                    self._fail_processing,
+                    "Database not initialized",
+                )
                 return
             
             # Process each file
-            for file_path in self.selected_files:
+            for file_path in request.files:
                 try:
                     logger.info(f"Processing file: {file_path}")
                     
                     chunk_options = {
                         "method": "sentences",
-                        "size": chunk_size,
+                        "size": request.chunk_size,
                         "overlap": 100,
-                    } if perform_chunking else None
+                    } if request.perform_chunking else None
                     
                     result = ingest_local_file(
                         file_path=file_path,
                         media_db=self.media_db,
-                        title=title or file_path.stem,
-                        author=author,
-                        keywords=keywords,
-                        perform_analysis=perform_analysis,
+                        title=request.title or file_path.stem,
+                        author=request.author,
+                        keywords=list(request.keywords) if request.keywords else None,
+                        perform_analysis=request.perform_analysis,
                         chunk_options=chunk_options
                     )
                     
@@ -289,45 +322,70 @@ class LocalIngestionPanel(ScrollableContainer):
                     })
                 
                 # Update progress
-                progress_bar.advance(1)
+                self._call_from_worker(self._advance_processing_progress)
             
             # Post completion message
-            self.post_message(ProcessingComplete(results + errors))
-            
-            # Show summary notification
-            success_count = len(results)
-            error_count = len(errors)
-            if error_count == 0:
-                self.notify(
-                    f"Successfully processed {success_count} file(s)",
-                    severity="information"
-                )
-            else:
-                self.notify(
-                    f"Processed {success_count} file(s), {error_count} error(s)",
-                    severity="warning"
-                )
+            self._call_from_worker(self._complete_processing, results + errors, len(results), len(errors))
             
         except Exception as e:
             logger.error(f"Processing error: {e}")
-            self.post_message(ProcessingError(str(e)))
-            self.notify(f"Processing failed: {e}", severity="error")
+            self._call_from_worker(self._fail_processing, str(e))
         
         finally:
-            # Reset UI state
-            self.processing = False
-            self.selected_files = []
-            process_btn.disabled = True
-            process_btn.label = "Process Selected Files"
-            
-            # Reset and hide progress bar
-            progress_bar = self.query_one("#ingest-progress-bar", ProgressBar)
-            progress_bar.add_class("hidden")
-            progress_bar.update(progress=0)
-            
-            # Reset label
-            label = self.query_one("#batch-info-label", Label)
-            label.update("")
+            self._call_from_worker(self._reset_processing_ui)
+
+    def _call_from_worker(self, callback, *args) -> None:
+        """Schedule a UI-thread callback from the ingestion worker thread."""
+        call_from_thread = self._call_from_thread
+        if call_from_thread is None:
+            raise RuntimeError("Local ingestion worker started without a UI callback.")
+        call_from_thread(callback, *args)
+
+    def _advance_processing_progress(self) -> None:
+        """Advance the progress bar on the UI thread."""
+        progress_bar = self.query_one("#ingest-progress-bar", ProgressBar)
+        progress_bar.advance(1)
+
+    def _complete_processing(
+        self,
+        results: List[Dict[str, Any]],
+        success_count: int,
+        error_count: int,
+    ) -> None:
+        """Post completion and notify from the UI thread."""
+        self.post_message(ProcessingComplete(results))
+
+        if error_count == 0:
+            self.notify(
+                f"Successfully processed {success_count} file(s)",
+                severity="information"
+            )
+        else:
+            self.notify(
+                f"Processed {success_count} file(s), {error_count} error(s)",
+                severity="warning"
+            )
+
+    def _fail_processing(self, error: str) -> None:
+        """Post processing failure and notify from the UI thread."""
+        self.post_message(ProcessingError(error))
+        self.notify(f"Processing failed: {error}", severity="error")
+
+    def _reset_processing_ui(self) -> None:
+        """Reset processing controls on the UI thread."""
+        self.processing = False
+        self.selected_files = []
+
+        process_btn = self.query_one("#local-process-btn", Button)
+        process_btn.disabled = True
+        process_btn.label = "Process Selected Files"
+
+        progress_bar = self.query_one("#ingest-progress-bar", ProgressBar)
+        progress_bar.add_class("hidden")
+        progress_bar.update(progress=0)
+
+        label = self.query_one("#batch-info-label", Label)
+        label.update("")
 
 
 class RemoteIngestionPanel(ScrollableContainer):

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -1150,6 +1150,12 @@ class ChatScreen(BaseAppScreen):
             
             # Try to find the chat log container (it's a VerticalScroll)
             chat_log = None
+            log_selectors = [
+                "#chat-log",
+                ".chat-log",
+                "#chat-messages-container",
+                ".chat-messages"
+            ]
             
             # First try the direct approach used in Chat_Window_Enhanced
             try:
@@ -1160,22 +1166,15 @@ class ChatScreen(BaseAppScreen):
             
             # If not found, try other selectors
             if not chat_log:
-                log_selectors = [
-                    "#chat-log",
-                    ".chat-log",
-                    "#chat-messages-container",
-                    ".chat-messages"
-                ]
-            
-            for selector in log_selectors:
-                try:
-                    containers = self.chat_window.query(selector)
-                    if containers:
-                        chat_log = containers.first()
-                        logger.debug(f"Found chat log container with selector: {selector}")
-                        break
-                except Exception as e:
-                    logger.debug(f"Could not find chat log with {selector}: {e}")
+                for selector in log_selectors:
+                    try:
+                        containers = self.chat_window.query(selector)
+                        if containers:
+                            chat_log = containers.first()
+                            logger.debug(f"Found chat log container with selector: {selector}")
+                            break
+                    except Exception as e:
+                        logger.debug(f"Could not find chat log with {selector}: {e}")
             
             if not chat_log:
                 logger.warning("Could not find chat log container to save messages")

--- a/tldw_chatbook/UI/Screens/chatbooks_screen.py
+++ b/tldw_chatbook/UI/Screens/chatbooks_screen.py
@@ -3,17 +3,22 @@ Chatbooks Screen
 Screen wrapper for Chatbooks functionality in screen-based navigation.
 """
 
-from textual.screen import Screen
 from textual.app import ComposeResult
 from textual.reactive import reactive
 from typing import Optional, List, Dict, Any
 from loguru import logger
 
+from tldw_chatbook.Constants import TAB_CHATBOOKS
+
 from ..Chatbooks_Window_Improved import ChatbooksWindowImproved
+from ..Navigation.base_app_screen import BaseAppScreen
 
 
-class ChatbooksScreen(Screen):
+class ChatbooksScreen(BaseAppScreen):
     """Screen wrapper for Chatbooks functionality."""
+
+    def __init__(self, app_instance, **kwargs):
+        super().__init__(app_instance, TAB_CHATBOOKS, **kwargs)
     
     # Screen-specific state
     current_chatbook: reactive[Optional[Dict[str, Any]]] = reactive(None)
@@ -21,13 +26,14 @@ class ChatbooksScreen(Screen):
     is_editing: reactive[bool] = reactive(False)
     selected_chatbook_id: reactive[Optional[int]] = reactive(None)
     
-    def compose(self) -> ComposeResult:
+    def compose_content(self) -> ComposeResult:
         """Compose the Chatbooks screen with the Chatbooks window."""
         logger.info("Composing Chatbooks screen")
-        yield ChatbooksWindowImproved(self.app)
+        yield ChatbooksWindowImproved(self.app_instance)
     
     async def on_mount(self) -> None:
         """Initialize Chatbooks when screen is mounted."""
+        super().on_mount()
         logger.info("Chatbooks screen mounted")
         chatbooks_window = self.query_one(ChatbooksWindowImproved)
         self.chatbook_list = list(chatbooks_window.chatbooks)

--- a/tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py
+++ b/tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py
@@ -529,27 +529,32 @@ class SearchRAGWindow(SearchEventHandlersMixin, Container):
             table = self.query_one("#index-stats-table", DataTable)
             table.add_columns("Collection", "Documents", "Chunks", "Size", "Last Updated")
             self._refresh_index_stats()
+
+    def _load_available_collections(self) -> list[str]:
+        """Load available collection names without touching Textual widgets."""
+        return list(get_available_profiles())
+
+    async def _apply_available_collections(self, collections: list[str]) -> None:
+        """Apply loaded collection names to mounted Textual widgets."""
+        self.available_collections = list(collections)
+
+        collections_list = self.query_one("#collections-list", ListView)
+        await collections_list.clear()
+
+        for collection in self.available_collections:
+            await collections_list.append(ListItem(Static(collection)))
+
+        collection_select = self.query_one("#collection-select", Select)
+        collection_select.set_options(
+            [("All Collections", "all")] + [(c, c) for c in self.available_collections]
+        )
     
     @work(thread=True)
-    async def _refresh_collections_list(self) -> None:
+    def _refresh_collections_list(self) -> None:
         """Refresh the list of available collections"""
         try:
-            # Get available collections
-            self.available_collections = get_available_profiles()
-            
-            # Update UI
-            collections_list = self.query_one("#collections-list", ListView)
-            await collections_list.clear()
-            
-            for collection in self.available_collections:
-                item = ListItem(Static(collection))
-                await collections_list.append(item)
-                
-            # Update collection select
-            collection_select = self.query_one("#collection-select", Select)
-            collection_select.set_options(
-                [("all", "All Collections")] + [(c, c) for c in self.available_collections]
-            )
+            collections = self._load_available_collections()
+            self.app.call_from_thread(self._apply_available_collections, collections)
         except Exception as e:
             logger.error(f"Error refreshing collections: {e}")
     

--- a/tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py
+++ b/tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py
@@ -554,7 +554,7 @@ class SearchRAGWindow(SearchEventHandlersMixin, Container):
         """Refresh the list of available collections"""
         try:
             collections = self._load_available_collections()
-            self.app.call_from_thread(self._apply_available_collections, collections)
+            self.app.call_from_thread(lambda: self.run_worker(self._apply_available_collections(collections), exclusive=True))
         except Exception as e:
             logger.error(f"Error refreshing collections: {e}")
     


### PR DESCRIPTION
## Summary
- Mount Chatbooks inside the shared app shell and add route/smoke coverage for the navigation escape path.
- Add Phase 1 regressions and fixes for Ingest source defaults, Study empty quiz lists, Chat state-save, Search/RAG collection refresh threading, and Search action reachability.
- Update UX remediation docs to mark Phase 0/1 branch status.

## Test Plan
- [x] .venv/bin/python -m pytest -q Tests/UI/test_ux_audit_smoke.py Tests/UI/test_screen_navigation.py Tests/UI/test_chatbooks_screen_server_actions.py --tb=short
- [x] .venv/bin/python -m pytest -q Tests/UI/test_ingestion_ui_redesigned.py Tests/UI/test_media_ingestion_tab_integration.py Tests/Study_Interop/test_quiz_scope_service.py Tests/UI/test_chat_screen_state.py Tests/UI/test_search_rag_window.py Tests/UI/test_search_handoffs.py --tb=short
- [x] .venv/bin/python -m pytest -q Tests/UI/test_chat_first_handoffs.py Tests/UI/test_media_handoffs.py Tests/UI/test_chat_tab_container.py --tb=short
- [x] git diff --check