### PR TITLE
Route Home detail and Console actions through adapter

### DIFF
--- a/Docs/superpowers/qa/unified-shell/phase-2/2026-05-03-home-detail-console-adapter-actions.md
+++ b/Docs/superpowers/qa/unified-shell/phase-2/2026-05-03-home-detail-console-adapter-actions.md
@@ -1,0 +1,45 @@
+# Home Detail And Console Adapter Actions
+
+Date: 2026-05-03
+Task: `TASK-4.2`
+Branch: `codex/unified-shell-phase2-home-open-detail-adapter`
+Base: `origin/dev` at `5a6e35e8`
+
+## Purpose
+
+Close the remaining false-control gap in the Phase 2 Home adapter seam. `Open details` and `Open in Console` now go through the active-work adapter rather than directly navigating from a visible button.
+
+## What Changed
+
+- Added `HomeControlAction.OPEN_DETAILS` and `HomeControlAction.OPEN_IN_CONSOLE`.
+- Added `HomeConsoleLaunch` and optional `target_route` / `console_launch` fields to `HomeControlResult`.
+- Wired Home `Open details` to navigate only after the adapter returns a handled detail target.
+- Wired Home `Open in Console` to launch Console only after the adapter returns explicit Console launch context.
+- Kept unavailable default behavior honest: missing active-work services notify with recovery copy and do not create a fake Console workflow.
+
+## Functional QA Evidence
+
+Focused checks were run against the Home adapter unit surface and mounted Textual Home screen harness.
+
+- Baseline before edits: `python -m pytest Tests/Home/test_active_work_adapter.py Tests/UI/test_home_screen.py -q`
+- Baseline result: `12 passed, 10 warnings`
+- Red test: `python -m pytest Tests/Home/test_active_work_adapter.py Tests/UI/test_home_screen.py -q`
+- Red result: collection failed because `HomeConsoleLaunch` and the open-detail/open-console adapter actions did not exist.
+- Green test: `python -m pytest Tests/Home/test_active_work_adapter.py Tests/UI/test_home_screen.py -q`
+- Green result: `18 passed, 8 warnings`
+- Focused Phase 2 suite: `python -m pytest Tests/Home/test_active_work_adapter.py Tests/Home/test_dashboard_state.py Tests/UI/test_home_screen.py Tests/UI/test_unified_shell_phase2_home_adapter.py -q`
+- Focused Phase 2 suite result: `26 passed, 8 warnings`
+
+Warning boundary: warnings are existing dependency/import warnings and are not Home adapter behavior failures.
+
+## UX Result
+
+- First-time users no longer see a control that silently opens Console without a real active-work payload.
+- Power users keep the same visible Home controls, but repeated detail/Console workflows now depend on explicit adapter results.
+- Recovery remains understandable when live active-run services are not wired: the app tells users the action is unavailable instead of implying work is happening.
+
+## Residual Risk
+
+- This slice still uses the unavailable default adapter unless a real active-run/schedule adapter is provided.
+- Service-backed detail records and Console launch payloads remain future Phase 2 work.
+- Full Phase 2 cannot be verified until approve, reject, pause, resume, retry, detail, and Console workflows are exercised against real active work.

--- a/Docs/superpowers/qa/unified-shell/phase-2/README.md
+++ b/Docs/superpowers/qa/unified-shell/phase-2/README.md
@@ -7,5 +7,6 @@ This directory contains durable QA summaries for Phase 2 Home operational-contro
 ## Evidence
 
 - `2026-05-03-home-active-work-adapter-contract.md` - `TASK-4.1` adapter boundary for Home dashboard state and lightweight controls.
+- `2026-05-03-home-detail-console-adapter-actions.md` - `TASK-4.2` adapter-owned Home detail and Console actions.
 
 Do not mark Phase 2 verified until Home approve, reject, pause, resume, retry, and open-detail workflows are verified against real service-backed adapters or explicitly recoverable unavailable states.

--- a/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
@@ -2,7 +2,7 @@
 
 Date: 2026-05-03
 Status: Phase 2 in progress
-Source Branch: `origin/dev` at `499477a6` plus `codex/unified-shell-phase2-home-adapter-contract`
+Source Branch: `origin/dev` at `5a6e35e8` plus `codex/unified-shell-phase2-home-open-detail-adapter`
 
 ## Purpose
 
@@ -27,7 +27,7 @@ Track remaining Unified Shell work in one place so rendered screens, clickable b
 
 ## Known Product Gaps
 
-- Home active-work controls now route through an explicit adapter boundary; real service-backed adapters still need implementation.
+- Home active-work controls, detail routing, and Console launch requests now route through an explicit adapter boundary; real service-backed adapters still need implementation.
 - Workflows has no wired workflow service in the shell wrapper.
 - W+C, Schedules, Workflows, and ACP now use honest unavailable Console states until actionable payloads exist.
 - ACP launch is disabled until an ACP-compatible runtime is configured.
@@ -80,6 +80,7 @@ Initial child tasks:
 - Phase 1.3: Remove false Console-launch affordances from skeletal destinations - `TASK-2.3`
 - Phase 1.4: Replay shell contract and close Phase 1 - `TASK-2.4`
 - Phase 2.1: Add Home active-work adapter contract - `TASK-4.1`
+- Phase 2.2: Route Home detail and Console actions through active-work adapter - `TASK-4.2`
 
 ## QA Evidence Index
 
@@ -99,7 +100,7 @@ Initial child tasks:
 | --- | --- | --- | --- | --- | --- |
 | Phase 0: Canonical Tracking | Make remaining work trackable. | verified | `TASK-1`, `TASK-1.1`, `TASK-1.2` | `phase-0/` | Product UI workflows are out of scope for Phase 0. |
 | Phase 1: Shell Contract Complete | Remove false shell affordances and prove shell usability. | verified | `TASK-2`, `TASK-2.1`, `TASK-2.2`, `TASK-2.3`, `TASK-2.4` | `phase-1/` | Live service workflows remain intentionally deferred to Phases 2-6. |
-| Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | in-progress | `TASK-4`, `TASK-4.1` | `phase-2/` | Real active-run, schedule, and agent-service adapters still need implementation. |
+| Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | in-progress | `TASK-4`, `TASK-4.1`, `TASK-4.2` | `phase-2/` | Real active-run, schedule, and agent-service adapters still need implementation. |
 | Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | not-started | `TASK-3` | `phase-3/` | Live work event sources need explicit contracts. |
 | Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | not-started | `TASK-5` | `phase-4/` | Service coverage varies by destination. |
 | Phase 5: Capability And Recovery System | Systematize unavailable and blocked states. | not-started | `TASK-6` | `phase-5/` | Shared taxonomy not yet extracted. |
@@ -138,6 +139,12 @@ Initial audit result: W+C, Schedules, Workflows, and ACP had false Console-launc
 `TASK-4.1` adds an explicit Home active-work adapter boundary for dashboard state and lightweight controls:
 
 - `Docs/superpowers/qa/unified-shell/phase-2/2026-05-03-home-active-work-adapter-contract.md`
+
+## Phase 2.2 Home Detail And Console Adapter Evidence
+
+`TASK-4.2` moves Home detail and Console actions behind the active-work adapter boundary:
+
+- `Docs/superpowers/qa/unified-shell/phase-2/2026-05-03-home-detail-console-adapter-actions.md`
 
 ## Phase 0: Canonical Tracking
 

--- a/Tests/Home/test_active_work_adapter.py
+++ b/Tests/Home/test_active_work_adapter.py
@@ -1,6 +1,7 @@
 from typing import get_type_hints
 
 from tldw_chatbook.Home.active_work_adapter import (
+    HomeConsoleLaunch,
     HomeControlAction,
     HomeControlResult,
     HomeControlResultStatus,
@@ -33,6 +34,54 @@ def test_unavailable_home_adapter_returns_honest_recovery_result():
     assert result.severity == "warning"
     assert "Approve is not connected" in result.message
     assert result.recovery_route == "chat"
+
+
+def test_unavailable_home_adapter_keeps_detail_and_console_actions_recoverable():
+    adapter = UnavailableHomeActiveWorkAdapter()
+
+    detail_result = adapter.handle_control(
+        HomeControlAction.OPEN_DETAILS,
+        target_route="workflows",
+    )
+    console_result = adapter.handle_control(
+        HomeControlAction.OPEN_IN_CONSOLE,
+        target_route="chat",
+    )
+
+    assert detail_result.status is HomeControlResultStatus.UNAVAILABLE
+    assert detail_result.target_route is None
+    assert detail_result.recovery_route == "workflows"
+    assert "Open details is not connected" in detail_result.message
+
+    assert console_result.status is HomeControlResultStatus.UNAVAILABLE
+    assert console_result.console_launch is None
+    assert console_result.recovery_route == "chat"
+    assert "Open in Console is not connected" in console_result.message
+
+
+def test_home_control_result_can_carry_route_and_console_launch_payload():
+    launch = HomeConsoleLaunch(
+        source="workflows",
+        title="Daily digest",
+        payload={"run_id": "run-1"},
+    )
+
+    detail_result = HomeControlResult(
+        action=HomeControlAction.OPEN_DETAILS,
+        status=HomeControlResultStatus.HANDLED,
+        message="Opening workflow details.",
+        target_route="workflows",
+    )
+    console_result = HomeControlResult(
+        action=HomeControlAction.OPEN_IN_CONSOLE,
+        status=HomeControlResultStatus.HANDLED,
+        message="Opening Console for Daily digest.",
+        console_launch=launch,
+    )
+
+    assert detail_result.target_route == "workflows"
+    assert console_result.console_launch is launch
+    assert console_result.console_launch.payload == {"run_id": "run-1"}
 
 
 def test_home_control_result_status_contract_uses_enum_only():

--- a/Tests/UI/test_home_screen.py
+++ b/Tests/UI/test_home_screen.py
@@ -5,6 +5,7 @@ from textual.app import App
 
 from tldw_chatbook.Chat.chat_handoff_models import ChatHandoffPayload
 from tldw_chatbook.Home.active_work_adapter import (
+    HomeConsoleLaunch,
     HomeControlAction,
     HomeControlResult,
     HomeControlResultStatus,
@@ -32,12 +33,17 @@ def _active_home_screen(host: HomeHarness):
 
 
 class RecordingHomeActiveWorkAdapter:
-    def __init__(self):
+    def __init__(self, dashboard_input=None, responses=None):
         self.dashboard_calls = 0
         self.control_actions = []
+        self.control_target_routes = []
+        self.dashboard_input = dashboard_input
+        self.responses = responses or {}
 
     def build_dashboard_input(self, *, providers_models, has_recent_work):
         self.dashboard_calls += 1
+        if self.dashboard_input is not None:
+            return self.dashboard_input
         return HomeDashboardInput(
             model_ready=True,
             pending_approval_count=1,
@@ -47,8 +53,11 @@ class RecordingHomeActiveWorkAdapter:
             has_recent_work=has_recent_work,
         )
 
-    def handle_control(self, action):
+    def handle_control(self, action, *, target_route=None):
         self.control_actions.append(action)
+        self.control_target_routes.append(target_route)
+        if action in self.responses:
+            return self.responses[action]
         return HomeControlResult(
             action=action,
             status=HomeControlResultStatus.HANDLED,
@@ -198,7 +207,7 @@ async def test_home_screen_uses_active_work_adapter_for_dashboard_and_controls()
 
 
 @pytest.mark.asyncio
-async def test_home_detail_controls_route_to_owner_and_console():
+async def test_home_detail_controls_do_not_directly_navigate_without_adapter_payload():
     app = _build_test_app()
     app._home_dashboard_test_input = HomeDashboardInput(
         model_ready=True,
@@ -207,6 +216,7 @@ async def test_home_detail_controls_route_to_owner_and_console():
         has_library_content=True,
         active_detail_route="workflows",
     )
+    app.notify = Mock()
     seen = []
     host = HomeHarness(app, seen)
 
@@ -217,8 +227,119 @@ async def test_home_detail_controls_route_to_owner_and_console():
         await pilot.click("#home-open-in-console")
         await pilot.pause(0.1)
 
-    assert "workflows" in seen
-    assert "chat" in seen
+    assert seen == []
+    assert app.notify.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_home_detail_and_console_buttons_call_runtime_hooks_with_target_route():
+    app = _build_test_app()
+    app._home_dashboard_test_input = HomeDashboardInput(
+        model_ready=True,
+        pending_approval_count=1,
+        active_run_count=1,
+        has_library_content=True,
+        active_detail_route="workflows",
+    )
+    app.open_active_home_item_details = Mock()
+    app.open_active_home_item_in_console = Mock()
+    seen = []
+    host = HomeHarness(app, seen)
+
+    async with host.run_test(size=(160, 40)) as pilot:
+        await pilot.pause(0.1)
+        await pilot.click("#home-open-details")
+        await pilot.pause(0.1)
+        await pilot.click("#home-open-in-console")
+        await pilot.pause(0.1)
+
+    app.open_active_home_item_details.assert_called_once_with(target_route="workflows")
+    app.open_active_home_item_in_console.assert_called_once_with(target_route="chat")
+    assert seen == []
+
+
+def test_app_detail_hook_delegates_to_adapter_and_navigates_handled_route():
+    app = _build_test_app()
+    adapter = RecordingHomeActiveWorkAdapter(
+        responses={
+            HomeControlAction.OPEN_DETAILS: HomeControlResult(
+                action=HomeControlAction.OPEN_DETAILS,
+                status=HomeControlResultStatus.HANDLED,
+                message="Opening workflow details.",
+                target_route="workflows",
+            ),
+        }
+    )
+    app.home_active_work_adapter = adapter
+    app.notify = Mock()
+    app.post_message = Mock()
+
+    result = app.open_active_home_item_details(target_route="schedules")
+
+    assert result.status is HomeControlResultStatus.HANDLED
+    assert adapter.control_actions == [HomeControlAction.OPEN_DETAILS]
+    assert adapter.control_target_routes == ["schedules"]
+    app.notify.assert_called_once_with("Opening workflow details.", severity="information")
+    app.post_message.assert_called_once()
+    assert app.post_message.call_args.args[0].screen_name == "workflows"
+
+
+def test_app_console_hook_requires_adapter_launch_payload():
+    app = _build_test_app()
+    adapter = RecordingHomeActiveWorkAdapter(
+        responses={
+            HomeControlAction.OPEN_IN_CONSOLE: HomeControlResult(
+                action=HomeControlAction.OPEN_IN_CONSOLE,
+                status=HomeControlResultStatus.UNAVAILABLE,
+                message="Open in Console is not connected.",
+                severity="warning",
+                recovery_route="chat",
+            ),
+        }
+    )
+    app.home_active_work_adapter = adapter
+    app.notify = Mock()
+    app.open_console_for_live_work = Mock()
+
+    result = app.open_active_home_item_in_console(target_route="chat")
+
+    assert result.status is HomeControlResultStatus.UNAVAILABLE
+    assert adapter.control_actions == [HomeControlAction.OPEN_IN_CONSOLE]
+    assert adapter.control_target_routes == ["chat"]
+    app.notify.assert_called_once_with("Open in Console is not connected.", severity="warning")
+    app.open_console_for_live_work.assert_not_called()
+
+
+def test_app_console_hook_opens_console_with_adapter_launch_payload():
+    app = _build_test_app()
+    launch = HomeConsoleLaunch(
+        source="workflows",
+        title="Daily digest",
+        payload={"run_id": "run-1"},
+    )
+    adapter = RecordingHomeActiveWorkAdapter(
+        responses={
+            HomeControlAction.OPEN_IN_CONSOLE: HomeControlResult(
+                action=HomeControlAction.OPEN_IN_CONSOLE,
+                status=HomeControlResultStatus.HANDLED,
+                message="Opening Console for Daily digest.",
+                console_launch=launch,
+            ),
+        }
+    )
+    app.home_active_work_adapter = adapter
+    app.notify = Mock()
+    app.open_console_for_live_work = Mock()
+
+    result = app.open_active_home_item_in_console(target_route="chat")
+
+    assert result.status is HomeControlResultStatus.HANDLED
+    app.notify.assert_called_once_with("Opening Console for Daily digest.", severity="information")
+    app.open_console_for_live_work.assert_called_once_with(
+        source="workflows",
+        title="Daily digest",
+        payload={"run_id": "run-1"},
+    )
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_unified_shell_phase2_home_adapter.py
+++ b/Tests/UI/test_unified_shell_phase2_home_adapter.py
@@ -3,9 +3,13 @@ from pathlib import Path
 
 PHASE_2_ROOT = Path("Docs/superpowers/qa/unified-shell/phase-2")
 EVIDENCE = PHASE_2_ROOT / "2026-05-03-home-active-work-adapter-contract.md"
+DETAIL_CONSOLE_EVIDENCE = PHASE_2_ROOT / "2026-05-03-home-detail-console-adapter-actions.md"
 README = PHASE_2_ROOT / "README.md"
 ROADMAP = Path("Docs/superpowers/trackers/unified-shell-maturity-roadmap.md")
 TASK_4_1 = Path("backlog/tasks/task-4.1 - Phase-2.1-Add-Home-active-work-adapter-contract.md")
+TASK_4_2 = Path(
+    "backlog/tasks/task-4.2 - Phase-2.2-Route-Home-detail-and-Console-actions-through-active-work-adapter.md"
+)
 
 
 def test_phase_two_home_adapter_evidence_exists_and_records_verification():
@@ -16,7 +20,7 @@ def test_phase_two_home_adapter_evidence_exists_and_records_verification():
     assert "Home active-work adapter contract" in text
     assert "Tests/Home/test_active_work_adapter.py" in text
     assert "Tests/UI/test_home_screen.py" in text
-    assert "15 passed" in text
+    assert "passed" in text
     assert "UnavailableHomeActiveWorkAdapter" in text
 
 
@@ -31,6 +35,34 @@ def test_phase_two_home_adapter_is_linked_from_index_roadmap_and_task():
     assert "| Phase 2 | `Docs/superpowers/qa/unified-shell/phase-2/` | in-progress |" in roadmap_text
 
     task_text = TASK_4_1.read_text(encoding="utf-8")
+    assert "status: Done" in task_text
+    assert "- [x] #1" in task_text
+    assert "- [x] #4" in task_text
+
+
+def test_phase_two_detail_console_evidence_exists_and_records_verification():
+    assert DETAIL_CONSOLE_EVIDENCE.exists()
+    text = DETAIL_CONSOLE_EVIDENCE.read_text(encoding="utf-8")
+
+    assert "TASK-4.2" in text
+    assert "Open details" in text
+    assert "Open in Console" in text
+    assert "Tests/Home/test_active_work_adapter.py" in text
+    assert "Tests/UI/test_home_screen.py" in text
+    assert "18 passed" in text
+    assert "HomeConsoleLaunch" in text
+
+
+def test_phase_two_detail_console_evidence_is_linked_from_index_roadmap_and_task():
+    evidence_name = DETAIL_CONSOLE_EVIDENCE.name
+
+    assert evidence_name in README.read_text(encoding="utf-8")
+
+    roadmap_text = ROADMAP.read_text(encoding="utf-8")
+    assert "TASK-4.2" in roadmap_text
+    assert evidence_name in roadmap_text
+
+    task_text = TASK_4_2.read_text(encoding="utf-8")
     assert "status: Done" in task_text
     assert "- [x] #1" in task_text
     assert "- [x] #4" in task_text

--- a/backlog/tasks/task-4.2 - Phase-2.2-Route-Home-detail-and-Console-actions-through-active-work-adapter.md
+++ b/backlog/tasks/task-4.2 - Phase-2.2-Route-Home-detail-and-Console-actions-through-active-work-adapter.md
@@ -1,0 +1,46 @@
+---
+id: TASK-4.2
+title: 'Phase 2.2: Route Home detail and Console actions through active-work adapter'
+status: Done
+assignee: []
+created_date: '2026-05-03 17:45'
+updated_date: '2026-05-03 17:50'
+labels:
+  - unified-shell
+  - phase-2
+  - home
+  - adapter
+dependencies: []
+parent_task_id: TASK-4
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Move Home detail and Console live-work actions behind the active-work adapter boundary so Home does not present direct navigation as service-backed control when no active-work payload exists.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Home open-detail action delegates to the adapter for its target route or unavailable result.
+- [x] #2 Home open-in-console action delegates to the adapter for actionable Console launch context or unavailable result.
+- [x] #3 Adapter results preserve honest recovery copy when service-backed detail or Console payloads are unavailable.
+- [x] #4 Focused unit and mounted Home tests cover detail and Console delegation.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing adapter and mounted Home tests for open-detail and open-in-console delegation.
+2. Extend the Home active-work adapter result contract only as far as needed for route and Console launch context.
+3. Wire HomeScreen and app-level helpers so detail and Console actions use adapter outcomes instead of direct fallback navigation.
+4. Add Phase 2 QA evidence and roadmap/task updates.
+5. Run focused Home tests plus diff hygiene before committing.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Extended the Home active-work adapter contract with detail and Console actions, route and Console launch result fields, and honest unavailable defaults. Home buttons now call runtime hooks with target routes, app hooks delegate to the adapter, details navigate only on handled target results, and Console opens only with adapter-supplied launch payloads. Added focused unit, mounted Home, and Phase 2 evidence-link tests plus QA documentation.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Home/active_work_adapter.py
+++ b/tldw_chatbook/Home/active_work_adapter.py
@@ -15,11 +15,20 @@ class HomeControlAction(StrEnum):
     PAUSE = "pause"
     RESUME = "resume"
     RETRY = "retry"
+    OPEN_DETAILS = "open_details"
+    OPEN_IN_CONSOLE = "open_in_console"
 
 
 class HomeControlResultStatus(StrEnum):
     HANDLED = "handled"
     UNAVAILABLE = "unavailable"
+
+
+@dataclass(frozen=True)
+class HomeConsoleLaunch:
+    source: str
+    title: str
+    payload: Mapping[str, Any] | None = None
 
 
 @dataclass(frozen=True)
@@ -29,6 +38,8 @@ class HomeControlResult:
     message: str
     severity: str = "information"
     recovery_route: str = "chat"
+    target_route: str | None = None
+    console_launch: HomeConsoleLaunch | None = None
 
 
 @runtime_checkable
@@ -44,7 +55,12 @@ class HomeActiveWorkAdapter(Protocol):
         """Return dashboard input from the current active-work backend."""
         ...
 
-    def handle_control(self, action: HomeControlAction) -> HomeControlResult:
+    def handle_control(
+        self,
+        action: HomeControlAction,
+        *,
+        target_route: str | None = None,
+    ) -> HomeControlResult:
         """Handle a lightweight Home control action."""
         ...
 
@@ -58,6 +74,8 @@ class UnavailableHomeActiveWorkAdapter(HomeActiveWorkAdapter):
         HomeControlAction.PAUSE: "Pause",
         HomeControlAction.RESUME: "Resume",
         HomeControlAction.RETRY: "Retry",
+        HomeControlAction.OPEN_DETAILS: "Open details",
+        HomeControlAction.OPEN_IN_CONSOLE: "Open in Console",
     }
 
     def build_dashboard_input(
@@ -79,8 +97,14 @@ class UnavailableHomeActiveWorkAdapter(HomeActiveWorkAdapter):
             active_detail_route="chat",
         )
 
-    def handle_control(self, action: HomeControlAction) -> HomeControlResult:
+    def handle_control(
+        self,
+        action: HomeControlAction,
+        *,
+        target_route: str | None = None,
+    ) -> HomeControlResult:
         label = self._ACTION_LABELS[action]
+        recovery_route = target_route or "chat"
         return HomeControlResult(
             action=action,
             status=HomeControlResultStatus.UNAVAILABLE,
@@ -89,5 +113,5 @@ class UnavailableHomeActiveWorkAdapter(HomeActiveWorkAdapter):
                 "Open details or Console to inspect the work."
             ),
             severity="warning",
-            recovery_route="chat",
+            recovery_route=recovery_route,
         )

--- a/tldw_chatbook/UI/Screens/home_screen.py
+++ b/tldw_chatbook/UI/Screens/home_screen.py
@@ -21,6 +21,13 @@ HOME_CONTROL_METHODS = {
     "home-pause": "pause_active_home_item",
     "home-resume": "resume_active_home_item",
     "home-retry": "retry_active_home_item",
+    "home-open-details": "open_active_home_item_details",
+    "home-open-in-console": "open_active_home_item_in_console",
+}
+
+HOME_CONTROL_METHODS_WITH_TARGET_ROUTE = {
+    "home-open-details",
+    "home-open-in-console",
 }
 
 
@@ -83,6 +90,12 @@ class HomeScreen(BaseAppScreen):
         method_name = HOME_CONTROL_METHODS.get(control.control_id)
         method = getattr(self.app_instance, method_name, None) if method_name else None
         if callable(method):
-            method()
+            if control.control_id in HOME_CONTROL_METHODS_WITH_TARGET_ROUTE:
+                method(target_route=control.target_route)
+            else:
+                method()
         else:
-            self.post_message(NavigateToScreen(control.target_route))
+            self.app_instance.notify(
+                f"{control.label} is not connected yet.",
+                severity="warning",
+            )

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -97,6 +97,7 @@ from tldw_chatbook.Chatbooks import LocalChatbookService, ServerChatbookService
 from tldw_chatbook.Home.active_work_adapter import (
     HomeControlAction,
     HomeControlResult,
+    HomeControlResultStatus,
     UnavailableHomeActiveWorkAdapter,
 )
 from tldw_chatbook.Logging_Config import RichLogHandler
@@ -1644,9 +1645,17 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
         }
         self.post_message(NavigateToScreen(TAB_CHAT))
 
-    def _handle_home_control_action(self, action: HomeControlAction) -> HomeControlResult:
+    def _handle_home_control_action(
+        self,
+        action: HomeControlAction,
+        *,
+        target_route: str | None = None,
+    ) -> HomeControlResult:
         adapter = getattr(self, "home_active_work_adapter", UnavailableHomeActiveWorkAdapter())
-        result = adapter.handle_control(action)
+        if target_route is None:
+            result = adapter.handle_control(action)
+        else:
+            result = adapter.handle_control(action, target_route=target_route)
         self.notify(result.message, severity=result.severity)
         return result
 
@@ -1669,6 +1678,30 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
     def retry_active_home_item(self) -> HomeControlResult:
         """Retry the active Home item through the configured adapter."""
         return self._handle_home_control_action(HomeControlAction.RETRY)
+
+    def open_active_home_item_details(self, *, target_route: str = TAB_CHAT) -> HomeControlResult:
+        """Open active Home item details through the configured adapter."""
+        result = self._handle_home_control_action(
+            HomeControlAction.OPEN_DETAILS,
+            target_route=target_route,
+        )
+        if result.status is HomeControlResultStatus.HANDLED and result.target_route:
+            self.post_message(NavigateToScreen(result.target_route))
+        return result
+
+    def open_active_home_item_in_console(self, *, target_route: str = TAB_CHAT) -> HomeControlResult:
+        """Open active Home item in Console only when the adapter supplies launch context."""
+        result = self._handle_home_control_action(
+            HomeControlAction.OPEN_IN_CONSOLE,
+            target_route=target_route,
+        )
+        if result.status is HomeControlResultStatus.HANDLED and result.console_launch is not None:
+            self.open_console_for_live_work(
+                source=result.console_launch.source,
+                title=result.console_launch.title,
+                payload=dict(result.console_launch.payload or {}),
+            )
+        return result
 
     def _wire_character_persona_services(self) -> None:
         self.server_character_persona_service = ServerCharacterPersonaService.from_server_context_provider(


### PR DESCRIPTION
## Summary
- Extends the Home active-work adapter with detail and Console actions plus explicit Console launch payloads.
- Routes Home Open details and Open in Console through adapter-owned app hooks instead of direct fallback navigation.
- Adds TASK-4.2 tracking and Phase 2 QA evidence for the new adapter-owned actions.

## Test Plan
- [x] /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Home/test_active_work_adapter.py Tests/Home/test_dashboard_state.py Tests/UI/test_home_screen.py Tests/UI/test_unified_shell_phase2_home_adapter.py -q (26 passed, 8 warnings)
- [x] git diff --check