### PR TITLE
Explain Media analysis navigation states

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -1,8 +1,8 @@
 # UX Audit Remediation Plan
 
 Date: 2026-05-01
-Status: Current-dev rebaseline after UX remediation PRs #146-#169, plus active Media Highlight action-tooltip slice
-Branch context: current `dev` / `origin/dev` at `593672f1`; active branch `codex/ux-media-highlight-action-tooltips`
+Status: Current-dev rebaseline after UX remediation PRs #146-#170, plus active Media Analysis navigation-tooltip slice
+Branch context: current `dev` / `origin/dev` at `c8386c5f`; active branch `codex/ux-media-analysis-nav-tooltips`
 Previous audit baseline: `e2576cae`
 
 ## Goal
@@ -29,7 +29,7 @@ This is not a visual refresh. The work is ordered around workflow completion, re
 
 ## Current Dev Rebaseline
 
-Verified on current `dev` at `593672f1`:
+Verified on current `dev` at `c8386c5f`:
 
 - Phase 0 and Phase 1 are merged: the shared shell/Chatbooks trap, Ingest default source, quiz empty mapping response, Chat save-state, Search/RAG thread mutation, and Search primary-action reachability regressions are covered.
 - Phase 2 is merged: Chat has provider readiness and first-run orientation coverage.
@@ -57,11 +57,12 @@ Current source state plus this branch:
 - Phase 5 Study Flashcards disabled-action copy is merged through PR #167: disabled flashcard create/start/move/delete actions expose scope, selection, target deck, or server-mode recovery reasons.
 - Phase 5 Media Viewer action-tooltip copy is merged through PR #168: Media Viewer `Use in Chat` and `Save for Later` actions expose selection/capability recovery reasons.
 - Phase 5 Media Analysis action-tooltip copy is merged through PR #169: Media analysis save/note/edit/overwrite/delete actions expose generated-analysis and saved-version recovery reasons.
-- Phase 5 Media Highlight action-tooltip copy is active in `codex/ux-media-highlight-action-tooltips`: Media reading-highlight update/delete actions should expose selected-highlight recovery reasons.
+- Phase 5 Media Highlight action-tooltip copy is merged through PR #170: Media reading-highlight update/delete actions expose selected-highlight recovery reasons.
+- Phase 5 Media Analysis navigation-tooltip copy is active in `codex/ux-media-analysis-nav-tooltips`: Media analysis previous/next version navigation should explain empty, first-version, and last-version states.
 - Phase 6 still needs any remaining optional dependency gaps represented as user-facing capability states where relevant.
 - Phase 7 still needs end-to-end audit replay on a clean home/config.
 
-Planning consequence: remaining implementation should target remaining Phase 4 source-authority and broader live smoke cases, any remaining compact-label/descriptive copy outside top navigation and command-palette tab navigation, disabled-state consistency beyond Web Search, Media Source, Study Quiz, Study Flashcard, Media Viewer, Media Analysis, and Media Highlight actions, Phase 6 capability-state presentation beyond Speech/STTS and Web Search where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
+Planning consequence: remaining implementation should target remaining Phase 4 source-authority and broader live smoke cases, any remaining compact-label/descriptive copy outside top navigation and command-palette tab navigation, disabled-state consistency beyond Web Search, Media Source, Study Quiz, Study Flashcard, Media Viewer, Media Analysis, Media Highlight, and Media Analysis navigation actions, Phase 6 capability-state presentation beyond Speech/STTS and Web Search where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
 
 ## Issues Covered
 
@@ -300,7 +301,7 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 
 Purpose: make the app understandable without reducing expert efficiency.
 
-Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, #163, #164, #165, #166, #167, #168, and #169. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, Speech/STTS exposes local dependency capability states, Web Search missing dependencies render as disabled-state recovery copy, Media Source disabled actions expose recovery tooltips, Study Quiz disabled actions expose recovery tooltips, Study Flashcards disabled actions expose recovery tooltips, Media Viewer actions expose selection/capability tooltips, and Media Analysis actions expose generated-analysis/saved-version tooltips.
+Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, #163, #164, #165, #166, #167, #168, #169, and #170. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, Speech/STTS exposes local dependency capability states, Web Search missing dependencies render as disabled-state recovery copy, Media Source disabled actions expose recovery tooltips, Study Quiz disabled actions expose recovery tooltips, Study Flashcards disabled actions expose recovery tooltips, Media Viewer actions expose selection/capability tooltips, Media Analysis actions expose generated-analysis/saved-version tooltips, and Media Highlight actions expose selected-highlight tooltips.
 
 ### Files
 
@@ -333,6 +334,7 @@ Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #
 - [x] Add Media Viewer action tooltips for `Use in Chat` and `Save for Later` when selection or read-it-later capability is missing.
 - [x] Add Media Analysis action tooltips for save, note, edit, overwrite, and delete states when generated analysis or saved versions are missing.
 - [x] Add Media Reading Highlight action tooltips for update/delete states when no highlight is selected.
+- [x] Add Media Analysis navigation tooltips for previous/next saved-version boundary states.
 - [ ] Add tooltips or short descriptions where compact labels remain necessary outside top navigation.
 
 ### Acceptance Criteria
@@ -432,4 +434,4 @@ Current-dev state: not started. The smoke/replay artifacts need to be regenerate
 
 ## Next Step
 
-After this Media Highlight action-tooltip slice, the remaining Phase 4 work is invalid-selection/source-authority smoke coverage and the remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.
+After this Media Analysis navigation-tooltip slice, the remaining Phase 4 work is invalid-selection/source-authority smoke coverage and the remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.

--- a/Tests/UI/test_media_window_v2_parity.py
+++ b/Tests/UI/test_media_window_v2_parity.py
@@ -929,6 +929,55 @@ def test_media_viewer_load_analysis_versions_resets_button_state_when_empty():
 
 
 @pytest.mark.asyncio
+async def test_media_viewer_analysis_navigation_explains_boundary_states():
+    class TestMediaViewerPanel(MediaViewerPanel):
+        def populate_providers(self) -> None:
+            pass
+
+    class MediaViewerPanelApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield TestMediaViewerPanel(SimpleNamespace())
+
+    app = MediaViewerPanelApp()
+    async with app.run_test() as pilot:
+        panel = app.query_one(MediaViewerPanel)
+        prev_button = panel.query_one("#prev-analysis-btn", Button)
+        next_button = panel.query_one("#next-analysis-btn", Button)
+
+        panel.all_analyses = []
+        panel.current_analysis_index = 0
+        panel._update_analysis_navigation()
+        await pilot.pause()
+
+        assert prev_button.disabled is True
+        assert "No saved analysis versions to navigate" in str(prev_button.tooltip)
+        assert next_button.disabled is True
+        assert "No saved analysis versions to navigate" in str(next_button.tooltip)
+
+        panel.all_analyses = [
+            {"analysis_content": "Newest saved analysis", "version_number": 2},
+            {"analysis_content": "Older saved analysis", "version_number": 1},
+        ]
+        panel.current_analysis_index = 0
+        panel._update_analysis_navigation()
+        await pilot.pause()
+
+        assert prev_button.disabled is True
+        assert "Already viewing the first analysis version" in str(prev_button.tooltip)
+        assert next_button.disabled is False
+        assert "Show the next analysis version" in str(next_button.tooltip)
+
+        panel.current_analysis_index = 1
+        panel._update_analysis_navigation()
+        await pilot.pause()
+
+        assert prev_button.disabled is False
+        assert "Show the previous analysis version" in str(prev_button.tooltip)
+        assert next_button.disabled is True
+        assert "Already viewing the last analysis version" in str(next_button.tooltip)
+
+
+@pytest.mark.asyncio
 async def test_media_viewer_analysis_actions_explain_disabled_and_available_states():
     class TestMediaViewerPanel(MediaViewerPanel):
         def populate_providers(self) -> None:

--- a/tldw_chatbook/Widgets/Media/media_viewer_panel.py
+++ b/tldw_chatbook/Widgets/Media/media_viewer_panel.py
@@ -45,6 +45,11 @@ ANALYSIS_DELETE_ENABLED_TOOLTIP = "Delete this saved analysis version."
 ANALYSIS_DELETE_EDITING_TOOLTIP = "Cancel editing before deleting an analysis."
 ANALYSIS_SAVE_EDITING_TOOLTIP = "Finish or cancel editing before saving."
 ANALYSIS_SAVE_NOTE_EDITING_TOOLTIP = "Finish or cancel editing before saving as a note."
+ANALYSIS_NAV_EMPTY_TOOLTIP = "No saved analysis versions to navigate."
+ANALYSIS_NAV_PREVIOUS_ENABLED_TOOLTIP = "Show the previous analysis version."
+ANALYSIS_NAV_PREVIOUS_DISABLED_TOOLTIP = "Already viewing the first analysis version."
+ANALYSIS_NAV_NEXT_ENABLED_TOOLTIP = "Show the next analysis version."
+ANALYSIS_NAV_NEXT_DISABLED_TOOLTIP = "Already viewing the last analysis version."
 READING_HIGHLIGHT_ADD_TOOLTIP = "Add a reading highlight to this media item."
 READING_HIGHLIGHT_UPDATE_DISABLED_TOOLTIP = "Select a reading highlight before updating it."
 READING_HIGHLIGHT_UPDATE_ENABLED_TOOLTIP = "Update this reading highlight."
@@ -705,9 +710,19 @@ class MediaViewerPanel(Container):
                     
                     # Analysis navigation (for multiple analyses)
                     with Horizontal(classes="analysis-navigation"):
-                        yield Button("◀", id="prev-analysis-btn", disabled=True)
+                        yield Button(
+                            "◀",
+                            id="prev-analysis-btn",
+                            disabled=True,
+                            tooltip=ANALYSIS_NAV_EMPTY_TOOLTIP,
+                        )
                         yield Static("Analysis 0/0", id="analysis-indicator")
-                        yield Button("▶", id="next-analysis-btn", disabled=True)
+                        yield Button(
+                            "▶",
+                            id="next-analysis-btn",
+                            disabled=True,
+                            tooltip=ANALYSIS_NAV_EMPTY_TOOLTIP,
+                        )
                     
                     # Analysis date info
                     yield Static("", id="analysis-date-info")
@@ -1342,11 +1357,23 @@ class MediaViewerPanel(Container):
             if total_analyses == 0:
                 prev_btn.disabled = True
                 next_btn.disabled = True
+                prev_btn.tooltip = ANALYSIS_NAV_EMPTY_TOOLTIP
+                next_btn.tooltip = ANALYSIS_NAV_EMPTY_TOOLTIP
                 indicator.update("No analyses")
             else:
                 # Update navigation buttons
                 prev_btn.disabled = self.current_analysis_index == 0
                 next_btn.disabled = self.current_analysis_index >= total_analyses - 1
+                prev_btn.tooltip = (
+                    ANALYSIS_NAV_PREVIOUS_DISABLED_TOOLTIP
+                    if prev_btn.disabled
+                    else ANALYSIS_NAV_PREVIOUS_ENABLED_TOOLTIP
+                )
+                next_btn.tooltip = (
+                    ANALYSIS_NAV_NEXT_DISABLED_TOOLTIP
+                    if next_btn.disabled
+                    else ANALYSIS_NAV_NEXT_ENABLED_TOOLTIP
+                )
                 
                 # Update indicator (1-based for display)
                 current_display = self.current_analysis_index + 1


### PR DESCRIPTION
## Summary
- Adds Media Analysis previous/next version tooltips for empty, first-version, enabled, and last-version states.
- Initializes the navigation buttons with recovery copy before saved analyses are loaded.
- Updates the UX remediation plan through merged PR #170 and this active slice.

## Test Plan
- env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_media_window_v2_parity.py --tb=short
- git diff --check