### PR TITLE
Close Phase 6 Nielsen shell audit

### DIFF
--- a/Docs/superpowers/qa/unified-shell/phase-6/2026-05-05-phase-6-3-nielsen-heuristic-closeout.md
+++ b/Docs/superpowers/qa/unified-shell/phase-6/2026-05-05-phase-6-3-nielsen-heuristic-closeout.md
@@ -1,0 +1,105 @@
+# Phase 6.3 Nielsen Heuristic Closeout
+
+Date: 2026-05-05
+Task: `TASK-7.3`
+Parent Task: `TASK-7`
+Branch: `codex/unified-shell-phase6-nielsen-closeout`
+Base: `origin/dev` at `768de83c`
+
+<!-- PHASE_6_3_NIELSEN_CLOSEOUT_METADATA:BEGIN -->
+```json
+{
+  "task": "TASK-7.3",
+  "parent_task": "TASK-7",
+  "persona": "senior-ux-designer",
+  "decision": "nielsen_closeout_recorded",
+  "entry_path": "running-app-nielsen-heuristic-closeout",
+  "heuristics_reviewed": [
+    "Visibility of system status",
+    "Match between system and the real world",
+    "User control and freedom",
+    "Consistency and standards",
+    "Error prevention",
+    "Recognition rather than recall",
+    "Flexibility and efficiency of use",
+    "Aesthetic and minimalist design",
+    "Help users recognize diagnose and recover from errors",
+    "Help and documentation"
+  ],
+  "unresolved_findings": [
+    "library-subroute-return-affordance",
+    "full-keyboard-sweep-needs-manual-terminal-pass",
+    "service-depth-live-paths-remain-deferred"
+  ],
+  "red_contract_result": {
+    "passed": 1,
+    "failed": 1
+  },
+  "final_focused_replay_result": {
+    "passed": 2,
+    "failed": 0
+  },
+  "final_broader_shell_replay_result": {
+    "passed": 69,
+    "failed": 0
+  }
+}
+```
+<!-- PHASE_6_3_NIELSEN_CLOSEOUT_METADATA:END -->
+
+## Environment
+
+- Runtime: running Textual app through the app test harness with splash disabled and first-run routing enabled.
+- Python: project-local virtual environment using Python 3.13.
+- Home/config boundary: temporary app test user-data directory created by the harness; no live user database was required.
+- Test command: `.venv/bin/python -m pytest Tests/UI/test_unified_shell_phase6_nielsen_closeout.py -q`
+
+## Heuristic Audit
+
+| Nielsen heuristic | Evidence from running app | Closeout result |
+| --- | --- | --- |
+| Visibility of system status | Home exposes Status, Attention, Active Work, Next Best Action, and Console source readiness. ACP exposes `Runtime not configured`. | Pass for shell-level status. |
+| Match between system and the real world | Navigation uses product nouns: Home, Console, Library, Artifacts, Personas, W+C, Schedules, Workflows, MCP, ACP, Skills, Settings. Settings explicitly says MCP/tool-control settings live under MCP. | Pass for top-level IA language. |
+| User control and freedom | Top navigation keeps Home, Console, Library, and Settings reachable; Console can follow W+C live work into run detail context. | Pass with one P2 caveat: Library subroutes need an explicit return-to-Library-hub affordance. |
+| Consistency and standards | Destination screens share title, purpose, panel, status, action, and disabled-state patterns. | Pass for shell wrappers. |
+| Error prevention | ACP launch and Console follow are disabled until runtime/session payloads exist. Earlier Phase 5 recovery states prevent false affordances. | Pass for known unavailable states. |
+| Recognition rather than recall | Console status cards show source, title, status, recovery, action, and payload rows; Home exposes next-best action copy. | Pass for core shell tasks. |
+| Flexibility and efficiency of use | Configured Home opens Console directly; top nav and `Ctrl+P` are visible speed paths; Library exposes Search/RAG and Import/Export actions. | Pass with keyboard-sweep residual risk. |
+| Aesthetic and minimalist design | Destination wrappers keep short purpose copy, compact panels, and stable action labels instead of dense configuration dumps. | Pass for shell-level audit. |
+| Help users recognize diagnose and recover from errors | ACP and recovery states use what/why/next-action copy. Phase 5 covers destination, runtime-policy, and optional-dependency recovery patterns. | Pass for shell blockers. |
+| Help and documentation | Phase 6 evidence now records first-time, power-user, and heuristic closeout walkthroughs; roadmap links tasks and durable QA evidence. | Pass for internal QA handoff documentation. |
+
+## Prioritized Findings
+
+| Finding | Severity | Disposition |
+| --- | --- | --- |
+| Library subroutes lack an explicit return-to-Library-hub affordance while the Library top-nav item remains active. | P2 workflow-degradation | Record as future UX refinement; not a Phase 6 blocker because Home/Console/command-palette/top-nav paths remain available. |
+| Full keyboard-only Tab/Enter traversal was not manually replayed in a live terminal. | P2 recoverability | Record as residual risk; automated checks verify `Ctrl+P` binding and visible affordance but not complete terminal focus order. |
+| Live server/API, optional dependency, and remote-auth paths were not re-exercised in Phase 6. | P2 service-depth | Keep tracked as service-depth future work; Phase 5 recovery contracts cover representative blocked states. |
+
+## UX Decision
+
+Phase 6 is verified for Unified Shell audit replay. The shell now has durable first-time user, power-user, and Nielsen heuristic evidence tied to running-app tests. The remaining findings are not P0/P1 blockers for the shell because the product model is visible, unavailable states are honest, Console is reachable as the primary control surface, and recovery paths are documented.
+
+## Deferred Service-Depth Work
+
+- Library-native detail views, embedded Search/RAG completion, and embedded Import/Export transactions remain outside this shell closeout.
+- Personas import/export, archetypes, exemplars, dictionaries, lore, and edit flows remain service-depth work.
+- Skills import, validation, editing, execution, and server skill flows remain service-depth work.
+- ACP complete runtime operation and MCP live-work event production remain future work.
+- Live server/auth paths need separate service-parity QA once those services are wired.
+
+## Residual Risk
+
+- A manual terminal screenshot/focus-order sweep can still find visual clipping or focus issues that mounted app tests do not capture.
+- Service-depth workflows can still be incomplete even though the shell-level IA, recovery, and launch paths are verified.
+- Library subroute return affordance should be improved in a future polish slice if repeated source-hub work remains awkward in manual use.
+
+## Verification
+
+- Red contract after test creation: `.venv/bin/python -m pytest Tests/UI/test_unified_shell_phase6_nielsen_closeout.py -q`
+- Red result: `1 passed, 1 failed`; the failure was `FileNotFoundError` for this missing evidence file.
+- Final focused replay after evidence/tracking updates: `.venv/bin/python -m pytest Tests/UI/test_unified_shell_phase6_nielsen_closeout.py -q`
+- Final focused replay result: `2 passed`.
+- Final broader shell/product-model replay: `.venv/bin/python -m pytest Tests/UI/test_unified_shell_qa_protocol.py Tests/UI/test_shell_product_model_visibility.py Tests/UI/test_master_shell_navigation.py Tests/UI/test_screen_navigation.py Tests/UI/test_shell_chrome_contract.py Tests/UI/test_unified_shell_phase234_maturity_gate.py Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py Tests/UI/test_unified_shell_phase6_first_time_replay.py Tests/UI/test_unified_shell_phase6_power_user_replay.py Tests/UI/test_unified_shell_phase6_nielsen_closeout.py -q`
+- Final broader shell/product-model replay result: `69 passed`.

--- a/Docs/superpowers/qa/unified-shell/phase-6/README.md
+++ b/Docs/superpowers/qa/unified-shell/phase-6/README.md
@@ -1,6 +1,6 @@
 # Phase 6 QA Evidence
 
-Status: in-progress
+Status: verified
 
 This directory contains durable QA summaries for Phase 6 audit replay and closeout work.
 
@@ -8,5 +8,6 @@ This directory contains durable QA summaries for Phase 6 audit replay and closeo
 
 - `2026-05-05-phase-6-1-first-time-user-replay.md` - `TASK-7.1` first-time user replay covering clean Home launch, Console orientation, and representative Library, Personas, and Skills destination orientation paths.
 - `2026-05-05-phase-6-2-power-user-workflow-replay.md` - `TASK-7.2` power-user replay covering configured Home-to-Console launch, Console live-work readiness, Library Search/RAG, Library Import/Export, and W+C live-work follow-through.
+- `2026-05-05-phase-6-3-nielsen-heuristic-closeout.md` - `TASK-7.3` Nielsen heuristic closeout covering all ten heuristics, prioritized residual findings, and final Phase 6 verification.
 
-Phase 6 is in progress. Do not mark the phase verified until Nielsen heuristic closeout evidence is also replayed against the running app.
+Phase 6 is verified for Unified Shell audit replay. Service-depth and live-path risks remain tracked for future work.

--- a/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
@@ -1,8 +1,8 @@
 # Unified Shell Maturity Roadmap
 
 Date: 2026-05-05
-Status: Phase 2, Phase 3, Phase 4, and Phase 5 verified; Phase 6 in progress
-Source Branch: `origin/dev` at `1261b1cb` plus `codex/unified-shell-phase6-power-user-replay`
+Status: Phase 2, Phase 3, Phase 4, and Phase 5 verified; Phase 6 verified
+Source Branch: `origin/dev` at `768de83c` plus `codex/unified-shell-phase6-nielsen-closeout`
 
 ## Purpose
 
@@ -37,7 +37,7 @@ Track remaining Unified Shell work in one place so rendered screens, clickable b
 - Library now surfaces a local source snapshot from notes, media, and conversations and can stage concrete source context into Console; full Library-native detail views, embedded Import/Export, and embedded Search/RAG remain future work.
 - Personas now surfaces a local behavior snapshot from characters and persona profiles and can stage concrete behavior context into Console; detail, edit, import/export, archetypes, exemplars, dictionaries, and lore remain future work.
 - W+C now surfaces a local monitored-source and saved-collection snapshot from `watchlist_scope_service` and `media_reading_scope_service` and can stage concrete W+C context into Console; full detail, edit, import/export, feed WebSub, alert-rule, retry/backoff, and server collection-feed UX remain future work.
-- Phase 2, Phase 3, Phase 4, and Phase 5 implementation and maturity-gate replays are verified. Phase 5 recovery coverage includes shell destination blockers, representative runtime-policy denials, and representative optional-dependency blockers; Phase 6 has first-time and power-user replays recorded and remains open for Nielsen audit replay.
+- Phase 2, Phase 3, Phase 4, Phase 5, and Phase 6 implementation and maturity-gate replays are verified. Phase 5 recovery coverage includes shell destination blockers, representative runtime-policy denials, and representative optional-dependency blockers; Phase 6 has first-time power-user and Nielsen audit replay evidence recorded.
 
 ## Definition Of Done
 
@@ -114,6 +114,7 @@ Initial child tasks:
 - Phase 5.5: Replay capability recovery maturity gate - `TASK-6.5`
 - Phase 6.1: Replay first-time user walkthrough - `TASK-7.1`
 - Phase 6.2: Replay power-user workflows - `TASK-7.2`
+- Phase 6.3: Replay Nielsen heuristic closeout - `TASK-7.3`
 
 ## QA Evidence Index
 
@@ -125,7 +126,7 @@ Initial child tasks:
 | Phase 3 | `Docs/superpowers/qa/unified-shell/phase-3/` | verified |
 | Phase 4 | `Docs/superpowers/qa/unified-shell/phase-4/` | verified |
 | Phase 5 | `Docs/superpowers/qa/unified-shell/phase-5/` | verified |
-| Phase 6 | `Docs/superpowers/qa/unified-shell/phase-6/` | in-progress |
+| Phase 6 | `Docs/superpowers/qa/unified-shell/phase-6/` | verified |
 
 ## Phase Overview
 
@@ -137,7 +138,7 @@ Initial child tasks:
 | Phase 3: Console Live Work Hub | Make Console the live-agent control surface. | verified | `TASK-3`, `TASK-3.1`, `TASK-3.2`, `TASK-3.3`, `TASK-3.4`, `TASK-3.5`, `TASK-3.6`, `TASK-3.7`, `TASK-3.8`, `TASK-3.9`, `TASK-3.10`, `TASK-3.11` | `phase-3/` | ACP, MCP, and durable live event streams remain future work; Phase 3 is verified for implemented Console source launch, follow, status, and recovery flows. |
 | Phase 4: Destination Service Adoption | Turn wrappers into useful product surfaces. | verified | `TASK-5`, `TASK-5.1`, `TASK-5.2`, `TASK-5.3`, `TASK-5.4`, `TASK-5.5`, `TASK-5.6` | `phase-4/` | Full CRUD/server-parity depth remains future work; Phase 4 is verified for destination ownership, concrete local workflows, Console staging, and honest recovery states. |
 | Phase 5: Capability And Recovery System | Systematize unavailable and blocked states. | verified | `TASK-6`, `TASK-6.1`, `TASK-6.2`, `TASK-6.3`, `TASK-6.4`, `TASK-6.5` | `phase-5/` | Recovery taxonomy is verified for destination blockers, runtime-policy denials, and optional-dependency blockers; live server/auth and full optional-extra execution remain residual risk. |
-| Phase 6: Audit Replay And Closeout | Prove shell works for first-time and power users. | in-progress | `TASK-7`, `TASK-7.1`, `TASK-7.2` | `phase-6/` | First-time and power-user replays are recorded; Nielsen closeout remains open. |
+| Phase 6: Audit Replay And Closeout | Prove shell works for first-time and power users. | verified | `TASK-7`, `TASK-7.1`, `TASK-7.2`, `TASK-7.3` | `phase-6/` | Phase 6 shell audit replay is verified; service-depth and live-path risks remain tracked for future work. |
 
 ## Phase 1.1 QA Harness Evidence
 
@@ -364,6 +365,12 @@ Initial audit result: W+C, Schedules, Workflows, and ACP had false Console-launc
 `TASK-7.2` replays fast repeated workflows against the running Textual app, covering configured Home-to-Console launch, Console live-work readiness, Library Search/RAG, Library Import/Export, and W+C live-work follow-through:
 
 - `Docs/superpowers/qa/unified-shell/phase-6/2026-05-05-phase-6-2-power-user-workflow-replay.md`
+
+## Phase 6.3 Nielsen Heuristic Closeout
+
+`TASK-7.3` replays the Unified Shell against Nielsen heuristics from a senior UX perspective and closes Phase 6 as verified while preserving residual service-depth and live-path risks:
+
+- `Docs/superpowers/qa/unified-shell/phase-6/2026-05-05-phase-6-3-nielsen-heuristic-closeout.md`
 
 ## Phase 0: Canonical Tracking
 

--- a/Tests/UI/test_unified_shell_phase234_maturity_gate.py
+++ b/Tests/UI/test_unified_shell_phase234_maturity_gate.py
@@ -81,7 +81,7 @@ def _assert_roadmap_status_tracks_current_phase_progress(roadmap_text: str) -> N
     assert "phase 4" in normalized_status
     assert "verified" in normalized_status
     assert re.search(r"phase\s+5\s+verified", normalized_status)
-    assert re.search(r"phase\s+6\s+in\s+progress", normalized_status)
+    assert re.search(r"phase\s+6\s+verified", normalized_status)
 
 
 def _markdown_path(path: Path) -> str:

--- a/Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py
+++ b/Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py
@@ -66,7 +66,7 @@ def _assert_roadmap_tracks_phase_five_progress(roadmap: str) -> None:
     assert "phase 4" in normalized_status
     assert "verified" in normalized_status
     assert re.search(r"phase\s+5\s+verified", normalized_status)
-    assert re.search(r"phase\s+6\s+in\s+progress", normalized_status)
+    assert re.search(r"phase\s+6\s+verified", normalized_status)
 
 
 def _roadmap_phase_evidence_row(text: str, phase_name: str) -> list[str]:

--- a/Tests/UI/test_unified_shell_phase6_first_time_replay.py
+++ b/Tests/UI/test_unified_shell_phase6_first_time_replay.py
@@ -212,27 +212,27 @@ def test_phase_six_first_time_replay_evidence_and_tracking_are_current() -> None
     assert "running Textual app" in evidence
     assert "Tests/UI/test_unified_shell_phase6_first_time_replay.py" in evidence
 
-    assert _status_line(readme) == "in-progress"
+    assert _status_line(readme) == "verified"
     assert PHASE_6_FIRST_TIME_EVIDENCE.name in readme
     assert "TASK-7.1" in readme
 
     normalized_status = _status_line(roadmap).lower().replace("-", " ")
     assert re.search(r"phase\s+5\s+verified", normalized_status)
-    assert re.search(r"phase\s+6\s+in\s+progress", normalized_status)
-    assert _phase_evidence_row(roadmap, "Phase 6")[2] == "in-progress"
+    assert re.search(r"phase\s+6\s+verified", normalized_status)
+    assert _phase_evidence_row(roadmap, "Phase 6")[2] == "verified"
     assert str(PHASE_6_FIRST_TIME_EVIDENCE).replace("\\", "/") in roadmap
     assert "Phase 6.1: Replay first-time user walkthrough - `TASK-7.1`" in roadmap
     phase_six_overview = _phase_overview_row(roadmap, "Phase 6: Audit Replay And Closeout")
-    assert phase_six_overview[2] == "in-progress"
+    assert phase_six_overview[2] == "verified"
     assert "TASK-7" in phase_six_overview[3]
     assert "TASK-7.1" in phase_six_overview[3]
-    assert "Nielsen closeout remains open" in phase_six_overview[5]
+    assert "service-depth and live-path risks remain tracked" in phase_six_overview[5]
 
-    assert "status: In Progress" in parent_task
+    assert "status: Done" in parent_task
     assert "TASK-7.1" in parent_task
     assert "- [x] #1 First-time user walkthrough is replayed against the running app." in parent_task
     assert "- [x] #2 Power-user workflows are replayed against the running app." in parent_task
-    assert "- [ ] #3 Nielsen heuristic closeout documents remaining defects and residual risks." in parent_task
+    assert "- [x] #3 Nielsen heuristic closeout documents remaining defects and residual risks." in parent_task
 
     assert "status: Done" in first_time_task
     for acceptance_criterion in range(1, 5):

--- a/Tests/UI/test_unified_shell_phase6_nielsen_closeout.py
+++ b/Tests/UI/test_unified_shell_phase6_nielsen_closeout.py
@@ -1,0 +1,192 @@
+"""Phase 6.3 Nielsen heuristic closeout contract."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from textual.widgets import Button
+
+from Tests.UI.test_screen_navigation import _build_test_app
+from Tests.UI.test_unified_shell_phase6_first_time_replay import (
+    EXPECTED_NAV,
+    PHASE_6_PARENT_TASK,
+    PHASE_6_README,
+    ROADMAP,
+    _phase_evidence_row,
+    _phase_overview_row,
+    _screen_text,
+    _status_line,
+    _test_cli_setting,
+    _text,
+    _wait_until,
+)
+
+
+PHASE_6_NIELSEN_EVIDENCE = Path(
+    "Docs/superpowers/qa/unified-shell/phase-6/2026-05-05-phase-6-3-nielsen-heuristic-closeout.md"
+)
+PHASE_6_NIELSEN_TASK = Path(
+    "backlog/tasks/task-7.3 - Phase-6.3-Replay-Nielsen-heuristic-closeout.md"
+)
+
+NIELSEN_HEURISTICS = [
+    "Visibility of system status",
+    "Match between system and the real world",
+    "User control and freedom",
+    "Consistency and standards",
+    "Error prevention",
+    "Recognition rather than recall",
+    "Flexibility and efficiency of use",
+    "Aesthetic and minimalist design",
+    "Help users recognize diagnose and recover from errors",
+    "Help and documentation",
+]
+
+
+def _phase_six_nielsen_metadata(text: str) -> dict:
+    match = re.search(
+        r"<!-- PHASE_6_3_NIELSEN_CLOSEOUT_METADATA:BEGIN -->\s*```json\s*(.*?)\s*```\s*"
+        r"<!-- PHASE_6_3_NIELSEN_CLOSEOUT_METADATA:END -->",
+        text,
+        re.DOTALL,
+    )
+    assert match is not None
+    return json.loads(match.group(1))
+
+
+@pytest.mark.asyncio
+async def test_nielsen_closeout_replays_core_heuristic_signals_in_running_app() -> None:
+    """Verify visible shell behavior maps to the closeout's heuristic evidence."""
+    app = _build_test_app()
+    app.app_config["_first_run"] = True
+    app._initial_tab_value = "chat"
+
+    with patch("tldw_chatbook.app.get_cli_setting", side_effect=_test_cli_setting):
+        async with app.run_test(size=(180, 50)) as pilot:
+            await _wait_until(
+                pilot,
+                lambda: app.current_tab == "home" and app.screen.__class__.__name__ == "HomeScreen",
+            )
+
+            nav_buttons = list(app.screen.query("MainNavigationBar").first().query(Button))
+            assert [(button.id, str(button.label).strip()) for button in nav_buttons] == EXPECTED_NAV
+
+            home_text = _screen_text(app)
+            assert "Status" in home_text
+            assert "Model: Blocked" in home_text
+            assert "Attention" in home_text
+            assert "Next Best Action" in home_text
+            assert "More: Ctrl+P" in home_text
+
+            app.screen.query_one("#nav-console", Button).press()
+            await _wait_until(
+                pilot,
+                lambda: app.current_tab == "chat" and app.screen.__class__.__name__ == "ChatScreen",
+            )
+            console_text = _screen_text(app)
+            assert "Live work sources" in console_text
+            assert "ACP: Not wired" in console_text
+            assert "MCP: Not wired" in console_text
+            assert "RAG: Connected" in console_text
+
+            app.screen.query_one("#nav-acp", Button).press()
+            await _wait_until(
+                pilot,
+                lambda: app.current_tab == "acp" and app.screen.__class__.__name__ == "ACPScreen",
+            )
+            acp_text = _screen_text(app)
+            assert "Runtime not configured" in acp_text
+            assert "Why: no ACP-compatible runtime is configured" in acp_text
+            assert "Next: Configure an ACP runtime in Settings before launch." in acp_text
+            assert app.screen.query_one("#acp-launch-agent", Button).disabled is True
+
+            app.screen.query_one("#nav-library", Button).press()
+            await _wait_until(
+                pilot,
+                lambda: app.current_tab == "library" and app.screen.__class__.__name__ == "LibraryScreen",
+            )
+            library_text = _screen_text(app)
+            assert "Library" in library_text
+            assert "Import/Export Sources" in library_text
+            assert "Search/RAG" in library_text
+
+            app.screen.query_one("#nav-settings", Button).press()
+            await _wait_until(
+                pilot,
+                lambda: app.current_tab == "settings" and app.screen.__class__.__name__ == "SettingsScreen",
+            )
+            settings_text = _screen_text(app)
+            assert "Settings owns global preferences" in settings_text
+            assert "MCP and tool-control settings live under MCP, not global Settings." in settings_text
+
+
+def test_phase_six_nielsen_closeout_evidence_and_tracking_are_current() -> None:
+    """Verify Phase 6.3 evidence closes the phase without losing residual-risk detail."""
+    evidence = _text(PHASE_6_NIELSEN_EVIDENCE)
+    readme = _text(PHASE_6_README)
+    roadmap = _text(ROADMAP)
+    parent_task = _text(PHASE_6_PARENT_TASK)
+    nielsen_task = _text(PHASE_6_NIELSEN_TASK)
+    metadata = _phase_six_nielsen_metadata(evidence)
+
+    assert "/Users/" not in evidence
+    assert metadata["task"] == "TASK-7.3"
+    assert metadata["parent_task"] == "TASK-7"
+    assert metadata["persona"] == "senior-ux-designer"
+    assert metadata["decision"] == "nielsen_closeout_recorded"
+    assert metadata["entry_path"] == "running-app-nielsen-heuristic-closeout"
+    assert metadata["heuristics_reviewed"] == NIELSEN_HEURISTICS
+    assert metadata["unresolved_findings"] == [
+        "library-subroute-return-affordance",
+        "full-keyboard-sweep-needs-manual-terminal-pass",
+        "service-depth-live-paths-remain-deferred",
+    ]
+    assert metadata["final_focused_replay_result"]["failed"] == 0
+    assert metadata["final_focused_replay_result"]["passed"] > 0
+
+    for section in (
+        "## Environment",
+        "## Heuristic Audit",
+        "## Prioritized Findings",
+        "## UX Decision",
+        "## Deferred Service-Depth Work",
+        "## Residual Risk",
+        "## Verification",
+    ):
+        assert section in evidence
+    for heuristic in NIELSEN_HEURISTICS:
+        assert heuristic in evidence
+    assert "running Textual app" in evidence
+    assert "Tests/UI/test_unified_shell_phase6_nielsen_closeout.py" in evidence
+
+    assert _status_line(readme) == "verified"
+    assert PHASE_6_NIELSEN_EVIDENCE.name in readme
+    assert "TASK-7.3" in readme
+
+    normalized_status = _status_line(roadmap).lower().replace("-", " ")
+    assert re.search(r"phase\s+6\s+verified", normalized_status)
+    assert _phase_evidence_row(roadmap, "Phase 6")[2] == "verified"
+    assert str(PHASE_6_NIELSEN_EVIDENCE).replace("\\", "/") in roadmap
+    assert "Phase 6.3: Replay Nielsen heuristic closeout - `TASK-7.3`" in roadmap
+    phase_six_overview = _phase_overview_row(roadmap, "Phase 6: Audit Replay And Closeout")
+    assert phase_six_overview[2] == "verified"
+    assert "TASK-7" in phase_six_overview[3]
+    assert "TASK-7.1" in phase_six_overview[3]
+    assert "TASK-7.2" in phase_six_overview[3]
+    assert "TASK-7.3" in phase_six_overview[3]
+    assert "service-depth and live-path risks remain tracked" in phase_six_overview[5]
+
+    assert "status: Done" in parent_task
+    assert "TASK-7.3" in parent_task
+    for acceptance_criterion in range(1, 5):
+        assert f"- [x] #{acceptance_criterion}" in parent_task
+    assert "Implementation Notes" in parent_task
+
+    assert "status: Done" in nielsen_task
+    for acceptance_criterion in range(1, 5):
+        assert f"- [x] #{acceptance_criterion}" in nielsen_task
+    assert "Implementation Notes" in nielsen_task

--- a/Tests/UI/test_unified_shell_phase6_power_user_replay.py
+++ b/Tests/UI/test_unified_shell_phase6_power_user_replay.py
@@ -178,28 +178,28 @@ def test_phase_six_power_user_replay_evidence_and_tracking_are_current() -> None
     assert "running Textual app" in evidence
     assert "Tests/UI/test_unified_shell_phase6_power_user_replay.py" in evidence
 
-    assert _status_line(readme) == "in-progress"
+    assert _status_line(readme) == "verified"
     assert PHASE_6_POWER_USER_EVIDENCE.name in readme
     assert "TASK-7.2" in readme
 
     normalized_status = _status_line(roadmap).lower().replace("-", " ")
-    assert re.search(r"phase\s+6\s+in\s+progress", normalized_status)
-    assert _phase_evidence_row(roadmap, "Phase 6")[2] == "in-progress"
+    assert re.search(r"phase\s+6\s+verified", normalized_status)
+    assert _phase_evidence_row(roadmap, "Phase 6")[2] == "verified"
     assert str(PHASE_6_POWER_USER_EVIDENCE).replace("\\", "/") in roadmap
     assert "Phase 6.2: Replay power-user workflows - `TASK-7.2`" in roadmap
     phase_six_overview = _phase_overview_row(roadmap, "Phase 6: Audit Replay And Closeout")
-    assert phase_six_overview[2] == "in-progress"
+    assert phase_six_overview[2] == "verified"
     assert "TASK-7" in phase_six_overview[3]
     assert "TASK-7.1" in phase_six_overview[3]
     assert "TASK-7.2" in phase_six_overview[3]
-    assert "Nielsen closeout remains open" in phase_six_overview[5]
+    assert "service-depth and live-path risks remain tracked" in phase_six_overview[5]
 
-    assert "status: In Progress" in parent_task
+    assert "status: Done" in parent_task
     assert "TASK-7.2" in parent_task
     assert "- [x] #1 First-time user walkthrough is replayed against the running app." in parent_task
     assert "- [x] #2 Power-user workflows are replayed against the running app." in parent_task
-    assert "- [ ] #3 Nielsen heuristic closeout documents remaining defects and residual risks." in parent_task
-    assert "- [ ] #4 Durable QA summaries exist under Docs/superpowers/qa/unified-shell/phase-6/." in parent_task
+    assert "- [x] #3 Nielsen heuristic closeout documents remaining defects and residual risks." in parent_task
+    assert "- [x] #4 Durable QA summaries exist under Docs/superpowers/qa/unified-shell/phase-6/." in parent_task
 
     assert "status: Done" in power_user_task
     for acceptance_criterion in range(1, 5):

--- a/backlog/tasks/task-7 - Phase-6-Audit-Replay-And-Closeout.md
+++ b/backlog/tasks/task-7 - Phase-6-Audit-Replay-And-Closeout.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-7
 title: 'Phase 6: Audit Replay And Closeout'
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-05-03 14:47'
-updated_date: '2026-05-05 07:20'
+updated_date: '2026-05-05 07:40'
 labels:
   - unified-shell
   - phase-6
@@ -16,6 +16,7 @@ documentation:
   - Docs/superpowers/specs/2026-05-03-unified-shell-maturity-tracking-design.md
   - Docs/superpowers/qa/unified-shell/phase-6/2026-05-05-phase-6-1-first-time-user-replay.md
   - Docs/superpowers/qa/unified-shell/phase-6/2026-05-05-phase-6-2-power-user-workflow-replay.md
+  - Docs/superpowers/qa/unified-shell/phase-6/2026-05-05-phase-6-3-nielsen-heuristic-closeout.md
 priority: medium
 ---
 
@@ -29,8 +30,8 @@ Replay first-time user, power-user, and Nielsen heuristic walkthroughs to prove 
 <!-- AC:BEGIN -->
 - [x] #1 First-time user walkthrough is replayed against the running app.
 - [x] #2 Power-user workflows are replayed against the running app.
-- [ ] #3 Nielsen heuristic closeout documents remaining defects and residual risks.
-- [ ] #4 Durable QA summaries exist under Docs/superpowers/qa/unified-shell/phase-6/.
+- [x] #3 Nielsen heuristic closeout documents remaining defects and residual risks.
+- [x] #4 Durable QA summaries exist under Docs/superpowers/qa/unified-shell/phase-6/.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -38,6 +39,12 @@ Replay first-time user, power-user, and Nielsen heuristic walkthroughs to prove 
 <!-- SECTION:PLAN:BEGIN -->
 1. Complete `TASK-7.1` for first-time user replay against the running app.
 2. Complete `TASK-7.2` for repeated core workflows and speed paths.
-3. Add a Nielsen heuristic closeout slice that maps residual defects and risks.
+3. Complete `TASK-7.3` for Nielsen heuristic closeout and residual-risk mapping.
 4. Mark Phase 6 verified only after all three replay families have durable QA evidence.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Completed Phase 6 closeout with durable first-time user replay power-user replay and Nielsen heuristic evidence. The shell is verified for audit replay while residual Library subroute return affordance keyboard-sweep and service-depth live-path risks remain documented for future work.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-7.3 - Phase-6.3-Replay-Nielsen-heuristic-closeout.md
+++ b/backlog/tasks/task-7.3 - Phase-6.3-Replay-Nielsen-heuristic-closeout.md
@@ -1,0 +1,54 @@
+---
+id: TASK-7.3
+title: Phase 6.3 Replay Nielsen heuristic closeout
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-05-05 07:40'
+updated_date: '2026-05-05 07:40'
+labels:
+  - unified-shell
+  - phase-6
+  - audit-replay
+  - nielsen
+  - qa
+dependencies: []
+documentation:
+  - Docs/superpowers/specs/2026-05-03-unified-shell-maturity-tracking-design.md
+  - Docs/superpowers/qa/unified-shell/phase-1/walkthrough-protocol.md
+  - Docs/superpowers/trackers/unified-shell-maturity-roadmap.md
+  - Docs/superpowers/qa/unified-shell/phase-6/2026-05-05-phase-6-3-nielsen-heuristic-closeout.md
+parent_task_id: TASK-7
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replay the Unified Shell against Nielsen usability heuristics from a senior UX perspective so remaining shell-level defects residual risks and closeout decisions are documented with durable running-app evidence.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Nielsen heuristic evidence covers all ten heuristics against running-app shell behavior.
+- [x] #2 Evidence identifies prioritized residual findings and distinguishes blockers from future service-depth work.
+- [x] #3 Phase 6 README roadmap and parent task tracking are updated to verified only after first-time power-user and Nielsen evidence all exist.
+- [x] #4 Focused and broader shell replay tests pass after the closeout update.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a failing Phase 6.3 Nielsen closeout contract that expects durable evidence README roadmap and task tracking.
+2. Run the focused contract to confirm it fails before closeout evidence exists.
+3. Exercise the running Textual app through the app test harness across Home Console ACP Library and Settings heuristic signals.
+4. Record Nielsen heuristic evidence with prioritized findings deferred work residual risks and verification commands.
+5. Update the Phase 6 README roadmap parent task and child task state to verified/done.
+6. Run focused Phase 6 tests plus relevant shell navigation and product-model checks before committing.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added a Phase 6.3 Nielsen closeout contract and durable QA evidence mapping all ten heuristics to running-app shell behavior. Updated Phase 6 tracking to verified and closed the parent task while preserving residual risks for Library subroute return affordance full keyboard sweep and future service-depth live paths.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary
- add Phase 6.3 Nielsen heuristic closeout contract and durable QA evidence
- mark Phase 6 verified and close TASK-7/TASK-7.3 while preserving residual risks
- update prior phase tracking tests for the now-verified Phase 6 state

## Verification
- .venv/bin/python -m pytest Tests/UI/test_unified_shell_phase6_nielsen_closeout.py -q
- .venv/bin/python -m pytest Tests/UI/test_unified_shell_qa_protocol.py Tests/UI/test_shell_product_model_visibility.py Tests/UI/test_master_shell_navigation.py Tests/UI/test_screen_navigation.py Tests/UI/test_shell_chrome_contract.py Tests/UI/test_unified_shell_phase234_maturity_gate.py Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py Tests/UI/test_unified_shell_phase6_first_time_replay.py Tests/UI/test_unified_shell_phase6_power_user_replay.py Tests/UI/test_unified_shell_phase6_nielsen_closeout.py -q
- git diff --check
- git diff --cached --check