### PR TITLE
Clarify Library empty states

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -1,8 +1,8 @@
 # UX Audit Remediation Plan
 
 Date: 2026-05-01
-Status: Current-dev rebaseline after UX remediation PRs #146-#155
-Branch context: current `dev` / `origin/dev` at `ea3525ae`
+Status: Current-dev rebaseline after UX remediation PRs #146-#156, plus active Library empty-state slice
+Branch context: current `dev` / `origin/dev` at `0b068e6b`; active branch `codex/ux-library-empty-states`
 Previous audit baseline: `e2576cae`
 
 ## Goal
@@ -29,14 +29,14 @@ This is not a visual refresh. The work is ordered around workflow completion, re
 
 ## Current Dev Rebaseline
 
-Verified on current `dev` at `ea3525ae`:
+Verified on current `dev` at `0b068e6b`:
 
 - Phase 0 and Phase 1 are merged: the shared shell/Chatbooks trap, Ingest default source, quiz empty mapping response, Chat save-state, Search/RAG thread mutation, and Search primary-action reachability regressions are covered.
 - Phase 2 is merged: Chat has provider readiness and first-run orientation coverage.
 - Phase 3 clear/dismiss is merged: staged Chat context can be cleared before send, sent context cards are retained, and source handoff focused tests remain in place.
 - Phase 6 startup-log polish is partially merged: splash import, optional OpenAI TTS mapping fallback, and NLTK falsy-download logging regressions are covered.
 
-Still open by current source inspection:
+Current source state plus this branch:
 
 - Phase 4 still needs disabled-state/recovery consistency for blocked source handoffs and live smoke replay.
 - Phase 5 top-level IA labels are merged: visible navigation now uses `Library`, `Models`, and `Speech` while preserving route IDs.
@@ -44,10 +44,11 @@ Still open by current source inspection:
 - Phase 5 Study empty-state cleanup is merged: flashcards and quizzes now separate no-content guidance for global/local vs workspace scopes while preserving backend-unavailable states.
 - Phase 5 Search empty-state cleanup is merged: initial and zero-result panes now provide visible guidance for plain search, RAG collections, and Chat handoff flow.
 - Phase 5 Notes empty-state cleanup is merged: local, server, and workspace scopes now provide visible creation/import routes.
+- Phase 5 CCP/Library empty-state cleanup is implemented in `codex/ux-library-empty-states`: conversations, characters, personas, prompts, dictionaries, and world/lore books now explain creation/import routes and their relationship to Chat.
 - Phase 6 still needs optional dependency gaps represented as user-facing capability states where relevant.
 - Phase 7 still needs end-to-end audit replay on a clean home/config.
 
-Planning consequence: remaining implementation should target Phase 4 disabled/recovery states, the remaining Phase 5 empty-state surfaces, Phase 6 capability-state presentation, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
+Planning consequence: remaining implementation should target Phase 4 disabled/recovery states, the remaining Chatbooks/tooltips portion of Phase 5, Phase 6 capability-state presentation, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
 
 ## Issues Covered
 
@@ -284,7 +285,7 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 
 Purpose: make the app understandable without reducing expert efficiency.
 
-Branch state: partially merged through PRs #152, #153, #154, and #155. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, and Notes empty states clarify local/server/workspace scope and creation/import routes.
+Branch state: partially merged through PRs #152, #153, #154, #155, and #156. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, and the current `codex/ux-library-empty-states` slice clarifies Library assets and their Chat flow.
 
 ### Files
 
@@ -305,7 +306,7 @@ Branch state: partially merged through PRs #152, #153, #154, and #155. Top-level
 - [x] Media empty states point to Ingest and explain when analysis/save/export need a selected item.
 - [x] Search empty states explain plain search vs RAG, collections, and Chat handoff flow.
 - [x] Notes empty states clarify local/server/workspace scope and creation/import routes.
-- [ ] CCP/Library empty states explain personas, characters, prompts, dictionaries, and how they relate to Chat.
+- [x] CCP/Library empty states explain personas, characters, prompts, dictionaries, and how they relate to Chat.
 - [ ] Chatbooks empty state keeps portable knowledge-pack explanation and retains escape navigation.
 - [x] Rename top-level navigation jargon while preserving route IDs: `CCP` -> `Library`, `LLM` -> `Models`, and `S/TT/S` -> `Speech`.
 - [ ] Add tooltips or short descriptions where compact labels remain necessary.
@@ -387,6 +388,7 @@ Current-dev state: not started. The smoke/replay artifacts need to be regenerate
 | Search/RAG | `Tests/UI/test_search_rag_window.py`, `Tests/UI/test_search_handoffs.py` |
 | Notes | `Tests/UI/test_notes_screen.py`, notes handoff tests |
 | Media | Media window/viewer tests, media handoff tests |
+| Library | `Tests/Widgets/test_ccp_widgets.py`, `Tests/UI/test_ccp_handlers.py`, `Tests/UI/test_ccp_screen.py` |
 | Startup polish | `Tests/Utils/test_startup_polish_regressions.py` |
 | Final audit | Clean-home Textual probe with saved artifacts |
 
@@ -401,4 +403,4 @@ Current-dev state: not started. The smoke/replay artifacts need to be regenerate
 
 ## Next Step
 
-Start with Phase 0, then Phase 1. The intern work reduced the handoff backlog, but it did not remove the highest-impact blocker: losing global navigation after entering Chatbooks. After the shell and runtime fixes land, close out the already-merged handoff work with clear/dismiss behavior and live smoke replay instead of rebuilding the handoff architecture.
+After this Library empty-state slice, the next highest-leverage Phase 5 work is Chatbooks empty-state guidance and any compact-label descriptions that remain necessary. Phase 4 disabled/recovery state hardening and Phase 7 live replay remain the higher-risk workflow-completion follow-ups.

--- a/Tests/UI/test_ccp_handlers.py
+++ b/Tests/UI/test_ccp_handlers.py
@@ -3,6 +3,8 @@
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import ListView, Static
 
 from tldw_chatbook.Character_Chat.character_persona_scope_service import CharacterPersonaScopeService
 from tldw_chatbook.UI.CCP_Modules import (
@@ -10,6 +12,7 @@ from tldw_chatbook.UI.CCP_Modules import (
     CCPConversationHandler,
     CCPMessageManager,
     CCPPersonaHandler,
+    CCPPromptHandler,
     PersonaMessage,
     ViewChangeMessage,
 )
@@ -292,6 +295,32 @@ class TestCCPPersonaHandler:
             "Local chat greetings are not available yet.",
             severity="warning",
         )
+
+
+class TestCCPPromptHandler:
+    """Prompt handler Library empty-state coverage."""
+
+    @pytest.mark.asyncio
+    async def test_empty_prompt_search_results_keep_library_guidance(self, mock_window):
+        class TestApp(App):
+            def compose(self) -> ComposeResult:
+                yield ListView(id="ccp-prompts-listview")
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            list_view = pilot.app.query_one("#ccp-prompts-listview", ListView)
+            mock_window.query_one.return_value = list_view
+            handler = CCPPromptHandler(mock_window)
+            handler.search_results = []
+
+            await handler._update_search_results_ui()
+            await pilot.pause()
+
+            assert len(list_view.children) == 1
+            empty_text = str(list_view.children[0].query_one(Static).render())
+            assert "No prompts yet." in empty_text
+            assert "Create New Prompt" in empty_text
+            assert "Chat instructions" in empty_text
 
 
 class TestCCPMessageManager:

--- a/Tests/Widgets/test_ccp_widgets.py
+++ b/Tests/Widgets/test_ccp_widgets.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 from textual.app import App, ComposeResult
+from textual.widgets import Label, ListView, Select, Static
 
 from tldw_chatbook.UI.Screens.ccp_screen import CCPScreenState
 from tldw_chatbook.Widgets.CCP_Widgets import (
@@ -15,6 +16,26 @@ from tldw_chatbook.Widgets.CCP_Widgets import (
     PersonaSaveRequested,
     StartPersonaChatRequested,
 )
+
+
+def _list_text(list_view: ListView) -> str:
+    if not list_view.children:
+        return ""
+    list_item = list_view.children[0]
+    try:
+        return str(list_item.query_one(Static).render())
+    except Exception:
+        return str(list_item.query_one(Label).render())
+
+
+def _select_option_text(select: Select) -> str:
+    labels = []
+    for option in getattr(select, "_options", []):
+        if isinstance(option, tuple):
+            labels.append(str(option[0]))
+        else:
+            labels.append(str(getattr(option, "prompt", option)))
+    return "\n".join(labels)
 
 
 @pytest.fixture
@@ -53,6 +74,47 @@ class TestCCPSidebarWidget:
             assert sidebar.query_one("#ccp-persona-select")
             assert sidebar.query_one("#ccp-load-persona-button")
             assert sidebar.query_one("#ccp-refresh-persona-list-button")
+
+    @pytest.mark.asyncio
+    async def test_empty_library_states_explain_assets_and_chat_flow(self, mock_parent_screen):
+        class TestApp(App):
+            def compose(self) -> ComposeResult:
+                yield CCPSidebarWidget(parent_screen=mock_parent_screen)
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            sidebar = pilot.app.query_one(CCPSidebarWidget)
+
+            sidebar.update_conversation_results([])
+            sidebar.update_character_list([])
+            sidebar.update_persona_list([])
+            sidebar.update_dictionary_list([])
+
+            conversation_text = _list_text(sidebar.query_one("#conv-char-search-results-list", ListView))
+            prompt_text = _list_text(sidebar.query_one("#ccp-prompts-listview", ListView))
+            worldbook_text = _list_text(sidebar.query_one("#ccp-worldbooks-listview", ListView))
+            character_text = _select_option_text(sidebar.query_one("#conv-char-character-select", Select))
+            persona_text = _select_option_text(sidebar.query_one("#ccp-persona-select", Select))
+            dictionary_text = _select_option_text(sidebar.query_one("#ccp-dictionary-select", Select))
+
+            assert "No conversations yet." in conversation_text
+            assert "Chat" in conversation_text
+            assert "Import Conversation" in conversation_text
+            assert "No characters yet." in character_text
+            assert "Create Character" in character_text
+            assert "character-backed Chat" in character_text
+            assert "No personas yet." in persona_text
+            assert "Create Persona" in persona_text
+            assert "persona-backed Chat" in persona_text
+            assert "No prompts yet." in prompt_text
+            assert "Create New Prompt" in prompt_text
+            assert "Chat instructions" in prompt_text
+            assert "No chat dictionaries yet." in dictionary_text
+            assert "Create Dictionary" in dictionary_text
+            assert "Chat context" in dictionary_text
+            assert "No world books yet." in worldbook_text
+            assert "Create World Book" in worldbook_text
+            assert "Chat context" in worldbook_text
 
     @pytest.mark.asyncio
     async def test_load_persona_button_posts_message(self, mock_parent_screen):

--- a/tldw_chatbook/UI/CCP_Modules/ccp_prompt_handler.py
+++ b/tldw_chatbook/UI/CCP_Modules/ccp_prompt_handler.py
@@ -6,6 +6,7 @@ from textual import work
 from textual.widgets import ListView, ListItem, Input, TextArea, Button, Static
 
 from .ccp_messages import PromptMessage, ViewChangeMessage
+from ...Widgets.CCP_Widgets.ccp_sidebar_widget import CCPSidebarWidget
 
 if TYPE_CHECKING:
     from ..Conv_Char_Window import CCPWindow
@@ -169,6 +170,10 @@ class CCPPromptHandler:
             results_list = self.window.query_one("#ccp-prompts-listview", ListView)
             results_list.clear()
             self._prompt_result_ids = {}
+
+            if not self.search_results:
+                results_list.append(ListItem(Static(CCPSidebarWidget.empty_state_text("prompts"))))
+                return
             
             for index, prompt in enumerate(self.search_results):
                 name = prompt.get('name', 'Untitled')

--- a/tldw_chatbook/Widgets/CCP_Widgets/ccp_sidebar_widget.py
+++ b/tldw_chatbook/Widgets/CCP_Widgets/ccp_sidebar_widget.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Optional, List, Dict, Any, Union
 from loguru import logger
 from textual.app import ComposeResult
 from textual.containers import Container, VerticalScroll, Horizontal
-from textual.widgets import Static, Button, Input, ListView, Select, Collapsible, Label, TextArea, Checkbox
+from textual.widgets import Static, Button, Input, ListView, Select, Collapsible, Label, TextArea, Checkbox, ListItem
 from textual.reactive import reactive
 from textual import on
 from textual.message import Message
@@ -183,6 +183,30 @@ class CCPSidebarWidget(VerticalScroll):
     
     # Reactive state reference (will be linked to parent screen's state)
     state: reactive[Optional['CCPScreenState']] = reactive(None)
+    EMPTY_STATE_TEXT = {
+        "conversations": (
+            "No conversations yet. Start in Chat to create a conversation, "
+            "or Import Conversation to bring one into the Library."
+        ),
+        "characters": (
+            "No characters yet. Create Character or Import Character Card, "
+            "then launch character-backed Chat from here."
+        ),
+        "personas": (
+            "No personas yet. Create Persona to define reusable behavior, "
+            "then launch persona-backed Chat from here."
+        ),
+        "prompts": (
+            "No prompts yet. Create New Prompt to save reusable Chat instructions."
+        ),
+        "dictionaries": (
+            "No chat dictionaries yet. Create Dictionary to add terms, lore, or rules "
+            "that can enrich Chat context."
+        ),
+        "worldbooks": (
+            "No world books yet. Create World Book for setting and lore that can become Chat context."
+        ),
+    }
     
     def __init__(self, parent_screen: Optional['CCPScreen'] = None, **kwargs):
         """Initialize the sidebar widget.
@@ -205,7 +229,7 @@ class CCPSidebarWidget(VerticalScroll):
     
     def compose(self) -> ComposeResult:
         """Compose the sidebar UI."""
-        yield Static("CCP Navigation", classes="sidebar-title")
+        yield Static("Library Navigation", classes="sidebar-title")
         
         # ===== Conversations Section =====
         with Collapsible(title="Conversations", id="ccp-conversations-collapsible"):
@@ -232,7 +256,11 @@ class CCPSidebarWidget(VerticalScroll):
                          value=True)
             
             # Results list
-            yield ListView(id="conv-char-search-results-list", classes="sidebar-listview")
+            yield ListView(
+                self._empty_list_item("conversations"),
+                id="conv-char-search-results-list",
+                classes="sidebar-listview",
+            )
             yield Button("Load Selected", id="conv-char-load-button", classes="sidebar-button")
             
             # Conversation details (shown when a conversation is loaded)
@@ -259,8 +287,12 @@ class CCPSidebarWidget(VerticalScroll):
                        classes="sidebar-button")
             yield Button("Create Character", id="ccp-create-character-button", 
                        classes="sidebar-button")
-            yield Select([], prompt="Select Character...", allow_blank=True, 
-                       id="conv-char-character-select")
+            yield Select(
+                self._empty_select_options("characters"),
+                prompt="Select Character...",
+                allow_blank=True,
+                id="conv-char-character-select",
+            )
             yield Button("Load Character", id="ccp-right-pane-load-character-button", 
                        classes="sidebar-button")
             yield Button("Refresh List", id="ccp-refresh-character-list-button", 
@@ -280,7 +312,12 @@ class CCPSidebarWidget(VerticalScroll):
         # ===== Personas Section =====
         with Collapsible(title="Persona Profiles", id="ccp-personas-collapsible", collapsed=False):
             yield Button("Create Persona", id="ccp-create-persona-button", classes="sidebar-button")
-            yield Select([], prompt="Select Persona...", allow_blank=True, id="ccp-persona-select")
+            yield Select(
+                self._empty_select_options("personas"),
+                prompt="Select Persona...",
+                allow_blank=True,
+                id="ccp-persona-select",
+            )
             yield Button("Load Persona", id="ccp-load-persona-button", classes="sidebar-button")
             yield Button("Refresh Personas", id="ccp-refresh-persona-list-button", classes="sidebar-button")
         
@@ -291,7 +328,11 @@ class CCPSidebarWidget(VerticalScroll):
                        classes="sidebar-button")
             yield Input(id="ccp-prompt-search-input", placeholder="Search prompts...", 
                       classes="sidebar-input")
-            yield ListView(id="ccp-prompts-listview", classes="sidebar-listview")
+            yield ListView(
+                self._empty_list_item("prompts"),
+                id="ccp-prompts-listview",
+                classes="sidebar-listview",
+            )
             yield Button("Load Selected", id="ccp-prompt-load-selected-button", 
                        classes="sidebar-button")
             
@@ -308,8 +349,12 @@ class CCPSidebarWidget(VerticalScroll):
                        classes="sidebar-button")
             yield Button("Create Dictionary", id="ccp-create-dictionary-button", 
                        classes="sidebar-button")
-            yield Select([], prompt="Select Dictionary...", allow_blank=True, 
-                       id="ccp-dictionary-select")
+            yield Select(
+                self._empty_select_options("dictionaries"),
+                prompt="Select Dictionary...",
+                allow_blank=True,
+                id="ccp-dictionary-select",
+            )
             yield Button("Load Dictionary", id="ccp-load-dictionary-button", 
                        classes="sidebar-button")
             yield Button("Refresh List", id="ccp-refresh-dictionary-list-button", 
@@ -332,7 +377,11 @@ class CCPSidebarWidget(VerticalScroll):
                        classes="sidebar-button")
             yield Input(id="ccp-worldbook-search-input", placeholder="Search world books...", 
                       classes="sidebar-input")
-            yield ListView(id="ccp-worldbooks-listview", classes="sidebar-listview")
+            yield ListView(
+                self._empty_list_item("worldbooks"),
+                id="ccp-worldbooks-listview",
+                classes="sidebar-listview",
+            )
             yield Button("Load Selected", id="ccp-worldbook-load-button", 
                        classes="sidebar-button")
             yield Button("Edit Selected", id="ccp-worldbook-edit-button", 
@@ -361,6 +410,23 @@ class CCPSidebarWidget(VerticalScroll):
             self._dictionary_select = self.query_one("#ccp-dictionary-select", Select)
         except Exception as e:
             logger.warning(f"Could not cache all widget references: {e}")
+
+    @classmethod
+    def empty_state_text(cls, item_type: str) -> str:
+        return cls.EMPTY_STATE_TEXT.get(item_type, "No Library items yet.")
+
+    @classmethod
+    def _empty_list_item(cls, item_type: str) -> ListItem:
+        return ListItem(Static(cls.empty_state_text(item_type)))
+
+    @classmethod
+    def _empty_select_options(cls, item_type: str) -> list[tuple[str, Any]]:
+        return [(cls.empty_state_text(item_type), Select.BLANK)]
+
+    @staticmethod
+    def _has_selected_value(select: Select) -> bool:
+        value = select.value
+        return value not in {None, "", Select.BLANK, Select.NULL}
 
     async def _emit_message_to_app(self, message: Message, handler_name: str) -> None:
         """Post the message through Textual and mirror it to app-level test callbacks."""
@@ -425,7 +491,7 @@ class CCPSidebarWidget(VerticalScroll):
         """Handle load character button press."""
         event.stop()
         # Get selected character from select widget
-        if self._character_select and self._character_select.value:
+        if self._character_select and self._has_selected_value(self._character_select):
             self.post_message(CharacterLoadRequested(str(self._character_select.value)))
         else:
             self.post_message(CharacterLoadRequested())
@@ -434,7 +500,7 @@ class CCPSidebarWidget(VerticalScroll):
     async def handle_load_persona(self, event: Button.Pressed) -> None:
         """Handle load persona button press."""
         event.stop()
-        if self._persona_select and self._persona_select.value:
+        if self._persona_select and self._has_selected_value(self._persona_select):
             await self._emit_message_to_app(
                 PersonaLoadRequested(str(self._persona_select.value)),
                 "on_persona_load_requested",
@@ -487,7 +553,7 @@ class CCPSidebarWidget(VerticalScroll):
         """Handle load dictionary button press."""
         event.stop()
         # Get selected dictionary from select widget
-        if self._dictionary_select and self._dictionary_select.value:
+        if self._dictionary_select and self._has_selected_value(self._dictionary_select):
             try:
                 dict_id = int(self._dictionary_select.value)
                 self.post_message(DictionaryLoadRequested(dict_id))
@@ -512,8 +578,10 @@ class CCPSidebarWidget(VerticalScroll):
         """
         if self._conv_results_list:
             self._conv_results_list.clear()
+            if not results:
+                self._conv_results_list.append(self._empty_list_item("conversations"))
+                return
             for conv in results:
-                from textual.widgets import ListItem, Static
                 title = conv.get('name', 'Untitled')
                 conv_id = conv.get('conversation_id', conv.get('id'))
                 list_item = ListItem(Static(title), id=f"conv-result-{conv_id}")
@@ -526,8 +594,11 @@ class CCPSidebarWidget(VerticalScroll):
             characters: List of available characters
         """
         if self._character_select:
-            options = [(char.get('name', 'Unnamed'), str(char.get('id'))) 
-                      for char in characters]
+            options = (
+                [(char.get('name', 'Unnamed'), str(char.get('id'))) for char in characters]
+                if characters
+                else self._empty_select_options("characters")
+            )
             self._character_select.set_options(options)
     
     def update_dictionary_list(self, dictionaries: List[Dict[str, Any]]) -> None:
@@ -537,17 +608,21 @@ class CCPSidebarWidget(VerticalScroll):
             dictionaries: List of available dictionaries
         """
         if self._dictionary_select:
-            options = [(d.get('name', 'Unnamed'), str(d.get('id'))) 
-                      for d in dictionaries]
+            options = (
+                [(d.get('name', 'Unnamed'), str(d.get('id'))) for d in dictionaries]
+                if dictionaries
+                else self._empty_select_options("dictionaries")
+            )
             self._dictionary_select.set_options(options)
 
     def update_persona_list(self, personas: List[Dict[str, Any]]) -> None:
         """Update the persona select options."""
         if self._persona_select:
-            options = [
-                (persona.get("name", "Unnamed Persona"), str(persona.get("id")))
-                for persona in personas
-            ]
+            options = (
+                [(persona.get("name", "Unnamed Persona"), str(persona.get("id"))) for persona in personas]
+                if personas
+                else self._empty_select_options("personas")
+            )
             self._persona_select.set_options(options)
     
     def show_conversation_details(self, show: bool = True) -> None:


### PR DESCRIPTION
## Summary
- Adds Library empty-state guidance for conversations, characters, personas, prompts, chat dictionaries, and world/lore books.
- Keeps Library load actions from treating placeholder values as real selections.
- Rebaselines the UX remediation plan after PR #156 and marks the Library slice complete.

## Test Plan
- [x] env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_ccp_handlers.py::TestCCPPromptHandler::test_empty_prompt_search_results_keep_library_guidance Tests/Widgets/test_ccp_widgets.py::TestCCPSidebarWidget::test_empty_library_states_explain_assets_and_chat_flow --tb=short
- [x] env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Widgets/test_ccp_widgets.py Tests/UI/test_ccp_screen.py Tests/UI/test_ccp_handlers.py --tb=short
- [x] git diff --check