### PR TITLE
Launch active Workflows run in Console

### DIFF
--- a/Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-console-live-work-source-readiness.md
+++ b/Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-console-live-work-source-readiness.md
@@ -14,8 +14,10 @@ Continue Phase 3 by making Console source readiness visible when no live-work it
 - Added `ConsoleLiveWorkSourceReadinessState` and source readiness rows.
 - Marked W+C as connected because Home W+C active work can now launch and route run details through Console.
 - Marked Schedules as connected because Schedules can now follow active schedule-run context into Console when adapter context exists.
-- Marked Workflows, ACP, MCP, RAG, and Artifacts as `Not wired` with explicit recovery copy.
-- Follow-up: `TASK-3.8` changes RAG to connected after Search/RAG result Console launch wiring landed.
+- Marked RAG as connected because Search/RAG results can stage selected evidence into Console.
+- Marked Artifacts as connected because latest local Chatbook artifacts can launch into Console.
+- Marked Workflows as connected because Workflows can launch active workflow-run context into Console when adapter context exists.
+- Marked ACP and MCP as `Not wired` with explicit recovery copy.
 - Updated `ChatScreen` to render the source readiness summary only when no pending Console live-work launch is staged.
 - Preserved pending launch focus by suppressing the readiness summary while a live-work card is visible.
 
@@ -36,13 +38,13 @@ Warning boundary: warnings are existing dependency/import warnings and are not C
 
 ## UX Result
 
-- First-time users can see that W+C, Schedules, and RAG are connected live-work sources after the `TASK-3.8` update.
+- First-time users can see that W+C, Schedules, RAG, Artifacts, and Workflows are connected live-work sources.
 - Power users can quickly distinguish supported Console follow-through from future source integrations.
 - Planned sources remain visible without false affordances because unavailable rows are informational only.
 
 ## Residual Risk
 
 - This is a source-readiness visibility slice, not full Phase 3 completion.
-- Workflows, ACP, MCP, and Artifacts still need source-specific payload producers.
+- ACP, MCP, and deeper source-specific live event producers still need implementation.
 - Console still does not subscribe to real live event streams.
 - Full Phase 3 cannot be verified until all relevant launch, follow, status, and recovery flows are exercised in the running app.

--- a/Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-workflows-console-launch.md
+++ b/Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-workflows-console-launch.md
@@ -1,0 +1,45 @@
+# Workflows Destination Console Launch
+
+Date: 2026-05-03
+Task: `TASK-3.10`
+Branch: `codex/unified-shell-phase3-workflows-live-work`
+Base: `origin/dev` at `0fbbe48e`
+
+## Purpose
+
+Continue Phase 3 by making the Workflows destination expose a real Console launch action when the Home active-work adapter has actionable workflow-run context.
+
+## What Changed
+
+- Added a Workflows destination Console launch producer using the existing Home active-work adapter seam.
+- Kept the Workflows Console launch action disabled with explicit recovery copy when no active workflow run exists.
+- Enabled `workflows-launch-in-console` when an active `Workflows` item has Console context.
+- Routed Workflows Console launch through `open_active_home_item_in_console` so Home and destination surfaces share the same launch path.
+- Updated Console source readiness so Workflows is shown as connected.
+
+## Functional QA Evidence
+
+Focused checks were run against the Workflows destination and Console handoff harness.
+
+- Baseline before the slice: `python -m pytest -q Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_destination_shells.py --tb=short`
+- Baseline result: `73 passed, 3 warnings in 22.46s`.
+- Red Workflows Console launch test: `python -m pytest -q Tests/UI/test_console_live_work_handoffs.py --tb=short`
+- Red result: `8 failed, 35 passed, 1 warning in 14.92s`; failures were expected because Workflows still rendered an unavailable Console action, source readiness still marked Workflows as `Not wired`, adapter discovery was missing, and this evidence/task tracking did not exist.
+- Focused Console handoff verification after implementation: `python -m pytest -q Tests/UI/test_console_live_work_handoffs.py --tb=short`
+- Focused Console handoff result: `43 passed, 1 warning in 14.07s`.
+- Broader Phase 3 regression check: `python -m pytest -q Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_destination_shells.py Tests/UI/test_home_screen.py Tests/Home/test_active_work_adapter.py Tests/UI/test_subscription_window_watchlists.py Tests/UI/test_screen_navigation.py Tests/UI/test_unified_shell_phase2_home_adapter.py --tb=short`
+- Broader Phase 3 result: `174 passed, 8 warnings in 83.11s`.
+
+Warning boundary: warnings are existing dependency/import warnings and are not Workflows Console-launch behavior failures.
+
+## UX Result
+
+- First-time users still see an honest unavailable state when no workflow run can be launched.
+- Power users can jump directly from Workflows to Console when an active workflow-run context exists.
+- The Workflows surface now matches the W+C and Schedules adapter-backed Console pattern instead of remaining a permanent false-negative disabled action.
+
+## Residual Risk
+
+- This slice wires the destination producer to adapter-provided context; it does not create a workflow-run backend snapshot adapter.
+- Console still does not subscribe to real live event streams.
+- Full Phase 3 still requires ACP, MCP, server Artifacts, and deeper live-work producers.

--- a/Docs/superpowers/qa/unified-shell/phase-3/README.md
+++ b/Docs/superpowers/qa/unified-shell/phase-3/README.md
@@ -11,10 +11,11 @@ This directory contains durable QA summaries for Phase 3 Console live-work hub s
 - `2026-05-03-home-wc-active-work-console-launch.md` - `TASK-3.3` Home W+C active-work source launch into the Console status-card surface.
 - `2026-05-03-console-wc-action-routing.md` - `TASK-3.4` Console W+C live-work action routing into W+C run details.
 - `2026-05-03-wc-destination-console-launch.md` - `TASK-3.5` W+C destination Console follow producer for the latest active W+C run.
-- `2026-05-03-console-live-work-source-readiness.md` - `TASK-3.6` Console source-readiness summary showing W+C and Schedules connected while future sources remain honestly unavailable.
+- `2026-05-03-console-live-work-source-readiness.md` - `TASK-3.6` Console source-readiness summary showing W+C, Schedules, RAG, Artifacts, and Workflows connected while future sources remain honestly unavailable.
 - `2026-05-03-schedules-console-launch.md` - `TASK-3.7` Schedules destination Console follow producer for active schedule runs.
 - `2026-05-03-schedules-digest-console-launch.md` - `TASK-3.7` Schedules destination Console launch producer for the latest local reading-digest output.
 - `2026-05-03-rag-search-console-launch.md` - `TASK-3.8` Search/RAG result Console launch producer for selected retrieved evidence.
 - `2026-05-03-artifacts-chatbook-console-launch.md` - `TASK-3.9` Artifacts destination Console launch producer for the latest local Chatbook artifact.
+- `2026-05-03-workflows-console-launch.md` - `TASK-3.10` Workflows destination Console launch producer for active workflow runs.
 
 Do not mark Phase 3 verified until launch, follow, status, and recovery flows are verified in the running app against workflows, schedules, ACP, MCP, RAG, artifacts, and active-work source adapters.

--- a/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
@@ -28,9 +28,9 @@ Track remaining Unified Shell work in one place so rendered screens, clickable b
 ## Known Product Gaps
 
 - Home active-work controls, detail routing, Console launch requests, item identity, local unread notification counts, notification review routing, local W+C watchlist run snapshots, and local W+C run detail routing now route through explicit adapter boundaries; schedule and agent-service adapters still need implementation.
-- Workflows has no wired workflow service in the shell wrapper.
-- W+C and Schedules now expose Console follow when the existing active-work adapter has actionable run context; Schedules also exposes Console launch for the latest local reading-digest output when no active run is available; Search/RAG result cards can stage selected retrieved evidence into Console; Artifacts can launch the latest local Chatbook artifact into Console; Workflows and ACP still use honest unavailable Console states until actionable payloads exist.
-- Console now has a typed app-owned launch contract, reusable status-card display seam, source-readiness summary, Home W+C active-work source producer, W+C and Schedules destination follow producers, a Schedules reading-digest output fallback producer, a RAG search-result producer, an Artifacts Chatbook producer, and W+C run-detail action routing for staged live-work payloads; additional source-specific live event producers still need implementation.
+- Workflows has no wired workflow service in the shell wrapper, but can launch Console when the active-work adapter already has actionable workflow-run context.
+- W+C, Schedules, and Workflows now expose Console follow or launch when the existing active-work adapter has actionable run context; Schedules also exposes Console launch for the latest local reading-digest output when no active run is available; Search/RAG result cards can stage selected retrieved evidence into Console; Artifacts can launch the latest local Chatbook artifact into Console; ACP still uses honest unavailable Console states until actionable payloads exist.
+- Console now has a typed app-owned launch contract, reusable status-card display seam, source-readiness summary, Home W+C active-work source producer, W+C, Schedules, and Workflows destination producers, a Schedules reading-digest output fallback producer, a RAG search-result producer, an Artifacts Chatbook producer, and W+C run-detail action routing for staged live-work payloads; additional source-specific live event producers still need implementation.
 - ACP launch is disabled until an ACP-compatible runtime is configured.
 - MCP management is not embedded in the top-level MCP wrapper.
 - Skills local/server services exist, but the top-level Skills shell still leaves import disabled and lacks list/detail/import UX adoption.
@@ -96,6 +96,7 @@ Initial child tasks:
 - Phase 3.7: Launch active Schedules run from Schedules into Console - `TASK-3.7`
 - Phase 3.8: Launch RAG search result from Search/RAG into Console - `TASK-3.8`
 - Phase 3.9: Launch latest Chatbook artifact from Artifacts into Console - `TASK-3.9`
+- Phase 3.10: Launch active Workflows run from Workflows into Console - `TASK-3.10`
 
 ## QA Evidence Index
 
@@ -116,7 +117,7 @@ Initial child tasks:
 | Phase 0: Canonical Tracking | Make remaining work trackable. | verified | `TASK-1`, `TASK-1.1`, `TASK-1.2` | `phase-0/` | Product UI workflows are out of scope for Phase 0. |
 | Phase 1: Shell Contract Complete | Remove false shell affordances and prove shell usability. | verified | `TASK-2`, `TASK-2.1`, `TASK-2.2`, `TASK-2.3`, `TASK-2.4` | `phase-1/` | Live service workflows remain intentionally deferred to Phases 2-6. |
 | Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | in-progress | `TASK-4`, `TASK-4.1`, `TASK-4.2`, `TASK-4.3`, `TASK-4.4`, `TASK-4.5`, `TASK-4.6`, `TASK-4.7` | `phase-2/` | Schedule and agent-service adapters still need implementation; local watchlist retry/pause/resume remain recoverable rather than fully controllable. |
-| Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | in-progress | `TASK-3`, `TASK-3.1`, `TASK-3.2`, `TASK-3.3`, `TASK-3.4`, `TASK-3.5`, `TASK-3.6`, `TASK-3.7`, `TASK-3.8`, `TASK-3.9` | `phase-3/` | Workflows, ACP, MCP, server Artifacts, and deeper source-specific live event streams still need implementation. |
+| Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | in-progress | `TASK-3`, `TASK-3.1`, `TASK-3.2`, `TASK-3.3`, `TASK-3.4`, `TASK-3.5`, `TASK-3.6`, `TASK-3.7`, `TASK-3.8`, `TASK-3.9`, `TASK-3.10` | `phase-3/` | ACP, MCP, server Artifacts, and deeper source-specific live event streams still need implementation. |
 | Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | not-started | `TASK-5` | `phase-4/` | Service coverage varies by destination. |
 | Phase 5: Capability And Recovery System | Systematize unavailable and blocked states. | not-started | `TASK-6` | `phase-5/` | Shared taxonomy not yet extracted. |
 | Phase 6: Audit Replay And Closeout | Prove shell works for first-time and power users. | not-started | `TASK-7` | `phase-6/` | Depends on prior phases and running-app QA. |
@@ -250,6 +251,12 @@ Initial audit result: W+C, Schedules, Workflows, and ACP had false Console-launc
 `TASK-3.9` lets Artifacts stage the latest local Chatbook artifact in Console while preserving the existing Chatbooks destination route:
 
 - `Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-artifacts-chatbook-console-launch.md`
+
+## Phase 3.10 Workflows Destination Console Launch Evidence
+
+`TASK-3.10` makes Workflows itself expose Console launch for active workflow runs when adapter context exists:
+
+- `Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-workflows-console-launch.md`
 
 ## Phase 0: Canonical Tracking
 

--- a/Tests/UI/test_console_live_work_handoffs.py
+++ b/Tests/UI/test_console_live_work_handoffs.py
@@ -13,6 +13,7 @@ from tldw_chatbook.Chat.chat_handoff_models import ChatHandoffPayload
 from tldw_chatbook.Home.dashboard_state import HomeActiveWorkItem, HomeDashboardInput
 from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 from tldw_chatbook.UI.Screens.schedules_screen import SchedulesScreen
+from tldw_chatbook.UI.Screens.workflows_screen import WorkflowsScreen
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -42,6 +43,9 @@ PHASE3_RAG_CONSOLE_EVIDENCE = (
 )
 PHASE3_ARTIFACTS_CHATBOOK_CONSOLE_EVIDENCE = (
     REPO_ROOT / "Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-artifacts-chatbook-console-launch.md"
+)
+PHASE3_WORKFLOWS_CONSOLE_EVIDENCE = (
+    REPO_ROOT / "Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-workflows-console-launch.md"
 )
 
 
@@ -358,8 +362,15 @@ def test_console_live_work_source_readiness_marks_connected_sources_and_future_s
         "RAG: Connected - Search/RAG results can stage retrieved evidence in Console."
     )
     assert "console-live-work-source-connected" in rows_by_id["console-live-work-source-rag"].classes
+    assert rows_by_id["console-live-work-source-workflows"].text == (
+        "Workflows: Connected - Workflows active work can open Console when adapter context exists."
+    )
+    assert "console-live-work-source-connected" in rows_by_id["console-live-work-source-workflows"].classes
+    assert rows_by_id["console-live-work-source-artifacts"].text == (
+        "Artifacts: Connected - Latest local Chatbook artifacts can launch into Console."
+    )
+    assert "console-live-work-source-connected" in rows_by_id["console-live-work-source-artifacts"].classes
     for source_id in (
-        "console-live-work-source-workflows",
         "console-live-work-source-acp",
         "console-live-work-source-mcp",
     ):
@@ -564,6 +575,27 @@ def test_phase3_artifacts_chatbook_console_launch_tracking_evidence_links_task_a
     assert "Chatbook payload" in task
 
 
+def test_phase3_workflows_console_tracking_evidence_links_task_and_roadmap():
+    evidence = PHASE3_WORKFLOWS_CONSOLE_EVIDENCE.read_text()
+    readme = (REPO_ROOT / "Docs/superpowers/qa/unified-shell/phase-3/README.md").read_text()
+    roadmap = (REPO_ROOT / "Docs/superpowers/trackers/unified-shell-maturity-roadmap.md").read_text()
+    task = (
+        REPO_ROOT
+        / "backlog/tasks/task-3.10 - Phase-3.10-Launch-active-Workflows-run-from-Workflows-into-Console.md"
+    ).read_text()
+
+    assert "TASK-3.10" in evidence
+    assert "Workflows destination Console launch" in evidence
+    assert "workflows-launch-in-console" in evidence
+    assert "2026-05-03-workflows-console-launch.md" in readme
+    assert "Phase 3.10: Launch active Workflows run from Workflows into Console - `TASK-3.10`" in roadmap
+    assert (
+        "`TASK-3`, `TASK-3.1`, `TASK-3.2`, `TASK-3.3`, `TASK-3.4`, "
+        "`TASK-3.5`, `TASK-3.6`, `TASK-3.7`, `TASK-3.8`, `TASK-3.9`, `TASK-3.10`"
+    ) in roadmap
+    assert "workflows-launch-in-console" in task
+
+
 def test_schedules_console_follow_uses_home_dashboard_app_inputs():
     app = _build_test_app()
     app.providers_models = {"OpenAI": ["gpt-4.1"]}
@@ -629,7 +661,7 @@ async def test_schedules_destination_loads_console_follow_item_off_main_thread()
         (
             "workflows",
             "workflows-launch-in-console",
-            "Console launch is unavailable until workflow execution payloads are wired.",
+            "No active workflow run is available for Console launch.",
         ),
         (
             "acp",
@@ -719,6 +751,144 @@ async def test_schedules_destination_routes_latest_active_run_to_console():
 
     app.open_active_home_item_in_console.assert_called_once_with(
         target_id="schedule:run:7",
+        target_route="chat",
+    )
+
+
+def test_workflows_console_launch_uses_home_dashboard_app_inputs():
+    app = _build_test_app()
+    app.providers_models = {"OpenAI": ["gpt-4.1"]}
+    app._screen_states = {"chat": {"conversation_id": "c1"}}
+    app.home_active_work_adapter = StaticHomeActiveWorkAdapter(
+        (
+            HomeActiveWorkItem(
+                item_id="workflow:run:11",
+                title="Digest workflow",
+                source="Workflows",
+                status="running",
+                detail_route="workflows",
+                console_available=True,
+            ),
+        )
+    )
+    screen = WorkflowsScreen(app)
+
+    item = screen._latest_console_follow_item()
+
+    assert getattr(item, "item_id", None) == "workflow:run:11"
+    assert app.home_active_work_adapter.build_calls == [
+        {
+            "providers_models": {"OpenAI": ["gpt-4.1"]},
+            "has_recent_work": True,
+        }
+    ]
+
+
+def test_workflows_console_launch_accepts_route_style_source():
+    app = _build_test_app()
+    app.home_active_work_adapter = StaticHomeActiveWorkAdapter(
+        (
+            HomeActiveWorkItem(
+                item_id="workflow:run:12",
+                title="Route style workflow",
+                source="workflows",
+                status="running",
+                detail_route="workflows",
+                console_available=True,
+            ),
+        )
+    )
+    screen = WorkflowsScreen(app)
+
+    item = screen._latest_console_follow_item()
+
+    assert getattr(item, "item_id", None) == "workflow:run:12"
+
+
+@pytest.mark.asyncio
+async def test_workflows_destination_loads_console_follow_item_off_main_thread():
+    main_thread_id = threading.get_ident()
+    app = _build_test_app()
+    app.home_active_work_adapter = ThreadRecordingHomeActiveWorkAdapter(
+        (
+            HomeActiveWorkItem(
+                item_id="workflow:run:11",
+                title="Digest workflow",
+                source="Workflows",
+                status="running",
+                detail_route="workflows",
+                console_available=True,
+            ),
+        )
+    )
+    host = DestinationHarness(app, "workflows")
+
+    async with host.run_test(size=(180, 40)) as pilot:
+        await pilot.pause(0.1)
+
+    assert app.home_active_work_adapter.call_threads
+    assert main_thread_id not in app.home_active_work_adapter.call_threads
+
+
+@pytest.mark.asyncio
+async def test_workflows_destination_keeps_console_launch_disabled_without_active_run():
+    app = _build_test_app()
+    app.home_active_work_adapter = StaticHomeActiveWorkAdapter(())
+    app.open_active_home_item_in_console = Mock()
+    host = DestinationHarness(app, "workflows")
+
+    async with host.run_test(size=(180, 40)) as pilot:
+        await pilot.pause(0.1)
+        screen = _active_console_screen(host)
+        button = screen.query_one("#workflows-launch-in-console")
+
+        assert button.disabled is True
+        assert str(button.label) == "Console launch unavailable"
+        assert "No active workflow run is available for Console launch." in _screen_static_text(screen)
+
+    app.open_active_home_item_in_console.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_workflows_destination_routes_latest_active_run_to_console():
+    app = _build_test_app()
+    app.home_active_work_adapter = StaticHomeActiveWorkAdapter(
+        (
+            HomeActiveWorkItem(
+                item_id="workflow:run:7",
+                title="Daily digest workflow",
+                source="Workflows",
+                status="failed",
+                detail_route="workflows",
+                console_available=True,
+            ),
+            HomeActiveWorkItem(
+                item_id="schedule:run:7",
+                title="Schedule run",
+                source="Schedules",
+                status="failed",
+                detail_route="schedules",
+                console_available=True,
+            ),
+        )
+    )
+    app.open_active_home_item_in_console = Mock()
+    host = DestinationHarness(app, "workflows")
+
+    async with host.run_test(size=(180, 40)) as pilot:
+        await pilot.pause(0.1)
+        screen = _active_console_screen(host)
+        button = screen.query_one("#workflows-launch-in-console")
+
+        assert button.disabled is False
+        assert "Daily digest workflow" in str(button.label)
+        assert "failed" in _screen_static_text(screen)
+
+        await pilot.click("#workflows-launch-in-console")
+        await pilot.pause(0.1)
+
+    app.open_active_home_item_in_console.assert_called_once_with(
+        target_id="workflow:run:7",
         target_route="chat",
     )
 
@@ -1264,7 +1434,7 @@ async def test_console_renders_source_readiness_summary_without_pending_launch()
         assert screen.query_one("#console-live-work-source-wc").renderable == (
             "W+C: Connected - Home W+C active work can open and route run details in Console."
         )
-        assert "Workflows: Not wired" in str(screen.query_one("#console-live-work-source-workflows").renderable)
+        assert "Workflows: Connected" in str(screen.query_one("#console-live-work-source-workflows").renderable)
         assert "Schedules: Connected" in str(screen.query_one("#console-live-work-source-schedules").renderable)
         assert "ACP: Not wired" in str(screen.query_one("#console-live-work-source-acp").renderable)
         assert "MCP: Not wired" in str(screen.query_one("#console-live-work-source-mcp").renderable)

--- a/backlog/tasks/task-3.10 - Phase-3.10-Launch-active-Workflows-run-from-Workflows-into-Console.md
+++ b/backlog/tasks/task-3.10 - Phase-3.10-Launch-active-Workflows-run-from-Workflows-into-Console.md
@@ -1,0 +1,49 @@
+---
+id: TASK-3.10
+title: 'Phase 3.10: Launch active Workflows run from Workflows into Console'
+status: Done
+assignee: []
+created_date: '2026-05-03 19:18'
+updated_date: '2026-05-03 19:22'
+labels:
+  - unified-shell
+  - phase-3
+  - console
+  - workflows
+dependencies: []
+documentation:
+  - Docs/superpowers/specs/2026-05-02-agentic-terminal-design-system-design.md
+  - Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+parent_task_id: TASK-3
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make the Workflows destination expose a real Console launch action when the existing active-work adapter can identify an actionable workflow run, while preserving an honest disabled state when no run context exists.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Workflows destination keeps Console launch disabled with recovery copy when no actionable workflow run exists.
+- [x] #2 Workflows destination enables Console launch when a visible Workflows active-work item has Console launch context.
+- [x] #3 Clicking the enabled Workflows Console launch action routes through the existing Home active-work adapter Console launch path.
+- [x] #4 Focused automated tests and Phase 3 QA evidence verify the `workflows-launch-in-console` producer and roadmap/task updates.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing regressions for Workflows destination disabled fallback, enabled active-run Console launch, adapter-routed click behavior, source readiness, off-thread adapter loading, and Phase 3.10 tracking evidence.
+2. Reuse the existing Home active-work adapter from Workflows to discover an active Console-capable workflow run without inventing a separate workflow service.
+3. Render the Workflows Console launch button as enabled only when that adapter context exists, and route clicks through the existing app-level Home Console launch method.
+4. Add Phase 3.10 QA evidence plus roadmap and task updates.
+5. Run focused destination, Console handoff, navigation, and diff hygiene checks before commit/PR.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Updated the Workflows destination to reuse the existing Home active-work adapter for active workflow-run Console discovery. The `workflows-launch-in-console` action now stays disabled with explicit recovery copy when no active workflow run exists, becomes enabled when adapter context exists, and routes clicks through `open_active_home_item_in_console` so Home and Workflows share the same Console launch path. Updated Console source readiness to show Workflows as connected and added focused destination/Console regressions plus Phase 3.10 QA evidence and roadmap tracking. The active-work lookup runs in a Textual thread worker so Workflows composition does not block on adapter work.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-3.6 - Phase-3.6-Show-Console-live-work-source-readiness.md
+++ b/backlog/tasks/task-3.6 - Phase-3.6-Show-Console-live-work-source-readiness.md
@@ -21,12 +21,12 @@ priority: high
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Show a compact Console live-work source readiness summary so users can see W+C and Schedules are connected while Workflows, ACP, MCP, RAG, and Artifacts remain honest unavailable states until source-specific payloads exist.
+Show a compact Console live-work source readiness summary so users can see connected live-work sources while ACP and MCP remain honest unavailable states until source-specific payloads exist.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [x] #1 Console source readiness state marks W+C and Schedules as connected and remaining planned sources as explicitly unavailable or not wired with recovery copy.
+- [x] #1 Console source readiness state marks connected sources as connected and remaining planned sources as explicitly unavailable or not wired with recovery copy.
 - [x] #2 ChatScreen renders the source readiness summary when no pending live-work launch is staged and keeps pending launch cards focused when a launch exists.
 - [x] #3 The readiness summary exposes stable IDs/classes for source-specific follow-up tests without creating fake source actions.
 - [x] #4 Focused Console tests and Phase 3 QA evidence verify source readiness state, mounted Console rendering, and roadmap/task updates.
@@ -45,5 +45,5 @@ Show a compact Console live-work source readiness summary so users can see W+C a
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Added `ConsoleLiveWorkSourceReadinessState` with stable source row IDs/classes, marking W+C and Schedules connected and future live-work source families as informational `Not wired` rows with recovery copy. `ChatScreen` now renders the readiness summary only when no pending Console live-work launch is staged, preserving the focused pending launch card when a launch exists. Added regression coverage for the display model, mounted Console rendering, pending-card suppression, and Phase 3.6 evidence/roadmap/task tracking.
+Added `ConsoleLiveWorkSourceReadinessState` with stable source row IDs/classes, marking connected source families connected and future live-work source families as informational `Not wired` rows with recovery copy. `ChatScreen` now renders the readiness summary only when no pending Console live-work launch is staged, preserving the focused pending launch card when a launch exists. Added regression coverage for the display model, mounted Console rendering, pending-card suppression, and Phase 3.6 evidence/roadmap/task tracking.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_live_work.py
+++ b/tldw_chatbook/Chat/console_live_work.py
@@ -228,10 +228,10 @@ class ConsoleLiveWorkSourceReadinessState:
         """Build the default Console live-work source readiness summary.
 
         Returns:
-            ConsoleLiveWorkSourceReadinessState: Readiness state that marks W+C
-                and Schedules as connected while planned future Console
-                live-work sources stay unavailable until their payload
-                producers are wired.
+            ConsoleLiveWorkSourceReadinessState: Readiness state that marks W+C,
+                Schedules, Workflows, RAG, and Artifacts as connected while
+                planned future Console live-work sources stay unavailable until
+                their payload producers are wired.
         """
         connected = "destination-section console-live-work-source-row console-live-work-source-connected"
         unavailable = "destination-section console-live-work-source-row console-live-work-source-unavailable"
@@ -247,9 +247,9 @@ class ConsoleLiveWorkSourceReadinessState:
                 ConsoleLiveWorkSourceReadinessRow(
                     widget_id="console-live-work-source-workflows",
                     label="Workflows",
-                    status="Not wired",
-                    recovery="Workflow execution payloads are not wired yet.",
-                    classes=unavailable,
+                    status="Connected",
+                    recovery="Workflows active work can open Console when adapter context exists.",
+                    classes=connected,
                 ),
                 ConsoleLiveWorkSourceReadinessRow(
                     widget_id="console-live-work-source-schedules",

--- a/tldw_chatbook/UI/Screens/workflows_screen.py
+++ b/tldw_chatbook/UI/Screens/workflows_screen.py
@@ -1,5 +1,9 @@
 """Workflows destination shell for reusable agent procedures."""
 
+from loguru import logger as _logger
+from rich.markup import escape as escape_markup
+from rich.text import Text
+from textual import on, work
 from textual.app import ComposeResult
 from textual.containers import Vertical
 from textual.widgets import Button, Static
@@ -7,13 +11,74 @@ from textual.widgets import Button, Static
 from ..Navigation.base_app_screen import BaseAppScreen
 
 
+logger = _logger.bind(module="WorkflowsScreen")
+
+
 class WorkflowsScreen(BaseAppScreen):
     """Reusable procedures, recipes, dry-runs, and outputs."""
 
     def __init__(self, app_instance, **kwargs):
         super().__init__(app_instance, "workflows", **kwargs)
+        self._current_console_follow_item = None
+        self._latest_console_follow_item_id = None
+
+    def on_mount(self) -> None:
+        super().on_mount()
+        self._refresh_latest_console_context()
+
+    @work(exclusive=True, thread=True)
+    def _refresh_latest_console_context(self) -> None:
+        latest_console_item = self._latest_console_follow_item_from_adapter()
+        self.app.call_from_thread(self._apply_latest_console_context, latest_console_item)
+
+    def _apply_latest_console_context(self, latest_console_item) -> None:
+        self._current_console_follow_item = latest_console_item
+        self._latest_console_follow_item_id = (
+            getattr(latest_console_item, "item_id", None)
+            if latest_console_item is not None
+            else None
+        )
+        if self.is_mounted:
+            self.refresh(recompose=True)
+
+    def _latest_console_follow_item(self):
+        return self._latest_console_follow_item_from_adapter()
+
+    def _latest_console_follow_item_from_adapter(self):
+        adapter = getattr(self.app_instance, "home_active_work_adapter", None)
+        build_dashboard_input = getattr(adapter, "build_dashboard_input", None)
+        if not callable(build_dashboard_input):
+            return None
+        try:
+            providers = getattr(self.app_instance, "providers_models", {}) or {}
+            has_recent_work = bool(getattr(self.app_instance, "_screen_states", {}))
+            dashboard_input = build_dashboard_input(
+                providers_models=providers,
+                has_recent_work=has_recent_work,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to load Workflows Console launch item from Home active-work adapter.",
+                exc_info=True,
+            )
+            return None
+        for item in tuple(getattr(dashboard_input, "active_work_items", ()) or ()):
+            source = str(getattr(item, "source", "") or "").strip().lower()
+            if (
+                source == "workflows"
+                and bool(getattr(item, "console_available", False))
+                and getattr(item, "item_id", None)
+            ):
+                return item
+        return None
 
     def compose_content(self) -> ComposeResult:
+        latest_console_item = self._current_console_follow_item
+        self._latest_console_follow_item_id = (
+            getattr(latest_console_item, "item_id", None)
+            if latest_console_item is not None
+            else None
+        )
         with Vertical(id="workflows-shell"):
             yield Static("Workflows", id="workflows-title", classes="ds-destination-header")
             yield Static(
@@ -28,15 +93,56 @@ class WorkflowsScreen(BaseAppScreen):
                 yield Static("Dry Run", classes="destination-section")
                 yield Static("Approvals", classes="destination-section")
                 yield Static("Outputs", classes="destination-section")
-                yield Static("Console launch unavailable", classes="destination-section")
-                yield Static("No workflow service is wired yet.", id="workflows-empty-state")
-                yield Static(
-                    "Console launch is unavailable until workflow execution payloads are wired.",
-                    id="workflows-console-unavailable",
-                )
-                yield Button(
-                    "Console launch unavailable",
-                    id="workflows-launch-in-console",
-                    disabled=True,
-                    tooltip="Unavailable until Workflows can pass actionable execution context to Console.",
-                )
+                if latest_console_item is not None:
+                    title = str(getattr(latest_console_item, "title", None) or "Untitled")
+                    status = str(getattr(latest_console_item, "status", None) or "unknown")
+                    yield Static("Console launch available", classes="destination-section")
+                    yield Static(
+                        Text.from_markup(
+                            "Console can launch active workflow run: "
+                            f"{escape_markup(title)} ({escape_markup(status)})."
+                        ),
+                        id="workflows-console-available",
+                    )
+                    yield Button(
+                        Text.from_markup(f"Launch {escape_markup(title)} in Console"),
+                        id="workflows-launch-in-console",
+                        tooltip="Open the active workflow run in Console.",
+                    )
+                else:
+                    yield Static("Console launch unavailable", classes="destination-section")
+                    yield Static("No workflow service is wired yet.", id="workflows-empty-state")
+                    yield Static(
+                        "No active workflow run is available for Console launch.",
+                        id="workflows-console-unavailable",
+                    )
+                    yield Button(
+                        "Console launch unavailable",
+                        id="workflows-launch-in-console",
+                        disabled=True,
+                        tooltip="Unavailable until Workflows can pass actionable execution context to Console.",
+                    )
+
+    @on(Button.Pressed, "#workflows-launch-in-console")
+    def launch_latest_workflow_run_in_console(self, event: Button.Pressed) -> None:
+        event.stop()
+        target_id = self._latest_console_follow_item_id
+        if not target_id:
+            self.app_instance.notify(
+                "No active workflow run is available for Console launch.",
+                severity="warning",
+            )
+            return
+
+        open_active_item_in_console = getattr(self.app_instance, "open_active_home_item_in_console", None)
+        if not callable(open_active_item_in_console):
+            self.app_instance.notify(
+                "Console launch is unavailable for Workflows in this runtime.",
+                severity="warning",
+            )
+            return
+
+        open_active_item_in_console(
+            target_id=target_id,
+            target_route="chat",
+        )


### PR DESCRIPTION
## Summary
- Adds adapter-backed Workflows Console launch when active-work context exists.
- Keeps Workflows Console launch disabled with recovery copy when no workflow run exists.
- Updates Phase 3.8 tests, QA evidence, Backlog task, and roadmap tracking.

## Test Plan
- [x] env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_console_live_work_handoffs.py --tb=short
- [x] env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_destination_shells.py Tests/UI/test_home_screen.py Tests/Home/test_active_work_adapter.py Tests/UI/test_subscription_window_watchlists.py Tests/UI/test_screen_navigation.py Tests/UI/test_unified_shell_phase2_home_adapter.py --tb=short
- [x] git diff --check

## Scope Note
This is an implementation slice for the unified-shell design-system rollout, not the visual design-system creation task itself. It wires one Console affordance to real adapter-backed behavior so the shell does not present false or permanently disabled UX.