### PR TITLE
Add source handoff replay smoke coverage

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -1,8 +1,8 @@
 # UX Audit Remediation Plan
 
 Date: 2026-05-01
-Status: Current-dev rebaseline after UX remediation PRs #146-#175, plus active invalid-selection smoke slice
-Branch context: current `dev` / `origin/dev` at `ab921c01`; active branch `codex/ux-invalid-selection-smoke`
+Status: Current-dev rebaseline after UX remediation PRs #146-#176, plus active source-handoff replay smoke slice
+Branch context: current `dev` / `origin/dev` at `c7488caa`; active branch `codex/ux-source-handoff-replay-smoke`
 Previous audit baseline: `e2576cae`
 
 ## Goal
@@ -29,7 +29,7 @@ This is not a visual refresh. The work is ordered around workflow completion, re
 
 ## Current Dev Rebaseline
 
-Verified on current `dev` at `ab921c01`:
+Verified on current `dev` at `c7488caa`:
 
 - Phase 0 and Phase 1 are merged: the shared shell/Chatbooks trap, Ingest default source, quiz empty mapping response, Chat save-state, Search/RAG thread mutation, and Search primary-action reachability regressions are covered.
 - Phase 2 is merged: Chat has provider readiness and first-run orientation coverage.
@@ -63,7 +63,8 @@ Current source state plus this branch:
 - Phase 5 Media list pagination-tooltip copy is merged through PR #173: Media result pagination explains single-page, first-page, middle-page, and last-page navigation states.
 - Phase 5 Media multi-item review action-tooltip copy is merged through PR #174: batch Generate/Cancel analysis actions explain no-selection, selected, and in-progress states.
 - Phase 4/7 handoff first-send smoke coverage is merged through PR #175: a mounted Textual test stages a handoff into a real Chat tab and verifies the first-send path applies staged context before marking the payload sent.
-- Phase 4 invalid-selection smoke coverage is active in `codex/ux-invalid-selection-smoke`: mounted Textual tests press empty Notes, workspace source/artifact, and Media handoff actions and verify they expose recovery copy without staging Chat.
+- Phase 4 invalid-selection smoke coverage is merged through PR #176: mounted Textual tests press empty Notes, workspace source/artifact, and Media handoff actions and verify they expose recovery copy without staging Chat.
+- Phase 4 source-handoff replay smoke coverage is active in `codex/ux-source-handoff-replay-smoke`: mounted Textual tests replay selected Notes, workspace details/note/source/artifact, Media, RAG Search, and Web Search handoffs into the app-owned Chat seam.
 - Phase 6 still needs any remaining optional dependency gaps represented as user-facing capability states where relevant.
 - Phase 7 still needs end-to-end audit replay on a clean home/config.
 
@@ -264,7 +265,7 @@ Branch state: clear/dismiss behavior completed in `codex/ux-chat-handoff-clear-c
 
 Purpose: verify and harden the source-side handoff surfaces that have now landed in current `dev`.
 
-Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG Search, and dedicated Web Search handoffs are implemented and covered by focused tests. Notes, workspace source/artifact, and Media invalid-selection states now have shared-harness smoke coverage in the active branch. Remaining work is to close source-authority edge cases and broader source-handoff replay in the shared UX smoke pass.
+Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG Search, and dedicated Web Search handoffs are implemented and covered by focused tests. Notes, workspace source/artifact, and Media invalid-selection states now have shared-harness smoke coverage. The active branch replays valid source handoffs from mounted source surfaces into the app-owned Chat seam. Remaining work is to close source-authority edge cases in the shared UX smoke pass.
 
 ### Files
 
@@ -291,7 +292,7 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 - [ ] Disable or explain source actions when server/auth/capability contracts block them.
 - [ ] Consume backend-owned `UX_Interop` and `runtime_policy` contracts consistently; do not rebuild source authority from raw config.
 - [ ] Keep dry-run sync reports diagnostic only; do not imply mirroring or write sync in source screens.
-- [ ] Replay each source handoff in the Phase 0/7 smoke harness.
+- [x] Replay each source handoff in the Phase 0/7 smoke harness.
 - [x] Replay invalid-selection handoff states for Notes, workspace source/artifact, and Media in the Phase 0/7 smoke harness.
 
 ### Acceptance Criteria
@@ -443,4 +444,4 @@ Current-dev state: partially started. A mounted handoff first-send smoke test no
 
 ## Next Step
 
-After this invalid-selection smoke slice, the remaining Phase 4 work is source-authority smoke coverage and broader source-handoff replay across each source surface. The remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.
+After this source-handoff replay smoke slice, the remaining Phase 4 work is source-authority and backend/capability-contract smoke coverage. The remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.

--- a/Tests/UI/test_ux_audit_smoke.py
+++ b/Tests/UI/test_ux_audit_smoke.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from textual import on
@@ -12,11 +12,16 @@ from textual.widgets import Button, TextArea
 
 from tldw_chatbook.Chat.chat_handoff_models import ChatHandoffPayload
 from tldw_chatbook.Event_Handlers.Chat_Events.chat_events import apply_current_handoff_context
+from tldw_chatbook.UI.MediaWindow_v2 import MediaWindow
+from tldw_chatbook.UI.SearchWindow import SearchWindow
 from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+from tldw_chatbook.UI.Screens.media_runtime_state import MediaRuntimeState
 from tldw_chatbook.UI.Screens.notes_scope_models import ScopeType, WorkspaceSubview
 from tldw_chatbook.UI.Screens.notes_screen import NotesScreen
 from tldw_chatbook.UI.Chatbooks_Window_Improved import ChatbooksWindowImproved
 from tldw_chatbook.UI.Screens.chatbooks_screen import ChatbooksScreen
+from tldw_chatbook.UI.Views.RAGSearch import search_rag_window
+from tldw_chatbook.UI.Views.RAGSearch.search_rag_window import SearchRAGWindow
 from tldw_chatbook.Widgets.Chat_Widgets.chat_handoff_card import ChatHandoffCard
 from tldw_chatbook.Widgets.Chat_Widgets.chat_tab_container import ChatTabContainer
 from tldw_chatbook.Widgets.Media.media_viewer_panel import MediaViewerPanel
@@ -220,6 +225,134 @@ async def test_invalid_notes_and_workspace_handoffs_do_not_stage_chat_in_smoke()
         app.app_instance.open_chat_with_handoff.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_valid_notes_and_workspace_handoffs_stage_app_payloads_in_smoke():
+    app = InvalidNotesSelectionSmokeApp()
+
+    async with app.run_test(size=(160, 40)) as pilot:
+        await pilot.pause(0.1)
+        screen = app.screen_under_test
+
+        screen._set_state(
+            scope_type=ScopeType.LOCAL_NOTE,
+            selected_note_id=7,
+            selected_note_version=2,
+            selected_note_title="Draft Note",
+            selected_note_content="Saved body",
+        )
+        screen.query_one("#notes-editor-area", TextArea).text = "Visible draft body"
+        await pilot.pause(0.05)
+
+        note_button = screen.query_one("#notes-use-in-chat-button", Button)
+        assert note_button.disabled is False
+
+        note_button.press()
+        await pilot.pause(0.05)
+
+        note_payload = app.app_instance.open_chat_with_handoff.call_args.args[0]
+        assert note_payload.source == "notes"
+        assert note_payload.source_id == "7"
+        assert note_payload.title == "Draft Note"
+        assert note_payload.body == "Visible draft body"
+
+        app.app_instance.open_chat_with_handoff.reset_mock()
+        screen._workspace_context_payload = {
+            "workspace": {"id": "workspace-1", "name": "Research"},
+            "notes": [
+                {
+                    "id": "note-1",
+                    "title": "Workspace Note",
+                    "content": "Workspace note body",
+                    "version": 5,
+                }
+            ],
+            "sources": [
+                {
+                    "id": "source-1",
+                    "title": "Transcript",
+                    "source_type": "video",
+                    "url": "https://example.com/transcript",
+                }
+            ],
+            "artifacts": [
+                {
+                    "id": "artifact-1",
+                    "title": "Quiz Outline",
+                    "content": "Artifact body",
+                    "version": 3,
+                }
+            ],
+        }
+        screen._set_state(
+            scope_type=ScopeType.WORKSPACE,
+            workspace_subview=WorkspaceSubview.DETAILS,
+            selected_workspace_id="workspace-1",
+            selected_workspace_note_id="note-1",
+            selected_workspace_source_id="source-1",
+            selected_workspace_artifact_id="artifact-1",
+        )
+        await pilot.pause(0.05)
+
+        workspace_button = screen.query_one("#workspace-use-in-chat-button", Button)
+        assert workspace_button.disabled is False
+
+        workspace_button.press()
+        await pilot.pause(0.05)
+
+        workspace_payload = app.app_instance.open_chat_with_handoff.call_args.args[0]
+        assert workspace_payload.source == "workspace"
+        assert workspace_payload.item_type == "workspace"
+        assert workspace_payload.source_id == "workspace-1"
+        assert workspace_payload.title == "Research"
+
+        app.app_instance.open_chat_with_handoff.reset_mock()
+        screen._set_state(workspace_subview=WorkspaceSubview.NOTES)
+        screen.query_one("#notes-editor-area", TextArea).text = "Visible workspace note body"
+        await pilot.pause(0.05)
+
+        workspace_note_button = screen.query_one("#notes-use-in-chat-button", Button)
+        assert workspace_note_button.disabled is False
+
+        workspace_note_button.press()
+        await pilot.pause(0.05)
+
+        workspace_note_payload = app.app_instance.open_chat_with_handoff.call_args.args[0]
+        assert workspace_note_payload.source == "workspace"
+        assert workspace_note_payload.item_type == "workspace-note"
+        assert workspace_note_payload.source_id == "note-1"
+        assert workspace_note_payload.body == "Visible workspace note body"
+
+        app.app_instance.open_chat_with_handoff.reset_mock()
+        screen._set_state(workspace_subview=WorkspaceSubview.SOURCES)
+        await pilot.pause(0.05)
+
+        source_button = screen.query_one("#workspace-source-use-in-chat-button", Button)
+        artifact_button = screen.query_one("#workspace-artifact-use-in-chat-button", Button)
+        assert source_button.disabled is False
+        assert artifact_button.disabled is False
+
+        source_button.press()
+        await pilot.pause(0.05)
+
+        source_payload = app.app_instance.open_chat_with_handoff.call_args.args[0]
+        assert source_payload.source == "workspace"
+        assert source_payload.item_type == "workspace-source"
+        assert source_payload.workspace_id == "workspace-1"
+        assert source_payload.source_id == "source-1"
+        assert source_payload.title == "Transcript"
+
+        app.app_instance.open_chat_with_handoff.reset_mock()
+        artifact_button.press()
+        await pilot.pause(0.05)
+
+        artifact_payload = app.app_instance.open_chat_with_handoff.call_args.args[0]
+        assert artifact_payload.source == "workspace"
+        assert artifact_payload.item_type == "workspace-artifact"
+        assert artifact_payload.workspace_id == "workspace-1"
+        assert artifact_payload.source_id == "artifact-1"
+        assert artifact_payload.body == "Artifact body"
+
+
 class InvalidMediaSelectionSmokeApp(App[None]):
     def __init__(self) -> None:
         super().__init__()
@@ -250,3 +383,153 @@ async def test_invalid_media_handoff_selection_does_not_post_request_in_smoke():
 
         assert app.use_in_chat_requests == 0
         assert app.panel._build_use_in_chat_event() is None
+
+
+class ValidMediaWindowHandoffSmokeApp(App[None]):
+    def __init__(self) -> None:
+        super().__init__()
+        self.app_instance = SimpleNamespace(
+            _media_types_for_ui=[],
+            media_runtime_state=MediaRuntimeState(runtime_backend="local"),
+            media_reading_scope_service=SimpleNamespace(
+                search_media=AsyncMock(return_value={"items": [], "total": 0}),
+            ),
+            notify=Mock(),
+            open_chat_with_handoff=Mock(),
+            media_db=None,
+        )
+        self.window = MediaWindow(self.app_instance)
+
+    def compose(self) -> ComposeResult:
+        yield self.window
+
+
+@pytest.mark.asyncio
+async def test_valid_media_handoff_replays_from_mounted_window_to_app_seam():
+    app = ValidMediaWindowHandoffSmokeApp()
+
+    async with app.run_test(size=(160, 40)) as pilot:
+        await pilot.pause(0.1)
+        app.window.viewer_panel.load_media(
+            {
+                "id": "media-1",
+                "title": "Lecture",
+                "content": "Transcript body",
+                "media_type": "video",
+            }
+        )
+        await pilot.pause(0.05)
+
+        button = app.window.viewer_panel.query_one("#media-use-in-chat-button", Button)
+        assert button.disabled is False
+
+        button.press()
+        await pilot.pause(0.05)
+
+        payload = app.app_instance.open_chat_with_handoff.call_args.args[0]
+        assert payload.source == "media"
+        assert payload.source_id == "media-1"
+        assert payload.title == "Lecture"
+        assert payload.body == "Transcript body"
+
+
+class SearchRAGHandoffSmokeApp(App[None]):
+    def __init__(self) -> None:
+        super().__init__()
+        self.app_instance = SimpleNamespace(
+            notify=Mock(),
+            api_endpoint="test-endpoint",
+            get_authoritative_runtime_source=Mock(return_value="server"),
+            open_chat_with_handoff=Mock(),
+        )
+        self.window = SearchRAGWindow(self.app_instance)
+
+    def compose(self) -> ComposeResult:
+        yield self.window
+
+
+@pytest.mark.asyncio
+async def test_valid_rag_search_handoff_replays_from_mounted_window_to_app_seam(tmp_path):
+    with (
+        patch.dict(search_rag_window.DEPENDENCIES_AVAILABLE, {"embeddings_rag": True}, clear=False),
+        patch(
+            "tldw_chatbook.UI.Views.RAGSearch.search_rag_window.get_user_data_dir",
+            return_value=tmp_path,
+        ),
+        patch(
+            "tldw_chatbook.UI.Views.RAGSearch.saved_searches_panel.get_user_data_dir",
+            return_value=tmp_path,
+        ),
+    ):
+        app = SearchRAGHandoffSmokeApp()
+
+        async with app.run_test(size=(160, 40)) as pilot:
+            await pilot.pause(0.1)
+            app.window.search_results = [
+                {
+                    "title": "Retrieved Chunk",
+                    "content": "Evidence body",
+                    "source": "notes",
+                    "score": 0.91,
+                    "metadata": {"document_id": "doc-1"},
+                }
+            ]
+            app.window.total_results = 1
+            await app.window._display_results()
+            await pilot.pause(0.05)
+
+            button = app.window.query_one("#use-in-chat-0", Button)
+            button.press()
+            await pilot.pause(0.05)
+
+            payload = app.app_instance.open_chat_with_handoff.call_args.args[0]
+            assert payload.source == "search-rag"
+            assert payload.item_type == "rag-result"
+            assert payload.runtime_backend == "server"
+            assert payload.title == "Retrieved Chunk"
+            assert payload.body == "Evidence body"
+
+
+class WebSearchResultHandoffSmokeApp(App[None]):
+    def __init__(self) -> None:
+        super().__init__()
+        self.app_instance = SimpleNamespace(
+            notify=Mock(),
+            api_endpoint="test-endpoint",
+            search_active_sub_tab=None,
+            get_authoritative_runtime_source=Mock(return_value="local"),
+            open_chat_with_handoff=Mock(),
+        )
+        self.window = SearchWindow(self.app_instance)
+
+    def compose(self) -> ComposeResult:
+        yield self.window
+
+
+@pytest.mark.asyncio
+async def test_valid_web_search_handoff_replays_from_mounted_window_to_app_seam(monkeypatch):
+    monkeypatch.setattr("tldw_chatbook.UI.SearchWindow.WEB_SEARCH_AVAILABLE", True)
+    app = WebSearchResultHandoffSmokeApp()
+
+    async with app.run_test(size=(160, 40)) as pilot:
+        await pilot.pause(0.1)
+        app.window.web_search_results = [
+            {
+                "title": "Article",
+                "content": "Snippet body",
+                "source": "web",
+                "metadata": {"url": "https://example.com", "displayUrl": "example.com"},
+            }
+        ]
+        await app.window._render_web_search_result_cards()
+        await pilot.pause(0.05)
+
+        button = app.window.query_one("#use-in-chat-0", Button)
+        button.press()
+        await pilot.pause(0.05)
+
+        payload = app.app_instance.open_chat_with_handoff.call_args.args[0]
+        assert payload.source == "search-web"
+        assert payload.item_type == "web-result"
+        assert payload.metadata["url"] == "https://example.com"
+        assert payload.body == "Snippet body"

--- a/Tests/UI/test_ux_audit_smoke.py
+++ b/Tests/UI/test_ux_audit_smoke.py
@@ -156,7 +156,12 @@ def _empty_notes_service() -> Mock:
     return service
 
 
-class InvalidNotesSelectionSmokeApp(App[None]):
+def _assert_single_handoff_payload(open_chat_with_handoff: Mock) -> ChatHandoffPayload:
+    open_chat_with_handoff.assert_called_once()
+    return open_chat_with_handoff.call_args.args[0]
+
+
+class NotesSmokeApp(App[None]):
     def __init__(self) -> None:
         super().__init__()
         app_instance = SimpleNamespace(
@@ -184,7 +189,7 @@ class InvalidNotesSelectionSmokeApp(App[None]):
 
 @pytest.mark.asyncio
 async def test_invalid_notes_and_workspace_handoffs_do_not_stage_chat_in_smoke():
-    app = InvalidNotesSelectionSmokeApp()
+    app = NotesSmokeApp()
 
     async with app.run_test(size=(160, 40)) as pilot:
         await pilot.pause(0.1)
@@ -227,7 +232,7 @@ async def test_invalid_notes_and_workspace_handoffs_do_not_stage_chat_in_smoke()
 
 @pytest.mark.asyncio
 async def test_valid_notes_and_workspace_handoffs_stage_app_payloads_in_smoke():
-    app = InvalidNotesSelectionSmokeApp()
+    app = NotesSmokeApp()
 
     async with app.run_test(size=(160, 40)) as pilot:
         await pilot.pause(0.1)
@@ -249,7 +254,7 @@ async def test_valid_notes_and_workspace_handoffs_stage_app_payloads_in_smoke():
         note_button.press()
         await pilot.pause(0.05)
 
-        note_payload = app.app_instance.open_chat_with_handoff.call_args.args[0]
+        note_payload = _assert_single_handoff_payload(app.app_instance.open_chat_with_handoff)
         assert note_payload.source == "notes"
         assert note_payload.source_id == "7"
         assert note_payload.title == "Draft Note"
@@ -299,7 +304,7 @@ async def test_valid_notes_and_workspace_handoffs_stage_app_payloads_in_smoke():
         workspace_button.press()
         await pilot.pause(0.05)
 
-        workspace_payload = app.app_instance.open_chat_with_handoff.call_args.args[0]
+        workspace_payload = _assert_single_handoff_payload(app.app_instance.open_chat_with_handoff)
         assert workspace_payload.source == "workspace"
         assert workspace_payload.item_type == "workspace"
         assert workspace_payload.source_id == "workspace-1"
@@ -316,7 +321,7 @@ async def test_valid_notes_and_workspace_handoffs_stage_app_payloads_in_smoke():
         workspace_note_button.press()
         await pilot.pause(0.05)
 
-        workspace_note_payload = app.app_instance.open_chat_with_handoff.call_args.args[0]
+        workspace_note_payload = _assert_single_handoff_payload(app.app_instance.open_chat_with_handoff)
         assert workspace_note_payload.source == "workspace"
         assert workspace_note_payload.item_type == "workspace-note"
         assert workspace_note_payload.source_id == "note-1"
@@ -334,18 +339,19 @@ async def test_valid_notes_and_workspace_handoffs_stage_app_payloads_in_smoke():
         source_button.press()
         await pilot.pause(0.05)
 
-        source_payload = app.app_instance.open_chat_with_handoff.call_args.args[0]
+        source_payload = _assert_single_handoff_payload(app.app_instance.open_chat_with_handoff)
         assert source_payload.source == "workspace"
         assert source_payload.item_type == "workspace-source"
         assert source_payload.workspace_id == "workspace-1"
         assert source_payload.source_id == "source-1"
         assert source_payload.title == "Transcript"
+        assert source_payload.body == "Transcript\nvideo\nhttps://example.com/transcript"
 
         app.app_instance.open_chat_with_handoff.reset_mock()
         artifact_button.press()
         await pilot.pause(0.05)
 
-        artifact_payload = app.app_instance.open_chat_with_handoff.call_args.args[0]
+        artifact_payload = _assert_single_handoff_payload(app.app_instance.open_chat_with_handoff)
         assert artifact_payload.source == "workspace"
         assert artifact_payload.item_type == "workspace-artifact"
         assert artifact_payload.workspace_id == "workspace-1"
@@ -426,7 +432,7 @@ async def test_valid_media_handoff_replays_from_mounted_window_to_app_seam():
         button.press()
         await pilot.pause(0.05)
 
-        payload = app.app_instance.open_chat_with_handoff.call_args.args[0]
+        payload = _assert_single_handoff_payload(app.app_instance.open_chat_with_handoff)
         assert payload.source == "media"
         assert payload.source_id == "media-1"
         assert payload.title == "Lecture"
@@ -482,7 +488,7 @@ async def test_valid_rag_search_handoff_replays_from_mounted_window_to_app_seam(
             button.press()
             await pilot.pause(0.05)
 
-            payload = app.app_instance.open_chat_with_handoff.call_args.args[0]
+            payload = _assert_single_handoff_payload(app.app_instance.open_chat_with_handoff)
             assert payload.source == "search-rag"
             assert payload.item_type == "rag-result"
             assert payload.runtime_backend == "server"
@@ -528,7 +534,7 @@ async def test_valid_web_search_handoff_replays_from_mounted_window_to_app_seam(
         button.press()
         await pilot.pause(0.05)
 
-        payload = app.app_instance.open_chat_with_handoff.call_args.args[0]
+        payload = _assert_single_handoff_payload(app.app_instance.open_chat_with_handoff)
         assert payload.source == "search-web"
         assert payload.item_type == "web-result"
         assert payload.metadata["url"] == "https://example.com"


### PR DESCRIPTION
## Summary
- Add mounted UX smoke replay for valid Notes and workspace details/note/source/artifact handoffs.
- Add mounted Media, RAG Search, and Web Search handoff replay into the app-owned Chat seam.
- Update the UX remediation plan to reflect PR #176 on dev and the active source-replay slice.

## Test Plan
- env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_ux_audit_smoke.py Tests/UI/test_chat_first_handoffs.py Tests/UI/test_search_handoffs.py Tests/UI/test_media_handoffs.py Tests/UI/test_notes_screen.py::TestNotesScreenMethods::test_notes_use_in_chat_button_is_disabled_until_note_selected Tests/UI/test_notes_screen.py::TestNotesScreenMethods::test_workspace_item_handoff_buttons_track_selected_items --tb=short
- git diff --check