### PR TITLE
Replay Phase 6 first-time shell audit

### DIFF
--- a/Docs/superpowers/qa/unified-shell/phase-6/2026-05-05-phase-6-1-first-time-user-replay.md
+++ b/Docs/superpowers/qa/unified-shell/phase-6/2026-05-05-phase-6-1-first-time-user-replay.md
@@ -1,0 +1,119 @@
+# Phase 6.1 First-Time User Replay
+
+Date: 2026-05-05
+Task: `TASK-7.1`
+Parent Task: `TASK-7`
+Branch: `codex/unified-shell-phase6-first-time-audit`
+Base: `origin/dev` at `2a8dd1e1`
+
+<!-- PHASE_6_1_FIRST_TIME_REPLAY_METADATA:BEGIN -->
+```json
+{
+  "task": "TASK-7.1",
+  "parent_task": "TASK-7",
+  "persona": "first-time-user",
+  "decision": "first_time_walkthrough_recorded",
+  "entry_path": "clean-first-run-home",
+  "verified_routes": [
+    "home",
+    "console",
+    "library",
+    "personas",
+    "skills"
+  ],
+  "orientation_paths": [
+    "library",
+    "personas",
+    "skills"
+  ],
+  "red_contract_result": {
+    "passed": 1,
+    "failed": 1
+  },
+  "final_focused_replay_result": {
+    "passed": 2,
+    "failed": 0
+  },
+  "final_broader_shell_replay_result": {
+    "passed": 65,
+    "failed": 0
+  }
+}
+```
+<!-- PHASE_6_1_FIRST_TIME_REPLAY_METADATA:END -->
+
+## Environment
+
+- Runtime: running Textual app through the app test harness with splash disabled and first-run routing enabled.
+- Python: project-local virtual environment using Python 3.13.
+- Home/config boundary: temporary app test user-data directory created by the harness; no live user database was required.
+- Test command: `.venv/bin/python -m pytest Tests/UI/test_unified_shell_phase6_first_time_replay.py -q`
+
+## Entry Path
+
+Clean first-run launch from configured `chat` default. The shell correctly routes first-time startup to Home instead of dropping the user directly into Console.
+
+## Steps Attempted
+
+1. Launch the app from a first-run state with `app.app_config["_first_run"] = True` and `_initial_tab_value = "chat"`.
+2. Wait for the active screen to become `HomeScreen`.
+3. Verify top-level navigation order and labels: Home, Console, Library, Artifacts, Personas, W+C, Schedules, Workflows, MCP, ACP, Skills, Settings.
+4. Verify Home explains dashboard/status/notifications/active-work/next-action purpose and exposes the next action `Set up Console model`.
+5. Activate Console from the top nav and verify live-work source readiness copy is visible.
+6. Activate Library and verify source orientation paths, including Import/Export and Search/RAG.
+7. Activate Personas and verify behavior-profile orientation plus Console attachment affordance.
+8. Activate Skills and verify Agent Skills orientation plus `SKILL.md` model copy.
+
+## Visual Usability Notes
+
+- Home has a clear title, purpose line, status sections, active-work summary, next-best action, and recent-work empty state.
+- The top-level product model is visible without prior knowledge: Console, Library, Artifacts, Personas, W+C, Schedules, Workflows, MCP, ACP, Skills, and Settings.
+- `W+C` remains compact but still appears in a stable top-nav position; existing navigation metadata keeps its full meaning available through tooltip/full-label tests.
+- Console reads as a control surface because live-work source readiness appears before generic chat controls.
+- Library, Personas, and Skills each explain ownership boundaries in plain product language rather than exposing only implementation labels.
+
+## Keyboard Path Result
+
+The focused replay verifies deterministic button activation, top-nav order, and `More: Ctrl+P` visibility. It does not close the full keyboard-only Tab/Enter sweep; that remains a Phase 6 power-user and Nielsen closeout check.
+
+## Functional Result
+
+First-time orientation workflow completed for Home, Console, Library, Personas, and Skills. The user can understand where to begin, how Console relates to live work, where source/RAG actions live, where persona behavior belongs, and where Agent Skills are managed.
+
+## Defect Severity
+
+| Finding | Severity | Result |
+| --- | --- | --- |
+| Missing Phase 6.1 durable evidence before this slice | recoverability | Captured by the red contract and fixed by this document. |
+| First-time Home-to-Console orientation | none | Home shows status and next action; Console exposes live-work readiness. |
+| Library, Personas, Skills orientation | none | Each destination has visible owner/purpose copy and stable buttons. |
+
+## First-Time Onboarding Gaps
+
+- No P0 blocker was found in this focused replay.
+- The app still relies on destination purpose copy rather than a dedicated guided tour. This is acceptable for Phase 6.1 because Home provides next-best action and the nav model is visible, but the later Nielsen closeout should decide whether skippable guidance is needed.
+- Keyboard-only discoverability is not fully closed by this slice; it must be replayed in the remaining Phase 6 power-user/Nielsen work.
+
+## Deferred Service-Depth Work
+
+- This walkthrough intentionally verifies first-time orientation and destination affordances, not full service CRUD parity.
+- Library detail views, embedded Import/Export depth, and embedded Search/RAG completion remain service-depth work outside this first-time replay.
+- Personas import/export, archetypes, exemplars, dictionaries, lore, and edit flows remain service-depth work.
+- Skills import, validation, editing, execution, and server skill flows remain service-depth work.
+- ACP complete runtime operation remains outside this first-time replay.
+
+## Residual Risk
+
+- Power-user repeated workflows are not closed by this evidence.
+- Nielsen heuristic closeout is not closed by this evidence.
+- A live terminal/manual screenshot sweep can still find layout or focus issues that mounted app harness checks do not capture.
+- Live server/API, optional dependency, and remote-auth paths are represented by recovery states from earlier phases, not re-exercised here.
+
+## Verification
+
+- Red contract after test creation: `.venv/bin/python -m pytest Tests/UI/test_unified_shell_phase6_first_time_replay.py -q`
+- Red result: `1 passed, 1 failed`; the failure was `FileNotFoundError` for this missing evidence file.
+- Final focused replay after evidence/tracking updates: `.venv/bin/python -m pytest Tests/UI/test_unified_shell_phase6_first_time_replay.py -q`
+- Final focused replay result: `2 passed`.
+- Final broader shell/product-model replay: `.venv/bin/python -m pytest Tests/UI/test_unified_shell_qa_protocol.py Tests/UI/test_shell_product_model_visibility.py Tests/UI/test_master_shell_navigation.py Tests/UI/test_screen_navigation.py Tests/UI/test_shell_chrome_contract.py Tests/UI/test_unified_shell_phase234_maturity_gate.py Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py Tests/UI/test_unified_shell_phase6_first_time_replay.py -q`
+- Final broader shell/product-model replay result: `65 passed`.

--- a/Docs/superpowers/qa/unified-shell/phase-6/README.md
+++ b/Docs/superpowers/qa/unified-shell/phase-6/README.md
@@ -1,5 +1,11 @@
 # Phase 6 QA Evidence
 
-Status: not-started
+Status: in-progress
 
-This directory will contain durable QA summaries for this phase. Do not mark the phase verified until running-app walkthrough evidence exists here.
+This directory contains durable QA summaries for Phase 6 audit replay and closeout work.
+
+## Evidence
+
+- `2026-05-05-phase-6-1-first-time-user-replay.md` - `TASK-7.1` first-time user replay covering clean Home launch, Console orientation, and representative Library, Personas, and Skills destination orientation paths.
+
+Phase 6 is in progress. Do not mark the phase verified until power-user workflows and Nielsen heuristic closeout evidence are also replayed against the running app.

--- a/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
@@ -1,8 +1,8 @@
 # Unified Shell Maturity Roadmap
 
 Date: 2026-05-05
-Status: Phase 2, Phase 3, Phase 4, and Phase 5 verified; Phase 6 not started
-Source Branch: `origin/dev` at `9d1cfe50` plus `codex/unified-shell-phase5-closeout`
+Status: Phase 2, Phase 3, Phase 4, and Phase 5 verified; Phase 6 in progress
+Source Branch: `origin/dev` at `2a8dd1e1` plus `codex/unified-shell-phase6-first-time-audit`
 
 ## Purpose
 
@@ -37,7 +37,7 @@ Track remaining Unified Shell work in one place so rendered screens, clickable b
 - Library now surfaces a local source snapshot from notes, media, and conversations and can stage concrete source context into Console; full Library-native detail views, embedded Import/Export, and embedded Search/RAG remain future work.
 - Personas now surfaces a local behavior snapshot from characters and persona profiles and can stage concrete behavior context into Console; detail, edit, import/export, archetypes, exemplars, dictionaries, and lore remain future work.
 - W+C now surfaces a local monitored-source and saved-collection snapshot from `watchlist_scope_service` and `media_reading_scope_service` and can stage concrete W+C context into Console; full detail, edit, import/export, feed WebSub, alert-rule, retry/backoff, and server collection-feed UX remain future work.
-- Phase 2, Phase 3, Phase 4, and Phase 5 implementation and maturity-gate replays are verified. Phase 5 recovery coverage includes shell destination blockers, representative runtime-policy denials, and representative optional-dependency blockers; Phase 6 remains open for full first-time/power-user audit replay.
+- Phase 2, Phase 3, Phase 4, and Phase 5 implementation and maturity-gate replays are verified. Phase 5 recovery coverage includes shell destination blockers, representative runtime-policy denials, and representative optional-dependency blockers; Phase 6 has started with first-time user replay and remains open for power-user and Nielsen audit replay.
 
 ## Definition Of Done
 
@@ -112,6 +112,7 @@ Initial child tasks:
 - Phase 5.3: Apply recovery taxonomy to runtime-policy blockers - `TASK-6.3`
 - Phase 5.4: Apply recovery taxonomy to optional dependency blockers - `TASK-6.4`
 - Phase 5.5: Replay capability recovery maturity gate - `TASK-6.5`
+- Phase 6.1: Replay first-time user walkthrough - `TASK-7.1`
 
 ## QA Evidence Index
 
@@ -123,7 +124,7 @@ Initial child tasks:
 | Phase 3 | `Docs/superpowers/qa/unified-shell/phase-3/` | verified |
 | Phase 4 | `Docs/superpowers/qa/unified-shell/phase-4/` | verified |
 | Phase 5 | `Docs/superpowers/qa/unified-shell/phase-5/` | verified |
-| Phase 6 | `Docs/superpowers/qa/unified-shell/phase-6/` | not-started |
+| Phase 6 | `Docs/superpowers/qa/unified-shell/phase-6/` | in-progress |
 
 ## Phase Overview
 
@@ -135,7 +136,7 @@ Initial child tasks:
 | Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | verified | `TASK-3`, `TASK-3.1`, `TASK-3.2`, `TASK-3.3`, `TASK-3.4`, `TASK-3.5`, `TASK-3.6`, `TASK-3.7`, `TASK-3.8`, `TASK-3.9`, `TASK-3.10`, `TASK-3.11` | `phase-3/` | ACP, MCP, and durable live event streams remain future work; Phase 3 is verified for implemented Console source launch, follow, status, and recovery flows. |
 | Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | verified | `TASK-5`, `TASK-5.1`, `TASK-5.2`, `TASK-5.3`, `TASK-5.4`, `TASK-5.5`, `TASK-5.6` | `phase-4/` | Full CRUD/server-parity depth remains future work; Phase 4 is verified for destination ownership, concrete local workflows, Console staging, and honest recovery states. |
 | Phase 5: Capability And Recovery System | Systematize unavailable and blocked states. | verified | `TASK-6`, `TASK-6.1`, `TASK-6.2`, `TASK-6.3`, `TASK-6.4`, `TASK-6.5` | `phase-5/` | Recovery taxonomy is verified for destination blockers, runtime-policy denials, and optional-dependency blockers; live server/auth and full optional-extra execution remain residual risk. |
-| Phase 6: Audit Replay And Closeout | Prove shell works for first-time and power users. | not-started | `TASK-7` | `phase-6/` | Depends on prior phases and running-app QA. |
+| Phase 6: Audit Replay And Closeout | Prove shell works for first-time and power users. | in-progress | `TASK-7`, `TASK-7.1` | `phase-6/` | First-time replay is recorded; power-user and Nielsen closeout remain open. |
 
 ## Phase 1.1 QA Harness Evidence
 
@@ -350,6 +351,12 @@ Initial audit result: W+C, Schedules, Workflows, and ACP had false Console-launc
 `TASK-6.5` replays the Phase 5 capability and recovery maturity gate after the taxonomy, destination, runtime-policy, and optional-dependency blocker slices:
 
 - `Docs/superpowers/qa/unified-shell/phase-5/2026-05-05-phase-5-capability-recovery-closeout.md`
+
+## Phase 6.1 First-Time User Replay
+
+`TASK-7.1` replays first-time user orientation against the running Textual app, covering clean Home launch, Console orientation, and representative Library, Personas, and Skills destination paths:
+
+- `Docs/superpowers/qa/unified-shell/phase-6/2026-05-05-phase-6-1-first-time-user-replay.md`
 
 ## Phase 0: Canonical Tracking
 

--- a/Tests/UI/test_unified_shell_phase234_maturity_gate.py
+++ b/Tests/UI/test_unified_shell_phase234_maturity_gate.py
@@ -80,8 +80,8 @@ def _assert_roadmap_status_tracks_current_phase_progress(roadmap_text: str) -> N
     assert "phase 3" in normalized_status
     assert "phase 4" in normalized_status
     assert "verified" in normalized_status
-    assert re.search(r"phase\s+5\s+in\s+progress", normalized_status)
-    assert re.search(r"phase\s+6\s+not\s+started", normalized_status)
+    assert re.search(r"phase\s+5\s+verified", normalized_status)
+    assert re.search(r"phase\s+6\s+in\s+progress", normalized_status)
 
 
 def _markdown_path(path: Path) -> str:

--- a/Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py
+++ b/Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py
@@ -66,7 +66,7 @@ def _assert_roadmap_tracks_phase_five_progress(roadmap: str) -> None:
     assert "phase 4" in normalized_status
     assert "verified" in normalized_status
     assert re.search(r"phase\s+5\s+verified", normalized_status)
-    assert re.search(r"phase\s+6\s+not\s+started", normalized_status)
+    assert re.search(r"phase\s+6\s+in\s+progress", normalized_status)
 
 
 def _roadmap_phase_evidence_row(text: str, phase_name: str) -> list[str]:

--- a/Tests/UI/test_unified_shell_phase6_first_time_replay.py
+++ b/Tests/UI/test_unified_shell_phase6_first_time_replay.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+import time
 from collections.abc import Callable
 from pathlib import Path
 from unittest.mock import patch
@@ -62,6 +63,16 @@ def _phase_evidence_row(text: str, phase_name: str) -> list[str]:
     raise AssertionError(f"{phase_name} evidence row not found")
 
 
+def _phase_overview_row(text: str, phase_title: str) -> list[str]:
+    for line in text.splitlines():
+        if not line.startswith("|"):
+            continue
+        columns = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if columns and columns[0] == phase_title:
+            return columns
+    raise AssertionError(f"{phase_title} overview row not found")
+
+
 def _phase_six_first_time_metadata(text: str) -> dict:
     match = re.search(
         r"<!-- PHASE_6_1_FIRST_TIME_REPLAY_METADATA:BEGIN -->\s*```json\s*(.*?)\s*```\s*"
@@ -82,12 +93,21 @@ def _screen_text(app) -> str:
     return "\n".join(pieces)
 
 
-async def _wait_until(pilot, condition: Callable[[], bool], *, attempts: int = 40) -> None:
-    for _ in range(attempts):
+async def _wait_until(
+    pilot,
+    condition: Callable[[], bool],
+    *,
+    timeout_seconds: float = 10.0,
+    interval_seconds: float = 0.05,
+) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
         if condition():
             return
-        await pilot.pause(0.05)
-    raise AssertionError("condition was not met before timeout")
+        await pilot.pause(interval_seconds)
+    if condition():
+        return
+    raise AssertionError(f"condition was not met within {timeout_seconds:.1f}s")
 
 
 def _test_cli_setting(section: str, key: str, default=None):
@@ -97,7 +117,8 @@ def _test_cli_setting(section: str, key: str, default=None):
 
 
 @pytest.mark.asyncio
-async def test_first_time_shell_replay_exposes_home_console_and_orientation_paths():
+async def test_first_time_shell_replay_exposes_home_console_and_orientation_paths() -> None:
+    """Verify first-time launch exposes the shell's primary orientation paths."""
     app = _build_test_app()
     app.app_config["_first_run"] = True
     app._initial_tab_value = "chat"
@@ -155,7 +176,8 @@ async def test_first_time_shell_replay_exposes_home_console_and_orientation_path
                     assert copy in screen_text
 
 
-def test_phase_six_first_time_replay_evidence_and_tracking_are_current():
+def test_phase_six_first_time_replay_evidence_and_tracking_are_current() -> None:
+    """Verify Phase 6.1 evidence and tracking stay aligned with the roadmap."""
     evidence = _text(PHASE_6_FIRST_TIME_EVIDENCE)
     readme = _text(PHASE_6_README)
     roadmap = _text(ROADMAP)
@@ -200,10 +222,11 @@ def test_phase_six_first_time_replay_evidence_and_tracking_are_current():
     assert _phase_evidence_row(roadmap, "Phase 6")[2] == "in-progress"
     assert str(PHASE_6_FIRST_TIME_EVIDENCE).replace("\\", "/") in roadmap
     assert "Phase 6.1: Replay first-time user walkthrough - `TASK-7.1`" in roadmap
-    assert (
-        "| Phase 6: Audit Replay And Closeout | Prove shell works for first-time and power users. | "
-        "in-progress | `TASK-7`, `TASK-7.1` |"
-    ) in roadmap
+    phase_six_overview = _phase_overview_row(roadmap, "Phase 6: Audit Replay And Closeout")
+    assert phase_six_overview[2] == "in-progress"
+    assert "TASK-7" in phase_six_overview[3]
+    assert "TASK-7.1" in phase_six_overview[3]
+    assert "power-user and Nielsen closeout remain open" in phase_six_overview[5]
 
     assert "status: In Progress" in parent_task
     assert "TASK-7.1" in parent_task

--- a/Tests/UI/test_unified_shell_phase6_first_time_replay.py
+++ b/Tests/UI/test_unified_shell_phase6_first_time_replay.py
@@ -1,0 +1,217 @@
+"""Phase 6.1 first-time user replay contract."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from textual.widgets import Button, Static
+
+from Tests.UI.test_screen_navigation import _build_test_app
+from tldw_chatbook.UI.Navigation.main_navigation import MainNavigationBar
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ROADMAP = Path("Docs/superpowers/trackers/unified-shell-maturity-roadmap.md")
+PHASE_6_README = Path("Docs/superpowers/qa/unified-shell/phase-6/README.md")
+PHASE_6_FIRST_TIME_EVIDENCE = Path(
+    "Docs/superpowers/qa/unified-shell/phase-6/2026-05-05-phase-6-1-first-time-user-replay.md"
+)
+PHASE_6_PARENT_TASK = Path("backlog/tasks/task-7 - Phase-6-Audit-Replay-And-Closeout.md")
+PHASE_6_FIRST_TIME_TASK = Path(
+    "backlog/tasks/task-7.1 - Phase-6.1-Replay-first-time-user-walkthrough.md"
+)
+
+EXPECTED_NAV = [
+    ("nav-home", "Home"),
+    ("nav-console", "Console"),
+    ("nav-library", "Library"),
+    ("nav-artifacts", "Artifacts"),
+    ("nav-personas", "Personas"),
+    ("nav-watchlists_collections", "W+C"),
+    ("nav-schedules", "Schedules"),
+    ("nav-workflows", "Workflows"),
+    ("nav-mcp", "MCP"),
+    ("nav-acp", "ACP"),
+    ("nav-skills", "Skills"),
+    ("nav-settings", "Settings"),
+]
+
+
+def _text(path: Path) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def _status_line(text: str) -> str:
+    match = re.search(r"^Status:\s*(.+)$", text, re.MULTILINE)
+    assert match is not None
+    return match.group(1).strip()
+
+
+def _phase_evidence_row(text: str, phase_name: str) -> list[str]:
+    for line in text.splitlines():
+        if not line.startswith("|"):
+            continue
+        columns = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if columns and columns[0] == phase_name:
+            return columns
+    raise AssertionError(f"{phase_name} evidence row not found")
+
+
+def _phase_six_first_time_metadata(text: str) -> dict:
+    match = re.search(
+        r"<!-- PHASE_6_1_FIRST_TIME_REPLAY_METADATA:BEGIN -->\s*```json\s*(.*?)\s*```\s*"
+        r"<!-- PHASE_6_1_FIRST_TIME_REPLAY_METADATA:END -->",
+        text,
+        re.DOTALL,
+    )
+    assert match is not None
+    return json.loads(match.group(1))
+
+
+def _screen_text(app) -> str:
+    pieces: list[str] = []
+    for widget in app.screen.query(Static):
+        pieces.append(str(widget.renderable))
+    for widget in app.screen.query(Button):
+        pieces.append(str(widget.label).strip())
+    return "\n".join(pieces)
+
+
+async def _wait_until(pilot, condition: Callable[[], bool], *, attempts: int = 40) -> None:
+    for _ in range(attempts):
+        if condition():
+            return
+        await pilot.pause(0.05)
+    raise AssertionError("condition was not met before timeout")
+
+
+def _test_cli_setting(section: str, key: str, default=None):
+    if section == "splash_screen" and key == "enabled":
+        return False
+    return default
+
+
+@pytest.mark.asyncio
+async def test_first_time_shell_replay_exposes_home_console_and_orientation_paths():
+    app = _build_test_app()
+    app.app_config["_first_run"] = True
+    app._initial_tab_value = "chat"
+
+    with patch("tldw_chatbook.app.get_cli_setting", side_effect=_test_cli_setting):
+        async with app.run_test(size=(180, 50)) as pilot:
+            await _wait_until(
+                pilot,
+                lambda: app.current_tab == "home" and app.screen.__class__.__name__ == "HomeScreen",
+            )
+
+            nav_buttons = list(app.screen.query(MainNavigationBar).first().query(Button))
+            assert [(button.id, str(button.label).strip()) for button in nav_buttons] == EXPECTED_NAV
+
+            home_text = _screen_text(app)
+            assert "Dashboard, notifications, status, active work, and next actions." in home_text
+            assert "Set up Console model" in home_text
+            assert "More: Ctrl+P" in home_text
+
+            for button_id, current_tab, screen_name, required_copy in (
+                (
+                    "nav-console",
+                    "chat",
+                    "ChatScreen",
+                    ("Live work sources", "W+C: Connected"),
+                ),
+                (
+                    "nav-library",
+                    "library",
+                    "LibraryScreen",
+                    ("Library", "Import/Export Sources", "Search/RAG"),
+                ),
+                (
+                    "nav-personas",
+                    "personas",
+                    "PersonasScreen",
+                    ("Personas", "behavior profiles", "Attach to Console"),
+                ),
+                (
+                    "nav-skills",
+                    "skills",
+                    "SkillsScreen",
+                    ("Skills", "Agent Skills", "SKILL.md"),
+                ),
+            ):
+                app.screen.query_one(f"#{button_id}", Button).press()
+                await _wait_until(
+                    pilot,
+                    lambda current_tab=current_tab, screen_name=screen_name: (
+                        app.current_tab == current_tab and app.screen.__class__.__name__ == screen_name
+                    ),
+                )
+                screen_text = _screen_text(app)
+                for copy in required_copy:
+                    assert copy in screen_text
+
+
+def test_phase_six_first_time_replay_evidence_and_tracking_are_current():
+    evidence = _text(PHASE_6_FIRST_TIME_EVIDENCE)
+    readme = _text(PHASE_6_README)
+    roadmap = _text(ROADMAP)
+    parent_task = _text(PHASE_6_PARENT_TASK)
+    first_time_task = _text(PHASE_6_FIRST_TIME_TASK)
+    metadata = _phase_six_first_time_metadata(evidence)
+
+    assert "/Users/" not in evidence
+    assert metadata["task"] == "TASK-7.1"
+    assert metadata["parent_task"] == "TASK-7"
+    assert metadata["persona"] == "first-time-user"
+    assert metadata["decision"] == "first_time_walkthrough_recorded"
+    assert metadata["entry_path"] == "clean-first-run-home"
+    assert metadata["verified_routes"] == ["home", "console", "library", "personas", "skills"]
+    assert metadata["orientation_paths"] == ["library", "personas", "skills"]
+    assert metadata["final_focused_replay_result"]["failed"] == 0
+    assert metadata["final_focused_replay_result"]["passed"] > 0
+
+    for section in (
+        "## Environment",
+        "## Entry Path",
+        "## Steps Attempted",
+        "## Visual Usability Notes",
+        "## Keyboard Path Result",
+        "## Functional Result",
+        "## Defect Severity",
+        "## First-Time Onboarding Gaps",
+        "## Deferred Service-Depth Work",
+        "## Residual Risk",
+    ):
+        assert section in evidence
+    assert "running Textual app" in evidence
+    assert "Tests/UI/test_unified_shell_phase6_first_time_replay.py" in evidence
+
+    assert _status_line(readme) == "in-progress"
+    assert PHASE_6_FIRST_TIME_EVIDENCE.name in readme
+    assert "TASK-7.1" in readme
+
+    normalized_status = _status_line(roadmap).lower().replace("-", " ")
+    assert re.search(r"phase\s+5\s+verified", normalized_status)
+    assert re.search(r"phase\s+6\s+in\s+progress", normalized_status)
+    assert _phase_evidence_row(roadmap, "Phase 6")[2] == "in-progress"
+    assert str(PHASE_6_FIRST_TIME_EVIDENCE).replace("\\", "/") in roadmap
+    assert "Phase 6.1: Replay first-time user walkthrough - `TASK-7.1`" in roadmap
+    assert (
+        "| Phase 6: Audit Replay And Closeout | Prove shell works for first-time and power users. | "
+        "in-progress | `TASK-7`, `TASK-7.1` |"
+    ) in roadmap
+
+    assert "status: In Progress" in parent_task
+    assert "TASK-7.1" in parent_task
+    assert "- [x] #1 First-time user walkthrough is replayed against the running app." in parent_task
+    assert "- [ ] #2 Power-user workflows are replayed against the running app." in parent_task
+    assert "- [ ] #3 Nielsen heuristic closeout documents remaining defects and residual risks." in parent_task
+
+    assert "status: Done" in first_time_task
+    for acceptance_criterion in range(1, 5):
+        assert f"- [x] #{acceptance_criterion}" in first_time_task
+    assert "Implementation Notes" in first_time_task

--- a/backlog/tasks/task-7 - Phase-6-Audit-Replay-And-Closeout.md
+++ b/backlog/tasks/task-7 - Phase-6-Audit-Replay-And-Closeout.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-7
 title: 'Phase 6: Audit Replay And Closeout'
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@codex'
 created_date: '2026-05-03 14:47'
+updated_date: '2026-05-05 05:45'
 labels:
   - unified-shell
   - phase-6
@@ -12,6 +14,7 @@ labels:
 dependencies: []
 documentation:
   - Docs/superpowers/specs/2026-05-03-unified-shell-maturity-tracking-design.md
+  - Docs/superpowers/qa/unified-shell/phase-6/2026-05-05-phase-6-1-first-time-user-replay.md
 priority: medium
 ---
 
@@ -23,8 +26,17 @@ Replay first-time user, power-user, and Nielsen heuristic walkthroughs to prove 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 First-time user walkthrough is replayed against the running app.
+- [x] #1 First-time user walkthrough is replayed against the running app.
 - [ ] #2 Power-user workflows are replayed against the running app.
 - [ ] #3 Nielsen heuristic closeout documents remaining defects and residual risks.
 - [ ] #4 Durable QA summaries exist under Docs/superpowers/qa/unified-shell/phase-6/.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Complete `TASK-7.1` for first-time user replay against the running app.
+2. Add a power-user replay slice for repeated core workflows and speed paths.
+3. Add a Nielsen heuristic closeout slice that maps residual defects and risks.
+4. Mark Phase 6 verified only after all three replay families have durable QA evidence.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-7.1 - Phase-6.1-Replay-first-time-user-walkthrough.md
+++ b/backlog/tasks/task-7.1 - Phase-6.1-Replay-first-time-user-walkthrough.md
@@ -1,0 +1,54 @@
+---
+id: TASK-7.1
+title: Phase 6.1 Replay first-time user walkthrough
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-05-05 05:35'
+updated_date: '2026-05-05 05:45'
+labels:
+  - unified-shell
+  - phase-6
+  - audit-replay
+  - first-time-user
+  - qa
+dependencies: []
+documentation:
+  - Docs/superpowers/specs/2026-05-03-unified-shell-maturity-tracking-design.md
+  - Docs/superpowers/qa/unified-shell/phase-1/walkthrough-protocol.md
+  - Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+  - Docs/superpowers/qa/unified-shell/phase-6/2026-05-05-phase-6-1-first-time-user-replay.md
+parent_task_id: TASK-7
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replay the Unified Shell from a first-time user perspective against the running Textual app so orientation navigation labels recovery states and obvious starting paths are verified with durable evidence.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Clean first-time launch walkthrough records Home Console navigation and at least three top-level destination orientation paths
+- [x] #2 Evidence captures visual usability keyboard path functional result defect severity and residual risk using the QA walkthrough protocol
+- [x] #3 Findings distinguish first-time onboarding gaps from intentionally deferred service-depth work
+- [x] #4 Phase 6 README roadmap and parent task tracking are updated without prematurely closing Phase 6
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a failing Phase 6 first-time replay contract that expects durable evidence README roadmap and task tracking.
+2. Run the focused contract to confirm it fails before evidence exists.
+3. Exercise the running Textual app through the app test harness from a clean first-time state, covering Home Console and representative destinations.
+4. Record first-time walkthrough evidence with workflow matrix visual usability notes defects residual risks and verification commands.
+5. Update the Phase 6 README roadmap and Backlog task state without closing the Phase 6 parent.
+6. Run focused Phase 6 tests plus relevant shell navigation and destination checks before committing.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added a Phase 6.1 first-time replay contract and durable QA evidence for clean Home launch Console orientation and representative Library Personas and Skills orientation paths. Updated the Phase 6 README roadmap and parent task to in-progress while leaving power-user and Nielsen closeout criteria open.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
Summary: Adds the Phase 6.1 first-time user replay contract and durable QA evidence, moves Phase 6 to in-progress without closing power-user/Nielsen work, and updates stale maturity-gate status assertions. Verification: .venv/bin/python -m pytest Tests/UI/test_unified_shell_phase6_first_time_replay.py -q (2 passed); .venv/bin/python -m pytest Tests/UI/test_unified_shell_qa_protocol.py Tests/UI/test_shell_product_model_visibility.py Tests/UI/test_master_shell_navigation.py Tests/UI/test_screen_navigation.py Tests/UI/test_shell_chrome_contract.py Tests/UI/test_unified_shell_phase234_maturity_gate.py Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py Tests/UI/test_unified_shell_phase6_first_time_replay.py -q (65 passed); py_compile; git diff --cached --check.