### PR TITLE
Launch latest W+C run from W+C into Console

### DIFF
--- a/Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-wc-destination-console-launch.md
+++ b/Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-wc-destination-console-launch.md
@@ -15,6 +15,7 @@ Make the W+C destination produce a real Console follow action when an actionable
 - `watchlists-follow-in-console` stays disabled with recovery copy when no active W+C run is available.
 - When a Console-capable W+C run exists, `watchlists-follow-in-console` becomes enabled and identifies the latest run by title and status.
 - Clicking the enabled W+C Console follow action routes through `open_active_home_item_in_console`, preserving the existing Home adapter and Console launch contracts.
+- PR review hardening now logs active-work adapter failures, keeps the click target pinned to the item shown in the button label, and renders run title/status through markup-safe Rich text.
 
 ## Functional QA Evidence
 
@@ -23,7 +24,10 @@ Focused checks were run against W+C destination fallback state, W+C destination 
 - Red test: `python -m pytest Tests/UI/test_console_live_work_handoffs.py::test_watchlists_destination_keeps_console_follow_disabled_without_active_run Tests/UI/test_console_live_work_handoffs.py::test_watchlists_destination_routes_latest_active_run_to_console Tests/UI/test_console_live_work_handoffs.py::test_phase3_wc_destination_console_tracking_evidence_links_task_and_roadmap -q`
 - Red result: `3 failed`; failures covered stale disabled copy, always-disabled Console follow, and missing Phase 3.5 evidence.
 - Green targeted result: `3 passed, 1 warning in 4.70s`.
-- Final focused Phase 3.5 suite: `154 passed, 8 warnings in 70.35s` for `Tests/UI/test_console_live_work_handoffs.py`, `Tests/UI/test_destination_shells.py`, `Tests/UI/test_home_screen.py`, `Tests/Home/test_active_work_adapter.py`, `Tests/UI/test_subscription_window_watchlists.py`, `Tests/UI/test_screen_navigation.py`, and `Tests/UI/test_unified_shell_phase2_home_adapter.py`.
+- PR review red test: `python -m pytest Tests/UI/test_console_live_work_handoffs.py::test_watchlists_destination_logs_adapter_failure_and_disables_follow Tests/UI/test_console_live_work_handoffs.py::test_watchlists_destination_click_uses_item_promised_by_button_label Tests/UI/test_console_live_work_handoffs.py::test_watchlists_destination_escapes_console_follow_markup_labels -q`
+- PR review red result: `3 failed`; failures covered silent adapter errors, label/target drift, and markup-interpreted run titles.
+- PR review green targeted result: `3 passed, 1 warning in 5.39s`.
+- Final focused Phase 3.5 suite: `157 passed, 8 warnings in 78.88s` for `Tests/UI/test_console_live_work_handoffs.py`, `Tests/UI/test_destination_shells.py`, `Tests/UI/test_home_screen.py`, `Tests/Home/test_active_work_adapter.py`, `Tests/UI/test_subscription_window_watchlists.py`, `Tests/UI/test_screen_navigation.py`, and `Tests/UI/test_unified_shell_phase2_home_adapter.py`.
 
 Warning boundary: warnings are existing dependency/import warnings and are not W+C destination Console follow failures.
 

--- a/Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-wc-destination-console-launch.md
+++ b/Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-wc-destination-console-launch.md
@@ -1,0 +1,40 @@
+# W+C Destination Console Launch
+
+Date: 2026-05-03
+Task: `TASK-3.5`
+Branch: `codex/unified-shell-phase3-wc-console-launch`
+Base: `origin/dev` at `fa37fdb0`
+
+## Purpose
+
+Make the W+C destination produce a real Console follow action when an actionable W+C active-work run is available, while preserving an honest disabled state when no run context exists.
+
+## What Changed
+
+- `WatchlistsCollectionsScreen` now queries the existing Home active-work adapter for a latest Console-capable W+C run.
+- `watchlists-follow-in-console` stays disabled with recovery copy when no active W+C run is available.
+- When a Console-capable W+C run exists, `watchlists-follow-in-console` becomes enabled and identifies the latest run by title and status.
+- Clicking the enabled W+C Console follow action routes through `open_active_home_item_in_console`, preserving the existing Home adapter and Console launch contracts.
+
+## Functional QA Evidence
+
+Focused checks were run against W+C destination fallback state, W+C destination enabled state, click routing, and Phase 3.5 tracking evidence.
+
+- Red test: `python -m pytest Tests/UI/test_console_live_work_handoffs.py::test_watchlists_destination_keeps_console_follow_disabled_without_active_run Tests/UI/test_console_live_work_handoffs.py::test_watchlists_destination_routes_latest_active_run_to_console Tests/UI/test_console_live_work_handoffs.py::test_phase3_wc_destination_console_tracking_evidence_links_task_and_roadmap -q`
+- Red result: `3 failed`; failures covered stale disabled copy, always-disabled Console follow, and missing Phase 3.5 evidence.
+- Green targeted result: `3 passed, 1 warning in 4.70s`.
+- Final focused Phase 3.5 suite: `154 passed, 8 warnings in 70.35s` for `Tests/UI/test_console_live_work_handoffs.py`, `Tests/UI/test_destination_shells.py`, `Tests/UI/test_home_screen.py`, `Tests/Home/test_active_work_adapter.py`, `Tests/UI/test_subscription_window_watchlists.py`, `Tests/UI/test_screen_navigation.py`, and `Tests/UI/test_unified_shell_phase2_home_adapter.py`.
+
+Warning boundary: warnings are existing dependency/import warnings and are not W+C destination Console follow failures.
+
+## UX Result
+
+- W+C no longer presents Console follow as permanently unavailable when the app already has actionable W+C active-work context.
+- The destination reuses the same active-work source of truth as Home, so users see a consistent latest W+C run across dashboard and destination surfaces.
+- No active run still produces a clear, non-clickable recovery state rather than a false affordance.
+
+## Residual Risk
+
+- This slice follows the latest available W+C active-work item only; it does not add selection or filtering inside the W+C shell wrapper.
+- Retry, pause, resume, and cancel controls for local watchlist runs remain deferred.
+- Workflow, schedule, ACP, MCP, RAG, artifact, and other source-specific Console producers remain intentionally unwired until their service contracts exist.

--- a/Docs/superpowers/qa/unified-shell/phase-3/README.md
+++ b/Docs/superpowers/qa/unified-shell/phase-3/README.md
@@ -10,5 +10,6 @@ This directory contains durable QA summaries for Phase 3 Console live-work hub s
 - `2026-05-03-console-live-work-status-card-seam.md` - `TASK-3.2` reusable Console live-work status card state and stable render selectors.
 - `2026-05-03-home-wc-active-work-console-launch.md` - `TASK-3.3` Home W+C active-work source launch into the Console status-card surface.
 - `2026-05-03-console-wc-action-routing.md` - `TASK-3.4` Console W+C live-work action routing into W+C run details.
+- `2026-05-03-wc-destination-console-launch.md` - `TASK-3.5` W+C destination Console follow producer for the latest active W+C run.
 
 Do not mark Phase 3 verified until launch, follow, status, and recovery flows are verified in the running app against workflows, schedules, ACP, MCP, RAG, artifacts, and active-work source adapters.

--- a/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
@@ -2,7 +2,7 @@
 
 Date: 2026-05-03
 Status: Phase 2 and Phase 3 in progress
-Source Branch: `origin/dev` at `96f15eae` plus `codex/unified-shell-phase3-console-action-routing`
+Source Branch: `origin/dev` at `fa37fdb0` plus `codex/unified-shell-phase3-wc-console-launch`
 
 ## Purpose
 
@@ -29,8 +29,8 @@ Track remaining Unified Shell work in one place so rendered screens, clickable b
 
 - Home active-work controls, detail routing, Console launch requests, item identity, local unread notification counts, notification review routing, local W+C watchlist run snapshots, and local W+C run detail routing now route through explicit adapter boundaries; schedule and agent-service adapters still need implementation.
 - Workflows has no wired workflow service in the shell wrapper.
-- W+C, Schedules, Workflows, and ACP now use honest unavailable Console states until actionable payloads exist.
-- Console now has a typed app-owned launch contract, reusable status-card display seam, Home W+C active-work source producer, and W+C run-detail action routing for staged live-work payloads; additional source-specific live event producers still need implementation.
+- W+C now exposes Console follow when the existing active-work adapter has an actionable run; Schedules, Workflows, and ACP still use honest unavailable Console states until actionable payloads exist.
+- Console now has a typed app-owned launch contract, reusable status-card display seam, Home W+C active-work source producer, W+C destination follow producer, and W+C run-detail action routing for staged live-work payloads; additional source-specific live event producers still need implementation.
 - ACP launch is disabled until an ACP-compatible runtime is configured.
 - MCP management is not embedded in the top-level MCP wrapper.
 - Skills local/server services exist, but the top-level Skills shell still leaves import disabled and lacks list/detail/import UX adoption.
@@ -91,6 +91,7 @@ Initial child tasks:
 - Phase 3.2: Add Console live-work status card seam - `TASK-3.2`
 - Phase 3.3: Open Home W+C active work in Console - `TASK-3.3`
 - Phase 3.4: Route Console W+C live-work actions - `TASK-3.4`
+- Phase 3.5: Launch latest W+C run from W+C into Console - `TASK-3.5`
 
 ## QA Evidence Index
 
@@ -111,7 +112,7 @@ Initial child tasks:
 | Phase 0: Canonical Tracking | Make remaining work trackable. | verified | `TASK-1`, `TASK-1.1`, `TASK-1.2` | `phase-0/` | Product UI workflows are out of scope for Phase 0. |
 | Phase 1: Shell Contract Complete | Remove false shell affordances and prove shell usability. | verified | `TASK-2`, `TASK-2.1`, `TASK-2.2`, `TASK-2.3`, `TASK-2.4` | `phase-1/` | Live service workflows remain intentionally deferred to Phases 2-6. |
 | Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | in-progress | `TASK-4`, `TASK-4.1`, `TASK-4.2`, `TASK-4.3`, `TASK-4.4`, `TASK-4.5`, `TASK-4.6`, `TASK-4.7` | `phase-2/` | Schedule and agent-service adapters still need implementation; local watchlist retry/pause/resume remain recoverable rather than fully controllable. |
-| Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | in-progress | `TASK-3`, `TASK-3.1`, `TASK-3.2`, `TASK-3.3`, `TASK-3.4` | `phase-3/` | Additional source-specific live event producers and follow/status wiring still need implementation. |
+| Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | in-progress | `TASK-3`, `TASK-3.1`, `TASK-3.2`, `TASK-3.3`, `TASK-3.4`, `TASK-3.5` | `phase-3/` | Additional source-specific live event producers and follow/status wiring still need implementation. |
 | Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | not-started | `TASK-5` | `phase-4/` | Service coverage varies by destination. |
 | Phase 5: Capability And Recovery System | Systematize unavailable and blocked states. | not-started | `TASK-6` | `phase-5/` | Shared taxonomy not yet extracted. |
 | Phase 6: Audit Replay And Closeout | Prove shell works for first-time and power users. | not-started | `TASK-7` | `phase-6/` | Depends on prior phases and running-app QA. |
@@ -209,6 +210,12 @@ Initial audit result: W+C, Schedules, Workflows, and ACP had false Console-launc
 `TASK-3.4` makes supported Console W+C live-work actions route to existing W+C run details:
 
 - `Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-console-wc-action-routing.md`
+
+## Phase 3.5 W+C Destination Console Launch Evidence
+
+`TASK-3.5` makes W+C itself expose Console follow for the latest active W+C run when adapter context exists:
+
+- `Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-wc-destination-console-launch.md`
 
 ## Phase 0: Canonical Tracking
 

--- a/Tests/UI/test_console_live_work_handoffs.py
+++ b/Tests/UI/test_console_live_work_handoffs.py
@@ -79,6 +79,22 @@ class StaticHomeActiveWorkAdapter:
         raise AssertionError(f"Unexpected direct control call: {action} {target_id} {target_route}")
 
 
+class RaisingHomeActiveWorkAdapter:
+    def build_dashboard_input(self, *, providers_models, has_recent_work):
+        raise RuntimeError("adapter unavailable")
+
+
+class RotatingHomeActiveWorkAdapter:
+    def __init__(self, *snapshots):
+        self.snapshots = tuple(tuple(snapshot) for snapshot in snapshots)
+        self.build_calls = 0
+
+    def build_dashboard_input(self, *, providers_models, has_recent_work):
+        snapshot_index = min(self.build_calls, len(self.snapshots) - 1)
+        self.build_calls += 1
+        return HomeDashboardInput(active_work_items=self.snapshots[snapshot_index])
+
+
 def test_app_exposes_open_console_for_live_work_helper():
     app = _build_test_app()
 
@@ -426,6 +442,105 @@ async def test_watchlists_destination_routes_latest_active_run_to_console():
         target_id="local:watchlist_run:5",
         target_route="chat",
     )
+
+
+@pytest.mark.asyncio
+async def test_watchlists_destination_logs_adapter_failure_and_disables_follow(monkeypatch):
+    from tldw_chatbook.UI.Screens import watchlists_collections_screen
+
+    app = _build_test_app()
+    app.home_active_work_adapter = RaisingHomeActiveWorkAdapter()
+    app.open_active_home_item_in_console = Mock()
+    logger = Mock()
+    monkeypatch.setattr(watchlists_collections_screen, "logger", logger, raising=False)
+    host = DestinationHarness(app, "watchlists_collections")
+
+    async with host.run_test(size=(180, 40)) as pilot:
+        await pilot.pause(0.1)
+        screen = _active_console_screen(host)
+        button = screen.query_one("#watchlists-follow-in-console")
+
+        assert button.disabled is True
+        assert "No active W+C run is available for Console follow." in _screen_static_text(screen)
+
+    logger.warning.assert_called_once()
+    assert "W+C Console follow" in logger.warning.call_args.args[0]
+    assert logger.warning.call_args.kwargs["exc_info"] is True
+    app.open_active_home_item_in_console.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_watchlists_destination_click_uses_item_promised_by_button_label():
+    app = _build_test_app()
+    app.home_active_work_adapter = RotatingHomeActiveWorkAdapter(
+        (
+            HomeActiveWorkItem(
+                item_id="local:watchlist_run:5",
+                title="First visible run",
+                source="W+C",
+                status="failed",
+                detail_route="subscriptions",
+                console_available=True,
+            ),
+        ),
+        (
+            HomeActiveWorkItem(
+                item_id="local:watchlist_run:7",
+                title="Newer unseen run",
+                source="W+C",
+                status="running",
+                detail_route="subscriptions",
+                console_available=True,
+            ),
+        ),
+    )
+    app.open_active_home_item_in_console = Mock()
+    host = DestinationHarness(app, "watchlists_collections")
+
+    async with host.run_test(size=(180, 40)) as pilot:
+        await pilot.pause(0.1)
+        screen = _active_console_screen(host)
+        button = screen.query_one("#watchlists-follow-in-console")
+
+        assert "First visible run" in str(button.label)
+        assert "Newer unseen run" not in str(button.label)
+
+        await pilot.click("#watchlists-follow-in-console")
+        await pilot.pause(0.1)
+
+    app.open_active_home_item_in_console.assert_called_once_with(
+        target_id="local:watchlist_run:5",
+        target_route="chat",
+    )
+
+
+@pytest.mark.asyncio
+async def test_watchlists_destination_escapes_console_follow_markup_labels():
+    app = _build_test_app()
+    app.home_active_work_adapter = StaticHomeActiveWorkAdapter(
+        (
+            HomeActiveWorkItem(
+                item_id="local:watchlist_run:5",
+                title="[red]Daily[/red] feed",
+                source="W+C",
+                status="[bold]failed[/bold]",
+                detail_route="subscriptions",
+                console_available=True,
+            ),
+        )
+    )
+    host = DestinationHarness(app, "watchlists_collections")
+
+    async with host.run_test(size=(180, 40)) as pilot:
+        await pilot.pause(0.1)
+        screen = _active_console_screen(host)
+        button = screen.query_one("#watchlists-follow-in-console")
+        static_text = _screen_static_text(screen)
+
+        assert "[red]Daily[/red] feed" in str(button.label)
+        assert getattr(button.label, "spans", []) == []
+        assert "[red]Daily[/red] feed" in static_text
+        assert "[bold]failed[/bold]" in static_text
 
 
 @pytest.mark.parametrize(

--- a/Tests/UI/test_console_live_work_handoffs.py
+++ b/Tests/UI/test_console_live_work_handoffs.py
@@ -9,6 +9,7 @@ from textual.app import App
 from Tests.UI.test_destination_shells import DestinationHarness
 from Tests.UI.test_screen_navigation import _build_test_app
 from tldw_chatbook.Chat.chat_handoff_models import ChatHandoffPayload
+from tldw_chatbook.Home.dashboard_state import HomeActiveWorkItem, HomeDashboardInput
 from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 
 
@@ -21,6 +22,9 @@ PHASE3_HOME_WC_CONSOLE_EVIDENCE = (
 )
 PHASE3_CONSOLE_WC_ACTION_EVIDENCE = (
     REPO_ROOT / "Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-console-wc-action-routing.md"
+)
+PHASE3_WC_DESTINATION_CONSOLE_EVIDENCE = (
+    REPO_ROOT / "Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-wc-destination-console-launch.md"
 )
 
 
@@ -55,6 +59,24 @@ def _active_console_screen(host: ConsoleHarness):
 
 def _screen_static_text(screen) -> str:
     return " ".join(str(widget.renderable) for widget in screen.query("Static"))
+
+
+class StaticHomeActiveWorkAdapter:
+    def __init__(self, items):
+        self.items = tuple(items)
+        self.build_calls = []
+
+    def build_dashboard_input(self, *, providers_models, has_recent_work):
+        self.build_calls.append(
+            {
+                "providers_models": providers_models,
+                "has_recent_work": has_recent_work,
+            }
+        )
+        return HomeDashboardInput(active_work_items=self.items)
+
+    def handle_control(self, action, *, target_id=None, target_route=None):
+        raise AssertionError(f"Unexpected direct control call: {action} {target_id} {target_route}")
 
 
 def test_app_exposes_open_console_for_live_work_helper():
@@ -282,14 +304,27 @@ def test_phase3_console_wc_action_tracking_evidence_links_task_and_roadmap():
     assert "console-live-work-primary-action" in task
 
 
+def test_phase3_wc_destination_console_tracking_evidence_links_task_and_roadmap():
+    evidence = PHASE3_WC_DESTINATION_CONSOLE_EVIDENCE.read_text()
+    readme = (REPO_ROOT / "Docs/superpowers/qa/unified-shell/phase-3/README.md").read_text()
+    roadmap = (REPO_ROOT / "Docs/superpowers/trackers/unified-shell-maturity-roadmap.md").read_text()
+    task = (
+        REPO_ROOT
+        / "backlog/tasks/task-3.5 - Phase-3.5-Launch-latest-WC-run-from-WC-into-Console.md"
+    ).read_text()
+
+    assert "TASK-3.5" in evidence
+    assert "W+C destination Console follow" in evidence
+    assert "watchlists-follow-in-console" in evidence
+    assert "2026-05-03-wc-destination-console-launch.md" in readme
+    assert "Phase 3.5: Launch latest W+C run from W+C into Console - `TASK-3.5`" in roadmap
+    assert "`TASK-3`, `TASK-3.1`, `TASK-3.2`, `TASK-3.3`, `TASK-3.4`, `TASK-3.5`" in roadmap
+    assert "watchlists-follow-in-console" in task
+
+
 @pytest.mark.parametrize(
     ("route", "button_id", "expected_copy"),
     [
-        (
-            "watchlists_collections",
-            "watchlists-follow-in-console",
-            "Console follow is unavailable until watchlist and collection live-work payloads are wired.",
-        ),
         (
             "schedules",
             "schedules-follow-in-console",
@@ -327,6 +362,70 @@ async def test_skeletal_destination_console_actions_are_disabled_with_recovery_c
         await pilot.pause(0.1)
 
     app.open_console_for_live_work.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_watchlists_destination_keeps_console_follow_disabled_without_active_run():
+    app = _build_test_app()
+    app.home_active_work_adapter = StaticHomeActiveWorkAdapter(())
+    app.open_active_home_item_in_console = Mock()
+    host = DestinationHarness(app, "watchlists_collections")
+
+    async with host.run_test(size=(180, 40)) as pilot:
+        await pilot.pause(0.1)
+        screen = _active_console_screen(host)
+        button = screen.query_one("#watchlists-follow-in-console")
+
+        assert button.disabled is True
+        assert str(button.label) == "Console follow unavailable"
+        text = _screen_static_text(screen)
+        assert "No active W+C run is available for Console follow." in text
+
+    app.open_active_home_item_in_console.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_watchlists_destination_routes_latest_active_run_to_console():
+    app = _build_test_app()
+    app.home_active_work_adapter = StaticHomeActiveWorkAdapter(
+        (
+            HomeActiveWorkItem(
+                item_id="local:watchlist_run:5",
+                title="Daily security feed",
+                source="W+C",
+                status="failed",
+                detail_route="subscriptions",
+                console_available=True,
+            ),
+            HomeActiveWorkItem(
+                item_id="local:watchlist_run:9",
+                title="Other source",
+                source="W+C",
+                status="queued",
+                detail_route="subscriptions",
+                console_available=False,
+            ),
+        )
+    )
+    app.open_active_home_item_in_console = Mock()
+    host = DestinationHarness(app, "watchlists_collections")
+
+    async with host.run_test(size=(180, 40)) as pilot:
+        await pilot.pause(0.1)
+        screen = _active_console_screen(host)
+        button = screen.query_one("#watchlists-follow-in-console")
+
+        assert button.disabled is False
+        assert "Daily security feed" in str(button.label)
+        assert "failed" in _screen_static_text(screen)
+
+        await pilot.click("#watchlists-follow-in-console")
+        await pilot.pause(0.1)
+
+    app.open_active_home_item_in_console.assert_called_once_with(
+        target_id="local:watchlist_run:5",
+        target_route="chat",
+    )
 
 
 @pytest.mark.parametrize(

--- a/backlog/tasks/task-3.5 - Phase-3.5-Launch-latest-WC-run-from-WC-into-Console.md
+++ b/backlog/tasks/task-3.5 - Phase-3.5-Launch-latest-WC-run-from-WC-into-Console.md
@@ -1,0 +1,46 @@
+---
+id: TASK-3.5
+title: 'Phase 3.5: Launch latest W+C run from W+C into Console'
+status: Done
+assignee: []
+created_date: '2026-05-03 22:52'
+updated_date: '2026-05-03 22:56'
+labels:
+  - unified-shell
+  - phase-3
+  - console
+  - watchlists
+dependencies: []
+parent_task_id: TASK-3
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make the W+C destination expose a real Console follow action when the existing active-work adapter can identify an actionable local watchlist run, while preserving an honest disabled state when no run context exists.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 W+C destination keeps Console follow disabled with recovery copy when no actionable W+C run exists.
+- [x] #2 W+C destination enables Console follow when a visible W+C active-work item has Console launch context.
+- [x] #3 Clicking the enabled W+C Console follow action routes through the existing Home active-work adapter Console launch path.
+- [x] #4 Focused automated tests and Phase 3 QA evidence verify the `watchlists-follow-in-console` producer and roadmap/task updates.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing regressions for W+C destination disabled fallback, enabled latest-run Console follow, adapter-routed click behavior, and Phase 3.5 tracking evidence.
+2. Reuse the existing Home active-work adapter from W+C to discover a latest Console-capable W+C run without duplicating watchlist snapshot logic.
+3. Render the W+C Console follow button as enabled only when that adapter context exists, and route clicks through the existing app-level Home Console launch method.
+4. Add Phase 3.5 QA evidence plus roadmap and task updates.
+5. Run focused destination, Console handoff, Home adapter, navigation, and diff hygiene checks before commit/PR.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Updated the W+C destination to reuse the existing Home active-work adapter for latest Console-capable W+C run discovery. The `watchlists-follow-in-console` action now stays disabled with explicit recovery copy when no active run exists, becomes enabled when adapter context exists, and routes clicks through `open_active_home_item_in_console` so Home and W+C share the same Console launch path. Added focused destination/Console regressions plus Phase 3.5 QA evidence and roadmap tracking.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-3.5 - Phase-3.5-Launch-latest-WC-run-from-WC-into-Console.md
+++ b/backlog/tasks/task-3.5 - Phase-3.5-Launch-latest-WC-run-from-WC-into-Console.md
@@ -42,5 +42,5 @@ Make the W+C destination expose a real Console follow action when the existing a
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Updated the W+C destination to reuse the existing Home active-work adapter for latest Console-capable W+C run discovery. The `watchlists-follow-in-console` action now stays disabled with explicit recovery copy when no active run exists, becomes enabled when adapter context exists, and routes clicks through `open_active_home_item_in_console` so Home and W+C share the same Console launch path. Added focused destination/Console regressions plus Phase 3.5 QA evidence and roadmap tracking.
+Updated the W+C destination to reuse the existing Home active-work adapter for latest Console-capable W+C run discovery. The `watchlists-follow-in-console` action now stays disabled with explicit recovery copy when no active run exists, becomes enabled when adapter context exists, and routes clicks through `open_active_home_item_in_console` so Home and W+C share the same Console launch path. PR review hardening added contextual adapter-failure logging, pinned click routing to the item shown in the rendered button label, and escaped markup-sensitive run title/status labels. Added focused destination/Console regressions plus Phase 3.5 QA evidence and roadmap tracking.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -15,7 +15,29 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     def __init__(self, app_instance, **kwargs):
         super().__init__(app_instance, "watchlists_collections", **kwargs)
 
+    def _latest_console_follow_item(self):
+        adapter = getattr(self.app_instance, "home_active_work_adapter", None)
+        build_dashboard_input = getattr(adapter, "build_dashboard_input", None)
+        if not callable(build_dashboard_input):
+            return None
+        try:
+            dashboard_input = build_dashboard_input(
+                providers_models={},
+                has_recent_work=False,
+            )
+        except Exception:
+            return None
+        for item in tuple(getattr(dashboard_input, "active_work_items", ()) or ()):
+            if (
+                getattr(item, "source", None) == "W+C"
+                and bool(getattr(item, "console_available", False))
+                and getattr(item, "item_id", None)
+            ):
+                return item
+        return None
+
     def compose_content(self) -> ComposeResult:
+        latest_console_item = self._latest_console_follow_item()
         with Vertical(id="watchlists-collections-shell"):
             yield Static(
                 "W+C",
@@ -41,17 +63,53 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                     id="wc-open-watchlists",
                     tooltip="Open the current watchlist/subscription surface.",
                 )
-                yield Static(
-                    "Console follow is unavailable until watchlist and collection live-work payloads are wired.",
-                    id="watchlists-console-unavailable",
-                )
-                yield Button(
-                    "Console follow unavailable",
-                    id="watchlists-follow-in-console",
-                    disabled=True,
-                    tooltip="Unavailable until W+C can pass actionable live-work context to Console.",
-                )
+                if latest_console_item is not None:
+                    yield Static(
+                        (
+                            "Console can follow latest W+C run: "
+                            f"{latest_console_item.title} ({latest_console_item.status})."
+                        ),
+                        id="watchlists-console-available",
+                    )
+                    yield Button(
+                        f"Follow {latest_console_item.title} in Console",
+                        id="watchlists-follow-in-console",
+                        tooltip="Open the latest active W+C run in Console.",
+                    )
+                else:
+                    yield Static(
+                        "No active W+C run is available for Console follow.",
+                        id="watchlists-console-unavailable",
+                    )
+                    yield Button(
+                        "Console follow unavailable",
+                        id="watchlists-follow-in-console",
+                        disabled=True,
+                        tooltip="Unavailable until W+C has an active run with Console context.",
+                    )
 
     @on(Button.Pressed, "#wc-open-watchlists")
     def open_watchlists(self) -> None:
         self.post_message(NavigateToScreen("subscriptions"))
+
+    @on(Button.Pressed, "#watchlists-follow-in-console")
+    def follow_latest_watchlist_run_in_console(self, event: Button.Pressed) -> None:
+        event.stop()
+        latest_console_item = self._latest_console_follow_item()
+        if latest_console_item is None:
+            self.app_instance.notify(
+                "No active W+C run is available for Console follow.",
+                severity="warning",
+            )
+            return
+        open_in_console = getattr(self.app_instance, "open_active_home_item_in_console", None)
+        if not callable(open_in_console):
+            self.app_instance.notify(
+                "Console follow is unavailable for W+C in this runtime.",
+                severity="warning",
+            )
+            return
+        open_in_console(
+            target_id=latest_console_item.item_id,
+            target_route="chat",
+        )

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -1,5 +1,8 @@
 """W+C destination shell."""
 
+from loguru import logger
+from rich.markup import escape as escape_markup
+from rich.text import Text
 from textual.app import ComposeResult
 from textual import on
 from textual.containers import Vertical
@@ -9,11 +12,15 @@ from ..Navigation.base_app_screen import BaseAppScreen
 from ..Navigation.main_navigation import NavigateToScreen
 
 
+logger = logger.bind(module="WatchlistsCollectionsScreen")
+
+
 class WatchlistsCollectionsScreen(BaseAppScreen):
     """Monitored sources and curated reading/content collections."""
 
     def __init__(self, app_instance, **kwargs):
         super().__init__(app_instance, "watchlists_collections", **kwargs)
+        self._latest_console_follow_item_id = None
 
     def _latest_console_follow_item(self):
         adapter = getattr(self.app_instance, "home_active_work_adapter", None)
@@ -26,6 +33,10 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                 has_recent_work=False,
             )
         except Exception:
+            logger.warning(
+                "Failed to load W+C Console follow item from Home active-work adapter.",
+                exc_info=True,
+            )
             return None
         for item in tuple(getattr(dashboard_input, "active_work_items", ()) or ()):
             if (
@@ -38,6 +49,11 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
 
     def compose_content(self) -> ComposeResult:
         latest_console_item = self._latest_console_follow_item()
+        self._latest_console_follow_item_id = (
+            getattr(latest_console_item, "item_id", None)
+            if latest_console_item is not None
+            else None
+        )
         with Vertical(id="watchlists-collections-shell"):
             yield Static(
                 "W+C",
@@ -64,15 +80,17 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                     tooltip="Open the current watchlist/subscription surface.",
                 )
                 if latest_console_item is not None:
+                    title = str(getattr(latest_console_item, "title", None) or "Untitled")
+                    status = str(getattr(latest_console_item, "status", None) or "unknown")
                     yield Static(
-                        (
+                        Text.from_markup(
                             "Console can follow latest W+C run: "
-                            f"{latest_console_item.title} ({latest_console_item.status})."
+                            f"{escape_markup(title)} ({escape_markup(status)})."
                         ),
                         id="watchlists-console-available",
                     )
                     yield Button(
-                        f"Follow {latest_console_item.title} in Console",
+                        Text.from_markup(f"Follow {escape_markup(title)} in Console"),
                         id="watchlists-follow-in-console",
                         tooltip="Open the latest active W+C run in Console.",
                     )
@@ -95,8 +113,8 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     @on(Button.Pressed, "#watchlists-follow-in-console")
     def follow_latest_watchlist_run_in_console(self, event: Button.Pressed) -> None:
         event.stop()
-        latest_console_item = self._latest_console_follow_item()
-        if latest_console_item is None:
+        target_id = self._latest_console_follow_item_id
+        if not target_id:
             self.app_instance.notify(
                 "No active W+C run is available for Console follow.",
                 severity="warning",
@@ -110,6 +128,6 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             )
             return
         open_in_console(
-            target_id=latest_console_item.item_id,
+            target_id=target_id,
             target_route="chat",
         )


### PR DESCRIPTION
## Summary
- Enables the W+C destination to reuse the Home active-work adapter to find the latest Console-capable W+C run.
- Keeps Console follow disabled with recovery copy when no actionable W+C run exists.
- Routes enabled W+C Console follow through the existing Home active-work Console launch path and updates Phase 3.5 evidence/backlog tracking.

## Test Plan
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_destination_shells.py Tests/UI/test_home_screen.py Tests/Home/test_active_work_adapter.py Tests/UI/test_subscription_window_watchlists.py Tests/UI/test_screen_navigation.py Tests/UI/test_unified_shell_phase2_home_adapter.py -q
- git diff --check