### PR TITLE
Close Phase 2 Home maturity gate

### DIFF
--- a/Docs/superpowers/qa/unified-shell/phase-2/2026-05-05-phase-2-home-operational-control-closeout.md
+++ b/Docs/superpowers/qa/unified-shell/phase-2/2026-05-05-phase-2-home-operational-control-closeout.md
@@ -1,0 +1,74 @@
+# Phase 2 Home Operational-Control Closeout
+
+Date: 2026-05-05
+Task: `TASK-4.8`
+Parent Task: `TASK-4`
+Branch: `codex/unified-shell-phase2-home-closeout`
+Base: `origin/dev` at `32ac2bdc`
+
+## Current Baseline
+
+Phase 2 is replayed after the merged Home operational-control slices:
+
+- `TASK-4.1` - Home active-work adapter boundary and unavailable default controls.
+- `TASK-4.2` - adapter-owned `Open details` and `Open in Console` actions.
+- `TASK-4.3` - item-scoped Home control target identity.
+- `TASK-4.4` - local unread notification snapshot.
+- `TASK-4.5` - notification review routing into the notifications inbox.
+- `TASK-4.6` - local W+C watchlist runs surfaced as Home active work.
+- `TASK-4.7` - W+C watchlist run details opened from Home.
+- `TASK-4.8` - maturity-gate replay and closeout.
+
+The implemented product boundary is explicit-adapter control, not full schedule or agent-service execution. Unsupported approve, reject, pause, resume, and retry controls are valid only when they return honest unavailable messages with a recovery route. W+C watchlist run detail and Console paths are handled when the local watchlist adapter can resolve the target run.
+
+## Workflow Matrix
+
+| Workflow | Running-app path | Result | Severity |
+| --- | --- | --- | --- |
+| Approve active Home item | Mounted Home screen renders `#home-approve`; click calls `approve_active_home_item`; app hook delegates to `HomeControlAction.APPROVE`. | Functional through adapter boundary; unavailable default is explicitly recoverable when no active-run service is wired. | none |
+| Reject active Home item | Mounted Home screen renders `#home-reject`; click calls `reject_active_home_item`; app hook delegates to `HomeControlAction.REJECT`. | Functional through adapter boundary; unavailable default is explicitly recoverable when no active-run service is wired. | none |
+| Pause active Home item | Mounted Home screen renders `#home-pause`; item-scoped click passes `target_id` to the app hook and adapter. | Functional through adapter boundary; unavailable default is explicitly recoverable when no active-run service is wired. | none |
+| Resume active Home item | Mounted Home screen renders `#home-resume`; click calls `resume_active_home_item`; app hook delegates to `HomeControlAction.RESUME`. | Functional through adapter boundary; unavailable default is explicitly recoverable when no active-run service is wired. | none |
+| Retry failed Home item | Failed W+C active-work row selects `#home-retry` with `target_id=local:watchlist_run:*`; click passes the target to the app hook and adapter. | Functional through adapter boundary; current local W+C retry remains recoverable via W+C detail/Console rather than fake retry execution. | none |
+| Open details | `#home-open-details` delegates to the adapter; handled W+C targets stage `pending_subscription_initial_tab=watchlist-runs` and navigate to `subscriptions`. | Functional for local W+C run details; unavailable default does not navigate falsely and shows recovery copy. | none |
+| Open in Console | `#home-open-in-console` delegates to the adapter; handled W+C targets create `HomeConsoleLaunch` and call `open_console_for_live_work`. | Functional for local W+C Console launch payloads; unavailable default does not create fake Console work. | none |
+| Notification review | Home primary action for unread notifications stages `pending_subscription_initial_tab=notifications` and opens the notifications inbox. | Functional local notification recovery path. | none |
+
+## Focused Verification
+
+Commands run from `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/codex-unified-shell-phase2-home-closeout`:
+
+- Baseline replay: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Home/test_dashboard_state.py Tests/Home/test_active_work_adapter.py Tests/UI/test_home_screen.py Tests/UI/test_screen_navigation.py::test_app_initializes_watchlists_and_notifications_services Tests/UI/test_unified_shell_phase2_home_adapter.py Tests/UI/test_unified_shell_phase234_maturity_gate.py -q`
+- Baseline replay result before closeout tracker updates: `57 passed, 2 failed, 10 warnings`
+- Baseline failures were tracker drift only:
+  - `Tests/UI/test_unified_shell_phase2_home_adapter.py::test_phase_two_home_adapter_is_linked_from_index_roadmap_and_task` still expected Phase 2 `in-progress`.
+  - `Tests/UI/test_unified_shell_phase234_maturity_gate.py::test_phase_two_three_four_closeout_tasks_keep_parent_phases_open` still expected `TASK-4.8` to remain `To Do`.
+- Red closeout contract: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_unified_shell_phase234_maturity_gate.py::test_phase_two_closeout_doc_records_verified_workflows_and_task_completion -q`
+- Red closeout result before evidence existed: `1 failed` with `FileNotFoundError` for this closeout document.
+- Final focused replay: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Home/test_dashboard_state.py Tests/Home/test_active_work_adapter.py Tests/UI/test_home_screen.py Tests/UI/test_screen_navigation.py::test_app_initializes_watchlists_and_notifications_services Tests/UI/test_unified_shell_phase2_home_adapter.py Tests/UI/test_unified_shell_phase234_maturity_gate.py -q`
+- Final focused replay result after closeout updates: `60 passed, 8 warnings`
+
+Warning boundary: final warnings are existing dependency/import warnings. Baseline replay also emitted train splash string warnings. None are Home operational-control behavior failures.
+
+## UX Notes
+
+- Home remains a usable status and control dashboard without pretending unavailable backend actions are wired.
+- Visible controls are not render-only: mounted Textual tests click controls and verify app hooks, adapter calls, target IDs, target routes, notifications, navigation staging, and Console launch payloads.
+- Beginner recovery copy is explicit when no live run service owns an action.
+- Power-user density and speed are preserved: the Home controls remain directly clickable and item-scoped controls carry target identity instead of forcing users through a generic detail page.
+
+## Defects And Blockers
+
+No Phase 2 closeout blocker remains.
+
+The only issues found during replay were stale tracker tests created by the transition from implementation slices to maturity-gate QA. Those are resolved by this closeout test update and evidence document.
+
+## Residual Risk
+
+- Schedule and agent-service adapters still need future implementation; Phase 2 verifies the Home adapter/control contract and local W+C/notification flows, not every future backend.
+- Local W+C retry remains recoverable via W+C detail or Console context rather than a direct retry service action.
+- Full first-time-user and power-user shell replay remains Phase 6 scope.
+
+## Closeout Decision: verified
+
+Phase 2 is verified because Home approve, reject, pause, resume, retry, open-detail, notification review, and Console handoff paths are covered by mounted running-app tests and adapter-level tests. Unsupported backend actions are explicitly recoverable, and handled local W+C and notification workflows route to concrete app state instead of only rendering or firing empty click handlers.

--- a/Docs/superpowers/qa/unified-shell/phase-2/2026-05-05-phase-2-home-operational-control-closeout.md
+++ b/Docs/superpowers/qa/unified-shell/phase-2/2026-05-05-phase-2-home-operational-control-closeout.md
@@ -6,6 +6,37 @@ Parent Task: `TASK-4`
 Branch: `codex/unified-shell-phase2-home-closeout`
 Base: `origin/dev` at `32ac2bdc`
 
+<!-- PHASE_2_CLOSEOUT_METADATA:BEGIN -->
+```json
+{
+  "closeout_task": "TASK-4.8",
+  "parent_task": "TASK-4",
+  "decision": "verified",
+  "verified_workflows": [
+    "approve",
+    "reject",
+    "pause",
+    "resume",
+    "retry",
+    "open-detail",
+    "open-in-console",
+    "notification-review"
+  ],
+  "unsupported_controls_policy": "explicitly_recoverable",
+  "baseline_replay_result": {
+    "passed": 57,
+    "failed": 2,
+    "warnings": 10
+  },
+  "final_focused_replay_result": {
+    "passed": 60,
+    "failed": 0,
+    "warnings": 8
+  }
+}
+```
+<!-- PHASE_2_CLOSEOUT_METADATA:END -->
+
 ## Current Baseline
 
 Phase 2 is replayed after the merged Home operational-control slices:
@@ -36,16 +67,16 @@ The implemented product boundary is explicit-adapter control, not full schedule 
 
 ## Focused Verification
 
-Commands run from `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/codex-unified-shell-phase2-home-closeout`:
+Commands were run from the repository root using the project virtual environment. Portable command form:
 
-- Baseline replay: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Home/test_dashboard_state.py Tests/Home/test_active_work_adapter.py Tests/UI/test_home_screen.py Tests/UI/test_screen_navigation.py::test_app_initializes_watchlists_and_notifications_services Tests/UI/test_unified_shell_phase2_home_adapter.py Tests/UI/test_unified_shell_phase234_maturity_gate.py -q`
+- Baseline replay: `python3 -m pytest Tests/Home/test_dashboard_state.py Tests/Home/test_active_work_adapter.py Tests/UI/test_home_screen.py Tests/UI/test_screen_navigation.py::test_app_initializes_watchlists_and_notifications_services Tests/UI/test_unified_shell_phase2_home_adapter.py Tests/UI/test_unified_shell_phase234_maturity_gate.py -q`
 - Baseline replay result before closeout tracker updates: `57 passed, 2 failed, 10 warnings`
 - Baseline failures were tracker drift only:
   - `Tests/UI/test_unified_shell_phase2_home_adapter.py::test_phase_two_home_adapter_is_linked_from_index_roadmap_and_task` still expected Phase 2 `in-progress`.
   - `Tests/UI/test_unified_shell_phase234_maturity_gate.py::test_phase_two_three_four_closeout_tasks_keep_parent_phases_open` still expected `TASK-4.8` to remain `To Do`.
-- Red closeout contract: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_unified_shell_phase234_maturity_gate.py::test_phase_two_closeout_doc_records_verified_workflows_and_task_completion -q`
+- Red closeout contract: `python3 -m pytest Tests/UI/test_unified_shell_phase234_maturity_gate.py::test_phase_two_closeout_doc_records_verified_workflows_and_task_completion -q`
 - Red closeout result before evidence existed: `1 failed` with `FileNotFoundError` for this closeout document.
-- Final focused replay: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Home/test_dashboard_state.py Tests/Home/test_active_work_adapter.py Tests/UI/test_home_screen.py Tests/UI/test_screen_navigation.py::test_app_initializes_watchlists_and_notifications_services Tests/UI/test_unified_shell_phase2_home_adapter.py Tests/UI/test_unified_shell_phase234_maturity_gate.py -q`
+- Final focused replay: `python3 -m pytest Tests/Home/test_dashboard_state.py Tests/Home/test_active_work_adapter.py Tests/UI/test_home_screen.py Tests/UI/test_screen_navigation.py::test_app_initializes_watchlists_and_notifications_services Tests/UI/test_unified_shell_phase2_home_adapter.py Tests/UI/test_unified_shell_phase234_maturity_gate.py -q`
 - Final focused replay result after closeout updates: `60 passed, 8 warnings`
 
 Warning boundary: final warnings are existing dependency/import warnings. Baseline replay also emitted train splash string warnings. None are Home operational-control behavior failures.

--- a/Docs/superpowers/qa/unified-shell/phase-2/README.md
+++ b/Docs/superpowers/qa/unified-shell/phase-2/README.md
@@ -1,6 +1,6 @@
 # Phase 2 QA Evidence
 
-Status: qa-needed
+Status: verified
 
 This directory contains durable QA summaries for Phase 2 Home operational-control work.
 
@@ -13,9 +13,8 @@ This directory contains durable QA summaries for Phase 2 Home operational-contro
 - `2026-05-03-home-notification-review-routing.md` - `TASK-4.5` Home notification review CTA routing into the existing inbox.
 - `2026-05-03-home-local-watchlist-run-snapshot.md` - `TASK-4.6` local W+C watchlist run snapshot state for Home active work.
 - `2026-05-03-home-local-watchlist-run-details.md` - `TASK-4.7` Home local W+C watchlist run detail routing into the W+C runs surface.
+- `2026-05-05-phase-2-home-operational-control-closeout.md` - `TASK-4.8` running-app QA replay for Home operational-control completion.
 
-## Pending Maturity-Gate QA
+## Closeout
 
-- `2026-05-05-phase-2-home-operational-control-closeout.md` - planned `TASK-4.8` running-app QA replay for Home operational-control completion.
-
-Do not mark Phase 2 verified until Home approve, reject, pause, resume, retry, and open-detail workflows are verified against real service-backed adapters or explicitly recoverable unavailable states.
+Phase 2 is verified for Home operational-control completion because Home approve, reject, pause, resume, retry, open-detail, notification review, and Console handoff workflows are verified against real local adapters or explicitly recoverable unavailable states.

--- a/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
@@ -1,8 +1,8 @@
 # Unified Shell Maturity Roadmap
 
 Date: 2026-05-05
-Status: Phase 2, Phase 3, and Phase 4 need maturity-gate QA
-Source Branch: `origin/dev` at `5d178698` plus `codex/unified-shell-phase234-closeout`
+Status: Phase 2 verified; Phase 3 and Phase 4 need maturity-gate QA
+Source Branch: `origin/dev` at `32ac2bdc` plus `codex/unified-shell-phase2-home-closeout`
 
 ## Purpose
 
@@ -37,7 +37,7 @@ Track remaining Unified Shell work in one place so rendered screens, clickable b
 - Library now surfaces a local source snapshot from notes, media, and conversations and can stage concrete source context into Console; full Library-native detail views, embedded Import/Export, and embedded Search/RAG remain future work.
 - Personas now surfaces a local behavior snapshot from characters and persona profiles and can stage concrete behavior context into Console; detail, edit, import/export, archetypes, exemplars, dictionaries, and lore remain future work.
 - W+C now surfaces a local monitored-source and saved-collection snapshot from `watchlist_scope_service` and `media_reading_scope_service` and can stage concrete W+C context into Console; full detail, edit, import/export, feed WebSub, alert-rule, retry/backoff, and server collection-feed UX remain future work.
-- Phase 2, Phase 3, and Phase 4 implementation slices are merged, but the parent phases remain open until `TASK-4.8`, `TASK-3.11`, and `TASK-5.6` replay running-app maturity-gate QA and prove workflows are not render-only or click-only behavior.
+- Phase 2 implementation and maturity-gate replay are verified. Phase 3 and Phase 4 implementation slices are merged, but their parent phases remain open until `TASK-3.11` and `TASK-5.6` replay running-app maturity-gate QA and prove workflows are not render-only or click-only behavior.
 
 ## Definition Of Done
 
@@ -114,7 +114,7 @@ Initial child tasks:
 | --- | --- | --- |
 | Phase 0 | `Docs/superpowers/qa/unified-shell/phase-0/` | verified |
 | Phase 1 | `Docs/superpowers/qa/unified-shell/phase-1/` | verified |
-| Phase 2 | `Docs/superpowers/qa/unified-shell/phase-2/` | qa-needed |
+| Phase 2 | `Docs/superpowers/qa/unified-shell/phase-2/` | verified |
 | Phase 3 | `Docs/superpowers/qa/unified-shell/phase-3/` | qa-needed |
 | Phase 4 | `Docs/superpowers/qa/unified-shell/phase-4/` | qa-needed |
 | Phase 5 | `Docs/superpowers/qa/unified-shell/phase-5/` | not-started |
@@ -126,7 +126,7 @@ Initial child tasks:
 | --- | --- | --- | --- | --- | --- |
 | Phase 0: Canonical Tracking | Make remaining work trackable. | verified | `TASK-1`, `TASK-1.1`, `TASK-1.2` | `phase-0/` | Product UI workflows are out of scope for Phase 0. |
 | Phase 1: Shell Contract Complete | Remove false shell affordances and prove shell usability. | verified | `TASK-2`, `TASK-2.1`, `TASK-2.2`, `TASK-2.3`, `TASK-2.4` | `phase-1/` | Live service workflows remain intentionally deferred to Phases 2-6. |
-| Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | qa-needed | `TASK-4`, `TASK-4.1`, `TASK-4.2`, `TASK-4.3`, `TASK-4.4`, `TASK-4.5`, `TASK-4.6`, `TASK-4.7`, `TASK-4.8` | `phase-2/` | Implementation slices are merged, but `TASK-4.8` must replay running-app QA before the parent phase can be verified. |
+| Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | verified | `TASK-4`, `TASK-4.1`, `TASK-4.2`, `TASK-4.3`, `TASK-4.4`, `TASK-4.5`, `TASK-4.6`, `TASK-4.7`, `TASK-4.8` | `phase-2/` | Schedule and agent-service adapters remain future work; Phase 2 is verified for explicit Home adapter behavior, local W+C/notification flows, and recoverable unavailable states. |
 | Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | qa-needed | `TASK-3`, `TASK-3.1`, `TASK-3.2`, `TASK-3.3`, `TASK-3.4`, `TASK-3.5`, `TASK-3.6`, `TASK-3.7`, `TASK-3.8`, `TASK-3.9`, `TASK-3.10`, `TASK-3.11` | `phase-3/` | Implementation slices are merged, but `TASK-3.11` must replay running-app QA before the parent phase can be verified. |
 | Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | qa-needed | `TASK-5`, `TASK-5.1`, `TASK-5.2`, `TASK-5.3`, `TASK-5.4`, `TASK-5.5`, `TASK-5.6` | `phase-4/` | Implementation slices are merged, but `TASK-5.6` must replay running-app QA before the parent phase can be verified. |
 | Phase 5: Capability And Recovery System | Systematize unavailable and blocked states. | not-started | `TASK-6` | `phase-5/` | Shared taxonomy not yet extracted. |
@@ -204,9 +204,9 @@ Initial audit result: W+C, Schedules, Workflows, and ACP had false Console-launc
 
 ## Phase 2.8 Home Operational-Control Maturity-Gate QA
 
-`TASK-4.8` must replay Home operational-control workflows in the running app before `TASK-4` can be verified:
+`TASK-4.8` replays Home operational-control workflows in the running app and closes `TASK-4` as verified:
 
-- Planned evidence path: `Docs/superpowers/qa/unified-shell/phase-2/2026-05-05-phase-2-home-operational-control-closeout.md`
+- `Docs/superpowers/qa/unified-shell/phase-2/2026-05-05-phase-2-home-operational-control-closeout.md`
 
 ## Phase 3.1 Console Live-Work Launch Contract Evidence
 

--- a/Tests/UI/test_unified_shell_phase234_maturity_gate.py
+++ b/Tests/UI/test_unified_shell_phase234_maturity_gate.py
@@ -1,8 +1,15 @@
+import json
+import re
 from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 ROADMAP = Path("Docs/superpowers/trackers/unified-shell-maturity-roadmap.md")
+PHASE_2_CLOSEOUT_METADATA = re.compile(
+    r"<!-- PHASE_2_CLOSEOUT_METADATA:BEGIN -->\s*```json\s*(.*?)\s*```\s*"
+    r"<!-- PHASE_2_CLOSEOUT_METADATA:END -->",
+    re.DOTALL,
+)
 
 PHASES = {
     "Phase 2": {
@@ -74,6 +81,12 @@ def _markdown_path(path: Path) -> str:
     return relative_path.as_posix()
 
 
+def _phase_two_closeout_metadata(text: str) -> dict:
+    metadata_match = PHASE_2_CLOSEOUT_METADATA.search(text)
+    assert metadata_match is not None
+    return json.loads(metadata_match.group(1))
+
+
 def test_phase_two_three_four_roadmap_and_indexes_record_current_gate_status():
     roadmap_text = _text(ROADMAP)
 
@@ -114,20 +127,27 @@ def test_phase_two_three_four_closeout_tasks_record_current_parent_status():
 def test_phase_two_closeout_doc_records_verified_workflows_and_task_completion():
     phase = PHASES["Phase 2"]
     closeout_text = _text(phase["closeout_doc"])
+    metadata = _phase_two_closeout_metadata(closeout_text)
 
-    for expected in [
-        "TASK-4.8",
-        "Closeout Decision: verified",
+    assert "/Users/" not in closeout_text
+    assert metadata["closeout_task"] == "TASK-4.8"
+    assert metadata["parent_task"] == "TASK-4"
+    assert metadata["decision"] == "verified"
+    assert metadata["verified_workflows"] == [
         "approve",
         "reject",
         "pause",
         "resume",
         "retry",
         "open-detail",
-        "explicitly recoverable",
-        "57 passed",
-    ]:
-        assert expected in closeout_text
+        "open-in-console",
+        "notification-review",
+    ]
+    assert metadata["unsupported_controls_policy"] == "explicitly_recoverable"
+    assert metadata["baseline_replay_result"]["failed"] == 2
+    assert metadata["final_focused_replay_result"]["failed"] == 0
+    assert metadata["final_focused_replay_result"]["passed"] > 0
+    assert metadata["final_focused_replay_result"]["warnings"] >= 0
 
     parent_text = _text(phase["parent_task_file"])
     assert "status: Done" in parent_text

--- a/Tests/UI/test_unified_shell_phase234_maturity_gate.py
+++ b/Tests/UI/test_unified_shell_phase234_maturity_gate.py
@@ -7,9 +7,10 @@ ROADMAP = Path("Docs/superpowers/trackers/unified-shell-maturity-roadmap.md")
 PHASES = {
     "Phase 2": {
         "qa_dir": "phase-2",
-        "status": "qa-needed",
+        "status": "verified",
         "parent_task": "TASK-4",
         "closeout_task": "TASK-4.8",
+        "parent_task_file": Path("backlog/tasks/task-4 - Phase-2-Home-Operational-Control.md"),
         "task_file": Path(
             "backlog/tasks/task-4.8 - Phase-2.8-Replay-Home-operational-control-maturity-gate.md"
         ),
@@ -19,14 +20,16 @@ PHASES = {
         ),
         "overview_row": (
             "| Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | "
-            "qa-needed |"
+            "verified |"
         ),
+        "task_status": "Done",
     },
     "Phase 3": {
         "qa_dir": "phase-3",
         "status": "qa-needed",
         "parent_task": "TASK-3",
         "closeout_task": "TASK-3.11",
+        "parent_task_file": Path("backlog/tasks/task-3 - Phase-3-Console-Live-Work-Hub.md"),
         "task_file": Path(
             "backlog/tasks/task-3.11 - Phase-3.11-Replay-Console-live-work-maturity-gate.md"
         ),
@@ -38,12 +41,14 @@ PHASES = {
             "| Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | "
             "qa-needed |"
         ),
+        "task_status": "To Do",
     },
     "Phase 4": {
         "qa_dir": "phase-4",
         "status": "qa-needed",
         "parent_task": "TASK-5",
         "closeout_task": "TASK-5.6",
+        "parent_task_file": Path("backlog/tasks/task-5 - Phase-4-Destination-Service-Adoption.md"),
         "task_file": Path(
             "backlog/tasks/task-5.6 - Phase-4.6-Replay-destination-service-adoption-maturity-gate.md"
         ),
@@ -55,15 +60,9 @@ PHASES = {
             "| Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | "
             "qa-needed |"
         ),
+        "task_status": "To Do",
     },
 }
-
-PARENT_TASK_FILES = {
-    "TASK-3": Path("backlog/tasks/task-3 - Phase-3-Console-Live-Work-Hub.md"),
-    "TASK-4": Path("backlog/tasks/task-4 - Phase-2-Home-Operational-Control.md"),
-    "TASK-5": Path("backlog/tasks/task-5 - Phase-4-Destination-Service-Adoption.md"),
-}
-
 
 def _text(path: Path) -> str:
     resolved_path = path if path.is_absolute() else REPO_ROOT / path
@@ -75,10 +74,10 @@ def _markdown_path(path: Path) -> str:
     return relative_path.as_posix()
 
 
-def test_phase_two_three_four_roadmap_and_indexes_mark_qa_needed():
+def test_phase_two_three_four_roadmap_and_indexes_record_current_gate_status():
     roadmap_text = _text(ROADMAP)
 
-    assert "Status: Phase 2, Phase 3, and Phase 4 need maturity-gate QA" in roadmap_text
+    assert "Status: Phase 2 verified; Phase 3 and Phase 4 need maturity-gate QA" in roadmap_text
 
     for phase_name, phase in PHASES.items():
         qa_row = (
@@ -91,21 +90,52 @@ def test_phase_two_three_four_roadmap_and_indexes_mark_qa_needed():
         assert phase["closeout_task"] in roadmap_text
 
         readme_text = _text(phase["readme"])
-        assert "Status: qa-needed" in readme_text
+        assert f"Status: {phase['status']}" in readme_text
         assert phase["closeout_task"] in readme_text
         assert phase["closeout_doc"].name in readme_text
 
 
-def test_phase_two_three_four_closeout_tasks_keep_parent_phases_open():
+def test_phase_two_three_four_closeout_tasks_record_current_parent_status():
     for phase in PHASES.values():
         closeout_text = _text(phase["task_file"])
         assert f"id: {phase['closeout_task']}" in closeout_text
-        assert "status: To Do" in closeout_text
+        assert f"status: {phase['task_status']}" in closeout_text
         assert f"parent_task_id: {phase['parent_task']}" in closeout_text
         assert "running-app QA walkthrough" in closeout_text
         assert "not render-only or click-only behavior" in closeout_text
 
-        parent_text = _text(PARENT_TASK_FILES[phase["parent_task"]])
-        assert "status: In Progress" in parent_text
+        parent_text = _text(phase["parent_task_file"])
+        expected_parent_status = "Done" if phase["status"] == "verified" else "In Progress"
+        assert f"status: {expected_parent_status}" in parent_text
         assert phase["closeout_task"] in parent_text
         assert "maturity-gate QA" in parent_text
+
+
+def test_phase_two_closeout_doc_records_verified_workflows_and_task_completion():
+    phase = PHASES["Phase 2"]
+    closeout_text = _text(phase["closeout_doc"])
+
+    for expected in [
+        "TASK-4.8",
+        "Closeout Decision: verified",
+        "approve",
+        "reject",
+        "pause",
+        "resume",
+        "retry",
+        "open-detail",
+        "explicitly recoverable",
+        "57 passed",
+    ]:
+        assert expected in closeout_text
+
+    parent_text = _text(phase["parent_task_file"])
+    assert "status: Done" in parent_text
+    assert "- [x] #1" in parent_text
+    assert "- [x] #4" in parent_text
+
+    task_text = _text(phase["task_file"])
+    assert "status: Done" in task_text
+    assert "- [x] #1" in task_text
+    assert "- [x] #3" in task_text
+    assert "Implementation Notes" in task_text

--- a/Tests/UI/test_unified_shell_phase2_home_adapter.py
+++ b/Tests/UI/test_unified_shell_phase2_home_adapter.py
@@ -50,7 +50,7 @@ def test_phase_two_home_adapter_is_linked_from_index_roadmap_and_task():
     roadmap_text = ROADMAP.read_text(encoding="utf-8")
     assert "TASK-4.1" in roadmap_text
     assert evidence_name in roadmap_text
-    assert "| Phase 2 | `Docs/superpowers/qa/unified-shell/phase-2/` | in-progress |" in roadmap_text
+    assert "| Phase 2 | `Docs/superpowers/qa/unified-shell/phase-2/` | verified |" in roadmap_text
 
     task_text = TASK_4_1.read_text(encoding="utf-8")
     assert "status: Done" in task_text

--- a/backlog/tasks/task-4 - Phase-2-Home-Operational-Control.md
+++ b/backlog/tasks/task-4 - Phase-2-Home-Operational-Control.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-4
 title: 'Phase 2: Home Operational Control'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-03 14:47'
-updated_date: '2026-05-05 00:19'
+updated_date: '2026-05-05 01:07'
 labels:
   - unified-shell
   - phase-2
@@ -24,10 +24,10 @@ Make Home a real dashboard and control surface for status, notifications, schedu
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Home controls route to real services or explicit adapters.
-- [ ] #2 Approve, reject, pause, resume, retry, and open-detail workflows are verified in the running app.
-- [ ] #3 Unavailable states remain honest and recoverable.
-- [ ] #4 Durable QA summary exists under Docs/superpowers/qa/unified-shell/phase-2/.
+- [x] #1 Home controls route to real services or explicit adapters.
+- [x] #2 Approve, reject, pause, resume, retry, and open-detail workflows are verified in the running app.
+- [x] #3 Unavailable states remain honest and recoverable.
+- [x] #4 Durable QA summary exists under Docs/superpowers/qa/unified-shell/phase-2/.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -37,3 +37,9 @@ Make Home a real dashboard and control surface for status, notifications, schedu
 2. Keep parent TASK-4 open until TASK-4.8 completes maturity-gate QA in the running app.
 3. Use TASK-4.8 to decide whether Home approve reject pause resume retry and open-detail workflows are verified or need explicit follow-up blockers.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Closed the Phase 2 parent after TASK-4.8 replayed Home operational-control workflows with mounted Textual click-path evidence, adapter-level control verification, and durable QA documentation. The phase is verified for explicit adapters, local W+C detail and Console launch, notification review routing, and recoverable unavailable states while future schedule and agent-service adapters remain outside this phase.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-4.8 - Phase-2.8-Replay-Home-operational-control-maturity-gate.md
+++ b/backlog/tasks/task-4.8 - Phase-2.8-Replay-Home-operational-control-maturity-gate.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-4.8
 title: Phase 2.8 Replay Home operational-control maturity gate
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-05-05 00:19'
+updated_date: '2026-05-05 01:07'
 labels:
   - unified-shell
   - phase-2
@@ -23,7 +24,23 @@ Replay Phase 2 Home operational-control workflows in the running app and decide 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 running-app QA walkthrough verifies Home active-work controls and open-detail paths are functional or explicitly recoverable
-- [ ] #2 QA evidence proves approve reject pause resume retry and open-detail states are not render-only or click-only behavior
-- [ ] #3 Phase 2 roadmap README and parent task status are updated from the walkthrough result
+- [x] #1 running-app QA walkthrough verifies Home active-work controls and open-detail paths are functional or explicitly recoverable
+- [x] #2 QA evidence proves approve reject pause resume retry and open-detail states are not render-only or click-only behavior
+- [x] #3 Phase 2 roadmap README and parent task status are updated from the walkthrough result
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Re-read Phase 2 child evidence and Home active-work tests to define the maturity-gate checklist.
+2. Run the focused Home adapter/dashboard/screen/navigation tests that exercise approve reject pause resume retry open-detail and recoverable unavailable states.
+3. Record a Phase 2 closeout QA artifact with exact verification output, workflow matrix, defects, and residual risks.
+4. Update Phase 2 README, roadmap, and parent task status according to the QA result without marking Phase 2 verified unless the evidence supports it.
+5. Add or update a tracking regression test so the closeout state cannot drift.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Closed Phase 2 Home maturity-gate QA with focused running-app Textual replay evidence, tracker status updates, and a closeout contract test. Phase 2 is verified for explicit Home adapter behavior, local W+C and notification flows, and recoverable unavailable states; schedule and agent-service adapters remain future work.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary
- Added the Phase 2 Home operational-control closeout QA evidence.
- Marked Phase 2 Home roadmap, README, parent task, and closeout task verified/done.
- Updated maturity-gate contract tests so Phase 2 verified state and remaining Phase 3/4 QA-needed state cannot drift.
- Addressed review feedback by moving machine-checked closeout fields into structured metadata and removing local absolute paths from QA commands.

## Test Plan
- python3 -m pytest Tests/UI/test_unified_shell_phase234_maturity_gate.py::test_phase_two_closeout_doc_records_verified_workflows_and_task_completion -q
- python3 -m pytest Tests/Home/test_dashboard_state.py Tests/Home/test_active_work_adapter.py Tests/UI/test_home_screen.py Tests/UI/test_screen_navigation.py::test_app_initializes_watchlists_and_notifications_services Tests/UI/test_unified_shell_phase2_home_adapter.py Tests/UI/test_unified_shell_phase234_maturity_gate.py -q
- git diff --check