### PR TITLE
Clarify Search empty states

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -1,8 +1,8 @@
 # UX Audit Remediation Plan
 
 Date: 2026-05-01
-Status: Current-dev rebaseline after UX remediation PRs #146-#153
-Branch context: current `dev` / `origin/dev` at `4554130e`
+Status: Current-dev rebaseline after UX remediation PRs #146-#154
+Branch context: current `dev` / `origin/dev` at `860e2524`
 Previous audit baseline: `e2576cae`
 
 ## Goal
@@ -29,7 +29,7 @@ This is not a visual refresh. The work is ordered around workflow completion, re
 
 ## Current Dev Rebaseline
 
-Verified on current `dev` at `4554130e`:
+Verified on current `dev` at `860e2524`:
 
 - Phase 0 and Phase 1 are merged: the shared shell/Chatbooks trap, Ingest default source, quiz empty mapping response, Chat save-state, Search/RAG thread mutation, and Search primary-action reachability regressions are covered.
 - Phase 2 is merged: Chat has provider readiness and first-run orientation coverage.
@@ -41,7 +41,8 @@ Still open by current source inspection:
 - Phase 4 still needs disabled-state/recovery consistency for blocked source handoffs and live smoke replay.
 - Phase 5 top-level IA labels are merged: visible navigation now uses `Library`, `Models`, and `Speech` while preserving route IDs.
 - Phase 5 Media empty-state copy is merged: Media now points users toward Ingest and selected-item requirements for analysis/save/export.
-- Phase 5 Study empty-state cleanup is in progress on `codex/ux-study-empty-state`: flashcards and quizzes need separate no-content guidance for global/local vs workspace scopes while preserving backend-unavailable states.
+- Phase 5 Study empty-state cleanup is merged: flashcards and quizzes now separate no-content guidance for global/local vs workspace scopes while preserving backend-unavailable states.
+- Phase 5 Search empty-state cleanup is in progress on `codex/ux-search-empty-states`: initial and zero-result panes need visible guidance for plain search, RAG collections, and Chat handoff flow.
 - Phase 6 still needs optional dependency gaps represented as user-facing capability states where relevant.
 - Phase 7 still needs end-to-end audit replay on a clean home/config.
 
@@ -282,7 +283,7 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 
 Purpose: make the app understandable without reducing expert efficiency.
 
-Branch state: partially merged through PRs #152 and #153. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, and Media empty states now direct users to Ingest plus selected-item recovery actions. Current slice `codex/ux-study-empty-state` covers Study flashcard/quiz empty states.
+Branch state: partially merged through PRs #152, #153, and #154. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, and Study flashcard/quiz empty states distinguish no-content from unavailable runtime. Current slice `codex/ux-search-empty-states` covers Search/RAG empty states.
 
 ### Files
 
@@ -301,7 +302,7 @@ Branch state: partially merged through PRs #152 and #153. Top-level navigation l
 - [ ] Standardize disabled primary actions: disabled reason, next action, and no silent no-op.
 - [x] Study empty states distinguish no decks/quizzes from unavailable runtime.
 - [x] Media empty states point to Ingest and explain when analysis/save/export need a selected item.
-- [ ] Search empty states explain plain search vs RAG, collections, and Chat handoff flow.
+- [x] Search empty states explain plain search vs RAG, collections, and Chat handoff flow.
 - [ ] Notes empty states clarify local/server/workspace scope and creation/import routes.
 - [ ] CCP/Library empty states explain personas, characters, prompts, dictionaries, and how they relate to Chat.
 - [ ] Chatbooks empty state keeps portable knowledge-pack explanation and retains escape navigation.

--- a/Tests/UI/test_search_rag_window.py
+++ b/Tests/UI/test_search_rag_window.py
@@ -144,6 +144,26 @@ class TestSearchRAGWindow:
             assert window.query_one("#saved-searches-panel", SavedSearchesPanel)
 
     @pytest.mark.asyncio
+    async def test_initial_search_empty_state_explains_search_modes_collections_and_chat_handoff(
+        self,
+        mock_app_instance: MagicMock,
+        search_rag_test_env,
+        widget_pilot,
+    ) -> None:
+        """First-run Search should explain modes, collection scope, and Chat handoff."""
+        async with await widget_pilot(SearchRAGWindow, app_instance=mock_app_instance) as pilot:
+            window = pilot.app.test_widget
+
+            empty_state = window.query_one("#search-empty-state", Static)
+            empty_text = _text(empty_state)
+
+            assert "Plain Search" in empty_text
+            assert "RAG" in empty_text
+            assert "collections" in empty_text
+            assert "Use in Chat" in empty_text
+            assert "Chat context" in empty_text
+
+    @pytest.mark.asyncio
     async def test_primary_search_action_is_reachable_in_default_layout(
         self,
         mock_app_instance: MagicMock,
@@ -248,6 +268,33 @@ class TestSearchRAGWindow:
             assert "hidden" not in window.query_one("#pagination-enhanced").classes
             assert "Page 1 of 2" in _text(page_info)
             assert "12 results" in _text(page_info)
+
+    @pytest.mark.asyncio
+    async def test_display_results_shows_zero_result_recovery_empty_state(
+        self,
+        mock_app_instance: MagicMock,
+        search_rag_test_env,
+        widget_pilot,
+    ) -> None:
+        """Zero-result searches should leave a recovery path instead of a blank pane."""
+        async with await widget_pilot(SearchRAGWindow, app_instance=mock_app_instance) as pilot:
+            window = pilot.app.test_widget
+
+            window.search_results = []
+            window.total_results = 0
+            window.last_search_config = {"query": "missing topic", "mode": "hybrid", "collection": "all"}
+
+            await window._display_results()
+            await pilot.pause()
+
+            empty_state = window.query_one("#search-empty-state", Static)
+            empty_text = _text(empty_state)
+
+            assert "No results found" in empty_text
+            assert "Plain Search" in empty_text
+            assert "All Collections" in empty_text
+            assert "Ingest" in empty_text
+            assert "Use in Chat" in empty_text
 
     @pytest.mark.asyncio
     async def test_record_search_to_history_persists_entry(

--- a/Tests/UI/test_search_rag_window.py
+++ b/Tests/UI/test_search_rag_window.py
@@ -98,6 +98,20 @@ class TestSearchRAGWindow:
         ):
             assert window._load_available_collections() == ["default", "research"]
 
+    def test_handle_search_worker_runs_on_textual_thread(
+        self,
+        mock_app_instance: MagicMock,
+        search_rag_test_env,
+    ) -> None:
+        """Search orchestration should keep UI mutations on the Textual thread."""
+        window = SearchRAGWindow(mock_app_instance, id="test-search-window")
+        window.run_worker = MagicMock()
+
+        window.handle_search(MagicMock())
+
+        assert window.run_worker.call_args.kwargs["exclusive"] is True
+        assert window.run_worker.call_args.kwargs["thread"] is False
+
     @pytest.mark.asyncio
     async def test_apply_available_collections_updates_list_and_select(
         self,

--- a/tldw_chatbook/UI/Views/RAGSearch/search_event_handlers.py
+++ b/tldw_chatbook/UI/Views/RAGSearch/search_event_handlers.py
@@ -91,7 +91,7 @@ class SearchEventHandlersMixin:
             history_dropdown.hide()
             
             # Clear previous results
-            await self._clear_results()
+            await self._clear_results(show_empty_state=False)
             
             # Perform search based on mode
             search_mode = search_config['mode']
@@ -258,10 +258,12 @@ class SearchEventHandlersMixin:
         
         return config
     
-    async def _clear_results(self) -> None:
+    async def _clear_results(self, *, show_empty_state: bool = True) -> None:
         """Clear the results display"""
         results_list = self.query_one("#results-list-enhanced")
         await results_list.remove_children()
+        if show_empty_state:
+            await self._mount_search_empty_state()
     
     def _update_parent_inclusion_preview(self) -> None:
         """Update the parent inclusion preview text"""

--- a/tldw_chatbook/UI/Views/RAGSearch/search_event_handlers.py
+++ b/tldw_chatbook/UI/Views/RAGSearch/search_event_handlers.py
@@ -43,7 +43,7 @@ class SearchEventHandlersMixin:
     """Mixin class containing all event handlers for SearchRAGWindow"""
     
     @on(Button.Pressed, "#search-button")
-    @work(exclusive=True, thread=True)
+    @work(exclusive=True)
     async def handle_search(self, event: Button.Pressed) -> None:
         """Handle search button press with improved error handling and feedback"""
         if self.is_searching or self.active_searches >= MAX_CONCURRENT_SEARCHES:

--- a/tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py
+++ b/tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py
@@ -174,6 +174,30 @@ class SearchRAGWindow(SearchEventHandlersMixin, Container):
             "fastest_search": float('inf'),
             "slowest_search": 0.0
         }
+
+    def _search_empty_state_text(self, *, no_results: bool = False) -> str:
+        if no_results:
+            return (
+                "No results found.\n"
+                "Try Plain Search, switch Collection to All Collections, or use Ingest to add/index content.\n"
+                "When results appear, Use in Chat turns a selected result into Chat context."
+            )
+        return (
+            "Start with a query.\n"
+            "Plain Search scans indexed text quickly; contextual and hybrid RAG use collections for deeper retrieval.\n"
+            "Use All Collections to search broadly, or choose a collection to narrow scope.\n"
+            "Each result can be sent to Chat with Use in Chat, turning search evidence into Chat context."
+        )
+
+    async def _mount_search_empty_state(self, *, no_results: bool = False) -> None:
+        results_list = self.query_one("#results-list-enhanced")
+        await results_list.mount(
+            Static(
+                self._search_empty_state_text(no_results=no_results),
+                id="search-empty-state",
+                classes="search-empty-state",
+            )
+        )
         
     def compose(self) -> ComposeResult:
         """Create the UI layout"""
@@ -344,7 +368,12 @@ class SearchRAGWindow(SearchEventHandlersMixin, Container):
                                     yield Button("🔄 Refresh", id="refresh-results", classes="results-action-button")
                             
                             # Results list
-                            yield VerticalScroll(id="results-list-enhanced", classes="results-list-enhanced")
+                            with VerticalScroll(id="results-list-enhanced", classes="results-list-enhanced"):
+                                yield Static(
+                                    self._search_empty_state_text(),
+                                    id="search-empty-state",
+                                    classes="search-empty-state",
+                                )
                             
                             # Pagination
                             with Horizontal(id="pagination-enhanced", classes="pagination-enhanced hidden"):
@@ -696,6 +725,10 @@ class SearchRAGWindow(SearchEventHandlersMixin, Container):
         start_idx = (self.current_page - 1) * self.results_per_page
         end_idx = start_idx + self.results_per_page
         page_results = self.search_results[start_idx:end_idx]
+        if not page_results:
+            await self._mount_search_empty_state(no_results=True)
+            self._update_pagination()
+            return
         
         # Display results
         for idx, result in enumerate(page_results):


### PR DESCRIPTION
## Summary

- Adds an initial Search/RAG empty state that explains Plain Search, contextual/hybrid RAG, collection scope, and Use in Chat.
- Shows a zero-result recovery state instead of leaving the results pane blank.
- Updates the UX remediation plan to reflect PR #154 and the Search empty-state slice.

## Test Plan

- [x] `env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_search_rag_window.py --tb=short`
- [x] `git diff --check`
