### PR TITLE
Add invalid handoff selection smoke coverage

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -1,8 +1,8 @@
 # UX Audit Remediation Plan
 
 Date: 2026-05-01
-Status: Current-dev rebaseline after UX remediation PRs #146-#174, plus active handoff first-send smoke slice
-Branch context: current `dev` / `origin/dev` at `d0fbcad6`; active branch `codex/ux-handoff-first-send-smoke`
+Status: Current-dev rebaseline after UX remediation PRs #146-#175, plus active invalid-selection smoke slice
+Branch context: current `dev` / `origin/dev` at `ab921c01`; active branch `codex/ux-invalid-selection-smoke`
 Previous audit baseline: `e2576cae`
 
 ## Goal
@@ -29,7 +29,7 @@ This is not a visual refresh. The work is ordered around workflow completion, re
 
 ## Current Dev Rebaseline
 
-Verified on current `dev` at `d0fbcad6`:
+Verified on current `dev` at `ab921c01`:
 
 - Phase 0 and Phase 1 are merged: the shared shell/Chatbooks trap, Ingest default source, quiz empty mapping response, Chat save-state, Search/RAG thread mutation, and Search primary-action reachability regressions are covered.
 - Phase 2 is merged: Chat has provider readiness and first-run orientation coverage.
@@ -62,11 +62,12 @@ Current source state plus this branch:
 - Phase 5 Search/RAG saved-search action recovery is merged through PR #172: saved-search Load/Delete actions explain selection requirements and selected searches repopulate the Search/RAG controls.
 - Phase 5 Media list pagination-tooltip copy is merged through PR #173: Media result pagination explains single-page, first-page, middle-page, and last-page navigation states.
 - Phase 5 Media multi-item review action-tooltip copy is merged through PR #174: batch Generate/Cancel analysis actions explain no-selection, selected, and in-progress states.
-- Phase 4/7 handoff first-send smoke coverage is active in `codex/ux-handoff-first-send-smoke`: a mounted Textual test stages a handoff into a real Chat tab and verifies the first-send path applies staged context before marking the payload sent.
+- Phase 4/7 handoff first-send smoke coverage is merged through PR #175: a mounted Textual test stages a handoff into a real Chat tab and verifies the first-send path applies staged context before marking the payload sent.
+- Phase 4 invalid-selection smoke coverage is active in `codex/ux-invalid-selection-smoke`: mounted Textual tests press empty Notes, workspace source/artifact, and Media handoff actions and verify they expose recovery copy without staging Chat.
 - Phase 6 still needs any remaining optional dependency gaps represented as user-facing capability states where relevant.
 - Phase 7 still needs end-to-end audit replay on a clean home/config.
 
-Planning consequence: remaining implementation should target remaining Phase 4 source-authority and broader live smoke cases, any remaining compact-label/descriptive copy outside top navigation and command-palette tab navigation, disabled-state consistency beyond Web Search, Media Source, Study Quiz, Study Flashcard, Media Viewer, Media Analysis, Media Highlight, Media Analysis navigation, Search/RAG saved-search actions, Media list pagination, and Media multi-item review actions, Phase 6 capability-state presentation beyond Speech/STTS and Web Search where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
+Planning consequence: remaining implementation should target remaining Phase 4 source-authority and broader live source-handoff replay cases, any remaining compact-label/descriptive copy outside top navigation and command-palette tab navigation, disabled-state consistency beyond Web Search, Media Source, Study Quiz, Study Flashcard, Media Viewer, Media Analysis, Media Highlight, Media Analysis navigation, Search/RAG saved-search actions, Media list pagination, and Media multi-item review actions, Phase 6 capability-state presentation beyond Speech/STTS and Web Search where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
 
 ## Issues Covered
 
@@ -263,7 +264,7 @@ Branch state: clear/dismiss behavior completed in `codex/ux-chat-handoff-clear-c
 
 Purpose: verify and harden the source-side handoff surfaces that have now landed in current `dev`.
 
-Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG Search, and dedicated Web Search handoffs are implemented and covered by focused tests. The active invalid-selection slice disables Notes and workspace source/artifact handoffs until a valid item is selected. Remaining work is to close source-authority edge cases in the shared UX smoke pass.
+Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG Search, and dedicated Web Search handoffs are implemented and covered by focused tests. Notes, workspace source/artifact, and Media invalid-selection states now have shared-harness smoke coverage in the active branch. Remaining work is to close source-authority edge cases and broader source-handoff replay in the shared UX smoke pass.
 
 ### Files
 
@@ -291,12 +292,13 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 - [ ] Consume backend-owned `UX_Interop` and `runtime_policy` contracts consistently; do not rebuild source authority from raw config.
 - [ ] Keep dry-run sync reports diagnostic only; do not imply mirroring or write sync in source screens.
 - [ ] Replay each source handoff in the Phase 0/7 smoke harness.
+- [x] Replay invalid-selection handoff states for Notes, workspace source/artifact, and Media in the Phase 0/7 smoke harness.
 
 ### Acceptance Criteria
 
 - [x] Notes, Workspaces, Media, RAG Search, and Web Search can each stage one selected item into Chat in focused tests.
 - [x] Notes and workspace item invalid-selection actions are disabled with recovery copy in mounted Textual tests.
-- [ ] No invalid selection navigates to Chat in live smoke coverage.
+- [x] No invalid selection navigates to Chat in live smoke coverage.
 - [ ] Disabled handoff actions have a reason and a recovery path.
 - [x] Workspace handoffs preserve `workspace_id` and isolation metadata in focused tests.
 - [x] Web Search is in scope and not silently omitted.
@@ -441,4 +443,4 @@ Current-dev state: partially started. A mounted handoff first-send smoke test no
 
 ## Next Step
 
-After this handoff first-send smoke slice, the remaining Phase 4 work is invalid-selection/source-authority smoke coverage across each source surface and the remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.
+After this invalid-selection smoke slice, the remaining Phase 4 work is source-authority smoke coverage and broader source-handoff replay across each source surface. The remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.

--- a/Tests/UI/test_ux_audit_smoke.py
+++ b/Tests/UI/test_ux_audit_smoke.py
@@ -6,16 +6,20 @@ from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
+from textual import on
 from textual.app import App, ComposeResult
 from textual.widgets import Button, TextArea
 
 from tldw_chatbook.Chat.chat_handoff_models import ChatHandoffPayload
 from tldw_chatbook.Event_Handlers.Chat_Events.chat_events import apply_current_handoff_context
 from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+from tldw_chatbook.UI.Screens.notes_scope_models import ScopeType, WorkspaceSubview
+from tldw_chatbook.UI.Screens.notes_screen import NotesScreen
 from tldw_chatbook.UI.Chatbooks_Window_Improved import ChatbooksWindowImproved
 from tldw_chatbook.UI.Screens.chatbooks_screen import ChatbooksScreen
 from tldw_chatbook.Widgets.Chat_Widgets.chat_handoff_card import ChatHandoffCard
 from tldw_chatbook.Widgets.Chat_Widgets.chat_tab_container import ChatTabContainer
+from tldw_chatbook.Widgets.Media.media_viewer_panel import MediaViewerPanel
 
 
 class ChatbooksShellSmokeApp(App[None]):
@@ -86,20 +90,21 @@ async def test_handoff_smoke_replays_chat_staging_and_first_send(monkeypatch):
     app = HandoffFirstSendSmokeApp(payload)
     observed: dict[str, str | None] = {}
 
-    async def fake_send_handler(app, event):
-        tab_container = app.query_one(ChatTabContainer)
+    async def fake_send_handler(chat_app, event):
+        tab_container = app.tab_container
+        assert tab_container is not None
         session = tab_container.sessions[tab_container.active_session_id]
         payload = session.session_data.handoff_payload
 
-        app.host._current_chat_handoff_payload = payload
+        chat_app._current_chat_handoff_payload = payload
         observed["wrapped_prompt"] = apply_current_handoff_context(
-            app.host,
+            chat_app,
             "Summarize the usability issue.",
         )
-        observed["active_handoff_title"] = app.host._current_chat_handoff_payload.title
+        observed["active_handoff_title"] = chat_app._current_chat_handoff_payload.title
 
         payload.status = "sent"
-        app.host._current_chat_handoff_payload = None
+        chat_app._current_chat_handoff_payload = None
 
     monkeypatch.setattr(
         "tldw_chatbook.Event_Handlers.Chat_Events.chat_events.handle_chat_send_button_pressed",
@@ -138,3 +143,110 @@ async def test_handoff_smoke_replays_chat_staging_and_first_send(monkeypatch):
         assert "[User prompt]\nSummarize the usability issue." in observed["wrapped_prompt"]
         assert session.session_data.handoff_payload.status == "sent"
         assert app.host._current_chat_handoff_payload is None
+
+
+def _empty_notes_service() -> Mock:
+    service = Mock()
+    service.list_notes.return_value = []
+    return service
+
+
+class InvalidNotesSelectionSmokeApp(App[None]):
+    def __init__(self) -> None:
+        super().__init__()
+        app_instance = SimpleNamespace(
+            notes_service=_empty_notes_service(),
+            notes_user_id="default_user",
+            notes_scope_service=None,
+            server_notes_workspace_service=None,
+            notify=Mock(),
+            open_chat_with_handoff=Mock(),
+            open_study_screen=Mock(),
+            open_notes_workspace=Mock(),
+            call_from_thread=Mock(),
+            loguru_logger=Mock(),
+            current_selected_note_id=None,
+            current_selected_note_version=None,
+            current_selected_note_title="",
+            current_selected_note_content="",
+        )
+        self.app_instance = app_instance
+        self.screen_under_test = NotesScreen(app_instance)
+
+    def on_mount(self) -> None:
+        self.push_screen(self.screen_under_test)
+
+
+@pytest.mark.asyncio
+async def test_invalid_notes_and_workspace_handoffs_do_not_stage_chat_in_smoke():
+    app = InvalidNotesSelectionSmokeApp()
+
+    async with app.run_test(size=(160, 40)) as pilot:
+        await pilot.pause(0.1)
+        screen = app.screen_under_test
+
+        note_button = screen.query_one("#notes-use-in-chat-button", Button)
+        assert note_button.disabled is True
+        assert "Select a note" in str(note_button.tooltip)
+
+        note_button.press()
+        await pilot.pause(0.05)
+
+        app.app_instance.open_chat_with_handoff.assert_not_called()
+
+        screen._set_state(
+            scope_type=ScopeType.WORKSPACE,
+            workspace_subview=WorkspaceSubview.SOURCES,
+            selected_workspace_id="workspace-1",
+            selected_workspace_source_id=None,
+            selected_workspace_artifact_id=None,
+        )
+        await pilot.pause(0.05)
+
+        workspace_button = screen.query_one("#workspace-use-in-chat-button", Button)
+        source_button = screen.query_one("#workspace-source-use-in-chat-button", Button)
+        artifact_button = screen.query_one("#workspace-artifact-use-in-chat-button", Button)
+
+        assert workspace_button.disabled is False
+        assert source_button.disabled is True
+        assert "Select a workspace source" in str(source_button.tooltip)
+        assert artifact_button.disabled is True
+        assert "Select a workspace artifact" in str(artifact_button.tooltip)
+
+        source_button.press()
+        artifact_button.press()
+        await pilot.pause(0.05)
+
+        app.app_instance.open_chat_with_handoff.assert_not_called()
+
+
+class InvalidMediaSelectionSmokeApp(App[None]):
+    def __init__(self) -> None:
+        super().__init__()
+        self.use_in_chat_requests = 0
+        self.panel = MediaViewerPanel(SimpleNamespace(notify=Mock()))
+
+    def compose(self) -> ComposeResult:
+        yield self.panel
+
+    @on(MediaViewerPanel.UseInChatRequested)
+    def handle_media_use_in_chat(self, event: MediaViewerPanel.UseInChatRequested) -> None:
+        self.use_in_chat_requests += 1
+
+
+@pytest.mark.asyncio
+async def test_invalid_media_handoff_selection_does_not_post_request_in_smoke():
+    app = InvalidMediaSelectionSmokeApp()
+
+    async with app.run_test(size=(160, 40)) as pilot:
+        await pilot.pause(0.1)
+
+        button = app.panel.query_one("#media-use-in-chat-button", Button)
+        assert button.disabled is True
+        assert "Select a media item before using it in Chat" in str(button.tooltip)
+
+        button.press()
+        await pilot.pause(0.05)
+
+        assert app.use_in_chat_requests == 0
+        assert app.panel._build_use_in_chat_event() is None


### PR DESCRIPTION
## Summary
- Add shared UX smoke coverage for invalid Notes, workspace source/artifact, and Media handoff selections.
- Verify disabled recovery copy is visible and invalid selections do not stage Chat.
- Update the UX remediation plan to reflect PR #175 on dev and the active invalid-selection smoke slice.

## Test Plan
- env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_ux_audit_smoke.py Tests/UI/test_chat_first_handoffs.py Tests/UI/test_search_handoffs.py Tests/UI/test_media_handoffs.py Tests/UI/test_notes_screen.py::TestNotesScreenMethods::test_notes_use_in_chat_button_is_disabled_until_note_selected Tests/UI/test_notes_screen.py::TestNotesScreenMethods::test_workspace_item_handoff_buttons_track_selected_items --tb=short
- git diff --check