### PR TITLE
Gate Notes handoff actions on runtime policy

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -1,8 +1,8 @@
 # UX Audit Remediation Plan
 
 Date: 2026-05-01
-Status: Current-dev rebaseline after UX remediation PRs #146-#177, plus active backend-contract card-copy slice
-Branch context: current `dev` / `origin/dev` at `308c2d4f`; active branch `codex/ux-handoff-contract-card-copy`
+Status: Current-dev rebaseline after UX remediation PRs #146-#178, plus active source capability-contract smoke slice
+Branch context: current `dev` / `origin/dev` at `b6694dd7`; active branch `codex/ux-source-capability-contract-smoke`
 Previous audit baseline: `e2576cae`
 
 ## Goal
@@ -29,7 +29,7 @@ This is not a visual refresh. The work is ordered around workflow completion, re
 
 ## Current Dev Rebaseline
 
-Verified on current `dev` at `308c2d4f`:
+Verified on current `dev` at `b6694dd7`:
 
 - Phase 0 and Phase 1 are merged: the shared shell/Chatbooks trap, Ingest default source, quiz empty mapping response, Chat save-state, Search/RAG thread mutation, and Search primary-action reachability regressions are covered.
 - Phase 2 is merged: Chat has provider readiness and first-run orientation coverage.
@@ -65,7 +65,8 @@ Current source state plus this branch:
 - Phase 4/7 handoff first-send smoke coverage is merged through PR #175: a mounted Textual test stages a handoff into a real Chat tab and verifies the first-send path applies staged context before marking the payload sent.
 - Phase 4 invalid-selection smoke coverage is merged through PR #176: mounted Textual tests press empty Notes, workspace source/artifact, and Media handoff actions and verify they expose recovery copy without staging Chat.
 - Phase 4 source-handoff replay smoke coverage is merged through PR #177: mounted Textual tests replay selected Notes, workspace details/note/source/artifact, Media, RAG Search, and Web Search handoffs into the app-owned Chat seam.
-- Phase 4 backend-contract card copy is active in `codex/ux-handoff-contract-card-copy`: staged Chat context cards surface dry-run sync diagnostics and unsupported-action recovery messages without implying write sync.
+- Phase 4 backend-contract card copy is merged through PR #178: staged Chat context cards surface dry-run sync diagnostics and unsupported-action recovery messages without implying write sync.
+- Phase 4 source capability-contract smoke coverage is active in `codex/ux-source-capability-contract-smoke`: Notes/Workspace handoff buttons consume runtime-policy denial state and expose recovery copy without staging Chat.
 - Phase 6 still needs any remaining optional dependency gaps represented as user-facing capability states where relevant.
 - Phase 7 still needs end-to-end audit replay on a clean home/config.
 
@@ -266,7 +267,7 @@ Branch state: clear/dismiss behavior completed in `codex/ux-chat-handoff-clear-c
 
 Purpose: verify and harden the source-side handoff surfaces that have now landed in current `dev`.
 
-Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG Search, and dedicated Web Search handoffs are implemented and covered by focused tests. Notes, workspace source/artifact, and Media invalid-selection states now have shared-harness smoke coverage. Valid source handoffs from mounted source surfaces replay into the app-owned Chat seam. The active branch makes backend-provided dry-run and unsupported-action messages visible on staged Chat context cards. Remaining work is to close source-action capability edge cases in the shared UX smoke pass.
+Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG Search, and dedicated Web Search handoffs are implemented and covered by focused tests. Notes, workspace source/artifact, and Media invalid-selection states now have shared-harness smoke coverage. Valid source handoffs from mounted source surfaces replay into the app-owned Chat seam. Backend-provided dry-run and unsupported-action messages are visible on staged Chat context cards. The active branch adds runtime-policy-denied Notes/Workspace handoff smoke coverage. Remaining work is to close remaining source-action capability edge cases in the shared UX smoke pass.
 
 ### Files
 
@@ -296,6 +297,7 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 - [x] Replay each source handoff in the Phase 0/7 smoke harness.
 - [x] Replay invalid-selection handoff states for Notes, workspace source/artifact, and Media in the Phase 0/7 smoke harness.
 - [x] Surface backend dry-run sync and unsupported-action messages on staged Chat context cards without implying write sync.
+- [x] Add mounted smoke coverage for runtime-policy-blocked Notes/Workspace handoff actions with recovery copy and no Chat staging.
 
 ### Acceptance Criteria
 
@@ -446,4 +448,4 @@ Current-dev state: partially started. A mounted handoff first-send smoke test no
 
 ## Next Step
 
-After this backend-contract card-copy slice, the remaining Phase 4 work is source-action backend/capability-contract smoke coverage. The remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.
+After this source capability-contract smoke slice, the remaining Phase 4 work is extending source-action backend/capability-contract recovery to other source surfaces where policy state can block a visible action. The remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.

--- a/Tests/UI/test_ux_audit_smoke.py
+++ b/Tests/UI/test_ux_audit_smoke.py
@@ -277,6 +277,43 @@ async def test_contract_blocked_workspace_handoff_explains_recovery_without_stag
 
 
 @pytest.mark.asyncio
+async def test_contract_blocked_local_note_handoff_explains_recovery_without_staging():
+    app = NotesSmokeApp(
+        RuntimeSourceState(
+            active_source="server",
+            active_server_id="srv-primary",
+            server_configured=True,
+            server_reachability="reachable",
+            server_auth_state="authenticated",
+        )
+    )
+
+    async with app.run_test(size=(160, 40)) as pilot:
+        await pilot.pause(0.1)
+        screen = app.screen_under_test
+
+        screen._set_state(
+            scope_type=ScopeType.LOCAL_NOTE,
+            selected_note_id=1,
+            selected_note_title="Local Note",
+            selected_note_content="Body",
+        )
+        await pilot.pause(0.05)
+
+        note_button = screen.query_one("#notes-use-in-chat-button", Button)
+
+        assert note_button.disabled is True
+        tooltip = str(note_button.tooltip)
+        assert "notes.detail.local requires local mode" in tooltip
+        assert "switch source" in tooltip
+
+        note_button.press()
+        await pilot.pause(0.05)
+
+        app.app_instance.open_chat_with_handoff.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_valid_notes_and_workspace_handoffs_stage_app_payloads_in_smoke():
     app = NotesSmokeApp()
 

--- a/Tests/UI/test_ux_audit_smoke.py
+++ b/Tests/UI/test_ux_audit_smoke.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -12,6 +13,9 @@ from textual.widgets import Button, TextArea
 
 from tldw_chatbook.Chat.chat_handoff_models import ChatHandoffPayload
 from tldw_chatbook.Event_Handlers.Chat_Events.chat_events import apply_current_handoff_context
+from tldw_chatbook.runtime_policy.engine import PolicyEngine
+from tldw_chatbook.runtime_policy.registry import CAPABILITY_REGISTRY
+from tldw_chatbook.runtime_policy.types import RuntimeSourceState
 from tldw_chatbook.UI.MediaWindow_v2 import MediaWindow
 from tldw_chatbook.UI.SearchWindow import SearchWindow
 from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
@@ -162,7 +166,7 @@ def _assert_single_handoff_payload(open_chat_with_handoff: Mock) -> ChatHandoffP
 
 
 class NotesSmokeApp(App[None]):
-    def __init__(self) -> None:
+    def __init__(self, runtime_state: RuntimeSourceState | None = None) -> None:
         super().__init__()
         app_instance = SimpleNamespace(
             notes_service=_empty_notes_service(),
@@ -180,6 +184,9 @@ class NotesSmokeApp(App[None]):
             current_selected_note_title="",
             current_selected_note_content="",
         )
+        if runtime_state is not None:
+            app_instance.runtime_policy = SimpleNamespace(state=runtime_state)
+            app_instance.ui_policy_engine = PolicyEngine(CAPABILITY_REGISTRY)
         self.app_instance = app_instance
         self.screen_under_test = NotesScreen(app_instance)
 
@@ -225,6 +232,45 @@ async def test_invalid_notes_and_workspace_handoffs_do_not_stage_chat_in_smoke()
 
         source_button.press()
         artifact_button.press()
+        await pilot.pause(0.05)
+
+        app.app_instance.open_chat_with_handoff.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_contract_blocked_workspace_handoff_explains_recovery_without_staging():
+    checked_at = datetime.now(timezone.utc)
+    app = NotesSmokeApp(
+        RuntimeSourceState(
+            active_source="server",
+            active_server_id="srv-primary",
+            server_configured=True,
+            server_reachability="reachable",
+            server_reachability_checked_at=checked_at,
+            server_auth_state="auth_required",
+            server_auth_checked_at=checked_at,
+        )
+    )
+
+    async with app.run_test(size=(160, 40)) as pilot:
+        await pilot.pause(0.1)
+        screen = app.screen_under_test
+
+        screen._set_state(
+            scope_type=ScopeType.WORKSPACE,
+            workspace_subview=WorkspaceSubview.DETAILS,
+            selected_workspace_id="workspace-1",
+        )
+        await pilot.pause(0.05)
+
+        workspace_button = screen.query_one("#workspace-use-in-chat-button", Button)
+
+        assert workspace_button.disabled is True
+        tooltip = str(workspace_button.tooltip)
+        assert "notes.workspace.detail.server requires server authentication" in tooltip
+        assert "Sign in" in tooltip
+
+        workspace_button.press()
         await pilot.pause(0.05)
 
         app.app_instance.open_chat_with_handoff.assert_not_called()

--- a/tldw_chatbook/UI/Screens/notes_screen.py
+++ b/tldw_chatbook/UI/Screens/notes_screen.py
@@ -280,6 +280,8 @@ class NotesScreen(BaseAppScreen):
                 return "notes.detail.server"
             if self.state.scope_type == ScopeType.WORKSPACE:
                 return "notes.detail.workspace"
+            if self.state.scope_type == ScopeType.LOCAL_NOTE:
+                return "notes.detail.local"
             return None
         if action_id in {
             "workspace-use-in-chat-button",

--- a/tldw_chatbook/UI/Screens/notes_screen.py
+++ b/tldw_chatbook/UI/Screens/notes_screen.py
@@ -22,6 +22,7 @@ from textual.widgets import Button, Input, Label, ListView, Select, Switch, Text
 from ...Chat.chat_handoff_messages import USE_IN_CHAT_UNAVAILABLE_RECOVERY
 from ...Chat.chat_handoff_models import ChatHandoffPayload
 from ...Event_Handlers.Audio_Events.dictation_integration_events import InsertDictationTextEvent
+from ...runtime_policy.types import RuntimeSourceState
 from ...Third_Party.textual_fspicker import FileSave
 from ...Widgets.delete_confirmation_dialog import create_delete_confirmation
 from ...Widgets.Note_Widgets.notes_sidebar_left import NotesSidebarLeft
@@ -33,6 +34,8 @@ from ...Widgets.emoji_picker import EmojiPickerScreen, EmojiSelected
 from ..Navigation.base_app_screen import BaseAppScreen
 from .notes_scope_models import NotesScreenState, PendingNavigation, ScopeType, WorkspaceSubview
 from .study_scope_models import StudyScopeContext, StudyScopeType
+
+HANDOFF_POLICY_RECOVERY = "Sign in, reconnect the server, or switch source before using this item in Chat."
 
 if TYPE_CHECKING:
     from tldw_chatbook.app import TldwCli
@@ -271,32 +274,85 @@ class NotesScreen(BaseAppScreen):
         button.disabled = disabled
         button.tooltip = disabled_tooltip if disabled else enabled_tooltip
 
+    def _handoff_runtime_action_id(self, action_id: str | None) -> str | None:
+        if action_id == "notes-use-in-chat-button":
+            if self.state.scope_type == ScopeType.SERVER_NOTE:
+                return "notes.detail.server"
+            if self.state.scope_type == ScopeType.WORKSPACE:
+                return "notes.detail.workspace"
+            return None
+        if action_id in {
+            "workspace-use-in-chat-button",
+            "workspace-source-use-in-chat-button",
+            "workspace-artifact-use-in-chat-button",
+        }:
+            return "notes.workspace.detail.server"
+        return None
+
+    def _handoff_policy_blocking_message(self, action_id: str | None) -> str:
+        runtime_action_id = self._handoff_runtime_action_id(action_id)
+        if not runtime_action_id:
+            return ""
+        runtime_state = getattr(getattr(self.app_instance, "runtime_policy", None), "state", None)
+        policy_engine = getattr(self.app_instance, "ui_policy_engine", None)
+        evaluate = getattr(policy_engine, "evaluate", None)
+        if not isinstance(runtime_state, RuntimeSourceState) or not callable(evaluate):
+            return ""
+        decision = evaluate(action_id=runtime_action_id, state=runtime_state)
+        if getattr(decision, "allowed", True):
+            return ""
+        message = str(getattr(decision, "user_message", None) or "This source action is blocked by runtime policy.")
+        return f"{message} {HANDOFF_POLICY_RECOVERY}"
+
     def _update_use_in_chat_action_states(self) -> None:
         if not self.is_mounted:
             return
+        note_selected = self._has_selected_note_for_handoff()
+        notes_policy_message = (
+            self._handoff_policy_blocking_message("notes-use-in-chat-button")
+            if note_selected
+            else ""
+        )
         self._set_handoff_button_state(
             "#notes-use-in-chat-button",
-            disabled=not self._has_selected_note_for_handoff(),
-            disabled_tooltip="Select a note before using it in Chat.",
+            disabled=(not note_selected) or bool(notes_policy_message),
+            disabled_tooltip=notes_policy_message or "Select a note before using it in Chat.",
             enabled_tooltip="Use the selected note in Chat.",
         )
         workspace_selected = bool(self.state.selected_workspace_id)
+        workspace_policy_message = (
+            self._handoff_policy_blocking_message("workspace-use-in-chat-button")
+            if workspace_selected
+            else ""
+        )
         self._set_handoff_button_state(
             "#workspace-use-in-chat-button",
-            disabled=not workspace_selected,
-            disabled_tooltip="Select a workspace before using it in Chat.",
+            disabled=(not workspace_selected) or bool(workspace_policy_message),
+            disabled_tooltip=workspace_policy_message or "Select a workspace before using it in Chat.",
             enabled_tooltip="Use the selected workspace in Chat.",
+        )
+        source_selected = workspace_selected and self.state.selected_workspace_source_id is not None
+        source_policy_message = (
+            self._handoff_policy_blocking_message("workspace-source-use-in-chat-button")
+            if source_selected
+            else ""
         )
         self._set_handoff_button_state(
             "#workspace-source-use-in-chat-button",
-            disabled=not (workspace_selected and self.state.selected_workspace_source_id is not None),
-            disabled_tooltip="Select a workspace source before using it in Chat.",
+            disabled=(not source_selected) or bool(source_policy_message),
+            disabled_tooltip=source_policy_message or "Select a workspace source before using it in Chat.",
             enabled_tooltip="Use the selected workspace source in Chat.",
+        )
+        artifact_selected = workspace_selected and self.state.selected_workspace_artifact_id is not None
+        artifact_policy_message = (
+            self._handoff_policy_blocking_message("workspace-artifact-use-in-chat-button")
+            if artifact_selected
+            else ""
         )
         self._set_handoff_button_state(
             "#workspace-artifact-use-in-chat-button",
-            disabled=not (workspace_selected and self.state.selected_workspace_artifact_id is not None),
-            disabled_tooltip="Select a workspace artifact before using it in Chat.",
+            disabled=(not artifact_selected) or bool(artifact_policy_message),
+            disabled_tooltip=artifact_policy_message or "Select a workspace artifact before using it in Chat.",
             enabled_tooltip="Use the selected workspace artifact in Chat.",
         )
 
@@ -2366,6 +2422,10 @@ class NotesScreen(BaseAppScreen):
         action_id = getattr(getattr(event, "button", None), "id", None)
         if not isinstance(action_id, str):
             action_id = None
+        policy_message = self._handoff_policy_blocking_message(action_id)
+        if policy_message:
+            self._notify(policy_message, severity="warning")
+            return
         payload = self._build_current_chat_handoff_payload(action_id=action_id)
         if payload is None:
             self._notify("Select an item before using it in Chat.", severity="warning")


### PR DESCRIPTION
## Summary
- Disable Notes/Workspace handoff buttons when runtime policy denies the backing source action.
- Show policy denial plus recovery copy without staging Chat context.
- Rebaseline the UX remediation plan after PR #178 and record this Phase 4 source contract slice.

## Test Plan
- env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_ux_audit_smoke.py Tests/UI/test_notes_screen.py --tb=short
- env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_chat_first_handoffs.py Tests/UI/test_search_handoffs.py Tests/UI/test_media_handoffs.py --tb=short
- git diff --check