### PR TITLE
Explain Media Viewer action states

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -1,8 +1,8 @@
 # UX Audit Remediation Plan
 
 Date: 2026-05-01
-Status: Current-dev rebaseline after UX remediation PRs #146-#166, plus active Study Flashcards disabled-actions slice
-Branch context: current `dev` / `origin/dev` at `498c69c7`; active branch `codex/ux-study-flashcard-disabled-actions`
+Status: Current-dev rebaseline after UX remediation PRs #146-#167, plus active Media Viewer action-tooltip slice
+Branch context: current `dev` / `origin/dev` at `5445f1d8`; active branch `codex/ux-media-viewer-action-tooltips`
 Previous audit baseline: `e2576cae`
 
 ## Goal
@@ -29,7 +29,7 @@ This is not a visual refresh. The work is ordered around workflow completion, re
 
 ## Current Dev Rebaseline
 
-Verified on current `dev` at `498c69c7`:
+Verified on current `dev` at `5445f1d8`:
 
 - Phase 0 and Phase 1 are merged: the shared shell/Chatbooks trap, Ingest default source, quiz empty mapping response, Chat save-state, Search/RAG thread mutation, and Search primary-action reachability regressions are covered.
 - Phase 2 is merged: Chat has provider readiness and first-run orientation coverage.
@@ -54,11 +54,12 @@ Current source state plus this branch:
 - Phase 5/6 Web Search disabled-state copy is merged through PR #164: missing Web Search optional dependencies render as a real disabled action with recovery copy, not a clickable-looking no-op.
 - Phase 5 Media Source disabled-action copy is merged through PR #165: disabled source sync/save/upload actions expose mode, selection, or archive-support recovery reasons.
 - Phase 5 Study Quiz disabled-action copy is merged through PR #166: disabled quiz edit/start/load/submit actions expose scope or active-attempt recovery reasons.
-- Phase 5 Study Flashcards disabled-action copy is active in `codex/ux-study-flashcard-disabled-actions`: disabled flashcard create/start/move/delete actions should expose scope, selection, target deck, or server-mode recovery reasons.
+- Phase 5 Study Flashcards disabled-action copy is merged through PR #167: disabled flashcard create/start/move/delete actions expose scope, selection, target deck, or server-mode recovery reasons.
+- Phase 5 Media Viewer action-tooltip copy is active in `codex/ux-media-viewer-action-tooltips`: Media Viewer `Use in Chat` and `Save for Later` actions should expose selection/capability recovery reasons.
 - Phase 6 still needs any remaining optional dependency gaps represented as user-facing capability states where relevant.
 - Phase 7 still needs end-to-end audit replay on a clean home/config.
 
-Planning consequence: remaining implementation should target remaining Phase 4 source-authority and broader live smoke cases, any remaining compact-label/descriptive copy outside top navigation and command-palette tab navigation, disabled-state consistency beyond Web Search, Media Source, Study Quiz, and Study Flashcard actions, Phase 6 capability-state presentation beyond Speech/STTS and Web Search where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
+Planning consequence: remaining implementation should target remaining Phase 4 source-authority and broader live smoke cases, any remaining compact-label/descriptive copy outside top navigation and command-palette tab navigation, disabled-state consistency beyond Web Search, Media Source, Study Quiz, Study Flashcard, and Media Viewer actions, Phase 6 capability-state presentation beyond Speech/STTS and Web Search where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
 
 ## Issues Covered
 
@@ -297,7 +298,7 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 
 Purpose: make the app understandable without reducing expert efficiency.
 
-Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, #163, #164, #165, and #166. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, Speech/STTS exposes local dependency capability states, Web Search missing dependencies render as disabled-state recovery copy, Media Source disabled actions expose recovery tooltips, and Study Quiz disabled actions expose recovery tooltips.
+Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, #163, #164, #165, #166, and #167. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, Speech/STTS exposes local dependency capability states, Web Search missing dependencies render as disabled-state recovery copy, Media Source disabled actions expose recovery tooltips, Study Quiz disabled actions expose recovery tooltips, and Study Flashcards disabled actions expose recovery tooltips.
 
 ### Files
 
@@ -327,6 +328,7 @@ Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #
 - [x] Add disabled-action recovery tooltips for Media Source sync/save/upload actions when server mode, selected source, or archive support is missing.
 - [x] Add disabled-action recovery tooltips for Study Quiz editing and attempt actions when scope is unavailable or an attempt is active.
 - [x] Add disabled-action recovery tooltips for Study Flashcards create/start/move/delete actions when scope, deck, card, target deck, or server-mode deletion support is missing.
+- [x] Add Media Viewer action tooltips for `Use in Chat` and `Save for Later` when selection or read-it-later capability is missing.
 - [ ] Add tooltips or short descriptions where compact labels remain necessary outside top navigation.
 
 ### Acceptance Criteria
@@ -426,4 +428,4 @@ Current-dev state: not started. The smoke/replay artifacts need to be regenerate
 
 ## Next Step
 
-After this Study Flashcards disabled-actions slice, the remaining Phase 4 work is invalid-selection/source-authority smoke coverage and the remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.
+After this Media Viewer action-tooltip slice, the remaining Phase 4 work is invalid-selection/source-authority smoke coverage and the remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.

--- a/Tests/UI/test_media_handoffs.py
+++ b/Tests/UI/test_media_handoffs.py
@@ -61,11 +61,13 @@ async def test_media_viewer_use_in_chat_button_tracks_loaded_media():
     async with app.run_test() as pilot:
         button = panel.query_one("#media-use-in-chat-button", Button)
         assert button.disabled is True
+        assert "Select a media item before using it in Chat" in str(button.tooltip)
 
         panel.load_media({"id": "media-1", "title": "Lecture", "content": "Transcript"})
         await pilot.pause()
 
         assert button.disabled is False
+        assert "Use the selected media item in Chat" in str(button.tooltip)
 
 
 def test_media_window_builds_handoff_from_hydrated_detail():

--- a/Tests/UI/test_media_window_v2_parity.py
+++ b/Tests/UI/test_media_window_v2_parity.py
@@ -120,6 +120,7 @@ async def test_media_viewer_updates_saved_button_state_from_normalized_record():
         assert button.label == "Remove from Read-it-later"
         assert button.disabled is False
         assert button.has_class("hidden") is False
+        assert "Remove this item from Read-it-later" in str(button.tooltip)
 
         panel.load_media(
             {
@@ -135,6 +136,7 @@ async def test_media_viewer_updates_saved_button_state_from_normalized_record():
         assert button.label == "Save for Later"
         assert button.disabled is False
         assert button.has_class("hidden") is False
+        assert "Save this item for later reading" in str(button.tooltip)
 
         panel.load_media(
             {
@@ -150,6 +152,7 @@ async def test_media_viewer_updates_saved_button_state_from_normalized_record():
         assert button.label == "Save for Later"
         assert button.disabled is True
         assert button.has_class("hidden") is True
+        assert "Read-it-later is unavailable for this media item" in str(button.tooltip)
 
 
 @pytest.mark.asyncio

--- a/tldw_chatbook/Widgets/Media/media_viewer_panel.py
+++ b/tldw_chatbook/Widgets/Media/media_viewer_panel.py
@@ -25,6 +25,13 @@ if TYPE_CHECKING:
     from ...app import TldwCli
 
 
+MEDIA_USE_IN_CHAT_DISABLED_TOOLTIP = "Select a media item before using it in Chat."
+MEDIA_USE_IN_CHAT_ENABLED_TOOLTIP = "Use the selected media item in Chat."
+READ_IT_LATER_DISABLED_TOOLTIP = "Read-it-later is unavailable for this media item."
+READ_IT_LATER_SAVE_TOOLTIP = "Save this item for later reading."
+READ_IT_LATER_REMOVE_TOOLTIP = "Remove this item from Read-it-later."
+
+
 class ContentSearchEvent(Message):
     """Event fired when searching within content."""
     
@@ -491,6 +498,7 @@ class MediaViewerPanel(Container):
                                     id="media-use-in-chat-button",
                                     variant="primary",
                                     disabled=True,
+                                    tooltip=MEDIA_USE_IN_CHAT_DISABLED_TOOLTIP,
                                 )
                                 yield Button(
                                     "Save for Later",
@@ -498,6 +506,7 @@ class MediaViewerPanel(Container):
                                     variant="default",
                                     classes="hidden",
                                     disabled=True,
+                                    tooltip=READ_IT_LATER_DISABLED_TOOLTIP,
                                 )
                                 yield Button("Delete", id="delete-button", variant="error")
 
@@ -878,6 +887,11 @@ class MediaViewerPanel(Container):
         except Exception:
             return
         button.disabled = not bool(self.media_data)
+        button.tooltip = (
+            MEDIA_USE_IN_CHAT_ENABLED_TOOLTIP
+            if self.media_data
+            else MEDIA_USE_IN_CHAT_DISABLED_TOOLTIP
+        )
 
     def _build_use_in_chat_event(self) -> Optional[UseInChatRequested]:
         if not self.media_data:
@@ -899,9 +913,11 @@ class MediaViewerPanel(Container):
         if supports_toggle:
             button.remove_class("hidden")
             button.label = "Remove from Read-it-later" if is_saved else "Save for Later"
+            button.tooltip = READ_IT_LATER_REMOVE_TOOLTIP if is_saved else READ_IT_LATER_SAVE_TOOLTIP
         else:
             button.add_class("hidden")
             button.label = "Save for Later"
+            button.tooltip = READ_IT_LATER_DISABLED_TOOLTIP
     
     def _format_content_for_reading(self, content: str) -> str:
         """Format content for better readability."""


### PR DESCRIPTION
Summary: Adds recovery tooltips for Media Viewer Use in Chat when no media item is selected. Adds Save for Later/Read-it-later tooltips for save, remove, and unsupported states. Updates the UX remediation plan through PR #167 and records this active Media Viewer action-tooltip slice. Test plan: env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_media_handoffs.py Tests/UI/test_media_window_v2_parity.py --tb=short. git diff --check.