### PR TITLE
Explain Media handoff policy blocks

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -1,8 +1,8 @@
 # UX Audit Remediation Plan
 
 Date: 2026-05-01
-Status: Current-dev rebaseline after UX remediation PRs #146-#178, plus active source capability-contract smoke slice
-Branch context: current `dev` / `origin/dev` at `b6694dd7`; active branch `codex/ux-source-capability-contract-smoke`
+Status: Current-dev rebaseline after UX remediation PRs #146-#179, plus active Media handoff policy-smoke slice
+Branch context: current `dev` / `origin/dev` at `0a5a30d6`; active branch `codex/ux-media-handoff-policy-smoke`
 Previous audit baseline: `e2576cae`
 
 ## Goal
@@ -29,7 +29,7 @@ This is not a visual refresh. The work is ordered around workflow completion, re
 
 ## Current Dev Rebaseline
 
-Verified on current `dev` at `b6694dd7`:
+Verified on current `dev` at `0a5a30d6`:
 
 - Phase 0 and Phase 1 are merged: the shared shell/Chatbooks trap, Ingest default source, quiz empty mapping response, Chat save-state, Search/RAG thread mutation, and Search primary-action reachability regressions are covered.
 - Phase 2 is merged: Chat has provider readiness and first-run orientation coverage.
@@ -38,7 +38,7 @@ Verified on current `dev` at `b6694dd7`:
 
 Current source state plus this branch:
 
-- Phase 4 still needs disabled-state/recovery consistency for blocked source handoffs and live smoke replay.
+- Phase 4 still needs disabled-state/recovery consistency for remaining policy-blocked source handoffs and live smoke replay.
 - Phase 5 top-level IA labels are merged: visible navigation now uses `Library`, `Models`, and `Speech` while preserving route IDs.
 - Phase 5 Media empty-state copy is merged: Media now points users toward Ingest and selected-item requirements for analysis/save/export.
 - Phase 5 Study empty-state cleanup is merged: flashcards and quizzes now separate no-content guidance for global/local vs workspace scopes while preserving backend-unavailable states.
@@ -66,11 +66,12 @@ Current source state plus this branch:
 - Phase 4 invalid-selection smoke coverage is merged through PR #176: mounted Textual tests press empty Notes, workspace source/artifact, and Media handoff actions and verify they expose recovery copy without staging Chat.
 - Phase 4 source-handoff replay smoke coverage is merged through PR #177: mounted Textual tests replay selected Notes, workspace details/note/source/artifact, Media, RAG Search, and Web Search handoffs into the app-owned Chat seam.
 - Phase 4 backend-contract card copy is merged through PR #178: staged Chat context cards surface dry-run sync diagnostics and unsupported-action recovery messages without implying write sync.
-- Phase 4 source capability-contract smoke coverage is active in `codex/ux-source-capability-contract-smoke`: Notes/Workspace handoff buttons consume runtime-policy denial state and expose recovery copy without staging Chat.
+- Phase 4 Notes/Workspace source capability-contract smoke coverage is merged through PR #179: Notes/Workspace handoff buttons consume runtime-policy denial state and expose recovery copy without staging Chat.
+- Phase 4 Media handoff policy-smoke is active in `codex/ux-media-handoff-policy-smoke`: Media `Use in Chat` consumes runtime-policy denial state and exposes recovery copy without staging Chat.
 - Phase 6 still needs any remaining optional dependency gaps represented as user-facing capability states where relevant.
 - Phase 7 still needs end-to-end audit replay on a clean home/config.
 
-Planning consequence: remaining implementation should target remaining Phase 4 source-authority and broader live source-handoff replay cases, any remaining compact-label/descriptive copy outside top navigation and command-palette tab navigation, disabled-state consistency beyond Web Search, Media Source, Study Quiz, Study Flashcard, Media Viewer, Media Analysis, Media Highlight, Media Analysis navigation, Search/RAG saved-search actions, Media list pagination, and Media multi-item review actions, Phase 6 capability-state presentation beyond Speech/STTS and Web Search where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
+Planning consequence: remaining implementation should target remaining Phase 4 source-authority and broader live source-handoff replay cases, any remaining compact-label/descriptive copy outside top navigation and command-palette tab navigation, disabled-state consistency beyond Web Search, Media Source, Study Quiz, Study Flashcard, Media Viewer, Media Analysis, Media Highlight, Media Analysis navigation, Search/RAG saved-search actions, Media list pagination, Media multi-item review actions, and Media handoff policy-denial recovery, Phase 6 capability-state presentation beyond Speech/STTS and Web Search where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
 
 ## Issues Covered
 
@@ -267,7 +268,7 @@ Branch state: clear/dismiss behavior completed in `codex/ux-chat-handoff-clear-c
 
 Purpose: verify and harden the source-side handoff surfaces that have now landed in current `dev`.
 
-Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG Search, and dedicated Web Search handoffs are implemented and covered by focused tests. Notes, workspace source/artifact, and Media invalid-selection states now have shared-harness smoke coverage. Valid source handoffs from mounted source surfaces replay into the app-owned Chat seam. Backend-provided dry-run and unsupported-action messages are visible on staged Chat context cards. The active branch adds runtime-policy-denied Notes/Workspace handoff smoke coverage. Remaining work is to close remaining source-action capability edge cases in the shared UX smoke pass.
+Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG Search, and dedicated Web Search handoffs are implemented and covered by focused tests. Notes, workspace source/artifact, and Media invalid-selection states now have shared-harness smoke coverage. Valid source handoffs from mounted source surfaces replay into the app-owned Chat seam. Backend-provided dry-run and unsupported-action messages are visible on staged Chat context cards. Runtime-policy-denied Notes/Workspace handoff smoke coverage is merged through PR #179. The active branch extends policy-denial recovery to Media `Use in Chat`. Remaining work is to close remaining source-action capability edge cases in the shared UX smoke pass.
 
 ### Files
 
@@ -298,6 +299,7 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 - [x] Replay invalid-selection handoff states for Notes, workspace source/artifact, and Media in the Phase 0/7 smoke harness.
 - [x] Surface backend dry-run sync and unsupported-action messages on staged Chat context cards without implying write sync.
 - [x] Add mounted smoke coverage for runtime-policy-blocked Notes/Workspace handoff actions with recovery copy and no Chat staging.
+- [x] Explain runtime-policy-blocked Media handoff actions with recovery copy and no Chat staging.
 
 ### Acceptance Criteria
 
@@ -448,4 +450,4 @@ Current-dev state: partially started. A mounted handoff first-send smoke test no
 
 ## Next Step
 
-After this source capability-contract smoke slice, the remaining Phase 4 work is extending source-action backend/capability-contract recovery to other source surfaces where policy state can block a visible action. The remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.
+After this Media handoff policy-smoke slice, the remaining Phase 4 work is extending source-action backend/capability-contract recovery to Search/RAG, Web Search, or other source surfaces where policy state can block a visible action. The remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.

--- a/Tests/UI/test_media_handoffs.py
+++ b/Tests/UI/test_media_handoffs.py
@@ -3,12 +3,16 @@ from __future__ import annotations
 import ast
 import inspect
 import textwrap
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
 from textual.app import App, ComposeResult
 from textual.widgets import Button
 
+from tldw_chatbook.runtime_policy.engine import PolicyEngine
+from tldw_chatbook.runtime_policy.registry import CAPABILITY_REGISTRY
+from tldw_chatbook.runtime_policy.types import RuntimeSourceState
 from tldw_chatbook.UI.MediaWindow_v2 import MediaWindow
 from tldw_chatbook.UI.Screens.media_runtime_state import MediaRuntimeState
 from tldw_chatbook.Widgets.Media.media_viewer_panel import MediaViewerPanel
@@ -135,4 +139,30 @@ def test_media_window_use_in_chat_unavailable_explains_recovery():
     assert "Use in Chat is unavailable" in message
     assert "Open Chat" in message
     assert "try again" in message
+    assert app.notify.call_args.kwargs["severity"] == "warning"
+
+
+def test_media_window_use_in_chat_policy_block_explains_recovery():
+    app = _media_app(runtime_backend="local")
+    app.runtime_policy = SimpleNamespace(state=RuntimeSourceState(active_source="local"))
+    app.ui_policy_engine = PolicyEngine(CAPABILITY_REGISTRY)
+    window = MediaWindow(app)
+    window.runtime_state = app.media_runtime_state
+    window.viewer_panel = Mock()
+    window.viewer_panel.media_data = None
+    event = MediaViewerPanel.UseInChatRequested(
+        {
+            "id": "media-1",
+            "backend": "server",
+            "title": "Lecture",
+            "content": "Transcript",
+        }
+    )
+
+    window.handle_media_use_in_chat(event)
+
+    app.open_chat_with_handoff.assert_not_called()
+    message = app.notify.call_args.args[0]
+    assert "media.items.detail.server requires server mode" in message
+    assert "switch source" in message.lower()
     assert app.notify.call_args.kwargs["severity"] == "warning"

--- a/tldw_chatbook/UI/MediaWindow_v2.py
+++ b/tldw_chatbook/UI/MediaWindow_v2.py
@@ -47,6 +47,7 @@ from ..Event_Handlers.media_events import (
 )
 from ..Chat.chat_handoff_messages import USE_IN_CHAT_UNAVAILABLE_RECOVERY
 from ..Chat.chat_handoff_models import ChatHandoffPayload
+from ..runtime_policy.types import RuntimeSourceState
 
 if TYPE_CHECKING:
     from ..app import TldwCli
@@ -57,6 +58,7 @@ MEDIA_EMPTY_STATE_COPY = (
     "Use Ingest to add files, URLs, archives, or transcripts. Select a media item here.\n"
     "Details, analysis, save/export, and Use in Chat actions appear after a media item is selected."
 )
+MEDIA_HANDOFF_POLICY_RECOVERY = "Switch source, sign in, or reconnect the server before using this media item in Chat."
 
 
 class MediaWindow(Container):
@@ -413,6 +415,32 @@ class MediaWindow(Container):
                 "content_available": bool(detail.get("content")),
             },
         )
+
+    @staticmethod
+    def _media_handoff_runtime_action_id(backend: str | None) -> str | None:
+        """Return the runtime-policy action for a Media detail handoff."""
+        normalized = str(backend or "").strip().lower()
+        if normalized not in {"local", "server"}:
+            return None
+        return f"media.items.detail.{normalized}"
+
+    def _media_handoff_policy_blocking_message(self, payload: ChatHandoffPayload) -> str:
+        action_id = self._media_handoff_runtime_action_id(payload.runtime_backend)
+        if not action_id:
+            return ""
+
+        runtime_state = getattr(getattr(self.app_instance, "runtime_policy", None), "state", None)
+        policy_engine = getattr(self.app_instance, "ui_policy_engine", None)
+        evaluate = getattr(policy_engine, "evaluate", None)
+        if not isinstance(runtime_state, RuntimeSourceState) or not callable(evaluate):
+            return ""
+
+        decision = evaluate(action_id=action_id, state=runtime_state)
+        if getattr(decision, "allowed", True):
+            return ""
+
+        message = str(getattr(decision, "user_message", None) or "This media source action is blocked by runtime policy.")
+        return f"{message} {MEDIA_HANDOFF_POLICY_RECOVERY}"
 
     def _show_viewer(self) -> None:
         """Hide the empty state and display the viewer panel."""
@@ -988,6 +1016,10 @@ class MediaWindow(Container):
         payload = self._build_current_media_chat_handoff_payload(event.media_data)
         if payload is None:
             self.app_instance.notify("Select a media item before using it in Chat.", severity="warning")
+            return
+        policy_message = self._media_handoff_policy_blocking_message(payload)
+        if policy_message:
+            self.app_instance.notify(policy_message, severity="warning")
             return
         open_chat = getattr(self.app_instance, "open_chat_with_handoff", None)
         if not callable(open_chat):

--- a/tldw_chatbook/UI/MediaWindow_v2.py
+++ b/tldw_chatbook/UI/MediaWindow_v2.py
@@ -429,9 +429,10 @@ class MediaWindow(Container):
         if not action_id:
             return ""
 
-        runtime_state = getattr(getattr(self.app_instance, "runtime_policy", None), "state", None)
+        runtime_policy = getattr(self.app_instance, "runtime_policy", None)
+        runtime_state = getattr(runtime_policy, "state", None) if runtime_policy else None
         policy_engine = getattr(self.app_instance, "ui_policy_engine", None)
-        evaluate = getattr(policy_engine, "evaluate", None)
+        evaluate = getattr(policy_engine, "evaluate", None) if policy_engine else None
         if not isinstance(runtime_state, RuntimeSourceState) or not callable(evaluate):
             return ""
 


### PR DESCRIPTION
## Summary
- Add a Media Use in Chat runtime-policy guard so server-owned media is not staged while local mode is active.
- Show recovery copy when Media handoff policy denies the action.
- Rebaseline the UX remediation plan through PR #179 and this active Media slice.

## Test Plan
- env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_media_handoffs.py::test_media_window_use_in_chat_policy_block_explains_recovery Tests/UI/test_media_handoffs.py::test_media_window_use_in_chat_handler_routes_event_to_app --tb=short
- env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_media_handoffs.py Tests/UI/test_ux_audit_smoke.py --tb=short
- env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_chat_first_handoffs.py Tests/UI/test_search_handoffs.py --tb=short
- git diff --check