### PR TITLE
Explain Study quiz start availability

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -1,8 +1,8 @@
 # UX Audit Remediation Plan
 
 Date: 2026-05-01
-Status: Current-dev rebaseline after UX remediation PRs #146-#184, plus active Study dashboard resume-tooltip slice
-Branch context: current `dev` / `origin/dev` at `991b6da5`; active branch `codex/ux-study-dashboard-resume-tooltip`
+Status: Current-dev rebaseline after UX remediation PRs #146-#185, plus active Study quiz start-tooltip slice
+Branch context: current `dev` / `origin/dev` at `91ed8ff7`; active branch `codex/ux-quiz-start-tooltip`
 Previous audit baseline: `e2576cae`
 
 ## Goal
@@ -29,7 +29,7 @@ This is not a visual refresh. The work is ordered around workflow completion, re
 
 ## Current Dev Rebaseline
 
-Verified on current `dev` at `991b6da5`:
+Verified on current `dev` at `91ed8ff7`:
 
 - Phase 0 and Phase 1 are merged: the shared shell/Chatbooks trap, Ingest default source, quiz empty mapping response, Chat save-state, Search/RAG thread mutation, and Search primary-action reachability regressions are covered.
 - Phase 2 is merged: Chat has provider readiness and first-run orientation coverage.
@@ -72,11 +72,12 @@ Current source state plus this branch:
 - Phase 4 Web Search handoff policy-smoke is merged through PR #182: dedicated Web Search result `Use in Chat` consumes runtime-policy denial state and exposes recovery copy without staging Chat.
 - Phase 4 source-policy handoff smoke closeout is merged through PR #183: mounted smoke coverage replays policy-blocked Media, RAG, and Web Search handoffs through real button events.
 - Phase 6 Search/RAG dependency action-state is merged through PR #184: missing embeddings/RAG dependencies disable the primary Search action and expose install recovery copy.
-- Phase 5 Study dashboard resume-tooltip is active in `codex/ux-study-dashboard-resume-tooltip`: the disabled Resume action explains that no study session exists and points users to flashcards/quizzes.
+- Phase 5 Study dashboard resume-tooltip is merged through PR #185: the disabled Resume action explains that no study session exists and points users to flashcards/quizzes.
+- Phase 5 Study quiz start-tooltip is active in `codex/ux-quiz-start-tooltip`: the shell-level Start quiz action explains no-quiz, select-quiz, unavailable-scope, active-attempt, and start-ready states.
 - Phase 6 still needs any remaining optional dependency gaps represented as user-facing capability states where relevant.
 - Phase 7 still needs end-to-end audit replay on a clean home/config.
 
-Planning consequence: remaining implementation should target broader live source-handoff replay cases, any non-handoff source actions where policy state can still block a visible action, any remaining compact-label/descriptive copy outside top navigation and command-palette tab navigation, disabled-state consistency beyond the already-covered Web Search, Media Source, Study Quiz, Study Flashcard, Study dashboard resume, Media Viewer, Media Analysis, Media Highlight, Media Analysis navigation, Search/RAG saved-search actions, Media list pagination, and Media multi-item review actions, Phase 6 capability-state presentation beyond Speech/STTS, Web Search, and Search/RAG embeddings where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
+Planning consequence: remaining implementation should target broader live source-handoff replay cases, any non-handoff source actions where policy state can still block a visible action, any remaining compact-label/descriptive copy outside top navigation and command-palette tab navigation, disabled-state consistency beyond the already-covered Web Search, Media Source, Study Quiz, Study Flashcard, Study dashboard resume, Study quiz start, Media Viewer, Media Analysis, Media Highlight, Media Analysis navigation, Search/RAG saved-search actions, Media list pagination, and Media multi-item review actions, Phase 6 capability-state presentation beyond Speech/STTS, Web Search, and Search/RAG embeddings where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
 
 ## Issues Covered
 
@@ -322,7 +323,7 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 
 Purpose: make the app understandable without reducing expert efficiency.
 
-Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, #163, #164, #165, #166, #167, #168, #169, #170, #171, #172, #173, and #174. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, Speech/STTS exposes local dependency capability states, Web Search missing dependencies render as disabled-state recovery copy, Media Source disabled actions expose recovery tooltips, Study Quiz disabled actions expose recovery tooltips, Study Flashcards disabled actions expose recovery tooltips, Study dashboard Resume action recovery is active in `codex/ux-study-dashboard-resume-tooltip`, Media Viewer actions expose selection/capability tooltips, Media Analysis actions expose generated-analysis/saved-version tooltips, Media Highlight actions expose selected-highlight tooltips, Media Analysis navigation actions expose saved-version boundary tooltips, Search/RAG saved-search actions expose selection/reuse recovery, Media list pagination exposes result-page boundary tooltips, and Media multi-item review actions expose generation/cancellation state tooltips.
+Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, #163, #164, #165, #166, #167, #168, #169, #170, #171, #172, #173, #174, and #185. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, Speech/STTS exposes local dependency capability states, Web Search missing dependencies render as disabled-state recovery copy, Media Source disabled actions expose recovery tooltips, Study Quiz disabled actions expose recovery tooltips, Study Flashcards disabled actions expose recovery tooltips, Study dashboard Resume action recovery is merged through PR #185, Study quiz Start action recovery is active in `codex/ux-quiz-start-tooltip`, Media Viewer actions expose selection/capability tooltips, Media Analysis actions expose generated-analysis/saved-version tooltips, Media Highlight actions expose selected-highlight tooltips, Media Analysis navigation actions expose saved-version boundary tooltips, Search/RAG saved-search actions expose selection/reuse recovery, Media list pagination exposes result-page boundary tooltips, and Media multi-item review actions expose generation/cancellation state tooltips.
 
 ### Files
 
@@ -360,6 +361,7 @@ Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #
 - [x] Add Media list pagination tooltips for single-page and first/last result-page states.
 - [x] Add Media multi-item review action tooltips for Generate/Cancel analysis states.
 - [x] Add Study dashboard Resume action tooltip copy for no-session and resumable-session states.
+- [x] Add Study quiz Start action tooltip copy for no-quiz, select-quiz, scope-unavailable, active-attempt, and ready states.
 - [ ] Add tooltips or short descriptions where compact labels remain necessary outside top navigation.
 
 ### Acceptance Criteria
@@ -461,4 +463,4 @@ Current-dev state: partially started. A mounted handoff first-send smoke test no
 
 ## Next Step
 
-After this Study dashboard resume-tooltip slice, remaining Phase 4 work should focus on broader live audit replay or any non-handoff source actions where policy state can still block a visible action. The remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.
+After this Study quiz start-tooltip slice, remaining Phase 4 work should focus on broader live audit replay or any non-handoff source actions where policy state can still block a visible action. The remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.

--- a/Tests/UI/test_study_dashboard.py
+++ b/Tests/UI/test_study_dashboard.py
@@ -173,6 +173,8 @@ async def test_study_quizzes_section_offers_shell_level_start_flow():
         assert quiz_session is not None
         assert quiz_start is not None
         assert "Tree Drill" in _text(quiz_summary)
+        assert quiz_start.disabled is False
+        assert "Start the selected quiz" in str(quiz_start.tooltip)
 
         await pilot.click("#quiz-start")
         await pilot.pause(0.3)
@@ -182,3 +184,23 @@ async def test_study_quizzes_section_offers_shell_level_start_flow():
 
         assert study_window.current_view == "quizzes"
         assert "Question 1 of 1." in _text(quiz_status)
+
+
+@pytest.mark.asyncio
+async def test_study_quizzes_start_action_explains_no_quiz_recovery():
+    app_instance = _build_app_instance()
+    app_instance.study_quiz_scope_service.quizzes = []
+    app_instance.study_quiz_scope_service.questions = []
+    app = StudyDashboardTestApp(app_instance)
+
+    async with app.run_test() as pilot:
+        await pilot.pause(0.3)
+        await pilot.click("#view-quizzes-btn")
+        await pilot.pause(0.4)
+
+        quiz_start = app.screen.query_one("#quiz-start", Button)
+        quiz_summary = app.screen.query_one("#quiz-session-summary", Static)
+
+        assert "No quizzes available yet." in _text(quiz_summary)
+        assert quiz_start.disabled is True
+        assert "Create or import a quiz" in str(quiz_start.tooltip)

--- a/tldw_chatbook/UI/Screens/study_screen.py
+++ b/tldw_chatbook/UI/Screens/study_screen.py
@@ -15,6 +15,13 @@ from textual.widgets import Button
 from ..Navigation.base_app_screen import BaseAppScreen
 from ..Study_Window import StudyWindow
 from ...Widgets.Study import QuizSessionWidget, StudyDashboard
+from ...Widgets.Study.quiz_session_widget import (
+    QUIZ_START_ATTEMPT_ACTIVE_TOOLTIP,
+    QUIZ_START_ENABLED_TOOLTIP,
+    QUIZ_START_NO_QUIZZES_TOOLTIP,
+    QUIZ_START_SCOPE_UNAVAILABLE_TOOLTIP,
+    QUIZ_START_SELECT_TOOLTIP,
+)
 from .notes_scope_models import WorkspaceSubview
 from .study_scope_models import StudyScopeContext, StudyScopeState, StudyScopeType
 
@@ -268,7 +275,7 @@ class StudyScreen(BaseAppScreen):
         if controller is None:
             self.quiz_session_widget.update_session_summary("Select a quiz to begin.")
             self.quiz_session_widget.update_status("")
-            self.quiz_session_widget.set_start_enabled(False)
+            self.quiz_session_widget.set_start_enabled(False, QUIZ_START_SELECT_TOOLTIP)
             return
 
         quiz_name = None
@@ -294,7 +301,18 @@ class StudyScreen(BaseAppScreen):
         attempt_active = bool(getattr(controller, "current_attempt_id", None)) and bool(
             getattr(controller, "current_attempt_questions", None)
         )
-        self.quiz_session_widget.set_start_enabled(bool(quiz_name) and scope_available and not attempt_active)
+        start_enabled = bool(quiz_name) and scope_available and not attempt_active
+        if start_enabled:
+            tooltip = QUIZ_START_ENABLED_TOOLTIP
+        elif quiz_name and not scope_available:
+            tooltip = QUIZ_START_SCOPE_UNAVAILABLE_TOOLTIP
+        elif quiz_name and attempt_active:
+            tooltip = QUIZ_START_ATTEMPT_ACTIVE_TOOLTIP
+        elif getattr(controller, "has_quizzes", False):
+            tooltip = QUIZ_START_SELECT_TOOLTIP
+        else:
+            tooltip = QUIZ_START_NO_QUIZZES_TOOLTIP
+        self.quiz_session_widget.set_start_enabled(start_enabled, tooltip)
 
     def sync_shell_from_window(self) -> None:
         self._sync_dashboard_widgets()

--- a/tldw_chatbook/Widgets/Study/quiz_session_widget.py
+++ b/tldw_chatbook/Widgets/Study/quiz_session_widget.py
@@ -8,6 +8,13 @@ from textual.widget import Widget
 from textual.widgets import Button, Static
 
 
+QUIZ_START_ENABLED_TOOLTIP = "Start the selected quiz."
+QUIZ_START_SELECT_TOOLTIP = "Select a quiz before starting."
+QUIZ_START_NO_QUIZZES_TOOLTIP = "Create or import a quiz before starting a session."
+QUIZ_START_SCOPE_UNAVAILABLE_TOOLTIP = "Switch to an available study scope before starting a quiz."
+QUIZ_START_ATTEMPT_ACTIVE_TOOLTIP = "Finish the current quiz attempt before starting another."
+
+
 class QuizSessionWidget(Widget):
     """Compact shell-level summary for quiz launch and progress."""
 
@@ -48,7 +55,13 @@ class QuizSessionWidget(Widget):
             yield Static("Select a quiz to begin.", id="quiz-session-summary")
             yield Static("", id="quiz-session-status")
             with Horizontal(classes="quiz-session-actions"):
-                yield Button("Start quiz", id="quiz-start", variant="primary", disabled=True)
+                yield Button(
+                    "Start quiz",
+                    id="quiz-start",
+                    variant="primary",
+                    disabled=True,
+                    tooltip=QUIZ_START_SELECT_TOOLTIP,
+                )
                 yield Button("Review in chat", id="quiz-open-in-chat")
 
     def update_scope_summary(self, summary: str) -> None:
@@ -63,6 +76,10 @@ class QuizSessionWidget(Widget):
         if self.is_mounted:
             self.query_one("#quiz-session-status", Static).update(status)
 
-    def set_start_enabled(self, enabled: bool) -> None:
+    def set_start_enabled(self, enabled: bool, tooltip: str | None = None) -> None:
         if self.is_mounted:
-            self.query_one("#quiz-start", Button).disabled = not enabled
+            button = self.query_one("#quiz-start", Button)
+            button.disabled = not enabled
+            button.tooltip = tooltip or (
+                QUIZ_START_ENABLED_TOOLTIP if enabled else QUIZ_START_SELECT_TOOLTIP
+            )


### PR DESCRIPTION
## Summary
- Add tooltip recovery copy for the Study shell Start quiz action when no quiz exists or a quiz still needs selection.
- Add enabled/blocked tooltips for start-ready, unavailable-scope, and active-attempt states.
- Update the UX remediation plan to mark PR #185 merged and track this Phase 5 disabled-action consistency slice.

## Test Plan
- env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_study_dashboard.py --tb=short
- env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_study_screen.py --tb=short
- git diff --check