### PR TITLE
Add disabled action recovery tooltips

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -1,8 +1,8 @@
 # UX Audit Remediation Plan
 
 Date: 2026-05-01
-Status: Current-dev rebaseline after UX remediation PRs #146-#197, plus active bulk-selection tooltip slice
-Branch context: current `origin/dev` at `40b6f2ac`; active branch `codex/ux-bulk-selection-tooltips`
+Status: Current-dev rebaseline after UX remediation PRs #146-#200, plus active disabled-action recovery tooltip slice
+Branch context: current `origin/dev` at `6f6a31e3`; active branch `codex/ux-disabled-template-history-tooltips`
 Previous audit baseline: `e2576cae`
 
 ## Goal
@@ -29,7 +29,7 @@ This is not a visual refresh. The work is ordered around workflow completion, re
 
 ## Current Dev Rebaseline
 
-Rebaselined on current `dev` at `40b6f2ac`:
+Rebaselined on current `dev` at `6f6a31e3`:
 
 - Phase 0 and Phase 1 are merged: the shared shell/Chatbooks trap, Ingest default source, quiz empty mapping response, Chat save-state, Search/RAG thread mutation, and Search primary-action reachability regressions are covered.
 - Phase 2 is merged: Chat has provider readiness and first-run orientation coverage.
@@ -84,11 +84,14 @@ Current source state plus this branch:
 - Phase 5 Media Details content-search tooltips are merged through PR #194: compact search and match-navigation buttons explain their action inside selected media content.
 - Phase 5 Embeddings batch-control tooltips are merged through PR #196: repeated model/collection selection and deletion controls explain which scope they affect.
 - Phase 5 Embedding Wizard selector tooltips are merged through PR #197: source-content Select All, Clear All, and Invert actions explain their visible-item scope.
-- Phase 5 bulk-selection control tooltips are active in `codex/ux-bulk-selection-tooltips`: Evals, Notes, tags, multi-item review, and Mindmap source selection explain what each select/clear action affects.
+- Phase 5 bulk-selection control tooltips are merged through PR #198: Evals, Notes, tags, multi-item review, and Mindmap source selection explain what each select/clear action affects.
+- Phase 5 browse/import/file-picker tooltips are merged through PR #199: file selection and import controls explain what kind of files or folders they operate on.
+- Phase 5 LLM/runtime browse tooltips are merged through PR #200: runtime executable/model/path browse controls explain the expected artifact before opening a picker.
+- Phase 5 disabled-action recovery tooltips are active in `codex/ux-disabled-template-history-tooltips`: transcription history, evaluation template preview/selection, and chunking template actions explain selection or built-in-template prerequisites.
 - Phase 6 still needs any remaining optional dependency gaps represented as user-facing capability states where relevant.
 - Phase 7 clean-home audit replay was captured at `6c0d2469` under `/private/tmp/tldw-chatbook-ux-remediation-verify/` before merging PRs #192 and #193; live external API/server paths remain documented uncertainty.
 
-Planning consequence: after this bulk-selection slice, continue the approved sequential cleanup with browse/import/file-picker controls, then LLM/runtime browse controls. Remaining implementation should otherwise target broader live source-handoff replay cases, any non-handoff source actions where policy state can still block a visible action, any remaining compact-label/descriptive copy outside top navigation, Phase 6 capability-state presentation beyond Speech/STTS, Web Search, and Search/RAG embeddings where user-relevant, and Phase 7 replay. Do not rebuild already-merged Chat handoff architecture.
+Planning consequence: batch A/B/C are now merged. Continue with small, evidence-backed disabled-action recovery gaps, then reassess remaining Phase 5 controls before moving to broader Phase 6 capability states or Phase 7 live replay. Remaining implementation should target visible no-op or disabled controls with unclear prerequisites, broader live source-handoff replay cases, any non-handoff source actions where policy state can still block a visible action, and any compact-label/descriptive copy outside top navigation. Do not rebuild already-merged Chat handoff architecture.
 
 ## Issues Covered
 
@@ -334,7 +337,7 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 
 Purpose: make the app understandable without reducing expert efficiency.
 
-Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, #163, #164, #165, #166, #167, #168, #169, #170, #171, #172, #173, #174, #185, #186, #187, #188, #189, #191, #192, #193, #194, #196, and #197, with bulk-selection tooltip cleanup active in `codex/ux-bulk-selection-tooltips`. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, Speech/STTS exposes local dependency capability states, Web Search missing dependencies render as disabled-state recovery copy, Media Source disabled actions expose recovery tooltips, Study Quiz disabled actions expose recovery tooltips, Study Flashcards disabled actions expose recovery tooltips, Study dashboard Resume action recovery is merged through PR #185, Study quiz Start action recovery is merged through PR #186, Study quiz Review in Chat recovery/handoff is merged through PR #187, Study section-bar compact label tooltips are merged through PR #188, Chatbooks view-toggle compact label tooltips are merged through PR #189, Mindmap compact-control tooltips are merged through PR #192, SmartContentTree compact-control tooltips are merged through PR #193, Media Details content-search tooltips are merged through PR #194, Embeddings batch-control tooltips are merged through PR #196, Embedding Wizard selector tooltips are merged through PR #197, Media Viewer actions expose selection/capability tooltips, Media Analysis actions expose generated-analysis/saved-version tooltips, Media Highlight actions expose selected-highlight tooltips, Media Analysis navigation actions expose saved-version boundary tooltips, Search/RAG saved-search actions expose selection/reuse recovery, Media list pagination exposes result-page boundary tooltips, and Media multi-item review actions expose generation/cancellation state tooltips.
+Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, #163, #164, #165, #166, #167, #168, #169, #170, #171, #172, #173, #174, #185, #186, #187, #188, #189, #191, #192, #193, #194, #196, #197, #198, #199, and #200, with disabled-action recovery cleanup active in `codex/ux-disabled-template-history-tooltips`. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, Speech/STTS exposes local dependency capability states, Web Search missing dependencies render as disabled-state recovery copy, Media Source disabled actions expose recovery tooltips, Study Quiz disabled actions expose recovery tooltips, Study Flashcards disabled actions expose recovery tooltips, Study dashboard Resume action recovery is merged through PR #185, Study quiz Start action recovery is merged through PR #186, Study quiz Review in Chat recovery/handoff is merged through PR #187, Study section-bar compact label tooltips are merged through PR #188, Chatbooks view-toggle compact label tooltips are merged through PR #189, Mindmap compact-control tooltips are merged through PR #192, SmartContentTree compact-control tooltips are merged through PR #193, Media Details content-search tooltips are merged through PR #194, Embeddings batch-control tooltips are merged through PR #196, Embedding Wizard selector tooltips are merged through PR #197, bulk-selection control tooltips are merged through PR #198, browse/import/file-picker tooltips are merged through PR #199, LLM/runtime browse tooltips are merged through PR #200, Media Viewer actions expose selection/capability tooltips, Media Analysis actions expose generated-analysis/saved-version tooltips, Media Highlight actions expose selected-highlight tooltips, Media Analysis navigation actions expose saved-version boundary tooltips, Search/RAG saved-search actions expose selection/reuse recovery, Media list pagination exposes result-page boundary tooltips, and Media multi-item review actions expose generation/cancellation state tooltips.
 
 ### Files
 
@@ -382,6 +385,9 @@ Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #
 - [x] Add Embeddings batch-control tooltips for model and collection selection/deletion scopes.
 - [x] Add Embedding Wizard content selector tooltips for visible source-item bulk actions.
 - [x] Add bulk-selection control tooltips for Evals, Notes, tags, multi-item review, and Mindmap source selection.
+- [x] Add browse/import/file-picker tooltips for file and folder selection actions.
+- [x] Add LLM/runtime browse tooltips for executable, model, script, and path controls.
+- [x] Add disabled-action recovery tooltips for transcription history and template management selection states.
 - [ ] Add tooltips or short descriptions where compact labels remain necessary outside top navigation.
 
 ### Acceptance Criteria
@@ -484,4 +490,4 @@ Current-dev state: complete on local `dev` at `6c0d2469`. A clean-home Textual r
 
 ## Next Step
 
-After this bulk-selection tooltip slice, continue the approved sequential cleanup with batch B for browse/import/file-picker controls, then batch C for LLM/runtime browse controls. Remaining Phase 4 work should focus on broader live audit replay or any non-handoff source actions where policy state can still block a visible action. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.
+After this disabled-action recovery tooltip slice, re-scan current `dev` for remaining visible disabled/no-op controls that still lack a reason or recovery path before starting broader work. Remaining Phase 4 work should focus on broader live audit replay or any non-handoff source actions where policy state can still block a visible action. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.

--- a/Tests/UI/test_disabled_action_recovery_tooltips.py
+++ b/Tests/UI/test_disabled_action_recovery_tooltips.py
@@ -1,0 +1,235 @@
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Button
+
+from tldw_chatbook.Audio.transcription_history import TranscriptionEntry
+from tldw_chatbook.Widgets.chunking_templates_widget import ChunkingTemplatesWidget
+from tldw_chatbook.Widgets.template_selector import (
+    TemplatePreviewWidget,
+    TemplateSelectorDialog,
+)
+from tldw_chatbook.Widgets.transcription_history_viewer import TranscriptionHistoryViewer
+
+
+class _WidgetHost(App):
+    def __init__(self, widget):
+        super().__init__()
+        self.widget_under_test = widget
+
+    def compose(self) -> ComposeResult:
+        yield self.widget_under_test
+
+
+class _ScreenHost(App):
+    def __init__(self, screen):
+        super().__init__()
+        self.screen_under_test = screen
+
+    async def on_mount(self) -> None:
+        await self.push_screen(self.screen_under_test)
+
+
+class _FakeScopeService:
+    def __init__(self, templates=None):
+        self.templates = list(templates or [])
+
+    async def list_templates(self, *, mode, **kwargs):
+        return list(self.templates)
+
+
+class _ChunkingTemplatesTestApp(App):
+    def __init__(self, templates=None):
+        super().__init__()
+        self.current_runtime_backend = "local"
+        self.rag_admin_scope_service = _FakeScopeService(templates)
+        self.notify = Mock()
+        self.push_screen = Mock()
+        self.push_screen_wait = Mock()
+        self.media_db = None
+        self.widget = ChunkingTemplatesWidget(app_instance=self)
+
+    def compose(self) -> ComposeResult:
+        yield self.widget
+
+
+def _normalized_template(name: str, *, is_builtin: bool = False) -> dict:
+    return {
+        "record_id": f"local:chunking_template:{name}",
+        "backend": "local",
+        "backing_template_name": name,
+        "name": name,
+        "description": f"{name} description",
+        "template_json": '{"chunking": {"method": "words"}}',
+        "template": {"chunking": {"method": "words"}},
+        "is_builtin": is_builtin,
+        "tags": [],
+        "created_at": "2026-04-20T00:00:00",
+        "updated_at": "2026-04-20T00:00:00",
+        "version": 1,
+        "backing_id": name,
+    }
+
+
+def _assert_button_tooltips(root, expected_tooltips: dict[str, str]) -> None:
+    for button_id, expected_tooltip in expected_tooltips.items():
+        button = root.query_one(f"#{button_id}", Button)
+        assert str(button.tooltip) == expected_tooltip
+
+
+@pytest.mark.asyncio
+async def test_transcription_history_disabled_actions_explain_selection_requirement(monkeypatch):
+    monkeypatch.setattr(TranscriptionHistoryViewer, "on_mount", lambda self: None)
+    monkeypatch.setattr(TranscriptionHistoryViewer, "on_select_changed", lambda self, event: None)
+    monkeypatch.setattr(
+        "tldw_chatbook.Widgets.transcription_history_viewer.get_transcription_history",
+        lambda: SimpleNamespace(is_encrypted=lambda: False),
+    )
+
+    app = _WidgetHost(TranscriptionHistoryViewer())
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        _assert_button_tooltips(
+            app.widget_under_test,
+            {
+                "copy-btn": "Select a transcription entry before copying text.",
+                "export-btn": "Select a transcription entry before exporting it.",
+                "delete-btn": "Select a transcription entry before deleting it.",
+            },
+        )
+
+        app.widget_under_test._show_entry_details(
+            TranscriptionEntry(
+                id="entry-1",
+                timestamp=datetime(2026, 4, 20, 9, 0),
+                transcript="The selected transcript text.",
+                duration=4.2,
+                word_count=4,
+                language="en",
+                provider="test",
+            )
+        )
+
+        _assert_button_tooltips(
+            app.widget_under_test,
+            {
+                "copy-btn": "Copy the selected transcription text.",
+                "export-btn": "Export the selected transcription entry.",
+                "delete-btn": "Delete the selected transcription entry.",
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_template_preview_actions_explain_selection_requirement():
+    app = _WidgetHost(TemplatePreviewWidget())
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        _assert_button_tooltips(
+            app.widget_under_test,
+            {
+                "create-task-btn": "Select an evaluation template before creating a task.",
+                "export-template-btn": "Select an evaluation template before exporting it.",
+            },
+        )
+
+        app.widget_under_test.update_preview(
+            {
+                "name": "QA Template",
+                "description": "Answer quality checks.",
+                "category": "quality",
+                "difficulty": "medium",
+                "task_type": "qa",
+            }
+        )
+
+        _assert_button_tooltips(
+            app.widget_under_test,
+            {
+                "create-task-btn": "Create an evaluation task from this template.",
+                "export-template-btn": "Export this evaluation template.",
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_template_selector_select_action_explains_selection_requirement(monkeypatch):
+    monkeypatch.setattr(TemplateSelectorDialog, "_load_templates", lambda self: None)
+    app = _ScreenHost(TemplateSelectorDialog())
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        _assert_button_tooltips(
+            app.screen_under_test,
+            {"select-button": "Select an evaluation template before continuing."},
+        )
+
+        app.screen_under_test._on_template_selected(
+            {
+                "name": "QA Template",
+                "description": "Answer quality checks.",
+                "category": "quality",
+                "difficulty": "medium",
+                "task_type": "qa",
+            }
+        )
+
+        _assert_button_tooltips(
+            app.screen_under_test,
+            {"select-button": "Use the selected evaluation template."},
+        )
+
+
+@pytest.mark.asyncio
+async def test_chunking_template_actions_explain_missing_and_builtin_selection():
+    custom_template = _normalized_template("custom-template")
+    builtin_template = _normalized_template("builtin-template", is_builtin=True)
+    app = _ChunkingTemplatesTestApp(templates=[custom_template, builtin_template])
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        widget = app.widget
+
+        _assert_button_tooltips(
+            widget,
+            {
+                "edit-template-btn": "Select a custom chunking template before editing.",
+                "duplicate-template-btn": "Select a chunking template before duplicating it.",
+                "delete-template-btn": "Select a custom chunking template before deleting.",
+                "export-template-btn": "Select a chunking template before exporting it.",
+            },
+        )
+
+        widget.selected_template_record_id = custom_template["record_id"]
+        await pilot.pause()
+
+        _assert_button_tooltips(
+            widget,
+            {
+                "edit-template-btn": "Edit the selected custom chunking template.",
+                "duplicate-template-btn": "Duplicate the selected chunking template.",
+                "delete-template-btn": "Delete the selected custom chunking template.",
+                "export-template-btn": "Export the selected chunking template.",
+            },
+        )
+
+        widget.selected_template_record_id = builtin_template["record_id"]
+        await pilot.pause()
+
+        _assert_button_tooltips(
+            widget,
+            {
+                "edit-template-btn": "Built-in chunking templates cannot be edited; duplicate it first.",
+                "duplicate-template-btn": "Duplicate the selected chunking template.",
+                "delete-template-btn": "Built-in chunking templates cannot be deleted.",
+                "export-template-btn": "Export the selected chunking template.",
+            },
+        )

--- a/tldw_chatbook/Widgets/chunking_templates_widget.py
+++ b/tldw_chatbook/Widgets/chunking_templates_widget.py
@@ -30,6 +30,18 @@ if TYPE_CHECKING:
     from ..app import TldwCli
 
 
+CHUNKING_EDIT_DISABLED_TOOLTIP = "Select a custom chunking template before editing."
+CHUNKING_DUPLICATE_DISABLED_TOOLTIP = "Select a chunking template before duplicating it."
+CHUNKING_DELETE_DISABLED_TOOLTIP = "Select a custom chunking template before deleting."
+CHUNKING_EXPORT_DISABLED_TOOLTIP = "Select a chunking template before exporting it."
+CHUNKING_EDIT_ENABLED_TOOLTIP = "Edit the selected custom chunking template."
+CHUNKING_DUPLICATE_ENABLED_TOOLTIP = "Duplicate the selected chunking template."
+CHUNKING_DELETE_ENABLED_TOOLTIP = "Delete the selected custom chunking template."
+CHUNKING_EXPORT_ENABLED_TOOLTIP = "Export the selected chunking template."
+CHUNKING_EDIT_BUILTIN_TOOLTIP = "Built-in chunking templates cannot be edited; duplicate it first."
+CHUNKING_DELETE_BUILTIN_TOOLTIP = "Built-in chunking templates cannot be deleted."
+
+
 class ChunkingTemplatesWidget(Container):
     """
     A widget for managing chunking templates with full CRUD operations.
@@ -114,11 +126,39 @@ class ChunkingTemplatesWidget(Container):
         # Action buttons
         with Horizontal(classes="templates-actions"):
             yield Button("➕ New Template", id="new-template-btn", variant="primary", classes="action-button")
-            yield Button("📝 Edit", id="edit-template-btn", variant="default", classes="action-button", disabled=True)
-            yield Button("📋 Duplicate", id="duplicate-template-btn", variant="default", classes="action-button", disabled=True)
-            yield Button("🗑️ Delete", id="delete-template-btn", variant="error", classes="action-button", disabled=True)
+            yield Button(
+                "📝 Edit",
+                id="edit-template-btn",
+                variant="default",
+                classes="action-button",
+                disabled=True,
+                tooltip=CHUNKING_EDIT_DISABLED_TOOLTIP,
+            )
+            yield Button(
+                "📋 Duplicate",
+                id="duplicate-template-btn",
+                variant="default",
+                classes="action-button",
+                disabled=True,
+                tooltip=CHUNKING_DUPLICATE_DISABLED_TOOLTIP,
+            )
+            yield Button(
+                "🗑️ Delete",
+                id="delete-template-btn",
+                variant="error",
+                classes="action-button",
+                disabled=True,
+                tooltip=CHUNKING_DELETE_DISABLED_TOOLTIP,
+            )
             yield Button("📥 Import", id="import-template-btn", variant="default", classes="action-button")
-            yield Button("📤 Export", id="export-template-btn", variant="default", classes="action-button", disabled=True)
+            yield Button(
+                "📤 Export",
+                id="export-template-btn",
+                variant="default",
+                classes="action-button",
+                disabled=True,
+                tooltip=CHUNKING_EXPORT_DISABLED_TOOLTIP,
+            )
         
         # Templates table
         with Container(classes="templates-table-container"):
@@ -226,9 +266,33 @@ class ChunkingTemplatesWidget(Container):
         self.query_one("#duplicate-template-btn", Button).disabled = not has_selection
         self.query_one("#delete-template-btn", Button).disabled = not has_selection or is_system
         self.query_one("#export-template-btn", Button).disabled = not has_selection
+        self._update_action_tooltips(has_selection=has_selection, is_system=is_system)
         
         # Update details display
         self._update_template_details()
+
+    def _update_action_tooltips(self, *, has_selection: bool, is_system: bool) -> None:
+        """Explain why template actions are unavailable and what enabled actions do."""
+        edit_button = self.query_one("#edit-template-btn", Button)
+        duplicate_button = self.query_one("#duplicate-template-btn", Button)
+        delete_button = self.query_one("#delete-template-btn", Button)
+        export_button = self.query_one("#export-template-btn", Button)
+
+        if not has_selection:
+            edit_button.tooltip = CHUNKING_EDIT_DISABLED_TOOLTIP
+            duplicate_button.tooltip = CHUNKING_DUPLICATE_DISABLED_TOOLTIP
+            delete_button.tooltip = CHUNKING_DELETE_DISABLED_TOOLTIP
+            export_button.tooltip = CHUNKING_EXPORT_DISABLED_TOOLTIP
+            return
+
+        edit_button.tooltip = (
+            CHUNKING_EDIT_BUILTIN_TOOLTIP if is_system else CHUNKING_EDIT_ENABLED_TOOLTIP
+        )
+        duplicate_button.tooltip = CHUNKING_DUPLICATE_ENABLED_TOOLTIP
+        delete_button.tooltip = (
+            CHUNKING_DELETE_BUILTIN_TOOLTIP if is_system else CHUNKING_DELETE_ENABLED_TOOLTIP
+        )
+        export_button.tooltip = CHUNKING_EXPORT_ENABLED_TOOLTIP
     
     def watch_filter_text(self, old_text: str, new_text: str) -> None:
         """React to filter text changes."""

--- a/tldw_chatbook/Widgets/template_selector.py
+++ b/tldw_chatbook/Widgets/template_selector.py
@@ -23,6 +23,15 @@ from textual.widgets import (
 )
 from loguru import logger
 
+
+TEMPLATE_CREATE_DISABLED_TOOLTIP = "Select an evaluation template before creating a task."
+TEMPLATE_EXPORT_DISABLED_TOOLTIP = "Select an evaluation template before exporting it."
+TEMPLATE_CREATE_ENABLED_TOOLTIP = "Create an evaluation task from this template."
+TEMPLATE_EXPORT_ENABLED_TOOLTIP = "Export this evaluation template."
+TEMPLATE_SELECT_DISABLED_TOOLTIP = "Select an evaluation template before continuing."
+TEMPLATE_SELECT_ENABLED_TOOLTIP = "Use the selected evaluation template."
+
+
 class TemplatePreviewWidget(Container):
     """Widget for displaying template preview information."""
     
@@ -38,8 +47,19 @@ class TemplatePreviewWidget(Container):
             yield Static("", id="config-display", classes="config-display")
         
         with Horizontal(classes="preview-actions"):
-            yield Button("Create Task", id="create-task-btn", variant="primary", disabled=True)
-            yield Button("Export Template", id="export-template-btn", disabled=True)
+            yield Button(
+                "Create Task",
+                id="create-task-btn",
+                variant="primary",
+                disabled=True,
+                tooltip=TEMPLATE_CREATE_DISABLED_TOOLTIP,
+            )
+            yield Button(
+                "Export Template",
+                id="export-template-btn",
+                disabled=True,
+                tooltip=TEMPLATE_EXPORT_DISABLED_TOOLTIP,
+            )
     
     def update_preview(self, template: Dict[str, Any]):
         """Update the preview with template information."""
@@ -66,8 +86,7 @@ class TemplatePreviewWidget(Container):
             config_widget.update(config_text)
             
             # Enable buttons
-            self.query_one("#create-task-btn").disabled = False
-            self.query_one("#export-template-btn").disabled = False
+            self._set_action_state(has_template=True)
             
         except Exception as e:
             logger.error(f"Error updating template preview: {e}")
@@ -79,10 +98,27 @@ class TemplatePreviewWidget(Container):
         try:
             self.query_one("#template-description").update("Select a template to see details")
             self.query_one("#config-display").update("")
-            self.query_one("#create-task-btn").disabled = True
-            self.query_one("#export-template-btn").disabled = True
+            self._set_action_state(has_template=False)
         except:
             pass
+
+    def _set_action_state(self, *, has_template: bool) -> None:
+        """Keep disabled preview actions paired with the required next step."""
+        create_button = self.query_one("#create-task-btn", Button)
+        create_button.disabled = not has_template
+        create_button.tooltip = (
+            TEMPLATE_CREATE_ENABLED_TOOLTIP
+            if has_template
+            else TEMPLATE_CREATE_DISABLED_TOOLTIP
+        )
+
+        export_button = self.query_one("#export-template-btn", Button)
+        export_button.disabled = not has_template
+        export_button.tooltip = (
+            TEMPLATE_EXPORT_ENABLED_TOOLTIP
+            if has_template
+            else TEMPLATE_EXPORT_DISABLED_TOOLTIP
+        )
 
 class TemplateListWidget(Container):
     """Widget for displaying template lists organized by category."""
@@ -223,7 +259,13 @@ class TemplateSelectorDialog(ModalScreen):
             
             with Horizontal(classes="dialog-buttons"):
                 yield Button("Cancel", id="cancel-button", variant="error")
-                yield Button("Select Template", id="select-button", variant="primary", disabled=True)
+                yield Button(
+                    "Select Template",
+                    id="select-button",
+                    variant="primary",
+                    disabled=True,
+                    tooltip=TEMPLATE_SELECT_DISABLED_TOOLTIP,
+                )
     
     def _on_template_selected(self, template: Dict[str, Any]):
         """Handle template selection."""
@@ -238,7 +280,9 @@ class TemplateSelectorDialog(ModalScreen):
         
         # Enable select button
         try:
-            self.query_one("#select-button").disabled = False
+            select_button = self.query_one("#select-button", Button)
+            select_button.disabled = False
+            select_button.tooltip = TEMPLATE_SELECT_ENABLED_TOOLTIP
         except:
             pass
     

--- a/tldw_chatbook/Widgets/transcription_history_viewer.py
+++ b/tldw_chatbook/Widgets/transcription_history_viewer.py
@@ -25,6 +25,14 @@ from ..Widgets.enhanced_file_picker import EnhancedFileSave as FileSave
 from ..Third_Party.textual_fspicker import Filters
 
 
+TRANSCRIPTION_COPY_DISABLED_TOOLTIP = "Select a transcription entry before copying text."
+TRANSCRIPTION_EXPORT_DISABLED_TOOLTIP = "Select a transcription entry before exporting it."
+TRANSCRIPTION_DELETE_DISABLED_TOOLTIP = "Select a transcription entry before deleting it."
+TRANSCRIPTION_COPY_ENABLED_TOOLTIP = "Copy the selected transcription text."
+TRANSCRIPTION_EXPORT_ENABLED_TOOLTIP = "Export the selected transcription entry."
+TRANSCRIPTION_DELETE_ENABLED_TOOLTIP = "Delete the selected transcription entry."
+
+
 class TranscriptionHistoryViewer(Widget):
     """
     Widget for viewing and managing transcription history.
@@ -117,9 +125,8 @@ class TranscriptionHistoryViewer(Widget):
     }
     
     .encryption-status {
-        padding: 0.5 1;
+        padding: 1;
         margin-bottom: 1;
-        border-radius: 3;
     }
     
     .encryption-status.encrypted {
@@ -229,9 +236,25 @@ class TranscriptionHistoryViewer(Widget):
                     
                     # Action buttons
                     with Horizontal(classes="action-buttons"):
-                        yield Button("📋 Copy", id="copy-btn", disabled=True)
-                        yield Button("💾 Export", id="export-btn", disabled=True)
-                        yield Button("🗑️ Delete", id="delete-btn", disabled=True, variant="error")
+                        yield Button(
+                            "📋 Copy",
+                            id="copy-btn",
+                            disabled=True,
+                            tooltip=TRANSCRIPTION_COPY_DISABLED_TOOLTIP,
+                        )
+                        yield Button(
+                            "💾 Export",
+                            id="export-btn",
+                            disabled=True,
+                            tooltip=TRANSCRIPTION_EXPORT_DISABLED_TOOLTIP,
+                        )
+                        yield Button(
+                            "🗑️ Delete",
+                            id="delete-btn",
+                            disabled=True,
+                            variant="error",
+                            tooltip=TRANSCRIPTION_DELETE_DISABLED_TOOLTIP,
+                        )
     
     def on_mount(self):
         """Initialize on mount."""
@@ -388,10 +411,28 @@ class TranscriptionHistoryViewer(Widget):
         text_area = self.query_one("#transcript-text", TextArea)
         text_area.load_text(entry.transcript)
         
-        # Enable action buttons
-        self.query_one("#copy-btn", Button).disabled = False
-        self.query_one("#export-btn", Button).disabled = False
-        self.query_one("#delete-btn", Button).disabled = False
+        self._update_action_button_state(has_selection=True)
+
+    def _update_action_button_state(self, *, has_selection: bool) -> None:
+        """Keep disabled controls explanatory instead of silent."""
+        button_states = {
+            "#copy-btn": (
+                TRANSCRIPTION_COPY_ENABLED_TOOLTIP,
+                TRANSCRIPTION_COPY_DISABLED_TOOLTIP,
+            ),
+            "#export-btn": (
+                TRANSCRIPTION_EXPORT_ENABLED_TOOLTIP,
+                TRANSCRIPTION_EXPORT_DISABLED_TOOLTIP,
+            ),
+            "#delete-btn": (
+                TRANSCRIPTION_DELETE_ENABLED_TOOLTIP,
+                TRANSCRIPTION_DELETE_DISABLED_TOOLTIP,
+            ),
+        }
+        for selector, (enabled_tooltip, disabled_tooltip) in button_states.items():
+            button = self.query_one(selector, Button)
+            button.disabled = not has_selection
+            button.tooltip = enabled_tooltip if has_selection else disabled_tooltip
     
     def on_button_pressed(self, event: Button.Pressed) -> None:
         """Handle button presses."""
@@ -485,6 +526,7 @@ class TranscriptionHistoryViewer(Widget):
             self.app.notify("Entry deleted")
             self.selected_entry = None
             self.selected_entry_id = None
+            self._update_action_button_state(has_selection=False)
             self.run_worker(self._refresh_entries())
         else:
             self.app.notify("Failed to delete entry", severity="error")


### PR DESCRIPTION
## Summary
- Add selection-recovery tooltips for transcription history actions, evaluation template selection, and chunking template actions.
- Update enabled-state tooltip copy so controls explain their action after a valid selection.
- Fix transcription history Textual CSS that prevented isolated widget mounting.
- Rebaseline the UX remediation plan after merged PRs #198, #199, and #200.

## Verification
- env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_disabled_action_recovery_tooltips.py Tests/UI/test_chunking_templates_widget_parity.py Tests/UI/test_ux_audit_smoke.py --tb=short
- git diff --cached --check