### PR TITLE
Clarify blocked handoff source recovery

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -1,8 +1,8 @@
 # UX Audit Remediation Plan
 
 Date: 2026-05-01
-Status: Current-dev rebaseline after UX remediation PRs #146-#189, plus active UX smoke collection repair slice
-Branch context: current `dev` / `origin/dev` at `39c39cb0`; active branch `codex/ux-smoke-indent-fix`
+Status: Current-dev rebaseline after UX remediation PRs #146-#190, plus active source-authority handoff recovery slice
+Branch context: current `dev` / `origin/dev` at `a3f8a536`; active branch `codex/ux-handoff-policy-recovery-detail`
 Previous audit baseline: `e2576cae`
 
 ## Goal
@@ -29,7 +29,7 @@ This is not a visual refresh. The work is ordered around workflow completion, re
 
 ## Current Dev Rebaseline
 
-Verified on current `dev` at `39c39cb0`:
+Verified on current `dev` at `a3f8a536`:
 
 - Phase 0 and Phase 1 are merged: the shared shell/Chatbooks trap, Ingest default source, quiz empty mapping response, Chat save-state, Search/RAG thread mutation, and Search primary-action reachability regressions are covered.
 - Phase 2 is merged: Chat has provider readiness and first-run orientation coverage.
@@ -77,7 +77,8 @@ Current source state plus this branch:
 - Phase 5 Study quiz Review in Chat is merged through PR #187: the shell-level Review in chat action fails closed until a selected quiz and Chat handoff seam exist, then stages quiz context into Chat.
 - Phase 5 Study section label tooltips are merged through PR #188: compact Study section labels keep fast navigation while explaining Dashboard, Paths, Flashcards, Quizzes, Guides, Mindmaps, Course, and Map.
 - Phase 5 Chatbooks view-toggle tooltips are merged through PR #189: the compact `▦ Grid` and `☰ List` labels explain whether Chatbooks render as visual cards or a dense text list.
-- Phase 7 UX smoke collection repair is active in `codex/ux-smoke-indent-fix`: `Tests/UI/test_ux_audit_smoke.py` had a malformed `async with` block in the Web Search handoff policy smoke test, blocking collection of the Phase 7 shell/navigation smoke target.
+- Phase 7 UX smoke collection repair is merged through PR #190: `Tests/UI/test_ux_audit_smoke.py` collection is restored after the malformed Web Search handoff policy smoke block.
+- Phase 4 source-authority handoff recovery copy is active in `codex/ux-handoff-policy-recovery-detail`: runtime-policy-blocked Notes/Workspace, Media, RAG, and Web Search handoffs include source authority, UX interop active source, server reachability/auth state, and concrete recovery instructions.
 - Phase 6 still needs any remaining optional dependency gaps represented as user-facing capability states where relevant.
 - Phase 7 still needs end-to-end audit replay on a clean home/config.
 
@@ -302,8 +303,8 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 - [x] Wire RAG result card `Use in Chat` through a Textual message.
 - [x] Cardify dedicated Web Search results enough to support `Use in Chat`.
 - [x] Disable Notes and workspace item `Use in Chat` actions until a valid selected item exists, with tooltip recovery copy.
-- [ ] Disable or explain source actions when server/auth/capability contracts block them.
-- [ ] Consume backend-owned `UX_Interop` and `runtime_policy` contracts consistently; do not rebuild source authority from raw config.
+- [x] Disable or explain source actions when server/auth/capability contracts block them.
+- [x] Consume backend-owned `UX_Interop` and `runtime_policy` contracts consistently; do not rebuild source authority from raw config.
 - [ ] Keep dry-run sync reports diagnostic only; do not imply mirroring or write sync in source screens.
 - [x] Replay each source handoff in the Phase 0/7 smoke harness.
 - [x] Replay invalid-selection handoff states for Notes, workspace source/artifact, and Media in the Phase 0/7 smoke harness.
@@ -319,7 +320,7 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 - [x] Notes, Workspaces, Media, RAG Search, and Web Search can each stage one selected item into Chat in focused tests.
 - [x] Notes and workspace item invalid-selection actions are disabled with recovery copy in mounted Textual tests.
 - [x] No invalid selection navigates to Chat in live smoke coverage.
-- [ ] Disabled handoff actions have a reason and a recovery path.
+- [x] Disabled handoff actions have a reason and a recovery path.
 - [x] Workspace handoffs preserve `workspace_id` and isolation metadata in focused tests.
 - [x] Web Search is in scope and not silently omitted.
 
@@ -420,7 +421,7 @@ Branch state: partially completed in `codex/ux-startup-log-polish`, with Speech/
 
 Purpose: prove the plan actually fixes the observed UX failures.
 
-Current-dev state: partially started. A mounted handoff first-send smoke test now covers Chat staging and send-time context application; the broader replay artifacts still need to be regenerated after Phases 0, 1, 2, 5, and 6 land, then rerun against each source workflow. Current `dev` at `39c39cb0` has a collection-blocking indentation regression in `Tests/UI/test_ux_audit_smoke.py`; this branch repairs that before broader replay.
+Current-dev state: partially started. A mounted handoff first-send smoke test now covers Chat staging and send-time context application; the broader replay artifacts still need to be regenerated after Phases 0, 1, 2, 5, and 6 land, then rerun against each source workflow. Current `dev` at `a3f8a536` has the UX smoke collection repair merged; this branch strengthens the policy-blocked handoff assertions before broader replay.
 
 ### Files
 
@@ -471,4 +472,4 @@ Current-dev state: partially started. A mounted handoff first-send smoke test no
 
 ## Next Step
 
-After this UX smoke collection repair slice, remaining Phase 4 work should focus on broader live audit replay or any non-handoff source actions where policy state can still block a visible action. The remaining Phase 5 work is any remaining compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.
+After this source-authority handoff recovery slice, remaining Phase 4 work should focus on broader live audit replay or any non-handoff source actions where policy state can still block a visible action. The remaining Phase 5 work is any remaining compact-label descriptions outside top navigation plus broader disabled primary-action consistency. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.

--- a/Tests/UI/test_ux_audit_smoke.py
+++ b/Tests/UI/test_ux_audit_smoke.py
@@ -268,6 +268,9 @@ async def test_contract_blocked_workspace_handoff_explains_recovery_without_stag
         assert workspace_button.disabled is True
         tooltip = str(workspace_button.tooltip)
         assert "notes.workspace.detail.server requires server authentication" in tooltip
+        assert "source authority: runtime_policy/server" in tooltip.lower()
+        assert "ux interop: active source server" in tooltip.lower()
+        assert "server auth auth_required" in tooltip.lower()
         assert "Sign in" in tooltip
 
         workspace_button.press()
@@ -305,7 +308,9 @@ async def test_contract_blocked_local_note_handoff_explains_recovery_without_sta
         assert note_button.disabled is True
         tooltip = str(note_button.tooltip)
         assert "notes.detail.local requires local mode" in tooltip
-        assert "switch source" in tooltip
+        assert "source authority: runtime_policy/local" in tooltip.lower()
+        assert "ux interop: active source server" in tooltip.lower()
+        assert "switch source to local" in tooltip.lower()
 
         note_button.press()
         await pilot.pause(0.05)
@@ -550,7 +555,9 @@ async def test_contract_blocked_media_handoff_explains_recovery_without_staging(
         app.app_instance.open_chat_with_handoff.assert_not_called()
         message = app.app_instance.notify.call_args.args[0]
         assert "media.items.detail.server requires server mode" in message
-        assert "switch source" in message.lower()
+        assert "source authority: runtime_policy/server" in message.lower()
+        assert "ux interop: active source local" in message.lower()
+        assert "switch source to server" in message.lower()
 
 
 class SearchRAGHandoffSmokeApp(App[None]):
@@ -649,7 +656,9 @@ async def test_contract_blocked_rag_search_handoff_explains_recovery_without_sta
             app.app_instance.open_chat_with_handoff.assert_not_called()
             message = app.app_instance.notify.call_args.args[0]
             assert "rag.media_embeddings.search.server requires server mode" in message
-            assert "switch source" in message.lower()
+            assert "source authority: runtime_policy/server" in message.lower()
+            assert "ux interop: active source local" in message.lower()
+            assert "switch source to server" in message.lower()
 
 
 class WebSearchResultHandoffSmokeApp(App[None]):
@@ -736,4 +745,6 @@ async def test_contract_blocked_web_search_handoff_explains_recovery_without_sta
             app.app_instance.open_chat_with_handoff.assert_not_called()
             message = app.app_instance.notify.call_args.args[0]
             assert "research.search.providers.launch.server requires server mode" in message
-            assert "switch source" in message.lower()
+            assert "source authority: runtime_policy/server" in message.lower()
+            assert "ux interop: active source local" in message.lower()
+            assert "switch source to server" in message.lower()

--- a/tldw_chatbook/Chat/chat_handoff_messages.py
+++ b/tldw_chatbook/Chat/chat_handoff_messages.py
@@ -1,6 +1,98 @@
 """Shared user-facing copy for Chat handoff recovery states."""
 
+from __future__ import annotations
+
+from typing import Any
+
+from tldw_chatbook.UX_Interop.server_parity_contracts import (
+    ActiveServerStatusContract,
+    SourceSelectorStateContract,
+)
+from tldw_chatbook.runtime_policy.registry import get_capability_entry
+from tldw_chatbook.runtime_policy.types import PolicyDecision, PolicyDeniedError, RuntimeSourceState
+
 USE_IN_CHAT_UNAVAILABLE_RECOVERY = (
     "Use in Chat is unavailable because the Chat handoff surface is not mounted. "
     "Open Chat from the navigation, then try again."
 )
+
+
+def build_handoff_policy_blocking_message(
+    app_instance: Any,
+    *,
+    action_id: str | None,
+    fallback_message: str,
+) -> str:
+    """Return source-authority recovery copy when runtime policy blocks a handoff."""
+    if not action_id:
+        return ""
+
+    runtime_state = getattr(getattr(app_instance, "runtime_policy", None), "state", None)
+    policy_engine = getattr(app_instance, "ui_policy_engine", None)
+    evaluate = getattr(policy_engine, "evaluate", None) if policy_engine else None
+    if not isinstance(runtime_state, RuntimeSourceState) or not callable(evaluate):
+        return ""
+
+    decision = evaluate(action_id=action_id, state=runtime_state)
+    if getattr(decision, "allowed", True):
+        return ""
+
+    return format_handoff_policy_blocking_message(
+        action_id=action_id,
+        decision=decision,
+        runtime_state=runtime_state,
+        fallback_message=fallback_message,
+    )
+
+
+def format_handoff_policy_blocking_message(
+    *,
+    action_id: str,
+    decision: PolicyDecision,
+    runtime_state: RuntimeSourceState,
+    fallback_message: str,
+) -> str:
+    selector_contract = SourceSelectorStateContract.from_runtime_state(runtime_state)
+    server_contract = ActiveServerStatusContract.from_runtime_state(runtime_state)
+    authority_owner = str(getattr(decision, "authority_owner", None) or "unknown")
+    base_message = str(getattr(decision, "user_message", None) or fallback_message)
+    recovery = _recovery_for_policy_decision(
+        reason_code=getattr(decision, "reason_code", None),
+        required_source=_required_source_for_action(action_id),
+    )
+
+    return (
+        f"{base_message} "
+        f"Source authority: runtime_policy/{authority_owner}. "
+        f"UX Interop: active source {selector_contract.active_source}; "
+        f"server reachability {server_contract.server_reachability}; "
+        f"server auth {server_contract.server_auth_state}. "
+        f"Recovery: {recovery}"
+    )
+
+
+def _required_source_for_action(action_id: str) -> str | None:
+    try:
+        return get_capability_entry(action_id).required_source
+    except PolicyDeniedError:
+        if action_id.endswith(".server"):
+            return "server"
+        if action_id.endswith(".local"):
+            return "local"
+    return None
+
+
+def _recovery_for_policy_decision(*, reason_code: str | None, required_source: str | None) -> str:
+    if reason_code == "wrong_source" and required_source in {"local", "server"}:
+        return f"Switch Source to {required_source.title()}, then try again."
+    if reason_code == "server_not_configured":
+        return "Configure an active server profile in Settings, then try again."
+    if reason_code == "server_unreachable":
+        return "Reconnect the active server, then try again."
+    if reason_code in {"server_auth_required", "auth_required"}:
+        return "Sign in to the active server, then try again."
+    if reason_code == "server_session_invalid":
+        return "Sign in again or refresh the server session, then try again."
+    if reason_code == "capability_disabled":
+        return "Enable the required capability or use a supported source, then try again."
+    return "Refresh runtime policy, switch to a supported source, or retry after the source is available."

--- a/tldw_chatbook/UI/MediaWindow_v2.py
+++ b/tldw_chatbook/UI/MediaWindow_v2.py
@@ -45,9 +45,11 @@ from ..Event_Handlers.media_events import (
     MediaReadingHighlightUpdateEvent,
     MediaReadingHighlightDeleteEvent,
 )
-from ..Chat.chat_handoff_messages import USE_IN_CHAT_UNAVAILABLE_RECOVERY
+from ..Chat.chat_handoff_messages import (
+    USE_IN_CHAT_UNAVAILABLE_RECOVERY,
+    build_handoff_policy_blocking_message,
+)
 from ..Chat.chat_handoff_models import ChatHandoffPayload
-from ..runtime_policy.types import RuntimeSourceState
 
 if TYPE_CHECKING:
     from ..app import TldwCli
@@ -58,9 +60,6 @@ MEDIA_EMPTY_STATE_COPY = (
     "Use Ingest to add files, URLs, archives, or transcripts. Select a media item here.\n"
     "Details, analysis, save/export, and Use in Chat actions appear after a media item is selected."
 )
-MEDIA_HANDOFF_POLICY_RECOVERY = "Switch source, sign in, or reconnect the server before using this media item in Chat."
-
-
 class MediaWindow(Container):
     """
     Orchestrator for the Media Tab components.
@@ -426,22 +425,11 @@ class MediaWindow(Container):
 
     def _media_handoff_policy_blocking_message(self, payload: ChatHandoffPayload) -> str:
         action_id = self._media_handoff_runtime_action_id(payload.runtime_backend)
-        if not action_id:
-            return ""
-
-        runtime_policy = getattr(self.app_instance, "runtime_policy", None)
-        runtime_state = getattr(runtime_policy, "state", None) if runtime_policy else None
-        policy_engine = getattr(self.app_instance, "ui_policy_engine", None)
-        evaluate = getattr(policy_engine, "evaluate", None) if policy_engine else None
-        if not isinstance(runtime_state, RuntimeSourceState) or not callable(evaluate):
-            return ""
-
-        decision = evaluate(action_id=action_id, state=runtime_state)
-        if getattr(decision, "allowed", True):
-            return ""
-
-        message = str(getattr(decision, "user_message", None) or "This media source action is blocked by runtime policy.")
-        return f"{message} {MEDIA_HANDOFF_POLICY_RECOVERY}"
+        return build_handoff_policy_blocking_message(
+            self.app_instance,
+            action_id=action_id,
+            fallback_message="This media source action is blocked by runtime policy.",
+        )
 
     def _show_viewer(self) -> None:
         """Hide the empty state and display the viewer panel."""

--- a/tldw_chatbook/UI/Screens/notes_screen.py
+++ b/tldw_chatbook/UI/Screens/notes_screen.py
@@ -19,10 +19,12 @@ from textual.reactive import reactive
 from textual.timer import Timer
 from textual.widgets import Button, Input, Label, ListView, Select, Switch, TextArea
 
-from ...Chat.chat_handoff_messages import USE_IN_CHAT_UNAVAILABLE_RECOVERY
+from ...Chat.chat_handoff_messages import (
+    USE_IN_CHAT_UNAVAILABLE_RECOVERY,
+    build_handoff_policy_blocking_message,
+)
 from ...Chat.chat_handoff_models import ChatHandoffPayload
 from ...Event_Handlers.Audio_Events.dictation_integration_events import InsertDictationTextEvent
-from ...runtime_policy.types import RuntimeSourceState
 from ...Third_Party.textual_fspicker import FileSave
 from ...Widgets.delete_confirmation_dialog import create_delete_confirmation
 from ...Widgets.Note_Widgets.notes_sidebar_left import NotesSidebarLeft
@@ -34,8 +36,6 @@ from ...Widgets.emoji_picker import EmojiPickerScreen, EmojiSelected
 from ..Navigation.base_app_screen import BaseAppScreen
 from .notes_scope_models import NotesScreenState, PendingNavigation, ScopeType, WorkspaceSubview
 from .study_scope_models import StudyScopeContext, StudyScopeType
-
-HANDOFF_POLICY_RECOVERY = "Sign in, reconnect the server, or switch source before using this item in Chat."
 
 if TYPE_CHECKING:
     from tldw_chatbook.app import TldwCli
@@ -293,18 +293,11 @@ class NotesScreen(BaseAppScreen):
 
     def _handoff_policy_blocking_message(self, action_id: str | None) -> str:
         runtime_action_id = self._handoff_runtime_action_id(action_id)
-        if not runtime_action_id:
-            return ""
-        runtime_state = getattr(getattr(self.app_instance, "runtime_policy", None), "state", None)
-        policy_engine = getattr(self.app_instance, "ui_policy_engine", None)
-        evaluate = getattr(policy_engine, "evaluate", None)
-        if not isinstance(runtime_state, RuntimeSourceState) or not callable(evaluate):
-            return ""
-        decision = evaluate(action_id=runtime_action_id, state=runtime_state)
-        if getattr(decision, "allowed", True):
-            return ""
-        message = str(getattr(decision, "user_message", None) or "This source action is blocked by runtime policy.")
-        return f"{message} {HANDOFF_POLICY_RECOVERY}"
+        return build_handoff_policy_blocking_message(
+            self.app_instance,
+            action_id=runtime_action_id,
+            fallback_message="This source action is blocked by runtime policy.",
+        )
 
     def _update_use_in_chat_action_states(self) -> None:
         if not self.is_mounted:

--- a/tldw_chatbook/UI/SearchWindow.py
+++ b/tldw_chatbook/UI/SearchWindow.py
@@ -17,10 +17,12 @@ import inspect
 from loguru import logger
 from pathlib import Path
 
-from ..Chat.chat_handoff_messages import USE_IN_CHAT_UNAVAILABLE_RECOVERY
+from ..Chat.chat_handoff_messages import (
+    USE_IN_CHAT_UNAVAILABLE_RECOVERY,
+    build_handoff_policy_blocking_message,
+)
 from ..Chat.chat_handoff_models import ChatHandoffPayload
 from ..Notes.Notes_Library import NotesInteropService
-from ..runtime_policy.types import RuntimeSourceState
 from .Views.RAGSearch.search_handoff import build_search_chat_handoff_payload
 from .Views.RAGSearch.search_result import SearchResult
 
@@ -86,9 +88,6 @@ WEB_SEARCH_DEPENDENCY_RECOVERY = (
     'Web Search requires optional dependencies. Install them with pip install -e ".[websearch]" '
     "and restart Chatbook."
 )
-WEB_HANDOFF_POLICY_RECOVERY = "Switch source, sign in, or reconnect the server before using this web result in Chat."
-
-
 class SearchWindow(Container):
     """
     Container for the Search Tab's UI, featuring a vertical tab bar and content areas.
@@ -358,22 +357,11 @@ class SearchWindow(Container):
 
     def _web_handoff_policy_blocking_message(self, payload: ChatHandoffPayload) -> str:
         action_id = self._web_handoff_runtime_action_id(payload)
-        if not action_id:
-            return ""
-
-        runtime_policy = getattr(self.app_instance, "runtime_policy", None)
-        runtime_state = getattr(runtime_policy, "state", None) if runtime_policy else None
-        policy_engine = getattr(self.app_instance, "ui_policy_engine", None)
-        evaluate = getattr(policy_engine, "evaluate", None) if policy_engine else None
-        if not isinstance(runtime_state, RuntimeSourceState) or not callable(evaluate):
-            return ""
-
-        decision = evaluate(action_id=action_id, state=runtime_state)
-        if getattr(decision, "allowed", True):
-            return ""
-
-        message = str(getattr(decision, "user_message", None) or "This Web Search action is blocked by runtime policy.")
-        return f"{message} {WEB_HANDOFF_POLICY_RECOVERY}"
+        return build_handoff_policy_blocking_message(
+            self.app_instance,
+            action_id=action_id,
+            fallback_message="This Web Search action is blocked by runtime policy.",
+        )
 
     def _normalize_web_search_results(self, raw_results: Any, query: str) -> List[Dict[str, Any]]:
         if isinstance(raw_results, dict) and "web_search_results_dict" in raw_results:

--- a/tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py
+++ b/tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py
@@ -36,9 +36,11 @@ from .constants import (
     MAX_CONCURRENT_SEARCHES, SEARCH_MODES, PARENT_STRATEGIES
 )
 
-from ....Chat.chat_handoff_messages import USE_IN_CHAT_UNAVAILABLE_RECOVERY
+from ....Chat.chat_handoff_messages import (
+    USE_IN_CHAT_UNAVAILABLE_RECOVERY,
+    build_handoff_policy_blocking_message,
+)
 from ....Chat.chat_handoff_models import ChatHandoffPayload
-from ....runtime_policy.types import RuntimeSourceState
 from ....Utils.optional_deps import DEPENDENCIES_AVAILABLE
 from ....DB.search_history_db import SearchHistoryDB
 from ....Utils.paths import get_user_data_dir
@@ -131,7 +133,6 @@ if TYPE_CHECKING:
     from ....app import TldwCli
 
 logger = logger.bind(module="SearchRAGWindow")
-RAG_HANDOFF_POLICY_RECOVERY = "Switch source, sign in, or reconnect the server before using this result in Chat."
 
 # Import event handler mixin
 from .search_event_handlers import SearchEventHandlersMixin
@@ -523,22 +524,11 @@ class SearchRAGWindow(SearchEventHandlersMixin, Container):
 
     def _rag_handoff_policy_blocking_message(self, payload: ChatHandoffPayload) -> str:
         action_id = self._rag_handoff_runtime_action_id(payload)
-        if not action_id:
-            return ""
-
-        runtime_policy = getattr(self.app_instance, "runtime_policy", None)
-        runtime_state = getattr(runtime_policy, "state", None) if runtime_policy else None
-        policy_engine = getattr(self.app_instance, "ui_policy_engine", None)
-        evaluate = getattr(policy_engine, "evaluate", None) if policy_engine else None
-        if not isinstance(runtime_state, RuntimeSourceState) or not callable(evaluate):
-            return ""
-
-        decision = evaluate(action_id=action_id, state=runtime_state)
-        if getattr(decision, "allowed", True):
-            return ""
-
-        message = str(getattr(decision, "user_message", None) or "This RAG search action is blocked by runtime policy.")
-        return f"{message} {RAG_HANDOFF_POLICY_RECOVERY}"
+        return build_handoff_policy_blocking_message(
+            self.app_instance,
+            action_id=action_id,
+            fallback_message="This RAG search action is blocked by runtime policy.",
+        )
 
     @on(SearchResult.UseInChatRequested)
     def handle_search_result_use_in_chat(self, event: SearchResult.UseInChatRequested) -> None:


### PR DESCRIPTION
## Summary
- Centralize runtime-policy blocked handoff recovery copy through `chat_handoff_messages`.
- Include source authority, UX interop active source, server reachability/auth state, and concrete recovery instructions for Notes/Workspace, Media, RAG, and Web Search handoffs.
- Update the UX remediation plan to reflect PR #190 as merged and this source-authority recovery slice.

## Test Plan
- [x] `env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_ux_audit_smoke.py --tb=short`
- [x] `env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_media_handoffs.py --tb=short`
- [x] `env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_search_handoffs.py --tb=short`
- [x] `git diff --check`

## Notes
- The repository root worktree still has pre-existing uncommitted changes in related files; this branch was built from a clean `origin/dev` worktree to avoid overwriting them.
