### PR TITLE
Explain disabled Study quiz actions

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -1,8 +1,8 @@
 # UX Audit Remediation Plan
 
 Date: 2026-05-01
-Status: Current-dev rebaseline after UX remediation PRs #146-#164, plus active Media Source disabled-actions slice
-Branch context: current `dev` / `origin/dev` at `b57746c9`; active branch `codex/ux-media-source-disabled-actions`
+Status: Current-dev rebaseline after UX remediation PRs #146-#165, plus active Study Quiz disabled-actions slice
+Branch context: current `dev` / `origin/dev` at `d668a953`; active branch `codex/ux-study-quiz-disabled-actions`
 Previous audit baseline: `e2576cae`
 
 ## Goal
@@ -29,7 +29,7 @@ This is not a visual refresh. The work is ordered around workflow completion, re
 
 ## Current Dev Rebaseline
 
-Verified on current `dev` at `b57746c9`:
+Verified on current `dev` at `d668a953`:
 
 - Phase 0 and Phase 1 are merged: the shared shell/Chatbooks trap, Ingest default source, quiz empty mapping response, Chat save-state, Search/RAG thread mutation, and Search primary-action reachability regressions are covered.
 - Phase 2 is merged: Chat has provider readiness and first-run orientation coverage.
@@ -52,11 +52,12 @@ Current source state plus this branch:
 - Phase 5 main-navigation tooltip copy is merged through PR #162: compact top-level labels expose concise descriptions of each destination without changing route IDs.
 - Phase 6 Speech/STTS capability-state copy is merged through PR #163: local Text-to-Speech and Speech Recognition dependency gaps are visible before failed actions.
 - Phase 5/6 Web Search disabled-state copy is merged through PR #164: missing Web Search optional dependencies render as a real disabled action with recovery copy, not a clickable-looking no-op.
-- Phase 5 Media Source disabled-action copy is active in `codex/ux-media-source-disabled-actions`: disabled source sync/save/upload actions should expose mode, selection, or archive-support recovery reasons.
+- Phase 5 Media Source disabled-action copy is merged through PR #165: disabled source sync/save/upload actions expose mode, selection, or archive-support recovery reasons.
+- Phase 5 Study Quiz disabled-action copy is active in `codex/ux-study-quiz-disabled-actions`: disabled quiz edit/start/load/submit actions should expose scope or active-attempt recovery reasons.
 - Phase 6 still needs any remaining optional dependency gaps represented as user-facing capability states where relevant.
 - Phase 7 still needs end-to-end audit replay on a clean home/config.
 
-Planning consequence: remaining implementation should target remaining Phase 4 source-authority and broader live smoke cases, any remaining compact-label/descriptive copy outside top navigation and command-palette tab navigation, disabled-state consistency beyond Web Search and Media Source actions, Phase 6 capability-state presentation beyond Speech/STTS and Web Search where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
+Planning consequence: remaining implementation should target remaining Phase 4 source-authority and broader live smoke cases, any remaining compact-label/descriptive copy outside top navigation and command-palette tab navigation, disabled-state consistency beyond Web Search, Media Source, and Study Quiz actions, Phase 6 capability-state presentation beyond Speech/STTS and Web Search where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
 
 ## Issues Covered
 
@@ -295,7 +296,7 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 
 Purpose: make the app understandable without reducing expert efficiency.
 
-Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, #163, and #164. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, Speech/STTS exposes local dependency capability states, and Web Search missing dependencies render as disabled-state recovery copy.
+Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, #163, #164, and #165. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, Speech/STTS exposes local dependency capability states, Web Search missing dependencies render as disabled-state recovery copy, and Media Source disabled actions expose recovery tooltips.
 
 ### Files
 
@@ -323,6 +324,7 @@ Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #
 - [x] Add main-navigation tooltips that explain compact destination labels without changing route IDs.
 - [x] Render missing Web Search dependencies as a disabled nav action with tooltip and pane recovery copy.
 - [x] Add disabled-action recovery tooltips for Media Source sync/save/upload actions when server mode, selected source, or archive support is missing.
+- [x] Add disabled-action recovery tooltips for Study Quiz editing and attempt actions when scope is unavailable or an attempt is active.
 - [ ] Add tooltips or short descriptions where compact labels remain necessary outside top navigation.
 
 ### Acceptance Criteria
@@ -422,4 +424,4 @@ Current-dev state: not started. The smoke/replay artifacts need to be regenerate
 
 ## Next Step
 
-After this Media Source disabled-actions slice, the remaining Phase 4 work is invalid-selection/source-authority smoke coverage and the remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.
+After this Study Quiz disabled-actions slice, the remaining Phase 4 work is invalid-selection/source-authority smoke coverage and the remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.

--- a/Tests/UI/test_study_quizzes_screen.py
+++ b/Tests/UI/test_study_quizzes_screen.py
@@ -555,6 +555,16 @@ async def test_workspace_scope_local_mode_disables_quiz_actions_and_shows_unavai
         assert start_attempt_button.disabled is True
         assert submit_answer_button.disabled is True
         assert load_attempt_button.disabled is True
+        for button in (
+            create_quiz_button,
+            delete_quiz_button,
+            create_question_button,
+            delete_question_button,
+            start_attempt_button,
+            submit_answer_button,
+            load_attempt_button,
+        ):
+            assert "Workspace Study requires server mode" in str(button.tooltip)
 
 
 @pytest.mark.asyncio
@@ -750,6 +760,16 @@ async def test_active_attempt_disables_quiz_mutations_and_blocks_second_start():
         assert history_select.disabled is True
         assert answer_input.disabled is False
         assert submit_answer_button.disabled is False
+        for button in (
+            create_quiz_button,
+            delete_quiz_button,
+            create_question_button,
+            delete_question_button,
+            start_attempt_button,
+            load_attempt_button,
+        ):
+            assert "Submit the active quiz attempt" in str(button.tooltip)
+        assert submit_answer_button.tooltip is None
 
         await controller.start_attempt()
         await pilot.pause(0.1)

--- a/tldw_chatbook/UI/Study_Window.py
+++ b/tldw_chatbook/UI/Study_Window.py
@@ -22,6 +22,12 @@ from tldw_chatbook.UI.Study_Modules import StudyFlashcardsController, StudyQuizz
 from .Screens.study_scope_models import StudyScopeType
 # StudyDB import removed - using ChaChaNotes_DB instead
 
+QUIZ_SCOPE_UNAVAILABLE_TOOLTIP = (
+    "Workspace Study requires server mode. Switch to server mode or use Global Study to edit quizzes."
+)
+QUIZ_ATTEMPT_ACTIVE_TOOLTIP = "Submit the active quiz attempt before editing quizzes or starting another attempt."
+QUIZ_SUBMIT_INACTIVE_TOOLTIP = "Start a quiz attempt before submitting an answer."
+
 # Type checking imports
 if TYPE_CHECKING:
     from tldw_chatbook.app import TldwCli
@@ -971,6 +977,31 @@ class StudyWindow(Container):
         submit_answer_button.disabled = not scope_enabled or not attempt_active
         load_attempt_button.disabled = not scope_enabled or attempt_active
         history_select.disabled = not scope_enabled or attempt_active
+
+        if not scope_enabled:
+            for button in (
+                create_quiz_button,
+                delete_quiz_button,
+                create_question_button,
+                delete_question_button,
+                start_attempt_button,
+                submit_answer_button,
+                load_attempt_button,
+            ):
+                button.tooltip = QUIZ_SCOPE_UNAVAILABLE_TOOLTIP
+            return
+
+        mutation_buttons = (
+            create_quiz_button,
+            delete_quiz_button,
+            create_question_button,
+            delete_question_button,
+            start_attempt_button,
+            load_attempt_button,
+        )
+        for button in mutation_buttons:
+            button.tooltip = QUIZ_ATTEMPT_ACTIVE_TOOLTIP if attempt_active else None
+        submit_answer_button.tooltip = None if attempt_active else QUIZ_SUBMIT_INACTIVE_TOOLTIP
 
     @on(Button.Pressed, "#create-deck-button")
     def handle_create_deck(self) -> None:


### PR DESCRIPTION
Summary: Adds recovery tooltips for disabled Study Quiz edit, start, load, and submit actions when workspace scope is unavailable or a quiz attempt is active. Clears stale tooltips when actions become available. Updates the UX remediation plan through PR #165 and records this active slice. Test plan: env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_study_quizzes_screen.py --tb=short. git diff --check.