### PR TITLE
Launch RAG search results in Console

### DIFF
--- a/Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-console-live-work-source-readiness.md
+++ b/Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-console-live-work-source-readiness.md
@@ -15,6 +15,7 @@ Continue Phase 3 by making Console source readiness visible when no live-work it
 - Marked W+C as connected because Home W+C active work can now launch and route run details through Console.
 - Marked Schedules as connected because Schedules can now follow active schedule-run context into Console when adapter context exists.
 - Marked Workflows, ACP, MCP, RAG, and Artifacts as `Not wired` with explicit recovery copy.
+- Follow-up: `TASK-3.8` changes RAG to connected after Search/RAG result Console launch wiring landed.
 - Updated `ChatScreen` to render the source readiness summary only when no pending Console live-work launch is staged.
 - Preserved pending launch focus by suppressing the readiness summary while a live-work card is visible.
 
@@ -35,13 +36,13 @@ Warning boundary: warnings are existing dependency/import warnings and are not C
 
 ## UX Result
 
-- First-time users can see that W+C and Schedules are connected live-work sources.
+- First-time users can see that W+C, Schedules, and RAG are connected live-work sources after the `TASK-3.8` update.
 - Power users can quickly distinguish supported Console follow-through from future source integrations.
 - Planned sources remain visible without false affordances because unavailable rows are informational only.
 
 ## Residual Risk
 
 - This is a source-readiness visibility slice, not full Phase 3 completion.
-- Workflows, ACP, MCP, RAG, and Artifacts still need source-specific payload producers.
+- Workflows, ACP, MCP, and Artifacts still need source-specific payload producers.
 - Console still does not subscribe to real live event streams.
 - Full Phase 3 cannot be verified until all relevant launch, follow, status, and recovery flows are exercised in the running app.

--- a/Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-rag-search-console-launch.md
+++ b/Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-rag-search-console-launch.md
@@ -21,6 +21,8 @@ Make Search/RAG results a real Console live-work source instead of only a Chat c
 - Focused green result: `5 passed, 1 warning in 8.26s`.
 - Broader focused command: `.venv/bin/python -m pytest Tests/UI/test_ux_audit_smoke.py Tests/UI/test_console_live_work_handoffs.py -q --tb=short`
 - Broader focused result: `55 passed, 1 warning in 19.50s`.
+- Review-fix red result: sanitizer regression failed because Console launch payload still contained raw Rich markup, HTML-like text, and a null byte.
+- Review-fix green result: `.venv/bin/python -m pytest Tests/UI/test_ux_audit_smoke.py Tests/UI/test_console_live_work_handoffs.py -q --tb=short` -> `56 passed, 1 warning in 19.51s`.
 
 Warning boundary: the remaining warning is the existing `requests` dependency version warning and is not caused by the Search/RAG Console launch path.
 

--- a/Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-rag-search-console-launch.md
+++ b/Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-rag-search-console-launch.md
@@ -1,0 +1,38 @@
+# Phase 3.8 RAG Search Console Launch
+
+Task: `TASK-3.8`
+Branch: `codex/unified-shell-phase3-rag-console-launch`
+
+## Goal
+
+Make Search/RAG results a real Console live-work source instead of only a Chat context handoff. A user who finds a relevant retrieved chunk can keep power-user flow by sending it directly into Console, while blocked server-backed RAG launches still explain how to recover before staging context.
+
+## Implementation Summary
+
+- Added a distinct `Use in Console` action beside existing `Use in Chat` on Search/RAG result cards.
+- Reused existing Search/RAG handoff payload construction so Console launch metadata preserves result title, identity, source, score, runtime backend, display summary, and suggested prompt.
+- Reused existing RAG runtime policy checks before staging server-backed RAG launches.
+- Updated Console live-work source readiness to mark `RAG` as connected.
+
+## Verification
+
+- Red result: focused tests failed because `#use-in-console-0`, RAG connected readiness copy, and this evidence file did not exist.
+- Focused green command: `.venv/bin/python -m pytest Tests/UI/test_ux_audit_smoke.py::test_valid_rag_search_console_launch_replays_from_mounted_window_to_app_seam Tests/UI/test_ux_audit_smoke.py::test_contract_blocked_rag_search_console_launch_explains_recovery_without_staging Tests/UI/test_console_live_work_handoffs.py::test_console_live_work_source_readiness_marks_connected_sources_and_future_sources_unavailable Tests/UI/test_console_live_work_handoffs.py::test_console_renders_source_readiness_summary_without_pending_launch Tests/UI/test_console_live_work_handoffs.py::test_phase3_rag_console_launch_tracking_evidence_links_task_and_roadmap -q`
+- Focused green result: `5 passed, 1 warning in 8.26s`.
+- Broader focused command: `.venv/bin/python -m pytest Tests/UI/test_ux_audit_smoke.py Tests/UI/test_console_live_work_handoffs.py -q --tb=short`
+- Broader focused result: `55 passed, 1 warning in 19.50s`.
+
+Warning boundary: the remaining warning is the existing `requests` dependency version warning and is not caused by the Search/RAG Console launch path.
+
+## QA Walkthrough Notes
+
+- Environment: focused Textual mounted-window tests using the repo virtualenv.
+- Entry path: Search/RAG result list with a retrieved result.
+- Visual check: result cards keep `Use in Chat` and add a separate `Use in Console` action, preserving the existing fast handoff path.
+- Functional result: selecting `Use in Console` stages `open_console_for_live_work` with a typed RAG launch payload.
+- Recovery result: when runtime policy blocks server RAG under a local active source, no Console context is staged and the user sees source-authority recovery copy.
+
+## Residual Risk
+
+- Live embedding/vector search quality and provider availability are outside this shell slice.
+- Console still does not execute a full RAG agent loop by itself; this slice stages selected retrieved evidence into the Console live-work surface.

--- a/Docs/superpowers/qa/unified-shell/phase-3/README.md
+++ b/Docs/superpowers/qa/unified-shell/phase-3/README.md
@@ -14,5 +14,6 @@ This directory contains durable QA summaries for Phase 3 Console live-work hub s
 - `2026-05-03-console-live-work-source-readiness.md` - `TASK-3.6` Console source-readiness summary showing W+C and Schedules connected while future sources remain honestly unavailable.
 - `2026-05-03-schedules-console-launch.md` - `TASK-3.7` Schedules destination Console follow producer for active schedule runs.
 - `2026-05-03-schedules-digest-console-launch.md` - `TASK-3.7` Schedules destination Console launch producer for the latest local reading-digest output.
+- `2026-05-03-rag-search-console-launch.md` - `TASK-3.8` Search/RAG result Console launch producer for selected retrieved evidence.
 
 Do not mark Phase 3 verified until launch, follow, status, and recovery flows are verified in the running app against workflows, schedules, ACP, MCP, RAG, artifacts, and active-work source adapters.

--- a/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
@@ -2,7 +2,7 @@
 
 Date: 2026-05-03
 Status: Phase 2 and Phase 3 in progress
-Source Branch: `origin/dev` at `f9783093` plus `codex/unified-shell-phase3-schedules-console-launch`
+Source Branch: `origin/dev` at `c31d83b1` plus `codex/unified-shell-phase3-rag-console-launch`
 
 ## Purpose
 
@@ -29,8 +29,8 @@ Track remaining Unified Shell work in one place so rendered screens, clickable b
 
 - Home active-work controls, detail routing, Console launch requests, item identity, local unread notification counts, notification review routing, local W+C watchlist run snapshots, and local W+C run detail routing now route through explicit adapter boundaries; schedule and agent-service adapters still need implementation.
 - Workflows has no wired workflow service in the shell wrapper.
-- W+C and Schedules now expose Console follow when the existing active-work adapter has actionable run context; Schedules also exposes Console launch for the latest local reading-digest output when no active run is available; Workflows and ACP still use honest unavailable Console states until actionable payloads exist.
-- Console now has a typed app-owned launch contract, reusable status-card display seam, source-readiness summary, Home W+C active-work source producer, W+C and Schedules destination follow producers, a Schedules reading-digest output fallback producer, and W+C run-detail action routing for staged live-work payloads; additional source-specific live event producers still need implementation.
+- W+C and Schedules now expose Console follow when the existing active-work adapter has actionable run context; Schedules also exposes Console launch for the latest local reading-digest output when no active run is available; Search/RAG result cards can stage selected retrieved evidence into Console; Workflows and ACP still use honest unavailable Console states until actionable payloads exist.
+- Console now has a typed app-owned launch contract, reusable status-card display seam, source-readiness summary, Home W+C active-work source producer, W+C and Schedules destination follow producers, a Schedules reading-digest output fallback producer, a RAG search-result producer, and W+C run-detail action routing for staged live-work payloads; additional source-specific live event producers still need implementation.
 - ACP launch is disabled until an ACP-compatible runtime is configured.
 - MCP management is not embedded in the top-level MCP wrapper.
 - Skills local/server services exist, but the top-level Skills shell still leaves import disabled and lacks list/detail/import UX adoption.
@@ -94,6 +94,7 @@ Initial child tasks:
 - Phase 3.5: Launch latest W+C run from W+C into Console - `TASK-3.5`
 - Phase 3.6: Show Console live-work source readiness - `TASK-3.6`
 - Phase 3.7: Launch active Schedules run from Schedules into Console - `TASK-3.7`
+- Phase 3.8: Launch RAG search result from Search/RAG into Console - `TASK-3.8`
 
 ## QA Evidence Index
 
@@ -114,7 +115,7 @@ Initial child tasks:
 | Phase 0: Canonical Tracking | Make remaining work trackable. | verified | `TASK-1`, `TASK-1.1`, `TASK-1.2` | `phase-0/` | Product UI workflows are out of scope for Phase 0. |
 | Phase 1: Shell Contract Complete | Remove false shell affordances and prove shell usability. | verified | `TASK-2`, `TASK-2.1`, `TASK-2.2`, `TASK-2.3`, `TASK-2.4` | `phase-1/` | Live service workflows remain intentionally deferred to Phases 2-6. |
 | Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | in-progress | `TASK-4`, `TASK-4.1`, `TASK-4.2`, `TASK-4.3`, `TASK-4.4`, `TASK-4.5`, `TASK-4.6`, `TASK-4.7` | `phase-2/` | Schedule and agent-service adapters still need implementation; local watchlist retry/pause/resume remain recoverable rather than fully controllable. |
-| Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | in-progress | `TASK-3`, `TASK-3.1`, `TASK-3.2`, `TASK-3.3`, `TASK-3.4`, `TASK-3.5`, `TASK-3.6`, `TASK-3.7` | `phase-3/` | Additional source-specific live event producers and follow/status wiring still need implementation. |
+| Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | in-progress | `TASK-3`, `TASK-3.1`, `TASK-3.2`, `TASK-3.3`, `TASK-3.4`, `TASK-3.5`, `TASK-3.6`, `TASK-3.7`, `TASK-3.8` | `phase-3/` | Workflows, ACP, MCP, Artifacts, and deeper source-specific live event streams still need implementation. |
 | Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | not-started | `TASK-5` | `phase-4/` | Service coverage varies by destination. |
 | Phase 5: Capability And Recovery System | Systematize unavailable and blocked states. | not-started | `TASK-6` | `phase-5/` | Shared taxonomy not yet extracted. |
 | Phase 6: Audit Replay And Closeout | Prove shell works for first-time and power users. | not-started | `TASK-7` | `phase-6/` | Depends on prior phases and running-app QA. |
@@ -236,6 +237,12 @@ Initial audit result: W+C, Schedules, Workflows, and ACP had false Console-launc
 `TASK-3.7` also lets Schedules stage the latest local reading-digest output in Console when no active schedule-run context exists:
 
 - `Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-schedules-digest-console-launch.md`
+
+## Phase 3.8 RAG Search Console Launch Evidence
+
+`TASK-3.8` lets Search/RAG result cards stage selected retrieved evidence in Console while preserving existing Use in Chat behavior:
+
+- `Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-rag-search-console-launch.md`
 
 ## Phase 0: Canonical Tracking
 

--- a/Tests/UI/test_console_live_work_handoffs.py
+++ b/Tests/UI/test_console_live_work_handoffs.py
@@ -37,6 +37,9 @@ PHASE3_SCHEDULES_CONSOLE_EVIDENCE = (
 PHASE3_SCHEDULES_DIGEST_CONSOLE_EVIDENCE = (
     REPO_ROOT / "Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-schedules-digest-console-launch.md"
 )
+PHASE3_RAG_CONSOLE_EVIDENCE = (
+    REPO_ROOT / "Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-rag-search-console-launch.md"
+)
 
 
 def _load_console_live_work_contract():
@@ -326,11 +329,14 @@ def test_console_live_work_source_readiness_marks_connected_sources_and_future_s
         "Schedules: Connected - Schedules active work can open Console when adapter context exists."
     )
     assert "console-live-work-source-connected" in rows_by_id["console-live-work-source-schedules"].classes
+    assert rows_by_id["console-live-work-source-rag"].text == (
+        "RAG: Connected - Search/RAG results can stage retrieved evidence in Console."
+    )
+    assert "console-live-work-source-connected" in rows_by_id["console-live-work-source-rag"].classes
     for source_id in (
         "console-live-work-source-workflows",
         "console-live-work-source-acp",
         "console-live-work-source-mcp",
-        "console-live-work-source-rag",
         "console-live-work-source-artifacts",
     ):
         assert "Not wired" in rows_by_id[source_id].text
@@ -486,6 +492,27 @@ def test_phase3_schedules_digest_console_tracking_evidence_links_task_and_roadma
     assert "2026-05-03-schedules-digest-console-launch.md" in readme
     assert "Schedules Reading Digest Console Launch Evidence" in roadmap
     assert "reading-digest" in task
+
+
+def test_phase3_rag_console_launch_tracking_evidence_links_task_and_roadmap():
+    evidence = PHASE3_RAG_CONSOLE_EVIDENCE.read_text()
+    readme = (REPO_ROOT / "Docs/superpowers/qa/unified-shell/phase-3/README.md").read_text()
+    roadmap = (REPO_ROOT / "Docs/superpowers/trackers/unified-shell-maturity-roadmap.md").read_text()
+    task = (
+        REPO_ROOT
+        / "backlog/tasks/task-3.8 - Phase-3.8-Launch-RAG-search-result-from-Search-RAG-into-Console.md"
+    ).read_text()
+
+    assert "TASK-3.8" in evidence
+    assert "Search/RAG" in evidence
+    assert "open_console_for_live_work" in evidence
+    assert "2026-05-03-rag-search-console-launch.md" in readme
+    assert "Phase 3.8: Launch RAG search result from Search/RAG into Console - `TASK-3.8`" in roadmap
+    assert (
+        "`TASK-3`, `TASK-3.1`, `TASK-3.2`, `TASK-3.3`, `TASK-3.4`, "
+        "`TASK-3.5`, `TASK-3.6`, `TASK-3.7`, `TASK-3.8`"
+    ) in roadmap
+    assert "RAG result" in task
 
 
 def test_schedules_console_follow_uses_home_dashboard_app_inputs():
@@ -1003,7 +1030,7 @@ async def test_console_renders_source_readiness_summary_without_pending_launch()
         assert "Schedules: Connected" in str(screen.query_one("#console-live-work-source-schedules").renderable)
         assert "ACP: Not wired" in str(screen.query_one("#console-live-work-source-acp").renderable)
         assert "MCP: Not wired" in str(screen.query_one("#console-live-work-source-mcp").renderable)
-        assert "RAG: Not wired" in str(screen.query_one("#console-live-work-source-rag").renderable)
+        assert "RAG: Connected" in str(screen.query_one("#console-live-work-source-rag").renderable)
         assert "Artifacts: Not wired" in str(screen.query_one("#console-live-work-source-artifacts").renderable)
 
 

--- a/Tests/UI/test_ux_audit_smoke.py
+++ b/Tests/UI/test_ux_audit_smoke.py
@@ -743,6 +743,49 @@ async def test_valid_rag_search_console_launch_replays_from_mounted_window_to_ap
 
 
 @pytest.mark.asyncio
+async def test_rag_search_console_launch_escapes_result_markup_before_staging(tmp_path):
+    with (
+        patch.dict(search_rag_window.DEPENDENCIES_AVAILABLE, {"embeddings_rag": True}, clear=False),
+        patch(
+            "tldw_chatbook.UI.Views.RAGSearch.search_rag_window.get_user_data_dir",
+            return_value=tmp_path,
+        ),
+        patch(
+            "tldw_chatbook.UI.Views.RAGSearch.saved_searches_panel.get_user_data_dir",
+            return_value=tmp_path,
+        ),
+    ):
+        app = SearchRAGHandoffSmokeApp()
+
+        async with app.run_test(size=(160, 40)) as pilot:
+            await pilot.pause(0.1)
+            app.window.search_results = [
+                {
+                    "title": "[red]Retrieved[/red] <script>\x00",
+                    "content": "[bold]Evidence[/bold] <script>alert(1)</script>\x00",
+                    "source": "notes",
+                    "score": 0.91,
+                    "metadata": {"document_id": "doc-[red]-<script>"},
+                }
+            ]
+            app.window.total_results = 1
+            await app.window._display_results()
+            await pilot.pause(0.05)
+
+            app.window.query_one("#use-in-console-0", Button).press()
+            await pilot.pause(0.05)
+
+            app.app_instance.open_console_for_live_work.assert_called_once()
+            call_kwargs = app.app_instance.open_console_for_live_work.call_args.kwargs
+            assert call_kwargs["title"] == r"\[red]Retrieved\[/red] &lt;script&gt;"
+            assert call_kwargs["payload"]["target_id"] == r"search-rag:doc-\[red]-&lt;script&gt;"
+            assert call_kwargs["payload"]["source"] == "notes"
+            assert call_kwargs["payload"]["display_summary"] == (
+                r"\[bold]Evidence\[/bold] &lt;script&gt;alert(1)&lt;/script&gt;"
+            )
+
+
+@pytest.mark.asyncio
 async def test_contract_blocked_rag_search_handoff_explains_recovery_without_staging(tmp_path):
     with (
         patch.dict(search_rag_window.DEPENDENCIES_AVAILABLE, {"embeddings_rag": True}, clear=False),

--- a/Tests/UI/test_ux_audit_smoke.py
+++ b/Tests/UI/test_ux_audit_smoke.py
@@ -638,6 +638,7 @@ class SearchRAGHandoffSmokeApp(App[None]):
             api_endpoint="test-endpoint",
             get_authoritative_runtime_source=Mock(return_value="server"),
             open_chat_with_handoff=Mock(),
+            open_console_for_live_work=Mock(),
         )
         self.window = SearchRAGWindow(self.app_instance)
 
@@ -688,6 +689,60 @@ async def test_valid_rag_search_handoff_replays_from_mounted_window_to_app_seam(
 
 
 @pytest.mark.asyncio
+async def test_valid_rag_search_console_launch_replays_from_mounted_window_to_app_seam(tmp_path):
+    with (
+        patch.dict(search_rag_window.DEPENDENCIES_AVAILABLE, {"embeddings_rag": True}, clear=False),
+        patch(
+            "tldw_chatbook.UI.Views.RAGSearch.search_rag_window.get_user_data_dir",
+            return_value=tmp_path,
+        ),
+        patch(
+            "tldw_chatbook.UI.Views.RAGSearch.saved_searches_panel.get_user_data_dir",
+            return_value=tmp_path,
+        ),
+    ):
+        app = SearchRAGHandoffSmokeApp()
+
+        async with app.run_test(size=(160, 40)) as pilot:
+            await pilot.pause(0.1)
+            app.window.search_results = [
+                {
+                    "title": "Retrieved Chunk",
+                    "content": "Evidence body",
+                    "source": "notes",
+                    "score": 0.91,
+                    "metadata": {"document_id": "doc-1", "chunk_id": "chunk-7"},
+                }
+            ]
+            app.window.total_results = 1
+            await app.window._display_results()
+            await pilot.pause(0.05)
+
+            button = app.window.query_one("#use-in-console-0", Button)
+            button.press()
+            await pilot.pause(0.05)
+
+            app.app_instance.open_chat_with_handoff.assert_not_called()
+            app.app_instance.open_console_for_live_work.assert_called_once_with(
+                source="RAG",
+                title="Retrieved Chunk",
+                payload={
+                    "target_id": "search-rag:doc-1",
+                    "source_id": "doc-1",
+                    "content_ref": "search-rag:doc-1",
+                    "runtime_backend": "server",
+                    "source": "notes",
+                    "score": 0.91,
+                    "display_summary": "Evidence body",
+                    "suggested_prompt": "Use this retrieved result as context and answer or reason from it carefully.",
+                },
+                status="ready",
+                recovery="Use this retrieved RAG result as Console context, or return to Search/RAG to adjust the query.",
+                action_label="Ask from RAG result",
+            )
+
+
+@pytest.mark.asyncio
 async def test_contract_blocked_rag_search_handoff_explains_recovery_without_staging(tmp_path):
     with (
         patch.dict(search_rag_window.DEPENDENCIES_AVAILABLE, {"embeddings_rag": True}, clear=False),
@@ -723,6 +778,51 @@ async def test_contract_blocked_rag_search_handoff_explains_recovery_without_sta
             button.press()
             await pilot.pause(0.05)
 
+            app.app_instance.open_chat_with_handoff.assert_not_called()
+            message = app.app_instance.notify.call_args.args[0]
+            assert "rag.media_embeddings.search.server requires server mode" in message
+            assert "source authority: runtime_policy/server" in message.lower()
+            assert "ux interop: active source local" in message.lower()
+            assert "switch source to server" in message.lower()
+
+
+@pytest.mark.asyncio
+async def test_contract_blocked_rag_search_console_launch_explains_recovery_without_staging(tmp_path):
+    with (
+        patch.dict(search_rag_window.DEPENDENCIES_AVAILABLE, {"embeddings_rag": True}, clear=False),
+        patch(
+            "tldw_chatbook.UI.Views.RAGSearch.search_rag_window.get_user_data_dir",
+            return_value=tmp_path,
+        ),
+        patch(
+            "tldw_chatbook.UI.Views.RAGSearch.saved_searches_panel.get_user_data_dir",
+            return_value=tmp_path,
+        ),
+    ):
+        app = SearchRAGHandoffSmokeApp()
+        app.app_instance.runtime_policy = SimpleNamespace(state=RuntimeSourceState(active_source="local"))
+        app.app_instance.ui_policy_engine = PolicyEngine(CAPABILITY_REGISTRY)
+
+        async with app.run_test(size=(160, 40)) as pilot:
+            await pilot.pause(0.1)
+            app.window.search_results = [
+                {
+                    "title": "Server Chunk",
+                    "content": "Evidence body",
+                    "source": "notes",
+                    "score": 0.91,
+                    "metadata": {"document_id": "doc-1"},
+                }
+            ]
+            app.window.total_results = 1
+            await app.window._display_results()
+            await pilot.pause(0.05)
+
+            button = app.window.query_one("#use-in-console-0", Button)
+            button.press()
+            await pilot.pause(0.05)
+
+            app.app_instance.open_console_for_live_work.assert_not_called()
             app.app_instance.open_chat_with_handoff.assert_not_called()
             message = app.app_instance.notify.call_args.args[0]
             assert "rag.media_embeddings.search.server requires server mode" in message

--- a/backlog/tasks/task-3.8 - Phase-3.8-Launch-RAG-search-result-from-Search-RAG-into-Console.md
+++ b/backlog/tasks/task-3.8 - Phase-3.8-Launch-RAG-search-result-from-Search-RAG-into-Console.md
@@ -4,7 +4,7 @@ title: 'Phase 3.8: Launch RAG search result from Search/RAG into Console'
 status: Done
 assignee: []
 created_date: '2026-05-04 01:54'
-updated_date: '2026-05-04 02:02'
+updated_date: '2026-05-04 02:23'
 labels: []
 dependencies: []
 parent_task_id: TASK-3
@@ -40,4 +40,6 @@ Make Search/RAG results a real Phase 3 Console live-work source by allowing a se
 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented a separate Search/RAG Use in Console action that reuses existing RAG handoff payloads and runtime-policy blocking before staging a typed Console live-work launch. Updated Console source readiness to mark RAG connected, added focused mounted-window regressions, and recorded Phase 3.8 roadmap and QA evidence.
+
+Review follow-up sanitized Console-bound Search/RAG result strings with input_validation.sanitize_string plus Rich/HTML escaping before staging, added a regression for markup/control-character payloads, and added a Google-style docstring to the Console event handler.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-3.8 - Phase-3.8-Launch-RAG-search-result-from-Search-RAG-into-Console.md
+++ b/backlog/tasks/task-3.8 - Phase-3.8-Launch-RAG-search-result-from-Search-RAG-into-Console.md
@@ -1,0 +1,43 @@
+---
+id: TASK-3.8
+title: 'Phase 3.8: Launch RAG search result from Search/RAG into Console'
+status: Done
+assignee: []
+created_date: '2026-05-04 01:54'
+updated_date: '2026-05-04 02:02'
+labels: []
+dependencies: []
+parent_task_id: TASK-3
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make Search/RAG results a real Phase 3 Console live-work source by allowing a selected retrieved result to be staged into Console with clear recovery and runtime-policy behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Search/RAG result cards expose a distinct Console launch action separate from Use in Chat.
+- [x] #2 Selecting a RAG result Console action stages a typed Console live-work launch with result identity score source and recovery context.
+- [x] #3 Runtime policy blocks server-backed RAG Console launch with recovery copy before staging when the active runtime is incompatible.
+- [x] #4 Console source readiness marks RAG as connected while leaving still-unwired sources honest.
+- [x] #5 Focused automated tests and Phase 3 QA evidence verify the RAG Console launch workflow roadmap and task updates.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing regressions for the Search/RAG result Console action, policy-blocked server RAG launch, Console readiness copy, and Phase 3.8 tracking evidence.
+2. Extend the SearchResult event/button contract with a separate Use in Console request without changing Use in Chat.
+3. Reuse existing RAG handoff payload construction and policy checks to stage a typed ConsoleLiveWorkLaunch through app.open_console_for_live_work.
+4. Update Console source readiness, roadmap, Backlog, and QA evidence to reflect RAG as connected.
+5. Run focused UI/Console tests plus diff hygiene verification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented a separate Search/RAG Use in Console action that reuses existing RAG handoff payloads and runtime-policy blocking before staging a typed Console live-work launch. Updated Console source readiness to mark RAG connected, added focused mounted-window regressions, and recorded Phase 3.8 roadmap and QA evidence.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_live_work.py
+++ b/tldw_chatbook/Chat/console_live_work.py
@@ -275,9 +275,9 @@ class ConsoleLiveWorkSourceReadinessState:
                 ConsoleLiveWorkSourceReadinessRow(
                     widget_id="console-live-work-source-rag",
                     label="RAG",
-                    status="Not wired",
-                    recovery="RAG live-run payloads are not wired yet; use Search/RAG handoff for context.",
-                    classes=unavailable,
+                    status="Connected",
+                    recovery="Search/RAG results can stage retrieved evidence in Console.",
+                    classes=connected,
                 ),
                 ConsoleLiveWorkSourceReadinessRow(
                     widget_id="console-live-work-source-artifacts",

--- a/tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py
+++ b/tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py
@@ -47,6 +47,10 @@ from ....Utils.paths import get_user_data_dir
 
 # Conditionally import web search functionality
 WEB_SEARCH_AVAILABLE = DEPENDENCIES_AVAILABLE.get('websearch', False)
+USE_IN_CONSOLE_UNAVAILABLE_RECOVERY = (
+    "Use in Console is unavailable because the Console live-work surface is not mounted. "
+    "Open Console from the navigation, then try again."
+)
 if WEB_SEARCH_AVAILABLE:
     try:
         from ....Web_Scraping.WebSearch_APIs import search_web_bing, parse_bing_results
@@ -514,6 +518,42 @@ class SearchRAGWindow(SearchEventHandlersMixin, Container):
             runtime_backend=self._authoritative_runtime_backend(),
         )
 
+    def _build_search_console_launch(self, result: Dict[str, Any]) -> dict[str, Any]:
+        handoff_payload = self._build_search_chat_handoff_payload(result)
+        metadata = dict(handoff_payload.metadata or {})
+        source_id = str(handoff_payload.source_id or "").strip()
+        content_ref = str(handoff_payload.content_ref or "").strip()
+        target_id = content_ref or (
+            f"{handoff_payload.source}:{source_id}" if source_id else handoff_payload.source
+        )
+        is_web = handoff_payload.source == "search-web"
+        launch_payload = {
+            "target_id": target_id,
+            "source_id": source_id,
+            "content_ref": content_ref,
+            "runtime_backend": handoff_payload.runtime_backend or self._authoritative_runtime_backend(),
+            "source": str(result.get("source") or "unknown").strip() or "unknown",
+            "score": metadata.get("score"),
+            "display_summary": handoff_payload.display_summary,
+            "suggested_prompt": handoff_payload.suggested_prompt,
+        }
+        return {
+            "source": "Web Search" if is_web else "RAG",
+            "title": handoff_payload.title,
+            "payload": {
+                key: value
+                for key, value in launch_payload.items()
+                if value is not None and str(value).strip()
+            },
+            "status": "ready",
+            "recovery": (
+                "Use this web result as Console context, or return to Search/RAG to adjust the query."
+                if is_web
+                else "Use this retrieved RAG result as Console context, or return to Search/RAG to adjust the query."
+            ),
+            "action_label": "Ask from web result" if is_web else "Ask from RAG result",
+        }
+
     @staticmethod
     def _rag_handoff_runtime_action_id(payload: ChatHandoffPayload) -> str | None:
         if payload.source != "search-rag":
@@ -544,6 +584,20 @@ class SearchRAGWindow(SearchEventHandlersMixin, Container):
             self.app_instance.notify(USE_IN_CHAT_UNAVAILABLE_RECOVERY, severity="warning")
             return
         open_chat(payload)
+
+    @on(SearchResult.UseInConsoleRequested)
+    def handle_search_result_use_in_console(self, event: SearchResult.UseInConsoleRequested) -> None:
+        event.stop()
+        payload = self._build_search_chat_handoff_payload(event.result)
+        policy_message = self._rag_handoff_policy_blocking_message(payload)
+        if policy_message:
+            self.app_instance.notify(policy_message, severity="warning")
+            return
+        open_console = getattr(self.app_instance, "open_console_for_live_work", None)
+        if not callable(open_console):
+            self.app_instance.notify(USE_IN_CONSOLE_UNAVAILABLE_RECOVERY, severity="warning")
+            return
+        open_console(**self._build_search_console_launch(event.result))
 
     @on(SavedSearchesPanel.LoadRequested)
     def handle_saved_search_load_requested(self, event: SavedSearchesPanel.LoadRequested) -> None:

--- a/tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py
+++ b/tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, List, Dict, Any, Tuple
 import asyncio
 from datetime import datetime
+from html import escape as html_escape
 from pathlib import Path
 import json
 
@@ -43,6 +44,7 @@ from ....Chat.chat_handoff_messages import (
 from ....Chat.chat_handoff_models import ChatHandoffPayload
 from ....Utils.optional_deps import DEPENDENCIES_AVAILABLE
 from ....DB.search_history_db import SearchHistoryDB
+from ....Utils.input_validation import sanitize_string
 from ....Utils.paths import get_user_data_dir
 
 # Conditionally import web search functionality
@@ -51,6 +53,14 @@ USE_IN_CONSOLE_UNAVAILABLE_RECOVERY = (
     "Use in Console is unavailable because the Console live-work surface is not mounted. "
     "Open Console from the navigation, then try again."
 )
+
+
+def _sanitize_console_text(value: Any, *, max_length: int = 1000) -> str:
+    """Return text safe for Rich/Textual status-row rendering."""
+    cleaned = sanitize_string(str(value or ""), max_length=max_length)
+    return escape(html_escape(cleaned, quote=False))
+
+
 if WEB_SEARCH_AVAILABLE:
     try:
         from ....Web_Scraping.WebSearch_APIs import search_web_bing, parse_bing_results
@@ -528,18 +538,21 @@ class SearchRAGWindow(SearchEventHandlersMixin, Container):
         )
         is_web = handoff_payload.source == "search-web"
         launch_payload = {
-            "target_id": target_id,
-            "source_id": source_id,
-            "content_ref": content_ref,
+            "target_id": _sanitize_console_text(target_id),
+            "source_id": _sanitize_console_text(source_id),
+            "content_ref": _sanitize_console_text(content_ref),
             "runtime_backend": handoff_payload.runtime_backend or self._authoritative_runtime_backend(),
-            "source": str(result.get("source") or "unknown").strip() or "unknown",
+            "source": _sanitize_console_text(
+                str(result.get("source") or "unknown").strip() or "unknown",
+                max_length=120,
+            ),
             "score": metadata.get("score"),
-            "display_summary": handoff_payload.display_summary,
-            "suggested_prompt": handoff_payload.suggested_prompt,
+            "display_summary": _sanitize_console_text(handoff_payload.display_summary),
+            "suggested_prompt": _sanitize_console_text(handoff_payload.suggested_prompt),
         }
         return {
             "source": "Web Search" if is_web else "RAG",
-            "title": handoff_payload.title,
+            "title": _sanitize_console_text(handoff_payload.title, max_length=500),
             "payload": {
                 key: value
                 for key, value in launch_payload.items()
@@ -587,6 +600,11 @@ class SearchRAGWindow(SearchEventHandlersMixin, Container):
 
     @on(SearchResult.UseInConsoleRequested)
     def handle_search_result_use_in_console(self, event: SearchResult.UseInConsoleRequested) -> None:
+        """Stage a selected Search/RAG result as Console live-work context.
+
+        Args:
+            event: Result-card event carrying the selected search result.
+        """
         event.stop()
         payload = self._build_search_chat_handoff_payload(event.result)
         policy_message = self._rag_handoff_policy_blocking_message(payload)

--- a/tldw_chatbook/UI/Views/RAGSearch/search_result.py
+++ b/tldw_chatbook/UI/Views/RAGSearch/search_result.py
@@ -24,6 +24,14 @@ class SearchResult(Container):
             super().__init__()
             self.index = index
             self.result = dict(result)
+
+    class UseInConsoleRequested(Message):
+        """Request staging a search result into Console live-work context."""
+
+        def __init__(self, index: int, result: Dict[str, Any]) -> None:
+            super().__init__()
+            self.index = index
+            self.result = dict(result)
     
     def __init__(self, result: Dict[str, Any], index: int):
         super().__init__(id=f"result-{index}", classes="search-result-card-enhanced")
@@ -124,14 +132,21 @@ class SearchResult(Container):
                     yield Button("📋 Copy", id=f"copy-{self.index}", classes="result-button")
                     yield Button("📝 Note", id=f"add-note-{self.index}", classes="result-button")
                     yield Button("Use in Chat", id=f"use-in-chat-{self.index}", classes="result-button")
+                    yield Button("Use in Console", id=f"use-in-console-{self.index}", classes="result-button")
                     yield Button("📤 Export", id=f"export-{self.index}", classes="result-button")
 
     def _build_use_in_chat_event(self) -> UseInChatRequested:
         return self.UseInChatRequested(self.index, self.result)
 
+    def _build_use_in_console_event(self) -> UseInConsoleRequested:
+        return self.UseInConsoleRequested(self.index, self.result)
+
     @on(Button.Pressed)
     def handle_button_pressed(self, event: Button.Pressed) -> None:
-        if event.button.id != f"use-in-chat-{self.index}":
+        if event.button.id == f"use-in-chat-{self.index}":
+            event.stop()
+            self.post_message(self._build_use_in_chat_event())
             return
-        event.stop()
-        self.post_message(self._build_use_in_chat_event())
+        if event.button.id == f"use-in-console-{self.index}":
+            event.stop()
+            self.post_message(self._build_use_in_console_event())


### PR DESCRIPTION
## Summary
- Add a distinct Search/RAG result `Use in Console` action while preserving existing `Use in Chat` behavior.
- Stage selected RAG results through `open_console_for_live_work` with identity, source, score, runtime, summary, and recovery metadata.
- Mark RAG as connected in Console source readiness and add `TASK-3.8` roadmap/backlog/QA evidence.

## Test Plan
- [x] Red run: targeted tests failed on missing `#use-in-console-0`, RAG connected readiness, and evidence file.
- [x] `.venv/bin/python -m pytest Tests/UI/test_ux_audit_smoke.py Tests/UI/test_console_live_work_handoffs.py -q --tb=short` -> 55 passed, 1 warning.
- [x] `.venv/bin/python -m pytest Tests/UI/test_console_live_work_handoffs.py::test_phase3_rag_console_launch_tracking_evidence_links_task_and_roadmap -q` -> 1 passed, 1 warning.
- [x] `git diff --cached --check` clean.