### PR TITLE
Explain Media list pagination states

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -1,8 +1,8 @@
 # UX Audit Remediation Plan
 
 Date: 2026-05-01
-Status: Current-dev rebaseline after UX remediation PRs #146-#171, plus active Search/RAG saved-search action slice
-Branch context: current `dev` / `origin/dev` at `03ab9b8d`; active branch `codex/ux-rag-saved-search-actions`
+Status: Current-dev rebaseline after UX remediation PRs #146-#172, plus active Media list pagination-tooltip slice
+Branch context: current `dev` / `origin/dev` at `32f44093`; active branch `codex/ux-media-list-pagination-tooltips`
 Previous audit baseline: `e2576cae`
 
 ## Goal
@@ -29,7 +29,7 @@ This is not a visual refresh. The work is ordered around workflow completion, re
 
 ## Current Dev Rebaseline
 
-Verified on current `dev` at `03ab9b8d`:
+Verified on current `dev` at `32f44093`:
 
 - Phase 0 and Phase 1 are merged: the shared shell/Chatbooks trap, Ingest default source, quiz empty mapping response, Chat save-state, Search/RAG thread mutation, and Search primary-action reachability regressions are covered.
 - Phase 2 is merged: Chat has provider readiness and first-run orientation coverage.
@@ -59,11 +59,12 @@ Current source state plus this branch:
 - Phase 5 Media Analysis action-tooltip copy is merged through PR #169: Media analysis save/note/edit/overwrite/delete actions expose generated-analysis and saved-version recovery reasons.
 - Phase 5 Media Highlight action-tooltip copy is merged through PR #170: Media reading-highlight update/delete actions expose selected-highlight recovery reasons.
 - Phase 5 Media Analysis navigation-tooltip copy is merged through PR #171: Media analysis previous/next version navigation explains empty, first-version, and last-version states.
-- Phase 5 Search/RAG saved-search action recovery is active in `codex/ux-rag-saved-search-actions`: saved-search Load/Delete actions should explain selection requirements and let selected searches repopulate the Search/RAG controls.
+- Phase 5 Search/RAG saved-search action recovery is merged through PR #172: saved-search Load/Delete actions explain selection requirements and selected searches repopulate the Search/RAG controls.
+- Phase 5 Media list pagination-tooltip copy is active in `codex/ux-media-list-pagination-tooltips`: Media result pagination should explain single-page, first-page, middle-page, and last-page navigation states.
 - Phase 6 still needs any remaining optional dependency gaps represented as user-facing capability states where relevant.
 - Phase 7 still needs end-to-end audit replay on a clean home/config.
 
-Planning consequence: remaining implementation should target remaining Phase 4 source-authority and broader live smoke cases, any remaining compact-label/descriptive copy outside top navigation and command-palette tab navigation, disabled-state consistency beyond Web Search, Media Source, Study Quiz, Study Flashcard, Media Viewer, Media Analysis, Media Highlight, Media Analysis navigation, and Search/RAG saved-search actions, Phase 6 capability-state presentation beyond Speech/STTS and Web Search where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
+Planning consequence: remaining implementation should target remaining Phase 4 source-authority and broader live smoke cases, any remaining compact-label/descriptive copy outside top navigation and command-palette tab navigation, disabled-state consistency beyond Web Search, Media Source, Study Quiz, Study Flashcard, Media Viewer, Media Analysis, Media Highlight, Media Analysis navigation, Search/RAG saved-search actions, and Media list pagination, Phase 6 capability-state presentation beyond Speech/STTS and Web Search where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
 
 ## Issues Covered
 
@@ -302,7 +303,7 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 
 Purpose: make the app understandable without reducing expert efficiency.
 
-Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, #163, #164, #165, #166, #167, #168, #169, #170, and #171. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, Speech/STTS exposes local dependency capability states, Web Search missing dependencies render as disabled-state recovery copy, Media Source disabled actions expose recovery tooltips, Study Quiz disabled actions expose recovery tooltips, Study Flashcards disabled actions expose recovery tooltips, Media Viewer actions expose selection/capability tooltips, Media Analysis actions expose generated-analysis/saved-version tooltips, Media Highlight actions expose selected-highlight tooltips, and Media Analysis navigation actions expose saved-version boundary tooltips.
+Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, #163, #164, #165, #166, #167, #168, #169, #170, #171, and #172. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, Speech/STTS exposes local dependency capability states, Web Search missing dependencies render as disabled-state recovery copy, Media Source disabled actions expose recovery tooltips, Study Quiz disabled actions expose recovery tooltips, Study Flashcards disabled actions expose recovery tooltips, Media Viewer actions expose selection/capability tooltips, Media Analysis actions expose generated-analysis/saved-version tooltips, Media Highlight actions expose selected-highlight tooltips, Media Analysis navigation actions expose saved-version boundary tooltips, and Search/RAG saved-search actions expose selection/reuse recovery.
 
 ### Files
 
@@ -337,6 +338,7 @@ Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #
 - [x] Add Media Reading Highlight action tooltips for update/delete states when no highlight is selected.
 - [x] Add Media Analysis navigation tooltips for previous/next saved-version boundary states.
 - [x] Add Search/RAG saved-search action recovery for Load/Delete selection states and selected-config reuse.
+- [x] Add Media list pagination tooltips for single-page and first/last result-page states.
 - [ ] Add tooltips or short descriptions where compact labels remain necessary outside top navigation.
 
 ### Acceptance Criteria
@@ -436,4 +438,4 @@ Current-dev state: not started. The smoke/replay artifacts need to be regenerate
 
 ## Next Step
 
-After this Search/RAG saved-search action slice, the remaining Phase 4 work is invalid-selection/source-authority smoke coverage and the remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.
+After this Media list pagination-tooltip slice, the remaining Phase 4 work is invalid-selection/source-authority smoke coverage and the remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.

--- a/Tests/UI/test_media_window_v2_parity.py
+++ b/Tests/UI/test_media_window_v2_parity.py
@@ -18,6 +18,7 @@ from tldw_chatbook.Event_Handlers.media_events import (
 )
 from tldw_chatbook.UI.MediaWindow_v2 import MediaWindow
 from tldw_chatbook.UI.Screens.media_runtime_state import MediaRuntimeState
+from tldw_chatbook.Widgets.Media.media_list_panel import MediaListPanel
 from tldw_chatbook.Widgets.Media.media_search_panel import MediaBrowseSubviewChangedEvent, MediaSearchPanel
 from tldw_chatbook.Widgets.Media.media_viewer_panel import MediaViewerPanel
 
@@ -89,6 +90,59 @@ async def test_media_empty_state_orients_first_time_users():
         assert "Select a media item" in text
         assert "analysis" in text
         assert "Use in Chat" in text
+
+
+@pytest.mark.asyncio
+async def test_media_list_pagination_explains_boundary_states():
+    class MediaListPanelApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield MediaListPanel(SimpleNamespace())
+
+    app = MediaListPanelApp()
+    async with app.run_test() as pilot:
+        panel = app.query_one(MediaListPanel)
+        prev_button = panel.query_one("#prev-button", Button)
+        next_button = panel.query_one("#next-button", Button)
+
+        panel.current_page = 1
+        panel.total_pages = 1
+        panel.update_pagination()
+        await pilot.pause()
+
+        assert prev_button.disabled is True
+        assert "Only one page of media results is available" in str(prev_button.tooltip)
+        assert next_button.disabled is True
+        assert "Only one page of media results is available" in str(next_button.tooltip)
+
+        panel.current_page = 1
+        panel.total_pages = 3
+        panel.update_pagination()
+        await pilot.pause()
+
+        assert prev_button.disabled is True
+        assert "Already on the first media results page" in str(prev_button.tooltip)
+        assert next_button.disabled is False
+        assert "Show the next media results page" in str(next_button.tooltip)
+
+        panel.current_page = 2
+        panel.total_pages = 3
+        panel.update_pagination()
+        await pilot.pause()
+
+        assert prev_button.disabled is False
+        assert "Show the previous media results page" in str(prev_button.tooltip)
+        assert next_button.disabled is False
+        assert "Show the next media results page" in str(next_button.tooltip)
+
+        panel.current_page = 3
+        panel.total_pages = 3
+        panel.update_pagination()
+        await pilot.pause()
+
+        assert prev_button.disabled is False
+        assert "Show the previous media results page" in str(prev_button.tooltip)
+        assert next_button.disabled is True
+        assert "Already on the last media results page" in str(next_button.tooltip)
 
 
 @pytest.mark.asyncio

--- a/tldw_chatbook/Widgets/Media/media_list_panel.py
+++ b/tldw_chatbook/Widgets/Media/media_list_panel.py
@@ -21,6 +21,13 @@ if TYPE_CHECKING:
     from ...app import TldwCli
 
 
+MEDIA_PAGINATION_SINGLE_PAGE_TOOLTIP = "Only one page of media results is available."
+MEDIA_PAGINATION_PREVIOUS_ENABLED_TOOLTIP = "Show the previous media results page."
+MEDIA_PAGINATION_PREVIOUS_FIRST_TOOLTIP = "Already on the first media results page."
+MEDIA_PAGINATION_NEXT_ENABLED_TOOLTIP = "Show the next media results page."
+MEDIA_PAGINATION_NEXT_LAST_TOOLTIP = "Already on the last media results page."
+
+
 class MediaItemSelectedEvent(Message):
     """Event fired when a media item is selected."""
     
@@ -170,9 +177,19 @@ class MediaListPanel(Container):
         
         # Pagination
         with Horizontal(classes="pagination-bar"):
-            yield Button("Previous", id="prev-button", disabled=True)
+            yield Button(
+                "Previous",
+                id="prev-button",
+                disabled=True,
+                tooltip=MEDIA_PAGINATION_SINGLE_PAGE_TOOLTIP,
+            )
             yield Label("Page 1 / 1", id="page-label", classes="page-label")
-            yield Button("Next", id="next-button", disabled=True)
+            yield Button(
+                "Next",
+                id="next-button",
+                disabled=True,
+                tooltip=MEDIA_PAGINATION_SINGLE_PAGE_TOOLTIP,
+            )
     
     def watch_items(self, items: List[Dict[str, Any]]) -> None:
         """Update the list when items change."""
@@ -300,6 +317,20 @@ class MediaListPanel(Container):
             
             prev_button.disabled = self.current_page <= 1
             next_button.disabled = self.current_page >= self.total_pages
+            if self.total_pages <= 1:
+                prev_button.tooltip = MEDIA_PAGINATION_SINGLE_PAGE_TOOLTIP
+                next_button.tooltip = MEDIA_PAGINATION_SINGLE_PAGE_TOOLTIP
+            else:
+                prev_button.tooltip = (
+                    MEDIA_PAGINATION_PREVIOUS_FIRST_TOOLTIP
+                    if prev_button.disabled
+                    else MEDIA_PAGINATION_PREVIOUS_ENABLED_TOOLTIP
+                )
+                next_button.tooltip = (
+                    MEDIA_PAGINATION_NEXT_LAST_TOOLTIP
+                    if next_button.disabled
+                    else MEDIA_PAGINATION_NEXT_ENABLED_TOOLTIP
+                )
             
             page_label.update(f"Page {self.current_page} / {self.total_pages}")
         except:


### PR DESCRIPTION
## Summary
- Adds disabled and enabled tooltips for Media result list pagination states.
- Explains single-page, first-page, middle-page, and last-page Previous/Next behavior without changing pagination contracts.
- Updates the UX remediation plan through merged PR #172 and this active Media pagination slice.

## Test Plan
- env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_media_window_v2_parity.py --tb=short
- git diff --check