### PR TITLE
Add product maturity Phase 1.1 QA harness

### DIFF
--- a/Docs/superpowers/plans/2026-05-05-product-maturity-phase-1-1-qa-harness-implementation.md
+++ b/Docs/superpowers/plans/2026-05-05-product-maturity-phase-1-1-qa-harness-implementation.md
@@ -152,7 +152,39 @@ git commit -m "Add product maturity backlog anchors"
 
 Expected: commit succeeds with only new Backlog task files.
 
-## Task 2: Add Failing Harness Contract Test
+## Task 2: Move Phase 1.1 Backlog Task Into Progress
+
+**Files:**
+- Modify: `backlog/tasks/task-<phase-1-1-id> - Product-Maturity-Phase-1.1-Canonical-QA-Harness.md`
+
+- [ ] **Step 1: Set the Phase 1.1 child task to In Progress**
+
+Use Backlog MCP `task_edit` or the CLI to set only the Phase 1.1 child task to `In Progress`. Do not move the Phase 1 parent task to `Done`.
+
+- [ ] **Step 2: Add the mandatory Backlog implementation plan**
+
+Add this implementation plan to the Phase 1.1 child task:
+
+```text
+1. Add the focused product-maturity QA harness regression test and confirm it fails before harness docs exist.
+2. Create the product-maturity tracker, QA evidence root, Phase 1 protocol, template, README, and harness smoke evidence.
+3. Run the focused harness test and adjacent Unified Shell QA protocol regression.
+4. Update Phase 1.1 tracker and evidence status after verification.
+5. Mark Phase 1.1 acceptance criteria complete with implementation notes while leaving Phase 1 open.
+```
+
+- [ ] **Step 3: Commit Backlog in-progress state**
+
+Run:
+
+```bash
+git add backlog/tasks
+git commit -m "Start product maturity Phase 1.1 QA harness task"
+```
+
+Expected: commit succeeds with only the Phase 1.1 task state and implementation plan changed.
+
+## Task 3: Add Failing Harness Contract Test
 
 **Files:**
 - Create: `Tests/UI/test_product_maturity_phase1_harness.py`
@@ -279,6 +311,7 @@ def test_product_maturity_tracker_links_phase_one_harness_and_tasks() -> None:
     phase_one_row = _phase_row(tracker, "Phase 1: QA Baseline And Usability Guardrails")
     assert phase_one_row[2] in {"planned", "in_progress"}
     assert "Phase 1.1" in phase_one_row[3]
+    assert "TASK-" in phase_one_row[3]
     assert "phase-1/" in phase_one_row[4]
 
     assert "QA walkthrough verifies the running app is usable" in phase_one_task
@@ -308,7 +341,12 @@ python3 -m pytest Tests/UI/test_product_maturity_phase1_harness.py -q
 
 Expected: FAIL because `Docs/superpowers/trackers/product-maturity-roadmap.md`, product-maturity QA docs, and Backlog pointer doc do not exist yet.
 
-- [ ] **Step 3: Commit failing test**
+## Task 4: Commit Failing Harness Contract Test
+
+**Files:**
+- Create: `Tests/UI/test_product_maturity_phase1_harness.py`
+
+- [ ] **Step 1: Commit failing test**
 
 Run:
 
@@ -319,7 +357,7 @@ git commit -m "Add product maturity QA harness contract test"
 
 Expected: commit succeeds with one new test file.
 
-## Task 3: Create Product-Maturity Tracker And QA Harness Docs
+## Task 5: Create Product-Maturity Tracker And QA Harness Docs
 
 **Files:**
 - Create: `Docs/superpowers/trackers/product-maturity-roadmap.md`
@@ -417,7 +455,7 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 
 | Phase | Goal | Status | Backlog Tasks | QA Evidence | Residual Risk |
 | --- | --- | --- | --- | --- | --- |
-| Phase 1: QA Baseline And Usability Guardrails | Establish clean-run usability guardrails before feature depth. | planned | `<PHASE_1_TASK_ID>`, `<PHASE_1_1_TASK_ID>` | `phase-1/` | Phase 1.1 is harness-only; product walkthroughs remain future Phase 1 gates. |
+| Phase 1: QA Baseline And Usability Guardrails | Establish clean-run usability guardrails before feature depth. | in_progress | `<PHASE_1_TASK_ID>`, Phase 1.1 (`<PHASE_1_1_TASK_ID>`) | `phase-1/` | Phase 1.1 is harness-only; product walkthroughs remain future Phase 1 gates. |
 | Phase 2: Core Agentic Loop | Complete source/question to grounded Console to Artifact/Chatbook loop. | planned | `<PHASE_2_TASK_ID>` | not-started | Depends on Phase 1 QA baseline. |
 | Phase 3: Knowledge And Study Workflows | Mature ingest, organize, retrieve, study, and reuse workflows. | planned | `<PHASE_3_TASK_ID>` | not-started | Depends on Phase 2 core loop and later task slicing. |
 | Phase 4: Agent Configuration And Execution | Mature Personas, Skills, MCP, ACP, Schedules, and Workflows. | planned | `<PHASE_4_TASK_ID>` | not-started | Depends on service adapters and runtime readiness. |
@@ -767,7 +805,7 @@ git commit -m "Add product maturity QA harness docs"
 
 Expected: commit succeeds with new product-maturity docs.
 
-## Task 4: Close Phase 1.1 Backlog Task
+## Task 6: Close Phase 1.1 Backlog Task
 
 **Files:**
 - Modify: `backlog/tasks/task-<phase-1-1-id> - Product-Maturity-Phase-1.1-Canonical-QA-Harness.md`
@@ -817,6 +855,7 @@ Use Backlog MCP `task_edit` or the CLI:
 
 - check every Phase 1.1 acceptance criterion.
 - add implementation notes summarizing tracker, protocol, template, smoke evidence, and test coverage.
+- document any deviation from the Backlog implementation plan if one occurred.
 - set only the Phase 1.1 child task to `Done`.
 - do not mark the Phase 1 parent done.
 
@@ -842,7 +881,7 @@ git commit -m "Verify product maturity Phase 1.1 QA harness"
 
 Expected: commit succeeds.
 
-## Task 5: Final Branch Verification
+## Task 7: Final Branch Verification
 
 **Files:**
 - No new files.

--- a/Docs/superpowers/plans/2026-05-05-product-maturity-phase-1-1-qa-harness-implementation.md
+++ b/Docs/superpowers/plans/2026-05-05-product-maturity-phase-1-1-qa-harness-implementation.md
@@ -1,0 +1,924 @@
+# Product Maturity Phase 1.1 QA Harness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create the first executable product-maturity planning slice: Backlog anchors plus the canonical Phase 1.1 QA harness for clean-run usability evidence.
+
+**Architecture:** Reuse the verified Unified Shell maturity model instead of creating a parallel process. Product-maturity tracking gets its own tracker and QA evidence directory, while Backlog.md owns PR-sized execution tasks. The first implementation slice is harness-only: it creates repeatable protocol, template, and smoke evidence, but does not complete the full first-run, focus, visual, empty-state, or core-loop audit.
+
+**Tech Stack:** Python 3.11+, pytest, Textual test pilot conventions, Backlog.md, Markdown documentation under `Docs/superpowers/`.
+
+---
+
+## Source Inputs
+
+- Spec: `Docs/superpowers/specs/2026-05-05-product-maturity-phased-roadmap-design.md`
+- Existing QA protocol: `Docs/superpowers/qa/unified-shell/phase-1/walkthrough-protocol.md`
+- Existing QA template: `Docs/superpowers/qa/unified-shell/phase-1/walkthrough-template.md`
+- Existing tracker: `Docs/superpowers/trackers/unified-shell-maturity-roadmap.md`
+- Backlog pointer doc: `backlog/docs/unified-shell-maturity-roadmap.md`
+
+## Scope Check
+
+This plan covers one small execution slice:
+
+- create Backlog parent anchors for the six product-maturity phases.
+- create one child task for Phase 1.1.
+- create the product-maturity tracker and Backlog pointer doc.
+- create the Phase 1.1 QA protocol, evidence template, README, and harness smoke summary.
+- add a focused regression test that prevents the harness from disappearing or drifting.
+- close only the Phase 1.1 Backlog child task if verification passes.
+
+This plan does not:
+
+- perform the full first-run audit.
+- perform the full keyboard/focus sweep.
+- perform the full visual broken-state audit.
+- implement product module depth.
+- create child tasks for later phases beyond Phase 1.1.
+
+## File Structure
+
+- Create: `Docs/superpowers/trackers/product-maturity-roadmap.md`
+  - Product-maturity source of truth. Tracks phase goals, Backlog task IDs, QA evidence paths, and residual risks.
+- Create: `Docs/superpowers/qa/product-maturity/README.md`
+  - QA evidence index and rules for the new workstream.
+- Create: `Docs/superpowers/qa/product-maturity/phase-1/README.md`
+  - Phase 1 QA index.
+- Create: `Docs/superpowers/qa/product-maturity/phase-1/walkthrough-protocol.md`
+  - Canonical clean-run protocol, severity mapping, terminal-size matrix, and entry commands.
+- Create: `Docs/superpowers/qa/product-maturity/phase-1/walkthrough-template.md`
+  - Reusable evidence template.
+- Create: `Docs/superpowers/qa/product-maturity/phase-1/2026-05-05-phase-1-1-harness-smoke.md`
+  - Harness-only smoke evidence. Must explicitly say it does not verify product workflows.
+- Create: `backlog/docs/product-maturity-roadmap.md`
+  - Backlog pointer to the canonical spec, tracker, and QA evidence.
+- Create: `Tests/UI/test_product_maturity_phase1_harness.py`
+  - Focused contract tests for docs, Backlog anchors, severity taxonomy, and QA boundary.
+- Modify: new Backlog task files under `backlog/tasks/`
+  - Create parent tasks for product-maturity phases.
+  - Create one child task for Phase 1.1.
+  - Do not hard-code task IDs before creation. Record the IDs returned by Backlog.md and use those IDs consistently in docs.
+
+## Task 1: Create Backlog Product-Maturity Anchors
+
+**Files:**
+- Create: `backlog/tasks/task-<returned-id> - Product-Maturity-Phase-1-QA-Baseline-And-Usability-Guardrails.md`
+- Create: `backlog/tasks/task-<returned-id> - Product-Maturity-Phase-2-Core-Agentic-Loop.md`
+- Create: `backlog/tasks/task-<returned-id> - Product-Maturity-Phase-3-Knowledge-And-Study-Workflows.md`
+- Create: `backlog/tasks/task-<returned-id> - Product-Maturity-Phase-4-Agent-Configuration-And-Execution.md`
+- Create: `backlog/tasks/task-<returned-id> - Product-Maturity-Phase-5-Server-Parity-And-Live-Integrations.md`
+- Create: `backlog/tasks/task-<returned-id> - Product-Maturity-Phase-6-Release-Hardening-And-Documentation.md`
+- Create: `backlog/tasks/task-<returned-id> - Product-Maturity-Phase-1.1-Canonical-QA-Harness.md`
+
+- [ ] **Step 1: Inspect current Backlog IDs**
+
+Run:
+
+```bash
+backlog task list --plain
+```
+
+Expected: existing Unified Shell `TASK-1` through `TASK-7.3` are present and done. If the CLI is unavailable, use the Backlog MCP `task_list` tool.
+
+- [ ] **Step 2: Create six parent tasks**
+
+Use Backlog MCP `task_create` or the CLI. Set all parent tasks to `To Do`, priority `medium`, label `product-maturity`, and add the phase label from the spec.
+
+Parent task titles:
+
+```text
+Product Maturity Phase 1: QA Baseline And Usability Guardrails
+Product Maturity Phase 2: Core Agentic Loop
+Product Maturity Phase 3: Knowledge And Study Workflows
+Product Maturity Phase 4: Agent Configuration And Execution
+Product Maturity Phase 5: Server-Parity And Live Integrations
+Product Maturity Phase 6: Release Hardening And Documentation
+```
+
+Each parent task description should be one sentence copied from the phase purpose in the spec. Each parent task acceptance criteria should include:
+
+```text
+QA walkthrough verifies the running app is usable for this phase's target workflows.
+Focused regression evidence exists for changed seams.
+Repo-tracked QA evidence exists under Docs/superpowers/qa/product-maturity/.
+P0/P1 findings are fixed or explicitly accepted according to the spec severity policy.
+```
+
+- [ ] **Step 3: Create the Phase 1.1 child task**
+
+Create it under the Phase 1 parent task.
+
+Title:
+
+```text
+Product Maturity Phase 1.1: Canonical QA Harness
+```
+
+Description:
+
+```text
+Create the reusable product-maturity QA protocol, template, evidence index, severity mapping, and smoke evidence so later usability work can be verified against the running app rather than render-only checks.
+```
+
+Acceptance criteria:
+
+```text
+Product-maturity QA protocol defines clean-run setup, entry commands, terminal-size matrix, severity mapping, and evidence rules.
+Product-maturity QA template captures environment, entry path, steps, visual/focus notes, functional result, defects, evidence, residual risk, and exit decision.
+Product-maturity tracker links the spec, Backlog tasks, Phase 1.1 evidence, and residual risks.
+Focused pytest coverage verifies the protocol, template, tracker, and Backlog anchors exist and preserve the harness-only boundary.
+Harness smoke evidence states that Phase 1.1 verifies the QA harness only and does not complete the full product walkthrough.
+```
+
+- [ ] **Step 4: Record returned task IDs**
+
+Run:
+
+```bash
+backlog task list --plain
+```
+
+Expected: six new product-maturity parent tasks and one Phase 1.1 child task exist. Record actual IDs for later docs. If current Backlog state is unchanged, likely IDs are `TASK-8` through `TASK-13` and `TASK-8.1`, but do not assume.
+
+- [ ] **Step 5: Commit Backlog anchors**
+
+Run:
+
+```bash
+git add backlog/tasks
+git commit -m "Add product maturity backlog anchors"
+```
+
+Expected: commit succeeds with only new Backlog task files.
+
+## Task 2: Add Failing Harness Contract Test
+
+**Files:**
+- Create: `Tests/UI/test_product_maturity_phase1_harness.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/UI/test_product_maturity_phase1_harness.py`:
+
+```python
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SPEC = Path("Docs/superpowers/specs/2026-05-05-product-maturity-phased-roadmap-design.md")
+TRACKER = Path("Docs/superpowers/trackers/product-maturity-roadmap.md")
+BACKLOG_DOC = Path("backlog/docs/product-maturity-roadmap.md")
+QA_ROOT = Path("Docs/superpowers/qa/product-maturity")
+PHASE_1_ROOT = QA_ROOT / "phase-1"
+PHASE_1_README = PHASE_1_ROOT / "README.md"
+PROTOCOL = PHASE_1_ROOT / "walkthrough-protocol.md"
+TEMPLATE = PHASE_1_ROOT / "walkthrough-template.md"
+SMOKE = PHASE_1_ROOT / "2026-05-05-phase-1-1-harness-smoke.md"
+BACKLOG_TASKS = Path("backlog/tasks")
+
+REQUIRED_TEMPLATE_SECTIONS = {
+    "Environment",
+    "Task Or Phase",
+    "Entry Path",
+    "Terminal Size",
+    "Clean-Run Setup",
+    "Steps Attempted",
+    "Visual/Focus Notes",
+    "Keyboard Path Result",
+    "Mouse/Click Path Result",
+    "Functional Result",
+    "Defects Found",
+    "Evidence",
+    "Residual Risk",
+    "Exit Decision",
+    "Product QA Boundary",
+}
+
+REQUIRED_SEVERITIES = {
+    "blocker",
+    "workflow-degradation",
+    "recoverability",
+    "polish",
+}
+
+REQUIRED_PRIORITY_LABELS = {"P0", "P1", "P2", "P3"}
+
+
+def _text(path: Path) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def _task_text_containing(title_fragment: str) -> str:
+    matches: list[str] = []
+    for path in (REPO_ROOT / BACKLOG_TASKS).glob("*.md"):
+        text = path.read_text(encoding="utf-8")
+        if title_fragment in text:
+            matches.append(text)
+    assert len(matches) == 1, f"expected one task containing {title_fragment!r}, found {len(matches)}"
+    return matches[0]
+
+
+def _phase_row(markdown: str, phase_title: str) -> list[str]:
+    for line in markdown.splitlines():
+        if not line.startswith("|"):
+            continue
+        columns = [column.strip() for column in line.strip().strip("|").split("|")]
+        if columns and columns[0] == phase_title:
+            return columns
+    raise AssertionError(f"{phase_title!r} row not found")
+
+
+def test_product_maturity_phase_one_harness_files_exist() -> None:
+    for path in (SPEC, TRACKER, BACKLOG_DOC, QA_ROOT / "README.md", PHASE_1_README, PROTOCOL, TEMPLATE, SMOKE):
+        assert (REPO_ROOT / path).exists(), f"{path} should exist"
+
+
+def test_product_maturity_template_captures_required_fields_and_severity() -> None:
+    text = _text(TEMPLATE)
+
+    for section in REQUIRED_TEMPLATE_SECTIONS:
+        assert f"## {section}" in text
+    for severity in REQUIRED_SEVERITIES:
+        assert severity in text
+    for priority in REQUIRED_PRIORITY_LABELS:
+        assert priority in text
+    assert "usable, not merely rendered" in text
+
+
+def test_product_maturity_protocol_defines_clean_run_and_terminal_matrix() -> None:
+    text = _text(PROTOCOL)
+
+    assert "python3 -m tldw_chatbook.app" in text
+    assert "Fresh HOME" in text
+    assert "XDG_CONFIG_HOME" in text
+    assert "XDG_DATA_HOME" in text
+    assert "minimum supported compact" in text
+    assert "common laptop terminal" in text
+    assert "large power-user workspace" in text
+    assert "render-only" in text
+    assert "click-event-only" in text
+    assert "Tests/UI/test_product_maturity_phase1_harness.py" in text
+
+
+def test_product_maturity_tracker_links_phase_one_harness_and_tasks() -> None:
+    tracker = _text(TRACKER)
+    phase_one_task = _task_text_containing("Product Maturity Phase 1: QA Baseline And Usability Guardrails")
+    phase_one_one_task = _task_text_containing("Product Maturity Phase 1.1: Canonical QA Harness")
+
+    assert str(SPEC) in tracker
+    assert str(PROTOCOL) in tracker
+    assert str(TEMPLATE) in tracker
+    assert str(SMOKE) in tracker
+    assert "Phase 1.1" in tracker
+    assert "<PHASE_" not in tracker
+
+    phase_one_row = _phase_row(tracker, "Phase 1: QA Baseline And Usability Guardrails")
+    assert phase_one_row[2] in {"planned", "in_progress"}
+    assert "Phase 1.1" in phase_one_row[3]
+    assert "phase-1/" in phase_one_row[4]
+
+    assert "QA walkthrough verifies the running app is usable" in phase_one_task
+    assert "Product-maturity QA protocol defines clean-run setup" in phase_one_one_task
+    assert "Harness smoke evidence states" in phase_one_one_task
+
+
+def test_phase_one_one_smoke_evidence_records_harness_only_boundary() -> None:
+    text = _text(SMOKE)
+
+    assert "Phase 1.1" in text
+    assert "Canonical QA Harness" in text
+    assert "Product QA Boundary" in text
+    assert re.search(r"harness[- ]only", text, re.IGNORECASE)
+    assert "does not complete the full product walkthrough" in text
+    assert "Tests/UI/test_product_maturity_phase1_harness.py" in text
+    assert "<PHASE_" not in text
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+python3 -m pytest Tests/UI/test_product_maturity_phase1_harness.py -q
+```
+
+Expected: FAIL because `Docs/superpowers/trackers/product-maturity-roadmap.md`, product-maturity QA docs, and Backlog pointer doc do not exist yet.
+
+- [ ] **Step 3: Commit failing test**
+
+Run:
+
+```bash
+git add Tests/UI/test_product_maturity_phase1_harness.py
+git commit -m "Add product maturity QA harness contract test"
+```
+
+Expected: commit succeeds with one new test file.
+
+## Task 3: Create Product-Maturity Tracker And QA Harness Docs
+
+**Files:**
+- Create: `Docs/superpowers/trackers/product-maturity-roadmap.md`
+- Create: `Docs/superpowers/qa/product-maturity/README.md`
+- Create: `Docs/superpowers/qa/product-maturity/phase-1/README.md`
+- Create: `Docs/superpowers/qa/product-maturity/phase-1/walkthrough-protocol.md`
+- Create: `Docs/superpowers/qa/product-maturity/phase-1/walkthrough-template.md`
+- Create: `Docs/superpowers/qa/product-maturity/phase-1/2026-05-05-phase-1-1-harness-smoke.md`
+- Create: `backlog/docs/product-maturity-roadmap.md`
+
+- [ ] **Step 1: Create QA directories**
+
+Run:
+
+```bash
+mkdir -p Docs/superpowers/qa/product-maturity/phase-1
+```
+
+Expected: directory exists.
+
+- [ ] **Step 2: Create Backlog pointer doc**
+
+Create `backlog/docs/product-maturity-roadmap.md` with:
+
+```markdown
+# Product Maturity Roadmap
+
+The canonical product-maturity design spec lives at:
+
+`Docs/superpowers/specs/2026-05-05-product-maturity-phased-roadmap-design.md`
+
+The canonical product-maturity tracker lives at:
+
+`Docs/superpowers/trackers/product-maturity-roadmap.md`
+
+Durable QA evidence lives at:
+
+`Docs/superpowers/qa/product-maturity/`
+
+Backlog tasks in `backlog/tasks/` are PR-sized execution units. Parent tasks represent product-maturity phases; child tasks represent implementation or QA gates.
+
+Do not mark a product-maturity task or phase complete because UI renders or a button is clickable. Completion requires automated evidence, running-app QA evidence where product behavior is in scope, and a repo-tracked QA summary.
+```
+
+- [ ] **Step 3: Create product-maturity tracker**
+
+Create `Docs/superpowers/trackers/product-maturity-roadmap.md`. Use the actual Backlog task IDs returned in Task 1.
+
+Minimum required content is below. The `<PHASE_...>` markers are implementation variables for this plan only; the committed tracker must contain actual Backlog task IDs and must not contain these markers.
+
+```markdown
+# Product Maturity Roadmap
+
+Date: 2026-05-05
+Status: Phase 1.1 planned
+Source Branch: `dev`
+Source Spec: `Docs/superpowers/specs/2026-05-05-product-maturity-phased-roadmap-design.md`
+
+## Purpose
+
+Track product-depth maturity after Unified Shell Phase 6 so rendered screens, clickable controls, and complete usable workflows stay distinct.
+
+## Current Verified Baseline
+
+- Unified Shell Phase 0-6 are verified in `Docs/superpowers/trackers/unified-shell-maturity-roadmap.md`.
+- Product-maturity work starts with a QA baseline before new feature depth.
+- Phase 1.1 creates the reusable harness only; it does not complete the full first-run, focus, visual, empty-state, or core-loop audits.
+
+## Severity Policy
+
+| Priority | Taxonomy | Exit Rule |
+| --- | --- | --- |
+| P0 | `blocker` | Must be fixed before the phase or gate can close. |
+| P1 | `workflow-degradation` | Must be fixed before phase close unless explicitly accepted with owner, rationale, and follow-up task. |
+| P2 | `recoverability` | May remain only with residual risk and a scoped follow-up. |
+| P3 | `polish` | May remain as backlog polish if it does not hide status, source authority, or recovery action. |
+
+## Backlog Task Hierarchy
+
+- Phase 1: QA Baseline And Usability Guardrails - `<PHASE_1_TASK_ID>`
+- Phase 1.1: Canonical QA Harness - `<PHASE_1_1_TASK_ID>`
+- Phase 2: Core Agentic Loop - `<PHASE_2_TASK_ID>`
+- Phase 3: Knowledge And Study Workflows - `<PHASE_3_TASK_ID>`
+- Phase 4: Agent Configuration And Execution - `<PHASE_4_TASK_ID>`
+- Phase 5: Server-Parity And Live Integrations - `<PHASE_5_TASK_ID>`
+- Phase 6: Release Hardening And Documentation - `<PHASE_6_TASK_ID>`
+
+## QA Evidence Index
+
+| Phase | Evidence Path | Status |
+| --- | --- | --- |
+| Phase 1 | `Docs/superpowers/qa/product-maturity/phase-1/` | planned |
+
+## Phase Overview
+
+| Phase | Goal | Status | Backlog Tasks | QA Evidence | Residual Risk |
+| --- | --- | --- | --- | --- | --- |
+| Phase 1: QA Baseline And Usability Guardrails | Establish clean-run usability guardrails before feature depth. | planned | `<PHASE_1_TASK_ID>`, `<PHASE_1_1_TASK_ID>` | `phase-1/` | Phase 1.1 is harness-only; product walkthroughs remain future Phase 1 gates. |
+| Phase 2: Core Agentic Loop | Complete source/question to grounded Console to Artifact/Chatbook loop. | planned | `<PHASE_2_TASK_ID>` | not-started | Depends on Phase 1 QA baseline. |
+| Phase 3: Knowledge And Study Workflows | Mature ingest, organize, retrieve, study, and reuse workflows. | planned | `<PHASE_3_TASK_ID>` | not-started | Depends on Phase 2 core loop and later task slicing. |
+| Phase 4: Agent Configuration And Execution | Mature Personas, Skills, MCP, ACP, Schedules, and Workflows. | planned | `<PHASE_4_TASK_ID>` | not-started | Depends on service adapters and runtime readiness. |
+| Phase 5: Server-Parity And Live Integrations | Close high-value `tldw_server2` parity gaps. | planned | `<PHASE_5_TASK_ID>` | not-started | Requires parity inventory. |
+| Phase 6: Release Hardening And Documentation | Reach release-candidate usability. | planned | `<PHASE_6_TASK_ID>` | not-started | Depends on earlier phase evidence. |
+
+## Phase 1.1 Evidence
+
+- `Docs/superpowers/qa/product-maturity/phase-1/walkthrough-protocol.md`
+- `Docs/superpowers/qa/product-maturity/phase-1/walkthrough-template.md`
+- `Docs/superpowers/qa/product-maturity/phase-1/2026-05-05-phase-1-1-harness-smoke.md`
+```
+
+Replace all `<...>` markers before running tests.
+
+- [ ] **Step 4: Create product-maturity QA README**
+
+Create `Docs/superpowers/qa/product-maturity/README.md`:
+
+```markdown
+# Product Maturity QA Evidence
+
+This directory stores durable QA evidence for the product-maturity roadmap.
+
+Canonical tracker:
+
+`Docs/superpowers/trackers/product-maturity-roadmap.md`
+
+Canonical spec:
+
+`Docs/superpowers/specs/2026-05-05-product-maturity-phased-roadmap-design.md`
+
+Rules:
+
+- Verify running-app behavior, not only rendered widgets.
+- Record whether each workflow completed, was honestly blocked with recovery, or failed.
+- Use one defect taxonomy label: `blocker`, `workflow-degradation`, `recoverability`, or `polish`.
+- Record P0/P1/P2/P3 only when release or phase-exit decisions need that mapping.
+- Store one markdown QA summary per gate.
+```
+
+- [ ] **Step 5: Create Phase 1 README**
+
+Create `Docs/superpowers/qa/product-maturity/phase-1/README.md`:
+
+```markdown
+# Product Maturity Phase 1 QA
+
+Status: planned
+
+Phase 1 establishes QA baselines and usability guardrails before additional product-depth work.
+
+Phase 1.1 evidence:
+
+- `walkthrough-protocol.md`
+- `walkthrough-template.md`
+- `2026-05-05-phase-1-1-harness-smoke.md`
+
+Phase 1.1 is harness-only. It does not complete the full first-run, focus, visual, empty-state, or core-loop audits.
+```
+
+- [ ] **Step 6: Create walkthrough protocol**
+
+Create `Docs/superpowers/qa/product-maturity/phase-1/walkthrough-protocol.md`.
+
+Required content:
+
+````markdown
+# Product Maturity Phase 1 Walkthrough Protocol
+
+Status: active for Phase 1.1 harness setup
+
+Use this protocol before marking product-maturity workflows usable. Run it against the actual Textual app when product behavior is in scope. Render-only checks and click-event-only checks do not prove workflow completion.
+
+## Clean-Run Setup
+
+Use a fresh `HOME` and `XDG_*` directory set when validating first-run or setup behavior:
+
+- Fresh HOME
+- XDG_CONFIG_HOME
+- XDG_DATA_HOME
+- XDG_CACHE_HOME
+
+Record the exact directories in the QA summary. Do not use a developer's normal app state for first-run claims.
+
+## Entry Commands
+
+Manual app entry:
+
+```bash
+python3 -m tldw_chatbook.app
+```
+
+Focused harness contract:
+
+```bash
+python3 -m pytest Tests/UI/test_product_maturity_phase1_harness.py -q
+```
+
+Existing shell support checks:
+
+```bash
+python3 -m pytest Tests/UI/test_master_shell_navigation.py -q
+python3 -m pytest Tests/UI/test_shell_destinations.py -q
+python3 -m pytest Tests/UI/test_unified_shell_qa_protocol.py -q
+```
+
+## Terminal-Size Matrix
+
+Record the terminal size used for every visual/focus walkthrough:
+
+- minimum supported compact
+- common laptop terminal
+- large power-user workspace
+
+The implementation task that performs a visual sweep must replace these labels with exact dimensions after confirming supported sizes.
+
+## Required Walkthrough Scope
+
+For each product workflow or harness gate, record:
+
+- Navigation entry path.
+- Whether status and source authority are visible.
+- Whether primary actions are reachable by keyboard and mouse.
+- Whether disabled, blocked, unavailable, pending approval, and recovery states explain owner, reason, and next action.
+- Whether the workflow completes, is honestly blocked with recovery, or fails.
+- Whether repeated use remains fast enough for power users.
+
+## Severity Labels
+
+Use exactly one taxonomy label when a defect is found:
+
+- `blocker` - P0; prevents basic use, traps the user, corrupts or loses user work, or makes a required workflow impossible.
+- `workflow-degradation` - P1; breaks or seriously slows a core workflow but leaves a workaround.
+- `recoverability` - P2; blocked/error state exists but recovery copy, ownership, or next action is unclear.
+- `polish` - P3; visual or wording issue that does not block completion.
+
+## Evidence Rules
+
+- Do not count render-only checks as workflow completion.
+- Do not count click-event-only checks as workflow completion.
+- If a workflow is blocked, record the recovery path and severity instead of treating the blocked state as a pass.
+- Record screenshots only when they materially clarify layout, focus, or visual defects.
+
+## Output
+
+Create one markdown summary per gate using `walkthrough-template.md`. Store summaries in this directory and link them from `Docs/superpowers/trackers/product-maturity-roadmap.md` and the relevant Backlog task.
+````
+
+- [ ] **Step 7: Create walkthrough template**
+
+Create `Docs/superpowers/qa/product-maturity/phase-1/walkthrough-template.md`:
+
+```markdown
+# Product Maturity Phase 1 Walkthrough Summary
+
+## Environment
+
+- Date:
+- Branch:
+- Commit:
+- Python version:
+- Runtime source:
+- Config/home directory:
+
+## Task Or Phase
+
+- Backlog task:
+- Phase:
+- Destination or workflow:
+
+## Entry Path
+
+- Launch command, direct route, command palette path, focused mounted test, or manual terminal replay:
+
+## Terminal Size
+
+- Category:
+- Dimensions:
+
+## Clean-Run Setup
+
+- Fresh HOME:
+- XDG_CONFIG_HOME:
+- XDG_DATA_HOME:
+- XDG_CACHE_HOME:
+- Reused state:
+
+## Steps Attempted
+
+1.
+
+## Visual/Focus Notes
+
+- Layout:
+- Clipping:
+- Focus indication:
+- Labels:
+- Disabled or blocked states:
+- Information hierarchy:
+
+## Keyboard Path Result
+
+- Completed, blocked with recovery, failed, or not tested:
+
+## Mouse/Click Path Result
+
+- Completed, blocked with recovery, failed, or not tested:
+
+## Functional Result
+
+- Completed workflow:
+- Honest blocked state:
+- Failed workflow:
+- Recovery path:
+
+## Defects Found
+
+Use one taxonomy label and optional P-level:
+
+- `blocker` / P0:
+- `workflow-degradation` / P1:
+- `recoverability` / P2:
+- `polish` / P3:
+
+## Evidence
+
+- Screenshots:
+- Logs:
+- Probe JSON:
+- Test commands:
+- Related PRs or commits:
+
+## Residual Risk
+
+- Untested live server/API paths:
+- Optional dependency limits:
+- Environment limits:
+- Follow-up tasks:
+
+## Exit Decision
+
+- Pass, blocked, failed, or harness-only:
+
+## Product QA Boundary
+
+State whether this walkthrough verifies a real product workflow, only validates the protocol/harness, or intentionally leaves product workflow verification to a later task.
+
+This summary must prove the app is usable, not merely rendered, when product behavior is in scope.
+```
+
+- [ ] **Step 8: Create Phase 1.1 smoke evidence**
+
+Create `Docs/superpowers/qa/product-maturity/phase-1/2026-05-05-phase-1-1-harness-smoke.md`:
+
+```markdown
+# Phase 1.1 Canonical QA Harness Smoke
+
+## Environment
+
+- Date: 2026-05-05
+- Branch:
+- Commit:
+- Python version: not executed in this evidence slice
+- Runtime source: documentation/test harness
+- Config/home directory: not applicable
+
+## Task Or Phase
+
+- Backlog task: `<PHASE_1_1_TASK_ID>`
+- Phase: Phase 1.1
+- Destination or workflow: Canonical QA Harness
+
+## Entry Path
+
+- Focused contract: `python3 -m pytest Tests/UI/test_product_maturity_phase1_harness.py -q`
+
+## Steps Attempted
+
+1. Created product-maturity tracker.
+2. Created product-maturity QA protocol.
+3. Created product-maturity QA template.
+4. Linked Backlog task anchors and QA evidence.
+5. Ran focused harness contract test.
+
+## Visual/Focus Notes
+
+- Layout: not tested in this harness-only slice.
+- Clipping: not tested in this harness-only slice.
+- Focus indication: not tested in this harness-only slice.
+- Labels: protocol and template labels verified by focused tests.
+- Disabled or blocked states: not tested in this harness-only slice.
+- Information hierarchy: tracker and evidence index verified by focused tests.
+
+## Functional Result
+
+- Completed workflow: QA harness exists and is linked.
+- Honest blocked state: product workflow verification remains future Phase 1 work.
+- Failed workflow: none for harness scope.
+- Recovery path: future product workflow defects must use the severity policy in the protocol.
+
+## Defects Found
+
+- None in harness scope.
+
+## Evidence
+
+- Test commands: `python3 -m pytest Tests/UI/test_product_maturity_phase1_harness.py -q`
+- Related PRs or commits:
+
+## Residual Risk
+
+- Untested live server/API paths: all product live paths remain outside Phase 1.1.
+- Optional dependency limits: not exercised.
+- Environment limits: visual/focus behavior requires later manual terminal replay.
+- Follow-up tasks: full first-run, navigation, visual, empty-state, and core-loop product audits.
+
+## Exit Decision
+
+- harness-only
+
+## Product QA Boundary
+
+Phase 1.1 is harness-only. It does not complete the full product walkthrough. It verifies that later product-maturity work has a reusable protocol, template, severity mapping, tracker linkage, and focused regression test.
+```
+
+Replace `<PHASE_1_1_TASK_ID>` before running tests. The committed smoke evidence must contain the actual Backlog task ID and must not contain this marker.
+
+- [ ] **Step 9: Run focused test to verify it passes**
+
+Run:
+
+```bash
+python3 -m pytest Tests/UI/test_product_maturity_phase1_harness.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit harness docs**
+
+Run:
+
+```bash
+git add Docs/superpowers/trackers/product-maturity-roadmap.md Docs/superpowers/qa/product-maturity backlog/docs/product-maturity-roadmap.md
+git commit -m "Add product maturity QA harness docs"
+```
+
+Expected: commit succeeds with new product-maturity docs.
+
+## Task 4: Close Phase 1.1 Backlog Task
+
+**Files:**
+- Modify: `backlog/tasks/task-<phase-1-1-id> - Product-Maturity-Phase-1.1-Canonical-QA-Harness.md`
+- Modify: `Docs/superpowers/trackers/product-maturity-roadmap.md`
+- Modify: `Docs/superpowers/qa/product-maturity/phase-1/README.md`
+- Modify: `Docs/superpowers/qa/product-maturity/phase-1/2026-05-05-phase-1-1-harness-smoke.md`
+
+- [ ] **Step 1: Re-run focused verification before closing task**
+
+Run:
+
+```bash
+python3 -m pytest Tests/UI/test_product_maturity_phase1_harness.py -q
+git diff --check
+```
+
+Expected: pytest PASS; diff check has no output.
+
+- [ ] **Step 2: Update Phase 1.1 smoke evidence with final commit/test output**
+
+Edit `Docs/superpowers/qa/product-maturity/phase-1/2026-05-05-phase-1-1-harness-smoke.md`:
+
+- fill branch and commit.
+- fill Python version if command was run locally.
+- add focused test result.
+- add related commit IDs.
+
+- [ ] **Step 3: Update tracker status for Phase 1.1**
+
+Edit `Docs/superpowers/trackers/product-maturity-roadmap.md`:
+
+- mark Phase 1.1 as `verified`.
+- keep Phase 1 as `planned` or `in_progress`; do not mark Phase 1 complete.
+- keep Phase 1 residual risk clear: full first-run, focus, visual, empty-state, and core-loop audits remain future gates.
+
+- [ ] **Step 4: Update Phase 1 README**
+
+Edit `Docs/superpowers/qa/product-maturity/phase-1/README.md`:
+
+- set Phase 1.1 harness status to `verified`.
+- keep Phase 1 overall status as `planned` or `in_progress`.
+- link the smoke evidence.
+
+- [ ] **Step 5: Mark Phase 1.1 Backlog acceptance criteria complete**
+
+Use Backlog MCP `task_edit` or the CLI:
+
+- check every Phase 1.1 acceptance criterion.
+- add implementation notes summarizing tracker, protocol, template, smoke evidence, and test coverage.
+- set only the Phase 1.1 child task to `Done`.
+- do not mark the Phase 1 parent done.
+
+- [ ] **Step 6: Run final verification**
+
+Run:
+
+```bash
+python3 -m pytest Tests/UI/test_product_maturity_phase1_harness.py -q
+git diff --check
+```
+
+Expected: pytest PASS; diff check has no output.
+
+- [ ] **Step 7: Commit closeout**
+
+Run:
+
+```bash
+git add backlog/tasks Docs/superpowers/trackers/product-maturity-roadmap.md Docs/superpowers/qa/product-maturity/phase-1/README.md Docs/superpowers/qa/product-maturity/phase-1/2026-05-05-phase-1-1-harness-smoke.md
+git commit -m "Verify product maturity Phase 1.1 QA harness"
+```
+
+Expected: commit succeeds.
+
+## Task 5: Final Branch Verification
+
+**Files:**
+- No new files.
+
+- [ ] **Step 1: Run focused product-maturity verification**
+
+Run:
+
+```bash
+python3 -m pytest Tests/UI/test_product_maturity_phase1_harness.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run adjacent QA protocol regression**
+
+Run:
+
+```bash
+python3 -m pytest Tests/UI/test_unified_shell_qa_protocol.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run diff hygiene**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Inspect final status**
+
+Run:
+
+```bash
+git status --short --branch
+git log --oneline -5
+```
+
+Expected: only intentional product-maturity commits are ahead of `dev`; unrelated untracked files remain untouched.
+
+## Implementation Notes Template
+
+Use this for the Phase 1.1 Backlog task:
+
+```markdown
+## Implementation Notes
+
+- Added product-maturity Backlog anchors for Phase 1 through Phase 6 and one Phase 1.1 child task.
+- Added `Docs/superpowers/trackers/product-maturity-roadmap.md` as the product-maturity tracker.
+- Added the product-maturity QA evidence root and Phase 1.1 protocol/template/smoke evidence.
+- Added `Tests/UI/test_product_maturity_phase1_harness.py` to lock the harness, tracker, severity mapping, and harness-only QA boundary.
+- Phase 1.1 verifies harness readiness only. Full first-run, visual/focus, empty-state, and core-loop walkthroughs remain future Phase 1 gates.
+```
+
+## PR Description Template
+
+```markdown
+## Summary
+
+- Adds product-maturity Backlog anchors and Phase 1.1 canonical QA harness.
+- Adds tracker and QA evidence docs for the product-maturity roadmap.
+- Adds focused pytest coverage to prevent harness/tracker drift.
+
+## Verification
+
+- `python3 -m pytest Tests/UI/test_product_maturity_phase1_harness.py -q`
+- `python3 -m pytest Tests/UI/test_unified_shell_qa_protocol.py -q`
+- `git diff --check`
+
+## Residual Risk
+
+- Phase 1.1 is harness-only.
+- Full first-run, keyboard/focus, visual, empty/error state, and core-loop product audits remain future Phase 1 tasks.
+```

--- a/Docs/superpowers/qa/product-maturity/README.md
+++ b/Docs/superpowers/qa/product-maturity/README.md
@@ -1,0 +1,19 @@
+# Product Maturity QA Evidence
+
+This directory stores durable QA evidence for the product-maturity roadmap.
+
+Canonical tracker:
+
+`Docs/superpowers/trackers/product-maturity-roadmap.md`
+
+Canonical spec:
+
+`Docs/superpowers/specs/2026-05-05-product-maturity-phased-roadmap-design.md`
+
+Rules:
+
+- Verify running-app behavior, not only rendered widgets.
+- Record whether each workflow completed, was honestly blocked with recovery, or failed.
+- Use one defect taxonomy label: `blocker`, `workflow-degradation`, `recoverability`, or `polish`.
+- Record P0/P1/P2/P3 only when release or phase-exit decisions need that mapping.
+- Store one markdown QA summary per gate.

--- a/Docs/superpowers/qa/product-maturity/phase-1/2026-05-05-phase-1-1-harness-smoke.md
+++ b/Docs/superpowers/qa/product-maturity/phase-1/2026-05-05-phase-1-1-harness-smoke.md
@@ -1,0 +1,68 @@
+# Phase 1.1 Canonical QA Harness Smoke
+
+## Environment
+
+- Date: 2026-05-05
+- Branch: codex/product-maturity-phase1-1
+- Commit:
+- Python version: not executed in this evidence slice
+- Runtime source: documentation/test harness
+- Config/home directory: not applicable
+
+## Task Or Phase
+
+- Backlog task: TASK-8.1
+- Phase: Phase 1.1
+- Destination or workflow: Canonical QA Harness
+
+## Entry Path
+
+- Focused contract: `python3 -m pytest Tests/UI/test_product_maturity_phase1_harness.py -q`
+
+## Steps Attempted
+
+1. Created product-maturity tracker.
+2. Created product-maturity QA protocol.
+3. Created product-maturity QA template.
+4. Linked Backlog task anchors and QA evidence.
+5. Ran focused harness contract test.
+
+## Visual/Focus Notes
+
+- Layout: not tested in this harness-only slice.
+- Clipping: not tested in this harness-only slice.
+- Focus indication: not tested in this harness-only slice.
+- Labels: protocol and template labels verified by focused tests.
+- Disabled or blocked states: not tested in this harness-only slice.
+- Information hierarchy: tracker and evidence index verified by focused tests.
+
+## Functional Result
+
+- Completed workflow: QA harness exists and is linked.
+- Honest blocked state: product workflow verification remains future Phase 1 work.
+- Failed workflow: none for harness scope.
+- Recovery path: future product workflow defects must use the severity policy in the protocol.
+
+## Defects Found
+
+- None in harness scope.
+
+## Evidence
+
+- Test commands: `python3 -m pytest Tests/UI/test_product_maturity_phase1_harness.py -q`
+- Related PRs or commits:
+
+## Residual Risk
+
+- Untested live server/API paths: all product live paths remain outside Phase 1.1.
+- Optional dependency limits: not exercised.
+- Environment limits: visual/focus behavior requires later manual terminal replay.
+- Follow-up tasks: full first-run, navigation, visual, empty-state, and core-loop product audits.
+
+## Exit Decision
+
+- harness-only
+
+## Product QA Boundary
+
+Phase 1.1 is harness-only. It does not complete the full product walkthrough. It verifies that later product-maturity work has a reusable protocol, template, severity mapping, tracker linkage, and focused regression test.

--- a/Docs/superpowers/qa/product-maturity/phase-1/2026-05-05-phase-1-1-harness-smoke.md
+++ b/Docs/superpowers/qa/product-maturity/phase-1/2026-05-05-phase-1-1-harness-smoke.md
@@ -4,9 +4,9 @@
 
 - Date: 2026-05-05
 - Branch: codex/product-maturity-phase1-1
-- Commit: 0e3d093e
-- Python version: Python 3.9.6
-- Runtime source: documentation/test harness
+- Commit: PR #247 review-fix worktree
+- Python version: Python 3.12.11
+- Runtime source: root repository virtualenv at `../../.venv/bin/python` from this worktree
 - Config/home directory: not applicable
 
 ## Task Or Phase
@@ -17,7 +17,7 @@
 
 ## Entry Path
 
-- Focused contract: `python3 -m pytest Tests/UI/test_product_maturity_phase1_harness.py -q`
+- Focused contract: `../../.venv/bin/python -m pytest Tests/UI/test_product_maturity_phase1_harness.py -q`
 
 ## Steps Attempted
 
@@ -49,9 +49,10 @@
 
 ## Evidence
 
-- Test commands: `python3 -m pytest Tests/UI/test_product_maturity_phase1_harness.py -q` -> 5 passed
+- Test commands: `../../.venv/bin/python -m pytest Tests/UI/test_product_maturity_phase1_harness.py -q` -> 5 passed
+- Adjacent protocol check: `../../.venv/bin/python -m pytest Tests/UI/test_unified_shell_qa_protocol.py -q` -> 5 passed
 - Diff hygiene: `git diff --check` -> no output
-- Related PRs or commits: `abe83f6e`, `0e3d093e`
+- Related PRs or commits: `abe83f6e`, `0e3d093e`, PR #247 review-fix worktree
 
 ## Residual Risk
 

--- a/Docs/superpowers/qa/product-maturity/phase-1/2026-05-05-phase-1-1-harness-smoke.md
+++ b/Docs/superpowers/qa/product-maturity/phase-1/2026-05-05-phase-1-1-harness-smoke.md
@@ -4,8 +4,8 @@
 
 - Date: 2026-05-05
 - Branch: codex/product-maturity-phase1-1
-- Commit:
-- Python version: not executed in this evidence slice
+- Commit: 0e3d093e
+- Python version: Python 3.9.6
 - Runtime source: documentation/test harness
 - Config/home directory: not applicable
 
@@ -49,8 +49,9 @@
 
 ## Evidence
 
-- Test commands: `python3 -m pytest Tests/UI/test_product_maturity_phase1_harness.py -q`
-- Related PRs or commits:
+- Test commands: `python3 -m pytest Tests/UI/test_product_maturity_phase1_harness.py -q` -> 5 passed
+- Diff hygiene: `git diff --check` -> no output
+- Related PRs or commits: `abe83f6e`, `0e3d093e`
 
 ## Residual Risk
 

--- a/Docs/superpowers/qa/product-maturity/phase-1/README.md
+++ b/Docs/superpowers/qa/product-maturity/phase-1/README.md
@@ -1,0 +1,13 @@
+# Product Maturity Phase 1 QA
+
+Status: in_progress
+
+Phase 1 establishes QA baselines and usability guardrails before additional product-depth work.
+
+Phase 1.1 evidence:
+
+- `walkthrough-protocol.md`
+- `walkthrough-template.md`
+- `2026-05-05-phase-1-1-harness-smoke.md`
+
+Phase 1.1 is harness-only. It does not complete the full first-run, focus, visual, empty-state, or core-loop audits.

--- a/Docs/superpowers/qa/product-maturity/phase-1/README.md
+++ b/Docs/superpowers/qa/product-maturity/phase-1/README.md
@@ -6,6 +6,8 @@ Phase 1 establishes QA baselines and usability guardrails before additional prod
 
 Phase 1.1 evidence:
 
+Phase 1.1 harness status: verified
+
 - `walkthrough-protocol.md`
 - `walkthrough-template.md`
 - `2026-05-05-phase-1-1-harness-smoke.md`

--- a/Docs/superpowers/qa/product-maturity/phase-1/walkthrough-protocol.md
+++ b/Docs/superpowers/qa/product-maturity/phase-1/walkthrough-protocol.md
@@ -1,0 +1,79 @@
+# Product Maturity Phase 1 Walkthrough Protocol
+
+Status: active for Phase 1.1 harness setup
+
+Use this protocol before marking product-maturity workflows usable. Run it against the actual Textual app when product behavior is in scope. Render-only checks and click-event-only checks do not prove workflow completion.
+
+## Clean-Run Setup
+
+Use a fresh `HOME` and `XDG_*` directory set when validating first-run or setup behavior:
+
+- Fresh HOME
+- XDG_CONFIG_HOME
+- XDG_DATA_HOME
+- XDG_CACHE_HOME
+
+Record the exact directories in the QA summary. Do not use a developer's normal app state for first-run claims.
+
+## Entry Commands
+
+Manual app entry:
+
+```bash
+python3 -m tldw_chatbook.app
+```
+
+Focused harness contract:
+
+```bash
+python3 -m pytest Tests/UI/test_product_maturity_phase1_harness.py -q
+```
+
+Existing shell support checks:
+
+```bash
+python3 -m pytest Tests/UI/test_master_shell_navigation.py -q
+python3 -m pytest Tests/UI/test_shell_destinations.py -q
+python3 -m pytest Tests/UI/test_unified_shell_qa_protocol.py -q
+```
+
+## Terminal-Size Matrix
+
+Record the terminal size used for every visual/focus walkthrough:
+
+- minimum supported compact
+- common laptop terminal
+- large power-user workspace
+
+The implementation task that performs a visual sweep must replace these labels with exact dimensions after confirming supported sizes.
+
+## Required Walkthrough Scope
+
+For each product workflow or harness gate, record:
+
+- Navigation entry path.
+- Whether status and source authority are visible.
+- Whether primary actions are reachable by keyboard and mouse.
+- Whether disabled, blocked, unavailable, pending approval, and recovery states explain owner, reason, and next action.
+- Whether the workflow completes, is honestly blocked with recovery, or fails.
+- Whether repeated use remains fast enough for power users.
+
+## Severity Labels
+
+Use exactly one taxonomy label when a defect is found:
+
+- `blocker` - P0; prevents basic use, traps the user, corrupts or loses user work, or makes a required workflow impossible.
+- `workflow-degradation` - P1; breaks or seriously slows a core workflow but leaves a workaround.
+- `recoverability` - P2; blocked/error state exists but recovery copy, ownership, or next action is unclear.
+- `polish` - P3; visual or wording issue that does not block completion.
+
+## Evidence Rules
+
+- Do not count render-only checks as workflow completion.
+- Do not count click-event-only checks as workflow completion.
+- If a workflow is blocked, record the recovery path and severity instead of treating the blocked state as a pass.
+- Record screenshots only when they materially clarify layout, focus, or visual defects.
+
+## Output
+
+Create one markdown summary per gate using `walkthrough-template.md`. Store summaries in this directory and link them from `Docs/superpowers/trackers/product-maturity-roadmap.md` and the relevant Backlog task.

--- a/Docs/superpowers/qa/product-maturity/phase-1/walkthrough-template.md
+++ b/Docs/superpowers/qa/product-maturity/phase-1/walkthrough-template.md
@@ -1,0 +1,95 @@
+# Product Maturity Phase 1 Walkthrough Summary
+
+## Environment
+
+- Date:
+- Branch:
+- Commit:
+- Python version:
+- Runtime source:
+- Config/home directory:
+
+## Task Or Phase
+
+- Backlog task:
+- Phase:
+- Destination or workflow:
+
+## Entry Path
+
+- Launch command, direct route, command palette path, focused mounted test, or manual terminal replay:
+
+## Terminal Size
+
+- Category:
+- Dimensions:
+
+## Clean-Run Setup
+
+- Fresh HOME:
+- XDG_CONFIG_HOME:
+- XDG_DATA_HOME:
+- XDG_CACHE_HOME:
+- Reused state:
+
+## Steps Attempted
+
+1.
+
+## Visual/Focus Notes
+
+- Layout:
+- Clipping:
+- Focus indication:
+- Labels:
+- Disabled or blocked states:
+- Information hierarchy:
+
+## Keyboard Path Result
+
+- Completed, blocked with recovery, failed, or not tested:
+
+## Mouse/Click Path Result
+
+- Completed, blocked with recovery, failed, or not tested:
+
+## Functional Result
+
+- Completed workflow:
+- Honest blocked state:
+- Failed workflow:
+- Recovery path:
+
+## Defects Found
+
+Use one taxonomy label and optional P-level:
+
+- `blocker` / P0:
+- `workflow-degradation` / P1:
+- `recoverability` / P2:
+- `polish` / P3:
+
+## Evidence
+
+- Screenshots:
+- Logs:
+- Probe JSON:
+- Test commands:
+- Related PRs or commits:
+
+## Residual Risk
+
+- Untested live server/API paths:
+- Optional dependency limits:
+- Environment limits:
+- Follow-up tasks:
+
+## Exit Decision
+
+- Pass, blocked, failed, or harness-only:
+
+## Product QA Boundary
+
+State whether this walkthrough verifies a real product workflow, only validates the protocol/harness, or intentionally leaves product workflow verification to a later task.
+
+This summary must prove the app is usable, not merely rendered, when product behavior is in scope.

--- a/Docs/superpowers/specs/2026-05-05-product-maturity-phased-roadmap-design.md
+++ b/Docs/superpowers/specs/2026-05-05-product-maturity-phased-roadmap-design.md
@@ -1,0 +1,360 @@
+# Product Maturity Phased Roadmap Design
+
+Date: 2026-05-05
+Status: User-approved design, pending spec review and implementation planning
+Primary Repo: `tldw_chatbook`
+Source Baseline: `dev` at `9c4b3bf0` (`Close Phase 6 Nielsen shell audit (#246)`)
+Related Specs:
+
+- `Docs/superpowers/specs/2026-05-02-new-user-first-run-shell-ux-design.md`
+- `Docs/superpowers/specs/2026-05-02-agentic-terminal-design-system-design.md`
+- `Docs/superpowers/specs/2026-05-03-unified-shell-maturity-tracking-design.md`
+- `Docs/superpowers/trackers/unified-shell-maturity-roadmap.md`
+
+## Summary
+
+The Unified Shell maturity roadmap is verified through Phase 6. The next workstream should move beyond shell correctness into product-depth maturity: making each visible module useful for real workflows while preserving the verified shell guardrails.
+
+The roadmap should use a hybrid maturity-gate model:
+
+- 6 major phases for executive-level tracking.
+- PR-sized child gates for execution.
+- mandatory QA walkthrough evidence for every phase.
+- explicit "usable, not merely rendered" exit criteria.
+
+The first phase must establish a stronger QA baseline before new feature depth. This prevents repeating the earlier failure mode where screens render, controls are clickable, but the app is visually broken, confusing, or unusable.
+
+## Current Baseline
+
+The current `dev` branch has verified Unified Shell work:
+
+- Home is the default dashboard/status surface.
+- Console is the primary live agentic control surface.
+- Top-level destinations exist for Home, Console, Library, Artifacts, Personas, W+C, Schedules, Workflows, MCP, ACP, Skills, and Settings.
+- Destination wrappers expose honest unavailable or recovery states instead of false affordances.
+- Console has an app-owned launch contract and multiple staged-context producers.
+- Local Library, Personas, Skills, and W+C snapshots can stage context into Console.
+- MCP adopts the existing Unified MCP management panel.
+- ACP remains intentionally unavailable until an ACP-compatible runtime is configured.
+- Phase 6 first-time user, power-user, and Nielsen heuristic evidence is recorded under `Docs/superpowers/qa/unified-shell/phase-6/`.
+
+This baseline proves the shell direction. It does not prove that every product module has deep, complete, local/server-parity workflows.
+
+## Problem Statement
+
+The app now has a coherent shell, but the remaining work is fragmented across product depth, local/server parity, and reliability:
+
+- Library still needs native detail, import/export, and embedded Search/RAG workflows.
+- Console needs deeper live-work producers, durable run context, and stronger agent-control ergonomics.
+- Artifacts and Chatbooks need stronger persistence, reopen, export, and reuse paths.
+- Personas need detail, edit, import/export, archetypes, exemplars, dictionaries, and lore workflows.
+- Skills need Agent Skills discovery, import, detail, validation, edit, and execution workflows.
+- W+C needs detail, edit, import/export, feed/WebSub, alert rules, retry/backoff, and server collection-feed UX.
+- Schedules and Workflows need service adapters and usable execution/recovery controls.
+- MCP needs deeper live-work integration with Console.
+- ACP needs its own runtime/session model, separate from MCP.
+- Workspaces, flashcards, and quizzes need explicit placement in the product model.
+- Live server/API paths and optional dependency states still need broader verification.
+
+The next roadmap must make this work trackable without turning it into one large, unreviewable plan.
+
+## Goals
+
+- Preserve the verified Unified Shell operating model.
+- Prioritize actual workflow completion over visual redesign.
+- Keep Console as the agentic programming/control interface, similar in role to Claude Code, Codex, or Gemini CLI.
+- Keep Home useful as a notification center, status page, and lightweight control dashboard.
+- Mature visible modules into real workflows in small, independently shippable gates.
+- Keep Workspaces, flashcards, quizzes, sources, Artifacts/Chatbooks, Personas, Skills, W+C, Schedules, Workflows, MCP, ACP, Search/RAG, media, notes, and handoffs explicit in planning.
+- Add beginner orientation without slowing power users.
+- Require QA walkthrough evidence that proves the running app is usable, not just rendering.
+- Maintain clear local parity targets with the adjacent `tldw_server2` checkout, representing the server capability model previously discussed as `tldw_server`.
+
+## Non-Goals
+
+- Do not reopen the completed Unified Shell Phase 0-6 work unless a regression is found.
+- Do not implement concept images as literal screen requirements.
+- Do not redesign for aesthetics alone.
+- Do not collapse MCP and ACP.
+- Do not turn every destination into an alternate live-agent surface.
+- Do not create broad rewrites or large task batches before PR-sized gates are defined.
+- Do not treat automated tests alone as proof of UX completion.
+
+## Operating Model
+
+Each phase must define:
+
+- **Product outcome**: what becomes meaningfully usable for a real user.
+- **Scope boundary**: what is explicitly deferred.
+- **PR-sized gates**: independently reviewable slices.
+- **Acceptance criteria**: user-visible outcomes, not implementation steps.
+- **QA walkthrough**: clean-user and power-user checks proving workflow completion.
+- **Regression coverage**: focused tests for the changed seams.
+- **Evidence artifact**: repo-tracked QA note under `Docs/superpowers/qa/`.
+- **Exit gate**: the phase is not done until the intended workflows can be completed end-to-end or blocked states are understandable and recoverable.
+
+Backlog.md should track execution after this spec is accepted:
+
+- one parent task per phase.
+- child tasks only for PR-sized gates.
+- child tasks should include "QA walkthrough verifies the running app is usable" as acceptance criteria.
+- phase completion requires evidence, not just task status.
+
+## Product Model
+
+The roadmap should preserve this product model:
+
+- **Home**: cross-module status, notifications, active work, next-best actions, and lightweight approve/pause/retry/open controls.
+- **Console**: live chat, agentic programming/control, RAG answers, staged context, tool calls, approvals, MCP tool use, ACP sessions, run logs, recovery, and artifact creation.
+- **Library**: notes, media, conversations, imports/exports, Search/RAG, source browsing, metadata, and evidence.
+- **Artifacts**: generated outputs, reusable deliverables, Chatbooks, reports, datasets, drafts, and exports.
+- **Personas**: behavior configuration, characters, profiles, archetypes, exemplars, dictionaries, and lore.
+- **W+C**: Watchlists and Collections, with local parity to server watch/collection concepts.
+- **Schedules**: when work runs, health, retries, pause/resume, and execution history.
+- **Workflows**: what procedure runs, steps, inputs, outputs, approvals, and recovery.
+- **MCP**: external tool/resource protocol management and readiness.
+- **ACP**: separate agent/session protocol runtime and live agent collaboration model.
+- **Skills**: Agent Skills-compatible capability packs built around `SKILL.md`, bundled resources, validation, import, and attachment to Console/workflows.
+- **Settings**: global configuration, providers, privacy, runtime policy, optional dependencies, and diagnostics.
+
+## Phase Roadmap
+
+| Phase | Product Outcome | Done When |
+| --- | --- | --- |
+| Phase 1: QA Baseline And Usability Guardrails | The app can be launched, navigated, visually inspected, and exercised from a clean user state with reliable evidence. | A fresh user can navigate every top-level module without broken layout, dead controls, confusing empty states, or unclear blocked states; at least one narrow core loop is exercised end-to-end. |
+| Phase 2: Core Agentic Loop | The main value loop works: source/question -> grounded Console interaction -> saved/reopened Artifact or Chatbook. | User can start from Library/RAG or Console, produce grounded output, save it, reopen it from Artifacts/Home, and recover from missing-source or missing-runtime states. |
+| Phase 3: Knowledge And Study Workflows | Knowledge workflows become coherent: ingest, organize, retrieve, study, and reuse. | User can move through Library, Import/Export, notes, media, Search/RAG, Workspaces, flashcards, quizzes, and collections without losing context or hitting placeholder UI. |
+| Phase 4: Agent Configuration And Execution | Agent setup and run control become coherent across Personas, Skills, MCP, ACP, Schedules, and Workflows. | User can configure an agent run, understand tool/runtime readiness, approve/pause/retry work, and diagnose failure states. |
+| Phase 5: Server-Parity And Live Integrations | High-value local/server parity gaps are closed where they materially improve local use. | Local Chatbook has documented parity coverage for priority `tldw_server2` workflows, live adapters/events where needed, and explicit residual gaps. |
+| Phase 6: Release Hardening And Documentation | The product reaches release-candidate usability. | Full first-time, power-user, accessibility/focus, visual, recovery, docs, and regression replays pass or produce tracked defects. |
+
+## Phase 1: QA Baseline And Usability Guardrails
+
+Purpose:
+
+Create the quality floor for all later product-depth work.
+
+PR-sized gates:
+
+- Clean first-run launch and configuration walkthrough.
+- Top-level navigation smoke for Home, Console, Library, Artifacts, Personas, W+C, Schedules, Workflows, MCP, ACP, Skills, and Settings.
+- Keyboard/focus sweep for navigation, command palette, forms, tables, and major actions.
+- Visual broken-state audit for clipped panels, unreadable labels, low-contrast states, and misleading disabled controls.
+- Empty/error/setup-state coverage for missing API keys, optional dependencies, server connections, and local runtime blockers.
+- Narrow core-loop proof: one source or query can reach Console and produce a recoverable output or honest blocker.
+
+Done when:
+
+- A fresh-user walkthrough can be repeated deterministically.
+- The QA artifact records what was tested, what passed, what failed, and what remains uncertain.
+- Focused regression tests cover the highest-risk async/loading paths.
+- Any P0 or P1 usability defect discovered during the walkthrough is fixed before the phase closes.
+
+## Phase 2: Core Agentic Loop
+
+Purpose:
+
+Make the central product loop complete enough to be useful every day.
+
+PR-sized gates:
+
+- Library/RAG search and source selection can stage evidence into Console.
+- Console can ask/answer with visible grounded context and source authority.
+- Console can create or update an Artifact/Chatbook.
+- Artifacts can reopen the result and route it back into Console.
+- Home can show recent/active work and provide resume/open controls.
+- Recovery states cover missing source, missing provider, missing model, missing runtime, and failed generation.
+
+Done when:
+
+- A user can complete source/question -> grounded chat -> saved Artifact/Chatbook -> reopen/resume without manual state reconstruction.
+- Power-user flow supports keyboard-first repeated use.
+- Beginner flow exposes enough labels/help text to understand what happened and what to do next.
+
+## Phase 3: Knowledge And Study Workflows
+
+Purpose:
+
+Turn Library and study-adjacent surfaces into a coherent knowledge workbench.
+
+PR-sized gates:
+
+- Library-native detail views for notes, media, conversations, and imported sources.
+- Import/Export entry points under Library with progress, validation, and recovery.
+- Search/RAG as both deliberate Library workflow and Console-integrated retrieval mode.
+- Workspaces as scope containers for sources, chats, notes, artifacts, and study outputs.
+- Flashcards from selected sources or Console outputs.
+- Quizzes from selected sources or Console outputs.
+- Collections as reusable source sets for RAG, study, schedules, and workflows.
+
+Done when:
+
+- A user can ingest or select material, organize it in a workspace or collection, retrieve from it, generate study material, and reuse it in Console.
+- The UI distinguishes source material, generated outputs, and study derivatives.
+- Import/export failures are diagnosable and recoverable.
+
+## Phase 4: Agent Configuration And Execution
+
+Purpose:
+
+Make agent configuration, tools, skills, schedules, and workflows understandable and controllable.
+
+PR-sized gates:
+
+- Personas detail/edit/import/export workflows.
+- Skills discovery/import/detail/validation/edit workflow following the Agent Skills `SKILL.md` model.
+- Skills attachment to Console, Workflows, or Personas where appropriate.
+- MCP readiness, available tools/resources, and Console launch/follow integration.
+- ACP runtime/session readiness, separate from MCP.
+- Schedules service adapter with pause/resume/retry/history.
+- Workflows service adapter with step status, inputs, outputs, approvals, and recovery.
+- Home active-work controls connected to real schedule/workflow/agent items.
+
+Done when:
+
+- A user can configure the behavior, capabilities, tools, schedule, and procedure for an agent-assisted task.
+- Runtime readiness is visible before launch.
+- Failures show cause, impact, and recovery action.
+- Console remains the live execution surface.
+
+## Phase 5: Server-Parity And Live Integrations
+
+Purpose:
+
+Close the highest-value local/server parity gaps without losing local-first usability.
+
+PR-sized gates:
+
+- Compare Chatbook modules against adjacent `tldw_server2` capabilities.
+- Prioritize parity gaps by user value and local feasibility.
+- Wire server-backed Library/Search/RAG capabilities where useful.
+- Expand W+C watchlist, collection-feed, alert-rule, feed/WebSub, retry/backoff, and history behavior.
+- Add server/local sync or import paths for Personas, Skills, sources, and artifacts where appropriate.
+- Add live event producers for Console and Home where services support them.
+- Record explicit parity coverage and residual gaps.
+
+Done when:
+
+- Highest-value server-backed workflows have local equivalents, server-backed paths, or honest unavailable states.
+- Users can see whether local, server, workspace, remote-only, or dry-run authority applies.
+- Remaining parity gaps are documented and not hidden behind misleading UI.
+
+## Phase 6: Release Hardening And Documentation
+
+Purpose:
+
+Convert the matured product into a release-candidate state.
+
+PR-sized gates:
+
+- Full first-time user walkthrough.
+- Full power-user replay across at least 5 core workflows.
+- Nielsen heuristic audit replay.
+- Keyboard/focus and accessibility sweep.
+- Visual polish against the agentic terminal design system.
+- Error/recovery copy review.
+- Docs/onboarding/help updates.
+- Regression suite hardening and CI review.
+
+Done when:
+
+- Core workflows complete in the running app.
+- Layout is coherent across supported terminal sizes.
+- Failure states are actionable.
+- Docs match current behavior.
+- P0 and P1 defects are closed or explicitly accepted with owner and follow-up.
+
+## Workflow Matrix For Planning
+
+Each implementation plan should preserve these workflow families:
+
+| Workflow | Primary Modules | Expected Result |
+| --- | --- | --- |
+| First-run orientation | Home, Settings, Console, Library | User knows what is configured, what is missing, and where to start. |
+| Grounded answer | Library, Search/RAG, Console, Artifacts | User asks against sources, sees evidence, and saves/reopens output. |
+| Study loop | Library, Workspaces, flashcards, quizzes, Console | User turns source material into study artifacts and can reuse context. |
+| Agent run | Personas, Skills, MCP, ACP, Schedules, Workflows, Console | User configures, launches, approves, monitors, and recovers agentic work. |
+| Monitoring loop | W+C, Schedules, Home, Console, Artifacts | User watches sources, reviews changes, acts on alerts, and saves outputs. |
+| Recovery loop | Home, Console, Settings, affected module | User understands blocker cause and can retry, configure, pause, or route elsewhere. |
+
+## QA And Evidence Rules
+
+Every child task should include:
+
+- focused automated tests for the changed seam.
+- manual walkthrough of the running app.
+- keyboard/focus check when controls or navigation change.
+- visual check for layout, label clarity, and disabled/recovery states.
+- clean-environment or empty-state check when setup/configuration is affected.
+- QA note under `Docs/superpowers/qa/product-maturity/phase-N/`.
+
+Suggested QA artifact structure:
+
+```markdown
+# Phase N Gate QA
+
+Date:
+Branch/Commit:
+Task:
+Workflow:
+
+## What Was Verified
+
+## Automated Evidence
+
+## Manual Walkthrough
+
+## Visual/Focus Notes
+
+## Defects Found
+
+## Residual Risk
+
+## Exit Decision
+```
+
+## Backlog Planning Model
+
+After this spec is accepted, create Backlog.md tasks with this shape:
+
+- parent task for each phase.
+- child task for each gate only when it can fit in one PR.
+- each child task must be atomic, testable, and independently reviewable.
+- child tasks must not depend on future uncreated tasks.
+- every task acceptance criteria should include a QA walkthrough proving functionality works in the running app.
+
+Suggested phase labels:
+
+- `product-maturity`
+- `phase-1-qa-baseline`
+- `phase-2-core-agentic-loop`
+- `phase-3-knowledge-study`
+- `phase-4-agent-execution`
+- `phase-5-server-parity`
+- `phase-6-release-hardening`
+
+## Risks And Mitigations
+
+- **Risk: roadmap becomes too broad to execute.** Mitigate by creating only PR-sized child tasks and keeping future child tasks uncreated until scoped.
+- **Risk: QA becomes documentation-only.** Mitigate by requiring running-app walkthrough evidence and focused regression tests before completion.
+- **Risk: Console absorbs too much configuration.** Mitigate by keeping destinations responsible for setup/preparation and Console responsible for live execution.
+- **Risk: local and server authority blur.** Mitigate with explicit source-authority labels and parity notes.
+- **Risk: beginner guidance slows power users.** Mitigate with progressive disclosure, command palette discoverability, and keyboard-first flows.
+- **Risk: ACP and MCP collapse conceptually.** Mitigate by keeping MCP as tools/resources and ACP as agent/session runtime.
+
+## Open Questions For Implementation Planning
+
+- Which clean-run harness should become canonical for product-maturity QA?
+- Which single core-loop proof should anchor Phase 1?
+- Which `tldw_server2` parity inventory should Phase 5 use as the source of truth?
+- Which terminal sizes should be mandatory for visual QA?
+- Which five power-user workflows should become recurring release replay tests?
+
+## Transition Criteria To Implementation Planning
+
+Proceed to implementation planning only after:
+
+- this spec is reviewed and accepted.
+- any spec-review issues are resolved.
+- the first Backlog.md parent/child task set is approved.
+- Phase 1 scope is narrowed to a small first PR.

--- a/Docs/superpowers/specs/2026-05-05-product-maturity-phased-roadmap-design.md
+++ b/Docs/superpowers/specs/2026-05-05-product-maturity-phased-roadmap-design.md
@@ -1,7 +1,7 @@
 # Product Maturity Phased Roadmap Design
 
 Date: 2026-05-05
-Status: User-approved design, pending spec review and implementation planning
+Status: User-approved design; spec review approved; pending implementation planning
 Primary Repo: `tldw_chatbook`
 Source Baseline: `dev` at `9c4b3bf0` (`Close Phase 6 Nielsen shell audit (#246)`)
 Related Specs:
@@ -100,6 +100,19 @@ Backlog.md should track execution after this spec is accepted:
 - child tasks should include "QA walkthrough verifies the running app is usable" as acceptance criteria.
 - phase completion requires evidence, not just task status.
 
+## Severity Mapping
+
+Product-maturity QA should keep the existing Unified Shell defect taxonomy and map P0/P1 closure rules to it:
+
+| Priority | Taxonomy | Meaning | Phase Exit Rule |
+| --- | --- | --- | --- |
+| P0 | `blocker` | Prevents basic use, traps the user, corrupts or loses user work, or makes a required workflow impossible. | Must be fixed before the phase or gate can close. |
+| P1 | `workflow-degradation` | Breaks or seriously slows a core workflow but leaves a workaround. | Must be fixed before phase close unless explicitly accepted with owner, rationale, and follow-up task. |
+| P2 | `recoverability` | A blocked or error state exists, but recovery copy, ownership, or next action is unclear. | Can remain only with documented residual risk and a scoped follow-up. |
+| P3 | `polish` | Visual, wording, density, or minor interaction issue that does not block completion. | Can remain as backlog polish if it does not hide status, source authority, or recovery action. |
+
+QA evidence should use one taxonomy label per defect and may also include the P-level when useful for release decisions.
+
 ## Product Model
 
 The roadmap should preserve this product model:
@@ -116,6 +129,12 @@ The roadmap should preserve this product model:
 - **ACP**: separate agent/session protocol runtime and live agent collaboration model.
 - **Skills**: Agent Skills-compatible capability packs built around `SKILL.md`, bundled resources, validation, import, and attachment to Console/workflows.
 - **Settings**: global configuration, providers, privacy, runtime policy, optional dependencies, and diagnostics.
+
+Workspaces and Collections must not become duplicate grouping concepts:
+
+- **Workspaces** define broad user context and scope across sources, chats, notes, artifacts, study outputs, settings, and long-running work.
+- **Collections** define reusable source sets inside W+C/Library that can feed RAG, study generation, schedules, workflows, and monitoring.
+- A source can belong to a workspace and one or more collections, but implementation plans must identify which surface owns create, edit, and review actions for each grouping type.
 
 ## Phase Roadmap
 
@@ -142,6 +161,13 @@ PR-sized gates:
 - Visual broken-state audit for clipped panels, unreadable labels, low-contrast states, and misleading disabled controls.
 - Empty/error/setup-state coverage for missing API keys, optional dependencies, server connections, and local runtime blockers.
 - Narrow core-loop proof: one source or query can reach Console and produce a recoverable output or honest blocker.
+
+First execution boundary:
+
+- The first implementation plan should cover roadmap task setup plus **Phase 1.1: Canonical Product-Maturity QA Harness** only.
+- Phase 1.1 should create the reusable clean-run protocol, QA evidence template, severity mapping, selected terminal-size matrix, and one smoke command or test entry point.
+- Phase 1.1 should not attempt to complete the full first-run, focus, visual, empty-state, and core-loop audits in one PR.
+- Later Phase 1 child tasks should each own one independently reviewable gate from the list above.
 
 Done when:
 
@@ -350,6 +376,18 @@ Suggested phase labels:
 - Which terminal sizes should be mandatory for visual QA?
 - Which five power-user workflows should become recurring release replay tests?
 
+## Planning Decisions Required Before Phase 1 Execution
+
+Resolve these before creating implementation tasks beyond the Phase 1 parent and Phase 1.1 harness task:
+
+| Decision | Recommended Default | Why It Matters |
+| --- | --- | --- |
+| Canonical clean-run harness | Fresh `HOME`/`XDG_*` run using the existing Textual test pilot where possible, with manual terminal replay when visual/focus behavior cannot be proven in tests. | Prevents app-state leakage and makes first-run regressions reproducible. |
+| Phase 1 core-loop proof | Library or Search/RAG source/query stages context into Console and either produces a grounded answer path or an honest missing-runtime blocker. | Anchors QA in the product center without overloading Phase 1 with full feature depth. |
+| Terminal-size matrix | Minimum supported compact size, common laptop terminal, and large power-user workspace. | Prevents layouts that only work on the developer's current terminal dimensions. |
+| Recurring power-user workflows | Grounded answer, study loop, agent run, monitoring loop, and recovery loop from the workflow matrix. | Keeps later QA tied to repeated expert usage, not shallow navigation. |
+| Severity policy | Use the P0/P1/P2/P3 mapping in this spec. | Ensures the team knows which findings block phase completion. |
+
 ## Transition Criteria To Implementation Planning
 
 Proceed to implementation planning only after:
@@ -357,4 +395,4 @@ Proceed to implementation planning only after:
 - this spec is reviewed and accepted.
 - any spec-review issues are resolved.
 - the first Backlog.md parent/child task set is approved.
-- Phase 1 scope is narrowed to a small first PR.
+- Phase 1 scope is narrowed to roadmap task setup plus Phase 1.1 only.

--- a/Docs/superpowers/trackers/product-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/product-maturity-roadmap.md
@@ -1,0 +1,58 @@
+# Product Maturity Roadmap
+
+Date: 2026-05-05
+Status: Phase 1.1 in progress
+Source Branch: `dev`
+Source Spec: `Docs/superpowers/specs/2026-05-05-product-maturity-phased-roadmap-design.md`
+
+## Purpose
+
+Track product-depth maturity after Unified Shell Phase 6 so rendered screens, clickable controls, and complete usable workflows stay distinct.
+
+## Current Verified Baseline
+
+- Unified Shell Phase 0-6 are verified in `Docs/superpowers/trackers/unified-shell-maturity-roadmap.md`.
+- Product-maturity work starts with a QA baseline before new feature depth.
+- Phase 1.1 creates the reusable harness only; it does not complete the full first-run, focus, visual, empty-state, or core-loop audits.
+
+## Severity Policy
+
+| Priority | Taxonomy | Exit Rule |
+| --- | --- | --- |
+| P0 | `blocker` | Must be fixed before the phase or gate can close. |
+| P1 | `workflow-degradation` | Must be fixed before phase close unless explicitly accepted with owner, rationale, and follow-up task. |
+| P2 | `recoverability` | May remain only with residual risk and a scoped follow-up. |
+| P3 | `polish` | May remain as backlog polish if it does not hide status, source authority, or recovery action. |
+
+## Backlog Task Hierarchy
+
+- Phase 1: QA Baseline And Usability Guardrails - `TASK-8`
+- Phase 1.1: Canonical QA Harness - `TASK-8.1`
+- Phase 2: Core Agentic Loop - `TASK-9`
+- Phase 3: Knowledge And Study Workflows - `TASK-10`
+- Phase 4: Agent Configuration And Execution - `TASK-11`
+- Phase 5: Server-Parity And Live Integrations - `TASK-12`
+- Phase 6: Release Hardening And Documentation - `TASK-13`
+
+## QA Evidence Index
+
+| Phase | Evidence Path | Status |
+| --- | --- | --- |
+| Phase 1 | `Docs/superpowers/qa/product-maturity/phase-1/` | in_progress |
+
+## Phase Overview
+
+| Phase | Goal | Status | Backlog Tasks | QA Evidence | Residual Risk |
+| --- | --- | --- | --- | --- | --- |
+| Phase 1: QA Baseline And Usability Guardrails | Establish clean-run usability guardrails before feature depth. | in_progress | `TASK-8`, Phase 1.1 (`TASK-8.1`) | `phase-1/` | Phase 1.1 is harness-only; product walkthroughs remain future Phase 1 gates. |
+| Phase 2: Core Agentic Loop | Complete source/question to grounded Console to Artifact/Chatbook loop. | planned | `TASK-9` | not-started | Depends on Phase 1 QA baseline. |
+| Phase 3: Knowledge And Study Workflows | Mature ingest, organize, retrieve, study, and reuse workflows. | planned | `TASK-10` | not-started | Depends on Phase 2 core loop and later task slicing. |
+| Phase 4: Agent Configuration And Execution | Mature Personas, Skills, MCP, ACP, Schedules, and Workflows. | planned | `TASK-11` | not-started | Depends on service adapters and runtime readiness. |
+| Phase 5: Server-Parity And Live Integrations | Close high-value `tldw_server2` parity gaps. | planned | `TASK-12` | not-started | Requires parity inventory. |
+| Phase 6: Release Hardening And Documentation | Reach release-candidate usability. | planned | `TASK-13` | not-started | Depends on earlier phase evidence. |
+
+## Phase 1.1 Evidence
+
+- `Docs/superpowers/qa/product-maturity/phase-1/walkthrough-protocol.md`
+- `Docs/superpowers/qa/product-maturity/phase-1/walkthrough-template.md`
+- `Docs/superpowers/qa/product-maturity/phase-1/2026-05-05-phase-1-1-harness-smoke.md`

--- a/Docs/superpowers/trackers/product-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/product-maturity-roadmap.md
@@ -1,7 +1,7 @@
 # Product Maturity Roadmap
 
 Date: 2026-05-05
-Status: Phase 1.1 in progress
+Status: Phase 1.1 verified; Phase 1 in progress
 Source Branch: `dev`
 Source Spec: `Docs/superpowers/specs/2026-05-05-product-maturity-phased-roadmap-design.md`
 
@@ -52,6 +52,8 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 | Phase 6: Release Hardening And Documentation | Reach release-candidate usability. | planned | `TASK-13` | not-started | Depends on earlier phase evidence. |
 
 ## Phase 1.1 Evidence
+
+Status: verified
 
 - `Docs/superpowers/qa/product-maturity/phase-1/walkthrough-protocol.md`
 - `Docs/superpowers/qa/product-maturity/phase-1/walkthrough-template.md`

--- a/Tests/UI/test_product_maturity_phase1_harness.py
+++ b/Tests/UI/test_product_maturity_phase1_harness.py
@@ -1,0 +1,137 @@
+"""Product maturity Phase 1.1 QA harness contract."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SPEC = Path("Docs/superpowers/specs/2026-05-05-product-maturity-phased-roadmap-design.md")
+TRACKER = Path("Docs/superpowers/trackers/product-maturity-roadmap.md")
+BACKLOG_DOC = Path("backlog/docs/product-maturity-roadmap.md")
+QA_ROOT = Path("Docs/superpowers/qa/product-maturity")
+PHASE_1_ROOT = QA_ROOT / "phase-1"
+PHASE_1_README = PHASE_1_ROOT / "README.md"
+PROTOCOL = PHASE_1_ROOT / "walkthrough-protocol.md"
+TEMPLATE = PHASE_1_ROOT / "walkthrough-template.md"
+SMOKE = PHASE_1_ROOT / "2026-05-05-phase-1-1-harness-smoke.md"
+BACKLOG_TASKS = Path("backlog/tasks")
+
+REQUIRED_TEMPLATE_SECTIONS = {
+    "Environment",
+    "Task Or Phase",
+    "Entry Path",
+    "Terminal Size",
+    "Clean-Run Setup",
+    "Steps Attempted",
+    "Visual/Focus Notes",
+    "Keyboard Path Result",
+    "Mouse/Click Path Result",
+    "Functional Result",
+    "Defects Found",
+    "Evidence",
+    "Residual Risk",
+    "Exit Decision",
+    "Product QA Boundary",
+}
+
+REQUIRED_SEVERITIES = {
+    "blocker",
+    "workflow-degradation",
+    "recoverability",
+    "polish",
+}
+
+REQUIRED_PRIORITY_LABELS = {"P0", "P1", "P2", "P3"}
+
+
+def _text(path: Path) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def _task_text_containing(title_fragment: str) -> str:
+    matches: list[str] = []
+    for path in (REPO_ROOT / BACKLOG_TASKS).glob("*.md"):
+        text = path.read_text(encoding="utf-8")
+        if title_fragment in text:
+            matches.append(text)
+    assert len(matches) == 1, f"expected one task containing {title_fragment!r}, found {len(matches)}"
+    return matches[0]
+
+
+def _phase_row(markdown: str, phase_title: str) -> list[str]:
+    for line in markdown.splitlines():
+        if not line.startswith("|"):
+            continue
+        columns = [column.strip() for column in line.strip().strip("|").split("|")]
+        if columns and columns[0] == phase_title:
+            return columns
+    raise AssertionError(f"{phase_title!r} row not found")
+
+
+def test_product_maturity_phase_one_harness_files_exist() -> None:
+    for path in (SPEC, TRACKER, BACKLOG_DOC, QA_ROOT / "README.md", PHASE_1_README, PROTOCOL, TEMPLATE, SMOKE):
+        assert (REPO_ROOT / path).exists(), f"{path} should exist"
+
+
+def test_product_maturity_template_captures_required_fields_and_severity() -> None:
+    text = _text(TEMPLATE)
+
+    for section in REQUIRED_TEMPLATE_SECTIONS:
+        assert f"## {section}" in text
+    for severity in REQUIRED_SEVERITIES:
+        assert severity in text
+    for priority in REQUIRED_PRIORITY_LABELS:
+        assert priority in text
+    assert "usable, not merely rendered" in text
+
+
+def test_product_maturity_protocol_defines_clean_run_and_terminal_matrix() -> None:
+    text = _text(PROTOCOL)
+
+    assert "python3 -m tldw_chatbook.app" in text
+    assert "Fresh HOME" in text
+    assert "XDG_CONFIG_HOME" in text
+    assert "XDG_DATA_HOME" in text
+    assert "minimum supported compact" in text
+    assert "common laptop terminal" in text
+    assert "large power-user workspace" in text
+    assert "render-only" in text
+    assert "click-event-only" in text
+    assert "Tests/UI/test_product_maturity_phase1_harness.py" in text
+
+
+def test_product_maturity_tracker_links_phase_one_harness_and_tasks() -> None:
+    tracker = _text(TRACKER)
+    phase_one_task = _task_text_containing("Product Maturity Phase 1: QA Baseline And Usability Guardrails")
+    phase_one_one_task = _task_text_containing("Product Maturity Phase 1.1: Canonical QA Harness")
+
+    assert str(SPEC) in tracker
+    assert str(PROTOCOL) in tracker
+    assert str(TEMPLATE) in tracker
+    assert str(SMOKE) in tracker
+    assert "Phase 1.1" in tracker
+    assert "<PHASE_" not in tracker
+
+    phase_one_row = _phase_row(tracker, "Phase 1: QA Baseline And Usability Guardrails")
+    assert phase_one_row[2] in {"planned", "in_progress"}
+    assert "Phase 1.1" in phase_one_row[3]
+    assert "TASK-" in phase_one_row[3]
+    assert "phase-1/" in phase_one_row[4]
+
+    assert "QA walkthrough verifies the running app is usable" in phase_one_task
+    assert "Product-maturity QA protocol defines clean-run setup" in phase_one_one_task
+    assert "Harness smoke evidence states" in phase_one_one_task
+
+
+def test_phase_one_one_smoke_evidence_records_harness_only_boundary() -> None:
+    text = _text(SMOKE)
+
+    assert "Phase 1.1" in text
+    assert "Canonical QA Harness" in text
+    assert "Product QA Boundary" in text
+    assert re.search(r"harness[- ]only", text, re.IGNORECASE)
+    assert "does not complete the full product walkthrough" in text
+    assert "Tests/UI/test_product_maturity_phase1_harness.py" in text
+    assert "<PHASE_" not in text

--- a/Tests/UI/test_product_maturity_phase1_harness.py
+++ b/Tests/UI/test_product_maturity_phase1_harness.py
@@ -18,6 +18,9 @@ TEMPLATE = PHASE_1_ROOT / "walkthrough-template.md"
 SMOKE = PHASE_1_ROOT / "2026-05-05-phase-1-1-harness-smoke.md"
 BACKLOG_TASKS = Path("backlog/tasks")
 
+TASK_ID_RE = re.compile(r"`(TASK-[0-9]+(?:\.[0-9]+)*)`")
+FRONTMATTER_RE = re.compile(r"\A---\n(?P<body>.*?)\n---\n", re.DOTALL)
+
 REQUIRED_TEMPLATE_SECTIONS = {
     "Environment",
     "Task Or Phase",
@@ -50,14 +53,19 @@ def _text(path: Path) -> str:
     return (REPO_ROOT / path).read_text(encoding="utf-8")
 
 
-def _task_text_containing(title_fragment: str) -> str:
-    matches: list[str] = []
-    for path in (REPO_ROOT / BACKLOG_TASKS).glob("*.md"):
+def _task_ids_from_phase_row(row: list[str]) -> set[str]:
+    assert len(row) > 3, "phase row should include a task column"
+    return set(TASK_ID_RE.findall(row[3]))
+
+
+def _task_text_by_id(task_id: str) -> str:
+    id_line_re = re.compile(rf"^id:\s*['\"]?{re.escape(task_id)}['\"]?\s*$", re.MULTILINE)
+    for path in sorted((REPO_ROOT / BACKLOG_TASKS).glob("*.md")):
         text = path.read_text(encoding="utf-8")
-        if title_fragment in text:
-            matches.append(text)
-    assert len(matches) == 1, f"expected one task containing {title_fragment!r}, found {len(matches)}"
-    return matches[0]
+        frontmatter_match = FRONTMATTER_RE.match(text)
+        if frontmatter_match and id_line_re.search(frontmatter_match.group("body")):
+            return text
+    raise AssertionError(f"task {task_id!r} not found by YAML frontmatter id")
 
 
 def _phase_row(markdown: str, phase_title: str) -> list[str]:
@@ -104,8 +112,6 @@ def test_product_maturity_protocol_defines_clean_run_and_terminal_matrix() -> No
 
 def test_product_maturity_tracker_links_phase_one_harness_and_tasks() -> None:
     tracker = _text(TRACKER)
-    phase_one_task = _task_text_containing("Product Maturity Phase 1: QA Baseline And Usability Guardrails")
-    phase_one_one_task = _task_text_containing("Product Maturity Phase 1.1: Canonical QA Harness")
 
     assert str(SPEC) in tracker
     assert str(PROTOCOL) in tracker
@@ -115,6 +121,13 @@ def test_product_maturity_tracker_links_phase_one_harness_and_tasks() -> None:
     assert "<PHASE_" not in tracker
 
     phase_one_row = _phase_row(tracker, "Phase 1: QA Baseline And Usability Guardrails")
+    phase_one_task_ids = _task_ids_from_phase_row(phase_one_row)
+    assert len(phase_one_task_ids) == 2
+    phase_one_task_id = next(task_id for task_id in phase_one_task_ids if "." not in task_id)
+    phase_one_one_task_id = next(task_id for task_id in phase_one_task_ids if "." in task_id)
+    phase_one_task = _task_text_by_id(phase_one_task_id)
+    phase_one_one_task = _task_text_by_id(phase_one_one_task_id)
+
     assert phase_one_row[2] in {"planned", "in_progress"}
     assert "Phase 1.1" in phase_one_row[3]
     assert "TASK-" in phase_one_row[3]

--- a/backlog/docs/product-maturity-roadmap.md
+++ b/backlog/docs/product-maturity-roadmap.md
@@ -1,0 +1,17 @@
+# Product Maturity Roadmap
+
+The canonical product-maturity design spec lives at:
+
+`Docs/superpowers/specs/2026-05-05-product-maturity-phased-roadmap-design.md`
+
+The canonical product-maturity tracker lives at:
+
+`Docs/superpowers/trackers/product-maturity-roadmap.md`
+
+Durable QA evidence lives at:
+
+`Docs/superpowers/qa/product-maturity/`
+
+Backlog tasks in `backlog/tasks/` are PR-sized execution units. Parent tasks represent product-maturity phases; child tasks represent implementation or QA gates.
+
+Do not mark a product-maturity task or phase complete because UI renders or a button is clickable. Completion requires automated evidence, running-app QA evidence where product behavior is in scope, and a repo-tracked QA summary.

--- a/backlog/tasks/task-10 - Product-Maturity-Phase-3-Knowledge-And-Study-Workflows.md
+++ b/backlog/tasks/task-10 - Product-Maturity-Phase-3-Knowledge-And-Study-Workflows.md
@@ -1,0 +1,26 @@
+---
+id: TASK-10
+title: 'Product Maturity Phase 3: Knowledge And Study Workflows'
+status: To Do
+assignee: []
+created_date: '2026-05-05 15:11'
+labels:
+  - product-maturity
+  - phase-3-knowledge-study
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Mature ingest, organize, retrieve, study, and reuse workflows across Library, Workspaces, flashcards, quizzes, and collections.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 QA walkthrough verifies the running app is usable for this phase's target workflows.
+- [ ] #2 Focused regression evidence exists for changed seams.
+- [ ] #3 Repo-tracked QA evidence exists under Docs/superpowers/qa/product-maturity/.
+- [ ] #4 P0/P1 findings are fixed or explicitly accepted according to the spec severity policy.
+<!-- AC:END -->

--- a/backlog/tasks/task-11 - Product-Maturity-Phase-4-Agent-Configuration-And-Execution.md
+++ b/backlog/tasks/task-11 - Product-Maturity-Phase-4-Agent-Configuration-And-Execution.md
@@ -1,0 +1,26 @@
+---
+id: TASK-11
+title: 'Product Maturity Phase 4: Agent Configuration And Execution'
+status: To Do
+assignee: []
+created_date: '2026-05-05 15:11'
+labels:
+  - product-maturity
+  - phase-4-agent-execution
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make agent configuration, tools, skills, schedules, workflows, MCP, and ACP understandable and controllable.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 QA walkthrough verifies the running app is usable for this phase's target workflows.
+- [ ] #2 Focused regression evidence exists for changed seams.
+- [ ] #3 Repo-tracked QA evidence exists under Docs/superpowers/qa/product-maturity/.
+- [ ] #4 P0/P1 findings are fixed or explicitly accepted according to the spec severity policy.
+<!-- AC:END -->

--- a/backlog/tasks/task-12 - Product-Maturity-Phase-5-Server-Parity-And-Live-Integrations.md
+++ b/backlog/tasks/task-12 - Product-Maturity-Phase-5-Server-Parity-And-Live-Integrations.md
@@ -1,0 +1,26 @@
+---
+id: TASK-12
+title: 'Product Maturity Phase 5: Server-Parity And Live Integrations'
+status: To Do
+assignee: []
+created_date: '2026-05-05 15:11'
+labels:
+  - product-maturity
+  - phase-5-server-parity
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Close the highest-value local and server parity gaps where they materially improve local Chatbook use.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 QA walkthrough verifies the running app is usable for this phase's target workflows.
+- [ ] #2 Focused regression evidence exists for changed seams.
+- [ ] #3 Repo-tracked QA evidence exists under Docs/superpowers/qa/product-maturity/.
+- [ ] #4 P0/P1 findings are fixed or explicitly accepted according to the spec severity policy.
+<!-- AC:END -->

--- a/backlog/tasks/task-13 - Product-Maturity-Phase-6-Release-Hardening-And-Documentation.md
+++ b/backlog/tasks/task-13 - Product-Maturity-Phase-6-Release-Hardening-And-Documentation.md
@@ -1,0 +1,26 @@
+---
+id: TASK-13
+title: 'Product Maturity Phase 6: Release Hardening And Documentation'
+status: To Do
+assignee: []
+created_date: '2026-05-05 15:11'
+labels:
+  - product-maturity
+  - phase-6-release-hardening
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Convert the matured product into release-candidate usability with full walkthrough, power-user, visual, recovery, docs, and regression evidence.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 QA walkthrough verifies the running app is usable for this phase's target workflows.
+- [ ] #2 Focused regression evidence exists for changed seams.
+- [ ] #3 Repo-tracked QA evidence exists under Docs/superpowers/qa/product-maturity/.
+- [ ] #4 P0/P1 findings are fixed or explicitly accepted according to the spec severity policy.
+<!-- AC:END -->

--- a/backlog/tasks/task-8 - Product-Maturity-Phase-1-QA-Baseline-And-Usability-Guardrails.md
+++ b/backlog/tasks/task-8 - Product-Maturity-Phase-1-QA-Baseline-And-Usability-Guardrails.md
@@ -1,0 +1,26 @@
+---
+id: TASK-8
+title: 'Product Maturity Phase 1: QA Baseline And Usability Guardrails'
+status: To Do
+assignee: []
+created_date: '2026-05-05 15:11'
+labels:
+  - product-maturity
+  - phase-1-qa-baseline
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Establish clean-run usability guardrails before additional product-depth work.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 QA walkthrough verifies the running app is usable for this phase's target workflows.
+- [ ] #2 Focused regression evidence exists for changed seams.
+- [ ] #3 Repo-tracked QA evidence exists under Docs/superpowers/qa/product-maturity/.
+- [ ] #4 P0/P1 findings are fixed or explicitly accepted according to the spec severity policy.
+<!-- AC:END -->

--- a/backlog/tasks/task-8.1 - Product-Maturity-Phase-1.1-Canonical-QA-Harness.md
+++ b/backlog/tasks/task-8.1 - Product-Maturity-Phase-1.1-Canonical-QA-Harness.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-8.1
 title: 'Product Maturity Phase 1.1: Canonical QA Harness'
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-05-05 15:11'
+updated_date: '2026-05-05 15:12'
 labels:
   - product-maturity
   - phase-1-qa-baseline
@@ -26,3 +27,13 @@ Create the reusable product-maturity QA protocol, template, evidence index, seve
 - [ ] #4 Focused pytest coverage verifies the protocol, template, tracker, and Backlog anchors exist and preserve the harness-only boundary.
 - [ ] #5 Harness smoke evidence states that Phase 1.1 verifies the QA harness only and does not complete the full product walkthrough.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add the focused product-maturity QA harness regression test and confirm it fails before harness docs exist.
+2. Create the product-maturity tracker, QA evidence root, Phase 1 protocol, template, README, and harness smoke evidence.
+3. Run the focused harness test and adjacent Unified Shell QA protocol regression.
+4. Update Phase 1.1 tracker and evidence status after verification.
+5. Mark Phase 1.1 acceptance criteria complete with implementation notes while leaving Phase 1 open.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-8.1 - Product-Maturity-Phase-1.1-Canonical-QA-Harness.md
+++ b/backlog/tasks/task-8.1 - Product-Maturity-Phase-1.1-Canonical-QA-Harness.md
@@ -1,0 +1,28 @@
+---
+id: TASK-8.1
+title: 'Product Maturity Phase 1.1: Canonical QA Harness'
+status: To Do
+assignee: []
+created_date: '2026-05-05 15:11'
+labels:
+  - product-maturity
+  - phase-1-qa-baseline
+dependencies: []
+parent_task_id: TASK-8
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create the reusable product-maturity QA protocol, template, evidence index, severity mapping, and smoke evidence so later usability work can be verified against the running app rather than render-only checks.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Product-maturity QA protocol defines clean-run setup, entry commands, terminal-size matrix, severity mapping, and evidence rules.
+- [ ] #2 Product-maturity QA template captures environment, entry path, steps, visual/focus notes, functional result, defects, evidence, residual risk, and exit decision.
+- [ ] #3 Product-maturity tracker links the spec, Backlog tasks, Phase 1.1 evidence, and residual risks.
+- [ ] #4 Focused pytest coverage verifies the protocol, template, tracker, and Backlog anchors exist and preserve the harness-only boundary.
+- [ ] #5 Harness smoke evidence states that Phase 1.1 verifies the QA harness only and does not complete the full product walkthrough.
+<!-- AC:END -->

--- a/backlog/tasks/task-8.1 - Product-Maturity-Phase-1.1-Canonical-QA-Harness.md
+++ b/backlog/tasks/task-8.1 - Product-Maturity-Phase-1.1-Canonical-QA-Harness.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-8.1
 title: 'Product Maturity Phase 1.1: Canonical QA Harness'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-05 15:11'
-updated_date: '2026-05-05 15:12'
+updated_date: '2026-05-05 15:14'
 labels:
   - product-maturity
   - phase-1-qa-baseline
@@ -21,11 +21,11 @@ Create the reusable product-maturity QA protocol, template, evidence index, seve
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Product-maturity QA protocol defines clean-run setup, entry commands, terminal-size matrix, severity mapping, and evidence rules.
-- [ ] #2 Product-maturity QA template captures environment, entry path, steps, visual/focus notes, functional result, defects, evidence, residual risk, and exit decision.
-- [ ] #3 Product-maturity tracker links the spec, Backlog tasks, Phase 1.1 evidence, and residual risks.
-- [ ] #4 Focused pytest coverage verifies the protocol, template, tracker, and Backlog anchors exist and preserve the harness-only boundary.
-- [ ] #5 Harness smoke evidence states that Phase 1.1 verifies the QA harness only and does not complete the full product walkthrough.
+- [x] #1 Product-maturity QA protocol defines clean-run setup, entry commands, terminal-size matrix, severity mapping, and evidence rules.
+- [x] #2 Product-maturity QA template captures environment, entry path, steps, visual/focus notes, functional result, defects, evidence, residual risk, and exit decision.
+- [x] #3 Product-maturity tracker links the spec, Backlog tasks, Phase 1.1 evidence, and residual risks.
+- [x] #4 Focused pytest coverage verifies the protocol, template, tracker, and Backlog anchors exist and preserve the harness-only boundary.
+- [x] #5 Harness smoke evidence states that Phase 1.1 verifies the QA harness only and does not complete the full product walkthrough.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -37,3 +37,9 @@ Create the reusable product-maturity QA protocol, template, evidence index, seve
 4. Update Phase 1.1 tracker and evidence status after verification.
 5. Mark Phase 1.1 acceptance criteria complete with implementation notes while leaving Phase 1 open.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the Phase 1.1 product-maturity QA harness. Added product-maturity Backlog anchors for Phase 1 through Phase 6 and a Phase 1.1 child task. Added Docs/superpowers/trackers/product-maturity-roadmap.md, product-maturity QA evidence root, Phase 1 protocol/template, README, and harness smoke evidence. Added Tests/UI/test_product_maturity_phase1_harness.py to lock the harness, tracker, severity mapping, and harness-only QA boundary. Phase 1.1 verifies harness readiness only; full first-run, visual/focus, empty-state, and core-loop walkthroughs remain future Phase 1 gates.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-9 - Product-Maturity-Phase-2-Core-Agentic-Loop.md
+++ b/backlog/tasks/task-9 - Product-Maturity-Phase-2-Core-Agentic-Loop.md
@@ -1,0 +1,26 @@
+---
+id: TASK-9
+title: 'Product Maturity Phase 2: Core Agentic Loop'
+status: To Do
+assignee: []
+created_date: '2026-05-05 15:11'
+labels:
+  - product-maturity
+  - phase-2-core-agentic-loop
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make the central source/question to grounded Console to Artifact or Chatbook loop complete enough for daily use.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 QA walkthrough verifies the running app is usable for this phase's target workflows.
+- [ ] #2 Focused regression evidence exists for changed seams.
+- [ ] #3 Repo-tracked QA evidence exists under Docs/superpowers/qa/product-maturity/.
+- [ ] #4 P0/P1 findings are fixed or explicitly accepted according to the spec severity policy.
+<!-- AC:END -->


### PR DESCRIPTION
## Summary

- Adds product-maturity Backlog anchors for Phase 1 through Phase 6 and closes Phase 1.1 harness setup.
- Adds product-maturity tracker and QA evidence docs for Phase 1.1.
- Adds focused pytest coverage to prevent harness/tracker drift.

## Verification

- python3 -m pytest Tests/UI/test_product_maturity_phase1_harness.py -q
- python3 -m pytest Tests/UI/test_unified_shell_qa_protocol.py -q
- git diff --check

## Residual Risk

- Phase 1.1 is harness-only.
- Full first-run, keyboard/focus, visual, empty/error state, and core-loop product audits remain future Phase 1 tasks.