### PR TITLE
Close Phase 5 recovery maturity gate

### DIFF
--- a/Docs/superpowers/qa/unified-shell/phase-5/2026-05-05-phase-5-capability-recovery-closeout.md
+++ b/Docs/superpowers/qa/unified-shell/phase-5/2026-05-05-phase-5-capability-recovery-closeout.md
@@ -1,0 +1,121 @@
+# Phase 5 Capability Recovery Closeout
+
+Date: 2026-05-05
+Task: `TASK-6.5`
+Parent Task: `TASK-6`
+Branch: `codex/unified-shell-phase5-closeout`
+Base: `origin/dev` at `9d1cfe50`
+
+<!-- PHASE_5_CLOSEOUT_METADATA:BEGIN -->
+```json
+{
+  "closeout_task": "TASK-6.5",
+  "parent_task": "TASK-6",
+  "decision": "verified",
+  "verified_recovery_families": [
+    "destination-blockers",
+    "runtime-policy",
+    "optional-dependencies"
+  ],
+  "verified_blocked_states": [
+    "runtime_not_configured",
+    "empty_selection",
+    "wrong_source",
+    "server_auth_required",
+    "server_session_invalid",
+    "policy_denied",
+    "dependency_missing"
+  ],
+  "required_recovery_fields": [
+    "status_label",
+    "unavailable_what",
+    "why",
+    "next_action",
+    "recovery_action",
+    "authority_owner",
+    "stable_selector",
+    "disabled_tooltip"
+  ],
+  "baseline_replay_result": {
+    "passed": 93,
+    "failed": 0,
+    "deselected": 1,
+    "warnings": 3
+  },
+  "red_closeout_contract_result": {
+    "passed": 0,
+    "failed": 1,
+    "warnings": 1
+  },
+  "final_focused_replay_result": {
+    "passed": 16,
+    "failed": 0,
+    "warnings": 1
+  },
+  "final_broader_replay_result": {
+    "passed": 94,
+    "failed": 0,
+    "warnings": 1
+  }
+}
+```
+<!-- PHASE_5_CLOSEOUT_METADATA:END -->
+
+## Current Baseline
+
+Phase 5 is replayed after the merged capability and recovery slices:
+
+- `TASK-6.1` defines the shared recovery taxonomy and required user-facing fields.
+- `TASK-6.2` applies the taxonomy to ACP runtime, Schedules empty active-run, Workflows empty active-run, and Artifacts empty Chatbook blockers.
+- `TASK-6.3` applies the taxonomy to runtime-policy denials in Skills, Library, Personas, and W+C.
+- `TASK-6.4` applies the taxonomy to Search/RAG embeddings and local speech optional-dependency blockers.
+- `TASK-6.5` records the maturity-gate replay and closeout decision.
+
+The implemented boundary is blocked-state recovery, not full service completion. The shell now distinguishes unavailable capabilities from broken UI by showing what is blocked, why it is blocked, who owns the authority, what the user can do next, and where recovery should happen.
+
+## Workflow Matrix
+
+| Recovery Family | Running-app path | Result | Severity |
+| --- | --- | --- | --- |
+| Destination blockers | Open ACP, Schedules, Workflows, or Artifacts without actionable runtime/run/artifact context. | Disabled controls expose stable selectors, visible recovery copy, and tooltips instead of silent no-op actions. | none |
+| Runtime-policy denials | Open Skills, Library, Personas, or W+C under wrong-source, auth-required, expired-session, or policy-denied service states. | Recovery copy maps reason codes to user-understandable next actions and authority owners. | none |
+| Optional dependencies | Open Search/RAG without embeddings extras, or local speech without local TTS/STT extras. | Missing optional extras show install guidance, disabled tooltips, and persistent recovery copy without leaving the screen in an infinite loading state. | none |
+
+## Focused Verification
+
+Commands were run from the repository root using the project virtual environment. Portable command form:
+
+- Red closeout contract: `python3 -m pytest Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py::test_phase_five_closeout_doc_records_verified_recovery_paths_and_task_completion -q`
+- Red closeout result before evidence existed: `1 failed, 1 warning` with `FileNotFoundError` for this closeout document.
+- Baseline recovery replay before closeout updates: `python3 -m pytest Tests/UI/test_destination_shells.py Tests/UI/test_disabled_action_recovery_tooltips.py Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py -q -k "not closeout"`
+- Baseline recovery replay result: `93 passed, 1 deselected, 3 warnings`
+- Final focused closeout replay: `python3 -m pytest Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py -q`
+- Final focused closeout replay result after closeout updates: `16 passed, 1 warning`
+- Final broader recovery replay: `python3 -m pytest Tests/UI/test_destination_shells.py Tests/UI/test_disabled_action_recovery_tooltips.py Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py -q`
+- Final broader recovery replay result after closeout updates: `94 passed, 1 warning`
+
+Warning boundary: the remaining warnings are existing dependency/import warnings and do not indicate recovery workflow failures.
+
+## UX Notes
+
+- Blocked states now use consistent language: status, unavailable item, reason, next action, recovery target, owner, selector, and disabled tooltip.
+- Recovery copy is specific enough for first-time users without hiding power-user paths such as Console staging, direct destination routes, and existing legacy surfaces.
+- Disabled controls are intentionally explanatory rather than merely inert, reducing the false-affordance risk that started the shell rescue work.
+- The tested flows are not render-only: mounted Textual tests verify visible copy, disabled/enabled state, stable selectors, tooltip strings, event payloads, worker-safe loading behavior, and helper mappings.
+
+## Defects And Blockers
+
+No Phase 5 closeout blocker remains.
+
+The only issue found during closeout was the expected missing closeout evidence, captured by the red regression. The recovery taxonomy, destination blockers, runtime-policy blockers, optional-dependency blockers, and closeout tracking passed after the closeout evidence and task updates landed.
+
+## Residual Risk
+
+- Auth and server recovery paths are verified through policy-reason mappings and shell states, not against a live remote server.
+- Optional dependency recovery verifies missing dependency states and install guidance; it does not install or exercise every optional extra.
+- ACP remains runtime-not-configured and recoverable, not a complete ACP session workflow.
+- Full first-time-user, power-user, and Nielsen heuristic replay remains Phase 6 scope.
+
+## Closeout Decision: verified
+
+Phase 5 is verified because the shared recovery taxonomy is applied to representative destination blockers, runtime-policy denials, and optional-dependency blockers, and the running-app replay proves blocked states are understandable and recoverable rather than silent, generic, or visually broken.

--- a/Docs/superpowers/qa/unified-shell/phase-5/README.md
+++ b/Docs/superpowers/qa/unified-shell/phase-5/README.md
@@ -1,8 +1,8 @@
 # Phase 5 QA Evidence
 
-Status: in-progress
+Status: verified
 
-This directory contains durable QA summaries for Phase 5 capability-state and recovery work. Do not mark the phase verified until running-app walkthrough evidence proves blocked states are understandable and recoverable.
+This directory contains durable QA summaries for Phase 5 capability-state and recovery work.
 
 ## Evidence
 
@@ -10,3 +10,6 @@ This directory contains durable QA summaries for Phase 5 capability-state and re
 - `2026-05-05-destination-blocker-recovery.md` - `TASK-6.2` application of the recovery taxonomy to ACP, Schedules, Workflows, and Artifacts shell destination blockers.
 - `2026-05-05-runtime-policy-recovery.md` - `TASK-6.3` application of the recovery taxonomy to visible runtime-policy denials in Skills, Library, Personas, and W+C destination blockers.
 - `2026-05-05-optional-dependency-recovery.md` - `TASK-6.4` application of the recovery taxonomy to visible Search/RAG embeddings and local speech optional-dependency blockers.
+- `2026-05-05-phase-5-capability-recovery-closeout.md` - `TASK-6.5` running-app QA replay for capability and recovery system completion.
+
+Phase 5 is verified because destination blockers, runtime-policy denials, and optional-dependency blockers now use shared recovery fields and running-app replay evidence proves those blocked states are understandable and recoverable.

--- a/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
@@ -1,8 +1,8 @@
 # Unified Shell Maturity Roadmap
 
 Date: 2026-05-05
-Status: Phase 2, Phase 3, and Phase 4 verified; Phase 5 in progress; Phase 6 not started
-Source Branch: `origin/dev` at `73e430c5` plus `codex/unified-shell-phase5-optional-dependency-recovery`
+Status: Phase 2, Phase 3, Phase 4, and Phase 5 verified; Phase 6 not started
+Source Branch: `origin/dev` at `9d1cfe50` plus `codex/unified-shell-phase5-closeout`
 
 ## Purpose
 
@@ -37,7 +37,7 @@ Track remaining Unified Shell work in one place so rendered screens, clickable b
 - Library now surfaces a local source snapshot from notes, media, and conversations and can stage concrete source context into Console; full Library-native detail views, embedded Import/Export, and embedded Search/RAG remain future work.
 - Personas now surfaces a local behavior snapshot from characters and persona profiles and can stage concrete behavior context into Console; detail, edit, import/export, archetypes, exemplars, dictionaries, and lore remain future work.
 - W+C now surfaces a local monitored-source and saved-collection snapshot from `watchlist_scope_service` and `media_reading_scope_service` and can stage concrete W+C context into Console; full detail, edit, import/export, feed WebSub, alert-rule, retry/backoff, and server collection-feed UX remain future work.
-- Phase 2, Phase 3, and Phase 4 implementation and maturity-gate replays are verified. Phase 5 is in progress with a shared recovery taxonomy applied to shell destination blockers, representative runtime-policy denials, and representative optional-dependency blockers; Phase 6 remains open for full first-time/power-user audit replay.
+- Phase 2, Phase 3, Phase 4, and Phase 5 implementation and maturity-gate replays are verified. Phase 5 recovery coverage includes shell destination blockers, representative runtime-policy denials, and representative optional-dependency blockers; Phase 6 remains open for full first-time/power-user audit replay.
 
 ## Definition Of Done
 
@@ -111,6 +111,7 @@ Initial child tasks:
 - Phase 5.2: Apply recovery taxonomy to shell destination blockers - `TASK-6.2`
 - Phase 5.3: Apply recovery taxonomy to runtime-policy blockers - `TASK-6.3`
 - Phase 5.4: Apply recovery taxonomy to optional dependency blockers - `TASK-6.4`
+- Phase 5.5: Replay capability recovery maturity gate - `TASK-6.5`
 
 ## QA Evidence Index
 
@@ -121,7 +122,7 @@ Initial child tasks:
 | Phase 2 | `Docs/superpowers/qa/unified-shell/phase-2/` | verified |
 | Phase 3 | `Docs/superpowers/qa/unified-shell/phase-3/` | verified |
 | Phase 4 | `Docs/superpowers/qa/unified-shell/phase-4/` | verified |
-| Phase 5 | `Docs/superpowers/qa/unified-shell/phase-5/` | in-progress |
+| Phase 5 | `Docs/superpowers/qa/unified-shell/phase-5/` | verified |
 | Phase 6 | `Docs/superpowers/qa/unified-shell/phase-6/` | not-started |
 
 ## Phase Overview
@@ -133,7 +134,7 @@ Initial child tasks:
 | Phase 2: Home Operational Control | Make Home a real dashboard/control surface. | verified | `TASK-4`, `TASK-4.1`, `TASK-4.2`, `TASK-4.3`, `TASK-4.4`, `TASK-4.5`, `TASK-4.6`, `TASK-4.7`, `TASK-4.8` | `phase-2/` | Schedule and agent-service adapters remain future work; Phase 2 is verified for explicit Home adapter behavior, local W+C/notification flows, and recoverable unavailable states. |
 | Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | verified | `TASK-3`, `TASK-3.1`, `TASK-3.2`, `TASK-3.3`, `TASK-3.4`, `TASK-3.5`, `TASK-3.6`, `TASK-3.7`, `TASK-3.8`, `TASK-3.9`, `TASK-3.10`, `TASK-3.11` | `phase-3/` | ACP, MCP, and durable live event streams remain future work; Phase 3 is verified for implemented Console source launch, follow, status, and recovery flows. |
 | Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | verified | `TASK-5`, `TASK-5.1`, `TASK-5.2`, `TASK-5.3`, `TASK-5.4`, `TASK-5.5`, `TASK-5.6` | `phase-4/` | Full CRUD/server-parity depth remains future work; Phase 4 is verified for destination ownership, concrete local workflows, Console staging, and honest recovery states. |
-| Phase 5: Capability And Recovery System | Systematize unavailable and blocked states. | in-progress | `TASK-6`, `TASK-6.1`, `TASK-6.2`, `TASK-6.3`, `TASK-6.4` | `phase-5/` | Shared recovery taxonomy is defined and applied to ACP, Schedules, Workflows, Artifacts, representative runtime-policy destination blockers, and representative optional-dependency blockers; final running-app closeout QA still remains. |
+| Phase 5: Capability And Recovery System | Systematize unavailable and blocked states. | verified | `TASK-6`, `TASK-6.1`, `TASK-6.2`, `TASK-6.3`, `TASK-6.4`, `TASK-6.5` | `phase-5/` | Recovery taxonomy is verified for destination blockers, runtime-policy denials, and optional-dependency blockers; live server/auth and full optional-extra execution remain residual risk. |
 | Phase 6: Audit Replay And Closeout | Prove shell works for first-time and power users. | not-started | `TASK-7` | `phase-6/` | Depends on prior phases and running-app QA. |
 
 ## Phase 1.1 QA Harness Evidence
@@ -343,6 +344,12 @@ Initial audit result: W+C, Schedules, Workflows, and ACP had false Console-launc
 `TASK-6.4` applies the taxonomy to visible optional-dependency blockers in Search/RAG embeddings and local speech dependency states:
 
 - `Docs/superpowers/qa/unified-shell/phase-5/2026-05-05-optional-dependency-recovery.md`
+
+## Phase 5.5 Capability Recovery Closeout
+
+`TASK-6.5` replays the Phase 5 capability and recovery maturity gate after the taxonomy, destination, runtime-policy, and optional-dependency blocker slices:
+
+- `Docs/superpowers/qa/unified-shell/phase-5/2026-05-05-phase-5-capability-recovery-closeout.md`
 
 ## Phase 0: Canonical Tracking
 

--- a/Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py
+++ b/Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py
@@ -28,6 +28,9 @@ PHASE_5_RUNTIME_POLICY_RECOVERY = Path(
 PHASE_5_OPTIONAL_DEPENDENCY_RECOVERY = Path(
     "Docs/superpowers/qa/unified-shell/phase-5/2026-05-05-optional-dependency-recovery.md"
 )
+PHASE_5_CLOSEOUT = Path(
+    "Docs/superpowers/qa/unified-shell/phase-5/2026-05-05-phase-5-capability-recovery-closeout.md"
+)
 PHASE_5_PARENT_TASK = Path("backlog/tasks/task-6 - Phase-5-Capability-And-Recovery-System.md")
 PHASE_5_TAXONOMY_TASK = Path("backlog/tasks/task-6.1 - Phase-5.1-Create-shared-recovery-taxonomy.md")
 PHASE_5_DESTINATION_RECOVERY_TASK = Path(
@@ -38,6 +41,9 @@ PHASE_5_RUNTIME_POLICY_TASK = Path(
 )
 PHASE_5_OPTIONAL_DEPENDENCY_TASK = Path(
     "backlog/tasks/task-6.4 - Phase-5.4-Apply-recovery-taxonomy-to-optional-dependency-blockers.md"
+)
+PHASE_5_CLOSEOUT_TASK = Path(
+    "backlog/tasks/task-6.5 - Phase-5.5-Replay-capability-recovery-maturity-gate.md"
 )
 
 
@@ -59,7 +65,7 @@ def _assert_roadmap_tracks_phase_five_progress(roadmap: str) -> None:
     assert "phase 3" in normalized_status
     assert "phase 4" in normalized_status
     assert "verified" in normalized_status
-    assert re.search(r"phase\s+5\s+in\s+progress", normalized_status)
+    assert re.search(r"phase\s+5\s+verified", normalized_status)
     assert re.search(r"phase\s+6\s+not\s+started", normalized_status)
 
 
@@ -84,6 +90,17 @@ def _taxonomy_metadata(text: str) -> dict:
     return json.loads(metadata_match.group(1))
 
 
+def _phase_five_closeout_metadata(text: str) -> dict:
+    metadata_match = re.search(
+        r"<!-- PHASE_5_CLOSEOUT_METADATA:BEGIN -->\s*```json\s*(.*?)\s*```\s*"
+        r"<!-- PHASE_5_CLOSEOUT_METADATA:END -->",
+        text,
+        re.DOTALL,
+    )
+    assert metadata_match is not None
+    return json.loads(metadata_match.group(1))
+
+
 def test_phase_five_recovery_taxonomy_is_tracked_from_roadmap_readme_and_tasks():
     roadmap = _text(ROADMAP)
     readme = _text(PHASE_5_README)
@@ -96,7 +113,7 @@ def test_phase_five_recovery_taxonomy_is_tracked_from_roadmap_readme_and_tasks()
     _assert_roadmap_tracks_phase_five_progress(roadmap)
     phase_five_row = _roadmap_phase_evidence_row(roadmap, "Phase 5")
     assert phase_five_row[1] == "`Docs/superpowers/qa/unified-shell/phase-5/`"
-    assert phase_five_row[2] == "in-progress"
+    assert phase_five_row[2] == "verified"
     assert re.search(r"Phase\s+5\.1:.*shared recovery taxonomy.*`TASK-6\.1`", roadmap, re.IGNORECASE)
     assert re.search(
         r"Phase\s+5\.2:.*shell destination blockers.*`TASK-6\.2`",
@@ -113,26 +130,35 @@ def test_phase_five_recovery_taxonomy_is_tracked_from_roadmap_readme_and_tasks()
         roadmap,
         re.IGNORECASE,
     )
+    assert re.search(
+        r"Phase\s+5\.5:.*capability recovery maturity gate.*`TASK-6\.5`",
+        roadmap,
+        re.IGNORECASE,
+    )
     assert "2026-05-05-shared-recovery-taxonomy.md" in roadmap
     assert "2026-05-05-destination-blocker-recovery.md" in roadmap
     assert "2026-05-05-runtime-policy-recovery.md" in roadmap
     assert "2026-05-05-optional-dependency-recovery.md" in roadmap
+    assert "2026-05-05-phase-5-capability-recovery-closeout.md" in roadmap
 
-    assert _status_line(readme) == "in-progress"
+    assert _status_line(readme) == "verified"
     assert "`TASK-6.1`" in readme
     assert "`TASK-6.2`" in readme
     assert "`TASK-6.3`" in readme
     assert "`TASK-6.4`" in readme
+    assert "`TASK-6.5`" in readme
     assert "2026-05-05-shared-recovery-taxonomy.md" in readme
     assert "2026-05-05-destination-blocker-recovery.md" in readme
     assert "2026-05-05-runtime-policy-recovery.md" in readme
     assert "2026-05-05-optional-dependency-recovery.md" in readme
+    assert "2026-05-05-phase-5-capability-recovery-closeout.md" in readme
 
-    assert "status: In Progress" in parent_task
+    assert "status: Done" in parent_task
     assert "TASK-6.1" in parent_task
     assert "TASK-6.2" in parent_task
     assert "TASK-6.3" in parent_task
     assert "TASK-6.4" in parent_task
+    assert "TASK-6.5" in parent_task
     assert "status: Done" in child_task
     for acceptance_criterion in range(1, 5):
         assert f"- [x] #{acceptance_criterion}" in child_task
@@ -191,6 +217,65 @@ def test_phase_five_optional_dependency_recovery_evidence_records_applied_blocke
     assert "dependency_missing" in evidence
     assert "test_search_rag_missing_embeddings_dependency_exposes_phase_five_recovery" in evidence
     assert "test_stts_missing_speech_dependencies_expose_phase_five_recovery" in evidence
+
+
+def test_phase_five_closeout_doc_records_verified_recovery_paths_and_task_completion():
+    closeout = _text(PHASE_5_CLOSEOUT)
+    metadata = _phase_five_closeout_metadata(closeout)
+
+    assert "/Users/" not in closeout
+    assert metadata["closeout_task"] == "TASK-6.5"
+    assert metadata["parent_task"] == "TASK-6"
+    assert metadata["decision"] == "verified"
+    assert metadata["verified_recovery_families"] == [
+        "destination-blockers",
+        "runtime-policy",
+        "optional-dependencies",
+    ]
+    assert metadata["verified_blocked_states"] == [
+        "runtime_not_configured",
+        "empty_selection",
+        "wrong_source",
+        "server_auth_required",
+        "server_session_invalid",
+        "policy_denied",
+        "dependency_missing",
+    ]
+    assert metadata["required_recovery_fields"] == [
+        "status_label",
+        "unavailable_what",
+        "why",
+        "next_action",
+        "recovery_action",
+        "authority_owner",
+        "stable_selector",
+        "disabled_tooltip",
+    ]
+    assert metadata["final_focused_replay_result"]["failed"] == 0
+    assert metadata["final_focused_replay_result"]["passed"] > 0
+    assert metadata["final_broader_replay_result"]["failed"] == 0
+    assert metadata["final_broader_replay_result"]["passed"] >= metadata["final_focused_replay_result"]["passed"]
+
+    readme = _text(PHASE_5_README)
+    roadmap = _text(ROADMAP)
+    parent_task = _text(PHASE_5_PARENT_TASK)
+    closeout_task = _text(PHASE_5_CLOSEOUT_TASK)
+
+    assert _status_line(readme) == "verified"
+    assert PHASE_5_CLOSEOUT.name in readme
+    assert _roadmap_phase_evidence_row(roadmap, "Phase 5")[2] == "verified"
+    assert str(PHASE_5_CLOSEOUT).replace("\\", "/") in roadmap
+    assert "TASK-6.5" in roadmap
+
+    assert "status: Done" in parent_task
+    assert "TASK-6.5" in parent_task
+    for acceptance_criterion in range(1, 5):
+        assert f"- [x] #{acceptance_criterion}" in parent_task
+
+    assert "status: Done" in closeout_task
+    for acceptance_criterion in range(1, 5):
+        assert f"- [x] #{acceptance_criterion}" in closeout_task
+    assert "Implementation Notes" in closeout_task
 
 
 def test_phase_five_recovery_taxonomy_defines_required_contract_and_reason_mappings():

--- a/backlog/tasks/task-6 - Phase-5-Capability-And-Recovery-System.md
+++ b/backlog/tasks/task-6 - Phase-5-Capability-And-Recovery-System.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-6
 title: 'Phase 5: Capability And Recovery System'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-03 14:47'
-updated_date: '2026-05-05 02:32'
+updated_date: '2026-05-05 05:25'
 labels:
   - unified-shell
   - phase-5
@@ -24,10 +24,10 @@ Systematize missing dependency, auth, server, runtime, and policy states so bloc
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Shared capability-state taxonomy exists and is applied to remaining blocker states.
-- [ ] #2 Blocked states tell users what is unavailable, why, and what to do next.
-- [ ] #3 Running-app QA verifies understandable recovery paths.
-- [ ] #4 Durable QA summaries exist under Docs/superpowers/qa/unified-shell/phase-5/.
+- [x] #1 Shared capability-state taxonomy exists and is applied to remaining blocker states.
+- [x] #2 Blocked states tell users what is unavailable, why, and what to do next.
+- [x] #3 Running-app QA verifies understandable recovery paths.
+- [x] #4 Durable QA summaries exist under Docs/superpowers/qa/unified-shell/phase-5/.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -41,5 +41,5 @@ Systematize missing dependency, auth, server, runtime, and policy states so bloc
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Started Phase 5 with TASK-6.1, which defines the shared recovery taxonomy and tracking contract. TASK-6.2 applies the taxonomy to the first shell destination blocker family: ACP runtime configuration, Schedules empty active-run, Workflows empty active-run, and Artifacts empty Chatbook states. TASK-6.3 applies the taxonomy to representative runtime-policy denials in Skills, Library, Personas, and W+C. TASK-6.4 applies the taxonomy to representative optional-dependency blockers in Search/RAG and local speech. Parent Phase 5 remains In Progress until final running-app QA verifies recovery paths.
+Completed Phase 5 recovery closeout through TASK-6.5. TASK-6.1 defines the shared recovery taxonomy, TASK-6.2 applies it to shell destination blockers, TASK-6.3 applies it to runtime-policy denials, TASK-6.4 applies it to optional-dependency blockers, and TASK-6.5 replays maturity-gate QA. The verified recovery fields cover what is unavailable why it is unavailable next action recovery target authority owner stable selector and disabled tooltip copy. Phase 5 is verified; live server/auth execution and full optional-extra runtime coverage remain Phase 6 or future service-depth residual risk.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-6.5 - Phase-5.5-Replay-capability-recovery-maturity-gate.md
+++ b/backlog/tasks/task-6.5 - Phase-5.5-Replay-capability-recovery-maturity-gate.md
@@ -1,0 +1,55 @@
+---
+id: TASK-6.5
+title: Phase 5.5 Replay capability recovery maturity gate
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-05-05 05:22'
+updated_date: '2026-05-05 05:25'
+labels:
+  - unified-shell
+  - phase-5
+  - recovery
+  - qa
+  - closeout
+dependencies: []
+documentation:
+  - >-
+    Docs/superpowers/qa/unified-shell/phase-5/2026-05-05-shared-recovery-taxonomy.md
+  - Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+  - >-
+    Docs/superpowers/qa/unified-shell/phase-5/2026-05-05-phase-5-capability-recovery-closeout.md
+parent_task_id: TASK-6
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replay Phase 5 capability and recovery workflows in the running app and decide whether the recovery system can be verified or must remain blocked by understandable-recovery gaps.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 running-app QA walkthrough verifies shared recovery patterns across destination blockers runtime-policy denials and optional-dependency blockers
+- [x] #2 QA evidence proves blocked states explain what is unavailable why it is unavailable what to do next recovery target and authority owner
+- [x] #3 Phase 5 roadmap README and parent task status are updated from the walkthrough result
+- [x] #4 Automated closeout regression prevents Phase 5 from being marked verified without durable evidence
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Re-read Phase 5 child evidence and recovery taxonomy tests to define the maturity-gate checklist.
+2. Add a failing closeout regression that expects Phase 5 closeout evidence task state README and roadmap status.
+3. Run the focused regression and confirm it fails before closeout updates.
+4. Replay focused running-app recovery tests for destination runtime-policy and optional-dependency blocker states.
+5. Record Phase 5 closeout QA evidence and update README roadmap and Backlog task state according to the replay result.
+6. Run focused closeout recovery tests py_compile where relevant and diff hygiene before committing.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added the Phase 5 closeout contract and durable QA artifact for capability recovery. Replayed destination blocker runtime-policy and optional-dependency recovery tests, updated the Phase 5 README and maturity roadmap to verified, and closed the parent Phase 5 task with residual risks documented for live server/auth and full optional-extra execution paths.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary
- Add TASK-6.5 Phase 5 capability recovery closeout tracking and durable QA evidence.
- Mark Phase 5 verified in the maturity roadmap and Phase 5 QA index after replaying destination, runtime-policy, and optional-dependency recovery states.
- Extend Phase 5 regression coverage so closeout cannot be marked verified without the evidence doc, task state, README, and roadmap updates.

## Test Plan
- [x] python -m pytest Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py -q
- [x] python -m pytest Tests/UI/test_destination_shells.py Tests/UI/test_disabled_action_recovery_tooltips.py Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py -q
- [x] python -m py_compile Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py
- [x] git diff --check