### PR TITLE
Add Console live-work status card seam

### DIFF
--- a/Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-console-live-work-status-card-seam.md
+++ b/Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-console-live-work-status-card-seam.md
@@ -1,0 +1,49 @@
+# Console Live-Work Status Card Seam
+
+Date: 2026-05-03
+Task: `TASK-3.2`
+Branch: `codex/unified-shell-phase3-console-status-card`
+Base: `origin/dev` at `09ca0200`
+
+## Purpose
+
+Continue Phase 3 by turning the first pending Console launch card into a reusable status-card display seam. The goal is to make future workflows, schedules, ACP, MCP, RAG, artifacts, and Home active-work sources render the same live-work status language without duplicating `ChatScreen` markup.
+
+## What Changed
+
+- Added `ConsoleLiveWorkStatusCardState` and `ConsoleLiveWorkStatusCardRow` as a stable display contract derived from `ConsoleLiveWorkLaunch`.
+- Preserved the existing one-shot pending-launch behavior and existing user-visible copy.
+- Added stable row selectors for source, title, status, recovery, action, and payload metadata.
+- Moved `ChatScreen` pending launch rendering through a reusable `_render_console_live_work_status_card()` helper.
+
+## Functional QA Evidence
+
+Focused checks were run against the card-state model and a mounted Textual Console screen harness.
+
+- Red card-state/rendering test: `python -m pytest -q Tests/UI/test_console_live_work_handoffs.py --tb=short`
+- Red result: `2 failed, 12 passed, 1 warning`; failures were expected because `ConsoleLiveWorkStatusCardState` and stable row selectors did not exist.
+- Green card-state/rendering test: `python -m pytest -q Tests/UI/test_console_live_work_handoffs.py --tb=short`
+- Green result: `14 passed, 1 warning`
+- Red tracking evidence test: `python -m pytest -q Tests/UI/test_console_live_work_handoffs.py --tb=short`
+- Red tracking result: `1 failed, 14 passed, 1 warning`; failure was expected because this evidence file and roadmap links were not present.
+- Final Console evidence test: `python -m pytest -q Tests/UI/test_console_live_work_handoffs.py --tb=short`
+- Final Console evidence result: `15 passed, 1 warning`
+- Final combined focused regression: `python -m pytest -q Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_home_screen.py Tests/Home/test_active_work_adapter.py Tests/Home/test_dashboard_state.py Tests/UI/test_unified_shell_phase2_home_adapter.py Tests/UI/test_screen_navigation.py Tests/UI/test_destination_shells.py --tb=short`
+- Final combined focused result: `126 passed, 8 warnings`
+- Whitespace check: `git diff --check`
+- Whitespace check result: passed
+
+Warning boundary: warnings are existing dependency/import warnings and are not Console status-card behavior failures.
+
+## UX Result
+
+- First-time users still see the same understandable pending Console launch card.
+- Power users and future source integrations get a predictable display contract with stable selectors for fast regression coverage.
+- This reduces the risk that workflows, schedules, ACP, MCP, RAG, or artifact sources each invent different status/recovery language.
+
+## Residual Risk
+
+- This is a rendering seam, not full Phase 3 completion.
+- Console still does not subscribe to real live-work event streams.
+- Source-specific launch/follow/status producers remain future Phase 3 work.
+- Full Phase 3 cannot be verified until live or explicitly unavailable source flows are exercised in the running app.

--- a/Docs/superpowers/qa/unified-shell/phase-3/README.md
+++ b/Docs/superpowers/qa/unified-shell/phase-3/README.md
@@ -7,5 +7,6 @@ This directory contains durable QA summaries for Phase 3 Console live-work hub s
 ## Evidence
 
 - `2026-05-03-console-live-work-launch-contract.md` - `TASK-3.1` typed Console live-work launch contract and pending-launch card rendering.
+- `2026-05-03-console-live-work-status-card-seam.md` - `TASK-3.2` reusable Console live-work status card state and stable render selectors.
 
 Do not mark Phase 3 verified until launch, follow, status, and recovery flows are verified in the running app against workflows, schedules, ACP, MCP, RAG, artifacts, and active-work source adapters.

--- a/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
@@ -2,7 +2,7 @@
 
 Date: 2026-05-03
 Status: Phase 2 and Phase 3 in progress
-Source Branch: `origin/dev` at `48e4e747` plus `codex/unified-shell-phase2-home-watchlist-runs`
+Source Branch: `origin/dev` at `09ca0200` plus `codex/unified-shell-phase3-console-status-card`
 
 ## Purpose
 
@@ -30,7 +30,7 @@ Track remaining Unified Shell work in one place so rendered screens, clickable b
 - Home active-work controls, detail routing, Console launch requests, item identity, local unread notification counts, notification review routing, and local W+C watchlist run snapshots now route through explicit adapter boundaries; schedule and agent-service adapters still need implementation.
 - Workflows has no wired workflow service in the shell wrapper.
 - W+C, Schedules, Workflows, and ACP now use honest unavailable Console states until actionable payloads exist.
-- Console now has a typed app-owned launch contract for staged live-work payloads; source-specific live event producers still need implementation.
+- Console now has a typed app-owned launch contract and reusable status-card display seam for staged live-work payloads; source-specific live event producers still need implementation.
 - ACP launch is disabled until an ACP-compatible runtime is configured.
 - MCP management is not embedded in the top-level MCP wrapper.
 - Skills local/server services exist, but the top-level Skills shell still leaves import disabled and lacks list/detail/import UX adoption.
@@ -87,6 +87,7 @@ Initial child tasks:
 - Phase 2.5: Route Home notification review to the notifications inbox - `TASK-4.5`
 - Phase 2.6: Surface local watchlist runs in Home active work - `TASK-4.6`
 - Phase 3.1: Add Console live-work launch contract - `TASK-3.1`
+- Phase 3.2: Add Console live-work status card seam - `TASK-3.2`
 
 ## QA Evidence Index
 
@@ -107,7 +108,7 @@ Initial child tasks:
 | Phase 0: Canonical Tracking | Make remaining work trackable. | verified | `TASK-1`, `TASK-1.1`, `TASK-1.2` | `phase-0/` | Product UI workflows are out of scope for Phase 0. |
 | Phase 1: Shell Contract Complete | Remove false shell affordances and prove shell usability. | verified | `TASK-2`, `TASK-2.1`, `TASK-2.2`, `TASK-2.3`, `TASK-2.4` | `phase-1/` | Live service workflows remain intentionally deferred to Phases 2-6. |
 | Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | in-progress | `TASK-4`, `TASK-4.1`, `TASK-4.2`, `TASK-4.3`, `TASK-4.4`, `TASK-4.5`, `TASK-4.6` | `phase-2/` | Schedule and agent-service adapters still need implementation; local watchlist run controls remain recoverable rather than fully controllable. |
-| Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | in-progress | `TASK-3`, `TASK-3.1` | `phase-3/` | Source-specific live event producers and follow/status cards still need implementation. |
+| Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | in-progress | `TASK-3`, `TASK-3.1`, `TASK-3.2` | `phase-3/` | Source-specific live event producers and follow/status wiring still need implementation. |
 | Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | not-started | `TASK-5` | `phase-4/` | Service coverage varies by destination. |
 | Phase 5: Capability And Recovery System | Systematize unavailable and blocked states. | not-started | `TASK-6` | `phase-5/` | Shared taxonomy not yet extracted. |
 | Phase 6: Audit Replay And Closeout | Prove shell works for first-time and power users. | not-started | `TASK-7` | `phase-6/` | Depends on prior phases and running-app QA. |
@@ -181,6 +182,12 @@ Initial audit result: W+C, Schedules, Workflows, and ACP had false Console-launc
 `TASK-3.1` adds the normalized Console launch payload contract and renders pending launch details in Console:
 
 - `Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-console-live-work-launch-contract.md`
+
+## Phase 3.2 Console Live-Work Status Card Evidence
+
+`TASK-3.2` extracts reusable Console live-work status card state and stable render selectors:
+
+- `Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-console-live-work-status-card-seam.md`
 
 ## Phase 0: Canonical Tracking
 

--- a/Tests/UI/test_console_live_work_handoffs.py
+++ b/Tests/UI/test_console_live_work_handoffs.py
@@ -1,5 +1,6 @@
 """Console live-work launch and staged-context handoff boundary tests."""
 
+from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
@@ -11,12 +12,26 @@ from tldw_chatbook.Chat.chat_handoff_models import ChatHandoffPayload
 from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PHASE3_STATUS_CARD_EVIDENCE = (
+    REPO_ROOT / "Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-console-live-work-status-card-seam.md"
+)
+
+
 def _load_console_live_work_contract():
     try:
         from tldw_chatbook.Chat.console_live_work import ConsoleLiveWorkLaunch
     except ModuleNotFoundError:
         pytest.fail("Console live-work launch contract module is missing")
     return ConsoleLiveWorkLaunch
+
+
+def _load_console_live_work_status_card_state():
+    try:
+        from tldw_chatbook.Chat.console_live_work import ConsoleLiveWorkStatusCardState
+    except ImportError:
+        pytest.fail("Console live-work status card state is missing")
+    return ConsoleLiveWorkStatusCardState
 
 
 class ConsoleHarness(App):
@@ -115,6 +130,54 @@ def test_open_console_for_live_work_preserves_minimal_call_defaults():
     }
 
 
+def test_console_live_work_status_card_state_derives_stable_rows_from_launch():
+    ConsoleLiveWorkLaunch = _load_console_live_work_contract()
+    ConsoleLiveWorkStatusCardState = _load_console_live_work_status_card_state()
+    launch = ConsoleLiveWorkLaunch.from_values(
+        source="workflows",
+        title="Daily digest",
+        payload={"attempt": 2, "run_id": "run-1"},
+        status="running",
+        recovery="Workflow is starting.",
+        action_label="Open workflow run",
+    )
+
+    card_state = ConsoleLiveWorkStatusCardState.from_launch(launch)
+
+    assert card_state.container_id == "console-pending-launch-card"
+    assert "console-live-work-status-card" in card_state.container_classes
+    assert card_state.badge_text == "Pending Console launch"
+    rows_by_id = {row.widget_id: row.text for row in card_state.rows}
+    assert rows_by_id == {
+        "console-live-work-source": "Source: workflows",
+        "console-live-work-title": "Title: Daily digest",
+        "console-live-work-status": "Status: running",
+        "console-live-work-recovery": "Recovery: Workflow is starting.",
+        "console-live-work-action": "Action: Open workflow run",
+        "console-live-work-payload-attempt": "attempt: 2",
+        "console-live-work-payload-run-id": "run_id: run-1",
+    }
+    payload_row = next(row for row in card_state.rows if row.widget_id == "console-live-work-payload-run-id")
+    assert "console-live-work-payload-row" in payload_row.classes
+
+
+def test_phase3_status_card_tracking_evidence_links_task_and_roadmap():
+    evidence = PHASE3_STATUS_CARD_EVIDENCE.read_text()
+    readme = (REPO_ROOT / "Docs/superpowers/qa/unified-shell/phase-3/README.md").read_text()
+    roadmap = (REPO_ROOT / "Docs/superpowers/trackers/unified-shell-maturity-roadmap.md").read_text()
+    task = (
+        REPO_ROOT
+        / "backlog/tasks/task-3.2 - Phase-3.2-Add-Console-live-work-status-card-seam.md"
+    ).read_text()
+
+    assert "TASK-3.2" in evidence
+    assert "ConsoleLiveWorkStatusCardState" in evidence
+    assert "2026-05-03-console-live-work-status-card-seam.md" in readme
+    assert "Phase 3.2: Add Console live-work status card seam - `TASK-3.2`" in roadmap
+    assert "`TASK-3`, `TASK-3.1`, `TASK-3.2`" in roadmap
+    assert "ConsoleLiveWorkStatusCardState" in task
+
+
 @pytest.mark.parametrize(
     ("route", "button_id", "expected_copy"),
     [
@@ -210,6 +273,13 @@ async def test_console_renders_pending_launch_context():
         screen = _active_console_screen(host)
 
         assert screen.query_one("#console-pending-launch-card")
+        assert screen.query_one("#console-live-work-source").renderable == "Source: workflows"
+        assert screen.query_one("#console-live-work-title").renderable == "Title: Daily digest"
+        assert screen.query_one("#console-live-work-status").renderable == "Status: running"
+        assert screen.query_one("#console-live-work-recovery").renderable == "Recovery: Workflow is starting."
+        assert screen.query_one("#console-live-work-action").renderable == "Action: Open workflow run"
+        assert screen.query_one("#console-live-work-payload-attempt").renderable == "attempt: 2"
+        assert screen.query_one("#console-live-work-payload-run-id").renderable == "run_id: run-1"
         text = _screen_static_text(screen)
         assert "Source: workflows" in text
         assert "Title: Daily digest" in text

--- a/backlog/tasks/task-3.2 - Phase-3.2-Add-Console-live-work-status-card-seam.md
+++ b/backlog/tasks/task-3.2 - Phase-3.2-Add-Console-live-work-status-card-seam.md
@@ -1,0 +1,54 @@
+---
+id: TASK-3.2
+title: 'Phase 3.2: Add Console live-work status card seam'
+status: Done
+assignee: []
+created_date: '2026-05-03 20:35'
+updated_date: '2026-05-03 20:41'
+labels:
+  - unified-shell
+  - phase-3
+  - console
+  - live-work
+dependencies: []
+documentation:
+  - Docs/superpowers/specs/2026-05-02-agentic-terminal-design-system-design.md
+  - Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+parent_task_id: TASK-3
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Extract pending Console launch rendering into a reusable live-work status card contract so future workflows, schedules, ACP, MCP, RAG, and artifact sources can render consistent status, recovery, action, and metadata without duplicating ChatScreen markup.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Console live-work card state derives stable badge, title, source, status, recovery, action, and payload rows from a launch context.
+- [x] #2 ChatScreen renders pending launches through the reusable status card seam while preserving one-shot pending launch consumption.
+- [x] #3 The rendered card exposes stable IDs/classes for future live-work source tests without changing existing user-visible copy regressions.
+- [x] #4 Focused Console live-work tests and Phase 3 QA evidence verify the card-state model, mounted Console rendering, and roadmap/task updates.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing regressions for Console live-work card-state derivation and mounted card rendering with stable selectors.
+2. Verify the new tests fail before production changes.
+3. Add the minimal reusable `ConsoleLiveWorkStatusCardState` model and render helper, then wire ChatScreen through it without changing one-shot launch semantics.
+4. Add durable Phase 3 QA evidence and update the unified-shell roadmap index.
+5. Run focused Console/Home/destination regressions plus diff checks, then complete the Backlog task.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented a reusable Console live-work status card seam for pending launch context.
+
+- Added `ConsoleLiveWorkStatusCardState` and row state derived from `ConsoleLiveWorkLaunch`.
+- Updated `ChatScreen` to render pending launches through `_render_console_live_work_status_card()` while preserving one-shot pending launch consumption and existing copy.
+- Added stable row selectors/classes for status-card source, title, status, recovery, action, and payload metadata.
+- Added focused regressions plus Phase 3 QA evidence and roadmap tracking for `TASK-3.2`.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_live_work.py
+++ b/tldw_chatbook/Chat/console_live_work.py
@@ -144,14 +144,23 @@ class ConsoleLiveWorkStatusCardState:
                 text=f"Action: {launch.action_label}",
             ),
         ]
-        rows.extend(
-            ConsoleLiveWorkStatusCardRow(
-                widget_id=f"console-live-work-payload-{_safe_widget_suffix(key)}",
-                text=f"{key}: {value}",
-                classes="destination-section console-live-work-status-row console-live-work-payload-row",
+        seen_ids = set()
+        for key, value in launch.payload_display_items():
+            suffix = _safe_widget_suffix(key)
+            base_id = f"console-live-work-payload-{suffix}"
+            widget_id = base_id
+            counter = 1
+            while widget_id in seen_ids:
+                widget_id = f"{base_id}-{counter}"
+                counter += 1
+            seen_ids.add(widget_id)
+            rows.append(
+                ConsoleLiveWorkStatusCardRow(
+                    widget_id=widget_id,
+                    text=f"{key}: {value}",
+                    classes="destination-section console-live-work-status-row console-live-work-payload-row",
+                )
             )
-            for key, value in launch.payload_display_items()
-        )
         return cls(
             badge_text="Pending Console launch",
             rows=tuple(rows),

--- a/tldw_chatbook/Chat/console_live_work.py
+++ b/tldw_chatbook/Chat/console_live_work.py
@@ -9,6 +9,8 @@ from typing import Any
 
 DEFAULT_RECOVERY = "Console has staged this live-work request."
 DEFAULT_ACTION_LABEL = "Open in Console"
+PENDING_LAUNCH_CARD_ID = "console-pending-launch-card"
+LIVE_WORK_CARD_CLASS = "console-live-work-status-card"
 
 
 def _clean_text(value: Any, fallback: str) -> str:
@@ -20,6 +22,19 @@ def _copy_payload(payload: Mapping[str, Any] | None) -> dict[str, Any]:
     if isinstance(payload, Mapping):
         return dict(payload)
     return {}
+
+
+def _safe_widget_suffix(value: Any) -> str:
+    suffix = []
+    previous_dash = False
+    for character in str(value or "").strip().lower():
+        if character.isalnum():
+            suffix.append(character)
+            previous_dash = False
+        elif not previous_dash:
+            suffix.append("-")
+            previous_dash = True
+    return "".join(suffix).strip("-") or "item"
 
 
 @dataclass(frozen=True)
@@ -82,4 +97,62 @@ class ConsoleLiveWorkLaunch:
         return tuple(
             (str(key), self.payload[key])
             for key in sorted(self.payload, key=lambda item: str(item))
+        )
+
+
+@dataclass(frozen=True)
+class ConsoleLiveWorkStatusCardRow:
+    """A stable render row for Console live-work status cards."""
+
+    widget_id: str
+    text: str
+    classes: str = "destination-section console-live-work-status-row"
+
+
+@dataclass(frozen=True)
+class ConsoleLiveWorkStatusCardState:
+    """Reusable display contract for one Console live-work status card."""
+
+    badge_text: str
+    rows: tuple[ConsoleLiveWorkStatusCardRow, ...]
+    container_id: str = PENDING_LAUNCH_CARD_ID
+    container_classes: str = f"ds-panel {LIVE_WORK_CARD_CLASS}"
+    badge_id: str = "console-live-work-status-badge"
+    badge_classes: str = "ds-status-badge console-live-work-status-badge"
+
+    @classmethod
+    def from_launch(cls, launch: ConsoleLiveWorkLaunch) -> "ConsoleLiveWorkStatusCardState":
+        rows = [
+            ConsoleLiveWorkStatusCardRow(
+                widget_id="console-live-work-source",
+                text=f"Source: {launch.source}",
+            ),
+            ConsoleLiveWorkStatusCardRow(
+                widget_id="console-live-work-title",
+                text=f"Title: {launch.title}",
+            ),
+            ConsoleLiveWorkStatusCardRow(
+                widget_id="console-live-work-status",
+                text=f"Status: {launch.status}",
+            ),
+            ConsoleLiveWorkStatusCardRow(
+                widget_id="console-live-work-recovery",
+                text=f"Recovery: {launch.recovery}",
+            ),
+            ConsoleLiveWorkStatusCardRow(
+                widget_id="console-live-work-action",
+                text=f"Action: {launch.action_label}",
+            ),
+        ]
+        rows.extend(
+            ConsoleLiveWorkStatusCardRow(
+                widget_id=f"console-live-work-payload-{_safe_widget_suffix(key)}",
+                text=f"{key}: {value}",
+                classes="destination-section console-live-work-status-row console-live-work-payload-row",
+            )
+            for key, value in launch.payload_display_items()
+        )
+        return cls(
+            badge_text="Pending Console launch",
+            rows=tuple(rows),
         )

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -21,7 +21,7 @@ from .chat_screen_state import ChatScreenState, TabState, MessageData, TaskResum
 from ...Chat.chat_conversation_service import derive_conversation_title
 from ...Chat.chat_handoff_models import ChatHandoffPayload
 from ...Chat.chat_models import ChatSessionData
-from ...Chat.console_live_work import ConsoleLiveWorkLaunch
+from ...Chat.console_live_work import ConsoleLiveWorkLaunch, ConsoleLiveWorkStatusCardState
 from ...Utils.chat_diagnostics import ChatDiagnostics
 from ...state.ui_state import UIState
 from ...Widgets.Chat_Widgets.chat_tab_container import ChatTabContainer
@@ -156,20 +156,24 @@ class ChatScreen(BaseAppScreen):
             self._pending_console_launch_context = normalized_launch
             self.app_instance.pending_console_launch = None
         return self._pending_console_launch_context
+
+    def _render_console_live_work_status_card(self, launch: ConsoleLiveWorkLaunch) -> ComposeResult:
+        """Render a reusable live-work status card for Console launch context."""
+        card_state = ConsoleLiveWorkStatusCardState.from_launch(launch)
+        with Container(id=card_state.container_id, classes=card_state.container_classes):
+            yield Static(
+                card_state.badge_text,
+                id=card_state.badge_id,
+                classes=card_state.badge_classes,
+            )
+            for row in card_state.rows:
+                yield Static(row.text, id=row.widget_id, classes=row.classes)
         
     def compose_content(self) -> ComposeResult:
         """Compose the chat content."""
         pending_launch = self._consume_pending_console_launch()
         if pending_launch:
-            with Container(id="console-pending-launch-card", classes="ds-panel"):
-                yield Static("Pending Console launch", classes="ds-status-badge")
-                yield Static(f"Source: {pending_launch.source}", classes="destination-section")
-                yield Static(f"Title: {pending_launch.title}", classes="destination-section")
-                yield Static(f"Status: {pending_launch.status}", classes="destination-section")
-                yield Static(f"Recovery: {pending_launch.recovery}", classes="destination-section")
-                yield Static(f"Action: {pending_launch.action_label}", classes="destination-section")
-                for key, value in pending_launch.payload_display_items():
-                    yield Static(f"{key}: {value}", classes="destination-section")
+            yield from self._render_console_live_work_status_card(pending_launch)
         # Create and yield the chat window container
         self.chat_window = ChatWindowEnhanced(self.app_instance, id="chat-window", classes="window")
         yield self.chat_window


### PR DESCRIPTION
## Summary

- Add reusable `ConsoleLiveWorkStatusCardState` and row state derived from `ConsoleLiveWorkLaunch`.
- Render pending Console launches through a dedicated `ChatScreen` status-card helper while preserving existing one-shot behavior and copy.
- Add stable selectors/classes plus Phase 3 Backlog, roadmap, and QA evidence for `TASK-3.2`.

## Test Plan

- [x] `env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_home_screen.py Tests/Home/test_active_work_adapter.py Tests/Home/test_dashboard_state.py Tests/UI/test_unified_shell_phase2_home_adapter.py Tests/UI/test_screen_navigation.py Tests/UI/test_destination_shells.py --tb=short`
- [x] `git diff --check HEAD~1..HEAD`

## Notes

This is a Phase 3 rendering seam only. Source-specific live event producers and follow/status wiring remain follow-up work.
