### PR TITLE
Explain disabled Media source actions

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -1,8 +1,8 @@
 # UX Audit Remediation Plan
 
 Date: 2026-05-01
-Status: Current-dev rebaseline after UX remediation PRs #146-#163, plus active Web Search disabled-state slice
-Branch context: current `dev` / `origin/dev` at `1b80f96f`; active branch `codex/ux-web-search-disabled-state`
+Status: Current-dev rebaseline after UX remediation PRs #146-#164, plus active Media Source disabled-actions slice
+Branch context: current `dev` / `origin/dev` at `b57746c9`; active branch `codex/ux-media-source-disabled-actions`
 Previous audit baseline: `e2576cae`
 
 ## Goal
@@ -29,7 +29,7 @@ This is not a visual refresh. The work is ordered around workflow completion, re
 
 ## Current Dev Rebaseline
 
-Verified on current `dev` at `1b80f96f`:
+Verified on current `dev` at `b57746c9`:
 
 - Phase 0 and Phase 1 are merged: the shared shell/Chatbooks trap, Ingest default source, quiz empty mapping response, Chat save-state, Search/RAG thread mutation, and Search primary-action reachability regressions are covered.
 - Phase 2 is merged: Chat has provider readiness and first-run orientation coverage.
@@ -51,11 +51,12 @@ Current source state plus this branch:
 - Phase 5 command-palette label consistency is merged through PR #161: command-palette tab navigation uses the same `Library`, `Models`, `Speech`, and `Settings` labels as top-level navigation while preserving route IDs.
 - Phase 5 main-navigation tooltip copy is merged through PR #162: compact top-level labels expose concise descriptions of each destination without changing route IDs.
 - Phase 6 Speech/STTS capability-state copy is merged through PR #163: local Text-to-Speech and Speech Recognition dependency gaps are visible before failed actions.
-- Phase 5/6 Web Search disabled-state copy is active in `codex/ux-web-search-disabled-state`: missing Web Search optional dependencies should render as a real disabled action with recovery copy, not a clickable-looking no-op.
+- Phase 5/6 Web Search disabled-state copy is merged through PR #164: missing Web Search optional dependencies render as a real disabled action with recovery copy, not a clickable-looking no-op.
+- Phase 5 Media Source disabled-action copy is active in `codex/ux-media-source-disabled-actions`: disabled source sync/save/upload actions should expose mode, selection, or archive-support recovery reasons.
 - Phase 6 still needs any remaining optional dependency gaps represented as user-facing capability states where relevant.
 - Phase 7 still needs end-to-end audit replay on a clean home/config.
 
-Planning consequence: remaining implementation should target remaining Phase 4 source-authority and broader live smoke cases, any remaining compact-label/descriptive copy outside top navigation and command-palette tab navigation, disabled-state consistency beyond Web Search, Phase 6 capability-state presentation beyond Speech/STTS and Web Search where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
+Planning consequence: remaining implementation should target remaining Phase 4 source-authority and broader live smoke cases, any remaining compact-label/descriptive copy outside top navigation and command-palette tab navigation, disabled-state consistency beyond Web Search and Media Source actions, Phase 6 capability-state presentation beyond Speech/STTS and Web Search where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
 
 ## Issues Covered
 
@@ -294,7 +295,7 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 
 Purpose: make the app understandable without reducing expert efficiency.
 
-Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, and #163. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, and Speech/STTS exposes local dependency capability states.
+Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, #163, and #164. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, Speech/STTS exposes local dependency capability states, and Web Search missing dependencies render as disabled-state recovery copy.
 
 ### Files
 
@@ -321,6 +322,7 @@ Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #
 - [x] Align command-palette tab navigation with current top-level labels while preserving route IDs.
 - [x] Add main-navigation tooltips that explain compact destination labels without changing route IDs.
 - [x] Render missing Web Search dependencies as a disabled nav action with tooltip and pane recovery copy.
+- [x] Add disabled-action recovery tooltips for Media Source sync/save/upload actions when server mode, selected source, or archive support is missing.
 - [ ] Add tooltips or short descriptions where compact labels remain necessary outside top navigation.
 
 ### Acceptance Criteria
@@ -335,7 +337,7 @@ Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #
 
 Purpose: make first-run diagnostics truthful and actionable without hiding real failures.
 
-Branch state: partially completed in `codex/ux-startup-log-polish`, with Speech/STTS capability-state merged through PR #163 and the Web Search disabled-state slice active in `codex/ux-web-search-disabled-state`. Splash import regressions, optional OpenAI TTS mapping fallback logging, and NLTK download-result logging are covered by focused tests. Broader optional dependency capability-state presentation remains open.
+Branch state: partially completed in `codex/ux-startup-log-polish`, with Speech/STTS capability-state merged through PR #163 and Web Search disabled-state merged through PR #164. Splash import regressions, optional OpenAI TTS mapping fallback logging, and NLTK download-result logging are covered by focused tests. Broader optional dependency capability-state presentation remains open.
 
 ### Files
 
@@ -420,4 +422,4 @@ Current-dev state: not started. The smoke/replay artifacts need to be regenerate
 
 ## Next Step
 
-After this Web Search disabled-state slice, the remaining Phase 4 work is invalid-selection/source-authority smoke coverage and the remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.
+After this Media Source disabled-actions slice, the remaining Phase 4 work is invalid-selection/source-authority smoke coverage and the remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.

--- a/Tests/UI/test_media_ingestion_source_panel.py
+++ b/Tests/UI/test_media_ingestion_source_panel.py
@@ -80,6 +80,83 @@ async def test_ingestion_source_panel_create_is_disabled_in_local_mode():
 
 
 @pytest.mark.asyncio
+async def test_ingestion_source_panel_disabled_actions_explain_local_mode_recovery():
+    scope_service = Mock()
+    app = SourcePanelTestApp(runtime_backend="local", scope_service=scope_service)
+
+    async with app.run_test() as pilot:
+        panel = pilot.app.query_one(MediaIngestionSourcePanel)
+        panel.runtime_backend = "local"
+        await panel.refresh_for_mode()
+        await pilot.pause(0.05)
+
+        sync_button = panel.query_one("#sync-source-btn", Button)
+        save_button = panel.query_one("#save-source-btn", Button)
+        upload_button = panel.query_one("#upload-archive-btn", Button)
+
+        for button in (sync_button, save_button, upload_button):
+            assert button.disabled is True
+            assert "Switch Media to server mode" in str(button.tooltip)
+            assert "select a source" in str(button.tooltip)
+
+
+@pytest.mark.asyncio
+async def test_ingestion_source_panel_disabled_actions_explain_empty_server_sources():
+    scope_service = Mock()
+    scope_service.list_ingestion_sources = AsyncMock(return_value=[])
+    app = SourcePanelTestApp(runtime_backend="server", scope_service=scope_service)
+
+    async with app.run_test() as pilot:
+        panel = pilot.app.query_one(MediaIngestionSourcePanel)
+        panel.runtime_backend = "server"
+        await panel.refresh_for_mode()
+        await pilot.pause(0.05)
+
+        sync_button = panel.query_one("#sync-source-btn", Button)
+        save_button = panel.query_one("#save-source-btn", Button)
+        upload_button = panel.query_one("#upload-archive-btn", Button)
+
+        for button in (sync_button, save_button, upload_button):
+            assert button.disabled is True
+            assert "Create or select a server ingestion source" in str(button.tooltip)
+
+
+@pytest.mark.asyncio
+async def test_ingestion_source_panel_upload_disabled_action_explains_non_archive_source():
+    scope_service = Mock()
+    scope_service.list_ingestion_sources = AsyncMock(
+        return_value=[
+            {
+                "id": "server:ingestion_source:7",
+                "source_id": "7",
+                "source_type": "git_repository",
+                "sink_type": "media",
+                "enabled": True,
+            }
+        ]
+    )
+    scope_service.list_ingestion_source_items = AsyncMock(return_value=[])
+    app = SourcePanelTestApp(runtime_backend="server", scope_service=scope_service)
+
+    async with app.run_test() as pilot:
+        panel = pilot.app.query_one(MediaIngestionSourcePanel)
+        panel.runtime_backend = "server"
+        await panel.refresh_for_mode()
+        await pilot.pause(0.05)
+
+        sync_button = panel.query_one("#sync-source-btn", Button)
+        save_button = panel.query_one("#save-source-btn", Button)
+        upload_button = panel.query_one("#upload-archive-btn", Button)
+
+        assert sync_button.disabled is False
+        assert sync_button.tooltip is None
+        assert save_button.disabled is False
+        assert save_button.tooltip is None
+        assert upload_button.disabled is True
+        assert "only available for archive ingestion sources" in str(upload_button.tooltip)
+
+
+@pytest.mark.asyncio
 async def test_ingestion_source_panel_creates_allowed_server_source_and_refreshes_selection():
     created_source = {
         "id": "server:ingestion_source:7",

--- a/tldw_chatbook/Widgets/Media/media_ingestion_source_panel.py
+++ b/tldw_chatbook/Widgets/Media/media_ingestion_source_panel.py
@@ -259,7 +259,7 @@ class MediaIngestionSourcePanel(ScrollableContainer):
         if self.scope_service is None:
             self._set_create_controls_disabled(True)
             self.query_one("#source-detail", Static).update("Media source service is unavailable.")
-            self._set_source_action_state(disabled=True, tooltip="Media source service is unavailable.")
+            self._set_source_action_state(disabled=True, tooltip=SOURCE_ACTION_TOOLTIP_SERVICE_UNAVAILABLE)
             return
 
         sources = await self._maybe_await(self.scope_service.list_ingestion_sources(mode="server"))

--- a/tldw_chatbook/Widgets/Media/media_ingestion_source_panel.py
+++ b/tldw_chatbook/Widgets/Media/media_ingestion_source_panel.py
@@ -30,6 +30,7 @@ CREATE_SOURCE_POLICY_OPTIONS = [("Canonical", "canonical")]
 SOURCE_ACTION_TOOLTIP_LOCAL_MODE = "Switch Media to server mode and select a source to use this action."
 SOURCE_ACTION_TOOLTIP_NO_SOURCE = "Create or select a server ingestion source to use this action."
 SOURCE_ACTION_TOOLTIP_ARCHIVE_ONLY = "Upload Archive is only available for archive ingestion sources."
+SOURCE_ACTION_TOOLTIP_SERVICE_UNAVAILABLE = "Media source service is unavailable."
 
 
 class MediaIngestionSourcePanel(ScrollableContainer):

--- a/tldw_chatbook/Widgets/Media/media_ingestion_source_panel.py
+++ b/tldw_chatbook/Widgets/Media/media_ingestion_source_panel.py
@@ -27,6 +27,10 @@ CREATE_SOURCE_TYPE_OPTIONS = [
 ]
 CREATE_SOURCE_POLICY_OPTIONS = [("Canonical", "canonical")]
 
+SOURCE_ACTION_TOOLTIP_LOCAL_MODE = "Switch Media to server mode and select a source to use this action."
+SOURCE_ACTION_TOOLTIP_NO_SOURCE = "Create or select a server ingestion source to use this action."
+SOURCE_ACTION_TOOLTIP_ARCHIVE_ONLY = "Upload Archive is only available for archive ingestion sources."
+
 
 class MediaIngestionSourcePanel(ScrollableContainer):
     """Manage server-backed ingestion sources from the media ingest view."""
@@ -190,6 +194,26 @@ class MediaIngestionSourcePanel(ScrollableContainer):
         self.query_one("#create-config-input", Input).disabled = disabled
         self.query_one("#create-source-btn", Button).disabled = disabled
 
+    def _set_source_action_state(
+        self,
+        *,
+        disabled: bool,
+        tooltip: Optional[str],
+        upload_disabled: Optional[bool] = None,
+        upload_tooltip: Optional[str] = None,
+    ) -> None:
+        """Keep disabled source actions explanatory instead of silent no-ops."""
+        save_button = self.query_one("#save-source-btn", Button)
+        sync_button = self.query_one("#sync-source-btn", Button)
+        upload_button = self.query_one("#upload-archive-btn", Button)
+
+        for button in (save_button, sync_button):
+            button.disabled = disabled
+            button.tooltip = tooltip
+
+        upload_button.disabled = disabled if upload_disabled is None else upload_disabled
+        upload_button.tooltip = tooltip if upload_tooltip is None else upload_tooltip
+
     def _source_index_for_identity(self, source_identity: Any) -> Optional[int]:
         source_identity_str = str(source_identity or "")
         if not source_identity_str:
@@ -225,9 +249,7 @@ class MediaIngestionSourcePanel(ScrollableContainer):
             await self._clear_list_view("#source-list")
             await self._clear_list_view("#source-items-list")
             self.query_one("#source-detail", Static).update("Server ingestion sources require server mode.")
-            self.query_one("#save-source-btn", Button).disabled = True
-            self.query_one("#sync-source-btn", Button).disabled = True
-            self.query_one("#upload-archive-btn", Button).disabled = True
+            self._set_source_action_state(disabled=True, tooltip=SOURCE_ACTION_TOOLTIP_LOCAL_MODE)
             return
 
         self._show_server_ui(True)
@@ -236,6 +258,7 @@ class MediaIngestionSourcePanel(ScrollableContainer):
         if self.scope_service is None:
             self._set_create_controls_disabled(True)
             self.query_one("#source-detail", Static).update("Media source service is unavailable.")
+            self._set_source_action_state(disabled=True, tooltip="Media source service is unavailable.")
             return
 
         sources = await self._maybe_await(self.scope_service.list_ingestion_sources(mode="server"))
@@ -251,9 +274,7 @@ class MediaIngestionSourcePanel(ScrollableContainer):
             self.selected_source = None
             self.query_one("#source-detail", Static).update("No server ingestion sources found.")
             await self._clear_list_view("#source-items-list")
-            self.query_one("#save-source-btn", Button).disabled = True
-            self.query_one("#sync-source-btn", Button).disabled = True
-            self.query_one("#upload-archive-btn", Button).disabled = True
+            self._set_source_action_state(disabled=True, tooltip=SOURCE_ACTION_TOOLTIP_NO_SOURCE)
 
     async def _load_source_list(self) -> None:
         list_view = await self._clear_list_view("#source-list")
@@ -280,17 +301,12 @@ class MediaIngestionSourcePanel(ScrollableContainer):
         detail = self.query_one("#source-detail", Static)
         policy_input = self.query_one("#source-policy-input", Input)
         enabled_checkbox = self.query_one("#source-enabled-checkbox", Checkbox)
-        save_button = self.query_one("#save-source-btn", Button)
-        sync_button = self.query_one("#sync-source-btn", Button)
-        upload_button = self.query_one("#upload-archive-btn", Button)
 
         if not self.selected_source:
             detail.update("No source selected.")
             policy_input.value = ""
             enabled_checkbox.value = False
-            save_button.disabled = True
-            sync_button.disabled = True
-            upload_button.disabled = True
+            self._set_source_action_state(disabled=True, tooltip=SOURCE_ACTION_TOOLTIP_NO_SOURCE)
             return
 
         source = self.selected_source
@@ -307,9 +323,13 @@ class MediaIngestionSourcePanel(ScrollableContainer):
 
         policy_input.value = str(source.get("policy") or "")
         enabled_checkbox.value = bool(source.get("enabled", False))
-        save_button.disabled = False
-        sync_button.disabled = False
-        upload_button.disabled = not self._archive_upload_supported(source)
+        archive_supported = self._archive_upload_supported(source)
+        self._set_source_action_state(
+            disabled=False,
+            tooltip=None,
+            upload_disabled=not archive_supported,
+            upload_tooltip=None if archive_supported else SOURCE_ACTION_TOOLTIP_ARCHIVE_ONLY,
+        )
 
     async def _load_source_items(self) -> None:
         items_view = await self._clear_list_view("#source-items-list")


### PR DESCRIPTION
Summary: Adds recovery tooltips for disabled Media Source sync/save/upload actions in local mode, empty server-source state, service-unavailable state, and non-archive source upload state; updates the UX remediation plan through merged PR #164 and records this active disabled-actions slice. Test plan: env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_media_ingestion_source_panel.py Tests/UI/test_ingestion_ui_redesigned.py::TestMediaIngestWindowRebuilt::test_source_panel_defaults_to_local_mode_message Tests/UI/test_new_ingest_window_integration.py::test_server_mode_loads_source_detail_on_mount Tests/UI/test_new_ingest_window_integration.py::test_server_mode_save_sync_and_upload_use_scope_service --tb=short; git diff --check.