### PR TITLE
Explain disabled Study flashcard actions

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -1,8 +1,8 @@
 # UX Audit Remediation Plan
 
 Date: 2026-05-01
-Status: Current-dev rebaseline after UX remediation PRs #146-#165, plus active Study Quiz disabled-actions slice
-Branch context: current `dev` / `origin/dev` at `d668a953`; active branch `codex/ux-study-quiz-disabled-actions`
+Status: Current-dev rebaseline after UX remediation PRs #146-#166, plus active Study Flashcards disabled-actions slice
+Branch context: current `dev` / `origin/dev` at `498c69c7`; active branch `codex/ux-study-flashcard-disabled-actions`
 Previous audit baseline: `e2576cae`
 
 ## Goal
@@ -29,7 +29,7 @@ This is not a visual refresh. The work is ordered around workflow completion, re
 
 ## Current Dev Rebaseline
 
-Verified on current `dev` at `d668a953`:
+Verified on current `dev` at `498c69c7`:
 
 - Phase 0 and Phase 1 are merged: the shared shell/Chatbooks trap, Ingest default source, quiz empty mapping response, Chat save-state, Search/RAG thread mutation, and Search primary-action reachability regressions are covered.
 - Phase 2 is merged: Chat has provider readiness and first-run orientation coverage.
@@ -53,11 +53,12 @@ Current source state plus this branch:
 - Phase 6 Speech/STTS capability-state copy is merged through PR #163: local Text-to-Speech and Speech Recognition dependency gaps are visible before failed actions.
 - Phase 5/6 Web Search disabled-state copy is merged through PR #164: missing Web Search optional dependencies render as a real disabled action with recovery copy, not a clickable-looking no-op.
 - Phase 5 Media Source disabled-action copy is merged through PR #165: disabled source sync/save/upload actions expose mode, selection, or archive-support recovery reasons.
-- Phase 5 Study Quiz disabled-action copy is active in `codex/ux-study-quiz-disabled-actions`: disabled quiz edit/start/load/submit actions should expose scope or active-attempt recovery reasons.
+- Phase 5 Study Quiz disabled-action copy is merged through PR #166: disabled quiz edit/start/load/submit actions expose scope or active-attempt recovery reasons.
+- Phase 5 Study Flashcards disabled-action copy is active in `codex/ux-study-flashcard-disabled-actions`: disabled flashcard create/start/move/delete actions should expose scope, selection, target deck, or server-mode recovery reasons.
 - Phase 6 still needs any remaining optional dependency gaps represented as user-facing capability states where relevant.
 - Phase 7 still needs end-to-end audit replay on a clean home/config.
 
-Planning consequence: remaining implementation should target remaining Phase 4 source-authority and broader live smoke cases, any remaining compact-label/descriptive copy outside top navigation and command-palette tab navigation, disabled-state consistency beyond Web Search, Media Source, and Study Quiz actions, Phase 6 capability-state presentation beyond Speech/STTS and Web Search where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
+Planning consequence: remaining implementation should target remaining Phase 4 source-authority and broader live smoke cases, any remaining compact-label/descriptive copy outside top navigation and command-palette tab navigation, disabled-state consistency beyond Web Search, Media Source, Study Quiz, and Study Flashcard actions, Phase 6 capability-state presentation beyond Speech/STTS and Web Search where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
 
 ## Issues Covered
 
@@ -296,7 +297,7 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 
 Purpose: make the app understandable without reducing expert efficiency.
 
-Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, #163, #164, and #165. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, Speech/STTS exposes local dependency capability states, Web Search missing dependencies render as disabled-state recovery copy, and Media Source disabled actions expose recovery tooltips.
+Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, #163, #164, #165, and #166. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, Speech/STTS exposes local dependency capability states, Web Search missing dependencies render as disabled-state recovery copy, Media Source disabled actions expose recovery tooltips, and Study Quiz disabled actions expose recovery tooltips.
 
 ### Files
 
@@ -325,6 +326,7 @@ Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #
 - [x] Render missing Web Search dependencies as a disabled nav action with tooltip and pane recovery copy.
 - [x] Add disabled-action recovery tooltips for Media Source sync/save/upload actions when server mode, selected source, or archive support is missing.
 - [x] Add disabled-action recovery tooltips for Study Quiz editing and attempt actions when scope is unavailable or an attempt is active.
+- [x] Add disabled-action recovery tooltips for Study Flashcards create/start/move/delete actions when scope, deck, card, target deck, or server-mode deletion support is missing.
 - [ ] Add tooltips or short descriptions where compact labels remain necessary outside top navigation.
 
 ### Acceptance Criteria
@@ -424,4 +426,4 @@ Current-dev state: not started. The smoke/replay artifacts need to be regenerate
 
 ## Next Step
 
-After this Study Quiz disabled-actions slice, the remaining Phase 4 work is invalid-selection/source-authority smoke coverage and the remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.
+After this Study Flashcards disabled-actions slice, the remaining Phase 4 work is invalid-selection/source-authority smoke coverage and the remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.

--- a/Tests/UI/test_study_flashcards_screen.py
+++ b/Tests/UI/test_study_flashcards_screen.py
@@ -385,6 +385,7 @@ async def test_server_mode_keeps_delete_deck_visible_but_disabled():
         assert delete_note.display is True
         assert "server" in _text(delete_note).lower()
         assert "delete" in _text(delete_note).lower()
+        assert "Server mode does not support deck deletion" in str(delete_deck_button.tooltip)
 
 
 @pytest.mark.asyncio
@@ -434,6 +435,8 @@ async def test_flashcards_lifecycle_controls_disable_without_selected_card_or_ta
 
         assert delete_selected_button.disabled is True
         assert move_selected_button.disabled is True
+        assert "Select a flashcard before deleting it" in str(delete_selected_button.tooltip)
+        assert "Select a flashcard and a different target deck" in str(move_selected_button.tooltip)
 
 
 @pytest.mark.asyncio
@@ -814,6 +817,15 @@ async def test_workspace_flashcards_local_mode_fail_closed_ui_state():
         assert move_selected_button.disabled is True
         assert delete_selected_button.disabled is True
         assert delete_deck_button.disabled is True
+        for button in (
+            create_deck_button,
+            create_card_button,
+            start_review_button,
+            move_selected_button,
+            delete_selected_button,
+            delete_deck_button,
+        ):
+            assert "Workspace Flashcards require server mode" in str(button.tooltip)
 
 
 @pytest.mark.asyncio

--- a/tldw_chatbook/UI/Study_Modules/__init__.py
+++ b/tldw_chatbook/UI/Study_Modules/__init__.py
@@ -1,6 +1,15 @@
 """Study UI helpers."""
 
-from .flashcards_handler import StudyFlashcardsController
+from .flashcards_handler import (
+    FLASHCARD_DELETE_DECK_SERVER_TOOLTIP,
+    FLASHCARD_SCOPE_UNAVAILABLE_TOOLTIP,
+    StudyFlashcardsController,
+)
 from .quizzes_handler import StudyQuizzesController
 
-__all__ = ["StudyFlashcardsController", "StudyQuizzesController"]
+__all__ = [
+    "FLASHCARD_DELETE_DECK_SERVER_TOOLTIP",
+    "FLASHCARD_SCOPE_UNAVAILABLE_TOOLTIP",
+    "StudyFlashcardsController",
+    "StudyQuizzesController",
+]

--- a/tldw_chatbook/UI/Study_Modules/flashcards_handler.py
+++ b/tldw_chatbook/UI/Study_Modules/flashcards_handler.py
@@ -14,6 +14,18 @@ if TYPE_CHECKING:
     from ..Study_Window import StudyWindow
 
 
+FLASHCARD_SCOPE_UNAVAILABLE_TOOLTIP = (
+    "Workspace Flashcards require server mode. Switch to server mode or use Global Study to edit flashcards."
+)
+FLASHCARD_SELECT_DECK_TOOLTIP = "Select or create a deck before adding cards or starting review."
+FLASHCARD_SELECT_CARD_DELETE_TOOLTIP = "Select a flashcard before deleting it."
+FLASHCARD_SELECT_CARD_MOVE_TOOLTIP = "Select a flashcard and a different target deck before moving it."
+FLASHCARD_SELECT_DECK_DELETE_TOOLTIP = "Select a deck before deleting it."
+FLASHCARD_DELETE_DECK_SERVER_TOOLTIP = (
+    "Server mode does not support deck deletion. Delete cards individually or switch to local mode."
+)
+
+
 class StudyFlashcardsController:
     """Own flashcards deck/card/review interactions inside the Study screen."""
 
@@ -336,6 +348,15 @@ class StudyFlashcardsController:
         start_review_button.disabled = not scope_enabled or selected_deck is None
 
         if not scope_enabled:
+            for button in (
+                create_deck_button,
+                create_card_button,
+                start_review_button,
+                delete_selected_button,
+                move_selected_button,
+                delete_deck_button,
+            ):
+                button.tooltip = FLASHCARD_SCOPE_UNAVAILABLE_TOOLTIP
             delete_selected_button.disabled = True
             move_selected_button.disabled = True
             delete_deck_button.disabled = True
@@ -344,6 +365,17 @@ class StudyFlashcardsController:
         delete_selected_button.disabled = selected_card is None
         move_selected_button.disabled = selected_card is None or selected_target_deck is None
         delete_deck_button.disabled = self._current_mode() == "server" or selected_deck is None
+        create_deck_button.tooltip = None
+        create_card_button.tooltip = FLASHCARD_SELECT_DECK_TOOLTIP if selected_deck is None else None
+        start_review_button.tooltip = FLASHCARD_SELECT_DECK_TOOLTIP if selected_deck is None else None
+        delete_selected_button.tooltip = FLASHCARD_SELECT_CARD_DELETE_TOOLTIP if selected_card is None else None
+        move_selected_button.tooltip = (
+            FLASHCARD_SELECT_CARD_MOVE_TOOLTIP if selected_card is None or selected_target_deck is None else None
+        )
+        if self._current_mode() == "server":
+            delete_deck_button.tooltip = FLASHCARD_DELETE_DECK_SERVER_TOOLTIP
+        else:
+            delete_deck_button.tooltip = FLASHCARD_SELECT_DECK_DELETE_TOOLTIP if selected_deck is None else None
 
     def _parse_tags(self, text: str) -> list[str]:
         return [item for item in str(text or "").split() if item.strip()]

--- a/tldw_chatbook/UI/Study_Window.py
+++ b/tldw_chatbook/UI/Study_Window.py
@@ -18,7 +18,12 @@ from loguru import logger
 # Local imports
 from tldw_chatbook.config import get_cli_setting
 from tldw_chatbook.Utils.input_validation import validate_text_input
-from tldw_chatbook.UI.Study_Modules import StudyFlashcardsController, StudyQuizzesController
+from tldw_chatbook.UI.Study_Modules import (
+    FLASHCARD_DELETE_DECK_SERVER_TOOLTIP,
+    FLASHCARD_SCOPE_UNAVAILABLE_TOOLTIP,
+    StudyFlashcardsController,
+    StudyQuizzesController,
+)
 from .Screens.study_scope_models import StudyScopeType
 # StudyDB import removed - using ChaChaNotes_DB instead
 
@@ -921,6 +926,12 @@ class StudyWindow(Container):
             scope_enabled = bool(scope_checker())
 
         delete_deck_button.disabled = server_mode or not scope_enabled
+        if not scope_enabled:
+            delete_deck_button.tooltip = FLASHCARD_SCOPE_UNAVAILABLE_TOOLTIP
+        elif server_mode:
+            delete_deck_button.tooltip = FLASHCARD_DELETE_DECK_SERVER_TOOLTIP
+        else:
+            delete_deck_button.tooltip = None
         delete_deck_note.display = server_mode
 
     def _schedule_flashcards_refresh(self) -> None:

--- a/tldw_chatbook/UI/Study_Window.py
+++ b/tldw_chatbook/UI/Study_Window.py
@@ -925,13 +925,7 @@ class StudyWindow(Container):
         if callable(scope_checker):
             scope_enabled = bool(scope_checker())
 
-        delete_deck_button.disabled = server_mode or not scope_enabled
-        if not scope_enabled:
-            delete_deck_button.tooltip = FLASHCARD_SCOPE_UNAVAILABLE_TOOLTIP
-        elif server_mode:
-            delete_deck_button.tooltip = FLASHCARD_DELETE_DECK_SERVER_TOOLTIP
-        else:
-            delete_deck_button.tooltip = None
+        delete_deck_note.display = server_mode
         delete_deck_note.display = server_mode
 
     def _schedule_flashcards_refresh(self) -> None:


### PR DESCRIPTION
Summary: Adds recovery tooltips for disabled Study Flashcards create, start, move, and delete controls when workspace scope, deck selection, flashcard selection, target deck, or server-mode deck deletion support blocks the action. Clears stale tooltips when controls become available. Updates the UX remediation plan through PR #166 and records this active disabled-actions slice. Test plan: env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_study_flashcards_screen.py --tb=short. env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_study_screen.py --tb=short. git diff --check.