### PR TITLE
Disable invalid Notes handoff actions

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -1,8 +1,8 @@
 # UX Audit Remediation Plan
 
 Date: 2026-05-01
-Status: Current-dev rebaseline after UX remediation PRs #146-#158, plus active handoff recovery slice
-Branch context: current `dev` / `origin/dev` at `67fe89e1`; active branch `codex/ux-handoff-recovery-copy`
+Status: Current-dev rebaseline after UX remediation PRs #146-#159, plus active invalid-selection handoff slice
+Branch context: current `dev` / `origin/dev` at `abecc37b`; active branch `codex/ux-handoff-invalid-selection-smoke`
 Previous audit baseline: `e2576cae`
 
 ## Goal
@@ -46,11 +46,12 @@ Current source state plus this branch:
 - Phase 5 Notes empty-state cleanup is merged: local, server, and workspace scopes now provide visible creation/import routes.
 - Phase 5 CCP/Library empty-state cleanup is merged: conversations, characters, personas, prompts, dictionaries, and world/lore books now explain creation/import routes and their relationship to Chat.
 - Phase 5 Chatbooks empty-state cleanup is merged: empty Chatbooks explains portable context packs, import/create recovery, Chat reuse, and shared-navigation escape.
-- Phase 4 handoff recovery copy is implemented in `codex/ux-handoff-recovery-copy`: Notes, Media, RAG Search, and Web Search explain how to recover when the Chat handoff surface is unavailable.
+- Phase 4 handoff recovery copy is merged through PR #159: Notes, Media, RAG Search, and Web Search explain how to recover when the Chat handoff surface is unavailable.
+- Phase 4 invalid-selection hardening is active in `codex/ux-handoff-invalid-selection-smoke`: Notes and workspace source/artifact `Use in Chat` actions are disabled until a valid selection exists and expose tooltip recovery copy.
 - Phase 6 still needs optional dependency gaps represented as user-facing capability states where relevant.
 - Phase 7 still needs end-to-end audit replay on a clean home/config.
 
-Planning consequence: remaining implementation should target remaining Phase 4 invalid-selection/source-authority smoke cases, remaining compact-label/tooltips work in Phase 5, Phase 6 capability-state presentation, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
+Planning consequence: remaining implementation should target remaining Phase 4 source-authority and broader live smoke cases, remaining compact-label/tooltips work in Phase 5, Phase 6 capability-state presentation, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
 
 ## Issues Covered
 
@@ -247,7 +248,7 @@ Branch state: clear/dismiss behavior completed in `codex/ux-chat-handoff-clear-c
 
 Purpose: verify and harden the source-side handoff surfaces that have now landed in current `dev`.
 
-Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG Search, and dedicated Web Search handoffs are implemented and covered by focused tests. Remaining work is to close disabled-state, invalid-selection, and source-authority edge cases in the shared UX smoke pass.
+Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG Search, and dedicated Web Search handoffs are implemented and covered by focused tests. The active invalid-selection slice disables Notes and workspace source/artifact handoffs until a valid item is selected. Remaining work is to close source-authority edge cases in the shared UX smoke pass.
 
 ### Files
 
@@ -270,6 +271,7 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 - [x] Wire Media selected hydrated detail `Use in Chat`.
 - [x] Wire RAG result card `Use in Chat` through a Textual message.
 - [x] Cardify dedicated Web Search results enough to support `Use in Chat`.
+- [x] Disable Notes and workspace item `Use in Chat` actions until a valid selected item exists, with tooltip recovery copy.
 - [ ] Disable or explain source actions when server/auth/capability contracts block them.
 - [ ] Consume backend-owned `UX_Interop` and `runtime_policy` contracts consistently; do not rebuild source authority from raw config.
 - [ ] Keep dry-run sync reports diagnostic only; do not imply mirroring or write sync in source screens.
@@ -278,6 +280,7 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 ### Acceptance Criteria
 
 - [x] Notes, Workspaces, Media, RAG Search, and Web Search can each stage one selected item into Chat in focused tests.
+- [x] Notes and workspace item invalid-selection actions are disabled with recovery copy in mounted Textual tests.
 - [ ] No invalid selection navigates to Chat in live smoke coverage.
 - [ ] Disabled handoff actions have a reason and a recovery path.
 - [x] Workspace handoffs preserve `workspace_id` and isolation metadata in focused tests.

--- a/Tests/UI/test_notes_screen.py
+++ b/Tests/UI/test_notes_screen.py
@@ -378,6 +378,41 @@ class TestNotesScreenMethods:
 
             assert button.disabled is False
 
+    def test_notes_handoff_requires_note_editor_context(self, mock_app_instance):
+        screen = NotesScreen(mock_app_instance)
+
+        screen.state = NotesScreenState(
+            scope_type=ScopeType.WORKSPACE,
+            workspace_subview=WorkspaceSubview.SOURCES,
+            selected_workspace_id="workspace-1",
+            selected_note_id="source-1",
+            selected_workspace_source_id="source-1",
+        )
+
+        assert screen._has_selected_note_for_handoff() is False
+
+        screen.state = NotesScreenState(
+            scope_type=ScopeType.WORKSPACE,
+            workspace_subview=WorkspaceSubview.ARTIFACTS,
+            selected_workspace_id="workspace-1",
+            selected_note_id="artifact-1",
+            selected_workspace_artifact_id="artifact-1",
+        )
+
+        assert screen._has_selected_note_for_handoff() is False
+
+    def test_set_state_updates_handoff_actions_only_for_selection_changes(self, mock_app_instance):
+        screen = NotesScreen(mock_app_instance)
+        screen._update_use_in_chat_action_states = Mock()  # type: ignore[method-assign]
+
+        screen._set_state(word_count=12, has_unsaved_changes=True)
+
+        screen._update_use_in_chat_action_states.assert_not_called()
+
+        screen._set_state(selected_note_id=1)
+
+        screen._update_use_in_chat_action_states.assert_called_once_with()
+
     @pytest.mark.asyncio
     async def test_workspace_item_handoff_buttons_track_selected_items(self, mock_app_instance):
         screen = NotesScreen(mock_app_instance)

--- a/Tests/UI/test_notes_screen.py
+++ b/Tests/UI/test_notes_screen.py
@@ -356,6 +356,63 @@ class TestNotesScreenMethods:
         assert "try again" in message
         assert mock_app_instance.notify.call_args.kwargs["severity"] == "warning"
 
+    @pytest.mark.asyncio
+    async def test_notes_use_in_chat_button_is_disabled_until_note_selected(self, mock_app_instance):
+        screen = NotesScreen(mock_app_instance)
+        app = NotesScreenTestApp(screen, mock_app_instance.notes_service)
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            button = screen.query_one("#notes-use-in-chat-button", Button)
+            assert button.disabled is True
+            assert "Select a note" in str(button.tooltip)
+
+            screen._set_state(
+                scope_type=ScopeType.LOCAL_NOTE,
+                selected_note_id=1,
+                selected_note_title="Local Note 1",
+                selected_note_content="Content 1",
+            )
+            await pilot.pause()
+
+            assert button.disabled is False
+
+    @pytest.mark.asyncio
+    async def test_workspace_item_handoff_buttons_track_selected_items(self, mock_app_instance):
+        screen = NotesScreen(mock_app_instance)
+        app = NotesScreenTestApp(screen, mock_app_instance.notes_service)
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            screen._set_state(
+                scope_type=ScopeType.WORKSPACE,
+                workspace_subview=WorkspaceSubview.SOURCES,
+                selected_workspace_id="workspace-1",
+                selected_workspace_source_id=None,
+                selected_workspace_artifact_id=None,
+            )
+            await pilot.pause()
+
+            workspace_button = screen.query_one("#workspace-use-in-chat-button", Button)
+            source_button = screen.query_one("#workspace-source-use-in-chat-button", Button)
+            artifact_button = screen.query_one("#workspace-artifact-use-in-chat-button", Button)
+
+            assert workspace_button.disabled is False
+            assert source_button.disabled is True
+            assert "Select a workspace source" in str(source_button.tooltip)
+            assert artifact_button.disabled is True
+            assert "Select a workspace artifact" in str(artifact_button.tooltip)
+
+            screen._set_state(
+                selected_workspace_source_id="source-1",
+                selected_workspace_artifact_id="artifact-1",
+            )
+            await pilot.pause()
+
+            assert source_button.disabled is False
+            assert artifact_button.disabled is False
+
     def test_workspace_use_in_chat_button_uses_button_section_not_current_subview(self, mock_app_instance):
         screen = NotesScreen(mock_app_instance)
         screen.state = NotesScreenState(

--- a/tldw_chatbook/UI/Screens/notes_screen.py
+++ b/tldw_chatbook/UI/Screens/notes_screen.py
@@ -195,6 +195,7 @@ class NotesScreen(BaseAppScreen):
 
     def _set_state(self, **changes: Any) -> None:
         self.state = self.validate_state(replace(self.state, **changes))
+        self._update_use_in_chat_action_states()
 
     def _notify(self, message: str, *, severity: str = "information", timeout: Optional[float] = None) -> None:
         self.app_instance.notify(message, severity=severity, timeout=timeout)
@@ -229,6 +230,59 @@ class NotesScreen(BaseAppScreen):
                 "are also soft-deleted by the server."
             )
         return "This note will be moved to trash and can be recovered later."
+
+    def _has_selected_note_for_handoff(self) -> bool:
+        if self.state.scope_type == ScopeType.SERVER_NOTE:
+            return self.state.selected_server_note_id is not None or self.state.selected_note_id is not None
+        if self.state.scope_type == ScopeType.WORKSPACE:
+            return bool(self.state.selected_workspace_id) and (
+                self.state.selected_workspace_note_id is not None or self.state.selected_note_id is not None
+            )
+        return self.state.selected_note_id is not None or self.state.selected_local_note_id is not None
+
+    def _set_handoff_button_state(
+        self,
+        selector: str,
+        *,
+        disabled: bool,
+        disabled_tooltip: str,
+        enabled_tooltip: str,
+    ) -> None:
+        try:
+            button = self.query_one(selector, Button)
+        except QueryError:
+            return
+        button.disabled = disabled
+        button.tooltip = disabled_tooltip if disabled else enabled_tooltip
+
+    def _update_use_in_chat_action_states(self) -> None:
+        if not self.is_mounted:
+            return
+        self._set_handoff_button_state(
+            "#notes-use-in-chat-button",
+            disabled=not self._has_selected_note_for_handoff(),
+            disabled_tooltip="Select a note before using it in Chat.",
+            enabled_tooltip="Use the selected note in Chat.",
+        )
+        workspace_selected = bool(self.state.selected_workspace_id)
+        self._set_handoff_button_state(
+            "#workspace-use-in-chat-button",
+            disabled=not workspace_selected,
+            disabled_tooltip="Select a workspace before using it in Chat.",
+            enabled_tooltip="Use the selected workspace in Chat.",
+        )
+        self._set_handoff_button_state(
+            "#workspace-source-use-in-chat-button",
+            disabled=not (workspace_selected and self.state.selected_workspace_source_id is not None),
+            disabled_tooltip="Select a workspace source before using it in Chat.",
+            enabled_tooltip="Use the selected workspace source in Chat.",
+        )
+        self._set_handoff_button_state(
+            "#workspace-artifact-use-in-chat-button",
+            disabled=not (workspace_selected and self.state.selected_workspace_artifact_id is not None),
+            disabled_tooltip="Select a workspace artifact before using it in Chat.",
+            enabled_tooltip="Use the selected workspace artifact in Chat.",
+        )
 
     def _update_scope_context_ui(self) -> None:
         if not self.is_mounted:
@@ -295,6 +349,7 @@ class NotesScreen(BaseAppScreen):
                 save_button.label = "Save Note"
 
             sidebar_right.apply_scope_context(self.state.scope_type.value, resource_kind)
+            self._update_use_in_chat_action_states()
         except QueryError:
             return
 

--- a/tldw_chatbook/UI/Screens/notes_screen.py
+++ b/tldw_chatbook/UI/Screens/notes_screen.py
@@ -132,6 +132,19 @@ class NotesScreen(BaseAppScreen):
 
     _auto_save_timer: Optional[Timer] = None
     _search_timer: Optional[Timer] = None
+    _HANDOFF_ACTION_STATE_FIELDS = frozenset(
+        {
+            "scope_type",
+            "workspace_subview",
+            "selected_note_id",
+            "selected_local_note_id",
+            "selected_server_note_id",
+            "selected_workspace_id",
+            "selected_workspace_note_id",
+            "selected_workspace_source_id",
+            "selected_workspace_artifact_id",
+        }
+    )
 
     def __init__(self, app_instance: "TldwCli", **kwargs: Any):
         super().__init__(app_instance, "notes", **kwargs)
@@ -195,7 +208,8 @@ class NotesScreen(BaseAppScreen):
 
     def _set_state(self, **changes: Any) -> None:
         self.state = self.validate_state(replace(self.state, **changes))
-        self._update_use_in_chat_action_states()
+        if self._HANDOFF_ACTION_STATE_FIELDS.intersection(changes):
+            self._update_use_in_chat_action_states()
 
     def _notify(self, message: str, *, severity: str = "information", timeout: Optional[float] = None) -> None:
         self.app_instance.notify(message, severity=severity, timeout=timeout)
@@ -232,6 +246,8 @@ class NotesScreen(BaseAppScreen):
         return "This note will be moved to trash and can be recovered later."
 
     def _has_selected_note_for_handoff(self) -> bool:
+        if not self._is_note_editor_context():
+            return False
         if self.state.scope_type == ScopeType.SERVER_NOTE:
             return self.state.selected_server_note_id is not None or self.state.selected_note_id is not None
         if self.state.scope_type == ScopeType.WORKSPACE:


### PR DESCRIPTION
## Summary
- Disable Notes Use in Chat until a concrete note is selected.
- Disable workspace source/artifact handoff buttons until the corresponding item is selected, with tooltip recovery copy.
- Refresh the UX remediation plan to reflect PR #159 and this active invalid-selection slice.

## Test Plan
- [x] env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_notes_screen.py::TestNotesScreenMethods::test_notes_screen_returns_no_handoff_without_selected_note Tests/UI/test_notes_screen.py::TestNotesScreenMethods::test_notes_use_in_chat_button_calls_app_handoff Tests/UI/test_notes_screen.py::TestNotesScreenMethods::test_notes_use_in_chat_unavailable_explains_recovery Tests/UI/test_notes_screen.py::TestNotesScreenMethods::test_notes_use_in_chat_button_is_disabled_until_note_selected Tests/UI/test_notes_screen.py::TestNotesScreenMethods::test_workspace_item_handoff_buttons_track_selected_items Tests/UI/test_notes_screen.py::TestNotesScreenMethods::test_workspace_use_in_chat_button_uses_button_section_not_current_subview Tests/UI/test_media_handoffs.py Tests/UI/test_search_handoffs.py --tb=short
- [x] git diff --check