### PR TITLE
Restore UX audit smoke collection

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -1,8 +1,8 @@
 # UX Audit Remediation Plan
 
 Date: 2026-05-01
-Status: Current-dev rebaseline after UX remediation PRs #146-#188, plus active Chatbooks view-toggle tooltip slice
-Branch context: current `dev` / `origin/dev` at `0144d810`; active branch `codex/ux-chatbooks-view-tooltips`
+Status: Current-dev rebaseline after UX remediation PRs #146-#189, plus active UX smoke collection repair slice
+Branch context: current `dev` / `origin/dev` at `39c39cb0`; active branch `codex/ux-smoke-indent-fix`
 Previous audit baseline: `e2576cae`
 
 ## Goal
@@ -29,7 +29,7 @@ This is not a visual refresh. The work is ordered around workflow completion, re
 
 ## Current Dev Rebaseline
 
-Verified on current `dev` at `0144d810`:
+Verified on current `dev` at `39c39cb0`:
 
 - Phase 0 and Phase 1 are merged: the shared shell/Chatbooks trap, Ingest default source, quiz empty mapping response, Chat save-state, Search/RAG thread mutation, and Search primary-action reachability regressions are covered.
 - Phase 2 is merged: Chat has provider readiness and first-run orientation coverage.
@@ -76,7 +76,8 @@ Current source state plus this branch:
 - Phase 5 Study quiz start-tooltip is merged through PR #186: the shell-level Start quiz action explains no-quiz, select-quiz, unavailable-scope, active-attempt, and start-ready states.
 - Phase 5 Study quiz Review in Chat is merged through PR #187: the shell-level Review in chat action fails closed until a selected quiz and Chat handoff seam exist, then stages quiz context into Chat.
 - Phase 5 Study section label tooltips are merged through PR #188: compact Study section labels keep fast navigation while explaining Dashboard, Paths, Flashcards, Quizzes, Guides, Mindmaps, Course, and Map.
-- Phase 5 Chatbooks view-toggle tooltips are active in `codex/ux-chatbooks-view-tooltips`: the compact `▦ Grid` and `☰ List` labels explain whether Chatbooks render as visual cards or a dense text list.
+- Phase 5 Chatbooks view-toggle tooltips are merged through PR #189: the compact `▦ Grid` and `☰ List` labels explain whether Chatbooks render as visual cards or a dense text list.
+- Phase 7 UX smoke collection repair is active in `codex/ux-smoke-indent-fix`: `Tests/UI/test_ux_audit_smoke.py` had a malformed `async with` block in the Web Search handoff policy smoke test, blocking collection of the Phase 7 shell/navigation smoke target.
 - Phase 6 still needs any remaining optional dependency gaps represented as user-facing capability states where relevant.
 - Phase 7 still needs end-to-end audit replay on a clean home/config.
 
@@ -326,7 +327,7 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 
 Purpose: make the app understandable without reducing expert efficiency.
 
-Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, #163, #164, #165, #166, #167, #168, #169, #170, #171, #172, #173, #174, #185, #186, #187, and #188. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, Speech/STTS exposes local dependency capability states, Web Search missing dependencies render as disabled-state recovery copy, Media Source disabled actions expose recovery tooltips, Study Quiz disabled actions expose recovery tooltips, Study Flashcards disabled actions expose recovery tooltips, Study dashboard Resume action recovery is merged through PR #185, Study quiz Start action recovery is merged through PR #186, Study quiz Review in Chat recovery/handoff is merged through PR #187, Study section-bar compact label tooltips are merged through PR #188, Chatbooks view-toggle compact label tooltips are active in `codex/ux-chatbooks-view-tooltips`, Media Viewer actions expose selection/capability tooltips, Media Analysis actions expose generated-analysis/saved-version tooltips, Media Highlight actions expose selected-highlight tooltips, Media Analysis navigation actions expose saved-version boundary tooltips, Search/RAG saved-search actions expose selection/reuse recovery, Media list pagination exposes result-page boundary tooltips, and Media multi-item review actions expose generation/cancellation state tooltips.
+Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, #163, #164, #165, #166, #167, #168, #169, #170, #171, #172, #173, #174, #185, #186, #187, #188, and #189. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, Speech/STTS exposes local dependency capability states, Web Search missing dependencies render as disabled-state recovery copy, Media Source disabled actions expose recovery tooltips, Study Quiz disabled actions expose recovery tooltips, Study Flashcards disabled actions expose recovery tooltips, Study dashboard Resume action recovery is merged through PR #185, Study quiz Start action recovery is merged through PR #186, Study quiz Review in Chat recovery/handoff is merged through PR #187, Study section-bar compact label tooltips are merged through PR #188, Chatbooks view-toggle compact label tooltips are merged through PR #189, Media Viewer actions expose selection/capability tooltips, Media Analysis actions expose generated-analysis/saved-version tooltips, Media Highlight actions expose selected-highlight tooltips, Media Analysis navigation actions expose saved-version boundary tooltips, Search/RAG saved-search actions expose selection/reuse recovery, Media list pagination exposes result-page boundary tooltips, and Media multi-item review actions expose generation/cancellation state tooltips.
 
 ### Files
 
@@ -419,7 +420,7 @@ Branch state: partially completed in `codex/ux-startup-log-polish`, with Speech/
 
 Purpose: prove the plan actually fixes the observed UX failures.
 
-Current-dev state: partially started. A mounted handoff first-send smoke test now covers Chat staging and send-time context application; the broader replay artifacts still need to be regenerated after Phases 0, 1, 2, 5, and 6 land, then rerun against each source workflow.
+Current-dev state: partially started. A mounted handoff first-send smoke test now covers Chat staging and send-time context application; the broader replay artifacts still need to be regenerated after Phases 0, 1, 2, 5, and 6 land, then rerun against each source workflow. Current `dev` at `39c39cb0` has a collection-blocking indentation regression in `Tests/UI/test_ux_audit_smoke.py`; this branch repairs that before broader replay.
 
 ### Files
 
@@ -430,6 +431,7 @@ Current-dev state: partially started. A mounted handoff first-send smoke test no
 
 - [ ] Run focused tests from every phase.
 - [ ] Run `git diff --check`.
+- [x] Restore `Tests/UI/test_ux_audit_smoke.py` collection after the malformed Web Search handoff smoke block.
 - [ ] Launch with a clean home/config and verify first-run Chat.
 - [ ] Replay audited workflows: Chat readiness/send, Notes create/save/handoff, Ingest mount, Media search/handoff, Search/RAG/handoff, Study flashcards/quizzes, CCP persona chat, Chatbooks escape.
 - [ ] Capture probe JSON and screenshots/log excerpts under `/private/tmp/tldw-chatbook-ux-remediation-verify/`.
@@ -469,4 +471,4 @@ Current-dev state: partially started. A mounted handoff first-send smoke test no
 
 ## Next Step
 
-After this Chatbooks view-toggle tooltip slice, remaining Phase 4 work should focus on broader live audit replay or any non-handoff source actions where policy state can still block a visible action. The remaining Phase 5 work is any remaining compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.
+After this UX smoke collection repair slice, remaining Phase 4 work should focus on broader live audit replay or any non-handoff source actions where policy state can still block a visible action. The remaining Phase 5 work is any remaining compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.

--- a/Tests/UI/test_ux_audit_smoke.py
+++ b/Tests/UI/test_ux_audit_smoke.py
@@ -717,23 +717,23 @@ async def test_contract_blocked_web_search_handoff_explains_recovery_without_sta
         app.app_instance.ui_policy_engine = PolicyEngine(CAPABILITY_REGISTRY)
 
         async with app.run_test(size=(160, 40)) as pilot:
-        await pilot.pause(0.1)
-        app.window.web_search_results = [
-            {
-                "title": "Article",
-                "content": "Snippet body",
-                "source": "web",
-                "metadata": {"url": "https://example.com", "displayUrl": "example.com"},
-            }
-        ]
-        await app.window._render_web_search_result_cards()
-        await pilot.pause(0.05)
+            await pilot.pause(0.1)
+            app.window.web_search_results = [
+                {
+                    "title": "Article",
+                    "content": "Snippet body",
+                    "source": "web",
+                    "metadata": {"url": "https://example.com", "displayUrl": "example.com"},
+                }
+            ]
+            await app.window._render_web_search_result_cards()
+            await pilot.pause(0.05)
 
-        button = app.window.query_one("#use-in-chat-0", Button)
-        button.press()
-        await pilot.pause(0.05)
+            button = app.window.query_one("#use-in-chat-0", Button)
+            button.press()
+            await pilot.pause(0.05)
 
-        app.app_instance.open_chat_with_handoff.assert_not_called()
-        message = app.app_instance.notify.call_args.args[0]
-        assert "research.search.providers.launch.server requires server mode" in message
-        assert "switch source" in message.lower()
+            app.app_instance.open_chat_with_handoff.assert_not_called()
+            message = app.app_instance.notify.call_args.args[0]
+            assert "research.search.providers.launch.server requires server mode" in message
+            assert "switch source" in message.lower()


### PR DESCRIPTION
## Summary
- Fix the malformed indentation in the Web Search handoff policy smoke test so `Tests/UI/test_ux_audit_smoke.py` can collect again.
- Verify the targeted Web Search handoff smoke and the full UX audit smoke file now run.
- Update the UX remediation plan to reflect PR #189 as merged and this Phase 7 smoke collection repair.

## Test Plan
- [x] `env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_ux_audit_smoke.py::test_contract_blocked_web_search_handoff_explains_recovery_without_staging --tb=short`
- [x] `env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_ux_audit_smoke.py --tb=short`
- [x] `git diff --check`
