### PR TITLE
Add Unified Shell Phase 1 QA harness

### DIFF
--- a/Docs/superpowers/qa/unified-shell/phase-1/2026-05-03-phase-1-protocol-smoke.md
+++ b/Docs/superpowers/qa/unified-shell/phase-1/2026-05-03-phase-1-protocol-smoke.md
@@ -1,0 +1,76 @@
+# Phase 1.1 Protocol Smoke Walkthrough
+
+## Environment
+
+- Date: 2026-05-03
+- Branch: `codex/unified-shell-phase1-qa-harness`
+- Commit: pending
+- Python version: repo venv Python 3.12.11
+- Runtime source: repository checkout
+- Config/home directory: not exercised by this smoke
+
+## Task Or Phase
+
+- Backlog task: `TASK-2.1`
+- Phase: Phase 1.1
+- Destination or workflow: shell QA protocol and evidence template setup
+
+## Entry Path
+
+- Focused protocol regression: `python3 -m pytest Tests/UI/test_unified_shell_qa_protocol.py -q`
+- Supporting mounted navigation check: `python3 -m pytest Tests/UI/test_master_shell_navigation.py -q`
+
+## Steps Attempted
+
+1. Confirmed the Phase 1 protocol identifies `python3 -m tldw_chatbook.app` as the manual running-app entry point.
+2. Confirmed the protocol references focused mounted tests for navigation support.
+3. Confirmed the template includes visual, keyboard, mouse/click, functional, severity, evidence, and residual-risk sections.
+4. Confirmed the roadmap links the protocol, template, and smoke summary.
+
+## Visual Usability Notes
+
+- Layout: not a product UI walkthrough.
+- Clipping: not tested.
+- Focus indication: template requires this field for future walkthroughs.
+- Labels: template requires this field for future walkthroughs.
+- Disabled or blocked states: protocol requires owner, reason, and next action to be recorded.
+- Information hierarchy: protocol requires destination purpose, source authority, and current status to be recorded.
+
+## Keyboard Path Result
+
+- Not tested in product UI during this protocol smoke.
+
+## Mouse/Click Path Result
+
+- Not tested in product UI during this protocol smoke.
+
+## Functional Result
+
+- Completed workflow: Phase 1.1 protocol/template wiring.
+- Honest blocked state: product destination workflows are outside this smoke.
+- Failed workflow: none in protocol wiring.
+- Recovery path: use `walkthrough-template.md` for destination-level failures found in `TASK-2.2`.
+
+## Defect Severity
+
+- No product defect severity assigned. This is not a full destination workflow audit.
+
+## Evidence
+
+- Test commands:
+- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_unified_shell_qa_protocol.py -q`
+  - Result: 5 passed in 0.13s.
+- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_master_shell_navigation.py -q`
+  - Result: 3 passed, 3 warnings in 10.28s.
+- Related task: `TASK-2.1`
+
+## Residual Risk
+
+- Live app launch through `python3 -m tldw_chatbook.app` still needs manual walkthrough evidence in `TASK-2.2`.
+- Optional dependency, server, auth, runtime, and policy states are not exercised by this smoke.
+- This smoke confirms the QA harness is trackable and runnable; it is not a full destination workflow audit.
+- System Python 3.9.6 cannot run the mounted app import path because the project requires Python 3.11+ syntax; use the repo venv or another Python 3.11+ runtime for Phase 1 QA.
+
+## Product QA Boundary
+
+This summary validates the Phase 1 QA protocol and template. It does not verify that Home, Console, Library, Artifacts, Personas, W+C, Schedules, Workflows, MCP, ACP, Skills, or Settings are usable end-to-end.

--- a/Docs/superpowers/qa/unified-shell/phase-1/README.md
+++ b/Docs/superpowers/qa/unified-shell/phase-1/README.md
@@ -1,5 +1,13 @@
 # Phase 1 QA Evidence
 
-Status: not-started
+Status: in-progress
 
-This directory will contain durable QA summaries for this phase. Do not mark the phase verified until running-app walkthrough evidence exists here.
+This directory contains durable QA summaries for Phase 1 shell-contract work.
+
+## Harness Assets
+
+- `walkthrough-protocol.md` - repeatable protocol for running shell walkthroughs against the actual Textual app.
+- `walkthrough-template.md` - copyable evidence template for each destination or shell-contract workflow.
+- `2026-05-03-phase-1-protocol-smoke.md` - first smoke summary proving the protocol and template are wired into tracking.
+
+Do not mark Phase 1 verified until running-app walkthrough evidence exists here for the shell contract and destination action audit.

--- a/Docs/superpowers/qa/unified-shell/phase-1/walkthrough-protocol.md
+++ b/Docs/superpowers/qa/unified-shell/phase-1/walkthrough-protocol.md
@@ -1,0 +1,53 @@
+# Phase 1 Shell QA Walkthrough Protocol
+
+Status: active for `TASK-2.1`
+
+Use this protocol before marking shell destinations, primary actions, or recovery states usable. The protocol is intended to be run against the actual Textual app, not only route tables, static docs, or unit-level click handlers.
+
+## Entry Commands
+
+Use one of these entry paths and record which one was used:
+
+```bash
+python3 -m tldw_chatbook.app
+```
+
+Focused mounted checks that support, but do not replace, manual QA:
+
+```bash
+python3 -m pytest Tests/UI/test_master_shell_navigation.py -q
+python3 -m pytest Tests/UI/test_shell_destinations.py -q
+python3 -m pytest Tests/UI/test_unified_shell_qa_protocol.py -q
+```
+
+## Required Walkthrough Scope
+
+For each shell destination or shell-contract workflow, record:
+
+- Whether navigation reaches the expected destination.
+- Whether the destination header states the purpose, source authority, and current status.
+- Whether primary actions are reachable by keyboard and mouse.
+- Whether disabled, blocked, unavailable, pending approval, and recovery states explain the owner, reason, and next action.
+- Whether the workflow completes, is honestly blocked with recovery, or fails.
+- Whether repeated use remains fast enough for power users.
+
+## Evidence Rules
+
+- Do not count render-only checks as workflow completion.
+- Do not count click-event-only checks as workflow completion.
+- Do not mark a task verified unless the functional result is recorded.
+- Do not hide optional dependency, server, auth, runtime, or policy limits.
+- If a workflow is blocked, record the recovery path and severity instead of treating the blocked state as a pass.
+
+## Severity Labels
+
+Use exactly one severity when a defect is found:
+
+- `blocker` - prevents basic use or traps the user.
+- `workflow-degradation` - seriously slows or breaks a core workflow but leaves a workaround.
+- `recoverability` - blocked/error state exists but recovery copy, ownership, or next action is unclear.
+- `polish` - visual or wording issue that does not block completion.
+
+## Output
+
+Create one markdown summary per walkthrough using `walkthrough-template.md`. Store summaries in this directory and link them from `Docs/superpowers/trackers/unified-shell-maturity-roadmap.md` or the relevant Backlog task.

--- a/Docs/superpowers/qa/unified-shell/phase-1/walkthrough-template.md
+++ b/Docs/superpowers/qa/unified-shell/phase-1/walkthrough-template.md
@@ -1,0 +1,76 @@
+# Phase 1 Shell QA Walkthrough Summary
+
+## Environment
+
+- Date:
+- Branch:
+- Commit:
+- Python version:
+- Runtime source:
+- Config/home directory:
+
+## Task Or Phase
+
+- Backlog task:
+- Phase:
+- Destination or workflow:
+
+## Entry Path
+
+- Launch command, direct route, command palette path, or focused mounted test:
+
+## Steps Attempted
+
+1. 
+
+## Visual Usability Notes
+
+- Layout:
+- Clipping:
+- Focus indication:
+- Labels:
+- Disabled or blocked states:
+- Information hierarchy:
+
+## Keyboard Path Result
+
+- Completed, blocked with recovery, failed, or not tested:
+
+## Mouse/Click Path Result
+
+- Completed, blocked with recovery, failed, or not tested:
+
+## Functional Result
+
+- Completed workflow:
+- Honest blocked state:
+- Failed workflow:
+- Recovery path:
+
+## Defect Severity
+
+Use one if a defect exists:
+
+- `blocker`
+- `workflow-degradation`
+- `recoverability`
+- `polish`
+
+## Evidence
+
+- Screenshots:
+- Logs:
+- Probe JSON:
+- Test commands:
+- Related PRs or commits:
+
+## Residual Risk
+
+- Untested live server/API paths:
+- Optional dependency limits:
+- Environment limits:
+- Follow-up tasks:
+
+## Product QA Boundary
+
+State whether this walkthrough verifies a real product workflow, only validates the protocol/harness, or intentionally leaves product workflow verification to a later task.

--- a/Docs/superpowers/qa/unified-shell/phase-1/walkthrough-template.md
+++ b/Docs/superpowers/qa/unified-shell/phase-1/walkthrough-template.md
@@ -21,7 +21,7 @@
 
 ## Steps Attempted
 
-1. 
+1.
 
 ## Visual Usability Notes
 

--- a/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
@@ -101,6 +101,14 @@ Initial child tasks:
 | Phase 5: Capability And Recovery System | Systematize unavailable and blocked states. | not-started | `TASK-6` | `phase-5/` | Shared taxonomy not yet extracted. |
 | Phase 6: Audit Replay And Closeout | Prove shell works for first-time and power users. | not-started | `TASK-7` | `phase-6/` | Depends on prior phases and running-app QA. |
 
+## Phase 1.1 QA Harness Evidence
+
+`TASK-2.1` owns the first reusable Phase 1 QA harness assets:
+
+- `Docs/superpowers/qa/unified-shell/phase-1/walkthrough-protocol.md`
+- `Docs/superpowers/qa/unified-shell/phase-1/walkthrough-template.md`
+- `Docs/superpowers/qa/unified-shell/phase-1/2026-05-03-phase-1-protocol-smoke.md`
+
 ## Phase 0: Canonical Tracking
 
 Done when:

--- a/Tests/UI/test_unified_shell_qa_protocol.py
+++ b/Tests/UI/test_unified_shell_qa_protocol.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+
+
+QA_ROOT = Path("Docs/superpowers/qa/unified-shell")
+PHASE_1_ROOT = QA_ROOT / "phase-1"
+PROTOCOL = PHASE_1_ROOT / "walkthrough-protocol.md"
+TEMPLATE = PHASE_1_ROOT / "walkthrough-template.md"
+SMOKE_SUMMARY = PHASE_1_ROOT / "2026-05-03-phase-1-protocol-smoke.md"
+ROADMAP = Path("Docs/superpowers/trackers/unified-shell-maturity-roadmap.md")
+
+REQUIRED_TEMPLATE_FIELDS = {
+    "Environment",
+    "Entry Path",
+    "Steps Attempted",
+    "Visual Usability Notes",
+    "Keyboard Path Result",
+    "Mouse/Click Path Result",
+    "Functional Result",
+    "Defect Severity",
+    "Evidence",
+    "Residual Risk",
+}
+
+REQUIRED_SEVERITIES = {
+    "blocker",
+    "workflow-degradation",
+    "recoverability",
+    "polish",
+}
+
+
+def test_phase_one_qa_protocol_and_template_exist():
+    assert PROTOCOL.exists()
+    assert TEMPLATE.exists()
+    assert SMOKE_SUMMARY.exists()
+
+
+def test_phase_one_template_captures_required_walkthrough_fields():
+    text = TEMPLATE.read_text(encoding="utf-8")
+
+    for field in REQUIRED_TEMPLATE_FIELDS:
+        assert f"## {field}" in text
+    for severity in REQUIRED_SEVERITIES:
+        assert severity in text
+
+
+def test_phase_one_protocol_is_runnable_against_textual_app():
+    text = PROTOCOL.read_text(encoding="utf-8")
+
+    assert "python3 -m tldw_chatbook.app" in text
+    assert "Tests/UI/test_master_shell_navigation.py" in text
+    assert "actual Textual app" in text
+    assert "render-only" in text
+    assert "click-event-only" in text
+
+
+def test_phase_one_smoke_summary_records_boundary_and_evidence():
+    text = SMOKE_SUMMARY.read_text(encoding="utf-8")
+
+    assert "TASK-2.1" in text
+    assert "Phase 1.1" in text
+    assert "Product QA Boundary" in text
+    assert "Tests/UI/test_master_shell_navigation.py" in text
+    assert "not a full destination workflow audit" in text
+
+
+def test_roadmap_links_phase_one_protocol_evidence():
+    text = ROADMAP.read_text(encoding="utf-8")
+
+    assert "TASK-2.1" in text
+    assert "walkthrough-protocol.md" in text
+    assert "walkthrough-template.md" in text
+    assert "2026-05-03-phase-1-protocol-smoke.md" in text

--- a/backlog/tasks/task-2.1 - Phase-1.1-Create-shell-QA-walkthrough-harness-and-evidence-template.md
+++ b/backlog/tasks/task-2.1 - Phase-1.1-Create-shell-QA-walkthrough-harness-and-evidence-template.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-2.1
 title: 'Phase 1.1: Create shell QA walkthrough harness and evidence template'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-05-03 14:48'
+updated_date: '2026-05-03 15:02'
 labels:
   - unified-shell
   - phase-1
@@ -13,6 +14,11 @@ dependencies:
   - TASK-1.1
 documentation:
   - Docs/superpowers/specs/2026-05-03-unified-shell-maturity-tracking-design.md
+  - Docs/superpowers/qa/unified-shell/phase-1/walkthrough-protocol.md
+  - Docs/superpowers/qa/unified-shell/phase-1/walkthrough-template.md
+  - >-
+    Docs/superpowers/qa/unified-shell/phase-1/2026-05-03-phase-1-protocol-smoke.md
+  - Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
 parent_task_id: TASK-2
 priority: high
 ---
@@ -25,8 +31,25 @@ Create the repeatable running-app walkthrough protocol and evidence template nee
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Walkthrough template captures visual, keyboard, click, functional, severity, evidence, and residual-risk fields.
-- [ ] #2 Harness or manual protocol can be run against the actual Textual app.
-- [ ] #3 At least one smoke walkthrough summary is stored under Docs/superpowers/qa/unified-shell/phase-1/.
-- [ ] #4 The roadmap links the harness/template evidence.
+- [x] #1 Walkthrough template captures visual, keyboard, click, functional, severity, evidence, and residual-risk fields.
+- [x] #2 Harness or manual protocol can be run against the actual Textual app.
+- [x] #3 At least one smoke walkthrough summary is stored under Docs/superpowers/qa/unified-shell/phase-1/.
+- [x] #4 The roadmap links the harness/template evidence.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused regression test that validates the Phase 1 QA protocol/template contains the required walkthrough fields and product-QA guardrails.
+2. Run the focused test and confirm it fails before the template exists.
+3. Add the reusable Phase 1 walkthrough protocol, QA template, and an initial smoke summary under Docs/superpowers/qa/unified-shell/phase-1/.
+4. Link the Phase 1.1 evidence from the roadmap.
+5. Run the focused test and Backlog/docs verification commands.
+6. Check acceptance criteria, add implementation notes, and commit the slice.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added a Phase 1 shell QA walkthrough protocol, reusable evidence template, and protocol smoke summary under Docs/superpowers/qa/unified-shell/phase-1/. Added a focused docs regression test that fails when the protocol/template/smoke evidence or roadmap links are missing. Verified the protocol regression and supporting mounted master-shell navigation test under the repo Python 3.12 venv. Product destination workflow audit remains in TASK-2.2.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary

- Adds a repeatable Phase 1 shell QA walkthrough protocol and reusable evidence template.
- Adds the first Phase 1 protocol smoke summary and links the harness evidence from the maturity roadmap.
- Adds a focused regression test so required QA fields, severity labels, product-QA boundaries, and roadmap evidence links cannot silently disappear.
- Marks Backlog `TASK-2.1` complete with checked acceptance criteria and implementation notes.

## Verification

- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_unified_shell_qa_protocol.py -q` - 5 passed
- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_master_shell_navigation.py -q` - 3 passed, 1 warning
- `git diff --check origin/dev...HEAD`

## Product QA Boundary

- This PR creates the Phase 1 QA protocol/template and validates supporting mounted navigation checks.
- It does not claim full destination workflow usability; that remains in `TASK-2.2`.