### PR TITLE
Define Phase 5 recovery taxonomy

### DIFF
--- a/Docs/superpowers/qa/unified-shell/phase-5/2026-05-05-shared-recovery-taxonomy.md
+++ b/Docs/superpowers/qa/unified-shell/phase-5/2026-05-05-shared-recovery-taxonomy.md
@@ -1,0 +1,159 @@
+# Phase 5.1 Shared Recovery Taxonomy
+
+Date: 2026-05-05
+Task: `TASK-6.1`
+Parent Task: `TASK-6`
+Branch: `codex/unified-shell-phase5-recovery-taxonomy`
+Base: `origin/dev` at `42b2ac1e`
+
+<!-- PHASE_5_1_RECOVERY_TAXONOMY_METADATA:BEGIN -->
+```json
+{
+  "task": "TASK-6.1",
+  "parent_task": "TASK-6",
+  "decision": "foundation_defined",
+  "required_user_fields": [
+    "status_label",
+    "unavailable_what",
+    "why",
+    "next_action",
+    "recovery_action",
+    "authority_owner",
+    "stable_selector",
+    "disabled_tooltip"
+  ],
+  "canonical_states": [
+    "wrong_source",
+    "server_not_configured",
+    "server_unreachable",
+    "server_auth_required",
+    "server_session_invalid",
+    "policy_denied",
+    "capability_disabled",
+    "runtime_not_configured",
+    "service_unavailable",
+    "dependency_missing",
+    "empty_selection"
+  ],
+  "runtime_policy_reason_codes": [
+    "wrong_source",
+    "server_not_configured",
+    "server_unreachable",
+    "server_auth_required",
+    "server_session_invalid",
+    "authority_denied",
+    "capability_disabled"
+  ],
+  "destination_recovery_sources": [
+    "phase-1-destination-action-audit",
+    "phase-3-console-live-work-closeout",
+    "phase-4-destination-service-adoption-closeout",
+    "runtime-policy-domain-edge-contracts"
+  ]
+}
+```
+<!-- PHASE_5_1_RECOVERY_TAXONOMY_METADATA:END -->
+
+## Goal
+
+Define one shell-level recovery contract for blocked states so future Phase 5 slices can make dependency, auth, server, runtime, policy, and selection failures understandable without inventing copy and selectors screen by screen.
+
+This taxonomy sits above the existing `runtime_policy` package. It does not replace `PolicyDecision`, `PolicyDeniedError`, domain edge contracts, or service hard stops. It defines how those decisions should appear in the Unified Shell.
+
+## Required User-Facing Fields
+
+Every blocked state that appears in a visible shell or destination control should expose these fields:
+
+| Field | Requirement |
+| --- | --- |
+| `status_label` | Short state label such as `Server unavailable`, `Runtime not configured`, or `Select an item`. |
+| `unavailable_what` | The specific workflow or control that cannot run. |
+| `why` | The immediate reason in user language, mapped to a fixed policy or recovery state when possible. |
+| `next_action` | The next concrete user step, not generic failure copy. |
+| `recovery_action` | The target route, retry action, setup action, or selection action when one exists. |
+| `authority_owner` | The owner of the capability: local app, active server, shared backend, runtime, optional dependency, or user selection. |
+| `stable_selector` | A stable test selector for the blocked message or disabled control. |
+| `disabled_tooltip` | Tooltip copy on disabled controls that repeats the missing prerequisite or next action. |
+
+## Canonical States
+
+| Canonical state | Maps from | Required recovery behavior |
+| --- | --- | --- |
+| `wrong_source` | `PolicyDecision.reason_code == "wrong_source"` | Name the required source and offer the source switch or existing route when available. |
+| `server_not_configured` | `PolicyDecision.reason_code == "server_not_configured"` or `ServerContextFailure.reason_code == "server_not_configured"` | Point to server setup or Settings; do not imply retry will work without configuration. |
+| `server_unreachable` | `server_unreachable`, `server_unavailable`, or request-time connectivity classification | Offer retry and preserve local alternatives when they exist. |
+| `server_auth_required` | `server_auth_required`, `auth_required`, or credential-missing context | Point to sign-in or credential setup; do not hide the server-owned workflow. |
+| `server_session_invalid` | `server_session_invalid`, `stale_authorization`, or `profile_no_longer_authorized` | Tell the user to re-authenticate or reconnect the active server profile. |
+| `policy_denied` | `authority_denied`, `permission_denied`, or workspace policy denial | State that policy blocks the action and identify the authority owner where possible. |
+| `capability_disabled` | `capability_disabled` or feature flag disabled | State that the feature is disabled and where it must be enabled. |
+| `runtime_not_configured` | ACP runtime missing, local model runtime missing, or tool runtime missing | Name the missing runtime and the setup path. |
+| `service_unavailable` | Missing app service seam, failed local service lookup, or service exception | Offer retry only if retry can re-run the lookup; otherwise point to setup or later-phase work. |
+| `dependency_missing` | Optional dependency unavailable | Name the dependency or feature extra and point to install/setup guidance. |
+| `empty_selection` | No selected item, no active run, no artifact, or no local record | Tell users what to select or create before the action can run. |
+
+## Copy Contract
+
+Blocked-state copy should follow this shape:
+
+`<Workflow> is unavailable because <reason>. <Next action>.`
+
+Examples:
+
+| State | Good shell copy |
+| --- | --- |
+| `wrong_source` | `Server notes are unavailable in local mode. Switch to Server to browse server notes.` |
+| `server_not_configured` | `Sharing requires a configured server. Add a server profile in Settings before sharing.` |
+| `runtime_not_configured` | `ACP launch is unavailable because no ACP-compatible runtime is configured. Configure an ACP runtime before launch.` |
+| `empty_selection` | `Use in Console is unavailable until a Library source is available. Add or select a source first.` |
+
+Avoid these patterns:
+
+| Pattern | Why it fails |
+| --- | --- |
+| `Unavailable` alone | It omits what is blocked and what to do next. |
+| `Try again later` for configuration gaps | Retry cannot fix missing setup. |
+| Enabled-looking buttons that only notify failure | They create false affordances unless the click itself is a meaningful retry or setup action. |
+| Generic service-error copy for policy denial | Policy denial needs the authority owner, not a retry suggestion. |
+
+## Application Rules
+
+- Disabled controls must carry `disabled_tooltip` copy unless the blocked explanation is directly adjacent and focusable.
+- Recovery copy must be visible in the same panel as the disabled action or in a reachable status row.
+- A blocked state counts as honest recovery only when the user can identify what is unavailable, why, and what to do next without reading logs.
+- Retry controls are valid only for transient service, connectivity, or refresh states.
+- Setup controls are preferred for missing configuration, auth, runtime, or dependency states.
+- Selection states should preserve power-user speed by enabling immediately when a valid item appears.
+- Tests should verify both visible copy and disabled tooltip text for representative controls.
+
+## Source Alignment
+
+This taxonomy is grounded in existing repo contracts:
+
+| Source | Used for |
+| --- | --- |
+| `runtime_policy.types.PolicyDecision` | Fixed policy reason codes and authority owner fields. |
+| `runtime_policy.types.ServerContextFailure` | Server setup, credentials, authorization, and reachability states. |
+| `runtime_policy.domain_edge_contracts` | Domain ownership and unsupported action reports. |
+| `Docs/superpowers/qa/unified-shell/phase-1/2026-05-03-destination-action-audit.md` | Honest blocked-state baseline and false-affordance examples. |
+| `Docs/superpowers/qa/unified-shell/phase-3/2026-05-05-phase-3-console-live-work-closeout.md` | Console source-readiness recovery states. |
+| `Docs/superpowers/qa/unified-shell/phase-4/2026-05-05-phase-4-destination-service-adoption-closeout.md` | Destination recovery states for ACP, Schedules, Workflows, and Artifacts. |
+
+## Next Slices
+
+Phase 5.2 should apply this contract to the highest-impact remaining blocker-state family first. The likely order is:
+
+1. Shell destination blocked states: ACP runtime, Schedules empty active run, Workflows empty active run, Artifacts empty Chatbook.
+2. Runtime-policy blocked states: wrong source, server not configured, server auth/session, policy denied.
+3. Optional dependency states: local model, speech, transcription, embeddings/RAG extras.
+4. Selection and empty-data states that still expose generic disabled copy.
+
+## Verification
+
+- Red regression: `python3 -m pytest Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py -q`
+- Red result before this artifact existed: `2 failed`
+- Final focused verification: `python3 -m pytest Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py Tests/UI/test_unified_shell_phase234_maturity_gate.py -q`
+- Final focused result: `7 passed`
+
+## Closeout Decision: foundation_defined
+
+`TASK-6.1` defines the shared recovery taxonomy and tracking contract. It does not mark Phase 5 verified; `TASK-6` remains open until later slices apply the taxonomy to remaining blockers and running-app QA verifies understandable recovery paths.

--- a/Docs/superpowers/qa/unified-shell/phase-5/2026-05-05-shared-recovery-taxonomy.md
+++ b/Docs/superpowers/qa/unified-shell/phase-5/2026-05-05-shared-recovery-taxonomy.md
@@ -38,10 +38,18 @@ Base: `origin/dev` at `42b2ac1e`
   "runtime_policy_reason_codes": [
     "wrong_source",
     "server_not_configured",
+    "server_profile_missing",
     "server_unreachable",
+    "server_unavailable",
     "server_auth_required",
+    "auth_required",
+    "credential_store_unavailable",
+    "server_credentials_unavailable",
     "server_session_invalid",
+    "stale_authorization",
+    "profile_no_longer_authorized",
     "authority_denied",
+    "permission_denied",
     "capability_disabled"
   ],
   "destination_recovery_sources": [
@@ -80,9 +88,9 @@ Every blocked state that appears in a visible shell or destination control shoul
 | Canonical state | Maps from | Required recovery behavior |
 | --- | --- | --- |
 | `wrong_source` | `PolicyDecision.reason_code == "wrong_source"` | Name the required source and offer the source switch or existing route when available. |
-| `server_not_configured` | `PolicyDecision.reason_code == "server_not_configured"` or `ServerContextFailure.reason_code == "server_not_configured"` | Point to server setup or Settings; do not imply retry will work without configuration. |
+| `server_not_configured` | `PolicyDecision.reason_code == "server_not_configured"` or `ServerContextFailure.reason_code` in `["server_not_configured", "server_profile_missing"]` | Point to server setup or Settings; do not imply retry will work without configuration. |
 | `server_unreachable` | `server_unreachable`, `server_unavailable`, or request-time connectivity classification | Offer retry and preserve local alternatives when they exist. |
-| `server_auth_required` | `server_auth_required`, `auth_required`, or credential-missing context | Point to sign-in or credential setup; do not hide the server-owned workflow. |
+| `server_auth_required` | `server_auth_required`, `auth_required`, `credential_store_unavailable`, `server_credentials_unavailable`, or credential-missing context | Point to sign-in or credential setup; do not hide the server-owned workflow. |
 | `server_session_invalid` | `server_session_invalid`, `stale_authorization`, or `profile_no_longer_authorized` | Tell the user to re-authenticate or reconnect the active server profile. |
 | `policy_denied` | `authority_denied`, `permission_denied`, or workspace policy denial | State that policy blocks the action and identify the authority owner where possible. |
 | `capability_disabled` | `capability_disabled` or feature flag disabled | State that the feature is disabled and where it must be enabled. |

--- a/Docs/superpowers/qa/unified-shell/phase-5/README.md
+++ b/Docs/superpowers/qa/unified-shell/phase-5/README.md
@@ -1,5 +1,9 @@
 # Phase 5 QA Evidence
 
-Status: not-started
+Status: in-progress
 
-This directory will contain durable QA summaries for this phase. Do not mark the phase verified until running-app walkthrough evidence exists here.
+This directory contains durable QA summaries for Phase 5 capability-state and recovery work. Do not mark the phase verified until running-app walkthrough evidence proves blocked states are understandable and recoverable.
+
+## Evidence
+
+- `2026-05-05-shared-recovery-taxonomy.md` - `TASK-6.1` shared recovery taxonomy for missing dependency, auth, server, runtime, policy, service, and selection states.

--- a/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
@@ -1,8 +1,8 @@
 # Unified Shell Maturity Roadmap
 
 Date: 2026-05-05
-Status: Phase 2, Phase 3, and Phase 4 verified; Phase 5 and Phase 6 not started
-Source Branch: `origin/dev` at `4e025bf9` plus `codex/unified-shell-phase4-destination-closeout`
+Status: Phase 2, Phase 3, and Phase 4 verified; Phase 5 in progress; Phase 6 not started
+Source Branch: `origin/dev` at `42b2ac1e` plus `codex/unified-shell-phase5-recovery-taxonomy`
 
 ## Purpose
 
@@ -37,7 +37,7 @@ Track remaining Unified Shell work in one place so rendered screens, clickable b
 - Library now surfaces a local source snapshot from notes, media, and conversations and can stage concrete source context into Console; full Library-native detail views, embedded Import/Export, and embedded Search/RAG remain future work.
 - Personas now surfaces a local behavior snapshot from characters and persona profiles and can stage concrete behavior context into Console; detail, edit, import/export, archetypes, exemplars, dictionaries, and lore remain future work.
 - W+C now surfaces a local monitored-source and saved-collection snapshot from `watchlist_scope_service` and `media_reading_scope_service` and can stage concrete W+C context into Console; full detail, edit, import/export, feed WebSub, alert-rule, retry/backoff, and server collection-feed UX remain future work.
-- Phase 2, Phase 3, and Phase 4 implementation and maturity-gate replays are verified. Phase 5 and Phase 6 remain open for shared recovery patterns and full first-time/power-user audit replay.
+- Phase 2, Phase 3, and Phase 4 implementation and maturity-gate replays are verified. Phase 5 is in progress with a shared recovery taxonomy; Phase 6 remains open for full first-time/power-user audit replay.
 
 ## Definition Of Done
 
@@ -107,6 +107,7 @@ Initial child tasks:
 - Phase 4.4: Adopt Personas service in Personas destination - `TASK-5.4`
 - Phase 4.5: Adopt W+C services in W+C destination - `TASK-5.5`
 - Phase 4.6: Replay destination service-adoption maturity gate - `TASK-5.6`
+- Phase 5.1: Create shared recovery taxonomy - `TASK-6.1`
 
 ## QA Evidence Index
 
@@ -117,7 +118,7 @@ Initial child tasks:
 | Phase 2 | `Docs/superpowers/qa/unified-shell/phase-2/` | verified |
 | Phase 3 | `Docs/superpowers/qa/unified-shell/phase-3/` | verified |
 | Phase 4 | `Docs/superpowers/qa/unified-shell/phase-4/` | verified |
-| Phase 5 | `Docs/superpowers/qa/unified-shell/phase-5/` | not-started |
+| Phase 5 | `Docs/superpowers/qa/unified-shell/phase-5/` | in-progress |
 | Phase 6 | `Docs/superpowers/qa/unified-shell/phase-6/` | not-started |
 
 ## Phase Overview
@@ -129,7 +130,7 @@ Initial child tasks:
 | Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | verified | `TASK-4`, `TASK-4.1`, `TASK-4.2`, `TASK-4.3`, `TASK-4.4`, `TASK-4.5`, `TASK-4.6`, `TASK-4.7`, `TASK-4.8` | `phase-2/` | Schedule and agent-service adapters remain future work; Phase 2 is verified for explicit Home adapter behavior, local W+C/notification flows, and recoverable unavailable states. |
 | Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | verified | `TASK-3`, `TASK-3.1`, `TASK-3.2`, `TASK-3.3`, `TASK-3.4`, `TASK-3.5`, `TASK-3.6`, `TASK-3.7`, `TASK-3.8`, `TASK-3.9`, `TASK-3.10`, `TASK-3.11` | `phase-3/` | ACP, MCP, and durable live event streams remain future work; Phase 3 is verified for implemented Console source launch, follow, status, and recovery flows. |
 | Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | verified | `TASK-5`, `TASK-5.1`, `TASK-5.2`, `TASK-5.3`, `TASK-5.4`, `TASK-5.5`, `TASK-5.6` | `phase-4/` | Full CRUD/server-parity depth remains future work; Phase 4 is verified for destination ownership, concrete local workflows, Console staging, and honest recovery states. |
-| Phase 5: Capability And Recovery System | Systematize unavailable and blocked states. | not-started | `TASK-6` | `phase-5/` | Shared taxonomy not yet extracted. |
+| Phase 5: Capability And Recovery System | Systematize unavailable and blocked states. | in-progress | `TASK-6`, `TASK-6.1` | `phase-5/` | Shared recovery taxonomy is defined; remaining blocker-state families still need application and running-app QA. |
 | Phase 6: Audit Replay And Closeout | Prove shell works for first-time and power users. | not-started | `TASK-7` | `phase-6/` | Depends on prior phases and running-app QA. |
 
 ## Phase 1.1 QA Harness Evidence
@@ -315,6 +316,12 @@ Initial audit result: W+C, Schedules, Workflows, and ACP had false Console-launc
 `TASK-5.6` replays destination service-adoption workflows in the running app and closes `TASK-5` as verified:
 
 - `Docs/superpowers/qa/unified-shell/phase-4/2026-05-05-phase-4-destination-service-adoption-closeout.md`
+
+## Phase 5.1 Shared Recovery Taxonomy
+
+`TASK-6.1` defines the shell-level recovery taxonomy that later Phase 5 slices must apply to blocked dependency, auth, server, runtime, policy, service, and selection states:
+
+- `Docs/superpowers/qa/unified-shell/phase-5/2026-05-05-shared-recovery-taxonomy.md`
 
 ## Phase 0: Canonical Tracking
 

--- a/Tests/UI/test_unified_shell_phase234_maturity_gate.py
+++ b/Tests/UI/test_unified_shell_phase234_maturity_gate.py
@@ -90,7 +90,7 @@ def _extract_phase_metadata(text: str, phase_number: int) -> dict:
 def test_phase_two_three_four_roadmap_and_indexes_record_current_gate_status():
     roadmap_text = _text(ROADMAP)
 
-    assert "Status: Phase 2, Phase 3, and Phase 4 verified; Phase 5 and Phase 6 not started" in roadmap_text
+    assert "Status: Phase 2, Phase 3, and Phase 4 verified; Phase 5 in progress; Phase 6 not started" in roadmap_text
 
     for phase_name, phase in PHASES.items():
         qa_row = (

--- a/Tests/UI/test_unified_shell_phase234_maturity_gate.py
+++ b/Tests/UI/test_unified_shell_phase234_maturity_gate.py
@@ -71,6 +71,19 @@ def _text(path: Path) -> str:
     return resolved_path.read_text(encoding="utf-8")
 
 
+def _assert_roadmap_status_tracks_current_phase_progress(roadmap_text: str) -> None:
+    status_match = re.search(r"^Status:\s*(.+)$", roadmap_text, re.MULTILINE)
+    assert status_match is not None
+    normalized_status = status_match.group(1).lower().replace("-", " ")
+
+    assert "phase 2" in normalized_status
+    assert "phase 3" in normalized_status
+    assert "phase 4" in normalized_status
+    assert "verified" in normalized_status
+    assert re.search(r"phase\s+5\s+in\s+progress", normalized_status)
+    assert re.search(r"phase\s+6\s+not\s+started", normalized_status)
+
+
 def _markdown_path(path: Path) -> str:
     relative_path = path.relative_to(REPO_ROOT) if path.is_absolute() else path
     return relative_path.as_posix()
@@ -90,7 +103,7 @@ def _extract_phase_metadata(text: str, phase_number: int) -> dict:
 def test_phase_two_three_four_roadmap_and_indexes_record_current_gate_status():
     roadmap_text = _text(ROADMAP)
 
-    assert "Status: Phase 2, Phase 3, and Phase 4 verified; Phase 5 in progress; Phase 6 not started" in roadmap_text
+    _assert_roadmap_status_tracks_current_phase_progress(roadmap_text)
 
     for phase_name, phase in PHASES.items():
         qa_row = (

--- a/Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py
+++ b/Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py
@@ -1,0 +1,99 @@
+import json
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ROADMAP = Path("Docs/superpowers/trackers/unified-shell-maturity-roadmap.md")
+PHASE_5_README = Path("Docs/superpowers/qa/unified-shell/phase-5/README.md")
+PHASE_5_TAXONOMY = Path(
+    "Docs/superpowers/qa/unified-shell/phase-5/2026-05-05-shared-recovery-taxonomy.md"
+)
+PHASE_5_PARENT_TASK = Path("backlog/tasks/task-6 - Phase-5-Capability-And-Recovery-System.md")
+PHASE_5_TAXONOMY_TASK = Path("backlog/tasks/task-6.1 - Phase-5.1-Create-shared-recovery-taxonomy.md")
+
+
+def _text(path: Path) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def _taxonomy_metadata(text: str) -> dict:
+    metadata_match = re.search(
+        r"<!-- PHASE_5_1_RECOVERY_TAXONOMY_METADATA:BEGIN -->\s*```json\s*(.*?)\s*```\s*"
+        r"<!-- PHASE_5_1_RECOVERY_TAXONOMY_METADATA:END -->",
+        text,
+        re.DOTALL,
+    )
+    assert metadata_match is not None
+    return json.loads(metadata_match.group(1))
+
+
+def test_phase_five_recovery_taxonomy_is_tracked_from_roadmap_readme_and_tasks():
+    roadmap = _text(ROADMAP)
+    readme = _text(PHASE_5_README)
+    parent_task = _text(PHASE_5_PARENT_TASK)
+    child_task = _text(PHASE_5_TAXONOMY_TASK)
+
+    assert "Status: Phase 2, Phase 3, and Phase 4 verified; Phase 5 in progress; Phase 6 not started" in roadmap
+    assert "| Phase 5 | `Docs/superpowers/qa/unified-shell/phase-5/` | in-progress |" in roadmap
+    assert "Phase 5.1: Create shared recovery taxonomy - `TASK-6.1`" in roadmap
+    assert "2026-05-05-shared-recovery-taxonomy.md" in roadmap
+
+    assert "Status: in-progress" in readme
+    assert "`TASK-6.1`" in readme
+    assert "2026-05-05-shared-recovery-taxonomy.md" in readme
+
+    assert "status: In Progress" in parent_task
+    assert "TASK-6.1" in parent_task
+    assert "status: Done" in child_task
+    for acceptance_criterion in range(1, 5):
+        assert f"- [x] #{acceptance_criterion}" in child_task
+    assert "Implementation Notes" in child_task
+
+
+def test_phase_five_recovery_taxonomy_defines_required_contract_and_reason_mappings():
+    taxonomy = _text(PHASE_5_TAXONOMY)
+    metadata = _taxonomy_metadata(taxonomy)
+
+    assert "/Users/" not in taxonomy
+    assert metadata["task"] == "TASK-6.1"
+    assert metadata["parent_task"] == "TASK-6"
+    assert metadata["decision"] == "foundation_defined"
+    assert metadata["required_user_fields"] == [
+        "status_label",
+        "unavailable_what",
+        "why",
+        "next_action",
+        "recovery_action",
+        "authority_owner",
+        "stable_selector",
+        "disabled_tooltip",
+    ]
+    assert metadata["canonical_states"] == [
+        "wrong_source",
+        "server_not_configured",
+        "server_unreachable",
+        "server_auth_required",
+        "server_session_invalid",
+        "policy_denied",
+        "capability_disabled",
+        "runtime_not_configured",
+        "service_unavailable",
+        "dependency_missing",
+        "empty_selection",
+    ]
+    assert metadata["runtime_policy_reason_codes"] == [
+        "wrong_source",
+        "server_not_configured",
+        "server_unreachable",
+        "server_auth_required",
+        "server_session_invalid",
+        "authority_denied",
+        "capability_disabled",
+    ]
+    assert metadata["destination_recovery_sources"] == [
+        "phase-1-destination-action-audit",
+        "phase-3-console-live-work-closeout",
+        "phase-4-destination-service-adoption-closeout",
+        "runtime-policy-domain-edge-contracts",
+    ]

--- a/Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py
+++ b/Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py
@@ -14,7 +14,35 @@ PHASE_5_TAXONOMY_TASK = Path("backlog/tasks/task-6.1 - Phase-5.1-Create-shared-r
 
 
 def _text(path: Path) -> str:
-    return (REPO_ROOT / path).read_text(encoding="utf-8")
+    resolved_path = path if path.is_absolute() else REPO_ROOT / path
+    return resolved_path.read_text(encoding="utf-8")
+
+
+def _status_line(text: str) -> str:
+    status_match = re.search(r"^Status:\s*(.+)$", text, re.MULTILINE)
+    assert status_match is not None
+    return status_match.group(1).strip()
+
+
+def _assert_roadmap_tracks_phase_five_progress(roadmap: str) -> None:
+    normalized_status = _status_line(roadmap).lower().replace("-", " ")
+
+    assert "phase 2" in normalized_status
+    assert "phase 3" in normalized_status
+    assert "phase 4" in normalized_status
+    assert "verified" in normalized_status
+    assert re.search(r"phase\s+5\s+in\s+progress", normalized_status)
+    assert re.search(r"phase\s+6\s+not\s+started", normalized_status)
+
+
+def _roadmap_phase_evidence_row(text: str, phase_name: str) -> list[str]:
+    for line in text.splitlines():
+        if not line.startswith("|"):
+            continue
+        columns = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if columns and columns[0] == phase_name:
+            return columns
+    raise AssertionError(f"{phase_name} evidence row not found")
 
 
 def _taxonomy_metadata(text: str) -> dict:
@@ -34,12 +62,14 @@ def test_phase_five_recovery_taxonomy_is_tracked_from_roadmap_readme_and_tasks()
     parent_task = _text(PHASE_5_PARENT_TASK)
     child_task = _text(PHASE_5_TAXONOMY_TASK)
 
-    assert "Status: Phase 2, Phase 3, and Phase 4 verified; Phase 5 in progress; Phase 6 not started" in roadmap
-    assert "| Phase 5 | `Docs/superpowers/qa/unified-shell/phase-5/` | in-progress |" in roadmap
-    assert "Phase 5.1: Create shared recovery taxonomy - `TASK-6.1`" in roadmap
+    _assert_roadmap_tracks_phase_five_progress(roadmap)
+    phase_five_row = _roadmap_phase_evidence_row(roadmap, "Phase 5")
+    assert phase_five_row[1] == "`Docs/superpowers/qa/unified-shell/phase-5/`"
+    assert phase_five_row[2] == "in-progress"
+    assert re.search(r"Phase\s+5\.1:.*shared recovery taxonomy.*`TASK-6\.1`", roadmap, re.IGNORECASE)
     assert "2026-05-05-shared-recovery-taxonomy.md" in roadmap
 
-    assert "Status: in-progress" in readme
+    assert _status_line(readme) == "in-progress"
     assert "`TASK-6.1`" in readme
     assert "2026-05-05-shared-recovery-taxonomy.md" in readme
 
@@ -85,10 +115,18 @@ def test_phase_five_recovery_taxonomy_defines_required_contract_and_reason_mappi
     assert metadata["runtime_policy_reason_codes"] == [
         "wrong_source",
         "server_not_configured",
+        "server_profile_missing",
         "server_unreachable",
+        "server_unavailable",
         "server_auth_required",
+        "auth_required",
+        "credential_store_unavailable",
+        "server_credentials_unavailable",
         "server_session_invalid",
+        "stale_authorization",
+        "profile_no_longer_authorized",
         "authority_denied",
+        "permission_denied",
         "capability_disabled",
     ]
     assert metadata["destination_recovery_sources"] == [

--- a/backlog/tasks/task-6 - Phase-5-Capability-And-Recovery-System.md
+++ b/backlog/tasks/task-6 - Phase-5-Capability-And-Recovery-System.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-6
 title: 'Phase 5: Capability And Recovery System'
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-05-03 14:47'
+updated_date: '2026-05-05 02:32'
 labels:
   - unified-shell
   - phase-5
@@ -28,3 +29,17 @@ Systematize missing dependency, auth, server, runtime, and policy states so bloc
 - [ ] #3 Running-app QA verifies understandable recovery paths.
 - [ ] #4 Durable QA summaries exist under Docs/superpowers/qa/unified-shell/phase-5/.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Create child tasks for Phase 5 in dependency order, starting with a shared recovery taxonomy.
+2. Apply the taxonomy to blocker-state families in narrow implementation slices.
+3. Replay running-app QA for blocked states before marking Phase 5 verified.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Started Phase 5 with TASK-6.1, which defines the shared recovery taxonomy and tracking contract. Parent Phase 5 remains In Progress until later slices apply the taxonomy to blocker-state families and running-app QA verifies recovery paths.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-6.1 - Phase-5.1-Create-shared-recovery-taxonomy.md
+++ b/backlog/tasks/task-6.1 - Phase-5.1-Create-shared-recovery-taxonomy.md
@@ -1,0 +1,45 @@
+---
+id: TASK-6.1
+title: Phase 5.1 Create shared recovery taxonomy
+status: Done
+assignee: []
+created_date: '2026-05-05 02:31'
+updated_date: '2026-05-05 02:32'
+labels:
+  - unified-shell
+  - phase-5
+  - capability-state
+  - recovery
+dependencies: []
+parent_task_id: TASK-6
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Define the shared shell capability-state and recovery taxonomy that later Phase 5 slices can apply to blocked dependency auth server runtime and policy states.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Recovery taxonomy documents canonical blocked-state categories and required user-facing fields
+- [x] #2 Taxonomy maps to existing runtime-policy reason codes and destination recovery states
+- [x] #3 Phase 5 roadmap README and parent task record the Phase 5.1 slice
+- [x] #4 Regression test verifies the taxonomy artifact task and roadmap stay linked
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a failing Phase 5 tracking regression for the taxonomy artifact and TASK-6.1 linkage.
+2. Create the shared recovery taxonomy document using existing runtime-policy reason codes and shell recovery states.
+3. Update Phase 5 README and maturity roadmap to mark Phase 5 in progress and link TASK-6.1.
+4. Run the focused Phase 5 tracking regression and documentation checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Defined the shared Phase 5 recovery taxonomy in Docs/superpowers/qa/unified-shell/phase-5/2026-05-05-shared-recovery-taxonomy.md. The taxonomy maps shell blocked states to existing runtime-policy reason codes, domain edge contracts, and prior destination recovery evidence, then defines required user-facing fields for later application slices. Added a focused regression to keep the taxonomy artifact, Phase 5 README, roadmap, and task status linked.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary
- start Phase 5 by adding TASK-6.1 for the shared recovery taxonomy
- add the Phase 5 recovery taxonomy artifact with canonical blocked states, required user-facing fields, and runtime-policy mappings
- update Phase 5 README, maturity roadmap, and tracking tests so Phase 5 is in progress instead of not-started

## Verification
- python3 -m pytest Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py Tests/UI/test_unified_shell_phase234_maturity_gate.py -q -> 7 passed
- git diff --check -> clean