### PR TITLE
Explain Media highlight action states

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -1,8 +1,8 @@
 # UX Audit Remediation Plan
 
 Date: 2026-05-01
-Status: Current-dev rebaseline after UX remediation PRs #146-#168, plus active Media Analysis action-tooltip slice
-Branch context: current `dev` / `origin/dev` at `47080550`; active branch `codex/ux-media-analysis-action-tooltips`
+Status: Current-dev rebaseline after UX remediation PRs #146-#169, plus active Media Highlight action-tooltip slice
+Branch context: current `dev` / `origin/dev` at `593672f1`; active branch `codex/ux-media-highlight-action-tooltips`
 Previous audit baseline: `e2576cae`
 
 ## Goal
@@ -29,7 +29,7 @@ This is not a visual refresh. The work is ordered around workflow completion, re
 
 ## Current Dev Rebaseline
 
-Verified on current `dev` at `47080550`:
+Verified on current `dev` at `593672f1`:
 
 - Phase 0 and Phase 1 are merged: the shared shell/Chatbooks trap, Ingest default source, quiz empty mapping response, Chat save-state, Search/RAG thread mutation, and Search primary-action reachability regressions are covered.
 - Phase 2 is merged: Chat has provider readiness and first-run orientation coverage.
@@ -56,11 +56,12 @@ Current source state plus this branch:
 - Phase 5 Study Quiz disabled-action copy is merged through PR #166: disabled quiz edit/start/load/submit actions expose scope or active-attempt recovery reasons.
 - Phase 5 Study Flashcards disabled-action copy is merged through PR #167: disabled flashcard create/start/move/delete actions expose scope, selection, target deck, or server-mode recovery reasons.
 - Phase 5 Media Viewer action-tooltip copy is merged through PR #168: Media Viewer `Use in Chat` and `Save for Later` actions expose selection/capability recovery reasons.
-- Phase 5 Media Analysis action-tooltip copy is active in `codex/ux-media-analysis-action-tooltips`: Media analysis save/note/edit/overwrite/delete actions should expose generated-analysis and saved-version recovery reasons.
+- Phase 5 Media Analysis action-tooltip copy is merged through PR #169: Media analysis save/note/edit/overwrite/delete actions expose generated-analysis and saved-version recovery reasons.
+- Phase 5 Media Highlight action-tooltip copy is active in `codex/ux-media-highlight-action-tooltips`: Media reading-highlight update/delete actions should expose selected-highlight recovery reasons.
 - Phase 6 still needs any remaining optional dependency gaps represented as user-facing capability states where relevant.
 - Phase 7 still needs end-to-end audit replay on a clean home/config.
 
-Planning consequence: remaining implementation should target remaining Phase 4 source-authority and broader live smoke cases, any remaining compact-label/descriptive copy outside top navigation and command-palette tab navigation, disabled-state consistency beyond Web Search, Media Source, Study Quiz, Study Flashcard, Media Viewer, and Media Analysis actions, Phase 6 capability-state presentation beyond Speech/STTS and Web Search where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
+Planning consequence: remaining implementation should target remaining Phase 4 source-authority and broader live smoke cases, any remaining compact-label/descriptive copy outside top navigation and command-palette tab navigation, disabled-state consistency beyond Web Search, Media Source, Study Quiz, Study Flashcard, Media Viewer, Media Analysis, and Media Highlight actions, Phase 6 capability-state presentation beyond Speech/STTS and Web Search where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
 
 ## Issues Covered
 
@@ -299,7 +300,7 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 
 Purpose: make the app understandable without reducing expert efficiency.
 
-Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, #163, #164, #165, #166, #167, and #168. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, Speech/STTS exposes local dependency capability states, Web Search missing dependencies render as disabled-state recovery copy, Media Source disabled actions expose recovery tooltips, Study Quiz disabled actions expose recovery tooltips, Study Flashcards disabled actions expose recovery tooltips, and Media Viewer actions expose selection/capability tooltips.
+Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, #163, #164, #165, #166, #167, #168, and #169. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, Speech/STTS exposes local dependency capability states, Web Search missing dependencies render as disabled-state recovery copy, Media Source disabled actions expose recovery tooltips, Study Quiz disabled actions expose recovery tooltips, Study Flashcards disabled actions expose recovery tooltips, Media Viewer actions expose selection/capability tooltips, and Media Analysis actions expose generated-analysis/saved-version tooltips.
 
 ### Files
 
@@ -331,6 +332,7 @@ Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #
 - [x] Add disabled-action recovery tooltips for Study Flashcards create/start/move/delete actions when scope, deck, card, target deck, or server-mode deletion support is missing.
 - [x] Add Media Viewer action tooltips for `Use in Chat` and `Save for Later` when selection or read-it-later capability is missing.
 - [x] Add Media Analysis action tooltips for save, note, edit, overwrite, and delete states when generated analysis or saved versions are missing.
+- [x] Add Media Reading Highlight action tooltips for update/delete states when no highlight is selected.
 - [ ] Add tooltips or short descriptions where compact labels remain necessary outside top navigation.
 
 ### Acceptance Criteria
@@ -430,4 +432,4 @@ Current-dev state: not started. The smoke/replay artifacts need to be regenerate
 
 ## Next Step
 
-After this Media Analysis action-tooltip slice, the remaining Phase 4 work is invalid-selection/source-authority smoke coverage and the remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.
+After this Media Highlight action-tooltip slice, the remaining Phase 4 work is invalid-selection/source-authority smoke coverage and the remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.

--- a/Tests/UI/test_media_window_v2_parity.py
+++ b/Tests/UI/test_media_window_v2_parity.py
@@ -879,6 +879,28 @@ def test_media_viewer_metadata_display_includes_reading_highlights():
     assert "Check this" in rendered_text
 
 
+@pytest.mark.asyncio
+async def test_media_viewer_highlight_actions_explain_disabled_selection_state():
+    class TestMediaViewerPanel(MediaViewerPanel):
+        def populate_providers(self) -> None:
+            pass
+
+    class MediaViewerPanelApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield TestMediaViewerPanel(SimpleNamespace())
+
+    app = MediaViewerPanelApp()
+    async with app.run_test():
+        panel = app.query_one(MediaViewerPanel)
+        update_button = panel.query_one("#update-reading-highlight-btn", Button)
+        delete_button = panel.query_one("#delete-reading-highlight-btn", Button)
+
+        assert update_button.disabled is True
+        assert "Select a reading highlight before updating it" in str(update_button.tooltip)
+        assert delete_button.disabled is True
+        assert "Select a reading highlight before deleting it" in str(delete_button.tooltip)
+
+
 def test_media_viewer_load_analysis_versions_resets_button_state_when_empty():
     panel = MediaViewerPanel(Mock())
     panel.media_data = {"id": "local:media:7", "title": "Doc"}

--- a/tldw_chatbook/Widgets/Media/media_viewer_panel.py
+++ b/tldw_chatbook/Widgets/Media/media_viewer_panel.py
@@ -43,6 +43,9 @@ ANALYSIS_OVERWRITE_ENABLED_TOOLTIP = "Overwrite the saved analysis with the edit
 ANALYSIS_DELETE_DISABLED_TOOLTIP = "Select a saved analysis version before deleting it."
 ANALYSIS_DELETE_ENABLED_TOOLTIP = "Delete this saved analysis version."
 ANALYSIS_DELETE_EDITING_TOOLTIP = "Cancel editing before deleting an analysis."
+READING_HIGHLIGHT_ADD_TOOLTIP = "Add a reading highlight to this media item."
+READING_HIGHLIGHT_UPDATE_DISABLED_TOOLTIP = "Select a reading highlight before updating it."
+READING_HIGHLIGHT_DELETE_DISABLED_TOOLTIP = "Select a reading highlight before deleting it."
 ANALYSIS_SAVE_EDITING_TOOLTIP = "Finish or cancel editing before saving."
 ANALYSIS_SAVE_NOTE_EDITING_TOOLTIP = "Finish or cancel editing before saving as a note."
 
@@ -541,9 +544,26 @@ class MediaViewerPanel(Container):
                             yield Label("Color:", classes="edit-label")
                             yield Input("yellow", id="reading-highlight-color")
                             with Horizontal(classes="edit-actions"):
-                                yield Button("Add Highlight", id="add-reading-highlight-btn", variant="success")
-                                yield Button("Update Highlight", id="update-reading-highlight-btn", variant="primary", disabled=True)
-                                yield Button("Delete Highlight", id="delete-reading-highlight-btn", variant="error", disabled=True)
+                                yield Button(
+                                    "Add Highlight",
+                                    id="add-reading-highlight-btn",
+                                    variant="success",
+                                    tooltip=READING_HIGHLIGHT_ADD_TOOLTIP,
+                                )
+                                yield Button(
+                                    "Update Highlight",
+                                    id="update-reading-highlight-btn",
+                                    variant="primary",
+                                    disabled=True,
+                                    tooltip=READING_HIGHLIGHT_UPDATE_DISABLED_TOOLTIP,
+                                )
+                                yield Button(
+                                    "Delete Highlight",
+                                    id="delete-reading-highlight-btn",
+                                    variant="error",
+                                    disabled=True,
+                                    tooltip=READING_HIGHLIGHT_DELETE_DISABLED_TOOLTIP,
+                                )
                     
                     # Edit mode (hidden by default)
                     with Container(id="metadata-edit", classes="edit-section hidden"):

--- a/tldw_chatbook/Widgets/Media/media_viewer_panel.py
+++ b/tldw_chatbook/Widgets/Media/media_viewer_panel.py
@@ -43,11 +43,13 @@ ANALYSIS_OVERWRITE_ENABLED_TOOLTIP = "Overwrite the saved analysis with the edit
 ANALYSIS_DELETE_DISABLED_TOOLTIP = "Select a saved analysis version before deleting it."
 ANALYSIS_DELETE_ENABLED_TOOLTIP = "Delete this saved analysis version."
 ANALYSIS_DELETE_EDITING_TOOLTIP = "Cancel editing before deleting an analysis."
-READING_HIGHLIGHT_ADD_TOOLTIP = "Add a reading highlight to this media item."
-READING_HIGHLIGHT_UPDATE_DISABLED_TOOLTIP = "Select a reading highlight before updating it."
-READING_HIGHLIGHT_DELETE_DISABLED_TOOLTIP = "Select a reading highlight before deleting it."
 ANALYSIS_SAVE_EDITING_TOOLTIP = "Finish or cancel editing before saving."
 ANALYSIS_SAVE_NOTE_EDITING_TOOLTIP = "Finish or cancel editing before saving as a note."
+READING_HIGHLIGHT_ADD_TOOLTIP = "Add a reading highlight to this media item."
+READING_HIGHLIGHT_UPDATE_DISABLED_TOOLTIP = "Select a reading highlight before updating it."
+READING_HIGHLIGHT_UPDATE_ENABLED_TOOLTIP = "Update this reading highlight."
+READING_HIGHLIGHT_DELETE_DISABLED_TOOLTIP = "Select a reading highlight before deleting it."
+READING_HIGHLIGHT_DELETE_ENABLED_TOOLTIP = "Delete this reading highlight."
 
 
 class ContentSearchEvent(Message):


### PR DESCRIPTION
Summary: Adds recovery tooltips for Media Reading Highlight actions so disabled Update/Delete controls explain that a highlight must be selected. Adds a short tooltip for Add Highlight. Updates the UX remediation plan through PR #169 and records this active Media Highlight action-tooltip slice. Test plan: env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_media_window_v2_parity.py --tb=short. git diff --check.