### PR TITLE
Explain unavailable Web Search action

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -1,8 +1,8 @@
 # UX Audit Remediation Plan
 
 Date: 2026-05-01
-Status: Current-dev rebaseline after UX remediation PRs #146-#162, plus active Speech capability-state slice
-Branch context: current `dev` / `origin/dev` at `b375d7fe`; active branch `codex/ux-speech-capability-state`
+Status: Current-dev rebaseline after UX remediation PRs #146-#163, plus active Web Search disabled-state slice
+Branch context: current `dev` / `origin/dev` at `1b80f96f`; active branch `codex/ux-web-search-disabled-state`
 Previous audit baseline: `e2576cae`
 
 ## Goal
@@ -29,7 +29,7 @@ This is not a visual refresh. The work is ordered around workflow completion, re
 
 ## Current Dev Rebaseline
 
-Verified on current `dev` at `b375d7fe`:
+Verified on current `dev` at `1b80f96f`:
 
 - Phase 0 and Phase 1 are merged: the shared shell/Chatbooks trap, Ingest default source, quiz empty mapping response, Chat save-state, Search/RAG thread mutation, and Search primary-action reachability regressions are covered.
 - Phase 2 is merged: Chat has provider readiness and first-run orientation coverage.
@@ -50,11 +50,12 @@ Current source state plus this branch:
 - Phase 4 invalid-selection hardening is merged through PR #160: Notes and workspace source/artifact `Use in Chat` actions are disabled until a valid selection exists and expose tooltip recovery copy.
 - Phase 5 command-palette label consistency is merged through PR #161: command-palette tab navigation uses the same `Library`, `Models`, `Speech`, and `Settings` labels as top-level navigation while preserving route IDs.
 - Phase 5 main-navigation tooltip copy is merged through PR #162: compact top-level labels expose concise descriptions of each destination without changing route IDs.
-- Phase 6 Speech/STTS capability-state copy is active in `codex/ux-speech-capability-state`: local Text-to-Speech and Speech Recognition dependency gaps should be visible before failed actions.
+- Phase 6 Speech/STTS capability-state copy is merged through PR #163: local Text-to-Speech and Speech Recognition dependency gaps are visible before failed actions.
+- Phase 5/6 Web Search disabled-state copy is active in `codex/ux-web-search-disabled-state`: missing Web Search optional dependencies should render as a real disabled action with recovery copy, not a clickable-looking no-op.
 - Phase 6 still needs any remaining optional dependency gaps represented as user-facing capability states where relevant.
 - Phase 7 still needs end-to-end audit replay on a clean home/config.
 
-Planning consequence: remaining implementation should target remaining Phase 4 source-authority and broader live smoke cases, any remaining compact-label/descriptive copy outside top navigation and command-palette tab navigation, Phase 6 capability-state presentation beyond Speech/STTS where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
+Planning consequence: remaining implementation should target remaining Phase 4 source-authority and broader live smoke cases, any remaining compact-label/descriptive copy outside top navigation and command-palette tab navigation, disabled-state consistency beyond Web Search, Phase 6 capability-state presentation beyond Speech/STTS and Web Search where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
 
 ## Issues Covered
 
@@ -293,7 +294,7 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 
 Purpose: make the app understandable without reducing expert efficiency.
 
-Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, and #162. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, and compact main-navigation labels expose explanatory tooltips.
+Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, and #163. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, and Speech/STTS exposes local dependency capability states.
 
 ### Files
 
@@ -319,6 +320,7 @@ Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #
 - [x] Rename top-level navigation jargon while preserving route IDs: `CCP` -> `Library`, `LLM` -> `Models`, and `S/TT/S` -> `Speech`.
 - [x] Align command-palette tab navigation with current top-level labels while preserving route IDs.
 - [x] Add main-navigation tooltips that explain compact destination labels without changing route IDs.
+- [x] Render missing Web Search dependencies as a disabled nav action with tooltip and pane recovery copy.
 - [ ] Add tooltips or short descriptions where compact labels remain necessary outside top navigation.
 
 ### Acceptance Criteria
@@ -333,7 +335,7 @@ Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #
 
 Purpose: make first-run diagnostics truthful and actionable without hiding real failures.
 
-Branch state: partially completed in `codex/ux-startup-log-polish`, with the Speech/STTS capability-state slice active in `codex/ux-speech-capability-state`. Splash import regressions, optional OpenAI TTS mapping fallback logging, and NLTK download-result logging are covered by focused tests. Broader optional dependency capability-state presentation remains open.
+Branch state: partially completed in `codex/ux-startup-log-polish`, with Speech/STTS capability-state merged through PR #163 and the Web Search disabled-state slice active in `codex/ux-web-search-disabled-state`. Splash import regressions, optional OpenAI TTS mapping fallback logging, and NLTK download-result logging are covered by focused tests. Broader optional dependency capability-state presentation remains open.
 
 ### Files
 
@@ -351,6 +353,7 @@ Branch state: partially completed in `codex/ux-startup-log-polish`, with the Spe
 - [x] Add tests that missing optional OpenAI TTS mapping uses defaults without error-level startup noise.
 - [x] Make NLTK download logging truthful: no success message when download fails.
 - [x] Expose local Speech/STTS TTS and STT dependency gaps as an inline capability state before failed actions.
+- [x] Expose missing Web Search optional dependencies as disabled-state and pane recovery copy.
 - [ ] Present optional dependency gaps as capability states when user-relevant, not stack traces.
 - [ ] Keep real crashes/error states visible.
 
@@ -360,6 +363,7 @@ Branch state: partially completed in `codex/ux-startup-log-polish`, with the Spe
 - [x] Missing optional TTS mapping falls back quietly.
 - [x] Failed NLTK download is not logged as success.
 - [x] Speech/STTS tells users when local Text-to-Speech or Speech Recognition dependencies are unavailable and how to recover.
+- [x] Search tells users when Web Search dependencies are unavailable and how to recover.
 - [ ] Optional dependency gaps tell users what capability is unavailable and how to recover.
 
 ## Phase 7: End-To-End Audit Replay And Closeout
@@ -416,4 +420,4 @@ Current-dev state: not started. The smoke/replay artifacts need to be regenerate
 
 ## Next Step
 
-After this Speech capability-state slice, the remaining Phase 4 work is invalid-selection/source-authority smoke coverage and the remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.
+After this Web Search disabled-state slice, the remaining Phase 4 work is invalid-selection/source-authority smoke coverage and the remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.

--- a/Tests/UI/test_search_handoffs.py
+++ b/Tests/UI/test_search_handoffs.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Button, Markdown
 
+from tldw_chatbook.UI import SearchWindow as search_window_module
 from tldw_chatbook.UI.Views.RAGSearch import search_rag_window
 from tldw_chatbook.UI.SearchWindow import SearchWindow
 from tldw_chatbook.UI.Views.RAGSearch.search_rag_window import SearchRAGWindow
@@ -220,3 +223,26 @@ def test_search_window_dedicated_web_result_unavailable_explains_recovery():
     assert "Open Chat" in message
     assert "try again" in message
     assert app.notify.call_args.kwargs["severity"] == "warning"
+
+
+@pytest.mark.asyncio
+async def test_search_window_disabled_web_search_nav_explains_dependency_recovery(monkeypatch):
+    monkeypatch.setattr(search_window_module, "WEB_SEARCH_AVAILABLE", False)
+    app_instance = _search_app(runtime_backend="local")
+
+    class SearchWindowApp(App):
+        def compose(self) -> ComposeResult:
+            yield SearchWindow(app_instance=app_instance)
+
+    app = SearchWindowApp()
+    async with app.run_test(size=(140, 40)) as pilot:
+        await pilot.pause()
+
+        disabled_nav = app.query_one("#search-nav-web-search-disabled", Button)
+        disabled_message = app.query_one("#search-view-web-search Markdown", Markdown)
+
+        assert disabled_nav.disabled is True
+        assert "Web Search requires optional dependencies" in str(disabled_nav.tooltip)
+        assert 'pip install -e ".[websearch]"' in str(disabled_nav.tooltip)
+        assert "Web Search requires optional dependencies" in disabled_message.source
+        assert 'pip install -e ".[websearch]"' in disabled_message.source

--- a/tldw_chatbook/UI/SearchWindow.py
+++ b/tldw_chatbook/UI/SearchWindow.py
@@ -431,7 +431,6 @@ class SearchWindow(Container):
         button_id = event.button.id
         if not button_id or "-disabled" in button_id: 
             logger.debug(f"SearchWindow.handle_nav: Ignoring disabled button press: {button_id}")
-            self.app_instance.notify(WEB_SEARCH_DEPENDENCY_RECOVERY, severity="warning")
             return
 
         logger.info(f"SearchWindow.handle_nav: Search nav button '{button_id}' pressed.")

--- a/tldw_chatbook/UI/SearchWindow.py
+++ b/tldw_chatbook/UI/SearchWindow.py
@@ -80,6 +80,10 @@ SEARCH_NAV_EMBEDDINGS_MANAGE = "search-nav-embeddings-manage"
 # UI Constant for "Local Server" provider display name
 LOCAL_SERVER_PROVIDER_DISPLAY_NAME = "Local OpenAI-Compliant Server"
 LOCAL_SERVER_PROVIDER_INTERNAL_ID = "local_openai_compliant"  # Internal ID to distinguish
+WEB_SEARCH_DEPENDENCY_RECOVERY = (
+    'Web Search requires optional dependencies. Install them with pip install -e ".[websearch]" '
+    "and restart Chatbook."
+)
 
 
 class SearchWindow(Container):
@@ -196,7 +200,13 @@ class SearchWindow(Container):
             if WEB_SEARCH_AVAILABLE:
                 yield Button("Web Search", id=SEARCH_NAV_WEB_SEARCH, classes="search-nav-button")
             else:
-                yield Button("Web Search", id="search-nav-web-search-disabled", classes="search-nav-button disabled")
+                yield Button(
+                    "Web Search",
+                    id="search-nav-web-search-disabled",
+                    classes="search-nav-button disabled",
+                    disabled=True,
+                    tooltip=WEB_SEARCH_DEPENDENCY_RECOVERY,
+                )
             # Add Embeddings navigation buttons
             yield Button("Create Embeddings", id=SEARCH_NAV_EMBEDDINGS_CREATE, classes="search-nav-button")
             yield Button("Manage Embeddings", id=SEARCH_NAV_EMBEDDINGS_MANAGE, classes="search-nav-button")
@@ -242,7 +252,12 @@ class SearchWindow(Container):
             else:
                 with Container(id=SEARCH_VIEW_WEB_SEARCH, classes="search-view-area"):
                     with VerticalScroll():
-                        yield Markdown("### Web Search/Scraping Is Not Currently Installed\n\n...")
+                        yield Markdown(
+                            "### Web Search requires optional dependencies\n\n"
+                            "Install the Web Search extra and restart Chatbook:\n\n"
+                            '```bash\npip install -e ".[websearch]"\n```\n\n'
+                            "RAG search, saved collections, and embeddings remain available from the other Search sections."
+                        )
                         
             # Embeddings views
             # Create Embeddings View - Now using new SearchEmbeddingsWindow
@@ -416,6 +431,7 @@ class SearchWindow(Container):
         button_id = event.button.id
         if not button_id or "-disabled" in button_id: 
             logger.debug(f"SearchWindow.handle_nav: Ignoring disabled button press: {button_id}")
+            self.app_instance.notify(WEB_SEARCH_DEPENDENCY_RECOVERY, severity="warning")
             return
 
         logger.info(f"SearchWindow.handle_nav: Search nav button '{button_id}' pressed.")


### PR DESCRIPTION
Summary: Converts the missing-dependencies Web Search nav item from a clickable-looking no-op into a real disabled action with recovery tooltip; replaces the placeholder unavailable pane with install guidance and notes that RAG/collections/embeddings still work; updates the UX remediation plan through PR #163 and records this active disabled-state slice. Test plan: env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_search_handoffs.py Tests/UI/test_search_rag_window.py::TestSearchRAGWindow::test_initial_search_empty_state_explains_search_modes_collections_and_chat_handoff --tb=short; git diff --check.