### PR TITLE
Surface local watchlist runs on Home

### DIFF
--- a/Docs/superpowers/qa/unified-shell/phase-2/2026-05-03-home-local-watchlist-run-snapshot.md
+++ b/Docs/superpowers/qa/unified-shell/phase-2/2026-05-03-home-local-watchlist-run-snapshot.md
@@ -1,0 +1,46 @@
+# Home Local Watchlist Run Snapshot
+
+Date: 2026-05-03
+Task: `TASK-4.6`
+Branch: `codex/unified-shell-phase2-home-watchlist-runs`
+Base: `origin/dev` at `52e4e89e`
+
+## Purpose
+
+Expose real local W+C watchlist run state on Home so queued, running, and failed local runs appear as active work instead of leaving Home as a notification-only dashboard.
+
+## What Changed
+
+- Added `LocalWatchlistsService.list_home_run_snapshot` as a synchronous Home-safe snapshot over recent local watchlist runs.
+- Extended `LocalNotificationHomeActiveWorkAdapter` to accept the local watchlist service and map queued, running, paused, pending, and failed runs into `HomeActiveWorkItem` rows.
+- Kept completed and cancelled local runs out of Home active-work rows.
+- Prioritized failed active-work recovery through `review_failed_work` before generic active-work resume.
+- Routed failed local watchlist work to the existing subscriptions `watchlist-runs` context.
+- Wired `TldwCli` so the Home adapter receives both the local notification service and the local watchlist service.
+
+## Functional QA Evidence
+
+Focused checks were run against the local watchlist service, pure Home dashboard state, the Home adapter, mounted Home navigation, app service wiring, and Phase 2 tracking.
+
+- Red test: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Subscriptions/test_local_watchlists_service.py Tests/Home/test_active_work_adapter.py Tests/Home/test_dashboard_state.py Tests/UI/test_home_screen.py Tests/UI/test_screen_navigation.py Tests/UI/test_unified_shell_phase2_home_adapter.py -q`
+- Red result: `7 failed, 77 passed, 10 warnings`; failures covered the missing `list_home_run_snapshot`, missing `watchlist_service`, generic `resume_active_work` routing, missing `watchlist-runs` tab staging, and missing evidence links.
+- Additional red-green self-review check: `Tests/Home/test_dashboard_state.py::test_failed_work_details_follow_failed_item_when_mixed_with_running_work` failed before detail selection followed the failed item, then passed after the selector fix.
+- Green behavior test: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Subscriptions/test_local_watchlists_service.py Tests/Home/test_active_work_adapter.py Tests/Home/test_dashboard_state.py Tests/UI/test_home_screen.py Tests/UI/test_screen_navigation.py -q`
+- Green behavior result: `73 passed, 8 warnings`
+- Full focused Phase 2 test: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Subscriptions/test_local_watchlists_service.py Tests/Home/test_active_work_adapter.py Tests/Home/test_dashboard_state.py Tests/UI/test_home_screen.py Tests/UI/test_screen_navigation.py Tests/UI/test_unified_shell_phase2_home_adapter.py -q`
+- Full focused Phase 2 result: `85 passed, 8 warnings`
+
+Warning boundary: warnings are existing dependency/import warnings and are not Home watchlist-run failures.
+
+## UX Result
+
+- Home can now show concrete local W+C work such as "Daily security feed [failed] via W+C".
+- Failed local watchlist work no longer looks like generic live chat work; the next-best action opens the W+C runs context for diagnosis.
+- Completed local runs do not create stale active-work affordances.
+- Retry remains behind the Home adapter boundary until a safe run-specific retry operation is implemented.
+
+## Residual Risk
+
+- This slice does not implement retry, pause, or resume for local watchlist runs; unavailable adapter messaging still handles those controls.
+- The detail target uses the existing subscriptions/W+C surface rather than a dedicated run-detail route.
+- Full Phase 2 verification still requires a running-app QA walkthrough with persisted local watchlist runs created from the UI.

--- a/Docs/superpowers/qa/unified-shell/phase-2/README.md
+++ b/Docs/superpowers/qa/unified-shell/phase-2/README.md
@@ -11,5 +11,6 @@ This directory contains durable QA summaries for Phase 2 Home operational-contro
 - `2026-05-03-home-active-work-item-context.md` - `TASK-4.3` item-scoped Home active-work controls.
 - `2026-05-03-home-local-notification-snapshot.md` - `TASK-4.4` local unread notification snapshot state for Home.
 - `2026-05-03-home-notification-review-routing.md` - `TASK-4.5` Home notification review CTA routing into the existing inbox.
+- `2026-05-03-home-local-watchlist-run-snapshot.md` - `TASK-4.6` local W+C watchlist run snapshot state for Home active work.
 
 Do not mark Phase 2 verified until Home approve, reject, pause, resume, retry, and open-detail workflows are verified against real service-backed adapters or explicitly recoverable unavailable states.

--- a/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
@@ -2,7 +2,7 @@
 
 Date: 2026-05-03
 Status: Phase 2 in progress
-Source Branch: `origin/dev` at `6ba7304f` plus `codex/unified-shell-phase2-home-notification-review`
+Source Branch: `origin/dev` at `52e4e89e` plus `codex/unified-shell-phase2-home-watchlist-runs`
 
 ## Purpose
 
@@ -27,7 +27,7 @@ Track remaining Unified Shell work in one place so rendered screens, clickable b
 
 ## Known Product Gaps
 
-- Home active-work controls, detail routing, Console launch requests, item identity, local unread notification counts, and notification review routing now route through explicit adapter boundaries; real active-run service-backed adapters still need implementation.
+- Home active-work controls, detail routing, Console launch requests, item identity, local unread notification counts, notification review routing, and local W+C watchlist run snapshots now route through explicit adapter boundaries; schedule and agent-service adapters still need implementation.
 - Workflows has no wired workflow service in the shell wrapper.
 - W+C, Schedules, Workflows, and ACP now use honest unavailable Console states until actionable payloads exist.
 - ACP launch is disabled until an ACP-compatible runtime is configured.
@@ -84,6 +84,7 @@ Initial child tasks:
 - Phase 2.3: Bind Home controls to active-work item context - `TASK-4.3`
 - Phase 2.4: Wire Home to local notification snapshot adapter - `TASK-4.4`
 - Phase 2.5: Route Home notification review to the notifications inbox - `TASK-4.5`
+- Phase 2.6: Surface local watchlist runs in Home active work - `TASK-4.6`
 
 ## QA Evidence Index
 
@@ -103,7 +104,7 @@ Initial child tasks:
 | --- | --- | --- | --- | --- | --- |
 | Phase 0: Canonical Tracking | Make remaining work trackable. | verified | `TASK-1`, `TASK-1.1`, `TASK-1.2` | `phase-0/` | Product UI workflows are out of scope for Phase 0. |
 | Phase 1: Shell Contract Complete | Remove false shell affordances and prove shell usability. | verified | `TASK-2`, `TASK-2.1`, `TASK-2.2`, `TASK-2.3`, `TASK-2.4` | `phase-1/` | Live service workflows remain intentionally deferred to Phases 2-6. |
-| Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | in-progress | `TASK-4`, `TASK-4.1`, `TASK-4.2`, `TASK-4.3`, `TASK-4.4`, `TASK-4.5` | `phase-2/` | Real active-run, schedule, and agent-service adapters still need implementation. |
+| Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | in-progress | `TASK-4`, `TASK-4.1`, `TASK-4.2`, `TASK-4.3`, `TASK-4.4`, `TASK-4.5`, `TASK-4.6` | `phase-2/` | Schedule and agent-service adapters still need implementation; local watchlist run controls remain recoverable rather than fully controllable. |
 | Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | not-started | `TASK-3` | `phase-3/` | Live work event sources need explicit contracts. |
 | Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | not-started | `TASK-5` | `phase-4/` | Service coverage varies by destination. |
 | Phase 5: Capability And Recovery System | Systematize unavailable and blocked states. | not-started | `TASK-6` | `phase-5/` | Shared taxonomy not yet extracted. |
@@ -166,6 +167,12 @@ Initial audit result: W+C, Schedules, Workflows, and ACP had false Console-launc
 `TASK-4.5` makes Home notification review actions lead into the existing notifications inbox:
 
 - `Docs/superpowers/qa/unified-shell/phase-2/2026-05-03-home-notification-review-routing.md`
+
+## Phase 2.6 Home Local Watchlist Run Snapshot Evidence
+
+`TASK-4.6` surfaces queued, running, and failed local W+C watchlist runs as Home active work:
+
+- `Docs/superpowers/qa/unified-shell/phase-2/2026-05-03-home-local-watchlist-run-snapshot.md`
 
 ## Phase 0: Canonical Tracking
 

--- a/Tests/Home/test_active_work_adapter.py
+++ b/Tests/Home/test_active_work_adapter.py
@@ -60,6 +60,60 @@ def test_local_notification_adapter_counts_unread_local_notifications():
     assert service.calls == [{"limit": 100, "include_dismissed": False, "category": None}]
 
 
+def test_local_notification_adapter_maps_local_watchlist_runs_to_active_work():
+    class FakeWatchlistsService:
+        def __init__(self):
+            self.calls = []
+
+        def list_home_run_snapshot(self, *, limit=20):
+            self.calls.append({"limit": limit})
+            return [
+                {
+                    "id": "local:watchlist_run:5",
+                    "run_id": 5,
+                    "source_id": 7,
+                    "status": "failed",
+                    "source_title": "Daily security feed",
+                    "backend": "local",
+                },
+                {
+                    "id": "local:watchlist_run:4",
+                    "run_id": 4,
+                    "source_id": 7,
+                    "status": "completed",
+                    "source_title": "Completed feed",
+                    "backend": "local",
+                },
+                {
+                    "id": "local:watchlist_run:3",
+                    "run_id": 3,
+                    "source_id": 8,
+                    "status": "queued",
+                    "source_title": "Queued release feed",
+                    "backend": "local",
+                },
+            ]
+
+    service = FakeWatchlistsService()
+    adapter = LocalNotificationHomeActiveWorkAdapter(watchlist_service=service)
+
+    dashboard_input = adapter.build_dashboard_input(
+        providers_models={"OpenAI": ["gpt-4.1"]},
+        has_recent_work=False,
+    )
+
+    assert service.calls == [{"limit": 20}]
+    assert [item.item_id for item in dashboard_input.active_work_items] == [
+        "local:watchlist_run:5",
+        "local:watchlist_run:3",
+    ]
+    assert dashboard_input.active_work_items[0].title == "Daily security feed"
+    assert dashboard_input.active_work_items[0].source == "W+C"
+    assert dashboard_input.active_work_items[0].status == "failed"
+    assert dashboard_input.active_work_items[0].detail_route == "subscriptions"
+    assert dashboard_input.active_work_items[0].console_available is False
+
+
 def test_local_notification_adapter_fails_closed_when_snapshot_unavailable():
     class BrokenNotificationsService:
         def list_queue(self, *, limit=100, include_dismissed=False, category=None):

--- a/Tests/Home/test_dashboard_state.py
+++ b/Tests/Home/test_dashboard_state.py
@@ -61,6 +61,62 @@ def test_pending_approval_still_outranks_unread_notifications():
     assert action.action_id == "review_approvals"
 
 
+def test_failed_active_work_item_prioritizes_recovery_before_resume():
+    dashboard = summarize_home_dashboard(
+        HomeDashboardInput(
+            model_ready=True,
+            has_library_content=True,
+            active_work_items=(
+                HomeActiveWorkItem(
+                    item_id="local:watchlist_run:5",
+                    title="Daily security feed",
+                    source="W+C",
+                    status="failed",
+                    detail_route="subscriptions",
+                ),
+            ),
+        )
+    )
+
+    assert dashboard.next_action.action_id == "review_failed_work"
+    assert dashboard.next_action.label == "Review failed work"
+    assert dashboard.next_action.target_route == "subscriptions"
+    controls_by_id = {control.control_id: control for control in dashboard.controls}
+    assert controls_by_id["home-retry"].target_route == "subscriptions"
+    assert controls_by_id["home-retry"].target_id == "local:watchlist_run:5"
+    assert controls_by_id["home-open-details"].target_route == "subscriptions"
+
+
+def test_failed_work_details_follow_failed_item_when_mixed_with_running_work():
+    dashboard = summarize_home_dashboard(
+        HomeDashboardInput(
+            model_ready=True,
+            has_library_content=True,
+            active_work_items=(
+                HomeActiveWorkItem(
+                    item_id="local:watchlist_run:6",
+                    title="Queued release feed",
+                    source="W+C",
+                    status="queued",
+                    detail_route="subscriptions",
+                ),
+                HomeActiveWorkItem(
+                    item_id="local:watchlist_run:5",
+                    title="Daily security feed",
+                    source="W+C",
+                    status="failed",
+                    detail_route="subscriptions",
+                ),
+            ),
+        )
+    )
+
+    controls_by_id = {control.control_id: control for control in dashboard.controls}
+    assert dashboard.next_action.action_id == "review_failed_work"
+    assert controls_by_id["home-open-details"].target_id == "local:watchlist_run:5"
+    assert controls_by_id["home-retry"].target_id == "local:watchlist_run:5"
+
+
 def test_dashboard_summary_exposes_required_sections():
     dashboard = summarize_home_dashboard(
         HomeDashboardInput(

--- a/Tests/Subscriptions/test_local_watchlists_service.py
+++ b/Tests/Subscriptions/test_local_watchlists_service.py
@@ -1,3 +1,5 @@
+from inspect import isawaitable
+
 import pytest
 
 from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
@@ -29,6 +31,46 @@ async def test_local_watchlists_service_persists_run_queue_state(tmp_path):
     assert fetched["source_id"] == source["source_id"]
     assert detail["stats"]["source_id"] == source["source_id"]
     assert cancelled["status"] == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_local_watchlists_service_exposes_sync_home_run_snapshot(tmp_path):
+    db = SubscriptionsDB(tmp_path / "subscriptions.db", "test")
+    service = LocalWatchlistsService(db_factory=lambda: db)
+    queued_source = await service.create_source(
+        {
+            "name": "Queued Feed",
+            "url": "https://example.com/queued.xml",
+            "source_type": "rss",
+        }
+    )
+    failed_source = await service.create_source(
+        {
+            "name": "Failed Feed",
+            "url": "https://example.com/failed.xml",
+            "source_type": "rss",
+        }
+    )
+
+    queued = await service.launch_run(source_id=queued_source["source_id"])
+    failed = await service.launch_run(source_id=failed_source["source_id"])
+    await service.record_run_result(
+        failed["run_id"],
+        status="failed",
+        error_msg="boom",
+        dispatch_notifications=False,
+    )
+
+    snapshot = service.list_home_run_snapshot(limit=5)
+
+    assert not isawaitable(snapshot)
+    assert [run["run_id"] for run in snapshot[:2]] == [failed["run_id"], queued["run_id"]]
+    assert snapshot[0]["id"] == f"local:watchlist_run:{failed['run_id']}"
+    assert snapshot[0]["status"] == "failed"
+    assert snapshot[0]["source_title"] == "Failed Feed"
+    assert snapshot[0]["source_id"] == failed_source["source_id"]
+    assert snapshot[1]["status"] == "queued"
+    assert snapshot[1]["source_title"] == "Queued Feed"
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_home_screen.py
+++ b/Tests/UI/test_home_screen.py
@@ -178,6 +178,34 @@ async def test_home_notification_primary_action_opens_notifications_inbox_contex
 
 
 @pytest.mark.asyncio
+async def test_home_failed_watchlist_primary_action_opens_watchlist_runs_context():
+    app = _build_test_app()
+    app._home_dashboard_test_input = HomeDashboardInput(
+        model_ready=True,
+        has_library_content=True,
+        active_work_items=(
+            HomeActiveWorkItem(
+                item_id="local:watchlist_run:5",
+                title="Daily security feed",
+                source="W+C",
+                status="failed",
+                detail_route="subscriptions",
+            ),
+        ),
+    )
+    seen = []
+    host = HomeHarness(app, seen)
+
+    async with host.run_test(size=(160, 40)) as pilot:
+        await pilot.pause(0.1)
+        await pilot.click("#home-primary-action")
+        await pilot.pause(0.1)
+
+    assert seen[-1] == "subscriptions"
+    assert app.pending_subscription_initial_tab == "watchlist-runs"
+
+
+@pytest.mark.asyncio
 async def test_home_control_clicks_call_available_runtime_hooks():
     app = _build_test_app()
     app._home_dashboard_test_input = HomeDashboardInput(

--- a/Tests/UI/test_screen_navigation.py
+++ b/Tests/UI/test_screen_navigation.py
@@ -348,6 +348,7 @@ def test_app_initializes_watchlists_and_notifications_services():
     assert app.notifications_scope_service.local_service is app.client_notifications_service
     assert isinstance(app.home_active_work_adapter, LocalNotificationHomeActiveWorkAdapter)
     assert app.home_active_work_adapter.notification_service is app.client_notifications_service
+    assert app.home_active_work_adapter.watchlist_service is app.local_watchlists_service
     assert isinstance(app.server_outputs_service, ServerOutputsService)
     assert isinstance(app.outputs_scope_service, OutputsScopeService)
     assert isinstance(app.local_research_service, LocalResearchService)

--- a/Tests/UI/test_unified_shell_phase2_home_adapter.py
+++ b/Tests/UI/test_unified_shell_phase2_home_adapter.py
@@ -7,6 +7,7 @@ DETAIL_CONSOLE_EVIDENCE = PHASE_2_ROOT / "2026-05-03-home-detail-console-adapter
 ITEM_CONTEXT_EVIDENCE = PHASE_2_ROOT / "2026-05-03-home-active-work-item-context.md"
 LOCAL_NOTIFICATION_EVIDENCE = PHASE_2_ROOT / "2026-05-03-home-local-notification-snapshot.md"
 NOTIFICATION_REVIEW_EVIDENCE = PHASE_2_ROOT / "2026-05-03-home-notification-review-routing.md"
+WATCHLIST_RUN_EVIDENCE = PHASE_2_ROOT / "2026-05-03-home-local-watchlist-run-snapshot.md"
 README = PHASE_2_ROOT / "README.md"
 ROADMAP = Path("Docs/superpowers/trackers/unified-shell-maturity-roadmap.md")
 TASK_4_1 = Path("backlog/tasks/task-4.1 - Phase-2.1-Add-Home-active-work-adapter-contract.md")
@@ -19,6 +20,9 @@ TASK_4_4 = Path(
 )
 TASK_4_5 = Path(
     "backlog/tasks/task-4.5 - Phase-2.5-Route-Home-notification-review-to-the-notifications-inbox.md"
+)
+TASK_4_6 = Path(
+    "backlog/tasks/task-4.6 - Phase-2.6-Surface-local-watchlist-runs-in-Home-active-work.md"
 )
 
 
@@ -159,3 +163,32 @@ def test_phase_two_notification_review_routing_evidence_is_linked_from_index_roa
     assert "status: Done" in task_text
     assert "- [x] #1" in task_text
     assert "- [x] #5" in task_text
+
+
+def test_phase_two_local_watchlist_run_evidence_exists_and_records_verification():
+    assert WATCHLIST_RUN_EVIDENCE.exists()
+    text = WATCHLIST_RUN_EVIDENCE.read_text(encoding="utf-8")
+
+    assert "TASK-4.6" in text
+    assert "list_home_run_snapshot" in text
+    assert "HomeActiveWorkItem" in text
+    assert "review_failed_work" in text
+    assert "watchlist-runs" in text
+    assert "Tests/Subscriptions/test_local_watchlists_service.py" in text
+    assert "Tests/UI/test_home_screen.py" in text
+    assert "passed" in text
+
+
+def test_phase_two_local_watchlist_run_evidence_is_linked_from_index_roadmap_and_task():
+    evidence_name = WATCHLIST_RUN_EVIDENCE.name
+
+    assert evidence_name in README.read_text(encoding="utf-8")
+
+    roadmap_text = ROADMAP.read_text(encoding="utf-8")
+    assert "TASK-4.6" in roadmap_text
+    assert evidence_name in roadmap_text
+
+    task_text = TASK_4_6.read_text(encoding="utf-8")
+    assert "status: Done" in task_text
+    assert "- [x] #1" in task_text
+    assert "- [x] #6" in task_text

--- a/backlog/tasks/task-4.6 - Phase-2.6-Surface-local-watchlist-runs-in-Home-active-work.md
+++ b/backlog/tasks/task-4.6 - Phase-2.6-Surface-local-watchlist-runs-in-Home-active-work.md
@@ -1,0 +1,48 @@
+---
+id: TASK-4.6
+title: 'Phase 2.6: Surface local watchlist runs in Home active work'
+status: Done
+assignee: []
+created_date: '2026-05-03 19:03'
+updated_date: '2026-05-03 19:08'
+labels:
+  - unified-shell
+  - phase-2
+  - home
+  - watchlists
+  - active-work
+dependencies: []
+parent_task_id: TASK-4
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Expose queued, running, and failed local watchlist runs on Home so the dashboard reflects real local W+C work instead of only static counts or placeholder controls.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Local watchlist runs expose a synchronous Home-safe snapshot path that does not require awaiting inside Textual compose.
+- [x] #2 Home maps queued, running, and failed local watchlist runs into visible active-work rows with stable item identity and W+C detail routing.
+- [x] #3 Failed local watchlist runs become the next-best recovery action before generic active-work resume.
+- [x] #4 Home primary action for failed local watchlist work opens the subscriptions watchlist-runs context.
+- [x] #5 App wiring passes both local notification and local watchlist services into the Home adapter.
+- [x] #6 Focused automated tests and Phase 2 QA evidence verify the service snapshot, Home state, Home screen behavior, app wiring, and tracking updates.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing regressions for a synchronous local watchlist run snapshot, Home adapter mapping, failed-run prioritization, Home primary-action routing, app wiring, and Phase 2 evidence tracking.
+2. Implement the smallest service snapshot and Home adapter changes needed to expose queued, running, and failed local watchlist runs without adding false controls.
+3. Route failed local watchlist work to the W+C runs context and update roadmap, QA evidence, and backlog task hygiene.
+4. Run focused Home, W+C service, UI, and tracking verification plus diff hygiene before committing.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added a synchronous `LocalWatchlistsService.list_home_run_snapshot` path and extended the Home adapter to map local W+C watchlist runs into `HomeActiveWorkItem` rows while filtering completed/cancelled runs out of active work. Failed local watchlist runs now produce a `review_failed_work` next-best action that opens the subscriptions `watchlist-runs` context, and app startup wires Home to both notification and watchlist services. Added focused service, Home state, mounted Home screen, app wiring, and Phase 2 tracking tests plus QA evidence for `TASK-4.6`.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Home/active_work_adapter.py
+++ b/tldw_chatbook/Home/active_work_adapter.py
@@ -186,7 +186,8 @@ class LocalNotificationHomeActiveWorkAdapter(UnavailableHomeActiveWorkAdapter):
             return []
         try:
             runs = self.watchlist_service.list_home_run_snapshot(limit=20)
-        except Exception:
+        except Exception as e:
+            logger.warning(f"Failed to fetch local watchlist runs for Home: {e}")
             return []
 
         items: list[HomeActiveWorkItem] = []

--- a/tldw_chatbook/Home/active_work_adapter.py
+++ b/tldw_chatbook/Home/active_work_adapter.py
@@ -6,7 +6,22 @@ from dataclasses import dataclass, replace
 from enum import StrEnum
 from typing import Any, Mapping, Protocol, runtime_checkable
 
-from .dashboard_state import HomeDashboardInput
+from .dashboard_state import HomeActiveWorkItem, HomeDashboardInput
+
+
+_HOME_WATCHLIST_RUN_STATUSES = frozenset(
+    {
+        "approval_required",
+        "pending_approval",
+        "pending",
+        "running",
+        "queued",
+        "active",
+        "paused",
+        "failed",
+        "error",
+    }
+)
 
 
 class HomeControlAction(StrEnum):
@@ -128,8 +143,14 @@ class LocalNotificationHomeActiveWorkAdapter(UnavailableHomeActiveWorkAdapter):
     safe synchronous Home contract.
     """
 
-    def __init__(self, *, notification_service: Any | None = None):
+    def __init__(
+        self,
+        *,
+        notification_service: Any | None = None,
+        watchlist_service: Any | None = None,
+    ):
         self.notification_service = notification_service
+        self.watchlist_service = watchlist_service
 
     def build_dashboard_input(
         self,
@@ -141,7 +162,11 @@ class LocalNotificationHomeActiveWorkAdapter(UnavailableHomeActiveWorkAdapter):
             providers_models=providers_models,
             has_recent_work=has_recent_work,
         )
-        return replace(dashboard_input, notification_count=self._unread_notification_count())
+        return replace(
+            dashboard_input,
+            notification_count=self._unread_notification_count(),
+            active_work_items=tuple(self._local_watchlist_run_items()),
+        )
 
     def _unread_notification_count(self) -> int:
         if self.notification_service is None:
@@ -156,8 +181,51 @@ class LocalNotificationHomeActiveWorkAdapter(UnavailableHomeActiveWorkAdapter):
             return 0
         return sum(1 for notification in notifications if _notification_is_unread(notification))
 
+    def _local_watchlist_run_items(self) -> list[HomeActiveWorkItem]:
+        if self.watchlist_service is None:
+            return []
+        try:
+            runs = self.watchlist_service.list_home_run_snapshot(limit=20)
+        except Exception:
+            return []
+
+        items: list[HomeActiveWorkItem] = []
+        for run in runs:
+            status = str(_mapping_value(run, "status") or "unknown").strip().lower()
+            if status not in _HOME_WATCHLIST_RUN_STATUSES:
+                continue
+            run_id = _mapping_value(run, "run_id")
+            item_id = str(
+                _mapping_value(run, "id")
+                or (f"local:watchlist_run:{run_id}" if run_id is not None else "")
+            )
+            if not item_id:
+                continue
+            title = str(
+                _mapping_value(run, "title")
+                or _mapping_value(run, "source_title")
+                or (f"Watchlist run {run_id}" if run_id is not None else "Watchlist run")
+            )
+            items.append(
+                HomeActiveWorkItem(
+                    item_id=item_id,
+                    title=title,
+                    source="W+C",
+                    status=status,
+                    detail_route="subscriptions",
+                    console_available=False,
+                )
+            )
+        return items
+
 
 def _notification_is_unread(notification: Any) -> bool:
     if isinstance(notification, Mapping):
         return not bool(notification.get("is_read"))
     return not bool(getattr(notification, "is_read", False))
+
+
+def _mapping_value(value: Any, key: str) -> Any:
+    if isinstance(value, Mapping):
+        return value.get(key)
+    return getattr(value, key, None)

--- a/tldw_chatbook/Home/dashboard_state.py
+++ b/tldw_chatbook/Home/dashboard_state.py
@@ -93,6 +93,14 @@ def choose_next_best_action(state: HomeDashboardInput) -> HomeAction:
             "schedules",
             "Scheduled work needs recovery.",
         )
+    failed_item = _first_item_for_status(state, _FAILED_STATUSES)
+    if _failed_run_count(state):
+        return HomeAction(
+            "review_failed_work",
+            "Review failed work",
+            failed_item.detail_route if failed_item else state.active_detail_route,
+            "Failed work needs recovery.",
+        )
     if _active_run_count(state):
         return HomeAction(
             "resume_active_work",
@@ -130,7 +138,13 @@ def build_home_controls(state: HomeDashboardInput) -> tuple[HomeControl, ...]:
     running_item = _first_item_for_status(state, _RUNNING_STATUSES)
     paused_item = _first_item_for_status(state, _PAUSED_STATUSES)
     failed_item = _first_item_for_status(state, _FAILED_STATUSES)
-    detail_item = state.active_work_items[0] if state.active_work_items else None
+    detail_item = (
+        approval_item
+        or failed_item
+        or running_item
+        or paused_item
+        or (state.active_work_items[0] if state.active_work_items else None)
+    )
 
     if _pending_approval_count(state):
         controls.extend(
@@ -172,11 +186,12 @@ def build_home_controls(state: HomeDashboardInput) -> tuple[HomeControl, ...]:
             )
         )
     if _failed_run_count(state) or _failed_schedule_count(state):
+        failed_route = failed_item.detail_route if failed_item else "schedules"
         controls.append(
             HomeControl(
                 "home-retry",
                 "Retry",
-                "schedules",
+                failed_route,
                 "failed_work",
                 failed_item.item_id if failed_item else None,
             )

--- a/tldw_chatbook/Subscriptions/local_watchlists_service.py
+++ b/tldw_chatbook/Subscriptions/local_watchlists_service.py
@@ -228,6 +228,23 @@ class LocalWatchlistsService:
         )
         return [normalize_watchlist_run("local", self._run_row_to_dict(row)) for row in cursor.fetchall()]
 
+    def list_home_run_snapshot(self, *, limit: int = 20) -> list[dict[str, Any]]:
+        """Return recent local watchlist runs from a synchronous Home-safe path."""
+        db = self._db()
+        self._ensure_run_schema(db)
+        cursor = db.conn.cursor()
+        cursor.execute(
+            """
+            SELECT local_watchlist_runs.*, subscriptions.name AS source_title
+            FROM local_watchlist_runs
+            LEFT JOIN subscriptions ON subscriptions.id = local_watchlist_runs.source_id
+            ORDER BY local_watchlist_runs.id DESC
+            LIMIT ?
+            """,
+            (int(limit),),
+        )
+        return [self._normalize_home_run_snapshot(row) for row in cursor.fetchall()]
+
     async def get_run(self, run_id: Any) -> dict[str, Any]:
         db = self._db()
         self._ensure_run_schema(db)
@@ -871,6 +888,15 @@ class LocalWatchlistsService:
             "created_at": payload.get("created_at"),
             "updated_at": payload.get("updated_at"),
         }
+
+    def _normalize_home_run_snapshot(self, row: Mapping[str, Any]) -> dict[str, Any]:
+        payload = dict(row)
+        normalized = normalize_watchlist_run("local", self._run_row_to_dict(payload))
+        source_title = payload.get("source_title")
+        if source_title:
+            normalized["source_title"] = source_title
+            normalized["title"] = source_title
+        return normalized
 
     @staticmethod
     def _alert_rule_row_to_dict(row: Mapping[str, Any]) -> dict[str, Any]:

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -1694,6 +1694,11 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
         """Stage route-specific context before Home primary-action navigation."""
         if getattr(action, "action_id", None) == "review_notifications":
             self.pending_subscription_initial_tab = "notifications"
+        elif (
+            getattr(action, "action_id", None) == "review_failed_work"
+            and getattr(action, "target_route", None) == "subscriptions"
+        ):
+            self.pending_subscription_initial_tab = "watchlist-runs"
 
     def approve_active_home_item(self, *, target_id: str | None = None) -> HomeControlResult:
         """Approve the active Home item through the configured adapter."""
@@ -2029,6 +2034,7 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
         )
         self.home_active_work_adapter = LocalNotificationHomeActiveWorkAdapter(
             notification_service=self.client_notifications_service,
+            watchlist_service=self.local_watchlists_service,
         )
         self.notification_dispatch_service = NotificationDispatchService(
             store=self.client_notifications_db,


### PR DESCRIPTION
## Summary
- Add a synchronous local watchlist run snapshot for Home.
- Map queued/running/failed W+C runs into Home active-work rows and route failed recovery to watchlist runs.
- Add TASK-4.6 tracking, QA evidence, and focused regression coverage.

## Test Plan
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Subscriptions/test_local_watchlists_service.py Tests/Home/test_active_work_adapter.py Tests/Home/test_dashboard_state.py Tests/UI/test_home_screen.py Tests/UI/test_screen_navigation.py Tests/UI/test_unified_shell_phase2_home_adapter.py -q
- git diff --check