### PR TITLE
Verify product maturity Phase 1.7 core loop

### DIFF
--- a/Docs/superpowers/qa/product-maturity/phase-1/2026-05-05-phase-1-7-core-loop-proof.md
+++ b/Docs/superpowers/qa/product-maturity/phase-1/2026-05-05-phase-1-7-core-loop-proof.md
@@ -1,0 +1,77 @@
+# Phase 1.7 Narrow Core-Loop Proof
+
+Date: 2026-05-05
+Task: TASK-8.7
+Branch: codex/product-maturity-phase1-7-core-loop
+Workflow: Search/RAG result -> Console staged context
+
+## What Was Verified
+
+Phase 1.7 narrow core-loop proof verifies the remaining Phase 1 gate: a source-like Search/RAG result can reach Console as staged context with visible source authority and a draft prompt.
+
+Verified path:
+
+- Source producer: Search/RAG result payload.
+- Console entry: app-owned `open_chat_with_handoff` route.
+- Console state: ephemeral chat session with a visible staged-context card.
+- Source authority: local.
+- Recovery posture: the context is staged rather than auto-sent, and the user can review the draft before sending.
+
+## Automated Evidence
+
+Focused regression:
+
+```bash
+../../.venv/bin/python -m pytest Tests/UI/test_product_maturity_phase1_core_loop.py -q
+```
+
+Initial red run:
+
+- The running-app staged-context assertion passed after the test pinned only the relevant chat-tab settings.
+- The evidence assertion failed because Phase 1.7 evidence, tracker, README, and task closeout updates did not exist yet.
+
+Final focused verification:
+
+- `Tests/UI/test_product_maturity_phase1_core_loop.py -q`: 2 passed, 1 warning in 6.20s.
+- Phase 1 product-maturity sweep including Phase 1.1-1.7 tests: 42 passed, 1 warning in 21.79s.
+- Adjacent Search/RAG and Chat handoff regressions: 15 passed, 1 warning in 5.89s.
+
+## Manual Walkthrough
+
+The Textual pilot exercised the running app with chat tabs enabled, started from the shell, invoked the app-owned Search/RAG handoff path, navigated to Console, and verified the staged-context card.
+
+Observed user-facing Console state:
+
+- The card states `Context staged from RAG Search`.
+- The card shows the result title and `Type: rag-result`.
+- The card shows `Backend: local`.
+- The card shows `Source: Local source`.
+- The card includes the result score metadata.
+- The composer is preloaded with the suggested prompt so the user can review before sending.
+
+This is intentionally a narrow Phase 1 proof. It does not prove full grounded generation, artifact persistence, or Chatbook reopen. Those belong to Phase 2.
+
+## Visual/Focus Notes
+
+- The staged-context card is visible before the draft is sent.
+- The user remains in control because context is not automatically submitted.
+- Source authority is visible in the card rather than hidden in internal payload metadata.
+
+## Defects Found
+
+No P0/P1 defects found.
+
+One test-harness issue was corrected before closeout: the initial test patch returned `True` for unrelated settings and corrupted splash/navigation setup. The final test pins only splash disablement and chat-tab enablement.
+
+## Residual Risk
+
+Phase 1 is now complete as a QA baseline. Remaining product-depth risks move to Phase 2:
+
+- grounded answer generation with live provider/runtime configuration;
+- save/update Artifact or Chatbook;
+- reopen/resume from Artifacts or Home;
+- missing-source and failed-generation recovery in the full loop.
+
+## Exit Decision
+
+Pass for Phase 1.7 and Phase 1. The app has verified first-run, navigation, keyboard/focus, visual/chrome, empty/error/setup, and narrow core-loop guardrails. Phase 2 can now focus on completing the full source/question -> grounded Console -> Artifact/Chatbook loop.

--- a/Docs/superpowers/qa/product-maturity/phase-1/README.md
+++ b/Docs/superpowers/qa/product-maturity/phase-1/README.md
@@ -1,6 +1,6 @@
 # Product Maturity Phase 1 QA
 
-Status: in_progress
+Status: verified
 
 Phase 1 establishes QA baselines and usability guardrails before additional product-depth work.
 
@@ -54,3 +54,11 @@ Phase 1.6 empty/error/setup status: verified
 - `2026-05-05-phase-1-6-empty-error-setup-states.md`
 
 Phase 1.6 verifies clean-run setup blockers, missing optional dependencies, service-unavailable states, and local runtime blockers. It does not complete the narrow core-loop proof gate.
+
+Phase 1.7 evidence:
+
+Phase 1.7 narrow core-loop proof status: verified
+
+- `2026-05-05-phase-1-7-core-loop-proof.md`
+
+Phase 1.7 verifies that a Search/RAG result can reach Console as staged context with visible local source authority and a review-before-send draft prompt. This closes the Phase 1 QA baseline. Full grounded generation, Artifact/Chatbook persistence, and reopen/resume move to Phase 2.

--- a/Docs/superpowers/trackers/product-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/product-maturity-roadmap.md
@@ -1,7 +1,7 @@
 # Product Maturity Roadmap
 
 Date: 2026-05-05
-Status: Phase 1.6 verified; Phase 1 in progress
+Status: Phase 1 verified; Phase 2 planned
 Source Branch: `dev`
 Source Spec: `Docs/superpowers/specs/2026-05-05-product-maturity-phased-roadmap-design.md`
 
@@ -18,7 +18,8 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 - Phase 1.3 verifies top-level destination reachability only; keyboard/focus, visual, empty/error/setup, and core-loop gates remain open.
 - Phase 1.4 verifies keyboard reachability and fallback affordances only; visual, empty/error/setup, and core-loop gates remain open.
 - Phase 1.5 verifies visual/chrome integrity across the supported size matrix only; empty/error/setup and core-loop gates remain open.
-- Phase 1.6 verifies empty/error/setup-state coverage only; the narrow core-loop proof remains open.
+- Phase 1.6 verifies empty/error/setup-state coverage only.
+- Phase 1.7 verifies the remaining narrow core-loop proof gate: Search/RAG result context can stage into Console with visible local source authority.
 
 ## Severity Policy
 
@@ -38,6 +39,7 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 - Phase 1.4: Keyboard And Focus Sweep - `TASK-8.4`
 - Phase 1.5: Visual Broken-State Audit - `TASK-8.5`
 - Phase 1.6: Empty/Error/Setup State Coverage - `TASK-8.6`
+- Phase 1.7: Narrow Core-Loop Proof - `TASK-8.7`
 - Phase 2: Core Agentic Loop - `TASK-9`
 - Phase 3: Knowledge And Study Workflows - `TASK-10`
 - Phase 4: Agent Configuration And Execution - `TASK-11`
@@ -48,14 +50,14 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 
 | Phase | Evidence Path | Status |
 | --- | --- | --- |
-| Phase 1 | `Docs/superpowers/qa/product-maturity/phase-1/` | in_progress |
+| Phase 1 | `Docs/superpowers/qa/product-maturity/phase-1/` | verified |
 
 ## Phase Overview
 
 | Phase | Goal | Status | Backlog Tasks | QA Evidence | Residual Risk |
 | --- | --- | --- | --- | --- | --- |
-| Phase 1: QA Baseline And Usability Guardrails | Establish clean-run usability guardrails before feature depth. | in_progress | `TASK-8`, Phase 1.1 (`TASK-8.1`), Phase 1.2 (`TASK-8.2`), Phase 1.3 (`TASK-8.3`), Phase 1.4 (`TASK-8.4`), Phase 1.5 (`TASK-8.5`), Phase 1.6 (`TASK-8.6`) | `phase-1/` | Remaining gate: narrow core-loop proof. |
-| Phase 2: Core Agentic Loop | Complete source/question to grounded Console to Artifact/Chatbook loop. | planned | `TASK-9` | not-started | Depends on Phase 1 QA baseline. |
+| Phase 1: QA Baseline And Usability Guardrails | Establish clean-run usability guardrails before feature depth. | verified | `TASK-8`, Phase 1.1 (`TASK-8.1`), Phase 1.2 (`TASK-8.2`), Phase 1.3 (`TASK-8.3`), Phase 1.4 (`TASK-8.4`), Phase 1.5 (`TASK-8.5`), Phase 1.6 (`TASK-8.6`), Phase 1.7 (`TASK-8.7`) | `phase-1/` | Closed; full grounded generation and Artifact/Chatbook persistence move to Phase 2. |
+| Phase 2: Core Agentic Loop | Complete source/question to grounded Console to Artifact/Chatbook loop. | planned | `TASK-9` | not-started | Ready after Phase 1 QA baseline. |
 | Phase 3: Knowledge And Study Workflows | Mature ingest, organize, retrieve, study, and reuse workflows. | planned | `TASK-10` | not-started | Depends on Phase 2 core loop and later task slicing. |
 | Phase 4: Agent Configuration And Execution | Mature Personas, Skills, MCP, ACP, Schedules, and Workflows. | planned | `TASK-11` | not-started | Depends on service adapters and runtime readiness. |
 | Phase 5: Server-Parity And Live Integrations | Close high-value `tldw_server2` parity gaps. | planned | `TASK-12` | not-started | Requires parity inventory. |
@@ -99,3 +101,9 @@ Status: verified
 Status: verified
 
 - `Docs/superpowers/qa/product-maturity/phase-1/2026-05-05-phase-1-6-empty-error-setup-states.md`
+
+## Phase 1.7 Evidence
+
+Status: verified
+
+- `Docs/superpowers/qa/product-maturity/phase-1/2026-05-05-phase-1-7-core-loop-proof.md`

--- a/Tests/UI/test_product_maturity_phase1_core_loop.py
+++ b/Tests/UI/test_product_maturity_phase1_core_loop.py
@@ -105,9 +105,8 @@ async def test_search_rag_result_stages_context_into_console_core_loop() -> None
             )
 
             card_text = "\n".join(
-                str(widget.renderable)
+                str(card.query_one(".chat-handoff-card-body", Static).renderable)
                 for card in app.screen.query(ChatHandoffCard)
-                for widget in card.query(Static)
             )
             draft_text = "\n".join(widget.text for widget in app.screen.query(TextArea))
 
@@ -139,4 +138,6 @@ def test_phase_1_7_core_loop_evidence_is_tracked() -> None:
     assert "2026-05-05-phase-1-7-core-loop-proof.md" in readme
     assert "status: Done" in task
     assert "- [x] #1" in task
+    assert "- [x] #2" in task
+    assert "- [x] #3" in task
     assert "- [x] #4" in task

--- a/Tests/UI/test_product_maturity_phase1_core_loop.py
+++ b/Tests/UI/test_product_maturity_phase1_core_loop.py
@@ -24,6 +24,14 @@ TASK = Path("backlog/tasks/task-8.7 - Product-Maturity-Phase-1.7-Narrow-Core-Loo
 
 
 def _text(path: Path) -> str:
+    """Read a repository-relative text fixture.
+
+    Args:
+        path: Repository-relative path to read.
+
+    Returns:
+        UTF-8 decoded file contents.
+    """
     return (REPO_ROOT / path).read_text(encoding="utf-8")
 
 
@@ -35,6 +43,18 @@ async def _wait_until(
     interval_seconds: float = 0.05,
     context: str,
 ) -> None:
+    """Wait for an async Textual pilot condition to become true.
+
+    Args:
+        pilot: Textual test pilot driving the running app.
+        condition: Zero-argument predicate that returns true when ready.
+        timeout_seconds: Maximum time to wait before failing.
+        interval_seconds: Delay between event-loop polls.
+        context: Human-readable state being awaited for failure messages.
+
+    Raises:
+        AssertionError: If the condition is still false after the timeout.
+    """
     deadline = time.monotonic() + timeout_seconds
     while time.monotonic() < deadline:
         if condition():
@@ -47,6 +67,11 @@ async def _wait_until(
 
 
 def _core_loop_payload() -> ChatHandoffPayload:
+    """Build the deterministic Search/RAG handoff payload used by Phase 1.7.
+
+    Returns:
+        Handoff payload that stages a local RAG result into Console.
+    """
     return ChatHandoffPayload(
         source="search-rag",
         item_type="rag-result",
@@ -66,10 +91,23 @@ def _core_loop_payload() -> ChatHandoffPayload:
 
 
 def _test_cli_setting(section: str, key: str, default=None):
+    """Return deterministic settings for the running-app core-loop test.
+
+    Args:
+        section: Config section name requested by the app.
+        key: Config key requested by the app.
+        default: Caller-provided fallback value.
+
+    Returns:
+        Test-pinned setting value for relevant chat/splash keys, otherwise
+        the caller default.
+    """
     if section == "splash_screen" and key == "enabled":
         return False
     if section == "chat_defaults" and key == "enable_tabs":
         return True
+    if section == "chat_defaults" and key == "max_tabs":
+        return 10
     return default
 
 
@@ -83,6 +121,10 @@ async def test_search_rag_result_stages_context_into_console_core_loop() -> None
     with (
         patch("tldw_chatbook.app.get_cli_setting", side_effect=_test_cli_setting),
         patch("tldw_chatbook.UI.Chat_Window_Enhanced.get_cli_setting", side_effect=_test_cli_setting),
+        patch(
+            "tldw_chatbook.Widgets.Chat_Widgets.chat_tab_container.get_cli_setting",
+            side_effect=_test_cli_setting,
+        ),
     ):
         async with app.run_test(size=(140, 40)) as pilot:
             await _wait_until(

--- a/Tests/UI/test_product_maturity_phase1_core_loop.py
+++ b/Tests/UI/test_product_maturity_phase1_core_loop.py
@@ -1,0 +1,142 @@
+"""Product maturity Phase 1.7 narrow core-loop proof contract."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Callable
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from textual.widgets import Static, TextArea
+
+from Tests.UI.test_screen_navigation import _build_test_app
+from tldw_chatbook.Chat.chat_handoff_models import ChatHandoffPayload
+from tldw_chatbook.Widgets.Chat_Widgets.chat_handoff_card import ChatHandoffCard
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EVIDENCE = Path("Docs/superpowers/qa/product-maturity/phase-1/2026-05-05-phase-1-7-core-loop-proof.md")
+TRACKER = Path("Docs/superpowers/trackers/product-maturity-roadmap.md")
+PHASE_1_README = Path("Docs/superpowers/qa/product-maturity/phase-1/README.md")
+TASK = Path("backlog/tasks/task-8.7 - Product-Maturity-Phase-1.7-Narrow-Core-Loop-Proof.md")
+
+
+def _text(path: Path) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+async def _wait_until(
+    pilot,
+    condition: Callable[[], bool],
+    *,
+    timeout_seconds: float = 10.0,
+    interval_seconds: float = 0.05,
+    context: str,
+) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if condition():
+            return
+        await pilot.pause()
+        await asyncio.sleep(interval_seconds)
+    if condition():
+        return
+    raise AssertionError(f"condition was not met within {timeout_seconds:.1f}s for {context}")
+
+
+def _core_loop_payload() -> ChatHandoffPayload:
+    return ChatHandoffPayload(
+        source="search-rag",
+        item_type="rag-result",
+        title="Transcript chunk: Agentic terminal design",
+        body="The source states that Console is the live agentic control surface.",
+        source_id="rag-chunk-1",
+        content_ref="rag:rag-chunk-1",
+        display_summary="Console is the live agentic control surface.",
+        suggested_prompt="Use this RAG evidence to summarize the Console role.",
+        runtime_backend="local",
+        source_owner="local",
+        source_selector_state="local",
+        discovery_owner="rag_search",
+        discovery_entity_id="rag-chunk-1",
+        metadata={"score": 0.91, "source": "notes"},
+    )
+
+
+def _test_cli_setting(section: str, key: str, default=None):
+    if section == "splash_screen" and key == "enabled":
+        return False
+    if section == "chat_defaults" and key == "enable_tabs":
+        return True
+    return default
+
+
+@pytest.mark.asyncio
+async def test_search_rag_result_stages_context_into_console_core_loop() -> None:
+    app = _build_test_app()
+    app.app_config["_first_run"] = False
+    app._initial_tab_value = "home"
+    payload = _core_loop_payload()
+
+    with (
+        patch("tldw_chatbook.app.get_cli_setting", side_effect=_test_cli_setting),
+        patch("tldw_chatbook.UI.Chat_Window_Enhanced.get_cli_setting", side_effect=_test_cli_setting),
+    ):
+        async with app.run_test(size=(140, 40)) as pilot:
+            await _wait_until(
+                pilot,
+                lambda: app.current_tab == "home",
+                context="home initial route",
+            )
+
+            app.open_chat_with_handoff(payload)
+
+            await _wait_until(
+                pilot,
+                lambda: app.current_tab == "chat" and app.screen.__class__.__name__ == "ChatScreen",
+                context="console route after RAG handoff",
+            )
+            await _wait_until(
+                pilot,
+                lambda: bool(app.screen.query(ChatHandoffCard)),
+                context="staged RAG context card",
+            )
+
+            card_text = "\n".join(
+                str(widget.renderable)
+                for card in app.screen.query(ChatHandoffCard)
+                for widget in card.query(Static)
+            )
+            draft_text = "\n".join(widget.text for widget in app.screen.query(TextArea))
+
+            assert "Context staged from RAG Search" in card_text
+            assert "Title: Transcript chunk: Agentic terminal design" in card_text
+            assert "Type: rag-result" in card_text
+            assert "Backend: local" in card_text
+            assert "Source: Local source" in card_text
+            assert "score: 0.91" in card_text
+            assert payload.suggested_prompt in draft_text
+            assert app.pending_chat_handoff is None
+
+
+def test_phase_1_7_core_loop_evidence_is_tracked() -> None:
+    evidence = _text(EVIDENCE)
+    tracker = _text(TRACKER)
+    readme = _text(PHASE_1_README)
+    task = _text(TASK)
+
+    assert "Phase 1.7 narrow core-loop proof" in evidence
+    assert "Search/RAG result -> Console staged context" in evidence
+    assert "Source authority: local" in evidence
+    assert "No P0/P1 defects found" in evidence
+    assert "Phase 1.7 verifies the remaining narrow core-loop proof gate" in tracker
+    assert (
+        "Phase 1: QA Baseline And Usability Guardrails | "
+        "Establish clean-run usability guardrails before feature depth. | verified"
+    ) in tracker
+    assert "2026-05-05-phase-1-7-core-loop-proof.md" in readme
+    assert "status: Done" in task
+    assert "- [x] #1" in task
+    assert "- [x] #4" in task

--- a/Tests/UI/test_product_maturity_phase1_harness.py
+++ b/Tests/UI/test_product_maturity_phase1_harness.py
@@ -144,9 +144,10 @@ def test_product_maturity_tracker_links_phase_one_harness_and_tasks() -> None:
     phase_one_task = _task_text_by_id(phase_one_task_id)
     phase_one_child_tasks = [_task_text_by_id(task_id) for task_id in phase_one_child_ids]
 
-    assert phase_one_row[2] in {"planned", "in_progress"}
+    assert phase_one_row[2] in {"planned", "in_progress", "verified"}
     assert "Phase 1.1" in phase_one_row[3]
     assert "Phase 1.2" in phase_one_row[3]
+    assert "Phase 1.7" in phase_one_row[3]
     assert "TASK-" in phase_one_row[3]
     assert "phase-1/" in phase_one_row[4]
 
@@ -154,6 +155,7 @@ def test_product_maturity_tracker_links_phase_one_harness_and_tasks() -> None:
     assert any("Product-maturity QA protocol defines clean-run setup" in task for task in phase_one_child_tasks)
     assert any("Harness smoke evidence states" in task for task in phase_one_child_tasks)
     assert any("clean first-run launch" in task.lower() for task in phase_one_child_tasks)
+    assert any("Narrow Core Loop Proof" in task for task in phase_one_child_tasks)
 
 
 def test_product_maturity_phase_one_two_plan_scopes_first_run_walkthrough() -> None:

--- a/backlog/tasks/task-8 - Product-Maturity-Phase-1-QA-Baseline-And-Usability-Guardrails.md
+++ b/backlog/tasks/task-8 - Product-Maturity-Phase-1-QA-Baseline-And-Usability-Guardrails.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-8
 title: 'Product Maturity Phase 1: QA Baseline And Usability Guardrails'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-05-05 15:11'
+updated_date: '2026-05-05 20:22'
 labels:
   - product-maturity
   - phase-1-qa-baseline
@@ -19,8 +20,23 @@ Establish clean-run usability guardrails before additional product-depth work.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 QA walkthrough verifies the running app is usable for this phase's target workflows.
-- [ ] #2 Focused regression evidence exists for changed seams.
-- [ ] #3 Repo-tracked QA evidence exists under Docs/superpowers/qa/product-maturity/.
-- [ ] #4 P0/P1 findings are fixed or explicitly accepted according to the spec severity policy.
+- [x] #1 QA walkthrough verifies the running app is usable for this phase's target workflows.
+- [x] #2 Focused regression evidence exists for changed seams.
+- [x] #3 Repo-tracked QA evidence exists under Docs/superpowers/qa/product-maturity/.
+- [x] #4 P0/P1 findings are fixed or explicitly accepted according to the spec severity policy.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Execute Phase 1 child gates for harness, first-run, navigation, keyboard/focus, visual, empty/setup states, and narrow core-loop proof.
+2. Record repo-tracked QA evidence for each gate.
+3. Close P0/P1 findings or document residual risks under the severity policy.
+4. Close the parent once all Phase 1 child gates are verified.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Closed Phase 1 through child gates TASK-8.1 through TASK-8.7. The running app now has QA evidence for clean-run harness setup, first-run orientation, top-level navigation, keyboard/focus fallback, visual/chrome integrity, empty/error/setup recovery, and a narrow Search/RAG-to-Console staged-context core-loop proof. No P0/P1 Phase 1 blockers remain open; Phase 2 owns full grounded generation and Artifact/Chatbook persistence.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-8.7 - Product-Maturity-Phase-1.7-Narrow-Core-Loop-Proof.md
+++ b/backlog/tasks/task-8.7 - Product-Maturity-Phase-1.7-Narrow-Core-Loop-Proof.md
@@ -1,0 +1,44 @@
+---
+id: TASK-8.7
+title: 'Product Maturity Phase 1.7: Narrow Core Loop Proof'
+status: Done
+assignee: []
+created_date: '2026-05-05 20:19'
+updated_date: '2026-05-05 20:26'
+labels:
+  - product-maturity
+  - phase-1-qa-baseline
+dependencies:
+  - TASK-8.6
+parent_task_id: TASK-8
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Close the remaining Phase 1 gate by proving one source or Search/RAG query can reach Console with staged context and a recoverable output path or honest runtime blocker.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Running-app QA walkthrough verifies a Library or Search/RAG to Console core loop.
+- [x] #2 Focused regression coverage proves staged context reaches Console and exposes source authority.
+- [x] #3 Repo-tracked QA evidence records automated evidence manual walkthrough residual risk and exit decision.
+- [x] #4 P0/P1 findings are fixed or explicitly accepted according to the severity policy.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reuse existing Search/RAG and Console handoff seams to define the narrow core-loop contract.
+2. Add a focused product-maturity UI regression proving a RAG result stages context into Console.
+3. Record Phase 1.7 QA evidence and update the Phase 1 README and product-maturity roadmap.
+4. Mark the Phase 1 parent and Phase 1.7 child complete only if the gate evidence is clean.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added a Phase 1.7 running-app regression proving Search/RAG result context stages into Console with local source authority and a review-before-send draft prompt. Added Phase 1.7 QA evidence and updated the product-maturity roadmap and Phase 1 README to close the Phase 1 QA baseline. Full grounded generation and Artifact/Chatbook persistence remain scoped to Phase 2.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary

- Add Product Maturity Phase 1.7 as the final Phase 1 child gate.
- Add a running-app regression proving a Search/RAG result stages context into Console with local source authority and a review-before-send draft prompt.
- Close the Phase 1 roadmap/readme/task state and defer full grounded generation plus Artifact/Chatbook persistence to Phase 2.

## Verification

- `../../.venv/bin/python -m pytest Tests/UI/test_product_maturity_phase1_core_loop.py -q`
- `../../.venv/bin/python -m pytest Tests/UI/test_product_maturity_phase1_harness.py::test_product_maturity_tracker_links_phase_one_harness_and_tasks Tests/UI/test_product_maturity_phase1_core_loop.py -q`
- `../../.venv/bin/python -m pytest Tests/UI/test_product_maturity_phase1_harness.py Tests/UI/test_product_maturity_phase1_first_run.py Tests/UI/test_product_maturity_phase1_navigation_smoke.py Tests/UI/test_product_maturity_phase1_keyboard_focus.py Tests/UI/test_product_maturity_phase1_visual_audit.py Tests/UI/test_product_maturity_phase1_empty_setup_states.py Tests/UI/test_product_maturity_phase1_core_loop.py -q`
- `../../.venv/bin/python -m pytest Tests/UI/test_search_handoffs.py Tests/UI/test_chat_first_handoffs.py::test_open_chat_with_handoff_stores_payload_and_navigates Tests/UI/test_chat_first_handoffs.py::test_chat_screen_consumes_pending_handoff_into_fresh_ephemeral_tab Tests/UI/test_chat_first_handoffs.py::test_chat_handoff_payload_round_trip_preserves_runtime_scope_and_metadata -q`
- `git diff --cached --check`
