### PR TITLE
Clarify Notes empty states

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -43,7 +43,7 @@ Still open by current source inspection:
 - Phase 5 Media empty-state copy is merged: Media now points users toward Ingest and selected-item requirements for analysis/save/export.
 - Phase 5 Study empty-state cleanup is merged: flashcards and quizzes now separate no-content guidance for global/local vs workspace scopes while preserving backend-unavailable states.
 - Phase 5 Search empty-state cleanup is merged: initial and zero-result panes now provide visible guidance for plain search, RAG collections, and Chat handoff flow.
-- Phase 5 Notes empty-state cleanup is in progress on `codex/ux-notes-empty-states`: local, server, and workspace scopes need visible creation/import routes.
+- Phase 5 Notes empty-state cleanup is merged: local, server, and workspace scopes now provide visible creation/import routes.
 - Phase 6 still needs optional dependency gaps represented as user-facing capability states where relevant.
 - Phase 7 still needs end-to-end audit replay on a clean home/config.
 
@@ -284,7 +284,7 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 
 Purpose: make the app understandable without reducing expert efficiency.
 
-Branch state: partially merged through PRs #152, #153, #154, and #155. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, and Search/RAG empty states explain search modes, collections, and Chat handoffs. Current slice `codex/ux-notes-empty-states` covers Notes scope empty states.
+Branch state: partially merged through PRs #152, #153, #154, and #155. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, and Notes empty states clarify local/server/workspace scope and creation/import routes.
 
 ### Files
 

--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -1,8 +1,8 @@
 # UX Audit Remediation Plan
 
 Date: 2026-05-01
-Status: Current-dev rebaseline after UX remediation PRs #146-#154
-Branch context: current `dev` / `origin/dev` at `860e2524`
+Status: Current-dev rebaseline after UX remediation PRs #146-#155
+Branch context: current `dev` / `origin/dev` at `ea3525ae`
 Previous audit baseline: `e2576cae`
 
 ## Goal
@@ -29,7 +29,7 @@ This is not a visual refresh. The work is ordered around workflow completion, re
 
 ## Current Dev Rebaseline
 
-Verified on current `dev` at `860e2524`:
+Verified on current `dev` at `ea3525ae`:
 
 - Phase 0 and Phase 1 are merged: the shared shell/Chatbooks trap, Ingest default source, quiz empty mapping response, Chat save-state, Search/RAG thread mutation, and Search primary-action reachability regressions are covered.
 - Phase 2 is merged: Chat has provider readiness and first-run orientation coverage.
@@ -42,7 +42,8 @@ Still open by current source inspection:
 - Phase 5 top-level IA labels are merged: visible navigation now uses `Library`, `Models`, and `Speech` while preserving route IDs.
 - Phase 5 Media empty-state copy is merged: Media now points users toward Ingest and selected-item requirements for analysis/save/export.
 - Phase 5 Study empty-state cleanup is merged: flashcards and quizzes now separate no-content guidance for global/local vs workspace scopes while preserving backend-unavailable states.
-- Phase 5 Search empty-state cleanup is in progress on `codex/ux-search-empty-states`: initial and zero-result panes need visible guidance for plain search, RAG collections, and Chat handoff flow.
+- Phase 5 Search empty-state cleanup is merged: initial and zero-result panes now provide visible guidance for plain search, RAG collections, and Chat handoff flow.
+- Phase 5 Notes empty-state cleanup is in progress on `codex/ux-notes-empty-states`: local, server, and workspace scopes need visible creation/import routes.
 - Phase 6 still needs optional dependency gaps represented as user-facing capability states where relevant.
 - Phase 7 still needs end-to-end audit replay on a clean home/config.
 
@@ -283,7 +284,7 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 
 Purpose: make the app understandable without reducing expert efficiency.
 
-Branch state: partially merged through PRs #152, #153, and #154. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, and Study flashcard/quiz empty states distinguish no-content from unavailable runtime. Current slice `codex/ux-search-empty-states` covers Search/RAG empty states.
+Branch state: partially merged through PRs #152, #153, #154, and #155. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, and Search/RAG empty states explain search modes, collections, and Chat handoffs. Current slice `codex/ux-notes-empty-states` covers Notes scope empty states.
 
 ### Files
 
@@ -303,7 +304,7 @@ Branch state: partially merged through PRs #152, #153, and #154. Top-level navig
 - [x] Study empty states distinguish no decks/quizzes from unavailable runtime.
 - [x] Media empty states point to Ingest and explain when analysis/save/export need a selected item.
 - [x] Search empty states explain plain search vs RAG, collections, and Chat handoff flow.
-- [ ] Notes empty states clarify local/server/workspace scope and creation/import routes.
+- [x] Notes empty states clarify local/server/workspace scope and creation/import routes.
 - [ ] CCP/Library empty states explain personas, characters, prompts, dictionaries, and how they relate to Chat.
 - [ ] Chatbooks empty state keeps portable knowledge-pack explanation and retains escape navigation.
 - [x] Rename top-level navigation jargon while preserving route IDs: `CCP` -> `Library`, `LLM` -> `Models`, and `S/TT/S` -> `Speech`.

--- a/Tests/UI/test_notes_screen.py
+++ b/Tests/UI/test_notes_screen.py
@@ -5,6 +5,7 @@ Focused tests for the scope-aware NotesScreen state and routing hooks.
 from __future__ import annotations
 
 from dataclasses import replace
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -1206,6 +1207,43 @@ class TestNotesScreenMethods:
         await screen.handle_server_list_selection(event)
 
         screen.post_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_handle_server_empty_state_selection_switches_scope_without_loading_note(self, mock_app_instance):
+        screen = NotesScreen(mock_app_instance)
+        screen._load_server_note = AsyncMock()  # type: ignore[attr-defined]
+        screen.post_message = Mock()
+        event = SimpleNamespace(item=SimpleNamespace(note_id=None))
+
+        await screen.handle_server_list_selection(event)
+
+        screen._load_server_note.assert_not_awaited()
+        screen.post_message.assert_not_called()
+        assert screen.state.scope_type == ScopeType.SERVER_NOTE
+        assert screen.state.selected_server_note_id is None
+
+    @pytest.mark.asyncio
+    async def test_handle_workspace_empty_note_selection_opens_notes_subview_without_resource(self, mock_app_instance):
+        screen = NotesScreen(mock_app_instance)
+        screen.state = NotesScreenState(
+            scope_type=ScopeType.WORKSPACE,
+            workspace_subview=WorkspaceSubview.DETAILS,
+            selected_workspace_id="ws-1",
+        )
+        screen._select_workspace = AsyncMock(  # type: ignore[attr-defined]
+            return_value=PendingNavigation(
+                target_scope=ScopeType.WORKSPACE,
+                target_workspace_id="ws-1",
+                target_workspace_subview=WorkspaceSubview.NOTES,
+            )
+        )
+        screen._select_workspace_subview_item = AsyncMock()  # type: ignore[attr-defined]
+        event = SimpleNamespace(item=SimpleNamespace(note_id=None))
+
+        await screen.handle_workspace_note_selection(event)
+
+        screen._select_workspace.assert_awaited_once_with("ws-1", subview=WorkspaceSubview.NOTES)
+        screen._select_workspace_subview_item.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_scope_context_updates_sync_and_editor_visibility(self, mock_app_instance):

--- a/Tests/Widgets/test_workspace_context_panel.py
+++ b/Tests/Widgets/test_workspace_context_panel.py
@@ -10,6 +10,10 @@ from tldw_chatbook.Widgets.Note_Widgets.notes_sidebar_right import NotesSidebarR
 from tldw_chatbook.Widgets.Note_Widgets.workspace_context_panel import WorkspaceContextPanel
 
 
+def _list_item_text(list_view: ListView) -> str:
+    return str(list_view.children[0].query_one(Label).renderable)
+
+
 class PanelTestApp(App[None]):
     def __init__(self, widget):
         super().__init__()
@@ -143,6 +147,55 @@ async def test_notes_sidebar_left_scope_population_keeps_lists_separate():
         assert getattr(local_item, "note_id") == 1
         assert getattr(server_item, "note_id") == "srv-1"
         assert getattr(workspace_item, "workspace_id") == "ws-1"
+
+
+@pytest.mark.asyncio
+async def test_notes_sidebar_left_empty_states_explain_scope_and_creation_routes():
+    sidebar = NotesSidebarLeft()
+    app = PanelTestApp(sidebar)
+
+    async with app.run_test() as pilot:
+        await sidebar.populate_local_notes_list([])
+        await sidebar.populate_server_notes_list([])
+        await sidebar.populate_workspaces_list([])
+
+        local_text = _list_item_text(sidebar.query_one("#notes-list-view", ListView))
+        server_text = _list_item_text(sidebar.query_one("#server-notes-list-view", ListView))
+        workspace_text = _list_item_text(sidebar.query_one("#workspaces-list-view", ListView))
+
+        assert "No local notes yet." in local_text
+        assert "Create Blank Note" in local_text
+        assert "Import Note" in local_text
+        assert "No server notes yet." in server_text
+        assert "Server Notes" in server_text
+        assert "Create Server Note" in server_text
+        assert "No workspaces yet." in workspace_text
+        assert "Create Workspace" in workspace_text
+        assert "notes, sources, artifacts" in workspace_text
+
+
+@pytest.mark.asyncio
+async def test_workspace_context_panel_empty_states_explain_workspace_resource_routes():
+    panel = WorkspaceContextPanel()
+    app = PanelTestApp(panel)
+
+    async with app.run_test() as pilot:
+        await panel.populate_workspace_notes([])
+        await panel.populate_workspace_sources([])
+        await panel.populate_workspace_artifacts([])
+
+        notes_text = _list_item_text(panel.query_one("#workspace-notes-list", ListView))
+        sources_text = _list_item_text(panel.query_one("#workspace-sources-list", ListView))
+        artifacts_text = _list_item_text(panel.query_one("#workspace-artifacts-list", ListView))
+
+        assert "No workspace notes yet." in notes_text
+        assert "Create Workspace Note" in notes_text
+        assert "No workspace sources yet." in sources_text
+        assert "Add Source" in sources_text
+        assert "Media" in sources_text
+        assert "No workspace artifacts yet." in artifacts_text
+        assert "Create Artifact" in artifacts_text
+        assert "outputs" in artifacts_text
 
 
 @pytest.mark.asyncio

--- a/Tests/Widgets/test_workspace_context_panel.py
+++ b/Tests/Widgets/test_workspace_context_panel.py
@@ -175,6 +175,21 @@ async def test_notes_sidebar_left_empty_states_explain_scope_and_creation_routes
 
 
 @pytest.mark.asyncio
+async def test_notes_sidebar_left_server_empty_state_exposes_scope_transition_marker():
+    sidebar = NotesSidebarLeft()
+    app = PanelTestApp(sidebar)
+
+    async with app.run_test() as pilot:
+        await sidebar.populate_server_notes_list([])
+
+        server_item = sidebar.query_one("#server-notes-list-view", ListView).children[0]
+
+        assert hasattr(server_item, "note_id")
+        assert server_item.note_id is None
+        assert server_item.note_scope == "server"
+
+
+@pytest.mark.asyncio
 async def test_workspace_context_panel_empty_states_explain_workspace_resource_routes():
     panel = WorkspaceContextPanel()
     app = PanelTestApp(panel)
@@ -196,6 +211,21 @@ async def test_workspace_context_panel_empty_states_explain_workspace_resource_r
         assert "No workspace artifacts yet." in artifacts_text
         assert "Create Artifact" in artifacts_text
         assert "outputs" in artifacts_text
+
+
+@pytest.mark.asyncio
+async def test_workspace_context_panel_empty_note_state_exposes_subview_transition_marker():
+    panel = WorkspaceContextPanel()
+    app = PanelTestApp(panel)
+
+    async with app.run_test() as pilot:
+        await panel.populate_workspace_notes([])
+
+        notes_item = panel.query_one("#workspace-notes-list", ListView).children[0]
+
+        assert hasattr(notes_item, "note_id")
+        assert notes_item.note_id is None
+        assert notes_item.item_version is None
 
 
 @pytest.mark.asyncio

--- a/tldw_chatbook/UI/Screens/notes_screen.py
+++ b/tldw_chatbook/UI/Screens/notes_screen.py
@@ -2407,11 +2407,17 @@ class NotesScreen(BaseAppScreen):
     @on(ListView.Selected, "#server-notes-list-view")
     async def handle_server_list_selection(self, event: ListView.Selected) -> None:
         if event.item and hasattr(event.item, "note_id"):
-            navigation = await self._load_server_note(event.item.note_id)
+            note_id = event.item.note_id
+            if note_id is None:
+                navigation = self.request_scope_transition(ScopeType.SERVER_NOTE)
+                if navigation.requires_confirmation:
+                    self._notify("Unsaved changes require confirmation before switching notes.", severity="warning")
+                return
+            navigation = await self._load_server_note(note_id)
             if navigation is not None and navigation.requires_confirmation:
                 return
             if navigation is not None:
-                self.post_message(NoteSelected(event.item.note_id, {"title": self.state.selected_note_title}))
+                self.post_message(NoteSelected(note_id, {"title": self.state.selected_note_title}))
 
     @on(ListView.Selected, "#workspaces-list-view")
     async def handle_workspace_list_selection(self, event: ListView.Selected) -> None:
@@ -2421,6 +2427,17 @@ class NotesScreen(BaseAppScreen):
     @on(ListView.Selected, "#workspace-notes-list")
     async def handle_workspace_note_selection(self, event: ListView.Selected) -> None:
         if event.item and hasattr(event.item, "note_id"):
+            if event.item.note_id is None:
+                if self.state.selected_workspace_id:
+                    await self._select_workspace(self.state.selected_workspace_id, subview=WorkspaceSubview.NOTES)
+                else:
+                    navigation = self.request_scope_transition(
+                        ScopeType.WORKSPACE,
+                        workspace_subview=WorkspaceSubview.NOTES,
+                    )
+                    if navigation.requires_confirmation:
+                        self._notify("Unsaved changes require confirmation before switching notes.", severity="warning")
+                return
             navigation = await self._select_workspace_subview_item(
                 subview=WorkspaceSubview.NOTES,
                 item_id=event.item.note_id,

--- a/tldw_chatbook/Widgets/Note_Widgets/notes_sidebar_left.py
+++ b/tldw_chatbook/Widgets/Note_Widgets/notes_sidebar_left.py
@@ -158,7 +158,10 @@ class NotesSidebarLeft(VerticalScroll):
             "notes-list-view",
             notes_data,
             title_id="local-notes-title",
-            empty_message="No local notes found.",
+            empty_message=(
+                "No local notes yet. Create Blank Note for a private draft, "
+                "or Import Note to bring in a file."
+            ),
             item_kind="local",
         )
 
@@ -167,7 +170,10 @@ class NotesSidebarLeft(VerticalScroll):
             "server-notes-list-view",
             notes_data,
             title_id="server-notes-title",
-            empty_message="No server notes found.",
+            empty_message=(
+                "No server notes yet. Open Server Notes and Create Server Note "
+                "when the server backend is available."
+            ),
             item_kind="server",
         )
 
@@ -176,7 +182,10 @@ class NotesSidebarLeft(VerticalScroll):
             "workspaces-list-view",
             workspaces_data,
             title_id="workspaces-title",
-            empty_message="No workspaces found.",
+            empty_message=(
+                "No workspaces yet. Create Workspace to organize notes, sources, artifacts, "
+                "and Study materials together."
+            ),
             item_kind="workspace",
         )
 

--- a/tldw_chatbook/Widgets/Note_Widgets/notes_sidebar_left.py
+++ b/tldw_chatbook/Widgets/Note_Widgets/notes_sidebar_left.py
@@ -130,7 +130,12 @@ class NotesSidebarLeft(VerticalScroll):
         title_label.update(f"{title_prefix} ({len(normalized_items)})")
 
         if not normalized_items:
-            await list_view.append(ListItem(Label(empty_message)))
+            list_item = ListItem(Label(empty_message))
+            if item_kind == "server":
+                setattr(list_item, "note_id", None)
+                setattr(list_item, "note_version", None)
+                setattr(list_item, "note_scope", item_kind)
+            await list_view.append(list_item)
             return
 
         for item in normalized_items:

--- a/tldw_chatbook/Widgets/Note_Widgets/workspace_context_panel.py
+++ b/tldw_chatbook/Widgets/Note_Widgets/workspace_context_panel.py
@@ -217,13 +217,28 @@ class WorkspaceContextPanel(VerticalScroll):
             await list_view.append(list_item)
 
     async def populate_workspace_notes(self, notes: list[dict[str, Any]]) -> None:
-        await self._populate_list("workspace-notes-list", notes, "No workspace notes.", "note_id")
+        await self._populate_list(
+            "workspace-notes-list",
+            notes,
+            "No workspace notes yet. Create Workspace Note from the Notes Navigator to start this workspace.",
+            "note_id",
+        )
 
     async def populate_workspace_sources(self, sources: list[dict[str, Any]]) -> None:
-        await self._populate_list("workspace-sources-list", sources, "No workspace sources.", "source_id")
+        await self._populate_list(
+            "workspace-sources-list",
+            sources,
+            "No workspace sources yet. Add Source from selected Media so Chat and Study can use it.",
+            "source_id",
+        )
 
     async def populate_workspace_artifacts(self, artifacts: list[dict[str, Any]]) -> None:
-        await self._populate_list("workspace-artifacts-list", artifacts, "No workspace artifacts.", "artifact_id")
+        await self._populate_list(
+            "workspace-artifacts-list",
+            artifacts,
+            "No workspace artifacts yet. Create Artifact to capture generated outputs for this workspace.",
+            "artifact_id",
+        )
 
     async def on_mount(self) -> None:
         self.set_workspace_details(self.workspace)

--- a/tldw_chatbook/Widgets/Note_Widgets/workspace_context_panel.py
+++ b/tldw_chatbook/Widgets/Note_Widgets/workspace_context_panel.py
@@ -201,7 +201,10 @@ class WorkspaceContextPanel(VerticalScroll):
         await list_view.clear()
         normalized = list(items)
         if not normalized:
-            await list_view.append(ListItem(Label(empty_message)))
+            list_item = ListItem(Label(empty_message))
+            setattr(list_item, item_attr, None)
+            setattr(list_item, "item_version", None)
+            await list_view.append(list_item)
             return
         for item in normalized:
             title = (


### PR DESCRIPTION
## Summary

- Clarifies Notes empty states for local notes, server notes, and workspaces.
- Adds workspace resource empty-state guidance for notes, sources, and artifacts.
- Updates the UX remediation plan to reflect merged PR #155 and the Notes empty-state slice.

## Test Plan

- [x] `env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_notes_screen.py Tests/Widgets/test_workspace_context_panel.py --tb=short`
- [x] `git diff --check`
