### PR TITLE
Add file picker action tooltips

### DIFF
--- a/Tests/UI/test_file_picker_action_tooltips.py
+++ b/Tests/UI/test_file_picker_action_tooltips.py
@@ -1,0 +1,207 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Button
+
+from tldw_chatbook.UI.Chatbooks_Window_Improved import EmptyStateWidget
+from tldw_chatbook.UI.Wizards.BaseWizard import WizardStepConfig
+from tldw_chatbook.UI.Wizards.ChatbookImportWizard import FileSelectionStep
+from tldw_chatbook.UI.Wizards.EmbeddingSteps import SmartContentSelector
+from tldw_chatbook.Widgets.CCP_Widgets.ccp_sidebar_widget import CCPSidebarWidget
+from tldw_chatbook.Widgets.Evals.eval_additional_dialogs import FileUploadDialog
+from tldw_chatbook.Widgets.NewIngest.SmartFileDropZone import SmartFileDropZone
+from tldw_chatbook.Widgets.Note_Widgets.notes_sidebar_left import NotesSidebarLeft
+from tldw_chatbook.Widgets.Note_Widgets.notes_sync_widget import NotesSyncWidget
+from tldw_chatbook.Widgets.Note_Widgets.notes_sync_widget_improved import QuickSyncSection
+from tldw_chatbook.Widgets.file_picker_dialog import QuickPickerWidget
+
+
+class _WidgetHost(App):
+    def __init__(self, widget):
+        super().__init__()
+        self.widget_under_test = widget
+
+    def compose(self) -> ComposeResult:
+        yield self.widget_under_test
+
+
+class _ScreenHost(App):
+    def __init__(self, screen):
+        super().__init__()
+        self.screen_under_test = screen
+
+    async def on_mount(self) -> None:
+        await self.push_screen(self.screen_under_test)
+
+
+def _assert_button_tooltips(root, expected_tooltips: dict[str, str]) -> None:
+    for button_id, expected_tooltip in expected_tooltips.items():
+        button = root.query_one(f"#{button_id}", Button)
+        assert str(button.tooltip) == expected_tooltip
+
+
+@pytest.mark.asyncio
+async def test_eval_file_upload_actions_explain_browse_and_upload():
+    app = _ScreenHost(FileUploadDialog())
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        _assert_button_tooltips(
+            app.screen_under_test,
+            {
+                "browse-button": "Choose an evaluation task or dataset file from disk.",
+                "upload-button": "Upload the selected evaluation file.",
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_quick_file_picker_browse_action_explains_file_type_scope():
+    app = _WidgetHost(QuickPickerWidget(file_types="evaluation files"))
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        _assert_button_tooltips(
+            app.widget_under_test,
+            {
+                "browse-button": "Choose evaluation files from disk.",
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_notes_sync_folder_browse_actions_explain_sync_scope(monkeypatch):
+    app_instance = SimpleNamespace(notes_service=Mock(), db=Mock())
+    monkeypatch.setattr(NotesSyncWidget, "on_mount", lambda self: None)
+    app = _ScreenHost(NotesSyncWidget(app_instance=app_instance))
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        _assert_button_tooltips(
+            app.screen_under_test,
+            {
+                "sync-browse-button": "Choose the folder to sync with Notes.",
+            },
+        )
+
+    improved_app = _WidgetHost(QuickSyncSection())
+
+    async with improved_app.run_test() as pilot:
+        await pilot.pause()
+
+        _assert_button_tooltips(
+            improved_app.widget_under_test,
+            {
+                "browse-folder-btn": "Choose the folder to sync with Notes.",
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_notes_import_button_explains_file_import():
+    app = _WidgetHost(NotesSidebarLeft())
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        _assert_button_tooltips(
+            app.widget_under_test,
+            {
+                "notes-import-button": "Import a note file into the current Notes scope.",
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_chatbooks_empty_import_and_template_actions_have_tooltips():
+    app = _WidgetHost(EmptyStateWidget())
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        _assert_button_tooltips(
+            app.widget_under_test,
+            {
+                "empty-import-btn": "Import a local Chatbook pack from disk.",
+                "empty-templates-btn": "Browse Chatbook templates for a faster start.",
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_chatbook_import_wizard_browse_action_explains_zip_scope():
+    wizard = SimpleNamespace(app_instance=Mock(), refresh_current_step=Mock())
+    step = FileSelectionStep(
+        wizard=wizard,
+        config=WizardStepConfig(
+            id="file-selection",
+            title="Select File",
+            description="Choose chatbook to import",
+            step_number=1,
+        ),
+    )
+    app = _WidgetHost(step)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        _assert_button_tooltips(
+            app.widget_under_test,
+            {
+                "browse-file": "Choose a .zip Chatbook pack from disk.",
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_embedding_file_browse_action_explains_index_scope():
+    app = _WidgetHost(SmartContentSelector("files"))
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        _assert_button_tooltips(
+            app.widget_under_test,
+            {
+                "browse-files": "Choose local files to include in this embedding collection.",
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_ingest_drop_zone_browse_action_explains_file_selection():
+    app = _WidgetHost(SmartFileDropZone())
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        _assert_button_tooltips(
+            app.widget_under_test,
+            {
+                "browse-overlay": "Choose files from disk for ingestion.",
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_library_import_actions_explain_import_targets():
+    app = _WidgetHost(CCPSidebarWidget())
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        _assert_button_tooltips(
+            app.widget_under_test,
+            {
+                "ccp-import-conversation-button": "Import a conversation file into Library.",
+                "ccp-import-character-button": "Import a character card from disk.",
+                "ccp-import-prompt-button": "Import a prompt file into Library.",
+                "ccp-import-dictionary-button": "Import a dictionary file into Library.",
+                "ccp-import-worldbook-button": "Import a world or lore book file into Library.",
+            },
+        )

--- a/tldw_chatbook/UI/Chatbooks_Window_Improved.py
+++ b/tldw_chatbook/UI/Chatbooks_Window_Improved.py
@@ -170,8 +170,18 @@ class EmptyStateWidget(Container):
         
         with Container(classes="empty-state-actions"):
             yield Button("✨ Create Local Pack", id="empty-create-btn", variant="primary")
-            yield Button("📥 Import Local Pack", id="empty-import-btn", variant="default")
-            yield Button("📋 Browse Templates", id="empty-templates-btn", variant="default")
+            yield Button(
+                "📥 Import Local Pack",
+                id="empty-import-btn",
+                variant="default",
+                tooltip="Import a local Chatbook pack from disk.",
+            )
+            yield Button(
+                "📋 Browse Templates",
+                id="empty-templates-btn",
+                variant="default",
+                tooltip="Browse Chatbook templates for a faster start.",
+            )
 
 
 class ChatbooksWindowImproved(Screen):

--- a/tldw_chatbook/UI/Wizards/ChatbookImportWizard.py
+++ b/tldw_chatbook/UI/Wizards/ChatbookImportWizard.py
@@ -66,7 +66,13 @@ class FileSelectionStep(WizardStep):
                     yield Static("Drop chatbook file here", classes="drop-zone-text")
                     yield Static("or", classes="drop-zone-text")
             
-            yield Button("Browse for Chatbook", id="browse-file", variant="primary", classes="browse-button")
+            yield Button(
+                "Browse for Chatbook",
+                id="browse-file",
+                variant="primary",
+                classes="browse-button",
+                tooltip="Choose a .zip Chatbook pack from disk.",
+            )
             
             # File path display
             with Container(id="file-path-container", classes="file-path-display hidden"):

--- a/tldw_chatbook/UI/Wizards/EmbeddingSteps.py
+++ b/tldw_chatbook/UI/Wizards/EmbeddingSteps.py
@@ -350,7 +350,12 @@ class SmartContentSelector(Container):
             )
         )
         container.mount(
-            Button("Browse Files", id="browse-files", variant="primary")
+            Button(
+                "Browse Files",
+                id="browse-files",
+                variant="primary",
+                tooltip="Choose local files to include in this embedding collection.",
+            )
         )
         
     def load_media(self, container: Container) -> None:

--- a/tldw_chatbook/Widgets/CCP_Widgets/ccp_sidebar_widget.py
+++ b/tldw_chatbook/Widgets/CCP_Widgets/ccp_sidebar_widget.py
@@ -233,8 +233,12 @@ class CCPSidebarWidget(VerticalScroll):
         
         # ===== Conversations Section =====
         with Collapsible(title="Conversations", id="ccp-conversations-collapsible"):
-            yield Button("Import Conversation", id="ccp-import-conversation-button", 
-                       classes="sidebar-button")
+            yield Button(
+                "Import Conversation",
+                id="ccp-import-conversation-button",
+                classes="sidebar-button",
+                tooltip="Import a conversation file into Library.",
+            )
             
             # Search controls
             yield Label("Search by Title:", classes="sidebar-label")
@@ -283,8 +287,12 @@ class CCPSidebarWidget(VerticalScroll):
         
         # ===== Characters Section =====
         with Collapsible(title="Characters", id="ccp-characters-collapsible", collapsed=True):
-            yield Button("Import Character Card", id="ccp-import-character-button", 
-                       classes="sidebar-button")
+            yield Button(
+                "Import Character Card",
+                id="ccp-import-character-button",
+                classes="sidebar-button",
+                tooltip="Import a character card from disk.",
+            )
             yield Button("Create Character", id="ccp-create-character-button", 
                        classes="sidebar-button")
             yield Select(
@@ -323,7 +331,12 @@ class CCPSidebarWidget(VerticalScroll):
         
         # ===== Prompts Section =====
         with Collapsible(title="Prompts", id="ccp-prompts-collapsible", collapsed=True):
-            yield Button("Import Prompt", id="ccp-import-prompt-button", classes="sidebar-button")
+            yield Button(
+                "Import Prompt",
+                id="ccp-import-prompt-button",
+                classes="sidebar-button",
+                tooltip="Import a prompt file into Library.",
+            )
             yield Button("Create New Prompt", id="ccp-prompt-create-new-button", 
                        classes="sidebar-button")
             yield Input(id="ccp-prompt-search-input", placeholder="Search prompts...", 
@@ -345,8 +358,12 @@ class CCPSidebarWidget(VerticalScroll):
         
         # ===== Dictionaries Section =====
         with Collapsible(title="Chat Dictionaries", id="ccp-dictionaries-collapsible", collapsed=True):
-            yield Button("Import Dictionary", id="ccp-import-dictionary-button", 
-                       classes="sidebar-button")
+            yield Button(
+                "Import Dictionary",
+                id="ccp-import-dictionary-button",
+                classes="sidebar-button",
+                tooltip="Import a dictionary file into Library.",
+            )
             yield Button("Create Dictionary", id="ccp-create-dictionary-button", 
                        classes="sidebar-button")
             yield Select(
@@ -371,8 +388,12 @@ class CCPSidebarWidget(VerticalScroll):
         
         # ===== World Books Section =====
         with Collapsible(title="World/Lore Books", id="ccp-worldbooks-collapsible", collapsed=True):
-            yield Button("Import World Book", id="ccp-import-worldbook-button", 
-                       classes="sidebar-button")
+            yield Button(
+                "Import World Book",
+                id="ccp-import-worldbook-button",
+                classes="sidebar-button",
+                tooltip="Import a world or lore book file into Library.",
+            )
             yield Button("Create World Book", id="ccp-create-worldbook-button", 
                        classes="sidebar-button")
             yield Input(id="ccp-worldbook-search-input", placeholder="Search world books...", 

--- a/tldw_chatbook/Widgets/Evals/eval_additional_dialogs.py
+++ b/tldw_chatbook/Widgets/Evals/eval_additional_dialogs.py
@@ -64,9 +64,18 @@ class FileUploadDialog(ModalScreen):
                 )
             
             with Horizontal(classes="dialog-buttons"):
-                yield Button("Browse", id="browse-button")
+                yield Button(
+                    "Browse",
+                    id="browse-button",
+                    tooltip="Choose an evaluation task or dataset file from disk.",
+                )
                 yield Button("Cancel", id="cancel-button", variant="error")
-                yield Button("Upload", id="upload-button", variant="primary")
+                yield Button(
+                    "Upload",
+                    id="upload-button",
+                    variant="primary",
+                    tooltip="Upload the selected evaluation file.",
+                )
     
     @on(Button.Pressed, "#browse-button")
     def handle_browse(self):

--- a/tldw_chatbook/Widgets/NewIngest/SmartFileDropZone.py
+++ b/tldw_chatbook/Widgets/NewIngest/SmartFileDropZone.py
@@ -165,7 +165,11 @@ class SmartFileDropZone(CaptureSafePostMixin, Widget):
             with Container(id="drop-area"):
                 yield Static("Drop files here", id="drop-title")
                 yield Static("or browse", id="drop-subtitle")
-                yield ImmediateButton("Browse", id="browse-overlay")
+                yield ImmediateButton(
+                    "Browse",
+                    id="browse-overlay",
+                    tooltip="Choose files from disk for ingestion.",
+                )
             with Container(id="file-list-container"):
                 yield Vertical(id="file-list")
                 yield Static("", id="file-summary")

--- a/tldw_chatbook/Widgets/Note_Widgets/notes_sidebar_left.py
+++ b/tldw_chatbook/Widgets/Note_Widgets/notes_sidebar_left.py
@@ -82,7 +82,12 @@ class NotesSidebarLeft(VerticalScroll):
         )
         yield Button("Create from Template", id="notes-create-from-template-button", variant="success")
         yield Button("Create Blank Note", id="notes-create-new-button", variant="default")
-        yield Button("Import Note", id="notes-import-button", variant="default")
+        yield Button(
+            "Import Note",
+            id="notes-import-button",
+            variant="default",
+            tooltip="Import a note file into the current Notes scope.",
+        )
 
         yield Static("Search & Filter:", classes="sidebar-label")
         yield Input(placeholder="Search notes content...", id="notes-search-input")

--- a/tldw_chatbook/Widgets/Note_Widgets/notes_sync_widget.py
+++ b/tldw_chatbook/Widgets/Note_Widgets/notes_sync_widget.py
@@ -258,7 +258,11 @@ class NotesSyncWidget(ModalScreen):
                         placeholder="Select folder to sync...",
                         id="sync-folder-input"
                     )
-                    yield Button("Browse", id="sync-browse-button")
+                    yield Button(
+                        "Browse",
+                        id="sync-browse-button",
+                        tooltip="Choose the folder to sync with Notes.",
+                    )
                 
                 with Horizontal(classes="sync-controls"):
                     yield Select(

--- a/tldw_chatbook/Widgets/Note_Widgets/notes_sync_widget_improved.py
+++ b/tldw_chatbook/Widgets/Note_Widgets/notes_sync_widget_improved.py
@@ -131,7 +131,12 @@ class QuickSyncSection(Container):
                 placeholder="Select folder to sync...",
                 id="sync-folder-input"
             )
-            yield Button("Browse", id="browse-folder-btn", variant="default")
+            yield Button(
+                "Browse",
+                id="browse-folder-btn",
+                variant="default",
+                tooltip="Choose the folder to sync with Notes.",
+            )
         
         # Sync settings
         with Horizontal(classes="sync-settings-row"):

--- a/tldw_chatbook/Widgets/file_picker_dialog.py
+++ b/tldw_chatbook/Widgets/file_picker_dialog.py
@@ -240,7 +240,12 @@ class QuickPickerWidget(Container):
         with Horizontal(classes="quick-picker"):
             yield Label(self.label, classes="picker-label")
             yield Static("No file selected", id="selected-file-display", classes="file-display")
-            yield Button("Browse...", id="browse-button", classes="browse-button")
+            yield Button(
+                "Browse...",
+                id="browse-button",
+                classes="browse-button",
+                tooltip=f"Choose {self.file_types} from disk.",
+            )
     
     @on(Button.Pressed, "#browse-button")
     def handle_browse(self):


### PR DESCRIPTION
## Summary
- Add explanatory tooltips to content import, browse, and file-picker actions across Notes, Chatbooks, Evals, Ingest, Embeddings, and Library.
- Add mounted Textual regression coverage for the targeted browse/import controls.
- Keep LLM runtime path browse controls out of this PR for batch C.

## Test Plan
- env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_file_picker_action_tooltips.py Tests/UI/test_ux_audit_smoke.py --tb=short
- git diff --cached --check