### PR TITLE
Open Home watchlist run details

### DIFF
--- a/Docs/superpowers/qa/unified-shell/phase-2/2026-05-03-home-local-watchlist-run-details.md
+++ b/Docs/superpowers/qa/unified-shell/phase-2/2026-05-03-home-local-watchlist-run-details.md
@@ -1,0 +1,41 @@
+# Home Local Watchlist Run Details
+
+Date: 2026-05-03
+Task: `TASK-4.7`
+Branch: `codex/unified-shell-phase2-home-watchlist-details`
+Base: `origin/dev` at `09ca0200`
+
+## Purpose
+
+Make Home `Open details` for local W+C watchlist run active-work items open the existing W+C runs surface with the relevant run selected and loaded, instead of stopping at an unavailable adapter message.
+
+## What Changed
+
+- Added handled `Open details` support in `LocalNotificationHomeActiveWorkAdapter` for visible `local:watchlist_run:*` items.
+- Staged `pending_subscription_initial_tab = "watchlist-runs"` and `pending_subscription_watchlist_run_id` before navigating from Home details into subscriptions.
+- Made `SubscriptionWindow` consume the pending watchlist run id, restore the selected runs row, and load the run detail payload.
+- Kept local watchlist jobs honest as server-only while allowing local runs and alert rules to render through the existing scope service.
+
+## Functional QA Evidence
+
+Focused checks were run against the Home adapter, app detail navigation hook, SubscriptionWindow pending context, and local W+C runs rendering.
+
+- Red test: `python -m pytest Tests/Home/test_active_work_adapter.py::test_local_notification_adapter_opens_local_watchlist_run_details Tests/UI/test_home_screen.py::test_app_detail_hook_stages_watchlist_runs_context_for_handled_watchlist_detail Tests/UI/test_subscription_window_watchlists.py::test_subscription_window_consumes_pending_watchlist_run_detail_context Tests/UI/test_subscription_window_watchlists.py::test_local_mode_shows_watchlist_control_plane_guidance Tests/UI/test_subscription_window_watchlists.py::test_local_mode_pending_watchlist_run_context_loads_run_detail -q`
+- Red result: `5 failed`; failures covered unavailable adapter detail handling, missing Home subscription context staging, missing pending run consumption, and local W+C runs hidden behind local-only state.
+- Green targeted result: `5 passed, 8 warnings`
+- Full focused Phase 2.7 suite: `python -m pytest Tests/Home/test_active_work_adapter.py Tests/UI/test_home_screen.py Tests/UI/test_subscription_window_watchlists.py Tests/UI/test_screen_navigation.py Tests/UI/test_unified_shell_phase2_home_adapter.py -q`
+- Full focused Phase 2.7 result: `93 passed, 8 warnings`
+
+Warning boundary: warnings are existing dependency/import warnings and are not Home watchlist-run detail failures.
+
+## UX Result
+
+- Home `Open details` now takes the user to the W+C Runs tab for the selected local watchlist run.
+- The selected run is restored in the runs list and its detail JSON is loaded for diagnosis.
+- Local jobs remain honestly unavailable as a separate server-style control plane; local runs and alert rules are visible because local services already expose them.
+
+## Residual Risk
+
+- This slice does not implement Home retry/pause/resume for local watchlist runs.
+- This slice does not redesign the W+C runs detail layout; it uses the existing JSON detail panel.
+- Full Phase 2 verification still needs running-app QA with real persisted local runs created through the UI.

--- a/Docs/superpowers/qa/unified-shell/phase-2/2026-05-03-home-local-watchlist-run-details.md
+++ b/Docs/superpowers/qa/unified-shell/phase-2/2026-05-03-home-local-watchlist-run-details.md
@@ -23,8 +23,10 @@ Focused checks were run against the Home adapter, app detail navigation hook, Su
 - Red test: `python -m pytest Tests/Home/test_active_work_adapter.py::test_local_notification_adapter_opens_local_watchlist_run_details Tests/UI/test_home_screen.py::test_app_detail_hook_stages_watchlist_runs_context_for_handled_watchlist_detail Tests/UI/test_subscription_window_watchlists.py::test_subscription_window_consumes_pending_watchlist_run_detail_context Tests/UI/test_subscription_window_watchlists.py::test_local_mode_shows_watchlist_control_plane_guidance Tests/UI/test_subscription_window_watchlists.py::test_local_mode_pending_watchlist_run_context_loads_run_detail -q`
 - Red result: `5 failed`; failures covered unavailable adapter detail handling, missing Home subscription context staging, missing pending run consumption, and local W+C runs hidden behind local-only state.
 - Green targeted result: `5 passed, 8 warnings`
+- PR review regression: `python -m pytest Tests/Home/test_active_work_adapter.py::test_local_notification_adapter_opens_local_watchlist_run_details_with_synthesized_id -q`
+- PR review regression result: red `1 failed`, then green `1 passed`; verifies synthesized `local:watchlist_run:{run_id}` detail IDs open correctly when snapshot rows do not include an explicit `id`.
 - Full focused Phase 2.7 suite: `python -m pytest Tests/Home/test_active_work_adapter.py Tests/UI/test_home_screen.py Tests/UI/test_subscription_window_watchlists.py Tests/UI/test_screen_navigation.py Tests/UI/test_unified_shell_phase2_home_adapter.py -q`
-- Full focused Phase 2.7 result: `93 passed, 8 warnings`
+- Full focused Phase 2.7 result: `94 passed, 8 warnings`
 
 Warning boundary: warnings are existing dependency/import warnings and are not Home watchlist-run detail failures.
 

--- a/Docs/superpowers/qa/unified-shell/phase-2/README.md
+++ b/Docs/superpowers/qa/unified-shell/phase-2/README.md
@@ -12,5 +12,6 @@ This directory contains durable QA summaries for Phase 2 Home operational-contro
 - `2026-05-03-home-local-notification-snapshot.md` - `TASK-4.4` local unread notification snapshot state for Home.
 - `2026-05-03-home-notification-review-routing.md` - `TASK-4.5` Home notification review CTA routing into the existing inbox.
 - `2026-05-03-home-local-watchlist-run-snapshot.md` - `TASK-4.6` local W+C watchlist run snapshot state for Home active work.
+- `2026-05-03-home-local-watchlist-run-details.md` - `TASK-4.7` Home local W+C watchlist run detail routing into the W+C runs surface.
 
 Do not mark Phase 2 verified until Home approve, reject, pause, resume, retry, and open-detail workflows are verified against real service-backed adapters or explicitly recoverable unavailable states.

--- a/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
@@ -2,7 +2,7 @@
 
 Date: 2026-05-03
 Status: Phase 2 and Phase 3 in progress
-Source Branch: `origin/dev` at `48e4e747` plus `codex/unified-shell-phase2-home-watchlist-runs`
+Source Branch: `origin/dev` at `09ca0200` plus `codex/unified-shell-phase2-home-watchlist-details`
 
 ## Purpose
 
@@ -27,7 +27,7 @@ Track remaining Unified Shell work in one place so rendered screens, clickable b
 
 ## Known Product Gaps
 
-- Home active-work controls, detail routing, Console launch requests, item identity, local unread notification counts, notification review routing, and local W+C watchlist run snapshots now route through explicit adapter boundaries; schedule and agent-service adapters still need implementation.
+- Home active-work controls, detail routing, Console launch requests, item identity, local unread notification counts, notification review routing, local W+C watchlist run snapshots, and local W+C run detail routing now route through explicit adapter boundaries; schedule and agent-service adapters still need implementation.
 - Workflows has no wired workflow service in the shell wrapper.
 - W+C, Schedules, Workflows, and ACP now use honest unavailable Console states until actionable payloads exist.
 - Console now has a typed app-owned launch contract for staged live-work payloads; source-specific live event producers still need implementation.
@@ -86,6 +86,7 @@ Initial child tasks:
 - Phase 2.4: Wire Home to local notification snapshot adapter - `TASK-4.4`
 - Phase 2.5: Route Home notification review to the notifications inbox - `TASK-4.5`
 - Phase 2.6: Surface local watchlist runs in Home active work - `TASK-4.6`
+- Phase 2.7: Open Home local watchlist run details - `TASK-4.7`
 - Phase 3.1: Add Console live-work launch contract - `TASK-3.1`
 
 ## QA Evidence Index
@@ -106,7 +107,7 @@ Initial child tasks:
 | --- | --- | --- | --- | --- | --- |
 | Phase 0: Canonical Tracking | Make remaining work trackable. | verified | `TASK-1`, `TASK-1.1`, `TASK-1.2` | `phase-0/` | Product UI workflows are out of scope for Phase 0. |
 | Phase 1: Shell Contract Complete | Remove false shell affordances and prove shell usability. | verified | `TASK-2`, `TASK-2.1`, `TASK-2.2`, `TASK-2.3`, `TASK-2.4` | `phase-1/` | Live service workflows remain intentionally deferred to Phases 2-6. |
-| Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | in-progress | `TASK-4`, `TASK-4.1`, `TASK-4.2`, `TASK-4.3`, `TASK-4.4`, `TASK-4.5`, `TASK-4.6` | `phase-2/` | Schedule and agent-service adapters still need implementation; local watchlist run controls remain recoverable rather than fully controllable. |
+| Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | in-progress | `TASK-4`, `TASK-4.1`, `TASK-4.2`, `TASK-4.3`, `TASK-4.4`, `TASK-4.5`, `TASK-4.6`, `TASK-4.7` | `phase-2/` | Schedule and agent-service adapters still need implementation; local watchlist retry/pause/resume remain recoverable rather than fully controllable. |
 | Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | in-progress | `TASK-3`, `TASK-3.1` | `phase-3/` | Source-specific live event producers and follow/status cards still need implementation. |
 | Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | not-started | `TASK-5` | `phase-4/` | Service coverage varies by destination. |
 | Phase 5: Capability And Recovery System | Systematize unavailable and blocked states. | not-started | `TASK-6` | `phase-5/` | Shared taxonomy not yet extracted. |
@@ -175,6 +176,12 @@ Initial audit result: W+C, Schedules, Workflows, and ACP had false Console-launc
 `TASK-4.6` surfaces queued, running, and failed local W+C watchlist runs as Home active work:
 
 - `Docs/superpowers/qa/unified-shell/phase-2/2026-05-03-home-local-watchlist-run-snapshot.md`
+
+## Phase 2.7 Home Local Watchlist Run Details Evidence
+
+`TASK-4.7` makes Home local W+C watchlist run detail controls open the selected run in the W+C runs surface:
+
+- `Docs/superpowers/qa/unified-shell/phase-2/2026-05-03-home-local-watchlist-run-details.md`
 
 ## Phase 3.1 Console Live-Work Launch Contract Evidence
 

--- a/Tests/Home/test_active_work_adapter.py
+++ b/Tests/Home/test_active_work_adapter.py
@@ -152,6 +152,35 @@ def test_local_notification_adapter_opens_local_watchlist_run_details():
     assert missing_result.target_id == "local:watchlist_run:404"
 
 
+def test_local_notification_adapter_opens_local_watchlist_run_details_with_synthesized_id():
+    class FakeWatchlistsService:
+        def list_home_run_snapshot(self, *, limit=20):
+            return [
+                {
+                    "run_id": 6,
+                    "source_id": 8,
+                    "status": "running",
+                    "source_title": "Running release feed",
+                    "backend": "local",
+                },
+            ]
+
+    adapter = LocalNotificationHomeActiveWorkAdapter(
+        watchlist_service=FakeWatchlistsService()
+    )
+
+    result = adapter.handle_control(
+        HomeControlAction.OPEN_DETAILS,
+        target_id="local:watchlist_run:6",
+        target_route="subscriptions",
+    )
+
+    assert result.status is HomeControlResultStatus.HANDLED
+    assert result.target_id == "local:watchlist_run:6"
+    assert result.target_route == "subscriptions"
+    assert result.message == "Opening W+C run details for Running release feed."
+
+
 def test_local_notification_adapter_fails_closed_when_watchlist_snapshot_unavailable():
     class BrokenWatchlistsService:
         def list_home_run_snapshot(self, *, limit=20):

--- a/Tests/Home/test_active_work_adapter.py
+++ b/Tests/Home/test_active_work_adapter.py
@@ -114,6 +114,44 @@ def test_local_notification_adapter_maps_local_watchlist_runs_to_active_work():
     assert dashboard_input.active_work_items[0].console_available is False
 
 
+def test_local_notification_adapter_opens_local_watchlist_run_details():
+    class FakeWatchlistsService:
+        def list_home_run_snapshot(self, *, limit=20):
+            return [
+                {
+                    "id": "local:watchlist_run:5",
+                    "run_id": 5,
+                    "source_id": 7,
+                    "status": "failed",
+                    "source_title": "Daily security feed",
+                    "backend": "local",
+                },
+            ]
+
+    adapter = LocalNotificationHomeActiveWorkAdapter(
+        watchlist_service=FakeWatchlistsService()
+    )
+
+    result = adapter.handle_control(
+        HomeControlAction.OPEN_DETAILS,
+        target_id="local:watchlist_run:5",
+        target_route="subscriptions",
+    )
+    missing_result = adapter.handle_control(
+        HomeControlAction.OPEN_DETAILS,
+        target_id="local:watchlist_run:404",
+        target_route="subscriptions",
+    )
+
+    assert result.status is HomeControlResultStatus.HANDLED
+    assert result.target_id == "local:watchlist_run:5"
+    assert result.target_route == "subscriptions"
+    assert result.message == "Opening W+C run details for Daily security feed."
+
+    assert missing_result.status is HomeControlResultStatus.UNAVAILABLE
+    assert missing_result.target_id == "local:watchlist_run:404"
+
+
 def test_local_notification_adapter_fails_closed_when_watchlist_snapshot_unavailable():
     class BrokenWatchlistsService:
         def list_home_run_snapshot(self, *, limit=20):

--- a/Tests/UI/test_home_screen.py
+++ b/Tests/UI/test_home_screen.py
@@ -399,6 +399,35 @@ def test_app_detail_hook_delegates_to_adapter_and_navigates_handled_route():
     assert app.post_message.call_args.args[0].screen_name == "workflows"
 
 
+def test_app_detail_hook_stages_watchlist_runs_context_for_handled_watchlist_detail():
+    app = _build_test_app()
+    adapter = RecordingHomeActiveWorkAdapter(
+        responses={
+            HomeControlAction.OPEN_DETAILS: HomeControlResult(
+                action=HomeControlAction.OPEN_DETAILS,
+                status=HomeControlResultStatus.HANDLED,
+                message="Opening W+C run details for Daily security feed.",
+                target_id="local:watchlist_run:5",
+                target_route="subscriptions",
+            ),
+        }
+    )
+    app.home_active_work_adapter = adapter
+    app.notify = Mock()
+    app.post_message = Mock()
+
+    result = app.open_active_home_item_details(
+        target_id="local:watchlist_run:5",
+        target_route="subscriptions",
+    )
+
+    assert result.status is HomeControlResultStatus.HANDLED
+    assert app.pending_subscription_initial_tab == "watchlist-runs"
+    assert app.pending_subscription_watchlist_run_id == "local:watchlist_run:5"
+    app.post_message.assert_called_once()
+    assert app.post_message.call_args.args[0].screen_name == "subscriptions"
+
+
 def test_app_console_hook_requires_adapter_launch_payload():
     app = _build_test_app()
     adapter = RecordingHomeActiveWorkAdapter(

--- a/Tests/UI/test_subscription_window_watchlists.py
+++ b/Tests/UI/test_subscription_window_watchlists.py
@@ -85,6 +85,7 @@ def build_window(
     runtime_backend: str,
     policy_allowed: bool = True,
     pending_initial_tab: str | None = None,
+    pending_watchlist_run_id: str | None = None,
 ) -> SubscriptionWindow:
     notifications_store = ClientNotificationsDB(
         db_path=tmp_path / f"notifications-{runtime_backend}.sqlite3",
@@ -103,6 +104,8 @@ def build_window(
     )
     if pending_initial_tab is not None:
         app.pending_subscription_initial_tab = pending_initial_tab
+    if pending_watchlist_run_id is not None:
+        app.pending_subscription_watchlist_run_id = pending_watchlist_run_id
     app.watchlist_scope_service.list_watch_items = AsyncMock(
         return_value=[_normalized_watch_row(runtime_backend)]
     )
@@ -142,17 +145,17 @@ def build_window(
         return_value={"id": "server:watchlist_job:31", "job_id": 31, "title": "Daily Briefing"}
     )
     app.watchlist_scope_service.trigger_job = AsyncMock(
-        return_value={"id": "server:watchlist_run:91", "run_id": 91, "job_id": 31, "status": "queued"}
+        return_value={"id": f"{runtime_backend}:watchlist_run:91", "run_id": 91, "job_id": 31, "status": "queued"}
     )
     app.watchlist_scope_service.list_runs = AsyncMock(
         return_value={
-            "items": [{"id": "server:watchlist_run:91", "run_id": 91, "job_id": 31, "status": "running"}],
+            "items": [{"id": f"{runtime_backend}:watchlist_run:91", "run_id": 91, "job_id": 31, "status": "running"}],
             "total": 1,
         }
     )
     app.watchlist_scope_service.get_run_detail = AsyncMock(
         return_value={
-            "id": "server:watchlist_run:91",
+            "id": f"{runtime_backend}:watchlist_run:91",
             "run_id": 91,
             "job_id": 31,
             "status": "running",
@@ -301,6 +304,20 @@ def test_subscription_window_consumes_pending_notifications_initial_tab(tmp_path
 
     assert window.initial_tab == "notifications"
     assert not hasattr(window.app_instance, "pending_subscription_initial_tab")
+
+
+def test_subscription_window_consumes_pending_watchlist_run_detail_context(tmp_path: Path):
+    window = build_window(
+        tmp_path=tmp_path,
+        runtime_backend="local",
+        pending_initial_tab="watchlist-runs",
+        pending_watchlist_run_id="local:watchlist_run:91",
+    )
+
+    assert window.initial_tab == "watchlist-runs"
+    assert window._selected_watchlist_run_id == "local:watchlist_run:91"
+    assert not hasattr(window.app_instance, "pending_subscription_initial_tab")
+    assert not hasattr(window.app_instance, "pending_subscription_watchlist_run_id")
 
 
 @pytest.mark.asyncio
@@ -525,12 +542,34 @@ async def test_local_mode_shows_watchlist_control_plane_guidance(tmp_path: Path)
     await window.refresh_backend_view()
 
     assert window._test_widgets["#watchlist-jobs-local-state"].display is True
-    assert window._test_widgets["#watchlist-runs-local-state"].display is True
-    assert window._test_widgets["#watchlist-alert-rules-local-state"].display is True
+    assert window._test_widgets["#watchlist-runs-local-state"].display is False
+    assert window._test_widgets["#watchlist-alert-rules-local-state"].display is False
     assert "local subscriptions scheduler" in str(window._test_widgets["#watchlist-jobs-local-state"].updated[-1]).lower()
     window.app_instance.watchlist_scope_service.list_jobs.assert_not_called()
-    window.app_instance.watchlist_scope_service.list_runs.assert_not_called()
-    window.app_instance.watchlist_scope_service.list_alert_rules.assert_not_called()
+    window.app_instance.watchlist_scope_service.list_runs.assert_awaited_once_with(runtime_backend="local")
+    window.app_instance.watchlist_scope_service.list_alert_rules.assert_awaited_once_with(runtime_backend="local")
+
+
+@pytest.mark.asyncio
+async def test_local_mode_pending_watchlist_run_context_loads_run_detail(tmp_path: Path):
+    window = build_window(
+        tmp_path=tmp_path,
+        runtime_backend="local",
+        pending_initial_tab="watchlist-runs",
+        pending_watchlist_run_id="local:watchlist_run:91",
+    )
+
+    await window.refresh_backend_view()
+
+    list_view = window._test_widgets["#watchlist-runs-list"]
+    assert list_view.items[0].data["id"] == "local:watchlist_run:91"
+    assert list_view.highlighted_child is list_view.items[0]
+    assert list_view.index == 0
+    window.app_instance.watchlist_scope_service.get_run_detail.assert_awaited_once_with(
+        runtime_backend="local",
+        run_id="local:watchlist_run:91",
+    )
+    assert "started" in window.query_one("#watchlist-run-detail").text
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_unified_shell_phase2_home_adapter.py
+++ b/Tests/UI/test_unified_shell_phase2_home_adapter.py
@@ -8,6 +8,7 @@ ITEM_CONTEXT_EVIDENCE = PHASE_2_ROOT / "2026-05-03-home-active-work-item-context
 LOCAL_NOTIFICATION_EVIDENCE = PHASE_2_ROOT / "2026-05-03-home-local-notification-snapshot.md"
 NOTIFICATION_REVIEW_EVIDENCE = PHASE_2_ROOT / "2026-05-03-home-notification-review-routing.md"
 WATCHLIST_RUN_EVIDENCE = PHASE_2_ROOT / "2026-05-03-home-local-watchlist-run-snapshot.md"
+WATCHLIST_RUN_DETAIL_EVIDENCE = PHASE_2_ROOT / "2026-05-03-home-local-watchlist-run-details.md"
 README = PHASE_2_ROOT / "README.md"
 ROADMAP = Path("Docs/superpowers/trackers/unified-shell-maturity-roadmap.md")
 TASK_4_1 = Path("backlog/tasks/task-4.1 - Phase-2.1-Add-Home-active-work-adapter-contract.md")
@@ -23,6 +24,9 @@ TASK_4_5 = Path(
 )
 TASK_4_6 = Path(
     "backlog/tasks/task-4.6 - Phase-2.6-Surface-local-watchlist-runs-in-Home-active-work.md"
+)
+TASK_4_7 = Path(
+    "backlog/tasks/task-4.7 - Phase-2.7-Open-Home-local-watchlist-run-details.md"
 )
 
 
@@ -192,3 +196,31 @@ def test_phase_two_local_watchlist_run_evidence_is_linked_from_index_roadmap_and
     assert "status: Done" in task_text
     assert "- [x] #1" in task_text
     assert "- [x] #6" in task_text
+
+
+def test_phase_two_local_watchlist_run_detail_evidence_exists_and_records_verification():
+    assert WATCHLIST_RUN_DETAIL_EVIDENCE.exists()
+    text = WATCHLIST_RUN_DETAIL_EVIDENCE.read_text(encoding="utf-8")
+
+    assert "TASK-4.7" in text
+    assert "Open details" in text
+    assert "pending_subscription_watchlist_run_id" in text
+    assert "watchlist-runs" in text
+    assert "SubscriptionWindow" in text
+    assert "Tests/UI/test_subscription_window_watchlists.py" in text
+    assert "passed" in text
+
+
+def test_phase_two_local_watchlist_run_detail_evidence_is_linked_from_index_roadmap_and_task():
+    evidence_name = WATCHLIST_RUN_DETAIL_EVIDENCE.name
+
+    assert evidence_name in README.read_text(encoding="utf-8")
+
+    roadmap_text = ROADMAP.read_text(encoding="utf-8")
+    assert "TASK-4.7" in roadmap_text
+    assert evidence_name in roadmap_text
+
+    task_text = TASK_4_7.read_text(encoding="utf-8")
+    assert "status: Done" in task_text
+    assert "- [x] #1" in task_text
+    assert "- [x] #5" in task_text

--- a/backlog/tasks/task-4.7 - Phase-2.7-Open-Home-local-watchlist-run-details.md
+++ b/backlog/tasks/task-4.7 - Phase-2.7-Open-Home-local-watchlist-run-details.md
@@ -1,0 +1,47 @@
+---
+id: TASK-4.7
+title: 'Phase 2.7: Open Home local watchlist run details'
+status: Done
+assignee: []
+created_date: '2026-05-03 20:25'
+updated_date: '2026-05-03 20:30'
+labels:
+  - unified-shell
+  - phase-2
+  - home
+  - watchlists
+  - details
+dependencies: []
+parent_task_id: TASK-4
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make Home local W+C watchlist run detail controls open the existing W+C runs surface with the relevant run selected and loaded, instead of showing an unavailable active-work adapter message.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Home adapter handles `Open details` for visible local watchlist run active-work items and keeps unknown/non-run targets recoverable.
+- [x] #2 Home detail navigation stages the W+C runs tab and selected run id before opening subscriptions.
+- [x] #3 SubscriptionWindow consumes the pending Home-selected watchlist run id, restores the run selection, and loads its detail when local runs are available.
+- [x] #4 Local W+C runs remain visible in the runs tab while unrelated local-only server controls stay honest.
+- [x] #5 Focused automated tests and Phase 2 QA evidence verify the adapter, app navigation, W+C run detail workflow, and tracking updates.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing tests for Home adapter local watchlist detail handling, app detail navigation context, SubscriptionWindow pending run consumption, and local W+C runs visibility/detail loading.
+2. Implement the smallest adapter, app, and SubscriptionWindow changes needed to route local watchlist run details without enabling unrelated controls.
+3. Add Phase 2 QA evidence and update roadmap/task tracking.
+4. Run focused Home, W+C, and tracking tests plus diff hygiene before committing.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added handled Home detail routing for visible local W+C watchlist run items, including app-level staging of the W+C runs tab and selected run id before navigation. `SubscriptionWindow` now consumes that pending run context, restores the run selection, and loads run detail JSON while local W+C runs and alert rules remain visible through the existing scope service. Local watchlist jobs stay explicitly recoverable as server-style control-plane functionality. Added focused adapter, Home hook, SubscriptionWindow workflow, and Phase 2 tracking coverage plus QA evidence for `TASK-4.7`.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Home/active_work_adapter.py
+++ b/tldw_chatbook/Home/active_work_adapter.py
@@ -170,6 +170,30 @@ class LocalNotificationHomeActiveWorkAdapter(UnavailableHomeActiveWorkAdapter):
             active_work_items=tuple(self._local_watchlist_run_items()),
         )
 
+    def handle_control(
+        self,
+        action: HomeControlAction,
+        *,
+        target_id: str | None = None,
+        target_route: str | None = None,
+    ) -> HomeControlResult:
+        if action is HomeControlAction.OPEN_DETAILS and _is_local_watchlist_run_id(target_id):
+            run = self._local_watchlist_run_by_id(str(target_id))
+            if run is not None:
+                title = self._watchlist_run_title(run)
+                return HomeControlResult(
+                    action=action,
+                    status=HomeControlResultStatus.HANDLED,
+                    message=f"Opening W+C run details for {title}.",
+                    target_route=target_route or "subscriptions",
+                    target_id=target_id,
+                )
+        return super().handle_control(
+            action,
+            target_id=target_id,
+            target_route=target_route,
+        )
+
     def _unread_notification_count(self) -> int:
         if self.notification_service is None:
             return 0
@@ -221,6 +245,25 @@ class LocalNotificationHomeActiveWorkAdapter(UnavailableHomeActiveWorkAdapter):
             )
         return items
 
+    def _local_watchlist_run_by_id(self, target_id: str) -> Any | None:
+        if self.watchlist_service is None:
+            return None
+        try:
+            runs = self.watchlist_service.list_home_run_snapshot(limit=20)
+        except Exception as e:
+            logger.warning(f"Failed to fetch local watchlist run details for Home: {e}")
+            return None
+        return next((run for run in runs if str(_mapping_value(run, "id")) == target_id), None)
+
+    @staticmethod
+    def _watchlist_run_title(run: Any) -> str:
+        return str(
+            _mapping_value(run, "title")
+            or _mapping_value(run, "source_title")
+            or f"Watchlist run {_mapping_value(run, 'run_id') or ''}".strip()
+            or "Watchlist run"
+        )
+
 
 def _notification_is_unread(notification: Any) -> bool:
     if isinstance(notification, Mapping):
@@ -232,3 +275,7 @@ def _mapping_value(value: Any, key: str) -> Any:
     if isinstance(value, Mapping):
         return value.get(key)
     return getattr(value, key, None)
+
+
+def _is_local_watchlist_run_id(value: str | None) -> bool:
+    return bool(value and str(value).startswith("local:watchlist_run:"))

--- a/tldw_chatbook/Home/active_work_adapter.py
+++ b/tldw_chatbook/Home/active_work_adapter.py
@@ -222,10 +222,7 @@ class LocalNotificationHomeActiveWorkAdapter(UnavailableHomeActiveWorkAdapter):
             if status not in _HOME_WATCHLIST_RUN_STATUSES:
                 continue
             run_id = _mapping_value(run, "run_id")
-            item_id = str(
-                _mapping_value(run, "id")
-                or (f"local:watchlist_run:{run_id}" if run_id is not None else "")
-            )
+            item_id = self._local_watchlist_run_item_id(run)
             if not item_id:
                 continue
             title = str(
@@ -253,7 +250,18 @@ class LocalNotificationHomeActiveWorkAdapter(UnavailableHomeActiveWorkAdapter):
         except Exception as e:
             logger.warning(f"Failed to fetch local watchlist run details for Home: {e}")
             return None
-        return next((run for run in runs if str(_mapping_value(run, "id")) == target_id), None)
+        return next(
+            (run for run in runs if self._local_watchlist_run_item_id(run) == target_id),
+            None,
+        )
+
+    @staticmethod
+    def _local_watchlist_run_item_id(run: Any) -> str:
+        run_id = _mapping_value(run, "run_id")
+        return str(
+            _mapping_value(run, "id")
+            or (f"local:watchlist_run:{run_id}" if run_id is not None else "")
+        )
 
     @staticmethod
     def _watchlist_run_title(run: Any) -> str:

--- a/tldw_chatbook/UI/SubscriptionWindow.py
+++ b/tldw_chatbook/UI/SubscriptionWindow.py
@@ -206,6 +206,7 @@ class SubscriptionWindow(Container):
         super().__init__(*args, **kwargs)
         self.app_instance = app_instance  # Changed from self.app to self.app_instance
         self.initial_tab = self._consume_initial_tab(app_instance)
+        pending_watchlist_run_id = self._consume_pending_watchlist_run_id(app_instance)
         self.client_id = "cli"
         self.db: Optional[SubscriptionsDB] = None
         self.scheduler_worker: Optional[SubscriptionSchedulerWorker] = None
@@ -232,7 +233,8 @@ class SubscriptionWindow(Container):
         self.selected_items: List[int] = []
         self._selected_watch_item: Optional[Dict[str, Any]] = None
         self._selected_watchlist_job_id: Optional[str] = None
-        self._selected_watchlist_run_id: Optional[str] = None
+        self._selected_watchlist_run_id: Optional[str] = pending_watchlist_run_id
+        self._pending_watchlist_run_detail_id: Optional[str] = pending_watchlist_run_id
         self._selected_watchlist_alert_rule_id: Optional[str] = None
         self._selected_server_reminder_id: Optional[str] = None
         self._selected_server_notification_id: Optional[str] = None
@@ -290,6 +292,13 @@ class SubscriptionWindow(Container):
         if initial_tab in SUBSCRIPTION_INITIAL_TABS:
             return str(initial_tab)
         return "subscriptions"
+
+    @staticmethod
+    def _consume_pending_watchlist_run_id(app_instance: Any) -> Optional[str]:
+        run_id = getattr(app_instance, "pending_subscription_watchlist_run_id", None)
+        if hasattr(app_instance, "pending_subscription_watchlist_run_id"):
+            delattr(app_instance, "pending_subscription_watchlist_run_id")
+        return str(run_id) if run_id not in (None, "") else None
     
     def _compose_subscriptions_tab(self) -> ComposeResult:
         """Compose subscriptions management tab."""
@@ -1015,6 +1024,19 @@ class SubscriptionWindow(Container):
             fallback_key="run_id",
             entity_kind="watchlist_run",
         )
+
+    async def _load_pending_watchlist_run_detail(self) -> None:
+        run_id = self._pending_watchlist_run_detail_id
+        if not run_id:
+            return
+        self._pending_watchlist_run_detail_id = None
+        try:
+            detail = await self.backend_controller.get_watchlist_run_detail(run_id)
+        except Exception as exc:
+            logger.warning(f"Failed to load pending watchlist run detail: {exc}")
+            self.notify(f"Unable to load watchlist run details: {exc}", severity="warning")
+            return
+        self._load_text_area("#watchlist-run-detail", json.dumps(detail, indent=2, sort_keys=True, default=str))
 
     async def _render_watchlist_alert_rules(self, items: List[Dict[str, Any]]) -> None:
         await self._render_watchlist_record_list(

--- a/tldw_chatbook/UI/Subscription_Modules/subscription_backend_controller.py
+++ b/tldw_chatbook/UI/Subscription_Modules/subscription_backend_controller.py
@@ -155,16 +155,17 @@ class SubscriptionBackendController:
 
     async def _refresh_control_plane(self, *, runtime_backend: str) -> None:
         if runtime_backend != "server":
-            message = "Server watchlist jobs, runs, and alert rules are remote-only here. Use the local subscriptions scheduler, review queue, and notifications inbox for offline watchlist operations."
+            message = "Server watchlist jobs are remote-only here. Use the local subscriptions scheduler for offline watchlist operations."
             self.window._render_local_only_state(tab_id="watchlist-jobs", message=message)
-            self.window._render_local_only_state(tab_id="watchlist-runs", message=message)
-            self.window._render_local_only_state(tab_id="watchlist-alert-rules", message=message)
+            self.window._clear_local_only_state(tab_id="watchlist-runs")
+            self.window._clear_local_only_state(tab_id="watchlist-alert-rules")
             reminder_message = "Server reminders and notification feed are remote-only. Use the local Notifications inbox for offline client-owned notifications."
             self.window._render_local_only_state(tab_id="server-reminders", message=reminder_message)
             self.window._render_local_only_state(tab_id="server-feed", message=reminder_message)
             await self.window._render_watchlist_jobs([])
-            await self.window._render_watchlist_runs([])
-            await self.window._render_watchlist_alert_rules([])
+            await self.load_watchlist_runs()
+            await self.load_watchlist_alert_rules()
+            await self.window._load_pending_watchlist_run_detail()
             await self.window._render_server_reminders([])
             await self.window._render_server_feed([])
             return
@@ -177,6 +178,7 @@ class SubscriptionBackendController:
         await self.load_watchlist_jobs()
         await self.load_watchlist_runs()
         await self.load_watchlist_alert_rules()
+        await self.window._load_pending_watchlist_run_detail()
         await self.load_server_reminders()
         await self.load_server_feed()
 

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -1746,8 +1746,15 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
             target_route=target_route,
         )
         if result.status is HomeControlResultStatus.HANDLED and result.target_route:
+            if result.target_route == "subscriptions":
+                self._stage_subscription_watchlist_run_context(result.target_id or target_id)
             self.post_message(NavigateToScreen(result.target_route))
         return result
+
+    def _stage_subscription_watchlist_run_context(self, target_id: str | None) -> None:
+        if target_id and ":watchlist_run:" in str(target_id):
+            self.pending_subscription_initial_tab = "watchlist-runs"
+            self.pending_subscription_watchlist_run_id = str(target_id)
 
     def open_active_home_item_in_console(
         self,


### PR DESCRIPTION
## Summary
- Handle Home Open details for visible local W+C watchlist runs through the active-work adapter.
- Stage the W+C runs tab and selected run id before navigating from Home.
- Let SubscriptionWindow consume the pending run context, load local run details, and keep local runs/alert rules visible while jobs remain honest local-only.

## Test Plan
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Home/test_active_work_adapter.py Tests/UI/test_home_screen.py Tests/UI/test_subscription_window_watchlists.py Tests/UI/test_screen_navigation.py Tests/UI/test_unified_shell_phase2_home_adapter.py -q
- git diff --check