### PR TITLE
Make RAG saved search actions recoverable

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -1,8 +1,8 @@
 # UX Audit Remediation Plan
 
 Date: 2026-05-01
-Status: Current-dev rebaseline after UX remediation PRs #146-#170, plus active Media Analysis navigation-tooltip slice
-Branch context: current `dev` / `origin/dev` at `c8386c5f`; active branch `codex/ux-media-analysis-nav-tooltips`
+Status: Current-dev rebaseline after UX remediation PRs #146-#171, plus active Search/RAG saved-search action slice
+Branch context: current `dev` / `origin/dev` at `03ab9b8d`; active branch `codex/ux-rag-saved-search-actions`
 Previous audit baseline: `e2576cae`
 
 ## Goal
@@ -29,7 +29,7 @@ This is not a visual refresh. The work is ordered around workflow completion, re
 
 ## Current Dev Rebaseline
 
-Verified on current `dev` at `c8386c5f`:
+Verified on current `dev` at `03ab9b8d`:
 
 - Phase 0 and Phase 1 are merged: the shared shell/Chatbooks trap, Ingest default source, quiz empty mapping response, Chat save-state, Search/RAG thread mutation, and Search primary-action reachability regressions are covered.
 - Phase 2 is merged: Chat has provider readiness and first-run orientation coverage.
@@ -58,11 +58,12 @@ Current source state plus this branch:
 - Phase 5 Media Viewer action-tooltip copy is merged through PR #168: Media Viewer `Use in Chat` and `Save for Later` actions expose selection/capability recovery reasons.
 - Phase 5 Media Analysis action-tooltip copy is merged through PR #169: Media analysis save/note/edit/overwrite/delete actions expose generated-analysis and saved-version recovery reasons.
 - Phase 5 Media Highlight action-tooltip copy is merged through PR #170: Media reading-highlight update/delete actions expose selected-highlight recovery reasons.
-- Phase 5 Media Analysis navigation-tooltip copy is active in `codex/ux-media-analysis-nav-tooltips`: Media analysis previous/next version navigation should explain empty, first-version, and last-version states.
+- Phase 5 Media Analysis navigation-tooltip copy is merged through PR #171: Media analysis previous/next version navigation explains empty, first-version, and last-version states.
+- Phase 5 Search/RAG saved-search action recovery is active in `codex/ux-rag-saved-search-actions`: saved-search Load/Delete actions should explain selection requirements and let selected searches repopulate the Search/RAG controls.
 - Phase 6 still needs any remaining optional dependency gaps represented as user-facing capability states where relevant.
 - Phase 7 still needs end-to-end audit replay on a clean home/config.
 
-Planning consequence: remaining implementation should target remaining Phase 4 source-authority and broader live smoke cases, any remaining compact-label/descriptive copy outside top navigation and command-palette tab navigation, disabled-state consistency beyond Web Search, Media Source, Study Quiz, Study Flashcard, Media Viewer, Media Analysis, Media Highlight, and Media Analysis navigation actions, Phase 6 capability-state presentation beyond Speech/STTS and Web Search where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
+Planning consequence: remaining implementation should target remaining Phase 4 source-authority and broader live smoke cases, any remaining compact-label/descriptive copy outside top navigation and command-palette tab navigation, disabled-state consistency beyond Web Search, Media Source, Study Quiz, Study Flashcard, Media Viewer, Media Analysis, Media Highlight, Media Analysis navigation, and Search/RAG saved-search actions, Phase 6 capability-state presentation beyond Speech/STTS and Web Search where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
 
 ## Issues Covered
 
@@ -301,7 +302,7 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 
 Purpose: make the app understandable without reducing expert efficiency.
 
-Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, #163, #164, #165, #166, #167, #168, #169, and #170. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, Speech/STTS exposes local dependency capability states, Web Search missing dependencies render as disabled-state recovery copy, Media Source disabled actions expose recovery tooltips, Study Quiz disabled actions expose recovery tooltips, Study Flashcards disabled actions expose recovery tooltips, Media Viewer actions expose selection/capability tooltips, Media Analysis actions expose generated-analysis/saved-version tooltips, and Media Highlight actions expose selected-highlight tooltips.
+Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, #163, #164, #165, #166, #167, #168, #169, #170, and #171. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, Speech/STTS exposes local dependency capability states, Web Search missing dependencies render as disabled-state recovery copy, Media Source disabled actions expose recovery tooltips, Study Quiz disabled actions expose recovery tooltips, Study Flashcards disabled actions expose recovery tooltips, Media Viewer actions expose selection/capability tooltips, Media Analysis actions expose generated-analysis/saved-version tooltips, Media Highlight actions expose selected-highlight tooltips, and Media Analysis navigation actions expose saved-version boundary tooltips.
 
 ### Files
 
@@ -335,6 +336,7 @@ Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #
 - [x] Add Media Analysis action tooltips for save, note, edit, overwrite, and delete states when generated analysis or saved versions are missing.
 - [x] Add Media Reading Highlight action tooltips for update/delete states when no highlight is selected.
 - [x] Add Media Analysis navigation tooltips for previous/next saved-version boundary states.
+- [x] Add Search/RAG saved-search action recovery for Load/Delete selection states and selected-config reuse.
 - [ ] Add tooltips or short descriptions where compact labels remain necessary outside top navigation.
 
 ### Acceptance Criteria
@@ -434,4 +436,4 @@ Current-dev state: not started. The smoke/replay artifacts need to be regenerate
 
 ## Next Step
 
-After this Media Analysis navigation-tooltip slice, the remaining Phase 4 work is invalid-selection/source-authority smoke coverage and the remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.
+After this Search/RAG saved-search action slice, the remaining Phase 4 work is invalid-selection/source-authority smoke coverage and the remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.

--- a/Tests/UI/test_search_rag_window.py
+++ b/Tests/UI/test_search_rag_window.py
@@ -341,6 +341,48 @@ class TestSearchRAGWindow:
                 "notes": False,
             }
 
+    @pytest.mark.asyncio
+    async def test_saved_search_load_applies_selected_config_to_controls(
+        self,
+        mock_app_instance: MagicMock,
+        search_rag_test_env,
+        widget_pilot,
+    ) -> None:
+        """Loading a saved search should repopulate the search controls for reuse."""
+        async with await widget_pilot(SearchRAGWindow, app_instance=mock_app_instance) as pilot:
+            window = pilot.app.test_widget
+            saved_panel = window.query_one("#saved-searches-panel", SavedSearchesPanel)
+            saved_panel.save_search(
+                "Agent UX Search",
+                {
+                    "query": "agent UX",
+                    "mode": "hybrid",
+                    "collection": "all",
+                    "top_k": 7,
+                    "temperature": 0.35,
+                    "filters": {"media": True, "conversations": False, "notes": True},
+                },
+            )
+            await pilot.pause()
+
+            saved_list = saved_panel.query_one("#saved-searches-list", ListView)
+            saved_list.index = 0
+            saved_list.action_select_cursor()
+            await pilot.pause()
+
+            load_button = saved_panel.query_one("#load-saved-search", Button)
+            assert load_button.disabled is False
+            load_button.press()
+            await pilot.pause()
+
+            assert window.query_one("#search-query-input", Input).value == "agent UX"
+            assert window.query_one("#search-mode-select", Select).value == "hybrid"
+            assert window.query_one("#top-k-input", Input).value == "7"
+            assert window.query_one("#temperature-input", Input).value == "0.35"
+            assert window.query_one("#filter-media", Checkbox).value is True
+            assert window.query_one("#filter-conversations", Checkbox).value is False
+            assert window.query_one("#filter-notes", Checkbox).value is True
+
 
 @pytest.mark.ui
 class TestSearchHistoryDropdown:
@@ -407,6 +449,49 @@ class TestSavedSearchesPanel:
 
                 persisted = json.loads(saved_path.read_text())
                 assert persisted["Agent UX Search"]["config"] == config
+
+    @pytest.mark.asyncio
+    async def test_saved_search_actions_explain_selection_requirement_and_delete_selected(
+        self,
+        temp_user_data_dir: Path,
+        widget_pilot,
+    ) -> None:
+        """Saved-search actions should explain selection requirements and recover after deletion."""
+        with patch(
+            "tldw_chatbook.UI.Views.RAGSearch.saved_searches_panel.get_user_data_dir",
+            return_value=temp_user_data_dir,
+        ):
+            async with await widget_pilot(SavedSearchesPanel) as pilot:
+                panel = pilot.app.test_widget
+                load_button = panel.query_one("#load-saved-search", Button)
+                delete_button = panel.query_one("#delete-saved-search", Button)
+
+                assert load_button.disabled is True
+                assert "Select a saved search before loading it" in str(load_button.tooltip)
+                assert delete_button.disabled is True
+                assert "Select a saved search before deleting it" in str(delete_button.tooltip)
+
+                panel.save_search("Agent UX Search", {"query": "agent UX", "mode": "plain"})
+                await pilot.pause()
+
+                saved_list = panel.query_one("#saved-searches-list", ListView)
+                saved_list.index = 0
+                saved_list.action_select_cursor()
+                await pilot.pause()
+
+                assert panel.selected_search_name == "Agent UX Search"
+                assert load_button.disabled is False
+                assert "Load the selected saved search" in str(load_button.tooltip)
+                assert delete_button.disabled is False
+                assert "Delete the selected saved search" in str(delete_button.tooltip)
+
+                delete_button.press()
+                await pilot.pause()
+
+                assert "Agent UX Search" not in panel.saved_searches
+                assert panel.selected_search_name is None
+                assert load_button.disabled is True
+                assert "Select a saved search before loading it" in str(load_button.tooltip)
 
 
 @pytest.mark.ui

--- a/tldw_chatbook/UI/Views/RAGSearch/saved_searches_panel.py
+++ b/tldw_chatbook/UI/Views/RAGSearch/saved_searches_panel.py
@@ -9,17 +9,33 @@ from datetime import datetime
 import json
 from pathlib import Path
 
+from textual import on
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal
 from textual.widgets import Static, Button, ListView, ListItem
+from textual.message import Message
 from textual.css.query import NoMatches
 from loguru import logger
 
 from ....Utils.paths import get_user_data_dir
 
 
+SAVED_SEARCH_LOAD_DISABLED_TOOLTIP = "Select a saved search before loading it."
+SAVED_SEARCH_LOAD_ENABLED_TOOLTIP = "Load the selected saved search into the search controls."
+SAVED_SEARCH_DELETE_DISABLED_TOOLTIP = "Select a saved search before deleting it."
+SAVED_SEARCH_DELETE_ENABLED_TOOLTIP = "Delete the selected saved search."
+
+
 class SavedSearchesPanel(Container):
     """Enhanced panel for managing saved searches"""
+
+    class LoadRequested(Message):
+        """Request loading a saved search configuration into the parent search UI."""
+
+        def __init__(self, name: str, config: Dict[str, Any]) -> None:
+            super().__init__()
+            self.name = name
+            self.config = dict(config)
     
     def __init__(self):
         super().__init__(id="saved-searches-panel", classes="saved-searches-panel-enhanced")
@@ -47,8 +63,20 @@ class SavedSearchesPanel(Container):
             )
             
             with Horizontal(classes="saved-search-actions-enhanced"):
-                yield Button("📥 Load", id="load-saved-search", classes="saved-action-button", disabled=True)
-                yield Button("🗑️ Delete", id="delete-saved-search", classes="saved-action-button danger", disabled=True)
+                yield Button(
+                    "📥 Load",
+                    id="load-saved-search",
+                    classes="saved-action-button",
+                    disabled=True,
+                    tooltip=SAVED_SEARCH_LOAD_DISABLED_TOOLTIP,
+                )
+                yield Button(
+                    "🗑️ Delete",
+                    id="delete-saved-search",
+                    classes="saved-action-button danger",
+                    disabled=True,
+                    tooltip=SAVED_SEARCH_DELETE_DISABLED_TOOLTIP,
+                )
 
     def on_mount(self) -> None:
         """Populate the list view after the widget mounts."""
@@ -110,12 +138,27 @@ class SavedSearchesPanel(Container):
         saved_searches_path.parent.mkdir(parents=True, exist_ok=True)
         with open(saved_searches_path, 'w') as f:
             json.dump(self.saved_searches, f, indent=2)
+
+    def _set_saved_search_action_state(self, *, selected: bool) -> None:
+        """Keep saved-search actions and recovery copy synchronized."""
+        load_button = self.query_one("#load-saved-search", Button)
+        delete_button = self.query_one("#delete-saved-search", Button)
+
+        load_button.disabled = not selected
+        delete_button.disabled = not selected
+        load_button.tooltip = (
+            SAVED_SEARCH_LOAD_ENABLED_TOOLTIP if selected else SAVED_SEARCH_LOAD_DISABLED_TOOLTIP
+        )
+        delete_button.tooltip = (
+            SAVED_SEARCH_DELETE_ENABLED_TOOLTIP if selected else SAVED_SEARCH_DELETE_DISABLED_TOOLTIP
+        )
     
     async def refresh_list(self) -> None:
         """Refresh the saved searches list"""
         try:
             list_view = self.query_one("#saved-searches-list", ListView)
             empty_state = self.query_one("#saved-searches-empty-state", Static)
+            self.selected_search_name = None
             await list_view.clear()
 
             if self.saved_searches:
@@ -130,11 +173,52 @@ class SavedSearchesPanel(Container):
                 list_item = ListItem(
                     Static(f"{name}\n[dim]{created}[/dim]", classes="saved-search-item")
                 )
+                list_item.saved_search_name = name
                 await list_view.append(list_item)
                 
             # Enable/disable action buttons based on selection
-            self.query_one("#load-saved-search").disabled = True
-            self.query_one("#delete-saved-search").disabled = True
+            self._set_saved_search_action_state(selected=False)
         except NoMatches:
             logger.debug("Saved searches panel mounted without expected child widgets")
             pass
+
+    @on(ListView.Selected, "#saved-searches-list")
+    def handle_saved_search_selected(self, event: ListView.Selected) -> None:
+        """Enable saved-search actions after the user chooses a saved search."""
+        selected_name = getattr(event.item, "saved_search_name", None)
+        if not selected_name or selected_name not in self.saved_searches:
+            self.selected_search_name = None
+            self._set_saved_search_action_state(selected=False)
+            return
+
+        self.selected_search_name = selected_name
+        self._set_saved_search_action_state(selected=True)
+
+    @on(Button.Pressed, "#load-saved-search")
+    def handle_load_saved_search(self, event: Button.Pressed) -> None:
+        """Emit the selected saved search for the parent search window to apply."""
+        event.stop()
+        selected_name = self.selected_search_name
+        if not selected_name or selected_name not in self.saved_searches:
+            self.selected_search_name = None
+            self._set_saved_search_action_state(selected=False)
+            return
+
+        saved_data = self.saved_searches[selected_name]
+        saved_data["last_used"] = datetime.now().isoformat()
+        self._persist_saved_searches()
+        self.post_message(self.LoadRequested(selected_name, saved_data.get("config", {})))
+
+    @on(Button.Pressed, "#delete-saved-search")
+    async def handle_delete_saved_search(self, event: Button.Pressed) -> None:
+        """Delete the selected saved search and reset the action state."""
+        event.stop()
+        selected_name = self.selected_search_name
+        if not selected_name or selected_name not in self.saved_searches:
+            self.selected_search_name = None
+            self._set_saved_search_action_state(selected=False)
+            return
+
+        del self.saved_searches[selected_name]
+        self._persist_saved_searches()
+        await self.refresh_list()

--- a/tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py
+++ b/tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py
@@ -510,6 +510,44 @@ class SearchRAGWindow(SearchEventHandlersMixin, Container):
             self.app_instance.notify(USE_IN_CHAT_UNAVAILABLE_RECOVERY, severity="warning")
             return
         open_chat(payload)
+
+    @on(SavedSearchesPanel.LoadRequested)
+    def handle_saved_search_load_requested(self, event: SavedSearchesPanel.LoadRequested) -> None:
+        """Apply a selected saved search to the active Search/RAG controls."""
+        event.stop()
+        config = dict(event.config)
+
+        self.query_one("#search-query-input", Input).value = str(config.get("query", ""))
+        if "mode" in config:
+            self.query_one("#search-mode-select", Select).value = config["mode"]
+        if "collection" in config:
+            self.query_one("#collection-select", Select).value = config["collection"]
+        if "top_k" in config:
+            self.query_one("#top-k-input", Input).value = str(config["top_k"])
+        if "temperature" in config:
+            self.query_one("#temperature-input", Input).value = str(config["temperature"])
+
+        filters = config.get("filters") or config.get("sources") or {}
+        if filters:
+            self.query_one("#filter-media", Checkbox).value = bool(filters.get("media", True))
+            self.query_one("#filter-conversations", Checkbox).value = bool(filters.get("conversations", True))
+            self.query_one("#filter-notes", Checkbox).value = bool(filters.get("notes", True))
+
+        if "enable_parent_docs" in config:
+            parent_docs_enabled = bool(config["enable_parent_docs"])
+            self.enable_parent_docs = parent_docs_enabled
+            self.query_one("#parent-docs-checkbox", Checkbox).value = parent_docs_enabled
+        if "parent_strategy" in config:
+            self.query_one("#parent-strategy-select", Select).value = config["parent_strategy"]
+        if "parent_size" in config:
+            self.query_one("#parent-size-input", Input).value = str(config["parent_size"])
+
+        self.last_search_config = config
+        self.query_one("#search-query-input", Input).focus()
+        self.app_instance.notify(
+            f"Loaded saved search '{event.name}' into Search.",
+            severity="information",
+        )
     
     # Setup methods implementation
     def _setup_history_table(self) -> None:

--- a/tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py
+++ b/tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py
@@ -540,7 +540,7 @@ class SearchRAGWindow(SearchEventHandlersMixin, Container):
         if "parent_strategy" in config:
             self.query_one("#parent-strategy-select", Select).value = config["parent_strategy"]
         if "parent_size" in config:
-            self.query_one("#parent-size-input", Input).value = str(config["parent_size"])
+            self.query_one("#parent-size-input", Input).value = str(config["parent_size"] if config["parent_size"] is not None else "")
 
         self.last_search_config = config
         self.query_one("#search-query-input", Input).focus()

--- a/tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py
+++ b/tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py
@@ -517,15 +517,15 @@ class SearchRAGWindow(SearchEventHandlersMixin, Container):
         event.stop()
         config = dict(event.config)
 
-        self.query_one("#search-query-input", Input).value = str(config.get("query", ""))
+        self.query_one("#search-query-input", Input).value = str(config.get("query") or "")
         if "mode" in config:
             self.query_one("#search-mode-select", Select).value = config["mode"]
         if "collection" in config:
             self.query_one("#collection-select", Select).value = config["collection"]
         if "top_k" in config:
-            self.query_one("#top-k-input", Input).value = str(config["top_k"])
+            self.query_one("#top-k-input", Input).value = str(config["top_k"] if config["top_k"] is not None else "")
         if "temperature" in config:
-            self.query_one("#temperature-input", Input).value = str(config["temperature"])
+            self.query_one("#temperature-input", Input).value = str(config["temperature"] if config["temperature"] is not None else "")
 
         filters = config.get("filters") or config.get("sources") or {}
         if filters:


### PR DESCRIPTION
## Summary
- Adds disabled and enabled recovery tooltips for Search/RAG saved-search Load and Delete actions.
- Enables saved-search actions after selection, supports deleting the selected saved search, and loads selected configs back into Search/RAG controls.
- Updates the UX remediation plan through merged PR #171 and this active Search/RAG saved-search slice.

## Test Plan
- env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_search_rag_window.py --tb=short
- git diff --check