### PR TITLE
Bind Home controls to active work items

### DIFF
--- a/Docs/superpowers/qa/unified-shell/phase-2/2026-05-03-home-active-work-item-context.md
+++ b/Docs/superpowers/qa/unified-shell/phase-2/2026-05-03-home-active-work-item-context.md
@@ -1,0 +1,47 @@
+# Home Active-Work Item Context
+
+Date: 2026-05-03
+Task: `TASK-4.3`
+Branch: `codex/unified-shell-phase2-home-dashboard-snapshot`
+Base: `origin/dev` at `726f4954`
+
+## Purpose
+
+Make Home active-work controls less ambiguous by giving the dashboard an explicit visible work-item model. Home can now show what item is being acted on and pass that item's `target_id` through the app hooks into the active-work adapter.
+
+## What Changed
+
+- Added `HomeActiveWorkItem` with `item_id`, `title`, `source`, `status`, `detail_route`, and `console_available`.
+- Added `target_id` to `HomeControl` and `HomeControlResult`.
+- Derived Home controls from active-work item status when items are present.
+- Preserved count-only fallback behavior for unavailable and legacy adapter states.
+- Passed `target_id` through HomeScreen, app-level Home control hooks, and `HomeActiveWorkAdapter.handle_control`.
+
+## Functional QA Evidence
+
+Focused checks were run against pure Home dashboard state, the adapter contract, and the mounted Textual Home screen harness.
+
+- Baseline before edits: `python -m pytest Tests/Home/test_dashboard_state.py Tests/Home/test_active_work_adapter.py Tests/UI/test_home_screen.py Tests/UI/test_unified_shell_phase2_home_adapter.py -q`
+- Baseline result: `26 passed, 10 warnings`
+- Red test: `python -m pytest Tests/Home/test_dashboard_state.py Tests/Home/test_active_work_adapter.py Tests/UI/test_home_screen.py -q`
+- Red result: collection failed because `HomeActiveWorkItem` did not exist.
+- Green test: `python -m pytest Tests/Home/test_dashboard_state.py Tests/Home/test_active_work_adapter.py Tests/UI/test_home_screen.py -q`
+- Green result: `24 passed, 8 warnings`
+- Status-gating regression: `python -m pytest Tests/Home/test_dashboard_state.py::test_dashboard_item_statuses_gate_matching_controls -q`
+- Status-gating red result: failed because an approval-only item incorrectly exposed `home-pause`.
+- Focused Phase 2 suite: `python -m pytest Tests/Home/test_dashboard_state.py Tests/Home/test_active_work_adapter.py Tests/UI/test_home_screen.py Tests/UI/test_unified_shell_phase2_home_adapter.py -q`
+- Focused Phase 2 suite result: `31 passed, 8 warnings`
+
+Warning boundary: warnings are existing dependency/import warnings and are not Home item-context behavior failures.
+
+## UX Result
+
+- Home can show visible active-work context instead of only aggregate counts.
+- Approve, reject, pause, resume, retry, details, and Console actions can now target a specific active-work item.
+- Explicit item context reduces accidental approval or recovery actions when multiple services eventually feed Home.
+
+## Residual Risk
+
+- This slice does not yet provide a real service-backed active-work feed.
+- Real approval, schedule, workflow, and agent adapters still need to populate `HomeActiveWorkItem` records.
+- Full Phase 2 verification still requires running-app QA against real service-backed work items.

--- a/Docs/superpowers/qa/unified-shell/phase-2/README.md
+++ b/Docs/superpowers/qa/unified-shell/phase-2/README.md
@@ -8,5 +8,6 @@ This directory contains durable QA summaries for Phase 2 Home operational-contro
 
 - `2026-05-03-home-active-work-adapter-contract.md` - `TASK-4.1` adapter boundary for Home dashboard state and lightweight controls.
 - `2026-05-03-home-detail-console-adapter-actions.md` - `TASK-4.2` adapter-owned Home detail and Console actions.
+- `2026-05-03-home-active-work-item-context.md` - `TASK-4.3` item-scoped Home active-work controls.
 
 Do not mark Phase 2 verified until Home approve, reject, pause, resume, retry, and open-detail workflows are verified against real service-backed adapters or explicitly recoverable unavailable states.

--- a/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
@@ -2,7 +2,7 @@
 
 Date: 2026-05-03
 Status: Phase 2 in progress
-Source Branch: `origin/dev` at `5a6e35e8` plus `codex/unified-shell-phase2-home-open-detail-adapter`
+Source Branch: `origin/dev` at `726f4954` plus `codex/unified-shell-phase2-home-dashboard-snapshot`
 
 ## Purpose
 
@@ -27,7 +27,7 @@ Track remaining Unified Shell work in one place so rendered screens, clickable b
 
 ## Known Product Gaps
 
-- Home active-work controls, detail routing, and Console launch requests now route through an explicit adapter boundary; real service-backed adapters still need implementation.
+- Home active-work controls, detail routing, Console launch requests, and item identity now route through an explicit adapter boundary; real service-backed adapters still need implementation.
 - Workflows has no wired workflow service in the shell wrapper.
 - W+C, Schedules, Workflows, and ACP now use honest unavailable Console states until actionable payloads exist.
 - ACP launch is disabled until an ACP-compatible runtime is configured.
@@ -81,6 +81,7 @@ Initial child tasks:
 - Phase 1.4: Replay shell contract and close Phase 1 - `TASK-2.4`
 - Phase 2.1: Add Home active-work adapter contract - `TASK-4.1`
 - Phase 2.2: Route Home detail and Console actions through active-work adapter - `TASK-4.2`
+- Phase 2.3: Bind Home controls to active-work item context - `TASK-4.3`
 
 ## QA Evidence Index
 
@@ -100,7 +101,7 @@ Initial child tasks:
 | --- | --- | --- | --- | --- | --- |
 | Phase 0: Canonical Tracking | Make remaining work trackable. | verified | `TASK-1`, `TASK-1.1`, `TASK-1.2` | `phase-0/` | Product UI workflows are out of scope for Phase 0. |
 | Phase 1: Shell Contract Complete | Remove false shell affordances and prove shell usability. | verified | `TASK-2`, `TASK-2.1`, `TASK-2.2`, `TASK-2.3`, `TASK-2.4` | `phase-1/` | Live service workflows remain intentionally deferred to Phases 2-6. |
-| Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | in-progress | `TASK-4`, `TASK-4.1`, `TASK-4.2` | `phase-2/` | Real active-run, schedule, and agent-service adapters still need implementation. |
+| Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | in-progress | `TASK-4`, `TASK-4.1`, `TASK-4.2`, `TASK-4.3` | `phase-2/` | Real active-run, schedule, and agent-service adapters still need implementation. |
 | Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | not-started | `TASK-3` | `phase-3/` | Live work event sources need explicit contracts. |
 | Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | not-started | `TASK-5` | `phase-4/` | Service coverage varies by destination. |
 | Phase 5: Capability And Recovery System | Systematize unavailable and blocked states. | not-started | `TASK-6` | `phase-5/` | Shared taxonomy not yet extracted. |
@@ -145,6 +146,12 @@ Initial audit result: W+C, Schedules, Workflows, and ACP had false Console-launc
 `TASK-4.2` moves Home detail and Console actions behind the active-work adapter boundary:
 
 - `Docs/superpowers/qa/unified-shell/phase-2/2026-05-03-home-detail-console-adapter-actions.md`
+
+## Phase 2.3 Home Active-Work Item Context Evidence
+
+`TASK-4.3` binds Home controls to explicit visible active-work item context:
+
+- `Docs/superpowers/qa/unified-shell/phase-2/2026-05-03-home-active-work-item-context.md`
 
 ## Phase 0: Canonical Tracking
 

--- a/Tests/Home/test_active_work_adapter.py
+++ b/Tests/Home/test_active_work_adapter.py
@@ -27,10 +27,11 @@ def test_unavailable_home_adapter_builds_dashboard_input_from_runtime_context():
 def test_unavailable_home_adapter_returns_honest_recovery_result():
     adapter = UnavailableHomeActiveWorkAdapter()
 
-    result = adapter.handle_control(HomeControlAction.APPROVE)
+    result = adapter.handle_control(HomeControlAction.APPROVE, target_id="approval-1")
 
     assert result.action is HomeControlAction.APPROVE
     assert result.status is HomeControlResultStatus.UNAVAILABLE
+    assert result.target_id == "approval-1"
     assert result.severity == "warning"
     assert "Approve is not connected" in result.message
     assert result.recovery_route == "chat"

--- a/Tests/Home/test_dashboard_state.py
+++ b/Tests/Home/test_dashboard_state.py
@@ -1,4 +1,5 @@
 from tldw_chatbook.Home.dashboard_state import (
+    HomeActiveWorkItem,
     HomeDashboardInput,
     choose_next_best_action,
     summarize_home_dashboard,
@@ -76,3 +77,58 @@ def test_dashboard_summary_exposes_lightweight_control_ids_for_core_states():
         "home-open-details",
         "home-open-in-console",
     }.issubset(control_ids)
+
+
+def test_dashboard_summary_exposes_active_work_item_context_and_targets():
+    dashboard = summarize_home_dashboard(
+        HomeDashboardInput(
+            model_ready=True,
+            has_library_content=True,
+            active_work_items=(
+                HomeActiveWorkItem(
+                    item_id="run-1",
+                    title="Daily digest",
+                    source="workflows",
+                    status="running",
+                    detail_route="workflows",
+                    console_available=True,
+                ),
+            ),
+        )
+    )
+
+    active_work_section = next(section for section in dashboard.sections if section.section_id == "active_work")
+    assert "Daily digest" in "\n".join(active_work_section.lines)
+    assert "running" in "\n".join(active_work_section.lines)
+    assert "workflows" in "\n".join(active_work_section.lines)
+
+    controls_by_id = {control.control_id: control for control in dashboard.controls}
+    assert controls_by_id["home-pause"].target_id == "run-1"
+    assert controls_by_id["home-open-details"].target_id == "run-1"
+    assert controls_by_id["home-open-details"].target_route == "workflows"
+    assert controls_by_id["home-open-in-console"].target_id == "run-1"
+
+
+def test_dashboard_item_statuses_gate_matching_controls():
+    dashboard = summarize_home_dashboard(
+        HomeDashboardInput(
+            model_ready=True,
+            has_library_content=True,
+            active_work_items=(
+                HomeActiveWorkItem(
+                    item_id="approval-1",
+                    title="Tool request",
+                    source="mcp",
+                    status="approval_required",
+                    detail_route="mcp",
+                ),
+            ),
+        )
+    )
+
+    control_ids = {control.control_id for control in dashboard.controls}
+    assert "home-approve" in control_ids
+    assert "home-reject" in control_ids
+    assert "home-open-details" in control_ids
+    assert "home-pause" not in control_ids
+    assert "home-open-in-console" not in control_ids

--- a/Tests/UI/test_home_screen.py
+++ b/Tests/UI/test_home_screen.py
@@ -10,7 +10,7 @@ from tldw_chatbook.Home.active_work_adapter import (
     HomeControlResult,
     HomeControlResultStatus,
 )
-from tldw_chatbook.Home.dashboard_state import HomeDashboardInput
+from tldw_chatbook.Home.dashboard_state import HomeActiveWorkItem, HomeDashboardInput
 from tldw_chatbook.UI.Screens.home_screen import HomeScreen
 from Tests.UI.test_screen_navigation import _build_test_app
 
@@ -37,6 +37,7 @@ class RecordingHomeActiveWorkAdapter:
         self.dashboard_calls = 0
         self.control_actions = []
         self.control_target_routes = []
+        self.control_target_ids = []
         self.dashboard_input = dashboard_input
         self.responses = responses or {}
 
@@ -53,9 +54,10 @@ class RecordingHomeActiveWorkAdapter:
             has_recent_work=has_recent_work,
         )
 
-    def handle_control(self, action, *, target_route=None):
+    def handle_control(self, action, *, target_id=None, target_route=None):
         self.control_actions.append(action)
         self.control_target_routes.append(target_route)
+        self.control_target_ids.append(target_id)
         if action in self.responses:
             return self.responses[action]
         return HomeControlResult(
@@ -258,6 +260,48 @@ async def test_home_detail_and_console_buttons_call_runtime_hooks_with_target_ro
     assert seen == []
 
 
+@pytest.mark.asyncio
+async def test_home_active_work_item_controls_pass_target_id_to_runtime_hooks():
+    app = _build_test_app()
+    app._home_dashboard_test_input = HomeDashboardInput(
+        model_ready=True,
+        has_library_content=True,
+        active_work_items=(
+            HomeActiveWorkItem(
+                item_id="run-1",
+                title="Daily digest",
+                source="workflows",
+                status="running",
+                detail_route="workflows",
+                console_available=True,
+            ),
+        ),
+    )
+    app.pause_active_home_item = Mock()
+    app.open_active_home_item_details = Mock()
+    app.open_active_home_item_in_console = Mock()
+    host = HomeHarness(app, [])
+
+    async with host.run_test(size=(160, 40)) as pilot:
+        await pilot.pause(0.1)
+        await pilot.click("#home-pause")
+        await pilot.pause(0.1)
+        await pilot.click("#home-open-details")
+        await pilot.pause(0.1)
+        await pilot.click("#home-open-in-console")
+        await pilot.pause(0.1)
+
+    app.pause_active_home_item.assert_called_once_with(target_id="run-1")
+    app.open_active_home_item_details.assert_called_once_with(
+        target_id="run-1",
+        target_route="workflows",
+    )
+    app.open_active_home_item_in_console.assert_called_once_with(
+        target_id="run-1",
+        target_route="chat",
+    )
+
+
 def test_app_detail_hook_delegates_to_adapter_and_navigates_handled_route():
     app = _build_test_app()
     adapter = RecordingHomeActiveWorkAdapter(
@@ -274,10 +318,11 @@ def test_app_detail_hook_delegates_to_adapter_and_navigates_handled_route():
     app.notify = Mock()
     app.post_message = Mock()
 
-    result = app.open_active_home_item_details(target_route="schedules")
+    result = app.open_active_home_item_details(target_id="run-1", target_route="schedules")
 
     assert result.status is HomeControlResultStatus.HANDLED
     assert adapter.control_actions == [HomeControlAction.OPEN_DETAILS]
+    assert adapter.control_target_ids == ["run-1"]
     assert adapter.control_target_routes == ["schedules"]
     app.notify.assert_called_once_with("Opening workflow details.", severity="information")
     app.post_message.assert_called_once()
@@ -301,10 +346,11 @@ def test_app_console_hook_requires_adapter_launch_payload():
     app.notify = Mock()
     app.open_console_for_live_work = Mock()
 
-    result = app.open_active_home_item_in_console(target_route="chat")
+    result = app.open_active_home_item_in_console(target_id="run-1", target_route="chat")
 
     assert result.status is HomeControlResultStatus.UNAVAILABLE
     assert adapter.control_actions == [HomeControlAction.OPEN_IN_CONSOLE]
+    assert adapter.control_target_ids == ["run-1"]
     assert adapter.control_target_routes == ["chat"]
     app.notify.assert_called_once_with("Open in Console is not connected.", severity="warning")
     app.open_console_for_live_work.assert_not_called()
@@ -331,9 +377,10 @@ def test_app_console_hook_opens_console_with_adapter_launch_payload():
     app.notify = Mock()
     app.open_console_for_live_work = Mock()
 
-    result = app.open_active_home_item_in_console(target_route="chat")
+    result = app.open_active_home_item_in_console(target_id="run-1", target_route="chat")
 
     assert result.status is HomeControlResultStatus.HANDLED
+    assert adapter.control_target_ids == ["run-1"]
     app.notify.assert_called_once_with("Opening Console for Daily digest.", severity="information")
     app.open_console_for_live_work.assert_called_once_with(
         source="workflows",

--- a/Tests/UI/test_unified_shell_phase2_home_adapter.py
+++ b/Tests/UI/test_unified_shell_phase2_home_adapter.py
@@ -4,12 +4,14 @@ from pathlib import Path
 PHASE_2_ROOT = Path("Docs/superpowers/qa/unified-shell/phase-2")
 EVIDENCE = PHASE_2_ROOT / "2026-05-03-home-active-work-adapter-contract.md"
 DETAIL_CONSOLE_EVIDENCE = PHASE_2_ROOT / "2026-05-03-home-detail-console-adapter-actions.md"
+ITEM_CONTEXT_EVIDENCE = PHASE_2_ROOT / "2026-05-03-home-active-work-item-context.md"
 README = PHASE_2_ROOT / "README.md"
 ROADMAP = Path("Docs/superpowers/trackers/unified-shell-maturity-roadmap.md")
 TASK_4_1 = Path("backlog/tasks/task-4.1 - Phase-2.1-Add-Home-active-work-adapter-contract.md")
 TASK_4_2 = Path(
     "backlog/tasks/task-4.2 - Phase-2.2-Route-Home-detail-and-Console-actions-through-active-work-adapter.md"
 )
+TASK_4_3 = Path("backlog/tasks/task-4.3 - Phase-2.3-Bind-Home-controls-to-active-work-item-context.md")
 
 
 def test_phase_two_home_adapter_evidence_exists_and_records_verification():
@@ -66,3 +68,30 @@ def test_phase_two_detail_console_evidence_is_linked_from_index_roadmap_and_task
     assert "status: Done" in task_text
     assert "- [x] #1" in task_text
     assert "- [x] #4" in task_text
+
+
+def test_phase_two_item_context_evidence_exists_and_records_verification():
+    assert ITEM_CONTEXT_EVIDENCE.exists()
+    text = ITEM_CONTEXT_EVIDENCE.read_text(encoding="utf-8")
+
+    assert "TASK-4.3" in text
+    assert "HomeActiveWorkItem" in text
+    assert "target_id" in text
+    assert "Tests/Home/test_dashboard_state.py" in text
+    assert "Tests/UI/test_home_screen.py" in text
+    assert "31 passed" in text
+
+
+def test_phase_two_item_context_evidence_is_linked_from_index_roadmap_and_task():
+    evidence_name = ITEM_CONTEXT_EVIDENCE.name
+
+    assert evidence_name in README.read_text(encoding="utf-8")
+
+    roadmap_text = ROADMAP.read_text(encoding="utf-8")
+    assert "TASK-4.3" in roadmap_text
+    assert evidence_name in roadmap_text
+
+    task_text = TASK_4_3.read_text(encoding="utf-8")
+    assert "status: Done" in task_text
+    assert "- [x] #1" in task_text
+    assert "- [x] #5" in task_text

--- a/backlog/tasks/task-4.3 - Phase-2.3-Bind-Home-controls-to-active-work-item-context.md
+++ b/backlog/tasks/task-4.3 - Phase-2.3-Bind-Home-controls-to-active-work-item-context.md
@@ -1,0 +1,48 @@
+---
+id: TASK-4.3
+title: 'Phase 2.3: Bind Home controls to active-work item context'
+status: Done
+assignee: []
+created_date: '2026-05-03 18:04'
+updated_date: '2026-05-03 18:08'
+labels:
+  - unified-shell
+  - phase-2
+  - home
+  - adapter
+  - ux
+dependencies: []
+parent_task_id: TASK-4
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make Home active-work controls operate on explicit visible item context instead of anonymous aggregate counts, so future service adapters can approve, pause, resume, retry, open details, or launch Console for a specific work item.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Home dashboard state can carry active-work item identity, title, source, status, detail route, and Console availability.
+- [x] #2 Home active-work summary renders visible item context before controls are used.
+- [x] #3 Home controls carry target item ids and pass them through app hooks into the adapter.
+- [x] #4 Existing count-only unavailable states remain supported for backward compatibility.
+- [x] #5 Focused pure state, adapter, and mounted Home tests cover item-scoped controls.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing pure dashboard, adapter, and mounted Home tests for item-scoped active-work controls.
+2. Extend Home dashboard state with an active-work item model and target-aware controls while preserving count-only fallback behavior.
+3. Pass target item ids through HomeScreen app hooks and the active-work adapter contract.
+4. Add Phase 2 QA evidence plus roadmap and task updates.
+5. Run focused Home/Phase 2 tests and diff hygiene before committing.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added HomeActiveWorkItem context for Home dashboard state, derived visible active-work rows and target-aware controls from item status, preserved the existing count-only fallback path, and threaded target_id through HomeScreen, TldwCli Home hooks, and HomeActiveWorkAdapter.handle_control. Added focused pure state, adapter, mounted Home, and Phase 2 evidence-link coverage plus QA documentation.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Home/active_work_adapter.py
+++ b/tldw_chatbook/Home/active_work_adapter.py
@@ -38,6 +38,7 @@ class HomeControlResult:
     message: str
     severity: str = "information"
     recovery_route: str = "chat"
+    target_id: str | None = None
     target_route: str | None = None
     console_launch: HomeConsoleLaunch | None = None
 
@@ -59,6 +60,7 @@ class HomeActiveWorkAdapter(Protocol):
         self,
         action: HomeControlAction,
         *,
+        target_id: str | None = None,
         target_route: str | None = None,
     ) -> HomeControlResult:
         """Handle a lightweight Home control action."""
@@ -101,6 +103,7 @@ class UnavailableHomeActiveWorkAdapter(HomeActiveWorkAdapter):
         self,
         action: HomeControlAction,
         *,
+        target_id: str | None = None,
         target_route: str | None = None,
     ) -> HomeControlResult:
         label = self._ACTION_LABELS[action]
@@ -114,4 +117,5 @@ class UnavailableHomeActiveWorkAdapter(HomeActiveWorkAdapter):
             ),
             severity="warning",
             recovery_route=recovery_route,
+            target_id=target_id,
         )

--- a/tldw_chatbook/Home/dashboard_state.py
+++ b/tldw_chatbook/Home/dashboard_state.py
@@ -5,6 +5,22 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 
+_APPROVAL_STATUSES = frozenset({"approval_required", "pending_approval", "pending"})
+_RUNNING_STATUSES = frozenset({"running", "queued", "active"})
+_PAUSED_STATUSES = frozenset({"paused"})
+_FAILED_STATUSES = frozenset({"failed", "error"})
+
+
+@dataclass(frozen=True)
+class HomeActiveWorkItem:
+    item_id: str
+    title: str
+    source: str
+    status: str
+    detail_route: str = "chat"
+    console_available: bool = False
+
+
 @dataclass(frozen=True)
 class HomeDashboardInput:
     model_ready: bool = False
@@ -20,6 +36,7 @@ class HomeDashboardInput:
     has_library_content: bool = False
     has_recent_work: bool = False
     active_detail_route: str = "chat"
+    active_work_items: tuple[HomeActiveWorkItem, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -43,6 +60,7 @@ class HomeControl:
     label: str
     target_route: str
     applies_to: str
+    target_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -60,21 +78,21 @@ def choose_next_best_action(state: HomeDashboardInput) -> HomeAction:
             "llm",
             "Console needs a working model before live AI tasks.",
         )
-    if state.pending_approval_count:
+    if _pending_approval_count(state):
         return HomeAction(
             "review_approvals",
             "Review pending approvals",
             "chat",
             "Agent work is waiting for a decision.",
         )
-    if state.failed_schedule_count:
+    if _failed_schedule_count(state):
         return HomeAction(
             "recover_schedules",
             "Review failed schedules",
             "schedules",
             "Scheduled work needs recovery.",
         )
-    if state.active_run_count:
+    if _active_run_count(state):
         return HomeAction(
             "resume_active_work",
             "Resume active work",
@@ -100,39 +118,95 @@ def choose_next_best_action(state: HomeDashboardInput) -> HomeAction:
 
 def build_home_controls(state: HomeDashboardInput) -> tuple[HomeControl, ...]:
     controls: list[HomeControl] = []
-    if state.pending_approval_count:
+    approval_item = _first_item_for_status(state, _APPROVAL_STATUSES)
+    running_item = _first_item_for_status(state, _RUNNING_STATUSES)
+    paused_item = _first_item_for_status(state, _PAUSED_STATUSES)
+    failed_item = _first_item_for_status(state, _FAILED_STATUSES)
+    detail_item = state.active_work_items[0] if state.active_work_items else None
+
+    if _pending_approval_count(state):
         controls.extend(
             (
-                HomeControl("home-approve", "Approve", "chat", "approval"),
-                HomeControl("home-reject", "Reject", "chat", "approval"),
+                HomeControl(
+                    "home-approve",
+                    "Approve",
+                    "chat",
+                    "approval",
+                    approval_item.item_id if approval_item else None,
+                ),
+                HomeControl(
+                    "home-reject",
+                    "Reject",
+                    "chat",
+                    "approval",
+                    approval_item.item_id if approval_item else None,
+                ),
             )
         )
-    if state.running_run_count or state.active_run_count:
-        controls.append(HomeControl("home-pause", "Pause", "chat", "running_work"))
-    if state.paused_run_count:
-        controls.append(HomeControl("home-resume", "Resume", "chat", "paused_work"))
-    if state.failed_run_count or state.failed_schedule_count:
-        controls.append(HomeControl("home-retry", "Retry", "schedules", "failed_work"))
+    if _running_run_count(state) or (not state.active_work_items and state.active_run_count):
+        controls.append(
+            HomeControl(
+                "home-pause",
+                "Pause",
+                "chat",
+                "running_work",
+                running_item.item_id if running_item else None,
+            )
+        )
+    if _paused_run_count(state):
+        controls.append(
+            HomeControl(
+                "home-resume",
+                "Resume",
+                "chat",
+                "paused_work",
+                paused_item.item_id if paused_item else None,
+            )
+        )
+    if _failed_run_count(state) or _failed_schedule_count(state):
+        controls.append(
+            HomeControl(
+                "home-retry",
+                "Retry",
+                "schedules",
+                "failed_work",
+                failed_item.item_id if failed_item else None,
+            )
+        )
     if (
-        state.pending_approval_count
-        or state.active_run_count
-        or state.running_run_count
-        or state.paused_run_count
-        or state.failed_run_count
-        or state.failed_schedule_count
+        _pending_approval_count(state)
+        or _active_run_count(state)
+        or _running_run_count(state)
+        or _paused_run_count(state)
+        or _failed_run_count(state)
+        or _failed_schedule_count(state)
     ):
-        controls.extend(
-            (
-                HomeControl("home-open-details", "Open details", state.active_detail_route, "work_details"),
-                HomeControl("home-open-in-console", "Open in Console", "chat", "console"),
+        controls.append(
+            HomeControl(
+                "home-open-details",
+                "Open details",
+                detail_item.detail_route if detail_item else state.active_detail_route,
+                "work_details",
+                detail_item.item_id if detail_item else None,
             )
         )
+        if not state.active_work_items or any(item.console_available for item in state.active_work_items):
+            console_item = next((item for item in state.active_work_items if item.console_available), detail_item)
+            controls.append(
+                HomeControl(
+                    "home-open-in-console",
+                    "Open in Console",
+                    "chat",
+                    "console",
+                    console_item.item_id if console_item else None,
+                )
+            )
     return tuple(controls)
 
 
 def summarize_home_dashboard(state: HomeDashboardInput) -> HomeDashboard:
     next_action = choose_next_best_action(state)
-    approval_label = "Approval required" if state.pending_approval_count else "Ready"
+    approval_label = "Approval required" if _pending_approval_count(state) else "Ready"
     return HomeDashboard(
         next_action=next_action,
         sections=(
@@ -140,16 +214,12 @@ def summarize_home_dashboard(state: HomeDashboardInput) -> HomeDashboard:
             HomeSection(
                 "attention",
                 "Attention",
-                (approval_label, f"Pending approvals: {state.pending_approval_count}"),
+                (approval_label, f"Pending approvals: {_pending_approval_count(state)}"),
             ),
             HomeSection(
                 "active_work",
                 "Active Work",
-                (
-                    f"Running: {state.running_run_count}",
-                    f"Paused: {state.paused_run_count}",
-                    f"Failed: {state.failed_run_count}",
-                ),
+                _active_work_lines(state),
             ),
             HomeSection("next_best_action", "Next Best Action", (next_action.label, next_action.reason)),
             HomeSection(
@@ -159,4 +229,56 @@ def summarize_home_dashboard(state: HomeDashboardInput) -> HomeDashboard:
             ),
         ),
         controls=build_home_controls(state),
+    )
+
+
+def _normalized_status(item: HomeActiveWorkItem) -> str:
+    return item.status.strip().lower()
+
+
+def _count_items_for_status(state: HomeDashboardInput, statuses: frozenset[str]) -> int:
+    return sum(1 for item in state.active_work_items if _normalized_status(item) in statuses)
+
+
+def _first_item_for_status(
+    state: HomeDashboardInput,
+    statuses: frozenset[str],
+) -> HomeActiveWorkItem | None:
+    return next((item for item in state.active_work_items if _normalized_status(item) in statuses), None)
+
+
+def _pending_approval_count(state: HomeDashboardInput) -> int:
+    return state.pending_approval_count or _count_items_for_status(state, _APPROVAL_STATUSES)
+
+
+def _running_run_count(state: HomeDashboardInput) -> int:
+    return state.running_run_count or _count_items_for_status(state, _RUNNING_STATUSES)
+
+
+def _paused_run_count(state: HomeDashboardInput) -> int:
+    return state.paused_run_count or _count_items_for_status(state, _PAUSED_STATUSES)
+
+
+def _failed_run_count(state: HomeDashboardInput) -> int:
+    return state.failed_run_count or _count_items_for_status(state, _FAILED_STATUSES)
+
+
+def _failed_schedule_count(state: HomeDashboardInput) -> int:
+    return state.failed_schedule_count
+
+
+def _active_run_count(state: HomeDashboardInput) -> int:
+    return state.active_run_count or len(state.active_work_items)
+
+
+def _active_work_lines(state: HomeDashboardInput) -> tuple[str, ...]:
+    if state.active_work_items:
+        return tuple(
+            f"{item.title} [{item.status}] via {item.source}"
+            for item in state.active_work_items
+        )
+    return (
+        f"Running: {state.running_run_count}",
+        f"Paused: {state.paused_run_count}",
+        f"Failed: {state.failed_run_count}",
     )

--- a/tldw_chatbook/UI/Screens/home_screen.py
+++ b/tldw_chatbook/UI/Screens/home_screen.py
@@ -90,8 +90,13 @@ class HomeScreen(BaseAppScreen):
         method_name = HOME_CONTROL_METHODS.get(control.control_id)
         method = getattr(self.app_instance, method_name, None) if method_name else None
         if callable(method):
+            kwargs = {}
+            if control.target_id is not None:
+                kwargs["target_id"] = control.target_id
             if control.control_id in HOME_CONTROL_METHODS_WITH_TARGET_ROUTE:
-                method(target_route=control.target_route)
+                kwargs["target_route"] = control.target_route
+            if kwargs:
+                method(**kwargs)
             else:
                 method()
         else:

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -1649,50 +1649,67 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
         self,
         action: HomeControlAction,
         *,
+        target_id: str | None = None,
         target_route: str | None = None,
     ) -> HomeControlResult:
         adapter = getattr(self, "home_active_work_adapter", UnavailableHomeActiveWorkAdapter())
-        if target_route is None:
+        if target_id is None and target_route is None:
             result = adapter.handle_control(action)
         else:
-            result = adapter.handle_control(action, target_route=target_route)
+            result = adapter.handle_control(
+                action,
+                target_id=target_id,
+                target_route=target_route,
+            )
         self.notify(result.message, severity=result.severity)
         return result
 
-    def approve_active_home_item(self) -> HomeControlResult:
+    def approve_active_home_item(self, *, target_id: str | None = None) -> HomeControlResult:
         """Approve the active Home item through the configured adapter."""
-        return self._handle_home_control_action(HomeControlAction.APPROVE)
+        return self._handle_home_control_action(HomeControlAction.APPROVE, target_id=target_id)
 
-    def reject_active_home_item(self) -> HomeControlResult:
+    def reject_active_home_item(self, *, target_id: str | None = None) -> HomeControlResult:
         """Reject the active Home item through the configured adapter."""
-        return self._handle_home_control_action(HomeControlAction.REJECT)
+        return self._handle_home_control_action(HomeControlAction.REJECT, target_id=target_id)
 
-    def pause_active_home_item(self) -> HomeControlResult:
+    def pause_active_home_item(self, *, target_id: str | None = None) -> HomeControlResult:
         """Pause the active Home item through the configured adapter."""
-        return self._handle_home_control_action(HomeControlAction.PAUSE)
+        return self._handle_home_control_action(HomeControlAction.PAUSE, target_id=target_id)
 
-    def resume_active_home_item(self) -> HomeControlResult:
+    def resume_active_home_item(self, *, target_id: str | None = None) -> HomeControlResult:
         """Resume the active Home item through the configured adapter."""
-        return self._handle_home_control_action(HomeControlAction.RESUME)
+        return self._handle_home_control_action(HomeControlAction.RESUME, target_id=target_id)
 
-    def retry_active_home_item(self) -> HomeControlResult:
+    def retry_active_home_item(self, *, target_id: str | None = None) -> HomeControlResult:
         """Retry the active Home item through the configured adapter."""
-        return self._handle_home_control_action(HomeControlAction.RETRY)
+        return self._handle_home_control_action(HomeControlAction.RETRY, target_id=target_id)
 
-    def open_active_home_item_details(self, *, target_route: str = TAB_CHAT) -> HomeControlResult:
+    def open_active_home_item_details(
+        self,
+        *,
+        target_id: str | None = None,
+        target_route: str = TAB_CHAT,
+    ) -> HomeControlResult:
         """Open active Home item details through the configured adapter."""
         result = self._handle_home_control_action(
             HomeControlAction.OPEN_DETAILS,
+            target_id=target_id,
             target_route=target_route,
         )
         if result.status is HomeControlResultStatus.HANDLED and result.target_route:
             self.post_message(NavigateToScreen(result.target_route))
         return result
 
-    def open_active_home_item_in_console(self, *, target_route: str = TAB_CHAT) -> HomeControlResult:
+    def open_active_home_item_in_console(
+        self,
+        *,
+        target_id: str | None = None,
+        target_route: str = TAB_CHAT,
+    ) -> HomeControlResult:
         """Open active Home item in Console only when the adapter supplies launch context."""
         result = self._handle_home_control_action(
             HomeControlAction.OPEN_IN_CONSOLE,
+            target_id=target_id,
             target_route=target_route,
         )
         if result.status is HomeControlResultStatus.HANDLED and result.console_launch is not None:


### PR DESCRIPTION
## Summary
- Adds HomeActiveWorkItem so Home can show active-work item identity, source, status, detail route, and Console availability.
- Threads target_id through Home controls, TldwCli Home hooks, and HomeActiveWorkAdapter.handle_control.
- Adds TASK-4.3 tracking and Phase 2 QA evidence for item-scoped Home controls.

## Test Plan
- [x] /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Home/test_dashboard_state.py Tests/Home/test_active_work_adapter.py Tests/UI/test_home_screen.py Tests/UI/test_unified_shell_phase2_home_adapter.py -q (31 passed, 8 warnings)
- [x] git diff --check