### PR TITLE
Adopt Personas service in unified shell

### DIFF
--- a/Docs/superpowers/qa/unified-shell/phase-4/2026-05-04-personas-service-adoption.md
+++ b/Docs/superpowers/qa/unified-shell/phase-4/2026-05-04-personas-service-adoption.md
@@ -24,7 +24,10 @@ Turn the top-level Personas destination from static legacy-route links plus gene
 - First green behavior command after implementation: `.venv/bin/python -m pytest Tests/UI/test_destination_shells.py -q`
 - First green behavior result: `1 failed, 57 passed, 1 warning in 21.79s`; only the tracking evidence file was still missing.
 - Final focused command: `.venv/bin/python -m pytest Tests/UI/test_destination_shells.py Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_shell_product_model_visibility.py Tests/Character_Chat/test_character_persona_scope_service.py -q`
-- Final focused result: `161 passed, 8 warnings in 92.93s`.
+- Final focused result: `162 passed, 8 warnings in 93.70s`.
+- PR review follow-up red command: `.venv/bin/python -m pytest Tests/UI/test_destination_shells.py::test_personas_destination_waits_for_threaded_snapshot_without_fixed_sleep -q`
+- PR review follow-up red result: `1 failed, 1 warning in 7.47s` because a fixed `pilot.pause(0.2)` still observed the loading state while the threaded worker was running.
+- PR review follow-up green result: `162 passed, 8 warnings in 93.70s` for the focused UI and character/persona scope suite after replacing fixed Persona test sleeps with deterministic polling.
 
 ## QA Walkthrough Notes
 

--- a/Docs/superpowers/qa/unified-shell/phase-4/2026-05-04-personas-service-adoption.md
+++ b/Docs/superpowers/qa/unified-shell/phase-4/2026-05-04-personas-service-adoption.md
@@ -1,0 +1,43 @@
+# Phase 4.4 Personas Service Adoption
+
+Task: `TASK-5.4`
+Branch: `codex/unified-shell-phase4-personas-service`
+
+## Goal
+
+Turn the top-level Personas destination from static legacy-route links plus generic Console copy into a service-backed behavior snapshot that tells users whether local characters and persona profiles are available and stages concrete behavior context into Console.
+
+## Implementation Summary
+
+- Loaded local behavior context through `character_persona_scope_service.list_characters(mode="local")` and `character_persona_scope_service.list_persona_profiles(mode="local")`.
+- Rendered loading, available, empty, service-unavailable, and policy-denied recovery states with stable selectors.
+- Preserved the existing `Open Personas` route to the character/persona management surface.
+- Disabled `Attach to Console` until concrete local character or persona profile context exists.
+- Built `ChatHandoffPayload` from actual local character/profile counts, sample names, and descriptions instead of the previous generic Personas placeholder.
+
+## Verification
+
+- Baseline focused command before changes: `.venv/bin/python -m pytest Tests/UI/test_destination_shells.py Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_shell_product_model_visibility.py Tests/Character_Chat/test_character_persona_scope_service.py -q`
+- Baseline focused result: `157 passed, 10 warnings in 95.87s`.
+- Red command: `.venv/bin/python -m pytest Tests/UI/test_destination_shells.py -q`
+- Red result: `5 failed, 53 passed, 1 warning in 23.50s`.
+- First green behavior command after implementation: `.venv/bin/python -m pytest Tests/UI/test_destination_shells.py -q`
+- First green behavior result: `1 failed, 57 passed, 1 warning in 21.79s`; only the tracking evidence file was still missing.
+- Final focused command: `.venv/bin/python -m pytest Tests/UI/test_destination_shells.py Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_shell_product_model_visibility.py Tests/Character_Chat/test_character_persona_scope_service.py -q`
+- Final focused result: `161 passed, 8 warnings in 92.93s`.
+
+## QA Walkthrough Notes
+
+- Environment: focused Textual mounted-window tests using the repo virtualenv.
+- Entry path: top navigation `Personas` destination.
+- Visual check: Personas keeps the destination title, ownership copy, boundary copy, and existing profile-management route while adding a `Local Personas snapshot` section.
+- Available-state result: local service responses render character and persona profile counts plus visible sample names and enable `Attach to Console`.
+- Empty-state result: empty local service responses render `No local characters or persona profiles are available yet.` and disable Console handoff with add-profile recovery copy.
+- Service-error result: scope-service exceptions render `Personas service unavailable; retry Personas later.` and disable Console handoff with retry-oriented recovery copy.
+- Functional result: Console handoff stages `personas-context` with local character/profile counts, sample names, descriptions, runtime/source ownership metadata, and no generic placeholder body.
+
+## Residual Risk
+
+- This slice adopts local list and context staging only; persona detail, edit, import/export, archetypes, exemplars, dictionaries, and lore remain future Personas destination work.
+- The walkthrough uses focused mounted-window QA, not a full clean-HOME running app session.
+- Console handoff stages listed behavior summaries, not full character cards, lorebooks, prompt dictionaries, or exemplar corpora.

--- a/Docs/superpowers/qa/unified-shell/phase-4/README.md
+++ b/Docs/superpowers/qa/unified-shell/phase-4/README.md
@@ -9,5 +9,6 @@ This directory contains durable QA summaries for Phase 4 destination service ado
 - `2026-05-04-mcp-destination-service-adoption.md` - `TASK-5.1` MCP destination adoption of the existing Unified MCP management panel.
 - `2026-05-04-skills-destination-service-adoption.md` - `TASK-5.2` Skills destination adoption of local `skills_scope_service` listing and Console context staging.
 - `2026-05-04-library-source-service-adoption.md` - `TASK-5.3` Library destination adoption of local notes, media, and conversation source snapshots plus concrete Console context staging.
+- `2026-05-04-personas-service-adoption.md` - `TASK-5.4` Personas destination adoption of local character and persona profile snapshots plus concrete Console context staging.
 
 Do not mark Phase 4 verified until Skills, MCP, ACP, Library, Workflows, Schedules, Personas, Artifacts, W+C, and Settings destination workflows are verified through running-app QA evidence or honest recovery states.

--- a/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
@@ -2,7 +2,7 @@
 
 Date: 2026-05-04
 Status: Phase 2, Phase 3, and Phase 4 in progress
-Source Branch: `origin/dev` at `45fa942c` plus `codex/unified-shell-phase4-library-source-service`
+Source Branch: `origin/dev` at `e91edd01` plus `codex/unified-shell-phase4-personas-service`
 
 ## Purpose
 
@@ -35,6 +35,7 @@ Track remaining Unified Shell work in one place so rendered screens, clickable b
 - MCP now adopts the existing Unified MCP management panel in the top-level MCP wrapper; Console MCP live-work launch and deeper service expansion remain future work.
 - Skills now lists local Agent Skills through `skills_scope_service` and can stage local skill context into Console; server skills, import, detail, edit, validation, and execution UX remain future work.
 - Library now surfaces a local source snapshot from notes, media, and conversations and can stage concrete source context into Console; full Library-native detail views, embedded Import/Export, and embedded Search/RAG remain future work.
+- Personas now surfaces a local behavior snapshot from characters and persona profiles and can stage concrete behavior context into Console; detail, edit, import/export, archetypes, exemplars, dictionaries, and lore remain future work.
 - Product workflows remain unverified until running-app QA evidence is added in later phases.
 
 ## Definition Of Done
@@ -100,6 +101,7 @@ Initial child tasks:
 - Phase 4.1: Adopt Unified MCP panel in MCP destination - `TASK-5.1`
 - Phase 4.2: Adopt Skills services in Skills destination - `TASK-5.2`
 - Phase 4.3: Adopt Library source services in Library destination - `TASK-5.3`
+- Phase 4.4: Adopt Personas service in Personas destination - `TASK-5.4`
 
 ## QA Evidence Index
 
@@ -121,7 +123,7 @@ Initial child tasks:
 | Phase 1: Shell Contract Complete | Remove false shell affordances and prove shell usability. | verified | `TASK-2`, `TASK-2.1`, `TASK-2.2`, `TASK-2.3`, `TASK-2.4` | `phase-1/` | Live service workflows remain intentionally deferred to Phases 2-6. |
 | Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | in-progress | `TASK-4`, `TASK-4.1`, `TASK-4.2`, `TASK-4.3`, `TASK-4.4`, `TASK-4.5`, `TASK-4.6`, `TASK-4.7` | `phase-2/` | Schedule and agent-service adapters still need implementation; local watchlist retry/pause/resume remain recoverable rather than fully controllable. |
 | Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | in-progress | `TASK-3`, `TASK-3.1`, `TASK-3.2`, `TASK-3.3`, `TASK-3.4`, `TASK-3.5`, `TASK-3.6`, `TASK-3.7`, `TASK-3.8`, `TASK-3.9`, `TASK-3.10` | `phase-3/` | ACP, MCP, server Artifacts, and deeper source-specific live event streams still need implementation. |
-| Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | in-progress | `TASK-5`, `TASK-5.1`, `TASK-5.2`, `TASK-5.3` | `phase-4/` | Service coverage varies by destination; MCP now adopts the existing Unified MCP panel, Skills now lists/stages local Agent Skills, and Library now lists/stages local source snapshots, but remaining destinations and deeper Library/Skills flows still need adoption or verified recovery. |
+| Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | in-progress | `TASK-5`, `TASK-5.1`, `TASK-5.2`, `TASK-5.3`, `TASK-5.4` | `phase-4/` | Service coverage varies by destination; MCP now adopts the existing Unified MCP panel, Skills now lists/stages local Agent Skills, Library now lists/stages local source snapshots, and Personas now lists/stages local behavior snapshots, but remaining destinations and deeper Library/Skills/Personas flows still need adoption or verified recovery. |
 | Phase 5: Capability And Recovery System | Systematize unavailable and blocked states. | not-started | `TASK-6` | `phase-5/` | Shared taxonomy not yet extracted. |
 | Phase 6: Audit Replay And Closeout | Prove shell works for first-time and power users. | not-started | `TASK-7` | `phase-6/` | Depends on prior phases and running-app QA. |
 
@@ -278,6 +280,12 @@ Initial audit result: W+C, Schedules, Workflows, and ACP had false Console-launc
 `TASK-5.3` makes the top-level Library destination list local notes, media, and conversations through existing source services and stage concrete local source context into Console:
 
 - `Docs/superpowers/qa/unified-shell/phase-4/2026-05-04-library-source-service-adoption.md`
+
+## Phase 4.4 Personas Service Adoption Evidence
+
+`TASK-5.4` makes the top-level Personas destination list local characters and persona profiles through the existing character/persona scope service and stage concrete behavior context into Console:
+
+- `Docs/superpowers/qa/unified-shell/phase-4/2026-05-04-personas-service-adoption.md`
 
 ## Phase 0: Canonical Tracking
 

--- a/Tests/UI/test_console_live_work_handoffs.py
+++ b/Tests/UI/test_console_live_work_handoffs.py
@@ -1352,32 +1352,6 @@ async def test_artifacts_destination_distinguishes_chatbook_service_failure_from
     app.open_console_for_live_work.assert_not_called()
 
 
-@pytest.mark.parametrize(
-    ("route", "button_id"),
-    [
-        ("personas", "personas-attach-to-console"),
-    ],
-)
-@pytest.mark.asyncio
-async def test_staged_context_actions_use_chat_handoff_not_live_launch(route, button_id):
-    app = _build_test_app()
-    app.open_chat_with_handoff = Mock()
-    app.open_console_for_live_work = Mock()
-    host = DestinationHarness(app, route)
-
-    async with host.run_test(size=(180, 40)) as pilot:
-        await pilot.pause(0.1)
-        await pilot.click(f"#{button_id}")
-        await pilot.pause(0.1)
-
-    app.open_chat_with_handoff.assert_called_once()
-    payload = app.open_chat_with_handoff.call_args.args[0]
-    assert isinstance(payload, ChatHandoffPayload)
-    assert payload.source == route
-    app.open_console_for_live_work.assert_not_called()
-    assert getattr(app, "pending_console_launch", None) in (None, {})
-
-
 @pytest.mark.asyncio
 async def test_console_renders_pending_launch_context():
     ConsoleLiveWorkLaunch = _load_console_live_work_contract()

--- a/Tests/UI/test_destination_shells.py
+++ b/Tests/UI/test_destination_shells.py
@@ -1,6 +1,8 @@
 """Master shell destination wrapper tests."""
 
+import asyncio
 import inspect
+import time
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -80,6 +82,12 @@ class RaisingPersonasScopeService:
 
     async def list_persona_profiles(self, **kwargs):
         return []
+
+
+class SlowPersonasScopeService(StaticPersonasScopeService):
+    async def list_characters(self, **kwargs):
+        await asyncio.sleep(0.35)
+        return await super().list_characters(**kwargs)
 
 
 class StaticLibraryNotesScopeService:
@@ -191,6 +199,38 @@ def _visible_text(screen) -> str:
     )
 
 
+async def _wait_for_personas_snapshot(screen, pilot, *, timeout: float = 2.0) -> None:
+    deadline = time.monotonic() + timeout
+    terminal_selectors = (
+        "#personas-service-error",
+        "#personas-empty-state",
+        "#personas-characters-summary",
+        "#personas-profiles-summary",
+    )
+    while time.monotonic() < deadline:
+        terminal_state_visible = any(screen.query(selector) for selector in terminal_selectors)
+        buttons = list(screen.query("#personas-attach-to-console"))
+        if buttons:
+            button = buttons[0]
+            if button.disabled is False:
+                await pilot.pause()
+                return
+            if terminal_state_visible:
+                await pilot.pause()
+                return
+        await pilot.pause(0.01)
+    raise AssertionError(f"Timed out waiting for Personas snapshot. Visible text: {_visible_text(screen)}")
+
+
+async def _wait_for_mock_call(mock: Mock, pilot, *, timeout: float = 1.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if mock.call_count:
+            return
+        await pilot.pause()
+    raise AssertionError("Timed out waiting for mock call")
+
+
 @pytest.mark.parametrize(
     ("route", "title_id", "purpose_text"),
     [
@@ -245,8 +285,8 @@ async def test_personas_destination_lists_local_behavior_snapshot_from_service()
     host = DestinationHarness(app, "personas")
 
     async with host.run_test(size=(180, 50)) as pilot:
-        await pilot.pause(0.2)
         screen = _active_destination_screen(host)
+        await _wait_for_personas_snapshot(screen, pilot)
         text = _visible_text(screen)
         button = screen.query_one("#personas-attach-to-console", Button)
 
@@ -273,14 +313,30 @@ async def test_personas_destination_lists_local_behavior_snapshot_from_service()
 
 
 @pytest.mark.asyncio
+async def test_personas_destination_waits_for_threaded_snapshot_without_fixed_sleep():
+    app = _build_test_app()
+    app.character_persona_scope_service = SlowPersonasScopeService(
+        characters=[{"name": "Delayed Mentor", "id": 1}],
+        profiles=[],
+    )
+    host = DestinationHarness(app, "personas")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_personas_snapshot(screen, pilot)
+
+        assert "Delayed Mentor" in _visible_text(screen)
+
+
+@pytest.mark.asyncio
 async def test_personas_destination_empty_state_disables_console_attach():
     app = _build_test_app()
     app.character_persona_scope_service = StaticPersonasScopeService()
     host = DestinationHarness(app, "personas")
 
     async with host.run_test(size=(180, 50)) as pilot:
-        await pilot.pause(0.2)
         screen = _active_destination_screen(host)
+        await _wait_for_personas_snapshot(screen, pilot)
         button = screen.query_one("#personas-attach-to-console", Button)
 
         assert "No local characters or persona profiles are available yet." in _visible_text(screen)
@@ -295,8 +351,8 @@ async def test_personas_destination_service_failure_uses_recovery_copy():
     host = DestinationHarness(app, "personas")
 
     async with host.run_test(size=(180, 50)) as pilot:
-        await pilot.pause(0.2)
         screen = _active_destination_screen(host)
+        await _wait_for_personas_snapshot(screen, pilot)
         button = screen.query_one("#personas-attach-to-console", Button)
 
         assert "Personas service unavailable; retry Personas later." in _visible_text(screen)
@@ -319,9 +375,10 @@ async def test_personas_attach_to_console_uses_listed_behavior_context():
     host = DestinationHarness(app, "personas")
 
     async with host.run_test(size=(180, 50)) as pilot:
-        await pilot.pause(0.2)
+        screen = _active_destination_screen(host)
+        await _wait_for_personas_snapshot(screen, pilot)
         await pilot.click("#personas-attach-to-console")
-        await pilot.pause(0.1)
+        await _wait_for_mock_call(app.open_chat_with_handoff, pilot)
 
     app.open_chat_with_handoff.assert_called_once()
     payload = app.open_chat_with_handoff.call_args.args[0]

--- a/Tests/UI/test_destination_shells.py
+++ b/Tests/UI/test_destination_shells.py
@@ -26,6 +26,7 @@ from tldw_chatbook.UI.Screens.skills_screen import SkillsScreen
 from tldw_chatbook.UI.Screens.watchlists_collections_screen import WatchlistsCollectionsScreen
 from tldw_chatbook.UI.Screens.workflows_screen import WorkflowsScreen
 from tldw_chatbook.UI.Screens import library_screen as library_screen_module
+from tldw_chatbook.UI.Screens import personas_screen as personas_screen_module
 from tldw_chatbook.UI.Screens import skills_screen as skills_screen_module
 
 
@@ -52,6 +53,33 @@ PHASE4_SKILLS_ADOPTION_EVIDENCE = Path(
 PHASE4_LIBRARY_ADOPTION_EVIDENCE = Path(
     "Docs/superpowers/qa/unified-shell/phase-4/2026-05-04-library-source-service-adoption.md"
 )
+PHASE4_PERSONAS_ADOPTION_EVIDENCE = Path(
+    "Docs/superpowers/qa/unified-shell/phase-4/2026-05-04-personas-service-adoption.md"
+)
+
+
+class StaticPersonasScopeService:
+    def __init__(self, *, characters=(), profiles=()):
+        self.characters = tuple(characters)
+        self.profiles = tuple(profiles)
+        self.character_calls = []
+        self.profile_calls = []
+
+    async def list_characters(self, **kwargs):
+        self.character_calls.append(kwargs)
+        return list(self.characters)
+
+    async def list_persona_profiles(self, **kwargs):
+        self.profile_calls.append(kwargs)
+        return list(self.profiles)
+
+
+class RaisingPersonasScopeService:
+    async def list_characters(self, **kwargs):
+        raise RuntimeError("characters unavailable")
+
+    async def list_persona_profiles(self, **kwargs):
+        return []
 
 
 class StaticLibraryNotesScopeService:
@@ -200,6 +228,129 @@ async def test_watchlists_collections_uses_compact_title_and_clear_sections():
         visible_text = _visible_text(screen)
         assert "Watchlists" in visible_text
         assert "Collections" in visible_text
+
+
+@pytest.mark.asyncio
+async def test_personas_destination_lists_local_behavior_snapshot_from_service():
+    app = _build_test_app()
+    app.character_persona_scope_service = StaticPersonasScopeService(
+        characters=[
+            {"name": "Research Mentor", "id": 1},
+            {"name": "Code Reviewer", "id": 2},
+        ],
+        profiles=[
+            {"name": "Socratic Tutor", "id": "persona-1", "description": "Guides by asking questions."},
+        ],
+    )
+    host = DestinationHarness(app, "personas")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        screen = _active_destination_screen(host)
+        text = _visible_text(screen)
+        button = screen.query_one("#personas-attach-to-console", Button)
+
+        assert "Local Personas snapshot" in text
+        assert "Characters: 2" in text
+        assert "Persona profiles: 1" in text
+        assert "Research Mentor" in text
+        assert "Code Reviewer" in text
+        assert "Socratic Tutor" in text
+        assert button.disabled is False
+
+    assert app.character_persona_scope_service.character_calls[0] == {
+        "mode": "local",
+        "limit": getattr(personas_screen_module, "PERSONAS_LOCAL_PAGE_SIZE", None),
+        "offset": 0,
+    }
+    assert app.character_persona_scope_service.profile_calls[0] == {
+        "mode": "local",
+        "active_only": True,
+        "include_deleted": False,
+        "limit": getattr(personas_screen_module, "PERSONAS_LOCAL_PAGE_SIZE", None),
+        "offset": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_personas_destination_empty_state_disables_console_attach():
+    app = _build_test_app()
+    app.character_persona_scope_service = StaticPersonasScopeService()
+    host = DestinationHarness(app, "personas")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        screen = _active_destination_screen(host)
+        button = screen.query_one("#personas-attach-to-console", Button)
+
+        assert "No local characters or persona profiles are available yet." in _visible_text(screen)
+        assert button.disabled is True
+        assert "Stage local persona context" in str(button.tooltip)
+
+
+@pytest.mark.asyncio
+async def test_personas_destination_service_failure_uses_recovery_copy():
+    app = _build_test_app()
+    app.character_persona_scope_service = RaisingPersonasScopeService()
+    host = DestinationHarness(app, "personas")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        screen = _active_destination_screen(host)
+        button = screen.query_one("#personas-attach-to-console", Button)
+
+        assert "Personas service unavailable; retry Personas later." in _visible_text(screen)
+        assert button.disabled is True
+        assert "Personas service is unavailable" in str(button.tooltip)
+
+
+@pytest.mark.asyncio
+async def test_personas_attach_to_console_uses_listed_behavior_context():
+    app = _build_test_app()
+    app.character_persona_scope_service = StaticPersonasScopeService(
+        characters=[
+            {"name": "Research Mentor", "id": 1, "description": "Helps reason over sources."},
+        ],
+        profiles=[
+            {"name": "Socratic Tutor", "id": "persona-1", "description": "Guides by asking questions."},
+        ],
+    )
+    app.open_chat_with_handoff = Mock()
+    host = DestinationHarness(app, "personas")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        await pilot.click("#personas-attach-to-console")
+        await pilot.pause(0.1)
+
+    app.open_chat_with_handoff.assert_called_once()
+    payload = app.open_chat_with_handoff.call_args.args[0]
+    assert isinstance(payload, ChatHandoffPayload)
+    assert payload.source == "personas"
+    assert payload.item_type == "personas-context"
+    assert payload.title == "Local Personas Context"
+    assert "Characters: 1" in payload.body
+    assert "Persona profiles: 1" in payload.body
+    assert "Research Mentor" in payload.body
+    assert "Socratic Tutor" in payload.body
+    assert "Stage characters, prompts, dictionaries" not in payload.body
+    assert payload.metadata["character_count"] == 1
+    assert payload.metadata["persona_profile_count"] == 1
+    assert payload.metadata["character_names"] == ["Research Mentor"]
+    assert payload.metadata["persona_profile_names"] == ["Socratic Tutor"]
+
+
+def test_personas_destination_service_adoption_tracking_evidence_exists():
+    evidence = PHASE4_PERSONAS_ADOPTION_EVIDENCE.read_text(encoding="utf-8")
+    roadmap = Path("Docs/superpowers/trackers/unified-shell-maturity-roadmap.md").read_text(encoding="utf-8")
+    task = Path(
+        "backlog/tasks/task-5.4 - Phase-4.4-Adopt-Personas-service-in-Personas-destination.md"
+    ).read_text(encoding="utf-8")
+
+    assert "Phase 4.4 Personas Service Adoption" in evidence
+    assert "TASK-5.4" in evidence
+    assert "Phase 4.4: Adopt Personas service in Personas destination - `TASK-5.4`" in roadmap
+    assert "character_persona_scope_service" in task
 
 
 @pytest.mark.asyncio

--- a/backlog/tasks/task-5.4 - Phase-4.4-Adopt-Personas-service-in-Personas-destination.md
+++ b/backlog/tasks/task-5.4 - Phase-4.4-Adopt-Personas-service-in-Personas-destination.md
@@ -1,0 +1,52 @@
+---
+id: TASK-5.4
+title: Phase 4.4 Adopt Personas service in Personas destination
+status: Done
+assignee: []
+created_date: '2026-05-04 06:30'
+labels:
+  - unified-shell
+  - phase-4
+  - personas
+  - service-adoption
+dependencies: []
+parent_task_id: TASK-5
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make the top-level Personas destination use the existing character/persona scope service so users can see whether local characters and persona profiles are available and stage concrete behavior context into Console instead of generic placeholder copy.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Personas route lists a local behavior snapshot from character and persona profile services when available
+- [x] #2 Personas route shows honest empty and service-unavailable recovery states
+- [x] #3 Attach to Console stages concrete persona and character summary rather than generic placeholder copy
+- [x] #4 Focused automated tests cover Personas available empty error handoff and tracking behavior
+- [x] #5 QA evidence documents functional behavior visual usability residual risks and verification output
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing destination shell tests for Personas local behavior snapshot available empty error and concrete Console handoff behavior.
+2. Implement the smallest `PersonasScreen` local snapshot loader using `character_persona_scope_service.list_characters()` and `character_persona_scope_service.list_persona_profiles()`.
+3. Render local character/profile counts and sample names with stable selectors while preserving the existing legacy Personas route button.
+4. Disable `Attach to Console` when no concrete local behavior context exists and keep service failures distinct from empty Personas state.
+5. Build `ChatHandoffPayload` body from actual listed character and persona profile counts and sample names.
+6. Add Phase 4.4 QA evidence and roadmap links.
+7. Run focused Personas destination service tests plus git diff checks before commit.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added local Personas snapshot loading in `PersonasScreen` through `character_persona_scope_service.list_characters()` and `character_persona_scope_service.list_persona_profiles()`.
+- Rendered loading, available, empty, service-unavailable, and policy-denied recovery states while preserving the existing `Open Personas` route.
+- Changed `Attach to Console` from a generic placeholder to a disabled-until-ready `personas-context` Chat handoff with concrete local character/profile counts, sample names, and descriptions.
+- Added focused destination shell and Console handoff regression coverage plus Phase 4.4 QA evidence and roadmap links.
+- Verified with `.venv/bin/python -m pytest Tests/UI/test_destination_shells.py Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_shell_product_model_visibility.py Tests/Character_Chat/test_character_persona_scope_service.py -q` resulting in `161 passed, 8 warnings in 92.93s`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-5.4 - Phase-4.4-Adopt-Personas-service-in-Personas-destination.md
+++ b/backlog/tasks/task-5.4 - Phase-4.4-Adopt-Personas-service-in-Personas-destination.md
@@ -48,5 +48,6 @@ Make the top-level Personas destination use the existing character/persona scope
 - Rendered loading, available, empty, service-unavailable, and policy-denied recovery states while preserving the existing `Open Personas` route.
 - Changed `Attach to Console` from a generic placeholder to a disabled-until-ready `personas-context` Chat handoff with concrete local character/profile counts, sample names, and descriptions.
 - Added focused destination shell and Console handoff regression coverage plus Phase 4.4 QA evidence and roadmap links.
-- Verified with `.venv/bin/python -m pytest Tests/UI/test_destination_shells.py Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_shell_product_model_visibility.py Tests/Character_Chat/test_character_persona_scope_service.py -q` resulting in `161 passed, 8 warnings in 92.93s`.
+- Replaced Personas destination test fixed sleeps with deterministic polling for loaded/error/empty UI states and added a delayed-service regression for the threaded worker path.
+- Verified with `.venv/bin/python -m pytest Tests/UI/test_destination_shells.py Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_shell_product_model_visibility.py Tests/Character_Chat/test_character_persona_scope_service.py -q` resulting in `162 passed, 8 warnings in 93.70s`.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -1,22 +1,214 @@
 """Personas destination shell for behavior profiles and prompt context."""
 
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from loguru import logger
+from rich.markup import escape as escape_markup
+from rich.text import Text
+from textual import on, work
 from textual.app import ComposeResult
-from textual import on
 from textual.containers import Vertical
 from textual.widgets import Button, Static
 
 from ...Chat.chat_handoff_models import ChatHandoffPayload
+from ...runtime_policy.types import PolicyDeniedError
+from ...Utils.input_validation import sanitize_string, validate_text_input
 from ..Navigation.base_app_screen import BaseAppScreen
 from ..Navigation.main_navigation import NavigateToScreen
+
+
+logger = logger.bind(module="PersonasScreen")
+PERSONAS_LOCAL_PAGE_SIZE = 5
+PERSONAS_SERVICE_ERROR_COPY = "Personas service unavailable; retry Personas later."
+PERSONAS_SERVICE_UNAVAILABLE_COPY = "Personas service is unavailable in this runtime."
+PERSONAS_EMPTY_COPY = "No local characters or persona profiles are available yet."
 
 
 class PersonasScreen(BaseAppScreen):
     """Characters, personas, prompts, dictionaries, and behavior profiles."""
 
-    def __init__(self, app_instance, **kwargs):
+    def __init__(self, app_instance: Any, **kwargs: Any) -> None:
         super().__init__(app_instance, "personas", **kwargs)
+        self._local_behavior_records: dict[str, tuple[Mapping[str, Any], ...]] = {
+            "characters": (),
+            "profiles": (),
+        }
+        self._local_behavior_counts: dict[str, int] = {
+            "characters": 0,
+            "profiles": 0,
+        }
+        self._personas_lookup_error: str | None = None
+        self._personas_loaded = False
+
+    def on_mount(self) -> None:
+        super().on_mount()
+        self._refresh_local_behavior_snapshot()
+
+    @work(exclusive=True, thread=True)
+    def _refresh_local_behavior_snapshot(self) -> None:
+        records, counts, lookup_error = self._list_local_behavior_snapshot()
+        self.app.call_from_thread(self._apply_local_behavior_snapshot, records, counts, lookup_error)
+
+    def _apply_local_behavior_snapshot(
+        self,
+        records: dict[str, tuple[Mapping[str, Any], ...]],
+        counts: dict[str, int],
+        lookup_error: str | None = None,
+    ) -> None:
+        self._local_behavior_records = records
+        self._local_behavior_counts = counts
+        self._personas_lookup_error = lookup_error
+        self._personas_loaded = True
+        if self.is_mounted:
+            self.refresh(recompose=True)
+
+    @staticmethod
+    def _run_maybe_awaitable(value: Any) -> Any:
+        if inspect.isawaitable(value):
+            return asyncio.run(value)
+        return value
+
+    @staticmethod
+    def _safe_text(value: Any, fallback: str = "", *, max_length: int = 500) -> str:
+        text = sanitize_string(str(value or ""), max_length=max_length).strip()
+        if not text:
+            return fallback
+        text = text.replace("<", "").replace(">", "")
+        for pattern in ("javascript:", "onclick=", "onerror="):
+            text = text.replace(pattern, "")
+        if validate_text_input(text, max_length=max_length, allow_html=False):
+            return text
+        return fallback
+
+    @classmethod
+    def _record_name(cls, record_type: str, record: Mapping[str, Any]) -> str:
+        keys = {
+            "characters": ("name", "character_name", "title", "card_name"),
+            "profiles": ("name", "profile_name", "title", "label"),
+        }[record_type]
+        for key in keys:
+            name = cls._safe_text(record.get(key))
+            if name:
+                return name
+        return "Untitled persona"
+
+    @classmethod
+    def _record_description(cls, record: Mapping[str, Any]) -> str:
+        for key in ("description", "personality", "system_prompt", "summary"):
+            description = cls._safe_text(record.get(key), max_length=600)
+            if description:
+                return description
+        return ""
+
+    @staticmethod
+    def _response_records_and_count(result: Any) -> tuple[tuple[Mapping[str, Any], ...], int]:
+        if isinstance(result, Mapping):
+            raw_items = result.get("items") or result.get("profiles") or result.get("characters")
+            total = result.get("total")
+            pagination = result.get("pagination")
+            if isinstance(pagination, Mapping):
+                total = pagination.get("total", total)
+        elif isinstance(result, Sequence) and not isinstance(result, (str, bytes, bytearray)):
+            raw_items = result
+            total = None
+        else:
+            raw_items = ()
+            total = None
+
+        records = tuple(record for record in tuple(raw_items or ()) if isinstance(record, Mapping))
+        try:
+            count = int(total) if total is not None else len(records)
+        except (TypeError, ValueError):
+            count = len(records)
+        return records, count
+
+    def _list_local_behavior_snapshot(
+        self,
+    ) -> tuple[dict[str, tuple[Mapping[str, Any], ...]], dict[str, int], str | None]:
+        service = getattr(self.app_instance, "character_persona_scope_service", None)
+        list_characters = getattr(service, "list_characters", None)
+        list_profiles = getattr(service, "list_persona_profiles", None)
+        empty_records: dict[str, tuple[Mapping[str, Any], ...]] = {
+            "characters": (),
+            "profiles": (),
+        }
+        empty_counts = {"characters": 0, "profiles": 0}
+        if not callable(list_characters) or not callable(list_profiles):
+            return empty_records, empty_counts, PERSONAS_SERVICE_UNAVAILABLE_COPY
+
+        try:
+            characters_result = self._run_maybe_awaitable(
+                list_characters(
+                    mode="local",
+                    limit=PERSONAS_LOCAL_PAGE_SIZE,
+                    offset=0,
+                )
+            )
+            profiles_result = self._run_maybe_awaitable(
+                list_profiles(
+                    mode="local",
+                    active_only=True,
+                    include_deleted=False,
+                    limit=PERSONAS_LOCAL_PAGE_SIZE,
+                    offset=0,
+                )
+            )
+        except PolicyDeniedError as exc:
+            policy_message = self._safe_text(exc.user_message, PERSONAS_SERVICE_ERROR_COPY)
+            return empty_records, empty_counts, policy_message
+        except Exception:
+            logger.warning(
+                "Failed to load local Personas behavior snapshot.",
+                exc_info=True,
+            )
+            return empty_records, empty_counts, PERSONAS_SERVICE_ERROR_COPY
+
+        characters, character_count = self._response_records_and_count(characters_result)
+        profiles, profile_count = self._response_records_and_count(profiles_result)
+        return (
+            {
+                "characters": characters,
+                "profiles": profiles,
+            },
+            {
+                "characters": character_count,
+                "profiles": profile_count,
+            },
+            None,
+        )
+
+    def _has_local_behavior_context(self) -> bool:
+        return any(count > 0 for count in self._local_behavior_counts.values())
+
+    def _snapshot_body(self) -> str:
+        lines = ["Local Personas behavior context staged for Console:", ""]
+        for record_type, label in (
+            ("characters", "Characters"),
+            ("profiles", "Persona profiles"),
+        ):
+            lines.append(f"{label}: {self._local_behavior_counts[record_type]}")
+            for index, record in enumerate(self._local_behavior_records[record_type], start=1):
+                name = self._record_name(record_type, record)
+                description = self._record_description(record)
+                lines.append(f"  {index}. {name}")
+                if description:
+                    lines.append(f"     description: {description}")
+            lines.append("")
+        return "\n".join(lines).strip()
+
+    def _record_names(self, record_type: str) -> list[str]:
+        return [
+            self._record_name(record_type, record)
+            for record in self._local_behavior_records[record_type]
+        ]
 
     def compose_content(self) -> ComposeResult:
+        has_context = self._has_local_behavior_context()
         with Vertical(id="personas-shell"):
             yield Static("Personas", id="personas-title", classes="ds-destination-header")
             yield Static(
@@ -35,10 +227,51 @@ class PersonasScreen(BaseAppScreen):
                     id="personas-boundary",
                     classes="destination-purpose",
                 )
+                yield Static("Local Personas snapshot", classes="destination-section")
+                if not self._personas_loaded:
+                    yield Static(
+                        "Loading local Personas behavior context...",
+                        id="personas-loading-state",
+                    )
+                    attach_disabled = True
+                    attach_tooltip = "Stage local persona context after Personas finishes loading."
+                elif self._personas_lookup_error:
+                    yield Static(
+                        self._personas_lookup_error,
+                        id="personas-service-error",
+                    )
+                    attach_disabled = True
+                    attach_tooltip = "Personas service is unavailable; retry Personas later."
+                elif not has_context:
+                    yield Static(
+                        PERSONAS_EMPTY_COPY,
+                        id="personas-empty-state",
+                    )
+                    attach_disabled = True
+                    attach_tooltip = "Stage local persona context after adding characters or persona profiles."
+                else:
+                    for record_type, label, widget_id in (
+                        ("characters", "Characters", "personas-characters-summary"),
+                        ("profiles", "Persona profiles", "personas-profiles-summary"),
+                    ):
+                        yield Static(
+                            f"{label}: {self._local_behavior_counts[record_type]}",
+                            id=widget_id,
+                        )
+                        for index, record in enumerate(self._local_behavior_records[record_type]):
+                            yield Static(
+                                Text.from_markup(
+                                    escape_markup(self._record_name(record_type, record))
+                                ),
+                                id=f"personas-{record_type}-item-{index}",
+                            )
+                    attach_disabled = False
+                    attach_tooltip = "Stage local persona context in Console."
                 yield Button(
                     "Attach to Console",
                     id="personas-attach-to-console",
-                    tooltip="Stage persona context in Console.",
+                    disabled=attach_disabled,
+                    tooltip=attach_tooltip,
                 )
 
     @on(Button.Pressed, "#personas-open-profiles")
@@ -46,12 +279,42 @@ class PersonasScreen(BaseAppScreen):
         self.post_message(NavigateToScreen("ccp"))
 
     @on(Button.Pressed, "#personas-attach-to-console")
-    def attach_to_console(self) -> None:
-        self.app_instance.open_chat_with_handoff(
+    def attach_to_console(self, event: Button.Pressed) -> None:
+        event.stop()
+        if not self._has_local_behavior_context():
+            notify = getattr(self.app_instance, "notify", None)
+            if callable(notify):
+                notify(
+                    self._personas_lookup_error or PERSONAS_EMPTY_COPY,
+                    severity="warning",
+                )
+            return
+        open_chat_with_handoff = getattr(self.app_instance, "open_chat_with_handoff", None)
+        if not callable(open_chat_with_handoff):
+            notify = getattr(self.app_instance, "notify", None)
+            if callable(notify):
+                notify(
+                    "Console handoff is unavailable for Personas in this runtime.",
+                    severity="warning",
+                )
+            return
+        open_chat_with_handoff(
             ChatHandoffPayload(
                 source="personas",
-                item_type="persona-context",
-                title="Persona context",
-                body="Stage characters, prompts, dictionaries, lore, or behavior profiles for Console.",
+                item_type="personas-context",
+                title="Local Personas Context",
+                body=self._snapshot_body(),
+                display_summary="Local Personas context staged.",
+                suggested_prompt="Use these local characters and persona profiles to guide the next response.",
+                runtime_backend="local",
+                source_owner="local",
+                source_selector_state="local",
+                metadata={
+                    "character_count": self._local_behavior_counts["characters"],
+                    "persona_profile_count": self._local_behavior_counts["profiles"],
+                    "character_names": self._record_names("characters"),
+                    "persona_profile_names": self._record_names("profiles"),
+                    "backend": "local",
+                },
             )
         )


### PR DESCRIPTION
## Summary
- Load local Personas snapshots from `character_persona_scope_service` characters and persona profiles.
- Disable Console handoff for empty/unavailable states and stage concrete `personas-context` when behavior context exists.
- Add TASK-5.4 Backlog tracking plus Phase 4.4 QA evidence and roadmap updates.

## Test Plan
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_destination_shells.py Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_shell_product_model_visibility.py Tests/Character_Chat/test_character_persona_scope_service.py -q` (`161 passed, 8 warnings in 91.51s`)