### PR TITLE
Clarify Chatbooks empty state

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -1,8 +1,8 @@
 # UX Audit Remediation Plan
 
 Date: 2026-05-01
-Status: Current-dev rebaseline after UX remediation PRs #146-#156, plus active Library empty-state slice
-Branch context: current `dev` / `origin/dev` at `0b068e6b`; active branch `codex/ux-library-empty-states`
+Status: Current-dev rebaseline after UX remediation PRs #146-#157, plus active Chatbooks empty-state slice
+Branch context: current `dev` / `origin/dev` at `3ed276eb`; active branch `codex/ux-chatbooks-empty-states`
 Previous audit baseline: `e2576cae`
 
 ## Goal
@@ -29,7 +29,7 @@ This is not a visual refresh. The work is ordered around workflow completion, re
 
 ## Current Dev Rebaseline
 
-Verified on current `dev` at `0b068e6b`:
+Verified on current `dev` at `3ed276eb`:
 
 - Phase 0 and Phase 1 are merged: the shared shell/Chatbooks trap, Ingest default source, quiz empty mapping response, Chat save-state, Search/RAG thread mutation, and Search primary-action reachability regressions are covered.
 - Phase 2 is merged: Chat has provider readiness and first-run orientation coverage.
@@ -44,11 +44,12 @@ Current source state plus this branch:
 - Phase 5 Study empty-state cleanup is merged: flashcards and quizzes now separate no-content guidance for global/local vs workspace scopes while preserving backend-unavailable states.
 - Phase 5 Search empty-state cleanup is merged: initial and zero-result panes now provide visible guidance for plain search, RAG collections, and Chat handoff flow.
 - Phase 5 Notes empty-state cleanup is merged: local, server, and workspace scopes now provide visible creation/import routes.
-- Phase 5 CCP/Library empty-state cleanup is implemented in `codex/ux-library-empty-states`: conversations, characters, personas, prompts, dictionaries, and world/lore books now explain creation/import routes and their relationship to Chat.
+- Phase 5 CCP/Library empty-state cleanup is merged: conversations, characters, personas, prompts, dictionaries, and world/lore books now explain creation/import routes and their relationship to Chat.
+- Phase 5 Chatbooks empty-state cleanup is implemented in `codex/ux-chatbooks-empty-states`: empty Chatbooks explains portable context packs, import/create recovery, Chat reuse, and shared-navigation escape.
 - Phase 6 still needs optional dependency gaps represented as user-facing capability states where relevant.
 - Phase 7 still needs end-to-end audit replay on a clean home/config.
 
-Planning consequence: remaining implementation should target Phase 4 disabled/recovery states, the remaining Chatbooks/tooltips portion of Phase 5, Phase 6 capability-state presentation, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
+Planning consequence: remaining implementation should target Phase 4 disabled/recovery states, remaining compact-label/tooltips work in Phase 5, Phase 6 capability-state presentation, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
 
 ## Issues Covered
 
@@ -285,7 +286,7 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 
 Purpose: make the app understandable without reducing expert efficiency.
 
-Branch state: partially merged through PRs #152, #153, #154, #155, and #156. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, and the current `codex/ux-library-empty-states` slice clarifies Library assets and their Chat flow.
+Branch state: partially merged through PRs #152, #153, #154, #155, #156, and #157. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, and the current `codex/ux-chatbooks-empty-states` slice clarifies Chatbooks as portable context packs.
 
 ### Files
 
@@ -307,7 +308,7 @@ Branch state: partially merged through PRs #152, #153, #154, #155, and #156. Top
 - [x] Search empty states explain plain search vs RAG, collections, and Chat handoff flow.
 - [x] Notes empty states clarify local/server/workspace scope and creation/import routes.
 - [x] CCP/Library empty states explain personas, characters, prompts, dictionaries, and how they relate to Chat.
-- [ ] Chatbooks empty state keeps portable knowledge-pack explanation and retains escape navigation.
+- [x] Chatbooks empty state keeps portable knowledge-pack explanation and retains escape navigation.
 - [x] Rename top-level navigation jargon while preserving route IDs: `CCP` -> `Library`, `LLM` -> `Models`, and `S/TT/S` -> `Speech`.
 - [ ] Add tooltips or short descriptions where compact labels remain necessary.
 
@@ -403,4 +404,4 @@ Current-dev state: not started. The smoke/replay artifacts need to be regenerate
 
 ## Next Step
 
-After this Library empty-state slice, the next highest-leverage Phase 5 work is Chatbooks empty-state guidance and any compact-label descriptions that remain necessary. Phase 4 disabled/recovery state hardening and Phase 7 live replay remain the higher-risk workflow-completion follow-ups.
+After this Chatbooks empty-state slice, the remaining Phase 5 work is compact-label descriptions and disabled primary-action consistency. Phase 4 disabled/recovery state hardening and Phase 7 live replay remain the higher-risk workflow-completion follow-ups.

--- a/Tests/UI/test_chatbooks_screen_server_actions.py
+++ b/Tests/UI/test_chatbooks_screen_server_actions.py
@@ -1,8 +1,9 @@
 import pytest
 
 from textual.app import App, ComposeResult
+from textual.widgets import Button, Static
 
-from tldw_chatbook.UI.Chatbooks_Window_Improved import ChatbooksWindowImproved
+from tldw_chatbook.UI.Chatbooks_Window_Improved import ChatbooksWindowImproved, EmptyStateWidget
 from tldw_chatbook.UI.Screens.chatbooks_screen import ChatbooksScreen
 
 
@@ -20,6 +21,43 @@ async def test_chatbooks_screen_uses_improved_window(monkeypatch):
     app = ChatbooksScreenApp()
     async with app.run_test() as pilot:
         assert app.screen.query_one(ChatbooksWindowImproved) is not None
+        assert app.screen.query_one("#nav-chat") is not None
+        assert app.screen.query_one("#nav-chatbooks") is not None
+
+
+@pytest.mark.asyncio
+async def test_chatbooks_empty_state_explains_portable_context_and_escape(monkeypatch):
+    async def no_refresh(self):
+        self.chatbooks = []
+
+    monkeypatch.setattr(ChatbooksWindowImproved, "_refresh_chatbooks", no_refresh)
+
+    class ChatbooksScreenApp(App):
+        def compose(self) -> ComposeResult:
+            yield ChatbooksScreen(self)
+
+    app = ChatbooksScreenApp()
+    async with app.run_test(size=(160, 40)) as pilot:
+        await pilot.pause()
+
+        empty_state = app.screen.query_one(EmptyStateWidget)
+        empty_text = "\n".join(str(widget.render()) for widget in empty_state.query(Static))
+        empty_buttons = [button.label.plain for button in empty_state.query(Button)]
+
+        assert "portable knowledge packs" in empty_text
+        assert "sessions" in empty_text
+        assert "machines" in empty_text
+        assert "teams" in empty_text
+        assert "conversations" in empty_text
+        assert "notes" in empty_text
+        assert "characters/personas" in empty_text
+        assert "prompts" in empty_text
+        assert "media" in empty_text
+        assert "seed Chat" in empty_text
+        assert "shared navigation" in empty_text
+        assert "return to Chat" in empty_text
+        assert any("Create Local Pack" in label for label in empty_buttons)
+        assert any("Import Local Pack" in label for label in empty_buttons)
         assert app.screen.query_one("#nav-chat") is not None
         assert app.screen.query_one("#nav-chatbooks") is not None
 

--- a/tldw_chatbook/UI/Chatbooks_Window_Improved.py
+++ b/tldw_chatbook/UI/Chatbooks_Window_Improved.py
@@ -160,14 +160,17 @@ class EmptyStateWidget(Container):
         yield Static(book_art, classes="empty-state-icon")
         yield Static("No Chatbooks Yet", classes="empty-state-title")
         yield Static(
-            "Chatbooks are portable knowledge packs containing conversations, notes, "
-            "characters, and media. Create your first one to get started!",
+            "Chatbooks are portable knowledge packs for moving reusable context "
+            "between sessions, machines, or teams. They can bundle conversations, "
+            "notes, characters/personas, prompts, and media so you can restore a "
+            "project or seed Chat later. Start with Create Local Pack, Import Local "
+            "Pack, or use the shared navigation to return to Chat.",
             classes="empty-state-description"
         )
         
         with Container(classes="empty-state-actions"):
-            yield Button("✨ Create New", id="empty-create-btn", variant="primary")
-            yield Button("📥 Import", id="empty-import-btn", variant="default")
+            yield Button("✨ Create Local Pack", id="empty-create-btn", variant="primary")
+            yield Button("📥 Import Local Pack", id="empty-import-btn", variant="default")
             yield Button("📋 Browse Templates", id="empty-templates-btn", variant="default")
 
 


### PR DESCRIPTION
## Summary
- Expands Chatbooks empty-state copy to explain portable context packs across sessions, machines, and teams.
- Names the content users can bundle, including conversations, notes, characters/personas, prompts, and media, with Chat reuse guidance.
- Updates the UX remediation plan after PR #157 and marks the Chatbooks empty-state slice complete.

## Test Plan
- [x] env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_chatbooks_screen_server_actions.py::test_chatbooks_empty_state_explains_portable_context_and_escape --tb=short
- [x] env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_ux_audit_smoke.py Tests/UI/test_chatbooks_screen_server_actions.py Tests/UI/test_chatbook_management_server_jobs.py --tb=short
- [x] git diff --check