### PR TITLE
Harden master shell action affordances

### DIFF
--- a/Docs/Design/master-shell-design-system-contract.md
+++ b/Docs/Design/master-shell-design-system-contract.md
@@ -50,7 +50,7 @@ All new shell surfaces must support `.density-compact` and `.density-comfortable
 
 - Home and all primary destination wrappers use `.ds-destination-header` and `.ds-panel`.
 - Console renders pending live-work launch context with `.ds-panel` and a readable source/title label.
-- Static source/artifact/persona/skill actions stage `ChatHandoffPayload` context; live work from Watchlists+Collections, Schedules, Workflows, and ACP uses `open_console_for_live_work()`.
+- Static source/artifact/persona/skill actions stage `ChatHandoffPayload` context; live work from W+C, Schedules, Workflows, and ACP uses `open_console_for_live_work()`.
 - `tools_settings` resolves to MCP; global preferences are owned by Settings.
 
 ## Stop Conditions

--- a/Docs/Design/master-shell-route-inventory.md
+++ b/Docs/Design/master-shell-route-inventory.md
@@ -15,7 +15,7 @@ This inventory maps current routes and UI surfaces onto the approved master shel
 | Library | `notes`, `media`, `ingest`, `search`, `conversation`, conversation browsing | `LibraryScreen` plus legacy screens | Library | Wrapper links to source routes; staged source context uses Chat handoff payloads |
 | Artifacts | `chatbooks` | `ArtifactsScreen` plus `ChatbooksScreen` | Artifacts | Wrapper owns Chatbooks and generated/portable outputs; staged artifacts use Chat handoff payloads |
 | Personas | `ccp`, character/persona/prompt/lore subviews | `PersonasScreen` plus `ConversationScreen` | Personas | Personas owns behavior and identity management; staged persona context uses Chat handoff payloads |
-| Watchlists+Collections | `subscriptions` plus collections services | `WatchlistsCollectionsScreen` plus `SubscriptionScreen` | Watchlists+Collections | Wrapper separates Watchlists from Collections and can follow live work in Console |
+| W+C | `subscriptions` plus collections services | `WatchlistsCollectionsScreen` plus `SubscriptionScreen` | W+C | Wrapper separates Watchlists from Collections and can follow live work in Console |
 | Schedules | schedule surfaces | `SchedulesScreen` | Schedules | Wrapper owns when-runs and can follow timing/recovery work in Console |
 | Workflows | workflow surfaces | `WorkflowsScreen` | Workflows | Wrapper owns what-runs and can launch live work in Console |
 | MCP | `tools_settings`, tools/MCP settings | `MCPScreen` | MCP | Wrapper owns MCP tool/server capability control; `tools_settings` is an MCP alias, not global Settings |
@@ -31,7 +31,7 @@ This inventory maps current routes and UI surfaces onto the approved master shel
 | Chat route | `chat` | Console | Keep route ID; change user-facing label to Console |
 | Tools/settings route | `tools_settings` | MCP | Keep as legacy MCP alias, not global Settings |
 | Models shortcut | `llm` alias and `llm_management` tab ID | Legacy direct command | Keep alias to `TAB_LLM` until a later Models/MCP decision |
-| Subscription route | `subscription`, `subscriptions` | Watchlists+Collections | Keep both aliases |
+| Subscription route | `subscription`, `subscriptions` | W+C | Keep both aliases |
 
 ## Import/Export Boundary
 

--- a/Docs/superpowers/specs/2026-05-02-agentic-terminal-design-system-design.md
+++ b/Docs/superpowers/specs/2026-05-02-agentic-terminal-design-system-design.md
@@ -16,7 +16,7 @@ The system is two-layered:
 1. Product/UI grammar: principles, layout rules, status language, density, component behavior, and validation expectations.
 2. Textual/TCSS mapping: semantic tokens, reusable classes, state classes, component hooks, and migration constraints that fit the existing Textual app.
 
-This is not a theme-only refresh. It is the visual and interaction grammar for the approved master shell: `Home`, `Console`, `Library`, `Artifacts`, `Personas`, `Watchlists+Collections`, `Schedules`, `Workflows`, `MCP`, `ACP`, `Skills`, and `Settings`.
+This is not a theme-only refresh. It is the visual and interaction grammar for the approved master shell: `Home`, `Console`, `Library`, `Artifacts`, `Personas`, `W+C`, `Schedules`, `Workflows`, `MCP`, `ACP`, `Skills`, and `Settings`.
 
 ## Source Material
 
@@ -343,7 +343,7 @@ Source role chips label how a source or artifact will be used:
 
 Rules:
 
-- Role chips must appear in Console staged context, Library staging, Workflows, Artifacts reuse, and Watchlists+Collections send-to-Console flows.
+- Role chips must appear in Console staged context, Library staging, Workflows, Artifacts reuse, and W+C send-to-Console flows.
 - Role changes must be visible before launch/send.
 - Editable-target role must expose approval implications.
 
@@ -444,7 +444,7 @@ Recommended composition:
 - optional local inspector
 - one primary action
 
-Use for Library, Artifacts, Personas, Watchlists+Collections, MCP, ACP, Skills, and Settings where appropriate.
+Use for Library, Artifacts, Personas, W+C, MCP, ACP, Skills, and Settings where appropriate.
 
 ### Builder Or Wizard
 
@@ -492,7 +492,7 @@ Recommended composition:
 - authority badges
 - clear/edit/send-to-Console controls
 
-Use in Library, Artifacts, Workflows, Watchlists+Collections, and Console staged context.
+Use in Library, Artifacts, Workflows, W+C, and Console staged context.
 
 ### Layout Rules
 
@@ -633,7 +633,7 @@ Components must show readiness, active state, blockers, approvals, and source au
 
 ### Match Between System And Real World
 
-Labels must align with the approved master shell vocabulary: Home, Console, Library, Artifacts, Personas, Watchlists+Collections, Schedules, Workflows, MCP, ACP, Skills, and Settings.
+Labels must align with the approved master shell vocabulary: Home, Console, Library, Artifacts, Personas, W+C, Schedules, Workflows, MCP, ACP, Skills, and Settings.
 
 ### User Control And Freedom
 
@@ -693,7 +693,7 @@ Destination empty states and Home next-best actions should teach enough to compl
 
 - Adopt shared headers, panels, inspectors, tables, status badges, recovery callouts, and shortcut bars destination by destination.
 - Start with Home and Console because the master shell spec depends on them.
-- Continue through Library, Artifacts, Personas, Watchlists+Collections, Schedules, Workflows, MCP, ACP, Skills, and Settings.
+- Continue through Library, Artifacts, Personas, W+C, Schedules, Workflows, MCP, ACP, Skills, and Settings.
 
 ### Phase 5: Audit Replay
 

--- a/Tests/UI/test_destination_shells.py
+++ b/Tests/UI/test_destination_shells.py
@@ -55,6 +55,14 @@ def _static_text(widget: Static) -> str:
     return getattr(renderable, "plain", str(renderable))
 
 
+def _visible_text(screen) -> str:
+    return " ".join(
+        _static_text(widget)
+        for widget in screen.query(Static)
+        if hasattr(widget, "renderable")
+    )
+
+
 @pytest.mark.parametrize(
     ("route", "title_id", "purpose_text"),
     [
@@ -77,6 +85,21 @@ async def test_primary_destination_wrappers_mount(route, title_id, purpose_text)
         assert title.has_class("ds-destination-header")
         assert purpose_text in _static_text(screen.query_one(".destination-purpose", Static)).lower()
         assert screen.query_one(".ds-panel")
+
+
+@pytest.mark.asyncio
+async def test_watchlists_collections_uses_compact_title_and_clear_sections():
+    app = _build_test_app()
+    host = DestinationHarness(app, "watchlists_collections")
+
+    async with host.run_test(size=(160, 40)) as pilot:
+        await pilot.pause(0.1)
+        screen = _active_destination_screen(host)
+
+        assert _static_text(screen.query_one("#watchlists-collections-title", Static)) == "W+C"
+        visible_text = _visible_text(screen)
+        assert "Watchlists" in visible_text
+        assert "Collections" in visible_text
 
 
 @pytest.mark.asyncio
@@ -125,6 +148,22 @@ async def test_destination_action_buttons_emit_compatibility_routes(route, selec
     assert seen_routes[-1] == target_route
 
 
+@pytest.mark.parametrize("route", SCREEN_BY_ROUTE)
+@pytest.mark.asyncio
+async def test_destination_action_buttons_explain_their_outcome(route):
+    app = _build_test_app()
+    host = DestinationHarness(app, route)
+
+    async with host.run_test(size=(180, 40)) as pilot:
+        await pilot.pause(0.1)
+        screen = _active_destination_screen(host)
+
+        for button in screen.query(Button):
+            tooltip = getattr(button, "tooltip", None)
+            assert tooltip is not None, button.id
+            assert str(tooltip).strip().lower() not in {"", "none"}, button.id
+
+
 @pytest.mark.parametrize(
     ("route", "expected_sections"),
     [
@@ -142,11 +181,7 @@ async def test_automation_destination_wrappers_explain_ownership(route, expected
         await pilot.pause(0.1)
         screen = _active_destination_screen(host)
 
-        visible_text = " ".join(
-            _static_text(widget)
-            for widget in screen.query(Static)
-            if hasattr(widget, "renderable")
-        )
+        visible_text = _visible_text(screen)
         for section in expected_sections:
             assert section in visible_text
 
@@ -169,11 +204,7 @@ async def test_protocol_and_settings_wrappers_have_distinct_boundaries(route, ex
         await pilot.pause(0.1)
         screen = _active_destination_screen(host)
 
-        visible_text = " ".join(
-            _static_text(widget)
-            for widget in screen.query(Static)
-            if hasattr(widget, "renderable")
-        )
+        visible_text = _visible_text(screen)
         assert expected_text in visible_text
 
 
@@ -195,11 +226,7 @@ async def test_unwired_destination_actions_are_disabled_with_honest_copy(route, 
 
         button = screen.query_one(selector, Button)
         assert button.disabled is True
-        assert copy in " ".join(
-            _static_text(widget)
-            for widget in screen.query(Static)
-            if hasattr(widget, "renderable")
-        )
+        assert copy in _visible_text(screen)
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_destination_shells.py
+++ b/Tests/UI/test_destination_shells.py
@@ -59,7 +59,7 @@ def _visible_text(screen) -> str:
     return " ".join(
         _static_text(widget)
         for widget in screen.query(Static)
-        if hasattr(widget, "renderable")
+        if widget.display and hasattr(widget, "renderable")
     )
 
 

--- a/Tests/UI/test_master_shell_navigation.py
+++ b/Tests/UI/test_master_shell_navigation.py
@@ -26,7 +26,7 @@ async def test_master_shell_navigation_order_and_labels():
         ("nav-library", "Library"),
         ("nav-artifacts", "Artifacts"),
         ("nav-personas", "Personas"),
-        ("nav-watchlists_collections", "Watchlists+Collections"),
+        ("nav-watchlists_collections", "W+C"),
         ("nav-schedules", "Schedules"),
         ("nav-workflows", "Workflows"),
         ("nav-mcp", "MCP"),

--- a/Tests/UI/test_screen_navigation.py
+++ b/Tests/UI/test_screen_navigation.py
@@ -576,7 +576,7 @@ async def test_main_navigation_copy_and_order():
         ("nav-library", "Library"),
         ("nav-artifacts", "Artifacts"),
         ("nav-personas", "Personas"),
-        ("nav-watchlists_collections", "Watchlists+Collections"),
+        ("nav-watchlists_collections", "W+C"),
         ("nav-schedules", "Schedules"),
         ("nav-workflows", "Workflows"),
         ("nav-mcp", "MCP"),

--- a/Tests/UI/test_shell_destinations.py
+++ b/Tests/UI/test_shell_destinations.py
@@ -12,7 +12,7 @@ def test_master_shell_destination_order_matches_spec():
         "Library",
         "Artifacts",
         "Personas",
-        "Watchlists+Collections",
+        "W+C",
         "Schedules",
         "Workflows",
         "MCP",

--- a/tldw_chatbook/Constants.py
+++ b/tldw_chatbook/Constants.py
@@ -80,7 +80,7 @@ TAB_DISPLAY_LABELS = {
     TAB_LIBRARY: "Library",
     TAB_ARTIFACTS: "Artifacts",
     TAB_PERSONAS: "Personas",
-    TAB_WATCHLISTS_COLLECTIONS: "Watchlists+Collections",
+    TAB_WATCHLISTS_COLLECTIONS: "W+C",
     TAB_SCHEDULES: "Schedules",
     TAB_WORKFLOWS: "Workflows",
     TAB_MCP: "MCP",

--- a/tldw_chatbook/UI/Navigation/shell_destinations.py
+++ b/tldw_chatbook/UI/Navigation/shell_destinations.py
@@ -65,7 +65,7 @@ SHELL_DESTINATION_ORDER: tuple[ShellDestination, ...] = (
     ),
     ShellDestination(
         "watchlists_collections",
-        "Watchlists+Collections",
+        "W+C",
         "watchlists_collections",
         "Monitored sources and curated reading/content collections.",
         "Monitor feeds and curate collections.",

--- a/tldw_chatbook/UI/Screens/acp_screen.py
+++ b/tldw_chatbook/UI/Screens/acp_screen.py
@@ -32,8 +32,17 @@ class ACPScreen(BaseAppScreen):
                     "ACP runtime is not configured yet. Install or configure an ACP-compatible agent before launch.",
                     id="acp-empty-state",
                 )
-                yield Button("Follow in Console", id="acp-follow-in-console")
-                yield Button("Launch ACP Agent", id="acp-launch-agent", disabled=True)
+                yield Button(
+                    "Follow in Console",
+                    id="acp-follow-in-console",
+                    tooltip="Open Console to inspect ACP sessions and agent work.",
+                )
+                yield Button(
+                    "Launch ACP Agent",
+                    id="acp-launch-agent",
+                    disabled=True,
+                    tooltip="Unavailable until an ACP-compatible runtime is configured.",
+                )
 
     @on(Button.Pressed, "#acp-follow-in-console")
     def follow_in_console(self) -> None:

--- a/tldw_chatbook/UI/Screens/artifacts_screen.py
+++ b/tldw_chatbook/UI/Screens/artifacts_screen.py
@@ -25,13 +25,21 @@ class ArtifactsScreen(BaseAppScreen):
                 classes="destination-purpose",
             )
             with Vertical(id="artifacts-sections", classes="ds-panel"):
-                yield Button("Open Chatbooks", id="artifacts-open-chatbooks")
+                yield Button(
+                    "Open Chatbooks",
+                    id="artifacts-open-chatbooks",
+                    tooltip="Open portable Chatbook bundles.",
+                )
                 yield Static(
                     "Generated outputs from local and server output services will appear here.",
                     id="artifacts-output-status",
                     classes="destination-purpose",
                 )
-                yield Button("Use in Console", id="artifacts-use-in-console")
+                yield Button(
+                    "Use in Console",
+                    id="artifacts-use-in-console",
+                    tooltip="Stage artifact context in Console.",
+                )
 
     @on(Button.Pressed, "#artifacts-open-chatbooks")
     def open_chatbooks(self) -> None:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -25,12 +25,24 @@ class LibraryScreen(BaseAppScreen):
                 classes="destination-purpose",
             )
             with Vertical(id="library-sections", classes="ds-panel"):
-                yield Button("Open Notes", id="library-open-notes")
-                yield Button("Open Media", id="library-open-media")
-                yield Button("Open Conversations", id="library-open-conversations")
-                yield Button("Import/Export Sources", id="library-open-import-export")
-                yield Button("Search/RAG", id="library-open-search")
-                yield Button("Use in Console", id="library-use-in-console")
+                yield Button("Open Notes", id="library-open-notes", tooltip="Open saved notes and workspaces.")
+                yield Button("Open Media", id="library-open-media", tooltip="Open ingested media and transcripts.")
+                yield Button(
+                    "Open Conversations",
+                    id="library-open-conversations",
+                    tooltip="Open saved conversation browsing inside Library.",
+                )
+                yield Button(
+                    "Import/Export Sources",
+                    id="library-open-import-export",
+                    tooltip="Open source import and export tools.",
+                )
+                yield Button("Search/RAG", id="library-open-search", tooltip="Search or ask over indexed sources.")
+                yield Button(
+                    "Use in Console",
+                    id="library-use-in-console",
+                    tooltip="Stage Library context in Console.",
+                )
 
     @on(Button.Pressed, "#library-open-notes")
     def open_notes(self) -> None:

--- a/tldw_chatbook/UI/Screens/mcp_screen.py
+++ b/tldw_chatbook/UI/Screens/mcp_screen.py
@@ -32,4 +32,9 @@ class MCPScreen(BaseAppScreen):
                     "Unified MCP management is not embedded in this shell yet.",
                     id="mcp-management-unavailable",
                 )
-                yield Button("Open MCP Management", id="mcp-open-management", disabled=True)
+                yield Button(
+                    "Open MCP Management",
+                    id="mcp-open-management",
+                    disabled=True,
+                    tooltip="Unavailable until MCP management is embedded in this shell.",
+                )

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -25,13 +25,21 @@ class PersonasScreen(BaseAppScreen):
                 classes="destination-purpose",
             )
             with Vertical(id="personas-sections", classes="ds-panel"):
-                yield Button("Open Personas", id="personas-open-profiles")
+                yield Button(
+                    "Open Personas",
+                    id="personas-open-profiles",
+                    tooltip="Open character, prompt, dictionary, and lore management.",
+                )
                 yield Static(
                     "Characters, prompts, dictionaries, and lore stay here; Library owns saved conversation browsing.",
                     id="personas-boundary",
                     classes="destination-purpose",
                 )
-                yield Button("Attach to Console", id="personas-attach-to-console")
+                yield Button(
+                    "Attach to Console",
+                    id="personas-attach-to-console",
+                    tooltip="Stage persona context in Console.",
+                )
 
     @on(Button.Pressed, "#personas-open-profiles")
     def open_profiles(self) -> None:

--- a/tldw_chatbook/UI/Screens/schedules_screen.py
+++ b/tldw_chatbook/UI/Screens/schedules_screen.py
@@ -29,7 +29,11 @@ class SchedulesScreen(BaseAppScreen):
                 yield Static("Failed", classes="destination-section")
                 yield Static("Retry", classes="destination-section")
                 yield Static("Open in Console", classes="destination-section")
-                yield Button("Follow in Console", id="schedules-follow-in-console")
+                yield Button(
+                    "Follow in Console",
+                    id="schedules-follow-in-console",
+                    tooltip="Open Console to inspect schedule timing and recovery work.",
+                )
 
     @on(Button.Pressed, "#schedules-follow-in-console")
     def follow_in_console(self) -> None:

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -30,7 +30,11 @@ class SettingsScreen(BaseAppScreen):
                 yield Static("Storage", classes="destination-section")
                 yield Static("App-level behavior", classes="destination-section")
                 yield Static("MCP and tool-control settings live under MCP, not global Settings.")
-                yield Button("Open Appearance", id="settings-open-appearance")
+                yield Button(
+                    "Open Appearance",
+                    id="settings-open-appearance",
+                    tooltip="Open appearance customization settings.",
+                )
 
     @on(Button.Pressed, "#settings-open-appearance")
     def open_appearance_settings(self) -> None:

--- a/tldw_chatbook/UI/Screens/skills_screen.py
+++ b/tldw_chatbook/UI/Screens/skills_screen.py
@@ -40,8 +40,17 @@ class SkillsScreen(BaseAppScreen):
                     "Skill import is not wired in this shell yet.",
                     id="skills-import-unavailable",
                 )
-                yield Button("Import Skill", id="skills-import-skill", disabled=True)
-                yield Button("Attach to Console", id="skills-attach-to-console")
+                yield Button(
+                    "Import Skill",
+                    id="skills-import-skill",
+                    disabled=True,
+                    tooltip="Unavailable until skill import is wired in this shell.",
+                )
+                yield Button(
+                    "Attach to Console",
+                    id="skills-attach-to-console",
+                    tooltip="Stage Agent Skills context in Console.",
+                )
 
     @on(Button.Pressed, "#skills-attach-to-console")
     def attach_to_console(self) -> None:

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -1,4 +1,4 @@
-"""Watchlists+Collections destination shell."""
+"""W+C destination shell."""
 
 from textual.app import ComposeResult
 from textual import on
@@ -18,7 +18,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     def compose_content(self) -> ComposeResult:
         with Vertical(id="watchlists-collections-shell"):
             yield Static(
-                "Watchlists+Collections",
+                "W+C",
                 id="watchlists-collections-title",
                 classes="ds-destination-header",
             )
@@ -36,8 +36,16 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                 yield Static(
                     "Reading/content items, highlights, saved searches, archive state, note links, templates, feeds, import/export."
                 )
-                yield Button("Open current Watchlists", id="wc-open-watchlists")
-                yield Button("Follow in Console", id="watchlists-follow-in-console")
+                yield Button(
+                    "Open current Watchlists",
+                    id="wc-open-watchlists",
+                    tooltip="Open the current watchlist/subscription surface.",
+                )
+                yield Button(
+                    "Follow in Console",
+                    id="watchlists-follow-in-console",
+                    tooltip="Open Console to inspect watchlist and collection work.",
+                )
 
     @on(Button.Pressed, "#wc-open-watchlists")
     def open_watchlists(self) -> None:
@@ -47,5 +55,5 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     def follow_in_console(self) -> None:
         self.app_instance.open_console_for_live_work(
             source="watchlists_collections",
-            title="Watchlists+Collections",
+            title="W+C",
         )

--- a/tldw_chatbook/UI/Screens/workflows_screen.py
+++ b/tldw_chatbook/UI/Screens/workflows_screen.py
@@ -31,7 +31,11 @@ class WorkflowsScreen(BaseAppScreen):
                 yield Static("Outputs", classes="destination-section")
                 yield Static("Launch in Console", classes="destination-section")
                 yield Static("No workflow service is wired yet.", id="workflows-empty-state")
-                yield Button("Launch in Console", id="workflows-launch-in-console")
+                yield Button(
+                    "Launch in Console",
+                    id="workflows-launch-in-console",
+                    tooltip="Open Console to start or inspect workflow execution.",
+                )
 
     @on(Button.Pressed, "#workflows-launch-in-console")
     def launch_in_console(self) -> None:

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -494,7 +494,7 @@ class TabNavigationProvider(Provider):
         TAB_LIBRARY: "Open Library for source material, imports, notes, media, conversations, and Search/RAG",
         TAB_ARTIFACTS: "Open Artifacts for generated outputs, reports, datasets, and Chatbooks",
         TAB_PERSONAS: "Open Personas for characters, prompts, dictionaries, and behavior profiles",
-        TAB_WATCHLISTS_COLLECTIONS: "Open Watchlists+Collections for monitored sources and curated collections",
+        TAB_WATCHLISTS_COLLECTIONS: "Open W+C for monitored sources and curated collections",
         TAB_SCHEDULES: "Open Schedules for run timing, triggers, pauses, retries, and recovery",
         TAB_WORKFLOWS: "Open Workflows for reusable procedures, dry-runs, and outputs",
         TAB_MCP: "Open MCP for servers, tools, permissions, auth, and audit",


### PR DESCRIPTION
## Summary
- Rename the visible Watchlists/Collections shell label to W+C across navigation, destination title, command palette copy, and shell docs.
- Add explicit tooltips to destination-shell action buttons so every visible action explains its outcome or unavailable state.
- Add regression coverage for compact W+C copy and destination action affordance tooltips.

## Verification
- RED: expected failures for W+C copy and missing action tooltips.
- GREEN: env HOME=/private/tmp/tldw-chatbook-test-home-hardening-green XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home-hardening-green/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_destination_shells.py Tests/UI/test_master_shell_navigation.py Tests/UI/test_screen_navigation.py Tests/UI/test_shell_destinations.py --tb=short
- Related: env HOME=/private/tmp/tldw-chatbook-test-home-hardening-related XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home-hardening-related/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_destination_shells.py Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_command_palette_providers.py Tests/UI/test_navigation_label_language.py Tests/UI/test_tab_links_navigation.py Tests/UI/test_master_shell_navigation.py Tests/UI/test_screen_navigation.py Tests/UI/test_shell_destinations.py --tb=short
- Smoke: env HOME=/private/tmp/tldw-chatbook-test-home-hardening-full XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home-hardening-full/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_master_shell_design_system_contract.py Tests/UI/test_shell_destinations.py Tests/Home/test_dashboard_state.py Tests/UI/test_home_screen.py Tests/UI/test_master_shell_navigation.py Tests/UI/test_destination_shells.py Tests/UI/test_screen_navigation.py Tests/UI/test_navigation_label_language.py Tests/UI/test_command_palette_shell_routes.py Tests/UI/test_command_palette_providers.py Tests/UI/test_command_palette_basic.py Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_chat_first_handoffs.py Tests/UI/test_ux_audit_smoke.py --tb=short
- Static: git diff --check
- Static: python -m py_compile touched Python files