### PR TITLE
Apply Phase 5 recovery taxonomy to runtime-policy blockers

### DIFF
--- a/Docs/superpowers/qa/unified-shell/phase-5/2026-05-05-runtime-policy-recovery.md
+++ b/Docs/superpowers/qa/unified-shell/phase-5/2026-05-05-runtime-policy-recovery.md
@@ -1,0 +1,55 @@
+# Phase 5.3 Runtime-Policy Recovery
+
+Date: 2026-05-05
+Task: `TASK-6.3`
+Parent Task: `TASK-6`
+Branch: `codex/unified-shell-phase5-runtime-policy-recovery`
+Base: `origin/dev` at `264490d7`
+
+## Goal
+
+Apply the Phase 5 recovery taxonomy to visible runtime-policy denial states in service-backed destination shells. The UX goal is to stop treating policy denials as generic service failures and instead show what is unavailable, why policy blocked it, what the user can do next, the recovery target, and the authority owner.
+
+## Applied Blockers
+
+| Destination | Representative reason code | Blocked workflow | Recovery state |
+| --- | --- | --- | --- |
+| Skills | `authority_denied` | Attach local Skills to Console | Policy denied; review workspace policy or ask the authority owner to allow the action. |
+| Library | `wrong_source` | Use Library sources in Console | Wrong source; switch to the required source, then retry. |
+| Personas | `server_auth_required` | Attach Personas context to Console | Server sign-in required; reconnect or configure server credentials in Settings. |
+| W+C | `server_session_invalid` | Stage W+C context in Console | Server session expired; re-authenticate the active server profile. |
+
+## UX Verification
+
+Focused Textual widget walkthroughs mounted each affected destination through `DestinationHarness`, injected policy-denied service responses, waited for the async snapshot terminal state, and verified:
+
+- Visible status label.
+- `Unavailable:` field.
+- `Why:` field from the policy message.
+- `Next:` recovery step.
+- `Recovery:` target.
+- `Owner:` authority owner.
+- Disabled Console action tooltip repeats the reason and next step.
+
+## Automated Evidence
+
+- Red regression: `python -m pytest Tests/UI/test_destination_shells.py -q -k "policy_denial or policy_denied"`
+- Red result before implementation: `3 failed`, showing raw policy messages without recovery taxonomy fields.
+- Focused runtime-policy verification: `python -m pytest Tests/UI/test_destination_shells.py -q -k "policy_denial or policy_denied"`
+- Focused runtime-policy result after implementation: `4 passed`
+- Affected destination and tracking verification: `python -m pytest Tests/UI/test_destination_shells.py Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py -q`
+- Affected destination and tracking result: `78 passed`
+
+Representative regression tests:
+
+- `test_watchlists_collections_policy_denial_uses_runtime_recovery_taxonomy`
+- `test_personas_policy_denial_uses_runtime_recovery_taxonomy`
+- `test_library_policy_denial_uses_runtime_recovery_taxonomy`
+- `test_skills_destination_policy_denied_surfaces_policy_message`
+
+## Residual Risk
+
+- This slice verifies representative policy denial paths in service-backed destination shells, not every runtime-policy action in the registry.
+- Live server failure classification still depends on upstream service adapters producing the correct `PolicyDeniedError.reason_code`.
+- Optional dependency states remain outside this slice and still need Phase 5 taxonomy application.
+- Parent `TASK-6` remains In Progress until optional-dependency blocker families and final running-app closeout QA are complete.

--- a/Docs/superpowers/qa/unified-shell/phase-5/README.md
+++ b/Docs/superpowers/qa/unified-shell/phase-5/README.md
@@ -8,3 +8,4 @@ This directory contains durable QA summaries for Phase 5 capability-state and re
 
 - `2026-05-05-shared-recovery-taxonomy.md` - `TASK-6.1` shared recovery taxonomy for missing dependency, auth, server, runtime, policy, service, and selection states.
 - `2026-05-05-destination-blocker-recovery.md` - `TASK-6.2` application of the recovery taxonomy to ACP, Schedules, Workflows, and Artifacts shell destination blockers.
+- `2026-05-05-runtime-policy-recovery.md` - `TASK-6.3` application of the recovery taxonomy to visible runtime-policy denials in Skills, Library, Personas, and W+C destination blockers.

--- a/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
@@ -2,7 +2,7 @@
 
 Date: 2026-05-05
 Status: Phase 2, Phase 3, and Phase 4 verified; Phase 5 in progress; Phase 6 not started
-Source Branch: `origin/dev` at `42b2ac1e` plus `codex/unified-shell-phase5-recovery-taxonomy`
+Source Branch: `origin/dev` at `264490d7` plus `codex/unified-shell-phase5-runtime-policy-recovery`
 
 ## Purpose
 
@@ -37,7 +37,7 @@ Track remaining Unified Shell work in one place so rendered screens, clickable b
 - Library now surfaces a local source snapshot from notes, media, and conversations and can stage concrete source context into Console; full Library-native detail views, embedded Import/Export, and embedded Search/RAG remain future work.
 - Personas now surfaces a local behavior snapshot from characters and persona profiles and can stage concrete behavior context into Console; detail, edit, import/export, archetypes, exemplars, dictionaries, and lore remain future work.
 - W+C now surfaces a local monitored-source and saved-collection snapshot from `watchlist_scope_service` and `media_reading_scope_service` and can stage concrete W+C context into Console; full detail, edit, import/export, feed WebSub, alert-rule, retry/backoff, and server collection-feed UX remain future work.
-- Phase 2, Phase 3, and Phase 4 implementation and maturity-gate replays are verified. Phase 5 is in progress with a shared recovery taxonomy applied to the first shell destination blocker family; Phase 6 remains open for full first-time/power-user audit replay.
+- Phase 2, Phase 3, and Phase 4 implementation and maturity-gate replays are verified. Phase 5 is in progress with a shared recovery taxonomy applied to shell destination blockers and representative runtime-policy denials; Phase 6 remains open for full first-time/power-user audit replay.
 
 ## Definition Of Done
 
@@ -109,6 +109,7 @@ Initial child tasks:
 - Phase 4.6: Replay destination service-adoption maturity gate - `TASK-5.6`
 - Phase 5.1: Create shared recovery taxonomy - `TASK-6.1`
 - Phase 5.2: Apply recovery taxonomy to shell destination blockers - `TASK-6.2`
+- Phase 5.3: Apply recovery taxonomy to runtime-policy blockers - `TASK-6.3`
 
 ## QA Evidence Index
 
@@ -131,7 +132,7 @@ Initial child tasks:
 | Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | verified | `TASK-4`, `TASK-4.1`, `TASK-4.2`, `TASK-4.3`, `TASK-4.4`, `TASK-4.5`, `TASK-4.6`, `TASK-4.7`, `TASK-4.8` | `phase-2/` | Schedule and agent-service adapters remain future work; Phase 2 is verified for explicit Home adapter behavior, local W+C/notification flows, and recoverable unavailable states. |
 | Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | verified | `TASK-3`, `TASK-3.1`, `TASK-3.2`, `TASK-3.3`, `TASK-3.4`, `TASK-3.5`, `TASK-3.6`, `TASK-3.7`, `TASK-3.8`, `TASK-3.9`, `TASK-3.10`, `TASK-3.11` | `phase-3/` | ACP, MCP, and durable live event streams remain future work; Phase 3 is verified for implemented Console source launch, follow, status, and recovery flows. |
 | Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | verified | `TASK-5`, `TASK-5.1`, `TASK-5.2`, `TASK-5.3`, `TASK-5.4`, `TASK-5.5`, `TASK-5.6` | `phase-4/` | Full CRUD/server-parity depth remains future work; Phase 4 is verified for destination ownership, concrete local workflows, Console staging, and honest recovery states. |
-| Phase 5: Capability And Recovery System | Systematize unavailable and blocked states. | in-progress | `TASK-6`, `TASK-6.1`, `TASK-6.2` | `phase-5/` | Shared recovery taxonomy is defined and applied to ACP, Schedules, Workflows, and Artifacts shell destination blockers; runtime-policy and optional-dependency blocker families still need application and running-app QA. |
+| Phase 5: Capability And Recovery System | Systematize unavailable and blocked states. | in-progress | `TASK-6`, `TASK-6.1`, `TASK-6.2`, `TASK-6.3` | `phase-5/` | Shared recovery taxonomy is defined and applied to ACP, Schedules, Workflows, Artifacts, and representative runtime-policy destination blockers; optional-dependency blocker families and final running-app closeout QA still remain. |
 | Phase 6: Audit Replay And Closeout | Prove shell works for first-time and power users. | not-started | `TASK-7` | `phase-6/` | Depends on prior phases and running-app QA. |
 
 ## Phase 1.1 QA Harness Evidence
@@ -329,6 +330,12 @@ Initial audit result: W+C, Schedules, Workflows, and ACP had false Console-launc
 `TASK-6.2` applies the taxonomy to ACP runtime, Schedules empty active-run, Workflows empty active-run, and Artifacts empty Chatbook blockers:
 
 - `Docs/superpowers/qa/unified-shell/phase-5/2026-05-05-destination-blocker-recovery.md`
+
+## Phase 5.3 Runtime-Policy Recovery
+
+`TASK-6.3` applies the taxonomy to visible runtime-policy blockers in Skills, Library, Personas, and W+C destination shells:
+
+- `Docs/superpowers/qa/unified-shell/phase-5/2026-05-05-runtime-policy-recovery.md`
 
 ## Phase 0: Canonical Tracking
 

--- a/Tests/UI/test_destination_shells.py
+++ b/Tests/UI/test_destination_shells.py
@@ -142,6 +142,30 @@ class RaisingLibraryNotesScopeService:
         raise RuntimeError("notes unavailable")
 
 
+class PolicyDeniedLibraryNotesScopeService:
+    def __init__(
+        self,
+        *,
+        reason_code="wrong_source",
+        user_message="Server Library sources require server mode.",
+        effective_source="local",
+        authority_owner="active server",
+    ):
+        self.reason_code = reason_code
+        self.user_message = user_message
+        self.effective_source = effective_source
+        self.authority_owner = authority_owner
+
+    async def list_notes(self, **kwargs):
+        raise PolicyDeniedError(
+            action_id="library.sources.list",
+            reason_code=self.reason_code,
+            user_message=self.user_message,
+            effective_source=self.effective_source,
+            authority_owner=self.authority_owner,
+        )
+
+
 class StaticWatchlistsScopeService:
     def __init__(self, watch_items):
         self.watch_items = tuple(watch_items)
@@ -155,6 +179,30 @@ class StaticWatchlistsScopeService:
 class RaisingWatchlistsScopeService:
     async def list_watch_items(self, **kwargs):
         raise RuntimeError("watchlists unavailable")
+
+
+class PolicyDeniedWatchlistsScopeService:
+    def __init__(
+        self,
+        *,
+        reason_code="server_session_invalid",
+        user_message="The W+C server session has expired.",
+        effective_source="server",
+        authority_owner="active server",
+    ):
+        self.reason_code = reason_code
+        self.user_message = user_message
+        self.effective_source = effective_source
+        self.authority_owner = authority_owner
+
+    async def list_watch_items(self, **kwargs):
+        raise PolicyDeniedError(
+            action_id="wc.watchlists.list",
+            reason_code=self.reason_code,
+            user_message=self.user_message,
+            effective_source=self.effective_source,
+            authority_owner=self.authority_owner,
+        )
 
 
 class StaticReadItLaterScopeService:
@@ -183,14 +231,54 @@ class RaisingSkillsScopeService:
 
 
 class PolicyDeniedSkillsScopeService:
+    def __init__(
+        self,
+        *,
+        reason_code="authority_denied",
+        user_message="Local Skills are disabled by workspace policy.",
+        effective_source="local",
+        authority_owner="local",
+    ):
+        self.reason_code = reason_code
+        self.user_message = user_message
+        self.effective_source = effective_source
+        self.authority_owner = authority_owner
+
     async def list_skills(self, **kwargs):
         raise PolicyDeniedError(
             action_id="skills.list.local",
-            reason_code="authority_denied",
-            user_message="Local Skills are disabled by workspace policy.",
-            effective_source="local",
-            authority_owner="local",
+            reason_code=self.reason_code,
+            user_message=self.user_message,
+            effective_source=self.effective_source,
+            authority_owner=self.authority_owner,
         )
+
+
+class PolicyDeniedPersonasScopeService:
+    def __init__(
+        self,
+        *,
+        reason_code="server_auth_required",
+        user_message="Server Personas require sign-in.",
+        effective_source="server",
+        authority_owner="active server",
+    ):
+        self.reason_code = reason_code
+        self.user_message = user_message
+        self.effective_source = effective_source
+        self.authority_owner = authority_owner
+
+    async def list_characters(self, **kwargs):
+        raise PolicyDeniedError(
+            action_id="personas.characters.list",
+            reason_code=self.reason_code,
+            user_message=self.user_message,
+            effective_source=self.effective_source,
+            authority_owner=self.authority_owner,
+        )
+
+    async def list_persona_profiles(self, **kwargs):
+        return []
 
 
 class DestinationHarness(App):
@@ -267,6 +355,38 @@ async def _wait_for_wc_snapshot(screen, pilot, *, timeout: float = 2.0) -> None:
     raise AssertionError(f"Timed out waiting for W+C snapshot. Visible text: {_visible_text(screen)}")
 
 
+async def _wait_for_library_snapshot(screen, pilot, *, timeout: float = 2.0) -> None:
+    deadline = time.monotonic() + timeout
+    terminal_selectors = (
+        "#library-source-error",
+        "#library-source-empty",
+        "#library-notes-summary",
+        "#library-media-summary",
+        "#library-conversations-summary",
+    )
+    while time.monotonic() < deadline:
+        if any(screen.query(selector) for selector in terminal_selectors):
+            await pilot.pause()
+            return
+        await pilot.pause(0.01)
+    raise AssertionError(f"Timed out waiting for Library snapshot. Visible text: {_visible_text(screen)}")
+
+
+async def _wait_for_skills_snapshot(screen, pilot, *, timeout: float = 2.0) -> None:
+    deadline = time.monotonic() + timeout
+    terminal_selectors = (
+        "#skills-service-error",
+        "#skills-empty-state",
+        "#skills-local-summary",
+    )
+    while time.monotonic() < deadline:
+        if any(screen.query(selector) for selector in terminal_selectors):
+            await pilot.pause()
+            return
+        await pilot.pause(0.01)
+    raise AssertionError(f"Timed out waiting for Skills snapshot. Visible text: {_visible_text(screen)}")
+
+
 async def _wait_for_mock_call(mock: Mock, pilot, *, timeout: float = 1.0) -> None:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
@@ -274,6 +394,28 @@ async def _wait_for_mock_call(mock: Mock, pilot, *, timeout: float = 1.0) -> Non
             return
         await pilot.pause()
     raise AssertionError("Timed out waiting for mock call")
+
+
+def _assert_policy_recovery_copy(
+    *,
+    visible_text: str,
+    button: Button,
+    status_label: str,
+    unavailable_what: str,
+    why: str,
+    next_action: str,
+    recovery_action: str,
+    authority_owner: str,
+) -> None:
+    assert status_label in visible_text
+    assert f"Unavailable: {unavailable_what}." in visible_text
+    assert f"Why: {why}." in visible_text
+    assert f"Next: {next_action}" in visible_text
+    assert f"Recovery: {recovery_action}." in visible_text
+    assert f"Owner: {authority_owner}." in visible_text
+    assert button.disabled is True
+    assert why in str(button.tooltip)
+    assert next_action in str(button.tooltip)
 
 
 @pytest.mark.parametrize(
@@ -389,6 +531,31 @@ async def test_watchlists_collections_service_failure_uses_recovery_copy():
         assert "W+C services unavailable; retry W+C later." in _visible_text(screen)
         assert button.disabled is True
         assert "W+C services are unavailable" in str(button.tooltip)
+
+
+@pytest.mark.asyncio
+async def test_watchlists_collections_policy_denial_uses_runtime_recovery_taxonomy():
+    app = _build_test_app()
+    app.watchlist_scope_service = PolicyDeniedWatchlistsScopeService()
+    app.media_reading_scope_service = StaticReadItLaterScopeService([])
+    host = DestinationHarness(app, "watchlists_collections")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_wc_snapshot(screen, pilot)
+        error = screen.query_one("#wc-service-error", Static)
+        button = screen.query_one("#wc-attach-to-console", Button)
+
+        _assert_policy_recovery_copy(
+            visible_text=_static_text(error),
+            button=button,
+            status_label="Server session expired",
+            unavailable_what="Stage W+C context in Console",
+            why="The W+C server session has expired",
+            next_action="Re-authenticate the active server profile before retrying.",
+            recovery_action="Settings",
+            authority_owner="active server",
+        )
 
 
 @pytest.mark.asyncio
@@ -538,6 +705,30 @@ async def test_personas_destination_service_failure_uses_recovery_copy():
         assert "Personas service unavailable; retry Personas later." in _visible_text(screen)
         assert button.disabled is True
         assert "Personas service is unavailable" in str(button.tooltip)
+
+
+@pytest.mark.asyncio
+async def test_personas_policy_denial_uses_runtime_recovery_taxonomy():
+    app = _build_test_app()
+    app.character_persona_scope_service = PolicyDeniedPersonasScopeService()
+    host = DestinationHarness(app, "personas")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_personas_snapshot(screen, pilot)
+        error = screen.query_one("#personas-service-error", Static)
+        button = screen.query_one("#personas-attach-to-console", Button)
+
+        _assert_policy_recovery_copy(
+            visible_text=_static_text(error),
+            button=button,
+            status_label="Server sign-in required",
+            unavailable_what="Attach Personas context to Console",
+            why="Server Personas require sign-in",
+            next_action="Reconnect or configure server credentials in Settings before retrying.",
+            recovery_action="Settings",
+            authority_owner="active server",
+        )
 
 
 @pytest.mark.asyncio
@@ -736,6 +927,32 @@ async def test_library_destination_service_failure_uses_recovery_copy():
         assert "Library source services unavailable; retry Library later." in _visible_text(screen)
         assert button.disabled is True
         assert "Library source services are unavailable" in str(button.tooltip)
+
+
+@pytest.mark.asyncio
+async def test_library_policy_denial_uses_runtime_recovery_taxonomy():
+    app = _build_test_app()
+    app.notes_scope_service = PolicyDeniedLibraryNotesScopeService()
+    app.media_reading_scope_service = StaticLibraryMediaScopeService([])
+    app.chat_conversation_scope_service = StaticLibraryConversationScopeService([])
+    host = DestinationHarness(app, "library")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_library_snapshot(screen, pilot)
+        error = screen.query_one("#library-source-error", Static)
+        button = screen.query_one("#library-use-in-console", Button)
+
+        _assert_policy_recovery_copy(
+            visible_text=_static_text(error),
+            button=button,
+            status_label="Wrong source",
+            unavailable_what="Use Library sources in Console",
+            why="Server Library sources require server mode",
+            next_action="Switch to the required source, then retry this workflow.",
+            recovery_action="Source switch or Settings",
+            authority_owner="active server",
+        )
 
 
 @pytest.mark.asyncio
@@ -1105,12 +1322,20 @@ async def test_skills_destination_policy_denied_surfaces_policy_message():
     host = DestinationHarness(app, "skills")
 
     async with host.run_test(size=(180, 50)) as pilot:
-        await pilot.pause(0.2)
         screen = _active_destination_screen(host)
+        await _wait_for_skills_snapshot(screen, pilot)
         button = screen.query_one("#skills-attach-to-console", Button)
 
-        assert "Local Skills are disabled by workspace policy." in _visible_text(screen)
-        assert button.disabled is True
+        _assert_policy_recovery_copy(
+            visible_text=_visible_text(screen),
+            button=button,
+            status_label="Policy denied",
+            unavailable_what="Attach local Skills to Console",
+            why="Local Skills are disabled by workspace policy",
+            next_action="Review workspace policy or ask the authority owner to allow this action.",
+            recovery_action="Workspace policy",
+            authority_owner="local",
+        )
         assert "Skills service unavailable; retry Skills later." not in _visible_text(screen)
 
 

--- a/Tests/UI/test_destination_shells.py
+++ b/Tests/UI/test_destination_shells.py
@@ -19,6 +19,7 @@ from tldw_chatbook.runtime_policy.types import PolicyDeniedError
 from tldw_chatbook.UI.MCP_Modules.unified_mcp_panel import UnifiedMCPPanel
 from tldw_chatbook.UI.Screens.artifacts_screen import ArtifactsScreen
 from tldw_chatbook.UI.Screens.acp_screen import ACPScreen
+from tldw_chatbook.UI.Screens.destination_recovery import DestinationRecoveryState
 from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
 from tldw_chatbook.UI.Screens.mcp_screen import MCPScreen
 from tldw_chatbook.UI.Screens.personas_screen import PersonasScreen
@@ -387,6 +388,16 @@ async def _wait_for_skills_snapshot(screen, pilot, *, timeout: float = 2.0) -> N
     raise AssertionError(f"Timed out waiting for Skills snapshot. Visible text: {_visible_text(screen)}")
 
 
+async def _wait_for_selector(screen, pilot, selector: str, *, timeout: float = 2.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if screen.query(selector):
+            await pilot.pause()
+            return
+        await pilot.pause(0.01)
+    raise AssertionError(f"Timed out waiting for {selector}. Visible text: {_visible_text(screen)}")
+
+
 async def _wait_for_mock_call(mock: Mock, pilot, *, timeout: float = 1.0) -> None:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
@@ -416,6 +427,19 @@ def _assert_policy_recovery_copy(
     assert button.disabled is True
     assert why in str(button.tooltip)
     assert next_action in str(button.tooltip)
+
+
+def _custom_policy_recovery_state(exc, *, unavailable_what, stable_selector, policy_message=None):
+    return DestinationRecoveryState(
+        status_label="Custom policy state",
+        unavailable_what=unavailable_what,
+        why=policy_message or exc.user_message,
+        next_action="Use the custom recovery target.",
+        recovery_action="Custom recovery",
+        authority_owner=exc.authority_owner,
+        stable_selector=f"custom-{stable_selector}",
+        disabled_tooltip="Custom policy tooltip.",
+    )
 
 
 @pytest.mark.parametrize(
@@ -556,6 +580,27 @@ async def test_watchlists_collections_policy_denial_uses_runtime_recovery_taxono
             recovery_action="Settings",
             authority_owner="active server",
         )
+
+
+@pytest.mark.asyncio
+async def test_watchlists_collections_policy_denial_uses_recovery_state_selector(monkeypatch):
+    monkeypatch.setattr(
+        wc_screen_module,
+        "policy_denied_recovery_state",
+        _custom_policy_recovery_state,
+    )
+    app = _build_test_app()
+    app.watchlist_scope_service = PolicyDeniedWatchlistsScopeService()
+    app.media_reading_scope_service = StaticReadItLaterScopeService([])
+    host = DestinationHarness(app, "watchlists_collections")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_selector(screen, pilot, "#custom-wc-service-error")
+        button = screen.query_one("#wc-attach-to-console", Button)
+
+        assert "Custom policy state" in _visible_text(screen)
+        assert button.tooltip == "Custom policy tooltip."
 
 
 @pytest.mark.asyncio
@@ -729,6 +774,26 @@ async def test_personas_policy_denial_uses_runtime_recovery_taxonomy():
             recovery_action="Settings",
             authority_owner="active server",
         )
+
+
+@pytest.mark.asyncio
+async def test_personas_policy_denial_uses_recovery_state_selector(monkeypatch):
+    monkeypatch.setattr(
+        personas_screen_module,
+        "policy_denied_recovery_state",
+        _custom_policy_recovery_state,
+    )
+    app = _build_test_app()
+    app.character_persona_scope_service = PolicyDeniedPersonasScopeService()
+    host = DestinationHarness(app, "personas")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_selector(screen, pilot, "#custom-personas-service-error")
+        button = screen.query_one("#personas-attach-to-console", Button)
+
+        assert "Custom policy state" in _visible_text(screen)
+        assert button.tooltip == "Custom policy tooltip."
 
 
 @pytest.mark.asyncio
@@ -953,6 +1018,28 @@ async def test_library_policy_denial_uses_runtime_recovery_taxonomy():
             recovery_action="Source switch or Settings",
             authority_owner="active server",
         )
+
+
+@pytest.mark.asyncio
+async def test_library_policy_denial_uses_recovery_state_selector(monkeypatch):
+    monkeypatch.setattr(
+        library_screen_module,
+        "policy_denied_recovery_state",
+        _custom_policy_recovery_state,
+    )
+    app = _build_test_app()
+    app.notes_scope_service = PolicyDeniedLibraryNotesScopeService()
+    app.media_reading_scope_service = StaticLibraryMediaScopeService([])
+    app.chat_conversation_scope_service = StaticLibraryConversationScopeService([])
+    host = DestinationHarness(app, "library")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_selector(screen, pilot, "#custom-library-source-error")
+        button = screen.query_one("#library-use-in-console", Button)
+
+        assert "Custom policy state" in _visible_text(screen)
+        assert button.tooltip == "Custom policy tooltip."
 
 
 @pytest.mark.asyncio
@@ -1337,6 +1424,26 @@ async def test_skills_destination_policy_denied_surfaces_policy_message():
             authority_owner="local",
         )
         assert "Skills service unavailable; retry Skills later." not in _visible_text(screen)
+
+
+@pytest.mark.asyncio
+async def test_skills_policy_denial_uses_recovery_state_selector(monkeypatch):
+    monkeypatch.setattr(
+        skills_screen_module,
+        "policy_denied_recovery_state",
+        _custom_policy_recovery_state,
+    )
+    app = _build_test_app()
+    app.skills_scope_service = PolicyDeniedSkillsScopeService()
+    host = DestinationHarness(app, "skills")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_selector(screen, pilot, "#custom-skills-service-error")
+        button = screen.query_one("#skills-attach-to-console", Button)
+
+        assert "Custom policy state" in _visible_text(screen)
+        assert button.tooltip == "Custom policy tooltip."
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py
+++ b/Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py
@@ -274,9 +274,46 @@ def test_phase_five_runtime_policy_recovery_helper_maps_reason_groups(
     )
 
     assert recovery_state.status_label == status_label
-    assert recovery_state.why == "Policy message from service"
+    assert recovery_state.why == "Policy message from service."
     assert recovery_state.next_action == next_action
     assert recovery_state.recovery_action == recovery_action
     assert recovery_state.authority_owner == "active server"
     assert "Policy message from service." in recovery_state.disabled_tooltip
     assert next_action in recovery_state.disabled_tooltip
+
+
+def test_phase_five_recovery_copy_preserves_policy_message_terminal_punctuation():
+    exc = PolicyDeniedError(
+        action_id="test.action",
+        reason_code="authority_denied",
+        user_message="Allow this action?",
+        effective_source="server",
+        authority_owner="workspace policy!",
+    )
+
+    recovery_state = policy_denied_recovery_state(
+        exc,
+        unavailable_what="Test workflow!",
+        stable_selector="test-recovery",
+    )
+
+    assert recovery_state.why == "Allow this action?"
+    assert recovery_state.authority_owner == "workspace policy!"
+    assert "Unavailable: Test workflow!" in recovery_state.visible_copy
+    assert "Why: Allow this action?" in recovery_state.visible_copy
+    assert "Owner: workspace policy!" in recovery_state.visible_copy
+    assert "Allow this action?" in recovery_state.disabled_tooltip
+
+
+def test_service_backed_policy_destinations_use_async_workers_without_asyncio_run():
+    screen_paths = [
+        Path("tldw_chatbook/UI/Screens/library_screen.py"),
+        Path("tldw_chatbook/UI/Screens/personas_screen.py"),
+        Path("tldw_chatbook/UI/Screens/skills_screen.py"),
+    ]
+
+    for screen_path in screen_paths:
+        source = _text(screen_path)
+        assert "thread=True" not in source, screen_path
+        assert "asyncio.run" not in source, screen_path
+        assert "_run_maybe_awaitable" not in source, screen_path

--- a/Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py
+++ b/Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py
@@ -2,6 +2,11 @@ import json
 import re
 from pathlib import Path
 
+import pytest
+
+from tldw_chatbook.runtime_policy.types import PolicyDeniedError
+from tldw_chatbook.UI.Screens.destination_recovery import policy_denied_recovery_state
+
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 ROADMAP = Path("Docs/superpowers/trackers/unified-shell-maturity-roadmap.md")
@@ -12,10 +17,16 @@ PHASE_5_TAXONOMY = Path(
 PHASE_5_DESTINATION_RECOVERY = Path(
     "Docs/superpowers/qa/unified-shell/phase-5/2026-05-05-destination-blocker-recovery.md"
 )
+PHASE_5_RUNTIME_POLICY_RECOVERY = Path(
+    "Docs/superpowers/qa/unified-shell/phase-5/2026-05-05-runtime-policy-recovery.md"
+)
 PHASE_5_PARENT_TASK = Path("backlog/tasks/task-6 - Phase-5-Capability-And-Recovery-System.md")
 PHASE_5_TAXONOMY_TASK = Path("backlog/tasks/task-6.1 - Phase-5.1-Create-shared-recovery-taxonomy.md")
 PHASE_5_DESTINATION_RECOVERY_TASK = Path(
     "backlog/tasks/task-6.2 - Phase-5.2-Apply-recovery-taxonomy-to-shell-destination-blockers.md"
+)
+PHASE_5_RUNTIME_POLICY_TASK = Path(
+    "backlog/tasks/task-6.3 - Phase-5.3-Apply-recovery-taxonomy-to-runtime-policy-blockers.md"
 )
 
 
@@ -68,6 +79,7 @@ def test_phase_five_recovery_taxonomy_is_tracked_from_roadmap_readme_and_tasks()
     parent_task = _text(PHASE_5_PARENT_TASK)
     child_task = _text(PHASE_5_TAXONOMY_TASK)
     destination_recovery_task = _text(PHASE_5_DESTINATION_RECOVERY_TASK)
+    runtime_policy_task = _text(PHASE_5_RUNTIME_POLICY_TASK)
 
     _assert_roadmap_tracks_phase_five_progress(roadmap)
     phase_five_row = _roadmap_phase_evidence_row(roadmap, "Phase 5")
@@ -79,18 +91,27 @@ def test_phase_five_recovery_taxonomy_is_tracked_from_roadmap_readme_and_tasks()
         roadmap,
         re.IGNORECASE,
     )
+    assert re.search(
+        r"Phase\s+5\.3:.*runtime-policy blockers.*`TASK-6\.3`",
+        roadmap,
+        re.IGNORECASE,
+    )
     assert "2026-05-05-shared-recovery-taxonomy.md" in roadmap
     assert "2026-05-05-destination-blocker-recovery.md" in roadmap
+    assert "2026-05-05-runtime-policy-recovery.md" in roadmap
 
     assert _status_line(readme) == "in-progress"
     assert "`TASK-6.1`" in readme
     assert "`TASK-6.2`" in readme
+    assert "`TASK-6.3`" in readme
     assert "2026-05-05-shared-recovery-taxonomy.md" in readme
     assert "2026-05-05-destination-blocker-recovery.md" in readme
+    assert "2026-05-05-runtime-policy-recovery.md" in readme
 
     assert "status: In Progress" in parent_task
     assert "TASK-6.1" in parent_task
     assert "TASK-6.2" in parent_task
+    assert "TASK-6.3" in parent_task
     assert "status: Done" in child_task
     for acceptance_criterion in range(1, 5):
         assert f"- [x] #{acceptance_criterion}" in child_task
@@ -99,6 +120,10 @@ def test_phase_five_recovery_taxonomy_is_tracked_from_roadmap_readme_and_tasks()
     for acceptance_criterion in range(1, 6):
         assert f"- [x] #{acceptance_criterion}" in destination_recovery_task
     assert "Implementation Notes" in destination_recovery_task
+    assert "status: Done" in runtime_policy_task
+    for acceptance_criterion in range(1, 6):
+        assert f"- [x] #{acceptance_criterion}" in runtime_policy_task
+    assert "Implementation Notes" in runtime_policy_task
 
 
 def test_phase_five_destination_recovery_evidence_records_applied_blockers():
@@ -112,6 +137,23 @@ def test_phase_five_destination_recovery_evidence_records_applied_blockers():
     assert "Console launch for Chatbook artifacts" in evidence
     assert "test_phase_five_destination_blockers_expose_taxonomy_recovery_fields" in evidence
     assert "13 passed" in evidence
+
+
+def test_phase_five_runtime_policy_recovery_evidence_records_applied_blockers():
+    evidence = _text(PHASE_5_RUNTIME_POLICY_RECOVERY)
+
+    assert "/Users/" not in evidence
+    assert "TASK-6.3" in evidence
+    assert "wrong_source" in evidence
+    assert "server_auth_required" in evidence
+    assert "server_session_invalid" in evidence
+    assert "authority_denied" in evidence
+    assert "Skills" in evidence
+    assert "Library" in evidence
+    assert "Personas" in evidence
+    assert "W+C" in evidence
+    assert "test_watchlists_collections_policy_denial_uses_runtime_recovery_taxonomy" in evidence
+    assert "4 passed" in evidence
 
 
 def test_phase_five_recovery_taxonomy_defines_required_contract_and_reason_mappings():
@@ -168,3 +210,73 @@ def test_phase_five_recovery_taxonomy_defines_required_contract_and_reason_mappi
         "phase-4-destination-service-adoption-closeout",
         "runtime-policy-domain-edge-contracts",
     ]
+
+
+@pytest.mark.parametrize(
+    ("reason_code", "status_label", "next_action", "recovery_action"),
+    [
+        (
+            "wrong_source",
+            "Wrong source",
+            "Switch to the required source, then retry this workflow.",
+            "Source switch or Settings",
+        ),
+        (
+            "server_not_configured",
+            "Server not configured",
+            "Add an active server profile in Settings before retrying.",
+            "Settings",
+        ),
+        (
+            "server_auth_required",
+            "Server sign-in required",
+            "Reconnect or configure server credentials in Settings before retrying.",
+            "Settings",
+        ),
+        (
+            "server_session_invalid",
+            "Server session expired",
+            "Re-authenticate the active server profile before retrying.",
+            "Settings",
+        ),
+        (
+            "capability_disabled",
+            "Capability disabled",
+            "Enable this capability in Settings or the governing policy before retrying.",
+            "Settings or governing policy",
+        ),
+        (
+            "authority_denied",
+            "Policy denied",
+            "Review workspace policy or ask the authority owner to allow this action.",
+            "Workspace policy",
+        ),
+    ],
+)
+def test_phase_five_runtime_policy_recovery_helper_maps_reason_groups(
+    reason_code,
+    status_label,
+    next_action,
+    recovery_action,
+):
+    exc = PolicyDeniedError(
+        action_id="test.action",
+        reason_code=reason_code,
+        user_message="Policy message from service.",
+        effective_source="server",
+        authority_owner="active server",
+    )
+
+    recovery_state = policy_denied_recovery_state(
+        exc,
+        unavailable_what="Test workflow",
+        stable_selector="test-recovery",
+    )
+
+    assert recovery_state.status_label == status_label
+    assert recovery_state.why == "Policy message from service"
+    assert recovery_state.next_action == next_action
+    assert recovery_state.recovery_action == recovery_action
+    assert recovery_state.authority_owner == "active server"
+    assert "Policy message from service." in recovery_state.disabled_tooltip
+    assert next_action in recovery_state.disabled_tooltip

--- a/backlog/tasks/task-6 - Phase-5-Capability-And-Recovery-System.md
+++ b/backlog/tasks/task-6 - Phase-5-Capability-And-Recovery-System.md
@@ -41,5 +41,5 @@ Systematize missing dependency, auth, server, runtime, and policy states so bloc
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Started Phase 5 with TASK-6.1, which defines the shared recovery taxonomy and tracking contract. TASK-6.2 applies the taxonomy to the first shell destination blocker family: ACP runtime configuration, Schedules empty active-run, Workflows empty active-run, and Artifacts empty Chatbook states. Parent Phase 5 remains In Progress until later slices apply the taxonomy to remaining runtime-policy and optional-dependency blocker families and running-app QA verifies recovery paths.
+Started Phase 5 with TASK-6.1, which defines the shared recovery taxonomy and tracking contract. TASK-6.2 applies the taxonomy to the first shell destination blocker family: ACP runtime configuration, Schedules empty active-run, Workflows empty active-run, and Artifacts empty Chatbook states. TASK-6.3 applies the taxonomy to representative runtime-policy denials in Skills, Library, Personas, and W+C. Parent Phase 5 remains In Progress until later slices apply the taxonomy to optional-dependency blocker families and final running-app QA verifies recovery paths.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-6.3 - Phase-5.3-Apply-recovery-taxonomy-to-runtime-policy-blockers.md
+++ b/backlog/tasks/task-6.3 - Phase-5.3-Apply-recovery-taxonomy-to-runtime-policy-blockers.md
@@ -1,0 +1,48 @@
+---
+id: TASK-6.3
+title: Phase 5.3 Apply recovery taxonomy to runtime-policy blockers
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-05-05 03:40'
+labels:
+  - unified-shell
+  - phase-5
+  - recovery
+  - runtime-policy
+dependencies: []
+documentation:
+  - >-
+    Docs/superpowers/qa/unified-shell/phase-5/2026-05-05-shared-recovery-taxonomy.md
+  - >-
+    Docs/superpowers/qa/unified-shell/phase-4/2026-05-05-phase-4-destination-service-adoption-closeout.md
+parent_task_id: TASK-6
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Apply the shared Phase 5 recovery taxonomy to visible runtime-policy denial states in service-backed shell destinations so users can distinguish wrong-source, server setup/auth/session, policy, and disabled-capability blockers from generic service failures.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Skills, Library, Personas, and W+C destination policy-denied states expose what is unavailable, why, next action, recovery target, authority owner, stable selector, and disabled tooltip copy.
+- [x] #2 Runtime-policy reason codes are mapped to user-facing recovery states for wrong source, server setup, server auth/session, policy denied, and capability disabled blockers.
+- [x] #3 Automated UI regressions verify visible recovery copy and disabled tooltips for representative destination policy denials.
+- [x] #4 Durable Phase 5 QA evidence records verification, residual risks, and the remaining Phase 5 blocker families.
+- [x] #5 Parent Phase 5 tracking is updated without marking the phase verified.
+<!-- AC:END -->
+
+## Implementation Plan
+
+1. Add failing UI regressions for representative policy-denied states across Skills, Library, Personas, and W+C destination shells.
+2. Add the smallest shared recovery helper needed to map `PolicyDeniedError` reason codes into `DestinationRecoveryState` fields.
+3. Wire the helper into the four service-backed destination shells while preserving existing service-error and empty-state behavior.
+4. Update Phase 5 QA evidence, roadmap, and Backlog tracking for `TASK-6.3`.
+5. Run focused UI and Phase 5 tracking tests before opening the PR.
+
+## Implementation Notes
+
+Added a shared runtime-policy recovery mapper that converts `PolicyDeniedError.reason_code` values into `DestinationRecoveryState` copy and tooltips. Wired it into Skills, Library, Personas, and W+C service-backed destination blocked states while preserving generic service-error and empty-state behavior. Added focused UI regressions for authority-denied, wrong-source, server-auth, and server-session blockers, plus Phase 5 tracking evidence for `TASK-6.3`.

--- a/tldw_chatbook/UI/Screens/destination_recovery.py
+++ b/tldw_chatbook/UI/Screens/destination_recovery.py
@@ -44,17 +44,17 @@ class DestinationRecoveryState:
         return "\n".join(
             (
                 self.status_label,
-                f"Unavailable: {self.unavailable_what}.",
-                f"Why: {self.why}.",
+                f"Unavailable: {self._sentence(self.unavailable_what)}",
+                f"Why: {self._sentence(self.why)}",
                 f"Next: {self._sentence(self.next_action)}",
-                f"Recovery: {self.recovery_action}.",
-                f"Owner: {self.authority_owner}.",
+                f"Recovery: {self._sentence(self.recovery_action)}",
+                f"Owner: {self._sentence(self.authority_owner)}",
             )
         )
 
 
 def _clause(value: Any, fallback: str) -> str:
-    text = str(value or "").strip().rstrip(".!?")
+    text = str(value or "").strip()
     return text or fallback
 
 
@@ -119,7 +119,17 @@ def policy_denied_recovery_state(
     stable_selector: str,
     policy_message: str | None = None,
 ) -> DestinationRecoveryState:
-    """Map a runtime-policy denial into visible destination recovery copy."""
+    """Map a runtime-policy denial into visible destination recovery copy.
+
+    Args:
+        exc: Runtime-policy denial object with reason, message, and owner fields.
+        unavailable_what: Specific workflow or control blocked by the denial.
+        stable_selector: Stable widget selector for the rendered recovery state.
+        policy_message: Optional sanitized policy message to prefer over `exc`.
+
+    Returns:
+        Destination recovery state with taxonomy-aligned visible copy and tooltip.
+    """
 
     status_label, next_action, recovery_action = _policy_recovery_for_reason(
         getattr(exc, "reason_code", None)

--- a/tldw_chatbook/UI/Screens/destination_recovery.py
+++ b/tldw_chatbook/UI/Screens/destination_recovery.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass(frozen=True)
@@ -50,3 +51,97 @@ class DestinationRecoveryState:
                 f"Owner: {self.authority_owner}.",
             )
         )
+
+
+def _clause(value: Any, fallback: str) -> str:
+    text = str(value or "").strip().rstrip(".!?")
+    return text or fallback
+
+
+def _policy_recovery_for_reason(reason_code: str | None) -> tuple[str, str, str]:
+    normalized_reason = str(reason_code or "").strip().lower()
+    if normalized_reason == "wrong_source":
+        return (
+            "Wrong source",
+            "Switch to the required source, then retry this workflow.",
+            "Source switch or Settings",
+        )
+    if normalized_reason in {"server_not_configured", "server_profile_missing"}:
+        return (
+            "Server not configured",
+            "Add an active server profile in Settings before retrying.",
+            "Settings",
+        )
+    if normalized_reason in {"server_unreachable", "server_unavailable"}:
+        return (
+            "Server unavailable",
+            "Check server availability, then retry this workflow.",
+            "Retry",
+        )
+    if normalized_reason in {
+        "server_auth_required",
+        "auth_required",
+        "credential_store_unavailable",
+        "server_credentials_unavailable",
+    }:
+        return (
+            "Server sign-in required",
+            "Reconnect or configure server credentials in Settings before retrying.",
+            "Settings",
+        )
+    if normalized_reason in {
+        "server_session_invalid",
+        "stale_authorization",
+        "profile_no_longer_authorized",
+    }:
+        return (
+            "Server session expired",
+            "Re-authenticate the active server profile before retrying.",
+            "Settings",
+        )
+    if normalized_reason == "capability_disabled":
+        return (
+            "Capability disabled",
+            "Enable this capability in Settings or the governing policy before retrying.",
+            "Settings or governing policy",
+        )
+    return (
+        "Policy denied",
+        "Review workspace policy or ask the authority owner to allow this action.",
+        "Workspace policy",
+    )
+
+
+def policy_denied_recovery_state(
+    exc: Any,
+    *,
+    unavailable_what: str,
+    stable_selector: str,
+    policy_message: str | None = None,
+) -> DestinationRecoveryState:
+    """Map a runtime-policy denial into visible destination recovery copy."""
+
+    status_label, next_action, recovery_action = _policy_recovery_for_reason(
+        getattr(exc, "reason_code", None)
+    )
+    why = _clause(
+        policy_message if policy_message is not None else getattr(exc, "user_message", None),
+        "Runtime policy blocked this action",
+    )
+    authority_owner = _clause(getattr(exc, "authority_owner", None), "runtime policy")
+    disabled_tooltip = " ".join(
+        (
+            DestinationRecoveryState._sentence(why),
+            DestinationRecoveryState._sentence(next_action),
+        )
+    )
+    return DestinationRecoveryState(
+        status_label=status_label,
+        unavailable_what=unavailable_what,
+        why=why,
+        next_action=next_action,
+        recovery_action=recovery_action,
+        authority_owner=authority_owner,
+        stable_selector=stable_selector,
+        disabled_tooltip=disabled_tooltip,
+    )

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -20,6 +20,7 @@ from ...runtime_policy.types import PolicyDeniedError
 from ...Utils.input_validation import sanitize_string, validate_text_input
 from ..Navigation.base_app_screen import BaseAppScreen
 from ..Navigation.main_navigation import NavigateToScreen
+from .destination_recovery import policy_denied_recovery_state
 
 
 logger = logger.bind(module="LibraryScreen")
@@ -50,6 +51,7 @@ class LibraryScreen(BaseAppScreen):
             "conversations": True,
         }
         self._library_lookup_error: str | None = None
+        self._library_lookup_error_tooltip: str | None = None
         self._library_loaded = False
 
     def on_mount(self) -> None:
@@ -58,13 +60,20 @@ class LibraryScreen(BaseAppScreen):
 
     @work(exclusive=True, thread=True)
     def _refresh_local_source_snapshot(self) -> None:
-        records, counts, total_known, lookup_error = self._list_local_source_snapshot()
+        (
+            records,
+            counts,
+            total_known,
+            lookup_error,
+            lookup_error_tooltip,
+        ) = self._list_local_source_snapshot()
         self.app.call_from_thread(
             self._apply_local_source_snapshot,
             records,
             counts,
             total_known,
             lookup_error,
+            lookup_error_tooltip,
         )
 
     def _apply_local_source_snapshot(
@@ -73,11 +82,13 @@ class LibraryScreen(BaseAppScreen):
         counts: dict[str, int],
         total_known: dict[str, bool],
         lookup_error: str | None = None,
+        lookup_error_tooltip: str | None = None,
     ) -> None:
         self._local_source_records = records
         self._local_source_counts = counts
         self._local_source_total_known = total_known
         self._library_lookup_error = lookup_error
+        self._library_lookup_error_tooltip = lookup_error_tooltip
         self._library_loaded = True
         if self.is_mounted:
             self.refresh(recompose=True)
@@ -143,6 +154,7 @@ class LibraryScreen(BaseAppScreen):
         dict[str, int],
         dict[str, bool],
         str | None,
+        str | None,
     ]:
         notes_service = getattr(self.app_instance, "notes_scope_service", None)
         media_service = getattr(self.app_instance, "media_reading_scope_service", None)
@@ -159,7 +171,7 @@ class LibraryScreen(BaseAppScreen):
         empty_counts = {"notes": 0, "media": 0, "conversations": 0}
         empty_total_known = {"notes": True, "media": True, "conversations": True}
         if not all(callable(call) for call in (list_notes, list_media, list_conversations)):
-            return empty_records, empty_counts, empty_total_known, LIBRARY_SERVICE_UNAVAILABLE_COPY
+            return empty_records, empty_counts, empty_total_known, LIBRARY_SERVICE_UNAVAILABLE_COPY, None
 
         try:
             notes_result = self._run_maybe_awaitable(
@@ -187,13 +199,25 @@ class LibraryScreen(BaseAppScreen):
             )
         except PolicyDeniedError as exc:
             policy_message = self._safe_text(exc.user_message, LIBRARY_SERVICE_ERROR_COPY)
-            return empty_records, empty_counts, empty_total_known, policy_message
+            recovery_state = policy_denied_recovery_state(
+                exc,
+                unavailable_what="Use Library sources in Console",
+                stable_selector="library-source-error",
+                policy_message=policy_message,
+            )
+            return (
+                empty_records,
+                empty_counts,
+                empty_total_known,
+                recovery_state.visible_copy,
+                recovery_state.disabled_tooltip,
+            )
         except Exception:
             logger.warning(
                 "Failed to load local Library source snapshot.",
                 exc_info=True,
             )
-            return empty_records, empty_counts, empty_total_known, LIBRARY_SERVICE_ERROR_COPY
+            return empty_records, empty_counts, empty_total_known, LIBRARY_SERVICE_ERROR_COPY, None
 
         notes, notes_count, notes_total_known = self._response_records_and_count(notes_result)
         media, media_count, media_total_known = self._response_records_and_count(media_result)
@@ -218,6 +242,7 @@ class LibraryScreen(BaseAppScreen):
                 "media": media_total_known,
                 "conversations": conversations_total_known,
             },
+            None,
             None,
         )
 
@@ -306,7 +331,10 @@ class LibraryScreen(BaseAppScreen):
                         id="library-source-error",
                     )
                     handoff_disabled = True
-                    handoff_tooltip = "Library source services are unavailable; retry Library later."
+                    handoff_tooltip = (
+                        self._library_lookup_error_tooltip
+                        or "Library source services are unavailable; retry Library later."
+                    )
                 elif not has_sources:
                     yield Static(
                         LIBRARY_EMPTY_COPY,

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -20,7 +20,7 @@ from ...runtime_policy.types import PolicyDeniedError
 from ...Utils.input_validation import sanitize_string, validate_text_input
 from ..Navigation.base_app_screen import BaseAppScreen
 from ..Navigation.main_navigation import NavigateToScreen
-from .destination_recovery import policy_denied_recovery_state
+from .destination_recovery import DestinationRecoveryState, policy_denied_recovery_state
 
 
 logger = logger.bind(module="LibraryScreen")
@@ -51,30 +51,23 @@ class LibraryScreen(BaseAppScreen):
             "conversations": True,
         }
         self._library_lookup_error: str | None = None
-        self._library_lookup_error_tooltip: str | None = None
+        self._library_lookup_recovery_state: DestinationRecoveryState | None = None
         self._library_loaded = False
 
     def on_mount(self) -> None:
         super().on_mount()
         self._refresh_local_source_snapshot()
 
-    @work(exclusive=True, thread=True)
-    def _refresh_local_source_snapshot(self) -> None:
+    @work(exclusive=True)
+    async def _refresh_local_source_snapshot(self) -> None:
         (
             records,
             counts,
             total_known,
             lookup_error,
-            lookup_error_tooltip,
-        ) = self._list_local_source_snapshot()
-        self.app.call_from_thread(
-            self._apply_local_source_snapshot,
-            records,
-            counts,
-            total_known,
-            lookup_error,
-            lookup_error_tooltip,
-        )
+            recovery_state,
+        ) = await self._list_local_source_snapshot()
+        self._apply_local_source_snapshot(records, counts, total_known, lookup_error, recovery_state)
 
     def _apply_local_source_snapshot(
         self,
@@ -82,21 +75,21 @@ class LibraryScreen(BaseAppScreen):
         counts: dict[str, int],
         total_known: dict[str, bool],
         lookup_error: str | None = None,
-        lookup_error_tooltip: str | None = None,
+        recovery_state: DestinationRecoveryState | None = None,
     ) -> None:
         self._local_source_records = records
         self._local_source_counts = counts
         self._local_source_total_known = total_known
         self._library_lookup_error = lookup_error
-        self._library_lookup_error_tooltip = lookup_error_tooltip
+        self._library_lookup_recovery_state = recovery_state
         self._library_loaded = True
         if self.is_mounted:
             self.refresh(recompose=True)
 
     @staticmethod
-    def _run_maybe_awaitable(value: Any) -> Any:
+    async def _resolve_maybe_awaitable(value: Any) -> Any:
         if inspect.isawaitable(value):
-            return asyncio.run(value)
+            return await value
         return value
 
     @staticmethod
@@ -147,14 +140,14 @@ class LibraryScreen(BaseAppScreen):
             total_known = False
         return records, max(count, 0), total_known
 
-    def _list_local_source_snapshot(
+    async def _list_local_source_snapshot(
         self,
     ) -> tuple[
         dict[str, tuple[Mapping[str, Any], ...]],
         dict[str, int],
         dict[str, bool],
         str | None,
-        str | None,
+        DestinationRecoveryState | None,
     ]:
         notes_service = getattr(self.app_instance, "notes_scope_service", None)
         media_service = getattr(self.app_instance, "media_reading_scope_service", None)
@@ -174,28 +167,27 @@ class LibraryScreen(BaseAppScreen):
             return empty_records, empty_counts, empty_total_known, LIBRARY_SERVICE_UNAVAILABLE_COPY, None
 
         try:
-            notes_result = self._run_maybe_awaitable(
-                list_notes(
-                    scope="local_note",
-                    limit=LIBRARY_SOURCE_PAGE_SIZE,
-                    offset=0,
-                    user_id=getattr(self.app_instance, "notes_user_id", None) or "default_user",
-                )
+            notes_value = list_notes(
+                scope="local_note",
+                limit=LIBRARY_SOURCE_PAGE_SIZE,
+                offset=0,
+                user_id=getattr(self.app_instance, "notes_user_id", None) or "default_user",
             )
-            media_result = self._run_maybe_awaitable(
-                list_media(
-                    mode="local",
-                    page=1,
-                    results_per_page=LIBRARY_SOURCE_PAGE_SIZE,
-                    include_keywords=False,
-                )
+            media_value = list_media(
+                mode="local",
+                page=1,
+                results_per_page=LIBRARY_SOURCE_PAGE_SIZE,
+                include_keywords=False,
             )
-            conversation_result = self._run_maybe_awaitable(
-                list_conversations(
-                    mode="local",
-                    limit=LIBRARY_SOURCE_PAGE_SIZE,
-                    offset=0,
-                )
+            conversation_value = list_conversations(
+                mode="local",
+                limit=LIBRARY_SOURCE_PAGE_SIZE,
+                offset=0,
+            )
+            notes_result, media_result, conversation_result = await asyncio.gather(
+                self._resolve_maybe_awaitable(notes_value),
+                self._resolve_maybe_awaitable(media_value),
+                self._resolve_maybe_awaitable(conversation_value),
             )
         except PolicyDeniedError as exc:
             policy_message = self._safe_text(exc.user_message, LIBRARY_SERVICE_ERROR_COPY)
@@ -210,7 +202,7 @@ class LibraryScreen(BaseAppScreen):
                 empty_counts,
                 empty_total_known,
                 recovery_state.visible_copy,
-                recovery_state.disabled_tooltip,
+                recovery_state,
             )
         except Exception:
             logger.warning(
@@ -326,14 +318,20 @@ class LibraryScreen(BaseAppScreen):
                     handoff_disabled = True
                     handoff_tooltip = "Stage Library source context after Library finishes loading."
                 elif self._library_lookup_error:
+                    recovery_state = self._library_lookup_recovery_state
                     yield Static(
                         self._library_lookup_error,
-                        id="library-source-error",
+                        id=(
+                            recovery_state.stable_selector
+                            if recovery_state is not None
+                            else "library-source-error"
+                        ),
                     )
                     handoff_disabled = True
                     handoff_tooltip = (
-                        self._library_lookup_error_tooltip
-                        or "Library source services are unavailable; retry Library later."
+                        recovery_state.disabled_tooltip
+                        if recovery_state is not None
+                        else "Library source services are unavailable; retry Library later."
                     )
                 elif not has_sources:
                     yield Static(

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -20,7 +20,7 @@ from ...runtime_policy.types import PolicyDeniedError
 from ...Utils.input_validation import sanitize_string, validate_text_input
 from ..Navigation.base_app_screen import BaseAppScreen
 from ..Navigation.main_navigation import NavigateToScreen
-from .destination_recovery import policy_denied_recovery_state
+from .destination_recovery import DestinationRecoveryState, policy_denied_recovery_state
 
 
 logger = logger.bind(module="PersonasScreen")
@@ -44,43 +44,37 @@ class PersonasScreen(BaseAppScreen):
             "profiles": 0,
         }
         self._personas_lookup_error: str | None = None
-        self._personas_lookup_error_tooltip: str | None = None
+        self._personas_lookup_recovery_state: DestinationRecoveryState | None = None
         self._personas_loaded = False
 
     def on_mount(self) -> None:
         super().on_mount()
         self._refresh_local_behavior_snapshot()
 
-    @work(exclusive=True, thread=True)
-    def _refresh_local_behavior_snapshot(self) -> None:
-        records, counts, lookup_error, lookup_error_tooltip = self._list_local_behavior_snapshot()
-        self.app.call_from_thread(
-            self._apply_local_behavior_snapshot,
-            records,
-            counts,
-            lookup_error,
-            lookup_error_tooltip,
-        )
+    @work(exclusive=True)
+    async def _refresh_local_behavior_snapshot(self) -> None:
+        records, counts, lookup_error, recovery_state = await self._list_local_behavior_snapshot()
+        self._apply_local_behavior_snapshot(records, counts, lookup_error, recovery_state)
 
     def _apply_local_behavior_snapshot(
         self,
         records: dict[str, tuple[Mapping[str, Any], ...]],
         counts: dict[str, int],
         lookup_error: str | None = None,
-        lookup_error_tooltip: str | None = None,
+        recovery_state: DestinationRecoveryState | None = None,
     ) -> None:
         self._local_behavior_records = records
         self._local_behavior_counts = counts
         self._personas_lookup_error = lookup_error
-        self._personas_lookup_error_tooltip = lookup_error_tooltip
+        self._personas_lookup_recovery_state = recovery_state
         self._personas_loaded = True
         if self.is_mounted:
             self.refresh(recompose=True)
 
     @staticmethod
-    def _run_maybe_awaitable(value: Any) -> Any:
+    async def _resolve_maybe_awaitable(value: Any) -> Any:
         if inspect.isawaitable(value):
-            return asyncio.run(value)
+            return await value
         return value
 
     @staticmethod
@@ -137,9 +131,14 @@ class PersonasScreen(BaseAppScreen):
             count = len(records)
         return records, count
 
-    def _list_local_behavior_snapshot(
+    async def _list_local_behavior_snapshot(
         self,
-    ) -> tuple[dict[str, tuple[Mapping[str, Any], ...]], dict[str, int], str | None, str | None]:
+    ) -> tuple[
+        dict[str, tuple[Mapping[str, Any], ...]],
+        dict[str, int],
+        str | None,
+        DestinationRecoveryState | None,
+    ]:
         service = getattr(self.app_instance, "character_persona_scope_service", None)
         list_characters = getattr(service, "list_characters", None)
         list_profiles = getattr(service, "list_persona_profiles", None)
@@ -152,21 +151,21 @@ class PersonasScreen(BaseAppScreen):
             return empty_records, empty_counts, PERSONAS_SERVICE_UNAVAILABLE_COPY, None
 
         try:
-            characters_result = self._run_maybe_awaitable(
-                list_characters(
-                    mode="local",
-                    limit=PERSONAS_LOCAL_PAGE_SIZE,
-                    offset=0,
-                )
+            characters_value = list_characters(
+                mode="local",
+                limit=PERSONAS_LOCAL_PAGE_SIZE,
+                offset=0,
             )
-            profiles_result = self._run_maybe_awaitable(
-                list_profiles(
-                    mode="local",
-                    active_only=True,
-                    include_deleted=False,
-                    limit=PERSONAS_LOCAL_PAGE_SIZE,
-                    offset=0,
-                )
+            profiles_value = list_profiles(
+                mode="local",
+                active_only=True,
+                include_deleted=False,
+                limit=PERSONAS_LOCAL_PAGE_SIZE,
+                offset=0,
+            )
+            characters_result, profiles_result = await asyncio.gather(
+                self._resolve_maybe_awaitable(characters_value),
+                self._resolve_maybe_awaitable(profiles_value),
             )
         except PolicyDeniedError as exc:
             policy_message = self._safe_text(exc.user_message, PERSONAS_SERVICE_ERROR_COPY)
@@ -176,7 +175,7 @@ class PersonasScreen(BaseAppScreen):
                 stable_selector="personas-service-error",
                 policy_message=policy_message,
             )
-            return empty_records, empty_counts, recovery_state.visible_copy, recovery_state.disabled_tooltip
+            return empty_records, empty_counts, recovery_state.visible_copy, recovery_state
         except Exception:
             logger.warning(
                 "Failed to load local Personas behavior snapshot.",
@@ -253,14 +252,20 @@ class PersonasScreen(BaseAppScreen):
                     attach_disabled = True
                     attach_tooltip = "Stage local persona context after Personas finishes loading."
                 elif self._personas_lookup_error:
+                    recovery_state = self._personas_lookup_recovery_state
                     yield Static(
                         self._personas_lookup_error,
-                        id="personas-service-error",
+                        id=(
+                            recovery_state.stable_selector
+                            if recovery_state is not None
+                            else "personas-service-error"
+                        ),
                     )
                     attach_disabled = True
                     attach_tooltip = (
-                        self._personas_lookup_error_tooltip
-                        or "Personas service is unavailable; retry Personas later."
+                        recovery_state.disabled_tooltip
+                        if recovery_state is not None
+                        else "Personas service is unavailable; retry Personas later."
                     )
                 elif not has_context:
                     yield Static(

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -20,6 +20,7 @@ from ...runtime_policy.types import PolicyDeniedError
 from ...Utils.input_validation import sanitize_string, validate_text_input
 from ..Navigation.base_app_screen import BaseAppScreen
 from ..Navigation.main_navigation import NavigateToScreen
+from .destination_recovery import policy_denied_recovery_state
 
 
 logger = logger.bind(module="PersonasScreen")
@@ -43,6 +44,7 @@ class PersonasScreen(BaseAppScreen):
             "profiles": 0,
         }
         self._personas_lookup_error: str | None = None
+        self._personas_lookup_error_tooltip: str | None = None
         self._personas_loaded = False
 
     def on_mount(self) -> None:
@@ -51,18 +53,26 @@ class PersonasScreen(BaseAppScreen):
 
     @work(exclusive=True, thread=True)
     def _refresh_local_behavior_snapshot(self) -> None:
-        records, counts, lookup_error = self._list_local_behavior_snapshot()
-        self.app.call_from_thread(self._apply_local_behavior_snapshot, records, counts, lookup_error)
+        records, counts, lookup_error, lookup_error_tooltip = self._list_local_behavior_snapshot()
+        self.app.call_from_thread(
+            self._apply_local_behavior_snapshot,
+            records,
+            counts,
+            lookup_error,
+            lookup_error_tooltip,
+        )
 
     def _apply_local_behavior_snapshot(
         self,
         records: dict[str, tuple[Mapping[str, Any], ...]],
         counts: dict[str, int],
         lookup_error: str | None = None,
+        lookup_error_tooltip: str | None = None,
     ) -> None:
         self._local_behavior_records = records
         self._local_behavior_counts = counts
         self._personas_lookup_error = lookup_error
+        self._personas_lookup_error_tooltip = lookup_error_tooltip
         self._personas_loaded = True
         if self.is_mounted:
             self.refresh(recompose=True)
@@ -129,7 +139,7 @@ class PersonasScreen(BaseAppScreen):
 
     def _list_local_behavior_snapshot(
         self,
-    ) -> tuple[dict[str, tuple[Mapping[str, Any], ...]], dict[str, int], str | None]:
+    ) -> tuple[dict[str, tuple[Mapping[str, Any], ...]], dict[str, int], str | None, str | None]:
         service = getattr(self.app_instance, "character_persona_scope_service", None)
         list_characters = getattr(service, "list_characters", None)
         list_profiles = getattr(service, "list_persona_profiles", None)
@@ -139,7 +149,7 @@ class PersonasScreen(BaseAppScreen):
         }
         empty_counts = {"characters": 0, "profiles": 0}
         if not callable(list_characters) or not callable(list_profiles):
-            return empty_records, empty_counts, PERSONAS_SERVICE_UNAVAILABLE_COPY
+            return empty_records, empty_counts, PERSONAS_SERVICE_UNAVAILABLE_COPY, None
 
         try:
             characters_result = self._run_maybe_awaitable(
@@ -160,13 +170,19 @@ class PersonasScreen(BaseAppScreen):
             )
         except PolicyDeniedError as exc:
             policy_message = self._safe_text(exc.user_message, PERSONAS_SERVICE_ERROR_COPY)
-            return empty_records, empty_counts, policy_message
+            recovery_state = policy_denied_recovery_state(
+                exc,
+                unavailable_what="Attach Personas context to Console",
+                stable_selector="personas-service-error",
+                policy_message=policy_message,
+            )
+            return empty_records, empty_counts, recovery_state.visible_copy, recovery_state.disabled_tooltip
         except Exception:
             logger.warning(
                 "Failed to load local Personas behavior snapshot.",
                 exc_info=True,
             )
-            return empty_records, empty_counts, PERSONAS_SERVICE_ERROR_COPY
+            return empty_records, empty_counts, PERSONAS_SERVICE_ERROR_COPY, None
 
         characters, character_count = self._response_records_and_count(characters_result)
         profiles, profile_count = self._response_records_and_count(profiles_result)
@@ -179,6 +195,7 @@ class PersonasScreen(BaseAppScreen):
                 "characters": character_count,
                 "profiles": profile_count,
             },
+            None,
             None,
         )
 
@@ -241,7 +258,10 @@ class PersonasScreen(BaseAppScreen):
                         id="personas-service-error",
                     )
                     attach_disabled = True
-                    attach_tooltip = "Personas service is unavailable; retry Personas later."
+                    attach_tooltip = (
+                        self._personas_lookup_error_tooltip
+                        or "Personas service is unavailable; retry Personas later."
+                    )
                 elif not has_context:
                     yield Static(
                         PERSONAS_EMPTY_COPY,

--- a/tldw_chatbook/UI/Screens/skills_screen.py
+++ b/tldw_chatbook/UI/Screens/skills_screen.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import inspect
 from collections.abc import Mapping
 from typing import Any
@@ -19,7 +18,7 @@ from ...Chat.chat_handoff_models import ChatHandoffPayload
 from ...runtime_policy.types import PolicyDeniedError
 from ...Utils.input_validation import sanitize_string, validate_text_input
 from ..Navigation.base_app_screen import BaseAppScreen
-from .destination_recovery import policy_denied_recovery_state
+from .destination_recovery import DestinationRecoveryState, policy_denied_recovery_state
 
 
 logger = logger.bind(module="SkillsScreen")
@@ -45,37 +44,34 @@ class SkillsScreen(BaseAppScreen):
         super().__init__(app_instance, "skills", **kwargs)
         self._local_skill_records: tuple[Mapping[str, Any], ...] = ()
         self._skills_lookup_error: str | None = None
-        self._skills_lookup_error_tooltip: str | None = None
+        self._skills_lookup_recovery_state: DestinationRecoveryState | None = None
         self._skills_loaded = False
 
     def on_mount(self) -> None:
         super().on_mount()
         self._refresh_local_skills_context()
 
-    @work(exclusive=True, thread=True)
-    def _refresh_local_skills_context(self) -> None:
-        records, lookup_error, lookup_error_tooltip = self._list_local_skills()
-        self.app.call_from_thread(
-            self._apply_local_skills_context,
-            records,
-            lookup_error,
-            lookup_error_tooltip,
-        )
+    @work(exclusive=True)
+    async def _refresh_local_skills_context(self) -> None:
+        records, lookup_error, recovery_state = await self._list_local_skills()
+        self._apply_local_skills_context(records, lookup_error, recovery_state)
 
     def _apply_local_skills_context(
         self,
         records: tuple[Mapping[str, Any], ...],
         lookup_error: str | None = None,
-        lookup_error_tooltip: str | None = None,
+        recovery_state: DestinationRecoveryState | None = None,
     ) -> None:
         self._local_skill_records = records
         self._skills_lookup_error = lookup_error
-        self._skills_lookup_error_tooltip = lookup_error_tooltip
+        self._skills_lookup_recovery_state = recovery_state
         self._skills_loaded = True
         if self.is_mounted:
             self.refresh(recompose=True)
 
-    def _list_local_skills(self) -> tuple[tuple[Mapping[str, Any], ...], str | None, str | None]:
+    async def _list_local_skills(
+        self,
+    ) -> tuple[tuple[Mapping[str, Any], ...], str | None, DestinationRecoveryState | None]:
         service = getattr(self.app_instance, "skills_scope_service", None)
         list_skills = getattr(service, "list_skills", None)
         if not callable(list_skills):
@@ -88,7 +84,7 @@ class SkillsScreen(BaseAppScreen):
                 include_hidden=False,
             )
             if inspect.isawaitable(result):
-                result = asyncio.run(result)
+                result = await result
         except PolicyDeniedError as exc:
             logger.info(
                 "Runtime policy denied local Agent Skills listing.",
@@ -106,7 +102,7 @@ class SkillsScreen(BaseAppScreen):
                 stable_selector="skills-service-error",
                 policy_message=policy_message,
             )
-            return (), recovery_state.visible_copy, recovery_state.disabled_tooltip
+            return (), recovery_state.visible_copy, recovery_state
         except Exception:
             logger.warning(
                 "Failed to load local Agent Skills for Skills destination.",
@@ -192,15 +188,21 @@ class SkillsScreen(BaseAppScreen):
                     attach_disabled = True
                     attach_tooltip = "Stage local skill context after Skills finishes loading."
                 elif self._skills_lookup_error:
+                    recovery_state = self._skills_lookup_recovery_state
                     yield Static(
                         self._skills_lookup_error,
-                        id="skills-service-error",
+                        id=(
+                            recovery_state.stable_selector
+                            if recovery_state is not None
+                            else "skills-service-error"
+                        ),
                     )
                     attach_label = "Attach local Skills to Console"
                     attach_disabled = True
                     attach_tooltip = (
-                        self._skills_lookup_error_tooltip
-                        or "Skills service is unavailable; retry Skills later."
+                        recovery_state.disabled_tooltip
+                        if recovery_state is not None
+                        else "Skills service is unavailable; retry Skills later."
                     )
                 elif not self._local_skill_records:
                     yield Static(

--- a/tldw_chatbook/UI/Screens/skills_screen.py
+++ b/tldw_chatbook/UI/Screens/skills_screen.py
@@ -19,6 +19,7 @@ from ...Chat.chat_handoff_models import ChatHandoffPayload
 from ...runtime_policy.types import PolicyDeniedError
 from ...Utils.input_validation import sanitize_string, validate_text_input
 from ..Navigation.base_app_screen import BaseAppScreen
+from .destination_recovery import policy_denied_recovery_state
 
 
 logger = logger.bind(module="SkillsScreen")
@@ -44,6 +45,7 @@ class SkillsScreen(BaseAppScreen):
         super().__init__(app_instance, "skills", **kwargs)
         self._local_skill_records: tuple[Mapping[str, Any], ...] = ()
         self._skills_lookup_error: str | None = None
+        self._skills_lookup_error_tooltip: str | None = None
         self._skills_loaded = False
 
     def on_mount(self) -> None:
@@ -52,25 +54,32 @@ class SkillsScreen(BaseAppScreen):
 
     @work(exclusive=True, thread=True)
     def _refresh_local_skills_context(self) -> None:
-        records, lookup_error = self._list_local_skills()
-        self.app.call_from_thread(self._apply_local_skills_context, records, lookup_error)
+        records, lookup_error, lookup_error_tooltip = self._list_local_skills()
+        self.app.call_from_thread(
+            self._apply_local_skills_context,
+            records,
+            lookup_error,
+            lookup_error_tooltip,
+        )
 
     def _apply_local_skills_context(
         self,
         records: tuple[Mapping[str, Any], ...],
         lookup_error: str | None = None,
+        lookup_error_tooltip: str | None = None,
     ) -> None:
         self._local_skill_records = records
         self._skills_lookup_error = lookup_error
+        self._skills_lookup_error_tooltip = lookup_error_tooltip
         self._skills_loaded = True
         if self.is_mounted:
             self.refresh(recompose=True)
 
-    def _list_local_skills(self) -> tuple[tuple[Mapping[str, Any], ...], str | None]:
+    def _list_local_skills(self) -> tuple[tuple[Mapping[str, Any], ...], str | None, str | None]:
         service = getattr(self.app_instance, "skills_scope_service", None)
         list_skills = getattr(service, "list_skills", None)
         if not callable(list_skills):
-            return (), SKILLS_SERVICE_UNAVAILABLE_COPY
+            return (), SKILLS_SERVICE_UNAVAILABLE_COPY, None
         try:
             result = list_skills(
                 mode="local",
@@ -91,17 +100,23 @@ class SkillsScreen(BaseAppScreen):
                 fallback=SKILLS_POLICY_DENIED_FALLBACK_COPY,
                 max_length=SKILL_TEXT_LIMITS["policy_message"],
             )
-            return (), policy_message
+            recovery_state = policy_denied_recovery_state(
+                exc,
+                unavailable_what="Attach local Skills to Console",
+                stable_selector="skills-service-error",
+                policy_message=policy_message,
+            )
+            return (), recovery_state.visible_copy, recovery_state.disabled_tooltip
         except Exception:
             logger.warning(
                 "Failed to load local Agent Skills for Skills destination.",
                 exc_info=True,
             )
-            return (), SKILLS_SERVICE_ERROR_COPY
+            return (), SKILLS_SERVICE_ERROR_COPY, None
 
         skills = result.get("skills") if isinstance(result, Mapping) else None
         records = tuple(record for record in tuple(skills or ()) if isinstance(record, Mapping))
-        return records, None
+        return records, None, None
 
     @staticmethod
     def _safe_skill_text(value: Any, fallback: str = "", *, max_length: int = 1000) -> str:
@@ -183,7 +198,10 @@ class SkillsScreen(BaseAppScreen):
                     )
                     attach_label = "Attach local Skills to Console"
                     attach_disabled = True
-                    attach_tooltip = "Skills service is unavailable; retry Skills later."
+                    attach_tooltip = (
+                        self._skills_lookup_error_tooltip
+                        or "Skills service is unavailable; retry Skills later."
+                    )
                 elif not self._local_skill_records:
                     yield Static(
                         "No local Agent Skills are installed yet.",

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -18,6 +18,7 @@ from ...runtime_policy.types import PolicyDeniedError
 from ...Utils.input_validation import sanitize_string, validate_text_input
 from ..Navigation.base_app_screen import BaseAppScreen
 from ..Navigation.main_navigation import NavigateToScreen
+from .destination_recovery import policy_denied_recovery_state
 
 
 logger = logger.bind(module="WatchlistsCollectionsScreen")
@@ -43,6 +44,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         self._watchlist_total_known = True
         self._collection_total_known = True
         self._wc_lookup_error: str | None = None
+        self._wc_lookup_error_tooltip: str | None = None
         self._wc_loaded = False
 
     def on_mount(self) -> None:
@@ -59,6 +61,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             watchlist_total_known,
             collection_total_known,
             lookup_error,
+            lookup_error_tooltip,
         ) = await self._list_local_wc_snapshot()
         self._apply_local_wc_snapshot(
             watchlists,
@@ -68,6 +71,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             watchlist_total_known,
             collection_total_known,
             lookup_error,
+            lookup_error_tooltip,
         )
 
     def _apply_local_wc_snapshot(
@@ -79,6 +83,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         watchlist_total_known: bool,
         collection_total_known: bool,
         lookup_error: str | None = None,
+        lookup_error_tooltip: str | None = None,
     ) -> None:
         self._local_watchlist_records = watchlists
         self._local_collection_records = collections
@@ -87,6 +92,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         self._watchlist_total_known = watchlist_total_known
         self._collection_total_known = collection_total_known
         self._wc_lookup_error = lookup_error
+        self._wc_lookup_error_tooltip = lookup_error_tooltip
         self._wc_loaded = True
         if self.is_mounted:
             self.refresh(recompose=True)
@@ -141,13 +147,14 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         bool,
         bool,
         str | None,
+        str | None,
     ]:
         watchlist_service = getattr(self.app_instance, "watchlist_scope_service", None)
         collection_service = getattr(self.app_instance, "media_reading_scope_service", None)
         list_watch_items = getattr(watchlist_service, "list_watch_items", None)
         list_read_it_later = getattr(collection_service, "list_read_it_later", None)
         if not callable(list_watch_items) or not callable(list_read_it_later):
-            return (), (), 0, 0, True, True, WC_SERVICE_UNAVAILABLE_COPY
+            return (), (), 0, 0, True, True, WC_SERVICE_UNAVAILABLE_COPY, None
 
         try:
             watchlist_result = await list_watch_items(
@@ -162,13 +169,19 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             )
         except PolicyDeniedError as exc:
             policy_message = self._safe_text(exc.user_message, WC_SERVICE_ERROR_COPY)
-            return (), (), 0, 0, True, True, policy_message
+            recovery_state = policy_denied_recovery_state(
+                exc,
+                unavailable_what="Stage W+C context in Console",
+                stable_selector="wc-service-error",
+                policy_message=policy_message,
+            )
+            return (), (), 0, 0, True, True, recovery_state.visible_copy, recovery_state.disabled_tooltip
         except Exception:
             logger.debug(
                 "Failed to load local W+C snapshot.",
                 exc_info=True,
             )
-            return (), (), 0, 0, True, True, WC_SERVICE_ERROR_COPY
+            return (), (), 0, 0, True, True, WC_SERVICE_ERROR_COPY, None
 
         watchlists, watchlist_count, watchlist_total_known = self._response_records_and_count(watchlist_result)
         collections, collection_count, collection_total_known = self._response_records_and_count(collection_result)
@@ -179,6 +192,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             collection_count,
             watchlist_total_known,
             collection_total_known,
+            None,
             None,
         )
 
@@ -290,7 +304,10 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                         id="wc-service-error",
                     )
                     attach_disabled = True
-                    attach_tooltip = "W+C services are unavailable; retry W+C before staging Console context."
+                    attach_tooltip = (
+                        self._wc_lookup_error_tooltip
+                        or "W+C services are unavailable; retry W+C before staging Console context."
+                    )
                 elif not self._has_local_wc_context():
                     yield Static(
                         WC_EMPTY_COPY,

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -18,7 +18,7 @@ from ...runtime_policy.types import PolicyDeniedError
 from ...Utils.input_validation import sanitize_string, validate_text_input
 from ..Navigation.base_app_screen import BaseAppScreen
 from ..Navigation.main_navigation import NavigateToScreen
-from .destination_recovery import policy_denied_recovery_state
+from .destination_recovery import DestinationRecoveryState, policy_denied_recovery_state
 
 
 logger = logger.bind(module="WatchlistsCollectionsScreen")
@@ -44,7 +44,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         self._watchlist_total_known = True
         self._collection_total_known = True
         self._wc_lookup_error: str | None = None
-        self._wc_lookup_error_tooltip: str | None = None
+        self._wc_lookup_recovery_state: DestinationRecoveryState | None = None
         self._wc_loaded = False
 
     def on_mount(self) -> None:
@@ -61,7 +61,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             watchlist_total_known,
             collection_total_known,
             lookup_error,
-            lookup_error_tooltip,
+            recovery_state,
         ) = await self._list_local_wc_snapshot()
         self._apply_local_wc_snapshot(
             watchlists,
@@ -71,7 +71,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             watchlist_total_known,
             collection_total_known,
             lookup_error,
-            lookup_error_tooltip,
+            recovery_state,
         )
 
     def _apply_local_wc_snapshot(
@@ -83,7 +83,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         watchlist_total_known: bool,
         collection_total_known: bool,
         lookup_error: str | None = None,
-        lookup_error_tooltip: str | None = None,
+        recovery_state: DestinationRecoveryState | None = None,
     ) -> None:
         self._local_watchlist_records = watchlists
         self._local_collection_records = collections
@@ -92,7 +92,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         self._watchlist_total_known = watchlist_total_known
         self._collection_total_known = collection_total_known
         self._wc_lookup_error = lookup_error
-        self._wc_lookup_error_tooltip = lookup_error_tooltip
+        self._wc_lookup_recovery_state = recovery_state
         self._wc_loaded = True
         if self.is_mounted:
             self.refresh(recompose=True)
@@ -147,7 +147,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         bool,
         bool,
         str | None,
-        str | None,
+        DestinationRecoveryState | None,
     ]:
         watchlist_service = getattr(self.app_instance, "watchlist_scope_service", None)
         collection_service = getattr(self.app_instance, "media_reading_scope_service", None)
@@ -175,7 +175,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                 stable_selector="wc-service-error",
                 policy_message=policy_message,
             )
-            return (), (), 0, 0, True, True, recovery_state.visible_copy, recovery_state.disabled_tooltip
+            return (), (), 0, 0, True, True, recovery_state.visible_copy, recovery_state
         except Exception:
             logger.debug(
                 "Failed to load local W+C snapshot.",
@@ -299,14 +299,20 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                     attach_disabled = True
                     attach_tooltip = "Stage local W+C context after the local snapshot loads."
                 elif self._wc_lookup_error:
+                    recovery_state = self._wc_lookup_recovery_state
                     yield Static(
                         self._wc_lookup_error,
-                        id="wc-service-error",
+                        id=(
+                            recovery_state.stable_selector
+                            if recovery_state is not None
+                            else "wc-service-error"
+                        ),
                     )
                     attach_disabled = True
                     attach_tooltip = (
-                        self._wc_lookup_error_tooltip
-                        or "W+C services are unavailable; retry W+C before staging Console context."
+                        recovery_state.disabled_tooltip
+                        if recovery_state is not None
+                        else "W+C services are unavailable; retry W+C before staging Console context."
                     )
                 elif not self._has_local_wc_context():
                     yield Static(


### PR DESCRIPTION
## Summary

- Map `PolicyDeniedError` reason codes into shared Phase 5 recovery copy and disabled-action tooltips.
- Apply runtime-policy recovery states to Skills, Library, Personas, and W+C destination blockers.
- Add `TASK-6.3` tracking plus Phase 5 QA evidence while keeping parent `TASK-6` in progress.

## Verification

- Red check before implementation: `python -m pytest Tests/UI/test_destination_shells.py -q -k "policy_denial or policy_denied"` produced `3 failed`.
- Focused affected suite: `python -m pytest Tests/UI/test_destination_shells.py Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py -q` produced `78 passed`.
- Tracking check after evidence update: `python -m pytest Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py -q` produced `10 passed`.
- Whitespace: `git diff --check`.

## Residual Risk

- This verifies representative runtime-policy destination blockers, not every action in the runtime-policy registry.
- Optional dependency recovery states and final Phase 5 running-app closeout QA remain for later slices.
