### PR TITLE
Show Speech dependency capability state

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -1,8 +1,8 @@
 # UX Audit Remediation Plan
 
 Date: 2026-05-01
-Status: Current-dev rebaseline after UX remediation PRs #146-#161, plus active main-navigation tooltip slice
-Branch context: current `dev` / `origin/dev` at `6e88af24`; active branch `codex/ux-main-nav-tooltips`
+Status: Current-dev rebaseline after UX remediation PRs #146-#162, plus active Speech capability-state slice
+Branch context: current `dev` / `origin/dev` at `b375d7fe`; active branch `codex/ux-speech-capability-state`
 Previous audit baseline: `e2576cae`
 
 ## Goal
@@ -29,7 +29,7 @@ This is not a visual refresh. The work is ordered around workflow completion, re
 
 ## Current Dev Rebaseline
 
-Verified on current `dev` at `6e88af24`:
+Verified on current `dev` at `b375d7fe`:
 
 - Phase 0 and Phase 1 are merged: the shared shell/Chatbooks trap, Ingest default source, quiz empty mapping response, Chat save-state, Search/RAG thread mutation, and Search primary-action reachability regressions are covered.
 - Phase 2 is merged: Chat has provider readiness and first-run orientation coverage.
@@ -49,11 +49,12 @@ Current source state plus this branch:
 - Phase 4 handoff recovery copy is merged through PR #159: Notes, Media, RAG Search, and Web Search explain how to recover when the Chat handoff surface is unavailable.
 - Phase 4 invalid-selection hardening is merged through PR #160: Notes and workspace source/artifact `Use in Chat` actions are disabled until a valid selection exists and expose tooltip recovery copy.
 - Phase 5 command-palette label consistency is merged through PR #161: command-palette tab navigation uses the same `Library`, `Models`, `Speech`, and `Settings` labels as top-level navigation while preserving route IDs.
-- Phase 5 main-navigation tooltip copy is active in `codex/ux-main-nav-tooltips`: compact top-level labels should expose concise descriptions of each destination without changing route IDs.
-- Phase 6 still needs optional dependency gaps represented as user-facing capability states where relevant.
+- Phase 5 main-navigation tooltip copy is merged through PR #162: compact top-level labels expose concise descriptions of each destination without changing route IDs.
+- Phase 6 Speech/STTS capability-state copy is active in `codex/ux-speech-capability-state`: local Text-to-Speech and Speech Recognition dependency gaps should be visible before failed actions.
+- Phase 6 still needs any remaining optional dependency gaps represented as user-facing capability states where relevant.
 - Phase 7 still needs end-to-end audit replay on a clean home/config.
 
-Planning consequence: remaining implementation should target remaining Phase 4 source-authority and broader live smoke cases, any remaining compact-label/tooltips work outside top navigation and command-palette tab navigation, Phase 6 capability-state presentation, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
+Planning consequence: remaining implementation should target remaining Phase 4 source-authority and broader live smoke cases, any remaining compact-label/descriptive copy outside top navigation and command-palette tab navigation, Phase 6 capability-state presentation beyond Speech/STTS where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
 
 ## Issues Covered
 
@@ -292,7 +293,7 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 
 Purpose: make the app understandable without reducing expert efficiency.
 
-Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, and #161. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, and command-palette tab navigation aligns with the same IA names. The active `codex/ux-main-nav-tooltips` slice adds explanatory descriptions to compact main-navigation labels.
+Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, and #162. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, and compact main-navigation labels expose explanatory tooltips.
 
 ### Files
 
@@ -318,7 +319,7 @@ Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #
 - [x] Rename top-level navigation jargon while preserving route IDs: `CCP` -> `Library`, `LLM` -> `Models`, and `S/TT/S` -> `Speech`.
 - [x] Align command-palette tab navigation with current top-level labels while preserving route IDs.
 - [x] Add main-navigation tooltips that explain compact destination labels without changing route IDs.
-- [ ] Add tooltips or short descriptions where compact labels remain necessary.
+- [ ] Add tooltips or short descriptions where compact labels remain necessary outside top navigation.
 
 ### Acceptance Criteria
 
@@ -332,7 +333,7 @@ Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #
 
 Purpose: make first-run diagnostics truthful and actionable without hiding real failures.
 
-Branch state: partially completed in `codex/ux-startup-log-polish`. Splash import regressions, optional OpenAI TTS mapping fallback logging, and NLTK download-result logging are covered by focused tests. Broader optional dependency capability-state presentation remains open.
+Branch state: partially completed in `codex/ux-startup-log-polish`, with the Speech/STTS capability-state slice active in `codex/ux-speech-capability-state`. Splash import regressions, optional OpenAI TTS mapping fallback logging, and NLTK download-result logging are covered by focused tests. Broader optional dependency capability-state presentation remains open.
 
 ### Files
 
@@ -349,6 +350,7 @@ Branch state: partially completed in `codex/ux-startup-log-polish`. Splash impor
 - [x] Fix missing typing imports.
 - [x] Add tests that missing optional OpenAI TTS mapping uses defaults without error-level startup noise.
 - [x] Make NLTK download logging truthful: no success message when download fails.
+- [x] Expose local Speech/STTS TTS and STT dependency gaps as an inline capability state before failed actions.
 - [ ] Present optional dependency gaps as capability states when user-relevant, not stack traces.
 - [ ] Keep real crashes/error states visible.
 
@@ -357,6 +359,7 @@ Branch state: partially completed in `codex/ux-startup-log-polish`. Splash impor
 - [x] Splash effects import without missing typing-name errors.
 - [x] Missing optional TTS mapping falls back quietly.
 - [x] Failed NLTK download is not logged as success.
+- [x] Speech/STTS tells users when local Text-to-Speech or Speech Recognition dependencies are unavailable and how to recover.
 - [ ] Optional dependency gaps tell users what capability is unavailable and how to recover.
 
 ## Phase 7: End-To-End Audit Replay And Closeout
@@ -413,4 +416,4 @@ Current-dev state: not started. The smoke/replay artifacts need to be regenerate
 
 ## Next Step
 
-After this handoff recovery slice, the remaining Phase 4 work is invalid-selection/source-authority smoke coverage and the remaining Phase 5 work is compact-label descriptions plus broader disabled primary-action consistency. Phase 7 live replay remains the higher-risk workflow-completion follow-up.
+After this Speech capability-state slice, the remaining Phase 4 work is invalid-selection/source-authority smoke coverage and the remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.

--- a/Tests/UI/test_stts_capability_state.py
+++ b/Tests/UI/test_stts_capability_state.py
@@ -8,11 +8,11 @@ from tldw_chatbook.Utils.optional_deps import DEPENDENCIES_AVAILABLE
 
 
 @pytest.mark.asyncio
-async def test_stts_window_explains_missing_local_speech_dependencies():
-    original_tts = DEPENDENCIES_AVAILABLE.get("tts_processing")
-    original_stt = DEPENDENCIES_AVAILABLE.get("stt_processing")
-    DEPENDENCIES_AVAILABLE["tts_processing"] = False
-    DEPENDENCIES_AVAILABLE["stt_processing"] = False
+async def test_stts_window_explains_missing_local_speech_dependencies(monkeypatch):
+    monkeypatch.setitem(DEPENDENCIES_AVAILABLE, "tts_processing", False)
+    monkeypatch.setitem(DEPENDENCIES_AVAILABLE, "stt_processing", False)
+    monkeypatch.setattr("tldw_chatbook.UI.STTS_Window.check_tts_deps", lambda: False)
+    monkeypatch.setattr("tldw_chatbook.UI.STTS_Window.check_stt_deps", lambda: False)
 
     class STTSCapabilityApp(App):
         def compose(self) -> ComposeResult:
@@ -20,27 +20,44 @@ async def test_stts_window_explains_missing_local_speech_dependencies():
 
     app = STTSCapabilityApp()
 
-    try:
-        async with app.run_test(size=(120, 40)) as pilot:
-            await pilot.pause()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
 
-            status = app.query_one("#speech-capability-status", Static)
-            rendered_status = str(status.render())
+        status = app.query_one("#speech-capability-status", Static)
+        rendered_status = str(status.render())
 
-            assert "Local speech capabilities need optional dependencies" in rendered_status
-            assert "Text-to-Speech unavailable" in rendered_status
-            assert "Speech Recognition unavailable" in rendered_status
-            recovery_command = (
-                'pip install -e ".[local_tts,transcription_faster_whisper,speech_recording]"'
-            )
-            assert recovery_command in rendered_status
-    finally:
-        if original_tts is None:
-            DEPENDENCIES_AVAILABLE.pop("tts_processing", None)
-        else:
-            DEPENDENCIES_AVAILABLE["tts_processing"] = original_tts
+        assert rendered_status == "Local speech missing: TTS, STT"
+        assert (
+            'pip install "tldw_chatbook[local_tts,transcription_faster_whisper,speech_recording]"'
+            in status.tooltip
+        )
 
-        if original_stt is None:
-            DEPENDENCIES_AVAILABLE.pop("stt_processing", None)
-        else:
-            DEPENDENCIES_AVAILABLE["stt_processing"] = original_stt
+
+@pytest.mark.asyncio
+async def test_stts_window_refreshes_local_speech_dependency_flags(monkeypatch):
+    monkeypatch.setitem(DEPENDENCIES_AVAILABLE, "tts_processing", False)
+    monkeypatch.setitem(DEPENDENCIES_AVAILABLE, "stt_processing", False)
+
+    def mark_tts_available() -> bool:
+        DEPENDENCIES_AVAILABLE["tts_processing"] = True
+        return True
+
+    def mark_stt_available() -> bool:
+        DEPENDENCIES_AVAILABLE["stt_processing"] = True
+        return True
+
+    monkeypatch.setattr("tldw_chatbook.UI.STTS_Window.check_tts_deps", mark_tts_available)
+    monkeypatch.setattr("tldw_chatbook.UI.STTS_Window.check_stt_deps", mark_stt_available)
+
+    class STTSCapabilityApp(App):
+        def compose(self) -> ComposeResult:
+            yield STTSWindow(self)
+
+    app = STTSCapabilityApp()
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+
+        status = app.query_one("#speech-capability-status", Static)
+
+        assert str(status.render()) == "Local speech: ready"

--- a/Tests/UI/test_stts_capability_state.py
+++ b/Tests/UI/test_stts_capability_state.py
@@ -1,0 +1,46 @@
+import pytest
+
+from textual.app import App, ComposeResult
+from textual.widgets import Static
+
+from tldw_chatbook.UI.STTS_Window import STTSWindow
+from tldw_chatbook.Utils.optional_deps import DEPENDENCIES_AVAILABLE
+
+
+@pytest.mark.asyncio
+async def test_stts_window_explains_missing_local_speech_dependencies():
+    original_tts = DEPENDENCIES_AVAILABLE.get("tts_processing")
+    original_stt = DEPENDENCIES_AVAILABLE.get("stt_processing")
+    DEPENDENCIES_AVAILABLE["tts_processing"] = False
+    DEPENDENCIES_AVAILABLE["stt_processing"] = False
+
+    class STTSCapabilityApp(App):
+        def compose(self) -> ComposeResult:
+            yield STTSWindow(self)
+
+    app = STTSCapabilityApp()
+
+    try:
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+
+            status = app.query_one("#speech-capability-status", Static)
+            rendered_status = str(status.render())
+
+            assert "Local speech capabilities need optional dependencies" in rendered_status
+            assert "Text-to-Speech unavailable" in rendered_status
+            assert "Speech Recognition unavailable" in rendered_status
+            recovery_command = (
+                'pip install -e ".[local_tts,transcription_faster_whisper,speech_recording]"'
+            )
+            assert recovery_command in rendered_status
+    finally:
+        if original_tts is None:
+            DEPENDENCIES_AVAILABLE.pop("tts_processing", None)
+        else:
+            DEPENDENCIES_AVAILABLE["tts_processing"] = original_tts
+
+        if original_stt is None:
+            DEPENDENCIES_AVAILABLE.pop("stt_processing", None)
+        else:
+            DEPENDENCIES_AVAILABLE["stt_processing"] = original_stt

--- a/tldw_chatbook/UI/STTS_Window.py
+++ b/tldw_chatbook/UI/STTS_Window.py
@@ -21,7 +21,7 @@ from tldw_chatbook.Widgets.voice_blend_dialog import VoiceBlendDialog
 from tldw_chatbook.Widgets.enhanced_file_picker import EnhancedFileOpen as FileOpen, EnhancedFileSave as FileSave
 from tldw_chatbook.Third_Party.textual_fspicker import Filters
 from tldw_chatbook.UI.Dictation_Window_Improved import ImprovedDictationWindow as DictationWindow
-from tldw_chatbook.Utils.optional_deps import DEPENDENCIES_AVAILABLE
+from tldw_chatbook.Utils.optional_deps import DEPENDENCIES_AVAILABLE, check_stt_deps, check_tts_deps
 # Note: Not using form_components due to generator/widget incompatibility
 
 import json
@@ -4135,11 +4135,13 @@ class STTSWindow(Container):
             yield Button("🎙️ Voice Cloning", id="view-voice-cloning-btn", classes="sidebar-button")
             yield Button("🔤 Speech Recognition", id="view-stt-btn", classes="sidebar-button")
             yield Button("🎵 Audio Effects", id="view-effects-btn", classes="sidebar-button", disabled=True)
-            yield Static(
+            capability_status = Static(
                 self._speech_capability_status_text(),
                 id="speech-capability-status",
                 classes="speech-capability-status",
             )
+            capability_status.tooltip = self._speech_capability_status_tooltip()
+            yield capability_status
         
         # Content area
         with Container(classes="stts-content"):
@@ -4148,25 +4150,29 @@ class STTSWindow(Container):
 
     def _speech_capability_status_text(self) -> str:
         """Return a concise local speech dependency status for the sidebar."""
+        check_tts_deps()
+        check_stt_deps()
+
         tts_available = DEPENDENCIES_AVAILABLE.get("tts_processing", False)
         stt_available = DEPENDENCIES_AVAILABLE.get("stt_processing", False)
 
         if tts_available and stt_available:
-            return "Local speech capabilities ready: Text-to-Speech and Speech Recognition dependencies detected."
+            return "Local speech: ready"
 
         unavailable = []
         if not tts_available:
-            unavailable.append("Text-to-Speech unavailable")
+            unavailable.append("TTS")
         if not stt_available:
-            unavailable.append("Speech Recognition unavailable")
+            unavailable.append("STT")
 
+        return "Local speech missing: " + ", ".join(unavailable)
+
+    def _speech_capability_status_tooltip(self) -> str:
+        """Return install guidance for local speech dependencies."""
         return (
-            "Local speech capabilities need optional dependencies: "
-            + "; ".join(unavailable)
-            + (
-                '. Install local providers with pip install -e '
-                '".[local_tts,transcription_faster_whisper,speech_recording]" and restart.'
-            )
+            "Install local providers with pip install "
+            '"tldw_chatbook[local_tts,transcription_faster_whisper,speech_recording]" '
+            "and restart."
         )
     
     def watch_current_view(self, old_view: str, new_view: str) -> None:

--- a/tldw_chatbook/UI/STTS_Window.py
+++ b/tldw_chatbook/UI/STTS_Window.py
@@ -21,6 +21,7 @@ from tldw_chatbook.Widgets.voice_blend_dialog import VoiceBlendDialog
 from tldw_chatbook.Widgets.enhanced_file_picker import EnhancedFileOpen as FileOpen, EnhancedFileSave as FileSave
 from tldw_chatbook.Third_Party.textual_fspicker import Filters
 from tldw_chatbook.UI.Dictation_Window_Improved import ImprovedDictationWindow as DictationWindow
+from tldw_chatbook.Utils.optional_deps import DEPENDENCIES_AVAILABLE
 # Note: Not using form_components due to generator/widget incompatibility
 
 import json
@@ -4103,6 +4104,13 @@ class STTSWindow(Container):
         width: 100%;
         margin-bottom: 1;
     }
+
+    .speech-capability-status {
+        margin-top: 1;
+        padding: 1;
+        border: round $surface;
+        color: $text-muted;
+    }
     """
     
     current_view = reactive("playground")
@@ -4127,11 +4135,39 @@ class STTSWindow(Container):
             yield Button("🎙️ Voice Cloning", id="view-voice-cloning-btn", classes="sidebar-button")
             yield Button("🔤 Speech Recognition", id="view-stt-btn", classes="sidebar-button")
             yield Button("🎵 Audio Effects", id="view-effects-btn", classes="sidebar-button", disabled=True)
+            yield Static(
+                self._speech_capability_status_text(),
+                id="speech-capability-status",
+                classes="speech-capability-status",
+            )
         
         # Content area
         with Container(classes="stts-content"):
             # Show playground by default
             yield TTSPlaygroundWidget()
+
+    def _speech_capability_status_text(self) -> str:
+        """Return a concise local speech dependency status for the sidebar."""
+        tts_available = DEPENDENCIES_AVAILABLE.get("tts_processing", False)
+        stt_available = DEPENDENCIES_AVAILABLE.get("stt_processing", False)
+
+        if tts_available and stt_available:
+            return "Local speech capabilities ready: Text-to-Speech and Speech Recognition dependencies detected."
+
+        unavailable = []
+        if not tts_available:
+            unavailable.append("Text-to-Speech unavailable")
+        if not stt_available:
+            unavailable.append("Speech Recognition unavailable")
+
+        return (
+            "Local speech capabilities need optional dependencies: "
+            + "; ".join(unavailable)
+            + (
+                '. Install local providers with pip install -e '
+                '".[local_tts,transcription_faster_whisper,speech_recording]" and restart.'
+            )
+        )
     
     def watch_current_view(self, old_view: str, new_view: str) -> None:
         """Handle view changes"""


### PR DESCRIPTION
Summary: Adds an inline Speech/STTS capability status for local Text-to-Speech and Speech Recognition optional dependency gaps, with recovery install guidance; updates the UX remediation plan through PR #162 and records this active Phase 6 slice. Test plan: env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_stts_capability_state.py Tests/Utils/test_optional_deps.py::test_tts_deps Tests/Utils/test_optional_deps.py::test_stt_deps Tests/UI/test_screen_navigation.py::test_main_navigation_buttons_explain_compact_labels --tb=short; git diff --check.