### PR TITLE
Add Chatbook action recovery tooltips

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -1,8 +1,8 @@
 # UX Audit Remediation Plan
 
 Date: 2026-05-01
-Status: Current-dev rebaseline after UX remediation PRs #146-#200, plus active disabled-action recovery tooltip slice
-Branch context: current `origin/dev` at `6f6a31e3`; active branch `codex/ux-disabled-template-history-tooltips`
+Status: Current-dev rebaseline after UX remediation PRs #146-#201, plus active Chatbook action recovery tooltip slice
+Branch context: current `origin/dev` at `1017cfc2`; active branch `codex/ux-disabled-action-tooltips-followup`
 Previous audit baseline: `e2576cae`
 
 ## Goal
@@ -29,7 +29,7 @@ This is not a visual refresh. The work is ordered around workflow completion, re
 
 ## Current Dev Rebaseline
 
-Rebaselined on current `dev` at `6f6a31e3`:
+Rebaselined on current `dev` at `1017cfc2`:
 
 - Phase 0 and Phase 1 are merged: the shared shell/Chatbooks trap, Ingest default source, quiz empty mapping response, Chat save-state, Search/RAG thread mutation, and Search primary-action reachability regressions are covered.
 - Phase 2 is merged: Chat has provider readiness and first-run orientation coverage.
@@ -87,7 +87,8 @@ Current source state plus this branch:
 - Phase 5 bulk-selection control tooltips are merged through PR #198: Evals, Notes, tags, multi-item review, and Mindmap source selection explain what each select/clear action affects.
 - Phase 5 browse/import/file-picker tooltips are merged through PR #199: file selection and import controls explain what kind of files or folders they operate on.
 - Phase 5 LLM/runtime browse tooltips are merged through PR #200: runtime executable/model/path browse controls explain the expected artifact before opening a picker.
-- Phase 5 disabled-action recovery tooltips are active in `codex/ux-disabled-template-history-tooltips`: transcription history, evaluation template preview/selection, and chunking template actions explain selection or built-in-template prerequisites.
+- Phase 5 disabled-action recovery tooltips are merged through PR #201: transcription history, evaluation template preview/selection, and chunking template actions explain selection or built-in-template prerequisites.
+- Phase 5 Chatbook action recovery tooltips are active in `codex/ux-disabled-action-tooltips-followup`: Chatbook template selection, exported-pack toolbar actions, and server-job actions explain selection and job-state prerequisites.
 - Phase 6 still needs any remaining optional dependency gaps represented as user-facing capability states where relevant.
 - Phase 7 clean-home audit replay was captured at `6c0d2469` under `/private/tmp/tldw-chatbook-ux-remediation-verify/` before merging PRs #192 and #193; live external API/server paths remain documented uncertainty.
 
@@ -337,7 +338,7 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 
 Purpose: make the app understandable without reducing expert efficiency.
 
-Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, #163, #164, #165, #166, #167, #168, #169, #170, #171, #172, #173, #174, #185, #186, #187, #188, #189, #191, #192, #193, #194, #196, #197, #198, #199, and #200, with disabled-action recovery cleanup active in `codex/ux-disabled-template-history-tooltips`. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, Speech/STTS exposes local dependency capability states, Web Search missing dependencies render as disabled-state recovery copy, Media Source disabled actions expose recovery tooltips, Study Quiz disabled actions expose recovery tooltips, Study Flashcards disabled actions expose recovery tooltips, Study dashboard Resume action recovery is merged through PR #185, Study quiz Start action recovery is merged through PR #186, Study quiz Review in Chat recovery/handoff is merged through PR #187, Study section-bar compact label tooltips are merged through PR #188, Chatbooks view-toggle compact label tooltips are merged through PR #189, Mindmap compact-control tooltips are merged through PR #192, SmartContentTree compact-control tooltips are merged through PR #193, Media Details content-search tooltips are merged through PR #194, Embeddings batch-control tooltips are merged through PR #196, Embedding Wizard selector tooltips are merged through PR #197, bulk-selection control tooltips are merged through PR #198, browse/import/file-picker tooltips are merged through PR #199, LLM/runtime browse tooltips are merged through PR #200, Media Viewer actions expose selection/capability tooltips, Media Analysis actions expose generated-analysis/saved-version tooltips, Media Highlight actions expose selected-highlight tooltips, Media Analysis navigation actions expose saved-version boundary tooltips, Search/RAG saved-search actions expose selection/reuse recovery, Media list pagination exposes result-page boundary tooltips, and Media multi-item review actions expose generation/cancellation state tooltips.
+Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, #163, #164, #165, #166, #167, #168, #169, #170, #171, #172, #173, #174, #185, #186, #187, #188, #189, #191, #192, #193, #194, #196, #197, #198, #199, #200, and #201, with Chatbook action recovery cleanup active in `codex/ux-disabled-action-tooltips-followup`. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, Speech/STTS exposes local dependency capability states, Web Search missing dependencies render as disabled-state recovery copy, Media Source disabled actions expose recovery tooltips, Study Quiz disabled actions expose recovery tooltips, Study Flashcards disabled actions expose recovery tooltips, Study dashboard Resume action recovery is merged through PR #185, Study quiz Start action recovery is merged through PR #186, Study quiz Review in Chat recovery/handoff is merged through PR #187, Study section-bar compact label tooltips are merged through PR #188, Chatbooks view-toggle compact label tooltips are merged through PR #189, Mindmap compact-control tooltips are merged through PR #192, SmartContentTree compact-control tooltips are merged through PR #193, Media Details content-search tooltips are merged through PR #194, Embeddings batch-control tooltips are merged through PR #196, Embedding Wizard selector tooltips are merged through PR #197, bulk-selection control tooltips are merged through PR #198, browse/import/file-picker tooltips are merged through PR #199, LLM/runtime browse tooltips are merged through PR #200, transcription/template-management disabled action recovery is merged through PR #201, Media Viewer actions expose selection/capability tooltips, Media Analysis actions expose generated-analysis/saved-version tooltips, Media Highlight actions expose selected-highlight tooltips, Media Analysis navigation actions expose saved-version boundary tooltips, Search/RAG saved-search actions expose selection/reuse recovery, Media list pagination exposes result-page boundary tooltips, and Media multi-item review actions expose generation/cancellation state tooltips.
 
 ### Files
 
@@ -388,6 +389,7 @@ Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #
 - [x] Add browse/import/file-picker tooltips for file and folder selection actions.
 - [x] Add LLM/runtime browse tooltips for executable, model, script, and path controls.
 - [x] Add disabled-action recovery tooltips for transcription history and template management selection states.
+- [x] Add disabled-action recovery tooltips for Chatbook template selection, exported-pack actions, and server-job states.
 - [ ] Add tooltips or short descriptions where compact labels remain necessary outside top navigation.
 
 ### Acceptance Criteria
@@ -490,4 +492,4 @@ Current-dev state: complete on local `dev` at `6c0d2469`. A clean-home Textual r
 
 ## Next Step
 
-After this disabled-action recovery tooltip slice, re-scan current `dev` for remaining visible disabled/no-op controls that still lack a reason or recovery path before starting broader work. Remaining Phase 4 work should focus on broader live audit replay or any non-handoff source actions where policy state can still block a visible action. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.
+After this Chatbook action recovery tooltip slice, re-scan current `dev` for remaining visible disabled/no-op controls that still lack a reason or recovery path before starting broader work. Remaining Phase 4 work should focus on broader live audit replay or any non-handoff source actions where policy state can still block a visible action. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.

--- a/Tests/UI/test_chatbook_action_recovery_tooltips.py
+++ b/Tests/UI/test_chatbook_action_recovery_tooltips.py
@@ -1,0 +1,169 @@
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Button
+
+from tldw_chatbook.UI.ChatbookExportManagementWindow import ChatbookExportManagementWindow
+from tldw_chatbook.UI.ChatbookTemplatesWindow import ChatbookTemplatesWindow
+
+
+def _assert_button_tooltips(root, expected_tooltips: dict[str, str]) -> None:
+    for button_id, expected_tooltip in expected_tooltips.items():
+        button = root.query_one(f"#{button_id}", Button)
+        assert str(button.tooltip) == expected_tooltip
+
+
+@pytest.mark.asyncio
+async def test_chatbook_template_use_action_explains_selection_requirement():
+    class TemplatesApp(App):
+        def compose(self) -> ComposeResult:
+            yield ChatbookTemplatesWindow(SimpleNamespace())
+
+    app = TemplatesApp()
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        window = app.query_one(ChatbookTemplatesWindow)
+
+        _assert_button_tooltips(
+            window,
+            {"use-template": "Select a Chatbook template before using it."},
+        )
+
+        await window._select_template("research_project")
+
+        _assert_button_tooltips(
+            window,
+            {"use-template": "Create a Chatbook from the selected template."},
+        )
+
+
+@pytest.mark.asyncio
+async def test_chatbook_export_toolbar_actions_explain_selected_pack_requirement(monkeypatch, tmp_path):
+    async def no_refresh(self):
+        return None
+
+    async def no_load_details(self, index):
+        return None
+
+    monkeypatch.setattr(ChatbookExportManagementWindow, "refresh_chatbook_list", no_refresh)
+    monkeypatch.setattr(ChatbookExportManagementWindow, "refresh_server_job_list", no_refresh)
+    monkeypatch.setattr(ChatbookExportManagementWindow, "_load_chatbook_details", no_load_details)
+
+    class ManagementApp(App):
+        def __init__(self):
+            super().__init__()
+            self.config_data = {}
+            self.notify = Mock()
+
+        def compose(self) -> ComposeResult:
+            yield ChatbookExportManagementWindow(self)
+
+    app = ManagementApp()
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        window = app.query_one(ChatbookExportManagementWindow)
+
+        _assert_button_tooltips(
+            window,
+            {
+                "delete-selected": "Select an exported Chatbook before deleting it.",
+                "re-export": "Select an exported Chatbook before re-exporting it.",
+                "share-selected": "Select an exported Chatbook before sharing it.",
+                "open-location": "Select an exported Chatbook before opening its folder.",
+            },
+        )
+
+        window.chatbook_files = [
+            {
+                "name": "Research Pack",
+                "path": tmp_path / "Research Pack.chatbook.zip",
+                "size": 1024,
+                "created": datetime(2026, 4, 20, 9, 0),
+                "modified": datetime(2026, 4, 20, 9, 0),
+            }
+        ]
+        await window.on_option_list_option_selected(SimpleNamespace(option_id="0"))
+
+        _assert_button_tooltips(
+            window,
+            {
+                "delete-selected": "Delete the selected exported Chatbook.",
+                "re-export": "Re-export the selected Chatbook.",
+                "share-selected": "Share the selected Chatbook.",
+                "open-location": "Open the selected Chatbook location.",
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_chatbook_server_job_actions_explain_job_state(monkeypatch):
+    async def no_refresh(self):
+        return None
+
+    monkeypatch.setattr(ChatbookExportManagementWindow, "refresh_chatbook_list", no_refresh)
+    monkeypatch.setattr(ChatbookExportManagementWindow, "refresh_server_job_list", no_refresh)
+
+    class ManagementApp(App):
+        def __init__(self):
+            super().__init__()
+            self.config_data = {}
+            self.notify = Mock()
+
+        def compose(self) -> ComposeResult:
+            yield ChatbookExportManagementWindow(self)
+
+    app = ManagementApp()
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        window = app.query_one(ChatbookExportManagementWindow)
+
+        _assert_button_tooltips(
+            window,
+            {
+                "cancel-server-job": "Select a running server Chatbook job before cancelling it.",
+                "download-server-job": "Select a completed server export job before downloading it.",
+                "remove-server-job": "Select a completed, failed, or cancelled server job before removing it.",
+            },
+        )
+
+        window._select_server_job_record(
+            {
+                "source": "server",
+                "job_type": "import",
+                "job_id": "import-1",
+                "status": "running",
+            }
+        )
+
+        _assert_button_tooltips(
+            window,
+            {
+                "cancel-server-job": "Cancel the selected running server Chatbook job.",
+                "download-server-job": "Only completed server export jobs can be downloaded.",
+                "remove-server-job": "Only completed, failed, or cancelled server jobs can be removed.",
+            },
+        )
+
+        window._select_server_job_record(
+            {
+                "source": "server",
+                "job_type": "export",
+                "job_id": "export-1",
+                "status": "completed",
+            }
+        )
+
+        _assert_button_tooltips(
+            window,
+            {
+                "cancel-server-job": "Completed server jobs cannot be cancelled.",
+                "download-server-job": "Download the selected server Chatbook export.",
+                "remove-server-job": "Remove the selected completed server job record.",
+            },
+        )

--- a/tldw_chatbook/UI/ChatbookExportManagementWindow.py
+++ b/tldw_chatbook/UI/ChatbookExportManagementWindow.py
@@ -56,6 +56,24 @@ TERMINAL_SERVER_JOB_STATUSES = {
 
 DOWNLOADABLE_SERVER_JOB_STATUSES = {"completed", "success"}
 
+CHATBOOK_EXPORT_DELETE_DISABLED_TOOLTIP = "Select an exported Chatbook before deleting it."
+CHATBOOK_EXPORT_REEXPORT_DISABLED_TOOLTIP = "Select an exported Chatbook before re-exporting it."
+CHATBOOK_EXPORT_SHARE_DISABLED_TOOLTIP = "Select an exported Chatbook before sharing it."
+CHATBOOK_EXPORT_OPEN_DISABLED_TOOLTIP = "Select an exported Chatbook before opening its folder."
+CHATBOOK_EXPORT_DELETE_ENABLED_TOOLTIP = "Delete the selected exported Chatbook."
+CHATBOOK_EXPORT_REEXPORT_ENABLED_TOOLTIP = "Re-export the selected Chatbook."
+CHATBOOK_EXPORT_SHARE_ENABLED_TOOLTIP = "Share the selected Chatbook."
+CHATBOOK_EXPORT_OPEN_ENABLED_TOOLTIP = "Open the selected Chatbook location."
+
+SERVER_JOB_CANCEL_DISABLED_TOOLTIP = "Select a running server Chatbook job before cancelling it."
+SERVER_JOB_DOWNLOAD_DISABLED_TOOLTIP = "Select a completed server export job before downloading it."
+SERVER_JOB_REMOVE_DISABLED_TOOLTIP = "Select a completed, failed, or cancelled server job before removing it."
+SERVER_JOB_REQUIRES_SERVER_TOOLTIP = "Server job actions require a server-owned Chatbook job."
+SERVER_JOB_CANCEL_ENABLED_TOOLTIP = "Cancel the selected running server Chatbook job."
+SERVER_JOB_DOWNLOAD_ENABLED_TOOLTIP = "Download the selected server Chatbook export."
+SERVER_JOB_DOWNLOAD_INELIGIBLE_TOOLTIP = "Only completed server export jobs can be downloaded."
+SERVER_JOB_REMOVE_INELIGIBLE_TOOLTIP = "Only completed, failed, or cancelled server jobs can be removed."
+
 
 class ChatbookExportManagementWindow(ModalScreen):
     """Window for managing exported chatbooks."""
@@ -297,10 +315,34 @@ class ChatbookExportManagementWindow(ModalScreen):
             with Container(classes="toolbar"):
                 with Horizontal(classes="toolbar-buttons"):
                     yield Button("🔄 Refresh", id="refresh-list", variant="default")
-                    yield Button("🗑️ Delete", id="delete-selected", variant="warning", disabled=True)
-                    yield Button("📤 Re-export", id="re-export", variant="default", disabled=True)
-                    yield Button("🔗 Share", id="share-selected", variant="default", disabled=True)
-                    yield Button("📁 Open Location", id="open-location", variant="default", disabled=True)
+                    yield Button(
+                        "🗑️ Delete",
+                        id="delete-selected",
+                        variant="warning",
+                        disabled=True,
+                        tooltip=CHATBOOK_EXPORT_DELETE_DISABLED_TOOLTIP,
+                    )
+                    yield Button(
+                        "📤 Re-export",
+                        id="re-export",
+                        variant="default",
+                        disabled=True,
+                        tooltip=CHATBOOK_EXPORT_REEXPORT_DISABLED_TOOLTIP,
+                    )
+                    yield Button(
+                        "🔗 Share",
+                        id="share-selected",
+                        variant="default",
+                        disabled=True,
+                        tooltip=CHATBOOK_EXPORT_SHARE_DISABLED_TOOLTIP,
+                    )
+                    yield Button(
+                        "📁 Open Location",
+                        id="open-location",
+                        variant="default",
+                        disabled=True,
+                        tooltip=CHATBOOK_EXPORT_OPEN_DISABLED_TOOLTIP,
+                    )
             
             # Main content area
             with Container(classes="main-content"):
@@ -321,9 +363,27 @@ class ChatbookExportManagementWindow(ModalScreen):
                             zebra_stripes=True,
                         )
                         with Horizontal(classes="server-job-actions"):
-                            yield Button("Cancel Job", id="cancel-server-job", variant="warning", disabled=True)
-                            yield Button("Download", id="download-server-job", variant="primary", disabled=True)
-                            yield Button("Remove Job", id="remove-server-job", variant="error", disabled=True)
+                            yield Button(
+                                "Cancel Job",
+                                id="cancel-server-job",
+                                variant="warning",
+                                disabled=True,
+                                tooltip=SERVER_JOB_CANCEL_DISABLED_TOOLTIP,
+                            )
+                            yield Button(
+                                "Download",
+                                id="download-server-job",
+                                variant="primary",
+                                disabled=True,
+                                tooltip=SERVER_JOB_DOWNLOAD_DISABLED_TOOLTIP,
+                            )
+                            yield Button(
+                                "Remove Job",
+                                id="remove-server-job",
+                                variant="error",
+                                disabled=True,
+                                tooltip=SERVER_JOB_REMOVE_DISABLED_TOOLTIP,
+                            )
                 
                 # Right: Details
                 with Container(classes="details-container"):
@@ -582,6 +642,56 @@ class ChatbookExportManagementWindow(ModalScreen):
         cancel_button.disabled = not (is_remote and has_job_id and not is_terminal)
         download_button.disabled = not (is_remote and has_job_id and is_export and is_downloadable)
         remove_button.disabled = not (is_remote and has_job_id and is_terminal)
+        self._update_server_job_action_tooltips(
+            is_remote=is_remote,
+            has_job_id=has_job_id,
+            status=status,
+            is_terminal=is_terminal,
+            is_downloadable=is_downloadable,
+            is_export=is_export,
+        )
+
+    def _update_server_job_action_tooltips(
+        self,
+        *,
+        is_remote: bool,
+        has_job_id: bool,
+        status: str,
+        is_terminal: bool,
+        is_downloadable: bool,
+        is_export: bool,
+    ) -> None:
+        cancel_button = self.query_one("#cancel-server-job", Button)
+        download_button = self.query_one("#download-server-job", Button)
+        remove_button = self.query_one("#remove-server-job", Button)
+
+        if not self.selected_server_job_record:
+            cancel_button.tooltip = SERVER_JOB_CANCEL_DISABLED_TOOLTIP
+            download_button.tooltip = SERVER_JOB_DOWNLOAD_DISABLED_TOOLTIP
+            remove_button.tooltip = SERVER_JOB_REMOVE_DISABLED_TOOLTIP
+            return
+
+        if not (is_remote and has_job_id):
+            cancel_button.tooltip = SERVER_JOB_REQUIRES_SERVER_TOOLTIP
+            download_button.tooltip = SERVER_JOB_REQUIRES_SERVER_TOOLTIP
+            remove_button.tooltip = SERVER_JOB_REQUIRES_SERVER_TOOLTIP
+            return
+
+        cancel_button.tooltip = (
+            SERVER_JOB_CANCEL_ENABLED_TOOLTIP
+            if not is_terminal
+            else f"{status.title()} server jobs cannot be cancelled."
+        )
+        download_button.tooltip = (
+            SERVER_JOB_DOWNLOAD_ENABLED_TOOLTIP
+            if is_export and is_downloadable
+            else SERVER_JOB_DOWNLOAD_INELIGIBLE_TOOLTIP
+        )
+        remove_button.tooltip = (
+            f"Remove the selected {status} server job record."
+            if is_terminal
+            else SERVER_JOB_REMOVE_INELIGIBLE_TOOLTIP
+        )
 
     async def _with_server_chatbook_service(self, operation):
         config = getattr(self.app_instance, "config_data", {}) or {}
@@ -740,10 +850,7 @@ class ChatbookExportManagementWindow(ModalScreen):
             self.selected_chatbook = index
             
             # Enable action buttons
-            self.query_one("#delete-selected", Button).disabled = False
-            self.query_one("#re-export", Button).disabled = False
-            self.query_one("#share-selected", Button).disabled = False
-            self.query_one("#open-location", Button).disabled = False
+            self._update_selected_chatbook_action_buttons(has_selection=True)
             
             # Load and display details
             await self._load_chatbook_details(index)
@@ -883,10 +990,7 @@ class ChatbookExportManagementWindow(ModalScreen):
                 self.query_one("#details-content", Container).display = False
                 
                 # Disable buttons
-                self.query_one("#delete-selected", Button).disabled = True
-                self.query_one("#re-export", Button).disabled = True
-                self.query_one("#share-selected", Button).disabled = True
-                self.query_one("#open-location", Button).disabled = True
+                self._update_selected_chatbook_action_buttons(has_selection=False)
                 
                 self.app_instance.notify(f"Deleted '{chatbook['name']}'", severity="success")
                 
@@ -899,6 +1003,30 @@ class ChatbookExportManagementWindow(ModalScreen):
         # For now, just show notification
         # In future, could launch creation wizard with pre-filled selections
         self.app_instance.notify("Re-export functionality coming soon!", severity="info")
+
+    def _update_selected_chatbook_action_buttons(self, *, has_selection: bool) -> None:
+        button_states = {
+            "#delete-selected": (
+                CHATBOOK_EXPORT_DELETE_ENABLED_TOOLTIP,
+                CHATBOOK_EXPORT_DELETE_DISABLED_TOOLTIP,
+            ),
+            "#re-export": (
+                CHATBOOK_EXPORT_REEXPORT_ENABLED_TOOLTIP,
+                CHATBOOK_EXPORT_REEXPORT_DISABLED_TOOLTIP,
+            ),
+            "#share-selected": (
+                CHATBOOK_EXPORT_SHARE_ENABLED_TOOLTIP,
+                CHATBOOK_EXPORT_SHARE_DISABLED_TOOLTIP,
+            ),
+            "#open-location": (
+                CHATBOOK_EXPORT_OPEN_ENABLED_TOOLTIP,
+                CHATBOOK_EXPORT_OPEN_DISABLED_TOOLTIP,
+            ),
+        }
+        for selector, (enabled_tooltip, disabled_tooltip) in button_states.items():
+            button = self.query_one(selector, Button)
+            button.disabled = not has_selection
+            button.tooltip = enabled_tooltip if has_selection else disabled_tooltip
     
     async def _open_location(self) -> None:
         """Open the folder containing the chatbook."""

--- a/tldw_chatbook/UI/ChatbookTemplatesWindow.py
+++ b/tldw_chatbook/UI/ChatbookTemplatesWindow.py
@@ -22,6 +22,10 @@ if TYPE_CHECKING:
     from ..app import TldwCli
 
 
+CHATBOOK_TEMPLATE_USE_DISABLED_TOOLTIP = "Select a Chatbook template before using it."
+CHATBOOK_TEMPLATE_USE_ENABLED_TOOLTIP = "Create a Chatbook from the selected template."
+
+
 class ChatbookTemplate:
     """Represents a chatbook template."""
     
@@ -297,7 +301,13 @@ class ChatbookTemplatesWindow(ModalScreen):
             
             # Action buttons
             with Container(classes="action-buttons"):
-                yield Button("Use Template", id="use-template", variant="primary", disabled=True)
+                yield Button(
+                    "Use Template",
+                    id="use-template",
+                    variant="primary",
+                    disabled=True,
+                    tooltip=CHATBOOK_TEMPLATE_USE_DISABLED_TOOLTIP,
+                )
                 yield Button("Cancel", id="cancel", variant="default")
     
     async def on_mount(self) -> None:
@@ -351,7 +361,9 @@ class ChatbookTemplatesWindow(ModalScreen):
         self._update_details(template)
         
         # Enable use button
-        self.query_one("#use-template", Button).disabled = False
+        use_button = self.query_one("#use-template", Button)
+        use_button.disabled = False
+        use_button.tooltip = CHATBOOK_TEMPLATE_USE_ENABLED_TOOLTIP
     
     def _update_details(self, template: Optional[ChatbookTemplate]) -> None:
         """Update the details panel."""


### PR DESCRIPTION
## Summary
- Add selection-recovery and enabled-state tooltips for Chatbook template usage.
- Add recovery/enabled tooltips for exported Chatbook delete, re-export, share, and open-location actions.
- Add job-state-specific tooltips for Chatbook server job cancel, download, and remove actions.
- Rebaseline the UX remediation plan after merged PR #201 and mark this Chatbook slice as active.

## Verification
- env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_chatbook_action_recovery_tooltips.py Tests/UI/test_chatbook_management_server_jobs.py Tests/UI/test_chatbooks_screen_server_actions.py Tests/UI/test_ux_audit_smoke.py --tb=short
- git diff --cached --check