### PR TITLE
Add LLM runtime browse tooltips

### DIFF
--- a/Tests/UI/test_llm_runtime_browse_tooltips.py
+++ b/Tests/UI/test_llm_runtime_browse_tooltips.py
@@ -1,0 +1,58 @@
+from types import SimpleNamespace
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Button
+
+from tldw_chatbook.UI.LLM_Management_Window import LLMManagementWindow
+
+
+class _LLMWindowHost(App):
+    def compose(self) -> ComposeResult:
+        app_instance = SimpleNamespace(
+            app_config={"llm_management": {"model_download_dir": "/private/tmp/tldw-models"}}
+        )
+        yield LLMManagementWindow(app_instance)
+
+
+@pytest.mark.asyncio
+async def test_llm_runtime_browse_controls_explain_expected_paths(monkeypatch):
+    monkeypatch.setattr(
+        "tldw_chatbook.Widgets.HuggingFace.model_search_widget.ModelSearchWidget._initial_browse",
+        lambda self: None,
+    )
+    monkeypatch.setattr(
+        "tldw_chatbook.Widgets.HuggingFace.download_manager.DownloadManager.on_mount",
+        lambda self: None,
+    )
+    monkeypatch.setattr(
+        "tldw_chatbook.Widgets.HuggingFace.local_models_widget.LocalModelsWidget.on_mount",
+        lambda self: None,
+    )
+
+    expected_tooltips = {
+        "llamacpp-browse-exec-button": "Choose the llama.cpp server executable.",
+        "llamacpp-browse-model-button": "Choose a GGUF model file for llama.cpp.",
+        "llamafile-browse-exec-button": "Choose the llamafile executable.",
+        "llamafile-browse-model-button": "Choose an optional external GGUF model for llamafile.",
+        "vllm-browse-python-button": "Choose the Python interpreter used to launch vLLM.",
+        "vllm-browse-model-button": "Choose a local model directory for vLLM, or type a Hugging Face repo ID.",
+        "onnx-browse-python-button": "Choose the Python interpreter used to launch the ONNX server.",
+        "onnx-browse-script-button": "Choose the ONNX server script to run.",
+        "onnx-browse-model-button": "Choose the ONNX model file or directory to load.",
+        "transformers-browse-models-dir-button": "Choose the local Transformers models root directory.",
+        "transformers-browse-script-button": "Choose the custom Transformers server script to run.",
+        "mlx-browse-model-button": "Choose a local MLX model path, or type a Hugging Face repo ID.",
+        "ollama-browse-exec-button": "Choose the Ollama executable.",
+        "ollama-browse-modelfile-button": "Choose the Modelfile used to create an Ollama model.",
+    }
+
+    app = _LLMWindowHost()
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        window = app.query_one(LLMManagementWindow)
+
+        for button_id, expected_tooltip in expected_tooltips.items():
+            button = window.query_one(f"#{button_id}", Button)
+            assert str(button.tooltip) == expected_tooltip

--- a/tldw_chatbook/UI/LLM_Management_Window.py
+++ b/tldw_chatbook/UI/LLM_Management_Window.py
@@ -283,12 +283,22 @@ class LLMManagementWindow(Container):
                 yield Label("Llama.cpp Server Executable Path:", classes="label")
                 with Container(classes="input_container"):
                     yield Input(id="llamacpp-exec-path", placeholder="/path/to/llama.cpp/build/bin/server")
-                    yield Button("Browse", id="llamacpp-browse-exec-button", classes="browse_button")
+                    yield Button(
+                        "Browse",
+                        id="llamacpp-browse-exec-button",
+                        classes="browse_button",
+                        tooltip="Choose the llama.cpp server executable.",
+                    )
                 
                 yield Label("GGUF Model File Path:", classes="label")
                 with Container(classes="input_container"):
                     yield Input(id="llamacpp-model-path", placeholder="/path/to/model.gguf")
-                    yield Button("Browse", id="llamacpp-browse-model-button", classes="browse_button")
+                    yield Button(
+                        "Browse",
+                        id="llamacpp-browse-model-button",
+                        classes="browse_button",
+                        tooltip="Choose a GGUF model file for llama.cpp.",
+                    )
                 
                 yield Label("Host:", classes="label")
                 yield Input(id="llamacpp-host", value="127.0.0.1")
@@ -322,12 +332,22 @@ class LLMManagementWindow(Container):
                 yield Label("Llamafile Executable (.llamafile):", classes="label")
                 with Container(classes="input_container"):
                     yield Input(id="llamafile-exec-path", placeholder="/path/to/model.llamafile")
-                    yield Button("Browse", id="llamafile-browse-exec-button", classes="browse_button")
+                    yield Button(
+                        "Browse",
+                        id="llamafile-browse-exec-button",
+                        classes="browse_button",
+                        tooltip="Choose the llamafile executable.",
+                    )
                 
                 yield Label("Optional External Model (GGUF):", classes="label")
                 with Container(classes="input_container"):
                     yield Input(id="llamafile-model-path", placeholder="/path/to/external-model.gguf (optional)")
-                    yield Button("Browse", id="llamafile-browse-model-button", classes="browse_button")
+                    yield Button(
+                        "Browse",
+                        id="llamafile-browse-model-button",
+                        classes="browse_button",
+                        tooltip="Choose an optional external GGUF model for llamafile.",
+                    )
                 
                 yield Label("Host:", classes="label")
                 yield Input(id="llamafile-host", value="127.0.0.1")
@@ -361,12 +381,22 @@ class LLMManagementWindow(Container):
                 yield Label("Python Interpreter Path:", classes="label")
                 with Container(classes="input_container"):
                     yield Input(id="vllm-python-path", value="python", placeholder="e.g., /path/to/venv/bin/python")
-                    yield Button("Browse", id="vllm-browse-python-button", classes="browse_button")
+                    yield Button(
+                        "Browse",
+                        id="vllm-browse-python-button",
+                        classes="browse_button",
+                        tooltip="Choose the Python interpreter used to launch vLLM.",
+                    )
                 
                 yield Label("Model Path (or HuggingFace Repo ID):", classes="label")
                 with Container(classes="input_container"):
                     yield Input(id="vllm-model-path", placeholder="e.g., /path/to/model or HuggingFaceName/ModelName")
-                    yield Button("Browse", id="vllm-browse-model-button", classes="browse_button")
+                    yield Button(
+                        "Browse",
+                        id="vllm-browse-model-button",
+                        classes="browse_button",
+                        tooltip="Choose a local model directory for vLLM, or type a Hugging Face repo ID.",
+                    )
                 
                 yield Label("Host:", classes="label")
                 yield Input(id="vllm-host", value="127.0.0.1")
@@ -391,17 +421,32 @@ class LLMManagementWindow(Container):
                 yield Label("Python Interpreter Path:", classes="label")
                 with Container(classes="input_container"):
                     yield Input(id="onnx-python-path", value="python", placeholder="e.g., /path/to/venv/bin/python")
-                    yield Button("Browse", id="onnx-browse-python-button", classes="browse_button")
+                    yield Button(
+                        "Browse",
+                        id="onnx-browse-python-button",
+                        classes="browse_button",
+                        tooltip="Choose the Python interpreter used to launch the ONNX server.",
+                    )
                 
                 yield Label("Path to your ONNX Server Script (.py):", classes="label")
                 with Container(classes="input_container"):
                     yield Input(id="onnx-script-path", placeholder="/path/to/your/onnx_server_script.py")
-                    yield Button("Browse Script", id="onnx-browse-script-button", classes="browse_button")
+                    yield Button(
+                        "Browse Script",
+                        id="onnx-browse-script-button",
+                        classes="browse_button",
+                        tooltip="Choose the ONNX server script to run.",
+                    )
                 
                 yield Label("Model to Load (Path for script):", classes="label")
                 with Container(classes="input_container"):
                     yield Input(id="onnx-model-path", placeholder="Path to your .onnx model file or directory")
-                    yield Button("Browse Model", id="onnx-browse-model-button", classes="browse_button")
+                    yield Button(
+                        "Browse Model",
+                        id="onnx-browse-model-button",
+                        classes="browse_button",
+                        tooltip="Choose the ONNX model file or directory to load.",
+                    )
                 
                 yield Label("Host:", classes="label")
                 yield Input(id="onnx-host", value="127.0.0.1", classes="input_field")
@@ -426,8 +471,12 @@ class LLMManagementWindow(Container):
                 with Container(classes="input_container"):
                     yield Input(id="transformers-models-dir-path",
                               placeholder="/path/to/your/hf_models_cache_or_local_dir")
-                    yield Button("Browse Dir", id="transformers-browse-models-dir-button",
-                               classes="browse_button")
+                    yield Button(
+                        "Browse Dir",
+                        id="transformers-browse-models-dir-button",
+                        classes="browse_button",
+                        tooltip="Choose the local Transformers models root directory.",
+                    )
                 
                 yield Button("List Local Models", id="transformers-list-local-models-button",
                            classes="action_button")
@@ -454,8 +503,12 @@ class LLMManagementWindow(Container):
                 with Container(classes="input_container"):
                     yield Input(id="transformers-script-path", 
                               placeholder="/path/to/your_transformers_server_script.py")
-                    yield Button("Browse Script", id="transformers-browse-script-button", 
-                               classes="browse_button")
+                    yield Button(
+                        "Browse Script",
+                        id="transformers-browse-script-button",
+                        classes="browse_button",
+                        tooltip="Choose the custom Transformers server script to run.",
+                    )
                 
                 yield Label("Model to Load (ID or Path for script):", classes="label")
                 yield Input(id="transformers-server-model-arg", 
@@ -488,7 +541,12 @@ class LLMManagementWindow(Container):
                 with Container(classes="input_container"):
                     yield Input(id="mlx-model-path", 
                               placeholder="e.g., mlx-community/Nous-Hermes-2-Mistral-7B-DPO-4bit-MLX")
-                    yield Button("Browse", id="mlx-browse-model-button", classes="browse_button")
+                    yield Button(
+                        "Browse",
+                        id="mlx-browse-model-button",
+                        classes="browse_button",
+                        tooltip="Choose a local MLX model path, or type a Hugging Face repo ID.",
+                    )
                 
                 yield Label("Host:", classes="label")
                 yield Input(id="mlx-host", value="127.0.0.1", classes="input_field")
@@ -522,7 +580,12 @@ class LLMManagementWindow(Container):
                 with Container(classes="input_container"):
                     yield Input(id="ollama-exec-path",
                               placeholder="Path to ollama executable (e.g., /usr/local/bin/ollama)")
-                    yield Button("Browse", id="ollama-browse-exec-button", classes="browse_button")
+                    yield Button(
+                        "Browse",
+                        id="ollama-browse-exec-button",
+                        classes="browse_button",
+                        tooltip="Choose the Ollama executable.",
+                    )
                 
                 with Horizontal(classes="ollama-button-bar"):
                     yield Button("Start Ollama Service", id="ollama-start-service-button")
@@ -589,8 +652,12 @@ class LLMManagementWindow(Container):
                             yield Input(id="ollama-create-modelfile-path", 
                                       placeholder="Path to Modelfile...", disabled=True, 
                                       classes="input_field_short")
-                            yield Button("Browse", id="ollama-browse-modelfile-button", 
-                                       classes="browse_button_short")
+                            yield Button(
+                                "Browse",
+                                id="ollama-browse-modelfile-button",
+                                classes="browse_button_short",
+                                tooltip="Choose the Modelfile used to create an Ollama model.",
+                            )
                         yield Button("Create Model", id="ollama-create-model-button", 
                                    classes="full_width_button")
                 


### PR DESCRIPTION
## Summary
- Add explanatory tooltips to LLM runtime browse controls for executables, Python interpreters, model paths, server scripts, directories, and Ollama Modelfiles.
- Add mounted Textual regression coverage for all LLM runtime browse controls.
- Keep this PR isolated from general file-picker/import tooltip work in PR #199.

## Test Plan
- env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_llm_runtime_browse_tooltips.py Tests/UI/test_ux_audit_smoke.py --tb=short
- git diff --cached --check