### PR TITLE
Launch Chatbook artifacts into Console

### DIFF
--- a/Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-artifacts-chatbook-console-launch.md
+++ b/Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-artifacts-chatbook-console-launch.md
@@ -1,0 +1,37 @@
+# Phase 3.9 Artifacts Chatbook Console Launch
+
+Task: `TASK-3.9`
+Branch: `codex/unified-shell-phase3-artifacts-console-launch`
+
+## Goal
+
+Make Artifacts a real Console live-work source for local Chatbook artifacts. A user who has generated or imported a Chatbook can launch the latest local Chatbook into Console from Artifacts, while users without a local Chatbook get an honest unavailable state instead of a false generic handoff.
+
+## Implementation Summary
+
+- Added latest-local-Chatbook lookup to the Artifacts destination using the existing `local_chatbook_service.list_chatbooks` seam.
+- Changed `artifacts-use-in-console` from generic chat handoff behavior to a typed `open_console_for_live_work` launch when a Chatbook record exists.
+- Kept the Artifacts Console action disabled with recovery copy when no local Chatbook exists or the service is unavailable.
+- Updated Console source readiness to mark `Artifacts` connected for the local Chatbook launch path.
+
+## Verification
+
+- Red result: focused tests failed because Artifacts still showed `Use in Console` as a generic handoff, did not disable the action without Chatbooks, Console readiness reported `Artifacts: Not wired`, and this evidence file did not exist.
+- Focused green command: `.venv/bin/python -m pytest Tests/UI/test_console_live_work_handoffs.py -q`
+- Focused green result: `41 passed, 1 warning in 16.17s`.
+- Broader focused command: `.venv/bin/python -m pytest Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_destination_shells.py -q`
+- Broader focused result: `76 passed, 1 warning in 24.15s`.
+- Whitespace check: `git diff --check` completed with no output.
+
+## QA Walkthrough Notes
+
+- Environment: focused Textual mounted-window tests using the repo virtualenv.
+- Entry path: Artifacts destination screen.
+- Visual check: Artifacts preserves the `Open Chatbooks` primary route and shows either `Console launch available` with the latest Chatbook title or `Console launch unavailable` with recovery copy.
+- Functional result: selecting `artifacts-use-in-console` with a local Chatbook stages a typed Console launch payload containing Chatbook identity, file path, description, tags, categories, and updated timestamp.
+- Recovery result: without a local Chatbook, the Console launch control is disabled and does not stage chat or Console context.
+
+## Residual Risk
+
+- This slice covers local Chatbook artifacts only; server output artifacts, report bundles, datasets, and generated-output live streams remain future Artifacts work.
+- Console stages the Chatbook payload but does not yet open a dedicated Chatbook detail action from the Console primary-action button.

--- a/Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-artifacts-chatbook-console-launch.md
+++ b/Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-artifacts-chatbook-console-launch.md
@@ -22,6 +22,11 @@ Make Artifacts a real Console live-work source for local Chatbook artifacts. A u
 - Broader focused command: `.venv/bin/python -m pytest Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_destination_shells.py -q`
 - Broader focused result: `76 passed, 1 warning in 24.15s`.
 - Whitespace check: `git diff --check` completed with no output.
+- Review-fix red result: three focused regressions failed for unsafe Chatbook metadata, lexicographic latest-Chatbook tie-break, and service errors rendering as empty-state copy.
+- Review-fix focused green command: `.venv/bin/python -m pytest Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_sanitizes_chatbook_metadata_before_console_launch Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_uses_numeric_id_tie_break_for_latest_chatbook Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_distinguishes_chatbook_service_failure_from_empty_state -q`
+- Review-fix focused green result: `3 passed, 1 warning in 8.87s`.
+- Review-fix broader focused command: `.venv/bin/python -m pytest Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_destination_shells.py -q`
+- Review-fix broader focused result: `79 passed, 1 warning in 26.35s`.
 
 ## QA Walkthrough Notes
 
@@ -30,6 +35,8 @@ Make Artifacts a real Console live-work source for local Chatbook artifacts. A u
 - Visual check: Artifacts preserves the `Open Chatbooks` primary route and shows either `Console launch available` with the latest Chatbook title or `Console launch unavailable` with recovery copy.
 - Functional result: selecting `artifacts-use-in-console` with a local Chatbook stages a typed Console launch payload containing Chatbook identity, file path, description, tags, categories, and updated timestamp.
 - Recovery result: without a local Chatbook, the Console launch control is disabled and does not stage chat or Console context.
+- Review-fix recovery result: if the local Chatbook service fails, Artifacts now shows distinct service-unavailable recovery copy instead of claiming there are no local Chatbooks.
+- Review-fix security result: Chatbook metadata is sanitized through `input_validation.py` before being staged into Console launch payloads.
 
 ## Residual Risk
 

--- a/Docs/superpowers/qa/unified-shell/phase-3/README.md
+++ b/Docs/superpowers/qa/unified-shell/phase-3/README.md
@@ -15,5 +15,6 @@ This directory contains durable QA summaries for Phase 3 Console live-work hub s
 - `2026-05-03-schedules-console-launch.md` - `TASK-3.7` Schedules destination Console follow producer for active schedule runs.
 - `2026-05-03-schedules-digest-console-launch.md` - `TASK-3.7` Schedules destination Console launch producer for the latest local reading-digest output.
 - `2026-05-03-rag-search-console-launch.md` - `TASK-3.8` Search/RAG result Console launch producer for selected retrieved evidence.
+- `2026-05-03-artifacts-chatbook-console-launch.md` - `TASK-3.9` Artifacts destination Console launch producer for the latest local Chatbook artifact.
 
 Do not mark Phase 3 verified until launch, follow, status, and recovery flows are verified in the running app against workflows, schedules, ACP, MCP, RAG, artifacts, and active-work source adapters.

--- a/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
@@ -2,7 +2,7 @@
 
 Date: 2026-05-03
 Status: Phase 2 and Phase 3 in progress
-Source Branch: `origin/dev` at `c31d83b1` plus `codex/unified-shell-phase3-rag-console-launch`
+Source Branch: `origin/dev` at `0fbbe48e` plus `codex/unified-shell-phase3-artifacts-console-launch`
 
 ## Purpose
 
@@ -29,8 +29,8 @@ Track remaining Unified Shell work in one place so rendered screens, clickable b
 
 - Home active-work controls, detail routing, Console launch requests, item identity, local unread notification counts, notification review routing, local W+C watchlist run snapshots, and local W+C run detail routing now route through explicit adapter boundaries; schedule and agent-service adapters still need implementation.
 - Workflows has no wired workflow service in the shell wrapper.
-- W+C and Schedules now expose Console follow when the existing active-work adapter has actionable run context; Schedules also exposes Console launch for the latest local reading-digest output when no active run is available; Search/RAG result cards can stage selected retrieved evidence into Console; Workflows and ACP still use honest unavailable Console states until actionable payloads exist.
-- Console now has a typed app-owned launch contract, reusable status-card display seam, source-readiness summary, Home W+C active-work source producer, W+C and Schedules destination follow producers, a Schedules reading-digest output fallback producer, a RAG search-result producer, and W+C run-detail action routing for staged live-work payloads; additional source-specific live event producers still need implementation.
+- W+C and Schedules now expose Console follow when the existing active-work adapter has actionable run context; Schedules also exposes Console launch for the latest local reading-digest output when no active run is available; Search/RAG result cards can stage selected retrieved evidence into Console; Artifacts can launch the latest local Chatbook artifact into Console; Workflows and ACP still use honest unavailable Console states until actionable payloads exist.
+- Console now has a typed app-owned launch contract, reusable status-card display seam, source-readiness summary, Home W+C active-work source producer, W+C and Schedules destination follow producers, a Schedules reading-digest output fallback producer, a RAG search-result producer, an Artifacts Chatbook producer, and W+C run-detail action routing for staged live-work payloads; additional source-specific live event producers still need implementation.
 - ACP launch is disabled until an ACP-compatible runtime is configured.
 - MCP management is not embedded in the top-level MCP wrapper.
 - Skills local/server services exist, but the top-level Skills shell still leaves import disabled and lacks list/detail/import UX adoption.
@@ -95,6 +95,7 @@ Initial child tasks:
 - Phase 3.6: Show Console live-work source readiness - `TASK-3.6`
 - Phase 3.7: Launch active Schedules run from Schedules into Console - `TASK-3.7`
 - Phase 3.8: Launch RAG search result from Search/RAG into Console - `TASK-3.8`
+- Phase 3.9: Launch latest Chatbook artifact from Artifacts into Console - `TASK-3.9`
 
 ## QA Evidence Index
 
@@ -115,7 +116,7 @@ Initial child tasks:
 | Phase 0: Canonical Tracking | Make remaining work trackable. | verified | `TASK-1`, `TASK-1.1`, `TASK-1.2` | `phase-0/` | Product UI workflows are out of scope for Phase 0. |
 | Phase 1: Shell Contract Complete | Remove false shell affordances and prove shell usability. | verified | `TASK-2`, `TASK-2.1`, `TASK-2.2`, `TASK-2.3`, `TASK-2.4` | `phase-1/` | Live service workflows remain intentionally deferred to Phases 2-6. |
 | Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | in-progress | `TASK-4`, `TASK-4.1`, `TASK-4.2`, `TASK-4.3`, `TASK-4.4`, `TASK-4.5`, `TASK-4.6`, `TASK-4.7` | `phase-2/` | Schedule and agent-service adapters still need implementation; local watchlist retry/pause/resume remain recoverable rather than fully controllable. |
-| Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | in-progress | `TASK-3`, `TASK-3.1`, `TASK-3.2`, `TASK-3.3`, `TASK-3.4`, `TASK-3.5`, `TASK-3.6`, `TASK-3.7`, `TASK-3.8` | `phase-3/` | Workflows, ACP, MCP, Artifacts, and deeper source-specific live event streams still need implementation. |
+| Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | in-progress | `TASK-3`, `TASK-3.1`, `TASK-3.2`, `TASK-3.3`, `TASK-3.4`, `TASK-3.5`, `TASK-3.6`, `TASK-3.7`, `TASK-3.8`, `TASK-3.9` | `phase-3/` | Workflows, ACP, MCP, server Artifacts, and deeper source-specific live event streams still need implementation. |
 | Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | not-started | `TASK-5` | `phase-4/` | Service coverage varies by destination. |
 | Phase 5: Capability And Recovery System | Systematize unavailable and blocked states. | not-started | `TASK-6` | `phase-5/` | Shared taxonomy not yet extracted. |
 | Phase 6: Audit Replay And Closeout | Prove shell works for first-time and power users. | not-started | `TASK-7` | `phase-6/` | Depends on prior phases and running-app QA. |
@@ -243,6 +244,12 @@ Initial audit result: W+C, Schedules, Workflows, and ACP had false Console-launc
 `TASK-3.8` lets Search/RAG result cards stage selected retrieved evidence in Console while preserving existing Use in Chat behavior:
 
 - `Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-rag-search-console-launch.md`
+
+## Phase 3.9 Artifacts Chatbook Console Launch Evidence
+
+`TASK-3.9` lets Artifacts stage the latest local Chatbook artifact in Console while preserving the existing Chatbooks destination route:
+
+- `Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-artifacts-chatbook-console-launch.md`
 
 ## Phase 0: Canonical Tracking
 

--- a/Tests/UI/test_console_live_work_handoffs.py
+++ b/Tests/UI/test_console_live_work_handoffs.py
@@ -185,6 +185,11 @@ class StaticLocalChatbookService:
         return list(self.chatbooks)[int(offset) : int(offset) + int(limit)]
 
 
+class RaisingLocalChatbookService:
+    async def list_chatbooks(self, *, q=None, limit=100, offset=0, **kwargs):
+        raise RuntimeError("registry read failed")
+
+
 def test_app_exposes_open_console_for_live_work_helper():
     app = _build_test_app()
 
@@ -1075,6 +1080,106 @@ async def test_artifacts_destination_launches_latest_local_chatbook_in_console()
         action_label="Open Chatbook artifact",
     )
     app.open_chat_with_handoff.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_artifacts_destination_sanitizes_chatbook_metadata_before_console_launch():
+    app = _build_test_app()
+    app.local_chatbook_service = StaticLocalChatbookService(
+        (
+            {
+                "chatbook_id": "7",
+                "id": "7",
+                "name": "Research <script>alert(1)</script> Pack\x00",
+                "description": "Open javascript:alert(1) and onerror=bad",
+                "file_path": "/tmp/<script>bad</script>.chatbook\x00",
+                "tags": ["safe", "<script>tag</script>"],
+                "categories": ["onclick=bad", "Library"],
+                "updated_at": "2026-05-03T20:00:00Z",
+            },
+        )
+    )
+    app.open_console_for_live_work = Mock()
+    host = DestinationHarness(app, "artifacts")
+
+    async with host.run_test(size=(180, 40)) as pilot:
+        await pilot.pause(0.1)
+        await pilot.click("#artifacts-use-in-console")
+        await pilot.pause(0.1)
+
+    launch_kwargs = app.open_console_for_live_work.call_args.kwargs
+    payload_strings = [launch_kwargs["title"]]
+    payload_strings.extend(
+        str(value)
+        for value in launch_kwargs["payload"].values()
+        if value is not None
+    )
+    combined = " ".join(payload_strings).lower()
+    assert "\x00" not in combined
+    assert "<script" not in combined
+    assert "javascript:" not in combined
+    assert "onclick=" not in combined
+    assert "onerror=" not in combined
+    assert "&lt;script&gt;" in combined
+
+
+@pytest.mark.asyncio
+async def test_artifacts_destination_uses_numeric_id_tie_break_for_latest_chatbook():
+    app = _build_test_app()
+    app.local_chatbook_service = StaticLocalChatbookService(
+        (
+            {
+                "chatbook_id": 9,
+                "id": "9",
+                "name": "Nine Pack",
+                "updated_at": "2026-05-03T20:00:00Z",
+            },
+            {
+                "chatbook_id": 10,
+                "id": "10",
+                "name": "Ten Pack",
+                "updated_at": "2026-05-03T20:00:00Z",
+            },
+        )
+    )
+    app.open_console_for_live_work = Mock()
+    host = DestinationHarness(app, "artifacts")
+
+    async with host.run_test(size=(180, 40)) as pilot:
+        await pilot.pause(0.1)
+        screen = _active_console_screen(host)
+        button = screen.query_one("#artifacts-use-in-console")
+
+        assert "Ten Pack" in str(button.label)
+
+        await pilot.click("#artifacts-use-in-console")
+        await pilot.pause(0.1)
+
+    app.open_console_for_live_work.assert_called_once()
+    assert app.open_console_for_live_work.call_args.kwargs["payload"]["chatbook_id"] == 10
+
+
+@pytest.mark.asyncio
+async def test_artifacts_destination_distinguishes_chatbook_service_failure_from_empty_state():
+    app = _build_test_app()
+    app.local_chatbook_service = RaisingLocalChatbookService()
+    app.open_console_for_live_work = Mock()
+    host = DestinationHarness(app, "artifacts")
+
+    async with host.run_test(size=(180, 40)) as pilot:
+        await pilot.pause(0.1)
+        screen = _active_console_screen(host)
+        button = screen.query_one("#artifacts-use-in-console")
+        text = _screen_static_text(screen)
+
+        assert button.disabled is True
+        assert "Chatbook service unavailable; retry Artifacts later." in text
+        assert "No local Chatbook artifact is available" not in text
+
+        await pilot.click("#artifacts-use-in-console")
+        await pilot.pause(0.1)
+
+    app.open_console_for_live_work.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/Tests/UI/test_console_live_work_handoffs.py
+++ b/Tests/UI/test_console_live_work_handoffs.py
@@ -40,6 +40,9 @@ PHASE3_SCHEDULES_DIGEST_CONSOLE_EVIDENCE = (
 PHASE3_RAG_CONSOLE_EVIDENCE = (
     REPO_ROOT / "Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-rag-search-console-launch.md"
 )
+PHASE3_ARTIFACTS_CHATBOOK_CONSOLE_EVIDENCE = (
+    REPO_ROOT / "Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-artifacts-chatbook-console-launch.md"
+)
 
 
 def _load_console_live_work_contract():
@@ -163,6 +166,23 @@ class ThreadRecordingReadingDigestService(StaticReadingDigestService):
             limit=limit,
             offset=offset,
         )
+
+
+class StaticLocalChatbookService:
+    def __init__(self, chatbooks):
+        self.chatbooks = tuple(chatbooks)
+        self.calls = []
+
+    async def list_chatbooks(self, *, q=None, limit=100, offset=0, **kwargs):
+        self.calls.append(
+            {
+                "q": q,
+                "limit": limit,
+                "offset": offset,
+                "kwargs": dict(kwargs),
+            }
+        )
+        return list(self.chatbooks)[int(offset) : int(offset) + int(limit)]
 
 
 def test_app_exposes_open_console_for_live_work_helper():
@@ -337,10 +357,13 @@ def test_console_live_work_source_readiness_marks_connected_sources_and_future_s
         "console-live-work-source-workflows",
         "console-live-work-source-acp",
         "console-live-work-source-mcp",
-        "console-live-work-source-artifacts",
     ):
         assert "Not wired" in rows_by_id[source_id].text
         assert "console-live-work-source-unavailable" in rows_by_id[source_id].classes
+    assert rows_by_id["console-live-work-source-artifacts"].text == (
+        "Artifacts: Connected - Latest local Chatbook artifacts can launch into Console."
+    )
+    assert "console-live-work-source-connected" in rows_by_id["console-live-work-source-artifacts"].classes
 
 
 def test_app_console_live_work_primary_action_routes_wc_run_details():
@@ -513,6 +536,27 @@ def test_phase3_rag_console_launch_tracking_evidence_links_task_and_roadmap():
         "`TASK-3.5`, `TASK-3.6`, `TASK-3.7`, `TASK-3.8`"
     ) in roadmap
     assert "RAG result" in task
+
+
+def test_phase3_artifacts_chatbook_console_launch_tracking_evidence_links_task_and_roadmap():
+    evidence = PHASE3_ARTIFACTS_CHATBOOK_CONSOLE_EVIDENCE.read_text()
+    readme = (REPO_ROOT / "Docs/superpowers/qa/unified-shell/phase-3/README.md").read_text()
+    roadmap = (REPO_ROOT / "Docs/superpowers/trackers/unified-shell-maturity-roadmap.md").read_text()
+    task = (
+        REPO_ROOT
+        / "backlog/tasks/task-3.9 - Phase-3.9-Launch-latest-Chatbook-artifact-from-Artifacts-into-Console.md"
+    ).read_text()
+
+    assert "TASK-3.9" in evidence
+    assert "Artifacts Chatbook Console Launch" in evidence
+    assert "artifacts-use-in-console" in evidence
+    assert "2026-05-03-artifacts-chatbook-console-launch.md" in readme
+    assert "Phase 3.9: Launch latest Chatbook artifact from Artifacts into Console - `TASK-3.9`" in roadmap
+    assert (
+        "`TASK-3`, `TASK-3.1`, `TASK-3.2`, `TASK-3.3`, `TASK-3.4`, "
+        "`TASK-3.5`, `TASK-3.6`, `TASK-3.7`, `TASK-3.8`, `TASK-3.9`"
+    ) in roadmap
+    assert "Chatbook payload" in task
 
 
 def test_schedules_console_follow_uses_home_dashboard_app_inputs():
@@ -943,11 +987,100 @@ async def test_schedules_destination_routes_latest_digest_output_to_console():
     )
 
 
+@pytest.mark.asyncio
+async def test_artifacts_destination_keeps_console_launch_disabled_without_chatbooks():
+    app = _build_test_app()
+    app.local_chatbook_service = StaticLocalChatbookService(())
+    app.open_console_for_live_work = Mock()
+    app.open_chat_with_handoff = Mock()
+    host = DestinationHarness(app, "artifacts")
+
+    async with host.run_test(size=(180, 40)) as pilot:
+        await pilot.pause(0.1)
+        screen = _active_console_screen(host)
+        button = screen.query_one("#artifacts-use-in-console")
+
+        assert button.disabled is True
+        assert str(button.label) == "Console launch unavailable"
+        assert "No local Chatbook artifact is available for Console launch." in _screen_static_text(screen)
+
+        await pilot.click("#artifacts-use-in-console")
+        await pilot.pause(0.1)
+
+    app.open_console_for_live_work.assert_not_called()
+    app.open_chat_with_handoff.assert_not_called()
+    assert app.local_chatbook_service.calls == [{"q": None, "limit": 25, "offset": 0, "kwargs": {}}]
+
+
+@pytest.mark.asyncio
+async def test_artifacts_destination_launches_latest_local_chatbook_in_console():
+    app = _build_test_app()
+    app.local_chatbook_service = StaticLocalChatbookService(
+        (
+            {
+                "chatbook_id": 41,
+                "id": "41",
+                "name": "Older Pack",
+                "description": "Previous bundle",
+                "file_path": "/tmp/older-pack.chatbook",
+                "tags": ["archive"],
+                "categories": ["Library"],
+                "updated_at": "2026-05-02T20:00:00Z",
+            },
+            {
+                "chatbook_id": 42,
+                "id": "42",
+                "name": "Research Pack",
+                "description": "A portable research bundle",
+                "file_path": "/tmp/research-pack.chatbook",
+                "tags": ["research", "portable"],
+                "categories": ["Library"],
+                "updated_at": "2026-05-03T20:00:00Z",
+            },
+        )
+    )
+    app.open_console_for_live_work = Mock()
+    app.open_chat_with_handoff = Mock()
+    host = DestinationHarness(app, "artifacts")
+
+    async with host.run_test(size=(180, 40)) as pilot:
+        await pilot.pause(0.1)
+        screen = _active_console_screen(host)
+        button = screen.query_one("#artifacts-use-in-console")
+
+        assert button.disabled is False
+        assert "Research Pack" in str(button.label)
+        text = _screen_static_text(screen)
+        assert "Console can launch latest Chatbook artifact: Research Pack." in text
+        assert "A portable research bundle" in text
+
+        await pilot.click("#artifacts-use-in-console")
+        await pilot.pause(0.1)
+
+    app.open_console_for_live_work.assert_called_once_with(
+        source="artifacts",
+        title="Research Pack",
+        payload={
+            "target_id": "local:chatbook:42",
+            "chatbook_id": 42,
+            "record_id": "42",
+            "file_path": "/tmp/research-pack.chatbook",
+            "description": "A portable research bundle",
+            "tags": "research, portable",
+            "categories": "Library",
+            "updated_at": "2026-05-03T20:00:00Z",
+        },
+        status="ready",
+        recovery="Review this Chatbook artifact in Console or return to Artifacts.",
+        action_label="Open Chatbook artifact",
+    )
+    app.open_chat_with_handoff.assert_not_called()
+
+
 @pytest.mark.parametrize(
     ("route", "button_id"),
     [
         ("library", "library-use-in-console"),
-        ("artifacts", "artifacts-use-in-console"),
         ("personas", "personas-attach-to-console"),
         ("skills", "skills-attach-to-console"),
     ],
@@ -1031,7 +1164,7 @@ async def test_console_renders_source_readiness_summary_without_pending_launch()
         assert "ACP: Not wired" in str(screen.query_one("#console-live-work-source-acp").renderable)
         assert "MCP: Not wired" in str(screen.query_one("#console-live-work-source-mcp").renderable)
         assert "RAG: Connected" in str(screen.query_one("#console-live-work-source-rag").renderable)
-        assert "Artifacts: Not wired" in str(screen.query_one("#console-live-work-source-artifacts").renderable)
+        assert "Artifacts: Connected" in str(screen.query_one("#console-live-work-source-artifacts").renderable)
 
 
 @pytest.mark.asyncio

--- a/backlog/tasks/task-3.9 - Phase-3.9-Launch-latest-Chatbook-artifact-from-Artifacts-into-Console.md
+++ b/backlog/tasks/task-3.9 - Phase-3.9-Launch-latest-Chatbook-artifact-from-Artifacts-into-Console.md
@@ -1,0 +1,50 @@
+---
+id: TASK-3.9
+title: Phase 3.9 Launch latest Chatbook artifact from Artifacts into Console
+status: Done
+assignee: []
+created_date: '2026-05-04 02:39'
+updated_date: '2026-05-04 02:46'
+labels:
+  - unified-shell
+  - phase-3
+  - console
+  - artifacts
+  - chatbooks
+dependencies: []
+parent_task_id: TASK-3
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make Artifacts participate in the Console live-work model through a real Chatbook payload instead of a generic chat handoff, so users can move from generated or portable artifacts into the primary agentic Console when a local Chatbook exists and get an honest unavailable state when none exists.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Artifacts shows Console launch as available only when a latest local Chatbook can be resolved
+- [x] #2 Launching from Artifacts stages a typed Console live-work payload containing Chatbook identity and metadata
+- [x] #3 Artifacts remains non-actionable with clear recovery copy when no Chatbook is available
+- [x] #4 Console source readiness marks Artifacts connected after the Chatbook launch path is wired
+- [x] #5 Focused automated tests cover available unavailable readiness and tracking evidence paths
+- [x] #6 QA walkthrough evidence documents functional behavior visual usability residual risks and focused verification output
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing UI tests for Artifacts unavailable and latest Chatbook Console launch behavior.
+2. Add failing readiness and tracking evidence tests for Artifacts as a connected Console source.
+3. Implement the smallest Artifacts screen state loader that reads the latest local Chatbook off the main thread and only enables Console launch when a real Chatbook record exists.
+4. Update Console source readiness copy and route Artifacts button presses through open_console_for_live_work with Chatbook metadata.
+5. Add QA evidence and roadmap/readme/task links.
+6. Run focused regression tests and git diff checks before completing the task.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented a local Chatbook-backed Artifacts Console launch path. Artifacts now loads the latest local Chatbook through the existing local_chatbook_service seam, disables Console launch with recovery copy when no Chatbook exists, and stages a typed Console live-work payload when a Chatbook is available. Updated Console readiness, Phase 3 roadmap/readme evidence, and focused UI regression coverage.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-3.9 - Phase-3.9-Launch-latest-Chatbook-artifact-from-Artifacts-into-Console.md
+++ b/backlog/tasks/task-3.9 - Phase-3.9-Launch-latest-Chatbook-artifact-from-Artifacts-into-Console.md
@@ -4,7 +4,7 @@ title: Phase 3.9 Launch latest Chatbook artifact from Artifacts into Console
 status: Done
 assignee: []
 created_date: '2026-05-04 02:39'
-updated_date: '2026-05-04 02:46'
+updated_date: '2026-05-04 02:59'
 labels:
   - unified-shell
   - phase-3
@@ -47,4 +47,6 @@ Make Artifacts participate in the Console live-work model through a real Chatboo
 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented a local Chatbook-backed Artifacts Console launch path. Artifacts now loads the latest local Chatbook through the existing local_chatbook_service seam, disables Console launch with recovery copy when no Chatbook exists, and stages a typed Console live-work payload when a Chatbook is available. Updated Console readiness, Phase 3 roadmap/readme evidence, and focused UI regression coverage.
+
+Review fixes: sanitized Chatbook metadata through input_validation.py before Console staging, changed latest Chatbook tie-break to parsed timestamp plus numeric ID ordering, and split service-unavailable recovery copy from the empty-Chatbook state. Added focused regressions for all three PR findings.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_live_work.py
+++ b/tldw_chatbook/Chat/console_live_work.py
@@ -282,9 +282,9 @@ class ConsoleLiveWorkSourceReadinessState:
                 ConsoleLiveWorkSourceReadinessRow(
                     widget_id="console-live-work-source-artifacts",
                     label="Artifacts",
-                    status="Not wired",
-                    recovery="Artifact live-work payloads are not wired yet; use artifact handoff for context.",
-                    classes=unavailable,
+                    status="Connected",
+                    recovery="Latest local Chatbook artifacts can launch into Console.",
+                    classes=connected,
                 ),
             )
         )

--- a/tldw_chatbook/UI/Screens/artifacts_screen.py
+++ b/tldw_chatbook/UI/Screens/artifacts_screen.py
@@ -1,13 +1,25 @@
 """Artifacts destination shell for generated outputs and Chatbooks."""
 
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from loguru import logger
+from rich.markup import escape as escape_markup
+from rich.text import Text
+from textual import on, work
 from textual.app import ComposeResult
-from textual import on
 from textual.containers import Vertical
 from textual.widgets import Button, Static
 
-from ...Chat.chat_handoff_models import ChatHandoffPayload
 from ..Navigation.base_app_screen import BaseAppScreen
 from ..Navigation.main_navigation import NavigateToScreen
+
+
+logger = logger.bind(module="ArtifactsScreen")
 
 
 class ArtifactsScreen(BaseAppScreen):
@@ -15,8 +27,93 @@ class ArtifactsScreen(BaseAppScreen):
 
     def __init__(self, app_instance, **kwargs):
         super().__init__(app_instance, "artifacts", **kwargs)
+        self._latest_chatbook_console_launch: dict[str, Any] | None = None
+
+    def on_mount(self) -> None:
+        super().on_mount()
+        self._refresh_latest_chatbook_context()
+
+    @work(exclusive=True, thread=True)
+    def _refresh_latest_chatbook_context(self) -> None:
+        launch_kwargs = self._latest_local_chatbook_console_launch()
+        self.app.call_from_thread(self._apply_latest_chatbook_context, launch_kwargs)
+
+    def _apply_latest_chatbook_context(self, launch_kwargs: dict[str, Any] | None) -> None:
+        self._latest_chatbook_console_launch = launch_kwargs
+        if self.is_mounted:
+            self.refresh(recompose=True)
+
+    @staticmethod
+    def _text(value: Any, fallback: str = "") -> str:
+        text = str(value or "").strip()
+        return text or fallback
+
+    @staticmethod
+    def _csv(value: Any) -> str | None:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return value.strip() or None
+        if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+            text = ", ".join(str(item).strip() for item in value if str(item).strip())
+            return text or None
+        return str(value).strip() or None
+
+    @classmethod
+    def _chatbook_sort_key(cls, record: Mapping[str, Any]) -> tuple[str, str]:
+        updated_at = cls._text(record.get("updated_at") or record.get("created_at"))
+        chatbook_id = cls._text(record.get("chatbook_id") or record.get("id"))
+        return (updated_at, chatbook_id)
+
+    @classmethod
+    def _build_chatbook_console_launch(cls, record: Mapping[str, Any]) -> dict[str, Any] | None:
+        chatbook_id = record.get("chatbook_id") or record.get("id")
+        if chatbook_id in (None, ""):
+            return None
+        title = cls._text(record.get("name") or record.get("title"), "Untitled Chatbook")
+        description = cls._text(record.get("description"))
+        payload = {
+            "target_id": f"local:chatbook:{chatbook_id}",
+            "chatbook_id": chatbook_id,
+            "record_id": record.get("id"),
+            "file_path": record.get("file_path"),
+            "description": description,
+            "tags": cls._csv(record.get("tags")),
+            "categories": cls._csv(record.get("categories")),
+            "updated_at": record.get("updated_at"),
+        }
+        return {
+            "source": "artifacts",
+            "title": title,
+            "payload": payload,
+            "status": "ready",
+            "recovery": "Review this Chatbook artifact in Console or return to Artifacts.",
+            "action_label": "Open Chatbook artifact",
+        }
+
+    def _latest_local_chatbook_console_launch(self) -> dict[str, Any] | None:
+        service = getattr(self.app_instance, "local_chatbook_service", None)
+        list_chatbooks = getattr(service, "list_chatbooks", None)
+        if not callable(list_chatbooks):
+            return None
+        try:
+            result = list_chatbooks(q=None, limit=25, offset=0)
+            if inspect.isawaitable(result):
+                result = asyncio.run(result)
+        except Exception:
+            logger.warning(
+                "Failed to load latest local Chatbook artifact for Console launch.",
+                exc_info=True,
+            )
+            return None
+        records = [record for record in tuple(result or ()) if isinstance(record, Mapping)]
+        if not records:
+            return None
+        latest_record = max(records, key=self._chatbook_sort_key)
+        return self._build_chatbook_console_launch(latest_record)
 
     def compose_content(self) -> ComposeResult:
+        launch_kwargs = self._latest_chatbook_console_launch
         with Vertical(id="artifacts-shell"):
             yield Static("Artifacts", id="artifacts-title", classes="ds-destination-header")
             yield Static(
@@ -35,23 +132,60 @@ class ArtifactsScreen(BaseAppScreen):
                     id="artifacts-output-status",
                     classes="destination-purpose",
                 )
-                yield Button(
-                    "Use in Console",
-                    id="artifacts-use-in-console",
-                    tooltip="Stage artifact context in Console.",
-                )
+                if launch_kwargs is not None:
+                    title = str(launch_kwargs["title"])
+                    payload = launch_kwargs.get("payload") or {}
+                    description = str(payload.get("description") or "").strip()
+                    yield Static("Console launch available", classes="destination-section")
+                    yield Static(
+                        Text.from_markup(
+                            "Console can launch latest Chatbook artifact: "
+                            f"{escape_markup(title)}."
+                        ),
+                        id="artifacts-console-available",
+                    )
+                    if description:
+                        yield Static(
+                            Text.from_markup(escape_markup(description)),
+                            id="artifacts-chatbook-description",
+                        )
+                    yield Button(
+                        Text.from_markup(f"Launch {escape_markup(title)} in Console"),
+                        id="artifacts-use-in-console",
+                        tooltip="Open the latest local Chatbook artifact in Console.",
+                    )
+                else:
+                    yield Static("Console launch unavailable", classes="destination-section")
+                    yield Static(
+                        "No local Chatbook artifact is available for Console launch.",
+                        id="artifacts-console-unavailable",
+                    )
+                    yield Button(
+                        "Console launch unavailable",
+                        id="artifacts-use-in-console",
+                        disabled=True,
+                        tooltip="Unavailable until a local Chatbook artifact exists.",
+                    )
 
     @on(Button.Pressed, "#artifacts-open-chatbooks")
     def open_chatbooks(self) -> None:
         self.post_message(NavigateToScreen("chatbooks"))
 
     @on(Button.Pressed, "#artifacts-use-in-console")
-    def use_in_console(self) -> None:
-        self.app_instance.open_chat_with_handoff(
-            ChatHandoffPayload(
-                source="artifacts",
-                item_type="artifact-context",
-                title="Artifact context",
-                body="Stage generated outputs, reports, datasets, exports, or Chatbook context.",
+    def use_in_console(self, event: Button.Pressed) -> None:
+        event.stop()
+        launch_kwargs = self._latest_chatbook_console_launch
+        if launch_kwargs is None:
+            self.app_instance.notify(
+                "No local Chatbook artifact is available for Console launch.",
+                severity="warning",
             )
-        )
+            return
+        open_in_console = getattr(self.app_instance, "open_console_for_live_work", None)
+        if not callable(open_in_console):
+            self.app_instance.notify(
+                "Console launch is unavailable for Artifacts in this runtime.",
+                severity="warning",
+            )
+            return
+        open_in_console(**launch_kwargs)

--- a/tldw_chatbook/UI/Screens/artifacts_screen.py
+++ b/tldw_chatbook/UI/Screens/artifacts_screen.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import re
 from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from html import escape as html_escape
 from typing import Any
 
 from loguru import logger
@@ -15,11 +18,14 @@ from textual.app import ComposeResult
 from textual.containers import Vertical
 from textual.widgets import Button, Static
 
+from ...Utils.input_validation import sanitize_string, validate_text_input
 from ..Navigation.base_app_screen import BaseAppScreen
 from ..Navigation.main_navigation import NavigateToScreen
 
 
 logger = logger.bind(module="ArtifactsScreen")
+CHATBOOK_SERVICE_ERROR_COPY = "Chatbook service unavailable; retry Artifacts later."
+DANGEROUS_TEXT_PATTERNS = ("javascript:", "onclick=", "onerror=")
 
 
 class ArtifactsScreen(BaseAppScreen):
@@ -28,6 +34,7 @@ class ArtifactsScreen(BaseAppScreen):
     def __init__(self, app_instance, **kwargs):
         super().__init__(app_instance, "artifacts", **kwargs)
         self._latest_chatbook_console_launch: dict[str, Any] | None = None
+        self._chatbook_lookup_error: str | None = None
 
     def on_mount(self) -> None:
         super().on_mount()
@@ -35,11 +42,16 @@ class ArtifactsScreen(BaseAppScreen):
 
     @work(exclusive=True, thread=True)
     def _refresh_latest_chatbook_context(self) -> None:
-        launch_kwargs = self._latest_local_chatbook_console_launch()
-        self.app.call_from_thread(self._apply_latest_chatbook_context, launch_kwargs)
+        launch_kwargs, lookup_error = self._latest_local_chatbook_console_launch()
+        self.app.call_from_thread(self._apply_latest_chatbook_context, launch_kwargs, lookup_error)
 
-    def _apply_latest_chatbook_context(self, launch_kwargs: dict[str, Any] | None) -> None:
+    def _apply_latest_chatbook_context(
+        self,
+        launch_kwargs: dict[str, Any] | None,
+        lookup_error: str | None = None,
+    ) -> None:
         self._latest_chatbook_console_launch = launch_kwargs
+        self._chatbook_lookup_error = lookup_error
         if self.is_mounted:
             self.refresh(recompose=True)
 
@@ -48,39 +60,82 @@ class ArtifactsScreen(BaseAppScreen):
         text = str(value or "").strip()
         return text or fallback
 
-    @staticmethod
-    def _csv(value: Any) -> str | None:
+    @classmethod
+    def _safe_text(cls, value: Any, fallback: str = "", *, max_length: int = 1000) -> str:
+        text = sanitize_string(str(value or ""), max_length=max_length).strip()
+        if not text:
+            return fallback
+        text = html_escape(text, quote=False)
+        if validate_text_input(text, max_length=max_length, allow_html=False):
+            return text
+        for pattern in DANGEROUS_TEXT_PATTERNS:
+            text = re.sub(re.escape(pattern), pattern.rstrip(":=").replace("=", ""), text, flags=re.IGNORECASE)
+        if validate_text_input(text, max_length=max_length, allow_html=False):
+            return text
+        return fallback
+
+    @classmethod
+    def _csv(cls, value: Any) -> str | None:
         if value is None:
             return None
         if isinstance(value, str):
-            return value.strip() or None
+            return cls._safe_text(value) or None
         if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
-            text = ", ".join(str(item).strip() for item in value if str(item).strip())
+            safe_items = [cls._safe_text(item) for item in value]
+            text = ", ".join(item for item in safe_items if item)
             return text or None
-        return str(value).strip() or None
+        return cls._safe_text(value) or None
 
     @classmethod
-    def _chatbook_sort_key(cls, record: Mapping[str, Any]) -> tuple[str, str]:
-        updated_at = cls._text(record.get("updated_at") or record.get("created_at"))
-        chatbook_id = cls._text(record.get("chatbook_id") or record.get("id"))
-        return (updated_at, chatbook_id)
+    def _safe_identifier(cls, value: Any) -> int | str | None:
+        if isinstance(value, int):
+            return value
+        text = cls._safe_text(value, max_length=128)
+        return text or None
+
+    @classmethod
+    def _datetime_sort_key(cls, value: Any) -> float:
+        text = cls._text(value)
+        if not text:
+            return 0.0
+        try:
+            normalized = text[:-1] + "+00:00" if text.endswith("Z") else text
+            parsed = datetime.fromisoformat(normalized)
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            return parsed.timestamp()
+        except (TypeError, ValueError):
+            return 0.0
+
+    @classmethod
+    def _chatbook_id_sort_key(cls, value: Any) -> tuple[int, int, str]:
+        text = cls._text(value)
+        if text.isdigit():
+            return (1, int(text), "")
+        return (0, 0, text)
+
+    @classmethod
+    def _chatbook_sort_key(cls, record: Mapping[str, Any]) -> tuple[float, int, int, str]:
+        updated_at = cls._datetime_sort_key(record.get("updated_at") or record.get("created_at"))
+        id_kind, id_number, id_text = cls._chatbook_id_sort_key(record.get("chatbook_id") or record.get("id"))
+        return (updated_at, id_kind, id_number, id_text)
 
     @classmethod
     def _build_chatbook_console_launch(cls, record: Mapping[str, Any]) -> dict[str, Any] | None:
-        chatbook_id = record.get("chatbook_id") or record.get("id")
+        chatbook_id = cls._safe_identifier(record.get("chatbook_id") or record.get("id"))
         if chatbook_id in (None, ""):
             return None
-        title = cls._text(record.get("name") or record.get("title"), "Untitled Chatbook")
-        description = cls._text(record.get("description"))
+        title = cls._safe_text(record.get("name") or record.get("title"), "Untitled Chatbook")
+        description = cls._safe_text(record.get("description"))
         payload = {
             "target_id": f"local:chatbook:{chatbook_id}",
             "chatbook_id": chatbook_id,
-            "record_id": record.get("id"),
-            "file_path": record.get("file_path"),
+            "record_id": cls._safe_text(record.get("id")),
+            "file_path": cls._safe_text(record.get("file_path"), max_length=2000),
             "description": description,
             "tags": cls._csv(record.get("tags")),
             "categories": cls._csv(record.get("categories")),
-            "updated_at": record.get("updated_at"),
+            "updated_at": cls._safe_text(record.get("updated_at")),
         }
         return {
             "source": "artifacts",
@@ -91,11 +146,11 @@ class ArtifactsScreen(BaseAppScreen):
             "action_label": "Open Chatbook artifact",
         }
 
-    def _latest_local_chatbook_console_launch(self) -> dict[str, Any] | None:
+    def _latest_local_chatbook_console_launch(self) -> tuple[dict[str, Any] | None, str | None]:
         service = getattr(self.app_instance, "local_chatbook_service", None)
         list_chatbooks = getattr(service, "list_chatbooks", None)
         if not callable(list_chatbooks):
-            return None
+            return None, None
         try:
             result = list_chatbooks(q=None, limit=25, offset=0)
             if inspect.isawaitable(result):
@@ -105,12 +160,12 @@ class ArtifactsScreen(BaseAppScreen):
                 "Failed to load latest local Chatbook artifact for Console launch.",
                 exc_info=True,
             )
-            return None
+            return None, CHATBOOK_SERVICE_ERROR_COPY
         records = [record for record in tuple(result or ()) if isinstance(record, Mapping)]
         if not records:
-            return None
+            return None, None
         latest_record = max(records, key=self._chatbook_sort_key)
-        return self._build_chatbook_console_launch(latest_record)
+        return self._build_chatbook_console_launch(latest_record), None
 
     def compose_content(self) -> ComposeResult:
         launch_kwargs = self._latest_chatbook_console_launch
@@ -156,15 +211,22 @@ class ArtifactsScreen(BaseAppScreen):
                     )
                 else:
                     yield Static("Console launch unavailable", classes="destination-section")
+                    unavailable_copy = self._chatbook_lookup_error or (
+                        "No local Chatbook artifact is available for Console launch."
+                    )
                     yield Static(
-                        "No local Chatbook artifact is available for Console launch.",
+                        unavailable_copy,
                         id="artifacts-console-unavailable",
                     )
                     yield Button(
                         "Console launch unavailable",
                         id="artifacts-use-in-console",
                         disabled=True,
-                        tooltip="Unavailable until a local Chatbook artifact exists.",
+                        tooltip=(
+                            "Unavailable while the local Chatbook service is unavailable."
+                            if self._chatbook_lookup_error
+                            else "Unavailable until a local Chatbook artifact exists."
+                        ),
                     )
 
     @on(Button.Pressed, "#artifacts-open-chatbooks")
@@ -177,7 +239,7 @@ class ArtifactsScreen(BaseAppScreen):
         launch_kwargs = self._latest_chatbook_console_launch
         if launch_kwargs is None:
             self.app_instance.notify(
-                "No local Chatbook artifact is available for Console launch.",
+                self._chatbook_lookup_error or "No local Chatbook artifact is available for Console launch.",
                 severity="warning",
             )
             return


### PR DESCRIPTION
## Summary
- wire Artifacts to launch the latest local Chatbook artifact into Console via open_console_for_live_work
- keep Artifacts Console launch disabled with recovery copy when no local Chatbook exists
- update Console source readiness, Phase 3 QA evidence, roadmap tracking, and TASK-3.9

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_destination_shells.py -q -> 76 passed, 1 warning
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_console_live_work_handoffs.py::test_phase3_artifacts_chatbook_console_launch_tracking_evidence_links_task_and_roadmap -q -> 1 passed, 1 warning
- git diff --check -> clean