### PR TITLE
Explain Media multi-item review action states

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -1,8 +1,8 @@
 # UX Audit Remediation Plan
 
 Date: 2026-05-01
-Status: Current-dev rebaseline after UX remediation PRs #146-#172, plus active Media list pagination-tooltip slice
-Branch context: current `dev` / `origin/dev` at `32f44093`; active branch `codex/ux-media-list-pagination-tooltips`
+Status: Current-dev rebaseline after UX remediation PRs #146-#173, plus active Media multi-item review action-tooltip slice
+Branch context: current `dev` / `origin/dev` at `fddf7dba`; active branch `codex/ux-multi-review-action-tooltips`
 Previous audit baseline: `e2576cae`
 
 ## Goal
@@ -29,7 +29,7 @@ This is not a visual refresh. The work is ordered around workflow completion, re
 
 ## Current Dev Rebaseline
 
-Verified on current `dev` at `32f44093`:
+Verified on current `dev` at `fddf7dba`:
 
 - Phase 0 and Phase 1 are merged: the shared shell/Chatbooks trap, Ingest default source, quiz empty mapping response, Chat save-state, Search/RAG thread mutation, and Search primary-action reachability regressions are covered.
 - Phase 2 is merged: Chat has provider readiness and first-run orientation coverage.
@@ -60,11 +60,12 @@ Current source state plus this branch:
 - Phase 5 Media Highlight action-tooltip copy is merged through PR #170: Media reading-highlight update/delete actions expose selected-highlight recovery reasons.
 - Phase 5 Media Analysis navigation-tooltip copy is merged through PR #171: Media analysis previous/next version navigation explains empty, first-version, and last-version states.
 - Phase 5 Search/RAG saved-search action recovery is merged through PR #172: saved-search Load/Delete actions explain selection requirements and selected searches repopulate the Search/RAG controls.
-- Phase 5 Media list pagination-tooltip copy is active in `codex/ux-media-list-pagination-tooltips`: Media result pagination should explain single-page, first-page, middle-page, and last-page navigation states.
+- Phase 5 Media list pagination-tooltip copy is merged through PR #173: Media result pagination explains single-page, first-page, middle-page, and last-page navigation states.
+- Phase 5 Media multi-item review action-tooltip copy is active in `codex/ux-multi-review-action-tooltips`: batch Generate/Cancel analysis actions should explain no-selection, selected, and in-progress states.
 - Phase 6 still needs any remaining optional dependency gaps represented as user-facing capability states where relevant.
 - Phase 7 still needs end-to-end audit replay on a clean home/config.
 
-Planning consequence: remaining implementation should target remaining Phase 4 source-authority and broader live smoke cases, any remaining compact-label/descriptive copy outside top navigation and command-palette tab navigation, disabled-state consistency beyond Web Search, Media Source, Study Quiz, Study Flashcard, Media Viewer, Media Analysis, Media Highlight, Media Analysis navigation, Search/RAG saved-search actions, and Media list pagination, Phase 6 capability-state presentation beyond Speech/STTS and Web Search where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
+Planning consequence: remaining implementation should target remaining Phase 4 source-authority and broader live smoke cases, any remaining compact-label/descriptive copy outside top navigation and command-palette tab navigation, disabled-state consistency beyond Web Search, Media Source, Study Quiz, Study Flashcard, Media Viewer, Media Analysis, Media Highlight, Media Analysis navigation, Search/RAG saved-search actions, Media list pagination, and Media multi-item review actions, Phase 6 capability-state presentation beyond Speech/STTS and Web Search where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
 
 ## Issues Covered
 
@@ -303,7 +304,7 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 
 Purpose: make the app understandable without reducing expert efficiency.
 
-Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, #163, #164, #165, #166, #167, #168, #169, #170, #171, and #172. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, Speech/STTS exposes local dependency capability states, Web Search missing dependencies render as disabled-state recovery copy, Media Source disabled actions expose recovery tooltips, Study Quiz disabled actions expose recovery tooltips, Study Flashcards disabled actions expose recovery tooltips, Media Viewer actions expose selection/capability tooltips, Media Analysis actions expose generated-analysis/saved-version tooltips, Media Highlight actions expose selected-highlight tooltips, Media Analysis navigation actions expose saved-version boundary tooltips, and Search/RAG saved-search actions expose selection/reuse recovery.
+Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, #163, #164, #165, #166, #167, #168, #169, #170, #171, #172, and #173. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, Speech/STTS exposes local dependency capability states, Web Search missing dependencies render as disabled-state recovery copy, Media Source disabled actions expose recovery tooltips, Study Quiz disabled actions expose recovery tooltips, Study Flashcards disabled actions expose recovery tooltips, Media Viewer actions expose selection/capability tooltips, Media Analysis actions expose generated-analysis/saved-version tooltips, Media Highlight actions expose selected-highlight tooltips, Media Analysis navigation actions expose saved-version boundary tooltips, Search/RAG saved-search actions expose selection/reuse recovery, and Media list pagination exposes result-page boundary tooltips.
 
 ### Files
 
@@ -339,6 +340,7 @@ Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #
 - [x] Add Media Analysis navigation tooltips for previous/next saved-version boundary states.
 - [x] Add Search/RAG saved-search action recovery for Load/Delete selection states and selected-config reuse.
 - [x] Add Media list pagination tooltips for single-page and first/last result-page states.
+- [x] Add Media multi-item review action tooltips for Generate/Cancel analysis states.
 - [ ] Add tooltips or short descriptions where compact labels remain necessary outside top navigation.
 
 ### Acceptance Criteria
@@ -438,4 +440,4 @@ Current-dev state: not started. The smoke/replay artifacts need to be regenerate
 
 ## Next Step
 
-After this Media list pagination-tooltip slice, the remaining Phase 4 work is invalid-selection/source-authority smoke coverage and the remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.
+After this Media multi-item review action-tooltip slice, the remaining Phase 4 work is invalid-selection/source-authority smoke coverage and the remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.

--- a/Tests/UI/test_multi_item_review_window.py
+++ b/Tests/UI/test_multi_item_review_window.py
@@ -1,0 +1,49 @@
+from types import SimpleNamespace
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Button
+
+from tldw_chatbook.Widgets.multi_item_review_window import MultiItemReviewWindow
+
+
+@pytest.mark.asyncio
+async def test_multi_item_review_generation_actions_explain_states():
+    class MultiItemReviewApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield MultiItemReviewWindow(SimpleNamespace(notify=lambda *args, **kwargs: None))
+
+    app = MultiItemReviewApp()
+    async with app.run_test() as pilot:
+        window = app.query_one(MultiItemReviewWindow)
+        generate_button = window.query_one("#generate-analyses", Button)
+        cancel_button = window.query_one("#cancel-generation", Button)
+
+        window.selected_items = []
+        window.analysis_in_progress = False
+        window.update_generate_button()
+        await pilot.pause()
+
+        assert generate_button.disabled is True
+        assert "Select at least one media item before generating analyses" in str(generate_button.tooltip)
+        assert cancel_button.disabled is True
+        assert "No analysis generation is running" in str(cancel_button.tooltip)
+
+        window.selected_items = [{"id": 1, "title": "Transcript"}]
+        window.analysis_in_progress = False
+        window.update_generate_button()
+        await pilot.pause()
+
+        assert generate_button.disabled is False
+        assert "Generate analyses for the selected media items" in str(generate_button.tooltip)
+        assert cancel_button.disabled is True
+        assert "No analysis generation is running" in str(cancel_button.tooltip)
+
+        window.analysis_in_progress = True
+        window.update_generate_button()
+        await pilot.pause()
+
+        assert generate_button.disabled is True
+        assert "Analysis generation is already running" in str(generate_button.tooltip)
+        assert cancel_button.disabled is False
+        assert "Cancel the running analysis generation" in str(cancel_button.tooltip)

--- a/Tests/UI/test_multi_item_review_window.py
+++ b/Tests/UI/test_multi_item_review_window.py
@@ -4,11 +4,20 @@ import pytest
 from textual.app import App, ComposeResult
 from textual.widgets import Button
 
-from tldw_chatbook.Widgets.multi_item_review_window import MultiItemReviewWindow
+from tldw_chatbook.Widgets.multi_item_review_window import (
+    CANCEL_GENERATION_DISABLED_TOOLTIP,
+    CANCEL_GENERATION_ENABLED_TOOLTIP,
+    GENERATE_ANALYSES_ENABLED_TOOLTIP,
+    GENERATE_ANALYSES_IN_PROGRESS_TOOLTIP,
+    GENERATE_ANALYSES_NO_SELECTION_TOOLTIP,
+    MultiItemReviewWindow,
+)
 
 
 @pytest.mark.asyncio
 async def test_multi_item_review_generation_actions_explain_states():
+    """Generation controls should explain selection, ready, and running states."""
+
     class MultiItemReviewApp(App[None]):
         def compose(self) -> ComposeResult:
             yield MultiItemReviewWindow(SimpleNamespace(notify=lambda *args, **kwargs: None))
@@ -19,31 +28,34 @@ async def test_multi_item_review_generation_actions_explain_states():
         generate_button = window.query_one("#generate-analyses", Button)
         cancel_button = window.query_one("#cancel-generation", Button)
 
+        # State 1: no selected media, so generation cannot start.
         window.selected_items = []
         window.analysis_in_progress = False
         window.update_generate_button()
         await pilot.pause()
 
         assert generate_button.disabled is True
-        assert "Select at least one media item before generating analyses" in str(generate_button.tooltip)
+        assert str(generate_button.tooltip) == GENERATE_ANALYSES_NO_SELECTION_TOOLTIP
         assert cancel_button.disabled is True
-        assert "No analysis generation is running" in str(cancel_button.tooltip)
+        assert str(cancel_button.tooltip) == CANCEL_GENERATION_DISABLED_TOOLTIP
 
+        # State 2: selected media is ready to generate, with no cancellation target.
         window.selected_items = [{"id": 1, "title": "Transcript"}]
         window.analysis_in_progress = False
         window.update_generate_button()
         await pilot.pause()
 
         assert generate_button.disabled is False
-        assert "Generate analyses for the selected media items" in str(generate_button.tooltip)
+        assert str(generate_button.tooltip) == GENERATE_ANALYSES_ENABLED_TOOLTIP
         assert cancel_button.disabled is True
-        assert "No analysis generation is running" in str(cancel_button.tooltip)
+        assert str(cancel_button.tooltip) == CANCEL_GENERATION_DISABLED_TOOLTIP
 
+        # State 3: an active generation can be cancelled but not duplicated.
         window.analysis_in_progress = True
         window.update_generate_button()
         await pilot.pause()
 
         assert generate_button.disabled is True
-        assert "Analysis generation is already running" in str(generate_button.tooltip)
+        assert str(generate_button.tooltip) == GENERATE_ANALYSES_IN_PROGRESS_TOOLTIP
         assert cancel_button.disabled is False
-        assert "Cancel the running analysis generation" in str(cancel_button.tooltip)
+        assert str(cancel_button.tooltip) == CANCEL_GENERATION_ENABLED_TOOLTIP

--- a/tldw_chatbook/Widgets/multi_item_review_window.py
+++ b/tldw_chatbook/Widgets/multi_item_review_window.py
@@ -278,22 +278,22 @@ class MultiItemReviewWindow(Container):
         generate_button = self.query_one("#generate-analyses", Button)
         cancel_button = self.query_one("#cancel-generation", Button)
 
-        has_selection = len(self.selected_items) > 0
-        generate_button.disabled = not has_selection or self.analysis_in_progress
-        cancel_button.disabled = not self.analysis_in_progress
-
         if self.analysis_in_progress:
+            generate_button.disabled = True
             generate_button.tooltip = GENERATE_ANALYSES_IN_PROGRESS_TOOLTIP
-        elif not has_selection:
-            generate_button.tooltip = GENERATE_ANALYSES_NO_SELECTION_TOOLTIP
-        else:
-            generate_button.tooltip = GENERATE_ANALYSES_ENABLED_TOOLTIP
+            cancel_button.disabled = False
+            cancel_button.tooltip = CANCEL_GENERATION_ENABLED_TOOLTIP
+            return
 
-        cancel_button.tooltip = (
-            CANCEL_GENERATION_ENABLED_TOOLTIP
-            if self.analysis_in_progress
-            else CANCEL_GENERATION_DISABLED_TOOLTIP
+        has_selection = len(self.selected_items) > 0
+        generate_button.disabled = not has_selection
+        generate_button.tooltip = (
+            GENERATE_ANALYSES_ENABLED_TOOLTIP
+            if has_selection
+            else GENERATE_ANALYSES_NO_SELECTION_TOOLTIP
         )
+        cancel_button.disabled = True
+        cancel_button.tooltip = CANCEL_GENERATION_DISABLED_TOOLTIP
         
     @on(Button.Pressed, "#generate-analyses")
     async def handle_generate_analyses(self) -> None:

--- a/tldw_chatbook/Widgets/multi_item_review_window.py
+++ b/tldw_chatbook/Widgets/multi_item_review_window.py
@@ -20,6 +20,13 @@ if TYPE_CHECKING:
     from ..app import TldwCli
 
 
+GENERATE_ANALYSES_NO_SELECTION_TOOLTIP = "Select at least one media item before generating analyses."
+GENERATE_ANALYSES_ENABLED_TOOLTIP = "Generate analyses for the selected media items."
+GENERATE_ANALYSES_IN_PROGRESS_TOOLTIP = "Analysis generation is already running."
+CANCEL_GENERATION_DISABLED_TOOLTIP = "No analysis generation is running."
+CANCEL_GENERATION_ENABLED_TOOLTIP = "Cancel the running analysis generation."
+
+
 class AnalysisGenerationEvent(Message):
     """Event for analysis generation progress updates."""
     
@@ -96,8 +103,20 @@ class MultiItemReviewWindow(Container):
                 # Analysis controls
                 with Horizontal(classes="analysis-controls"):
                     yield Checkbox("Save analyses permanently", id="save-analyses-checkbox", value=False)
-                    yield Button("Generate Analyses", id="generate-analyses", variant="success", disabled=True)
-                    yield Button("Cancel", id="cancel-generation", variant="error", disabled=True)
+                    yield Button(
+                        "Generate Analyses",
+                        id="generate-analyses",
+                        variant="success",
+                        disabled=True,
+                        tooltip=GENERATE_ANALYSES_NO_SELECTION_TOOLTIP,
+                    )
+                    yield Button(
+                        "Cancel",
+                        id="cancel-generation",
+                        variant="error",
+                        disabled=True,
+                        tooltip=CANCEL_GENERATION_DISABLED_TOOLTIP,
+                    )
                     
                 # Progress indicator
                 yield ProgressBar(id="analysis-progress", classes="analysis-progress hidden", show_eta=False)
@@ -252,8 +271,29 @@ class MultiItemReviewWindow(Container):
         
     def update_generate_button(self) -> None:
         """Enable/disable generate button based on selection."""
-        button = self.query_one("#generate-analyses", Button)
-        button.disabled = len(self.selected_items) == 0 or self.analysis_in_progress
+        self._update_generation_action_states()
+
+    def _update_generation_action_states(self) -> None:
+        """Keep generation controls and recovery copy synchronized."""
+        generate_button = self.query_one("#generate-analyses", Button)
+        cancel_button = self.query_one("#cancel-generation", Button)
+
+        has_selection = len(self.selected_items) > 0
+        generate_button.disabled = not has_selection or self.analysis_in_progress
+        cancel_button.disabled = not self.analysis_in_progress
+
+        if self.analysis_in_progress:
+            generate_button.tooltip = GENERATE_ANALYSES_IN_PROGRESS_TOOLTIP
+        elif not has_selection:
+            generate_button.tooltip = GENERATE_ANALYSES_NO_SELECTION_TOOLTIP
+        else:
+            generate_button.tooltip = GENERATE_ANALYSES_ENABLED_TOOLTIP
+
+        cancel_button.tooltip = (
+            CANCEL_GENERATION_ENABLED_TOOLTIP
+            if self.analysis_in_progress
+            else CANCEL_GENERATION_DISABLED_TOOLTIP
+        )
         
     @on(Button.Pressed, "#generate-analyses")
     async def handle_generate_analyses(self) -> None:
@@ -265,8 +305,7 @@ class MultiItemReviewWindow(Container):
         self.analysis_results.clear()
         
         # Update UI
-        self.query_one("#generate-analyses", Button).disabled = True
-        self.query_one("#cancel-generation", Button).disabled = False
+        self._update_generation_action_states()
         self.query_one("#analysis-progress", ProgressBar).remove_class("hidden")
         self.query_one("#progress-label", Static).remove_class("hidden")
         
@@ -365,8 +404,7 @@ class MultiItemReviewWindow(Container):
     def _reset_generation_ui(self) -> None:
         """Reset the UI after generation completes."""
         self.analysis_in_progress = False
-        self.query_one("#generate-analyses", Button).disabled = len(self.selected_items) == 0
-        self.query_one("#cancel-generation", Button).disabled = True
+        self._update_generation_action_states()
         self.query_one("#analysis-progress", ProgressBar).add_class("hidden")
         self.query_one("#progress-label", Static).add_class("hidden")
         


### PR DESCRIPTION
## Summary
- Adds disabled and enabled tooltips for Media multi-item review Generate and Cancel analysis actions.
- Keeps Generate/Cancel action state copy synchronized for no-selection, selected-item, and generation-in-progress states.
- Updates the UX remediation plan through merged PR #173 and this active multi-item review slice.

## Test Plan
- env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_multi_item_review_window.py --tb=short
- git diff --check