### PR TITLE
Adopt Library source services in shell

### DIFF
--- a/Docs/superpowers/qa/unified-shell/phase-4/2026-05-04-library-source-service-adoption.md
+++ b/Docs/superpowers/qa/unified-shell/phase-4/2026-05-04-library-source-service-adoption.md
@@ -1,0 +1,43 @@
+# Phase 4.3 Library Source Service Adoption
+
+Task: `TASK-5.3`
+Branch: `codex/unified-shell-phase4-library-source-service`
+
+## Goal
+
+Turn the top-level Library destination from static legacy-route links plus generic Console copy into a service-backed source snapshot that tells users whether local notes, media, and conversations are available and stages concrete Library context into Console.
+
+## Implementation Summary
+
+- Loaded local source context through `notes_scope_service.list_notes(scope="local_note")`, `media_reading_scope_service.list_media_items(mode="local")`, and `chat_conversation_scope_service.list_conversations(mode="local")`.
+- Rendered loading, available, empty, service-unavailable, and policy-denied recovery states with stable selectors.
+- Kept existing legacy navigation buttons for Notes, Media, Conversations, Import/Export, and Search/RAG so current user paths remain reachable.
+- Disabled `Use in Console` until concrete local source context exists.
+- Built `ChatHandoffPayload` from actual local source counts and sample titles instead of the previous generic Library placeholder.
+
+## Verification
+
+- Baseline focused command before changes: `.venv/bin/python -m pytest Tests/UI/test_destination_shells.py Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_shell_product_model_visibility.py -q`
+- Baseline focused result: `99 passed, 1 warning in 30.74s` after rerun; the first run had a transient Skills handoff timing failure that passed individually and on full rerun.
+- Red command: `.venv/bin/python -m pytest Tests/UI/test_destination_shells.py -q`
+- Red result: `5 failed, 47 passed, 1 warning in 21.22s`.
+- First green behavior command after implementation: `.venv/bin/python -m pytest Tests/UI/test_destination_shells.py -q`
+- First green behavior result: `1 failed, 51 passed, 1 warning in 22.07s`; only the tracking evidence file was still missing.
+- Final focused command: `.venv/bin/python -m pytest Tests/UI/test_destination_shells.py Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_shell_product_model_visibility.py -q`
+- Final focused result: `103 passed, 1 warning in 32.21s`.
+
+## QA Walkthrough Notes
+
+- Environment: focused Textual mounted-window tests using the repo virtualenv.
+- Entry path: top navigation `Library` destination.
+- Visual check: Library keeps the destination title, ownership copy, and existing source navigation buttons while adding a `Local Library snapshot` section.
+- Available-state result: local service responses render source counts for Notes, Media, and Conversations plus visible sample titles and enable `Use in Console`.
+- Empty-state result: empty local service responses render `No local Library sources are available yet.` and disable Console handoff with add-source recovery copy.
+- Service-error result: source-service exceptions render `Library source services unavailable; retry Library later.` and disable Console handoff with retry-oriented recovery copy.
+- Functional result: Console handoff stages `library-source-snapshot` with local source counts, sample titles, runtime/source ownership metadata, and no generic placeholder body.
+
+## Residual Risk
+
+- This slice adopts source snapshot and Console staging only; full Library-native note/media/conversation detail views remain future Phase 4 work.
+- Import/Export and Search/RAG still route to existing legacy surfaces rather than becoming embedded Library-native pages.
+- The walkthrough uses focused mounted-window QA, not a full clean-HOME running app session.

--- a/Docs/superpowers/qa/unified-shell/phase-4/2026-05-04-library-source-service-adoption.md
+++ b/Docs/superpowers/qa/unified-shell/phase-4/2026-05-04-library-source-service-adoption.md
@@ -13,7 +13,8 @@ Turn the top-level Library destination from static legacy-route links plus gener
 - Rendered loading, available, empty, service-unavailable, and policy-denied recovery states with stable selectors.
 - Kept existing legacy navigation buttons for Notes, Media, Conversations, Import/Export, and Search/RAG so current user paths remain reachable.
 - Disabled `Use in Console` until concrete local source context exists.
-- Built `ChatHandoffPayload` from actual local source counts and sample titles instead of the previous generic Library placeholder.
+- Built `ChatHandoffPayload` from local source totals when available, explicit sample counts when totals are unavailable, and sample titles instead of the previous generic Library placeholder.
+- Rendered staged Chat handoff cards as plain text so user-controlled Library titles cannot be interpreted as Rich markup.
 
 ## Verification
 
@@ -23,18 +24,19 @@ Turn the top-level Library destination from static legacy-route links plus gener
 - Red result: `5 failed, 47 passed, 1 warning in 21.22s`.
 - First green behavior command after implementation: `.venv/bin/python -m pytest Tests/UI/test_destination_shells.py -q`
 - First green behavior result: `1 failed, 51 passed, 1 warning in 22.07s`; only the tracking evidence file was still missing.
-- Final focused command: `.venv/bin/python -m pytest Tests/UI/test_destination_shells.py Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_shell_product_model_visibility.py -q`
-- Final focused result: `103 passed, 1 warning in 32.21s`.
+- Initial focused result before review fixes: `103 passed, 1 warning in 32.21s`.
+- Post-review focused command: `.venv/bin/python -m pytest Tests/UI/test_destination_shells.py Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_shell_product_model_visibility.py Tests/UI/test_chat_first_handoffs.py -q`
+- Post-review focused result: `128 passed, 1 warning in 30.71s`.
 
 ## QA Walkthrough Notes
 
 - Environment: focused Textual mounted-window tests using the repo virtualenv.
 - Entry path: top navigation `Library` destination.
 - Visual check: Library keeps the destination title, ownership copy, and existing source navigation buttons while adding a `Local Library snapshot` section.
-- Available-state result: local service responses render source counts for Notes, Media, and Conversations plus visible sample titles and enable `Use in Console`.
+- Available-state result: local service responses render known source totals when the service provides them, explicit `showing up to 5` sample labels when totals are unavailable, and visible sample titles while enabling `Use in Console`.
 - Empty-state result: empty local service responses render `No local Library sources are available yet.` and disable Console handoff with add-source recovery copy.
 - Service-error result: source-service exceptions render `Library source services unavailable; retry Library later.` and disable Console handoff with retry-oriented recovery copy.
-- Functional result: Console handoff stages `library-source-snapshot` with local source counts, sample titles, runtime/source ownership metadata, and no generic placeholder body.
+- Functional result: Console handoff stages `library-source-snapshot` with local source total/sample metadata, sample titles, runtime/source ownership metadata, and no generic placeholder body.
 
 ## Residual Risk
 

--- a/Docs/superpowers/qa/unified-shell/phase-4/README.md
+++ b/Docs/superpowers/qa/unified-shell/phase-4/README.md
@@ -8,5 +8,6 @@ This directory contains durable QA summaries for Phase 4 destination service ado
 
 - `2026-05-04-mcp-destination-service-adoption.md` - `TASK-5.1` MCP destination adoption of the existing Unified MCP management panel.
 - `2026-05-04-skills-destination-service-adoption.md` - `TASK-5.2` Skills destination adoption of local `skills_scope_service` listing and Console context staging.
+- `2026-05-04-library-source-service-adoption.md` - `TASK-5.3` Library destination adoption of local notes, media, and conversation source snapshots plus concrete Console context staging.
 
 Do not mark Phase 4 verified until Skills, MCP, ACP, Library, Workflows, Schedules, Personas, Artifacts, W+C, and Settings destination workflows are verified through running-app QA evidence or honest recovery states.

--- a/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
@@ -2,7 +2,7 @@
 
 Date: 2026-05-04
 Status: Phase 2, Phase 3, and Phase 4 in progress
-Source Branch: `origin/dev` at `5a413536` plus `codex/unified-shell-phase4-skills-destination-service`
+Source Branch: `origin/dev` at `45fa942c` plus `codex/unified-shell-phase4-library-source-service`
 
 ## Purpose
 
@@ -34,7 +34,7 @@ Track remaining Unified Shell work in one place so rendered screens, clickable b
 - ACP launch is disabled until an ACP-compatible runtime is configured.
 - MCP now adopts the existing Unified MCP management panel in the top-level MCP wrapper; Console MCP live-work launch and deeper service expansion remain future work.
 - Skills now lists local Agent Skills through `skills_scope_service` and can stage local skill context into Console; server skills, import, detail, edit, validation, and execution UX remain future work.
-- Library still links into legacy Notes, Media, Ingest, Search/RAG, and conversation screens rather than fully Library-native views.
+- Library now surfaces a local source snapshot from notes, media, and conversations and can stage concrete source context into Console; full Library-native detail views, embedded Import/Export, and embedded Search/RAG remain future work.
 - Product workflows remain unverified until running-app QA evidence is added in later phases.
 
 ## Definition Of Done
@@ -99,6 +99,7 @@ Initial child tasks:
 - Phase 3.10: Launch active Workflows run from Workflows into Console - `TASK-3.10`
 - Phase 4.1: Adopt Unified MCP panel in MCP destination - `TASK-5.1`
 - Phase 4.2: Adopt Skills services in Skills destination - `TASK-5.2`
+- Phase 4.3: Adopt Library source services in Library destination - `TASK-5.3`
 
 ## QA Evidence Index
 
@@ -120,7 +121,7 @@ Initial child tasks:
 | Phase 1: Shell Contract Complete | Remove false shell affordances and prove shell usability. | verified | `TASK-2`, `TASK-2.1`, `TASK-2.2`, `TASK-2.3`, `TASK-2.4` | `phase-1/` | Live service workflows remain intentionally deferred to Phases 2-6. |
 | Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | in-progress | `TASK-4`, `TASK-4.1`, `TASK-4.2`, `TASK-4.3`, `TASK-4.4`, `TASK-4.5`, `TASK-4.6`, `TASK-4.7` | `phase-2/` | Schedule and agent-service adapters still need implementation; local watchlist retry/pause/resume remain recoverable rather than fully controllable. |
 | Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | in-progress | `TASK-3`, `TASK-3.1`, `TASK-3.2`, `TASK-3.3`, `TASK-3.4`, `TASK-3.5`, `TASK-3.6`, `TASK-3.7`, `TASK-3.8`, `TASK-3.9`, `TASK-3.10` | `phase-3/` | ACP, MCP, server Artifacts, and deeper source-specific live event streams still need implementation. |
-| Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | in-progress | `TASK-5`, `TASK-5.1`, `TASK-5.2` | `phase-4/` | Service coverage varies by destination; MCP now adopts the existing Unified MCP panel and Skills now lists/stages local Agent Skills, but remaining destinations and deeper Skills flows still need adoption or verified recovery. |
+| Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | in-progress | `TASK-5`, `TASK-5.1`, `TASK-5.2`, `TASK-5.3` | `phase-4/` | Service coverage varies by destination; MCP now adopts the existing Unified MCP panel, Skills now lists/stages local Agent Skills, and Library now lists/stages local source snapshots, but remaining destinations and deeper Library/Skills flows still need adoption or verified recovery. |
 | Phase 5: Capability And Recovery System | Systematize unavailable and blocked states. | not-started | `TASK-6` | `phase-5/` | Shared taxonomy not yet extracted. |
 | Phase 6: Audit Replay And Closeout | Prove shell works for first-time and power users. | not-started | `TASK-7` | `phase-6/` | Depends on prior phases and running-app QA. |
 
@@ -271,6 +272,12 @@ Initial audit result: W+C, Schedules, Workflows, and ACP had false Console-launc
 `TASK-5.2` makes the top-level Skills destination list local Agent Skills through `skills_scope_service` and stage concrete local skill context into Console:
 
 - `Docs/superpowers/qa/unified-shell/phase-4/2026-05-04-skills-destination-service-adoption.md`
+
+## Phase 4.3 Library Source Service Adoption Evidence
+
+`TASK-5.3` makes the top-level Library destination list local notes, media, and conversations through existing source services and stage concrete local source context into Console:
+
+- `Docs/superpowers/qa/unified-shell/phase-4/2026-05-04-library-source-service-adoption.md`
 
 ## Phase 0: Canonical Tracking
 

--- a/Tests/UI/test_chat_first_handoffs.py
+++ b/Tests/UI/test_chat_first_handoffs.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 from textual.app import App, ComposeResult
 from textual.css.query import NoMatches
-from textual.widgets import Button, TextArea
+from textual.widgets import Button, Static, TextArea
 
 from tldw_chatbook.Chat.chat_models import ChatSessionData
 from tldw_chatbook.Chat.chat_handoff_models import ChatHandoffPayload, HANDOFF_BODY_CHAR_LIMIT
@@ -367,6 +367,33 @@ def test_handoff_card_uses_status_source_title_and_metadata():
     assert "Server: srv-primary" in text
     assert "Sync: dry-run only" in text
     assert "https://example.com" in text
+
+
+@pytest.mark.asyncio
+async def test_handoff_card_renders_user_controlled_text_as_plain_text():
+    class HandoffCardHarness(App):
+        def compose(self) -> ComposeResult:
+            yield ChatHandoffCard(
+                ChatHandoffPayload(
+                    source="library",
+                    item_type="library-source-snapshot",
+                    title="[bold red]Injected title[/]",
+                    body="[green]Injected body[/]",
+                    display_summary="[blue]Injected summary[/]",
+                    metadata={"note_titles": ["[reverse]Injected note[/]"]},
+                )
+            )
+
+    async with HandoffCardHarness().run_test(size=(120, 20)) as pilot:
+        card_body = pilot.app.query_one(".chat-handoff-card-body", Static)
+        card = pilot.app.query_one(ChatHandoffCard)
+        renderable = card_body.renderable
+
+        assert getattr(renderable, "plain", "") == card.render_text()
+        assert getattr(renderable, "spans", []) == []
+        assert "[bold red]Injected title[/]" in renderable.plain
+        assert "[blue]Injected summary[/]" in renderable.plain
+        assert "[reverse]Injected note[/]" in renderable.plain
 
 
 def test_handoff_card_surfaces_backend_contract_recovery_without_implying_write_sync():

--- a/Tests/UI/test_console_live_work_handoffs.py
+++ b/Tests/UI/test_console_live_work_handoffs.py
@@ -1355,7 +1355,6 @@ async def test_artifacts_destination_distinguishes_chatbook_service_failure_from
 @pytest.mark.parametrize(
     ("route", "button_id"),
     [
-        ("library", "library-use-in-console"),
         ("personas", "personas-attach-to-console"),
     ],
 )

--- a/Tests/UI/test_destination_shells.py
+++ b/Tests/UI/test_destination_shells.py
@@ -64,6 +64,19 @@ class StaticLibraryNotesScopeService:
         return {"items": list(self.notes), "pagination": {"total": len(self.notes)}}
 
 
+class StaticLibraryNotesListScopeService:
+    def __init__(self, notes):
+        self.notes = tuple(notes)
+        self.calls = []
+
+    async def list_notes(self, **kwargs):
+        self.calls.append(kwargs)
+        limit = kwargs.get("limit")
+        if isinstance(limit, int):
+            return list(self.notes[:limit])
+        return list(self.notes)
+
+
 class StaticLibraryMediaScopeService:
     def __init__(self, media_items):
         self.media_items = tuple(media_items)
@@ -276,6 +289,47 @@ async def test_library_destination_empty_state_disables_console_handoff():
         assert "No local Library sources are available yet." in _visible_text(screen)
         assert button.disabled is True
         assert "Stage Library source context" in str(button.tooltip)
+
+
+@pytest.mark.asyncio
+async def test_library_destination_labels_plain_list_notes_as_sample_snapshot():
+    app = _build_test_app()
+    app.notes_scope_service = StaticLibraryNotesListScopeService(
+        [{"title": f"Research Note {index}", "id": f"note-{index}"} for index in range(1, 7)]
+    )
+    app.media_reading_scope_service = StaticLibraryMediaScopeService([])
+    app.chat_conversation_scope_service = StaticLibraryConversationScopeService([])
+    app.open_chat_with_handoff = Mock()
+    host = DestinationHarness(app, "library")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        screen = _active_destination_screen(host)
+        text = _visible_text(screen)
+
+        assert "Notes (showing up to 5): 5" in text
+        assert "Notes: 5" not in text
+        assert "Research Note 1" in text
+        assert "Research Note 5" in text
+        assert "Research Note 6" not in text
+
+        await pilot.click("#library-use-in-console")
+        await pilot.pause(0.1)
+
+    app.open_chat_with_handoff.assert_called_once()
+    payload = app.open_chat_with_handoff.call_args.args[0]
+    assert "Notes (showing up to 5): 5" in payload.body
+    assert "Notes: 5" not in payload.body
+    assert payload.metadata["notes_sample_count"] == 5
+    assert payload.metadata["notes_total_count"] is None
+    assert "notes_count" not in payload.metadata
+    assert payload.metadata["note_titles"] == [
+        "Research Note 1",
+        "Research Note 2",
+        "Research Note 3",
+        "Research Note 4",
+        "Research Note 5",
+    ]
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_destination_shells.py
+++ b/Tests/UI/test_destination_shells.py
@@ -25,6 +25,7 @@ from tldw_chatbook.UI.Screens.settings_screen import SettingsScreen
 from tldw_chatbook.UI.Screens.skills_screen import SkillsScreen
 from tldw_chatbook.UI.Screens.watchlists_collections_screen import WatchlistsCollectionsScreen
 from tldw_chatbook.UI.Screens.workflows_screen import WorkflowsScreen
+from tldw_chatbook.UI.Screens import library_screen as library_screen_module
 from tldw_chatbook.UI.Screens import skills_screen as skills_screen_module
 
 
@@ -48,6 +49,44 @@ PHASE4_MCP_ADOPTION_EVIDENCE = Path(
 PHASE4_SKILLS_ADOPTION_EVIDENCE = Path(
     "Docs/superpowers/qa/unified-shell/phase-4/2026-05-04-skills-destination-service-adoption.md"
 )
+PHASE4_LIBRARY_ADOPTION_EVIDENCE = Path(
+    "Docs/superpowers/qa/unified-shell/phase-4/2026-05-04-library-source-service-adoption.md"
+)
+
+
+class StaticLibraryNotesScopeService:
+    def __init__(self, notes):
+        self.notes = tuple(notes)
+        self.calls = []
+
+    async def list_notes(self, **kwargs):
+        self.calls.append(kwargs)
+        return {"items": list(self.notes), "pagination": {"total": len(self.notes)}}
+
+
+class StaticLibraryMediaScopeService:
+    def __init__(self, media_items):
+        self.media_items = tuple(media_items)
+        self.calls = []
+
+    async def list_media_items(self, **kwargs):
+        self.calls.append(kwargs)
+        return {"items": list(self.media_items), "pagination": {"total_items": len(self.media_items)}}
+
+
+class StaticLibraryConversationScopeService:
+    def __init__(self, conversations):
+        self.conversations = tuple(conversations)
+        self.calls = []
+
+    async def list_conversations(self, **kwargs):
+        self.calls.append(kwargs)
+        return {"items": list(self.conversations), "pagination": {"total": len(self.conversations)}}
+
+
+class RaisingLibraryNotesScopeService:
+    async def list_notes(self, **kwargs):
+        raise RuntimeError("notes unavailable")
 
 
 class StaticSkillsScopeService:
@@ -167,6 +206,146 @@ async def test_library_exposes_source_sections_and_import_export_boundary():
             "#library-open-search",
         ]:
             assert screen.query_one(selector)
+
+
+@pytest.mark.asyncio
+async def test_library_destination_lists_local_source_snapshot_from_services():
+    app = _build_test_app()
+    app.notes_user_id = "unit-user"
+    app.notes_scope_service = StaticLibraryNotesScopeService(
+        [
+            {"title": "Research Note", "id": "note-1"},
+            {"title": "Meeting Note", "id": "note-2"},
+        ]
+    )
+    app.media_reading_scope_service = StaticLibraryMediaScopeService(
+        [{"title": "Transcript A", "id": "media-1"}]
+    )
+    app.chat_conversation_scope_service = StaticLibraryConversationScopeService(
+        [{"title": "Planning Chat", "id": "chat-1"}]
+    )
+    host = DestinationHarness(app, "library")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        screen = _active_destination_screen(host)
+        text = _visible_text(screen)
+        button = screen.query_one("#library-use-in-console", Button)
+
+        assert "Local Library snapshot" in text
+        assert "Notes: 2" in text
+        assert "Media: 1" in text
+        assert "Conversations: 1" in text
+        assert "Research Note" in text
+        assert "Transcript A" in text
+        assert "Planning Chat" in text
+        assert button.disabled is False
+
+    assert app.notes_scope_service.calls[0] == {
+        "scope": "local_note",
+        "limit": getattr(library_screen_module, "LIBRARY_SOURCE_PAGE_SIZE", None),
+        "offset": 0,
+        "user_id": "unit-user",
+    }
+    assert app.media_reading_scope_service.calls[0] == {
+        "mode": "local",
+        "page": 1,
+        "results_per_page": getattr(library_screen_module, "LIBRARY_SOURCE_PAGE_SIZE", None),
+        "include_keywords": False,
+    }
+    assert app.chat_conversation_scope_service.calls[0] == {
+        "mode": "local",
+        "limit": getattr(library_screen_module, "LIBRARY_SOURCE_PAGE_SIZE", None),
+        "offset": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_library_destination_empty_state_disables_console_handoff():
+    app = _build_test_app()
+    app.notes_scope_service = StaticLibraryNotesScopeService([])
+    app.media_reading_scope_service = StaticLibraryMediaScopeService([])
+    app.chat_conversation_scope_service = StaticLibraryConversationScopeService([])
+    host = DestinationHarness(app, "library")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        screen = _active_destination_screen(host)
+        button = screen.query_one("#library-use-in-console", Button)
+
+        assert "No local Library sources are available yet." in _visible_text(screen)
+        assert button.disabled is True
+        assert "Stage Library source context" in str(button.tooltip)
+
+
+@pytest.mark.asyncio
+async def test_library_destination_service_failure_uses_recovery_copy():
+    app = _build_test_app()
+    app.notes_scope_service = RaisingLibraryNotesScopeService()
+    app.media_reading_scope_service = StaticLibraryMediaScopeService([])
+    app.chat_conversation_scope_service = StaticLibraryConversationScopeService([])
+    host = DestinationHarness(app, "library")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        screen = _active_destination_screen(host)
+        button = screen.query_one("#library-use-in-console", Button)
+
+        assert "Library source services unavailable; retry Library later." in _visible_text(screen)
+        assert button.disabled is True
+        assert "Library source services are unavailable" in str(button.tooltip)
+
+
+@pytest.mark.asyncio
+async def test_library_use_in_console_uses_source_snapshot_context():
+    app = _build_test_app()
+    app.notes_scope_service = StaticLibraryNotesScopeService(
+        [{"title": "Research Note", "id": "note-1"}]
+    )
+    app.media_reading_scope_service = StaticLibraryMediaScopeService(
+        [{"title": "Transcript A", "id": "media-1"}]
+    )
+    app.chat_conversation_scope_service = StaticLibraryConversationScopeService(
+        [{"title": "Planning Chat", "id": "chat-1"}]
+    )
+    app.open_chat_with_handoff = Mock()
+    host = DestinationHarness(app, "library")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        await pilot.click("#library-use-in-console")
+        await pilot.pause(0.1)
+
+    app.open_chat_with_handoff.assert_called_once()
+    payload = app.open_chat_with_handoff.call_args.args[0]
+    assert isinstance(payload, ChatHandoffPayload)
+    assert payload.source == "library"
+    assert payload.item_type == "library-source-snapshot"
+    assert payload.title == "Local Library Sources"
+    assert "Notes: 1" in payload.body
+    assert "Media: 1" in payload.body
+    assert "Conversations: 1" in payload.body
+    assert "Research Note" in payload.body
+    assert "Transcript A" in payload.body
+    assert "Planning Chat" in payload.body
+    assert "Stage Library source material" not in payload.body
+    assert payload.metadata["notes_count"] == 1
+    assert payload.metadata["media_count"] == 1
+    assert payload.metadata["conversations_count"] == 1
+
+
+def test_library_destination_service_adoption_tracking_evidence_exists():
+    evidence = PHASE4_LIBRARY_ADOPTION_EVIDENCE.read_text(encoding="utf-8")
+    roadmap = Path("Docs/superpowers/trackers/unified-shell-maturity-roadmap.md").read_text(encoding="utf-8")
+    task = Path(
+        "backlog/tasks/task-5.3 - Phase-4.3-Adopt-Library-source-services-in-Library-destination.md"
+    ).read_text(encoding="utf-8")
+
+    assert "Phase 4.3 Library Source Service Adoption" in evidence
+    assert "TASK-5.3" in evidence
+    assert "Phase 4.3: Adopt Library source services in Library destination - `TASK-5.3`" in roadmap
+    assert "notes_scope_service" in task
+    assert "media_reading_scope_service" in task
 
 
 @pytest.mark.parametrize(

--- a/backlog/tasks/task-5.3 - Phase-4.3-Adopt-Library-source-services-in-Library-destination.md
+++ b/backlog/tasks/task-5.3 - Phase-4.3-Adopt-Library-source-services-in-Library-destination.md
@@ -46,7 +46,8 @@ Make the top-level Library destination use existing local source services so use
 <!-- SECTION:NOTES:BEGIN -->
 - Added local Library snapshot loading in `LibraryScreen` through `notes_scope_service`, `media_reading_scope_service`, and `chat_conversation_scope_service`.
 - Rendered loading, available, empty, service-unavailable, and policy-denied recovery states while preserving existing legacy Library navigation routes.
-- Changed `Use in Console` from a generic placeholder to a disabled-until-ready `library-source-snapshot` Chat handoff with concrete source counts and sample titles.
+- Changed `Use in Console` from a generic placeholder to a disabled-until-ready `library-source-snapshot` Chat handoff with concrete source totals when available, explicit sample counts when totals are unavailable, and sample titles.
 - Added focused destination shell and Console handoff regression coverage plus Phase 4.3 QA evidence and roadmap links.
-- Verified with `.venv/bin/python -m pytest Tests/UI/test_destination_shells.py Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_shell_product_model_visibility.py -q` resulting in `103 passed, 1 warning in 32.21s`.
+- Post-review hardening renders Chat handoff cards as plain text and adds regression coverage for the production plain-list notes return shape.
+- Verified with `.venv/bin/python -m pytest Tests/UI/test_destination_shells.py Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_shell_product_model_visibility.py Tests/UI/test_chat_first_handoffs.py -q` resulting in `128 passed, 1 warning in 30.71s`.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-5.3 - Phase-4.3-Adopt-Library-source-services-in-Library-destination.md
+++ b/backlog/tasks/task-5.3 - Phase-4.3-Adopt-Library-source-services-in-Library-destination.md
@@ -1,0 +1,52 @@
+---
+id: TASK-5.3
+title: Phase 4.3 Adopt Library source services in Library destination
+status: Done
+assignee: []
+created_date: '2026-05-04 05:36'
+labels:
+  - unified-shell
+  - phase-4
+  - library
+  - service-adoption
+dependencies: []
+parent_task_id: TASK-5
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make the top-level Library destination use existing local source services so users can see whether notes media and conversations are available and stage concrete Library source context into Console instead of generic placeholder copy.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Library route lists a local source snapshot from notes media and conversation services when available
+- [x] #2 Library route shows honest empty and service-unavailable recovery states
+- [x] #3 Use in Console stages concrete Library source summary rather than generic placeholder copy
+- [x] #4 Focused automated tests cover Library available empty error handoff and tracking behavior
+- [x] #5 QA evidence documents functional behavior visual usability residual risks and verification output
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing destination shell tests for Library local source snapshot available empty error and concrete Console handoff behavior.
+2. Implement the smallest LibraryScreen local snapshot loader using `notes_scope_service`, `media_reading_scope_service`, and `chat_conversation_scope_service`.
+3. Render local source counts and sample titles with stable selectors while preserving existing legacy navigation buttons.
+4. Disable Use in Console when no concrete local source context exists and keep service failures distinct from empty Library state.
+5. Build ChatHandoffPayload body from actual listed source categories counts and sample titles.
+6. Add Phase 4 QA evidence and roadmap links.
+7. Run focused Library destination service tests plus git diff checks before commit.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added local Library snapshot loading in `LibraryScreen` through `notes_scope_service`, `media_reading_scope_service`, and `chat_conversation_scope_service`.
+- Rendered loading, available, empty, service-unavailable, and policy-denied recovery states while preserving existing legacy Library navigation routes.
+- Changed `Use in Console` from a generic placeholder to a disabled-until-ready `library-source-snapshot` Chat handoff with concrete source counts and sample titles.
+- Added focused destination shell and Console handoff regression coverage plus Phase 4.3 QA evidence and roadmap links.
+- Verified with `.venv/bin/python -m pytest Tests/UI/test_destination_shells.py Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_shell_product_model_visibility.py -q` resulting in `103 passed, 1 warning in 32.21s`.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -44,6 +44,11 @@ class LibraryScreen(BaseAppScreen):
             "media": 0,
             "conversations": 0,
         }
+        self._local_source_total_known: dict[str, bool] = {
+            "notes": True,
+            "media": True,
+            "conversations": True,
+        }
         self._library_lookup_error: str | None = None
         self._library_loaded = False
 
@@ -53,17 +58,25 @@ class LibraryScreen(BaseAppScreen):
 
     @work(exclusive=True, thread=True)
     def _refresh_local_source_snapshot(self) -> None:
-        records, counts, lookup_error = self._list_local_source_snapshot()
-        self.app.call_from_thread(self._apply_local_source_snapshot, records, counts, lookup_error)
+        records, counts, total_known, lookup_error = self._list_local_source_snapshot()
+        self.app.call_from_thread(
+            self._apply_local_source_snapshot,
+            records,
+            counts,
+            total_known,
+            lookup_error,
+        )
 
     def _apply_local_source_snapshot(
         self,
         records: dict[str, tuple[Mapping[str, Any], ...]],
         counts: dict[str, int],
+        total_known: dict[str, bool],
         lookup_error: str | None = None,
     ) -> None:
         self._local_source_records = records
         self._local_source_counts = counts
+        self._local_source_total_known = total_known
         self._library_lookup_error = lookup_error
         self._library_loaded = True
         if self.is_mounted:
@@ -101,7 +114,8 @@ class LibraryScreen(BaseAppScreen):
         return "Untitled source"
 
     @staticmethod
-    def _response_records_and_count(result: Any) -> tuple[tuple[Mapping[str, Any], ...], int]:
+    def _response_records_and_count(result: Any) -> tuple[tuple[Mapping[str, Any], ...], int, bool]:
+        total = None
         if isinstance(result, Mapping):
             raw_items = result.get("items")
             pagination = result.get("pagination")
@@ -110,21 +124,26 @@ class LibraryScreen(BaseAppScreen):
                 total = pagination.get("total", pagination.get("total_items", total))
         elif isinstance(result, Sequence) and not isinstance(result, (str, bytes, bytearray)):
             raw_items = result
-            total = None
         else:
             raw_items = ()
-            total = None
 
         records = tuple(record for record in tuple(raw_items or ()) if isinstance(record, Mapping))
+        total_known = total is not None
         try:
             count = int(total) if total is not None else len(records)
         except (TypeError, ValueError):
             count = len(records)
-        return records, count
+            total_known = False
+        return records, max(count, 0), total_known
 
     def _list_local_source_snapshot(
         self,
-    ) -> tuple[dict[str, tuple[Mapping[str, Any], ...]], dict[str, int], str | None]:
+    ) -> tuple[
+        dict[str, tuple[Mapping[str, Any], ...]],
+        dict[str, int],
+        dict[str, bool],
+        str | None,
+    ]:
         notes_service = getattr(self.app_instance, "notes_scope_service", None)
         media_service = getattr(self.app_instance, "media_reading_scope_service", None)
         conversation_service = getattr(self.app_instance, "chat_conversation_scope_service", None)
@@ -138,8 +157,9 @@ class LibraryScreen(BaseAppScreen):
             "conversations": (),
         }
         empty_counts = {"notes": 0, "media": 0, "conversations": 0}
+        empty_total_known = {"notes": True, "media": True, "conversations": True}
         if not all(callable(call) for call in (list_notes, list_media, list_conversations)):
-            return empty_records, empty_counts, LIBRARY_SERVICE_UNAVAILABLE_COPY
+            return empty_records, empty_counts, empty_total_known, LIBRARY_SERVICE_UNAVAILABLE_COPY
 
         try:
             notes_result = self._run_maybe_awaitable(
@@ -167,17 +187,21 @@ class LibraryScreen(BaseAppScreen):
             )
         except PolicyDeniedError as exc:
             policy_message = self._safe_text(exc.user_message, LIBRARY_SERVICE_ERROR_COPY)
-            return empty_records, empty_counts, policy_message
+            return empty_records, empty_counts, empty_total_known, policy_message
         except Exception:
             logger.warning(
                 "Failed to load local Library source snapshot.",
                 exc_info=True,
             )
-            return empty_records, empty_counts, LIBRARY_SERVICE_ERROR_COPY
+            return empty_records, empty_counts, empty_total_known, LIBRARY_SERVICE_ERROR_COPY
 
-        notes, notes_count = self._response_records_and_count(notes_result)
-        media, media_count = self._response_records_and_count(media_result)
-        conversations, conversations_count = self._response_records_and_count(conversation_result)
+        notes, notes_count, notes_total_known = self._response_records_and_count(notes_result)
+        media, media_count, media_total_known = self._response_records_and_count(media_result)
+        (
+            conversations,
+            conversations_count,
+            conversations_total_known,
+        ) = self._response_records_and_count(conversation_result)
         return (
             {
                 "notes": notes,
@@ -188,6 +212,11 @@ class LibraryScreen(BaseAppScreen):
                 "notes": notes_count,
                 "media": media_count,
                 "conversations": conversations_count,
+            },
+            {
+                "notes": notes_total_known,
+                "media": media_total_known,
+                "conversations": conversations_total_known,
             },
             None,
         )
@@ -202,17 +231,43 @@ class LibraryScreen(BaseAppScreen):
             ("media", "Media"),
             ("conversations", "Conversations"),
         ):
-            lines.append(f"{label}: {self._local_source_counts[source_type]}")
+            lines.append(self._source_count_label(source_type, label))
             for index, record in enumerate(self._local_source_records[source_type], start=1):
                 lines.append(f"  {index}. {self._source_title(source_type, record)}")
             lines.append("")
         return "\n".join(lines).strip()
+
+    def _source_count_label(self, source_type: str, label: str) -> str:
+        count = self._local_source_counts[source_type]
+        if self._local_source_total_known[source_type]:
+            return f"{label}: {count}"
+        return f"{label} (showing up to {LIBRARY_SOURCE_PAGE_SIZE}): {count}"
 
     def _source_sample_titles(self, source_type: str) -> list[str]:
         return [
             self._source_title(source_type, record)
             for record in self._local_source_records[source_type]
         ]
+
+    def _source_count_metadata(self) -> dict[str, int | None]:
+        metadata: dict[str, int | None] = {}
+        for source_type in ("notes", "media", "conversations"):
+            count = self._local_source_counts[source_type]
+            metadata[f"{source_type}_sample_count"] = len(self._local_source_records[source_type])
+            metadata[f"{source_type}_total_count"] = (
+                count if self._local_source_total_known[source_type] else None
+            )
+            if self._local_source_total_known[source_type]:
+                metadata[f"{source_type}_count"] = count
+        return metadata
+
+    def _source_snapshot_metadata(self) -> dict[str, Any]:
+        return {
+            **self._source_count_metadata(),
+            "note_titles": self._source_sample_titles("notes"),
+            "media_titles": self._source_sample_titles("media"),
+            "conversation_titles": self._source_sample_titles("conversations"),
+        }
 
     def compose_content(self) -> ComposeResult:
         has_sources = self._has_local_sources()
@@ -266,7 +321,7 @@ class LibraryScreen(BaseAppScreen):
                         ("conversations", "Conversations", "library-conversations-summary"),
                     ):
                         yield Static(
-                            f"{label}: {self._local_source_counts[source_type]}",
+                            self._source_count_label(source_type, label),
                             id=widget_id,
                         )
                         for index, record in enumerate(self._local_source_records[source_type]):
@@ -336,13 +391,6 @@ class LibraryScreen(BaseAppScreen):
                 runtime_backend="local",
                 source_owner="local",
                 source_selector_state="local",
-                metadata={
-                    "notes_count": self._local_source_counts["notes"],
-                    "media_count": self._local_source_counts["media"],
-                    "conversations_count": self._local_source_counts["conversations"],
-                    "note_titles": self._source_sample_titles("notes"),
-                    "media_titles": self._source_sample_titles("media"),
-                    "conversation_titles": self._source_sample_titles("conversations"),
-                },
+                metadata=self._source_snapshot_metadata(),
             )
         )

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -1,22 +1,221 @@
 """Library destination shell for source material and Search/RAG."""
 
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from loguru import logger
+from rich.markup import escape as escape_markup
+from rich.text import Text
+from textual import on, work
 from textual.app import ComposeResult
-from textual import on
 from textual.containers import Vertical
 from textual.widgets import Button, Static
 
 from ...Chat.chat_handoff_models import ChatHandoffPayload
+from ...runtime_policy.types import PolicyDeniedError
+from ...Utils.input_validation import sanitize_string, validate_text_input
 from ..Navigation.base_app_screen import BaseAppScreen
 from ..Navigation.main_navigation import NavigateToScreen
+
+
+logger = logger.bind(module="LibraryScreen")
+LIBRARY_SOURCE_PAGE_SIZE = 5
+LIBRARY_SERVICE_ERROR_COPY = "Library source services unavailable; retry Library later."
+LIBRARY_SERVICE_UNAVAILABLE_COPY = "Library source services are unavailable in this runtime."
+LIBRARY_EMPTY_COPY = "No local Library sources are available yet."
 
 
 class LibraryScreen(BaseAppScreen):
     """Source material, imports/exports, conversations, and Search/RAG entry."""
 
-    def __init__(self, app_instance, **kwargs):
+    def __init__(self, app_instance: Any, **kwargs: Any) -> None:
         super().__init__(app_instance, "library", **kwargs)
+        self._local_source_records: dict[str, tuple[Mapping[str, Any], ...]] = {
+            "notes": (),
+            "media": (),
+            "conversations": (),
+        }
+        self._local_source_counts: dict[str, int] = {
+            "notes": 0,
+            "media": 0,
+            "conversations": 0,
+        }
+        self._library_lookup_error: str | None = None
+        self._library_loaded = False
+
+    def on_mount(self) -> None:
+        super().on_mount()
+        self._refresh_local_source_snapshot()
+
+    @work(exclusive=True, thread=True)
+    def _refresh_local_source_snapshot(self) -> None:
+        records, counts, lookup_error = self._list_local_source_snapshot()
+        self.app.call_from_thread(self._apply_local_source_snapshot, records, counts, lookup_error)
+
+    def _apply_local_source_snapshot(
+        self,
+        records: dict[str, tuple[Mapping[str, Any], ...]],
+        counts: dict[str, int],
+        lookup_error: str | None = None,
+    ) -> None:
+        self._local_source_records = records
+        self._local_source_counts = counts
+        self._library_lookup_error = lookup_error
+        self._library_loaded = True
+        if self.is_mounted:
+            self.refresh(recompose=True)
+
+    @staticmethod
+    def _run_maybe_awaitable(value: Any) -> Any:
+        if inspect.isawaitable(value):
+            return asyncio.run(value)
+        return value
+
+    @staticmethod
+    def _safe_text(value: Any, fallback: str = "", *, max_length: int = 500) -> str:
+        text = sanitize_string(str(value or ""), max_length=max_length).strip()
+        if not text:
+            return fallback
+        text = text.replace("<", "").replace(">", "")
+        for pattern in ("javascript:", "onclick=", "onerror="):
+            text = text.replace(pattern, "")
+        if validate_text_input(text, max_length=max_length, allow_html=False):
+            return text
+        return fallback
+
+    @classmethod
+    def _source_title(cls, source_type: str, record: Mapping[str, Any]) -> str:
+        title_keys_by_source = {
+            "notes": ("title", "name", "note_title", "note_name"),
+            "media": ("title", "name", "media_title", "file_name", "url"),
+            "conversations": ("title", "name", "conversation_title", "label"),
+        }
+        for key in title_keys_by_source[source_type]:
+            title = cls._safe_text(record.get(key))
+            if title:
+                return title
+        return "Untitled source"
+
+    @staticmethod
+    def _response_records_and_count(result: Any) -> tuple[tuple[Mapping[str, Any], ...], int]:
+        if isinstance(result, Mapping):
+            raw_items = result.get("items")
+            pagination = result.get("pagination")
+            total = result.get("total")
+            if isinstance(pagination, Mapping):
+                total = pagination.get("total", pagination.get("total_items", total))
+        elif isinstance(result, Sequence) and not isinstance(result, (str, bytes, bytearray)):
+            raw_items = result
+            total = None
+        else:
+            raw_items = ()
+            total = None
+
+        records = tuple(record for record in tuple(raw_items or ()) if isinstance(record, Mapping))
+        try:
+            count = int(total) if total is not None else len(records)
+        except (TypeError, ValueError):
+            count = len(records)
+        return records, count
+
+    def _list_local_source_snapshot(
+        self,
+    ) -> tuple[dict[str, tuple[Mapping[str, Any], ...]], dict[str, int], str | None]:
+        notes_service = getattr(self.app_instance, "notes_scope_service", None)
+        media_service = getattr(self.app_instance, "media_reading_scope_service", None)
+        conversation_service = getattr(self.app_instance, "chat_conversation_scope_service", None)
+        list_notes = getattr(notes_service, "list_notes", None)
+        list_media = getattr(media_service, "list_media_items", None)
+        list_conversations = getattr(conversation_service, "list_conversations", None)
+
+        empty_records: dict[str, tuple[Mapping[str, Any], ...]] = {
+            "notes": (),
+            "media": (),
+            "conversations": (),
+        }
+        empty_counts = {"notes": 0, "media": 0, "conversations": 0}
+        if not all(callable(call) for call in (list_notes, list_media, list_conversations)):
+            return empty_records, empty_counts, LIBRARY_SERVICE_UNAVAILABLE_COPY
+
+        try:
+            notes_result = self._run_maybe_awaitable(
+                list_notes(
+                    scope="local_note",
+                    limit=LIBRARY_SOURCE_PAGE_SIZE,
+                    offset=0,
+                    user_id=getattr(self.app_instance, "notes_user_id", None) or "default_user",
+                )
+            )
+            media_result = self._run_maybe_awaitable(
+                list_media(
+                    mode="local",
+                    page=1,
+                    results_per_page=LIBRARY_SOURCE_PAGE_SIZE,
+                    include_keywords=False,
+                )
+            )
+            conversation_result = self._run_maybe_awaitable(
+                list_conversations(
+                    mode="local",
+                    limit=LIBRARY_SOURCE_PAGE_SIZE,
+                    offset=0,
+                )
+            )
+        except PolicyDeniedError as exc:
+            policy_message = self._safe_text(exc.user_message, LIBRARY_SERVICE_ERROR_COPY)
+            return empty_records, empty_counts, policy_message
+        except Exception:
+            logger.warning(
+                "Failed to load local Library source snapshot.",
+                exc_info=True,
+            )
+            return empty_records, empty_counts, LIBRARY_SERVICE_ERROR_COPY
+
+        notes, notes_count = self._response_records_and_count(notes_result)
+        media, media_count = self._response_records_and_count(media_result)
+        conversations, conversations_count = self._response_records_and_count(conversation_result)
+        return (
+            {
+                "notes": notes,
+                "media": media,
+                "conversations": conversations,
+            },
+            {
+                "notes": notes_count,
+                "media": media_count,
+                "conversations": conversations_count,
+            },
+            None,
+        )
+
+    def _has_local_sources(self) -> bool:
+        return any(count > 0 for count in self._local_source_counts.values())
+
+    def _source_snapshot_body(self) -> str:
+        lines = ["Local Library source snapshot staged for Console:", ""]
+        for source_type, label in (
+            ("notes", "Notes"),
+            ("media", "Media"),
+            ("conversations", "Conversations"),
+        ):
+            lines.append(f"{label}: {self._local_source_counts[source_type]}")
+            for index, record in enumerate(self._local_source_records[source_type], start=1):
+                lines.append(f"  {index}. {self._source_title(source_type, record)}")
+            lines.append("")
+        return "\n".join(lines).strip()
+
+    def _source_sample_titles(self, source_type: str) -> list[str]:
+        return [
+            self._source_title(source_type, record)
+            for record in self._local_source_records[source_type]
+        ]
 
     def compose_content(self) -> ComposeResult:
+        has_sources = self._has_local_sources()
         with Vertical(id="library-shell"):
             yield Static("Library", id="library-title", classes="ds-destination-header")
             yield Static(
@@ -38,10 +237,52 @@ class LibraryScreen(BaseAppScreen):
                     tooltip="Open source import and export tools.",
                 )
                 yield Button("Search/RAG", id="library-open-search", tooltip="Search or ask over indexed sources.")
+                yield Static("Local Library snapshot", classes="destination-section")
+                if not self._library_loaded:
+                    yield Static(
+                        "Loading local Library sources...",
+                        id="library-source-loading",
+                    )
+                    handoff_disabled = True
+                    handoff_tooltip = "Stage Library source context after Library finishes loading."
+                elif self._library_lookup_error:
+                    yield Static(
+                        self._library_lookup_error,
+                        id="library-source-error",
+                    )
+                    handoff_disabled = True
+                    handoff_tooltip = "Library source services are unavailable; retry Library later."
+                elif not has_sources:
+                    yield Static(
+                        LIBRARY_EMPTY_COPY,
+                        id="library-source-empty",
+                    )
+                    handoff_disabled = True
+                    handoff_tooltip = "Stage Library source context after adding notes, media, or conversations."
+                else:
+                    for source_type, label, widget_id in (
+                        ("notes", "Notes", "library-notes-summary"),
+                        ("media", "Media", "library-media-summary"),
+                        ("conversations", "Conversations", "library-conversations-summary"),
+                    ):
+                        yield Static(
+                            f"{label}: {self._local_source_counts[source_type]}",
+                            id=widget_id,
+                        )
+                        for index, record in enumerate(self._local_source_records[source_type]):
+                            yield Static(
+                                Text.from_markup(
+                                    escape_markup(self._source_title(source_type, record))
+                                ),
+                                id=f"library-{source_type}-source-{index}",
+                            )
+                    handoff_disabled = False
+                    handoff_tooltip = "Stage Library source context in Console."
                 yield Button(
                     "Use in Console",
                     id="library-use-in-console",
-                    tooltip="Stage Library context in Console.",
+                    disabled=handoff_disabled,
+                    tooltip=handoff_tooltip,
                 )
 
     @on(Button.Pressed, "#library-open-notes")
@@ -65,12 +306,43 @@ class LibraryScreen(BaseAppScreen):
         self.post_message(NavigateToScreen("search"))
 
     @on(Button.Pressed, "#library-use-in-console")
-    def use_in_console(self) -> None:
-        self.app_instance.open_chat_with_handoff(
+    def use_in_console(self, event: Button.Pressed) -> None:
+        event.stop()
+        if not self._has_local_sources():
+            notify = getattr(self.app_instance, "notify", None)
+            if callable(notify):
+                notify(
+                    self._library_lookup_error or LIBRARY_EMPTY_COPY,
+                    severity="warning",
+                )
+            return
+        open_chat_with_handoff = getattr(self.app_instance, "open_chat_with_handoff", None)
+        if not callable(open_chat_with_handoff):
+            notify = getattr(self.app_instance, "notify", None)
+            if callable(notify):
+                notify(
+                    "Console handoff is unavailable for Library in this runtime.",
+                    severity="warning",
+                )
+            return
+        open_chat_with_handoff(
             ChatHandoffPayload(
                 source="library",
-                item_type="library-context",
-                title="Library context",
-                body="Stage Library source material, notes, media, conversations, imports/exports, or Search/RAG results.",
+                item_type="library-source-snapshot",
+                title="Local Library Sources",
+                body=self._source_snapshot_body(),
+                display_summary="Local Library source snapshot staged.",
+                suggested_prompt="Use these Library sources as grounding context for my next question.",
+                runtime_backend="local",
+                source_owner="local",
+                source_selector_state="local",
+                metadata={
+                    "notes_count": self._local_source_counts["notes"],
+                    "media_count": self._local_source_counts["media"],
+                    "conversations_count": self._local_source_counts["conversations"],
+                    "note_titles": self._source_sample_titles("notes"),
+                    "media_titles": self._source_sample_titles("media"),
+                    "conversation_titles": self._source_sample_titles("conversations"),
+                },
             )
         )

--- a/tldw_chatbook/Widgets/Chat_Widgets/chat_handoff_card.py
+++ b/tldw_chatbook/Widgets/Chat_Widgets/chat_handoff_card.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from rich.text import Text
 from textual.app import ComposeResult
 from textual.containers import Container
 from textual.message import Message
@@ -85,7 +86,7 @@ class ChatHandoffCard(Container):
         return "\n".join(parts)
 
     def compose(self) -> ComposeResult:
-        yield Static(self.render_text(), classes="chat-handoff-card-body")
+        yield Static(Text(self.render_text()), classes="chat-handoff-card-body")
         if self.payload.status != "sent" and self.clear_action_id:
             yield Button(
                 "Clear staged context",


### PR DESCRIPTION
## Summary
- Load local Library source snapshots from notes, media, and conversation scope services.
- Disable Console handoff for empty/unavailable states and stage concrete `library-source-snapshot` context when sources exist.
- Add TASK-5.3 Backlog tracking plus Phase 4.3 QA evidence and roadmap updates.

## Test Plan
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_destination_shells.py Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_shell_product_model_visibility.py -q` (`103 passed, 1 warning in 29.95s`)