### PR TITLE
Explain Study dashboard resume availability

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -1,8 +1,8 @@
 # UX Audit Remediation Plan
 
 Date: 2026-05-01
-Status: Current-dev rebaseline after UX remediation PRs #146-#183, plus active Search/RAG dependency action-state slice
-Branch context: current `dev` / `origin/dev` at `1b4a8e70`; active branch `codex/ux-rag-dependency-action-state`
+Status: Current-dev rebaseline after UX remediation PRs #146-#184, plus active Study dashboard resume-tooltip slice
+Branch context: current `dev` / `origin/dev` at `991b6da5`; active branch `codex/ux-study-dashboard-resume-tooltip`
 Previous audit baseline: `e2576cae`
 
 ## Goal
@@ -29,7 +29,7 @@ This is not a visual refresh. The work is ordered around workflow completion, re
 
 ## Current Dev Rebaseline
 
-Verified on current `dev` at `1b4a8e70`:
+Verified on current `dev` at `991b6da5`:
 
 - Phase 0 and Phase 1 are merged: the shared shell/Chatbooks trap, Ingest default source, quiz empty mapping response, Chat save-state, Search/RAG thread mutation, and Search primary-action reachability regressions are covered.
 - Phase 2 is merged: Chat has provider readiness and first-run orientation coverage.
@@ -71,11 +71,12 @@ Current source state plus this branch:
 - Phase 4 RAG handoff policy-smoke is merged through PR #181: server-owned RAG result `Use in Chat` consumes runtime-policy denial state and exposes recovery copy without staging Chat.
 - Phase 4 Web Search handoff policy-smoke is merged through PR #182: dedicated Web Search result `Use in Chat` consumes runtime-policy denial state and exposes recovery copy without staging Chat.
 - Phase 4 source-policy handoff smoke closeout is merged through PR #183: mounted smoke coverage replays policy-blocked Media, RAG, and Web Search handoffs through real button events.
-- Phase 6 Search/RAG dependency action-state is active in `codex/ux-rag-dependency-action-state`: missing embeddings/RAG dependencies disable the primary Search action and expose install recovery copy.
+- Phase 6 Search/RAG dependency action-state is merged through PR #184: missing embeddings/RAG dependencies disable the primary Search action and expose install recovery copy.
+- Phase 5 Study dashboard resume-tooltip is active in `codex/ux-study-dashboard-resume-tooltip`: the disabled Resume action explains that no study session exists and points users to flashcards/quizzes.
 - Phase 6 still needs any remaining optional dependency gaps represented as user-facing capability states where relevant.
 - Phase 7 still needs end-to-end audit replay on a clean home/config.
 
-Planning consequence: remaining implementation should target broader live source-handoff replay cases, any non-handoff source actions where policy state can still block a visible action, any remaining compact-label/descriptive copy outside top navigation and command-palette tab navigation, disabled-state consistency beyond the already-covered Web Search, Media Source, Study Quiz, Study Flashcard, Media Viewer, Media Analysis, Media Highlight, Media Analysis navigation, Search/RAG saved-search actions, Media list pagination, and Media multi-item review actions, Phase 6 capability-state presentation beyond Speech/STTS, Web Search, and Search/RAG embeddings where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
+Planning consequence: remaining implementation should target broader live source-handoff replay cases, any non-handoff source actions where policy state can still block a visible action, any remaining compact-label/descriptive copy outside top navigation and command-palette tab navigation, disabled-state consistency beyond the already-covered Web Search, Media Source, Study Quiz, Study Flashcard, Study dashboard resume, Media Viewer, Media Analysis, Media Highlight, Media Analysis navigation, Search/RAG saved-search actions, Media list pagination, and Media multi-item review actions, Phase 6 capability-state presentation beyond Speech/STTS, Web Search, and Search/RAG embeddings where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
 
 ## Issues Covered
 
@@ -321,7 +322,7 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 
 Purpose: make the app understandable without reducing expert efficiency.
 
-Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, #163, #164, #165, #166, #167, #168, #169, #170, #171, #172, #173, and #174. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, Speech/STTS exposes local dependency capability states, Web Search missing dependencies render as disabled-state recovery copy, Media Source disabled actions expose recovery tooltips, Study Quiz disabled actions expose recovery tooltips, Study Flashcards disabled actions expose recovery tooltips, Media Viewer actions expose selection/capability tooltips, Media Analysis actions expose generated-analysis/saved-version tooltips, Media Highlight actions expose selected-highlight tooltips, Media Analysis navigation actions expose saved-version boundary tooltips, Search/RAG saved-search actions expose selection/reuse recovery, Media list pagination exposes result-page boundary tooltips, and Media multi-item review actions expose generation/cancellation state tooltips.
+Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, #163, #164, #165, #166, #167, #168, #169, #170, #171, #172, #173, and #174. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, Speech/STTS exposes local dependency capability states, Web Search missing dependencies render as disabled-state recovery copy, Media Source disabled actions expose recovery tooltips, Study Quiz disabled actions expose recovery tooltips, Study Flashcards disabled actions expose recovery tooltips, Study dashboard Resume action recovery is active in `codex/ux-study-dashboard-resume-tooltip`, Media Viewer actions expose selection/capability tooltips, Media Analysis actions expose generated-analysis/saved-version tooltips, Media Highlight actions expose selected-highlight tooltips, Media Analysis navigation actions expose saved-version boundary tooltips, Search/RAG saved-search actions expose selection/reuse recovery, Media list pagination exposes result-page boundary tooltips, and Media multi-item review actions expose generation/cancellation state tooltips.
 
 ### Files
 
@@ -358,6 +359,7 @@ Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #
 - [x] Add Search/RAG saved-search action recovery for Load/Delete selection states and selected-config reuse.
 - [x] Add Media list pagination tooltips for single-page and first/last result-page states.
 - [x] Add Media multi-item review action tooltips for Generate/Cancel analysis states.
+- [x] Add Study dashboard Resume action tooltip copy for no-session and resumable-session states.
 - [ ] Add tooltips or short descriptions where compact labels remain necessary outside top navigation.
 
 ### Acceptance Criteria
@@ -372,7 +374,7 @@ Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #
 
 Purpose: make first-run diagnostics truthful and actionable without hiding real failures.
 
-Branch state: partially completed in `codex/ux-startup-log-polish`, with Speech/STTS capability-state merged through PR #163 and Web Search disabled-state merged through PR #164. Search/RAG embeddings dependency action-state is active in `codex/ux-rag-dependency-action-state`. Splash import regressions, optional OpenAI TTS mapping fallback logging, and NLTK download-result logging are covered by focused tests. Broader optional dependency capability-state presentation remains open.
+Branch state: partially completed in `codex/ux-startup-log-polish`, with Speech/STTS capability-state merged through PR #163, Web Search disabled-state merged through PR #164, and Search/RAG embeddings dependency action-state merged through PR #184. Splash import regressions, optional OpenAI TTS mapping fallback logging, and NLTK download-result logging are covered by focused tests. Broader optional dependency capability-state presentation remains open.
 
 ### Files
 
@@ -459,4 +461,4 @@ Current-dev state: partially started. A mounted handoff first-send smoke test no
 
 ## Next Step
 
-After this Search/RAG dependency action-state slice, remaining Phase 4 work should focus on broader live audit replay or any non-handoff source actions where policy state can still block a visible action. The remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.
+After this Study dashboard resume-tooltip slice, remaining Phase 4 work should focus on broader live audit replay or any non-handoff source actions where policy state can still block a visible action. The remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.

--- a/Tests/UI/test_study_dashboard.py
+++ b/Tests/UI/test_study_dashboard.py
@@ -133,6 +133,9 @@ async def test_study_dashboard_surfaces_due_and_recent_items():
         assert "Binary Trees" in _text(recent_decks)
         assert "Tree Drill" in _text(recent_quizzes)
         assert resume_button is not None
+        assert resume_button.disabled is True
+        assert "No study session to resume" in str(resume_button.tooltip)
+        assert "Open flashcards or quizzes" in str(resume_button.tooltip)
 
 
 @pytest.mark.asyncio
@@ -143,6 +146,10 @@ async def test_study_dashboard_resume_action_returns_to_last_session():
         await pilot.pause(0.3)
         app.screen.current_study_session = {"section": "quizzes", "topic": "Binary Trees"}
         await pilot.pause(0.1)
+
+        resume_button = app.screen.query_one("#study-resume-last", Button)
+        assert resume_button.disabled is False
+        assert "Resume the most recent study session" in str(resume_button.tooltip)
 
         await pilot.click("#study-resume-last")
         await pilot.pause(0.2)

--- a/tldw_chatbook/Widgets/Study/study_dashboard.py
+++ b/tldw_chatbook/Widgets/Study/study_dashboard.py
@@ -8,6 +8,12 @@ from textual.widget import Widget
 from textual.widgets import Button, Static
 
 
+RESUME_DISABLED_TOOLTIP = (
+    "No study session to resume. Open flashcards or quizzes to start a session."
+)
+RESUME_ENABLED_TOOLTIP = "Resume the most recent study session."
+
+
 class StudyDashboard(Widget):
     """Summarize due work, recents, and resume actions."""
 
@@ -70,7 +76,13 @@ class StudyDashboard(Widget):
                     yield Static("Recent Quizzes", classes="study-dashboard-heading")
                     yield Static("No recent quizzes yet.", id="study-recent-quizzes", classes="study-dashboard-value")
             with Horizontal(classes="study-dashboard-actions"):
-                yield Button("Resume last session", id="study-resume-last", disabled=True, variant="primary")
+                yield Button(
+                    "Resume last session",
+                    id="study-resume-last",
+                    disabled=True,
+                    variant="primary",
+                    tooltip=RESUME_DISABLED_TOOLTIP,
+                )
                 yield Button("Open flashcards", id="study-open-flashcards")
                 yield Button("Open quizzes", id="study-open-quizzes")
 
@@ -99,6 +111,8 @@ class StudyDashboard(Widget):
         if summary:
             button.label = f"Resume {summary}"
             button.disabled = False
+            button.tooltip = RESUME_ENABLED_TOOLTIP
         else:
             button.label = "Resume last session"
             button.disabled = True
+            button.tooltip = RESUME_DISABLED_TOOLTIP


### PR DESCRIPTION
## Summary
- Add Study dashboard tooltip copy for the disabled Resume action so first-time users understand why it is unavailable.
- Add enabled-state tooltip copy when a resumable Study session exists.
- Update the UX remediation plan to mark PR #184 merged and track this Phase 5 disabled-action consistency slice.

## Test Plan
- env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_study_dashboard.py --tb=short
- env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_study_screen.py --tb=short
- git diff --check