### PR TITLE
Clarify Media empty state

### DIFF
--- a/Tests/UI/test_media_window_v2_parity.py
+++ b/Tests/UI/test_media_window_v2_parity.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 from textual import on
 from textual.app import App, ComposeResult
-from textual.widgets import Button, Collapsible, Select, Static
+from textual.widgets import Button, Collapsible, Label, Select, Static
 
 from tldw_chatbook.Event_Handlers.media_events import (
     MediaAnalysisSaveEvent,
@@ -20,6 +20,11 @@ from tldw_chatbook.UI.MediaWindow_v2 import MediaWindow
 from tldw_chatbook.UI.Screens.media_runtime_state import MediaRuntimeState
 from tldw_chatbook.Widgets.Media.media_search_panel import MediaBrowseSubviewChangedEvent, MediaSearchPanel
 from tldw_chatbook.Widgets.Media.media_viewer_panel import MediaViewerPanel
+
+
+def _plain_text(widget) -> str:
+    rendered = widget.render()
+    return getattr(rendered, "plain", str(rendered))
 
 
 def _build_media_window(*, runtime_backend: str = "local", scope_service: Optional[Mock] = None):
@@ -55,6 +60,35 @@ def _build_media_window(*, runtime_backend: str = "local", scope_service: Option
     window.query_one = Mock(return_value=empty_state)
     window.run_worker = lambda coro, exclusive=True: coro.close()
     return window, app
+
+
+@pytest.mark.asyncio
+async def test_media_empty_state_orients_first_time_users():
+    app_instance = SimpleNamespace(
+        _media_types_for_ui=["All Media"],
+        media_runtime_state=MediaRuntimeState(runtime_backend="local"),
+        media_reading_scope_service=Mock(),
+        notify=Mock(),
+        media_db=None,
+    )
+    app_instance.media_reading_scope_service.search_media = AsyncMock(return_value={"items": [], "total": 0})
+
+    class MediaWindowApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield MediaWindow(app_instance)
+
+    app = MediaWindowApp()
+    async with app.run_test() as pilot:
+        await pilot.pause(0.05)
+
+        empty_label = app.query_one("#empty-state-label", Label)
+        text = _plain_text(empty_label)
+
+        assert "Media Library" in text
+        assert "Ingest" in text
+        assert "Select a media item" in text
+        assert "analysis" in text
+        assert "Use in Chat" in text
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_media_window_v2_parity.py
+++ b/Tests/UI/test_media_window_v2_parity.py
@@ -79,7 +79,7 @@ async def test_media_empty_state_orients_first_time_users():
 
     app = MediaWindowApp()
     async with app.run_test() as pilot:
-        await pilot.pause(0.05)
+        await pilot.pause()
 
         empty_label = app.query_one("#empty-state-label", Label)
         text = _plain_text(empty_label)

--- a/tldw_chatbook/UI/MediaWindow_v2.py
+++ b/tldw_chatbook/UI/MediaWindow_v2.py
@@ -51,6 +51,13 @@ if TYPE_CHECKING:
     from ..app import TldwCli
 
 
+MEDIA_EMPTY_STATE_COPY = (
+    "Media Library\n"
+    "Use Ingest to add files, URLs, archives, or transcripts. Select a media item here.\n"
+    "Details, analysis, save/export, and Use in Chat actions appear after a media item is selected."
+)
+
+
 class MediaWindow(Container):
     """
     Orchestrator for the Media Tab components.
@@ -824,7 +831,7 @@ class MediaWindow(Container):
                 
                 # Empty state placeholder (initially hidden or shown based on selection)
                 yield Container(
-                    Label("Select a media item to view details", id="empty-state-label"),
+                    Label(MEDIA_EMPTY_STATE_COPY, id="empty-state-label"),
                     id="media-empty-state",
                     classes="hidden"
                 )

--- a/tldw_chatbook/Widgets/Chat_Widgets/chat_session.py
+++ b/tldw_chatbook/Widgets/Chat_Widgets/chat_session.py
@@ -261,12 +261,11 @@ class ChatSession(Container):
 
         for card in list(self.query(ChatHandoffCard)):
             if getattr(card.payload, "status", "staged") == "sent":
-        for card in list(self.query(ChatHandoffCard)):
-            if card.payload.status != "sent":
-                try:
-                    await card.remove()
-                except Exception as e:
-                    logger.debug(f"Could not remove handoff card: {e}")
+                continue
+            try:
+                await card.remove()
+            except Exception as e:
+                logger.debug(f"Could not remove handoff card: {e}")
     
     # Button event handlers
     @on(Button.Pressed)


### PR DESCRIPTION
## Summary
- Replace the terse Media placeholder with first-run orientation that explains the library, points to Ingest, and names selected-item actions
- Add a focused Media empty-state regression
- Include the current-dev chat handoff clear syntax fix so UI imports work until PR #152 is merged into dev

## Verification
- env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_media_window_v2_parity.py::test_media_empty_state_orients_first_time_users Tests/UI/test_media_window_v2_parity.py::test_media_search_panel_shows_saved_view_disabled_reason Tests/UI/test_chat_first_handoffs.py::test_clear_staged_handoff_context_keeps_sent_handoff_cards --tb=short
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m py_compile tldw_chatbook/Widgets/Chat_Widgets/chat_session.py
- git diff --check