### PR TITLE
Apply Phase 5 recovery taxonomy to destination blockers

### DIFF
--- a/Docs/superpowers/qa/unified-shell/phase-5/2026-05-05-destination-blocker-recovery.md
+++ b/Docs/superpowers/qa/unified-shell/phase-5/2026-05-05-destination-blocker-recovery.md
@@ -1,0 +1,50 @@
+# Phase 5.2 Destination Blocker Recovery
+
+Date: 2026-05-05
+Task: `TASK-6.2`
+Parent Task: `TASK-6`
+Branch: `codex/unified-shell-phase5-destination-recovery`
+Base: `origin/dev` at `a9166379`
+
+## Goal
+
+Apply the Phase 5 shared recovery taxonomy to the first high-impact shell destination blocker family so disabled ACP, Schedules, Workflows, and Artifacts actions explain what is unavailable, why, what to do next, where recovery lives, who owns the blocker, and which stable selector tests the state.
+
+## Applied Blockers
+
+| Destination | Blocked workflow | Canonical state | Stable selector | Recovery behavior |
+| --- | --- | --- | --- | --- |
+| ACP | ACP agent launch | `runtime_not_configured` | `#acp-empty-state` | Configure an ACP runtime in Settings before launch. |
+| Schedules | Console follow for Schedules | `empty_selection` | `#schedules-console-unavailable` | Start or select a schedule run before opening it in Console. |
+| Workflows | Console launch for Workflows | `empty_selection` | `#workflows-console-unavailable` | Start or select a workflow run before opening it in Console. |
+| Artifacts | Console launch for Chatbook artifacts | `empty_selection` | `#artifacts-console-unavailable` | Create or import a Chatbook artifact before opening it in Console. |
+
+## UX Result
+
+Each target disabled state now exposes:
+
+- Status label, such as `Runtime not configured` or `Select an active run`.
+- Unavailable workflow, such as `Console follow for Schedules`.
+- Immediate reason, such as no active schedule run or no local Chatbook artifact.
+- Next action in user language.
+- Recovery target, such as Settings, Schedules, Workflows, or Artifacts.
+- Authority owner, such as local app runtime or local service data.
+- Stable selector and disabled tooltip copy.
+
+## Verification
+
+- Red regression: `python3 -m pytest Tests/UI/test_console_live_work_handoffs.py::test_phase_five_destination_blockers_expose_taxonomy_recovery_fields -q`
+- Red result before implementation: `4 failed`
+- Focused destination verification: `python3 -m pytest Tests/UI/test_destination_shells.py::test_automation_destination_wrappers_explain_ownership Tests/UI/test_console_live_work_handoffs.py::test_skeletal_destination_console_actions_are_disabled_with_recovery_copy Tests/UI/test_console_live_work_handoffs.py::test_schedules_destination_keeps_console_launch_disabled_without_digest_output Tests/UI/test_console_live_work_handoffs.py::test_schedules_destination_keeps_console_follow_disabled_without_active_run Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_keeps_console_launch_disabled_without_chatbooks Tests/UI/test_console_live_work_handoffs.py::test_phase_five_destination_blockers_expose_taxonomy_recovery_fields -q`
+- Focused destination result: `13 passed`
+
+## Residual Risks
+
+- This slice covers the first shell destination blocker family only.
+- Runtime-policy blockers such as wrong source, server auth, server session, and policy denial still need taxonomy application in later Phase 5 slices.
+- Optional dependency blockers for local models, speech, transcription, and embeddings/RAG extras still need a separate pass.
+- This QA evidence is focused widget/app harness verification, not the full Phase 6 first-time and power-user walkthrough.
+
+## Closeout Decision: destination_blockers_applied
+
+`TASK-6.2` applies the shared recovery taxonomy to the highest-impact shell destination blockers without marking Phase 5 complete. `TASK-6` remains open until the remaining blocker families are covered and running-app QA verifies recovery paths end to end.

--- a/Docs/superpowers/qa/unified-shell/phase-5/README.md
+++ b/Docs/superpowers/qa/unified-shell/phase-5/README.md
@@ -7,3 +7,4 @@ This directory contains durable QA summaries for Phase 5 capability-state and re
 ## Evidence
 
 - `2026-05-05-shared-recovery-taxonomy.md` - `TASK-6.1` shared recovery taxonomy for missing dependency, auth, server, runtime, policy, service, and selection states.
+- `2026-05-05-destination-blocker-recovery.md` - `TASK-6.2` application of the recovery taxonomy to ACP, Schedules, Workflows, and Artifacts shell destination blockers.

--- a/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
@@ -37,7 +37,7 @@ Track remaining Unified Shell work in one place so rendered screens, clickable b
 - Library now surfaces a local source snapshot from notes, media, and conversations and can stage concrete source context into Console; full Library-native detail views, embedded Import/Export, and embedded Search/RAG remain future work.
 - Personas now surfaces a local behavior snapshot from characters and persona profiles and can stage concrete behavior context into Console; detail, edit, import/export, archetypes, exemplars, dictionaries, and lore remain future work.
 - W+C now surfaces a local monitored-source and saved-collection snapshot from `watchlist_scope_service` and `media_reading_scope_service` and can stage concrete W+C context into Console; full detail, edit, import/export, feed WebSub, alert-rule, retry/backoff, and server collection-feed UX remain future work.
-- Phase 2, Phase 3, and Phase 4 implementation and maturity-gate replays are verified. Phase 5 is in progress with a shared recovery taxonomy; Phase 6 remains open for full first-time/power-user audit replay.
+- Phase 2, Phase 3, and Phase 4 implementation and maturity-gate replays are verified. Phase 5 is in progress with a shared recovery taxonomy applied to the first shell destination blocker family; Phase 6 remains open for full first-time/power-user audit replay.
 
 ## Definition Of Done
 
@@ -108,6 +108,7 @@ Initial child tasks:
 - Phase 4.5: Adopt W+C services in W+C destination - `TASK-5.5`
 - Phase 4.6: Replay destination service-adoption maturity gate - `TASK-5.6`
 - Phase 5.1: Create shared recovery taxonomy - `TASK-6.1`
+- Phase 5.2: Apply recovery taxonomy to shell destination blockers - `TASK-6.2`
 
 ## QA Evidence Index
 
@@ -130,7 +131,7 @@ Initial child tasks:
 | Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | verified | `TASK-4`, `TASK-4.1`, `TASK-4.2`, `TASK-4.3`, `TASK-4.4`, `TASK-4.5`, `TASK-4.6`, `TASK-4.7`, `TASK-4.8` | `phase-2/` | Schedule and agent-service adapters remain future work; Phase 2 is verified for explicit Home adapter behavior, local W+C/notification flows, and recoverable unavailable states. |
 | Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | verified | `TASK-3`, `TASK-3.1`, `TASK-3.2`, `TASK-3.3`, `TASK-3.4`, `TASK-3.5`, `TASK-3.6`, `TASK-3.7`, `TASK-3.8`, `TASK-3.9`, `TASK-3.10`, `TASK-3.11` | `phase-3/` | ACP, MCP, and durable live event streams remain future work; Phase 3 is verified for implemented Console source launch, follow, status, and recovery flows. |
 | Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | verified | `TASK-5`, `TASK-5.1`, `TASK-5.2`, `TASK-5.3`, `TASK-5.4`, `TASK-5.5`, `TASK-5.6` | `phase-4/` | Full CRUD/server-parity depth remains future work; Phase 4 is verified for destination ownership, concrete local workflows, Console staging, and honest recovery states. |
-| Phase 5: Capability And Recovery System | Systematize unavailable and blocked states. | in-progress | `TASK-6`, `TASK-6.1` | `phase-5/` | Shared recovery taxonomy is defined; remaining blocker-state families still need application and running-app QA. |
+| Phase 5: Capability And Recovery System | Systematize unavailable and blocked states. | in-progress | `TASK-6`, `TASK-6.1`, `TASK-6.2` | `phase-5/` | Shared recovery taxonomy is defined and applied to ACP, Schedules, Workflows, and Artifacts shell destination blockers; runtime-policy and optional-dependency blocker families still need application and running-app QA. |
 | Phase 6: Audit Replay And Closeout | Prove shell works for first-time and power users. | not-started | `TASK-7` | `phase-6/` | Depends on prior phases and running-app QA. |
 
 ## Phase 1.1 QA Harness Evidence
@@ -322,6 +323,12 @@ Initial audit result: W+C, Schedules, Workflows, and ACP had false Console-launc
 `TASK-6.1` defines the shell-level recovery taxonomy that later Phase 5 slices must apply to blocked dependency, auth, server, runtime, policy, service, and selection states:
 
 - `Docs/superpowers/qa/unified-shell/phase-5/2026-05-05-shared-recovery-taxonomy.md`
+
+## Phase 5.2 Shell Destination Blocker Recovery
+
+`TASK-6.2` applies the taxonomy to ACP runtime, Schedules empty active-run, Workflows empty active-run, and Artifacts empty Chatbook blockers:
+
+- `Docs/superpowers/qa/unified-shell/phase-5/2026-05-05-destination-blocker-recovery.md`
 
 ## Phase 0: Canonical Tracking
 

--- a/Tests/UI/test_console_live_work_handoffs.py
+++ b/Tests/UI/test_console_live_work_handoffs.py
@@ -201,6 +201,110 @@ class StaticLocalChatbookService:
         return list(self.chatbooks)[int(offset) : int(offset) + int(limit)]
 
 
+@pytest.mark.parametrize(
+    (
+        "route",
+        "button_selector",
+        "static_selector",
+        "service_setup",
+        "expected_fragments",
+        "expected_tooltip",
+    ),
+    [
+        (
+            "acp",
+            "#acp-launch-agent",
+            "#acp-empty-state",
+            "default",
+            (
+                "Runtime not configured",
+                "Unavailable: ACP agent launch.",
+                "Why: no ACP-compatible runtime is configured.",
+                "Next: Configure an ACP runtime in Settings before launch.",
+                "Recovery: Settings.",
+                "Owner: local app runtime.",
+            ),
+            "Configure an ACP-compatible runtime in Settings before launching an ACP agent.",
+        ),
+        (
+            "schedules",
+            "#schedules-follow-in-console",
+            "#schedules-console-unavailable",
+            "empty-schedules",
+            (
+                "Select an active run",
+                "Unavailable: Console follow for Schedules.",
+                "Why: no active schedule run or reading digest output is available.",
+                "Next: Start or select a schedule run before opening it in Console.",
+                "Recovery: Schedules.",
+                "Owner: local schedule data.",
+            ),
+            "Start or select a schedule run before opening it in Console.",
+        ),
+        (
+            "workflows",
+            "#workflows-launch-in-console",
+            "#workflows-console-unavailable",
+            "empty-workflows",
+            (
+                "Select an active run",
+                "Unavailable: Console launch for Workflows.",
+                "Why: no active workflow run is available.",
+                "Next: Start or select a workflow run before opening it in Console.",
+                "Recovery: Workflows.",
+                "Owner: local workflow data.",
+            ),
+            "Start or select a workflow run before opening it in Console.",
+        ),
+        (
+            "artifacts",
+            "#artifacts-use-in-console",
+            "#artifacts-console-unavailable",
+            "empty-chatbooks",
+            (
+                "Select an artifact",
+                "Unavailable: Console launch for Chatbook artifacts.",
+                "Why: no local Chatbook artifact exists.",
+                "Next: Create or import a Chatbook artifact before opening it in Console.",
+                "Recovery: Artifacts.",
+                "Owner: local Chatbook service.",
+            ),
+            "Create or import a Chatbook artifact before opening it in Console.",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_phase_five_destination_blockers_expose_taxonomy_recovery_fields(
+    route,
+    button_selector,
+    static_selector,
+    service_setup,
+    expected_fragments,
+    expected_tooltip,
+):
+    app = _build_test_app()
+    if service_setup == "empty-schedules":
+        app.home_active_work_adapter = StaticHomeActiveWorkAdapter(())
+        app.local_media_reading_service = StaticReadingDigestService(())
+    elif service_setup == "empty-workflows":
+        app.home_active_work_adapter = StaticHomeActiveWorkAdapter(())
+    elif service_setup == "empty-chatbooks":
+        app.local_chatbook_service = StaticLocalChatbookService(())
+
+    host = DestinationHarness(app, route)
+
+    async with host.run_test(size=(180, 40)) as pilot:
+        await pilot.pause(0.1)
+        screen = _active_console_screen(host)
+        button = screen.query_one(button_selector)
+        recovery_text = str(screen.query_one(static_selector).renderable)
+
+        assert button.disabled is True
+        assert str(button.tooltip) == expected_tooltip
+        for fragment in expected_fragments:
+            assert fragment in recovery_text
+
+
 class RaisingLocalChatbookService:
     async def list_chatbooks(self, *, q=None, limit=100, offset=0, **kwargs):
         raise RuntimeError("registry read failed")
@@ -678,17 +782,17 @@ async def test_schedules_destination_loads_console_follow_item_off_main_thread()
         (
             "schedules",
             "schedules-follow-in-console",
-            "No active schedule run is available for Console follow.",
+            "Unavailable: Console follow for Schedules.",
         ),
         (
             "workflows",
             "workflows-launch-in-console",
-            "No active workflow run is available for Console launch.",
+            "Unavailable: Console launch for Workflows.",
         ),
         (
             "acp",
             "acp-follow-in-console",
-            "Console follow is unavailable until ACP session payloads are wired.",
+            "Unavailable: Console follow for ACP sessions.",
         ),
     ],
 )
@@ -728,7 +832,8 @@ async def test_schedules_destination_keeps_console_follow_disabled_without_activ
 
         assert button.disabled is True
         assert str(button.label) == "Console recovery unavailable"
-        assert "No active schedule run is available for Console follow." in _screen_static_text(screen)
+        assert "Unavailable: Console follow for Schedules." in _screen_static_text(screen)
+        assert "Next: Start or select a schedule run before opening it in Console." in _screen_static_text(screen)
 
     app.open_active_home_item_in_console.assert_not_called()
 
@@ -866,7 +971,8 @@ async def test_workflows_destination_keeps_console_launch_disabled_without_activ
 
         assert button.disabled is True
         assert str(button.label) == "Console launch unavailable"
-        assert "No active workflow run is available for Console launch." in _screen_static_text(screen)
+        assert "Unavailable: Console launch for Workflows." in _screen_static_text(screen)
+        assert "Next: Start or select a workflow run before opening it in Console." in _screen_static_text(screen)
 
     app.open_active_home_item_in_console.assert_not_called()
 
@@ -1134,7 +1240,8 @@ async def test_schedules_destination_keeps_console_launch_disabled_without_diges
 
         assert button.disabled is True
         assert str(button.label) == "Console recovery unavailable"
-        assert "No active schedule run is available for Console follow." in _screen_static_text(screen)
+        assert "Unavailable: Console follow for Schedules." in _screen_static_text(screen)
+        assert "Next: Start or select a schedule run before opening it in Console." in _screen_static_text(screen)
         await pilot.click("#schedules-follow-in-console")
         await pilot.pause(0.1)
 
@@ -1240,7 +1347,10 @@ async def test_artifacts_destination_keeps_console_launch_disabled_without_chatb
 
         assert button.disabled is True
         assert str(button.label) == "Console launch unavailable"
-        assert "No local Chatbook artifact is available for Console launch." in _screen_static_text(screen)
+        assert "Unavailable: Console launch for Chatbook artifacts." in _screen_static_text(screen)
+        assert "Next: Create or import a Chatbook artifact before opening it in Console." in _screen_static_text(
+            screen
+        )
 
         await pilot.click("#artifacts-use-in-console")
         await pilot.pause(0.1)
@@ -1406,8 +1516,10 @@ async def test_artifacts_destination_distinguishes_chatbook_service_failure_from
         text = _screen_static_text(screen)
 
         assert button.disabled is True
-        assert "Chatbook service unavailable; retry Artifacts later." in text
-        assert "No local Chatbook artifact is available" not in text
+        assert "Unavailable: Console launch for Chatbook artifacts." in text
+        assert "Why: the local Chatbook service is unavailable." in text
+        assert "Next: Retry Artifacts after the local Chatbook service is available." in text
+        assert "Why: no local Chatbook artifact exists." not in text
 
         await pilot.click("#artifacts-use-in-console")
         await pilot.pause(0.1)

--- a/Tests/UI/test_console_live_work_handoffs.py
+++ b/Tests/UI/test_console_live_work_handoffs.py
@@ -1,6 +1,7 @@
 """Console live-work launch and staged-context handoff boundary tests."""
 
 import threading
+import time
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -201,6 +202,35 @@ class StaticLocalChatbookService:
         return list(self.chatbooks)[int(offset) : int(offset) + int(limit)]
 
 
+async def _wait_for_destination_recovery_state(
+    screen,
+    pilot,
+    *,
+    button_selector: str,
+    static_selector: str,
+    expected_tooltip: str,
+    expected_fragments: tuple[str, ...],
+    timeout: float = 2.0,
+) -> tuple[object, str]:
+    deadline = time.monotonic() + timeout
+    last_recovery_text = ""
+    while time.monotonic() < deadline:
+        if screen.query(button_selector) and screen.query(static_selector):
+            button = screen.query_one(button_selector)
+            last_recovery_text = str(screen.query_one(static_selector).renderable)
+            if (
+                button.disabled is True
+                and str(button.tooltip) == expected_tooltip
+                and all(fragment in last_recovery_text for fragment in expected_fragments)
+            ):
+                return button, last_recovery_text
+        await pilot.pause(0.02)
+    raise AssertionError(
+        "Destination recovery state did not become ready. "
+        f"selector={static_selector!r} last_text={last_recovery_text!r}"
+    )
+
+
 @pytest.mark.parametrize(
     (
         "route",
@@ -294,10 +324,15 @@ async def test_phase_five_destination_blockers_expose_taxonomy_recovery_fields(
     host = DestinationHarness(app, route)
 
     async with host.run_test(size=(180, 40)) as pilot:
-        await pilot.pause(0.1)
         screen = _active_console_screen(host)
-        button = screen.query_one(button_selector)
-        recovery_text = str(screen.query_one(static_selector).renderable)
+        button, recovery_text = await _wait_for_destination_recovery_state(
+            screen,
+            pilot,
+            button_selector=button_selector,
+            static_selector=static_selector,
+            expected_tooltip=expected_tooltip,
+            expected_fragments=expected_fragments,
+        )
 
         assert button.disabled is True
         assert str(button.tooltip) == expected_tooltip

--- a/Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py
+++ b/Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py
@@ -9,8 +9,14 @@ PHASE_5_README = Path("Docs/superpowers/qa/unified-shell/phase-5/README.md")
 PHASE_5_TAXONOMY = Path(
     "Docs/superpowers/qa/unified-shell/phase-5/2026-05-05-shared-recovery-taxonomy.md"
 )
+PHASE_5_DESTINATION_RECOVERY = Path(
+    "Docs/superpowers/qa/unified-shell/phase-5/2026-05-05-destination-blocker-recovery.md"
+)
 PHASE_5_PARENT_TASK = Path("backlog/tasks/task-6 - Phase-5-Capability-And-Recovery-System.md")
 PHASE_5_TAXONOMY_TASK = Path("backlog/tasks/task-6.1 - Phase-5.1-Create-shared-recovery-taxonomy.md")
+PHASE_5_DESTINATION_RECOVERY_TASK = Path(
+    "backlog/tasks/task-6.2 - Phase-5.2-Apply-recovery-taxonomy-to-shell-destination-blockers.md"
+)
 
 
 def _text(path: Path) -> str:
@@ -61,24 +67,51 @@ def test_phase_five_recovery_taxonomy_is_tracked_from_roadmap_readme_and_tasks()
     readme = _text(PHASE_5_README)
     parent_task = _text(PHASE_5_PARENT_TASK)
     child_task = _text(PHASE_5_TAXONOMY_TASK)
+    destination_recovery_task = _text(PHASE_5_DESTINATION_RECOVERY_TASK)
 
     _assert_roadmap_tracks_phase_five_progress(roadmap)
     phase_five_row = _roadmap_phase_evidence_row(roadmap, "Phase 5")
     assert phase_five_row[1] == "`Docs/superpowers/qa/unified-shell/phase-5/`"
     assert phase_five_row[2] == "in-progress"
     assert re.search(r"Phase\s+5\.1:.*shared recovery taxonomy.*`TASK-6\.1`", roadmap, re.IGNORECASE)
+    assert re.search(
+        r"Phase\s+5\.2:.*shell destination blockers.*`TASK-6\.2`",
+        roadmap,
+        re.IGNORECASE,
+    )
     assert "2026-05-05-shared-recovery-taxonomy.md" in roadmap
+    assert "2026-05-05-destination-blocker-recovery.md" in roadmap
 
     assert _status_line(readme) == "in-progress"
     assert "`TASK-6.1`" in readme
+    assert "`TASK-6.2`" in readme
     assert "2026-05-05-shared-recovery-taxonomy.md" in readme
+    assert "2026-05-05-destination-blocker-recovery.md" in readme
 
     assert "status: In Progress" in parent_task
     assert "TASK-6.1" in parent_task
+    assert "TASK-6.2" in parent_task
     assert "status: Done" in child_task
     for acceptance_criterion in range(1, 5):
         assert f"- [x] #{acceptance_criterion}" in child_task
     assert "Implementation Notes" in child_task
+    assert "status: Done" in destination_recovery_task
+    for acceptance_criterion in range(1, 6):
+        assert f"- [x] #{acceptance_criterion}" in destination_recovery_task
+    assert "Implementation Notes" in destination_recovery_task
+
+
+def test_phase_five_destination_recovery_evidence_records_applied_blockers():
+    evidence = _text(PHASE_5_DESTINATION_RECOVERY)
+
+    assert "/Users/" not in evidence
+    assert "TASK-6.2" in evidence
+    assert "ACP agent launch" in evidence
+    assert "Console follow for Schedules" in evidence
+    assert "Console launch for Workflows" in evidence
+    assert "Console launch for Chatbook artifacts" in evidence
+    assert "test_phase_five_destination_blockers_expose_taxonomy_recovery_fields" in evidence
+    assert "13 passed" in evidence
 
 
 def test_phase_five_recovery_taxonomy_defines_required_contract_and_reason_mappings():

--- a/backlog/tasks/task-6 - Phase-5-Capability-And-Recovery-System.md
+++ b/backlog/tasks/task-6 - Phase-5-Capability-And-Recovery-System.md
@@ -41,5 +41,5 @@ Systematize missing dependency, auth, server, runtime, and policy states so bloc
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Started Phase 5 with TASK-6.1, which defines the shared recovery taxonomy and tracking contract. Parent Phase 5 remains In Progress until later slices apply the taxonomy to blocker-state families and running-app QA verifies recovery paths.
+Started Phase 5 with TASK-6.1, which defines the shared recovery taxonomy and tracking contract. TASK-6.2 applies the taxonomy to the first shell destination blocker family: ACP runtime configuration, Schedules empty active-run, Workflows empty active-run, and Artifacts empty Chatbook states. Parent Phase 5 remains In Progress until later slices apply the taxonomy to remaining runtime-policy and optional-dependency blocker families and running-app QA verifies recovery paths.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-6.2 - Phase-5.2-Apply-recovery-taxonomy-to-shell-destination-blockers.md
+++ b/backlog/tasks/task-6.2 - Phase-5.2-Apply-recovery-taxonomy-to-shell-destination-blockers.md
@@ -1,0 +1,50 @@
+---
+id: TASK-6.2
+title: Phase 5.2 Apply recovery taxonomy to shell destination blockers
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-05-05 02:55'
+labels:
+  - unified-shell
+  - phase-5
+  - recovery
+  - destination-blockers
+dependencies: []
+documentation:
+  - >-
+    Docs/superpowers/qa/unified-shell/phase-5/2026-05-05-shared-recovery-taxonomy.md
+  - >-
+    Docs/superpowers/qa/unified-shell/phase-1/2026-05-03-destination-action-audit.md
+  - >-
+    Docs/superpowers/qa/unified-shell/phase-4/2026-05-05-phase-4-destination-service-adoption-closeout.md
+parent_task_id: TASK-6
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Apply the shared Phase 5 recovery taxonomy to the highest-impact shell destination blocked states so users can understand and recover from unavailable ACP, Schedules, Workflows, and Artifacts actions.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 ACP runtime-unconfigured state exposes what is unavailable, why, next action, recovery target, authority owner, stable selector, and disabled tooltip copy.
+- [x] #2 Schedules and Workflows empty active-run states expose taxonomy-aligned recovery copy and disabled tooltips without false Console-launch affordances.
+- [x] #3 Artifacts empty Chatbook state exposes taxonomy-aligned recovery copy and disabled tooltip without implying retry can fix missing selection/data.
+- [x] #4 Automated UI regressions verify the taxonomy fields or visible copy for representative blocked shell destination controls.
+- [x] #5 Durable Phase 5 QA evidence records the running-app or focused widget walkthrough result and residual risks.
+<!-- AC:END -->
+
+## Implementation Plan
+
+1. Inspect the current ACP, Schedules, Workflows, and Artifacts destination blocked-state rendering and existing tests.
+2. Add failing UI regressions that assert taxonomy-aligned visible copy, selectors, and disabled tooltips for representative destination blockers.
+3. Add the smallest shared helper or local state updates needed to make those blocked states expose the taxonomy fields consistently.
+4. Add Phase 5 QA evidence and update Phase 5 tracking docs for `TASK-6.2`.
+5. Run focused UI tests and documentation contract tests before opening the PR.
+
+## Implementation Notes
+
+Added a shared `DestinationRecoveryState` helper for destination-shell blocked states and applied it to ACP runtime configuration, Schedules empty Console follow, Workflows empty Console launch, and Artifacts empty Chatbook Console launch. Updated existing destination tests plus a new Phase 5 regression to assert visible taxonomy fields and disabled tooltips, and recorded QA evidence under the Phase 5 evidence directory.

--- a/tldw_chatbook/UI/Screens/acp_screen.py
+++ b/tldw_chatbook/UI/Screens/acp_screen.py
@@ -5,6 +5,30 @@ from textual.containers import Vertical
 from textual.widgets import Button, Static
 
 from ..Navigation.base_app_screen import BaseAppScreen
+from .destination_recovery import DestinationRecoveryState
+
+
+ACP_RUNTIME_NOT_CONFIGURED = DestinationRecoveryState(
+    status_label="Runtime not configured",
+    unavailable_what="ACP agent launch",
+    why="no ACP-compatible runtime is configured",
+    next_action="Configure an ACP runtime in Settings before launch.",
+    recovery_action="Settings",
+    authority_owner="local app runtime",
+    stable_selector="acp-empty-state",
+    disabled_tooltip="Configure an ACP-compatible runtime in Settings before launching an ACP agent.",
+)
+
+ACP_CONSOLE_FOLLOW_UNAVAILABLE = DestinationRecoveryState(
+    status_label="Runtime not configured",
+    unavailable_what="Console follow for ACP sessions",
+    why="ACP session payloads are not wired yet",
+    next_action="Configure an ACP runtime and start a session before following it in Console.",
+    recovery_action="ACP",
+    authority_owner="local app runtime",
+    stable_selector="acp-console-unavailable",
+    disabled_tooltip="Configure an ACP runtime and start a session before following it in Console.",
+)
 
 
 class ACPScreen(BaseAppScreen):
@@ -28,22 +52,22 @@ class ACPScreen(BaseAppScreen):
                 yield Static("Diffs", classes="destination-section")
                 yield Static("Terminal/Shell", classes="destination-section")
                 yield Static(
-                    "ACP runtime is not configured yet. Install or configure an ACP-compatible agent before launch.",
-                    id="acp-empty-state",
+                    ACP_RUNTIME_NOT_CONFIGURED.visible_copy,
+                    id=ACP_RUNTIME_NOT_CONFIGURED.stable_selector,
                 )
                 yield Static(
-                    "Console follow is unavailable until ACP session payloads are wired.",
-                    id="acp-console-unavailable",
+                    ACP_CONSOLE_FOLLOW_UNAVAILABLE.visible_copy,
+                    id=ACP_CONSOLE_FOLLOW_UNAVAILABLE.stable_selector,
                 )
                 yield Button(
                     "Console follow unavailable",
                     id="acp-follow-in-console",
                     disabled=True,
-                    tooltip="Unavailable until ACP can pass actionable session context to Console.",
+                    tooltip=ACP_CONSOLE_FOLLOW_UNAVAILABLE.disabled_tooltip,
                 )
                 yield Button(
                     "Launch ACP Agent",
                     id="acp-launch-agent",
                     disabled=True,
-                    tooltip="Unavailable until an ACP-compatible runtime is configured.",
+                    tooltip=ACP_RUNTIME_NOT_CONFIGURED.disabled_tooltip,
                 )

--- a/tldw_chatbook/UI/Screens/artifacts_screen.py
+++ b/tldw_chatbook/UI/Screens/artifacts_screen.py
@@ -21,11 +21,32 @@ from textual.widgets import Button, Static
 from ...Utils.input_validation import sanitize_string, validate_text_input
 from ..Navigation.base_app_screen import BaseAppScreen
 from ..Navigation.main_navigation import NavigateToScreen
+from .destination_recovery import DestinationRecoveryState
 
 
 logger = logger.bind(module="ArtifactsScreen")
 CHATBOOK_SERVICE_ERROR_COPY = "Chatbook service unavailable; retry Artifacts later."
 DANGEROUS_TEXT_PATTERNS = ("javascript:", "onclick=", "onerror=")
+ARTIFACTS_EMPTY_CHATBOOK_RECOVERY = DestinationRecoveryState(
+    status_label="Select an artifact",
+    unavailable_what="Console launch for Chatbook artifacts",
+    why="no local Chatbook artifact exists",
+    next_action="Create or import a Chatbook artifact before opening it in Console.",
+    recovery_action="Artifacts",
+    authority_owner="local Chatbook service",
+    stable_selector="artifacts-console-unavailable",
+    disabled_tooltip="Create or import a Chatbook artifact before opening it in Console.",
+)
+ARTIFACTS_CHATBOOK_SERVICE_UNAVAILABLE_RECOVERY = DestinationRecoveryState(
+    status_label="Service unavailable",
+    unavailable_what="Console launch for Chatbook artifacts",
+    why="the local Chatbook service is unavailable",
+    next_action="Retry Artifacts after the local Chatbook service is available.",
+    recovery_action="Retry Artifacts",
+    authority_owner="local Chatbook service",
+    stable_selector="artifacts-console-unavailable",
+    disabled_tooltip="Retry Artifacts after the local Chatbook service is available.",
+)
 
 
 class ArtifactsScreen(BaseAppScreen):
@@ -211,22 +232,20 @@ class ArtifactsScreen(BaseAppScreen):
                     )
                 else:
                     yield Static("Console launch unavailable", classes="destination-section")
-                    unavailable_copy = self._chatbook_lookup_error or (
-                        "No local Chatbook artifact is available for Console launch."
+                    recovery_state = (
+                        ARTIFACTS_CHATBOOK_SERVICE_UNAVAILABLE_RECOVERY
+                        if self._chatbook_lookup_error
+                        else ARTIFACTS_EMPTY_CHATBOOK_RECOVERY
                     )
                     yield Static(
-                        unavailable_copy,
-                        id="artifacts-console-unavailable",
+                        recovery_state.visible_copy,
+                        id=recovery_state.stable_selector,
                     )
                     yield Button(
                         "Console launch unavailable",
                         id="artifacts-use-in-console",
                         disabled=True,
-                        tooltip=(
-                            "Unavailable while the local Chatbook service is unavailable."
-                            if self._chatbook_lookup_error
-                            else "Unavailable until a local Chatbook artifact exists."
-                        ),
+                        tooltip=recovery_state.disabled_tooltip,
                     )
 
     @on(Button.Pressed, "#artifacts-open-chatbooks")
@@ -238,8 +257,13 @@ class ArtifactsScreen(BaseAppScreen):
         event.stop()
         launch_kwargs = self._latest_chatbook_console_launch
         if launch_kwargs is None:
+            recovery_state = (
+                ARTIFACTS_CHATBOOK_SERVICE_UNAVAILABLE_RECOVERY
+                if self._chatbook_lookup_error
+                else ARTIFACTS_EMPTY_CHATBOOK_RECOVERY
+            )
             self.app_instance.notify(
-                self._chatbook_lookup_error or "No local Chatbook artifact is available for Console launch.",
+                recovery_state.disabled_tooltip,
                 severity="warning",
             )
             return

--- a/tldw_chatbook/UI/Screens/artifacts_screen.py
+++ b/tldw_chatbook/UI/Screens/artifacts_screen.py
@@ -76,6 +76,14 @@ class ArtifactsScreen(BaseAppScreen):
         if self.is_mounted:
             self.refresh(recompose=True)
 
+    @property
+    def _blocked_chatbook_recovery_state(self) -> DestinationRecoveryState:
+        return (
+            ARTIFACTS_CHATBOOK_SERVICE_UNAVAILABLE_RECOVERY
+            if self._chatbook_lookup_error
+            else ARTIFACTS_EMPTY_CHATBOOK_RECOVERY
+        )
+
     @staticmethod
     def _text(value: Any, fallback: str = "") -> str:
         text = str(value or "").strip()
@@ -232,11 +240,7 @@ class ArtifactsScreen(BaseAppScreen):
                     )
                 else:
                     yield Static("Console launch unavailable", classes="destination-section")
-                    recovery_state = (
-                        ARTIFACTS_CHATBOOK_SERVICE_UNAVAILABLE_RECOVERY
-                        if self._chatbook_lookup_error
-                        else ARTIFACTS_EMPTY_CHATBOOK_RECOVERY
-                    )
+                    recovery_state = self._blocked_chatbook_recovery_state
                     yield Static(
                         recovery_state.visible_copy,
                         id=recovery_state.stable_selector,
@@ -257,13 +261,8 @@ class ArtifactsScreen(BaseAppScreen):
         event.stop()
         launch_kwargs = self._latest_chatbook_console_launch
         if launch_kwargs is None:
-            recovery_state = (
-                ARTIFACTS_CHATBOOK_SERVICE_UNAVAILABLE_RECOVERY
-                if self._chatbook_lookup_error
-                else ARTIFACTS_EMPTY_CHATBOOK_RECOVERY
-            )
             self.app_instance.notify(
-                recovery_state.disabled_tooltip,
+                self._blocked_chatbook_recovery_state.disabled_tooltip,
                 severity="warning",
             )
             return

--- a/tldw_chatbook/UI/Screens/destination_recovery.py
+++ b/tldw_chatbook/UI/Screens/destination_recovery.py
@@ -1,0 +1,32 @@
+"""Shared recovery copy helpers for destination shell blocked states."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DestinationRecoveryState:
+    """Taxonomy-aligned recovery state for a disabled destination action."""
+
+    status_label: str
+    unavailable_what: str
+    why: str
+    next_action: str
+    recovery_action: str
+    authority_owner: str
+    stable_selector: str
+    disabled_tooltip: str
+
+    @property
+    def visible_copy(self) -> str:
+        return "\n".join(
+            (
+                self.status_label,
+                f"Unavailable: {self.unavailable_what}.",
+                f"Why: {self.why}.",
+                f"Next: {self.next_action}",
+                f"Recovery: {self.recovery_action}.",
+                f"Owner: {self.authority_owner}.",
+            )
+        )

--- a/tldw_chatbook/UI/Screens/destination_recovery.py
+++ b/tldw_chatbook/UI/Screens/destination_recovery.py
@@ -7,7 +7,18 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class DestinationRecoveryState:
-    """Taxonomy-aligned recovery state for a disabled destination action."""
+    """Taxonomy-aligned recovery state for a disabled destination action.
+
+    Args:
+        status_label: Short user-facing state label.
+        unavailable_what: Specific workflow or control that cannot run.
+        why: Immediate reason in user language.
+        next_action: Concrete user step that can unblock or recover the workflow.
+        recovery_action: Target route, retry action, setup action, or selection action.
+        authority_owner: Owner of the capability or blocker.
+        stable_selector: Stable widget selector used to expose and test this state.
+        disabled_tooltip: Tooltip copy for the disabled control.
+    """
 
     status_label: str
     unavailable_what: str
@@ -18,14 +29,23 @@ class DestinationRecoveryState:
     stable_selector: str
     disabled_tooltip: str
 
+    @staticmethod
+    def _sentence(value: str) -> str:
+        text = value.strip()
+        if not text or text.endswith((".", "!", "?")):
+            return text
+        return f"{text}."
+
     @property
     def visible_copy(self) -> str:
+        """Render visible multi-line recovery copy."""
+
         return "\n".join(
             (
                 self.status_label,
                 f"Unavailable: {self.unavailable_what}.",
                 f"Why: {self.why}.",
-                f"Next: {self.next_action}",
+                f"Next: {self._sentence(self.next_action)}",
                 f"Recovery: {self.recovery_action}.",
                 f"Owner: {self.authority_owner}.",
             )

--- a/tldw_chatbook/UI/Screens/schedules_screen.py
+++ b/tldw_chatbook/UI/Screens/schedules_screen.py
@@ -12,9 +12,21 @@ from textual.containers import Vertical
 from textual.widgets import Button, Static
 
 from ..Navigation.base_app_screen import BaseAppScreen
+from .destination_recovery import DestinationRecoveryState
 
 
 logger = logger.bind(module="SchedulesScreen")
+
+SCHEDULES_EMPTY_CONSOLE_RECOVERY = DestinationRecoveryState(
+    status_label="Select an active run",
+    unavailable_what="Console follow for Schedules",
+    why="no active schedule run or reading digest output is available",
+    next_action="Start or select a schedule run before opening it in Console.",
+    recovery_action="Schedules",
+    authority_owner="local schedule data",
+    stable_selector="schedules-console-unavailable",
+    disabled_tooltip="Start or select a schedule run before opening it in Console.",
+)
 
 
 class SchedulesScreen(BaseAppScreen):
@@ -187,14 +199,14 @@ class SchedulesScreen(BaseAppScreen):
                 else:
                     yield Static("Console recovery unavailable", classes="destination-section")
                     yield Static(
-                        "No active schedule run is available for Console follow.",
-                        id="schedules-console-unavailable",
+                        SCHEDULES_EMPTY_CONSOLE_RECOVERY.visible_copy,
+                        id=SCHEDULES_EMPTY_CONSOLE_RECOVERY.stable_selector,
                     )
                     yield Button(
                         "Console recovery unavailable",
                         id="schedules-follow-in-console",
                         disabled=True,
-                        tooltip="Unavailable until Schedules has an active run with Console context.",
+                        tooltip=SCHEDULES_EMPTY_CONSOLE_RECOVERY.disabled_tooltip,
                     )
 
     @on(Button.Pressed, "#schedules-follow-in-console")
@@ -228,6 +240,6 @@ class SchedulesScreen(BaseAppScreen):
             return
 
         self.app_instance.notify(
-            "No active schedule run is available for Console follow.",
+            SCHEDULES_EMPTY_CONSOLE_RECOVERY.disabled_tooltip,
             severity="warning",
         )

--- a/tldw_chatbook/UI/Screens/workflows_screen.py
+++ b/tldw_chatbook/UI/Screens/workflows_screen.py
@@ -9,9 +9,21 @@ from textual.containers import Vertical
 from textual.widgets import Button, Static
 
 from ..Navigation.base_app_screen import BaseAppScreen
+from .destination_recovery import DestinationRecoveryState
 
 
 logger = _logger.bind(module="WorkflowsScreen")
+
+WORKFLOWS_EMPTY_CONSOLE_RECOVERY = DestinationRecoveryState(
+    status_label="Select an active run",
+    unavailable_what="Console launch for Workflows",
+    why="no active workflow run is available",
+    next_action="Start or select a workflow run before opening it in Console.",
+    recovery_action="Workflows",
+    authority_owner="local workflow data",
+    stable_selector="workflows-console-unavailable",
+    disabled_tooltip="Start or select a workflow run before opening it in Console.",
+)
 
 
 class WorkflowsScreen(BaseAppScreen):
@@ -113,14 +125,14 @@ class WorkflowsScreen(BaseAppScreen):
                     yield Static("Console launch unavailable", classes="destination-section")
                     yield Static("No workflow service is wired yet.", id="workflows-empty-state")
                     yield Static(
-                        "No active workflow run is available for Console launch.",
-                        id="workflows-console-unavailable",
+                        WORKFLOWS_EMPTY_CONSOLE_RECOVERY.visible_copy,
+                        id=WORKFLOWS_EMPTY_CONSOLE_RECOVERY.stable_selector,
                     )
                     yield Button(
                         "Console launch unavailable",
                         id="workflows-launch-in-console",
                         disabled=True,
-                        tooltip="Unavailable until Workflows can pass actionable execution context to Console.",
+                        tooltip=WORKFLOWS_EMPTY_CONSOLE_RECOVERY.disabled_tooltip,
                     )
 
     @on(Button.Pressed, "#workflows-launch-in-console")
@@ -129,7 +141,7 @@ class WorkflowsScreen(BaseAppScreen):
         target_id = self._latest_console_follow_item_id
         if not target_id:
             self.app_instance.notify(
-                "No active workflow run is available for Console launch.",
+                WORKFLOWS_EMPTY_CONSOLE_RECOVERY.disabled_tooltip,
                 severity="warning",
             )
             return

--- a/tldw_chatbook/UI/Screens/workflows_screen.py
+++ b/tldw_chatbook/UI/Screens/workflows_screen.py
@@ -123,7 +123,6 @@ class WorkflowsScreen(BaseAppScreen):
                     )
                 else:
                     yield Static("Console launch unavailable", classes="destination-section")
-                    yield Static("No workflow service is wired yet.", id="workflows-empty-state")
                     yield Static(
                         WORKFLOWS_EMPTY_CONSOLE_RECOVERY.visible_copy,
                         id=WORKFLOWS_EMPTY_CONSOLE_RECOVERY.stable_selector,


### PR DESCRIPTION
## Summary
- Add a shared destination recovery state helper for taxonomy-aligned blocked states
- Apply Phase 5 recovery copy/tooltips to ACP, Schedules, Workflows, and Artifacts blockers
- Add TASK-6.2 QA evidence, roadmap/readme tracking, and regression tests

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_destination_shells.py Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py -q
- git diff --check