### PR TITLE
Align command palette navigation labels

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -1,8 +1,8 @@
 # UX Audit Remediation Plan
 
 Date: 2026-05-01
-Status: Current-dev rebaseline after UX remediation PRs #146-#159, plus active invalid-selection handoff slice
-Branch context: current `dev` / `origin/dev` at `abecc37b`; active branch `codex/ux-handoff-invalid-selection-smoke`
+Status: Current-dev rebaseline after UX remediation PRs #146-#160, plus active command-palette label consistency slice
+Branch context: current `dev` / `origin/dev` at `e2304777`; active branch `codex/ux-command-palette-labels`
 Previous audit baseline: `e2576cae`
 
 ## Goal
@@ -29,7 +29,7 @@ This is not a visual refresh. The work is ordered around workflow completion, re
 
 ## Current Dev Rebaseline
 
-Verified on current `dev` at `67fe89e1`:
+Verified on current `dev` at `e2304777`:
 
 - Phase 0 and Phase 1 are merged: the shared shell/Chatbooks trap, Ingest default source, quiz empty mapping response, Chat save-state, Search/RAG thread mutation, and Search primary-action reachability regressions are covered.
 - Phase 2 is merged: Chat has provider readiness and first-run orientation coverage.
@@ -47,11 +47,12 @@ Current source state plus this branch:
 - Phase 5 CCP/Library empty-state cleanup is merged: conversations, characters, personas, prompts, dictionaries, and world/lore books now explain creation/import routes and their relationship to Chat.
 - Phase 5 Chatbooks empty-state cleanup is merged: empty Chatbooks explains portable context packs, import/create recovery, Chat reuse, and shared-navigation escape.
 - Phase 4 handoff recovery copy is merged through PR #159: Notes, Media, RAG Search, and Web Search explain how to recover when the Chat handoff surface is unavailable.
-- Phase 4 invalid-selection hardening is active in `codex/ux-handoff-invalid-selection-smoke`: Notes and workspace source/artifact `Use in Chat` actions are disabled until a valid selection exists and expose tooltip recovery copy.
+- Phase 4 invalid-selection hardening is merged through PR #160: Notes and workspace source/artifact `Use in Chat` actions are disabled until a valid selection exists and expose tooltip recovery copy.
+- Phase 5 command-palette label consistency is active in `codex/ux-command-palette-labels`: command-palette tab navigation should use the same `Library`, `Models`, `Speech`, and `Settings` labels as top-level navigation while preserving route IDs.
 - Phase 6 still needs optional dependency gaps represented as user-facing capability states where relevant.
 - Phase 7 still needs end-to-end audit replay on a clean home/config.
 
-Planning consequence: remaining implementation should target remaining Phase 4 source-authority and broader live smoke cases, remaining compact-label/tooltips work in Phase 5, Phase 6 capability-state presentation, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
+Planning consequence: remaining implementation should target remaining Phase 4 source-authority and broader live smoke cases, remaining compact-label/tooltips work outside command-palette tab navigation, Phase 6 capability-state presentation, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
 
 ## Issues Covered
 
@@ -290,7 +291,7 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 
 Purpose: make the app understandable without reducing expert efficiency.
 
-Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, and #158. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, and the current `codex/ux-handoff-recovery-copy` slice clarifies blocked handoff recovery.
+Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, and #160. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, and invalid source-selection handoff controls are disabled with recovery copy. The active `codex/ux-command-palette-labels` slice aligns command-palette tab navigation labels with the same IA names.
 
 ### Files
 
@@ -314,14 +315,15 @@ Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, a
 - [x] CCP/Library empty states explain personas, characters, prompts, dictionaries, and how they relate to Chat.
 - [x] Chatbooks empty state keeps portable knowledge-pack explanation and retains escape navigation.
 - [x] Rename top-level navigation jargon while preserving route IDs: `CCP` -> `Library`, `LLM` -> `Models`, and `S/TT/S` -> `Speech`.
+- [x] Align command-palette tab navigation with current top-level labels while preserving route IDs.
 - [ ] Add tooltips or short descriptions where compact labels remain necessary.
 
 ### Acceptance Criteria
 
 - [ ] A first-time user can identify what Chat, Notes, Media, Search, Study, personas, and Chatbooks are for from visible text.
 - [ ] A power user still has direct access to dense controls and shortcuts.
-- [ ] Route IDs and saved navigation contracts remain stable.
-- [ ] Tests assert the key user-facing labels and core product surfaces remain visible.
+- [x] Route IDs and saved navigation contracts remain stable for command-palette tab navigation.
+- [x] Tests assert command-palette labels and core top-level product surfaces remain visible.
 
 ## Phase 6: Startup Capability And Log Polish
 

--- a/Tests/UI/test_command_palette_providers.py
+++ b/Tests/UI/test_command_palette_providers.py
@@ -37,9 +37,10 @@ try:
         DeveloperProvider
     )
     from tldw_chatbook.Constants import (
+        ALL_TABS,
         TAB_CHAT, TAB_CCP, TAB_NOTES, TAB_MEDIA, TAB_SEARCH, 
         TAB_INGEST, TAB_TOOLS_SETTINGS, TAB_LLM, TAB_LOGS, 
-        TAB_STATS, TAB_EVALS, TAB_CODING
+        TAB_STATS, TAB_EVALS, TAB_CODING, TAB_STTS, get_tab_display_label
     )
     IMPORTS_AVAILABLE = True
 except ImportError as e:
@@ -76,6 +77,15 @@ except ImportError as e:
     TAB_STATS = "stats"
     TAB_EVALS = "evals"
     TAB_CODING = "coding"
+    TAB_STTS = "stts"
+    ALL_TABS = [
+        TAB_CHAT, TAB_CCP, TAB_NOTES, TAB_MEDIA, TAB_SEARCH,
+        TAB_INGEST, TAB_EVALS, TAB_LLM, TAB_STTS,
+        TAB_TOOLS_SETTINGS, TAB_LOGS, TAB_CODING, TAB_STATS,
+    ]
+
+    def get_tab_display_label(tab_id):
+        return tab_id.replace("_", " ").title()
 
 #######################################################################################################################
 #
@@ -250,9 +260,11 @@ class TestTabNavigationProvider:
         assert len(hits) == 6  # Popular tabs defined in discover method
         tab_names = [hit.text for hit in hits]
         assert any("Chat" in name for name in tab_names)
-        assert any("Character Chat" in name for name in tab_names)
+        assert any("Chatbooks" in name for name in tab_names)
         assert any("Notes" in name for name in tab_names)
-        assert any("Customize" in name for name in tab_names)
+        assert any("Media" in name for name in tab_names)
+        assert any("Search" in name for name in tab_names)
+        assert any("Settings" in name for name in tab_names)
     
     @pytest.mark.asyncio
     async def test_search_shows_all_tabs(self, tab_provider):
@@ -261,16 +273,34 @@ class TestTabNavigationProvider:
         async for hit in tab_provider.search("tab"):
             hits.append(hit)
         
-        # Should show all 13 tabs
-        assert len(hits) == 13
+        assert len(hits) == len(ALL_TABS)
         
         # Check that all major tabs are present
         tab_texts = [hit.text for hit in hits]
         assert any("Chat" in text for text in tab_texts)
-        assert any("Character Chat" in text for text in tab_texts)
-        assert any("Tools & Settings" in text for text in tab_texts)
-        assert any("LLM Management" in text for text in tab_texts)
+        assert any("Library" in text for text in tab_texts)
+        assert any("Settings" in text for text in tab_texts)
+        assert any("Models" in text for text in tab_texts)
+        assert any("Speech" in text for text in tab_texts)
         assert any("Coding" in text for text in tab_texts)
+
+    @pytest.mark.asyncio
+    async def test_search_uses_current_display_labels_for_renamed_tabs(self, tab_provider):
+        """Command palette labels should match top-level navigation labels."""
+        hits = []
+        async for hit in tab_provider.search("tab"):
+            hits.append(hit)
+
+        by_text = {hit.text: hit for hit in hits}
+
+        for tab_id in (TAB_CCP, TAB_LLM, TAB_STTS, TAB_TOOLS_SETTINGS):
+            expected_text = f"Tab Navigation: Switch to {get_tab_display_label(tab_id)}"
+            assert expected_text in by_text
+
+        joined_text = "\n".join(by_text)
+        assert "Character Chat" not in joined_text
+        assert "LLM Management" not in joined_text
+        assert "Tools & Settings" not in joined_text
     
     def test_switch_tab_success(self, tab_provider):
         """Test successful tab switching."""

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -76,7 +76,8 @@ from .config import (
 from .Logging_Config import configure_application_logging
 from tldw_chatbook.Constants import ALL_TABS, TAB_CCP, TAB_CHAT, TAB_LOGS, TAB_NOTES, TAB_STATS, TAB_TOOLS_SETTINGS, TAB_CUSTOMIZE, \
     TAB_INGEST, TAB_LLM, TAB_MEDIA, TAB_SEARCH, TAB_EVALS, LLAMA_CPP_SERVER_ARGS_HELP_TEXT, \
-    LLAMAFILE_SERVER_ARGS_HELP_TEXT, TAB_CODING, TAB_STTS, TAB_STUDY, TAB_WRITING, TAB_RESEARCH, TAB_SUBSCRIPTIONS, TAB_CHATBOOKS
+    LLAMAFILE_SERVER_ARGS_HELP_TEXT, TAB_CODING, TAB_STTS, TAB_STUDY, TAB_WRITING, TAB_RESEARCH, TAB_SUBSCRIPTIONS, TAB_CHATBOOKS, \
+    get_tab_display_label
 from tldw_chatbook.Chat.chat_conversation_scope_service import ChatConversationScopeService
 from tldw_chatbook.Chat.chat_conversation_service import ChatConversationService
 from tldw_chatbook.Chat.chat_handoff_models import ChatHandoffPayload
@@ -468,29 +469,51 @@ class ThemeProvider(Provider):
 
 class TabNavigationProvider(Provider):
     """Provider for tab navigation commands."""
+
+    TAB_HELP_TEXT = {
+        TAB_CHAT: "Switch to the main chat interface",
+        TAB_CCP: "Switch to Library for conversations, characters, personas, prompts, dictionaries, and world books",
+        TAB_NOTES: "Switch to notes management",
+        TAB_MEDIA: "Switch to media library",
+        TAB_SEARCH: "Switch to search and RAG",
+        TAB_INGEST: "Switch to content ingestion",
+        TAB_EVALS: "Switch to evaluation tools",
+        TAB_LLM: "Switch to model and provider management",
+        TAB_STTS: "Switch to speech-to-text and text-to-speech tools",
+        TAB_STUDY: "Switch to flashcards and quizzes",
+        TAB_WRITING: "Switch to writing tools",
+        TAB_RESEARCH: "Switch to research workflows",
+        TAB_SUBSCRIPTIONS: "Switch to subscriptions and watchlists",
+        TAB_CHATBOOKS: "Switch to portable Chatbook context packs",
+        TAB_TOOLS_SETTINGS: "Switch to settings and configuration",
+        TAB_LOGS: "Switch to application logs",
+        TAB_CODING: "Switch to coding assistant",
+        TAB_STATS: "Switch to statistics view",
+        TAB_CUSTOMIZE: "Switch to appearance customization",
+    }
+
+    POPULAR_TABS = (
+        TAB_CHAT,
+        TAB_CHATBOOKS,
+        TAB_NOTES,
+        TAB_MEDIA,
+        TAB_SEARCH,
+        TAB_TOOLS_SETTINGS,
+    )
     
     def __init__(self, screen, *args, **kwargs):
         """Initialize the TabNavigationProvider with required screen parameter."""
         super().__init__(screen, *args, **kwargs)
+
+    def _tab_command(self, tab_id: str) -> tuple[str, str, str]:
+        label = get_tab_display_label(tab_id)
+        help_text = self.TAB_HELP_TEXT.get(tab_id, f"Switch to {label}")
+        return f"Tab Navigation: Switch to {label}", tab_id, help_text
     
     async def search(self, query: str) -> Hits:
         matcher = self.matcher(query)
         
-        tab_commands = [
-            ("Tab Navigation: Switch to Chat", TAB_CHAT, "Switch to the main chat interface"),
-            ("Tab Navigation: Switch to Character Chat", TAB_CCP, "Switch to character and conversation management"),
-            ("Tab Navigation: Switch to Notes", TAB_NOTES, "Switch to notes management"),
-            ("Tab Navigation: Switch to Media", TAB_MEDIA, "Switch to media library"),
-            ("Tab Navigation: Switch to Search", TAB_SEARCH, "Switch to search interface"),
-            ("Tab Navigation: Switch to Ingest", TAB_INGEST, "Switch to content ingestion"),
-            ("Tab Navigation: Switch to Tools & Settings", TAB_TOOLS_SETTINGS, "Switch to settings and configuration"),
-            ("Tab Navigation: Switch to Customize", TAB_CUSTOMIZE, "Switch to appearance customization"),
-            ("Tab Navigation: Switch to LLM Management", TAB_LLM, "Switch to LLM provider management"),
-            ("Tab Navigation: Switch to Logs", TAB_LOGS, "Switch to application logs"),
-            ("Tab Navigation: Switch to Stats", TAB_STATS, "Switch to statistics view"),
-            ("Tab Navigation: Switch to Evaluations", TAB_EVALS, "Switch to evaluation tools"),
-            ("Tab Navigation: Switch to Coding", TAB_CODING, "Switch to coding assistant"),
-        ]
+        tab_commands = [self._tab_command(tab_id) for tab_id in ALL_TABS]
         
         for command_text, tab_id, help_text in tab_commands:
             score = matcher.match(command_text)
@@ -503,14 +526,7 @@ class TabNavigationProvider(Provider):
                 )
     
     async def discover(self) -> Hits:
-        popular_tabs = [
-            ("Tab Navigation: Switch to Chat", TAB_CHAT, "Switch to the main chat interface"),
-            ("Tab Navigation: Switch to Character Chat", TAB_CCP, "Switch to character and conversation management"),
-            ("Tab Navigation: Switch to Notes", TAB_NOTES, "Switch to notes management"),
-            ("Tab Navigation: Switch to Search", TAB_SEARCH, "Switch to search interface"),
-            ("Tab Navigation: Switch to Tools & Settings", TAB_TOOLS_SETTINGS, "Switch to settings and configuration"),
-            ("Tab Navigation: Switch to Customize", TAB_CUSTOMIZE, "Switch to appearance customization"),
-        ]
+        popular_tabs = [self._tab_command(tab_id) for tab_id in self.POPULAR_TABS]
         
         for command_text, tab_id, help_text in popular_tabs:
             yield Hit(


### PR DESCRIPTION
## Summary
- Generate command-palette tab navigation from the canonical tab list and display labels.
- Replace stale palette labels like Character Chat, LLM Management, and Tools & Settings with Library, Models, and Settings while preserving route IDs.
- Refresh the UX remediation plan to reflect PR #160 and this active label-consistency slice.

## Test Plan
- [x] env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_command_palette_providers.py Tests/UI/test_navigation_label_language.py --tb=short
- [x] git diff --check