### PR TITLE
Verify product maturity Phase 1.6 setup states

### DIFF
--- a/Docs/superpowers/qa/product-maturity/phase-1/2026-05-05-phase-1-6-empty-error-setup-states.md
+++ b/Docs/superpowers/qa/product-maturity/phase-1/2026-05-05-phase-1-6-empty-error-setup-states.md
@@ -1,0 +1,69 @@
+# Phase 1.6 Empty/Error/Setup State Coverage
+
+Date: 2026-05-05
+Task: TASK-8.6
+Branch: codex/product-maturity-phase1-6-empty-setup
+Workflow: Clean-run empty/error/setup states
+
+## What Was Verified
+
+Phase 1.6 verifies that clean-run setup, empty, unavailable, and blocked states expose honest recovery paths before Phase 1 closes.
+
+Verified states:
+
+- Home missing provider/model setup: clean-run Home shows `Model: Blocked`, `Set up Console model`, and explains that Console needs a working model before live AI tasks.
+- Console missing provider/API key setup: clean-run Console empty state explains OpenAI is not ready because the API key is missing and points to `api_settings.openai`.
+- Search/RAG optional dependency setup: missing `embeddings_rag` disables Search/RAG input and search action, explains the missing optional dependency, owner, install command, and recovery target.
+- ACP runtime not configured: ACP launch is disabled, shows `runtime not configured`, explains no ACP-compatible runtime is configured, and points to Settings.
+- Library service unavailable: Library source handoff is disabled and states that Library source services are unavailable.
+- Personas service unavailable: Persona attach-to-Console is disabled and states that Personas services are unavailable.
+- W+C service unavailable: W+C Console staging is disabled and states that W+C services are unavailable.
+- Skills service unavailable: Skills attach-to-Console is disabled and states that Skills services are unavailable.
+
+## Automated Evidence
+
+Focused regression:
+
+```bash
+../../.venv/bin/python -m pytest Tests/UI/test_product_maturity_phase1_empty_setup_states.py -q
+```
+
+Initial red run:
+
+- Runtime empty/error/setup checks passed after aligning the clean-run Console expectation to the app's actual default OpenAI missing API key state.
+- Evidence and tracker assertions failed because Phase 1.6 evidence and closeout links did not exist yet.
+
+Final focused verification:
+
+- `Tests/UI/test_product_maturity_phase1_empty_setup_states.py -q`: 8 passed, 1 warning in 9.82s.
+- Phase 1 product-maturity sweep including Phase 1.1-1.6 tests: 40 passed, 1 warning in 23.39s.
+- Adjacent recovery regressions for Search/RAG optional dependency and Library/Personas/W+C/Skills service unavailable states: 5 passed, 1 warning in 7.32s.
+
+## Manual Walkthrough
+
+The automated Textual pilot exercised the running app from a clean HOME/XDG environment and navigated Home -> Console -> ACP. Widget-hosted Search/RAG and destination harness checks exercised optional dependency and service-unavailable states deterministically.
+
+No local filesystem paths are recorded in this evidence. Temporary clean-run paths are represented only as clean HOME/XDG setup in the tests.
+
+## Visual/Focus Notes
+
+- Disabled actions remained visible and disabled rather than silently disappearing.
+- Recovery copy used stable fields where available: status, unavailable workflow, why, next action, recovery target, and owner.
+- Tooltips on disabled actions repeated the recovery action or setup requirement.
+
+## Defects Found
+
+No P0/P1 empty/error/setup blockers were found in this Phase 1.6 sweep.
+
+Observed residual risks:
+
+- Some service-unavailable copy is concise rather than fully taxonomy-expanded on every destination.
+- This gate does not prove a complete core product loop.
+
+## Residual Risk
+
+Remaining Phase 1 gate: narrow core-loop proof. Phase 1.6 does not verify source/question -> Console -> saved/reopened output.
+
+## Exit Decision
+
+Pass for Phase 1.6. Empty/error/setup states checked in this slice are visible, disabled actions avoid false affordances, and recovery paths are explicit enough to continue to the Phase 1 core-loop proof gate.

--- a/Docs/superpowers/qa/product-maturity/phase-1/2026-05-05-phase-1-6-empty-error-setup-states.md
+++ b/Docs/superpowers/qa/product-maturity/phase-1/2026-05-05-phase-1-6-empty-error-setup-states.md
@@ -33,11 +33,11 @@ Initial red run:
 - Runtime empty/error/setup checks passed after aligning the clean-run Console expectation to the app's actual default OpenAI missing API key state.
 - Evidence and tracker assertions failed because Phase 1.6 evidence and closeout links did not exist yet.
 
-Final focused verification:
+Final focused verification after PR review fixes:
 
-- `Tests/UI/test_product_maturity_phase1_empty_setup_states.py -q`: 8 passed, 1 warning in 9.82s.
-- Phase 1 product-maturity sweep including Phase 1.1-1.6 tests: 40 passed, 1 warning in 23.39s.
-- Adjacent recovery regressions for Search/RAG optional dependency and Library/Personas/W+C/Skills service unavailable states: 5 passed, 1 warning in 7.32s.
+- `Tests/UI/test_product_maturity_phase1_empty_setup_states.py -q`: 8 passed, 1 warning in 8.35s.
+- Phase 1 product-maturity sweep including Phase 1.1-1.6 tests: 40 passed, 1 warning in 20.16s.
+- Adjacent recovery regressions for Search/RAG optional dependency and Library/Personas/W+C/Skills service unavailable states: 5 passed, 1 warning in 5.70s.
 
 ## Manual Walkthrough
 

--- a/Docs/superpowers/qa/product-maturity/phase-1/README.md
+++ b/Docs/superpowers/qa/product-maturity/phase-1/README.md
@@ -46,3 +46,11 @@ Phase 1.5 visual broken-state status: verified
 - `2026-05-05-phase-1-5-visual-broken-state-audit.md`
 
 Phase 1.5 verifies clean-run visual/chrome integrity across compact, laptop, and large terminal sizes for every top-level destination. It does not complete the full empty/error/setup-state or core-loop audits.
+
+Phase 1.6 evidence:
+
+Phase 1.6 empty/error/setup status: verified
+
+- `2026-05-05-phase-1-6-empty-error-setup-states.md`
+
+Phase 1.6 verifies clean-run setup blockers, missing optional dependencies, service-unavailable states, and local runtime blockers. It does not complete the narrow core-loop proof gate.

--- a/Docs/superpowers/trackers/product-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/product-maturity-roadmap.md
@@ -1,7 +1,7 @@
 # Product Maturity Roadmap
 
 Date: 2026-05-05
-Status: Phase 1.5 verified; Phase 1 in progress
+Status: Phase 1.6 verified; Phase 1 in progress
 Source Branch: `dev`
 Source Spec: `Docs/superpowers/specs/2026-05-05-product-maturity-phased-roadmap-design.md`
 
@@ -18,6 +18,7 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 - Phase 1.3 verifies top-level destination reachability only; keyboard/focus, visual, empty/error/setup, and core-loop gates remain open.
 - Phase 1.4 verifies keyboard reachability and fallback affordances only; visual, empty/error/setup, and core-loop gates remain open.
 - Phase 1.5 verifies visual/chrome integrity across the supported size matrix only; empty/error/setup and core-loop gates remain open.
+- Phase 1.6 verifies empty/error/setup-state coverage only; the narrow core-loop proof remains open.
 
 ## Severity Policy
 
@@ -36,6 +37,7 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 - Phase 1.3: Top-Level Navigation Smoke Walkthrough - `TASK-8.3`
 - Phase 1.4: Keyboard And Focus Sweep - `TASK-8.4`
 - Phase 1.5: Visual Broken-State Audit - `TASK-8.5`
+- Phase 1.6: Empty/Error/Setup State Coverage - `TASK-8.6`
 - Phase 2: Core Agentic Loop - `TASK-9`
 - Phase 3: Knowledge And Study Workflows - `TASK-10`
 - Phase 4: Agent Configuration And Execution - `TASK-11`
@@ -52,7 +54,7 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 
 | Phase | Goal | Status | Backlog Tasks | QA Evidence | Residual Risk |
 | --- | --- | --- | --- | --- | --- |
-| Phase 1: QA Baseline And Usability Guardrails | Establish clean-run usability guardrails before feature depth. | in_progress | `TASK-8`, Phase 1.1 (`TASK-8.1`), Phase 1.2 (`TASK-8.2`), Phase 1.3 (`TASK-8.3`), Phase 1.4 (`TASK-8.4`), Phase 1.5 (`TASK-8.5`) | `phase-1/` | Remaining gates: empty/error/setup-state coverage and narrow core-loop proof. |
+| Phase 1: QA Baseline And Usability Guardrails | Establish clean-run usability guardrails before feature depth. | in_progress | `TASK-8`, Phase 1.1 (`TASK-8.1`), Phase 1.2 (`TASK-8.2`), Phase 1.3 (`TASK-8.3`), Phase 1.4 (`TASK-8.4`), Phase 1.5 (`TASK-8.5`), Phase 1.6 (`TASK-8.6`) | `phase-1/` | Remaining gate: narrow core-loop proof. |
 | Phase 2: Core Agentic Loop | Complete source/question to grounded Console to Artifact/Chatbook loop. | planned | `TASK-9` | not-started | Depends on Phase 1 QA baseline. |
 | Phase 3: Knowledge And Study Workflows | Mature ingest, organize, retrieve, study, and reuse workflows. | planned | `TASK-10` | not-started | Depends on Phase 2 core loop and later task slicing. |
 | Phase 4: Agent Configuration And Execution | Mature Personas, Skills, MCP, ACP, Schedules, and Workflows. | planned | `TASK-11` | not-started | Depends on service adapters and runtime readiness. |
@@ -91,3 +93,9 @@ Status: verified
 Status: verified
 
 - `Docs/superpowers/qa/product-maturity/phase-1/2026-05-05-phase-1-5-visual-broken-state-audit.md`
+
+## Phase 1.6 Evidence
+
+Status: verified
+
+- `Docs/superpowers/qa/product-maturity/phase-1/2026-05-05-phase-1-6-empty-error-setup-states.md`

--- a/Tests/UI/test_product_maturity_phase1_empty_setup_states.py
+++ b/Tests/UI/test_product_maturity_phase1_empty_setup_states.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
 from collections.abc import Callable
 from pathlib import Path
@@ -83,6 +84,12 @@ def _test_cli_setting(section: str, key: str, default=None):
     return default
 
 
+def _test_chat_window_setting(section: str, key: str, default=None):
+    if section == "chat_defaults" and key == "enable_tabs":
+        return False
+    return _test_cli_setting(section, key, default)
+
+
 def _prepare_clean_environment(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     for env_var, path_name in (
         ("HOME", "home"),
@@ -93,6 +100,15 @@ def _prepare_clean_environment(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) 
         path = tmp_path / path_name
         path.mkdir(parents=True, exist_ok=True)
         monkeypatch.setenv(env_var, str(path))
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        "[chat_defaults]\n"
+        'provider = "OpenAI"\n'
+        'model = "gpt-4o"\n'
+        "enable_tabs = false\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
 
 
 def _build_clean_setup_state_app(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
@@ -125,7 +141,8 @@ async def _wait_until(
     while time.monotonic() < deadline:
         if condition():
             return
-        await pilot.pause(interval_seconds)
+        await pilot.pause()
+        await asyncio.sleep(interval_seconds)
     if condition():
         return
     raise AssertionError(f"condition was not met within {timeout_seconds:.1f}s for {context}")
@@ -138,7 +155,10 @@ async def test_clean_run_setup_and_runtime_blockers_expose_recovery_copy(
 ) -> None:
     app = _build_clean_setup_state_app(monkeypatch, tmp_path)
 
-    with patch("tldw_chatbook.app.get_cli_setting", side_effect=_test_cli_setting):
+    with (
+        patch("tldw_chatbook.app.get_cli_setting", side_effect=_test_cli_setting),
+        patch("tldw_chatbook.UI.Chat_Window_Enhanced.get_cli_setting", side_effect=_test_chat_window_setting),
+    ):
         async with app.run_test(size=(140, 40)) as pilot:
             await _wait_until(
                 pilot,

--- a/Tests/UI/test_product_maturity_phase1_empty_setup_states.py
+++ b/Tests/UI/test_product_maturity_phase1_empty_setup_states.py
@@ -1,0 +1,319 @@
+"""Product maturity Phase 1.6 empty/error/setup-state coverage contract."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Button, Input, Static
+
+from Tests.UI.test_destination_shells import (
+    DestinationHarness,
+    RaisingLibraryNotesScopeService,
+    RaisingPersonasScopeService,
+    RaisingSkillsScopeService,
+    RaisingWatchlistsScopeService,
+    StaticLibraryConversationScopeService,
+    StaticLibraryMediaScopeService,
+    StaticReadItLaterScopeService,
+    _active_destination_screen,
+    _visible_text,
+    _wait_for_library_snapshot,
+    _wait_for_personas_snapshot,
+    _wait_for_skills_snapshot,
+    _wait_for_wc_snapshot,
+)
+from Tests.UI.test_screen_navigation import _build_test_app
+from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
+from tldw_chatbook.UI.Views.RAGSearch import search_rag_window as search_rag_module
+from tldw_chatbook.UI.Views.RAGSearch.search_rag_window import SearchRAGWindow
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EVIDENCE = Path("Docs/superpowers/qa/product-maturity/phase-1/2026-05-05-phase-1-6-empty-error-setup-states.md")
+TRACKER = Path("Docs/superpowers/trackers/product-maturity-roadmap.md")
+PHASE_1_README = Path("Docs/superpowers/qa/product-maturity/phase-1/README.md")
+TASK = Path("backlog/tasks/task-8.6 - Product-Maturity-Phase-1.6-Empty-Error-Setup-State-Coverage.md")
+LOCAL_PATH_PREFIXES = (
+    "/Users/",
+    "/home/",
+    "/var/home/",
+    "/private/var/folders/",
+    "C:\\Users\\",
+    "C:/Users/",
+)
+
+
+class _WidgetHost(App):
+    def __init__(self, widget) -> None:
+        super().__init__()
+        self.widget_under_test = widget
+
+    def compose(self) -> ComposeResult:
+        yield self.widget_under_test
+
+
+class _FakeAppInstance:
+    def __init__(self) -> None:
+        self.notifications = []
+
+    def notify(self, message, *args, **kwargs) -> None:
+        self.notifications.append((message, kwargs))
+
+    def get_authoritative_runtime_source(self) -> str:
+        return "local"
+
+
+def _text(path: Path) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def _assert_no_local_path_prefixes(text: str) -> None:
+    leaked_prefixes = [prefix for prefix in LOCAL_PATH_PREFIXES if prefix in text]
+    assert not leaked_prefixes, f"evidence contains local filesystem prefix(es): {leaked_prefixes}"
+
+
+def _test_cli_setting(section: str, key: str, default=None):
+    if section == "splash_screen" and key == "enabled":
+        return False
+    return default
+
+
+def _prepare_clean_environment(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    for env_var, path_name in (
+        ("HOME", "home"),
+        ("XDG_CONFIG_HOME", "xdg-config"),
+        ("XDG_DATA_HOME", "xdg-data"),
+        ("XDG_CACHE_HOME", "xdg-cache"),
+    ):
+        path = tmp_path / path_name
+        path.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv(env_var, str(path))
+
+
+def _build_clean_setup_state_app(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    _prepare_clean_environment(monkeypatch, tmp_path)
+    app = _build_test_app()
+    app.app_config["_first_run"] = True
+    app._initial_tab_value = "chat"
+    app.providers_models = {}
+    return app
+
+
+def _screen_text(app) -> str:
+    pieces: list[str] = []
+    for widget in app.screen.query(Static):
+        pieces.append(str(widget.renderable))
+    for widget in app.screen.query(Button):
+        pieces.append(str(widget.label).strip())
+    return "\n".join(piece for piece in pieces if piece.strip())
+
+
+async def _wait_until(
+    pilot,
+    condition: Callable[[], bool],
+    *,
+    timeout_seconds: float = 10.0,
+    interval_seconds: float = 0.05,
+    context: str,
+) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if condition():
+            return
+        await pilot.pause(interval_seconds)
+    if condition():
+        return
+    raise AssertionError(f"condition was not met within {timeout_seconds:.1f}s for {context}")
+
+
+@pytest.mark.asyncio
+async def test_clean_run_setup_and_runtime_blockers_expose_recovery_copy(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    app = _build_clean_setup_state_app(monkeypatch, tmp_path)
+
+    with patch("tldw_chatbook.app.get_cli_setting", side_effect=_test_cli_setting):
+        async with app.run_test(size=(140, 40)) as pilot:
+            await _wait_until(
+                pilot,
+                lambda: app.current_tab == "home" and app.screen.__class__.__name__ == "HomeScreen",
+                context="home initial setup state",
+            )
+
+            home_text = _screen_text(app)
+            assert "Model: Blocked" in home_text
+            assert "Set up Console model" in home_text
+            assert "Console needs a working model before live AI tasks." in home_text
+
+            await app.handle_screen_navigation(NavigateToScreen("chat"))
+            await _wait_until(
+                pilot,
+                lambda: app.current_tab == "chat" and app.screen.__class__.__name__ == "ChatScreen",
+                context="console setup route",
+            )
+            await _wait_until(
+                pilot,
+                lambda: bool(app.screen.query("#chat-empty-state")),
+                context="console empty state",
+            )
+            console_empty_state = app.screen.query_one("#chat-empty-state", Static)
+            console_text = str(console_empty_state.renderable)
+            assert "Provider readiness: OpenAI is not ready: Missing API key." in console_text
+            assert "Add api_key under [api_settings.openai]." in console_text
+            assert "Ctrl+P opens commands." in console_text
+
+            await app.handle_screen_navigation(NavigateToScreen("acp"))
+            await _wait_until(
+                pilot,
+                lambda: app.current_tab == "acp" and app.screen.__class__.__name__ == "ACPScreen",
+                context="acp runtime blocker",
+            )
+            acp_text = _screen_text(app)
+            acp_launch = app.screen.query_one("#acp-launch-agent", Button)
+            assert "Runtime not configured" in acp_text
+            assert "Why: no ACP-compatible runtime is configured." in acp_text
+            assert "Next: Configure an ACP runtime in Settings before launch." in acp_text
+            assert "Owner: local app runtime." in acp_text
+            assert acp_launch.disabled is True
+            assert "Configure an ACP-compatible runtime" in str(acp_launch.tooltip)
+
+
+@pytest.mark.asyncio
+async def test_optional_dependency_missing_state_exposes_owner_and_setup_action(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(search_rag_module, "get_user_data_dir", lambda: tmp_path)
+    monkeypatch.setitem(search_rag_module.DEPENDENCIES_AVAILABLE, "embeddings_rag", False)
+    monkeypatch.setattr(
+        "tldw_chatbook.Utils.widget_helpers.alert_embeddings_not_available",
+        lambda widget: None,
+    )
+
+    widget = SearchRAGWindow(_FakeAppInstance())
+    app = _WidgetHost(widget)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        recovery = widget.query_one("#search-rag-dependency-missing", Static)
+        recovery_text = str(recovery.renderable)
+        search_input = widget.query_one("#search-query-input", Input)
+        search_button = widget.query_one("#search-button", Button)
+
+        assert "Dependency missing" in recovery_text
+        assert "Unavailable: Search/RAG queries." in recovery_text
+        assert "Why: Missing optional dependencies: embeddings_rag." in recovery_text
+        assert 'Next: Install with pip install -e ".[embeddings_rag]" and restart.' in recovery_text
+        assert "Recovery: Settings > RAG." in recovery_text
+        assert "Owner: optional dependency." in recovery_text
+        assert search_input.disabled is True
+        assert search_button.disabled is True
+        assert 'pip install -e ".[embeddings_rag]"' in str(search_button.tooltip)
+
+
+@pytest.mark.parametrize(
+    ("route", "button_selector", "expected_copy", "setup"),
+    [
+        (
+            "library",
+            "#library-use-in-console",
+            "Library source services unavailable; retry Library later.",
+            "library-error",
+        ),
+        (
+            "personas",
+            "#personas-attach-to-console",
+            "Personas service unavailable; retry Personas later.",
+            "personas-error",
+        ),
+        (
+            "watchlists_collections",
+            "#wc-attach-to-console",
+            "W+C services unavailable; retry W+C later.",
+            "wc-error",
+        ),
+        (
+            "skills",
+            "#skills-attach-to-console",
+            "Skills service unavailable; retry Skills later.",
+            "skills-error",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_service_unavailable_states_disable_false_console_handoffs(
+    route: str,
+    button_selector: str,
+    expected_copy: str,
+    setup: str,
+) -> None:
+    app = _build_test_app()
+    if setup == "library-error":
+        app.notes_scope_service = RaisingLibraryNotesScopeService()
+        app.media_reading_scope_service = StaticLibraryMediaScopeService([])
+        app.chat_conversation_scope_service = StaticLibraryConversationScopeService([])
+        wait_for_snapshot = _wait_for_library_snapshot
+    elif setup == "personas-error":
+        app.character_persona_scope_service = RaisingPersonasScopeService()
+        wait_for_snapshot = _wait_for_personas_snapshot
+    elif setup == "wc-error":
+        app.watchlist_scope_service = RaisingWatchlistsScopeService()
+        app.collections_feeds_scope_service = StaticReadItLaterScopeService([])
+        wait_for_snapshot = _wait_for_wc_snapshot
+    elif setup == "skills-error":
+        app.skills_scope_service = RaisingSkillsScopeService()
+        wait_for_snapshot = _wait_for_skills_snapshot
+    else:
+        raise AssertionError(f"unexpected setup: {setup}")
+
+    host = DestinationHarness(app, route)
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await wait_for_snapshot(screen, pilot)
+        button = screen.query_one(button_selector, Button)
+
+        assert expected_copy in _visible_text(screen)
+        assert button.disabled is True
+        assert "unavailable" in str(button.tooltip).lower()
+
+
+def test_phase_one_six_evidence_records_empty_error_setup_state_coverage() -> None:
+    evidence = _text(EVIDENCE)
+
+    _assert_no_local_path_prefixes(evidence)
+    for required_text in (
+        "Phase 1.6",
+        "TASK-8.6",
+        "Empty/Error/Setup State Coverage",
+        "missing provider",
+        "optional dependency",
+        "service unavailable",
+        "runtime not configured",
+        "No P0/P1 empty/error/setup blockers",
+        "Remaining Phase 1 gate",
+    ):
+        assert required_text in evidence
+
+
+def test_phase_one_six_tracking_and_task_closeout_are_current() -> None:
+    tracker = _text(TRACKER)
+    readme = _text(PHASE_1_README)
+    task = _text(TASK)
+
+    assert "Phase 1.6" in tracker
+    assert "TASK-8.6" in tracker
+    assert EVIDENCE.name in tracker
+    assert EVIDENCE.name in readme
+    assert "Phase 1.6 empty/error/setup status: verified" in readme
+    assert "status: Done" in task
+    for acceptance_criterion in range(1, 5):
+        assert f"- [x] #{acceptance_criterion}" in task
+    assert "Implementation Notes" in task

--- a/backlog/tasks/task-8.6 - Product-Maturity-Phase-1.6-Empty-Error-Setup-State-Coverage.md
+++ b/backlog/tasks/task-8.6 - Product-Maturity-Phase-1.6-Empty-Error-Setup-State-Coverage.md
@@ -1,0 +1,45 @@
+---
+id: TASK-8.6
+title: 'Product Maturity Phase 1.6: Empty Error Setup State Coverage'
+status: Done
+assignee: []
+created_date: '2026-05-05 19:40'
+updated_date: '2026-05-05 19:40'
+labels:
+  - product-maturity
+  - phase-1-qa-baseline
+dependencies:
+  - TASK-8.5
+parent_task_id: TASK-8
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify clean-run empty error and setup states expose honest owner reason impact and recovery actions before Phase 1 closes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Clean-run evidence records missing provider optional dependency service unavailable and local-runtime setup states.
+- [x] #2 Each verified blocked or empty state explains owner reason impact and next action without false affordances.
+- [x] #3 Any P0/P1 empty error or setup findings are fixed or explicitly accepted under the product-maturity severity policy.
+- [x] #4 Focused regression coverage protects the Phase 1.6 evidence tracker README and task closeout seams.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused failing Phase 1.6 contract test for empty/error/setup evidence, tracker, README, and task closeout.
+2. Inspect existing clean-run setup and recovery surfaces for provider, optional dependency, service unavailable, and local-runtime blockers.
+3. Create Phase 1.6 QA evidence documenting verified blocked states, residual risk, and exit decision.
+4. Update the Phase 1 README and product-maturity tracker while keeping Phase 1 open for the core-loop proof gate.
+5. Mark TASK-8.6 acceptance criteria complete after focused verification and add implementation notes.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added a Phase 1.6 regression that exercises clean-run setup blockers, Console missing API key recovery, ACP runtime-not-configured recovery, Search/RAG missing optional dependency recovery, and Library/Personas/W+C/Skills service-unavailable states. Added Phase 1.6 QA evidence plus roadmap and Phase 1 README links while keeping Phase 1 open for the narrow core-loop proof gate. No P0/P1 empty/error/setup blockers were found in this slice.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary
- add TASK-8.6 for Phase 1.6 empty/error/setup-state coverage
- add running-app regression coverage for clean-run setup blockers, ACP runtime blockers, Search/RAG missing dependency recovery, and service-unavailable destination states
- record Phase 1.6 QA evidence and update the product-maturity tracker while keeping Phase 1 open for the core-loop proof gate

## Verification
- ../../.venv/bin/python -m pytest Tests/UI/test_product_maturity_phase1_empty_setup_states.py -q
- ../../.venv/bin/python -m pytest Tests/UI/test_product_maturity_phase1_harness.py Tests/UI/test_product_maturity_phase1_first_run.py Tests/UI/test_product_maturity_phase1_navigation_smoke.py Tests/UI/test_product_maturity_phase1_keyboard_focus.py Tests/UI/test_product_maturity_phase1_visual_audit.py Tests/UI/test_product_maturity_phase1_empty_setup_states.py -q
- ../../.venv/bin/python -m pytest Tests/UI/test_disabled_action_recovery_tooltips.py::test_search_rag_missing_embeddings_dependency_exposes_phase_five_recovery Tests/UI/test_destination_shells.py::test_library_destination_service_failure_uses_recovery_copy Tests/UI/test_destination_shells.py::test_personas_destination_service_failure_uses_recovery_copy Tests/UI/test_destination_shells.py::test_watchlists_collections_service_failure_uses_recovery_copy Tests/UI/test_destination_shells.py::test_skills_destination_service_failure_uses_recovery_copy -q
- git diff --check