### PR TITLE
Clarify Study empty states

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -1,8 +1,8 @@
 # UX Audit Remediation Plan
 
 Date: 2026-05-01
-Status: Current-dev rebaseline after UX remediation PRs #146-#150
-Branch context: current `dev` / `origin/dev` at `0f59a8e9`
+Status: Current-dev rebaseline after UX remediation PRs #146-#153
+Branch context: current `dev` / `origin/dev` at `4554130e`
 Previous audit baseline: `e2576cae`
 
 ## Goal
@@ -29,7 +29,7 @@ This is not a visual refresh. The work is ordered around workflow completion, re
 
 ## Current Dev Rebaseline
 
-Verified on current `dev` at `0f59a8e9`:
+Verified on current `dev` at `4554130e`:
 
 - Phase 0 and Phase 1 are merged: the shared shell/Chatbooks trap, Ingest default source, quiz empty mapping response, Chat save-state, Search/RAG thread mutation, and Search primary-action reachability regressions are covered.
 - Phase 2 is merged: Chat has provider readiness and first-run orientation coverage.
@@ -39,11 +39,13 @@ Verified on current `dev` at `0f59a8e9`:
 Still open by current source inspection:
 
 - Phase 4 still needs disabled-state/recovery consistency for blocked source handoffs and live smoke replay.
-- Phase 5 still needs cross-surface empty/disabled-state language cleanup. Current branch `codex/ux-ia-language-labels` addresses top-level `CCP`/`LLM`/`S/TT/S` navigation labels while preserving route IDs.
+- Phase 5 top-level IA labels are merged: visible navigation now uses `Library`, `Models`, and `Speech` while preserving route IDs.
+- Phase 5 Media empty-state copy is merged: Media now points users toward Ingest and selected-item requirements for analysis/save/export.
+- Phase 5 Study empty-state cleanup is in progress on `codex/ux-study-empty-state`: flashcards and quizzes need separate no-content guidance for global/local vs workspace scopes while preserving backend-unavailable states.
 - Phase 6 still needs optional dependency gaps represented as user-facing capability states where relevant.
 - Phase 7 still needs end-to-end audit replay on a clean home/config.
 
-Planning consequence: remaining implementation should target Phase 4 disabled/recovery states, Phase 5 empty-state/IA language, Phase 6 capability-state presentation, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
+Planning consequence: remaining implementation should target Phase 4 disabled/recovery states, the remaining Phase 5 empty-state surfaces, Phase 6 capability-state presentation, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
 
 ## Issues Covered
 
@@ -280,7 +282,7 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 
 Purpose: make the app understandable without reducing expert efficiency.
 
-Branch state: in progress in `codex/ux-ia-language-labels`. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs. Broader empty/disabled-state language remains open.
+Branch state: partially merged through PRs #152 and #153. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, and Media empty states now direct users to Ingest plus selected-item recovery actions. Current slice `codex/ux-study-empty-state` covers Study flashcard/quiz empty states.
 
 ### Files
 
@@ -297,8 +299,8 @@ Branch state: in progress in `codex/ux-ia-language-labels`. Top-level navigation
 ### Steps
 
 - [ ] Standardize disabled primary actions: disabled reason, next action, and no silent no-op.
-- [ ] Study empty states distinguish no decks/quizzes from unavailable runtime.
-- [ ] Media empty states point to Ingest and explain when analysis/save/export need a selected item.
+- [x] Study empty states distinguish no decks/quizzes from unavailable runtime.
+- [x] Media empty states point to Ingest and explain when analysis/save/export need a selected item.
 - [ ] Search empty states explain plain search vs RAG, collections, and Chat handoff flow.
 - [ ] Notes empty states clarify local/server/workspace scope and creation/import routes.
 - [ ] CCP/Library empty states explain personas, characters, prompts, dictionaries, and how they relate to Chat.

--- a/Tests/UI/test_study_flashcards_screen.py
+++ b/Tests/UI/test_study_flashcards_screen.py
@@ -731,7 +731,11 @@ async def test_flashcards_view_shows_explicit_empty_state_when_no_decks_exist():
         status = app.screen.query_one("#review-status", Static)
         create_button = app.screen.query_one("#create-deck-button", Button)
 
-        assert "Create a deck" in _text(status)
+        status_text = _text(status)
+        assert "No study decks yet." in status_text
+        assert "Create a deck" in status_text
+        assert "add flashcards" in status_text
+        assert "start reviewing" in status_text
         assert create_button.display is True
 
 
@@ -872,7 +876,10 @@ async def test_scope_transition_resets_review_state_and_clears_flashcards_panel(
         assert _is_blank(move_target_select.value)
         assert _text(review_front) == ""
         assert _text(review_back) == ""
-        assert "No study decks in this workspace yet." in _text(review_status)
+        status_text = _text(review_status)
+        assert "No study decks in this workspace yet." in status_text
+        assert "Create a workspace deck" in status_text
+        assert "switch to Global Study" in status_text
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_study_quizzes_screen.py
+++ b/Tests/UI/test_study_quizzes_screen.py
@@ -851,7 +851,46 @@ async def test_quizzes_view_shows_explicit_empty_state_when_no_quizzes_exist():
 
         status = app.screen.query_one("#quiz-attempt-status", Static)
 
-        assert "Create a quiz to begin practicing." in _text(status)
+        status_text = _text(status)
+        assert "No quizzes yet." in status_text
+        assert "Create a quiz" in status_text
+        assert "add questions" in status_text
+        assert "start an attempt" in status_text
+
+
+@pytest.mark.asyncio
+async def test_workspace_quizzes_empty_state_explains_workspace_recovery_path():
+    scope = WorkspaceFilteredQuizScopeService()
+    scope.workspace_quizzes = []
+    scope.workspace_attempts = []
+    app_instance = SimpleNamespace(
+        study_scope_service=None,
+        study_quiz_scope_service=scope,
+        pending_study_scope_context=StudyScopeContext(
+            scope_type=StudyScopeType.WORKSPACE,
+            workspace_id="ws-1",
+            workspace_name="Research",
+        ),
+        current_runtime_backend="server",
+        runtime_backend=None,
+        app_config={},
+        notify=lambda *args, **kwargs: None,
+    )
+    app = StudyTestApp(app_instance)
+
+    async with app.run_test() as pilot:
+        await pilot.pause(0.2)
+        await pilot.click("#view-quizzes-btn")
+        await pilot.pause(0.3)
+
+        status = app.screen.query_one("#quiz-attempt-status", Static)
+        create_button = app.screen.query_one("#create-quiz-button", Button)
+
+        status_text = _text(status)
+        assert "No quizzes in this workspace yet." in status_text
+        assert "Create a workspace quiz" in status_text
+        assert "switch to Global Study" in status_text
+        assert create_button.disabled is False
 
 
 @pytest.mark.asyncio
@@ -883,7 +922,7 @@ async def test_quizzes_view_deletes_selected_quiz_and_resets_selection():
 
         assert ("delete_quiz", "local", "quiz-local-1", None, False) in scope.calls
         assert _is_blank(quiz_select.value)
-        assert "Create a quiz to begin practicing." in _text(status)
+        assert "No quizzes yet." in _text(status)
 
 
 @pytest.mark.asyncio

--- a/tldw_chatbook/UI/Study_Modules/flashcards_handler.py
+++ b/tldw_chatbook/UI/Study_Modules/flashcards_handler.py
@@ -102,8 +102,11 @@ class StudyFlashcardsController:
 
     def _scope_empty_message(self) -> str:
         if self._scope_type() == "workspace":
-            return "No study decks in this workspace yet."
-        return "Create a deck to begin studying."
+            return (
+                "No study decks in this workspace yet. Create a workspace deck, "
+                "or switch to Global Study to review existing decks."
+            )
+        return "No study decks yet. Create a deck, add flashcards, then start reviewing."
 
     def _scope_arguments(self) -> dict[str, Any]:
         scope_type = self._scope_type()

--- a/tldw_chatbook/UI/Study_Modules/quizzes_handler.py
+++ b/tldw_chatbook/UI/Study_Modules/quizzes_handler.py
@@ -102,8 +102,11 @@ class StudyQuizzesController:
 
     def _scope_empty_message(self) -> str:
         if self._scope_type() == StudyScopeType.WORKSPACE.value:
-            return "No quizzes in this workspace yet."
-        return "Create a quiz to begin practicing."
+            return (
+                "No quizzes in this workspace yet. Create a workspace quiz, "
+                "or switch to Global Study to practice existing quizzes."
+            )
+        return "No quizzes yet. Create a quiz, add questions, then start an attempt."
 
     def _scope_arguments(self) -> dict[str, Any]:
         scope_type = self._scope_type()
@@ -403,7 +406,7 @@ class StudyQuizzesController:
         quiz_id = self._selected_quiz_id()
         if quiz_id is None:
             if not self.has_quizzes:
-                self.reset_quiz_panel(self._scope_empty_message() if self._scope_type() == StudyScopeType.WORKSPACE.value else "Create a quiz to begin practicing.")
+                self.reset_quiz_panel(self._scope_empty_message())
             else:
                 self.reset_quiz_panel("Select a quiz to manage its questions.")
             return


### PR DESCRIPTION
## Summary

- Clarifies Study flashcard and quiz empty states for no-content vs workspace no-content.
- Keeps runtime/backend-unavailable states distinct and fail-closed.
- Updates the UX remediation plan to reflect merged PR #152/#153 state and this Study slice.

## Test Plan

- [x] `env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_study_quizzes_screen.py Tests/UI/test_study_flashcards_screen.py --tb=short`
- [x] `git diff --check`
