### PR TITLE
Add tag action recovery tooltips

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
+++ b/Docs/superpowers/plans/2026-05-01-ux-audit-remediation.md
@@ -1,8 +1,8 @@
 # UX Audit Remediation Plan
 
 Date: 2026-05-01
-Status: Current-dev rebaseline after UX remediation PRs #146-#201, plus active Chatbook action recovery tooltip slice
-Branch context: current `origin/dev` at `1017cfc2`; active branch `codex/ux-disabled-action-tooltips-followup`
+Status: Current-dev rebaseline after UX remediation PRs #146-#202, plus active tag-management action recovery tooltip slice
+Branch context: current `origin/dev` at `d24268ae`; active branch `codex/ux-tag-action-tooltips`
 Previous audit baseline: `e2576cae`
 
 ## Goal
@@ -29,7 +29,7 @@ This is not a visual refresh. The work is ordered around workflow completion, re
 
 ## Current Dev Rebaseline
 
-Rebaselined on current `dev` at `1017cfc2`:
+Rebaselined on current `dev` at `d24268ae`:
 
 - Phase 0 and Phase 1 are merged: the shared shell/Chatbooks trap, Ingest default source, quiz empty mapping response, Chat save-state, Search/RAG thread mutation, and Search primary-action reachability regressions are covered.
 - Phase 2 is merged: Chat has provider readiness and first-run orientation coverage.
@@ -88,7 +88,8 @@ Current source state plus this branch:
 - Phase 5 browse/import/file-picker tooltips are merged through PR #199: file selection and import controls explain what kind of files or folders they operate on.
 - Phase 5 LLM/runtime browse tooltips are merged through PR #200: runtime executable/model/path browse controls explain the expected artifact before opening a picker.
 - Phase 5 disabled-action recovery tooltips are merged through PR #201: transcription history, evaluation template preview/selection, and chunking template actions explain selection or built-in-template prerequisites.
-- Phase 5 Chatbook action recovery tooltips are active in `codex/ux-disabled-action-tooltips-followup`: Chatbook template selection, exported-pack toolbar actions, and server-job actions explain selection and job-state prerequisites.
+- Phase 5 Chatbook action recovery tooltips are merged through PR #202: Chatbook template selection, exported-pack toolbar actions, and server-job actions explain selection and job-state prerequisites.
+- Phase 5 tag-management action recovery tooltips are active in `codex/ux-tag-action-tooltips`: Library tag Rename, Merge, and Delete actions explain exact selection requirements and enabled actions.
 - Phase 6 still needs any remaining optional dependency gaps represented as user-facing capability states where relevant.
 - Phase 7 clean-home audit replay was captured at `6c0d2469` under `/private/tmp/tldw-chatbook-ux-remediation-verify/` before merging PRs #192 and #193; live external API/server paths remain documented uncertainty.
 
@@ -338,7 +339,7 @@ Current-dev state: Notes, Workspace details/notes/sources/artifacts, Media, RAG 
 
 Purpose: make the app understandable without reducing expert efficiency.
 
-Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, #163, #164, #165, #166, #167, #168, #169, #170, #171, #172, #173, #174, #185, #186, #187, #188, #189, #191, #192, #193, #194, #196, #197, #198, #199, #200, and #201, with Chatbook action recovery cleanup active in `codex/ux-disabled-action-tooltips-followup`. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, Speech/STTS exposes local dependency capability states, Web Search missing dependencies render as disabled-state recovery copy, Media Source disabled actions expose recovery tooltips, Study Quiz disabled actions expose recovery tooltips, Study Flashcards disabled actions expose recovery tooltips, Study dashboard Resume action recovery is merged through PR #185, Study quiz Start action recovery is merged through PR #186, Study quiz Review in Chat recovery/handoff is merged through PR #187, Study section-bar compact label tooltips are merged through PR #188, Chatbooks view-toggle compact label tooltips are merged through PR #189, Mindmap compact-control tooltips are merged through PR #192, SmartContentTree compact-control tooltips are merged through PR #193, Media Details content-search tooltips are merged through PR #194, Embeddings batch-control tooltips are merged through PR #196, Embedding Wizard selector tooltips are merged through PR #197, bulk-selection control tooltips are merged through PR #198, browse/import/file-picker tooltips are merged through PR #199, LLM/runtime browse tooltips are merged through PR #200, transcription/template-management disabled action recovery is merged through PR #201, Media Viewer actions expose selection/capability tooltips, Media Analysis actions expose generated-analysis/saved-version tooltips, Media Highlight actions expose selected-highlight tooltips, Media Analysis navigation actions expose saved-version boundary tooltips, Search/RAG saved-search actions expose selection/reuse recovery, Media list pagination exposes result-page boundary tooltips, and Media multi-item review actions expose generation/cancellation state tooltips.
+Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #158, #159, #160, #161, #162, #163, #164, #165, #166, #167, #168, #169, #170, #171, #172, #173, #174, #185, #186, #187, #188, #189, #191, #192, #193, #194, #196, #197, #198, #199, #200, #201, and #202, with tag-management action recovery cleanup active in `codex/ux-tag-action-tooltips`. Top-level navigation labels now use `Library`, `Models`, and `Speech` while preserving route IDs, Media empty states now direct users to Ingest plus selected-item recovery actions, Study flashcard/quiz empty states distinguish no-content from unavailable runtime, Search/RAG empty states explain search modes, collections, and Chat handoffs, Notes empty states clarify local/server/workspace scope and creation/import routes, Library assets explain their Chat flow, Chatbooks clarifies portable context packs, blocked handoff recovery is clarified, invalid source-selection handoff controls are disabled with recovery copy, command-palette tab navigation aligns with the same IA names, compact main-navigation labels expose explanatory tooltips, Speech/STTS exposes local dependency capability states, Web Search missing dependencies render as disabled-state recovery copy, Media Source disabled actions expose recovery tooltips, Study Quiz disabled actions expose recovery tooltips, Study Flashcards disabled actions expose recovery tooltips, Study dashboard Resume action recovery is merged through PR #185, Study quiz Start action recovery is merged through PR #186, Study quiz Review in Chat recovery/handoff is merged through PR #187, Study section-bar compact label tooltips are merged through PR #188, Chatbooks view-toggle compact label tooltips are merged through PR #189, Mindmap compact-control tooltips are merged through PR #192, SmartContentTree compact-control tooltips are merged through PR #193, Media Details content-search tooltips are merged through PR #194, Embeddings batch-control tooltips are merged through PR #196, Embedding Wizard selector tooltips are merged through PR #197, bulk-selection control tooltips are merged through PR #198, browse/import/file-picker tooltips are merged through PR #199, LLM/runtime browse tooltips are merged through PR #200, transcription/template-management disabled action recovery is merged through PR #201, Chatbook action recovery is merged through PR #202, Media Viewer actions expose selection/capability tooltips, Media Analysis actions expose generated-analysis/saved-version tooltips, Media Highlight actions expose selected-highlight tooltips, Media Analysis navigation actions expose saved-version boundary tooltips, Search/RAG saved-search actions expose selection/reuse recovery, Media list pagination exposes result-page boundary tooltips, and Media multi-item review actions expose generation/cancellation state tooltips.
 
 ### Files
 
@@ -390,6 +391,7 @@ Branch state: partially merged through PRs #152, #153, #154, #155, #156, #157, #
 - [x] Add LLM/runtime browse tooltips for executable, model, script, and path controls.
 - [x] Add disabled-action recovery tooltips for transcription history and template management selection states.
 - [x] Add disabled-action recovery tooltips for Chatbook template selection, exported-pack actions, and server-job states.
+- [x] Add disabled-action recovery tooltips for Library tag Rename, Merge, and Delete selection states.
 - [ ] Add tooltips or short descriptions where compact labels remain necessary outside top navigation.
 
 ### Acceptance Criteria
@@ -492,4 +494,4 @@ Current-dev state: complete on local `dev` at `6c0d2469`. A clean-home Textual r
 
 ## Next Step
 
-After this Chatbook action recovery tooltip slice, re-scan current `dev` for remaining visible disabled/no-op controls that still lack a reason or recovery path before starting broader work. Remaining Phase 4 work should focus on broader live audit replay or any non-handoff source actions where policy state can still block a visible action. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.
+After this tag-management action recovery tooltip slice, re-scan current `dev` for remaining visible disabled/no-op controls that still lack a reason or recovery path before starting broader work. Remaining Phase 4 work should focus on broader live audit replay or any non-handoff source actions where policy state can still block a visible action. Phase 6 should only add more capability states where a missing optional dependency blocks a visible user workflow. Phase 7 live replay remains the higher-risk workflow-completion follow-up.

--- a/Tests/UI/test_tag_action_recovery_tooltips.py
+++ b/Tests/UI/test_tag_action_recovery_tooltips.py
@@ -1,0 +1,67 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Button
+
+from tldw_chatbook.Widgets.collections_tag_window import CollectionsTagWindow
+
+
+def _assert_button_tooltips(root, expected_tooltips: dict[str, str]) -> None:
+    for button_id, expected_tooltip in expected_tooltips.items():
+        button = root.query_one(f"#{button_id}", Button)
+        assert str(button.tooltip) == expected_tooltip
+
+
+@pytest.mark.asyncio
+async def test_tag_action_buttons_explain_selection_requirements_and_enabled_actions():
+    app_instance = SimpleNamespace(media_db=None, notify=Mock())
+
+    class TagWindowApp(App):
+        def compose(self) -> ComposeResult:
+            yield CollectionsTagWindow(app_instance=app_instance)
+
+    app = TagWindowApp()
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        window = app.query_one(CollectionsTagWindow)
+
+        _assert_button_tooltips(
+            window,
+            {
+                "rename-keyword": "Select exactly one keyword or tag before renaming.",
+                "merge-keywords": "Select at least two keywords or tags before merging.",
+                "delete-keywords": "Select one or more keywords or tags before deleting.",
+            },
+        )
+
+        window.selected_keywords = [
+            {"id": 1, "keyword": "research", "usage_count": 3},
+        ]
+        window.update_action_buttons()
+
+        _assert_button_tooltips(
+            window,
+            {
+                "rename-keyword": "Rename the selected keyword or tag.",
+                "merge-keywords": "Select at least two keywords or tags before merging.",
+                "delete-keywords": "Delete the selected keyword or tag.",
+            },
+        )
+
+        window.selected_keywords = [
+            {"id": 1, "keyword": "research", "usage_count": 3},
+            {"id": 2, "keyword": "notes", "usage_count": 5},
+        ]
+        window.update_action_buttons()
+
+        _assert_button_tooltips(
+            window,
+            {
+                "rename-keyword": "Select exactly one keyword or tag before renaming.",
+                "merge-keywords": "Merge the selected keywords or tags.",
+                "delete-keywords": "Delete the selected keywords or tags.",
+            },
+        )

--- a/tldw_chatbook/Widgets/collections_tag_window.py
+++ b/tldw_chatbook/Widgets/collections_tag_window.py
@@ -18,6 +18,15 @@ if TYPE_CHECKING:
     from ..app import TldwCli
 
 
+RENAME_KEYWORD_DISABLED_TOOLTIP = "Select exactly one keyword or tag before renaming."
+MERGE_KEYWORDS_DISABLED_TOOLTIP = "Select at least two keywords or tags before merging."
+DELETE_KEYWORDS_DISABLED_TOOLTIP = "Select one or more keywords or tags before deleting."
+RENAME_KEYWORD_ENABLED_TOOLTIP = "Rename the selected keyword or tag."
+MERGE_KEYWORDS_ENABLED_TOOLTIP = "Merge the selected keywords or tags."
+DELETE_KEYWORD_ENABLED_TOOLTIP = "Delete the selected keyword or tag."
+DELETE_KEYWORDS_ENABLED_TOOLTIP = "Delete the selected keywords or tags."
+
+
 class KeywordRenameDialog(ModalScreen):
     """Modal dialog for renaming a keyword."""
     
@@ -149,9 +158,27 @@ class CollectionsTagWindow(Container):
                 
                 # Action buttons
                 with Container(classes="action-buttons-container"):
-                    yield Button("Rename", id="rename-keyword", disabled=True, variant="primary")
-                    yield Button("Merge Selected", id="merge-keywords", disabled=True, variant="primary")
-                    yield Button("Delete Selected", id="delete-keywords", disabled=True, variant="error")
+                    yield Button(
+                        "Rename",
+                        id="rename-keyword",
+                        disabled=True,
+                        variant="primary",
+                        tooltip=RENAME_KEYWORD_DISABLED_TOOLTIP,
+                    )
+                    yield Button(
+                        "Merge Selected",
+                        id="merge-keywords",
+                        disabled=True,
+                        variant="primary",
+                        tooltip=MERGE_KEYWORDS_DISABLED_TOOLTIP,
+                    )
+                    yield Button(
+                        "Delete Selected",
+                        id="delete-keywords",
+                        disabled=True,
+                        variant="error",
+                        tooltip=DELETE_KEYWORDS_DISABLED_TOOLTIP,
+                    )
                     
                 # Keyword details
                 yield Label("Keyword Details", classes="section-title")
@@ -283,10 +310,31 @@ class CollectionsTagWindow(Container):
     def update_action_buttons(self) -> None:
         """Enable/disable action buttons based on selection."""
         count = len(self.selected_keywords)
-        
-        self.query_one("#rename-keyword", Button).disabled = count != 1
-        self.query_one("#merge-keywords", Button).disabled = count < 2
-        self.query_one("#delete-keywords", Button).disabled = count == 0
+
+        rename_button = self.query_one("#rename-keyword", Button)
+        rename_button.disabled = count != 1
+        rename_button.tooltip = (
+            RENAME_KEYWORD_ENABLED_TOOLTIP
+            if count == 1
+            else RENAME_KEYWORD_DISABLED_TOOLTIP
+        )
+
+        merge_button = self.query_one("#merge-keywords", Button)
+        merge_button.disabled = count < 2
+        merge_button.tooltip = (
+            MERGE_KEYWORDS_ENABLED_TOOLTIP
+            if count >= 2
+            else MERGE_KEYWORDS_DISABLED_TOOLTIP
+        )
+
+        delete_button = self.query_one("#delete-keywords", Button)
+        delete_button.disabled = count == 0
+        if count == 0:
+            delete_button.tooltip = DELETE_KEYWORDS_DISABLED_TOOLTIP
+        elif count == 1:
+            delete_button.tooltip = DELETE_KEYWORD_ENABLED_TOOLTIP
+        else:
+            delete_button.tooltip = DELETE_KEYWORDS_ENABLED_TOOLTIP
         
     def update_keyword_details(self) -> None:
         """Update the keyword details display."""


### PR DESCRIPTION
## Summary
- Add disabled/enabled-state tooltips for Library tag Rename, Merge, and Delete actions.
- Cover zero, single, and multi-selection states with a mounted Textual regression.
- Rebaseline the UX remediation plan after merged PR #202 and mark this tag-action slice as active.

## Verification
- env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_tag_action_recovery_tooltips.py Tests/UI/test_bulk_selection_tooltips.py Tests/UI/test_ux_audit_smoke.py --tb=short
- git diff --cached --check