### PR TITLE
Audit Unified Shell destination actions

### DIFF
--- a/Docs/superpowers/qa/unified-shell/phase-1/2026-05-03-destination-action-audit.md
+++ b/Docs/superpowers/qa/unified-shell/phase-1/2026-05-03-destination-action-audit.md
@@ -21,7 +21,7 @@ This audit treats "renders" and "posts a navigation event" as partial evidence o
 
 Focused checks were run against Textual `App.run_test(...)` harnesses that mount the actual navigation, destination screens, Home screen, Console handoff card, and app navigation handlers.
 
-- Red test first: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_unified_shell_destination_action_audit.py -q`
+- Red test first: python -m pytest Tests/UI/test_unified_shell_destination_action_audit.py -q
 - Expected red result before this document existed: `4 failed`
 - Mounted shell walkthrough set: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_master_shell_navigation.py Tests/UI/test_destination_shells.py Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_home_screen.py Tests/UI/test_shell_destinations.py -q`
 - Mounted shell walkthrough result: `61 passed, 3 warnings`

--- a/Docs/superpowers/qa/unified-shell/phase-1/2026-05-03-destination-action-audit.md
+++ b/Docs/superpowers/qa/unified-shell/phase-1/2026-05-03-destination-action-audit.md
@@ -1,0 +1,71 @@
+# Phase 1.2 Destination Action Audit
+
+Date: 2026-05-03
+Task: `TASK-2.2`
+Branch: `codex/unified-shell-phase1-destination-audit`
+Base: `origin/dev` at `2d0fd041`
+
+## Purpose
+
+Audit every top-level Unified Shell destination for real action ownership, honest disabled states, focus/navigation behavior, and workflow-level usability beyond render/click coverage.
+
+This audit treats "renders" and "posts a navigation event" as partial evidence only. A destination is only considered a working workflow when the user can reach a useful existing surface or stage meaningful context into Console.
+
+## Status Legend
+
+- Working workflow - `working-workflow`: the primary action reaches a useful existing surface, stages meaningful Console context, or performs the promised shell behavior.
+- Honest blocked state - `honest-blocked`: the shell clearly says the capability is unavailable or disabled and avoids pretending work was launched.
+- False affordance - `false-affordance`: the control is clickable or labeled as executable, but current code only opens a generic placeholder or lacks actionable payload/service backing.
+
+## Running-App QA Evidence
+
+Focused checks were run against Textual `App.run_test(...)` harnesses that mount the actual navigation, destination screens, Home screen, Console handoff card, and app navigation handlers.
+
+- Red test first: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_unified_shell_destination_action_audit.py -q`
+- Expected red result before this document existed: `4 failed`
+- Mounted shell walkthrough set: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_master_shell_navigation.py Tests/UI/test_destination_shells.py Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_home_screen.py Tests/UI/test_shell_destinations.py -q`
+- Mounted shell walkthrough result: `61 passed, 3 warnings`
+- Warning boundary: dependency/version warnings and splash string syntax warnings were unrelated to shell behavior.
+
+Residual risk: these checks exercise running Textual screens and event handlers, not live LLM provider calls, live scheduler services, ACP runtimes, MCP server sessions, or real local content databases.
+
+## Destination Matrix
+
+| Destination | Primary route | Destination ID | Action owner | Usability status | Classification | Evidence | Follow-up |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Home | `home` | `home` | `HomeScreen`, `HomeDashboardInput`, `summarize_home_dashboard`, app home control hooks | Dashboard sections and next-best-action routing are verified. Approve, reject, pause, resume, and retry hooks currently notify that no active run service is connected when surfaced. | Honest blocked state - `honest-blocked` | `Tests/UI/test_home_screen.py`; `tldw_chatbook/UI/Screens/home_screen.py`; `tldw_chatbook/app.py` | Phase 2 parent `TASK-4` should wire real active-work adapters before treating controls as operational. |
+| Console | `chat` | `console` | `ChatScreen`, `ChatWindowEnhanced`, app `open_chat_with_handoff`, app `open_console_for_live_work` | Console navigation works, pending live-work cards render, and staged context can be delivered to chat. Live model/API success remains outside this shell audit. | Working workflow - `working-workflow` | `Tests/UI/test_master_shell_navigation.py`; `Tests/UI/test_console_live_work_handoffs.py`; `tldw_chatbook/UI/Screens/chat_screen.py` | Phase 3 parent `TASK-3` owns full live-agent control completion. |
+| Library | `library` | `library` | `LibraryScreen`, legacy Notes/Media/Ingest/Search/Conversation screens, app chat handoff helper | Notes, Media, Conversations, Import/Export, Search/RAG, and Use in Console actions are mounted and route or stage context as promised. The surface is still a wrapper over legacy Library subroutes. | Working workflow - `working-workflow` | `Tests/UI/test_destination_shells.py`; `Tests/UI/test_console_live_work_handoffs.py`; `tldw_chatbook/UI/Screens/library_screen.py` | Phase 4 parent `TASK-5` owns Library-native service adoption. |
+| Artifacts | `artifacts` | `artifacts` | `ArtifactsScreen`, `ChatbooksScreen`, app chat handoff helper | Chatbooks opens an existing artifact surface and Use in Console stages artifact context. Generated output listing is only explanatory copy. | Working workflow - `working-workflow` | `Tests/UI/test_destination_shells.py`; `Tests/UI/test_console_live_work_handoffs.py`; `tldw_chatbook/UI/Screens/artifacts_screen.py` | Phase 4 parent `TASK-5` owns generated output service adoption. |
+| Personas | `personas` | `personas` | `PersonasScreen`, `ConversationScreen`, app chat handoff helper | Open Personas reaches the existing character/persona/prompt management surface and Attach to Console stages persona context. | Working workflow - `working-workflow` | `Tests/UI/test_destination_shells.py`; `Tests/UI/test_console_live_work_handoffs.py`; `tldw_chatbook/UI/Screens/personas_screen.py` | Phase 4 parent `TASK-5` owns deeper Persona-native refinement. |
+| W+C | `watchlists_collections` | `watchlists_collections` | `WatchlistsCollectionsScreen`, `SubscriptionScreen`, app live-work helper | Watchlists routes to the existing subscriptions surface. Collections are described but not actionable. Follow in Console opens a generic pending card without actionable watchlist/collection payload. | False affordance - `false-affordance` | `Tests/UI/test_destination_shells.py`; `Tests/UI/test_console_live_work_handoffs.py`; `tldw_chatbook/UI/Screens/watchlists_collections_screen.py` | New PR-sized follow-up: `TASK-2.3`. Broader W+C service adoption remains under `TASK-5`. |
+| Schedules | `schedules` | `schedules` | `SchedulesScreen`, app live-work helper | The screen honestly says no scheduler data is available, but Follow in Console implies schedule inspection/recovery while only opening a generic pending card. | False affordance - `false-affordance` | `Tests/UI/test_destination_shells.py`; `Tests/UI/test_console_live_work_handoffs.py`; `tldw_chatbook/UI/Screens/schedules_screen.py` | New PR-sized follow-up: `TASK-2.3`. Real scheduler adapters remain under `TASK-5`. |
+| Workflows | `workflows` | `workflows` | `WorkflowsScreen`, app live-work helper | The screen says no workflow service is wired, but Launch in Console is clickable and labeled as execution-oriented despite only opening a generic pending card. | False affordance - `false-affordance` | `Tests/UI/test_destination_shells.py`; `Tests/UI/test_console_live_work_handoffs.py`; `tldw_chatbook/UI/Screens/workflows_screen.py` | New PR-sized follow-up: `TASK-2.3`. Real workflow execution remains under `TASK-5`. |
+| MCP | `mcp` | `mcp` | `MCPScreen`, existing MCP module surfaces | MCP management is disabled with explicit unavailable copy. `tools_settings` correctly aliases to MCP rather than global Settings. | Honest blocked state - `honest-blocked` | `Tests/UI/test_destination_shells.py`; `Tests/UI/test_shell_destinations.py`; `tldw_chatbook/UI/Screens/mcp_screen.py` | Phase 4 parent `TASK-5` owns embedding or routing the full MCP management surface. |
+| ACP | `acp` | `acp` | `ACPScreen`, app live-work helper | Launch ACP Agent is disabled with clear runtime-unconfigured copy. Follow in Console is still generic and does not expose ACP session/runtime payload. | False affordance - `false-affordance` | `Tests/UI/test_destination_shells.py`; `Tests/UI/test_console_live_work_handoffs.py`; `tldw_chatbook/UI/Screens/acp_screen.py` | New PR-sized follow-up: `TASK-2.3`. Runtime integration remains under `TASK-5`/`TASK-6`. |
+| Skills | `skills` | `skills` | `SkillsScreen`, app chat handoff helper, local skills service hook | Import Skill is disabled with explicit unavailable copy. Attach to Console stages skills context and local skills directory status is visible when available. | Honest blocked state - `honest-blocked` | `Tests/UI/test_destination_shells.py`; `Tests/UI/test_console_live_work_handoffs.py`; `tldw_chatbook/UI/Screens/skills_screen.py` | Phase 4 parent `TASK-5` owns list/detail/import/validation adoption. |
+| Settings | `settings` | `settings` | `SettingsScreen`, `CustomizeScreen` | Open Appearance reaches the existing customization route. Settings clearly excludes MCP/tool-control ownership. | Working workflow - `working-workflow` | `Tests/UI/test_destination_shells.py`; `Tests/UI/test_shell_destinations.py`; `tldw_chatbook/UI/Screens/settings_screen.py` | No new follow-up from this audit. |
+
+## Findings
+
+- P1: W+C, Schedules, Workflows, and ACP expose Console follow/launch actions that do not carry actionable live-work payloads. This is the only new Phase 1 PR-sized fix created from the audit: `TASK-2.3`.
+- P1: Home active-work controls are not operational because the app only exposes placeholder notification hooks. This is already a Phase 2 scope item under `TASK-4`; creating a second broad task here would duplicate the phase plan.
+- P2: Library, Artifacts, Personas, Skills, and MCP are mostly compatibility wrappers over legacy or unavailable surfaces. The wrappers are honest enough for Phase 1 except for service-adoption depth, which belongs under `TASK-5`.
+- P2: Console is structurally the right live-work hub, but end-to-end agent execution depends on provider/model/runtime state and remains a Phase 3 validation target.
+
+## Follow-on Scope Boundary
+
+Created Backlog child task:
+
+- `TASK-2.3` - Remove false Console-launch affordances from skeletal destinations.
+
+No broader service-adoption Backlog child tasks were created in this audit because those would not be PR-sized. They are already covered by phase parent tasks:
+
+- `TASK-3` - Console Live Work Hub.
+- `TASK-4` - Home Operational Control.
+- `TASK-5` - Destination Service Adoption.
+- `TASK-6` - Capability And Recovery System.
+
+## QA Conclusion
+
+Phase 1.2 is sufficient to move from "we have render/click tests" to "we know which destination actions are real, blocked, or misleading." Phase 1 should not be considered shell-contract complete until `TASK-2.3` removes or hardens the false Console-launch affordances.

--- a/Docs/superpowers/qa/unified-shell/phase-1/2026-05-03-destination-action-audit.md
+++ b/Docs/superpowers/qa/unified-shell/phase-1/2026-05-03-destination-action-audit.md
@@ -23,7 +23,7 @@ Focused checks were run against Textual `App.run_test(...)` harnesses that mount
 
 - Red test first: python -m pytest Tests/UI/test_unified_shell_destination_action_audit.py -q
 - Expected red result before this document existed: `4 failed`
-- Mounted shell walkthrough set: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_master_shell_navigation.py Tests/UI/test_destination_shells.py Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_home_screen.py Tests/UI/test_shell_destinations.py -q`
+- Mounted shell walkthrough set: python -m pytest Tests/UI/test_master_shell_navigation.py Tests/UI/test_destination_shells.py Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_home_screen.py Tests/UI/test_shell_destinations.py -q
 - Mounted shell walkthrough result: `61 passed, 3 warnings`
 - Warning boundary: dependency/version warnings and splash string syntax warnings were unrelated to shell behavior.
 

--- a/Docs/superpowers/qa/unified-shell/phase-1/README.md
+++ b/Docs/superpowers/qa/unified-shell/phase-1/README.md
@@ -9,5 +9,6 @@ This directory contains durable QA summaries for Phase 1 shell-contract work.
 - `walkthrough-protocol.md` - repeatable protocol for running shell walkthroughs against the actual Textual app.
 - `walkthrough-template.md` - copyable evidence template for each destination or shell-contract workflow.
 - `2026-05-03-phase-1-protocol-smoke.md` - first smoke summary proving the protocol and template are wired into tracking.
+- `2026-05-03-destination-action-audit.md` - `TASK-2.2` evidence matrix for destination action ownership, usability status, and follow-up boundaries.
 
-Do not mark Phase 1 verified until running-app walkthrough evidence exists here for the shell contract and destination action audit.
+Do not mark Phase 1 verified until `TASK-2.3` resolves the false Console-launch affordances found by the destination action audit.

--- a/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
@@ -1,8 +1,8 @@
 # Unified Shell Maturity Roadmap
 
 Date: 2026-05-03
-Status: Phase 0 verified
-Source Branch: `origin/dev` at `534cf226` plus `codex/unified-shell-maturity-tracking`
+Status: Phase 1 in progress
+Source Branch: `origin/dev` at `2d0fd041` plus `codex/unified-shell-phase1-destination-audit`
 
 ## Purpose
 
@@ -29,6 +29,7 @@ Track remaining Unified Shell work in one place so rendered screens, clickable b
 
 - Home active-work controls still use placeholder notification hooks for approve, reject, pause, resume, and retry.
 - Workflows has no wired workflow service in the shell wrapper.
+- W+C, Schedules, Workflows, and ACP have Console follow/launch actions that need actionable payloads or honest unavailable states.
 - ACP launch is disabled until an ACP-compatible runtime is configured.
 - MCP management is not embedded in the top-level MCP wrapper.
 - Skills local/server services exist, but the top-level Skills shell still leaves import disabled and lacks list/detail/import UX adoption.
@@ -76,13 +77,14 @@ Initial child tasks:
 - Phase 0.2: Reconcile current dev state and merged evidence - `TASK-1.2`
 - Phase 1.1: Create shell QA walkthrough harness and evidence template - `TASK-2.1`
 - Phase 1.2: Audit destination action functionality beyond render/click tests - `TASK-2.2`
+- Phase 1.3: Remove false Console-launch affordances from skeletal destinations - `TASK-2.3`
 
 ## QA Evidence Index
 
 | Phase | Evidence Path | Status |
 | --- | --- | --- |
 | Phase 0 | `Docs/superpowers/qa/unified-shell/phase-0/` | verified |
-| Phase 1 | `Docs/superpowers/qa/unified-shell/phase-1/` | not-started |
+| Phase 1 | `Docs/superpowers/qa/unified-shell/phase-1/` | in-progress |
 | Phase 2 | `Docs/superpowers/qa/unified-shell/phase-2/` | not-started |
 | Phase 3 | `Docs/superpowers/qa/unified-shell/phase-3/` | not-started |
 | Phase 4 | `Docs/superpowers/qa/unified-shell/phase-4/` | not-started |
@@ -94,7 +96,7 @@ Initial child tasks:
 | Phase | Goal | Status | Backlog Tasks | QA Evidence | Residual Risk |
 | --- | --- | --- | --- | --- | --- |
 | Phase 0: Canonical Tracking | Make remaining work trackable. | verified | `TASK-1`, `TASK-1.1`, `TASK-1.2` | `phase-0/` | Product UI workflows are out of scope for Phase 0. |
-| Phase 1: Shell Contract Complete | Remove false shell affordances and prove shell usability. | not-started | `TASK-2`, `TASK-2.1`, `TASK-2.2` | `phase-1/` | App walkthrough harness not yet created. |
+| Phase 1: Shell Contract Complete | Remove false shell affordances and prove shell usability. | in-progress | `TASK-2`, `TASK-2.1`, `TASK-2.2`, `TASK-2.3` | `phase-1/` | False Console-launch affordances remain until `TASK-2.3` is complete. |
 | Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | not-started | `TASK-4` | `phase-2/` | Home action adapters still need design and implementation. |
 | Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | not-started | `TASK-3` | `phase-3/` | Live work event sources need explicit contracts. |
 | Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | not-started | `TASK-5` | `phase-4/` | Service coverage varies by destination. |
@@ -108,6 +110,14 @@ Initial child tasks:
 - `Docs/superpowers/qa/unified-shell/phase-1/walkthrough-protocol.md`
 - `Docs/superpowers/qa/unified-shell/phase-1/walkthrough-template.md`
 - `Docs/superpowers/qa/unified-shell/phase-1/2026-05-03-phase-1-protocol-smoke.md`
+
+## Phase 1.2 Destination Action Audit Evidence
+
+`TASK-2.2` records action ownership and usability status for every top-level destination:
+
+- `Docs/superpowers/qa/unified-shell/phase-1/2026-05-03-destination-action-audit.md`
+
+Audit result: W+C, Schedules, Workflows, and ACP have false Console-launch affordances that should be handled by the PR-sized follow-up `TASK-2.3`.
 
 ## Phase 0: Canonical Tracking
 

--- a/Tests/UI/test_unified_shell_destination_action_audit.py
+++ b/Tests/UI/test_unified_shell_destination_action_audit.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+
+from tldw_chatbook.UI.Navigation.shell_destinations import SHELL_DESTINATION_ORDER
+
+
+PHASE_1_ROOT = Path("Docs/superpowers/qa/unified-shell/phase-1")
+AUDIT = PHASE_1_ROOT / "2026-05-03-destination-action-audit.md"
+README = PHASE_1_ROOT / "README.md"
+ROADMAP = Path("Docs/superpowers/trackers/unified-shell-maturity-roadmap.md")
+
+REQUIRED_COLUMNS = {
+    "Destination",
+    "Primary route",
+    "Action owner",
+    "Usability status",
+    "Classification",
+    "Evidence",
+    "Follow-up",
+}
+
+REQUIRED_CLASSIFICATIONS = {
+    "working-workflow",
+    "honest-blocked",
+    "false-affordance",
+}
+
+REQUIRED_EVIDENCE = {
+    "Tests/UI/test_master_shell_navigation.py",
+    "Tests/UI/test_destination_shells.py",
+    "Tests/UI/test_unified_shell_destination_action_audit.py",
+}
+
+
+def test_destination_action_audit_exists_and_covers_every_top_level_destination():
+    assert AUDIT.exists()
+    text = AUDIT.read_text(encoding="utf-8")
+
+    for column in REQUIRED_COLUMNS:
+        assert column in text
+
+    for destination in SHELL_DESTINATION_ORDER:
+        assert f"| {destination.label} | `{destination.primary_route}` |" in text
+        assert destination.destination_id in text
+
+
+def test_destination_action_audit_distinguishes_workflow_statuses_and_false_affordances():
+    text = AUDIT.read_text(encoding="utf-8")
+
+    for classification in REQUIRED_CLASSIFICATIONS:
+        assert classification in text
+
+    assert "False affordance" in text
+    assert "Honest blocked state" in text
+    assert "Working workflow" in text
+
+
+def test_destination_action_audit_records_running_app_evidence_and_scope_boundary():
+    text = AUDIT.read_text(encoding="utf-8")
+
+    for evidence in REQUIRED_EVIDENCE:
+        assert evidence in text
+
+    assert "Running-App QA Evidence" in text
+    assert "Follow-on Scope Boundary" in text
+    assert "PR-sized" in text
+    assert "TASK-2.2" in text
+
+
+def test_phase_one_index_and_roadmap_link_destination_action_audit():
+    audit_name = AUDIT.name
+
+    assert audit_name in README.read_text(encoding="utf-8")
+    roadmap_text = ROADMAP.read_text(encoding="utf-8")
+    assert "TASK-2.2" in roadmap_text
+    assert audit_name in roadmap_text

--- a/backlog/tasks/task-2.2 - Phase-1.2-Audit-destination-action-functionality-beyond-render-click-tests.md
+++ b/backlog/tasks/task-2.2 - Phase-1.2-Audit-destination-action-functionality-beyond-render-click-tests.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-2.2
 title: 'Phase 1.2: Audit destination action functionality beyond render/click tests'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-05-03 14:48'
+updated_date: '2026-05-03 15:34'
 labels:
   - unified-shell
   - phase-1
@@ -25,8 +26,24 @@ Audit every top-level Unified Shell destination for real action ownership, hones
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Each top-level destination has an action ownership and usability status recorded.
-- [ ] #2 Findings distinguish working workflows, honest blocked states, and false affordances.
-- [ ] #3 Running-app QA evidence exists under Docs/superpowers/qa/unified-shell/phase-1/.
-- [ ] #4 Follow-on Backlog child tasks are created only for PR-sized fixes.
+- [x] #1 Each top-level destination has an action ownership and usability status recorded.
+- [x] #2 Findings distinguish working workflows, honest blocked states, and false affordances.
+- [x] #3 Running-app QA evidence exists under Docs/superpowers/qa/unified-shell/phase-1/.
+- [x] #4 Follow-on Backlog child tasks are created only for PR-sized fixes.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused regression test that defines the expected destination-action audit artifact and roadmap linkage.
+2. Verify the test fails before creating the audit evidence.
+3. Audit each Unified Shell top-level destination against route metadata, destination tests, current QA protocol, and implementation surfaces.
+4. Record action ownership, usability status, classifications, evidence, and PR-sized follow-up boundaries under Docs/superpowers/qa/unified-shell/phase-1/.
+5. Update the Phase 1 QA index, maturity roadmap, and TASK-2.2 state after focused verification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added a destination-action audit artifact covering all top-level Unified Shell destinations, created a focused regression test for the audit contract, linked the evidence from the Phase 1 README and maturity roadmap, and created TASK-2.3 for the only PR-sized false-affordance fix identified.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-2.3 - Phase-1.3-Remove-false-Console-launch-affordances-from-skeletal-destinations.md
+++ b/backlog/tasks/task-2.3 - Phase-1.3-Remove-false-Console-launch-affordances-from-skeletal-destinations.md
@@ -1,0 +1,28 @@
+---
+id: TASK-2.3
+title: 'Phase 1.3: Remove false Console-launch affordances from skeletal destinations'
+status: To Do
+assignee: []
+created_date: '2026-05-03 15:33'
+labels:
+  - unified-shell
+  - phase-1
+  - affordances
+dependencies: []
+parent_task_id: TASK-2
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Ensure skeletal Unified Shell destinations do not present Console launch/follow actions as executable workflows unless they carry actionable context or show an honest unavailable state.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Schedules, Workflows, ACP, and W+C Console actions either pass actionable payloads or are disabled with recovery copy.
+- [ ] #2 Button labels distinguish launch/follow/inspect based on actual capability.
+- [ ] #3 Automated mounted UI tests prove false affordances are removed.
+- [ ] #4 QA walkthrough evidence records the updated blocked or working behavior.
+<!-- AC:END -->


### PR DESCRIPTION
## Summary
- Add TASK-2.2 destination-action audit evidence covering all 12 top-level Unified Shell destinations.
- Add a regression test that requires the audit artifact, classifications, running-app evidence, and roadmap/index links.
- Create TASK-2.3 as the PR-sized follow-up for false Console-launch affordances in skeletal destinations.

## Verification
- RED: /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_unified_shell_destination_action_audit.py -q -> 4 failed before audit artifact existed
- GREEN: /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_unified_shell_destination_action_audit.py -q -> 4 passed
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_unified_shell_destination_action_audit.py Tests/UI/test_unified_shell_qa_protocol.py Tests/UI/test_master_shell_navigation.py Tests/UI/test_destination_shells.py Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_home_screen.py Tests/UI/test_shell_destinations.py -q -> 70 passed, 1 warning
- git diff --check -> clean