### PR TITLE
Replay Phase 6 power-user workflows

### DIFF
--- a/Docs/superpowers/qa/unified-shell/phase-6/2026-05-05-phase-6-2-power-user-workflow-replay.md
+++ b/Docs/superpowers/qa/unified-shell/phase-6/2026-05-05-phase-6-2-power-user-workflow-replay.md
@@ -1,0 +1,112 @@
+# Phase 6.2 Power-User Workflow Replay
+
+Date: 2026-05-05
+Task: `TASK-7.2`
+Parent Task: `TASK-7`
+Branch: `codex/unified-shell-phase6-power-user-replay`
+Base: `origin/dev` at `1261b1cb`
+
+<!-- PHASE_6_2_POWER_USER_REPLAY_METADATA:BEGIN -->
+```json
+{
+  "task": "TASK-7.2",
+  "parent_task": "TASK-7",
+  "persona": "power-user",
+  "decision": "power_user_workflows_recorded",
+  "entry_path": "running-app-fast-repeat-use",
+  "verified_workflows": [
+    "home-next-action-to-console",
+    "console-live-work-readiness",
+    "library-search-rag",
+    "library-import-export",
+    "console-live-work-follow-through"
+  ],
+  "speed_paths": [
+    "home-primary-action",
+    "top-nav",
+    "ctrl-p-affordance"
+  ],
+  "red_contract_result": {
+    "passed": 1,
+    "failed": 1
+  },
+  "final_focused_replay_result": {
+    "passed": 2,
+    "failed": 0
+  },
+  "final_broader_shell_replay_result": {
+    "passed": 67,
+    "failed": 0
+  }
+}
+```
+<!-- PHASE_6_2_POWER_USER_REPLAY_METADATA:END -->
+
+## Environment
+
+- Runtime: running Textual app through the app test harness with splash disabled.
+- Python: project-local virtual environment using Python 3.13.
+- Home/config boundary: temporary app test user-data directory created by the harness; no live user database was required.
+- Test command: `.venv/bin/python -m pytest Tests/UI/test_unified_shell_phase6_power_user_replay.py -q`
+
+## Workflow Matrix
+
+| Workflow | Goal | Steps Attempted | What Worked | Friction | Severity |
+| --- | --- | --- | --- | --- | --- |
+| Home next action to Console | Start work fast from a configured dashboard. | Launch Home in returning-user mode with model and Library content ready; activate `Start in Console`. | Home routes to Console and Console renders live-work source readiness. | This is fast after setup, but first-run users still get setup guidance instead. | none |
+| Console live-work readiness | Confirm Console is a control surface, not just chat. | Inspect Console after Home launch. | Source readiness shows W+C, Workflows, Schedules, RAG, and Artifacts as connected, with ACP and MCP honest unavailable states. | Readiness is visible, but deeper source event streams remain future work. | recoverability |
+| Library Search/RAG | Reach RAG from the source hub. | Navigate to Library and activate `Search/RAG`. | Search/RAG opens through the Library action path. | Search/RAG is a Library subroute, so the top-nav Library item stays active and is not a back-to-hub affordance. | workflow-degradation |
+| Library Import/Export | Reach source ingestion/export from the source hub. | Navigate to Library and activate `Import/Export Sources`. | Import/Export opens the ingestion route through the Library action path. | Same Library-subroute back affordance limitation as Search/RAG. | workflow-degradation |
+| Console live-work follow-through | Follow an active W+C live-work item into details. | Stage a W+C live-work payload, verify the Console status card, activate `Open W+C run`. | Console renders source/title/status/action and opens the subscriptions watchlist-runs context. | The replay uses a staged local payload, not a live watchlist execution. | none |
+
+## Repeated-Use Findings
+
+- Home supports fast repeated use once the user has model setup and Library content: the primary action becomes `Start in Console` rather than setup guidance.
+- Top-level nav supports fast hopping between Console and Library, and the visible `More: Ctrl+P` affordance plus registered `ctrl+p` binding preserve command-palette discovery.
+- Library subroutes for Search/RAG and Import/Export are reachable, but they inherit the Library top-nav active state. A power user who wants to return to the Library hub from a subroute needs another route path, such as Console/Home then Library or the command palette.
+- Console live-work follow-through works for the W+C run-detail action and consumes staged context into the subscription screen.
+
+## Visual Usability Notes
+
+- The Home configured-state primary action is direct and concise.
+- Console status cards use explicit source, title, status, recovery, action, and payload rows, which supports recognition over recall.
+- Library exposes Search/RAG and Import/Export as sibling action buttons, making the source model visible.
+- The Library subroute active-nav behavior is logically consistent with the product model, but it weakens wayfinding for fast repeated source-hub use.
+
+## Keyboard Path Result
+
+The replay verifies the `ctrl+p` command-palette binding exists and the shell exposes `More: Ctrl+P` in the running app. It does not complete a full keyboard-only Tab/Enter sweep; that remains part of the Nielsen closeout.
+
+## Functional Result
+
+Power-user replay completed for five core workflows: configured Home-to-Console launch, Console source-readiness review, Library-to-Search/RAG, Library-to-Import/Export, and W+C live-work Console follow-through into run details.
+
+## Defect Severity
+
+| Finding | Severity | Result |
+| --- | --- | --- |
+| Missing Phase 6.2 durable evidence before this slice | recoverability | Captured by the red contract and fixed by this document. |
+| Library subroutes lack an explicit return-to-Library-hub affordance | workflow-degradation | Recorded for Nielsen closeout; not a P0/P1 because top-level navigation and command palette paths remain available. |
+| Full keyboard-only sweep not replayed in this slice | recoverability | Deferred to Nielsen closeout. |
+
+## Deferred Service-Depth Work
+
+- The replay uses local shell contracts and staged live-work payloads; it does not run a live W+C job.
+- Search/RAG route reachability is verified, not retrieval quality or embedding execution.
+- Import/Export route reachability is verified, not a full import/export transaction.
+- MCP and ACP source-readiness rows remain honest unavailable or future-work states for deeper live event production.
+
+## Residual Risk
+
+- Nielsen heuristic closeout is not closed by this evidence.
+- A live terminal/manual screenshot sweep can still find layout, clipping, focus-order, or keyboard traversal issues not captured by mounted app harness checks.
+- Live server/API, optional dependency, and remote-auth paths are represented by recovery states from earlier phases, not re-exercised here.
+
+## Verification
+
+- Red contract after test creation and test harness correction: `.venv/bin/python -m pytest Tests/UI/test_unified_shell_phase6_power_user_replay.py -q`
+- Red result: `1 passed, 1 failed`; the failure was `FileNotFoundError` for this missing evidence file.
+- Final focused replay after evidence/tracking updates: `.venv/bin/python -m pytest Tests/UI/test_unified_shell_phase6_power_user_replay.py -q`
+- Final focused replay result: `2 passed`.
+- Final broader shell/product-model replay: `.venv/bin/python -m pytest Tests/UI/test_unified_shell_qa_protocol.py Tests/UI/test_shell_product_model_visibility.py Tests/UI/test_master_shell_navigation.py Tests/UI/test_screen_navigation.py Tests/UI/test_shell_chrome_contract.py Tests/UI/test_unified_shell_phase234_maturity_gate.py Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py Tests/UI/test_unified_shell_phase6_first_time_replay.py Tests/UI/test_unified_shell_phase6_power_user_replay.py -q`
+- Final broader shell/product-model replay result: `67 passed`.

--- a/Docs/superpowers/qa/unified-shell/phase-6/README.md
+++ b/Docs/superpowers/qa/unified-shell/phase-6/README.md
@@ -7,5 +7,6 @@ This directory contains durable QA summaries for Phase 6 audit replay and closeo
 ## Evidence
 
 - `2026-05-05-phase-6-1-first-time-user-replay.md` - `TASK-7.1` first-time user replay covering clean Home launch, Console orientation, and representative Library, Personas, and Skills destination orientation paths.
+- `2026-05-05-phase-6-2-power-user-workflow-replay.md` - `TASK-7.2` power-user replay covering configured Home-to-Console launch, Console live-work readiness, Library Search/RAG, Library Import/Export, and W+C live-work follow-through.
 
-Phase 6 is in progress. Do not mark the phase verified until power-user workflows and Nielsen heuristic closeout evidence are also replayed against the running app.
+Phase 6 is in progress. Do not mark the phase verified until Nielsen heuristic closeout evidence is also replayed against the running app.

--- a/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
@@ -2,7 +2,7 @@
 
 Date: 2026-05-05
 Status: Phase 2, Phase 3, Phase 4, and Phase 5 verified; Phase 6 in progress
-Source Branch: `origin/dev` at `2a8dd1e1` plus `codex/unified-shell-phase6-first-time-audit`
+Source Branch: `origin/dev` at `1261b1cb` plus `codex/unified-shell-phase6-power-user-replay`
 
 ## Purpose
 
@@ -37,7 +37,7 @@ Track remaining Unified Shell work in one place so rendered screens, clickable b
 - Library now surfaces a local source snapshot from notes, media, and conversations and can stage concrete source context into Console; full Library-native detail views, embedded Import/Export, and embedded Search/RAG remain future work.
 - Personas now surfaces a local behavior snapshot from characters and persona profiles and can stage concrete behavior context into Console; detail, edit, import/export, archetypes, exemplars, dictionaries, and lore remain future work.
 - W+C now surfaces a local monitored-source and saved-collection snapshot from `watchlist_scope_service` and `media_reading_scope_service` and can stage concrete W+C context into Console; full detail, edit, import/export, feed WebSub, alert-rule, retry/backoff, and server collection-feed UX remain future work.
-- Phase 2, Phase 3, Phase 4, and Phase 5 implementation and maturity-gate replays are verified. Phase 5 recovery coverage includes shell destination blockers, representative runtime-policy denials, and representative optional-dependency blockers; Phase 6 has started with first-time user replay and remains open for power-user and Nielsen audit replay.
+- Phase 2, Phase 3, Phase 4, and Phase 5 implementation and maturity-gate replays are verified. Phase 5 recovery coverage includes shell destination blockers, representative runtime-policy denials, and representative optional-dependency blockers; Phase 6 has first-time and power-user replays recorded and remains open for Nielsen audit replay.
 
 ## Definition Of Done
 
@@ -113,6 +113,7 @@ Initial child tasks:
 - Phase 5.4: Apply recovery taxonomy to optional dependency blockers - `TASK-6.4`
 - Phase 5.5: Replay capability recovery maturity gate - `TASK-6.5`
 - Phase 6.1: Replay first-time user walkthrough - `TASK-7.1`
+- Phase 6.2: Replay power-user workflows - `TASK-7.2`
 
 ## QA Evidence Index
 
@@ -136,7 +137,7 @@ Initial child tasks:
 | Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | verified | `TASK-3`, `TASK-3.1`, `TASK-3.2`, `TASK-3.3`, `TASK-3.4`, `TASK-3.5`, `TASK-3.6`, `TASK-3.7`, `TASK-3.8`, `TASK-3.9`, `TASK-3.10`, `TASK-3.11` | `phase-3/` | ACP, MCP, and durable live event streams remain future work; Phase 3 is verified for implemented Console source launch, follow, status, and recovery flows. |
 | Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | verified | `TASK-5`, `TASK-5.1`, `TASK-5.2`, `TASK-5.3`, `TASK-5.4`, `TASK-5.5`, `TASK-5.6` | `phase-4/` | Full CRUD/server-parity depth remains future work; Phase 4 is verified for destination ownership, concrete local workflows, Console staging, and honest recovery states. |
 | Phase 5: Capability And Recovery System | Systematize unavailable and blocked states. | verified | `TASK-6`, `TASK-6.1`, `TASK-6.2`, `TASK-6.3`, `TASK-6.4`, `TASK-6.5` | `phase-5/` | Recovery taxonomy is verified for destination blockers, runtime-policy denials, and optional-dependency blockers; live server/auth and full optional-extra execution remain residual risk. |
-| Phase 6: Audit Replay And Closeout | Prove shell works for first-time and power users. | in-progress | `TASK-7`, `TASK-7.1` | `phase-6/` | First-time replay is recorded; power-user and Nielsen closeout remain open. |
+| Phase 6: Audit Replay And Closeout | Prove shell works for first-time and power users. | in-progress | `TASK-7`, `TASK-7.1`, `TASK-7.2` | `phase-6/` | First-time and power-user replays are recorded; Nielsen closeout remains open. |
 
 ## Phase 1.1 QA Harness Evidence
 
@@ -358,6 +359,12 @@ Initial audit result: W+C, Schedules, Workflows, and ACP had false Console-launc
 
 - `Docs/superpowers/qa/unified-shell/phase-6/2026-05-05-phase-6-1-first-time-user-replay.md`
 
+## Phase 6.2 Power-User Workflow Replay
+
+`TASK-7.2` replays fast repeated workflows against the running Textual app, covering configured Home-to-Console launch, Console live-work readiness, Library Search/RAG, Library Import/Export, and W+C live-work follow-through:
+
+- `Docs/superpowers/qa/unified-shell/phase-6/2026-05-05-phase-6-2-power-user-workflow-replay.md`
+
 ## Phase 0: Canonical Tracking
 
 Done when:
@@ -391,7 +398,7 @@ Done when missing dependency, auth, server, runtime, and policy states use share
 
 ## Phase 6: Audit Replay And Closeout
 
-Done when first-time and power-user walkthroughs are replayed in the actual app with screenshots, logs, test evidence, and residual-risk notes.
+Done when first-time and power-user walkthroughs plus Nielsen heuristic closeout are replayed in the actual app with screenshots, logs, test evidence, and residual-risk notes.
 
 ## QA Walkthrough Protocol
 

--- a/Tests/UI/test_unified_shell_phase6_first_time_replay.py
+++ b/Tests/UI/test_unified_shell_phase6_first_time_replay.py
@@ -226,12 +226,12 @@ def test_phase_six_first_time_replay_evidence_and_tracking_are_current() -> None
     assert phase_six_overview[2] == "in-progress"
     assert "TASK-7" in phase_six_overview[3]
     assert "TASK-7.1" in phase_six_overview[3]
-    assert "power-user and Nielsen closeout remain open" in phase_six_overview[5]
+    assert "Nielsen closeout remains open" in phase_six_overview[5]
 
     assert "status: In Progress" in parent_task
     assert "TASK-7.1" in parent_task
     assert "- [x] #1 First-time user walkthrough is replayed against the running app." in parent_task
-    assert "- [ ] #2 Power-user workflows are replayed against the running app." in parent_task
+    assert "- [x] #2 Power-user workflows are replayed against the running app." in parent_task
     assert "- [ ] #3 Nielsen heuristic closeout documents remaining defects and residual risks." in parent_task
 
     assert "status: Done" in first_time_task

--- a/Tests/UI/test_unified_shell_phase6_power_user_replay.py
+++ b/Tests/UI/test_unified_shell_phase6_power_user_replay.py
@@ -1,0 +1,207 @@
+"""Phase 6.2 power-user workflow replay contract."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from textual.widgets import Button
+
+from Tests.UI.test_screen_navigation import _build_test_app
+from Tests.UI.test_unified_shell_phase6_first_time_replay import (
+    PHASE_6_PARENT_TASK,
+    PHASE_6_README,
+    ROADMAP,
+    _phase_evidence_row,
+    _phase_overview_row,
+    _screen_text,
+    _status_line,
+    _test_cli_setting,
+    _text,
+    _wait_until,
+)
+from tldw_chatbook.Home.dashboard_state import HomeDashboardInput
+from tldw_chatbook.app import TldwCli
+
+
+PHASE_6_POWER_USER_EVIDENCE = Path(
+    "Docs/superpowers/qa/unified-shell/phase-6/2026-05-05-phase-6-2-power-user-workflow-replay.md"
+)
+PHASE_6_POWER_USER_TASK = Path(
+    "backlog/tasks/task-7.2 - Phase-6.2-Replay-power-user-workflows.md"
+)
+
+
+def _phase_six_power_user_metadata(text: str) -> dict:
+    match = re.search(
+        r"<!-- PHASE_6_2_POWER_USER_REPLAY_METADATA:BEGIN -->\s*```json\s*(.*?)\s*```\s*"
+        r"<!-- PHASE_6_2_POWER_USER_REPLAY_METADATA:END -->",
+        text,
+        re.DOTALL,
+    )
+    assert match is not None
+    return json.loads(match.group(1))
+
+
+@pytest.mark.asyncio
+async def test_power_user_shell_replay_supports_fast_repeated_core_workflows() -> None:
+    """Verify repeated shell workflows use direct, deterministic app paths."""
+    app = _build_test_app()
+    app.app_config["_first_run"] = False
+    app._initial_tab_value = "home"
+    app._home_dashboard_test_input = HomeDashboardInput(
+        model_ready=True,
+        has_library_content=True,
+    )
+
+    with patch("tldw_chatbook.app.get_cli_setting", side_effect=_test_cli_setting):
+        async with app.run_test(size=(180, 50)) as pilot:
+            await _wait_until(
+                pilot,
+                lambda: app.current_tab == "home" and app.screen.__class__.__name__ == "HomeScreen",
+            )
+            assert "Start in Console" in _screen_text(app)
+
+            app.screen.query_one("#home-primary-action", Button).press()
+            await _wait_until(
+                pilot,
+                lambda: app.current_tab == "chat" and app.screen.__class__.__name__ == "ChatScreen",
+            )
+            console_text = _screen_text(app)
+            assert "Live work sources" in console_text
+            assert "W+C: Connected" in console_text
+            assert "More: Ctrl+P" in console_text
+            assert any(binding.key == "ctrl+p" for binding in TldwCli.BINDINGS)
+
+            app.screen.query_one("#nav-library", Button).press()
+            await _wait_until(
+                pilot,
+                lambda: app.current_tab == "library" and app.screen.__class__.__name__ == "LibraryScreen",
+            )
+            library_text = _screen_text(app)
+            assert "Import/Export Sources" in library_text
+            assert "Search/RAG" in library_text
+
+            app.screen.query_one("#library-open-import-export", Button).press()
+            await _wait_until(
+                pilot,
+                lambda: app.current_tab == "ingest"
+                and app.screen.__class__.__name__ == "MediaIngestScreen",
+            )
+
+            app.screen.query_one("#nav-console", Button).press()
+            await _wait_until(
+                pilot,
+                lambda: app.current_tab == "chat" and app.screen.__class__.__name__ == "ChatScreen",
+            )
+            app.screen.query_one("#nav-library", Button).press()
+            await _wait_until(
+                pilot,
+                lambda: app.current_tab == "library" and app.screen.__class__.__name__ == "LibraryScreen",
+            )
+            app.screen.query_one("#library-open-search", Button).press()
+            await _wait_until(
+                pilot,
+                lambda: app.current_tab == "search" and app.screen.__class__.__name__ == "SearchScreen",
+            )
+
+            app.open_console_for_live_work(
+                source="W+C",
+                title="Daily security feed",
+                payload={"target_id": "local:watchlist_run:91", "run_id": 91},
+                status="failed",
+                recovery="Review the W+C run details or retry from W+C.",
+                action_label="Open W+C run",
+            )
+            await _wait_until(
+                pilot,
+                lambda: app.current_tab == "chat" and app.screen.__class__.__name__ == "ChatScreen",
+            )
+            live_work_text = _screen_text(app)
+            assert "Source: W+C" in live_work_text
+            assert "Title: Daily security feed" in live_work_text
+            assert "Action: Open W+C run" in live_work_text
+
+            app.screen.query_one("#console-live-work-primary-action", Button).press()
+            await _wait_until(
+                pilot,
+                lambda: app.current_tab == "subscriptions"
+                and app.screen.__class__.__name__ == "SubscriptionScreen",
+            )
+            subscription_window = app.screen.subscription_window
+            assert subscription_window is not None
+            assert subscription_window.initial_tab == "watchlist-runs"
+            assert subscription_window._selected_watchlist_run_id == "local:watchlist_run:91"
+
+
+def test_phase_six_power_user_replay_evidence_and_tracking_are_current() -> None:
+    """Verify Phase 6.2 evidence and tracking stay aligned with the roadmap."""
+    evidence = _text(PHASE_6_POWER_USER_EVIDENCE)
+    readme = _text(PHASE_6_README)
+    roadmap = _text(ROADMAP)
+    parent_task = _text(PHASE_6_PARENT_TASK)
+    power_user_task = _text(PHASE_6_POWER_USER_TASK)
+    metadata = _phase_six_power_user_metadata(evidence)
+
+    assert "/Users/" not in evidence
+    assert metadata["task"] == "TASK-7.2"
+    assert metadata["parent_task"] == "TASK-7"
+    assert metadata["persona"] == "power-user"
+    assert metadata["decision"] == "power_user_workflows_recorded"
+    assert metadata["entry_path"] == "running-app-fast-repeat-use"
+    assert metadata["verified_workflows"] == [
+        "home-next-action-to-console",
+        "console-live-work-readiness",
+        "library-search-rag",
+        "library-import-export",
+        "console-live-work-follow-through",
+    ]
+    assert metadata["speed_paths"] == ["home-primary-action", "top-nav", "ctrl-p-affordance"]
+    assert metadata["final_focused_replay_result"]["failed"] == 0
+    assert metadata["final_focused_replay_result"]["passed"] > 0
+
+    for section in (
+        "## Environment",
+        "## Workflow Matrix",
+        "## Repeated-Use Findings",
+        "## Visual Usability Notes",
+        "## Keyboard Path Result",
+        "## Functional Result",
+        "## Defect Severity",
+        "## Deferred Service-Depth Work",
+        "## Residual Risk",
+    ):
+        assert section in evidence
+    assert "running Textual app" in evidence
+    assert "Tests/UI/test_unified_shell_phase6_power_user_replay.py" in evidence
+
+    assert _status_line(readme) == "in-progress"
+    assert PHASE_6_POWER_USER_EVIDENCE.name in readme
+    assert "TASK-7.2" in readme
+
+    normalized_status = _status_line(roadmap).lower().replace("-", " ")
+    assert re.search(r"phase\s+6\s+in\s+progress", normalized_status)
+    assert _phase_evidence_row(roadmap, "Phase 6")[2] == "in-progress"
+    assert str(PHASE_6_POWER_USER_EVIDENCE).replace("\\", "/") in roadmap
+    assert "Phase 6.2: Replay power-user workflows - `TASK-7.2`" in roadmap
+    phase_six_overview = _phase_overview_row(roadmap, "Phase 6: Audit Replay And Closeout")
+    assert phase_six_overview[2] == "in-progress"
+    assert "TASK-7" in phase_six_overview[3]
+    assert "TASK-7.1" in phase_six_overview[3]
+    assert "TASK-7.2" in phase_six_overview[3]
+    assert "Nielsen closeout remains open" in phase_six_overview[5]
+
+    assert "status: In Progress" in parent_task
+    assert "TASK-7.2" in parent_task
+    assert "- [x] #1 First-time user walkthrough is replayed against the running app." in parent_task
+    assert "- [x] #2 Power-user workflows are replayed against the running app." in parent_task
+    assert "- [ ] #3 Nielsen heuristic closeout documents remaining defects and residual risks." in parent_task
+    assert "- [ ] #4 Durable QA summaries exist under Docs/superpowers/qa/unified-shell/phase-6/." in parent_task
+
+    assert "status: Done" in power_user_task
+    for acceptance_criterion in range(1, 5):
+        assert f"- [x] #{acceptance_criterion}" in power_user_task
+    assert "Implementation Notes" in power_user_task

--- a/backlog/tasks/task-7 - Phase-6-Audit-Replay-And-Closeout.md
+++ b/backlog/tasks/task-7 - Phase-6-Audit-Replay-And-Closeout.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-05-03 14:47'
-updated_date: '2026-05-05 05:45'
+updated_date: '2026-05-05 07:20'
 labels:
   - unified-shell
   - phase-6
@@ -15,6 +15,7 @@ dependencies: []
 documentation:
   - Docs/superpowers/specs/2026-05-03-unified-shell-maturity-tracking-design.md
   - Docs/superpowers/qa/unified-shell/phase-6/2026-05-05-phase-6-1-first-time-user-replay.md
+  - Docs/superpowers/qa/unified-shell/phase-6/2026-05-05-phase-6-2-power-user-workflow-replay.md
 priority: medium
 ---
 
@@ -27,7 +28,7 @@ Replay first-time user, power-user, and Nielsen heuristic walkthroughs to prove 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
 - [x] #1 First-time user walkthrough is replayed against the running app.
-- [ ] #2 Power-user workflows are replayed against the running app.
+- [x] #2 Power-user workflows are replayed against the running app.
 - [ ] #3 Nielsen heuristic closeout documents remaining defects and residual risks.
 - [ ] #4 Durable QA summaries exist under Docs/superpowers/qa/unified-shell/phase-6/.
 <!-- AC:END -->
@@ -36,7 +37,7 @@ Replay first-time user, power-user, and Nielsen heuristic walkthroughs to prove 
 
 <!-- SECTION:PLAN:BEGIN -->
 1. Complete `TASK-7.1` for first-time user replay against the running app.
-2. Add a power-user replay slice for repeated core workflows and speed paths.
+2. Complete `TASK-7.2` for repeated core workflows and speed paths.
 3. Add a Nielsen heuristic closeout slice that maps residual defects and risks.
 4. Mark Phase 6 verified only after all three replay families have durable QA evidence.
 <!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-7.2 - Phase-6.2-Replay-power-user-workflows.md
+++ b/backlog/tasks/task-7.2 - Phase-6.2-Replay-power-user-workflows.md
@@ -1,0 +1,54 @@
+---
+id: TASK-7.2
+title: Phase 6.2 Replay power-user workflows
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-05-05 07:20'
+updated_date: '2026-05-05 07:20'
+labels:
+  - unified-shell
+  - phase-6
+  - audit-replay
+  - power-user
+  - qa
+dependencies: []
+documentation:
+  - Docs/superpowers/specs/2026-05-03-unified-shell-maturity-tracking-design.md
+  - Docs/superpowers/qa/unified-shell/phase-1/walkthrough-protocol.md
+  - Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+  - Docs/superpowers/qa/unified-shell/phase-6/2026-05-05-phase-6-2-power-user-workflow-replay.md
+parent_task_id: TASK-7
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replay the Unified Shell from a power-user perspective against the running Textual app so fast repeated workflows Console source readiness Library source actions and live-work follow-through are verified with durable evidence.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Configured Home primary action opens Console and shows live-work source readiness.
+- [x] #2 Library Search/RAG and Import/Export workflows are replayed from the running app.
+- [x] #3 Console live-work status-card follow-through opens W+C run context.
+- [x] #4 Phase 6 README roadmap and parent task tracking are updated without prematurely closing Phase 6.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a failing Phase 6.2 power-user replay contract that expects durable evidence README roadmap and task tracking.
+2. Run the focused contract to confirm it fails before evidence exists.
+3. Exercise the running Textual app through the app test harness in a configured returning-user state.
+4. Record power-user workflow evidence with workflow matrix repeated-use findings defects residual risks and verification commands.
+5. Update the Phase 6 README roadmap and Backlog task state while leaving Nielsen closeout open.
+6. Run focused Phase 6 tests plus relevant shell navigation and product-model checks before committing.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added a Phase 6.2 power-user replay contract and durable QA evidence for configured Home-to-Console launch Console live-work readiness Library Search/RAG Library Import/Export and W+C live-work follow-through. Updated Phase 6 tracking to include TASK-7.2 while keeping the parent phase in progress for Nielsen closeout.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary
- add Phase 6.2 power-user workflow replay contract and durable QA evidence
- update Phase 6 tracking/backlog so first-time and power-user replays are recorded while Nielsen remains open
- refresh Phase 6.1 contract expectations for the new parent task state

## Verification
- .venv/bin/python -m pytest Tests/UI/test_unified_shell_phase6_power_user_replay.py -q
- .venv/bin/python -m pytest Tests/UI/test_unified_shell_qa_protocol.py Tests/UI/test_shell_product_model_visibility.py Tests/UI/test_master_shell_navigation.py Tests/UI/test_screen_navigation.py Tests/UI/test_shell_chrome_contract.py Tests/UI/test_unified_shell_phase234_maturity_gate.py Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py Tests/UI/test_unified_shell_phase6_first_time_replay.py Tests/UI/test_unified_shell_phase6_power_user_replay.py -q
- git diff --cached --check