### PR TITLE
Track Phase 2-4 maturity gate closeouts

### DIFF
--- a/Docs/superpowers/qa/unified-shell/phase-2/README.md
+++ b/Docs/superpowers/qa/unified-shell/phase-2/README.md
@@ -1,6 +1,6 @@
 # Phase 2 QA Evidence
 
-Status: in-progress
+Status: qa-needed
 
 This directory contains durable QA summaries for Phase 2 Home operational-control work.
 
@@ -13,5 +13,9 @@ This directory contains durable QA summaries for Phase 2 Home operational-contro
 - `2026-05-03-home-notification-review-routing.md` - `TASK-4.5` Home notification review CTA routing into the existing inbox.
 - `2026-05-03-home-local-watchlist-run-snapshot.md` - `TASK-4.6` local W+C watchlist run snapshot state for Home active work.
 - `2026-05-03-home-local-watchlist-run-details.md` - `TASK-4.7` Home local W+C watchlist run detail routing into the W+C runs surface.
+
+## Pending Maturity-Gate QA
+
+- `2026-05-05-phase-2-home-operational-control-closeout.md` - planned `TASK-4.8` running-app QA replay for Home operational-control completion.
 
 Do not mark Phase 2 verified until Home approve, reject, pause, resume, retry, and open-detail workflows are verified against real service-backed adapters or explicitly recoverable unavailable states.

--- a/Docs/superpowers/qa/unified-shell/phase-3/README.md
+++ b/Docs/superpowers/qa/unified-shell/phase-3/README.md
@@ -1,6 +1,6 @@
 # Phase 3 QA Evidence
 
-Status: in-progress
+Status: qa-needed
 
 This directory contains durable QA summaries for Phase 3 Console live-work hub slices.
 
@@ -17,5 +17,9 @@ This directory contains durable QA summaries for Phase 3 Console live-work hub s
 - `2026-05-03-rag-search-console-launch.md` - `TASK-3.8` Search/RAG result Console launch producer for selected retrieved evidence.
 - `2026-05-03-artifacts-chatbook-console-launch.md` - `TASK-3.9` Artifacts destination Console launch producer for the latest local Chatbook artifact.
 - `2026-05-03-workflows-console-launch.md` - `TASK-3.10` Workflows destination Console launch producer for active workflow runs.
+
+## Pending Maturity-Gate QA
+
+- `2026-05-05-phase-3-console-live-work-closeout.md` - planned `TASK-3.11` running-app QA replay for Console live-work hub completion.
 
 Do not mark Phase 3 verified until launch, follow, status, and recovery flows are verified in the running app against workflows, schedules, ACP, MCP, RAG, artifacts, and active-work source adapters.

--- a/Docs/superpowers/qa/unified-shell/phase-4/README.md
+++ b/Docs/superpowers/qa/unified-shell/phase-4/README.md
@@ -1,6 +1,6 @@
 # Phase 4 QA Evidence
 
-Status: in-progress
+Status: qa-needed
 
 This directory contains durable QA summaries for Phase 4 destination service adoption slices.
 
@@ -11,5 +11,9 @@ This directory contains durable QA summaries for Phase 4 destination service ado
 - `2026-05-04-library-source-service-adoption.md` - `TASK-5.3` Library destination adoption of local notes, media, and conversation source snapshots plus concrete Console context staging.
 - `2026-05-04-personas-service-adoption.md` - `TASK-5.4` Personas destination adoption of local character and persona profile snapshots plus concrete Console context staging.
 - `2026-05-04-wc-service-adoption.md` - `TASK-5.5` W+C destination adoption of local watchlist source and saved collection snapshots plus concrete Console context staging.
+
+## Pending Maturity-Gate QA
+
+- `2026-05-05-phase-4-destination-service-adoption-closeout.md` - planned `TASK-5.6` running-app QA replay for destination service-adoption completion.
 
 Do not mark Phase 4 verified until Skills, MCP, ACP, Library, Workflows, Schedules, Personas, Artifacts, W+C, and Settings destination workflows are verified through running-app QA evidence or honest recovery states.

--- a/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
@@ -1,8 +1,8 @@
 # Unified Shell Maturity Roadmap
 
-Date: 2026-05-04
-Status: Phase 2, Phase 3, and Phase 4 in progress
-Source Branch: `origin/dev` at `2c3ce979` plus `codex/unified-shell-phase4-wc-service`
+Date: 2026-05-05
+Status: Phase 2, Phase 3, and Phase 4 need maturity-gate QA
+Source Branch: `origin/dev` at `5d178698` plus `codex/unified-shell-phase234-closeout`
 
 ## Purpose
 
@@ -37,7 +37,7 @@ Track remaining Unified Shell work in one place so rendered screens, clickable b
 - Library now surfaces a local source snapshot from notes, media, and conversations and can stage concrete source context into Console; full Library-native detail views, embedded Import/Export, and embedded Search/RAG remain future work.
 - Personas now surfaces a local behavior snapshot from characters and persona profiles and can stage concrete behavior context into Console; detail, edit, import/export, archetypes, exemplars, dictionaries, and lore remain future work.
 - W+C now surfaces a local monitored-source and saved-collection snapshot from `watchlist_scope_service` and `media_reading_scope_service` and can stage concrete W+C context into Console; full detail, edit, import/export, feed WebSub, alert-rule, retry/backoff, and server collection-feed UX remain future work.
-- Product workflows remain unverified until running-app QA evidence is added in later phases.
+- Phase 2, Phase 3, and Phase 4 implementation slices are merged, but the parent phases remain open until `TASK-4.8`, `TASK-3.11`, and `TASK-5.6` replay running-app maturity-gate QA and prove workflows are not render-only or click-only behavior.
 
 ## Definition Of Done
 
@@ -89,6 +89,7 @@ Initial child tasks:
 - Phase 2.5: Route Home notification review to the notifications inbox - `TASK-4.5`
 - Phase 2.6: Surface local watchlist runs in Home active work - `TASK-4.6`
 - Phase 2.7: Open Home local watchlist run details - `TASK-4.7`
+- Phase 2.8: Replay Home operational-control maturity gate - `TASK-4.8`
 - Phase 3.1: Add Console live-work launch contract - `TASK-3.1`
 - Phase 3.2: Add Console live-work status card seam - `TASK-3.2`
 - Phase 3.3: Open Home W+C active work in Console - `TASK-3.3`
@@ -99,11 +100,13 @@ Initial child tasks:
 - Phase 3.8: Launch RAG search result from Search/RAG into Console - `TASK-3.8`
 - Phase 3.9: Launch latest Chatbook artifact from Artifacts into Console - `TASK-3.9`
 - Phase 3.10: Launch active Workflows run from Workflows into Console - `TASK-3.10`
+- Phase 3.11: Replay Console live-work maturity gate - `TASK-3.11`
 - Phase 4.1: Adopt Unified MCP panel in MCP destination - `TASK-5.1`
 - Phase 4.2: Adopt Skills services in Skills destination - `TASK-5.2`
 - Phase 4.3: Adopt Library source services in Library destination - `TASK-5.3`
 - Phase 4.4: Adopt Personas service in Personas destination - `TASK-5.4`
 - Phase 4.5: Adopt W+C services in W+C destination - `TASK-5.5`
+- Phase 4.6: Replay destination service-adoption maturity gate - `TASK-5.6`
 
 ## QA Evidence Index
 
@@ -111,9 +114,9 @@ Initial child tasks:
 | --- | --- | --- |
 | Phase 0 | `Docs/superpowers/qa/unified-shell/phase-0/` | verified |
 | Phase 1 | `Docs/superpowers/qa/unified-shell/phase-1/` | verified |
-| Phase 2 | `Docs/superpowers/qa/unified-shell/phase-2/` | in-progress |
-| Phase 3 | `Docs/superpowers/qa/unified-shell/phase-3/` | in-progress |
-| Phase 4 | `Docs/superpowers/qa/unified-shell/phase-4/` | in-progress |
+| Phase 2 | `Docs/superpowers/qa/unified-shell/phase-2/` | qa-needed |
+| Phase 3 | `Docs/superpowers/qa/unified-shell/phase-3/` | qa-needed |
+| Phase 4 | `Docs/superpowers/qa/unified-shell/phase-4/` | qa-needed |
 | Phase 5 | `Docs/superpowers/qa/unified-shell/phase-5/` | not-started |
 | Phase 6 | `Docs/superpowers/qa/unified-shell/phase-6/` | not-started |
 
@@ -123,9 +126,9 @@ Initial child tasks:
 | --- | --- | --- | --- | --- | --- |
 | Phase 0: Canonical Tracking | Make remaining work trackable. | verified | `TASK-1`, `TASK-1.1`, `TASK-1.2` | `phase-0/` | Product UI workflows are out of scope for Phase 0. |
 | Phase 1: Shell Contract Complete | Remove false shell affordances and prove shell usability. | verified | `TASK-2`, `TASK-2.1`, `TASK-2.2`, `TASK-2.3`, `TASK-2.4` | `phase-1/` | Live service workflows remain intentionally deferred to Phases 2-6. |
-| Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | in-progress | `TASK-4`, `TASK-4.1`, `TASK-4.2`, `TASK-4.3`, `TASK-4.4`, `TASK-4.5`, `TASK-4.6`, `TASK-4.7` | `phase-2/` | Schedule and agent-service adapters still need implementation; local watchlist retry/pause/resume remain recoverable rather than fully controllable. |
-| Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | in-progress | `TASK-3`, `TASK-3.1`, `TASK-3.2`, `TASK-3.3`, `TASK-3.4`, `TASK-3.5`, `TASK-3.6`, `TASK-3.7`, `TASK-3.8`, `TASK-3.9`, `TASK-3.10` | `phase-3/` | ACP, MCP, server Artifacts, and deeper source-specific live event streams still need implementation. |
-| Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | in-progress | `TASK-5`, `TASK-5.1`, `TASK-5.2`, `TASK-5.3`, `TASK-5.4`, `TASK-5.5` | `phase-4/` | Service coverage varies by destination; MCP now adopts the existing Unified MCP panel, Skills now lists/stages local Agent Skills, Library now lists/stages local source snapshots, Personas now lists/stages local behavior snapshots, and W+C now lists/stages local monitored-source and collection snapshots, but remaining destinations and deeper flows still need adoption or verified recovery. |
+| Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | qa-needed | `TASK-4`, `TASK-4.1`, `TASK-4.2`, `TASK-4.3`, `TASK-4.4`, `TASK-4.5`, `TASK-4.6`, `TASK-4.7`, `TASK-4.8` | `phase-2/` | Implementation slices are merged, but `TASK-4.8` must replay running-app QA before the parent phase can be verified. |
+| Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | qa-needed | `TASK-3`, `TASK-3.1`, `TASK-3.2`, `TASK-3.3`, `TASK-3.4`, `TASK-3.5`, `TASK-3.6`, `TASK-3.7`, `TASK-3.8`, `TASK-3.9`, `TASK-3.10`, `TASK-3.11` | `phase-3/` | Implementation slices are merged, but `TASK-3.11` must replay running-app QA before the parent phase can be verified. |
+| Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | qa-needed | `TASK-5`, `TASK-5.1`, `TASK-5.2`, `TASK-5.3`, `TASK-5.4`, `TASK-5.5`, `TASK-5.6` | `phase-4/` | Implementation slices are merged, but `TASK-5.6` must replay running-app QA before the parent phase can be verified. |
 | Phase 5: Capability And Recovery System | Systematize unavailable and blocked states. | not-started | `TASK-6` | `phase-5/` | Shared taxonomy not yet extracted. |
 | Phase 6: Audit Replay And Closeout | Prove shell works for first-time and power users. | not-started | `TASK-7` | `phase-6/` | Depends on prior phases and running-app QA. |
 
@@ -199,6 +202,12 @@ Initial audit result: W+C, Schedules, Workflows, and ACP had false Console-launc
 
 - `Docs/superpowers/qa/unified-shell/phase-2/2026-05-03-home-local-watchlist-run-details.md`
 
+## Phase 2.8 Home Operational-Control Maturity-Gate QA
+
+`TASK-4.8` must replay Home operational-control workflows in the running app before `TASK-4` can be verified:
+
+- Planned evidence path: `Docs/superpowers/qa/unified-shell/phase-2/2026-05-05-phase-2-home-operational-control-closeout.md`
+
 ## Phase 3.1 Console Live-Work Launch Contract Evidence
 
 `TASK-3.1` adds the normalized Console launch payload contract and renders pending launch details in Console:
@@ -265,6 +274,12 @@ Initial audit result: W+C, Schedules, Workflows, and ACP had false Console-launc
 
 - `Docs/superpowers/qa/unified-shell/phase-3/2026-05-03-workflows-console-launch.md`
 
+## Phase 3.11 Console Live-Work Maturity-Gate QA
+
+`TASK-3.11` must replay Console live-work launch, follow, status, and recovery workflows in the running app before `TASK-3` can be verified:
+
+- Planned evidence path: `Docs/superpowers/qa/unified-shell/phase-3/2026-05-05-phase-3-console-live-work-closeout.md`
+
 ## Phase 4.1 MCP Destination Service Adoption Evidence
 
 `TASK-5.1` embeds the existing Unified MCP management panel in the top-level MCP destination while preserving the legacy `tools_settings` MCP alias:
@@ -294,6 +309,12 @@ Initial audit result: W+C, Schedules, Workflows, and ACP had false Console-launc
 `TASK-5.5` makes the top-level W+C destination list local monitored sources and saved collection items through existing Watchlists and Media Reading services and stage concrete W+C context into Console:
 
 - `Docs/superpowers/qa/unified-shell/phase-4/2026-05-04-wc-service-adoption.md`
+
+## Phase 4.6 Destination Service-Adoption Maturity-Gate QA
+
+`TASK-5.6` must replay destination service-adoption workflows in the running app before `TASK-5` can be verified:
+
+- Planned evidence path: `Docs/superpowers/qa/unified-shell/phase-4/2026-05-05-phase-4-destination-service-adoption-closeout.md`
 
 ## Phase 0: Canonical Tracking
 

--- a/Tests/UI/test_unified_shell_phase234_maturity_gate.py
+++ b/Tests/UI/test_unified_shell_phase234_maturity_gate.py
@@ -1,0 +1,104 @@
+from pathlib import Path
+
+
+ROADMAP = Path("Docs/superpowers/trackers/unified-shell-maturity-roadmap.md")
+
+PHASES = {
+    "Phase 2": {
+        "qa_dir": "phase-2",
+        "status": "qa-needed",
+        "parent_task": "TASK-4",
+        "closeout_task": "TASK-4.8",
+        "task_file": Path(
+            "backlog/tasks/task-4.8 - Phase-2.8-Replay-Home-operational-control-maturity-gate.md"
+        ),
+        "readme": Path("Docs/superpowers/qa/unified-shell/phase-2/README.md"),
+        "closeout_doc": Path(
+            "Docs/superpowers/qa/unified-shell/phase-2/2026-05-05-phase-2-home-operational-control-closeout.md"
+        ),
+        "overview_row": (
+            "| Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | "
+            "qa-needed |"
+        ),
+    },
+    "Phase 3": {
+        "qa_dir": "phase-3",
+        "status": "qa-needed",
+        "parent_task": "TASK-3",
+        "closeout_task": "TASK-3.11",
+        "task_file": Path(
+            "backlog/tasks/task-3.11 - Phase-3.11-Replay-Console-live-work-maturity-gate.md"
+        ),
+        "readme": Path("Docs/superpowers/qa/unified-shell/phase-3/README.md"),
+        "closeout_doc": Path(
+            "Docs/superpowers/qa/unified-shell/phase-3/2026-05-05-phase-3-console-live-work-closeout.md"
+        ),
+        "overview_row": (
+            "| Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | "
+            "qa-needed |"
+        ),
+    },
+    "Phase 4": {
+        "qa_dir": "phase-4",
+        "status": "qa-needed",
+        "parent_task": "TASK-5",
+        "closeout_task": "TASK-5.6",
+        "task_file": Path(
+            "backlog/tasks/task-5.6 - Phase-4.6-Replay-destination-service-adoption-maturity-gate.md"
+        ),
+        "readme": Path("Docs/superpowers/qa/unified-shell/phase-4/README.md"),
+        "closeout_doc": Path(
+            "Docs/superpowers/qa/unified-shell/phase-4/2026-05-05-phase-4-destination-service-adoption-closeout.md"
+        ),
+        "overview_row": (
+            "| Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | "
+            "qa-needed |"
+        ),
+    },
+}
+
+PARENT_TASK_FILES = {
+    "TASK-3": Path("backlog/tasks/task-3 - Phase-3-Console-Live-Work-Hub.md"),
+    "TASK-4": Path("backlog/tasks/task-4 - Phase-2-Home-Operational-Control.md"),
+    "TASK-5": Path("backlog/tasks/task-5 - Phase-4-Destination-Service-Adoption.md"),
+}
+
+
+def _text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_phase_two_three_four_roadmap_and_indexes_mark_qa_needed():
+    roadmap_text = _text(ROADMAP)
+
+    assert "Status: Phase 2, Phase 3, and Phase 4 need maturity-gate QA" in roadmap_text
+
+    for phase_name, phase in PHASES.items():
+        qa_row = (
+            f"| {phase_name} | `Docs/superpowers/qa/unified-shell/{phase['qa_dir']}/` | "
+            f"{phase['status']} |"
+        )
+        assert qa_row in roadmap_text
+        assert phase["overview_row"] in roadmap_text
+        assert str(phase["closeout_doc"]) in roadmap_text
+        assert phase["closeout_task"] in roadmap_text
+
+        readme_text = _text(phase["readme"])
+        assert "Status: qa-needed" in readme_text
+        assert phase["closeout_task"] in readme_text
+        assert phase["closeout_doc"].name in readme_text
+
+
+def test_phase_two_three_four_closeout_tasks_keep_parent_phases_open():
+    for phase in PHASES.values():
+        closeout_text = _text(phase["task_file"])
+        assert f"id: {phase['closeout_task']}" in closeout_text
+        assert "status: To Do" in closeout_text
+        assert f"parent_task_id: {phase['parent_task']}" in closeout_text
+        assert "running-app QA walkthrough" in closeout_text
+        assert "not render-only or click-only behavior" in closeout_text
+
+        parent_text = _text(PARENT_TASK_FILES[phase["parent_task"]])
+        assert "status: In Progress" in parent_text
+        assert phase["closeout_task"] in parent_text
+        assert "maturity-gate QA" in parent_text

--- a/Tests/UI/test_unified_shell_phase234_maturity_gate.py
+++ b/Tests/UI/test_unified_shell_phase234_maturity_gate.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
 ROADMAP = Path("Docs/superpowers/trackers/unified-shell-maturity-roadmap.md")
 
 PHASES = {
@@ -65,7 +66,13 @@ PARENT_TASK_FILES = {
 
 
 def _text(path: Path) -> str:
-    return path.read_text(encoding="utf-8")
+    resolved_path = path if path.is_absolute() else REPO_ROOT / path
+    return resolved_path.read_text(encoding="utf-8")
+
+
+def _markdown_path(path: Path) -> str:
+    relative_path = path.relative_to(REPO_ROOT) if path.is_absolute() else path
+    return relative_path.as_posix()
 
 
 def test_phase_two_three_four_roadmap_and_indexes_mark_qa_needed():
@@ -80,7 +87,7 @@ def test_phase_two_three_four_roadmap_and_indexes_mark_qa_needed():
         )
         assert qa_row in roadmap_text
         assert phase["overview_row"] in roadmap_text
-        assert str(phase["closeout_doc"]) in roadmap_text
+        assert _markdown_path(phase["closeout_doc"]) in roadmap_text
         assert phase["closeout_task"] in roadmap_text
 
         readme_text = _text(phase["readme"])

--- a/backlog/tasks/task-3 - Phase-3-Console-Live-Work-Hub.md
+++ b/backlog/tasks/task-3 - Phase-3-Console-Live-Work-Hub.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-3
 title: 'Phase 3: Console Live Work Hub'
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-05-03 14:47'
+updated_date: '2026-05-05 00:19'
 labels:
   - unified-shell
   - phase-3
@@ -28,3 +29,11 @@ Make Console the primary live-agent control surface for workflows, schedules, AC
 - [ ] #3 Console remains fast for repeated power-user use.
 - [ ] #4 Durable QA summary exists under Docs/superpowers/qa/unified-shell/phase-3/.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Treat TASK-3.1 through TASK-3.10 as implemented Console live-work slices.
+2. Keep parent TASK-3 open until TASK-3.11 completes maturity-gate QA in the running app.
+3. Use TASK-3.11 to decide whether launch follow status and recovery workflows are verified across implemented sources or need explicit follow-up blockers.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-3.11 - Phase-3.11-Replay-Console-live-work-maturity-gate.md
+++ b/backlog/tasks/task-3.11 - Phase-3.11-Replay-Console-live-work-maturity-gate.md
@@ -1,0 +1,30 @@
+---
+id: TASK-3.11
+title: Phase 3.11 Replay Console live-work maturity gate
+status: To Do
+assignee: []
+created_date: '2026-05-05 00:19'
+labels:
+  - unified-shell
+  - phase-3
+  - console
+  - qa
+  - closeout
+dependencies: []
+parent_task_id: TASK-3
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replay Phase 3 Console live-work workflows in the running app and decide whether the Console live-work hub can be verified or must remain blocked by source-specific runtime gaps.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 running-app QA walkthrough verifies Console launch follow status and recovery flows from implemented sources
+- [ ] #2 QA evidence proves workflows schedules RAG artifacts and active-work source launches are not render-only or click-only behavior
+- [ ] #3 ACP MCP and deeper event-stream gaps are documented as verified recovery states or follow-up blockers
+- [ ] #4 Phase 3 roadmap README and parent task status are updated from the walkthrough result
+<!-- AC:END -->

--- a/backlog/tasks/task-4 - Phase-2-Home-Operational-Control.md
+++ b/backlog/tasks/task-4 - Phase-2-Home-Operational-Control.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-4
 title: 'Phase 2: Home Operational Control'
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-05-03 14:47'
+updated_date: '2026-05-05 00:19'
 labels:
   - unified-shell
   - phase-2
@@ -28,3 +29,11 @@ Make Home a real dashboard and control surface for status, notifications, schedu
 - [ ] #3 Unavailable states remain honest and recoverable.
 - [ ] #4 Durable QA summary exists under Docs/superpowers/qa/unified-shell/phase-2/.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Treat TASK-4.1 through TASK-4.7 as implemented Home operational-control slices.
+2. Keep parent TASK-4 open until TASK-4.8 completes maturity-gate QA in the running app.
+3. Use TASK-4.8 to decide whether Home approve reject pause resume retry and open-detail workflows are verified or need explicit follow-up blockers.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-4.8 - Phase-2.8-Replay-Home-operational-control-maturity-gate.md
+++ b/backlog/tasks/task-4.8 - Phase-2.8-Replay-Home-operational-control-maturity-gate.md
@@ -1,0 +1,29 @@
+---
+id: TASK-4.8
+title: Phase 2.8 Replay Home operational-control maturity gate
+status: To Do
+assignee: []
+created_date: '2026-05-05 00:19'
+labels:
+  - unified-shell
+  - phase-2
+  - home
+  - qa
+  - closeout
+dependencies: []
+parent_task_id: TASK-4
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replay Phase 2 Home operational-control workflows in the running app and decide whether the phase can be verified or must remain blocked by real-service gaps.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 running-app QA walkthrough verifies Home active-work controls and open-detail paths are functional or explicitly recoverable
+- [ ] #2 QA evidence proves approve reject pause resume retry and open-detail states are not render-only or click-only behavior
+- [ ] #3 Phase 2 roadmap README and parent task status are updated from the walkthrough result
+<!-- AC:END -->

--- a/backlog/tasks/task-5 - Phase-4-Destination-Service-Adoption.md
+++ b/backlog/tasks/task-5 - Phase-4-Destination-Service-Adoption.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-5
 title: 'Phase 4: Destination Service Adoption'
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-05-03 14:47'
+updated_date: '2026-05-05 00:19'
 labels:
   - unified-shell
   - phase-4
@@ -28,3 +29,11 @@ Turn top-level wrappers into useful product surfaces by adopting real services a
 - [ ] #3 Running-app QA verifies destination workflows rather than render-only behavior.
 - [ ] #4 Durable QA summaries exist under Docs/superpowers/qa/unified-shell/phase-4/.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Treat TASK-5.1 through TASK-5.5 as implemented destination service-adoption slices.
+2. Keep parent TASK-5 open until TASK-5.6 completes maturity-gate QA in the running app.
+3. Use TASK-5.6 to decide whether each top-level destination has a meaningful workflow or honest recovery state, and whether deeper service gaps need explicit follow-up blockers.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-5.6 - Phase-4.6-Replay-destination-service-adoption-maturity-gate.md
+++ b/backlog/tasks/task-5.6 - Phase-4.6-Replay-destination-service-adoption-maturity-gate.md
@@ -1,0 +1,30 @@
+---
+id: TASK-5.6
+title: Phase 4.6 Replay destination service-adoption maturity gate
+status: To Do
+assignee: []
+created_date: '2026-05-05 00:19'
+labels:
+  - unified-shell
+  - phase-4
+  - destinations
+  - qa
+  - closeout
+dependencies: []
+parent_task_id: TASK-5
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replay Phase 4 destination service-adoption workflows in the running app and decide whether destination wrappers can be verified or must remain blocked by missing service-depth or recovery-state gaps.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 running-app QA walkthrough verifies each destination has at least one meaningful workflow or an honest recovery state
+- [ ] #2 QA evidence covers Skills MCP ACP Library Workflows Schedules Personas Artifacts W+C and Settings ownership
+- [ ] #3 QA evidence proves destination workflows are not render-only or click-only behavior
+- [ ] #4 Phase 4 roadmap README and parent task status are updated from the walkthrough result
+<!-- AC:END -->


### PR DESCRIPTION
## Summary
- Move Phase 2, Phase 3, and Phase 4 tracking from vague in-progress state to explicit qa-needed maturity gates.
- Add TASK-4.8, TASK-3.11, and TASK-5.6 as running-app QA closeout tasks while keeping parent phases open.
- Add a regression test that locks roadmap, QA README, and backlog parent/child status consistency.

## Test Plan
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_unified_shell_phase1_closeout.py Tests/UI/test_unified_shell_phase234_maturity_gate.py -q
- git diff --cached --check