### PR TITLE
Add Home local notification snapshot adapter

### DIFF
--- a/Docs/superpowers/qa/unified-shell/phase-2/2026-05-03-home-local-notification-snapshot.md
+++ b/Docs/superpowers/qa/unified-shell/phase-2/2026-05-03-home-local-notification-snapshot.md
@@ -1,0 +1,44 @@
+# Home Local Notification Snapshot Adapter
+
+Date: 2026-05-03
+Task: `TASK-4.4`
+Branch: `codex/unified-shell-phase2-home-local-snapshot-adapter`
+Base: `origin/dev` at `252b7ba8`
+
+## Purpose
+
+Connect Home to the local notification queue so the dashboard can surface real unread notification state without misclassifying generic notifications as approvals, active runs, or controllable work items.
+
+## What Changed
+
+- Added `notification_count` to `HomeDashboardInput`.
+- Added `LocalNotificationHomeActiveWorkAdapter`, which reads unread items from `ClientNotificationsService.list_queue`.
+- Wired `TldwCli` to replace the unavailable Home adapter with the local notification snapshot adapter after local notification services initialize.
+- Added Home dashboard and screen behavior so unread notifications appear in the Attention section and can become the next-best action after stronger live-work blockers.
+- Preserved unavailable active-run controls until real active-run, schedule, workflow, or agent services expose safe adapter contracts.
+
+## Functional QA Evidence
+
+Focused checks were run against the pure Home dashboard state, the adapter contract, the app service wiring, and the mounted Textual Home screen harness.
+
+- Red test: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Home/test_active_work_adapter.py Tests/Home/test_dashboard_state.py Tests/UI/test_home_screen.py Tests/UI/test_screen_navigation.py -q`
+- Red result: collection failed because `LocalNotificationHomeActiveWorkAdapter` did not exist.
+- Green test: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Home/test_active_work_adapter.py Tests/Home/test_dashboard_state.py Tests/UI/test_home_screen.py Tests/UI/test_screen_navigation.py -q`
+- Green result: `58 passed, 8 warnings`
+- Focused Phase 2 suite: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Home/test_dashboard_state.py Tests/Home/test_active_work_adapter.py Tests/UI/test_home_screen.py Tests/UI/test_screen_navigation.py Tests/UI/test_unified_shell_phase2_home_adapter.py -q`
+- Focused Phase 2 suite result: `66 passed, 8 warnings`
+
+Warning boundary: warnings are existing dependency/import warnings and are not Home notification snapshot behavior failures.
+
+## UX Result
+
+- Home now behaves more like a status and notification center instead of a static shell placeholder.
+- Users can see unread local notifications from Home without needing to know the notification queue implementation.
+- Generic notifications do not create approve, pause, retry, or Console controls, preventing false affordances.
+- The next-best action order remains conservative: model readiness, approvals, failed schedules, and active work outrank notification review.
+
+## Residual Risk
+
+- This slice only covers local notification snapshot state.
+- It does not add a notification detail drawer, batch mark-read actions, or category filters.
+- Real active-run, schedule, workflow, and agent-service adapters still need implementation before Phase 2 can be verified end-to-end.

--- a/Docs/superpowers/qa/unified-shell/phase-2/README.md
+++ b/Docs/superpowers/qa/unified-shell/phase-2/README.md
@@ -9,5 +9,6 @@ This directory contains durable QA summaries for Phase 2 Home operational-contro
 - `2026-05-03-home-active-work-adapter-contract.md` - `TASK-4.1` adapter boundary for Home dashboard state and lightweight controls.
 - `2026-05-03-home-detail-console-adapter-actions.md` - `TASK-4.2` adapter-owned Home detail and Console actions.
 - `2026-05-03-home-active-work-item-context.md` - `TASK-4.3` item-scoped Home active-work controls.
+- `2026-05-03-home-local-notification-snapshot.md` - `TASK-4.4` local unread notification snapshot state for Home.
 
 Do not mark Phase 2 verified until Home approve, reject, pause, resume, retry, and open-detail workflows are verified against real service-backed adapters or explicitly recoverable unavailable states.

--- a/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
@@ -2,7 +2,7 @@
 
 Date: 2026-05-03
 Status: Phase 2 in progress
-Source Branch: `origin/dev` at `726f4954` plus `codex/unified-shell-phase2-home-dashboard-snapshot`
+Source Branch: `origin/dev` at `252b7ba8` plus `codex/unified-shell-phase2-home-local-snapshot-adapter`
 
 ## Purpose
 
@@ -27,7 +27,7 @@ Track remaining Unified Shell work in one place so rendered screens, clickable b
 
 ## Known Product Gaps
 
-- Home active-work controls, detail routing, Console launch requests, and item identity now route through an explicit adapter boundary; real service-backed adapters still need implementation.
+- Home active-work controls, detail routing, Console launch requests, item identity, and local unread notification counts now route through explicit adapter boundaries; real active-run service-backed adapters still need implementation.
 - Workflows has no wired workflow service in the shell wrapper.
 - W+C, Schedules, Workflows, and ACP now use honest unavailable Console states until actionable payloads exist.
 - ACP launch is disabled until an ACP-compatible runtime is configured.
@@ -82,6 +82,7 @@ Initial child tasks:
 - Phase 2.1: Add Home active-work adapter contract - `TASK-4.1`
 - Phase 2.2: Route Home detail and Console actions through active-work adapter - `TASK-4.2`
 - Phase 2.3: Bind Home controls to active-work item context - `TASK-4.3`
+- Phase 2.4: Wire Home to local notification snapshot adapter - `TASK-4.4`
 
 ## QA Evidence Index
 
@@ -101,7 +102,7 @@ Initial child tasks:
 | --- | --- | --- | --- | --- | --- |
 | Phase 0: Canonical Tracking | Make remaining work trackable. | verified | `TASK-1`, `TASK-1.1`, `TASK-1.2` | `phase-0/` | Product UI workflows are out of scope for Phase 0. |
 | Phase 1: Shell Contract Complete | Remove false shell affordances and prove shell usability. | verified | `TASK-2`, `TASK-2.1`, `TASK-2.2`, `TASK-2.3`, `TASK-2.4` | `phase-1/` | Live service workflows remain intentionally deferred to Phases 2-6. |
-| Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | in-progress | `TASK-4`, `TASK-4.1`, `TASK-4.2`, `TASK-4.3` | `phase-2/` | Real active-run, schedule, and agent-service adapters still need implementation. |
+| Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | in-progress | `TASK-4`, `TASK-4.1`, `TASK-4.2`, `TASK-4.3`, `TASK-4.4` | `phase-2/` | Real active-run, schedule, and agent-service adapters still need implementation. |
 | Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | not-started | `TASK-3` | `phase-3/` | Live work event sources need explicit contracts. |
 | Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | not-started | `TASK-5` | `phase-4/` | Service coverage varies by destination. |
 | Phase 5: Capability And Recovery System | Systematize unavailable and blocked states. | not-started | `TASK-6` | `phase-5/` | Shared taxonomy not yet extracted. |
@@ -152,6 +153,12 @@ Initial audit result: W+C, Schedules, Workflows, and ACP had false Console-launc
 `TASK-4.3` binds Home controls to explicit visible active-work item context:
 
 - `Docs/superpowers/qa/unified-shell/phase-2/2026-05-03-home-active-work-item-context.md`
+
+## Phase 2.4 Home Local Notification Snapshot Evidence
+
+`TASK-4.4` wires Home to the local unread notification queue without creating false active-work controls:
+
+- `Docs/superpowers/qa/unified-shell/phase-2/2026-05-03-home-local-notification-snapshot.md`
 
 ## Phase 0: Canonical Tracking
 

--- a/Tests/Home/test_active_work_adapter.py
+++ b/Tests/Home/test_active_work_adapter.py
@@ -5,6 +5,7 @@ from tldw_chatbook.Home.active_work_adapter import (
     HomeControlAction,
     HomeControlResult,
     HomeControlResultStatus,
+    LocalNotificationHomeActiveWorkAdapter,
     UnavailableHomeActiveWorkAdapter,
 )
 
@@ -22,6 +23,61 @@ def test_unavailable_home_adapter_builds_dashboard_input_from_runtime_context():
     assert dashboard_input.pending_approval_count == 0
     assert dashboard_input.active_run_count == 0
     assert dashboard_input.active_detail_route == "chat"
+
+
+def test_local_notification_adapter_counts_unread_local_notifications():
+    class FakeNotificationsService:
+        def __init__(self):
+            self.calls = []
+
+        def list_queue(self, *, limit=100, include_dismissed=False, category=None):
+            self.calls.append(
+                {
+                    "limit": limit,
+                    "include_dismissed": include_dismissed,
+                    "category": category,
+                }
+            )
+            return [
+                {"id": "read", "is_read": True},
+                {"id": "unread-1", "is_read": False},
+                {"id": "unread-2", "is_read": False},
+            ]
+
+    service = FakeNotificationsService()
+    adapter = LocalNotificationHomeActiveWorkAdapter(notification_service=service)
+
+    dashboard_input = adapter.build_dashboard_input(
+        providers_models={"OpenAI": ["gpt-4.1"]},
+        has_recent_work=True,
+    )
+
+    assert dashboard_input.model_ready is True
+    assert dashboard_input.has_recent_work is True
+    assert dashboard_input.notification_count == 2
+    assert dashboard_input.pending_approval_count == 0
+    assert dashboard_input.active_run_count == 0
+    assert service.calls == [{"limit": 100, "include_dismissed": False, "category": None}]
+
+
+def test_local_notification_adapter_fails_closed_when_snapshot_unavailable():
+    class BrokenNotificationsService:
+        def list_queue(self, *, limit=100, include_dismissed=False, category=None):
+            raise RuntimeError("notification store unavailable")
+
+    adapter = LocalNotificationHomeActiveWorkAdapter(
+        notification_service=BrokenNotificationsService()
+    )
+
+    dashboard_input = adapter.build_dashboard_input(
+        providers_models={},
+        has_recent_work=False,
+    )
+
+    assert dashboard_input.model_ready is False
+    assert dashboard_input.notification_count == 0
+    assert dashboard_input.pending_approval_count == 0
+    assert dashboard_input.active_run_count == 0
 
 
 def test_unavailable_home_adapter_returns_honest_recovery_result():

--- a/Tests/Home/test_dashboard_state.py
+++ b/Tests/Home/test_dashboard_state.py
@@ -34,6 +34,33 @@ def test_next_best_action_prioritizes_pending_approval_after_readiness():
     assert action.target_route == "chat"
 
 
+def test_next_best_action_surfaces_notifications_after_live_work_blockers():
+    state = HomeDashboardInput(
+        model_ready=True,
+        notification_count=3,
+        has_library_content=True,
+    )
+
+    action = choose_next_best_action(state)
+
+    assert action.action_id == "review_notifications"
+    assert action.label == "Review notifications"
+    assert action.target_route == "home"
+
+
+def test_pending_approval_still_outranks_unread_notifications():
+    state = HomeDashboardInput(
+        model_ready=True,
+        pending_approval_count=1,
+        notification_count=3,
+        has_library_content=True,
+    )
+
+    action = choose_next_best_action(state)
+
+    assert action.action_id == "review_approvals"
+
+
 def test_dashboard_summary_exposes_required_sections():
     dashboard = summarize_home_dashboard(
         HomeDashboardInput(
@@ -51,6 +78,23 @@ def test_dashboard_summary_exposes_required_sections():
         "next_best_action",
         "recent_work",
     ]
+
+
+def test_dashboard_summary_exposes_notifications_without_live_work_controls():
+    dashboard = summarize_home_dashboard(
+        HomeDashboardInput(
+            model_ready=True,
+            notification_count=3,
+            has_library_content=True,
+        )
+    )
+
+    attention_section = next(
+        section for section in dashboard.sections if section.section_id == "attention"
+    )
+    assert "Unread notifications: 3" in attention_section.lines
+    assert dashboard.next_action.action_id == "review_notifications"
+    assert dashboard.controls == ()
 
 
 def test_dashboard_summary_exposes_lightweight_control_ids_for_core_states():

--- a/Tests/UI/test_home_screen.py
+++ b/Tests/UI/test_home_screen.py
@@ -136,6 +136,28 @@ async def test_home_screen_shows_lightweight_agent_and_schedule_controls():
 
 
 @pytest.mark.asyncio
+async def test_home_screen_renders_unread_notification_snapshot_without_controls():
+    app = _build_test_app()
+    app._home_dashboard_test_input = HomeDashboardInput(
+        model_ready=True,
+        notification_count=2,
+        has_library_content=True,
+    )
+    host = HomeHarness(app)
+
+    async with host.run_test(size=(160, 40)) as pilot:
+        await pilot.pause(0.1)
+        home = _active_home_screen(host)
+
+        assert "Unread notifications: 2" in str(
+            home.query_one("#home-attention-body").renderable
+        )
+        assert len(home.query("#home-approve")) == 0
+        assert len(home.query("#home-pause")) == 0
+        assert len(home.query("#home-open-in-console")) == 0
+
+
+@pytest.mark.asyncio
 async def test_home_control_clicks_call_available_runtime_hooks():
     app = _build_test_app()
     app._home_dashboard_test_input = HomeDashboardInput(

--- a/Tests/UI/test_screen_navigation.py
+++ b/Tests/UI/test_screen_navigation.py
@@ -79,6 +79,7 @@ from tldw_chatbook.Companion_Interop import CompanionScopeService, ServerCompani
 from tldw_chatbook.Collections_Interop import CollectionsFeedsScopeService, ServerCollectionsFeedsService
 from tldw_chatbook.External_Connectors_Interop import ConnectorsScopeService, ServerConnectorsService
 from tldw_chatbook.Feedback_Interop import FeedbackScopeService, LocalFeedbackService, ServerFeedbackService
+from tldw_chatbook.Home.active_work_adapter import LocalNotificationHomeActiveWorkAdapter
 from tldw_chatbook.Kanban_Interop import KanbanScopeService, LocalKanbanService, ServerKanbanService
 from tldw_chatbook.LLM_Provider_Catalog import (
     LLMProviderCatalogScopeService,
@@ -345,6 +346,8 @@ def test_app_initializes_watchlists_and_notifications_services():
     assert isinstance(app.server_notifications_service, ServerNotificationsService)
     assert isinstance(app.notifications_scope_service, NotificationsScopeService)
     assert app.notifications_scope_service.local_service is app.client_notifications_service
+    assert isinstance(app.home_active_work_adapter, LocalNotificationHomeActiveWorkAdapter)
+    assert app.home_active_work_adapter.notification_service is app.client_notifications_service
     assert isinstance(app.server_outputs_service, ServerOutputsService)
     assert isinstance(app.outputs_scope_service, OutputsScopeService)
     assert isinstance(app.local_research_service, LocalResearchService)

--- a/Tests/UI/test_unified_shell_phase2_home_adapter.py
+++ b/Tests/UI/test_unified_shell_phase2_home_adapter.py
@@ -5,6 +5,7 @@ PHASE_2_ROOT = Path("Docs/superpowers/qa/unified-shell/phase-2")
 EVIDENCE = PHASE_2_ROOT / "2026-05-03-home-active-work-adapter-contract.md"
 DETAIL_CONSOLE_EVIDENCE = PHASE_2_ROOT / "2026-05-03-home-detail-console-adapter-actions.md"
 ITEM_CONTEXT_EVIDENCE = PHASE_2_ROOT / "2026-05-03-home-active-work-item-context.md"
+LOCAL_NOTIFICATION_EVIDENCE = PHASE_2_ROOT / "2026-05-03-home-local-notification-snapshot.md"
 README = PHASE_2_ROOT / "README.md"
 ROADMAP = Path("Docs/superpowers/trackers/unified-shell-maturity-roadmap.md")
 TASK_4_1 = Path("backlog/tasks/task-4.1 - Phase-2.1-Add-Home-active-work-adapter-contract.md")
@@ -12,6 +13,9 @@ TASK_4_2 = Path(
     "backlog/tasks/task-4.2 - Phase-2.2-Route-Home-detail-and-Console-actions-through-active-work-adapter.md"
 )
 TASK_4_3 = Path("backlog/tasks/task-4.3 - Phase-2.3-Bind-Home-controls-to-active-work-item-context.md")
+TASK_4_4 = Path(
+    "backlog/tasks/task-4.4 - Phase-2.4-Wire-Home-to-local-notification-snapshot-adapter.md"
+)
 
 
 def test_phase_two_home_adapter_evidence_exists_and_records_verification():
@@ -92,6 +96,34 @@ def test_phase_two_item_context_evidence_is_linked_from_index_roadmap_and_task()
     assert evidence_name in roadmap_text
 
     task_text = TASK_4_3.read_text(encoding="utf-8")
+    assert "status: Done" in task_text
+    assert "- [x] #1" in task_text
+    assert "- [x] #5" in task_text
+
+
+def test_phase_two_local_notification_evidence_exists_and_records_verification():
+    assert LOCAL_NOTIFICATION_EVIDENCE.exists()
+    text = LOCAL_NOTIFICATION_EVIDENCE.read_text(encoding="utf-8")
+
+    assert "TASK-4.4" in text
+    assert "LocalNotificationHomeActiveWorkAdapter" in text
+    assert "notification_count" in text
+    assert "ClientNotificationsService.list_queue" in text
+    assert "Tests/UI/test_screen_navigation.py" in text
+    assert "58 passed" in text
+    assert "66 passed" in text
+
+
+def test_phase_two_local_notification_evidence_is_linked_from_index_roadmap_and_task():
+    evidence_name = LOCAL_NOTIFICATION_EVIDENCE.name
+
+    assert evidence_name in README.read_text(encoding="utf-8")
+
+    roadmap_text = ROADMAP.read_text(encoding="utf-8")
+    assert "TASK-4.4" in roadmap_text
+    assert evidence_name in roadmap_text
+
+    task_text = TASK_4_4.read_text(encoding="utf-8")
     assert "status: Done" in task_text
     assert "- [x] #1" in task_text
     assert "- [x] #5" in task_text

--- a/backlog/tasks/task-4.4 - Phase-2.4-Wire-Home-to-local-notification-snapshot-adapter.md
+++ b/backlog/tasks/task-4.4 - Phase-2.4-Wire-Home-to-local-notification-snapshot-adapter.md
@@ -1,0 +1,48 @@
+---
+id: TASK-4.4
+title: 'Phase 2.4: Wire Home to local notification snapshot adapter'
+status: Done
+assignee: []
+created_date: '2026-05-03 18:19'
+updated_date: '2026-05-03 18:22'
+labels:
+  - unified-shell
+  - phase-2
+  - home
+  - notifications
+  - adapter
+dependencies: []
+parent_task_id: TASK-4
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Connect Home to a synchronous local notification snapshot so the dashboard reflects real unread notification state without pretending generic notifications are controllable active runs.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Home adapter can derive unread notification count from the local client notification service.
+- [x] #2 Home Attention section exposes unread notifications without creating approval or active-run controls.
+- [x] #3 Next-best action still prioritizes model readiness, approvals, failed schedules, and active work before notification review.
+- [x] #4 Home falls back safely when no notification service is available or snapshot collection fails.
+- [x] #5 Focused tests and Phase 2 QA evidence verify the adapter state, screen rendering, and backlog tracking.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing adapter and dashboard tests for local unread notification snapshots.
+2. Implement the smallest Home dashboard state and adapter changes needed to expose unread notifications without live-work controls.
+3. Wire TldwCli to use the local notification snapshot adapter after notification services initialize.
+4. Add Phase 2 QA evidence and tracking updates.
+5. Run focused Home adapter, dashboard, screen, and tracking verification plus git diff checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented a local notification snapshot adapter for Home that reads unread local notifications from `ClientNotificationsService.list_queue`, exposes `notification_count` in Home dashboard state, and wires `TldwCli` to use the adapter after notification services initialize. Dashboard copy now surfaces unread notifications and can recommend notification review after stronger readiness and live-work blockers, while generic notifications still do not create approval, pause, retry, detail, or Console controls. Added focused adapter, state, mounted Home screen, app wiring, and Phase 2 tracking tests plus QA evidence for `TASK-4.4`.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Home/__init__.py
+++ b/tldw_chatbook/Home/__init__.py
@@ -13,6 +13,7 @@ from .active_work_adapter import (
     HomeControlAction,
     HomeControlResult,
     HomeControlResultStatus,
+    LocalNotificationHomeActiveWorkAdapter,
     UnavailableHomeActiveWorkAdapter,
 )
 
@@ -26,6 +27,7 @@ __all__ = [
     "HomeSection",
     "HomeControlResult",
     "HomeControlResultStatus",
+    "LocalNotificationHomeActiveWorkAdapter",
     "UnavailableHomeActiveWorkAdapter",
     "build_home_controls",
     "choose_next_best_action",

--- a/tldw_chatbook/Home/active_work_adapter.py
+++ b/tldw_chatbook/Home/active_work_adapter.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import StrEnum
 from typing import Any, Mapping, Protocol, runtime_checkable
 
@@ -141,23 +141,7 @@ class LocalNotificationHomeActiveWorkAdapter(UnavailableHomeActiveWorkAdapter):
             providers_models=providers_models,
             has_recent_work=has_recent_work,
         )
-        return HomeDashboardInput(
-            model_ready=dashboard_input.model_ready,
-            mcp_ready=dashboard_input.mcp_ready,
-            acp_ready=dashboard_input.acp_ready,
-            rag_ready=dashboard_input.rag_ready,
-            pending_approval_count=dashboard_input.pending_approval_count,
-            active_run_count=dashboard_input.active_run_count,
-            running_run_count=dashboard_input.running_run_count,
-            paused_run_count=dashboard_input.paused_run_count,
-            failed_run_count=dashboard_input.failed_run_count,
-            failed_schedule_count=dashboard_input.failed_schedule_count,
-            notification_count=self._unread_notification_count(),
-            has_library_content=dashboard_input.has_library_content,
-            has_recent_work=dashboard_input.has_recent_work,
-            active_detail_route=dashboard_input.active_detail_route,
-            active_work_items=dashboard_input.active_work_items,
-        )
+        return replace(dashboard_input, notification_count=self._unread_notification_count())
 
     def _unread_notification_count(self) -> int:
         if self.notification_service is None:

--- a/tldw_chatbook/Home/active_work_adapter.py
+++ b/tldw_chatbook/Home/active_work_adapter.py
@@ -119,3 +119,61 @@ class UnavailableHomeActiveWorkAdapter(HomeActiveWorkAdapter):
             recovery_route=recovery_route,
             target_id=target_id,
         )
+
+
+class LocalNotificationHomeActiveWorkAdapter(UnavailableHomeActiveWorkAdapter):
+    """Home adapter that exposes local notification queue state.
+
+    Active run controls remain unavailable until workflow/run services expose a
+    safe synchronous Home contract.
+    """
+
+    def __init__(self, *, notification_service: Any | None = None):
+        self.notification_service = notification_service
+
+    def build_dashboard_input(
+        self,
+        *,
+        providers_models: Mapping[str, Any],
+        has_recent_work: bool,
+    ) -> HomeDashboardInput:
+        dashboard_input = super().build_dashboard_input(
+            providers_models=providers_models,
+            has_recent_work=has_recent_work,
+        )
+        return HomeDashboardInput(
+            model_ready=dashboard_input.model_ready,
+            mcp_ready=dashboard_input.mcp_ready,
+            acp_ready=dashboard_input.acp_ready,
+            rag_ready=dashboard_input.rag_ready,
+            pending_approval_count=dashboard_input.pending_approval_count,
+            active_run_count=dashboard_input.active_run_count,
+            running_run_count=dashboard_input.running_run_count,
+            paused_run_count=dashboard_input.paused_run_count,
+            failed_run_count=dashboard_input.failed_run_count,
+            failed_schedule_count=dashboard_input.failed_schedule_count,
+            notification_count=self._unread_notification_count(),
+            has_library_content=dashboard_input.has_library_content,
+            has_recent_work=dashboard_input.has_recent_work,
+            active_detail_route=dashboard_input.active_detail_route,
+            active_work_items=dashboard_input.active_work_items,
+        )
+
+    def _unread_notification_count(self) -> int:
+        if self.notification_service is None:
+            return 0
+        try:
+            notifications = self.notification_service.list_queue(
+                limit=100,
+                include_dismissed=False,
+                category=None,
+            )
+        except Exception:
+            return 0
+        return sum(1 for notification in notifications if _notification_is_unread(notification))
+
+
+def _notification_is_unread(notification: Any) -> bool:
+    if isinstance(notification, Mapping):
+        return not bool(notification.get("is_read"))
+    return not bool(getattr(notification, "is_read", False))

--- a/tldw_chatbook/Home/dashboard_state.py
+++ b/tldw_chatbook/Home/dashboard_state.py
@@ -33,6 +33,7 @@ class HomeDashboardInput:
     paused_run_count: int = 0
     failed_run_count: int = 0
     failed_schedule_count: int = 0
+    notification_count: int = 0
     has_library_content: bool = False
     has_recent_work: bool = False
     active_detail_route: str = "chat"
@@ -98,6 +99,13 @@ def choose_next_best_action(state: HomeDashboardInput) -> HomeAction:
             "Resume active work",
             "chat",
             "Live work is already running.",
+        )
+    if state.notification_count:
+        return HomeAction(
+            "review_notifications",
+            "Review notifications",
+            "home",
+            "Unread notifications need review.",
         )
     if not state.has_library_content:
         return HomeAction(
@@ -214,7 +222,11 @@ def summarize_home_dashboard(state: HomeDashboardInput) -> HomeDashboard:
             HomeSection(
                 "attention",
                 "Attention",
-                (approval_label, f"Pending approvals: {_pending_approval_count(state)}"),
+                (
+                    approval_label,
+                    f"Pending approvals: {_pending_approval_count(state)}",
+                    f"Unread notifications: {state.notification_count}",
+                ),
             ),
             HomeSection(
                 "active_work",

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -98,6 +98,7 @@ from tldw_chatbook.Home.active_work_adapter import (
     HomeControlAction,
     HomeControlResult,
     HomeControlResultStatus,
+    LocalNotificationHomeActiveWorkAdapter,
     UnavailableHomeActiveWorkAdapter,
 )
 from tldw_chatbook.Logging_Config import RichLogHandler
@@ -1995,6 +1996,9 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
         self.client_notifications_service = ClientNotificationsService(
             store=self.client_notifications_db,
             policy_enforcer=self.service_policy_enforcer,
+        )
+        self.home_active_work_adapter = LocalNotificationHomeActiveWorkAdapter(
+            notification_service=self.client_notifications_service,
         )
         self.notification_dispatch_service = NotificationDispatchService(
             store=self.client_notifications_db,


### PR DESCRIPTION
## Summary
- Add TASK-4.4 for the Phase 2 Home local notification snapshot slice.
- Expose local unread notification count through Home dashboard state and a fail-closed Home adapter backed by ClientNotificationsService.
- Wire TldwCli to use the local notification adapter after notification services initialize, while keeping generic notifications from creating live-work controls.
- Update Phase 2 QA evidence and roadmap tracking.

## Test Plan
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Home/test_dashboard_state.py Tests/Home/test_active_work_adapter.py Tests/UI/test_home_screen.py Tests/UI/test_screen_navigation.py Tests/UI/test_unified_shell_phase2_home_adapter.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_unified_shell_phase2_home_adapter.py -q
- git diff --check