### PR TITLE
Add Home active work adapter contract

### DIFF
--- a/Docs/superpowers/qa/unified-shell/phase-2/2026-05-03-home-active-work-adapter-contract.md
+++ b/Docs/superpowers/qa/unified-shell/phase-2/2026-05-03-home-active-work-adapter-contract.md
@@ -1,0 +1,44 @@
+# Home Active-Work Adapter Contract
+
+Date: 2026-05-03
+Task: `TASK-4.1`
+Branch: `codex/unified-shell-phase2-home-adapter-contract`
+Base: `origin/dev` at `499477a6`
+
+## Purpose
+
+Begin Phase 2 by replacing hard-coded Home active-work placeholder behavior with an explicit adapter boundary. This Home active-work adapter contract makes Home dashboard state and approve/reject/pause/resume/retry controls replaceable by real run, schedule, or agent services in later Phase 2 slices.
+
+## What Changed
+
+- Added `HomeActiveWorkAdapter`, `HomeControlAction`, `HomeControlResult`, and `HomeControlResultStatus`.
+- Added `UnavailableHomeActiveWorkAdapter` as the honest default adapter.
+- Wired `HomeScreen` dashboard input through `app.home_active_work_adapter`.
+- Wired `TldwCli` approve, reject, pause, resume, and retry methods through the adapter.
+- Preserved honest unavailable behavior: the default adapter notifies users that the action is not connected to an active run service yet and points them to details or Console.
+
+## Running-App QA Evidence
+
+Focused checks were run against pure Home state and mounted Textual Home tests.
+
+- Red adapter test: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Home/test_active_work_adapter.py Tests/UI/test_home_screen.py::test_home_screen_uses_active_work_adapter_for_dashboard_and_controls -q`
+- Red result before adapter existed: import error for `tldw_chatbook.Home.active_work_adapter`.
+- Focused green check: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Home/test_active_work_adapter.py Tests/UI/test_home_screen.py::test_home_screen_uses_active_work_adapter_for_dashboard_and_controls -q`
+- Focused green result: `3 passed`
+- Home suite: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Home/test_active_work_adapter.py Tests/Home/test_dashboard_state.py Tests/UI/test_home_screen.py -q`
+- Home suite result: `15 passed, 8 warnings`
+- Evidence contract: `Tests/UI/test_unified_shell_phase2_home_adapter.py`
+
+Warning boundary: warnings are existing dependency/import warnings and are not Home adapter behavior failures.
+
+## UX Result
+
+- Home now has a real adapter seam for status and control ownership.
+- Beginner-facing copy remains honest when no active run service exists.
+- Power-user paths are preserved because the visible controls and routes remain stable while the backend source becomes replaceable.
+
+## Residual Risk
+
+- This slice does not implement real approve/reject/pause/resume/retry services.
+- Real active-run, schedule, and agent-service adapters remain future Phase 2 work under `TASK-4`.
+- Home still needs running-app QA for real service-backed control completion before Phase 2 can be verified.

--- a/Docs/superpowers/qa/unified-shell/phase-2/2026-05-03-home-active-work-adapter-contract.md
+++ b/Docs/superpowers/qa/unified-shell/phase-2/2026-05-03-home-active-work-adapter-contract.md
@@ -21,12 +21,12 @@ Begin Phase 2 by replacing hard-coded Home active-work placeholder behavior with
 
 Focused checks were run against pure Home state and mounted Textual Home tests.
 
-- Red adapter test: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Home/test_active_work_adapter.py Tests/UI/test_home_screen.py::test_home_screen_uses_active_work_adapter_for_dashboard_and_controls -q`
+- Red adapter test: `python -m pytest Tests/Home/test_active_work_adapter.py Tests/UI/test_home_screen.py::test_home_screen_uses_active_work_adapter_for_dashboard_and_controls -q`
 - Red result before adapter existed: import error for `tldw_chatbook.Home.active_work_adapter`.
-- Focused green check: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Home/test_active_work_adapter.py Tests/UI/test_home_screen.py::test_home_screen_uses_active_work_adapter_for_dashboard_and_controls -q`
-- Focused green result: `3 passed`
-- Home suite: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Home/test_active_work_adapter.py Tests/Home/test_dashboard_state.py Tests/UI/test_home_screen.py -q`
-- Home suite result: `15 passed, 8 warnings`
+- Focused green check: `python -m pytest Tests/Home/test_active_work_adapter.py Tests/UI/test_home_screen.py::test_home_screen_uses_active_work_adapter_for_dashboard_and_controls -q`
+- Focused green result after review follow-up: `4 passed`
+- Home suite: `python -m pytest Tests/Home/test_active_work_adapter.py Tests/Home/test_dashboard_state.py Tests/UI/test_home_screen.py -q`
+- Home suite result after review follow-up: `16 passed, 8 warnings`
 - Evidence contract: `Tests/UI/test_unified_shell_phase2_home_adapter.py`
 
 Warning boundary: warnings are existing dependency/import warnings and are not Home adapter behavior failures.

--- a/Docs/superpowers/qa/unified-shell/phase-2/README.md
+++ b/Docs/superpowers/qa/unified-shell/phase-2/README.md
@@ -1,5 +1,11 @@
 # Phase 2 QA Evidence
 
-Status: not-started
+Status: in-progress
 
-This directory will contain durable QA summaries for this phase. Do not mark the phase verified until running-app walkthrough evidence exists here.
+This directory contains durable QA summaries for Phase 2 Home operational-control work.
+
+## Evidence
+
+- `2026-05-03-home-active-work-adapter-contract.md` - `TASK-4.1` adapter boundary for Home dashboard state and lightweight controls.
+
+Do not mark Phase 2 verified until Home approve, reject, pause, resume, retry, and open-detail workflows are verified against real service-backed adapters or explicitly recoverable unavailable states.

--- a/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
@@ -1,8 +1,8 @@
 # Unified Shell Maturity Roadmap
 
 Date: 2026-05-03
-Status: Phase 1 verified
-Source Branch: `origin/dev` at `8acf1ed4` plus `codex/unified-shell-phase1-closeout-replay`
+Status: Phase 2 in progress
+Source Branch: `origin/dev` at `499477a6` plus `codex/unified-shell-phase2-home-adapter-contract`
 
 ## Purpose
 
@@ -27,7 +27,7 @@ Track remaining Unified Shell work in one place so rendered screens, clickable b
 
 ## Known Product Gaps
 
-- Home active-work controls still use placeholder notification hooks for approve, reject, pause, resume, and retry.
+- Home active-work controls now route through an explicit adapter boundary; real service-backed adapters still need implementation.
 - Workflows has no wired workflow service in the shell wrapper.
 - W+C, Schedules, Workflows, and ACP now use honest unavailable Console states until actionable payloads exist.
 - ACP launch is disabled until an ACP-compatible runtime is configured.
@@ -79,6 +79,7 @@ Initial child tasks:
 - Phase 1.2: Audit destination action functionality beyond render/click tests - `TASK-2.2`
 - Phase 1.3: Remove false Console-launch affordances from skeletal destinations - `TASK-2.3`
 - Phase 1.4: Replay shell contract and close Phase 1 - `TASK-2.4`
+- Phase 2.1: Add Home active-work adapter contract - `TASK-4.1`
 
 ## QA Evidence Index
 
@@ -86,7 +87,7 @@ Initial child tasks:
 | --- | --- | --- |
 | Phase 0 | `Docs/superpowers/qa/unified-shell/phase-0/` | verified |
 | Phase 1 | `Docs/superpowers/qa/unified-shell/phase-1/` | verified |
-| Phase 2 | `Docs/superpowers/qa/unified-shell/phase-2/` | not-started |
+| Phase 2 | `Docs/superpowers/qa/unified-shell/phase-2/` | in-progress |
 | Phase 3 | `Docs/superpowers/qa/unified-shell/phase-3/` | not-started |
 | Phase 4 | `Docs/superpowers/qa/unified-shell/phase-4/` | not-started |
 | Phase 5 | `Docs/superpowers/qa/unified-shell/phase-5/` | not-started |
@@ -98,7 +99,7 @@ Initial child tasks:
 | --- | --- | --- | --- | --- | --- |
 | Phase 0: Canonical Tracking | Make remaining work trackable. | verified | `TASK-1`, `TASK-1.1`, `TASK-1.2` | `phase-0/` | Product UI workflows are out of scope for Phase 0. |
 | Phase 1: Shell Contract Complete | Remove false shell affordances and prove shell usability. | verified | `TASK-2`, `TASK-2.1`, `TASK-2.2`, `TASK-2.3`, `TASK-2.4` | `phase-1/` | Live service workflows remain intentionally deferred to Phases 2-6. |
-| Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | not-started | `TASK-4` | `phase-2/` | Home action adapters still need design and implementation. |
+| Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | in-progress | `TASK-4`, `TASK-4.1` | `phase-2/` | Real active-run, schedule, and agent-service adapters still need implementation. |
 | Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | not-started | `TASK-3` | `phase-3/` | Live work event sources need explicit contracts. |
 | Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | not-started | `TASK-5` | `phase-4/` | Service coverage varies by destination. |
 | Phase 5: Capability And Recovery System | Systematize unavailable and blocked states. | not-started | `TASK-6` | `phase-5/` | Shared taxonomy not yet extracted. |
@@ -131,6 +132,12 @@ Initial audit result: W+C, Schedules, Workflows, and ACP had false Console-launc
 `TASK-2.4` replays the Phase 1 shell contract and closes the phase as verified:
 
 - `Docs/superpowers/qa/unified-shell/phase-1/2026-05-03-phase-1-shell-contract-closeout.md`
+
+## Phase 2.1 Home Adapter Evidence
+
+`TASK-4.1` adds an explicit Home active-work adapter boundary for dashboard state and lightweight controls:
+
+- `Docs/superpowers/qa/unified-shell/phase-2/2026-05-03-home-active-work-adapter-contract.md`
 
 ## Phase 0: Canonical Tracking
 

--- a/Tests/Home/test_active_work_adapter.py
+++ b/Tests/Home/test_active_work_adapter.py
@@ -1,0 +1,32 @@
+from tldw_chatbook.Home.active_work_adapter import (
+    HomeControlAction,
+    HomeControlResultStatus,
+    UnavailableHomeActiveWorkAdapter,
+)
+
+
+def test_unavailable_home_adapter_builds_dashboard_input_from_runtime_context():
+    adapter = UnavailableHomeActiveWorkAdapter()
+
+    dashboard_input = adapter.build_dashboard_input(
+        providers_models={"OpenAI": ["gpt-4.1"]},
+        has_recent_work=True,
+    )
+
+    assert dashboard_input.model_ready is True
+    assert dashboard_input.has_recent_work is True
+    assert dashboard_input.pending_approval_count == 0
+    assert dashboard_input.active_run_count == 0
+    assert dashboard_input.active_detail_route == "chat"
+
+
+def test_unavailable_home_adapter_returns_honest_recovery_result():
+    adapter = UnavailableHomeActiveWorkAdapter()
+
+    result = adapter.handle_control(HomeControlAction.APPROVE)
+
+    assert result.action is HomeControlAction.APPROVE
+    assert result.status is HomeControlResultStatus.UNAVAILABLE
+    assert result.severity == "warning"
+    assert "Approve is not connected" in result.message
+    assert result.recovery_route == "chat"

--- a/Tests/Home/test_active_work_adapter.py
+++ b/Tests/Home/test_active_work_adapter.py
@@ -1,5 +1,8 @@
+from typing import get_type_hints
+
 from tldw_chatbook.Home.active_work_adapter import (
     HomeControlAction,
+    HomeControlResult,
     HomeControlResultStatus,
     UnavailableHomeActiveWorkAdapter,
 )
@@ -30,3 +33,7 @@ def test_unavailable_home_adapter_returns_honest_recovery_result():
     assert result.severity == "warning"
     assert "Approve is not connected" in result.message
     assert result.recovery_route == "chat"
+
+
+def test_home_control_result_status_contract_uses_enum_only():
+    assert get_type_hints(HomeControlResult)["status"] is HomeControlResultStatus

--- a/Tests/UI/test_home_screen.py
+++ b/Tests/UI/test_home_screen.py
@@ -4,7 +4,11 @@ import pytest
 from textual.app import App
 
 from tldw_chatbook.Chat.chat_handoff_models import ChatHandoffPayload
-from tldw_chatbook.Home.active_work_adapter import HomeControlAction, HomeControlResult
+from tldw_chatbook.Home.active_work_adapter import (
+    HomeControlAction,
+    HomeControlResult,
+    HomeControlResultStatus,
+)
 from tldw_chatbook.Home.dashboard_state import HomeDashboardInput
 from tldw_chatbook.UI.Screens.home_screen import HomeScreen
 from Tests.UI.test_screen_navigation import _build_test_app
@@ -47,7 +51,7 @@ class RecordingHomeActiveWorkAdapter:
         self.control_actions.append(action)
         return HomeControlResult(
             action=action,
-            status="handled",
+            status=HomeControlResultStatus.HANDLED,
             message=f"{action.value} handled by adapter",
             severity="information",
             recovery_route="chat",

--- a/Tests/UI/test_home_screen.py
+++ b/Tests/UI/test_home_screen.py
@@ -4,6 +4,7 @@ import pytest
 from textual.app import App
 
 from tldw_chatbook.Chat.chat_handoff_models import ChatHandoffPayload
+from tldw_chatbook.Home.active_work_adapter import HomeControlAction, HomeControlResult
 from tldw_chatbook.Home.dashboard_state import HomeDashboardInput
 from tldw_chatbook.UI.Screens.home_screen import HomeScreen
 from Tests.UI.test_screen_navigation import _build_test_app
@@ -24,6 +25,33 @@ class HomeHarness(App):
 
 def _active_home_screen(host: HomeHarness):
     return host.screen_stack[-1]
+
+
+class RecordingHomeActiveWorkAdapter:
+    def __init__(self):
+        self.dashboard_calls = 0
+        self.control_actions = []
+
+    def build_dashboard_input(self, *, providers_models, has_recent_work):
+        self.dashboard_calls += 1
+        return HomeDashboardInput(
+            model_ready=True,
+            pending_approval_count=1,
+            running_run_count=1,
+            active_run_count=1,
+            has_library_content=True,
+            has_recent_work=has_recent_work,
+        )
+
+    def handle_control(self, action):
+        self.control_actions.append(action)
+        return HomeControlResult(
+            action=action,
+            status="handled",
+            message=f"{action.value} handled by adapter",
+            severity="information",
+            recovery_route="chat",
+        )
 
 
 @pytest.mark.asyncio
@@ -142,6 +170,27 @@ def test_app_exposes_home_runtime_control_hooks():
         "retry_active_home_item",
     ]:
         assert callable(getattr(app, method_name, None))
+
+
+@pytest.mark.asyncio
+async def test_home_screen_uses_active_work_adapter_for_dashboard_and_controls():
+    app = _build_test_app()
+    adapter = RecordingHomeActiveWorkAdapter()
+    app.home_active_work_adapter = adapter
+    app.notify = Mock()
+    host = HomeHarness(app)
+
+    async with host.run_test(size=(160, 40)) as pilot:
+        await pilot.pause(0.1)
+        await pilot.click("#home-approve")
+        await pilot.pause(0.1)
+
+    assert adapter.dashboard_calls == 1
+    assert adapter.control_actions == [HomeControlAction.APPROVE]
+    app.notify.assert_called_once_with(
+        "approve handled by adapter",
+        severity="information",
+    )
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_unified_shell_phase2_home_adapter.py
+++ b/Tests/UI/test_unified_shell_phase2_home_adapter.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+
+PHASE_2_ROOT = Path("Docs/superpowers/qa/unified-shell/phase-2")
+EVIDENCE = PHASE_2_ROOT / "2026-05-03-home-active-work-adapter-contract.md"
+README = PHASE_2_ROOT / "README.md"
+ROADMAP = Path("Docs/superpowers/trackers/unified-shell-maturity-roadmap.md")
+TASK_4_1 = Path("backlog/tasks/task-4.1 - Phase-2.1-Add-Home-active-work-adapter-contract.md")
+
+
+def test_phase_two_home_adapter_evidence_exists_and_records_verification():
+    assert EVIDENCE.exists()
+    text = EVIDENCE.read_text(encoding="utf-8")
+
+    assert "TASK-4.1" in text
+    assert "Home active-work adapter contract" in text
+    assert "Tests/Home/test_active_work_adapter.py" in text
+    assert "Tests/UI/test_home_screen.py" in text
+    assert "15 passed" in text
+    assert "UnavailableHomeActiveWorkAdapter" in text
+
+
+def test_phase_two_home_adapter_is_linked_from_index_roadmap_and_task():
+    evidence_name = EVIDENCE.name
+
+    assert evidence_name in README.read_text(encoding="utf-8")
+
+    roadmap_text = ROADMAP.read_text(encoding="utf-8")
+    assert "TASK-4.1" in roadmap_text
+    assert evidence_name in roadmap_text
+    assert "| Phase 2 | `Docs/superpowers/qa/unified-shell/phase-2/` | in-progress |" in roadmap_text
+
+    task_text = TASK_4_1.read_text(encoding="utf-8")
+    assert "status: Done" in task_text
+    assert "- [x] #1" in task_text
+    assert "- [x] #4" in task_text

--- a/backlog/tasks/task-4.1 - Phase-2.1-Add-Home-active-work-adapter-contract.md
+++ b/backlog/tasks/task-4.1 - Phase-2.1-Add-Home-active-work-adapter-contract.md
@@ -1,0 +1,46 @@
+---
+id: TASK-4.1
+title: 'Phase 2.1: Add Home active-work adapter contract'
+status: Done
+assignee: []
+created_date: '2026-05-03 16:54'
+updated_date: '2026-05-03 16:56'
+labels:
+  - unified-shell
+  - phase-2
+  - home
+  - adapter
+dependencies: []
+parent_task_id: TASK-4
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Introduce an explicit Home active-work adapter boundary so dashboard state and approve/reject/pause/resume/retry controls come from a replaceable service adapter rather than hard-coded placeholder app methods.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Home dashboard input is built through an explicit adapter contract.
+- [x] #2 Approve, reject, pause, resume, and retry controls delegate to the adapter.
+- [x] #3 Unavailable adapter results notify users with honest recovery copy.
+- [x] #4 Focused unit and mounted Home tests cover adapter delegation.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing tests for a Home active-work adapter contract and HomeScreen delegation.
+2. Implement the smallest adapter protocol/result model plus an unavailable adapter that preserves honest recovery copy.
+3. Wire TldwCli/HomeScreen to use the adapter for dashboard input and approve/reject/pause/resume/retry actions.
+4. Add Phase 2 QA evidence and update roadmap/task hygiene.
+5. Run focused Home and shell tests plus diff hygiene before committing.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Introduced a Home active-work adapter contract, wired Home dashboard input and approve/reject/pause/resume/retry controls through the adapter, preserved honest unavailable recovery copy through the default adapter, and added focused unit plus mounted Home tests for the delegation boundary.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-4.1 - Phase-2.1-Add-Home-active-work-adapter-contract.md
+++ b/backlog/tasks/task-4.1 - Phase-2.1-Add-Home-active-work-adapter-contract.md
@@ -43,4 +43,6 @@ Introduce an explicit Home active-work adapter boundary so dashboard state and a
 
 <!-- SECTION:NOTES:BEGIN -->
 Introduced a Home active-work adapter contract, wired Home dashboard input and approve/reject/pause/resume/retry controls through the adapter, preserved honest unavailable recovery copy through the default adapter, and added focused unit plus mounted Home tests for the delegation boundary.
+
+Review follow-up tightened the adapter result status contract to `HomeControlResultStatus`, made the unavailable adapter explicitly implement the protocol, removed dead HomeScreen fallback dashboard construction, and normalized QA evidence commands to repo-relative paths.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Home/__init__.py
+++ b/tldw_chatbook/Home/__init__.py
@@ -8,13 +8,25 @@ from .dashboard_state import (
     choose_next_best_action,
     summarize_home_dashboard,
 )
+from .active_work_adapter import (
+    HomeActiveWorkAdapter,
+    HomeControlAction,
+    HomeControlResult,
+    HomeControlResultStatus,
+    UnavailableHomeActiveWorkAdapter,
+)
 
 __all__ = [
     "HomeAction",
+    "HomeActiveWorkAdapter",
     "HomeControl",
+    "HomeControlAction",
     "HomeDashboard",
     "HomeDashboardInput",
     "HomeSection",
+    "HomeControlResult",
+    "HomeControlResultStatus",
+    "UnavailableHomeActiveWorkAdapter",
     "build_home_controls",
     "choose_next_best_action",
     "summarize_home_dashboard",

--- a/tldw_chatbook/Home/active_work_adapter.py
+++ b/tldw_chatbook/Home/active_work_adapter.py
@@ -1,0 +1,93 @@
+"""Home active-work adapter contract and default unavailable implementation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, Mapping, Protocol, runtime_checkable
+
+from .dashboard_state import HomeDashboardInput
+
+
+class HomeControlAction(StrEnum):
+    APPROVE = "approve"
+    REJECT = "reject"
+    PAUSE = "pause"
+    RESUME = "resume"
+    RETRY = "retry"
+
+
+class HomeControlResultStatus(StrEnum):
+    HANDLED = "handled"
+    UNAVAILABLE = "unavailable"
+
+
+@dataclass(frozen=True)
+class HomeControlResult:
+    action: HomeControlAction
+    status: HomeControlResultStatus | str
+    message: str
+    severity: str = "information"
+    recovery_route: str = "chat"
+
+
+@runtime_checkable
+class HomeActiveWorkAdapter(Protocol):
+    """Adapter boundary for Home dashboard state and lightweight controls."""
+
+    def build_dashboard_input(
+        self,
+        *,
+        providers_models: Mapping[str, Any],
+        has_recent_work: bool,
+    ) -> HomeDashboardInput:
+        """Return dashboard input from the current active-work backend."""
+        ...
+
+    def handle_control(self, action: HomeControlAction) -> HomeControlResult:
+        """Handle a lightweight Home control action."""
+        ...
+
+
+class UnavailableHomeActiveWorkAdapter:
+    """Honest default adapter until active-run services are wired."""
+
+    _ACTION_LABELS = {
+        HomeControlAction.APPROVE: "Approve",
+        HomeControlAction.REJECT: "Reject",
+        HomeControlAction.PAUSE: "Pause",
+        HomeControlAction.RESUME: "Resume",
+        HomeControlAction.RETRY: "Retry",
+    }
+
+    def build_dashboard_input(
+        self,
+        *,
+        providers_models: Mapping[str, Any],
+        has_recent_work: bool,
+    ) -> HomeDashboardInput:
+        return HomeDashboardInput(
+            model_ready=bool(providers_models),
+            pending_approval_count=0,
+            active_run_count=0,
+            running_run_count=0,
+            paused_run_count=0,
+            failed_run_count=0,
+            failed_schedule_count=0,
+            has_library_content=False,
+            has_recent_work=has_recent_work,
+            active_detail_route="chat",
+        )
+
+    def handle_control(self, action: HomeControlAction) -> HomeControlResult:
+        label = self._ACTION_LABELS[action]
+        return HomeControlResult(
+            action=action,
+            status=HomeControlResultStatus.UNAVAILABLE,
+            message=(
+                f"{label} is not connected to an active run service yet. "
+                "Open details or Console to inspect the work."
+            ),
+            severity="warning",
+            recovery_route="chat",
+        )

--- a/tldw_chatbook/Home/active_work_adapter.py
+++ b/tldw_chatbook/Home/active_work_adapter.py
@@ -25,7 +25,7 @@ class HomeControlResultStatus(StrEnum):
 @dataclass(frozen=True)
 class HomeControlResult:
     action: HomeControlAction
-    status: HomeControlResultStatus | str
+    status: HomeControlResultStatus
     message: str
     severity: str = "information"
     recovery_route: str = "chat"
@@ -49,7 +49,7 @@ class HomeActiveWorkAdapter(Protocol):
         ...
 
 
-class UnavailableHomeActiveWorkAdapter:
+class UnavailableHomeActiveWorkAdapter(HomeActiveWorkAdapter):
     """Honest default adapter until active-run services are wired."""
 
     _ACTION_LABELS = {

--- a/tldw_chatbook/UI/Screens/home_screen.py
+++ b/tldw_chatbook/UI/Screens/home_screen.py
@@ -38,15 +38,8 @@ class HomeScreen(BaseAppScreen):
 
         providers = getattr(self.app_instance, "providers_models", {}) or {}
         has_recent_work = bool(getattr(self.app_instance, "_screen_states", {}))
-        adapter = getattr(self.app_instance, "home_active_work_adapter", None)
-        if adapter is not None and hasattr(adapter, "build_dashboard_input"):
-            return adapter.build_dashboard_input(
-                providers_models=providers,
-                has_recent_work=has_recent_work,
-            )
-
-        return HomeDashboardInput(
-            model_ready=bool(providers),
+        return self.app_instance.home_active_work_adapter.build_dashboard_input(
+            providers_models=providers,
             has_recent_work=has_recent_work,
         )
 

--- a/tldw_chatbook/UI/Screens/home_screen.py
+++ b/tldw_chatbook/UI/Screens/home_screen.py
@@ -37,15 +37,17 @@ class HomeScreen(BaseAppScreen):
             return test_override
 
         providers = getattr(self.app_instance, "providers_models", {}) or {}
-        model_ready = bool(providers)
+        has_recent_work = bool(getattr(self.app_instance, "_screen_states", {}))
+        adapter = getattr(self.app_instance, "home_active_work_adapter", None)
+        if adapter is not None and hasattr(adapter, "build_dashboard_input"):
+            return adapter.build_dashboard_input(
+                providers_models=providers,
+                has_recent_work=has_recent_work,
+            )
+
         return HomeDashboardInput(
-            model_ready=model_ready,
-            pending_approval_count=0,
-            active_run_count=0,
-            running_run_count=0,
-            has_library_content=False,
-            has_recent_work=bool(getattr(self.app_instance, "_screen_states", {})),
-            active_detail_route="chat",
+            model_ready=bool(providers),
+            has_recent_work=has_recent_work,
         )
 
     def compose_content(self) -> ComposeResult:

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -94,6 +94,11 @@ from tldw_chatbook.Chat import (
     ServerChatConversationService,
 )
 from tldw_chatbook.Chatbooks import LocalChatbookService, ServerChatbookService
+from tldw_chatbook.Home.active_work_adapter import (
+    HomeControlAction,
+    HomeControlResult,
+    UnavailableHomeActiveWorkAdapter,
+)
 from tldw_chatbook.Logging_Config import RichLogHandler
 from tldw_chatbook.Prompt_Management import (
     LocalPromptService,
@@ -1361,6 +1366,7 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
         self.pending_console_launch: Optional[Dict[str, Any]] = None
         self.pending_study_scope_context: Optional[StudyScopeContext] = None
         self.pending_notes_workspace_context: Optional[Dict[str, Any]] = None
+        self.home_active_work_adapter = UnavailableHomeActiveWorkAdapter()
         self.loguru_logger = loguru_logger
         self.loguru_logger.info(f"Loaded app_config - strip_thinking_tags: {self.app_config.get('chat_defaults', {}).get('strip_thinking_tags', 'NOT SET')}") # Make loguru_logger an instance variable for handlers
         self.client_id = CLI_APP_CLIENT_ID
@@ -1638,31 +1644,31 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
         }
         self.post_message(NavigateToScreen(TAB_CHAT))
 
-    def _notify_home_control_unavailable(self, action_label: str) -> None:
-        self.notify(
-            f"{action_label} is not connected to an active run service yet. Open details or Console to inspect the work.",
-            severity="warning",
-        )
+    def _handle_home_control_action(self, action: HomeControlAction) -> HomeControlResult:
+        adapter = getattr(self, "home_active_work_adapter", UnavailableHomeActiveWorkAdapter())
+        result = adapter.handle_control(action)
+        self.notify(result.message, severity=result.severity)
+        return result
 
-    def approve_active_home_item(self) -> None:
-        """Placeholder hook for Home approval controls until run services are wired."""
-        self._notify_home_control_unavailable("Approve")
+    def approve_active_home_item(self) -> HomeControlResult:
+        """Approve the active Home item through the configured adapter."""
+        return self._handle_home_control_action(HomeControlAction.APPROVE)
 
-    def reject_active_home_item(self) -> None:
-        """Placeholder hook for Home approval controls until run services are wired."""
-        self._notify_home_control_unavailable("Reject")
+    def reject_active_home_item(self) -> HomeControlResult:
+        """Reject the active Home item through the configured adapter."""
+        return self._handle_home_control_action(HomeControlAction.REJECT)
 
-    def pause_active_home_item(self) -> None:
-        """Placeholder hook for Home run controls until run services are wired."""
-        self._notify_home_control_unavailable("Pause")
+    def pause_active_home_item(self) -> HomeControlResult:
+        """Pause the active Home item through the configured adapter."""
+        return self._handle_home_control_action(HomeControlAction.PAUSE)
 
-    def resume_active_home_item(self) -> None:
-        """Placeholder hook for Home run controls until run services are wired."""
-        self._notify_home_control_unavailable("Resume")
+    def resume_active_home_item(self) -> HomeControlResult:
+        """Resume the active Home item through the configured adapter."""
+        return self._handle_home_control_action(HomeControlAction.RESUME)
 
-    def retry_active_home_item(self) -> None:
-        """Placeholder hook for Home recovery controls until run services are wired."""
-        self._notify_home_control_unavailable("Retry")
+    def retry_active_home_item(self) -> HomeControlResult:
+        """Retry the active Home item through the configured adapter."""
+        return self._handle_home_control_action(HomeControlAction.RETRY)
 
     def _wire_character_persona_services(self) -> None:
         self.server_character_persona_service = ServerCharacterPersonaService.from_server_context_provider(


### PR DESCRIPTION
## Summary
- Add TASK-4.1 Home active-work adapter contract and default unavailable adapter.
- Route Home dashboard input and approve/reject/pause/resume/retry controls through the adapter boundary.
- Add Phase 2 QA evidence and update the roadmap to mark Phase 2 in progress.
- Address review feedback by tightening adapter result status typing, removing dead HomeScreen fallback logic, and normalizing QA evidence commands.

## Verification
- RED: `python -m pytest Tests/Home/test_active_work_adapter.py::test_home_control_result_status_contract_uses_enum_only -q` -> failed before tightening `HomeControlResult.status`.
- GREEN: `python -m pytest Tests/Home/test_active_work_adapter.py Tests/UI/test_home_screen.py::test_home_screen_uses_active_work_adapter_for_dashboard_and_controls -q` -> 4 passed, 8 warnings.
- `python -m pytest Tests/Home/test_active_work_adapter.py Tests/Home/test_dashboard_state.py Tests/UI/test_home_screen.py -q` -> 16 passed, 8 warnings.
- `python -m pytest Tests/Home/test_active_work_adapter.py Tests/Home/test_dashboard_state.py Tests/UI/test_home_screen.py Tests/UI/test_unified_shell_phase2_home_adapter.py Tests/UI/test_unified_shell_phase1_closeout.py Tests/UI/test_master_shell_navigation.py -q` -> 24 passed, 8 warnings.
- `git diff --check` -> clean.
- `git diff --cached --check` -> clean before commit.