### PR TITLE
Route Console W+C live-work actions

### DIFF
--- a/Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-console-wc-action-routing.md
+++ b/Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-console-wc-action-routing.md
@@ -1,0 +1,40 @@
+# Console W+C Action Routing
+
+Date: 2026-05-03
+Task: `TASK-3.4`
+Branch: `codex/unified-shell-phase3-console-action-routing`
+Base: `origin/dev` at `96f15eae`
+
+## Purpose
+
+Make the Console live-work action for W+C watchlist run launches complete a follow-through path into the existing W+C run detail surface instead of only rendering static action copy.
+
+## What Changed
+
+- `ConsoleLiveWorkStatusCardState` now exposes optional primary action metadata for supported launch payloads.
+- W+C watchlist run launches with a `target_id` render a `console-live-work-primary-action` button.
+- Clicking the Console live-work action stages `pending_subscription_initial_tab="watchlist-runs"` and `pending_subscription_watchlist_run_id` before navigating to W+C.
+- Unsupported launch payloads remain non-actionable status cards with recovery copy.
+
+## Functional QA Evidence
+
+Focused checks were run against the Console status-card state, rendered Console button path, app-level W+C routing, unsupported fallback, and Phase 3.4 tracking evidence.
+
+- Red test: `python -m pytest Tests/UI/test_console_live_work_handoffs.py::test_console_live_work_status_card_state_exposes_wc_primary_action Tests/UI/test_console_live_work_handoffs.py::test_console_live_work_status_card_state_keeps_unsupported_payloads_non_actionable Tests/UI/test_console_live_work_handoffs.py::test_app_console_live_work_primary_action_routes_wc_run_details Tests/UI/test_console_live_work_handoffs.py::test_console_wc_live_work_action_button_routes_run_details Tests/UI/test_console_live_work_handoffs.py::test_phase3_console_wc_action_tracking_evidence_links_task_and_roadmap -q`
+- Red result: `5 failed`; failures covered missing primary action metadata, missing app routing helper, missing rendered button, and missing Phase 3.4 evidence.
+- Green targeted result: `5 passed, 1 warning in 4.88s`.
+- Final focused Phase 3.4 suite: `117 passed, 8 warnings in 50.15s` for `Tests/UI/test_console_live_work_handoffs.py`, `Tests/UI/test_home_screen.py`, `Tests/Home/test_active_work_adapter.py`, `Tests/UI/test_subscription_window_watchlists.py`, `Tests/UI/test_screen_navigation.py`, and `Tests/UI/test_unified_shell_phase2_home_adapter.py`.
+
+Warning boundary: warnings are existing dependency/import warnings and are not Console W+C action routing failures.
+
+## UX Result
+
+- The Console status card now offers a real W+C follow-through action when the launch payload is actionable.
+- Users can recover from a failed W+C active-work run by opening its W+C run details from Console.
+- Unsupported sources still avoid false affordances until their service-specific routes exist.
+
+## Residual Risk
+
+- This slice does not add retry, pause, resume, or cancel controls from Console.
+- This slice does not add live event subscriptions for watchlist runs.
+- Workflow, schedule, ACP, MCP, RAG, artifact, and other source-specific Console actions remain intentionally unwired until their payload contracts exist.

--- a/Docs/superpowers/qa/unified-shell/phase-3/README.md
+++ b/Docs/superpowers/qa/unified-shell/phase-3/README.md
@@ -9,5 +9,6 @@ This directory contains durable QA summaries for Phase 3 Console live-work hub s
 - `2026-05-03-console-live-work-launch-contract.md` - `TASK-3.1` typed Console live-work launch contract and pending-launch card rendering.
 - `2026-05-03-console-live-work-status-card-seam.md` - `TASK-3.2` reusable Console live-work status card state and stable render selectors.
 - `2026-05-03-home-wc-active-work-console-launch.md` - `TASK-3.3` Home W+C active-work source launch into the Console status-card surface.
+- `2026-05-03-console-wc-action-routing.md` - `TASK-3.4` Console W+C live-work action routing into W+C run details.
 
 Do not mark Phase 3 verified until launch, follow, status, and recovery flows are verified in the running app against workflows, schedules, ACP, MCP, RAG, artifacts, and active-work source adapters.

--- a/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
@@ -2,7 +2,7 @@
 
 Date: 2026-05-03
 Status: Phase 2 and Phase 3 in progress
-Source Branch: `origin/dev` at `19605f0f` plus `codex/unified-shell-phase3-console-source-status`
+Source Branch: `origin/dev` at `96f15eae` plus `codex/unified-shell-phase3-console-action-routing`
 
 ## Purpose
 
@@ -30,7 +30,7 @@ Track remaining Unified Shell work in one place so rendered screens, clickable b
 - Home active-work controls, detail routing, Console launch requests, item identity, local unread notification counts, notification review routing, local W+C watchlist run snapshots, and local W+C run detail routing now route through explicit adapter boundaries; schedule and agent-service adapters still need implementation.
 - Workflows has no wired workflow service in the shell wrapper.
 - W+C, Schedules, Workflows, and ACP now use honest unavailable Console states until actionable payloads exist.
-- Console now has a typed app-owned launch contract, reusable status-card display seam, and Home W+C active-work source producer for staged live-work payloads; additional source-specific live event producers still need implementation.
+- Console now has a typed app-owned launch contract, reusable status-card display seam, Home W+C active-work source producer, and W+C run-detail action routing for staged live-work payloads; additional source-specific live event producers still need implementation.
 - ACP launch is disabled until an ACP-compatible runtime is configured.
 - MCP management is not embedded in the top-level MCP wrapper.
 - Skills local/server services exist, but the top-level Skills shell still leaves import disabled and lacks list/detail/import UX adoption.
@@ -90,6 +90,7 @@ Initial child tasks:
 - Phase 3.1: Add Console live-work launch contract - `TASK-3.1`
 - Phase 3.2: Add Console live-work status card seam - `TASK-3.2`
 - Phase 3.3: Open Home W+C active work in Console - `TASK-3.3`
+- Phase 3.4: Route Console W+C live-work actions - `TASK-3.4`
 
 ## QA Evidence Index
 
@@ -110,7 +111,7 @@ Initial child tasks:
 | Phase 0: Canonical Tracking | Make remaining work trackable. | verified | `TASK-1`, `TASK-1.1`, `TASK-1.2` | `phase-0/` | Product UI workflows are out of scope for Phase 0. |
 | Phase 1: Shell Contract Complete | Remove false shell affordances and prove shell usability. | verified | `TASK-2`, `TASK-2.1`, `TASK-2.2`, `TASK-2.3`, `TASK-2.4` | `phase-1/` | Live service workflows remain intentionally deferred to Phases 2-6. |
 | Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | in-progress | `TASK-4`, `TASK-4.1`, `TASK-4.2`, `TASK-4.3`, `TASK-4.4`, `TASK-4.5`, `TASK-4.6`, `TASK-4.7` | `phase-2/` | Schedule and agent-service adapters still need implementation; local watchlist retry/pause/resume remain recoverable rather than fully controllable. |
-| Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | in-progress | `TASK-3`, `TASK-3.1`, `TASK-3.2`, `TASK-3.3` | `phase-3/` | Additional source-specific live event producers and follow/status wiring still need implementation. |
+| Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | in-progress | `TASK-3`, `TASK-3.1`, `TASK-3.2`, `TASK-3.3`, `TASK-3.4` | `phase-3/` | Additional source-specific live event producers and follow/status wiring still need implementation. |
 | Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | not-started | `TASK-5` | `phase-4/` | Service coverage varies by destination. |
 | Phase 5: Capability And Recovery System | Systematize unavailable and blocked states. | not-started | `TASK-6` | `phase-5/` | Shared taxonomy not yet extracted. |
 | Phase 6: Audit Replay And Closeout | Prove shell works for first-time and power users. | not-started | `TASK-7` | `phase-6/` | Depends on prior phases and running-app QA. |
@@ -202,6 +203,12 @@ Initial audit result: W+C, Schedules, Workflows, and ACP had false Console-launc
 `TASK-3.3` makes Home W+C active-work rows produce a real Console live-work launch context:
 
 - `Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-home-wc-active-work-console-launch.md`
+
+## Phase 3.4 Console W+C Action Routing Evidence
+
+`TASK-3.4` makes supported Console W+C live-work actions route to existing W+C run details:
+
+- `Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-console-wc-action-routing.md`
 
 ## Phase 0: Canonical Tracking
 

--- a/Tests/UI/test_console_live_work_handoffs.py
+++ b/Tests/UI/test_console_live_work_handoffs.py
@@ -19,6 +19,9 @@ PHASE3_STATUS_CARD_EVIDENCE = (
 PHASE3_HOME_WC_CONSOLE_EVIDENCE = (
     REPO_ROOT / "Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-home-wc-active-work-console-launch.md"
 )
+PHASE3_CONSOLE_WC_ACTION_EVIDENCE = (
+    REPO_ROOT / "Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-console-wc-action-routing.md"
+)
 
 
 def _load_console_live_work_contract():
@@ -164,6 +167,68 @@ def test_console_live_work_status_card_state_derives_stable_rows_from_launch():
     assert "console-live-work-payload-row" in payload_row.classes
 
 
+def test_console_live_work_status_card_state_exposes_wc_primary_action():
+    ConsoleLiveWorkLaunch = _load_console_live_work_contract()
+    ConsoleLiveWorkStatusCardState = _load_console_live_work_status_card_state()
+    launch = ConsoleLiveWorkLaunch.from_values(
+        source="W+C",
+        title="Daily security feed",
+        payload={"target_id": "local:watchlist_run:91", "run_id": 91},
+        status="failed",
+        recovery="Review the W+C run details or retry from W+C.",
+        action_label="Open W+C run",
+    )
+
+    card_state = ConsoleLiveWorkStatusCardState.from_launch(launch)
+
+    assert card_state.primary_action is not None
+    assert card_state.primary_action.widget_id == "console-live-work-primary-action"
+    assert card_state.primary_action.label == "Open W+C run"
+    assert card_state.primary_action.target_route == "subscriptions"
+    assert card_state.primary_action.target_id == "local:watchlist_run:91"
+
+
+def test_console_live_work_status_card_state_keeps_unsupported_payloads_non_actionable():
+    ConsoleLiveWorkLaunch = _load_console_live_work_contract()
+    ConsoleLiveWorkStatusCardState = _load_console_live_work_status_card_state()
+    launch = ConsoleLiveWorkLaunch.from_values(
+        source="workflows",
+        title="Daily digest",
+        payload={"run_id": "run-1"},
+        status="running",
+        recovery="Workflow detail routing is not wired yet.",
+        action_label="Open workflow run",
+    )
+
+    card_state = ConsoleLiveWorkStatusCardState.from_launch(launch)
+
+    assert card_state.primary_action is None
+
+
+def test_app_console_live_work_primary_action_routes_wc_run_details():
+    ConsoleLiveWorkLaunch = _load_console_live_work_contract()
+    app = _build_test_app()
+    app.post_message = Mock()
+    app.notify = Mock()
+    launch = ConsoleLiveWorkLaunch.from_values(
+        source="W+C",
+        title="Daily security feed",
+        payload={"target_id": "local:watchlist_run:91", "run_id": 91},
+        status="failed",
+        recovery="Review the W+C run details or retry from W+C.",
+        action_label="Open W+C run",
+    )
+
+    handled = app.open_console_live_work_primary_action(launch)
+
+    assert handled is True
+    assert app.pending_subscription_initial_tab == "watchlist-runs"
+    assert app.pending_subscription_watchlist_run_id == "local:watchlist_run:91"
+    app.post_message.assert_called_once()
+    assert app.post_message.call_args.args[0].screen_name == "subscriptions"
+    app.notify.assert_not_called()
+
+
 def test_phase3_status_card_tracking_evidence_links_task_and_roadmap():
     evidence = PHASE3_STATUS_CARD_EVIDENCE.read_text()
     readme = (REPO_ROOT / "Docs/superpowers/qa/unified-shell/phase-3/README.md").read_text()
@@ -197,6 +262,24 @@ def test_phase3_home_wc_console_launch_tracking_evidence_links_task_and_roadmap(
     assert "Phase 3.3: Open Home W+C active work in Console - `TASK-3.3`" in roadmap
     assert "`TASK-3`, `TASK-3.1`, `TASK-3.2`, `TASK-3.3`" in roadmap
     assert "ConsoleLiveWorkLaunch" in task
+
+
+def test_phase3_console_wc_action_tracking_evidence_links_task_and_roadmap():
+    evidence = PHASE3_CONSOLE_WC_ACTION_EVIDENCE.read_text()
+    readme = (REPO_ROOT / "Docs/superpowers/qa/unified-shell/phase-3/README.md").read_text()
+    roadmap = (REPO_ROOT / "Docs/superpowers/trackers/unified-shell-maturity-roadmap.md").read_text()
+    task = (
+        REPO_ROOT
+        / "backlog/tasks/task-3.4 - Phase-3.4-Route-Console-WC-live-work-actions.md"
+    ).read_text()
+
+    assert "TASK-3.4" in evidence
+    assert "Console live-work action" in evidence
+    assert "console-live-work-primary-action" in evidence
+    assert "2026-05-03-console-wc-action-routing.md" in readme
+    assert "Phase 3.4: Route Console W+C live-work actions - `TASK-3.4`" in roadmap
+    assert "`TASK-3`, `TASK-3.1`, `TASK-3.2`, `TASK-3.3`, `TASK-3.4`" in roadmap
+    assert "console-live-work-primary-action" in task
 
 
 @pytest.mark.parametrize(
@@ -311,3 +394,34 @@ async def test_console_renders_pending_launch_context():
         assert "run_id: run-1" in text
         assert isinstance(screen._pending_console_launch_context, ConsoleLiveWorkLaunch)
         assert app.pending_console_launch is None
+
+
+@pytest.mark.asyncio
+async def test_console_wc_live_work_action_button_routes_run_details():
+    app = _build_test_app()
+    app.pending_console_launch = {
+        "source": "W+C",
+        "title": "Daily security feed",
+        "payload": {"target_id": "local:watchlist_run:91", "run_id": 91},
+        "status": "failed",
+        "recovery": "Review the W+C run details or retry from W+C.",
+        "action_label": "Open W+C run",
+    }
+    app.post_message = Mock()
+    app.notify = Mock()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(180, 40)) as pilot:
+        await pilot.pause(0.1)
+        screen = _active_console_screen(host)
+        button = screen.query_one("#console-live-work-primary-action")
+        assert str(button.label) == "Open W+C run"
+
+        await pilot.click("#console-live-work-primary-action")
+        await pilot.pause(0.1)
+
+    assert app.pending_subscription_initial_tab == "watchlist-runs"
+    assert app.pending_subscription_watchlist_run_id == "local:watchlist_run:91"
+    app.post_message.assert_called_once()
+    assert app.post_message.call_args.args[0].screen_name == "subscriptions"
+    app.notify.assert_not_called()

--- a/backlog/tasks/task-3.4 - Phase-3.4-Route-Console-WC-live-work-actions.md
+++ b/backlog/tasks/task-3.4 - Phase-3.4-Route-Console-WC-live-work-actions.md
@@ -1,0 +1,46 @@
+---
+id: TASK-3.4
+title: 'Phase 3.4: Route Console W+C live-work actions'
+status: Done
+assignee: []
+created_date: '2026-05-03 22:23'
+updated_date: '2026-05-03 22:27'
+labels:
+  - unified-shell
+  - phase-3
+  - console
+  - watchlists
+dependencies: []
+parent_task_id: TASK-3
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make the Console live-work status card action for W+C watchlist run launches route to the existing W+C run detail surface, so the Console card supports recovery follow-through instead of only displaying static action copy.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Console live-work status-card state exposes an actionable primary button only when the launch payload has a supported route context.
+- [x] #2 Clicking the W+C Console action stages the selected watchlist run context and navigates to the W+C runs surface.
+- [x] #3 Unsupported launch payloads remain non-actionable status cards with recovery copy.
+- [x] #4 Focused automated tests and Phase 3 QA evidence verify the `console-live-work-primary-action` route wiring and roadmap/task updates.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing regressions for actionable Console live-work card state, W+C button click navigation, unsupported payload fallback, and Phase 3.4 evidence tracking.
+2. Extend the Console live-work card contract with optional primary action metadata derived only from supported payload contexts.
+3. Render a Console action button when action metadata exists and route W+C watchlist run launches through the existing subscription watchlist run context.
+4. Add Phase 3.4 QA evidence plus roadmap and task updates.
+5. Run focused Console, navigation, W+C detail, and diff hygiene verification before commit/PR.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added a typed Console live-work primary action contract that only resolves W+C watchlist run payloads with a supported `target_id`. The Console status card now renders `console-live-work-primary-action` for those launches, and the app routes the action through the existing subscription watchlist-run context before navigating to W+C. Unsupported payloads remain non-actionable with recovery copy. Added focused regression tests plus Phase 3.4 roadmap, evidence, and Backlog tracking.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_live_work.py
+++ b/tldw_chatbook/Chat/console_live_work.py
@@ -11,6 +11,7 @@ DEFAULT_RECOVERY = "Console has staged this live-work request."
 DEFAULT_ACTION_LABEL = "Open in Console"
 PENDING_LAUNCH_CARD_ID = "console-pending-launch-card"
 LIVE_WORK_CARD_CLASS = "console-live-work-status-card"
+PRIMARY_ACTION_BUTTON_ID = "console-live-work-primary-action"
 
 
 def _clean_text(value: Any, fallback: str) -> str:
@@ -110,11 +111,38 @@ class ConsoleLiveWorkStatusCardRow:
 
 
 @dataclass(frozen=True)
+class ConsoleLiveWorkPrimaryAction:
+    """Action metadata for a supported Console live-work follow-through."""
+
+    label: str
+    target_route: str
+    target_id: str
+    widget_id: str = PRIMARY_ACTION_BUTTON_ID
+    classes: str = "destination-action-button console-live-work-primary-action"
+
+
+def resolve_console_live_work_primary_action(
+    launch: ConsoleLiveWorkLaunch,
+) -> ConsoleLiveWorkPrimaryAction | None:
+    """Resolve launch payloads that can safely route to an existing detail surface."""
+    source = launch.source.strip().lower()
+    target_id = str(launch.payload.get("target_id") or "").strip()
+    if source in {"w+c", "watchlists", "watchlists+collections"} and ":watchlist_run:" in target_id:
+        return ConsoleLiveWorkPrimaryAction(
+            label=launch.action_label,
+            target_route="subscriptions",
+            target_id=target_id,
+        )
+    return None
+
+
+@dataclass(frozen=True)
 class ConsoleLiveWorkStatusCardState:
     """Reusable display contract for one Console live-work status card."""
 
     badge_text: str
     rows: tuple[ConsoleLiveWorkStatusCardRow, ...]
+    primary_action: ConsoleLiveWorkPrimaryAction | None = None
     container_id: str = PENDING_LAUNCH_CARD_ID
     container_classes: str = f"ds-panel {LIVE_WORK_CARD_CLASS}"
     badge_id: str = "console-live-work-status-badge"
@@ -164,4 +192,5 @@ class ConsoleLiveWorkStatusCardState:
         return cls(
             badge_text="Pending Console launch",
             rows=tuple(rows),
+            primary_action=resolve_console_live_work_primary_action(launch),
         )

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -168,6 +168,28 @@ class ChatScreen(BaseAppScreen):
             )
             for row in card_state.rows:
                 yield Static(row.text, id=row.widget_id, classes=row.classes)
+            if card_state.primary_action is not None:
+                yield Button(
+                    card_state.primary_action.label,
+                    id=card_state.primary_action.widget_id,
+                    classes=card_state.primary_action.classes,
+                    variant="primary",
+                )
+
+    @on(Button.Pressed, "#console-live-work-primary-action")
+    def handle_console_live_work_primary_action(self, event: Button.Pressed) -> None:
+        """Route supported live-work card actions through the app-owned shell."""
+        event.stop()
+        launch = self._consume_pending_console_launch()
+        handler = getattr(self.app_instance, "open_console_live_work_primary_action", None)
+        if launch is not None and callable(handler):
+            handled = bool(handler(launch))
+            if handled:
+                return
+        self.app_instance.notify(
+            "Console action is unavailable for this live-work item.",
+            severity="warning",
+        )
         
     def compose_content(self) -> ComposeResult:
         """Compose the chat content."""

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -82,7 +82,10 @@ from tldw_chatbook.Constants import ALL_TABS, TAB_CCP, TAB_CHAT, TAB_HOME, TAB_L
 from tldw_chatbook.Chat.chat_conversation_scope_service import ChatConversationScopeService
 from tldw_chatbook.Chat.chat_conversation_service import ChatConversationService
 from tldw_chatbook.Chat.chat_handoff_models import ChatHandoffPayload
-from tldw_chatbook.Chat.console_live_work import ConsoleLiveWorkLaunch
+from tldw_chatbook.Chat.console_live_work import (
+    ConsoleLiveWorkLaunch,
+    resolve_console_live_work_primary_action,
+)
 from tldw_chatbook.Chat.chat_loop_scope_service import ServerChatLoopScopeService
 from tldw_chatbook.Chat.server_chat_conversation_service import ServerChatConversationService
 from tldw_chatbook.Chat.server_chat_loop_service import ServerChatLoopService
@@ -1683,6 +1686,26 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
             action_label=action_label,
         )
         self.post_message(NavigateToScreen(TAB_CHAT))
+
+    def open_console_live_work_primary_action(self, launch: Any) -> bool:
+        """Follow through on a supported Console live-work status-card action."""
+        normalized_launch = ConsoleLiveWorkLaunch.from_pending(launch)
+        if normalized_launch is None:
+            self.notify("Console action is unavailable for this live-work item.", severity="warning")
+            return False
+
+        action = resolve_console_live_work_primary_action(normalized_launch)
+        if action is None:
+            self.notify("Console action is unavailable for this live-work item.", severity="warning")
+            return False
+
+        if action.target_route == TAB_SUBSCRIPTIONS:
+            self._stage_subscription_watchlist_run_context(action.target_id)
+            self.post_message(NavigateToScreen(TAB_SUBSCRIPTIONS))
+            return True
+
+        self.notify("Console action route is not available yet.", severity="warning")
+        return False
 
     def _handle_home_control_action(
         self,


### PR DESCRIPTION
## Summary
- Adds optional primary action metadata for supported Console live-work status cards.
- Renders a Console W+C action button for actionable watchlist run payloads and routes it into the existing W+C run detail context.
- Keeps unsupported launch payloads non-actionable and updates Phase 3.4 roadmap, QA evidence, and Backlog tracking.

## Test Plan
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_console_live_work_handoffs.py::test_console_live_work_status_card_state_exposes_wc_primary_action Tests/UI/test_console_live_work_handoffs.py::test_console_live_work_status_card_state_keeps_unsupported_payloads_non_actionable Tests/UI/test_console_live_work_handoffs.py::test_app_console_live_work_primary_action_routes_wc_run_details Tests/UI/test_console_live_work_handoffs.py::test_console_wc_live_work_action_button_routes_run_details Tests/UI/test_console_live_work_handoffs.py::test_phase3_console_wc_action_tracking_evidence_links_task_and_roadmap -q
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_home_screen.py Tests/Home/test_active_work_adapter.py Tests/UI/test_subscription_window_watchlists.py Tests/UI/test_screen_navigation.py Tests/UI/test_unified_shell_phase2_home_adapter.py -q
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_console_live_work_handoffs.py::test_phase3_console_wc_action_tracking_evidence_links_task_and_roadmap -q
- git diff --check