### PR TITLE
Show Console live-work source readiness

### DIFF
--- a/Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-console-live-work-source-readiness.md
+++ b/Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-console-live-work-source-readiness.md
@@ -1,0 +1,46 @@
+# Console Live-Work Source Readiness
+
+Date: 2026-05-03
+Task: `TASK-3.5`
+Branch: `codex/unified-shell-phase3-next-slice`
+Base: `origin/dev` at `fa37fdb0`
+
+## Purpose
+
+Continue Phase 3 by making Console source readiness visible when no live-work item is staged. This avoids the UX gap where users can see a live-work card only after launch, but cannot tell which source families are currently connected.
+
+## What Changed
+
+- Added `ConsoleLiveWorkSourceReadinessState` and source readiness rows.
+- Marked W+C as connected because Home W+C active work can now launch and route run details through Console.
+- Marked Workflows, Schedules, ACP, MCP, RAG, and Artifacts as `Not wired` with explicit recovery copy.
+- Updated `ChatScreen` to render the source readiness summary only when no pending Console live-work launch is staged.
+- Preserved pending launch focus by suppressing the readiness summary while a live-work card is visible.
+
+## Functional QA Evidence
+
+Focused checks were run against the readiness model and mounted Textual Console screen harness.
+
+- Red source-readiness test: `python -m pytest -q Tests/UI/test_console_live_work_handoffs.py --tb=short`
+- Red result: `3 failed, 21 passed, 1 warning`; failures were expected because `ConsoleLiveWorkSourceReadinessState`, mounted source readiness rendering, and this evidence file did not exist.
+- Green behavior test before evidence: `python -m pytest -q Tests/UI/test_console_live_work_handoffs.py --tb=short`
+- Green behavior result: `1 failed, 23 passed, 1 warning`; the remaining failure was the intentionally missing evidence link.
+- Focused Console verification after evidence: `python -m pytest -q Tests/UI/test_console_live_work_handoffs.py --tb=short`
+- Focused Console result: `24 passed, 1 warning`.
+- Broader Phase 3 regression check: `python -m pytest -q Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_home_screen.py Tests/Home/test_active_work_adapter.py Tests/UI/test_subscription_window_watchlists.py Tests/UI/test_screen_navigation.py Tests/UI/test_unified_shell_phase2_home_adapter.py Tests/UI/test_destination_shells.py --tb=short`
+- Broader Phase 3 result: `155 passed, 8 warnings in 83.88s`.
+
+Warning boundary: warnings are existing dependency/import warnings and are not Console source-readiness behavior failures.
+
+## UX Result
+
+- First-time users can see that W+C is the first connected live-work source.
+- Power users can quickly distinguish supported Console follow-through from future source integrations.
+- Planned sources remain visible without false affordances because unavailable rows are informational only.
+
+## Residual Risk
+
+- This is a source-readiness visibility slice, not full Phase 3 completion.
+- Workflows, Schedules, ACP, MCP, RAG, and Artifacts still need source-specific payload producers.
+- Console still does not subscribe to real live event streams.
+- Full Phase 3 cannot be verified until all relevant launch, follow, status, and recovery flows are exercised in the running app.

--- a/Docs/superpowers/qa/unified-shell/phase-3/README.md
+++ b/Docs/superpowers/qa/unified-shell/phase-3/README.md
@@ -10,5 +10,6 @@ This directory contains durable QA summaries for Phase 3 Console live-work hub s
 - `2026-05-03-console-live-work-status-card-seam.md` - `TASK-3.2` reusable Console live-work status card state and stable render selectors.
 - `2026-05-03-home-wc-active-work-console-launch.md` - `TASK-3.3` Home W+C active-work source launch into the Console status-card surface.
 - `2026-05-03-console-wc-action-routing.md` - `TASK-3.4` Console W+C live-work action routing into W+C run details.
+- `2026-05-03-console-live-work-source-readiness.md` - `TASK-3.5` Console source-readiness summary showing W+C connected and future sources honestly unavailable.
 
 Do not mark Phase 3 verified until launch, follow, status, and recovery flows are verified in the running app against workflows, schedules, ACP, MCP, RAG, artifacts, and active-work source adapters.

--- a/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
@@ -2,7 +2,7 @@
 
 Date: 2026-05-03
 Status: Phase 2 and Phase 3 in progress
-Source Branch: `origin/dev` at `96f15eae` plus `codex/unified-shell-phase3-console-action-routing`
+Source Branch: `origin/dev` at `fa37fdb0` plus `codex/unified-shell-phase3-next-slice`
 
 ## Purpose
 
@@ -30,7 +30,7 @@ Track remaining Unified Shell work in one place so rendered screens, clickable b
 - Home active-work controls, detail routing, Console launch requests, item identity, local unread notification counts, notification review routing, local W+C watchlist run snapshots, and local W+C run detail routing now route through explicit adapter boundaries; schedule and agent-service adapters still need implementation.
 - Workflows has no wired workflow service in the shell wrapper.
 - W+C, Schedules, Workflows, and ACP now use honest unavailable Console states until actionable payloads exist.
-- Console now has a typed app-owned launch contract, reusable status-card display seam, Home W+C active-work source producer, and W+C run-detail action routing for staged live-work payloads; additional source-specific live event producers still need implementation.
+- Console now has a typed app-owned launch contract, reusable status-card display seam, source-readiness summary, Home W+C active-work source producer, and W+C run-detail action routing for staged live-work payloads; additional source-specific live event producers still need implementation.
 - ACP launch is disabled until an ACP-compatible runtime is configured.
 - MCP management is not embedded in the top-level MCP wrapper.
 - Skills local/server services exist, but the top-level Skills shell still leaves import disabled and lacks list/detail/import UX adoption.
@@ -91,6 +91,7 @@ Initial child tasks:
 - Phase 3.2: Add Console live-work status card seam - `TASK-3.2`
 - Phase 3.3: Open Home W+C active work in Console - `TASK-3.3`
 - Phase 3.4: Route Console W+C live-work actions - `TASK-3.4`
+- Phase 3.5: Show Console live-work source readiness - `TASK-3.5`
 
 ## QA Evidence Index
 
@@ -111,7 +112,7 @@ Initial child tasks:
 | Phase 0: Canonical Tracking | Make remaining work trackable. | verified | `TASK-1`, `TASK-1.1`, `TASK-1.2` | `phase-0/` | Product UI workflows are out of scope for Phase 0. |
 | Phase 1: Shell Contract Complete | Remove false shell affordances and prove shell usability. | verified | `TASK-2`, `TASK-2.1`, `TASK-2.2`, `TASK-2.3`, `TASK-2.4` | `phase-1/` | Live service workflows remain intentionally deferred to Phases 2-6. |
 | Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | in-progress | `TASK-4`, `TASK-4.1`, `TASK-4.2`, `TASK-4.3`, `TASK-4.4`, `TASK-4.5`, `TASK-4.6`, `TASK-4.7` | `phase-2/` | Schedule and agent-service adapters still need implementation; local watchlist retry/pause/resume remain recoverable rather than fully controllable. |
-| Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | in-progress | `TASK-3`, `TASK-3.1`, `TASK-3.2`, `TASK-3.3`, `TASK-3.4` | `phase-3/` | Additional source-specific live event producers and follow/status wiring still need implementation. |
+| Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | in-progress | `TASK-3`, `TASK-3.1`, `TASK-3.2`, `TASK-3.3`, `TASK-3.4`, `TASK-3.5` | `phase-3/` | Additional source-specific live event producers and follow/status wiring still need implementation. |
 | Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | not-started | `TASK-5` | `phase-4/` | Service coverage varies by destination. |
 | Phase 5: Capability And Recovery System | Systematize unavailable and blocked states. | not-started | `TASK-6` | `phase-5/` | Shared taxonomy not yet extracted. |
 | Phase 6: Audit Replay And Closeout | Prove shell works for first-time and power users. | not-started | `TASK-7` | `phase-6/` | Depends on prior phases and running-app QA. |
@@ -209,6 +210,12 @@ Initial audit result: W+C, Schedules, Workflows, and ACP had false Console-launc
 `TASK-3.4` makes supported Console W+C live-work actions route to existing W+C run details:
 
 - `Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-console-wc-action-routing.md`
+
+## Phase 3.5 Console Source Readiness Evidence
+
+`TASK-3.5` shows W+C as connected in Console while keeping planned future live-work sources honestly unavailable:
+
+- `Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-console-live-work-source-readiness.md`
 
 ## Phase 0: Canonical Tracking
 

--- a/Tests/UI/test_console_live_work_handoffs.py
+++ b/Tests/UI/test_console_live_work_handoffs.py
@@ -22,6 +22,9 @@ PHASE3_HOME_WC_CONSOLE_EVIDENCE = (
 PHASE3_CONSOLE_WC_ACTION_EVIDENCE = (
     REPO_ROOT / "Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-console-wc-action-routing.md"
 )
+PHASE3_CONSOLE_SOURCE_READINESS_EVIDENCE = (
+    REPO_ROOT / "Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-console-live-work-source-readiness.md"
+)
 
 
 def _load_console_live_work_contract():
@@ -38,6 +41,14 @@ def _load_console_live_work_status_card_state():
     except ImportError:
         pytest.fail("Console live-work status card state is missing")
     return ConsoleLiveWorkStatusCardState
+
+
+def _load_console_live_work_source_readiness_state():
+    try:
+        from tldw_chatbook.Chat.console_live_work import ConsoleLiveWorkSourceReadinessState
+    except ImportError:
+        pytest.fail("Console live-work source readiness state is missing")
+    return ConsoleLiveWorkSourceReadinessState
 
 
 class ConsoleHarness(App):
@@ -205,6 +216,30 @@ def test_console_live_work_status_card_state_keeps_unsupported_payloads_non_acti
     assert card_state.primary_action is None
 
 
+def test_console_live_work_source_readiness_marks_wc_connected_and_future_sources_unavailable():
+    ConsoleLiveWorkSourceReadinessState = _load_console_live_work_source_readiness_state()
+
+    state = ConsoleLiveWorkSourceReadinessState.default()
+
+    assert state.container_id == "console-live-work-source-readiness"
+    assert "console-live-work-source-readiness" in state.container_classes
+    rows_by_id = {row.widget_id: row for row in state.rows}
+    assert rows_by_id["console-live-work-source-wc"].text == (
+        "W+C: Connected - Home W+C active work can open and route run details in Console."
+    )
+    assert "console-live-work-source-connected" in rows_by_id["console-live-work-source-wc"].classes
+    for source_id in (
+        "console-live-work-source-workflows",
+        "console-live-work-source-schedules",
+        "console-live-work-source-acp",
+        "console-live-work-source-mcp",
+        "console-live-work-source-rag",
+        "console-live-work-source-artifacts",
+    ):
+        assert "Not wired" in rows_by_id[source_id].text
+        assert "console-live-work-source-unavailable" in rows_by_id[source_id].classes
+
+
 def test_app_console_live_work_primary_action_routes_wc_run_details():
     ConsoleLiveWorkLaunch = _load_console_live_work_contract()
     app = _build_test_app()
@@ -280,6 +315,23 @@ def test_phase3_console_wc_action_tracking_evidence_links_task_and_roadmap():
     assert "Phase 3.4: Route Console W+C live-work actions - `TASK-3.4`" in roadmap
     assert "`TASK-3`, `TASK-3.1`, `TASK-3.2`, `TASK-3.3`, `TASK-3.4`" in roadmap
     assert "console-live-work-primary-action" in task
+
+
+def test_phase3_console_source_readiness_tracking_evidence_links_task_and_roadmap():
+    evidence = PHASE3_CONSOLE_SOURCE_READINESS_EVIDENCE.read_text()
+    readme = (REPO_ROOT / "Docs/superpowers/qa/unified-shell/phase-3/README.md").read_text()
+    roadmap = (REPO_ROOT / "Docs/superpowers/trackers/unified-shell-maturity-roadmap.md").read_text()
+    task = (
+        REPO_ROOT
+        / "backlog/tasks/task-3.5 - Phase-3.5-Show-Console-live-work-source-readiness.md"
+    ).read_text()
+
+    assert "TASK-3.5" in evidence
+    assert "ConsoleLiveWorkSourceReadinessState" in evidence
+    assert "2026-05-03-console-live-work-source-readiness.md" in readme
+    assert "Phase 3.5: Show Console live-work source readiness - `TASK-3.5`" in roadmap
+    assert "`TASK-3`, `TASK-3.1`, `TASK-3.2`, `TASK-3.3`, `TASK-3.4`, `TASK-3.5`" in roadmap
+    assert "ConsoleLiveWorkSourceReadinessState" in task
 
 
 @pytest.mark.parametrize(
@@ -377,6 +429,7 @@ async def test_console_renders_pending_launch_context():
         screen = _active_console_screen(host)
 
         assert screen.query_one("#console-pending-launch-card")
+        assert len(screen.query("#console-live-work-source-readiness")) == 0
         assert screen.query_one("#console-live-work-source").renderable == "Source: workflows"
         assert screen.query_one("#console-live-work-title").renderable == "Title: Daily digest"
         assert screen.query_one("#console-live-work-status").renderable == "Status: running"
@@ -394,6 +447,29 @@ async def test_console_renders_pending_launch_context():
         assert "run_id: run-1" in text
         assert isinstance(screen._pending_console_launch_context, ConsoleLiveWorkLaunch)
         assert app.pending_console_launch is None
+
+
+@pytest.mark.asyncio
+async def test_console_renders_source_readiness_summary_without_pending_launch():
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(180, 40)) as pilot:
+        await pilot.pause(0.1)
+        screen = _active_console_screen(host)
+
+        assert len(screen.query("#console-pending-launch-card")) == 0
+        assert screen.query_one("#console-live-work-source-readiness")
+        assert screen.query_one("#console-live-work-source-readiness-title").renderable == "Live work sources"
+        assert screen.query_one("#console-live-work-source-wc").renderable == (
+            "W+C: Connected - Home W+C active work can open and route run details in Console."
+        )
+        assert "Workflows: Not wired" in str(screen.query_one("#console-live-work-source-workflows").renderable)
+        assert "Schedules: Not wired" in str(screen.query_one("#console-live-work-source-schedules").renderable)
+        assert "ACP: Not wired" in str(screen.query_one("#console-live-work-source-acp").renderable)
+        assert "MCP: Not wired" in str(screen.query_one("#console-live-work-source-mcp").renderable)
+        assert "RAG: Not wired" in str(screen.query_one("#console-live-work-source-rag").renderable)
+        assert "Artifacts: Not wired" in str(screen.query_one("#console-live-work-source-artifacts").renderable)
 
 
 @pytest.mark.asyncio

--- a/backlog/tasks/task-3.5 - Phase-3.5-Show-Console-live-work-source-readiness.md
+++ b/backlog/tasks/task-3.5 - Phase-3.5-Show-Console-live-work-source-readiness.md
@@ -1,0 +1,49 @@
+---
+id: TASK-3.5
+title: 'Phase 3.5: Show Console live-work source readiness'
+status: Done
+assignee: []
+created_date: '2026-05-03 22:59'
+updated_date: '2026-05-03 23:07'
+labels:
+  - unified-shell
+  - phase-3
+  - console
+  - live-work
+dependencies: []
+documentation:
+  - Docs/superpowers/specs/2026-05-02-agentic-terminal-design-system-design.md
+  - Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+parent_task_id: TASK-3
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Show a compact Console live-work source readiness summary so users can see W+C is connected while Workflows, Schedules, ACP, MCP, RAG, and Artifacts remain honest unavailable states until source-specific payloads exist.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Console source readiness state marks W+C as connected and remaining planned sources as explicitly unavailable or not wired with recovery copy.
+- [x] #2 ChatScreen renders the source readiness summary when no pending live-work launch is staged and keeps pending launch cards focused when a launch exists.
+- [x] #3 The readiness summary exposes stable IDs/classes for source-specific follow-up tests without creating fake source actions.
+- [x] #4 Focused Console tests and Phase 3 QA evidence verify source readiness state, mounted Console rendering, and roadmap/task updates.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing regressions for Console source-readiness state, mounted no-pending rendering, pending-launch suppression, and Phase 3.5 tracking evidence.
+2. Verify the new tests fail before production changes.
+3. Add the minimal `ConsoleLiveWorkSourceReadinessState` display model and render helper, then wire ChatScreen to show it only when no pending launch exists.
+4. Add durable Phase 3 QA evidence and update the unified-shell roadmap index.
+5. Run focused Console/Home/W+C/navigation regressions plus diff checks, then complete the Backlog task.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added `ConsoleLiveWorkSourceReadinessState` with stable source row IDs/classes, marking W+C connected and future live-work source families as informational `Not wired` rows with recovery copy. `ChatScreen` now renders the readiness summary only when no pending Console live-work launch is staged, preserving the focused pending launch card when a launch exists. Added regression coverage for the display model, mounted Console rendering, pending-card suppression, and Phase 3.5 evidence/roadmap/task tracking.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_live_work.py
+++ b/tldw_chatbook/Chat/console_live_work.py
@@ -12,6 +12,7 @@ DEFAULT_ACTION_LABEL = "Open in Console"
 PENDING_LAUNCH_CARD_ID = "console-pending-launch-card"
 LIVE_WORK_CARD_CLASS = "console-live-work-status-card"
 PRIMARY_ACTION_BUTTON_ID = "console-live-work-primary-action"
+SOURCE_READINESS_CARD_ID = "console-live-work-source-readiness"
 
 
 def _clean_text(value: Any, fallback: str) -> str:
@@ -193,4 +194,89 @@ class ConsoleLiveWorkStatusCardState:
             badge_text="Pending Console launch",
             rows=tuple(rows),
             primary_action=resolve_console_live_work_primary_action(launch),
+        )
+
+
+@dataclass(frozen=True)
+class ConsoleLiveWorkSourceReadinessRow:
+    """One row in the Console live-work source readiness summary."""
+
+    widget_id: str
+    label: str
+    status: str
+    recovery: str
+    classes: str
+
+    @property
+    def text(self) -> str:
+        return f"{self.label}: {self.status} - {self.recovery}"
+
+
+@dataclass(frozen=True)
+class ConsoleLiveWorkSourceReadinessState:
+    """Compact source support summary for Console live-work integrations."""
+
+    rows: tuple[ConsoleLiveWorkSourceReadinessRow, ...]
+    title: str = "Live work sources"
+    container_id: str = SOURCE_READINESS_CARD_ID
+    container_classes: str = "ds-panel console-live-work-source-readiness"
+    title_id: str = "console-live-work-source-readiness-title"
+    title_classes: str = "ds-status-badge console-live-work-source-readiness-title"
+
+    @classmethod
+    def default(cls) -> "ConsoleLiveWorkSourceReadinessState":
+        connected = "destination-section console-live-work-source-row console-live-work-source-connected"
+        unavailable = "destination-section console-live-work-source-row console-live-work-source-unavailable"
+        return cls(
+            rows=(
+                ConsoleLiveWorkSourceReadinessRow(
+                    widget_id="console-live-work-source-wc",
+                    label="W+C",
+                    status="Connected",
+                    recovery="Home W+C active work can open and route run details in Console.",
+                    classes=connected,
+                ),
+                ConsoleLiveWorkSourceReadinessRow(
+                    widget_id="console-live-work-source-workflows",
+                    label="Workflows",
+                    status="Not wired",
+                    recovery="Workflow execution payloads are not wired yet.",
+                    classes=unavailable,
+                ),
+                ConsoleLiveWorkSourceReadinessRow(
+                    widget_id="console-live-work-source-schedules",
+                    label="Schedules",
+                    status="Not wired",
+                    recovery="Schedule run payloads are not wired yet.",
+                    classes=unavailable,
+                ),
+                ConsoleLiveWorkSourceReadinessRow(
+                    widget_id="console-live-work-source-acp",
+                    label="ACP",
+                    status="Not wired",
+                    recovery="ACP session payloads require an ACP-compatible runtime.",
+                    classes=unavailable,
+                ),
+                ConsoleLiveWorkSourceReadinessRow(
+                    widget_id="console-live-work-source-mcp",
+                    label="MCP",
+                    status="Not wired",
+                    recovery="MCP management is not embedded in Console yet.",
+                    classes=unavailable,
+                ),
+                ConsoleLiveWorkSourceReadinessRow(
+                    widget_id="console-live-work-source-rag",
+                    label="RAG",
+                    status="Not wired",
+                    recovery="RAG live-run payloads are not wired yet; use Search/RAG handoff for context.",
+                    classes=unavailable,
+                ),
+                ConsoleLiveWorkSourceReadinessRow(
+                    widget_id="console-live-work-source-artifacts",
+                    label="Artifacts",
+                    status="Not wired",
+                    recovery="Artifact live-work payloads are not wired yet; use artifact handoff for context.",
+                    classes=unavailable,
+                ),
+            )
         )

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -21,7 +21,11 @@ from .chat_screen_state import ChatScreenState, TabState, MessageData, TaskResum
 from ...Chat.chat_conversation_service import derive_conversation_title
 from ...Chat.chat_handoff_models import ChatHandoffPayload
 from ...Chat.chat_models import ChatSessionData
-from ...Chat.console_live_work import ConsoleLiveWorkLaunch, ConsoleLiveWorkStatusCardState
+from ...Chat.console_live_work import (
+    ConsoleLiveWorkLaunch,
+    ConsoleLiveWorkSourceReadinessState,
+    ConsoleLiveWorkStatusCardState,
+)
 from ...Utils.chat_diagnostics import ChatDiagnostics
 from ...state.ui_state import UIState
 from ...Widgets.Chat_Widgets.chat_tab_container import ChatTabContainer
@@ -176,6 +180,18 @@ class ChatScreen(BaseAppScreen):
                     variant="primary",
                 )
 
+    def _render_console_live_work_source_readiness(self) -> ComposeResult:
+        """Render Console source readiness when no live-work item is staged."""
+        readiness = ConsoleLiveWorkSourceReadinessState.default()
+        with Container(id=readiness.container_id, classes=readiness.container_classes):
+            yield Static(
+                readiness.title,
+                id=readiness.title_id,
+                classes=readiness.title_classes,
+            )
+            for row in readiness.rows:
+                yield Static(row.text, id=row.widget_id, classes=row.classes)
+
     @on(Button.Pressed, "#console-live-work-primary-action")
     def handle_console_live_work_primary_action(self, event: Button.Pressed) -> None:
         """Route supported live-work card actions through the app-owned shell."""
@@ -196,6 +212,8 @@ class ChatScreen(BaseAppScreen):
         pending_launch = self._consume_pending_console_launch()
         if pending_launch:
             yield from self._render_console_live_work_status_card(pending_launch)
+        else:
+            yield from self._render_console_live_work_source_readiness()
         # Create and yield the chat window container
         self.chat_window = ChatWindowEnhanced(self.app_instance, id="chat-window", classes="window")
         yield self.chat_window


### PR DESCRIPTION
## Summary
- Add a Console live-work source-readiness display model showing W+C as connected and future sources as not wired.
- Render the readiness summary only when no pending Console live-work launch is staged.
- Add regression coverage plus Phase 3.5 QA evidence, roadmap, and backlog task updates.

## Test Plan
- env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_home_screen.py Tests/Home/test_active_work_adapter.py Tests/UI/test_subscription_window_watchlists.py Tests/UI/test_screen_navigation.py Tests/UI/test_unified_shell_phase2_home_adapter.py Tests/UI/test_destination_shells.py --tb=short
- git diff --check