### PR TITLE
Verify product maturity Phase 1.5 visual audit

### DIFF
--- a/Docs/superpowers/qa/product-maturity/phase-1/2026-05-05-phase-1-5-visual-broken-state-audit.md
+++ b/Docs/superpowers/qa/product-maturity/phase-1/2026-05-05-phase-1-5-visual-broken-state-audit.md
@@ -1,0 +1,123 @@
+# Product Maturity Phase 1.5 Visual Broken-State Audit
+
+## Environment
+
+- Date: 2026-05-05
+- Branch: codex/product-maturity-phase1-5-visual-audit
+- Commit: Phase 1.5 execution worktree before final PR commit
+- Python version: Python 3.12.11
+- Runtime source: running Textual app through the app test pilot
+- Config/home directory: fresh pytest temporary directories
+
+## Task Or Phase
+
+- Backlog task: TASK-8.5
+- Phase: Phase 1.5
+- Destination or workflow: Visual Broken-State Audit
+
+## Entry Path
+
+- Launch command, direct route, command palette path, focused mounted test, or manual terminal replay: clean first-run app test with `_first_run=True`, configured default route set to Console, splash disabled, then screen-navigation routing to every top-level destination.
+
+## Terminal Size
+
+- compact: 100x32
+- laptop: 140x40
+- large: 180x50
+
+## Clean-Run Setup
+
+- Fresh HOME: `<tmp>/home`
+- XDG_CONFIG_HOME: `<tmp>/xdg-config`
+- XDG_DATA_HOME: `<tmp>/xdg-data`
+- XDG_CACHE_HOME: `<tmp>/xdg-cache`
+- Reused state: none
+
+## Steps Attempted
+
+1. Launched the Textual app from fresh HOME and XDG directories.
+2. Verified first-run routing opened Home before the configured Console default.
+3. Routed through every top-level shell destination at compact, laptop, and large terminal sizes.
+4. Waited for stable shell chrome after async destination refreshes before recording visual state.
+5. Exported an in-memory SVG screenshot for each destination and size.
+6. Checked each rendered destination for non-empty body content, intact navigation chrome, `Ctrl+P` fallback hint, active destination state, traceback/unhandled-exception text, and raw object repr leakage.
+
+## Visual Size Matrix
+
+| Size | Dimensions | Destination count | SVG screenshot export | Result |
+| --- | --- | ---: | --- | --- |
+| compact | 100x32 | 12 | in-memory per destination | pass |
+| laptop | 140x40 | 12 | in-memory per destination | pass |
+| large | 180x50 | 12 | in-memory per destination | pass |
+
+## Destination Probe
+
+| Destination | Visual result |
+| --- | --- |
+| `home` | non-empty content, shared chrome, fallback hint, active state |
+| `console` | non-empty content, shared chrome, fallback hint, active state |
+| `library` | non-empty content, shared chrome, fallback hint, active state |
+| `artifacts` | non-empty content, shared chrome, fallback hint, active state |
+| `personas` | non-empty content, shared chrome, fallback hint, active state |
+| `watchlists_collections` | non-empty content, shared chrome, fallback hint, active state |
+| `schedules` | non-empty content, shared chrome, fallback hint, active state |
+| `workflows` | non-empty content, shared chrome, fallback hint, active state |
+| `mcp` | non-empty content, shared chrome, fallback hint, active state |
+| `acp` | non-empty content, shared chrome, fallback hint, active state |
+| `skills` | non-empty content, shared chrome, fallback hint, active state |
+| `settings` | non-empty content, shared chrome, fallback hint, active state |
+
+## Visual/Focus Notes
+
+- Layout: top-level destinations mount body content inside `#screen-content` with shared navigation chrome.
+- Clipping: no blank, traceback, or unmounted-content state was detected by SVG export and DOM assertions across compact, laptop, and large sizes.
+- Async refresh: Schedules and Workflows can refresh after mount; the audit waits for full navigation chrome before snapshot export.
+- Labels: the `Ctrl+P` overflow/fallback hint remains present across the size matrix.
+- Disabled or blocked states: blocked Console follow/launch actions remain visible as disabled controls with explanatory copy.
+
+## Keyboard Path Result
+
+- Completed, blocked with recovery, failed, or not tested: not retested here; Phase 1.4 already verifies keyboard reachability. This gate confirms the same destinations remain visually inspectable after routing.
+
+## Mouse/Click Path Result
+
+- Completed, blocked with recovery, failed, or not tested: not the target of this gate; Phase 1.3 already covers top-level button activation at the large layout, and Phase 1.4 covers keyboard fallback for overflow.
+
+## Functional Result
+
+- Completed workflow: all top-level destination shells can be visually rendered and exported across the supported size matrix.
+- Honest blocked state: optional backend/data-dependent states remain visibly blocked with recovery copy where available.
+- Failed workflow: none found for this Phase 1.5 scope.
+- Recovery path: use `Ctrl+P` when compact layouts make direct top navigation inefficient.
+
+## Defects Found
+
+- `blocker` / P0: none.
+- `workflow-degradation` / P1: none. No P0/P1 visual broken-state blockers were found.
+- `recoverability` / P2: live optional service/database setup states still need a dedicated empty/error/setup-state pass.
+- `polish` / P3: no screenshot files were retained because in-memory SVG screenshot export plus structural assertions were sufficient for this gate.
+
+## Evidence
+
+- Screenshots: in-memory SVG screenshot export for each top-level destination at compact, laptop, and large sizes; no file artifacts retained because no visual defect required illustration.
+- Logs: pytest captured standard Textual startup logs.
+- Probe JSON: not applicable.
+- Test command: `../../.venv/bin/python -m pytest Tests/UI/test_product_maturity_phase1_visual_audit.py -q` -> 5 passed.
+- Phase 1 regression: `../../.venv/bin/python -m pytest Tests/UI/test_product_maturity_phase1_harness.py Tests/UI/test_product_maturity_phase1_first_run.py Tests/UI/test_product_maturity_phase1_navigation_smoke.py Tests/UI/test_product_maturity_phase1_keyboard_focus.py Tests/UI/test_product_maturity_phase1_visual_audit.py -q` -> 31 passed.
+- Related shell regression: `../../.venv/bin/python -m pytest Tests/UI/test_command_palette_basic.py Tests/UI/test_shell_product_model_visibility.py Tests/UI/test_app_footer_shortcut_context.py -q` -> 14 passed.
+- Related PRs or commits: Phase 1.5 execution branch.
+
+## Residual Risk
+
+- Untested live server/API paths: no live backend calls are part of this gate.
+- Optional dependency limits: optional dependency setup screens were not exhaustively replayed.
+- Environment limits: screenshot files were not saved because no specific visual defect needed annotation.
+- Follow-up tasks: Remaining Phase 1 gates are empty/error/setup-state coverage and narrow core-loop proof.
+
+## Exit Decision
+
+- Pass for Phase 1.5 scope.
+
+## Product QA Boundary
+
+This walkthrough verifies that the top-level shell destinations are visually inspectable and do not collapse into blank, traceback, or unexplained broken states across compact, laptop, and large terminal sizes. It proves visual/chrome integrity, not detailed workflows inside every destination or the Phase 2 grounded Console to Artifact/Chatbook loop.

--- a/Docs/superpowers/qa/product-maturity/phase-1/README.md
+++ b/Docs/superpowers/qa/product-maturity/phase-1/README.md
@@ -38,3 +38,11 @@ Phase 1.4 keyboard/focus status: verified
 - `2026-05-05-phase-1-4-keyboard-focus.md`
 
 Phase 1.4 verifies clean-run keyboard reachability for top-level navigation and the first-run setup action. It does not complete the full visual broken-state, empty/error/setup-state, or core-loop audits.
+
+Phase 1.5 evidence:
+
+Phase 1.5 visual broken-state status: verified
+
+- `2026-05-05-phase-1-5-visual-broken-state-audit.md`
+
+Phase 1.5 verifies clean-run visual/chrome integrity across compact, laptop, and large terminal sizes for every top-level destination. It does not complete the full empty/error/setup-state or core-loop audits.

--- a/Docs/superpowers/trackers/product-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/product-maturity-roadmap.md
@@ -1,7 +1,7 @@
 # Product Maturity Roadmap
 
 Date: 2026-05-05
-Status: Phase 1.4 verified; Phase 1 in progress
+Status: Phase 1.5 verified; Phase 1 in progress
 Source Branch: `dev`
 Source Spec: `Docs/superpowers/specs/2026-05-05-product-maturity-phased-roadmap-design.md`
 
@@ -17,6 +17,7 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 - Phase 1.2 verifies clean first-run launch and setup orientation only; broader Phase 1 gates remain open.
 - Phase 1.3 verifies top-level destination reachability only; keyboard/focus, visual, empty/error/setup, and core-loop gates remain open.
 - Phase 1.4 verifies keyboard reachability and fallback affordances only; visual, empty/error/setup, and core-loop gates remain open.
+- Phase 1.5 verifies visual/chrome integrity across the supported size matrix only; empty/error/setup and core-loop gates remain open.
 
 ## Severity Policy
 
@@ -34,6 +35,7 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 - Phase 1.2: Clean First-Run Launch And Configuration Walkthrough - `TASK-8.2`
 - Phase 1.3: Top-Level Navigation Smoke Walkthrough - `TASK-8.3`
 - Phase 1.4: Keyboard And Focus Sweep - `TASK-8.4`
+- Phase 1.5: Visual Broken-State Audit - `TASK-8.5`
 - Phase 2: Core Agentic Loop - `TASK-9`
 - Phase 3: Knowledge And Study Workflows - `TASK-10`
 - Phase 4: Agent Configuration And Execution - `TASK-11`
@@ -50,7 +52,7 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 
 | Phase | Goal | Status | Backlog Tasks | QA Evidence | Residual Risk |
 | --- | --- | --- | --- | --- | --- |
-| Phase 1: QA Baseline And Usability Guardrails | Establish clean-run usability guardrails before feature depth. | in_progress | `TASK-8`, Phase 1.1 (`TASK-8.1`), Phase 1.2 (`TASK-8.2`), Phase 1.3 (`TASK-8.3`), Phase 1.4 (`TASK-8.4`) | `phase-1/` | Remaining gates: visual broken-state audit, empty/error/setup-state coverage, and narrow core-loop proof. |
+| Phase 1: QA Baseline And Usability Guardrails | Establish clean-run usability guardrails before feature depth. | in_progress | `TASK-8`, Phase 1.1 (`TASK-8.1`), Phase 1.2 (`TASK-8.2`), Phase 1.3 (`TASK-8.3`), Phase 1.4 (`TASK-8.4`), Phase 1.5 (`TASK-8.5`) | `phase-1/` | Remaining gates: empty/error/setup-state coverage and narrow core-loop proof. |
 | Phase 2: Core Agentic Loop | Complete source/question to grounded Console to Artifact/Chatbook loop. | planned | `TASK-9` | not-started | Depends on Phase 1 QA baseline. |
 | Phase 3: Knowledge And Study Workflows | Mature ingest, organize, retrieve, study, and reuse workflows. | planned | `TASK-10` | not-started | Depends on Phase 2 core loop and later task slicing. |
 | Phase 4: Agent Configuration And Execution | Mature Personas, Skills, MCP, ACP, Schedules, and Workflows. | planned | `TASK-11` | not-started | Depends on service adapters and runtime readiness. |
@@ -83,3 +85,9 @@ Status: verified
 Status: verified
 
 - `Docs/superpowers/qa/product-maturity/phase-1/2026-05-05-phase-1-4-keyboard-focus.md`
+
+## Phase 1.5 Evidence
+
+Status: verified
+
+- `Docs/superpowers/qa/product-maturity/phase-1/2026-05-05-phase-1-5-visual-broken-state-audit.md`

--- a/Tests/UI/test_product_maturity_phase1_visual_audit.py
+++ b/Tests/UI/test_product_maturity_phase1_visual_audit.py
@@ -6,6 +6,7 @@ import re
 import time
 from collections.abc import Callable
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
@@ -15,6 +16,11 @@ from Tests.UI.test_screen_navigation import _build_test_app
 from tldw_chatbook.UI.Navigation.main_navigation import MainNavigationBar, NavigateToScreen
 from tldw_chatbook.UI.Navigation.shell_destinations import SHELL_DESTINATION_ORDER
 
+if TYPE_CHECKING:
+    from textual.pilot import Pilot
+
+    from tldw_chatbook.app import TldwCli
+
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 EVIDENCE = Path("Docs/superpowers/qa/product-maturity/phase-1/2026-05-05-phase-1-5-visual-broken-state-audit.md")
@@ -22,11 +28,26 @@ TRACKER = Path("Docs/superpowers/trackers/product-maturity-roadmap.md")
 PHASE_1_README = Path("Docs/superpowers/qa/product-maturity/phase-1/README.md")
 TASK = Path("backlog/tasks/task-8.5 - Product-Maturity-Phase-1.5-Visual-Broken-State-Audit.md")
 TOP_LEVEL_DESTINATION_IDS = tuple(destination.destination_id for destination in SHELL_DESTINATION_ORDER)
+DESTINATION_BODY_SELECTORS: dict[str, tuple[str, ...]] = {
+    "home": ("#home-dashboard",),
+    "console": ("#console-live-work-source-readiness", "#chat-window"),
+    "library": ("#library-shell",),
+    "artifacts": ("#artifacts-shell",),
+    "personas": ("#personas-shell",),
+    "watchlists_collections": ("#watchlists-collections-shell",),
+    "schedules": ("#schedules-shell",),
+    "workflows": ("#workflows-shell",),
+    "mcp": ("#mcp-shell", "#unified-mcp-panel"),
+    "acp": ("#acp-shell",),
+    "skills": ("#skills-shell",),
+    "settings": ("#settings-shell",),
+}
 TERMINAL_SIZE_MATRIX = (
     ("compact", (100, 32)),
     ("laptop", (140, 40)),
     ("large", (180, 50)),
 )
+MIN_VALID_SVG_LENGTH = 1_000
 BROKEN_TEXT_PATTERNS = (
     "Traceback",
     "Unhandled exception",
@@ -71,7 +92,7 @@ def _prepare_clean_environment(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) 
         monkeypatch.setenv(env_var, str(path))
 
 
-def _build_clean_visual_audit_app(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+def _build_clean_visual_audit_app(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> "TldwCli":
     _prepare_clean_environment(monkeypatch, tmp_path)
     app = _build_test_app()
     app.app_config["_first_run"] = True
@@ -79,7 +100,7 @@ def _build_clean_visual_audit_app(monkeypatch: pytest.MonkeyPatch, tmp_path: Pat
     return app
 
 
-def _screen_text(app) -> str:
+def _screen_text(app: "TldwCli") -> str:
     content = app.screen.query_one("#screen-content")
     pieces: list[str] = []
     for widget in content.query(Static):
@@ -89,7 +110,17 @@ def _screen_text(app) -> str:
     return "\n".join(piece for piece in pieces if piece.strip())
 
 
-def _has_visual_chrome(app) -> bool:
+def _assert_destination_body_mounted(app: "TldwCli", destination_id: str, size_label: str) -> None:
+    selectors = DESTINATION_BODY_SELECTORS[destination_id]
+    content = app.screen.query_one("#screen-content")
+    missing_selectors = [selector for selector in selectors if not list(content.query(selector))]
+    assert not missing_selectors, (
+        f"{destination_id} missing primary body selector(s) at {size_label}: "
+        f"{', '.join(missing_selectors)}"
+    )
+
+
+def _has_visual_chrome(app: "TldwCli") -> bool:
     nav_bars = list(app.screen.query(MainNavigationBar))
     if not nav_bars or not list(app.screen.query("#screen-content")):
         return False
@@ -98,11 +129,12 @@ def _has_visual_chrome(app) -> bool:
 
 
 async def _wait_until(
-    pilot,
+    pilot: "Pilot",
     condition: Callable[[], bool],
     *,
     timeout_seconds: float = 10.0,
     interval_seconds: float = 0.05,
+    context: str | None = None,
 ) -> None:
     deadline = time.monotonic() + timeout_seconds
     while time.monotonic() < deadline:
@@ -111,15 +143,17 @@ async def _wait_until(
         await pilot.pause(interval_seconds)
     if condition():
         return
-    raise AssertionError(f"condition was not met within {timeout_seconds:.1f}s")
+    context_suffix = f" for {context}" if context else ""
+    raise AssertionError(f"condition was not met within {timeout_seconds:.1f}s{context_suffix}")
 
 
-def _assert_visual_snapshot_is_healthy(app, destination_id: str, size_label: str) -> None:
+def _assert_visual_snapshot_is_healthy(app: "TldwCli", destination_id: str, size_label: str) -> None:
     nav_bar = app.screen.query_one(MainNavigationBar)
     nav_ids = tuple(button.id.removeprefix("nav-") for button in nav_bar.query(Button))
     assert nav_ids == TOP_LEVEL_DESTINATION_IDS
     assert nav_bar.query_one(f"#nav-{destination_id}", Button).has_class("is-active")
     assert "Ctrl+P" in str(app.screen.query_one("#nav-overflow-hint", Static).renderable)
+    _assert_destination_body_mounted(app, destination_id, size_label)
 
     text = _screen_text(app)
     svg = app.export_screenshot(title=f"Phase 1.5 {size_label} {destination_id}", simplify=True)
@@ -127,7 +161,7 @@ def _assert_visual_snapshot_is_healthy(app, destination_id: str, size_label: str
     assert text.strip(), f"{destination_id} rendered empty content at {size_label}"
     assert "<svg" in svg
     assert "</svg>" in svg
-    assert len(svg) > 1_000
+    assert len(svg) > MIN_VALID_SVG_LENGTH
     for broken_text in BROKEN_TEXT_PATTERNS:
         assert broken_text not in text
         assert broken_text not in svg
@@ -147,9 +181,12 @@ async def test_clean_run_top_level_visual_snapshots_survive_terminal_size(
 
     with patch("tldw_chatbook.app.get_cli_setting", side_effect=_test_cli_setting):
         async with app.run_test(size=size) as pilot:
+            _initial_screen_name, initial_tab, initial_screen_class = app._resolve_screen_navigation_target("home")
+            assert initial_screen_class is not None
             await _wait_until(
                 pilot,
-                lambda: app.current_tab == "home" and app.screen.__class__.__name__ == "HomeScreen",
+                lambda: app.current_tab == initial_tab and isinstance(app.screen, initial_screen_class),
+                context=f"{size_label}:home:initial",
             )
 
             for destination in SHELL_DESTINATION_ORDER:
@@ -164,12 +201,21 @@ async def test_clean_run_top_level_visual_snapshots_survive_terminal_size(
                         pilot,
                         lambda expected_tab=expected_tab, expected_screen_class=expected_screen_class: (
                             app.current_tab == expected_tab
-                            and app.screen.__class__.__name__ == expected_screen_class.__name__
+                            and isinstance(app.screen, expected_screen_class)
                         ),
+                        context=f"{size_label}:{destination.destination_id}:navigation",
                     )
-                await _wait_until(pilot, lambda: _has_visual_chrome(app))
+                await _wait_until(
+                    pilot,
+                    lambda: _has_visual_chrome(app),
+                    context=f"{size_label}:{destination.destination_id}:chrome",
+                )
 
                 _assert_visual_snapshot_is_healthy(app, destination.destination_id, size_label)
+
+
+def test_visual_audit_destination_body_selectors_cover_top_level_destinations() -> None:
+    assert set(DESTINATION_BODY_SELECTORS) == set(TOP_LEVEL_DESTINATION_IDS)
 
 
 def test_phase_one_five_evidence_records_visual_broken_state_audit() -> None:

--- a/Tests/UI/test_product_maturity_phase1_visual_audit.py
+++ b/Tests/UI/test_product_maturity_phase1_visual_audit.py
@@ -1,0 +1,208 @@
+"""Product maturity Phase 1.5 visual broken-state audit contract."""
+
+from __future__ import annotations
+
+import re
+import time
+from collections.abc import Callable
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from textual.widgets import Button, Static
+
+from Tests.UI.test_screen_navigation import _build_test_app
+from tldw_chatbook.UI.Navigation.main_navigation import MainNavigationBar, NavigateToScreen
+from tldw_chatbook.UI.Navigation.shell_destinations import SHELL_DESTINATION_ORDER
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EVIDENCE = Path("Docs/superpowers/qa/product-maturity/phase-1/2026-05-05-phase-1-5-visual-broken-state-audit.md")
+TRACKER = Path("Docs/superpowers/trackers/product-maturity-roadmap.md")
+PHASE_1_README = Path("Docs/superpowers/qa/product-maturity/phase-1/README.md")
+TASK = Path("backlog/tasks/task-8.5 - Product-Maturity-Phase-1.5-Visual-Broken-State-Audit.md")
+TOP_LEVEL_DESTINATION_IDS = tuple(destination.destination_id for destination in SHELL_DESTINATION_ORDER)
+TERMINAL_SIZE_MATRIX = (
+    ("compact", (100, 32)),
+    ("laptop", (140, 40)),
+    ("large", (180, 50)),
+)
+BROKEN_TEXT_PATTERNS = (
+    "Traceback",
+    "Unhandled exception",
+    "No screens installed",
+    "Unable to mount",
+)
+RAW_OBJECT_REPR = re.compile(r"<[\w.]+ object at 0x[0-9a-fA-F]+>")
+LOCAL_PATH_PREFIXES = (
+    "/Users/",
+    "/home/",
+    "/var/home/",
+    "/private/var/folders/",
+    "C:\\Users\\",
+    "C:/Users/",
+)
+
+
+def _text(path: Path) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def _assert_no_local_path_prefixes(text: str) -> None:
+    leaked_prefixes = [prefix for prefix in LOCAL_PATH_PREFIXES if prefix in text]
+    assert not leaked_prefixes, f"evidence contains local filesystem prefix(es): {leaked_prefixes}"
+
+
+def _test_cli_setting(section: str, key: str, default=None):
+    if section == "splash_screen" and key == "enabled":
+        return False
+    return default
+
+
+def _prepare_clean_environment(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    for env_var, path_name in (
+        ("HOME", "home"),
+        ("XDG_CONFIG_HOME", "xdg-config"),
+        ("XDG_DATA_HOME", "xdg-data"),
+        ("XDG_CACHE_HOME", "xdg-cache"),
+    ):
+        path = tmp_path / path_name
+        path.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv(env_var, str(path))
+
+
+def _build_clean_visual_audit_app(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    _prepare_clean_environment(monkeypatch, tmp_path)
+    app = _build_test_app()
+    app.app_config["_first_run"] = True
+    app._initial_tab_value = "chat"
+    return app
+
+
+def _screen_text(app) -> str:
+    content = app.screen.query_one("#screen-content")
+    pieces: list[str] = []
+    for widget in content.query(Static):
+        pieces.append(str(widget.renderable))
+    for widget in content.query(Button):
+        pieces.append(str(widget.label).strip())
+    return "\n".join(piece for piece in pieces if piece.strip())
+
+
+def _has_visual_chrome(app) -> bool:
+    nav_bars = list(app.screen.query(MainNavigationBar))
+    if not nav_bars or not list(app.screen.query("#screen-content")):
+        return False
+    nav_buttons = tuple(button.id for button in nav_bars[0].query(Button))
+    return nav_buttons == tuple(f"nav-{destination_id}" for destination_id in TOP_LEVEL_DESTINATION_IDS)
+
+
+async def _wait_until(
+    pilot,
+    condition: Callable[[], bool],
+    *,
+    timeout_seconds: float = 10.0,
+    interval_seconds: float = 0.05,
+) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if condition():
+            return
+        await pilot.pause(interval_seconds)
+    if condition():
+        return
+    raise AssertionError(f"condition was not met within {timeout_seconds:.1f}s")
+
+
+def _assert_visual_snapshot_is_healthy(app, destination_id: str, size_label: str) -> None:
+    nav_bar = app.screen.query_one(MainNavigationBar)
+    nav_ids = tuple(button.id.removeprefix("nav-") for button in nav_bar.query(Button))
+    assert nav_ids == TOP_LEVEL_DESTINATION_IDS
+    assert nav_bar.query_one(f"#nav-{destination_id}", Button).has_class("is-active")
+    assert "Ctrl+P" in str(app.screen.query_one("#nav-overflow-hint", Static).renderable)
+
+    text = _screen_text(app)
+    svg = app.export_screenshot(title=f"Phase 1.5 {size_label} {destination_id}", simplify=True)
+
+    assert text.strip(), f"{destination_id} rendered empty content at {size_label}"
+    assert "<svg" in svg
+    assert "</svg>" in svg
+    assert len(svg) > 1_000
+    for broken_text in BROKEN_TEXT_PATTERNS:
+        assert broken_text not in text
+        assert broken_text not in svg
+    assert RAW_OBJECT_REPR.search(text) is None
+    assert RAW_OBJECT_REPR.search(svg) is None
+
+
+@pytest.mark.parametrize(("size_label", "size"), TERMINAL_SIZE_MATRIX)
+@pytest.mark.asyncio
+async def test_clean_run_top_level_visual_snapshots_survive_terminal_size(
+    size_label: str,
+    size: tuple[int, int],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    app = _build_clean_visual_audit_app(monkeypatch, tmp_path)
+
+    with patch("tldw_chatbook.app.get_cli_setting", side_effect=_test_cli_setting):
+        async with app.run_test(size=size) as pilot:
+            await _wait_until(
+                pilot,
+                lambda: app.current_tab == "home" and app.screen.__class__.__name__ == "HomeScreen",
+            )
+
+            for destination in SHELL_DESTINATION_ORDER:
+                _screen_name, expected_tab, expected_screen_class = app._resolve_screen_navigation_target(
+                    destination.primary_route
+                )
+                assert expected_screen_class is not None, destination.primary_route
+
+                if app.current_tab != expected_tab:
+                    await app.handle_screen_navigation(NavigateToScreen(destination.primary_route))
+                    await _wait_until(
+                        pilot,
+                        lambda expected_tab=expected_tab, expected_screen_class=expected_screen_class: (
+                            app.current_tab == expected_tab
+                            and app.screen.__class__.__name__ == expected_screen_class.__name__
+                        ),
+                    )
+                await _wait_until(pilot, lambda: _has_visual_chrome(app))
+
+                _assert_visual_snapshot_is_healthy(app, destination.destination_id, size_label)
+
+
+def test_phase_one_five_evidence_records_visual_broken_state_audit() -> None:
+    evidence = _text(EVIDENCE)
+
+    _assert_no_local_path_prefixes(evidence)
+    for required_text in (
+        "Phase 1.5",
+        "TASK-8.5",
+        "Visual Broken-State Audit",
+        "compact",
+        "laptop",
+        "large",
+        "SVG screenshot export",
+        "No P0/P1 visual broken-state blockers",
+        "Remaining Phase 1 gates",
+    ):
+        assert required_text in evidence
+    for destination_id in TOP_LEVEL_DESTINATION_IDS:
+        assert f"`{destination_id}`" in evidence
+
+
+def test_phase_one_five_tracking_and_task_closeout_are_current() -> None:
+    tracker = _text(TRACKER)
+    readme = _text(PHASE_1_README)
+    task = _text(TASK)
+
+    assert "Phase 1.5" in tracker
+    assert "TASK-8.5" in tracker
+    assert EVIDENCE.name in tracker
+    assert EVIDENCE.name in readme
+    assert "Phase 1.5 visual broken-state status: verified" in readme
+    assert "status: Done" in task
+    for acceptance_criterion in range(1, 6):
+        assert f"- [x] #{acceptance_criterion}" in task
+    assert "Implementation Notes" in task

--- a/backlog/tasks/task-8.5 - Product-Maturity-Phase-1.5-Visual-Broken-State-Audit.md
+++ b/backlog/tasks/task-8.5 - Product-Maturity-Phase-1.5-Visual-Broken-State-Audit.md
@@ -1,0 +1,46 @@
+---
+id: TASK-8.5
+title: 'Product Maturity Phase 1.5: Visual Broken-State Audit'
+status: Done
+assignee: []
+created_date: '2026-05-05 18:54'
+updated_date: '2026-05-05 18:59'
+labels:
+  - product-maturity
+  - phase-1-qa-baseline
+dependencies:
+  - TASK-8.4
+parent_task_id: TASK-8
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify the clean-run shell visually survives supported terminal sizes without blank, traceback, collapsed, or unexplained broken states across top-level destinations.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Fresh clean-run evidence records visual/chrome behavior across compact laptop and large terminal sizes
+- [x] #2 Top-level destinations render non-empty content with navigation chrome and fallback affordance intact
+- [x] #3 Any P0/P1 visual broken-state findings are fixed or explicitly accepted under the product-maturity severity policy
+- [x] #4 Screenshot or SVG evidence is captured when it materially clarifies layout or visual defects
+- [x] #5 Focused regression coverage protects the visual audit evidence and tracker/task closeout seams
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused failing Phase 1.5 visual-audit contract test for SVG export, destination content, and task/tracker links.
+2. Run the contract to confirm the missing Phase 1.5 evidence and tracking fail first.
+3. Exercise the running Textual app across compact, laptop, and large terminal sizes for every top-level destination.
+4. Create Phase 1.5 QA evidence and update the Phase 1 README and product-maturity tracker while keeping Phase 1 open for remaining gates.
+5. Mark TASK-8.5 acceptance criteria complete after focused verification and document implementation notes.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verified clean-run visual/chrome integrity across compact (100x32), laptop (140x40), and large (180x50) terminal sizes for every top-level destination. Added a focused Phase 1.5 regression that exports in-memory SVG screenshots, waits for async chrome stabilization, checks non-empty destination content, validates shared navigation/fallback affordance, and guards against traceback/raw-object broken states. Added Phase 1.5 QA evidence and tracker/README updates while keeping Phase 1 open for empty/error/setup-state and core-loop gates.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary
- Add TASK-8.5 for the Phase 1.5 visual broken-state audit.
- Add clean-run visual audit coverage that exports in-memory SVG screenshots for every top-level destination across compact, laptop, and large terminal sizes.
- Update Phase 1 QA evidence, README, and roadmap while leaving empty/error/setup-state and core-loop gates open.

## Test Plan
- [x] ../../.venv/bin/python -m pytest Tests/UI/test_product_maturity_phase1_visual_audit.py -q
- [x] ../../.venv/bin/python -m pytest Tests/UI/test_product_maturity_phase1_harness.py Tests/UI/test_product_maturity_phase1_first_run.py Tests/UI/test_product_maturity_phase1_navigation_smoke.py Tests/UI/test_product_maturity_phase1_keyboard_focus.py Tests/UI/test_product_maturity_phase1_visual_audit.py -q
- [x] ../../.venv/bin/python -m pytest Tests/UI/test_command_palette_basic.py Tests/UI/test_shell_product_model_visibility.py Tests/UI/test_app_footer_shortcut_context.py -q
- [x] git diff --check