### PR TITLE
Verify grounded Console response contract

### DIFF
--- a/Docs/superpowers/qa/product-maturity/phase-2/2026-05-05-phase-2-1-grounded-console-response-contract.md
+++ b/Docs/superpowers/qa/product-maturity/phase-2/2026-05-05-phase-2-1-grounded-console-response-contract.md
@@ -1,0 +1,86 @@
+# Phase 2.1 Grounded Console Response Contract
+
+Date: 2026-05-05
+Task: TASK-9.1
+Branch: codex/product-maturity-phase2-1-grounded-console
+Workflow: Search/RAG staged context -> Console send -> model-bound request
+
+## What Was Verified
+
+Phase 2.1 verifies the first Phase 2 gate: staged Search/RAG context is not only visible in Console, but also reaches the provider-bound request when the user sends a prompt.
+
+Verified contract:
+
+- Staged Search/RAG context is applied to the `chat_wrapper(message=...)` payload.
+- Source authority survives into the model-bound prompt through source, source ID, content ref, body, and metadata lines.
+- The user prompt is preserved under the staged-context block.
+- If the send handler exits before generation work starts, the handoff remains `staged` so recovery does not silently drop source context.
+
+## Automated Evidence
+
+Initial red run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/pytest Tests/Event_Handlers/Chat_Events/test_chat_events_tabs.py -q
+```
+
+Result:
+
+- Failed as expected in `test_tab_send_preserves_handoff_payload_when_original_handler_does_not_dispatch`.
+- Failure: payload status became `sent` after a blocked handler path instead of remaining `staged`.
+
+Focused verification:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/pytest Tests/Event_Handlers/Chat_Events/test_chat_events_tabs.py Tests/Event_Handlers/Chat_Events/test_chat_events.py -q
+```
+
+Result:
+
+- `26 passed, 16 skipped, 1 warning in 4.66s`.
+
+Adjacent handoff and product-maturity verification:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_chat_first_handoffs.py Tests/UI/test_product_maturity_phase1_core_loop.py -q
+```
+
+Result:
+
+- `26 passed, 3 warnings in 9.81s`.
+
+Full Phase 1 product-maturity regression sweep:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_product_maturity_phase1_harness.py Tests/UI/test_product_maturity_phase1_first_run.py Tests/UI/test_product_maturity_phase1_navigation_smoke.py Tests/UI/test_product_maturity_phase1_keyboard_focus.py Tests/UI/test_product_maturity_phase1_visual_audit.py Tests/UI/test_product_maturity_phase1_empty_setup_states.py Tests/UI/test_product_maturity_phase1_core_loop.py -q
+```
+
+Result:
+
+- `42 passed, 1 warning in 24.05s`.
+
+Collection note:
+
+- The same adjacent UI command run through the `pytest` console script failed before collection with `ModuleNotFoundError: No module named 'Tests'`.
+- The module form is the verified command because it preserves the worktree import root for `Tests` package imports.
+
+## Defects Fixed
+
+- `workflow-degradation`: tab-aware send consumed staged context even when validation or runtime setup stopped the send before generation work started. Fixed by marking handoff context `sent` only after generation work is dispatched.
+- `recoverability`: legacy selector mapping accepted a mock-like `_current_chat_tab_id`, producing invalid tab-specific selectors in event-handler tests. Fixed by using tab-specific selectors only when the tab ID is a non-empty string.
+
+## UX Notes
+
+- This slice preserves user control: staged source context is consumed only when a request is actually dispatched.
+- The blocked path keeps the source context available for retry after provider, model, or runtime recovery.
+- This is a contract-level proof, not a full visual walkthrough of generated answers.
+
+## Residual Risk
+
+- Full grounded generation against a live provider or local model remains unverified in this gate.
+- Artifact or Chatbook save, reopen, and Home resume controls are intentionally deferred to later Phase 2 gates.
+- Missing provider/model/runtime copy is preserved by not dropping context, but this gate does not redesign those recovery messages.
+
+## Exit Decision
+
+Pass for Phase 2.1. The model-bound Console request contract is covered, and blocked send paths preserve staged context for recovery. Phase 2 should continue with Artifact/Chatbook creation and reopen/resume gates.

--- a/Docs/superpowers/qa/product-maturity/phase-2/README.md
+++ b/Docs/superpowers/qa/product-maturity/phase-2/README.md
@@ -1,0 +1,7 @@
+# Product Maturity Phase 2 QA Evidence
+
+Phase 2 tracks the core agentic loop:
+
+`source/question -> grounded Console interaction -> saved/reopened Artifact or Chatbook`
+
+Each child gate should record whether the tested slice completes the full loop or intentionally stops at a narrower contract with explicit residual risk.

--- a/Docs/superpowers/trackers/product-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/product-maturity-roadmap.md
@@ -1,7 +1,7 @@
 # Product Maturity Roadmap
 
 Date: 2026-05-05
-Status: Phase 1 verified; Phase 2 planned
+Status: Phase 1 verified; Phase 2.1 verified
 Source Branch: `dev`
 Source Spec: `Docs/superpowers/specs/2026-05-05-product-maturity-phased-roadmap-design.md`
 
@@ -20,6 +20,7 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 - Phase 1.5 verifies visual/chrome integrity across the supported size matrix only; empty/error/setup and core-loop gates remain open.
 - Phase 1.6 verifies empty/error/setup-state coverage only.
 - Phase 1.7 verifies the remaining narrow core-loop proof gate: Search/RAG result context can stage into Console with visible local source authority.
+- Phase 2.1 verifies the first core-agentic-loop contract: staged Search/RAG context reaches the model-bound Console request and remains staged when send is blocked before generation starts.
 
 ## Severity Policy
 
@@ -41,6 +42,7 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 - Phase 1.6: Empty/Error/Setup State Coverage - `TASK-8.6`
 - Phase 1.7: Narrow Core-Loop Proof - `TASK-8.7`
 - Phase 2: Core Agentic Loop - `TASK-9`
+- Phase 2.1: Grounded Console Response Contract - `TASK-9.1`
 - Phase 3: Knowledge And Study Workflows - `TASK-10`
 - Phase 4: Agent Configuration And Execution - `TASK-11`
 - Phase 5: Server-Parity And Live Integrations - `TASK-12`
@@ -51,13 +53,14 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 | Phase | Evidence Path | Status |
 | --- | --- | --- |
 | Phase 1 | `Docs/superpowers/qa/product-maturity/phase-1/` | verified |
+| Phase 2.1 | `Docs/superpowers/qa/product-maturity/phase-2/2026-05-05-phase-2-1-grounded-console-response-contract.md` | verified |
 
 ## Phase Overview
 
 | Phase | Goal | Status | Backlog Tasks | QA Evidence | Residual Risk |
 | --- | --- | --- | --- | --- | --- |
 | Phase 1: QA Baseline And Usability Guardrails | Establish clean-run usability guardrails before feature depth. | verified | `TASK-8`, Phase 1.1 (`TASK-8.1`), Phase 1.2 (`TASK-8.2`), Phase 1.3 (`TASK-8.3`), Phase 1.4 (`TASK-8.4`), Phase 1.5 (`TASK-8.5`), Phase 1.6 (`TASK-8.6`), Phase 1.7 (`TASK-8.7`) | `phase-1/` | Closed; full grounded generation and Artifact/Chatbook persistence move to Phase 2. |
-| Phase 2: Core Agentic Loop | Complete source/question to grounded Console to Artifact/Chatbook loop. | planned | `TASK-9` | not-started | Ready after Phase 1 QA baseline. |
+| Phase 2: Core Agentic Loop | Complete source/question to grounded Console to Artifact/Chatbook loop. | in-progress | `TASK-9`, Phase 2.1 (`TASK-9.1`) | `phase-2/2026-05-05-phase-2-1-grounded-console-response-contract.md` | Grounded request contract verified; Artifact/Chatbook save, reopen, and Home resume remain. |
 | Phase 3: Knowledge And Study Workflows | Mature ingest, organize, retrieve, study, and reuse workflows. | planned | `TASK-10` | not-started | Depends on Phase 2 core loop and later task slicing. |
 | Phase 4: Agent Configuration And Execution | Mature Personas, Skills, MCP, ACP, Schedules, and Workflows. | planned | `TASK-11` | not-started | Depends on service adapters and runtime readiness. |
 | Phase 5: Server-Parity And Live Integrations | Close high-value `tldw_server2` parity gaps. | planned | `TASK-12` | not-started | Requires parity inventory. |
@@ -107,3 +110,9 @@ Status: verified
 Status: verified
 
 - `Docs/superpowers/qa/product-maturity/phase-1/2026-05-05-phase-1-7-core-loop-proof.md`
+
+## Phase 2.1 Evidence
+
+Status: verified
+
+- `Docs/superpowers/qa/product-maturity/phase-2/2026-05-05-phase-2-1-grounded-console-response-contract.md`

--- a/Tests/Event_Handlers/Chat_Events/test_chat_events.py
+++ b/Tests/Event_Handlers/Chat_Events/test_chat_events.py
@@ -23,6 +23,7 @@ from tldw_chatbook.Event_Handlers.Chat_Events.chat_events import (
     is_general_history_conversation,
     # ... import other handlers as you write tests for them
 )
+from tldw_chatbook.Chat.chat_handoff_models import ChatHandoffPayload
 from tldw_chatbook.Utils.Emoji_Handling import (
     EMOJI_SAVE_EDIT, FALLBACK_SAVE_EDIT, EMOJI_EDIT, FALLBACK_EDIT
 )
@@ -130,6 +131,45 @@ async def test_handle_chat_send_with_active_character(mock_chat_message_class, m
 
     wrapper_kwargs = mock_app.chat_wrapper.call_args.kwargs
     assert wrapper_kwargs['system_message'] == "You are TestChar."
+
+
+@patch('tldw_chatbook.Event_Handlers.Chat_Events.chat_events.ccl')
+@patch('tldw_chatbook.Event_Handlers.Chat_Events.chat_events.ChatMessageEnhanced')
+@patch('tldw_chatbook.Event_Handlers.Chat_Events.chat_events.ChatMessage')
+async def test_handle_chat_send_applies_staged_search_rag_context_to_provider_message(
+    mock_chat_message_class, mock_chat_message_enhanced_class, mock_ccl, mock_app
+):
+    """A staged Search/RAG handoff reaches the model-bound chat_wrapper message."""
+    mock_user_msg = MagicMock()
+    mock_ai_msg = MagicMock()
+    mock_chat_message_class.side_effect = [mock_user_msg, mock_ai_msg]
+    mock_chat_message_enhanced_class.side_effect = [mock_user_msg, mock_ai_msg]
+    mock_app._current_chat_handoff_payload = ChatHandoffPayload(
+        source="search-rag",
+        item_type="rag-result",
+        title="Local RAG result",
+        body="Grounded answer evidence",
+        content_ref="library://media/local-rag-result",
+        source_id="rag-result-42",
+        display_summary="Search/RAG evidence summary",
+        metadata={"authority": "local-index", "result_rank": 1},
+    )
+
+    with patch.dict("os.environ", {"OPENAI_API_KEY": "fake-key"}):
+        await handle_chat_send_button_pressed(mock_app, MagicMock())
+
+    worker_lambda = mock_app.run_worker.call_args[0][0]
+    worker_lambda()
+
+    provider_message = mock_app.chat_wrapper.call_args.kwargs["message"]
+    assert "[Staged context]" in provider_message
+    assert "Source: search-rag" in provider_message
+    assert "Source ID: rag-result-42" in provider_message
+    assert "Content ref: library://media/local-rag-result" in provider_message
+    assert "- authority: local-index" in provider_message
+    assert "- result_rank: 1" in provider_message
+    assert "Grounded answer evidence" in provider_message
+    assert "[User prompt]\nUser message" in provider_message
 
 
 async def test_handle_new_conversation_button_pressed(mock_app):

--- a/Tests/Event_Handlers/Chat_Events/test_chat_events_tabs.py
+++ b/Tests/Event_Handlers/Chat_Events/test_chat_events_tabs.py
@@ -240,6 +240,7 @@ class TestChatEventsTabsHandlers:
 
         async def fake_original_handler(app_arg, event_arg):
             assert app_arg._current_chat_handoff_payload.title == "Plan"
+            app_arg.current_chat_worker = Mock()
 
         with patch.object(chat_events_tabs, "get_tab_state_manager", return_value=fake_state_manager):
             with patch(
@@ -254,6 +255,52 @@ class TestChatEventsTabsHandlers:
                 )
 
         assert session_data.handoff_payload.status == "sent"
+        assert getattr(mock_app, "_current_chat_handoff_payload", None) is None
+
+    @pytest.mark.asyncio
+    async def test_tab_send_preserves_handoff_payload_when_original_handler_does_not_dispatch(
+        self, mock_app, session_data, mock_config
+    ):
+        payload = ChatHandoffPayload(
+            source="search-rag",
+            item_type="search-result",
+            title="Local RAG result",
+            body="Grounded answer evidence",
+            metadata={"authority": "local-index"},
+        )
+        session_data.handoff_payload = payload
+
+        class FakeStateManager:
+            @asynccontextmanager
+            async def tab_context(self, tab_id):
+                yield self
+
+            get_tab_state = AsyncMock(return_value=None)
+            create_tab_state = AsyncMock()
+            update_tab_state = AsyncMock()
+
+        fake_state_manager = FakeStateManager()
+
+        async def fake_blocked_handler(app_arg, event_arg):
+            assert app_arg._current_chat_handoff_payload.title == "Local RAG result"
+            # Simulates validation or runtime setup recovery returning before run_worker().
+            app_arg.current_chat_worker = None
+            app_arg.set_current_chat_is_streaming(False)
+
+        with patch.object(chat_events_tabs, "get_tab_state_manager", return_value=fake_state_manager):
+            with patch(
+                "tldw_chatbook.Event_Handlers.Chat_Events.chat_events.handle_chat_send_button_pressed",
+                side_effect=fake_blocked_handler,
+            ):
+                event = Mock()
+                event.button = Mock(spec=Button)
+
+                await chat_events_tabs.handle_chat_send_button_pressed_with_tabs(
+                    mock_app, event, session_data=session_data
+                )
+
+        assert session_data.handoff_payload is payload
+        assert session_data.handoff_payload.status == "staged"
         assert getattr(mock_app, "_current_chat_handoff_payload", None) is None
     
     @pytest.mark.skip(reason="Complex mocking of TabContext and state_manager required")

--- a/backlog/tasks/task-9.1 - Product-Maturity-Phase-2.1-Grounded-Console-Response-Contract.md
+++ b/backlog/tasks/task-9.1 - Product-Maturity-Phase-2.1-Grounded-Console-Response-Contract.md
@@ -1,0 +1,45 @@
+---
+id: TASK-9.1
+title: 'Product Maturity Phase 2.1: Grounded Console Response Contract'
+status: Done
+assignee: []
+created_date: '2026-05-05 21:03'
+updated_date: '2026-05-05 21:07'
+labels:
+  - product-maturity
+  - phase-2-core-agentic-loop
+dependencies: []
+parent_task_id: TASK-9
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Prove staged Search/RAG context can be sent from Console with model-bound grounded context and honest missing-runtime recovery while deferring Artifact or Chatbook persistence.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Running app or focused UI regression verifies staged Search RAG context is sent through Console with source authority preserved
+- [x] #2 Model bound prompt or request includes staged evidence metadata and user prompt
+- [x] #3 Missing provider or runtime path preserves staged context and exposes recovery instead of silently dropping the source
+- [x] #4 Repo tracked QA evidence records automated evidence residual risk and Phase 2.1 exit decision
+- [x] #5 P0 and P1 findings are fixed or explicitly accepted according to the severity policy
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Inspect current ChatSession send path and handoff payload formatting seams
+2. Add failing focused regression for staged context send behavior and missing runtime preservation
+3. Implement minimal code to route staged context into the model bound prompt or request or preserve blocker state
+4. Add Phase 2.1 QA evidence and update roadmap or task state
+5. Verify focused adjacent handoff and relevant Phase 2 and Phase 1 regressions
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented Phase 2.1 grounded Console response contract. Added focused regressions proving staged Search/RAG context reaches the provider-bound chat_wrapper message with source authority metadata and proving blocked tab send paths preserve staged context. Updated tab send completion to mark handoff payloads sent only after generation work starts and hardened legacy tab selector handling to ignore non-string mock tab IDs. Added Phase 2 QA evidence and product-maturity tracker updates. Verification covered focused event handler suites, adjacent Chat handoff/core-loop tests, full Phase 1 product-maturity sweep, and git diff whitespace checks.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Event_Handlers/Chat_Events/chat_events.py
+++ b/tldw_chatbook/Event_Handlers/Chat_Events/chat_events.py
@@ -116,7 +116,7 @@ def apply_current_handoff_context(app: "TldwCli", message_text: str) -> str:
 def _tabbed_chat_selector(app: "TldwCli", selector: str) -> str:
     """Map legacy chat selectors to the active tab-specific widgets."""
     current_tab_id = getattr(app, "_current_chat_tab_id", None)
-    if current_tab_id and selector in {"#chat-input", "#chat-log"}:
+    if isinstance(current_tab_id, str) and current_tab_id and selector in {"#chat-input", "#chat-log"}:
         return f"{selector}-{current_tab_id}"
     return selector
 

--- a/tldw_chatbook/Event_Handlers/Chat_Events/chat_events_tabs.py
+++ b/tldw_chatbook/Event_Handlers/Chat_Events/chat_events_tabs.py
@@ -69,6 +69,18 @@ async def _sync_session_state(state_manager, session_data: ChatSessionData, **up
     else:
         await state_manager.update_tab_state(session_data.tab_id, **updates)
 
+
+def _chat_send_started(app: 'TldwCli', starting_worker: object, starting_streaming: bool) -> bool:
+    """Return True only after the wrapped send path dispatches generation work."""
+    current_worker = getattr(app, "current_chat_worker", None)
+    if current_worker is not None and current_worker is not starting_worker:
+        return True
+    try:
+        current_streaming = bool(app.get_current_chat_is_streaming())
+    except Exception:
+        current_streaming = bool(getattr(app, "current_chat_is_streaming", False))
+    return current_streaming and not starting_streaming
+
 # Note: get_widget_id_for_session and get_tab_specific_widget_ids functions removed
 # These are now handled by the TabContext class
 
@@ -138,7 +150,13 @@ async def handle_chat_send_button_pressed_with_tabs(app: 'TldwCli', event: Butto
                 app._current_chat_handoff_payload = None
 
             # Call the original handler
+            starting_worker = getattr(app, "current_chat_worker", None)
+            try:
+                starting_streaming = bool(app.get_current_chat_is_streaming())
+            except Exception:
+                starting_streaming = bool(getattr(app, "current_chat_is_streaming", False))
             await chat_events.handle_chat_send_button_pressed(app, event)
+            send_started = _chat_send_started(app, starting_worker, starting_streaming)
             
             # Update session data after handler completes
             if session_data:
@@ -149,7 +167,7 @@ async def handle_chat_send_button_pressed_with_tabs(app: 'TldwCli', event: Butto
                 # Mark unsaved changes if message was sent
                 session_data.has_unsaved_changes = True
 
-                if session_data.handoff_payload and session_data.handoff_payload.status != "sent":
+                if send_started and session_data.handoff_payload and session_data.handoff_payload.status != "sent":
                     session_data.handoff_payload.status = "sent"
             
     finally:


### PR DESCRIPTION
## Summary
- Prove staged Search/RAG context reaches the provider-bound Console request with source authority metadata and user prompt preserved.
- Preserve staged handoff context when tab send exits before generation work starts, so missing provider/runtime recovery does not silently drop source context.
- Record Phase 2.1 QA evidence and update the product-maturity tracker plus Backlog task TASK-9.1.

## Test Plan
- [x] /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Event_Handlers/Chat_Events/test_chat_events_tabs.py Tests/Event_Handlers/Chat_Events/test_chat_events.py -q
- [x] /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_chat_first_handoffs.py Tests/UI/test_product_maturity_phase1_core_loop.py -q
- [x] /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_product_maturity_phase1_harness.py Tests/UI/test_product_maturity_phase1_first_run.py Tests/UI/test_product_maturity_phase1_navigation_smoke.py Tests/UI/test_product_maturity_phase1_keyboard_focus.py Tests/UI/test_product_maturity_phase1_visual_audit.py Tests/UI/test_product_maturity_phase1_empty_setup_states.py Tests/UI/test_product_maturity_phase1_core_loop.py -q
- [x] git diff --check
- [x] git diff --cached --check