### PR TITLE
Explain RAG handoff policy blocks

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -1,8 +1,8 @@
 # UX Audit Remediation Plan
 
 Date: 2026-05-01
-Status: Current-dev rebaseline after UX remediation PRs #146-#179, plus active Media handoff policy-smoke slice
-Branch context: current `dev` / `origin/dev` at `0a5a30d6`; active branch `codex/ux-media-handoff-policy-smoke`
+Status: Current-dev rebaseline after UX remediation PRs #146-#180, plus active RAG handoff policy-smoke slice
+Branch context: current `dev` / `origin/dev` at `87e945c4`; active branch `codex/ux-rag-handoff-policy-smoke`
 Previous audit baseline: `e2576cae`
 
 ## Goal
@@ -29,7 +29,7 @@ This is not a visual refresh. The work is ordered around workflow completion, re
 
 ## Current Dev Rebaseline
 
-Verified on current `dev` at `0a5a30d6`:
+Verified on current `dev` at `87e945c4`:
 
 - Phase 0 and Phase 1 are merged: the shared shell/Chatbooks trap, Ingest default source, quiz empty mapping response, Chat save-state, Search/RAG thread mutation, and Search primary-action reachability regressions are covered.
 - Phase 2 is merged: Chat has provider readiness and first-run orientation coverage.
@@ -67,11 +67,12 @@ Current source state plus this branch:
 - Phase 4 source-handoff replay smoke coverage is merged through PR #177: mounted Textual tests replay selected Notes, workspace details/note/source/artifact, Media, RAG Search, and Web Search handoffs into the app-owned Chat seam.
 - Phase 4 backend-contract card copy is merged through PR #178: staged Chat context cards surface dry-run sync diagnostics and unsupported-action recovery messages without implying write sync.
 - Phase 4 Notes/Workspace source capability-contract smoke coverage is merged through PR #179: Notes/Workspace handoff buttons consume runtime-policy denial state and expose recovery copy without staging Chat.
-- Phase 4 Media handoff policy-smoke is active in `codex/ux-media-handoff-policy-smoke`: Media `Use in Chat` consumes runtime-policy denial state and exposes recovery copy without staging Chat.
+- Phase 4 Media handoff policy-smoke is merged through PR #180: Media `Use in Chat` consumes runtime-policy denial state and exposes recovery copy without staging Chat.
+- Phase 4 RAG handoff policy-smoke is active in `codex/ux-rag-handoff-policy-smoke`: server-owned RAG result `Use in Chat` consumes runtime-policy denial state and exposes recovery copy without staging Chat.
 - Phase 6 still needs any remaining optional dependency gaps represented as user-facing capability states where relevant.
 - Phase 7 still needs end-to-end audit replay on a clean home/config.
 
-Planning consequence: remaining implementation should target remaining Phase 4 source-authority and broader live source-handoff replay cases, any remaining compact-label/descriptive copy outside top navigation and command-palette tab navigation, disabled-state consistency beyond Web Search, Media Source, Study Quiz, Study Flashcard, Media Viewer, Media Analysis, Media Highlight, Media Analysis navigation, Search/RAG saved-search actions, Media list pagination, Media multi-item review actions, and Media handoff policy-denial recovery, Phase 6 capability-state presentation beyond Speech/STTS and Web Search where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
+Planning consequence: remaining implementation should target Web Search or other remaining Phase 4 source-authority and broader live source-handoff replay cases, any remaining compact-label/descriptive copy outside top navigation and command-palette tab navigation, disabled-state consistency beyond Web Search, Media Source, Study Quiz, Study Flashcard, Media Viewer, Media Analysis, Media Highlight, Media Analysis navigation, Search/RAG saved-search actions, Media list pagination, and Media multi-item review actions, Phase 6 capability-state presentation beyond Speech/STTS and Web Search where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
 
 ## Issues Covered
 
@@ -268,7 +269,7 @@ Branch state: clear/dismiss behavior completed in `codex/ux-chat-handoff-clear-c
 
 Purpose: verify and harden the source-side handoff surfaces that have now landed in current `dev`.
 
-Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG Search, and dedicated Web Search handoffs are implemented and covered by focused tests. Notes, workspace source/artifact, and Media invalid-selection states now have shared-harness smoke coverage. Valid source handoffs from mounted source surfaces replay into the app-owned Chat seam. Backend-provided dry-run and unsupported-action messages are visible on staged Chat context cards. Runtime-policy-denied Notes/Workspace handoff smoke coverage is merged through PR #179. The active branch extends policy-denial recovery to Media `Use in Chat`. Remaining work is to close remaining source-action capability edge cases in the shared UX smoke pass.
+Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG Search, and dedicated Web Search handoffs are implemented and covered by focused tests. Notes, workspace source/artifact, and Media invalid-selection states now have shared-harness smoke coverage. Valid source handoffs from mounted source surfaces replay into the app-owned Chat seam. Backend-provided dry-run and unsupported-action messages are visible on staged Chat context cards. Runtime-policy-denied Notes/Workspace handoff smoke coverage is merged through PR #179. Media handoff policy-denial recovery is merged through PR #180. The active branch extends policy-denial recovery to server-owned RAG result `Use in Chat`. Remaining work is to close remaining source-action capability edge cases in the shared UX smoke pass.
 
 ### Files
 
@@ -300,6 +301,7 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 - [x] Surface backend dry-run sync and unsupported-action messages on staged Chat context cards without implying write sync.
 - [x] Add mounted smoke coverage for runtime-policy-blocked Notes/Workspace handoff actions with recovery copy and no Chat staging.
 - [x] Explain runtime-policy-blocked Media handoff actions with recovery copy and no Chat staging.
+- [x] Explain runtime-policy-blocked server RAG result handoff actions with recovery copy and no Chat staging.
 
 ### Acceptance Criteria
 
@@ -450,4 +452,4 @@ Current-dev state: partially started. A mounted handoff first-send smoke test no
 
 ## Next Step
 
-After this Media handoff policy-smoke slice, the remaining Phase 4 work is extending source-action backend/capability-contract recovery to Search/RAG, Web Search, or other source surfaces where policy state can block a visible action. The remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.
+After this RAG handoff policy-smoke slice, the remaining Phase 4 work is extending source-action backend/capability-contract recovery to Web Search or other source surfaces where policy state can block a visible action. The remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.

--- a/Tests/UI/test_search_handoffs.py
+++ b/Tests/UI/test_search_handoffs.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from textual.app import App, ComposeResult
 from textual.widgets import Button, Markdown
 
+from tldw_chatbook.runtime_policy.engine import PolicyEngine
+from tldw_chatbook.runtime_policy.registry import CAPABILITY_REGISTRY
+from tldw_chatbook.runtime_policy.types import RuntimeSourceState
 from tldw_chatbook.UI import SearchWindow as search_window_module
 from tldw_chatbook.UI.Views.RAGSearch import search_rag_window
 from tldw_chatbook.UI.SearchWindow import SearchWindow
@@ -121,6 +125,34 @@ def test_search_rag_window_use_in_chat_unavailable_explains_recovery(tmp_path):
     assert "Use in Chat is unavailable" in message
     assert "Open Chat" in message
     assert "try again" in message
+    assert app.notify.call_args.kwargs["severity"] == "warning"
+
+
+def test_search_rag_window_use_in_chat_policy_block_explains_recovery(tmp_path):
+    app = _search_app(runtime_backend="server")
+    app.runtime_policy = SimpleNamespace(state=RuntimeSourceState(active_source="local"))
+    app.ui_policy_engine = PolicyEngine(CAPABILITY_REGISTRY)
+    with patch(
+        "tldw_chatbook.UI.Views.RAGSearch.search_rag_window.get_user_data_dir",
+        return_value=tmp_path,
+    ):
+        window = SearchRAGWindow(app_instance=app)
+    event = SearchResult.UseInChatRequested(
+        0,
+        {
+            "title": "Server Chunk",
+            "content": "Retrieved text",
+            "source": "notes",
+            "metadata": {"document_id": "doc-1"},
+        },
+    )
+
+    window.handle_search_result_use_in_chat(event)
+
+    app.open_chat_with_handoff.assert_not_called()
+    message = app.notify.call_args.args[0]
+    assert "rag.media_embeddings.search.server requires server mode" in message
+    assert "switch source" in message.lower()
     assert app.notify.call_args.kwargs["severity"] == "warning"
 
 

--- a/tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py
+++ b/tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py
@@ -518,9 +518,10 @@ class SearchRAGWindow(SearchEventHandlersMixin, Container):
         if not action_id:
             return ""
 
-        runtime_state = getattr(getattr(self.app_instance, "runtime_policy", None), "state", None)
+        runtime_policy = getattr(self.app_instance, "runtime_policy", None)
+        runtime_state = getattr(runtime_policy, "state", None) if runtime_policy else None
         policy_engine = getattr(self.app_instance, "ui_policy_engine", None)
-        evaluate = getattr(policy_engine, "evaluate", None)
+        evaluate = getattr(policy_engine, "evaluate", None) if policy_engine else None
         if not isinstance(runtime_state, RuntimeSourceState) or not callable(evaluate):
             return ""
 

--- a/tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py
+++ b/tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py
@@ -37,6 +37,8 @@ from .constants import (
 )
 
 from ....Chat.chat_handoff_messages import USE_IN_CHAT_UNAVAILABLE_RECOVERY
+from ....Chat.chat_handoff_models import ChatHandoffPayload
+from ....runtime_policy.types import RuntimeSourceState
 from ....Utils.optional_deps import DEPENDENCIES_AVAILABLE
 from ....DB.search_history_db import SearchHistoryDB
 from ....Utils.paths import get_user_data_dir
@@ -129,6 +131,7 @@ if TYPE_CHECKING:
     from ....app import TldwCli
 
 logger = logger.bind(module="SearchRAGWindow")
+RAG_HANDOFF_POLICY_RECOVERY = "Switch source, sign in, or reconnect the server before using this result in Chat."
 
 # Import event handler mixin
 from .search_event_handlers import SearchEventHandlersMixin
@@ -501,10 +504,41 @@ class SearchRAGWindow(SearchEventHandlersMixin, Container):
             runtime_backend=self._authoritative_runtime_backend(),
         )
 
+    @staticmethod
+    def _rag_handoff_runtime_action_id(payload: ChatHandoffPayload) -> str | None:
+        if payload.source != "search-rag":
+            return None
+        backend = str(payload.runtime_backend or "").strip().lower()
+        if backend != "server":
+            return None
+        return "rag.media_embeddings.search.server"
+
+    def _rag_handoff_policy_blocking_message(self, payload: ChatHandoffPayload) -> str:
+        action_id = self._rag_handoff_runtime_action_id(payload)
+        if not action_id:
+            return ""
+
+        runtime_state = getattr(getattr(self.app_instance, "runtime_policy", None), "state", None)
+        policy_engine = getattr(self.app_instance, "ui_policy_engine", None)
+        evaluate = getattr(policy_engine, "evaluate", None)
+        if not isinstance(runtime_state, RuntimeSourceState) or not callable(evaluate):
+            return ""
+
+        decision = evaluate(action_id=action_id, state=runtime_state)
+        if getattr(decision, "allowed", True):
+            return ""
+
+        message = str(getattr(decision, "user_message", None) or "This RAG search action is blocked by runtime policy.")
+        return f"{message} {RAG_HANDOFF_POLICY_RECOVERY}"
+
     @on(SearchResult.UseInChatRequested)
     def handle_search_result_use_in_chat(self, event: SearchResult.UseInChatRequested) -> None:
         event.stop()
         payload = self._build_search_chat_handoff_payload(event.result)
+        policy_message = self._rag_handoff_policy_blocking_message(payload)
+        if policy_message:
+            self.app_instance.notify(policy_message, severity="warning")
+            return
         open_chat = getattr(self.app_instance, "open_chat_with_handoff", None)
         if not callable(open_chat):
             self.app_instance.notify(USE_IN_CHAT_UNAVAILABLE_RECOVERY, severity="warning")


### PR DESCRIPTION
## Summary
- Add a RAG result Use in Chat runtime-policy guard for server-owned search results.
- Show recovery copy instead of staging Chat when runtime policy denies the RAG handoff.
- Rebaseline the UX remediation plan through PR #180 and this active RAG slice.

## Test Plan
- env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_search_handoffs.py::test_search_rag_window_use_in_chat_policy_block_explains_recovery Tests/UI/test_search_handoffs.py::test_search_rag_window_use_in_chat_handler_routes_to_app --tb=short
- env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_search_handoffs.py Tests/UI/test_ux_audit_smoke.py --tb=short
- env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_chat_first_handoffs.py --tb=short
- git diff --check