### PR TITLE
Explain Media analysis action states

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -1,8 +1,8 @@
 # UX Audit Remediation Plan
 
 Date: 2026-05-01
-Status: Current-dev rebaseline after UX remediation PRs #146-#167, plus active Media Viewer action-tooltip slice
-Branch context: current `dev` / `origin/dev` at `5445f1d8`; active branch `codex/ux-media-viewer-action-tooltips`
+Status: Current-dev rebaseline after UX remediation PRs #146-#168, plus active Media Analysis action-tooltip slice
+Branch context: current `dev` / `origin/dev` at `47080550`; active branch `codex/ux-media-analysis-action-tooltips`
 Previous audit baseline: `e2576cae`
 
 ## Goal
@@ -29,7 +29,7 @@ This is not a visual refresh. The work is ordered around workflow completion, re
 
 ## Current Dev Rebaseline
 
-Verified on current `dev` at `5445f1d8`:
+Verified on current `dev` at `47080550`:
 
 - Phase 0 and Phase 1 are merged: the shared shell/Chatbooks trap, Ingest default source, quiz empty mapping response, Chat save-state, Search/RAG thread mutation, and Search primary-action reachability regressions are covered.
 - Phase 2 is merged: Chat has provider readiness and first-run orientation coverage.
@@ -55,11 +55,12 @@ Current source state plus this branch:
 - Phase 5 Media Source disabled-action copy is merged through PR #165: disabled source sync/save/upload actions expose mode, selection, or archive-support recovery reasons.
 - Phase 5 Study Quiz disabled-action copy is merged through PR #166: disabled quiz edit/start/load/submit actions expose scope or active-attempt recovery reasons.
 - Phase 5 Study Flashcards disabled-action copy is merged through PR #167: disabled flashcard create/start/move/delete actions expose scope, selection, target deck, or server-mode recovery reasons.
-- Phase 5 Media Viewer action-tooltip copy is active in `codex/ux-media-viewer-action-tooltips`: Media Viewer `Use in Chat` and `Save for Later` actions should expose selection/capability recovery reasons.
+- Phase 5 Media Viewer action-tooltip copy is merged through PR #168: Media Viewer `Use in Chat` and `Save for Later` actions expose selection/capability recovery reasons.
+- Phase 5 Media Analysis action-tooltip copy is active in `codex/ux-media-analysis-action-tooltips`: Media analysis save/note/edit/overwrite/delete actions should expose generated-analysis and saved-version recovery reasons.
 - Phase 6 still needs any remaining optional dependency gaps represented as user-facing capability states where relevant.
 - Phase 7 still needs end-to-end audit replay on a clean home/config.
 
-Planning consequence: remaining implementation should target remaining Phase 4 source-authority and broader live smoke cases, any remaining compact-label/descriptive copy outside top navigation and command-palette tab navigation, disabled-state consistency beyond Web Search, Media Source, Study Quiz, Study Flashcard, and Media Viewer actions, Phase 6 capability-state presentation beyond Speech/STTS and Web Search where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
+Planning consequence: remaining implementation should target remaining Phase 4 source-authority and broader live smoke cases, any remaining compact-label/descriptive copy outside top navigation and command-palette tab navigation, disabled-state consistency beyond Web Search, Media Source, Study Quiz, Study Flashcard, Media Viewer, and Media Analysis actions, Phase 6 capability-state presentation beyond Speech/STTS and Web Search where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
 
 ## Issues Covered
 
@@ -298,7 +299,7 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 
 Purpose: make the app understandable without reducing expert efficiency.
 
-Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, #163, #164, #165, #166, and #167. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, Speech/STTS exposes local dependency capability states, Web Search missing dependencies render as disabled-state recovery copy, Media Source disabled actions expose recovery tooltips, Study Quiz disabled actions expose recovery tooltips, and Study Flashcards disabled actions expose recovery tooltips.
+Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, #163, #164, #165, #166, #167, and #168. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, Speech/STTS exposes local dependency capability states, Web Search missing dependencies render as disabled-state recovery copy, Media Source disabled actions expose recovery tooltips, Study Quiz disabled actions expose recovery tooltips, Study Flashcards disabled actions expose recovery tooltips, and Media Viewer actions expose selection/capability tooltips.
 
 ### Files
 
@@ -329,6 +330,7 @@ Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #
 - [x] Add disabled-action recovery tooltips for Study Quiz editing and attempt actions when scope is unavailable or an attempt is active.
 - [x] Add disabled-action recovery tooltips for Study Flashcards create/start/move/delete actions when scope, deck, card, target deck, or server-mode deletion support is missing.
 - [x] Add Media Viewer action tooltips for `Use in Chat` and `Save for Later` when selection or read-it-later capability is missing.
+- [x] Add Media Analysis action tooltips for save, note, edit, overwrite, and delete states when generated analysis or saved versions are missing.
 - [ ] Add tooltips or short descriptions where compact labels remain necessary outside top navigation.
 
 ### Acceptance Criteria
@@ -428,4 +430,4 @@ Current-dev state: not started. The smoke/replay artifacts need to be regenerate
 
 ## Next Step
 
-After this Media Viewer action-tooltip slice, the remaining Phase 4 work is invalid-selection/source-authority smoke coverage and the remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.
+After this Media Analysis action-tooltip slice, the remaining Phase 4 work is invalid-selection/source-authority smoke coverage and the remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.

--- a/Tests/UI/test_media_window_v2_parity.py
+++ b/Tests/UI/test_media_window_v2_parity.py
@@ -904,3 +904,54 @@ def test_media_viewer_load_analysis_versions_resets_button_state_when_empty():
     assert panel.current_analysis is None
     assert panel.has_existing_analysis is False
     panel._update_analysis_button_states.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_media_viewer_analysis_actions_explain_disabled_and_available_states():
+    class TestMediaViewerPanel(MediaViewerPanel):
+        def populate_providers(self) -> None:
+            pass
+
+    class MediaViewerPanelApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield TestMediaViewerPanel(SimpleNamespace())
+
+    app = MediaViewerPanelApp()
+    async with app.run_test() as pilot:
+        panel = app.query_one(MediaViewerPanel)
+        panel._update_analysis_button_states()
+        await pilot.pause()
+
+        save_button = panel.query_one("#save-analysis-btn", Button)
+        save_as_note_button = panel.query_one("#save-as-note-btn", Button)
+        edit_button = panel.query_one("#edit-analysis-btn", Button)
+        overwrite_button = panel.query_one("#overwrite-analysis-btn", Button)
+        delete_button = panel.query_one("#delete-analysis-btn", Button)
+
+        assert save_button.disabled is True
+        assert "Generate an analysis before saving it" in str(save_button.tooltip)
+        assert save_as_note_button.disabled is True
+        assert "Generate an analysis before saving it as a note" in str(save_as_note_button.tooltip)
+        assert edit_button.disabled is True
+        assert "Generate or select an analysis before editing it" in str(edit_button.tooltip)
+        assert overwrite_button.disabled is True
+        assert "Save an analysis before overwriting it" in str(overwrite_button.tooltip)
+        assert delete_button.disabled is True
+        assert "Select a saved analysis version before deleting it" in str(delete_button.tooltip)
+
+        panel.current_analysis = "Generated analysis"
+        panel.has_existing_analysis = False
+        panel.all_analyses = []
+        panel._update_analysis_button_states()
+        await pilot.pause()
+
+        assert save_button.disabled is False
+        assert "Save this generated analysis" in str(save_button.tooltip)
+        assert save_as_note_button.disabled is False
+        assert "Save this analysis as a note" in str(save_as_note_button.tooltip)
+        assert edit_button.disabled is False
+        assert "Edit this analysis" in str(edit_button.tooltip)
+        assert overwrite_button.disabled is True
+        assert "Save an analysis before overwriting it" in str(overwrite_button.tooltip)
+        assert delete_button.disabled is True
+        assert "Select a saved analysis version before deleting it" in str(delete_button.tooltip)

--- a/tldw_chatbook/Widgets/Media/media_viewer_panel.py
+++ b/tldw_chatbook/Widgets/Media/media_viewer_panel.py
@@ -43,6 +43,8 @@ ANALYSIS_OVERWRITE_ENABLED_TOOLTIP = "Overwrite the saved analysis with the edit
 ANALYSIS_DELETE_DISABLED_TOOLTIP = "Select a saved analysis version before deleting it."
 ANALYSIS_DELETE_ENABLED_TOOLTIP = "Delete this saved analysis version."
 ANALYSIS_DELETE_EDITING_TOOLTIP = "Cancel editing before deleting an analysis."
+ANALYSIS_SAVE_EDITING_TOOLTIP = "Finish or cancel editing before saving."
+ANALYSIS_SAVE_NOTE_EDITING_TOOLTIP = "Finish or cancel editing before saving as a note."
 
 
 class ContentSearchEvent(Message):

--- a/tldw_chatbook/Widgets/Media/media_viewer_panel.py
+++ b/tldw_chatbook/Widgets/Media/media_viewer_panel.py
@@ -30,6 +30,19 @@ MEDIA_USE_IN_CHAT_ENABLED_TOOLTIP = "Use the selected media item in Chat."
 READ_IT_LATER_DISABLED_TOOLTIP = "Read-it-later is unavailable for this media item."
 READ_IT_LATER_SAVE_TOOLTIP = "Save this item for later reading."
 READ_IT_LATER_REMOVE_TOOLTIP = "Remove this item from Read-it-later."
+ANALYSIS_SAVE_DISABLED_TOOLTIP = "Generate an analysis before saving it."
+ANALYSIS_SAVE_ENABLED_TOOLTIP = "Save this generated analysis."
+ANALYSIS_SAVE_EXISTING_TOOLTIP = "This analysis is already saved. Use Overwrite to update it."
+ANALYSIS_SAVE_NOTE_DISABLED_TOOLTIP = "Generate an analysis before saving it as a note."
+ANALYSIS_SAVE_NOTE_ENABLED_TOOLTIP = "Save this analysis as a note."
+ANALYSIS_EDIT_DISABLED_TOOLTIP = "Generate or select an analysis before editing it."
+ANALYSIS_EDIT_ENABLED_TOOLTIP = "Edit this analysis."
+ANALYSIS_EDIT_CANCEL_TOOLTIP = "Cancel editing this analysis."
+ANALYSIS_OVERWRITE_DISABLED_TOOLTIP = "Save an analysis before overwriting it."
+ANALYSIS_OVERWRITE_ENABLED_TOOLTIP = "Overwrite the saved analysis with the edited text."
+ANALYSIS_DELETE_DISABLED_TOOLTIP = "Select a saved analysis version before deleting it."
+ANALYSIS_DELETE_ENABLED_TOOLTIP = "Delete this saved analysis version."
+ANALYSIS_DELETE_EDITING_TOOLTIP = "Cancel editing before deleting an analysis."
 
 
 class ContentSearchEvent(Message):
@@ -682,11 +695,41 @@ class MediaViewerPanel(Container):
                     
                     # Analysis action buttons
                     with Horizontal(classes="analysis-actions"):
-                        yield Button("Save", id="save-analysis-btn", variant="success", disabled=True)
-                        yield Button("Save as Note", id="save-as-note-btn", variant="success", disabled=True)
-                        yield Button("Edit", id="edit-analysis-btn", variant="primary", disabled=True)
-                        yield Button("Overwrite", id="overwrite-analysis-btn", variant="warning", disabled=True)
-                        yield Button("Delete", id="delete-analysis-btn", variant="error", disabled=True)
+                        yield Button(
+                            "Save",
+                            id="save-analysis-btn",
+                            variant="success",
+                            disabled=True,
+                            tooltip=ANALYSIS_SAVE_DISABLED_TOOLTIP,
+                        )
+                        yield Button(
+                            "Save as Note",
+                            id="save-as-note-btn",
+                            variant="success",
+                            disabled=True,
+                            tooltip=ANALYSIS_SAVE_NOTE_DISABLED_TOOLTIP,
+                        )
+                        yield Button(
+                            "Edit",
+                            id="edit-analysis-btn",
+                            variant="primary",
+                            disabled=True,
+                            tooltip=ANALYSIS_EDIT_DISABLED_TOOLTIP,
+                        )
+                        yield Button(
+                            "Overwrite",
+                            id="overwrite-analysis-btn",
+                            variant="warning",
+                            disabled=True,
+                            tooltip=ANALYSIS_OVERWRITE_DISABLED_TOOLTIP,
+                        )
+                        yield Button(
+                            "Delete",
+                            id="delete-analysis-btn",
+                            variant="error",
+                            disabled=True,
+                            tooltip=ANALYSIS_DELETE_DISABLED_TOOLTIP,
+                        )
                     
                     # Add some padding at the bottom to ensure scrolling works
                     yield Static("", classes="bottom-spacer")
@@ -1475,16 +1518,34 @@ class MediaViewerPanel(Container):
             
             if self.analysis_edit_mode:
                 save_btn.disabled = True
+                save_btn.tooltip = ANALYSIS_SAVE_DISABLED_TOOLTIP
                 save_as_note_btn.disabled = True
+                save_as_note_btn.tooltip = ANALYSIS_SAVE_NOTE_DISABLED_TOOLTIP
                 edit_btn.label = "Cancel Edit"
+                edit_btn.tooltip = ANALYSIS_EDIT_CANCEL_TOOLTIP
                 overwrite_btn.disabled = False
+                overwrite_btn.tooltip = ANALYSIS_OVERWRITE_ENABLED_TOOLTIP
                 delete_btn.disabled = True
+                delete_btn.tooltip = ANALYSIS_DELETE_EDITING_TOOLTIP
             else:
                 save_btn.disabled = not self.current_analysis or self.has_existing_analysis
+                if not self.current_analysis:
+                    save_btn.tooltip = ANALYSIS_SAVE_DISABLED_TOOLTIP
+                elif self.has_existing_analysis:
+                    save_btn.tooltip = ANALYSIS_SAVE_EXISTING_TOOLTIP
+                else:
+                    save_btn.tooltip = ANALYSIS_SAVE_ENABLED_TOOLTIP
                 save_as_note_btn.disabled = not self.current_analysis
+                save_as_note_btn.tooltip = (
+                    ANALYSIS_SAVE_NOTE_ENABLED_TOOLTIP if self.current_analysis else ANALYSIS_SAVE_NOTE_DISABLED_TOOLTIP
+                )
                 edit_btn.label = "Edit"
                 edit_btn.disabled = not self.current_analysis
+                edit_btn.tooltip = ANALYSIS_EDIT_ENABLED_TOOLTIP if self.current_analysis else ANALYSIS_EDIT_DISABLED_TOOLTIP
                 overwrite_btn.disabled = not self.has_existing_analysis
+                overwrite_btn.tooltip = (
+                    ANALYSIS_OVERWRITE_ENABLED_TOOLTIP if self.has_existing_analysis else ANALYSIS_OVERWRITE_DISABLED_TOOLTIP
+                )
                 # Delete button enabled only when there's a saved analysis with UUID
                 # Check if current analysis has a UUID (not a legacy analysis)
                 has_deletable_analysis = False
@@ -1495,6 +1556,9 @@ class MediaViewerPanel(Container):
                         has_deletable_analysis = (current_analysis.get('uuid') is not None or 
                                                   current_analysis.get('version_number') == 'unsaved')
                 delete_btn.disabled = not has_deletable_analysis
+                delete_btn.tooltip = (
+                    ANALYSIS_DELETE_ENABLED_TOOLTIP if has_deletable_analysis else ANALYSIS_DELETE_DISABLED_TOOLTIP
+                )
                 
         except Exception:
             pass

--- a/tldw_chatbook/Widgets/Media/media_viewer_panel.py
+++ b/tldw_chatbook/Widgets/Media/media_viewer_panel.py
@@ -1520,9 +1520,9 @@ class MediaViewerPanel(Container):
             
             if self.analysis_edit_mode:
                 save_btn.disabled = True
-                save_btn.tooltip = ANALYSIS_SAVE_DISABLED_TOOLTIP
+                save_btn.tooltip = ANALYSIS_SAVE_EDITING_TOOLTIP
                 save_as_note_btn.disabled = True
-                save_as_note_btn.tooltip = ANALYSIS_SAVE_NOTE_DISABLED_TOOLTIP
+                save_as_note_btn.tooltip = ANALYSIS_SAVE_NOTE_EDITING_TOOLTIP
                 edit_btn.label = "Cancel Edit"
                 edit_btn.tooltip = ANALYSIS_EDIT_CANCEL_TOOLTIP
                 overwrite_btn.disabled = False


### PR DESCRIPTION
Summary: Adds recovery tooltips for Media analysis Save, Save as Note, Edit, Overwrite, and Delete controls across empty, generated-unsaved, saved, and edit-mode states. Keeps existing enable/disable behavior while explaining what generated analysis or saved version is required. Updates the UX remediation plan through PR #168 and records this active Media Analysis action-tooltip slice. Test plan: env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_media_window_v2_parity.py --tb=short. git diff --check.