### PR TITLE
Open Home W+C active work in Console

### DIFF
--- a/Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-home-wc-active-work-console-launch.md
+++ b/Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-home-wc-active-work-console-launch.md
@@ -1,0 +1,41 @@
+# Home W+C Active-Work Console Launch
+
+Date: 2026-05-03
+Task: `TASK-3.3`
+Branch: `codex/unified-shell-phase3-console-source-status`
+Base: `origin/dev` at `19605f0f`
+
+## Purpose
+
+Make Home W+C active-work rows produce a real `ConsoleLiveWorkLaunch` so local watchlist runs can be inspected from the primary Console surface instead of stopping at an unavailable Console action.
+
+## What Changed
+
+- Local W+C watchlist run active-work rows now advertise Console availability when the Home adapter can resolve the visible run.
+- `LocalNotificationHomeActiveWorkAdapter` handles `OPEN_IN_CONSOLE` for visible `local:watchlist_run:*` targets and returns a `HomeConsoleLaunch`.
+- The launch includes W+C source, run title, current status, recovery copy, action label, and run metadata.
+- App-level Home Console routing now preserves launch status, recovery, and action label when staging the Console status card.
+- Unknown local watchlist run targets remain recoverable unavailable states.
+
+## Functional QA Evidence
+
+Focused checks were run against the Home adapter, app Console staging hook, and Phase 3 tracking evidence.
+
+- Red test: `python -m pytest Tests/Home/test_active_work_adapter.py::test_local_notification_adapter_opens_local_watchlist_run_in_console Tests/UI/test_home_screen.py::test_app_console_hook_preserves_status_recovery_and_action_label Tests/UI/test_console_live_work_handoffs.py::test_phase3_home_wc_console_launch_tracking_evidence_links_task_and_roadmap -q`
+- Red result: `3 failed`; failures covered unavailable W+C Console rows, missing HomeConsoleLaunch status/recovery/action metadata, and missing Phase 3.3 evidence.
+- Green targeted result: `3 passed, 8 warnings in 5.65s`.
+- Final focused Phase 3.3 suite: `88 passed, 8 warnings in 43.04s` for `Tests/Home/test_active_work_adapter.py`, `Tests/UI/test_home_screen.py`, `Tests/UI/test_console_live_work_handoffs.py`, `Tests/UI/test_screen_navigation.py`, and `Tests/UI/test_unified_shell_phase2_home_adapter.py`.
+
+Warning boundary: warnings are existing dependency/import warnings and are not Home W+C Console launch failures.
+
+## UX Result
+
+- Home W+C active work now has a meaningful `Open in Console` path.
+- Console receives the same status-card vocabulary introduced in `TASK-3.2`, with W+C-specific recovery guidance.
+- This is the first source-specific live-work producer for the Console hub after the generic launch contract and status-card seam.
+
+## Residual Risk
+
+- This slice does not implement retry, pause, or resume for local watchlist runs from Console.
+- This slice does not subscribe to live watchlist run event streams.
+- Full Phase 3 still needs source producers for workflows, schedules, ACP, MCP, RAG, artifacts, and additional active-work sources.

--- a/Docs/superpowers/qa/unified-shell/phase-3/README.md
+++ b/Docs/superpowers/qa/unified-shell/phase-3/README.md
@@ -8,5 +8,6 @@ This directory contains durable QA summaries for Phase 3 Console live-work hub s
 
 - `2026-05-03-console-live-work-launch-contract.md` - `TASK-3.1` typed Console live-work launch contract and pending-launch card rendering.
 - `2026-05-03-console-live-work-status-card-seam.md` - `TASK-3.2` reusable Console live-work status card state and stable render selectors.
+- `2026-05-03-home-wc-active-work-console-launch.md` - `TASK-3.3` Home W+C active-work source launch into the Console status-card surface.
 
 Do not mark Phase 3 verified until launch, follow, status, and recovery flows are verified in the running app against workflows, schedules, ACP, MCP, RAG, artifacts, and active-work source adapters.

--- a/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
@@ -2,7 +2,7 @@
 
 Date: 2026-05-03
 Status: Phase 2 and Phase 3 in progress
-Source Branch: `origin/dev` at `daf35dab` plus `codex/unified-shell-phase3-console-status-card`
+Source Branch: `origin/dev` at `19605f0f` plus `codex/unified-shell-phase3-console-source-status`
 
 ## Purpose
 
@@ -30,7 +30,7 @@ Track remaining Unified Shell work in one place so rendered screens, clickable b
 - Home active-work controls, detail routing, Console launch requests, item identity, local unread notification counts, notification review routing, local W+C watchlist run snapshots, and local W+C run detail routing now route through explicit adapter boundaries; schedule and agent-service adapters still need implementation.
 - Workflows has no wired workflow service in the shell wrapper.
 - W+C, Schedules, Workflows, and ACP now use honest unavailable Console states until actionable payloads exist.
-- Console now has a typed app-owned launch contract and reusable status-card display seam for staged live-work payloads; source-specific live event producers still need implementation.
+- Console now has a typed app-owned launch contract, reusable status-card display seam, and Home W+C active-work source producer for staged live-work payloads; additional source-specific live event producers still need implementation.
 - ACP launch is disabled until an ACP-compatible runtime is configured.
 - MCP management is not embedded in the top-level MCP wrapper.
 - Skills local/server services exist, but the top-level Skills shell still leaves import disabled and lacks list/detail/import UX adoption.
@@ -89,6 +89,7 @@ Initial child tasks:
 - Phase 2.7: Open Home local watchlist run details - `TASK-4.7`
 - Phase 3.1: Add Console live-work launch contract - `TASK-3.1`
 - Phase 3.2: Add Console live-work status card seam - `TASK-3.2`
+- Phase 3.3: Open Home W+C active work in Console - `TASK-3.3`
 
 ## QA Evidence Index
 
@@ -109,7 +110,7 @@ Initial child tasks:
 | Phase 0: Canonical Tracking | Make remaining work trackable. | verified | `TASK-1`, `TASK-1.1`, `TASK-1.2` | `phase-0/` | Product UI workflows are out of scope for Phase 0. |
 | Phase 1: Shell Contract Complete | Remove false shell affordances and prove shell usability. | verified | `TASK-2`, `TASK-2.1`, `TASK-2.2`, `TASK-2.3`, `TASK-2.4` | `phase-1/` | Live service workflows remain intentionally deferred to Phases 2-6. |
 | Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | in-progress | `TASK-4`, `TASK-4.1`, `TASK-4.2`, `TASK-4.3`, `TASK-4.4`, `TASK-4.5`, `TASK-4.6`, `TASK-4.7` | `phase-2/` | Schedule and agent-service adapters still need implementation; local watchlist retry/pause/resume remain recoverable rather than fully controllable. |
-| Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | in-progress | `TASK-3`, `TASK-3.1`, `TASK-3.2` | `phase-3/` | Source-specific live event producers and follow/status wiring still need implementation. |
+| Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | in-progress | `TASK-3`, `TASK-3.1`, `TASK-3.2`, `TASK-3.3` | `phase-3/` | Additional source-specific live event producers and follow/status wiring still need implementation. |
 | Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | not-started | `TASK-5` | `phase-4/` | Service coverage varies by destination. |
 | Phase 5: Capability And Recovery System | Systematize unavailable and blocked states. | not-started | `TASK-6` | `phase-5/` | Shared taxonomy not yet extracted. |
 | Phase 6: Audit Replay And Closeout | Prove shell works for first-time and power users. | not-started | `TASK-7` | `phase-6/` | Depends on prior phases and running-app QA. |
@@ -195,6 +196,12 @@ Initial audit result: W+C, Schedules, Workflows, and ACP had false Console-launc
 `TASK-3.2` extracts reusable Console live-work status card state and stable render selectors:
 
 - `Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-console-live-work-status-card-seam.md`
+
+## Phase 3.3 Home W+C Active-Work Console Launch Evidence
+
+`TASK-3.3` makes Home W+C active-work rows produce a real Console live-work launch context:
+
+- `Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-home-wc-active-work-console-launch.md`
 
 ## Phase 0: Canonical Tracking
 

--- a/Tests/Home/test_active_work_adapter.py
+++ b/Tests/Home/test_active_work_adapter.py
@@ -111,7 +111,7 @@ def test_local_notification_adapter_maps_local_watchlist_runs_to_active_work():
     assert dashboard_input.active_work_items[0].source == "W+C"
     assert dashboard_input.active_work_items[0].status == "failed"
     assert dashboard_input.active_work_items[0].detail_route == "subscriptions"
-    assert dashboard_input.active_work_items[0].console_available is False
+    assert dashboard_input.active_work_items[0].console_available is True
 
 
 def test_local_notification_adapter_opens_local_watchlist_run_details():
@@ -179,6 +179,58 @@ def test_local_notification_adapter_opens_local_watchlist_run_details_with_synth
     assert result.target_id == "local:watchlist_run:6"
     assert result.target_route == "subscriptions"
     assert result.message == "Opening W+C run details for Running release feed."
+
+
+def test_local_notification_adapter_opens_local_watchlist_run_in_console():
+    class FakeWatchlistsService:
+        def list_home_run_snapshot(self, *, limit=20):
+            return [
+                {
+                    "id": "local:watchlist_run:5",
+                    "run_id": 5,
+                    "job_id": 31,
+                    "source_id": 7,
+                    "status": "failed",
+                    "source_title": "Daily security feed",
+                    "backend": "local",
+                },
+            ]
+
+    adapter = LocalNotificationHomeActiveWorkAdapter(
+        watchlist_service=FakeWatchlistsService()
+    )
+
+    dashboard_input = adapter.build_dashboard_input(
+        providers_models={"OpenAI": ["gpt-4.1"]},
+        has_recent_work=False,
+    )
+    result = adapter.handle_control(
+        HomeControlAction.OPEN_IN_CONSOLE,
+        target_id="local:watchlist_run:5",
+        target_route="chat",
+    )
+    missing_result = adapter.handle_control(
+        HomeControlAction.OPEN_IN_CONSOLE,
+        target_id="local:watchlist_run:404",
+        target_route="chat",
+    )
+
+    assert dashboard_input.active_work_items[0].console_available is True
+    assert result.status is HomeControlResultStatus.HANDLED
+    assert result.console_launch is not None
+    assert result.console_launch.source == "W+C"
+    assert result.console_launch.title == "Daily security feed"
+    assert result.console_launch.status == "failed"
+    assert result.console_launch.recovery == "Review the W+C run details or retry from W+C."
+    assert result.console_launch.action_label == "Open W+C run"
+    assert result.console_launch.payload == {
+        "run_id": 5,
+        "job_id": 31,
+        "source_id": 7,
+        "target_id": "local:watchlist_run:5",
+    }
+    assert missing_result.status is HomeControlResultStatus.UNAVAILABLE
+    assert missing_result.console_launch is None
 
 
 def test_local_notification_adapter_fails_closed_when_watchlist_snapshot_unavailable():

--- a/Tests/UI/test_console_live_work_handoffs.py
+++ b/Tests/UI/test_console_live_work_handoffs.py
@@ -16,6 +16,9 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 PHASE3_STATUS_CARD_EVIDENCE = (
     REPO_ROOT / "Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-console-live-work-status-card-seam.md"
 )
+PHASE3_HOME_WC_CONSOLE_EVIDENCE = (
+    REPO_ROOT / "Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-home-wc-active-work-console-launch.md"
+)
 
 
 def _load_console_live_work_contract():
@@ -176,6 +179,24 @@ def test_phase3_status_card_tracking_evidence_links_task_and_roadmap():
     assert "Phase 3.2: Add Console live-work status card seam - `TASK-3.2`" in roadmap
     assert "`TASK-3`, `TASK-3.1`, `TASK-3.2`" in roadmap
     assert "ConsoleLiveWorkStatusCardState" in task
+
+
+def test_phase3_home_wc_console_launch_tracking_evidence_links_task_and_roadmap():
+    evidence = PHASE3_HOME_WC_CONSOLE_EVIDENCE.read_text()
+    readme = (REPO_ROOT / "Docs/superpowers/qa/unified-shell/phase-3/README.md").read_text()
+    roadmap = (REPO_ROOT / "Docs/superpowers/trackers/unified-shell-maturity-roadmap.md").read_text()
+    task = (
+        REPO_ROOT
+        / "backlog/tasks/task-3.3 - Phase-3.3-Open-Home-WC-active-work-in-Console.md"
+    ).read_text()
+
+    assert "TASK-3.3" in evidence
+    assert "Home W+C active-work" in evidence
+    assert "ConsoleLiveWorkLaunch" in evidence
+    assert "2026-05-03-home-wc-active-work-console-launch.md" in readme
+    assert "Phase 3.3: Open Home W+C active work in Console - `TASK-3.3`" in roadmap
+    assert "`TASK-3`, `TASK-3.1`, `TASK-3.2`, `TASK-3.3`" in roadmap
+    assert "ConsoleLiveWorkLaunch" in task
 
 
 @pytest.mark.parametrize(

--- a/Tests/UI/test_home_screen.py
+++ b/Tests/UI/test_home_screen.py
@@ -488,6 +488,46 @@ def test_app_console_hook_opens_console_with_adapter_launch_payload():
     )
 
 
+def test_app_console_hook_preserves_status_recovery_and_action_label():
+    app = _build_test_app()
+    launch = HomeConsoleLaunch(
+        source="W+C",
+        title="Daily security feed",
+        payload={"run_id": 5, "target_id": "local:watchlist_run:5"},
+        status="failed",
+        recovery="Review the W+C run details or retry from W+C.",
+        action_label="Open W+C run",
+    )
+    adapter = RecordingHomeActiveWorkAdapter(
+        responses={
+            HomeControlAction.OPEN_IN_CONSOLE: HomeControlResult(
+                action=HomeControlAction.OPEN_IN_CONSOLE,
+                status=HomeControlResultStatus.HANDLED,
+                message="Opening Console for Daily security feed.",
+                console_launch=launch,
+            ),
+        }
+    )
+    app.home_active_work_adapter = adapter
+    app.notify = Mock()
+    app.open_console_for_live_work = Mock()
+
+    result = app.open_active_home_item_in_console(
+        target_id="local:watchlist_run:5",
+        target_route="chat",
+    )
+
+    assert result.status is HomeControlResultStatus.HANDLED
+    app.open_console_for_live_work.assert_called_once_with(
+        source="W+C",
+        title="Daily security feed",
+        payload={"run_id": 5, "target_id": "local:watchlist_run:5"},
+        status="failed",
+        recovery="Review the W+C run details or retry from W+C.",
+        action_label="Open W+C run",
+    )
+
+
 @pytest.mark.asyncio
 async def test_pending_chat_handoff_does_not_create_live_work_controls():
     app = _build_test_app()

--- a/backlog/tasks/task-3.3 - Phase-3.3-Open-Home-WC-active-work-in-Console.md
+++ b/backlog/tasks/task-3.3 - Phase-3.3-Open-Home-WC-active-work-in-Console.md
@@ -1,0 +1,49 @@
+---
+id: TASK-3.3
+title: 'Phase 3.3: Open Home W+C active work in Console'
+status: Done
+assignee: []
+created_date: '2026-05-03 21:41'
+updated_date: '2026-05-03 21:48'
+labels:
+  - unified-shell
+  - phase-3
+  - console
+  - home
+  - watchlists
+dependencies: []
+parent_task_id: TASK-3
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make Home W+C active-work items produce a real Console live-work launch context so users can inspect local watchlist run status from the primary agentic Console surface instead of seeing an unavailable Console action.
+
+This slice uses the existing `ConsoleLiveWorkLaunch` status-card contract instead of introducing a parallel Console display path.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Home W+C active-work rows advertise Console availability only when the adapter can provide launch context.
+- [x] #2 Open in Console for a visible local watchlist run stages a Console launch with source, title, status, recovery, action, and run metadata.
+- [x] #3 Unknown or unavailable watchlist run targets remain recoverable unavailable states.
+- [x] #4 Focused automated tests and Phase 3 QA evidence verify the source-specific Console launch wiring and roadmap/task updates.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing regressions for Home local W+C active-work Console availability, adapter `OPEN_IN_CONSOLE` launch payloads, app Console staging metadata, and Phase 3 tracking evidence.
+2. Implement the smallest Home adapter changes needed to reuse visible local watchlist run identity and return a Console launch payload for known runs while preserving unavailable fallback for unknown targets.
+3. Pass status, recovery, and action label through app-level Console launch staging so the existing status card shows useful W+C run context.
+4. Add Phase 3 QA evidence and roadmap/task updates.
+5. Run focused Home, Console, roadmap, and diff hygiene checks before commit/PR.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented Home W+C active-work Console launches by marking visible local watchlist run rows as Console-capable, returning a `HomeConsoleLaunch` with W+C source, status, recovery, action label, and run metadata, and preserving that metadata through app-level Console staging. Unknown W+C targets still return recoverable unavailable states. Added focused regression coverage plus Phase 3.3 QA evidence and roadmap tracking.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Home/active_work_adapter.py
+++ b/tldw_chatbook/Home/active_work_adapter.py
@@ -46,6 +46,9 @@ class HomeConsoleLaunch:
     source: str
     title: str
     payload: Mapping[str, Any] | None = None
+    status: str | None = None
+    recovery: str | None = None
+    action_label: str | None = None
 
 
 @dataclass(frozen=True)
@@ -188,6 +191,24 @@ class LocalNotificationHomeActiveWorkAdapter(UnavailableHomeActiveWorkAdapter):
                     target_route=target_route or "subscriptions",
                     target_id=target_id,
                 )
+        if action is HomeControlAction.OPEN_IN_CONSOLE and _is_local_watchlist_run_id(target_id):
+            run = self._local_watchlist_run_by_id(str(target_id))
+            if run is not None:
+                title = self._watchlist_run_title(run)
+                return HomeControlResult(
+                    action=action,
+                    status=HomeControlResultStatus.HANDLED,
+                    message=f"Opening Console for {title}.",
+                    target_id=target_id,
+                    console_launch=HomeConsoleLaunch(
+                        source="W+C",
+                        title=title,
+                        payload=self._watchlist_console_payload(run, str(target_id)),
+                        status=str(_mapping_value(run, "status") or "pending"),
+                        recovery="Review the W+C run details or retry from W+C.",
+                        action_label="Open W+C run",
+                    ),
+                )
         return super().handle_control(
             action,
             target_id=target_id,
@@ -237,7 +258,7 @@ class LocalNotificationHomeActiveWorkAdapter(UnavailableHomeActiveWorkAdapter):
                     source="W+C",
                     status=status,
                     detail_route="subscriptions",
-                    console_available=False,
+                    console_available=True,
                 )
             )
         return items
@@ -262,6 +283,15 @@ class LocalNotificationHomeActiveWorkAdapter(UnavailableHomeActiveWorkAdapter):
             _mapping_value(run, "id")
             or (f"local:watchlist_run:{run_id}" if run_id is not None else "")
         )
+
+    @staticmethod
+    def _watchlist_console_payload(run: Any, target_id: str) -> Mapping[str, Any]:
+        payload: dict[str, Any] = {"target_id": target_id}
+        for key in ("run_id", "job_id", "source_id"):
+            value = _mapping_value(run, key)
+            if value is not None:
+                payload[key] = value
+        return payload
 
     @staticmethod
     def _watchlist_run_title(run: Any) -> str:

--- a/tldw_chatbook/Home/active_work_adapter.py
+++ b/tldw_chatbook/Home/active_work_adapter.py
@@ -204,7 +204,7 @@ class LocalNotificationHomeActiveWorkAdapter(UnavailableHomeActiveWorkAdapter):
                         source="W+C",
                         title=title,
                         payload=self._watchlist_console_payload(run, str(target_id)),
-                        status=str(_mapping_value(run, "status") or "pending"),
+                        status=str(_mapping_value(run, "status") or "pending").strip().lower(),
                         recovery="Review the W+C run details or retry from W+C.",
                         action_label="Open W+C run",
                     ),

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -1774,10 +1774,12 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
                 "title": result.console_launch.title,
                 "payload": dict(result.console_launch.payload or {}),
             }
-            for key in ("status", "recovery", "action_label"):
-                value = getattr(result.console_launch, key)
-                if value is not None:
-                    launch_kwargs[key] = value
+            if result.console_launch.status is not None:
+                launch_kwargs["status"] = result.console_launch.status
+            if result.console_launch.recovery is not None:
+                launch_kwargs["recovery"] = result.console_launch.recovery
+            if result.console_launch.action_label is not None:
+                launch_kwargs["action_label"] = result.console_launch.action_label
             self.open_console_for_live_work(**launch_kwargs)
         return result
 

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -1769,11 +1769,16 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
             target_route=target_route,
         )
         if result.status is HomeControlResultStatus.HANDLED and result.console_launch is not None:
-            self.open_console_for_live_work(
-                source=result.console_launch.source,
-                title=result.console_launch.title,
-                payload=dict(result.console_launch.payload or {}),
-            )
+            launch_kwargs = {
+                "source": result.console_launch.source,
+                "title": result.console_launch.title,
+                "payload": dict(result.console_launch.payload or {}),
+            }
+            for key in ("status", "recovery", "action_label"):
+                value = getattr(result.console_launch, key)
+                if value is not None:
+                    launch_kwargs[key] = value
+            self.open_console_for_live_work(**launch_kwargs)
         return result
 
     def _wire_character_persona_services(self) -> None:


### PR DESCRIPTION
## Summary
- Adds the first source-specific Console launch producer from Home W+C active-work rows.
- Sends visible local watchlist runs into the Console status-card seam with source, status, recovery, action label, and run metadata.
- Keeps unknown W+C targets on the existing recoverable unavailable path and updates Phase 3.3 roadmap, QA evidence, and Backlog task tracking.

## Test Plan
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Home/test_active_work_adapter.py Tests/UI/test_home_screen.py Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_screen_navigation.py Tests/UI/test_unified_shell_phase2_home_adapter.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_console_live_work_handoffs.py::test_phase3_home_wc_console_launch_tracking_evidence_links_task_and_roadmap -q
- git diff --check