### PR TITLE
Clarify Use in Chat recovery states

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -1,8 +1,8 @@
 # UX Audit Remediation Plan
 
 Date: 2026-05-01
-Status: Current-dev rebaseline after UX remediation PRs #146-#157, plus active Chatbooks empty-state slice
-Branch context: current `dev` / `origin/dev` at `3ed276eb`; active branch `codex/ux-chatbooks-empty-states`
+Status: Current-dev rebaseline after UX remediation PRs #146-#158, plus active handoff recovery slice
+Branch context: current `dev` / `origin/dev` at `67fe89e1`; active branch `codex/ux-handoff-recovery-copy`
 Previous audit baseline: `e2576cae`
 
 ## Goal
@@ -29,7 +29,7 @@ This is not a visual refresh. The work is ordered around workflow completion, re
 
 ## Current Dev Rebaseline
 
-Verified on current `dev` at `3ed276eb`:
+Verified on current `dev` at `67fe89e1`:
 
 - Phase 0 and Phase 1 are merged: the shared shell/Chatbooks trap, Ingest default source, quiz empty mapping response, Chat save-state, Search/RAG thread mutation, and Search primary-action reachability regressions are covered.
 - Phase 2 is merged: Chat has provider readiness and first-run orientation coverage.
@@ -45,11 +45,12 @@ Current source state plus this branch:
 - Phase 5 Search empty-state cleanup is merged: initial and zero-result panes now provide visible guidance for plain search, RAG collections, and Chat handoff flow.
 - Phase 5 Notes empty-state cleanup is merged: local, server, and workspace scopes now provide visible creation/import routes.
 - Phase 5 CCP/Library empty-state cleanup is merged: conversations, characters, personas, prompts, dictionaries, and world/lore books now explain creation/import routes and their relationship to Chat.
-- Phase 5 Chatbooks empty-state cleanup is implemented in `codex/ux-chatbooks-empty-states`: empty Chatbooks explains portable context packs, import/create recovery, Chat reuse, and shared-navigation escape.
+- Phase 5 Chatbooks empty-state cleanup is merged: empty Chatbooks explains portable context packs, import/create recovery, Chat reuse, and shared-navigation escape.
+- Phase 4 handoff recovery copy is implemented in `codex/ux-handoff-recovery-copy`: Notes, Media, RAG Search, and Web Search explain how to recover when the Chat handoff surface is unavailable.
 - Phase 6 still needs optional dependency gaps represented as user-facing capability states where relevant.
 - Phase 7 still needs end-to-end audit replay on a clean home/config.
 
-Planning consequence: remaining implementation should target Phase 4 disabled/recovery states, remaining compact-label/tooltips work in Phase 5, Phase 6 capability-state presentation, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
+Planning consequence: remaining implementation should target remaining Phase 4 invalid-selection/source-authority smoke cases, remaining compact-label/tooltips work in Phase 5, Phase 6 capability-state presentation, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
 
 ## Issues Covered
 
@@ -286,7 +287,7 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 
 Purpose: make the app understandable without reducing expert efficiency.
 
-Branch state: partially merged through PRs #152, #153, #154, #155, #156, and #157. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, and the current `codex/ux-chatbooks-empty-states` slice clarifies Chatbooks as portable context packs.
+Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, and #158. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, and the current `codex/ux-handoff-recovery-copy` slice clarifies blocked handoff recovery.
 
 ### Files
 
@@ -404,4 +405,4 @@ Current-dev state: not started. The smoke/replay artifacts need to be regenerate
 
 ## Next Step
 
-After this Chatbooks empty-state slice, the remaining Phase 5 work is compact-label descriptions and disabled primary-action consistency. Phase 4 disabled/recovery state hardening and Phase 7 live replay remain the higher-risk workflow-completion follow-ups.
+After this handoff recovery slice, the remaining Phase 4 work is invalid-selection/source-authority smoke coverage and the remaining Phase 5 work is compact-label descriptions plus broader disabled primary-action consistency. Phase 7 live replay remains the higher-risk workflow-completion follow-up.

--- a/Tests/UI/test_media_handoffs.py
+++ b/Tests/UI/test_media_handoffs.py
@@ -114,3 +114,23 @@ def test_media_window_use_in_chat_handler_routes_event_to_app():
     assert payload.source == "media"
     assert payload.source_id == "media-1"
     assert payload.body == "Transcript"
+
+
+def test_media_window_use_in_chat_unavailable_explains_recovery():
+    app = _media_app()
+    app.open_chat_with_handoff = None
+    window = MediaWindow(app)
+    window.runtime_state = app.media_runtime_state
+    window.viewer_panel = Mock()
+    window.viewer_panel.media_data = None
+    event = MediaViewerPanel.UseInChatRequested(
+        {"id": "media-1", "title": "Lecture", "content": "Transcript"}
+    )
+
+    window.handle_media_use_in_chat(event)
+
+    message = app.notify.call_args.args[0]
+    assert "Use in Chat is unavailable" in message
+    assert "Open Chat" in message
+    assert "try again" in message
+    assert app.notify.call_args.kwargs["severity"] == "warning"

--- a/Tests/UI/test_notes_screen.py
+++ b/Tests/UI/test_notes_screen.py
@@ -341,6 +341,21 @@ class TestNotesScreenMethods:
         event.stop.assert_called_once()
         mock_app_instance.open_chat_with_handoff.assert_called_once_with(payload)
 
+    def test_notes_use_in_chat_unavailable_explains_recovery(self, mock_app_instance):
+        screen = NotesScreen(mock_app_instance)
+        screen._build_current_chat_handoff_payload = Mock(return_value=Mock())
+        mock_app_instance.open_chat_with_handoff = None
+        event = Mock()
+
+        screen.handle_use_in_chat_button(event)
+
+        event.stop.assert_called_once()
+        message = mock_app_instance.notify.call_args.args[0]
+        assert "Use in Chat is unavailable" in message
+        assert "Open Chat" in message
+        assert "try again" in message
+        assert mock_app_instance.notify.call_args.kwargs["severity"] == "warning"
+
     def test_workspace_use_in_chat_button_uses_button_section_not_current_subview(self, mock_app_instance):
         screen = NotesScreen(mock_app_instance)
         screen.state = NotesScreenState(

--- a/Tests/UI/test_search_handoffs.py
+++ b/Tests/UI/test_search_handoffs.py
@@ -99,6 +99,28 @@ def test_search_rag_window_use_in_chat_handler_routes_to_app(tmp_path):
     assert payload.body == "Retrieved text"
 
 
+def test_search_rag_window_use_in_chat_unavailable_explains_recovery(tmp_path):
+    app = _search_app(runtime_backend="local")
+    app.open_chat_with_handoff = None
+    with patch(
+        "tldw_chatbook.UI.Views.RAGSearch.search_rag_window.get_user_data_dir",
+        return_value=tmp_path,
+    ):
+        window = SearchRAGWindow(app_instance=app)
+    event = SearchResult.UseInChatRequested(
+        0,
+        {"title": "Chunk", "content": "Retrieved text", "source": "notes"},
+    )
+
+    window.handle_search_result_use_in_chat(event)
+
+    message = app.notify.call_args.args[0]
+    assert "Use in Chat is unavailable" in message
+    assert "Open Chat" in message
+    assert "try again" in message
+    assert app.notify.call_args.kwargs["severity"] == "warning"
+
+
 @pytest.mark.asyncio
 async def test_search_rag_window_web_search_runs_bing_call_in_thread(tmp_path):
     app = _search_app(runtime_backend="local")
@@ -175,3 +197,26 @@ def test_search_window_dedicated_web_result_handoff_routes_to_app():
     payload = app.open_chat_with_handoff.call_args.args[0]
     assert payload.source == "search-web"
     assert payload.metadata["url"] == "https://example.com"
+
+
+def test_search_window_dedicated_web_result_unavailable_explains_recovery():
+    app = _search_app(runtime_backend="local")
+    app.open_chat_with_handoff = None
+    window = SearchWindow(app_instance=app)
+    event = SearchResult.UseInChatRequested(
+        0,
+        {
+            "title": "Article",
+            "content": "Snippet",
+            "source": "web",
+            "metadata": {"url": "https://example.com"},
+        },
+    )
+
+    window.handle_search_result_use_in_chat(event)
+
+    message = app.notify.call_args.args[0]
+    assert "Use in Chat is unavailable" in message
+    assert "Open Chat" in message
+    assert "try again" in message
+    assert app.notify.call_args.kwargs["severity"] == "warning"

--- a/tldw_chatbook/Chat/chat_handoff_messages.py
+++ b/tldw_chatbook/Chat/chat_handoff_messages.py
@@ -1,0 +1,6 @@
+"""Shared user-facing copy for Chat handoff recovery states."""
+
+USE_IN_CHAT_UNAVAILABLE_RECOVERY = (
+    "Use in Chat is unavailable because the Chat handoff surface is not mounted. "
+    "Open Chat from the navigation, then try again."
+)

--- a/tldw_chatbook/UI/MediaWindow_v2.py
+++ b/tldw_chatbook/UI/MediaWindow_v2.py
@@ -45,6 +45,7 @@ from ..Event_Handlers.media_events import (
     MediaReadingHighlightUpdateEvent,
     MediaReadingHighlightDeleteEvent,
 )
+from ..Chat.chat_handoff_messages import USE_IN_CHAT_UNAVAILABLE_RECOVERY
 from ..Chat.chat_handoff_models import ChatHandoffPayload
 
 if TYPE_CHECKING:
@@ -990,7 +991,7 @@ class MediaWindow(Container):
             return
         open_chat = getattr(self.app_instance, "open_chat_with_handoff", None)
         if not callable(open_chat):
-            self.app_instance.notify("Use in Chat is not available.", severity="warning")
+            self.app_instance.notify(USE_IN_CHAT_UNAVAILABLE_RECOVERY, severity="warning")
             return
         open_chat(payload)
     

--- a/tldw_chatbook/UI/Screens/notes_screen.py
+++ b/tldw_chatbook/UI/Screens/notes_screen.py
@@ -19,6 +19,7 @@ from textual.reactive import reactive
 from textual.timer import Timer
 from textual.widgets import Button, Input, Label, ListView, Select, Switch, TextArea
 
+from ...Chat.chat_handoff_messages import USE_IN_CHAT_UNAVAILABLE_RECOVERY
 from ...Chat.chat_handoff_models import ChatHandoffPayload
 from ...Event_Handlers.Audio_Events.dictation_integration_events import InsertDictationTextEvent
 from ...Third_Party.textual_fspicker import FileSave
@@ -2300,7 +2301,7 @@ class NotesScreen(BaseAppScreen):
             return
         open_chat = getattr(self.app_instance, "open_chat_with_handoff", None)
         if not callable(open_chat):
-            self._notify("Use in Chat is not available.", severity="warning")
+            self._notify(USE_IN_CHAT_UNAVAILABLE_RECOVERY, severity="warning")
             return
         open_chat(payload)
 

--- a/tldw_chatbook/UI/SearchWindow.py
+++ b/tldw_chatbook/UI/SearchWindow.py
@@ -17,6 +17,7 @@ import inspect
 from loguru import logger
 from pathlib import Path
 
+from ..Chat.chat_handoff_messages import USE_IN_CHAT_UNAVAILABLE_RECOVERY
 from ..Notes.Notes_Library import NotesInteropService
 from .Views.RAGSearch.search_handoff import build_search_chat_handoff_payload
 from .Views.RAGSearch.search_result import SearchResult
@@ -403,7 +404,7 @@ class SearchWindow(Container):
         payload = self._build_search_chat_handoff_payload(event.result)
         open_chat = getattr(self.app_instance, "open_chat_with_handoff", None)
         if not callable(open_chat):
-            self.app_instance.notify("Use in Chat is not available.", severity="warning")
+            self.app_instance.notify(USE_IN_CHAT_UNAVAILABLE_RECOVERY, severity="warning")
             return
         open_chat(payload)
 

--- a/tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py
+++ b/tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py
@@ -36,6 +36,7 @@ from .constants import (
     MAX_CONCURRENT_SEARCHES, SEARCH_MODES, PARENT_STRATEGIES
 )
 
+from ....Chat.chat_handoff_messages import USE_IN_CHAT_UNAVAILABLE_RECOVERY
 from ....Utils.optional_deps import DEPENDENCIES_AVAILABLE
 from ....DB.search_history_db import SearchHistoryDB
 from ....Utils.paths import get_user_data_dir
@@ -506,7 +507,7 @@ class SearchRAGWindow(SearchEventHandlersMixin, Container):
         payload = self._build_search_chat_handoff_payload(event.result)
         open_chat = getattr(self.app_instance, "open_chat_with_handoff", None)
         if not callable(open_chat):
-            self.app_instance.notify("Use in Chat is not available.", severity="warning")
+            self.app_instance.notify(USE_IN_CHAT_UNAVAILABLE_RECOVERY, severity="warning")
             return
         open_chat(payload)
     


### PR DESCRIPTION
## Summary
- Adds shared recovery copy for unavailable Use in Chat handoff paths.
- Applies the copy across Notes, Media, RAG Search, and dedicated Web Search so blocked source actions explain how to recover.
- Rebaselines the UX remediation plan after PR #158 and records this active Phase 4 recovery slice.

## Test Plan
- [x] env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_notes_screen.py::TestNotesScreenMethods::test_notes_use_in_chat_unavailable_explains_recovery Tests/UI/test_media_handoffs.py::test_media_window_use_in_chat_unavailable_explains_recovery Tests/UI/test_search_handoffs.py::test_search_rag_window_use_in_chat_unavailable_explains_recovery Tests/UI/test_search_handoffs.py::test_search_window_dedicated_web_result_unavailable_explains_recovery --tb=short
- [x] env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_notes_screen.py Tests/UI/test_media_handoffs.py Tests/UI/test_search_handoffs.py --tb=short
- [x] git diff --check