### PR TITLE
Connect Study quiz review to Chat handoff

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -1,8 +1,8 @@
 # UX Audit Remediation Plan
 
 Date: 2026-05-01
-Status: Current-dev rebaseline after UX remediation PRs #146-#185, plus active Study quiz start-tooltip slice
-Branch context: current `dev` / `origin/dev` at `91ed8ff7`; active branch `codex/ux-quiz-start-tooltip`
+Status: Current-dev rebaseline after UX remediation PRs #146-#186, plus active Study quiz Review in Chat slice
+Branch context: current `dev` / `origin/dev` at `6f1f39fc`; active branch `codex/ux-quiz-review-chat-handoff`
 Previous audit baseline: `e2576cae`
 
 ## Goal
@@ -29,7 +29,7 @@ This is not a visual refresh. The work is ordered around workflow completion, re
 
 ## Current Dev Rebaseline
 
-Verified on current `dev` at `91ed8ff7`:
+Verified on current `dev` at `6f1f39fc`:
 
 - Phase 0 and Phase 1 are merged: the shared shell/Chatbooks trap, Ingest default source, quiz empty mapping response, Chat save-state, Search/RAG thread mutation, and Search primary-action reachability regressions are covered.
 - Phase 2 is merged: Chat has provider readiness and first-run orientation coverage.
@@ -73,11 +73,12 @@ Current source state plus this branch:
 - Phase 4 source-policy handoff smoke closeout is merged through PR #183: mounted smoke coverage replays policy-blocked Media, RAG, and Web Search handoffs through real button events.
 - Phase 6 Search/RAG dependency action-state is merged through PR #184: missing embeddings/RAG dependencies disable the primary Search action and expose install recovery copy.
 - Phase 5 Study dashboard resume-tooltip is merged through PR #185: the disabled Resume action explains that no study session exists and points users to flashcards/quizzes.
-- Phase 5 Study quiz start-tooltip is active in `codex/ux-quiz-start-tooltip`: the shell-level Start quiz action explains no-quiz, select-quiz, unavailable-scope, active-attempt, and start-ready states.
+- Phase 5 Study quiz start-tooltip is merged through PR #186: the shell-level Start quiz action explains no-quiz, select-quiz, unavailable-scope, active-attempt, and start-ready states.
+- Phase 5 Study quiz Review in Chat is active in `codex/ux-quiz-review-chat-handoff`: the shell-level Review in chat action fails closed until a selected quiz and Chat handoff seam exist, then stages quiz context into Chat.
 - Phase 6 still needs any remaining optional dependency gaps represented as user-facing capability states where relevant.
 - Phase 7 still needs end-to-end audit replay on a clean home/config.
 
-Planning consequence: remaining implementation should target broader live source-handoff replay cases, any non-handoff source actions where policy state can still block a visible action, any remaining compact-label/descriptive copy outside top navigation and command-palette tab navigation, disabled-state consistency beyond the already-covered Web Search, Media Source, Study Quiz, Study Flashcard, Study dashboard resume, Study quiz start, Media Viewer, Media Analysis, Media Highlight, Media Analysis navigation, Search/RAG saved-search actions, Media list pagination, and Media multi-item review actions, Phase 6 capability-state presentation beyond Speech/STTS, Web Search, and Search/RAG embeddings where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
+Planning consequence: remaining implementation should target broader live source-handoff replay cases, any non-handoff source actions where policy state can still block a visible action, any remaining compact-label/descriptive copy outside top navigation and command-palette tab navigation, disabled-state consistency beyond the already-covered Web Search, Media Source, Study Quiz, Study Flashcard, Study dashboard resume, Study quiz start, Study quiz Review in Chat, Media Viewer, Media Analysis, Media Highlight, Media Analysis navigation, Search/RAG saved-search actions, Media list pagination, and Media multi-item review actions, Phase 6 capability-state presentation beyond Speech/STTS, Web Search, and Search/RAG embeddings where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
 
 ## Issues Covered
 
@@ -323,7 +324,7 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 
 Purpose: make the app understandable without reducing expert efficiency.
 
-Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, #163, #164, #165, #166, #167, #168, #169, #170, #171, #172, #173, #174, and #185. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, Speech/STTS exposes local dependency capability states, Web Search missing dependencies render as disabled-state recovery copy, Media Source disabled actions expose recovery tooltips, Study Quiz disabled actions expose recovery tooltips, Study Flashcards disabled actions expose recovery tooltips, Study dashboard Resume action recovery is merged through PR #185, Study quiz Start action recovery is active in `codex/ux-quiz-start-tooltip`, Media Viewer actions expose selection/capability tooltips, Media Analysis actions expose generated-analysis/saved-version tooltips, Media Highlight actions expose selected-highlight tooltips, Media Analysis navigation actions expose saved-version boundary tooltips, Search/RAG saved-search actions expose selection/reuse recovery, Media list pagination exposes result-page boundary tooltips, and Media multi-item review actions expose generation/cancellation state tooltips.
+Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, #163, #164, #165, #166, #167, #168, #169, #170, #171, #172, #173, #174, #185, and #186. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, Speech/STTS exposes local dependency capability states, Web Search missing dependencies render as disabled-state recovery copy, Media Source disabled actions expose recovery tooltips, Study Quiz disabled actions expose recovery tooltips, Study Flashcards disabled actions expose recovery tooltips, Study dashboard Resume action recovery is merged through PR #185, Study quiz Start action recovery is merged through PR #186, Study quiz Review in Chat recovery/handoff is active in `codex/ux-quiz-review-chat-handoff`, Media Viewer actions expose selection/capability tooltips, Media Analysis actions expose generated-analysis/saved-version tooltips, Media Highlight actions expose selected-highlight tooltips, Media Analysis navigation actions expose saved-version boundary tooltips, Search/RAG saved-search actions expose selection/reuse recovery, Media list pagination exposes result-page boundary tooltips, and Media multi-item review actions expose generation/cancellation state tooltips.
 
 ### Files
 
@@ -362,6 +363,7 @@ Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #
 - [x] Add Media multi-item review action tooltips for Generate/Cancel analysis states.
 - [x] Add Study dashboard Resume action tooltip copy for no-session and resumable-session states.
 - [x] Add Study quiz Start action tooltip copy for no-quiz, select-quiz, scope-unavailable, active-attempt, and ready states.
+- [x] Add Study quiz Review in Chat recovery copy and selected-quiz handoff through the app-owned Chat seam.
 - [ ] Add tooltips or short descriptions where compact labels remain necessary outside top navigation.
 
 ### Acceptance Criteria
@@ -463,4 +465,4 @@ Current-dev state: partially started. A mounted handoff first-send smoke test no
 
 ## Next Step
 
-After this Study quiz start-tooltip slice, remaining Phase 4 work should focus on broader live audit replay or any non-handoff source actions where policy state can still block a visible action. The remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.
+After this Study quiz Review in Chat slice, remaining Phase 4 work should focus on broader live audit replay or any non-handoff source actions where policy state can still block a visible action. The remaining Phase 5 work is any compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.

--- a/Tests/UI/test_study_dashboard.py
+++ b/Tests/UI/test_study_dashboard.py
@@ -1,10 +1,13 @@
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 from textual.app import App
 from textual.widgets import Button, Static
 
+from tldw_chatbook.Chat.chat_handoff_models import ChatHandoffPayload
 from tldw_chatbook.UI.Screens.study_screen import StudyScreen
+from tldw_chatbook.UI.Screens.study_scope_models import StudyScopeContext, StudyScopeType
 from tldw_chatbook.UI.Study_Window import StudyWindow
 
 
@@ -199,8 +202,74 @@ async def test_study_quizzes_start_action_explains_no_quiz_recovery():
         await pilot.pause(0.4)
 
         quiz_start = app.screen.query_one("#quiz-start", Button)
+        review_in_chat = app.screen.query_one("#quiz-open-in-chat", Button)
         quiz_summary = app.screen.query_one("#quiz-session-summary", Static)
 
         assert "No quizzes available yet." in _text(quiz_summary)
         assert quiz_start.disabled is True
         assert "Create or import a quiz" in str(quiz_start.tooltip)
+        assert review_in_chat.disabled is True
+        assert "Select a quiz before reviewing it in Chat" in str(review_in_chat.tooltip)
+
+
+@pytest.mark.asyncio
+async def test_study_quizzes_review_in_chat_stages_selected_quiz_context():
+    app_instance = _build_app_instance()
+    app_instance.open_chat_with_handoff = Mock()
+    app = StudyDashboardTestApp(app_instance)
+
+    async with app.run_test() as pilot:
+        await pilot.pause(0.3)
+        await pilot.click("#view-quizzes-btn")
+        await pilot.pause(0.4)
+
+        review_in_chat = app.screen.query_one("#quiz-open-in-chat", Button)
+
+        assert review_in_chat.disabled is False
+        assert "Review the selected quiz in Chat" in str(review_in_chat.tooltip)
+
+        await pilot.click("#quiz-open-in-chat")
+        await pilot.pause(0.2)
+
+        app_instance.open_chat_with_handoff.assert_called_once()
+        payload = app_instance.open_chat_with_handoff.call_args.args[0]
+
+        assert isinstance(payload, ChatHandoffPayload)
+        assert payload.source == "study"
+        assert payload.item_type == "quiz"
+        assert payload.title == "Tree Drill"
+        assert "Tree Drill" in payload.body
+        assert "Quiz status" in payload.body
+        assert payload.suggested_prompt == "Help me review this quiz and identify what to study next."
+
+
+@pytest.mark.asyncio
+async def test_study_quizzes_review_in_chat_preserves_workspace_scope_metadata():
+    app_instance = _build_app_instance()
+    app_instance.current_runtime_backend = "server"
+    app_instance.pending_study_scope_context = StudyScopeContext(
+        scope_type=StudyScopeType.WORKSPACE,
+        workspace_id="workspace-1",
+        workspace_name="Research Workspace",
+    )
+    app_instance.open_chat_with_handoff = Mock()
+    app = StudyDashboardTestApp(app_instance)
+
+    async with app.run_test() as pilot:
+        await pilot.pause(0.3)
+        await pilot.click("#view-quizzes-btn")
+        await pilot.pause(0.4)
+
+        await pilot.click("#quiz-open-in-chat")
+        await pilot.pause(0.2)
+
+        payload = app_instance.open_chat_with_handoff.call_args.args[0]
+
+        assert payload.runtime_backend == "server"
+        assert payload.source_owner == "workspace"
+        assert payload.source_selector_state == "workspace"
+        assert payload.scope_type == "workspace"
+        assert payload.workspace_id == "workspace-1"
+        assert payload.backend_contracts == {
+            "workspace_isolation": {"workspace_scope_id": "workspace-1"}
+        }

--- a/tldw_chatbook/UI/Screens/study_screen.py
+++ b/tldw_chatbook/UI/Screens/study_screen.py
@@ -12,10 +12,14 @@ from textual.containers import Horizontal, Vertical
 from textual.reactive import reactive
 from textual.widgets import Button
 
+from ...Chat.chat_handoff_models import ChatHandoffPayload
 from ..Navigation.base_app_screen import BaseAppScreen
 from ..Study_Window import StudyWindow
 from ...Widgets.Study import QuizSessionWidget, StudyDashboard
 from ...Widgets.Study.quiz_session_widget import (
+    QUIZ_REVIEW_ENABLED_TOOLTIP,
+    QUIZ_REVIEW_HANDOFF_UNAVAILABLE_TOOLTIP,
+    QUIZ_REVIEW_SELECT_TOOLTIP,
     QUIZ_START_ATTEMPT_ACTIVE_TOOLTIP,
     QUIZ_START_ENABLED_TOOLTIP,
     QUIZ_START_NO_QUIZZES_TOOLTIP,
@@ -276,6 +280,7 @@ class StudyScreen(BaseAppScreen):
             self.quiz_session_widget.update_session_summary("Select a quiz to begin.")
             self.quiz_session_widget.update_status("")
             self.quiz_session_widget.set_start_enabled(False, QUIZ_START_SELECT_TOOLTIP)
+            self.quiz_session_widget.set_review_in_chat_enabled(False, QUIZ_REVIEW_SELECT_TOOLTIP)
             return
 
         quiz_name = None
@@ -313,6 +318,73 @@ class StudyScreen(BaseAppScreen):
         else:
             tooltip = QUIZ_START_NO_QUIZZES_TOOLTIP
         self.quiz_session_widget.set_start_enabled(start_enabled, tooltip)
+
+        open_chat = getattr(self.app_instance, "open_chat_with_handoff", None)
+        if not quiz_name:
+            self.quiz_session_widget.set_review_in_chat_enabled(False, QUIZ_REVIEW_SELECT_TOOLTIP)
+        elif not callable(open_chat):
+            self.quiz_session_widget.set_review_in_chat_enabled(
+                False,
+                QUIZ_REVIEW_HANDOFF_UNAVAILABLE_TOOLTIP,
+            )
+        else:
+            self.quiz_session_widget.set_review_in_chat_enabled(True, QUIZ_REVIEW_ENABLED_TOOLTIP)
+
+    def _build_quiz_chat_handoff_payload(self) -> ChatHandoffPayload | None:
+        controller = getattr(self.study_window_widget, "quizzes_controller", None)
+        if controller is None:
+            return None
+
+        label_getter = getattr(controller, "selected_quiz_label", None)
+        quiz_name = label_getter() if callable(label_getter) else None
+        if not quiz_name:
+            return None
+
+        id_getter = getattr(controller, "_selected_quiz_id", None)
+        quiz_id = id_getter() if callable(id_getter) else None
+        status = self._status_text_from_window("#quiz-attempt-status") or "No active attempt."
+        question = self._status_text_from_window("#quiz-attempt-question")
+        attempt_questions = list(getattr(controller, "current_attempt_questions", None) or [])
+
+        body_lines = [
+            f"Quiz: {quiz_name}",
+            f"Scope: {self._scope_summary_text()}",
+            f"Quiz status: {status}",
+        ]
+        if attempt_questions:
+            body_lines.append(f"Active attempt questions: {len(attempt_questions)}")
+        if question:
+            body_lines.append(f"Current question: {question}")
+
+        runtime_backend = self._runtime_backend()
+        scope_type = self.scope_state.scope_type.value
+        workspace_id = (
+            self.scope_state.workspace_id
+            if scope_type == StudyScopeType.WORKSPACE.value
+            else None
+        )
+        source_owner = "workspace" if workspace_id else runtime_backend
+        backend_contracts = (
+            {"workspace_isolation": {"workspace_scope_id": workspace_id}}
+            if workspace_id
+            else {}
+        )
+        return ChatHandoffPayload.from_source_content(
+            source="study",
+            item_type="quiz",
+            title=str(quiz_name),
+            body="\n".join(body_lines),
+            source_id=str(quiz_id) if quiz_id else None,
+            display_summary=f"Study quiz: {quiz_name}",
+            suggested_prompt="Help me review this quiz and identify what to study next.",
+            runtime_backend=runtime_backend,
+            source_owner=source_owner,
+            source_selector_state=source_owner,
+            scope_type=scope_type,
+            workspace_id=workspace_id,
+            backend_contracts=backend_contracts,
+            metadata={"scope_summary": self._scope_summary_text()},
+        )
 
     def sync_shell_from_window(self) -> None:
         self._sync_dashboard_widgets()
@@ -674,3 +746,11 @@ class StudyScreen(BaseAppScreen):
         quiz_name = study_window.quizzes_controller.selected_quiz_label() or "Quiz session"
         self._record_study_session(section="quizzes", topic=quiz_name)
         self.sync_shell_from_window()
+
+    @on(Button.Pressed, "#quiz-open-in-chat")
+    def handle_quiz_review_in_chat(self) -> None:
+        open_chat = getattr(self.app_instance, "open_chat_with_handoff", None)
+        payload = self._build_quiz_chat_handoff_payload()
+        if not callable(open_chat) or payload is None:
+            return
+        open_chat(payload)

--- a/tldw_chatbook/Widgets/Study/quiz_session_widget.py
+++ b/tldw_chatbook/Widgets/Study/quiz_session_widget.py
@@ -13,6 +13,9 @@ QUIZ_START_SELECT_TOOLTIP = "Select a quiz before starting."
 QUIZ_START_NO_QUIZZES_TOOLTIP = "Create or import a quiz before starting a session."
 QUIZ_START_SCOPE_UNAVAILABLE_TOOLTIP = "Switch to an available study scope before starting a quiz."
 QUIZ_START_ATTEMPT_ACTIVE_TOOLTIP = "Finish the current quiz attempt before starting another."
+QUIZ_REVIEW_ENABLED_TOOLTIP = "Review the selected quiz in Chat."
+QUIZ_REVIEW_SELECT_TOOLTIP = "Select a quiz before reviewing it in Chat."
+QUIZ_REVIEW_HANDOFF_UNAVAILABLE_TOOLTIP = "Chat handoff is unavailable from this app state."
 
 
 class QuizSessionWidget(Widget):
@@ -62,7 +65,12 @@ class QuizSessionWidget(Widget):
                     disabled=True,
                     tooltip=QUIZ_START_SELECT_TOOLTIP,
                 )
-                yield Button("Review in chat", id="quiz-open-in-chat")
+                yield Button(
+                    "Review in chat",
+                    id="quiz-open-in-chat",
+                    disabled=True,
+                    tooltip=QUIZ_REVIEW_SELECT_TOOLTIP,
+                )
 
     def update_scope_summary(self, summary: str) -> None:
         if self.is_mounted:
@@ -82,4 +90,12 @@ class QuizSessionWidget(Widget):
             button.disabled = not enabled
             button.tooltip = tooltip or (
                 QUIZ_START_ENABLED_TOOLTIP if enabled else QUIZ_START_SELECT_TOOLTIP
+            )
+
+    def set_review_in_chat_enabled(self, enabled: bool, tooltip: str | None = None) -> None:
+        if self.is_mounted:
+            button = self.query_one("#quiz-open-in-chat", Button)
+            button.disabled = not enabled
+            button.tooltip = tooltip or (
+                QUIZ_REVIEW_ENABLED_TOOLTIP if enabled else QUIZ_REVIEW_SELECT_TOOLTIP
             )


### PR DESCRIPTION
## Summary
- Disable Study quiz `Review in chat` until a quiz is selected and the app-owned Chat handoff seam is available.
- Stage selected quiz context into Chat with quiz status, scope summary, runtime metadata, and workspace isolation metadata.
- Update the UX remediation plan to reflect PR #186 as merged and this active Study quiz handoff slice.

## Test Plan
- [x] `env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_study_dashboard.py --tb=short`
- [x] `env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_study_screen.py --tb=short`
- [x] `git diff --check`
