### PR TITLE
Add Console live-work launch contract

### DIFF
--- a/Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-console-live-work-launch-contract.md
+++ b/Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-console-live-work-launch-contract.md
@@ -1,0 +1,49 @@
+# Console Live-Work Launch Contract
+
+Date: 2026-05-03
+Task: `TASK-3.1`
+Branch: `codex/master-shell-ux-next-slice`
+Base: `origin/dev` at `52e4e89e`
+
+## Purpose
+
+Start Phase 3 by replacing ad hoc pending Console launch dictionaries with a typed launch contract. This gives Home, workflows, schedules, ACP, MCP, RAG, artifacts, and future live-work sources one consistent payload shape before deeper Console live-status rendering is added.
+
+## What Changed
+
+- Added `ConsoleLiveWorkLaunch` as the normalized app-owned launch contract.
+- Kept `TldwCli.open_console_for_live_work(source=..., title=..., payload=...)` backward compatible while adding optional `status`, `recovery`, and `action_label` metadata.
+- Updated `ChatScreen` to consume typed launches or legacy dicts, clear the one-shot pending app value, and render source, title, status, recovery copy, action label, and top-level payload metadata.
+- Preserved staged-context handoffs as separate `ChatHandoffPayload` flows so Library, Artifacts, Personas, and Skills do not masquerade as live work.
+
+## Functional QA Evidence
+
+Focused checks were run against the app helper and a mounted Textual Console screen harness.
+
+- Red test: `python -m pytest -q Tests/UI/test_console_live_work_handoffs.py --tb=short`
+- Red result: `4 failed, 9 passed, 1 warning`; failures were expected because `tldw_chatbook.Chat.console_live_work` did not exist.
+- Green test: `python -m pytest -q Tests/UI/test_console_live_work_handoffs.py --tb=short`
+- Green result: `13 passed, 1 warning`
+- Expanded Console/Home/navigation regression: `python -m pytest -q Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_home_screen.py Tests/Home/test_active_work_adapter.py Tests/Home/test_dashboard_state.py Tests/UI/test_unified_shell_phase2_home_adapter.py Tests/UI/test_screen_navigation.py --tb=short`
+- Expanded regression result: `82 passed, 8 warnings`
+- Destination shell regression: `python -m pytest -q Tests/UI/test_destination_shells.py --tb=short`
+- Destination shell result: `35 passed, 1 warning`
+- Final combined focused regression: `python -m pytest -q Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_home_screen.py Tests/Home/test_active_work_adapter.py Tests/Home/test_dashboard_state.py Tests/UI/test_unified_shell_phase2_home_adapter.py Tests/UI/test_screen_navigation.py Tests/UI/test_destination_shells.py --tb=short`
+- Final combined result: `117 passed, 8 warnings`
+- Whitespace check: `git diff --check`
+- Whitespace check result: passed
+
+Warning boundary: warnings are existing dependency/import warnings and are not Console launch behavior failures.
+
+## UX Result
+
+- First-time users see an explicit pending Console launch card instead of unexplained context transfer.
+- Power users keep the fast one-call launch helper, with richer metadata available for repeated live-work flows.
+- Recovery language is visible at the point of handoff, which avoids implying that a workflow is actively running when the source only staged a request.
+
+## Residual Risk
+
+- This is a contract slice, not full Phase 3 completion.
+- Source-specific live work from workflows, schedules, ACP, MCP, RAG, and artifacts still needs service-backed payload producers.
+- Console still needs richer live status/follow cards after real source events exist.
+- Full Phase 3 cannot be verified until launch, follow, status, and recovery flows are exercised in the running app against real or explicitly unavailable source adapters.

--- a/Docs/superpowers/qa/unified-shell/phase-3/README.md
+++ b/Docs/superpowers/qa/unified-shell/phase-3/README.md
@@ -1,5 +1,11 @@
 # Phase 3 QA Evidence
 
-Status: not-started
+Status: in-progress
 
-This directory will contain durable QA summaries for this phase. Do not mark the phase verified until running-app walkthrough evidence exists here.
+This directory contains durable QA summaries for Phase 3 Console live-work hub slices.
+
+## Evidence
+
+- `2026-05-03-console-live-work-launch-contract.md` - `TASK-3.1` typed Console live-work launch contract and pending-launch card rendering.
+
+Do not mark Phase 3 verified until launch, follow, status, and recovery flows are verified in the running app against workflows, schedules, ACP, MCP, RAG, artifacts, and active-work source adapters.

--- a/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
@@ -1,8 +1,8 @@
 # Unified Shell Maturity Roadmap
 
 Date: 2026-05-03
-Status: Phase 2 in progress
-Source Branch: `origin/dev` at `6ba7304f` plus `codex/unified-shell-phase2-home-notification-review`
+Status: Phase 2 and Phase 3 in progress
+Source Branch: `origin/dev` at `52e4e89e` plus `codex/master-shell-ux-next-slice`
 
 ## Purpose
 
@@ -30,6 +30,7 @@ Track remaining Unified Shell work in one place so rendered screens, clickable b
 - Home active-work controls, detail routing, Console launch requests, item identity, local unread notification counts, and notification review routing now route through explicit adapter boundaries; real active-run service-backed adapters still need implementation.
 - Workflows has no wired workflow service in the shell wrapper.
 - W+C, Schedules, Workflows, and ACP now use honest unavailable Console states until actionable payloads exist.
+- Console now has a typed app-owned launch contract for staged live-work payloads; source-specific live event producers still need implementation.
 - ACP launch is disabled until an ACP-compatible runtime is configured.
 - MCP management is not embedded in the top-level MCP wrapper.
 - Skills local/server services exist, but the top-level Skills shell still leaves import disabled and lacks list/detail/import UX adoption.
@@ -84,6 +85,7 @@ Initial child tasks:
 - Phase 2.3: Bind Home controls to active-work item context - `TASK-4.3`
 - Phase 2.4: Wire Home to local notification snapshot adapter - `TASK-4.4`
 - Phase 2.5: Route Home notification review to the notifications inbox - `TASK-4.5`
+- Phase 3.1: Add Console live-work launch contract - `TASK-3.1`
 
 ## QA Evidence Index
 
@@ -92,7 +94,7 @@ Initial child tasks:
 | Phase 0 | `Docs/superpowers/qa/unified-shell/phase-0/` | verified |
 | Phase 1 | `Docs/superpowers/qa/unified-shell/phase-1/` | verified |
 | Phase 2 | `Docs/superpowers/qa/unified-shell/phase-2/` | in-progress |
-| Phase 3 | `Docs/superpowers/qa/unified-shell/phase-3/` | not-started |
+| Phase 3 | `Docs/superpowers/qa/unified-shell/phase-3/` | in-progress |
 | Phase 4 | `Docs/superpowers/qa/unified-shell/phase-4/` | not-started |
 | Phase 5 | `Docs/superpowers/qa/unified-shell/phase-5/` | not-started |
 | Phase 6 | `Docs/superpowers/qa/unified-shell/phase-6/` | not-started |
@@ -104,7 +106,7 @@ Initial child tasks:
 | Phase 0: Canonical Tracking | Make remaining work trackable. | verified | `TASK-1`, `TASK-1.1`, `TASK-1.2` | `phase-0/` | Product UI workflows are out of scope for Phase 0. |
 | Phase 1: Shell Contract Complete | Remove false shell affordances and prove shell usability. | verified | `TASK-2`, `TASK-2.1`, `TASK-2.2`, `TASK-2.3`, `TASK-2.4` | `phase-1/` | Live service workflows remain intentionally deferred to Phases 2-6. |
 | Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | in-progress | `TASK-4`, `TASK-4.1`, `TASK-4.2`, `TASK-4.3`, `TASK-4.4`, `TASK-4.5` | `phase-2/` | Real active-run, schedule, and agent-service adapters still need implementation. |
-| Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | not-started | `TASK-3` | `phase-3/` | Live work event sources need explicit contracts. |
+| Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | in-progress | `TASK-3`, `TASK-3.1` | `phase-3/` | Source-specific live event producers and follow/status cards still need implementation. |
 | Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | not-started | `TASK-5` | `phase-4/` | Service coverage varies by destination. |
 | Phase 5: Capability And Recovery System | Systematize unavailable and blocked states. | not-started | `TASK-6` | `phase-5/` | Shared taxonomy not yet extracted. |
 | Phase 6: Audit Replay And Closeout | Prove shell works for first-time and power users. | not-started | `TASK-7` | `phase-6/` | Depends on prior phases and running-app QA. |
@@ -166,6 +168,12 @@ Initial audit result: W+C, Schedules, Workflows, and ACP had false Console-launc
 `TASK-4.5` makes Home notification review actions lead into the existing notifications inbox:
 
 - `Docs/superpowers/qa/unified-shell/phase-2/2026-05-03-home-notification-review-routing.md`
+
+## Phase 3.1 Console Live-Work Launch Contract Evidence
+
+`TASK-3.1` adds the normalized Console launch payload contract and renders pending launch details in Console:
+
+- `Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-console-live-work-launch-contract.md`
 
 ## Phase 0: Canonical Tracking
 

--- a/Tests/UI/test_console_live_work_handoffs.py
+++ b/Tests/UI/test_console_live_work_handoffs.py
@@ -11,6 +11,14 @@ from tldw_chatbook.Chat.chat_handoff_models import ChatHandoffPayload
 from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 
 
+def _load_console_live_work_contract():
+    try:
+        from tldw_chatbook.Chat.console_live_work import ConsoleLiveWorkLaunch
+    except ModuleNotFoundError:
+        pytest.fail("Console live-work launch contract module is missing")
+    return ConsoleLiveWorkLaunch
+
+
 class ConsoleHarness(App):
     def __init__(self, app_instance):
         super().__init__()
@@ -24,24 +32,86 @@ def _active_console_screen(host: ConsoleHarness):
     return host.screen_stack[-1]
 
 
+def _screen_static_text(screen) -> str:
+    return " ".join(str(widget.renderable) for widget in screen.query("Static"))
+
+
 def test_app_exposes_open_console_for_live_work_helper():
     app = _build_test_app()
 
     assert hasattr(app, "open_console_for_live_work")
 
 
+def test_console_live_work_launch_contract_normalizes_defaults_and_metadata():
+    ConsoleLiveWorkLaunch = _load_console_live_work_contract()
+
+    launch = ConsoleLiveWorkLaunch.from_values(
+        source=" workflows ",
+        title=" ",
+        payload={"run_id": "run-1", "attempt": 2},
+        status=" running ",
+        recovery=" Workflow is starting. ",
+        action_label=" Open workflow run ",
+    )
+
+    assert launch.source == "workflows"
+    assert launch.title == "Untitled"
+    assert launch.payload == {"run_id": "run-1", "attempt": 2}
+    assert launch.status == "running"
+    assert launch.recovery == "Workflow is starting."
+    assert launch.action_label == "Open workflow run"
+    assert launch.to_pending_payload() == {
+        "source": "workflows",
+        "title": "Untitled",
+        "payload": {"run_id": "run-1", "attempt": 2},
+        "status": "running",
+        "recovery": "Workflow is starting.",
+        "action_label": "Open workflow run",
+    }
+
+
 def test_open_console_for_live_work_routes_to_chat_route():
+    ConsoleLiveWorkLaunch = _load_console_live_work_contract()
     app = _build_test_app()
     seen = []
     app.post_message = lambda message: seen.append(getattr(message, "screen_name", None))
 
-    app.open_console_for_live_work(source="workflows", title="Daily digest")
+    app.open_console_for_live_work(
+        source="workflows",
+        title="Daily digest",
+        payload={"run_id": "run-1"},
+        status="running",
+        recovery="Workflow is starting.",
+        action_label="Open workflow run",
+    )
 
     assert seen == ["chat"]
-    assert app.pending_console_launch == {
+    assert isinstance(app.pending_console_launch, ConsoleLiveWorkLaunch)
+    assert app.pending_console_launch.to_pending_payload() == {
+        "source": "workflows",
+        "title": "Daily digest",
+        "payload": {"run_id": "run-1"},
+        "status": "running",
+        "recovery": "Workflow is starting.",
+        "action_label": "Open workflow run",
+    }
+
+
+def test_open_console_for_live_work_preserves_minimal_call_defaults():
+    ConsoleLiveWorkLaunch = _load_console_live_work_contract()
+    app = _build_test_app()
+    app.post_message = lambda message: None
+
+    app.open_console_for_live_work(source="workflows", title="Daily digest")
+
+    assert isinstance(app.pending_console_launch, ConsoleLiveWorkLaunch)
+    assert app.pending_console_launch.to_pending_payload() == {
         "source": "workflows",
         "title": "Daily digest",
         "payload": {},
+        "status": "pending",
+        "recovery": "Console has staged this live-work request.",
+        "action_label": "Open in Console",
     }
 
 
@@ -123,11 +193,15 @@ async def test_staged_context_actions_use_chat_handoff_not_live_launch(route, bu
 
 @pytest.mark.asyncio
 async def test_console_renders_pending_launch_context():
+    ConsoleLiveWorkLaunch = _load_console_live_work_contract()
     app = _build_test_app()
     app.pending_console_launch = {
         "source": "workflows",
         "title": "Daily digest",
-        "payload": {},
+        "payload": {"attempt": 2, "run_id": "run-1"},
+        "status": "running",
+        "recovery": "Workflow is starting.",
+        "action_label": "Open workflow run",
     }
     host = ConsoleHarness(app)
 
@@ -136,4 +210,13 @@ async def test_console_renders_pending_launch_context():
         screen = _active_console_screen(host)
 
         assert screen.query_one("#console-pending-launch-card")
+        text = _screen_static_text(screen)
+        assert "Source: workflows" in text
+        assert "Title: Daily digest" in text
+        assert "Status: running" in text
+        assert "Recovery: Workflow is starting." in text
+        assert "Action: Open workflow run" in text
+        assert "attempt: 2" in text
+        assert "run_id: run-1" in text
+        assert isinstance(screen._pending_console_launch_context, ConsoleLiveWorkLaunch)
         assert app.pending_console_launch is None

--- a/backlog/tasks/task-3.1 - Phase-3.1-Add-Console-live-work-launch-contract.md
+++ b/backlog/tasks/task-3.1 - Phase-3.1-Add-Console-live-work-launch-contract.md
@@ -1,0 +1,53 @@
+---
+id: TASK-3.1
+title: 'Phase 3.1: Add Console live-work launch contract'
+status: Done
+assignee: []
+created_date: '2026-05-03 19:14'
+updated_date: '2026-05-03 19:19'
+labels:
+  - unified-shell
+  - phase-3
+  - console
+  - live-work
+dependencies: []
+documentation:
+  - Docs/superpowers/specs/2026-05-02-agentic-terminal-design-system-design.md
+  - Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+parent_task_id: TASK-3
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace ad hoc pending Console launch dictionaries with a typed, backward-compatible live-work launch contract so source destinations can pass consistent status, recovery, action, and payload metadata into Console.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Console live-work launch model normalizes source, title, payload, status, recovery, and action metadata.
+- [x] #2 TldwCli.open_console_for_live_work remains backward compatible with existing source/title/payload callers while storing typed normalized launch context.
+- [x] #3 ChatScreen renders pending Console launch details including source, title, status, recovery/action copy, and payload metadata, then clears the one-shot app pending value.
+- [x] #4 Focused Console live-work tests and relevant Home/Console regressions pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused regression tests for the Console live-work launch payload contract, backward-compatible app helper behavior, and pending-launch card rendering.
+2. Verify the new tests fail before production changes.
+3. Add the smallest typed launch contract and wire TldwCli plus ChatScreen through it while preserving existing callers.
+4. Add durable Phase 3 QA evidence and update the unified-shell roadmap index for this slice.
+5. Run focused Console/Home regression tests plus git diff checks, then complete the Backlog task.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented a typed ConsoleLiveWorkLaunch contract for normalized live-work launch metadata.
+
+- Added backward-compatible TldwCli.open_console_for_live_work handling for source/title/payload callers plus optional status, recovery, and action copy.
+- Updated ChatScreen to normalize typed launches or legacy dicts, clear the one-shot pending value, and render source, title, status, recovery, action, and payload metadata.
+- Added focused Console handoff regressions and Phase 3 QA evidence; updated the unified-shell roadmap to show Phase 3 as in progress.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_live_work.py
+++ b/tldw_chatbook/Chat/console_live_work.py
@@ -1,0 +1,85 @@
+"""Typed contract for launching live work into Console."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+
+DEFAULT_RECOVERY = "Console has staged this live-work request."
+DEFAULT_ACTION_LABEL = "Open in Console"
+
+
+def _clean_text(value: Any, fallback: str) -> str:
+    text = str(value or "").strip()
+    return text or fallback
+
+
+def _copy_payload(payload: Mapping[str, Any] | None) -> dict[str, Any]:
+    if isinstance(payload, Mapping):
+        return dict(payload)
+    return {}
+
+
+@dataclass(frozen=True)
+class ConsoleLiveWorkLaunch:
+    """Serializable live-work launch context staged for the Console surface."""
+
+    source: str
+    title: str
+    payload: dict[str, Any] = field(default_factory=dict)
+    status: str = "pending"
+    recovery: str = DEFAULT_RECOVERY
+    action_label: str = DEFAULT_ACTION_LABEL
+
+    @classmethod
+    def from_values(
+        cls,
+        *,
+        source: Any,
+        title: Any,
+        payload: Mapping[str, Any] | None = None,
+        status: Any = None,
+        recovery: Any = None,
+        action_label: Any = None,
+    ) -> "ConsoleLiveWorkLaunch":
+        return cls(
+            source=_clean_text(source, "unknown"),
+            title=_clean_text(title, "Untitled"),
+            payload=_copy_payload(payload),
+            status=_clean_text(status, "pending"),
+            recovery=_clean_text(recovery, DEFAULT_RECOVERY),
+            action_label=_clean_text(action_label, DEFAULT_ACTION_LABEL),
+        )
+
+    @classmethod
+    def from_pending(cls, value: Any) -> "ConsoleLiveWorkLaunch | None":
+        if isinstance(value, cls):
+            return value
+        if not isinstance(value, Mapping):
+            return None
+        return cls.from_values(
+            source=value.get("source"),
+            title=value.get("title"),
+            payload=value.get("payload"),
+            status=value.get("status"),
+            recovery=value.get("recovery"),
+            action_label=value.get("action_label"),
+        )
+
+    def to_pending_payload(self) -> dict[str, Any]:
+        return {
+            "source": self.source,
+            "title": self.title,
+            "payload": dict(self.payload),
+            "status": self.status,
+            "recovery": self.recovery,
+            "action_label": self.action_label,
+        }
+
+    def payload_display_items(self) -> tuple[tuple[str, Any], ...]:
+        return tuple(
+            (str(key), self.payload[key])
+            for key in sorted(self.payload, key=lambda item: str(item))
+        )

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -152,8 +152,7 @@ class ChatScreen(BaseAppScreen):
             return self._pending_console_launch_context
 
         pending_launch = getattr(self.app_instance, "pending_console_launch", None)
-        normalized_launch = ConsoleLiveWorkLaunch.from_pending(pending_launch)
-        if normalized_launch is not None:
+        if (normalized_launch := ConsoleLiveWorkLaunch.from_pending(pending_launch)) is not None:
             self._pending_console_launch_context = normalized_launch
             self.app_instance.pending_console_launch = None
         return self._pending_console_launch_context

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -21,6 +21,7 @@ from .chat_screen_state import ChatScreenState, TabState, MessageData, TaskResum
 from ...Chat.chat_conversation_service import derive_conversation_title
 from ...Chat.chat_handoff_models import ChatHandoffPayload
 from ...Chat.chat_models import ChatSessionData
+from ...Chat.console_live_work import ConsoleLiveWorkLaunch
 from ...Utils.chat_diagnostics import ChatDiagnostics
 from ...state.ui_state import UIState
 from ...Widgets.Chat_Widgets.chat_tab_container import ChatTabContainer
@@ -141,18 +142,19 @@ class ChatScreen(BaseAppScreen):
         self._state_dirty = False
         self._diagnostics_run = False
         self._handoff_consumption_in_progress = False
-        self._pending_console_launch_context: Optional[Dict[str, Any]] = None
+        self._pending_console_launch_context: Optional[ConsoleLiveWorkLaunch] = None
         self.ui_state = UIState()
         self._load_sidebar_state()
 
-    def _consume_pending_console_launch(self) -> Optional[Dict[str, Any]]:
+    def _consume_pending_console_launch(self) -> Optional[ConsoleLiveWorkLaunch]:
         """Accept one-shot live-work launch context from another destination."""
         if self._pending_console_launch_context is not None:
             return self._pending_console_launch_context
 
         pending_launch = getattr(self.app_instance, "pending_console_launch", None)
-        if isinstance(pending_launch, dict) and pending_launch:
-            self._pending_console_launch_context = dict(pending_launch)
+        normalized_launch = ConsoleLiveWorkLaunch.from_pending(pending_launch)
+        if normalized_launch is not None:
+            self._pending_console_launch_context = normalized_launch
             self.app_instance.pending_console_launch = None
         return self._pending_console_launch_context
         
@@ -160,12 +162,15 @@ class ChatScreen(BaseAppScreen):
         """Compose the chat content."""
         pending_launch = self._consume_pending_console_launch()
         if pending_launch:
-            source = str(pending_launch.get("source") or "unknown")
-            title = str(pending_launch.get("title") or "Untitled")
             with Container(id="console-pending-launch-card", classes="ds-panel"):
                 yield Static("Pending Console launch", classes="ds-status-badge")
-                yield Static(f"Source: {source}", classes="destination-section")
-                yield Static(f"Title: {title}", classes="destination-section")
+                yield Static(f"Source: {pending_launch.source}", classes="destination-section")
+                yield Static(f"Title: {pending_launch.title}", classes="destination-section")
+                yield Static(f"Status: {pending_launch.status}", classes="destination-section")
+                yield Static(f"Recovery: {pending_launch.recovery}", classes="destination-section")
+                yield Static(f"Action: {pending_launch.action_label}", classes="destination-section")
+                for key, value in pending_launch.payload_display_items():
+                    yield Static(f"{key}: {value}", classes="destination-section")
         # Create and yield the chat window container
         self.chat_window = ChatWindowEnhanced(self.app_instance, id="chat-window", classes="window")
         yield self.chat_window

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -82,6 +82,7 @@ from tldw_chatbook.Constants import ALL_TABS, TAB_CCP, TAB_CHAT, TAB_HOME, TAB_L
 from tldw_chatbook.Chat.chat_conversation_scope_service import ChatConversationScopeService
 from tldw_chatbook.Chat.chat_conversation_service import ChatConversationService
 from tldw_chatbook.Chat.chat_handoff_models import ChatHandoffPayload
+from tldw_chatbook.Chat.console_live_work import ConsoleLiveWorkLaunch
 from tldw_chatbook.Chat.chat_loop_scope_service import ServerChatLoopScopeService
 from tldw_chatbook.Chat.server_chat_conversation_service import ServerChatConversationService
 from tldw_chatbook.Chat.server_chat_loop_service import ServerChatLoopService
@@ -1390,7 +1391,7 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
         )
         self.ui_policy_engine = PolicyEngine(CAPABILITY_REGISTRY)
         self.pending_chat_handoff: Optional[ChatHandoffPayload] = None
-        self.pending_console_launch: Optional[Dict[str, Any]] = None
+        self.pending_console_launch: Optional[ConsoleLiveWorkLaunch | Dict[str, Any]] = None
         self.pending_study_scope_context: Optional[StudyScopeContext] = None
         self.pending_notes_workspace_context: Optional[Dict[str, Any]] = None
         self.home_active_work_adapter = UnavailableHomeActiveWorkAdapter()
@@ -1662,13 +1663,25 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
         self.pending_chat_handoff = payload
         self.post_message(NavigateToScreen(TAB_CHAT))
 
-    def open_console_for_live_work(self, *, source: str, title: str, payload: dict | None = None) -> None:
+    def open_console_for_live_work(
+        self,
+        *,
+        source: str,
+        title: str,
+        payload: dict | None = None,
+        status: str | None = None,
+        recovery: str | None = None,
+        action_label: str | None = None,
+    ) -> None:
         """Open Console for live work launched from another destination."""
-        self.pending_console_launch = {
-            "source": source,
-            "title": title,
-            "payload": payload or {},
-        }
+        self.pending_console_launch = ConsoleLiveWorkLaunch.from_values(
+            source=source,
+            title=title,
+            payload=payload,
+            status=status,
+            recovery=recovery,
+            action_label=action_label,
+        )
         self.post_message(NavigateToScreen(TAB_CHAT))
 
     def _handle_home_control_action(


### PR DESCRIPTION
## Summary

- Add `ConsoleLiveWorkLaunch` as the typed, normalized live-work launch contract for Console handoffs.
- Keep `open_console_for_live_work(...)` backward compatible while adding status, recovery, action, and payload metadata.
- Update Console pending-launch rendering plus Phase 3 Backlog, roadmap, and QA evidence.

## Test Plan

- [x] `env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_home_screen.py Tests/Home/test_active_work_adapter.py Tests/Home/test_dashboard_state.py Tests/UI/test_unified_shell_phase2_home_adapter.py Tests/UI/test_screen_navigation.py Tests/UI/test_destination_shells.py --tb=short`
- [x] `git diff --check HEAD~1..HEAD`

## Notes

Phase 3 is now in progress, not complete. Source-specific live event producers and richer Console follow/status cards remain follow-up work.
