### PR TITLE
Explain Chatbooks view toggles

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -1,8 +1,8 @@
 # UX Audit Remediation Plan
 
 Date: 2026-05-01
-Status: Current-dev rebaseline after UX remediation PRs #146-#187, plus active Study section label-tooltip slice
-Branch context: current `dev` / `origin/dev` at `f3ccf246`; active branch `codex/ux-study-section-tooltips`
+Status: Current-dev rebaseline after UX remediation PRs #146-#188, plus active Chatbooks view-toggle tooltip slice
+Branch context: current `dev` / `origin/dev` at `0144d810`; active branch `codex/ux-chatbooks-view-tooltips`
 Previous audit baseline: `e2576cae`
 
 ## Goal
@@ -29,7 +29,7 @@ This is not a visual refresh. The work is ordered around workflow completion, re
 
 ## Current Dev Rebaseline
 
-Verified on current `dev` at `f3ccf246`:
+Verified on current `dev` at `0144d810`:
 
 - Phase 0 and Phase 1 are merged: the shared shell/Chatbooks trap, Ingest default source, quiz empty mapping response, Chat save-state, Search/RAG thread mutation, and Search primary-action reachability regressions are covered.
 - Phase 2 is merged: Chat has provider readiness and first-run orientation coverage.
@@ -75,11 +75,12 @@ Current source state plus this branch:
 - Phase 5 Study dashboard resume-tooltip is merged through PR #185: the disabled Resume action explains that no study session exists and points users to flashcards/quizzes.
 - Phase 5 Study quiz start-tooltip is merged through PR #186: the shell-level Start quiz action explains no-quiz, select-quiz, unavailable-scope, active-attempt, and start-ready states.
 - Phase 5 Study quiz Review in Chat is merged through PR #187: the shell-level Review in chat action fails closed until a selected quiz and Chat handoff seam exist, then stages quiz context into Chat.
-- Phase 5 Study section label tooltips are active in `codex/ux-study-section-tooltips`: compact Study section labels keep fast navigation while explaining Dashboard, Paths, Flashcards, Quizzes, Guides, Mindmaps, Course, and Map.
+- Phase 5 Study section label tooltips are merged through PR #188: compact Study section labels keep fast navigation while explaining Dashboard, Paths, Flashcards, Quizzes, Guides, Mindmaps, Course, and Map.
+- Phase 5 Chatbooks view-toggle tooltips are active in `codex/ux-chatbooks-view-tooltips`: the compact `▦ Grid` and `☰ List` labels explain whether Chatbooks render as visual cards or a dense text list.
 - Phase 6 still needs any remaining optional dependency gaps represented as user-facing capability states where relevant.
 - Phase 7 still needs end-to-end audit replay on a clean home/config.
 
-Planning consequence: remaining implementation should target broader live source-handoff replay cases, any non-handoff source actions where policy state can still block a visible action, any remaining compact-label/descriptive copy outside top navigation, command-palette tab navigation, and the Study section bar, disabled-state consistency beyond the already-covered Web Search, Media Source, Study Quiz, Study Flashcard, Study dashboard resume, Study quiz start, Study quiz Review in Chat, Media Viewer, Media Analysis, Media Highlight, Media Analysis navigation, Search/RAG saved-search actions, Media list pagination, and Media multi-item review actions, Phase 6 capability-state presentation beyond Speech/STTS, Web Search, and Search/RAG embeddings where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
+Planning consequence: remaining implementation should target broader live source-handoff replay cases, any non-handoff source actions where policy state can still block a visible action, any remaining compact-label/descriptive copy outside top navigation, command-palette tab navigation, the Study section bar, and Chatbooks view toggles, disabled-state consistency beyond the already-covered Web Search, Media Source, Study Quiz, Study Flashcard, Study dashboard resume, Study quiz start, Study quiz Review in Chat, Media Viewer, Media Analysis, Media Highlight, Media Analysis navigation, Search/RAG saved-search actions, Media list pagination, and Media multi-item review actions, Phase 6 capability-state presentation beyond Speech/STTS, Web Search, and Search/RAG embeddings where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
 
 ## Issues Covered
 
@@ -325,7 +326,7 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 
 Purpose: make the app understandable without reducing expert efficiency.
 
-Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, #163, #164, #165, #166, #167, #168, #169, #170, #171, #172, #173, #174, #185, #186, and #187. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, Speech/STTS exposes local dependency capability states, Web Search missing dependencies render as disabled-state recovery copy, Media Source disabled actions expose recovery tooltips, Study Quiz disabled actions expose recovery tooltips, Study Flashcards disabled actions expose recovery tooltips, Study dashboard Resume action recovery is merged through PR #185, Study quiz Start action recovery is merged through PR #186, Study quiz Review in Chat recovery/handoff is merged through PR #187, Study section-bar compact label tooltips are active in `codex/ux-study-section-tooltips`, Media Viewer actions expose selection/capability tooltips, Media Analysis actions expose generated-analysis/saved-version tooltips, Media Highlight actions expose selected-highlight tooltips, Media Analysis navigation actions expose saved-version boundary tooltips, Search/RAG saved-search actions expose selection/reuse recovery, Media list pagination exposes result-page boundary tooltips, and Media multi-item review actions expose generation/cancellation state tooltips.
+Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, #163, #164, #165, #166, #167, #168, #169, #170, #171, #172, #173, #174, #185, #186, #187, and #188. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, Speech/STTS exposes local dependency capability states, Web Search missing dependencies render as disabled-state recovery copy, Media Source disabled actions expose recovery tooltips, Study Quiz disabled actions expose recovery tooltips, Study Flashcards disabled actions expose recovery tooltips, Study dashboard Resume action recovery is merged through PR #185, Study quiz Start action recovery is merged through PR #186, Study quiz Review in Chat recovery/handoff is merged through PR #187, Study section-bar compact label tooltips are merged through PR #188, Chatbooks view-toggle compact label tooltips are active in `codex/ux-chatbooks-view-tooltips`, Media Viewer actions expose selection/capability tooltips, Media Analysis actions expose generated-analysis/saved-version tooltips, Media Highlight actions expose selected-highlight tooltips, Media Analysis navigation actions expose saved-version boundary tooltips, Search/RAG saved-search actions expose selection/reuse recovery, Media list pagination exposes result-page boundary tooltips, and Media multi-item review actions expose generation/cancellation state tooltips.
 
 ### Files
 
@@ -366,6 +367,7 @@ Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #
 - [x] Add Study quiz Start action tooltip copy for no-quiz, select-quiz, scope-unavailable, active-attempt, and ready states.
 - [x] Add Study quiz Review in Chat recovery copy and selected-quiz handoff through the app-owned Chat seam.
 - [x] Add Study section-bar tooltips for compact labels while preserving fast direct navigation.
+- [x] Add Chatbooks Grid/List view-toggle tooltips for compact labels while preserving fast direct navigation.
 - [ ] Add tooltips or short descriptions where compact labels remain necessary outside top navigation.
 
 ### Acceptance Criteria
@@ -467,4 +469,4 @@ Current-dev state: partially started. A mounted handoff first-send smoke test no
 
 ## Next Step
 
-After this Study section label-tooltip slice, remaining Phase 4 work should focus on broader live audit replay or any non-handoff source actions where policy state can still block a visible action. The remaining Phase 5 work is any remaining compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.
+After this Chatbooks view-toggle tooltip slice, remaining Phase 4 work should focus on broader live audit replay or any non-handoff source actions where policy state can still block a visible action. The remaining Phase 5 work is any remaining compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.

--- a/Tests/UI/test_chatbooks_screen_server_actions.py
+++ b/Tests/UI/test_chatbooks_screen_server_actions.py
@@ -81,6 +81,27 @@ async def test_improved_window_exposes_server_action_cards(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_chatbooks_view_toggles_explain_grid_and_list_modes(monkeypatch):
+    async def no_refresh(self):
+        self.chatbooks = []
+
+    monkeypatch.setattr(ChatbooksWindowImproved, "_refresh_chatbooks", no_refresh)
+
+    class ChatbooksWindowApp(App):
+        def compose(self) -> ComposeResult:
+            yield ChatbooksWindowImproved(self)
+
+    app = ChatbooksWindowApp()
+    async with app.run_test() as pilot:
+        window = app.query_one(ChatbooksWindowImproved)
+        grid_button = window.query_one("#view-grid", Button)
+        list_button = window.query_one("#view-list", Button)
+
+        assert str(grid_button.tooltip) == "Show chatbooks as visual cards."
+        assert str(list_button.tooltip) == "Show chatbooks as a dense text list."
+
+
+@pytest.mark.asyncio
 async def test_server_create_action_uses_server_mode(monkeypatch):
     async def no_refresh(self):
         self.chatbooks = []

--- a/tldw_chatbook/UI/Chatbooks_Window_Improved.py
+++ b/tldw_chatbook/UI/Chatbooks_Window_Improved.py
@@ -176,6 +176,9 @@ class EmptyStateWidget(Container):
 
 class ChatbooksWindowImproved(Screen):
     """Enhanced Chatbooks management interface."""
+
+    GRID_VIEW_TOOLTIP = "Show chatbooks as visual cards."
+    LIST_VIEW_TOOLTIP = "Show chatbooks as a dense text list."
     
     BINDINGS = [
         ("c", "create_chatbook", "Create"),
@@ -381,8 +384,19 @@ class ChatbooksWindowImproved(Screen):
                 
                 # View mode toggles
                 with Container(classes="view-toggles"):
-                    yield Button("▦ Grid", id="view-grid", classes="view-toggle", variant="primary")
-                    yield Button("☰ List", id="view-list", classes="view-toggle")
+                    yield Button(
+                        "▦ Grid",
+                        id="view-grid",
+                        classes="view-toggle",
+                        variant="primary",
+                        tooltip=self.GRID_VIEW_TOOLTIP,
+                    )
+                    yield Button(
+                        "☰ List",
+                        id="view-list",
+                        classes="view-toggle",
+                        tooltip=self.LIST_VIEW_TOOLTIP,
+                    )
             
             # Content container (will be populated based on chatbooks)
             yield Container(id="chatbooks-container")


### PR DESCRIPTION
## Summary
- Add concise tooltips to the Chatbooks `▦ Grid` and `☰ List` view toggles so compact labels explain their rendering modes.
- Preserve existing Chatbooks labels, toggle behavior, and navigation speed for power users.
- Update the UX remediation plan to reflect PR #188 as merged and this active compact-label slice.

## Test Plan
- [x] `env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_chatbooks_screen_server_actions.py --tb=short`
- [x] `git diff --check`
- [ ] `Tests/UI/test_ux_audit_smoke.py` currently has a pre-existing indentation error and was not used as a verification target for this slice.
