### PR TITLE
Add Chat provider readiness orientation

### DIFF
--- a/Tests/Chat/test_provider_readiness.py
+++ b/Tests/Chat/test_provider_readiness.py
@@ -1,0 +1,94 @@
+"""Provider readiness tests for first-run Chat guidance."""
+
+from tldw_chatbook.Chat.provider_readiness import (
+    ProviderReadiness,
+    get_provider_readiness,
+)
+
+
+def test_key_required_provider_reports_missing_key_without_value_leakage():
+    readiness = get_provider_readiness(
+        "OpenAI",
+        {
+            "api_settings": {
+                "openai": {
+                    "api_key": "",
+                    "api_key_env_var": "OPENAI_API_KEY",
+                }
+            }
+        },
+        environ={},
+    )
+
+    assert readiness == ProviderReadiness(
+        provider="OpenAI",
+        provider_key="openai",
+        requires_api_key=True,
+        ready=False,
+        api_key=None,
+        api_key_source=None,
+        env_var="OPENAI_API_KEY",
+        reason="Missing API key",
+        recovery="Set OPENAI_API_KEY or add api_key under [api_settings.openai].",
+    )
+    assert "OPENAI_API_KEY" in readiness.user_message
+    assert "api_settings.openai" in readiness.user_message
+    assert "sk-" not in readiness.user_message
+
+
+def test_key_required_provider_uses_environment_key_without_displaying_it():
+    readiness = get_provider_readiness(
+        "Anthropic",
+        {"api_settings": {"anthropic": {"api_key_env_var": "ANTHROPIC_API_KEY"}}},
+        environ={"ANTHROPIC_API_KEY": "sk-ant-secret"},
+    )
+
+    assert readiness.ready is True
+    assert readiness.requires_api_key is True
+    assert readiness.api_key == "sk-ant-secret"
+    assert readiness.api_key_source == "env:ANTHROPIC_API_KEY"
+    assert "sk-ant-secret" not in readiness.user_message
+
+
+def test_placeholder_config_key_is_not_ready():
+    readiness = get_provider_readiness(
+        "OpenRouter",
+        {
+            "api_settings": {
+                "openrouter": {
+                    "api_key": "<API_KEY_HERE>",
+                    "api_key_env_var": "OPENROUTER_API_KEY",
+                }
+            }
+        },
+        environ={},
+    )
+
+    assert readiness.ready is False
+    assert readiness.api_key is None
+    assert readiness.recovery == "Set OPENROUTER_API_KEY or add api_key under [api_settings.openrouter]."
+
+
+def test_key_required_provider_names_are_case_insensitive():
+    readiness = get_provider_readiness(
+        "openai",
+        {"api_settings": {"openai": {"api_key_env_var": "OPENAI_API_KEY"}}},
+        environ={},
+    )
+
+    assert readiness.requires_api_key is True
+    assert readiness.ready is False
+    assert readiness.recovery == "Set OPENAI_API_KEY or add api_key under [api_settings.openai]."
+
+
+def test_keyless_local_provider_is_ready_without_api_key():
+    readiness = get_provider_readiness(
+        "Ollama",
+        {"api_settings": {"ollama": {"api_url": "http://localhost:11434"}}},
+        environ={},
+    )
+
+    assert readiness.ready is True
+    assert readiness.requires_api_key is False
+    assert readiness.api_key is None
+    assert readiness.user_message == "Ollama is ready. No API key is required."

--- a/Tests/Chat/test_provider_readiness.py
+++ b/Tests/Chat/test_provider_readiness.py
@@ -1,5 +1,7 @@
 """Provider readiness tests for first-run Chat guidance."""
 
+import pytest
+
 from tldw_chatbook.Chat.provider_readiness import (
     ProviderReadiness,
     get_provider_readiness,
@@ -92,3 +94,32 @@ def test_keyless_local_provider_is_ready_without_api_key():
     assert readiness.requires_api_key is False
     assert readiness.api_key is None
     assert readiness.user_message == "Ollama is ready. No API key is required."
+
+
+@pytest.mark.parametrize("provider", ["vLLM", "Custom-2", "local-llm"])
+def test_known_keyless_provider_aliases_are_ready_without_api_key(provider):
+    readiness = get_provider_readiness(
+        provider,
+        {"api_settings": {}},
+        environ={},
+    )
+
+    assert readiness.ready is True
+    assert readiness.requires_api_key is False
+    assert readiness.api_key is None
+
+
+def test_unknown_provider_without_key_is_not_ready():
+    readiness = get_provider_readiness(
+        "OpenAi Typo",
+        {"api_settings": {}},
+        environ={},
+    )
+
+    assert readiness.ready is False
+    assert readiness.requires_api_key is True
+    assert readiness.api_key is None
+    assert readiness.reason == "Unknown provider"
+    assert readiness.recovery == (
+        "Choose a supported provider or add api_key under [api_settings.openai_typo]."
+    )

--- a/Tests/Event_Handlers/Chat_Events/test_chat_events.py
+++ b/Tests/Event_Handlers/Chat_Events/test_chat_events.py
@@ -58,13 +58,11 @@ async def test_general_history_excludes_ccp_owned_sessions():
 
 # Mock external dependencies used in chat_events.py
 @patch('tldw_chatbook.Event_Handlers.Chat_Events.chat_events.ccl')
-@patch('tldw_chatbook.Event_Handlers.Chat_Events.chat_events.os')
 @patch('tldw_chatbook.Event_Handlers.Chat_Events.chat_events.ChatMessageEnhanced')
 @patch('tldw_chatbook.Event_Handlers.Chat_Events.chat_events.ChatMessage')
-async def test_handle_chat_send_button_pressed_basic(mock_chat_message_class, mock_chat_message_enhanced_class, mock_os, mock_ccl, mock_app):
+async def test_handle_chat_send_button_pressed_basic(mock_chat_message_class, mock_chat_message_enhanced_class, mock_ccl, mock_app):
     """Test a basic message send operation."""
-    mock_os.environ.get.return_value = "fake-key"
-    
+
     # Mock ChatMessage instances to track mount calls
     mock_user_msg = MagicMock()
     mock_ai_msg = MagicMock()
@@ -72,7 +70,8 @@ async def test_handle_chat_send_button_pressed_basic(mock_chat_message_class, mo
     mock_chat_message_class.side_effect = [mock_user_msg, mock_ai_msg]
     mock_chat_message_enhanced_class.side_effect = [mock_user_msg, mock_ai_msg]
 
-    await handle_chat_send_button_pressed(mock_app, MagicMock())
+    with patch.dict("os.environ", {"OPENAI_API_KEY": "fake-key"}):
+        await handle_chat_send_button_pressed(mock_app, MagicMock())
 
     # Assert UI updates
     # TextArea.clear is sync, not async
@@ -108,13 +107,11 @@ async def test_handle_chat_send_button_pressed_basic(mock_chat_message_class, mo
 
 
 @patch('tldw_chatbook.Event_Handlers.Chat_Events.chat_events.ccl')
-@patch('tldw_chatbook.Event_Handlers.Chat_Events.chat_events.os')
 @patch('tldw_chatbook.Event_Handlers.Chat_Events.chat_events.ChatMessageEnhanced')
 @patch('tldw_chatbook.Event_Handlers.Chat_Events.chat_events.ChatMessage')
-async def test_handle_chat_send_with_active_character(mock_chat_message_class, mock_chat_message_enhanced_class, mock_os, mock_ccl, mock_app):
+async def test_handle_chat_send_with_active_character(mock_chat_message_class, mock_chat_message_enhanced_class, mock_ccl, mock_app):
     """Test that an active character's system prompt overrides the UI."""
-    mock_os.environ.get.return_value = "fake-key"
-    
+
     # Mock ChatMessage instances
     mock_user_msg = MagicMock()
     mock_ai_msg = MagicMock()
@@ -125,7 +122,8 @@ async def test_handle_chat_send_with_active_character(mock_chat_message_class, m
         'system_prompt': 'You are TestChar.'
     }
 
-    await handle_chat_send_button_pressed(mock_app, MagicMock())
+    with patch.dict("os.environ", {"OPENAI_API_KEY": "fake-key"}):
+        await handle_chat_send_button_pressed(mock_app, MagicMock())
 
     worker_lambda = mock_app.run_worker.call_args[0][0]
     worker_lambda()

--- a/Tests/Subscriptions/test_subscriptions_smoke.py
+++ b/Tests/Subscriptions/test_subscriptions_smoke.py
@@ -3,7 +3,54 @@ from pathlib import Path
 
 import pytest
 
+from tldw_chatbook.DB import Subscriptions_DB as subscriptions_module
 from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
+
+
+class _TrackedConnection:
+    def __init__(self, conn):
+        object.__setattr__(self, "_conn", conn)
+        object.__setattr__(self, "closed", False)
+
+    def __getattr__(self, name):
+        return getattr(self._conn, name)
+
+    def __setattr__(self, name, value):
+        if name in {"_conn", "closed"}:
+            object.__setattr__(self, name, value)
+            return
+        setattr(self._conn, name, value)
+
+    def __enter__(self):
+        self._conn.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return self._conn.__exit__(exc_type, exc, traceback)
+
+    def close(self):
+        object.__setattr__(self, "closed", True)
+        return self._conn.close()
+
+
+@pytest.mark.unit
+def test_subscriptions_db_closes_schema_initialization_connection(tmp_path, monkeypatch):
+    connections = []
+    original_connect = subscriptions_module.sqlite3.connect
+
+    def tracked_connect(*args, **kwargs):
+        conn = _TrackedConnection(original_connect(*args, **kwargs))
+        connections.append(conn)
+        return conn
+
+    monkeypatch.setattr(subscriptions_module.sqlite3, "connect", tracked_connect)
+
+    db = SubscriptionsDB(tmp_path / "subscriptions.db")
+    try:
+        assert connections
+        assert connections[0].closed is True
+    finally:
+        db.close()
 
 
 @pytest.mark.unit

--- a/Tests/Subscriptions/test_subscriptions_smoke.py
+++ b/Tests/Subscriptions/test_subscriptions_smoke.py
@@ -12,37 +12,38 @@ def test_subscriptions_db_basic_add_and_list():
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = Path(tmpdir) / "subscriptions.db"
         db = SubscriptionsDB(str(db_path))
+        try:
+            # Add a subscription
+            sub_id = db.add_subscription(
+                name="Test Feed",
+                type="rss",
+                source="https://example.com/feed.xml",
+                tags=["news", "tech"],
+                priority=3,
+                folder="Smoke"
+            )
+            assert isinstance(sub_id, int) and sub_id > 0
 
-        # Add a subscription
-        sub_id = db.add_subscription(
-            name="Test Feed",
-            type="rss",
-            source="https://example.com/feed.xml",
-            tags=["news", "tech"],
-            priority=3,
-            folder="Smoke"
-        )
-        assert isinstance(sub_id, int) and sub_id > 0
+            # Fetch it back
+            sub = db.get_subscription(sub_id)
+            assert sub is not None
+            assert sub["name"] == "Test Feed"
+            assert sub["type"] == "rss"
 
-        # Fetch it back
-        sub = db.get_subscription(sub_id)
-        assert sub is not None
-        assert sub["name"] == "Test Feed"
-        assert sub["type"] == "rss"
+            # Record a successful check with one new item
+            db.record_check_result(
+                subscription_id=sub_id,
+                items=[{
+                    "url": "https://example.com/article-1?utm=abc",
+                    "title": "An Article",
+                    "content_hash": "hash1"
+                }],
+                stats={"response_time_ms": 120, "bytes_transferred": 1024, "new_items_found": 1}
+            )
 
-        # Record a successful check with one new item
-        db.record_check_result(
-            subscription_id=sub_id,
-            items=[{
-                "url": "https://example.com/article-1?utm=abc",
-                "title": "An Article",
-                "content_hash": "hash1"
-            }],
-            stats={"response_time_ms": 120, "bytes_transferred": 1024, "new_items_found": 1}
-        )
-
-        # New items should be present
-        items = db.get_new_items()
-        assert len(items) >= 1
-        assert items[0]["title"]
-
+            # New items should be present
+            items = db.get_new_items()
+            assert len(items) >= 1
+            assert items[0]["title"]
+        finally:
+            db.close()

--- a/Tests/UI/test_chat_first_run_orientation.py
+++ b/Tests/UI/test_chat_first_run_orientation.py
@@ -1,0 +1,95 @@
+"""First-run Chat orientation tests."""
+
+from unittest.mock import Mock
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Static
+
+from tldw_chatbook.UI.Chat_Window_Enhanced import ChatWindowEnhanced
+
+
+def _text(widget: Static) -> str:
+    return str(widget.render())
+
+
+class _ChatFirstRunHarnessApp(App):
+    def __init__(self, app_instance) -> None:
+        super().__init__()
+        self._app_instance = app_instance
+
+    def compose(self) -> ComposeResult:
+        yield ChatWindowEnhanced(self._app_instance)
+
+
+@pytest.fixture
+def first_run_settings(monkeypatch):
+    def get_setting(section, key, default=None):
+        overrides = {
+            ("chat_defaults", "enable_tabs"): False,
+            ("chat.voice", "show_mic_button"): True,
+            ("chat.images", "show_attach_button"): True,
+        }
+        return overrides.get((section, key), default)
+
+    providers = {"OpenAI": ["gpt-4o"]}
+
+    monkeypatch.setattr("tldw_chatbook.config.get_cli_setting", get_setting)
+    monkeypatch.setattr("tldw_chatbook.UI.Chat_Window_Enhanced.get_cli_setting", get_setting)
+    monkeypatch.setattr("tldw_chatbook.Widgets.compact_model_bar.get_cli_setting", get_setting)
+    monkeypatch.setattr(
+        "tldw_chatbook.Widgets.compact_model_bar.get_cli_providers_and_models",
+        lambda: providers,
+    )
+    monkeypatch.setattr("tldw_chatbook.Widgets.enhanced_settings_sidebar.get_cli_setting", get_setting)
+    monkeypatch.setattr(
+        "tldw_chatbook.Widgets.enhanced_settings_sidebar.get_cli_providers_and_models",
+        lambda: providers,
+    )
+
+
+@pytest.fixture
+def first_run_host():
+    host = Mock()
+    host.app_config = {
+        "chat_defaults": {
+            "provider": "OpenAI",
+            "model": "gpt-4o",
+            "temperature": 0.7,
+        },
+        "api_settings": {
+            "openai": {
+                "api_key": "",
+                "api_key_env_var": "OPENAI_API_KEY",
+            }
+        },
+    }
+    host.chat_attached_files = {}
+    host.active_session_id = "default"
+    host.is_streaming = False
+    host.chat_sidebar_collapsed = False
+    host.chat_right_sidebar_collapsed = False
+    host.notify = Mock()
+    host.run_worker = Mock()
+    host.bell = Mock()
+    host.push_screen = Mock()
+    host.call_later = Mock()
+    return host
+
+
+@pytest.mark.asyncio
+async def test_chat_first_run_exposes_readiness_and_context_sources(first_run_settings, first_run_host):
+    app = _ChatFirstRunHarnessApp(first_run_host)
+
+    async with app.run_test() as pilot:
+        empty_state = pilot.app.query_one("#chat-empty-state", Static)
+        text = _text(empty_state)
+
+        assert "agentic control surface" in text
+        assert "OpenAI is not ready" in text
+        assert "OPENAI_API_KEY" in text
+        assert "Notes, Media, Search/RAG, Workspaces" in text
+        assert "Study flashcards/quizzes" in text
+        assert "personas" in text
+        assert "Chatbooks" in text
+        assert "Ctrl+P" in text

--- a/tldw_chatbook/Chat/provider_readiness.py
+++ b/tldw_chatbook/Chat/provider_readiness.py
@@ -7,19 +7,6 @@ from dataclasses import dataclass
 from typing import Mapping, Optional
 
 
-PROVIDERS_REQUIRING_API_KEY = frozenset(
-    {
-        "Anthropic",
-        "Cohere",
-        "DeepSeek",
-        "Google",
-        "Groq",
-        "HuggingFace",
-        "MistralAI",
-        "OpenAI",
-        "OpenRouter",
-    }
-)
 PROVIDERS_REQUIRING_API_KEY_KEYS = frozenset(
     {
         "anthropic",
@@ -28,11 +15,36 @@ PROVIDERS_REQUIRING_API_KEY_KEYS = frozenset(
         "google",
         "groq",
         "huggingface",
+        "mistral",
         "mistralai",
+        "moonshot",
         "openai",
         "openrouter",
+        "zai",
     }
 )
+KEYLESS_PROVIDER_KEYS = frozenset(
+    {
+        "aphrodite",
+        "custom",
+        "custom_2",
+        "koboldcpp",
+        "llama_cpp",
+        "local_llm",
+        "local_llamacpp",
+        "local_llamafile",
+        "local_mlx_lm",
+        "local_ollama",
+        "local_onnx",
+        "local_transformers",
+        "local_vllm",
+        "ollama",
+        "oobabooga",
+        "tabbyapi",
+        "vllm",
+    }
+)
+KNOWN_PROVIDER_KEYS = PROVIDERS_REQUIRING_API_KEY_KEYS | KEYLESS_PROVIDER_KEYS
 
 _PLACEHOLDER_KEYS = frozenset(
     {
@@ -87,6 +99,11 @@ def _valid_api_key(value: object) -> Optional[str]:
     return stripped or None
 
 
+def _requires_api_key(provider_key: str) -> bool:
+    """Return True unless the provider is known to work without credentials."""
+    return provider_key not in KEYLESS_PROVIDER_KEYS
+
+
 def get_provider_readiness(
     provider: Optional[str],
     app_config: Mapping[str, object],
@@ -128,12 +145,13 @@ def get_provider_readiness(
         if isinstance(maybe_provider_settings, Mapping):
             provider_settings = maybe_provider_settings
 
+    requires_api_key = _requires_api_key(provider_key)
     configured_key = _valid_api_key(provider_settings.get("api_key"))
     if configured_key:
         return ProviderReadiness(
             provider=provider_name,
             provider_key=provider_key,
-            requires_api_key=provider_key in PROVIDERS_REQUIRING_API_KEY_KEYS,
+            requires_api_key=requires_api_key,
             ready=True,
             api_key=configured_key,
             api_key_source=f"config:api_settings.{provider_key}.api_key",
@@ -149,7 +167,7 @@ def get_provider_readiness(
         return ProviderReadiness(
             provider=provider_name,
             provider_key=provider_key,
-            requires_api_key=provider_key in PROVIDERS_REQUIRING_API_KEY_KEYS,
+            requires_api_key=requires_api_key,
             ready=True,
             api_key=env_key,
             api_key_source=f"env:{env_var}",
@@ -158,7 +176,19 @@ def get_provider_readiness(
             recovery=None,
         )
 
-    requires_api_key = provider_key in PROVIDERS_REQUIRING_API_KEY_KEYS
+    if provider_key not in KNOWN_PROVIDER_KEYS and not provider_settings:
+        return ProviderReadiness(
+            provider=provider_name,
+            provider_key=provider_key,
+            requires_api_key=True,
+            ready=False,
+            api_key=None,
+            api_key_source=None,
+            env_var=env_var,
+            reason="Unknown provider",
+            recovery=f"Choose a supported provider or add api_key under [api_settings.{provider_key}].",
+        )
+
     if not requires_api_key:
         return ProviderReadiness(
             provider=provider_name,

--- a/tldw_chatbook/Chat/provider_readiness.py
+++ b/tldw_chatbook/Chat/provider_readiness.py
@@ -1,0 +1,191 @@
+"""Side-effect-free provider readiness helpers for Chat."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Mapping, Optional
+
+
+PROVIDERS_REQUIRING_API_KEY = frozenset(
+    {
+        "Anthropic",
+        "Cohere",
+        "DeepSeek",
+        "Google",
+        "Groq",
+        "HuggingFace",
+        "MistralAI",
+        "OpenAI",
+        "OpenRouter",
+    }
+)
+PROVIDERS_REQUIRING_API_KEY_KEYS = frozenset(
+    {
+        "anthropic",
+        "cohere",
+        "deepseek",
+        "google",
+        "groq",
+        "huggingface",
+        "mistralai",
+        "openai",
+        "openrouter",
+    }
+)
+
+_PLACEHOLDER_KEYS = frozenset(
+    {
+        "",
+        "<API_KEY_HERE>",
+        "YOUR_KEY",
+        "your_key",
+        "your-api-key",
+    }
+)
+
+
+@dataclass(frozen=True)
+class ProviderReadiness:
+    """Current readiness state for the selected Chat provider."""
+
+    provider: str
+    provider_key: str
+    requires_api_key: bool
+    ready: bool
+    api_key: Optional[str]
+    api_key_source: Optional[str]
+    env_var: Optional[str]
+    reason: str
+    recovery: Optional[str]
+
+    @property
+    def user_message(self) -> str:
+        """User-facing readiness text that never includes secret values."""
+        if self.ready:
+            if self.requires_api_key:
+                source = self.api_key_source or "configured credentials"
+                return f"{self.provider} is ready. API key found via {source}."
+            return f"{self.provider} is ready. No API key is required."
+
+        if self.recovery:
+            return f"{self.provider} is not ready: {self.reason}. {self.recovery}"
+        return f"{self.provider} is not ready: {self.reason}."
+
+
+def provider_config_key(provider: Optional[str]) -> str:
+    """Return the normalized key used under ``api_settings``."""
+    return (provider or "").strip().lower().replace(" ", "_").replace("-", "_")
+
+
+def _valid_api_key(value: object) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    if stripped in _PLACEHOLDER_KEYS:
+        return None
+    return stripped or None
+
+
+def get_provider_readiness(
+    provider: Optional[str],
+    app_config: Mapping[str, object],
+    *,
+    environ: Optional[Mapping[str, str]] = None,
+) -> ProviderReadiness:
+    """Resolve whether the selected provider has enough credentials to send.
+
+    Args:
+        provider: Display provider name from the Chat selector.
+        app_config: Loaded app configuration.
+        environ: Environment mapping, injectable for deterministic tests.
+
+    Returns:
+        Readiness state. If a key is found, it is returned for call wiring but
+        never included in ``user_message``.
+    """
+    provider_name = (provider or "").strip()
+    provider_key = provider_config_key(provider_name)
+    env = environ if environ is not None else os.environ
+
+    if not provider_name:
+        return ProviderReadiness(
+            provider="No provider",
+            provider_key="",
+            requires_api_key=False,
+            ready=False,
+            api_key=None,
+            api_key_source=None,
+            env_var=None,
+            reason="Select a provider",
+            recovery="Choose a provider and model before sending.",
+        )
+
+    api_settings = app_config.get("api_settings", {})
+    provider_settings = {}
+    if isinstance(api_settings, Mapping):
+        maybe_provider_settings = api_settings.get(provider_key, {})
+        if isinstance(maybe_provider_settings, Mapping):
+            provider_settings = maybe_provider_settings
+
+    configured_key = _valid_api_key(provider_settings.get("api_key"))
+    if configured_key:
+        return ProviderReadiness(
+            provider=provider_name,
+            provider_key=provider_key,
+            requires_api_key=provider_key in PROVIDERS_REQUIRING_API_KEY_KEYS,
+            ready=True,
+            api_key=configured_key,
+            api_key_source=f"config:api_settings.{provider_key}.api_key",
+            env_var=None,
+            reason="Ready",
+            recovery=None,
+        )
+
+    env_var_value = provider_settings.get("api_key_env_var")
+    env_var = env_var_value.strip() if isinstance(env_var_value, str) else None
+    env_key = _valid_api_key(env.get(env_var, "")) if env_var else None
+    if env_key:
+        return ProviderReadiness(
+            provider=provider_name,
+            provider_key=provider_key,
+            requires_api_key=provider_key in PROVIDERS_REQUIRING_API_KEY_KEYS,
+            ready=True,
+            api_key=env_key,
+            api_key_source=f"env:{env_var}",
+            env_var=env_var,
+            reason="Ready",
+            recovery=None,
+        )
+
+    requires_api_key = provider_key in PROVIDERS_REQUIRING_API_KEY_KEYS
+    if not requires_api_key:
+        return ProviderReadiness(
+            provider=provider_name,
+            provider_key=provider_key,
+            requires_api_key=False,
+            ready=True,
+            api_key=None,
+            api_key_source=None,
+            env_var=env_var,
+            reason="Ready",
+            recovery=None,
+        )
+
+    recovery_target = f"api_key under [api_settings.{provider_key}]"
+    if env_var:
+        recovery = f"Set {env_var} or add {recovery_target}."
+    else:
+        recovery = f"Add {recovery_target}."
+
+    return ProviderReadiness(
+        provider=provider_name,
+        provider_key=provider_key,
+        requires_api_key=True,
+        ready=False,
+        api_key=None,
+        api_key_source=None,
+        env_var=env_var,
+        reason="Missing API key",
+        recovery=recovery,
+    )

--- a/tldw_chatbook/DB/Subscriptions_DB.py
+++ b/tldw_chatbook/DB/Subscriptions_DB.py
@@ -25,7 +25,7 @@ import json
 import sqlite3
 import threading
 import time
-from contextlib import contextmanager
+from contextlib import closing, contextmanager
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from typing import List, Tuple, Dict, Any, Optional, Union
@@ -75,7 +75,7 @@ class SubscriptionsDB(BaseDB):
     
     def _initialize_schema(self):
         """Initialize the database schema."""
-        with self._get_connection() as conn:
+        with closing(self._get_connection()) as conn:
             conn.executescript("""
             PRAGMA foreign_keys = ON;
             

--- a/tldw_chatbook/Event_Handlers/Chat_Events/chat_events.py
+++ b/tldw_chatbook/Event_Handlers/Chat_Events/chat_events.py
@@ -25,6 +25,7 @@ from tldw_chatbook.Event_Handlers.Chat_Events import chat_events_sidebar
 from tldw_chatbook.Event_Handlers.Chat_Events import chat_events_worldbooks
 from tldw_chatbook.Event_Handlers.Chat_Events import chat_events_dictionaries
 from tldw_chatbook.Chat.chat_handoff_models import ChatHandoffPayload
+from tldw_chatbook.Chat.provider_readiness import get_provider_readiness
 from tldw_chatbook.Utils.Utils import safe_float, safe_int
 from tldw_chatbook.Utils.input_validation import validate_text_input, validate_number_range, sanitize_string
 from tldw_chatbook.Widgets.Chat_Widgets.chat_message import ChatMessage
@@ -626,40 +627,12 @@ async def handle_chat_send_button_pressed(app: 'TldwCli', event: Button.Pressed)
     text_area.focus()
 
     # --- 9. API Key Fetching ---
-    api_key_for_call = None
-    if selected_provider:
-        provider_settings_key = selected_provider.lower().replace(" ", "_")
-        provider_config_settings = app.app_config.get("api_settings", {}).get(provider_settings_key, {})
+    provider_readiness = get_provider_readiness(selected_provider, app.app_config)
+    api_key_for_call = provider_readiness.api_key
 
-        if "api_key" in provider_config_settings:
-            direct_config_key_checked = True
-            config_api_key = provider_config_settings.get("api_key", "").strip()
-            if config_api_key and config_api_key != "<API_KEY_HERE>":
-                api_key_for_call = config_api_key
-                loguru_logger.debug(f"Using API key for '{selected_provider}' from config file field.")
-
-        if not api_key_for_call: # If not found in direct 'api_key' field or it was empty
-            env_var_name = provider_config_settings.get("api_key_env_var", "").strip()
-            if env_var_name:
-                env_api_key = os.environ.get(env_var_name, "").strip()
-                if env_api_key:
-                    api_key_for_call = env_api_key
-                    loguru_logger.debug(f"Using API key for '{selected_provider}' from ENV var '{env_var_name}'.")
-                else:
-                    loguru_logger.debug(f"ENV var '{env_var_name}' for '{selected_provider}' not found or empty.")
-            else:
-                loguru_logger.debug(f"No 'api_key_env_var' specified for '{selected_provider}' in config.")
-
-    providers_requiring_key = ["OpenAI", "Anthropic", "Google", "MistralAI", "Groq", "Cohere", "OpenRouter", "HuggingFace", "DeepSeek"]
-    if selected_provider in providers_requiring_key and not api_key_for_call:
+    if provider_readiness.requires_api_key and not provider_readiness.ready:
         loguru_logger.error(f"API Key for '{selected_provider}' is missing and required.")
-        error_message_markup = (
-            f"API Key for {selected_provider} is missing.\n\n"
-            "Please add it to your config file under:\n"
-            f"\\[api_settings.{selected_provider.lower().replace(' ', '_')}\\]\n" 
-            "api_key = \"YOUR_KEY\"\n\n"
-            "Or set the environment variable specified by 'api_key_env_var' in the config for this provider."
-        )
+        error_message_markup = provider_readiness.user_message
         await chat_container.mount(ChatMessage(message=error_message_markup, role="System"))
         if app.current_ai_message_widget and app.current_ai_message_widget.is_mounted:
             await app.current_ai_message_widget.remove()

--- a/tldw_chatbook/UI/Chat_Window_Enhanced.py
+++ b/tldw_chatbook/UI/Chat_Window_Enhanced.py
@@ -24,6 +24,7 @@ from ..Widgets.enhanced_file_picker import EnhancedFileOpen as FileOpen, Filters
 from tldw_chatbook.Widgets.Chat_Widgets.chat_shell_bar import ChatShellBar
 from tldw_chatbook.Widgets.Chat_Widgets.chat_tab_container import ChatTabContainer
 from ..Widgets.voice_input_widget import VoiceInputWidget, VoiceInputMessage
+from ..Chat.provider_readiness import get_provider_readiness
 from ..config import get_cli_setting
 from ..Constants import TAB_CHAT
 from ..Utils.Emoji_Handling import get_char, EMOJI_SIDEBAR_TOGGLE, FALLBACK_SIDEBAR_TOGGLE, EMOJI_SEND, FALLBACK_SEND, \
@@ -150,6 +151,7 @@ class ChatWindowEnhanced(Container):
             chat_log.display = False
         except NoMatches:
             pass
+        self.refresh_first_run_orientation()
     
     # Message Handlers using Textual's Message System
     
@@ -353,6 +355,42 @@ class ChatWindowEnhanced(Container):
         try:
             chat_log = self.query_one("#chat-log")
             chat_log.display = False
+        except NoMatches:
+            pass
+
+    def _selected_provider_for_orientation(self) -> Optional[str]:
+        """Return the current provider selector value, falling back to config."""
+        try:
+            provider_select = self.query_one("#chat-api-provider", Select)
+            if provider_select.value != Select.BLANK:
+                return str(provider_select.value)
+        except NoMatches:
+            pass
+
+        defaults = self.app_instance.app_config.get("chat_defaults", {})
+        if isinstance(defaults, dict):
+            provider = defaults.get("provider")
+            if provider:
+                return str(provider)
+        return None
+
+    def build_first_run_orientation_text(self, provider: Optional[str] = None) -> str:
+        """Build compact first-run guidance for the empty Chat state."""
+        selected_provider = provider or self._selected_provider_for_orientation()
+        readiness = get_provider_readiness(selected_provider, self.app_instance.app_config)
+
+        return (
+            "Chat is the agentic control surface for programming, research, and workspace tasks.\n"
+            f"Provider readiness: {readiness.user_message}\n"
+            "Context: Notes, Media, Search/RAG, Workspaces, Study flashcards/quizzes, "
+            "personas, and Chatbooks. Ctrl+P opens commands."
+        )
+
+    def refresh_first_run_orientation(self, provider: Optional[str] = None) -> None:
+        """Refresh the first-run empty-state guidance if it is mounted."""
+        try:
+            empty_state = self.query_one("#chat-empty-state", Static)
+            empty_state.update(self.build_first_run_orientation_text(provider))
         except NoMatches:
             pass
 
@@ -799,9 +837,7 @@ class ChatWindowEnhanced(Container):
             else:
                 # Legacy single-session mode - empty state + chat log
                 yield Static(
-                    "Welcome to tldw chatbook\n\n"
-                    "Start a conversation by typing below.\n\n"
-                    "Tip: Press Ctrl+P for the command palette",
+                    self.build_first_run_orientation_text(),
                     id="chat-empty-state",
                 )
                 yield VerticalScroll(id="chat-log")

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -111,6 +111,7 @@ class ChatScreen(BaseAppScreen):
                     compact_bar.sync_from_sidebar(provider=new_provider)
                 except Exception:
                     logger.debug("Compact bar not found for provider sync")
+                self.chat_window.refresh_first_run_orientation(new_provider)
             else:
                 logger.error("chat_window is None")
 


### PR DESCRIPTION
## Summary
- Add side-effect-free Chat provider readiness checks for config/env API keys.
- Reuse the readiness helper for main send-time missing-key errors.
- Replace the first-run Chat empty state with a compact orientation strip that keeps context sources and Ctrl+P visible without blocking input.

## Test Plan
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chat/test_provider_readiness.py Tests/UI/test_chat_first_run_orientation.py Tests/UI/test_chat_window_enhanced_integration.py Tests/UI/test_chat_window_enhanced.py Tests/UI/test_chat_screen_state.py Tests/UI/test_chat_tab_container.py --tb=short
- git diff --check