### PR TITLE
Close Phase 4 destination maturity gate

### DIFF
--- a/Docs/superpowers/qa/unified-shell/phase-4/2026-05-05-phase-4-destination-service-adoption-closeout.md
+++ b/Docs/superpowers/qa/unified-shell/phase-4/2026-05-05-phase-4-destination-service-adoption-closeout.md
@@ -1,0 +1,133 @@
+# Phase 4 Destination Service-Adoption Closeout
+
+Date: 2026-05-05
+Task: `TASK-5.6`
+Parent Task: `TASK-5`
+Branch: `codex/unified-shell-phase4-destination-closeout`
+Base: `origin/dev` at `4e025bf9`
+
+<!-- PHASE_4_CLOSEOUT_METADATA:BEGIN -->
+```json
+{
+  "closeout_task": "TASK-5.6",
+  "parent_task": "TASK-5",
+  "decision": "verified",
+  "verified_destinations": [
+    "mcp",
+    "skills",
+    "library",
+    "personas",
+    "watchlists-collections",
+    "schedules",
+    "workflows",
+    "artifacts",
+    "settings"
+  ],
+  "verified_recovery_destinations": [
+    "acp"
+  ],
+  "destination_readiness": {
+    "mcp": "connected",
+    "skills": "connected",
+    "library": "connected",
+    "personas": "connected",
+    "watchlists-collections": "connected",
+    "schedules": "connected_or_recoverable",
+    "workflows": "connected_or_recoverable",
+    "artifacts": "connected_or_recoverable",
+    "settings": "connected",
+    "acp": "runtime_not_configured_recoverable"
+  },
+  "baseline_replay_result": {
+    "passed": 125,
+    "failed": 1,
+    "warnings": 3
+  },
+  "red_closeout_contract_result": {
+    "passed": 0,
+    "failed": 1,
+    "warnings": 0
+  },
+  "final_focused_replay_result": {
+    "passed": 5,
+    "failed": 0,
+    "warnings": 0
+  },
+  "final_broader_replay_result": {
+    "passed": 127,
+    "failed": 0,
+    "warnings": 1
+  }
+}
+```
+<!-- PHASE_4_CLOSEOUT_METADATA:END -->
+
+## Current Baseline
+
+Phase 4 is replayed after the merged destination service-adoption slices:
+
+- `TASK-5.1` - top-level MCP embeds the existing Unified MCP management panel.
+- `TASK-5.2` - Skills lists local Agent Skills through `skills_scope_service` and stages concrete Skills context into Console.
+- `TASK-5.3` - Library lists local notes, media, and conversations through source services and stages concrete Library context into Console.
+- `TASK-5.4` - Personas lists local characters and persona profiles through `character_persona_scope_service` and stages concrete behavior context into Console.
+- `TASK-5.5` - W+C lists local monitored sources and saved collection items through Watchlists and Media Reading services and stages concrete W+C context into Console.
+- `TASK-5.6` - maturity-gate replay and closeout.
+
+The implemented product boundary is destination service adoption, not full CRUD or server parity for every module. Destinations with available local services now expose concrete list, route, or Console-staging workflows. Destinations without configured runtimes keep honest disabled recovery states instead of fake launch controls.
+
+## Workflow Matrix
+
+| Destination | Running-app path | Result | Severity |
+| --- | --- | --- | --- |
+| MCP | Open MCP or legacy `tools_settings`; `MCPScreen` mounts `UnifiedMCPPanel` with source, server, scope, section, action, payload, and run controls. | Functional destination adoption; MCP no longer hides behind a placeholder or requires users to know the legacy route. | none |
+| Skills | Open Skills with a local `skills_scope_service`; listed skills render counts, names, descriptions, and `Attach local Skills to Console`. | Functional; click creates a `skills-context` `ChatHandoffPayload` from actual listed skill data rather than placeholder copy. | none |
+| Library | Open Library with notes, media, and conversation services; source counts and sample titles render under `Local Library snapshot`. | Functional; `Use in Console` stages a `library-source-snapshot` payload and Import/Export plus Search/RAG remain reachable through explicit Library buttons. | none |
+| Personas | Open Personas with local character/persona services; character and profile counts plus samples render under `Local Personas snapshot`. | Functional; `Attach to Console` stages a `personas-context` payload from actual behavior summaries. | none |
+| W+C | Open W+C with watchlist and read-it-later services; monitored-source and saved-collection samples render under `Local W+C snapshot`. | Functional; `Stage W+C Context in Console` stages a `wc-context` payload while active-run Console follow remains intact. | none |
+| Schedules | Open Schedules with active schedule-run adapter context or latest local reading-digest output. | Functional when actionable context exists; otherwise disabled Console recovery copy states that no active schedule run is available. | none |
+| Workflows | Open Workflows with active workflow adapter context. | Functional when actionable context exists; otherwise disabled recovery copy states that no active workflow run is available. | none |
+| Artifacts | Open Artifacts with local Chatbook records. | Functional when a Chatbook exists; otherwise disabled recovery copy or service-error copy explains why Console launch is unavailable. | none |
+| Settings | Open Settings and click `Open Appearance`. | Functional; route posts `NavigateToScreen("customize")`, and Settings explicitly excludes MCP/tool control ownership. | none |
+| ACP | Open ACP with no configured ACP-compatible runtime. | Verified honest recovery state; launch and Console follow buttons are disabled until runtime/session payloads exist. | none |
+
+## Focused Verification
+
+Commands were run from the repository root using the project virtual environment. Portable command form:
+
+- Baseline replay: `python3 -m pytest Tests/UI/test_destination_shells.py Tests/UI/test_shell_destinations.py Tests/UI/test_master_shell_navigation.py Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_unified_shell_phase234_maturity_gate.py -q`
+- Baseline replay result before closeout tracker updates: `125 passed, 1 failed, 3 warnings`
+- Baseline failure: `Tests/UI/test_unified_shell_phase234_maturity_gate.py::test_phase_two_three_four_closeout_tasks_record_current_parent_status` still expected `TASK-5.6` to remain `To Do` after the task was moved to `In Progress`.
+- Red closeout contract: `python3 -m pytest Tests/UI/test_unified_shell_phase234_maturity_gate.py::test_phase_four_closeout_doc_records_verified_destinations_and_task_completion -q`
+- Red closeout result before evidence existed: `1 failed` with `FileNotFoundError` for this closeout document.
+- Final focused replay: `python3 -m pytest Tests/UI/test_unified_shell_phase234_maturity_gate.py -q`
+- Final focused replay result after closeout updates: `5 passed`
+- Final broader replay: `python3 -m pytest Tests/UI/test_destination_shells.py Tests/UI/test_shell_destinations.py Tests/UI/test_master_shell_navigation.py Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_unified_shell_phase234_maturity_gate.py -q`
+- Final broader replay result after closeout updates: `127 passed, 1 warning`
+
+Warning boundary: the remaining warnings are existing dependency/import warnings and do not indicate destination workflow failures.
+
+## UX Notes
+
+- Destinations now describe ownership clearly enough for first-time users without reducing power-user density.
+- Connected destinations expose concrete data or routes: MCP controls, Skills lists, Library source snapshots, Personas behavior snapshots, W+C monitored/saved source snapshots, Settings appearance routing, and Console staging where appropriate.
+- Disabled controls are not ambiguous: ACP, empty Schedules, empty Workflows, and empty Artifacts states explain what is missing before the action can run.
+- The tested flows are not render-only: mounted Textual tests click buttons and verify navigation messages, payload construction, app method calls, state restoration, service call parameters, unavailable states, and recovery copy.
+
+## Defects And Blockers
+
+No Phase 4 closeout blocker remains.
+
+The only issue found during replay was stale tracker/test state from transitioning `TASK-5.6` into closeout. The destination wrapper, shell navigation, Console handoff, and maturity-gate checks passed after the closeout evidence and task status updates.
+
+## Residual Risk
+
+- Full Library-native detail views, embedded Import/Export, and embedded Search/RAG remain future work; current Library keeps those paths reachable through existing routes.
+- Skills import, detail, edit, validation, execution, and full `SKILL.md` body staging remain future work.
+- Personas detail/edit/import/export, archetypes, exemplars, dictionaries, lore, and full card staging remain future work.
+- W+C create/edit/delete, import/export, WebSub, alert-rule editing, retry/backoff, and server collection-feed UX remain future work.
+- ACP runtime/session management is not wired; Phase 4 verifies honest recovery state rather than an ACP session workflow.
+- Full first-time-user and power-user shell replay remains Phase 6 scope.
+
+## Closeout Decision: verified
+
+Phase 4 is verified because each required destination now has at least one meaningful workflow or an explicit honest recovery state. The replay covers Skills, MCP, ACP, Library, Workflows, Schedules, Personas, Artifacts, W+C, and Settings ownership, and the evidence distinguishes implemented destination workflows from deferred service-depth work.

--- a/Docs/superpowers/qa/unified-shell/phase-4/README.md
+++ b/Docs/superpowers/qa/unified-shell/phase-4/README.md
@@ -1,6 +1,6 @@
 # Phase 4 QA Evidence
 
-Status: qa-needed
+Status: verified
 
 This directory contains durable QA summaries for Phase 4 destination service adoption slices.
 
@@ -11,9 +11,8 @@ This directory contains durable QA summaries for Phase 4 destination service ado
 - `2026-05-04-library-source-service-adoption.md` - `TASK-5.3` Library destination adoption of local notes, media, and conversation source snapshots plus concrete Console context staging.
 - `2026-05-04-personas-service-adoption.md` - `TASK-5.4` Personas destination adoption of local character and persona profile snapshots plus concrete Console context staging.
 - `2026-05-04-wc-service-adoption.md` - `TASK-5.5` W+C destination adoption of local watchlist source and saved collection snapshots plus concrete Console context staging.
+- `2026-05-05-phase-4-destination-service-adoption-closeout.md` - `TASK-5.6` running-app QA replay for destination service-adoption completion.
 
-## Pending Maturity-Gate QA
+## Closeout
 
-- `2026-05-05-phase-4-destination-service-adoption-closeout.md` - planned `TASK-5.6` running-app QA replay for destination service-adoption completion.
-
-Do not mark Phase 4 verified until Skills, MCP, ACP, Library, Workflows, Schedules, Personas, Artifacts, W+C, and Settings destination workflows are verified through running-app QA evidence or honest recovery states.
+Phase 4 is verified because Skills, MCP, ACP, Library, Workflows, Schedules, Personas, Artifacts, W+C, and Settings destination workflows are covered by running-app QA evidence or honest recovery states.

--- a/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
@@ -1,8 +1,8 @@
 # Unified Shell Maturity Roadmap
 
 Date: 2026-05-05
-Status: Phase 2 and Phase 3 verified; Phase 4 needs maturity-gate QA
-Source Branch: `origin/dev` at `bbeaf32c` plus `codex/unified-shell-phase3-console-closeout`
+Status: Phase 2, Phase 3, and Phase 4 verified; Phase 5 and Phase 6 not started
+Source Branch: `origin/dev` at `4e025bf9` plus `codex/unified-shell-phase4-destination-closeout`
 
 ## Purpose
 
@@ -37,7 +37,7 @@ Track remaining Unified Shell work in one place so rendered screens, clickable b
 - Library now surfaces a local source snapshot from notes, media, and conversations and can stage concrete source context into Console; full Library-native detail views, embedded Import/Export, and embedded Search/RAG remain future work.
 - Personas now surfaces a local behavior snapshot from characters and persona profiles and can stage concrete behavior context into Console; detail, edit, import/export, archetypes, exemplars, dictionaries, and lore remain future work.
 - W+C now surfaces a local monitored-source and saved-collection snapshot from `watchlist_scope_service` and `media_reading_scope_service` and can stage concrete W+C context into Console; full detail, edit, import/export, feed WebSub, alert-rule, retry/backoff, and server collection-feed UX remain future work.
-- Phase 2 and Phase 3 implementation and maturity-gate replays are verified. Phase 4 implementation slices are merged, but its parent phase remains open until `TASK-5.6` replays running-app maturity-gate QA and proves workflows are not render-only or click-only behavior.
+- Phase 2, Phase 3, and Phase 4 implementation and maturity-gate replays are verified. Phase 5 and Phase 6 remain open for shared recovery patterns and full first-time/power-user audit replay.
 
 ## Definition Of Done
 
@@ -116,7 +116,7 @@ Initial child tasks:
 | Phase 1 | `Docs/superpowers/qa/unified-shell/phase-1/` | verified |
 | Phase 2 | `Docs/superpowers/qa/unified-shell/phase-2/` | verified |
 | Phase 3 | `Docs/superpowers/qa/unified-shell/phase-3/` | verified |
-| Phase 4 | `Docs/superpowers/qa/unified-shell/phase-4/` | qa-needed |
+| Phase 4 | `Docs/superpowers/qa/unified-shell/phase-4/` | verified |
 | Phase 5 | `Docs/superpowers/qa/unified-shell/phase-5/` | not-started |
 | Phase 6 | `Docs/superpowers/qa/unified-shell/phase-6/` | not-started |
 
@@ -128,7 +128,7 @@ Initial child tasks:
 | Phase 1: Shell Contract Complete | Remove false shell affordances and prove shell usability. | verified | `TASK-2`, `TASK-2.1`, `TASK-2.2`, `TASK-2.3`, `TASK-2.4` | `phase-1/` | Live service workflows remain intentionally deferred to Phases 2-6. |
 | Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | verified | `TASK-4`, `TASK-4.1`, `TASK-4.2`, `TASK-4.3`, `TASK-4.4`, `TASK-4.5`, `TASK-4.6`, `TASK-4.7`, `TASK-4.8` | `phase-2/` | Schedule and agent-service adapters remain future work; Phase 2 is verified for explicit Home adapter behavior, local W+C/notification flows, and recoverable unavailable states. |
 | Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | verified | `TASK-3`, `TASK-3.1`, `TASK-3.2`, `TASK-3.3`, `TASK-3.4`, `TASK-3.5`, `TASK-3.6`, `TASK-3.7`, `TASK-3.8`, `TASK-3.9`, `TASK-3.10`, `TASK-3.11` | `phase-3/` | ACP, MCP, and durable live event streams remain future work; Phase 3 is verified for implemented Console source launch, follow, status, and recovery flows. |
-| Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | qa-needed | `TASK-5`, `TASK-5.1`, `TASK-5.2`, `TASK-5.3`, `TASK-5.4`, `TASK-5.5`, `TASK-5.6` | `phase-4/` | Implementation slices are merged, but `TASK-5.6` must replay running-app QA before the parent phase can be verified. |
+| Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | verified | `TASK-5`, `TASK-5.1`, `TASK-5.2`, `TASK-5.3`, `TASK-5.4`, `TASK-5.5`, `TASK-5.6` | `phase-4/` | Full CRUD/server-parity depth remains future work; Phase 4 is verified for destination ownership, concrete local workflows, Console staging, and honest recovery states. |
 | Phase 5: Capability And Recovery System | Systematize unavailable and blocked states. | not-started | `TASK-6` | `phase-5/` | Shared taxonomy not yet extracted. |
 | Phase 6: Audit Replay And Closeout | Prove shell works for first-time and power users. | not-started | `TASK-7` | `phase-6/` | Depends on prior phases and running-app QA. |
 
@@ -312,9 +312,9 @@ Initial audit result: W+C, Schedules, Workflows, and ACP had false Console-launc
 
 ## Phase 4.6 Destination Service-Adoption Maturity-Gate QA
 
-`TASK-5.6` must replay destination service-adoption workflows in the running app before `TASK-5` can be verified:
+`TASK-5.6` replays destination service-adoption workflows in the running app and closes `TASK-5` as verified:
 
-- Planned evidence path: `Docs/superpowers/qa/unified-shell/phase-4/2026-05-05-phase-4-destination-service-adoption-closeout.md`
+- `Docs/superpowers/qa/unified-shell/phase-4/2026-05-05-phase-4-destination-service-adoption-closeout.md`
 
 ## Phase 0: Canonical Tracking
 

--- a/Tests/UI/test_unified_shell_phase234_maturity_gate.py
+++ b/Tests/UI/test_unified_shell_phase234_maturity_gate.py
@@ -5,21 +5,6 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 ROADMAP = Path("Docs/superpowers/trackers/unified-shell-maturity-roadmap.md")
-PHASE_2_CLOSEOUT_METADATA = re.compile(
-    r"<!-- PHASE_2_CLOSEOUT_METADATA:BEGIN -->\s*```json\s*(.*?)\s*```\s*"
-    r"<!-- PHASE_2_CLOSEOUT_METADATA:END -->",
-    re.DOTALL,
-)
-PHASE_3_CLOSEOUT_METADATA = re.compile(
-    r"<!-- PHASE_3_CLOSEOUT_METADATA:BEGIN -->\s*```json\s*(.*?)\s*```\s*"
-    r"<!-- PHASE_3_CLOSEOUT_METADATA:END -->",
-    re.DOTALL,
-)
-PHASE_4_CLOSEOUT_METADATA = re.compile(
-    r"<!-- PHASE_4_CLOSEOUT_METADATA:BEGIN -->\s*```json\s*(.*?)\s*```\s*"
-    r"<!-- PHASE_4_CLOSEOUT_METADATA:END -->",
-    re.DOTALL,
-)
 
 PHASES = {
     "Phase 2": {
@@ -91,21 +76,14 @@ def _markdown_path(path: Path) -> str:
     return relative_path.as_posix()
 
 
-def _phase_two_closeout_metadata(text: str) -> dict:
-    metadata_match = PHASE_2_CLOSEOUT_METADATA.search(text)
-    assert metadata_match is not None
-    return json.loads(metadata_match.group(1))
-
-
-def _phase_three_closeout_metadata(text: str) -> dict:
-    metadata_match = PHASE_3_CLOSEOUT_METADATA.search(text)
-    assert metadata_match is not None
-    return json.loads(metadata_match.group(1))
-
-
-def _phase_four_closeout_metadata(text: str) -> dict:
-    metadata_match = PHASE_4_CLOSEOUT_METADATA.search(text)
-    assert metadata_match is not None
+def _extract_phase_metadata(text: str, phase_number: int) -> dict:
+    metadata_pattern = re.compile(
+        rf"<!-- PHASE_{phase_number}_CLOSEOUT_METADATA:BEGIN -->\s*```json\s*(.*?)\s*```\s*"
+        rf"<!-- PHASE_{phase_number}_CLOSEOUT_METADATA:END -->",
+        re.DOTALL,
+    )
+    metadata_match = metadata_pattern.search(text)
+    assert metadata_match is not None, f"Metadata for Phase {phase_number} not found"
     return json.loads(metadata_match.group(1))
 
 
@@ -149,7 +127,7 @@ def test_phase_two_three_four_closeout_tasks_record_current_parent_status():
 def test_phase_two_closeout_doc_records_verified_workflows_and_task_completion():
     phase = PHASES["Phase 2"]
     closeout_text = _text(phase["closeout_doc"])
-    metadata = _phase_two_closeout_metadata(closeout_text)
+    metadata = _extract_phase_metadata(closeout_text, 2)
 
     assert "/Users/" not in closeout_text
     assert metadata["closeout_task"] == "TASK-4.8"
@@ -186,7 +164,7 @@ def test_phase_two_closeout_doc_records_verified_workflows_and_task_completion()
 def test_phase_three_closeout_doc_records_verified_workflows_and_task_completion():
     phase = PHASES["Phase 3"]
     closeout_text = _text(phase["closeout_doc"])
-    metadata = _phase_three_closeout_metadata(closeout_text)
+    metadata = _extract_phase_metadata(closeout_text, 3)
 
     assert "/Users/" not in closeout_text
     assert metadata["closeout_task"] == "TASK-3.11"
@@ -227,7 +205,7 @@ def test_phase_three_closeout_doc_records_verified_workflows_and_task_completion
 def test_phase_four_closeout_doc_records_verified_destinations_and_task_completion():
     phase = PHASES["Phase 4"]
     closeout_text = _text(phase["closeout_doc"])
-    metadata = _phase_four_closeout_metadata(closeout_text)
+    metadata = _extract_phase_metadata(closeout_text, 4)
 
     assert "/Users/" not in closeout_text
     assert metadata["closeout_task"] == "TASK-5.6"

--- a/Tests/UI/test_unified_shell_phase234_maturity_gate.py
+++ b/Tests/UI/test_unified_shell_phase234_maturity_gate.py
@@ -15,6 +15,11 @@ PHASE_3_CLOSEOUT_METADATA = re.compile(
     r"<!-- PHASE_3_CLOSEOUT_METADATA:END -->",
     re.DOTALL,
 )
+PHASE_4_CLOSEOUT_METADATA = re.compile(
+    r"<!-- PHASE_4_CLOSEOUT_METADATA:BEGIN -->\s*```json\s*(.*?)\s*```\s*"
+    r"<!-- PHASE_4_CLOSEOUT_METADATA:END -->",
+    re.DOTALL,
+)
 
 PHASES = {
     "Phase 2": {
@@ -57,7 +62,7 @@ PHASES = {
     },
     "Phase 4": {
         "qa_dir": "phase-4",
-        "status": "qa-needed",
+        "status": "verified",
         "parent_task": "TASK-5",
         "closeout_task": "TASK-5.6",
         "parent_task_file": Path("backlog/tasks/task-5 - Phase-4-Destination-Service-Adoption.md"),
@@ -70,9 +75,9 @@ PHASES = {
         ),
         "overview_row": (
             "| Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | "
-            "qa-needed |"
+            "verified |"
         ),
-        "task_status": "To Do",
+        "task_status": "Done",
     },
 }
 
@@ -98,10 +103,16 @@ def _phase_three_closeout_metadata(text: str) -> dict:
     return json.loads(metadata_match.group(1))
 
 
+def _phase_four_closeout_metadata(text: str) -> dict:
+    metadata_match = PHASE_4_CLOSEOUT_METADATA.search(text)
+    assert metadata_match is not None
+    return json.loads(metadata_match.group(1))
+
+
 def test_phase_two_three_four_roadmap_and_indexes_record_current_gate_status():
     roadmap_text = _text(ROADMAP)
 
-    assert "Status: Phase 2 and Phase 3 verified; Phase 4 needs maturity-gate QA" in roadmap_text
+    assert "Status: Phase 2, Phase 3, and Phase 4 verified; Phase 5 and Phase 6 not started" in roadmap_text
 
     for phase_name, phase in PHASES.items():
         qa_row = (
@@ -196,6 +207,54 @@ def test_phase_three_closeout_doc_records_verified_workflows_and_task_completion
     ]
     assert metadata["source_readiness"]["acp"] == "not_wired_recoverable"
     assert metadata["source_readiness"]["mcp"] == "not_wired_recoverable"
+    assert metadata["final_focused_replay_result"]["failed"] == 0
+    assert metadata["final_focused_replay_result"]["passed"] > 0
+    assert metadata["final_broader_replay_result"]["failed"] == 0
+    assert metadata["final_broader_replay_result"]["passed"] >= metadata["final_focused_replay_result"]["passed"]
+
+    parent_text = _text(phase["parent_task_file"])
+    assert "status: Done" in parent_text
+    for acceptance_criterion in range(1, 5):
+        assert f"- [x] #{acceptance_criterion}" in parent_text
+
+    task_text = _text(phase["task_file"])
+    assert "status: Done" in task_text
+    for acceptance_criterion in range(1, 5):
+        assert f"- [x] #{acceptance_criterion}" in task_text
+    assert "Implementation Notes" in task_text
+
+
+def test_phase_four_closeout_doc_records_verified_destinations_and_task_completion():
+    phase = PHASES["Phase 4"]
+    closeout_text = _text(phase["closeout_doc"])
+    metadata = _phase_four_closeout_metadata(closeout_text)
+
+    assert "/Users/" not in closeout_text
+    assert metadata["closeout_task"] == "TASK-5.6"
+    assert metadata["parent_task"] == "TASK-5"
+    assert metadata["decision"] == "verified"
+    assert metadata["verified_destinations"] == [
+        "mcp",
+        "skills",
+        "library",
+        "personas",
+        "watchlists-collections",
+        "schedules",
+        "workflows",
+        "artifacts",
+        "settings",
+    ]
+    assert metadata["verified_recovery_destinations"] == ["acp"]
+    assert metadata["destination_readiness"]["mcp"] == "connected"
+    assert metadata["destination_readiness"]["skills"] == "connected"
+    assert metadata["destination_readiness"]["library"] == "connected"
+    assert metadata["destination_readiness"]["personas"] == "connected"
+    assert metadata["destination_readiness"]["watchlists-collections"] == "connected"
+    assert metadata["destination_readiness"]["schedules"] == "connected_or_recoverable"
+    assert metadata["destination_readiness"]["workflows"] == "connected_or_recoverable"
+    assert metadata["destination_readiness"]["artifacts"] == "connected_or_recoverable"
+    assert metadata["destination_readiness"]["settings"] == "connected"
+    assert metadata["destination_readiness"]["acp"] == "runtime_not_configured_recoverable"
     assert metadata["final_focused_replay_result"]["failed"] == 0
     assert metadata["final_focused_replay_result"]["passed"] > 0
     assert metadata["final_broader_replay_result"]["failed"] == 0

--- a/backlog/tasks/task-5 - Phase-4-Destination-Service-Adoption.md
+++ b/backlog/tasks/task-5 - Phase-4-Destination-Service-Adoption.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-5
 title: 'Phase 4: Destination Service Adoption'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-03 14:47'
-updated_date: '2026-05-05 00:19'
+updated_date: '2026-05-05 01:57'
 labels:
   - unified-shell
   - phase-4
@@ -24,10 +24,10 @@ Turn top-level wrappers into useful product surfaces by adopting real services a
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Each destination supports at least one meaningful end-to-end workflow or an honest recovery state.
-- [ ] #2 Skills, MCP, ACP, Library, Workflows, Schedules, Personas, Artifacts, W+C, and Settings ownership is explicit.
-- [ ] #3 Running-app QA verifies destination workflows rather than render-only behavior.
-- [ ] #4 Durable QA summaries exist under Docs/superpowers/qa/unified-shell/phase-4/.
+- [x] #1 Each destination supports at least one meaningful end-to-end workflow or an honest recovery state.
+- [x] #2 Skills, MCP, ACP, Library, Workflows, Schedules, Personas, Artifacts, W+C, and Settings ownership is explicit.
+- [x] #3 Running-app QA verifies destination workflows rather than render-only behavior.
+- [x] #4 Durable QA summaries exist under Docs/superpowers/qa/unified-shell/phase-4/.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -37,3 +37,9 @@ Turn top-level wrappers into useful product surfaces by adopting real services a
 2. Keep parent TASK-5 open until TASK-5.6 completes maturity-gate QA in the running app.
 3. Use TASK-5.6 to decide whether each top-level destination has a meaningful workflow or honest recovery state, and whether deeper service gaps need explicit follow-up blockers.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Closed Phase 4 through TASK-5.6 maturity-gate replay. Destination wrappers now have durable QA evidence for meaningful local workflows, Console staging, explicit ownership, or honest recovery states across Skills, MCP, ACP, Library, Workflows, Schedules, Personas, Artifacts, W+C, and Settings. Full CRUD/server-parity depth remains tracked as later-phase residual risk, not a Phase 4 blocker.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-5.6 - Phase-4.6-Replay-destination-service-adoption-maturity-gate.md
+++ b/backlog/tasks/task-5.6 - Phase-4.6-Replay-destination-service-adoption-maturity-gate.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-5.6
 title: Phase 4.6 Replay destination service-adoption maturity gate
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-05-05 00:19'
+updated_date: '2026-05-05 01:57'
 labels:
   - unified-shell
   - phase-4
@@ -23,8 +24,24 @@ Replay Phase 4 destination service-adoption workflows in the running app and dec
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 running-app QA walkthrough verifies each destination has at least one meaningful workflow or an honest recovery state
-- [ ] #2 QA evidence covers Skills MCP ACP Library Workflows Schedules Personas Artifacts W+C and Settings ownership
-- [ ] #3 QA evidence proves destination workflows are not render-only or click-only behavior
-- [ ] #4 Phase 4 roadmap README and parent task status are updated from the walkthrough result
+- [x] #1 running-app QA walkthrough verifies each destination has at least one meaningful workflow or an honest recovery state
+- [x] #2 QA evidence covers Skills MCP ACP Library Workflows Schedules Personas Artifacts W+C and Settings ownership
+- [x] #3 QA evidence proves destination workflows are not render-only or click-only behavior
+- [x] #4 Phase 4 roadmap README and parent task status are updated from the walkthrough result
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Re-read Phase 4 child evidence and destination shell tests to define the maturity-gate checklist.
+2. Run focused destination service-adoption tests that exercise MCP, Skills, Library, Personas, W+C, Workflows, Schedules, Artifacts, ACP, and Settings workflows/recovery states.
+3. Record a Phase 4 closeout QA artifact with exact verification output, workflow matrix, defects, and residual risks.
+4. Update Phase 4 README, roadmap, and parent task status according to the QA result without marking Phase 4 verified unless the evidence supports it.
+5. Add or update a tracking regression test so the closeout state cannot drift.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added the Phase 4 closeout contract and durable QA artifact for destination service adoption. Updated the Phase 4 README and maturity roadmap to verified after replaying destination wrapper, shell navigation, Console handoff, and maturity-gate tests. The closeout verifies Skills, MCP, ACP, Library, Workflows, Schedules, Personas, Artifacts, W+C, and Settings ownership with meaningful workflows or honest recovery states.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary
- add the Phase 4 destination service-adoption closeout QA artifact
- update Phase 4 README, maturity roadmap, and Backlog tasks to verified/Done
- extend the Phase 2/3/4 maturity-gate test to require Phase 4 metadata, task completion, and verified destination ownership

## Verification
- python3 -m pytest Tests/UI/test_unified_shell_phase234_maturity_gate.py -q -> 5 passed
- python3 -m pytest Tests/UI/test_destination_shells.py Tests/UI/test_shell_destinations.py Tests/UI/test_master_shell_navigation.py Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_unified_shell_phase234_maturity_gate.py -q -> 127 passed, 1 warning
- git diff --check -> clean