### PR TITLE
Route Home notification review to inbox

### DIFF
--- a/Docs/superpowers/qa/unified-shell/phase-2/2026-05-03-home-notification-review-routing.md
+++ b/Docs/superpowers/qa/unified-shell/phase-2/2026-05-03-home-notification-review-routing.md
@@ -1,0 +1,42 @@
+# Home Notification Review Routing
+
+Date: 2026-05-03
+Task: `TASK-4.5`
+Branch: `codex/unified-shell-phase2-home-notification-review`
+Base: `origin/dev` at `6ba7304f`
+
+## Purpose
+
+Make the Home unread-notification next-best action lead to the existing local notifications inbox instead of looping users back to Home or requiring them to remember where notifications are reviewed.
+
+## What Changed
+
+- Changed the `review_notifications` next-best action target route from `home` to `subscriptions`.
+- Added a Home primary-action preparation hook that stages `pending_subscription_initial_tab = "notifications"` before navigation.
+- Added a `SubscriptionWindow` initial-tab seam that consumes the pending notifications tab request, validates it against known tabs, and clears the one-shot request.
+- Preserved notification count behavior and avoided creating active-work controls for generic notifications.
+
+## Functional QA Evidence
+
+Focused checks were run against pure Home dashboard state, mounted Home screen navigation, and the SubscriptionWindow tab context seam.
+
+- Red test: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Home/test_dashboard_state.py::test_next_best_action_surfaces_notifications_after_live_work_blockers Tests/UI/test_home_screen.py::test_home_notification_primary_action_opens_notifications_inbox_context Tests/UI/test_subscription_window_watchlists.py::test_subscription_window_consumes_pending_notifications_initial_tab -q`
+- Red result: `3 failed`; Home still routed notification review to `home`, and `SubscriptionWindow.initial_tab` did not exist.
+- Green test: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Home/test_dashboard_state.py::test_next_best_action_surfaces_notifications_after_live_work_blockers Tests/UI/test_home_screen.py::test_home_notification_primary_action_opens_notifications_inbox_context Tests/UI/test_subscription_window_watchlists.py::test_subscription_window_consumes_pending_notifications_initial_tab -q`
+- Green result: `3 passed, 8 warnings`
+- Focused Phase 2 Home/subscription suite: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Home/test_dashboard_state.py Tests/Home/test_active_work_adapter.py Tests/UI/test_home_screen.py Tests/UI/test_subscription_window_watchlists.py Tests/UI/test_screen_navigation.py Tests/UI/test_unified_shell_phase2_home_adapter.py -q`
+- Focused Phase 2 Home/subscription suite result: `91 passed, 8 warnings`
+
+Warning boundary: warnings are existing dependency/import warnings and are not notification review routing failures.
+
+## UX Result
+
+- The Home "Review notifications" CTA now leads toward the real inbox workflow.
+- Users do not need to know that the current inbox implementation lives under the subscriptions/W+C surface.
+- The initial-tab request is one-shot, so later manual visits to Subscriptions still default to the normal subscriptions tab.
+
+## Residual Risk
+
+- This slice does not redesign the notifications inbox or move it into a dedicated top-level destination.
+- The existing SubscriptionWindow notifications tab remains the current review surface.
+- Full Phase 2 verification still requires real running-app QA with notification records produced by local jobs.

--- a/Docs/superpowers/qa/unified-shell/phase-2/README.md
+++ b/Docs/superpowers/qa/unified-shell/phase-2/README.md
@@ -10,5 +10,6 @@ This directory contains durable QA summaries for Phase 2 Home operational-contro
 - `2026-05-03-home-detail-console-adapter-actions.md` - `TASK-4.2` adapter-owned Home detail and Console actions.
 - `2026-05-03-home-active-work-item-context.md` - `TASK-4.3` item-scoped Home active-work controls.
 - `2026-05-03-home-local-notification-snapshot.md` - `TASK-4.4` local unread notification snapshot state for Home.
+- `2026-05-03-home-notification-review-routing.md` - `TASK-4.5` Home notification review CTA routing into the existing inbox.
 
 Do not mark Phase 2 verified until Home approve, reject, pause, resume, retry, and open-detail workflows are verified against real service-backed adapters or explicitly recoverable unavailable states.

--- a/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
@@ -2,7 +2,7 @@
 
 Date: 2026-05-03
 Status: Phase 2 in progress
-Source Branch: `origin/dev` at `252b7ba8` plus `codex/unified-shell-phase2-home-local-snapshot-adapter`
+Source Branch: `origin/dev` at `6ba7304f` plus `codex/unified-shell-phase2-home-notification-review`
 
 ## Purpose
 
@@ -27,7 +27,7 @@ Track remaining Unified Shell work in one place so rendered screens, clickable b
 
 ## Known Product Gaps
 
-- Home active-work controls, detail routing, Console launch requests, item identity, and local unread notification counts now route through explicit adapter boundaries; real active-run service-backed adapters still need implementation.
+- Home active-work controls, detail routing, Console launch requests, item identity, local unread notification counts, and notification review routing now route through explicit adapter boundaries; real active-run service-backed adapters still need implementation.
 - Workflows has no wired workflow service in the shell wrapper.
 - W+C, Schedules, Workflows, and ACP now use honest unavailable Console states until actionable payloads exist.
 - ACP launch is disabled until an ACP-compatible runtime is configured.
@@ -83,6 +83,7 @@ Initial child tasks:
 - Phase 2.2: Route Home detail and Console actions through active-work adapter - `TASK-4.2`
 - Phase 2.3: Bind Home controls to active-work item context - `TASK-4.3`
 - Phase 2.4: Wire Home to local notification snapshot adapter - `TASK-4.4`
+- Phase 2.5: Route Home notification review to the notifications inbox - `TASK-4.5`
 
 ## QA Evidence Index
 
@@ -102,7 +103,7 @@ Initial child tasks:
 | --- | --- | --- | --- | --- | --- |
 | Phase 0: Canonical Tracking | Make remaining work trackable. | verified | `TASK-1`, `TASK-1.1`, `TASK-1.2` | `phase-0/` | Product UI workflows are out of scope for Phase 0. |
 | Phase 1: Shell Contract Complete | Remove false shell affordances and prove shell usability. | verified | `TASK-2`, `TASK-2.1`, `TASK-2.2`, `TASK-2.3`, `TASK-2.4` | `phase-1/` | Live service workflows remain intentionally deferred to Phases 2-6. |
-| Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | in-progress | `TASK-4`, `TASK-4.1`, `TASK-4.2`, `TASK-4.3`, `TASK-4.4` | `phase-2/` | Real active-run, schedule, and agent-service adapters still need implementation. |
+| Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | in-progress | `TASK-4`, `TASK-4.1`, `TASK-4.2`, `TASK-4.3`, `TASK-4.4`, `TASK-4.5` | `phase-2/` | Real active-run, schedule, and agent-service adapters still need implementation. |
 | Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | not-started | `TASK-3` | `phase-3/` | Live work event sources need explicit contracts. |
 | Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | not-started | `TASK-5` | `phase-4/` | Service coverage varies by destination. |
 | Phase 5: Capability And Recovery System | Systematize unavailable and blocked states. | not-started | `TASK-6` | `phase-5/` | Shared taxonomy not yet extracted. |
@@ -159,6 +160,12 @@ Initial audit result: W+C, Schedules, Workflows, and ACP had false Console-launc
 `TASK-4.4` wires Home to the local unread notification queue without creating false active-work controls:
 
 - `Docs/superpowers/qa/unified-shell/phase-2/2026-05-03-home-local-notification-snapshot.md`
+
+## Phase 2.5 Home Notification Review Routing Evidence
+
+`TASK-4.5` makes Home notification review actions lead into the existing notifications inbox:
+
+- `Docs/superpowers/qa/unified-shell/phase-2/2026-05-03-home-notification-review-routing.md`
 
 ## Phase 0: Canonical Tracking
 

--- a/Tests/Home/test_dashboard_state.py
+++ b/Tests/Home/test_dashboard_state.py
@@ -45,7 +45,7 @@ def test_next_best_action_surfaces_notifications_after_live_work_blockers():
 
     assert action.action_id == "review_notifications"
     assert action.label == "Review notifications"
-    assert action.target_route == "home"
+    assert action.target_route == "subscriptions"
 
 
 def test_pending_approval_still_outranks_unread_notifications():

--- a/Tests/UI/test_home_screen.py
+++ b/Tests/UI/test_home_screen.py
@@ -101,7 +101,7 @@ async def test_home_primary_action_opens_target_route():
         await pilot.click("#home-primary-action")
         await pilot.pause(0.1)
 
-    assert seen[-1] in {"chat", "llm", "library", "schedules"}
+    assert seen[-1] in {"chat", "llm", "library", "schedules", "subscriptions"}
 
 
 @pytest.mark.asyncio
@@ -155,6 +155,26 @@ async def test_home_screen_renders_unread_notification_snapshot_without_controls
         assert len(home.query("#home-approve")) == 0
         assert len(home.query("#home-pause")) == 0
         assert len(home.query("#home-open-in-console")) == 0
+
+
+@pytest.mark.asyncio
+async def test_home_notification_primary_action_opens_notifications_inbox_context():
+    app = _build_test_app()
+    app._home_dashboard_test_input = HomeDashboardInput(
+        model_ready=True,
+        notification_count=2,
+        has_library_content=True,
+    )
+    seen = []
+    host = HomeHarness(app, seen)
+
+    async with host.run_test(size=(160, 40)) as pilot:
+        await pilot.pause(0.1)
+        await pilot.click("#home-primary-action")
+        await pilot.pause(0.1)
+
+    assert seen[-1] == "subscriptions"
+    assert app.pending_subscription_initial_tab == "notifications"
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_subscription_window_watchlists.py
+++ b/Tests/UI/test_subscription_window_watchlists.py
@@ -79,7 +79,13 @@ def _select_list_item(list_view: _StubListView, index: int = 0) -> object:
     return item
 
 
-def build_window(*, tmp_path: Path, runtime_backend: str, policy_allowed: bool = True) -> SubscriptionWindow:
+def build_window(
+    *,
+    tmp_path: Path,
+    runtime_backend: str,
+    policy_allowed: bool = True,
+    pending_initial_tab: str | None = None,
+) -> SubscriptionWindow:
     notifications_store = ClientNotificationsDB(
         db_path=tmp_path / f"notifications-{runtime_backend}.sqlite3",
         client_id=f"tests-{runtime_backend}",
@@ -95,6 +101,8 @@ def build_window(*, tmp_path: Path, runtime_backend: str, policy_allowed: bool =
         require_ui_action_allowed=require_ui_action_allowed,
         notify=Mock(),
     )
+    if pending_initial_tab is not None:
+        app.pending_subscription_initial_tab = pending_initial_tab
     app.watchlist_scope_service.list_watch_items = AsyncMock(
         return_value=[_normalized_watch_row(runtime_backend)]
     )
@@ -282,6 +290,17 @@ def build_window(*, tmp_path: Path, runtime_backend: str, policy_allowed: bool =
     window.notifications_store = notifications_store
     window._test_widgets = widgets
     return window
+
+
+def test_subscription_window_consumes_pending_notifications_initial_tab(tmp_path: Path):
+    window = build_window(
+        tmp_path=tmp_path,
+        runtime_backend="local",
+        pending_initial_tab="notifications",
+    )
+
+    assert window.initial_tab == "notifications"
+    assert not hasattr(window.app_instance, "pending_subscription_initial_tab")
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_unified_shell_phase2_home_adapter.py
+++ b/Tests/UI/test_unified_shell_phase2_home_adapter.py
@@ -6,6 +6,7 @@ EVIDENCE = PHASE_2_ROOT / "2026-05-03-home-active-work-adapter-contract.md"
 DETAIL_CONSOLE_EVIDENCE = PHASE_2_ROOT / "2026-05-03-home-detail-console-adapter-actions.md"
 ITEM_CONTEXT_EVIDENCE = PHASE_2_ROOT / "2026-05-03-home-active-work-item-context.md"
 LOCAL_NOTIFICATION_EVIDENCE = PHASE_2_ROOT / "2026-05-03-home-local-notification-snapshot.md"
+NOTIFICATION_REVIEW_EVIDENCE = PHASE_2_ROOT / "2026-05-03-home-notification-review-routing.md"
 README = PHASE_2_ROOT / "README.md"
 ROADMAP = Path("Docs/superpowers/trackers/unified-shell-maturity-roadmap.md")
 TASK_4_1 = Path("backlog/tasks/task-4.1 - Phase-2.1-Add-Home-active-work-adapter-contract.md")
@@ -15,6 +16,9 @@ TASK_4_2 = Path(
 TASK_4_3 = Path("backlog/tasks/task-4.3 - Phase-2.3-Bind-Home-controls-to-active-work-item-context.md")
 TASK_4_4 = Path(
     "backlog/tasks/task-4.4 - Phase-2.4-Wire-Home-to-local-notification-snapshot-adapter.md"
+)
+TASK_4_5 = Path(
+    "backlog/tasks/task-4.5 - Phase-2.5-Route-Home-notification-review-to-the-notifications-inbox.md"
 )
 
 
@@ -124,6 +128,34 @@ def test_phase_two_local_notification_evidence_is_linked_from_index_roadmap_and_
     assert evidence_name in roadmap_text
 
     task_text = TASK_4_4.read_text(encoding="utf-8")
+    assert "status: Done" in task_text
+    assert "- [x] #1" in task_text
+    assert "- [x] #5" in task_text
+
+
+def test_phase_two_notification_review_routing_evidence_exists_and_records_verification():
+    assert NOTIFICATION_REVIEW_EVIDENCE.exists()
+    text = NOTIFICATION_REVIEW_EVIDENCE.read_text(encoding="utf-8")
+
+    assert "TASK-4.5" in text
+    assert "review_notifications" in text
+    assert "pending_subscription_initial_tab" in text
+    assert "SubscriptionWindow.initial_tab" in text
+    assert "Tests/UI/test_home_screen.py" in text
+    assert "3 passed" in text
+    assert "91 passed" in text
+
+
+def test_phase_two_notification_review_routing_evidence_is_linked_from_index_roadmap_and_task():
+    evidence_name = NOTIFICATION_REVIEW_EVIDENCE.name
+
+    assert evidence_name in README.read_text(encoding="utf-8")
+
+    roadmap_text = ROADMAP.read_text(encoding="utf-8")
+    assert "TASK-4.5" in roadmap_text
+    assert evidence_name in roadmap_text
+
+    task_text = TASK_4_5.read_text(encoding="utf-8")
     assert "status: Done" in task_text
     assert "- [x] #1" in task_text
     assert "- [x] #5" in task_text

--- a/backlog/tasks/task-4.5 - Phase-2.5-Route-Home-notification-review-to-the-notifications-inbox.md
+++ b/backlog/tasks/task-4.5 - Phase-2.5-Route-Home-notification-review-to-the-notifications-inbox.md
@@ -1,0 +1,48 @@
+---
+id: TASK-4.5
+title: 'Phase 2.5: Route Home notification review to the notifications inbox'
+status: Done
+assignee: []
+created_date: '2026-05-03 18:47'
+updated_date: '2026-05-03 18:50'
+labels:
+  - unified-shell
+  - phase-2
+  - home
+  - notifications
+  - navigation
+dependencies: []
+parent_task_id: TASK-4
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make Home notification next-best actions lead to the existing local notifications inbox instead of looping on Home or requiring users to remember where notifications live.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Home notification next-best action targets a real notifications review workflow.
+- [x] #2 Clicking the Home notification primary action opens the subscriptions notifications tab context.
+- [x] #3 The subscriptions surface can honor a pending notifications initial-tab request and then clear it.
+- [x] #4 Notification review routing does not create active-work controls or change approval priority.
+- [x] #5 Focused tests and Phase 2 QA evidence verify the end-to-end routing seam.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing dashboard and Home screen tests for notification review routing.
+2. Add failing subscriptions test for honoring a pending notifications tab request.
+3. Implement the smallest Home action and SubscriptionWindow initial-tab seam.
+4. Add Phase 2 QA evidence and tracking updates.
+5. Run focused Home, subscription, and tracking verification plus git diff checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Changed Home notification review from a self-looping Home route to the existing subscriptions notifications inbox path. Home primary-action clicks now stage a one-shot `pending_subscription_initial_tab = "notifications"` request before navigation, and `SubscriptionWindow` consumes that validated initial tab and clears it. Added regression coverage for dashboard routing, mounted Home primary-action behavior, SubscriptionWindow tab consumption, and Phase 2 tracking evidence.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Home/dashboard_state.py
+++ b/tldw_chatbook/Home/dashboard_state.py
@@ -104,7 +104,7 @@ def choose_next_best_action(state: HomeDashboardInput) -> HomeAction:
         return HomeAction(
             "review_notifications",
             "Review notifications",
-            "home",
+            "subscriptions",
             "Unread notifications need review.",
         )
     if not state.has_library_content:

--- a/tldw_chatbook/UI/Screens/home_screen.py
+++ b/tldw_chatbook/UI/Screens/home_screen.py
@@ -80,6 +80,9 @@ class HomeScreen(BaseAppScreen):
             return
 
         if button_id == "home-primary-action":
+            prepare = getattr(self.app_instance, "prepare_home_primary_action", None)
+            if callable(prepare):
+                prepare(dashboard.next_action)
             self.post_message(NavigateToScreen(dashboard.next_action.target_route))
             return
 

--- a/tldw_chatbook/UI/SubscriptionWindow.py
+++ b/tldw_chatbook/UI/SubscriptionWindow.py
@@ -65,6 +65,23 @@ if TYPE_CHECKING:
 #
 ########################################################################################################################
 
+SUBSCRIPTION_INITIAL_TABS = frozenset(
+    {
+        "subscriptions",
+        "review",
+        "notifications",
+        "server-reminders",
+        "server-feed",
+        "watchlist-jobs",
+        "watchlist-runs",
+        "watchlist-alert-rules",
+        "dashboard",
+        "briefings",
+        "settings",
+    }
+)
+
+
 class SubscriptionWindow(Container):
     """Main subscription management window."""
     
@@ -188,6 +205,7 @@ class SubscriptionWindow(Container):
         """
         super().__init__(*args, **kwargs)
         self.app_instance = app_instance  # Changed from self.app to self.app_instance
+        self.initial_tab = self._consume_initial_tab(app_instance)
         self.client_id = "cli"
         self.db: Optional[SubscriptionsDB] = None
         self.scheduler_worker: Optional[SubscriptionSchedulerWorker] = None
@@ -224,7 +242,7 @@ class SubscriptionWindow(Container):
     
     def compose(self) -> ComposeResult:
         """Compose the subscription UI."""
-        with TabbedContent(initial="subscriptions"):
+        with TabbedContent(initial=self.initial_tab):
             # Subscriptions tab
             with TabPane("Subscriptions", id="subscriptions"):
                 yield from self._compose_subscriptions_tab()
@@ -263,6 +281,15 @@ class SubscriptionWindow(Container):
             # Settings tab
             with TabPane("Settings", id="settings"):
                 yield from self._compose_settings_tab()
+
+    @staticmethod
+    def _consume_initial_tab(app_instance: Any) -> str:
+        initial_tab = getattr(app_instance, "pending_subscription_initial_tab", None)
+        if hasattr(app_instance, "pending_subscription_initial_tab"):
+            delattr(app_instance, "pending_subscription_initial_tab")
+        if initial_tab in SUBSCRIPTION_INITIAL_TABS:
+            return str(initial_tab)
+        return "subscriptions"
     
     def _compose_subscriptions_tab(self) -> ComposeResult:
         """Compose subscriptions management tab."""

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -1665,6 +1665,11 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
         self.notify(result.message, severity=result.severity)
         return result
 
+    def prepare_home_primary_action(self, action: Any) -> None:
+        """Stage route-specific context before Home primary-action navigation."""
+        if getattr(action, "action_id", None) == "review_notifications":
+            self.pending_subscription_initial_tab = "notifications"
+
     def approve_active_home_item(self, *, target_id: str | None = None) -> HomeControlResult:
         """Approve the active Home item through the configured adapter."""
         return self._handle_home_control_action(HomeControlAction.APPROVE, target_id=target_id)


### PR DESCRIPTION
## Summary
- Add TASK-4.5 for Home notification review routing.
- Route the Home Review notifications next-best action to the existing subscriptions notifications inbox instead of Home.
- Stage and consume a one-shot SubscriptionWindow initial-tab request for the Notifications tab.
- Update Phase 2 QA evidence and roadmap tracking.

## Test Plan
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Home/test_dashboard_state.py::test_next_best_action_surfaces_notifications_after_live_work_blockers Tests/UI/test_home_screen.py::test_home_notification_primary_action_opens_notifications_inbox_context Tests/UI/test_subscription_window_watchlists.py::test_subscription_window_consumes_pending_notifications_initial_tab -q
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Home/test_dashboard_state.py Tests/Home/test_active_work_adapter.py Tests/UI/test_home_screen.py Tests/UI/test_subscription_window_watchlists.py Tests/UI/test_screen_navigation.py Tests/UI/test_unified_shell_phase2_home_adapter.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_unified_shell_phase2_home_adapter.py -q
- git diff --check