### PR TITLE
Surface handoff contract recovery copy

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -1,8 +1,8 @@
 # UX Audit Remediation Plan
 
 Date: 2026-05-01
-Status: Current-dev rebaseline after UX remediation PRs #146-#176, plus active source-handoff replay smoke slice
-Branch context: current `dev` / `origin/dev` at `c7488caa`; active branch `codex/ux-source-handoff-replay-smoke`
+Status: Current-dev rebaseline after UX remediation PRs #146-#177, plus active backend-contract card-copy slice
+Branch context: current `dev` / `origin/dev` at `308c2d4f`; active branch `codex/ux-handoff-contract-card-copy`
 Previous audit baseline: `e2576cae`
 
 ## Goal
@@ -29,7 +29,7 @@ This is not a visual refresh. The work is ordered around workflow completion, re
 
 ## Current Dev Rebaseline
 
-Verified on current `dev` at `c7488caa`:
+Verified on current `dev` at `308c2d4f`:
 
 - Phase 0 and Phase 1 are merged: the shared shell/Chatbooks trap, Ingest default source, quiz empty mapping response, Chat save-state, Search/RAG thread mutation, and Search primary-action reachability regressions are covered.
 - Phase 2 is merged: Chat has provider readiness and first-run orientation coverage.
@@ -64,7 +64,8 @@ Current source state plus this branch:
 - Phase 5 Media multi-item review action-tooltip copy is merged through PR #174: batch Generate/Cancel analysis actions explain no-selection, selected, and in-progress states.
 - Phase 4/7 handoff first-send smoke coverage is merged through PR #175: a mounted Textual test stages a handoff into a real Chat tab and verifies the first-send path applies staged context before marking the payload sent.
 - Phase 4 invalid-selection smoke coverage is merged through PR #176: mounted Textual tests press empty Notes, workspace source/artifact, and Media handoff actions and verify they expose recovery copy without staging Chat.
-- Phase 4 source-handoff replay smoke coverage is active in `codex/ux-source-handoff-replay-smoke`: mounted Textual tests replay selected Notes, workspace details/note/source/artifact, Media, RAG Search, and Web Search handoffs into the app-owned Chat seam.
+- Phase 4 source-handoff replay smoke coverage is merged through PR #177: mounted Textual tests replay selected Notes, workspace details/note/source/artifact, Media, RAG Search, and Web Search handoffs into the app-owned Chat seam.
+- Phase 4 backend-contract card copy is active in `codex/ux-handoff-contract-card-copy`: staged Chat context cards surface dry-run sync diagnostics and unsupported-action recovery messages without implying write sync.
 - Phase 6 still needs any remaining optional dependency gaps represented as user-facing capability states where relevant.
 - Phase 7 still needs end-to-end audit replay on a clean home/config.
 
@@ -265,7 +266,7 @@ Branch state: clear/dismiss behavior completed in `codex/ux-chat-handoff-clear-c
 
 Purpose: verify and harden the source-side handoff surfaces that have now landed in current `dev`.
 
-Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG Search, and dedicated Web Search handoffs are implemented and covered by focused tests. Notes, workspace source/artifact, and Media invalid-selection states now have shared-harness smoke coverage. The active branch replays valid source handoffs from mounted source surfaces into the app-owned Chat seam. Remaining work is to close source-authority edge cases in the shared UX smoke pass.
+Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG Search, and dedicated Web Search handoffs are implemented and covered by focused tests. Notes, workspace source/artifact, and Media invalid-selection states now have shared-harness smoke coverage. Valid source handoffs from mounted source surfaces replay into the app-owned Chat seam. The active branch makes backend-provided dry-run and unsupported-action messages visible on staged Chat context cards. Remaining work is to close source-action capability edge cases in the shared UX smoke pass.
 
 ### Files
 
@@ -294,6 +295,7 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 - [ ] Keep dry-run sync reports diagnostic only; do not imply mirroring or write sync in source screens.
 - [x] Replay each source handoff in the Phase 0/7 smoke harness.
 - [x] Replay invalid-selection handoff states for Notes, workspace source/artifact, and Media in the Phase 0/7 smoke harness.
+- [x] Surface backend dry-run sync and unsupported-action messages on staged Chat context cards without implying write sync.
 
 ### Acceptance Criteria
 
@@ -444,4 +446,4 @@ Current-dev state: partially started. A mounted handoff first-send smoke test no
 
 ## Next Step
 
-After this source-handoff replay smoke slice, the remaining Phase 4 work is source-authority and backend/capability-contract smoke coverage. The remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.
+After this backend-contract card-copy slice, the remaining Phase 4 work is source-action backend/capability-contract smoke coverage. The remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.

--- a/Tests/UI/test_chat_first_handoffs.py
+++ b/Tests/UI/test_chat_first_handoffs.py
@@ -369,6 +369,34 @@ def test_handoff_card_uses_status_source_title_and_metadata():
     assert "https://example.com" in text
 
 
+def test_handoff_card_surfaces_backend_contract_recovery_without_implying_write_sync():
+    fixtures = build_server_parity_fixture_payloads()
+    payload = ChatHandoffPayload(
+        source="workspace",
+        item_type="workspace-source",
+        title="Workspace Transcript",
+        body="Transcript body",
+        runtime_backend="server",
+        source_owner="workspace",
+        source_selector_state="workspace",
+        active_server_profile_id="srv-primary",
+        workspace_id="workspace-a",
+        unsupported_reports=[fixtures["unsupported_action"]],
+        sync_dry_run_report=fixtures["sync_dry_run_report"],
+    )
+
+    card = ChatHandoffCard(payload)
+    text = card.render_text()
+
+    assert "Sync: dry-run only" in text
+    assert "Resolve workspace conflicts before syncing." in text
+    assert "Write sync is not enabled." in text
+    assert "Unsupported actions: 1" in text
+    assert "Server first-class conversation creation is not available." in text
+    assert "sync enabled" not in text.lower()
+    assert "will sync automatically" not in text.lower()
+
+
 class _HandoffSessionHarness(App):
     def __init__(self, session_data: ChatSessionData) -> None:
         super().__init__()

--- a/Tests/UI/test_chat_first_handoffs.py
+++ b/Tests/UI/test_chat_first_handoffs.py
@@ -397,6 +397,21 @@ def test_handoff_card_surfaces_backend_contract_recovery_without_implying_write_
     assert "will sync automatically" not in text.lower()
 
 
+def test_handoff_card_ignores_malformed_sync_dry_run_report_copy():
+    payload = {
+        "source": "workspace",
+        "item_type": "workspace-source",
+        "title": "Workspace Transcript",
+        "body": "Transcript body",
+        "sync_dry_run_report": ["malformed-report"],
+    }
+
+    text = ChatHandoffCard(payload).render_text()
+
+    assert "Sync: dry-run only" in text
+    assert "Write sync is not enabled." not in text
+
+
 class _HandoffSessionHarness(App):
     def __init__(self, session_data: ChatSessionData) -> None:
         super().__init__()

--- a/tldw_chatbook/Widgets/Chat_Widgets/chat_handoff_card.py
+++ b/tldw_chatbook/Widgets/Chat_Widgets/chat_handoff_card.py
@@ -110,7 +110,9 @@ class ChatHandoffCard(Container):
         return labels.get(str(state), str(state).replace("_", " ").title())
 
     def _sync_dry_run_labels(self) -> list[str]:
-        report = self.payload.sync_dry_run_report or {}
+        report = self.payload.sync_dry_run_report
+        if not isinstance(report, dict):
+            return []
         labels: list[str] = []
         if report.get("write_enabled") is False:
             labels.append("Write sync is not enabled.")

--- a/tldw_chatbook/Widgets/Chat_Widgets/chat_handoff_card.py
+++ b/tldw_chatbook/Widgets/Chat_Widgets/chat_handoff_card.py
@@ -73,10 +73,12 @@ class ChatHandoffCard(Container):
             parts.append(f"Workspace: {self.payload.workspace_id}")
         if self.payload.sync_dry_run_report:
             parts.append("Sync: dry-run only")
+            parts.extend(self._sync_dry_run_labels())
         if self.payload.body_truncated:
             parts.append("Content: preview truncated")
         if self.payload.unsupported_reports:
             parts.append(f"Unsupported actions: {len(self.payload.unsupported_reports)}")
+            parts.extend(self._unsupported_report_labels())
         if metadata:
             parts.append(metadata)
         parts.append("Review the draft below and send when ready.")
@@ -106,3 +108,23 @@ class ChatHandoffCard(Container):
             "shared": "Shared source",
         }
         return labels.get(str(state), str(state).replace("_", " ").title())
+
+    def _sync_dry_run_labels(self) -> list[str]:
+        report = self.payload.sync_dry_run_report or {}
+        labels: list[str] = []
+        if report.get("write_enabled") is False:
+            labels.append("Write sync is not enabled.")
+        user_message = report.get("user_message")
+        if user_message:
+            labels.append(str(user_message))
+        return labels
+
+    def _unsupported_report_labels(self) -> list[str]:
+        labels: list[str] = []
+        for report in self.payload.unsupported_reports[:3]:
+            user_message = None
+            if isinstance(report, dict):
+                user_message = report.get("user_message") or report.get("unsupported_user_message")
+            if user_message:
+                labels.append(str(user_message))
+        return labels


### PR DESCRIPTION
## Summary
- Surface backend dry-run sync diagnostics on staged Chat handoff cards.
- Surface backend unsupported-action recovery messages on the same cards.
- Rebaseline the UX remediation plan after PR #177 and record this active Phase 4 slice.

## Test Plan
- env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_chat_first_handoffs.py Tests/UI/test_ux_audit_smoke.py --tb=short
- env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_search_handoffs.py Tests/UI/test_media_handoffs.py --tb=short
- git diff --check