### PR TITLE
Adopt Unified MCP panel in MCP destination

### DIFF
--- a/Docs/superpowers/qa/unified-shell/phase-4/2026-05-04-mcp-destination-service-adoption.md
+++ b/Docs/superpowers/qa/unified-shell/phase-4/2026-05-04-mcp-destination-service-adoption.md
@@ -1,0 +1,40 @@
+# Phase 4.1 MCP Destination Service Adoption
+
+Task: `TASK-5.1`
+Branch: `codex/unified-shell-phase4-mcp-destination-service`
+
+## Goal
+
+Turn the top-level MCP destination from a disabled placeholder into a real service-backed control surface by adopting the existing `UnifiedMCPPanel` inside the primary shell.
+
+## Implementation Summary
+
+- Replaced the MCP destination placeholder panel with the existing `UnifiedMCPPanel`.
+- Preserved the `tools_settings` route as an MCP alias through the same `MCPScreen` destination.
+- Added MCP screen state save and restore for the Unified MCP view state.
+- Added runtime-backend refresh delegation so the embedded panel reloads context when runtime source changes.
+- Added tooltip copy to the shared Unified MCP action button so the newly exposed action remains self-explanatory in destination-level tooltip checks.
+
+## Verification
+
+- Baseline focused command before changes: `.venv/bin/python -m pytest Tests/UI/test_destination_shells.py Tests/UI/test_unified_mcp_panel.py -q`
+- Baseline focused result: `44 passed, 3 warnings in 19.61s`.
+- Red result: `test_mcp_destination_embeds_unified_mcp_management_panel` failed because no `UnifiedMCPPanel` was mounted on `MCPScreen`.
+- Green command after implementation: `.venv/bin/python -m pytest Tests/UI/test_destination_shells.py Tests/UI/test_unified_mcp_panel.py -q`
+- Green result: `44 passed, 1 warning in 15.64s`.
+- Tracking red result: `test_mcp_destination_service_adoption_tracking_evidence_exists` failed because this evidence file did not exist.
+
+## QA Walkthrough Notes
+
+- Environment: focused Textual mounted-window tests using the repo virtualenv.
+- Entry path: top navigation `MCP` destination and legacy `tools_settings` alias.
+- Visual check: MCP still shows the destination header and ownership copy, then exposes the Unified MCP panel with source, server, scope, section, action, payload, and result controls.
+- Functional result: the top-level MCP destination now reaches the existing Unified MCP service seam instead of requiring users to know the legacy Tools Settings route.
+- Alias result: `tools_settings` still resolves to `MCPScreen`, preserving compatibility while no longer behaving like global Settings.
+- Recovery result: if no Unified MCP service is available in the app session, the panel shows its existing unavailable status inside the real MCP management surface rather than a separate disabled shell placeholder.
+
+## Residual Risk
+
+- This slice adopts the existing Unified MCP panel; it does not expand MCP server capabilities, policy behavior, or action execution semantics.
+- Console source readiness still marks MCP as not wired for live-work context because this slice is destination-service adoption, not Console MCP launch/follow integration.
+- Manual full-app keyboard walkthrough remains part of later Phase 4/6 closeout; this slice is verified through focused mounted-window QA.

--- a/Docs/superpowers/qa/unified-shell/phase-4/README.md
+++ b/Docs/superpowers/qa/unified-shell/phase-4/README.md
@@ -1,5 +1,11 @@
 # Phase 4 QA Evidence
 
-Status: not-started
+Status: in-progress
 
-This directory will contain durable QA summaries for this phase. Do not mark the phase verified until running-app walkthrough evidence exists here.
+This directory contains durable QA summaries for Phase 4 destination service adoption slices.
+
+## Evidence
+
+- `2026-05-04-mcp-destination-service-adoption.md` - `TASK-5.1` MCP destination adoption of the existing Unified MCP management panel.
+
+Do not mark Phase 4 verified until Skills, MCP, ACP, Library, Workflows, Schedules, Personas, Artifacts, W+C, and Settings destination workflows are verified through running-app QA evidence or honest recovery states.

--- a/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
@@ -1,8 +1,8 @@
 # Unified Shell Maturity Roadmap
 
-Date: 2026-05-03
+Date: 2026-05-04
 Status: Phase 2 and Phase 3 in progress
-Source Branch: `origin/dev` at `0fbbe48e` plus `codex/unified-shell-phase3-artifacts-console-launch`
+Source Branch: `origin/dev` at `eeaac81c` plus `codex/unified-shell-phase4-mcp-destination-service`
 
 ## Purpose
 
@@ -32,7 +32,7 @@ Track remaining Unified Shell work in one place so rendered screens, clickable b
 - W+C and Schedules now expose Console follow when the existing active-work adapter has actionable run context; Schedules also exposes Console launch for the latest local reading-digest output when no active run is available; Search/RAG result cards can stage selected retrieved evidence into Console; Artifacts can launch the latest local Chatbook artifact into Console; Workflows and ACP still use honest unavailable Console states until actionable payloads exist.
 - Console now has a typed app-owned launch contract, reusable status-card display seam, source-readiness summary, Home W+C active-work source producer, W+C and Schedules destination follow producers, a Schedules reading-digest output fallback producer, a RAG search-result producer, an Artifacts Chatbook producer, and W+C run-detail action routing for staged live-work payloads; additional source-specific live event producers still need implementation.
 - ACP launch is disabled until an ACP-compatible runtime is configured.
-- MCP management is not embedded in the top-level MCP wrapper.
+- MCP now adopts the existing Unified MCP management panel in the top-level MCP wrapper; Console MCP live-work launch and deeper service expansion remain future work.
 - Skills local/server services exist, but the top-level Skills shell still leaves import disabled and lacks list/detail/import UX adoption.
 - Library still links into legacy Notes, Media, Ingest, Search/RAG, and conversation screens rather than fully Library-native views.
 - Product workflows remain unverified until running-app QA evidence is added in later phases.
@@ -96,6 +96,7 @@ Initial child tasks:
 - Phase 3.7: Launch active Schedules run from Schedules into Console - `TASK-3.7`
 - Phase 3.8: Launch RAG search result from Search/RAG into Console - `TASK-3.8`
 - Phase 3.9: Launch latest Chatbook artifact from Artifacts into Console - `TASK-3.9`
+- Phase 4.1: Adopt Unified MCP panel in MCP destination - `TASK-5.1`
 
 ## QA Evidence Index
 
@@ -105,7 +106,7 @@ Initial child tasks:
 | Phase 1 | `Docs/superpowers/qa/unified-shell/phase-1/` | verified |
 | Phase 2 | `Docs/superpowers/qa/unified-shell/phase-2/` | in-progress |
 | Phase 3 | `Docs/superpowers/qa/unified-shell/phase-3/` | in-progress |
-| Phase 4 | `Docs/superpowers/qa/unified-shell/phase-4/` | not-started |
+| Phase 4 | `Docs/superpowers/qa/unified-shell/phase-4/` | in-progress |
 | Phase 5 | `Docs/superpowers/qa/unified-shell/phase-5/` | not-started |
 | Phase 6 | `Docs/superpowers/qa/unified-shell/phase-6/` | not-started |
 
@@ -117,7 +118,7 @@ Initial child tasks:
 | Phase 1: Shell Contract Complete | Remove false shell affordances and prove shell usability. | verified | `TASK-2`, `TASK-2.1`, `TASK-2.2`, `TASK-2.3`, `TASK-2.4` | `phase-1/` | Live service workflows remain intentionally deferred to Phases 2-6. |
 | Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | in-progress | `TASK-4`, `TASK-4.1`, `TASK-4.2`, `TASK-4.3`, `TASK-4.4`, `TASK-4.5`, `TASK-4.6`, `TASK-4.7` | `phase-2/` | Schedule and agent-service adapters still need implementation; local watchlist retry/pause/resume remain recoverable rather than fully controllable. |
 | Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | in-progress | `TASK-3`, `TASK-3.1`, `TASK-3.2`, `TASK-3.3`, `TASK-3.4`, `TASK-3.5`, `TASK-3.6`, `TASK-3.7`, `TASK-3.8`, `TASK-3.9` | `phase-3/` | Workflows, ACP, MCP, server Artifacts, and deeper source-specific live event streams still need implementation. |
-| Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | not-started | `TASK-5` | `phase-4/` | Service coverage varies by destination. |
+| Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | in-progress | `TASK-5`, `TASK-5.1` | `phase-4/` | Service coverage varies by destination; MCP now adopts the existing Unified MCP panel but remaining destinations still need adoption or verified recovery. |
 | Phase 5: Capability And Recovery System | Systematize unavailable and blocked states. | not-started | `TASK-6` | `phase-5/` | Shared taxonomy not yet extracted. |
 | Phase 6: Audit Replay And Closeout | Prove shell works for first-time and power users. | not-started | `TASK-7` | `phase-6/` | Depends on prior phases and running-app QA. |
 
@@ -250,6 +251,12 @@ Initial audit result: W+C, Schedules, Workflows, and ACP had false Console-launc
 `TASK-3.9` lets Artifacts stage the latest local Chatbook artifact in Console while preserving the existing Chatbooks destination route:
 
 - `Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-artifacts-chatbook-console-launch.md`
+
+## Phase 4.1 MCP Destination Service Adoption Evidence
+
+`TASK-5.1` embeds the existing Unified MCP management panel in the top-level MCP destination while preserving the legacy `tools_settings` MCP alias:
+
+- `Docs/superpowers/qa/unified-shell/phase-4/2026-05-04-mcp-destination-service-adoption.md`
 
 ## Phase 0: Canonical Tracking
 

--- a/Tests/UI/test_destination_shells.py
+++ b/Tests/UI/test_destination_shells.py
@@ -1,10 +1,13 @@
 """Master shell destination wrapper tests."""
 
+from pathlib import Path
+
 import pytest
 from textual.app import App
-from textual.widgets import Button, Static
+from textual.widgets import Button, Select, Static, TextArea
 
 from Tests.UI.test_screen_navigation import _build_test_app
+from tldw_chatbook.UI.MCP_Modules.unified_mcp_panel import UnifiedMCPPanel
 from tldw_chatbook.UI.Screens.artifacts_screen import ArtifactsScreen
 from tldw_chatbook.UI.Screens.acp_screen import ACPScreen
 from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
@@ -30,6 +33,10 @@ SCREEN_BY_ROUTE = {
     "skills": SkillsScreen,
     "settings": SettingsScreen,
 }
+
+PHASE4_MCP_ADOPTION_EVIDENCE = Path(
+    "Docs/superpowers/qa/unified-shell/phase-4/2026-05-04-mcp-destination-service-adoption.md"
+)
 
 
 class DestinationHarness(App):
@@ -211,7 +218,6 @@ async def test_protocol_and_settings_wrappers_have_distinct_boundaries(route, ex
 @pytest.mark.parametrize(
     ("route", "selector", "copy"),
     [
-        ("mcp", "#mcp-open-management", "Unified MCP management is not embedded in this shell yet."),
         ("skills", "#skills-import-skill", "Skill import is not wired in this shell yet."),
     ],
 )
@@ -227,6 +233,40 @@ async def test_unwired_destination_actions_are_disabled_with_honest_copy(route, 
         button = screen.query_one(selector, Button)
         assert button.disabled is True
         assert copy in _visible_text(screen)
+
+
+@pytest.mark.asyncio
+async def test_mcp_destination_embeds_unified_mcp_management_panel():
+    app = _build_test_app()
+    host = DestinationHarness(app, "mcp")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.1)
+        screen = _active_destination_screen(host)
+
+        assert screen.query_one(UnifiedMCPPanel)
+        assert screen.query_one("#unified-mcp-source", Select)
+        assert screen.query_one("#unified-mcp-server-target", Select)
+        assert screen.query_one("#unified-mcp-scope", Select)
+        assert screen.query_one("#unified-mcp-section", Select)
+        assert screen.query_one("#unified-mcp-action", Select)
+        assert screen.query_one("#unified-mcp-action-payload", TextArea)
+        assert screen.query_one("#unified-mcp-action-run", Button)
+        assert not screen.query("#mcp-open-management")
+        assert "Unified MCP management is not embedded in this shell yet." not in _visible_text(screen)
+
+
+def test_mcp_destination_service_adoption_tracking_evidence_exists():
+    evidence = PHASE4_MCP_ADOPTION_EVIDENCE.read_text(encoding="utf-8")
+    roadmap = Path("Docs/superpowers/trackers/unified-shell-maturity-roadmap.md").read_text(encoding="utf-8")
+    task = Path(
+        "backlog/tasks/task-5.1 - Phase-4.1-Adopt-Unified-MCP-panel-in-MCP-destination.md"
+    ).read_text(encoding="utf-8")
+
+    assert "Phase 4.1 MCP Destination Service Adoption" in evidence
+    assert "TASK-5.1" in evidence
+    assert "Phase 4.1: Adopt Unified MCP panel in MCP destination - `TASK-5.1`" in roadmap
+    assert "UnifiedMCPPanel" in task
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_destination_shells.py
+++ b/Tests/UI/test_destination_shells.py
@@ -7,6 +7,9 @@ from textual.app import App
 from textual.widgets import Button, Select, Static, TextArea
 
 from Tests.UI.test_screen_navigation import _build_test_app
+from Tests.UI.test_unified_mcp_panel import FakeUnifiedMCPService
+from tldw_chatbook.MCP.server_target_store import ConfiguredServerTargetStore
+from tldw_chatbook.MCP.unified_control_models import ConfiguredServerTarget
 from tldw_chatbook.UI.MCP_Modules.unified_mcp_panel import UnifiedMCPPanel
 from tldw_chatbook.UI.Screens.artifacts_screen import ArtifactsScreen
 from tldw_chatbook.UI.Screens.acp_screen import ACPScreen
@@ -40,14 +43,18 @@ PHASE4_MCP_ADOPTION_EVIDENCE = Path(
 
 
 class DestinationHarness(App):
-    def __init__(self, app_instance, route, seen_routes=None):
+    def __init__(self, app_instance, route, seen_routes=None, restored_state=None):
         super().__init__()
         self.app_instance = app_instance
         self.route = route
         self.seen_routes = seen_routes if seen_routes is not None else []
+        self.restored_state = restored_state
 
     async def on_mount(self) -> None:
-        await self.push_screen(SCREEN_BY_ROUTE[self.route](self.app_instance))
+        screen = SCREEN_BY_ROUTE[self.route](self.app_instance)
+        if self.restored_state is not None:
+            screen.restore_state(self.restored_state)
+        await self.push_screen(screen)
 
     def on_navigate_to_screen(self, message) -> None:
         self.seen_routes.append(message.screen_name)
@@ -254,6 +261,63 @@ async def test_mcp_destination_embeds_unified_mcp_management_panel():
         assert screen.query_one("#unified-mcp-action-run", Button)
         assert not screen.query("#mcp-open-management")
         assert "Unified MCP management is not embedded in this shell yet." not in _visible_text(screen)
+
+
+@pytest.mark.asyncio
+async def test_mcp_destination_restores_unified_mcp_view_state_after_mount(tmp_path):
+    target_store = ConfiguredServerTargetStore(tmp_path / "targets.json")
+    target_store.save_targets(
+        [ConfiguredServerTarget(server_id="server-a", label="Server A", base_url="https://a.example/api", is_default=True)]
+    )
+    app = _build_test_app()
+    app.unified_mcp_service = FakeUnifiedMCPService(target_store)
+    host = DestinationHarness(
+        app,
+        "mcp",
+        restored_state={
+            "unified_mcp_view_state": {
+                "selected_source": "server",
+                "selected_active_server_id": "server-a",
+                "selected_scope": "team",
+                "selected_scope_ref": "21",
+                "selected_section": "inventory",
+            }
+        },
+    )
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        panel = _active_destination_screen(host).query_one(UnifiedMCPPanel)
+
+        assert panel.context.selected_source == "server"
+        assert panel.context.selected_active_server_id == "server-a"
+        assert panel.context.selected_scope == "team"
+        assert panel.context.selected_scope_ref == "21"
+        assert panel.context.selected_section == "inventory"
+
+
+@pytest.mark.asyncio
+async def test_mcp_destination_runtime_refresh_uses_exclusive_worker(monkeypatch):
+    app = _build_test_app()
+    screen = MCPScreen(app)
+    scheduled = {}
+
+    class FakePanel:
+        async def load_context(self):
+            return None
+
+    def capture_worker(coro, **kwargs):
+        scheduled["kwargs"] = kwargs
+        coro.close()
+
+    screen.mcp_panel = FakePanel()
+    monkeypatch.setattr(screen, "run_worker", capture_worker)
+
+    await screen.handle_runtime_backend_changed("server")
+
+    assert scheduled["kwargs"]["name"] == "mcp-screen-runtime-refresh"
+    assert scheduled["kwargs"]["group"] == "mcp-screen-runtime-refresh"
+    assert scheduled["kwargs"]["exclusive"] is True
 
 
 def test_mcp_destination_service_adoption_tracking_evidence_exists():

--- a/backlog/tasks/task-5.1 - Phase-4.1-Adopt-Unified-MCP-panel-in-MCP-destination.md
+++ b/backlog/tasks/task-5.1 - Phase-4.1-Adopt-Unified-MCP-panel-in-MCP-destination.md
@@ -1,0 +1,47 @@
+---
+id: TASK-5.1
+title: Phase 4.1 Adopt Unified MCP panel in MCP destination
+status: Done
+assignee: []
+created_date: '2026-05-04 03:19'
+updated_date: '2026-05-04 03:25'
+labels:
+  - unified-shell
+  - phase-4
+  - mcp
+  - service-adoption
+dependencies: []
+parent_task_id: TASK-5
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make the top-level MCP destination use the existing Unified MCP management panel so users can inspect and operate local or server MCP context from the primary shell instead of seeing a disabled placeholder.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 MCP route renders Unified MCP source server scope section and action controls
+- [x] #2 Legacy tools_settings alias still resolves to the MCP destination
+- [x] #3 The old disabled MCP management placeholder is removed from the top-level MCP route
+- [x] #4 Focused automated tests cover the adopted MCP destination behavior
+- [x] #5 QA evidence documents functional behavior visual usability residual risks and verification output
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing destination shell tests proving the MCP route mounts UnifiedMCPPanel controls and no longer exposes the disabled placeholder.
+2. Replace the placeholder MCPScreen content with UnifiedMCPPanel while preserving BaseAppScreen route identity.
+3. Preserve view-state save restore and runtime backend refresh delegation for the embedded panel.
+4. Add Phase 4 QA evidence and roadmap links.
+5. Run focused MCP destination and unified panel regression tests plus git diff checks before commit.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Embedded the existing `UnifiedMCPPanel` directly in the top-level MCP destination and preserved `tools_settings` as an MCP alias. Added MCP screen view-state save and restore, runtime-backend refresh delegation, a tooltip for the exposed Unified MCP action button, focused destination regression coverage, and Phase 4 QA/roadmap tracking.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/MCP_Modules/unified_mcp_panel.py
+++ b/tldw_chatbook/UI/MCP_Modules/unified_mcp_panel.py
@@ -165,7 +165,12 @@ class UnifiedMCPPanel(Container):
                     yield Label("Payload (JSON)", classes="form-label")
                     yield TextArea("{}", id="unified-mcp-action-payload")
                     with Horizontal(classes="unified-mcp-action-row"):
-                        yield Button("Run Action", id="unified-mcp-action-run", variant="primary")
+                        yield Button(
+                            "Run Action",
+                            id="unified-mcp-action-run",
+                            variant="primary",
+                            tooltip="Run the selected Unified MCP action with the JSON payload above.",
+                        )
                     yield Static("", id="unified-mcp-action-result", classes="help-text")
 
     async def on_mount(self) -> None:

--- a/tldw_chatbook/UI/MCP_Modules/unified_mcp_panel.py
+++ b/tldw_chatbook/UI/MCP_Modules/unified_mcp_panel.py
@@ -105,6 +105,30 @@ class UnifiedMCPPanel(Container):
             return None
 
     def compose(self) -> ComposeResult:
+        pending_view_state = self._pending_view_state or {}
+        initial_source = str(pending_view_state.get("selected_source") or "local")
+        if initial_source not in {"local", "server"}:
+            initial_source = "local"
+        initial_section = str(pending_view_state.get("selected_section") or "overview")
+        if initial_section not in {"overview", "inventory", "external_servers"}:
+            initial_section = "overview"
+        initial_scope = str(pending_view_state.get("selected_scope") or "personal")
+        if initial_scope not in {"personal", "team", "org", "system_admin"}:
+            initial_scope = "personal"
+        initial_scope_options = [("Personal", "personal")]
+        if initial_scope == "team":
+            initial_scope_options.append(("Team", "team"))
+        elif initial_scope == "org":
+            initial_scope_options.append(("Org", "org"))
+        elif initial_scope == "system_admin":
+            initial_scope_options.append(("System Admin", "system_admin"))
+        initial_scope_ref = pending_view_state.get("selected_scope_ref")
+        initial_scope_ref_options = [("No scope entities", Select.BLANK)]
+        initial_scope_ref_value = Select.BLANK
+        if initial_scope_ref not in (None, ""):
+            initial_scope_ref_value = str(initial_scope_ref)
+            initial_scope_ref_options = [(f"Scope {initial_scope_ref_value}", initial_scope_ref_value)]
+
         with Vertical(classes="unified-mcp-shell"):
             with Container(classes="settings-group"):
                 yield Static("Unified MCP", classes="settings-group-title")
@@ -120,7 +144,7 @@ class UnifiedMCPPanel(Container):
                                 [("Local", "local"), ("Server", "server")],
                                 id="unified-mcp-source",
                                 allow_blank=False,
-                                value="local",
+                                value=initial_source,
                             )
                         with Container(classes="unified-mcp-field"):
                             yield Label("Server", classes="form-label")
@@ -133,17 +157,17 @@ class UnifiedMCPPanel(Container):
                         with Container(classes="unified-mcp-field"):
                             yield Label("Scope", classes="form-label")
                             yield Select(
-                                [("Personal", "personal")],
+                                initial_scope_options,
                                 id="unified-mcp-scope",
                                 allow_blank=False,
-                                value="personal",
+                                value=initial_scope,
                             )
                         with Container(classes="unified-mcp-field"):
                             yield Label("Scope Entity", classes="form-label")
                             yield Select(
-                                [("No scope entities", Select.BLANK)],
+                                initial_scope_ref_options,
                                 id="unified-mcp-scope-ref",
-                                value=Select.BLANK,
+                                value=initial_scope_ref_value,
                             )
                         with Container(classes="unified-mcp-field"):
                             yield Label("Section", classes="form-label")
@@ -151,7 +175,7 @@ class UnifiedMCPPanel(Container):
                                 [("Overview", "overview"), ("Inventory", "inventory"), ("External Servers", "external_servers")],
                                 id="unified-mcp-section",
                                 allow_blank=False,
-                                value="overview",
+                                value=initial_section,
                             )
                 yield Static("", id="unified-mcp-status", classes="unified-mcp-status")
                 yield Static("Unified MCP is loading...", id="unified-mcp-content", classes="unified-mcp-content")

--- a/tldw_chatbook/UI/Screens/mcp_screen.py
+++ b/tldw_chatbook/UI/Screens/mcp_screen.py
@@ -2,8 +2,9 @@
 
 from textual.app import ComposeResult
 from textual.containers import Vertical
-from textual.widgets import Button, Static
+from textual.widgets import Static
 
+from ..MCP_Modules.unified_mcp_panel import UnifiedMCPPanel
 from ..Navigation.base_app_screen import BaseAppScreen
 
 
@@ -12,6 +13,7 @@ class MCPScreen(BaseAppScreen):
 
     def __init__(self, app_instance, **kwargs):
         super().__init__(app_instance, "mcp", **kwargs)
+        self.mcp_panel: UnifiedMCPPanel | None = None
 
     def compose_content(self) -> ComposeResult:
         with Vertical(id="mcp-shell"):
@@ -21,20 +23,24 @@ class MCPScreen(BaseAppScreen):
                 id="mcp-purpose",
                 classes="destination-purpose",
             )
-            with Vertical(id="mcp-sections", classes="ds-panel"):
-                yield Static("Servers", classes="destination-section")
-                yield Static("Tools", classes="destination-section")
-                yield Static("Permissions", classes="destination-section")
-                yield Static("Auth", classes="destination-section")
-                yield Static("Audit", classes="destination-section")
-                yield Static("Test Tool", classes="destination-section")
-                yield Static(
-                    "Unified MCP management is not embedded in this shell yet.",
-                    id="mcp-management-unavailable",
-                )
-                yield Button(
-                    "Open MCP Management",
-                    id="mcp-open-management",
-                    disabled=True,
-                    tooltip="Unavailable until MCP management is embedded in this shell.",
-                )
+            self.mcp_panel = UnifiedMCPPanel(self.app_instance, id="unified-mcp-panel", classes="ds-panel")
+            yield self.mcp_panel
+
+    def save_state(self):
+        """Save Unified MCP view state when the screen is switched away."""
+        state = super().save_state()
+        if self.mcp_panel:
+            state["unified_mcp_view_state"] = self.mcp_panel.get_view_state()
+        return state
+
+    def restore_state(self, state):
+        """Restore Unified MCP view state when the screen is revisited."""
+        super().restore_state(state)
+        if self.mcp_panel and isinstance(state, dict):
+            self.mcp_panel.set_initial_view_state(state.get("unified_mcp_view_state"))
+
+    async def handle_runtime_backend_changed(self, runtime_backend: str) -> None:
+        """Refresh MCP context when runtime backend/source changes."""
+        _ = runtime_backend
+        if self.mcp_panel:
+            await self.mcp_panel.load_context()

--- a/tldw_chatbook/UI/Screens/mcp_screen.py
+++ b/tldw_chatbook/UI/Screens/mcp_screen.py
@@ -1,5 +1,7 @@
 """MCP destination shell for tools, servers, permissions, and audit."""
 
+from typing import Any
+
 from textual.app import ComposeResult
 from textual.containers import Vertical
 from textual.widgets import Static
@@ -11,7 +13,7 @@ from ..Navigation.base_app_screen import BaseAppScreen
 class MCPScreen(BaseAppScreen):
     """MCP servers, tools, permissions, auth, and audit surface."""
 
-    def __init__(self, app_instance, **kwargs):
+    def __init__(self, app_instance: Any, **kwargs: Any) -> None:
         super().__init__(app_instance, "mcp", **kwargs)
         self.mcp_panel: UnifiedMCPPanel | None = None
 
@@ -24,23 +26,41 @@ class MCPScreen(BaseAppScreen):
                 classes="destination-purpose",
             )
             self.mcp_panel = UnifiedMCPPanel(self.app_instance, id="unified-mcp-panel", classes="ds-panel")
+            self.mcp_panel.set_initial_view_state(self.state_data.get("unified_mcp_view_state"))
             yield self.mcp_panel
 
-    def save_state(self):
-        """Save Unified MCP view state when the screen is switched away."""
+    def save_state(self) -> dict[str, Any]:
+        """Save Unified MCP view state when the screen is switched away.
+
+        Returns:
+            Screen state including the embedded Unified MCP panel selection.
+        """
         state = super().save_state()
         if self.mcp_panel:
             state["unified_mcp_view_state"] = self.mcp_panel.get_view_state()
         return state
 
-    def restore_state(self, state):
-        """Restore Unified MCP view state when the screen is revisited."""
+    def restore_state(self, state: dict[str, Any]) -> None:
+        """Restore Unified MCP view state when the screen is revisited.
+
+        Args:
+            state: Previously saved screen state.
+        """
         super().restore_state(state)
-        if self.mcp_panel and isinstance(state, dict):
+        if self.mcp_panel:
             self.mcp_panel.set_initial_view_state(state.get("unified_mcp_view_state"))
 
     async def handle_runtime_backend_changed(self, runtime_backend: str) -> None:
-        """Refresh MCP context when runtime backend/source changes."""
+        """Schedule MCP context refresh when runtime backend/source changes.
+
+        Args:
+            runtime_backend: Newly active runtime backend identifier.
+        """
         _ = runtime_backend
         if self.mcp_panel:
-            await self.mcp_panel.load_context()
+            self.run_worker(
+                self.mcp_panel.load_context(),
+                name="mcp-screen-runtime-refresh",
+                group="mcp-screen-runtime-refresh",
+                exclusive=True,
+            )


### PR DESCRIPTION
## Summary
- Embed the existing UnifiedMCPPanel in the top-level MCP shell destination.
- Preserve tools_settings as an MCP alias while removing the disabled placeholder affordance.
- Add Phase 4.1 Backlog, roadmap, and QA evidence tracking.

## Test Plan
- [x] /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_destination_shells.py Tests/UI/test_unified_mcp_panel.py -q
- [x] git diff --check HEAD