### PR TITLE
Add console Chatbook artifact save contract

### DIFF
--- a/Docs/superpowers/qa/product-maturity/phase-2/2026-05-05-phase-2-2-console-chatbook-artifact-save-contract.md
+++ b/Docs/superpowers/qa/product-maturity/phase-2/2026-05-05-phase-2-2-console-chatbook-artifact-save-contract.md
@@ -91,6 +91,66 @@ Result:
 
 - Passed with no whitespace errors.
 
+## PR Review Remediation
+
+Qodo review on PR #256 identified four follow-up issues:
+
+- Artifact creation ran inline on the chat action handler path.
+- `System` messages inherited the `-ai` style class and could expose/save artifacts.
+- The artifact action log line included a raw `message_text` snippet.
+- Optional metadata used a truthiness check that dropped valid `0` and `False` values.
+
+Review-fix red run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Event_Handlers/Chat_Events/test_chat_events.py::test_handle_chat_action_button_pressed_schedules_chatbook_artifact_worker Tests/Event_Handlers/Chat_Events/test_chat_events.py::test_handle_chat_action_button_pressed_reports_chatbook_create_failure Tests/Event_Handlers/Chat_Events/test_chat_events.py::test_handle_chat_action_button_pressed_rejects_system_artifact_save Tests/Event_Handlers/Chat_Events/test_chat_events.py::test_handle_chat_action_button_pressed_does_not_log_message_content Tests/Event_Handlers/Chat_Events/test_chat_events.py::test_console_chatbook_artifact_metadata_preserves_falsey_simple_values Tests/Widgets/test_chat_message_artifact_actions.py -q
+```
+
+Result:
+
+- `7 failed, 4 passed, 2 warnings in 3.01s`.
+- Failures matched the review issues.
+
+Review-fix focused green run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Event_Handlers/Chat_Events/test_chat_events.py::test_handle_chat_action_button_pressed_schedules_chatbook_artifact_worker Tests/Event_Handlers/Chat_Events/test_chat_events.py::test_handle_chat_action_button_pressed_reports_chatbook_create_failure Tests/Event_Handlers/Chat_Events/test_chat_events.py::test_handle_chat_action_button_pressed_rejects_system_artifact_save Tests/Event_Handlers/Chat_Events/test_chat_events.py::test_handle_chat_action_button_pressed_does_not_log_message_content Tests/Event_Handlers/Chat_Events/test_chat_events.py::test_console_chatbook_artifact_metadata_preserves_falsey_simple_values Tests/Widgets/test_chat_message_artifact_actions.py -q
+```
+
+Result:
+
+- `11 passed, 1 warning in 2.79s`.
+
+Review-fix broader verification:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Event_Handlers/Chat_Events/test_chat_events.py Tests/Widgets/test_chat_message_enhanced.py Tests/Widgets/test_chat_message_artifact_actions.py -q
+```
+
+Result:
+
+- `43 passed, 6 warnings in 11.71s`.
+
+Adjacent verification after review fixes:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_keeps_console_launch_disabled_without_chatbooks Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_launches_latest_local_chatbook_in_console Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_sanitizes_chatbook_metadata_before_console_launch Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_uses_numeric_id_tie_break_for_latest_chatbook Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_distinguishes_chatbook_service_failure_from_empty_state Tests/UI/test_product_maturity_phase1_harness.py::test_product_maturity_tracker_links_phase_one_harness_and_tasks -q
+```
+
+Result:
+
+- `6 passed, 1 warning in 10.06s`.
+
+Post-remediation diff hygiene:
+
+```bash
+git diff --check
+```
+
+Result:
+
+- Passed with no whitespace errors.
+
 ## Defects Fixed
 
 - `workflow-degradation`: Console assistant responses had no visible path to create a Chatbook artifact, so the Phase 2 loop stopped at generated text.

--- a/Docs/superpowers/qa/product-maturity/phase-2/2026-05-05-phase-2-2-console-chatbook-artifact-save-contract.md
+++ b/Docs/superpowers/qa/product-maturity/phase-2/2026-05-05-phase-2-2-console-chatbook-artifact-save-contract.md
@@ -1,0 +1,115 @@
+# Phase 2.2 Console Chatbook Artifact Save Contract
+
+Date: 2026-05-05
+Task: TASK-9.2
+Branch: codex/product-maturity-phase2-2-artifact-save-contract
+Workflow: Console assistant response -> Save artifact action -> local Chatbook artifact record
+
+## What Was Verified
+
+Phase 2.2 verifies the next narrow Phase 2 gate: a completed assistant response in Console can be saved as a local Chatbook artifact record without leaving the chat workflow.
+
+Verified contract:
+
+- Basic `ChatMessage` assistant responses expose a visible save-to-artifact action.
+- Enhanced `ChatMessageEnhanced` assistant responses expose the same save-to-artifact action.
+- User messages do not expose the assistant artifact save action.
+- The artifact action routes through `app.local_chatbook_service.create_chatbook(...)`.
+- Created records include bounded Console provenance metadata: source, artifact kind, conversation ID, message ID, role, provider, model, bounded content, and truncation status.
+- Missing local Chatbook service and create failures surface recovery notifications without deleting the source message.
+
+## Automated Evidence
+
+Initial red run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Event_Handlers/Chat_Events/test_chat_events.py::test_handle_chat_action_button_pressed_saves_ai_message_as_chatbook_artifact Tests/Event_Handlers/Chat_Events/test_chat_events.py::test_handle_chat_action_button_pressed_reports_missing_chatbook_service Tests/Event_Handlers/Chat_Events/test_chat_events.py::test_handle_chat_action_button_pressed_reports_chatbook_create_failure Tests/Widgets/test_chat_message_artifact_actions.py -q
+```
+
+Result:
+
+- `5 failed, 2 passed, 1 warning in 2.64s`.
+- Failures were expected: no `#save-artifact` button existed and the action handler never called `local_chatbook_service.create_chatbook`.
+
+Focused green verification:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Event_Handlers/Chat_Events/test_chat_events.py::test_handle_chat_action_button_pressed_saves_ai_message_as_chatbook_artifact Tests/Event_Handlers/Chat_Events/test_chat_events.py::test_handle_chat_action_button_pressed_reports_missing_chatbook_service Tests/Event_Handlers/Chat_Events/test_chat_events.py::test_handle_chat_action_button_pressed_reports_chatbook_create_failure Tests/Widgets/test_chat_message_artifact_actions.py -q
+```
+
+Result:
+
+- `7 passed, 1 warning in 1.70s`.
+
+Affected event-handler verification:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Event_Handlers/Chat_Events/test_chat_events.py -q
+```
+
+Result:
+
+- `11 passed, 1 warning in 4.41s`.
+
+Affected widget verification:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Widgets/test_chat_message_enhanced.py Tests/Widgets/test_chat_message_artifact_actions.py -q
+```
+
+Result:
+
+- `27 passed, 5 warnings in 3.59s`.
+
+Adjacent Artifacts/Console handoff verification:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_keeps_console_launch_disabled_without_chatbooks Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_launches_latest_local_chatbook_in_console Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_sanitizes_chatbook_metadata_before_console_launch Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_uses_numeric_id_tie_break_for_latest_chatbook Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_distinguishes_chatbook_service_failure_from_empty_state -q
+```
+
+Result:
+
+- `5 passed, 3 warnings in 9.98s`.
+
+Tracker regression:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_product_maturity_phase1_harness.py::test_product_maturity_tracker_links_phase_one_harness_and_tasks -q
+```
+
+Result:
+
+- `1 passed in 0.12s`.
+
+Diff hygiene:
+
+```bash
+git diff --check
+```
+
+Result:
+
+- Passed with no whitespace errors.
+
+## Defects Fixed
+
+- `workflow-degradation`: Console assistant responses had no visible path to create a Chatbook artifact, so the Phase 2 loop stopped at generated text.
+- `recoverability`: artifact persistence failures had no dedicated recovery message because the action did not exist.
+
+## UX Notes
+
+- The save action is assistant-only so user prompts are not accidentally persisted as result artifacts.
+- The action stays inline with existing message actions to preserve power-user speed.
+- The source message remains visible on every failure path, which preserves user control and retryability.
+- The metadata is intentionally bounded so long assistant responses do not create unbounded registry payloads.
+
+## Residual Risk
+
+- This gate creates a local Chatbook registry record; it does not export a full `.chatbook` package.
+- Artifacts reopen and route-back into Console were verified earlier for the latest existing local Chatbook, but this gate does not prove the newly saved record can be selected from Artifacts.
+- Home resume/open controls for newly saved artifacts remain unverified.
+- Full live-provider generation remains outside this gate; the save contract is tested at the completed-message/widget-handler layer.
+
+## Exit Decision
+
+Pass for Phase 2.2. Console now has a tested assistant-response-to-local-Chatbook-artifact save contract with recovery notifications. Phase 2 should continue with newly saved artifact visibility, reopen, and Home resume gates.

--- a/Docs/superpowers/qa/product-maturity/phase-2/README.md
+++ b/Docs/superpowers/qa/product-maturity/phase-2/README.md
@@ -5,3 +5,8 @@ Phase 2 tracks the core agentic loop:
 `source/question -> grounded Console interaction -> saved/reopened Artifact or Chatbook`
 
 Each child gate should record whether the tested slice completes the full loop or intentionally stops at a narrower contract with explicit residual risk.
+
+## Evidence
+
+- `2026-05-05-phase-2-1-grounded-console-response-contract.md`
+- `2026-05-05-phase-2-2-console-chatbook-artifact-save-contract.md`

--- a/Docs/superpowers/trackers/product-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/product-maturity-roadmap.md
@@ -1,7 +1,7 @@
 # Product Maturity Roadmap
 
 Date: 2026-05-05
-Status: Phase 1 verified; Phase 2.1 verified
+Status: Phase 1 verified; Phase 2.2 verified
 Source Branch: `dev`
 Source Spec: `Docs/superpowers/specs/2026-05-05-product-maturity-phased-roadmap-design.md`
 
@@ -21,6 +21,7 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 - Phase 1.6 verifies empty/error/setup-state coverage only.
 - Phase 1.7 verifies the remaining narrow core-loop proof gate: Search/RAG result context can stage into Console with visible local source authority.
 - Phase 2.1 verifies the first core-agentic-loop contract: staged Search/RAG context reaches the model-bound Console request and remains staged when send is blocked before generation starts.
+- Phase 2.2 verifies the next core-agentic-loop contract: completed assistant responses can create local Chatbook artifact records with bounded Console provenance and recoverable failure notifications.
 
 ## Severity Policy
 
@@ -43,6 +44,7 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 - Phase 1.7: Narrow Core-Loop Proof - `TASK-8.7`
 - Phase 2: Core Agentic Loop - `TASK-9`
 - Phase 2.1: Grounded Console Response Contract - `TASK-9.1`
+- Phase 2.2: Console Chatbook Artifact Save Contract - `TASK-9.2`
 - Phase 3: Knowledge And Study Workflows - `TASK-10`
 - Phase 4: Agent Configuration And Execution - `TASK-11`
 - Phase 5: Server-Parity And Live Integrations - `TASK-12`
@@ -54,13 +56,14 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 | --- | --- | --- |
 | Phase 1 | `Docs/superpowers/qa/product-maturity/phase-1/` | verified |
 | Phase 2.1 | `Docs/superpowers/qa/product-maturity/phase-2/2026-05-05-phase-2-1-grounded-console-response-contract.md` | verified |
+| Phase 2.2 | `Docs/superpowers/qa/product-maturity/phase-2/2026-05-05-phase-2-2-console-chatbook-artifact-save-contract.md` | verified |
 
 ## Phase Overview
 
 | Phase | Goal | Status | Backlog Tasks | QA Evidence | Residual Risk |
 | --- | --- | --- | --- | --- | --- |
 | Phase 1: QA Baseline And Usability Guardrails | Establish clean-run usability guardrails before feature depth. | verified | `TASK-8`, Phase 1.1 (`TASK-8.1`), Phase 1.2 (`TASK-8.2`), Phase 1.3 (`TASK-8.3`), Phase 1.4 (`TASK-8.4`), Phase 1.5 (`TASK-8.5`), Phase 1.6 (`TASK-8.6`), Phase 1.7 (`TASK-8.7`) | `phase-1/` | Closed; full grounded generation and Artifact/Chatbook persistence move to Phase 2. |
-| Phase 2: Core Agentic Loop | Complete source/question to grounded Console to Artifact/Chatbook loop. | in-progress | `TASK-9`, Phase 2.1 (`TASK-9.1`) | `phase-2/2026-05-05-phase-2-1-grounded-console-response-contract.md` | Grounded request contract verified; Artifact/Chatbook save, reopen, and Home resume remain. |
+| Phase 2: Core Agentic Loop | Complete source/question to grounded Console to Artifact/Chatbook loop. | in-progress | `TASK-9`, Phase 2.1 (`TASK-9.1`), Phase 2.2 (`TASK-9.2`) | `phase-2/2026-05-05-phase-2-1-grounded-console-response-contract.md`, `phase-2/2026-05-05-phase-2-2-console-chatbook-artifact-save-contract.md` | Grounded request and local Chatbook artifact save contracts verified; newly saved artifact visibility, reopen, and Home resume remain. |
 | Phase 3: Knowledge And Study Workflows | Mature ingest, organize, retrieve, study, and reuse workflows. | planned | `TASK-10` | not-started | Depends on Phase 2 core loop and later task slicing. |
 | Phase 4: Agent Configuration And Execution | Mature Personas, Skills, MCP, ACP, Schedules, and Workflows. | planned | `TASK-11` | not-started | Depends on service adapters and runtime readiness. |
 | Phase 5: Server-Parity And Live Integrations | Close high-value `tldw_server2` parity gaps. | planned | `TASK-12` | not-started | Requires parity inventory. |
@@ -116,3 +119,9 @@ Status: verified
 Status: verified
 
 - `Docs/superpowers/qa/product-maturity/phase-2/2026-05-05-phase-2-1-grounded-console-response-contract.md`
+
+## Phase 2.2 Evidence
+
+Status: verified
+
+- `Docs/superpowers/qa/product-maturity/phase-2/2026-05-05-phase-2-2-console-chatbook-artifact-save-contract.md`

--- a/Tests/Event_Handlers/Chat_Events/test_chat_events.py
+++ b/Tests/Event_Handlers/Chat_Events/test_chat_events.py
@@ -336,6 +336,91 @@ async def test_handle_chat_action_button_pressed_edit_and_save(mock_ccl, mock_te
     assert EMOJI_EDIT in mock_button.label or FALLBACK_EDIT in mock_button.label
 
 
+async def test_handle_chat_action_button_pressed_saves_ai_message_as_chatbook_artifact(mock_app):
+    """Assistant message artifact save routes through the local Chatbook service."""
+    mock_app.local_chatbook_service = MagicMock()
+    mock_app.local_chatbook_service.create_chatbook = AsyncMock(
+        return_value={"id": "artifact-1", "name": "Important answer"}
+    )
+    mock_app.current_chat_conversation_id = "conv-123"
+    mock_app.current_provider = "OpenAI"
+    mock_app.current_model = "gpt-4.1"
+    mock_button = MagicMock(spec=Button, classes=["artifact-button"])
+    mock_action_widget = MagicMock(spec=ChatMessage)
+    mock_action_widget.has_class.return_value = True
+    mock_action_widget.message_text = "Important answer\n\n" + ("x" * 21000)
+    mock_action_widget.role = "Assistant"
+    mock_action_widget.message_id_internal = "msg-456"
+    mock_action_widget.remove = AsyncMock()
+
+    await handle_chat_action_button_pressed(mock_app, mock_button, mock_action_widget)
+
+    mock_app.local_chatbook_service.create_chatbook.assert_awaited_once()
+    create_kwargs = mock_app.local_chatbook_service.create_chatbook.await_args.kwargs
+    assert create_kwargs["name"] == "Important answer"
+    assert create_kwargs["tags"] == ["console", "artifact"]
+    assert create_kwargs["categories"] == ["Console", "Artifacts"]
+    assert "Saved from Console assistant response." in create_kwargs["description"]
+    assert create_kwargs["metadata"]["artifact_source"] == "console"
+    assert create_kwargs["metadata"]["artifact_kind"] == "assistant-response"
+    assert create_kwargs["metadata"]["conversation_id"] == "conv-123"
+    assert create_kwargs["metadata"]["message_id"] == "msg-456"
+    assert create_kwargs["metadata"]["message_role"] == "Assistant"
+    assert create_kwargs["metadata"]["provider"] == "OpenAI"
+    assert create_kwargs["metadata"]["model"] == "gpt-4.1"
+    assert len(create_kwargs["metadata"]["content"]) == 20000
+    assert create_kwargs["metadata"]["content_truncated"] is True
+    mock_action_widget.remove.assert_not_awaited()
+    mock_app.notify.assert_called_with(
+        "Saved response as Chatbook artifact: Important answer",
+        severity="information",
+        timeout=4,
+    )
+
+
+async def test_handle_chat_action_button_pressed_reports_missing_chatbook_service(mock_app):
+    """Save-to-artifact failure is recoverable and preserves the message."""
+    mock_app.local_chatbook_service = None
+    mock_button = MagicMock(spec=Button, classes=["artifact-button"])
+    mock_action_widget = MagicMock(spec=ChatMessage)
+    mock_action_widget.has_class.return_value = True
+    mock_action_widget.message_text = "Answer that should stay visible"
+    mock_action_widget.role = "Assistant"
+    mock_action_widget.message_id_internal = "msg-789"
+    mock_action_widget.remove = AsyncMock()
+
+    await handle_chat_action_button_pressed(mock_app, mock_button, mock_action_widget)
+
+    mock_action_widget.remove.assert_not_awaited()
+    mock_app.notify.assert_called_with(
+        "Local Chatbook artifact service is unavailable.",
+        severity="warning",
+        timeout=5,
+    )
+
+
+async def test_handle_chat_action_button_pressed_reports_chatbook_create_failure(mock_app):
+    """Create failures notify the user without deleting the source response."""
+    mock_app.local_chatbook_service = MagicMock()
+    mock_app.local_chatbook_service.create_chatbook = AsyncMock(side_effect=RuntimeError("disk full"))
+    mock_button = MagicMock(spec=Button, classes=["artifact-button"])
+    mock_action_widget = MagicMock(spec=ChatMessage)
+    mock_action_widget.has_class.return_value = True
+    mock_action_widget.message_text = "Answer that should stay visible"
+    mock_action_widget.role = "Assistant"
+    mock_action_widget.message_id_internal = "msg-789"
+    mock_action_widget.remove = AsyncMock()
+
+    await handle_chat_action_button_pressed(mock_app, mock_button, mock_action_widget)
+
+    mock_action_widget.remove.assert_not_awaited()
+    mock_app.notify.assert_called_with(
+        "Failed to save Chatbook artifact: disk full",
+        severity="error",
+        timeout=7,
+    )
+
+
 @patch('tldw_chatbook.Event_Handlers.Chat_Events.chat_events.load_character_and_image')
 async def test_handle_chat_load_character_with_greeting(mock_load_char, mock_app):
     """Test that loading a character into an empty, ephemeral chat posts a greeting."""

--- a/Tests/Event_Handlers/Chat_Events/test_chat_events.py
+++ b/Tests/Event_Handlers/Chat_Events/test_chat_events.py
@@ -1,6 +1,8 @@
 # /tests/Event_Handlers/Chat_Events/test_chat_events.py
 # Unit tests for chat event handlers using mocked components
 
+import asyncio
+
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -20,6 +22,7 @@ from tldw_chatbook.Event_Handlers.Chat_Events.chat_events import (
     handle_chat_new_conversation_button_pressed,
     handle_chat_save_current_chat_button_pressed,
     handle_chat_load_character_button_pressed,
+    _console_chatbook_artifact_metadata,
     is_general_history_conversation,
     # ... import other handlers as you write tests for them
 )
@@ -336,12 +339,13 @@ async def test_handle_chat_action_button_pressed_edit_and_save(mock_ccl, mock_te
     assert EMOJI_EDIT in mock_button.label or FALLBACK_EDIT in mock_button.label
 
 
-async def test_handle_chat_action_button_pressed_saves_ai_message_as_chatbook_artifact(mock_app):
-    """Assistant message artifact save routes through the local Chatbook service."""
+async def test_handle_chat_action_button_pressed_schedules_chatbook_artifact_worker(mock_app):
+    """Assistant artifact save schedules disk work off the UI handler path."""
     mock_app.local_chatbook_service = MagicMock()
     mock_app.local_chatbook_service.create_chatbook = AsyncMock(
         return_value={"id": "artifact-1", "name": "Important answer"}
     )
+    mock_app.call_from_thread = MagicMock(side_effect=lambda func, *args, **kwargs: func(*args, **kwargs))
     mock_app.current_chat_conversation_id = "conv-123"
     mock_app.current_provider = "OpenAI"
     mock_app.current_model = "gpt-4.1"
@@ -354,6 +358,13 @@ async def test_handle_chat_action_button_pressed_saves_ai_message_as_chatbook_ar
     mock_action_widget.remove = AsyncMock()
 
     await handle_chat_action_button_pressed(mock_app, mock_button, mock_action_widget)
+
+    mock_app.local_chatbook_service.create_chatbook.assert_not_called()
+    mock_app.run_worker.assert_called_once()
+    worker_callable = mock_app.run_worker.call_args.args[0]
+    assert mock_app.run_worker.call_args.kwargs["thread"] is True
+    assert mock_app.run_worker.call_args.kwargs["name"] == "console-chatbook-artifact-save"
+    await asyncio.to_thread(worker_callable)
 
     mock_app.local_chatbook_service.create_chatbook.assert_awaited_once()
     create_kwargs = mock_app.local_chatbook_service.create_chatbook.await_args.kwargs
@@ -371,7 +382,8 @@ async def test_handle_chat_action_button_pressed_saves_ai_message_as_chatbook_ar
     assert len(create_kwargs["metadata"]["content"]) == 20000
     assert create_kwargs["metadata"]["content_truncated"] is True
     mock_action_widget.remove.assert_not_awaited()
-    mock_app.notify.assert_called_with(
+    mock_app.call_from_thread.assert_called_with(
+        mock_app.notify,
         "Saved response as Chatbook artifact: Important answer",
         severity="information",
         timeout=4,
@@ -403,6 +415,7 @@ async def test_handle_chat_action_button_pressed_reports_chatbook_create_failure
     """Create failures notify the user without deleting the source response."""
     mock_app.local_chatbook_service = MagicMock()
     mock_app.local_chatbook_service.create_chatbook = AsyncMock(side_effect=RuntimeError("disk full"))
+    mock_app.call_from_thread = MagicMock(side_effect=lambda func, *args, **kwargs: func(*args, **kwargs))
     mock_button = MagicMock(spec=Button, classes=["artifact-button"])
     mock_action_widget = MagicMock(spec=ChatMessage)
     mock_action_widget.has_class.return_value = True
@@ -413,12 +426,78 @@ async def test_handle_chat_action_button_pressed_reports_chatbook_create_failure
 
     await handle_chat_action_button_pressed(mock_app, mock_button, mock_action_widget)
 
+    worker_callable = mock_app.run_worker.call_args.args[0]
+    await asyncio.to_thread(worker_callable)
+
     mock_action_widget.remove.assert_not_awaited()
-    mock_app.notify.assert_called_with(
+    mock_app.call_from_thread.assert_called_with(
+        mock_app.notify,
         "Failed to save Chatbook artifact: disk full",
         severity="error",
         timeout=7,
     )
+
+
+async def test_handle_chat_action_button_pressed_rejects_system_artifact_save(mock_app):
+    """System/error bubbles are not assistant artifacts even when styled as -ai."""
+    mock_app.local_chatbook_service = MagicMock()
+    mock_app.local_chatbook_service.create_chatbook = AsyncMock()
+    mock_button = MagicMock(spec=Button, classes=["artifact-button"])
+    mock_action_widget = MagicMock(spec=ChatMessage)
+    mock_action_widget.has_class.return_value = True
+    mock_action_widget.message_text = "System setup warning"
+    mock_action_widget.role = "System"
+    mock_action_widget.message_id_internal = "msg-system"
+    mock_action_widget.remove = AsyncMock()
+
+    await handle_chat_action_button_pressed(mock_app, mock_button, mock_action_widget)
+
+    mock_app.run_worker.assert_not_called()
+    mock_app.local_chatbook_service.create_chatbook.assert_not_called()
+    mock_action_widget.remove.assert_not_awaited()
+    mock_app.notify.assert_called_with(
+        "Only assistant responses can be saved as Chatbook artifacts.",
+        severity="warning",
+        timeout=5,
+    )
+
+
+async def test_handle_chat_action_button_pressed_does_not_log_message_content(mock_app):
+    """Artifact action logs must not include untrusted chat content snippets."""
+    mock_app.local_chatbook_service = MagicMock()
+    mock_app.local_chatbook_service.create_chatbook = AsyncMock(return_value={"id": "artifact-1"})
+    mock_button = MagicMock(spec=Button, classes=["artifact-button"])
+    mock_action_widget = MagicMock(spec=ChatMessage)
+    mock_action_widget.has_class.return_value = True
+    mock_action_widget.message_text = "sk-test-secret-1234567890 should not enter logs"
+    mock_action_widget.role = "Assistant"
+    mock_action_widget.message_id_internal = "msg-secret"
+
+    with patch("tldw_chatbook.Event_Handlers.Chat_Events.chat_events.logging.info") as mock_log_info:
+        await handle_chat_action_button_pressed(mock_app, mock_button, mock_action_widget)
+
+    assert "sk-test-secret" not in repr(mock_log_info.call_args_list)
+
+
+async def test_console_chatbook_artifact_metadata_preserves_falsey_simple_values(mock_app):
+    """Valid numeric/boolean provenance should not be dropped by truthiness checks."""
+    mock_app.current_chat_conversation_id = 0
+    mock_app.current_provider = False
+    mock_app.current_model = ""
+    mock_action_widget = MagicMock(spec=ChatMessage)
+    mock_action_widget.message_id_internal = 0
+
+    metadata = _console_chatbook_artifact_metadata(
+        mock_app,
+        mock_action_widget,
+        "Short answer",
+        "Assistant",
+    )
+
+    assert metadata["conversation_id"] == 0
+    assert metadata["message_id"] == 0
+    assert metadata["provider"] is False
+    assert "model" not in metadata
 
 
 @patch('tldw_chatbook.Event_Handlers.Chat_Events.chat_events.load_character_and_image')

--- a/Tests/Widgets/test_chat_message_artifact_actions.py
+++ b/Tests/Widgets/test_chat_message_artifact_actions.py
@@ -39,3 +39,17 @@ async def test_user_messages_do_not_expose_save_artifact_action(widget_pilot, wi
         await pilot.pause()
 
         assert not widget.query("#save-artifact")
+
+
+@pytest.mark.parametrize("widget_class", [ChatMessage, ChatMessageEnhanced])
+async def test_system_messages_do_not_expose_save_artifact_action(widget_pilot, widget_class):
+    async with await widget_pilot(
+        widget_class,
+        message="System status",
+        role="System",
+    ) as pilot:
+        widget = pilot.app.test_widget
+        await pilot.pause()
+
+        assert widget.has_class("-ai")
+        assert not widget.query("#save-artifact")

--- a/Tests/Widgets/test_chat_message_artifact_actions.py
+++ b/Tests/Widgets/test_chat_message_artifact_actions.py
@@ -1,0 +1,41 @@
+"""Regression coverage for chat message artifact actions."""
+
+import pytest
+from textual.widgets import Button
+
+from Tests.textual_test_utils import widget_pilot
+from tldw_chatbook.Widgets.Chat_Widgets.chat_message import ChatMessage
+from tldw_chatbook.Widgets.Chat_Widgets.chat_message_enhanced import ChatMessageEnhanced
+
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.ui]
+
+
+@pytest.mark.parametrize("widget_class", [ChatMessage, ChatMessageEnhanced])
+async def test_ai_messages_expose_save_artifact_action(widget_pilot, widget_class):
+    async with await widget_pilot(
+        widget_class,
+        message="Assistant response",
+        role="Assistant",
+        generation_complete=True,
+    ) as pilot:
+        widget = pilot.app.test_widget
+        await pilot.pause()
+
+        save_button = widget.query_one("#save-artifact", Button)
+        assert save_button is not None
+        assert "artifact-button" in save_button.classes
+        assert save_button.tooltip == "Save response as Chatbook artifact"
+
+
+@pytest.mark.parametrize("widget_class", [ChatMessage, ChatMessageEnhanced])
+async def test_user_messages_do_not_expose_save_artifact_action(widget_pilot, widget_class):
+    async with await widget_pilot(
+        widget_class,
+        message="User prompt",
+        role="User",
+    ) as pilot:
+        widget = pilot.app.test_widget
+        await pilot.pause()
+
+        assert not widget.query("#save-artifact")

--- a/backlog/tasks/task-9.2 - Product-Maturity-Phase-2.2-Console-Chatbook-Artifact-Save-Contract.md
+++ b/backlog/tasks/task-9.2 - Product-Maturity-Phase-2.2-Console-Chatbook-Artifact-Save-Contract.md
@@ -1,0 +1,45 @@
+---
+id: TASK-9.2
+title: 'Product Maturity Phase 2.2: Console Chatbook Artifact Save Contract'
+status: Done
+assignee: []
+created_date: '2026-05-05 21:30'
+updated_date: '2026-05-05 21:36'
+labels:
+  - product-maturity
+  - phase-2-core-agentic-loop
+dependencies: []
+parent_task_id: TASK-9
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Prove Console can create a local Chatbook artifact record from a completed assistant response with source provenance while deferring full Artifact reopen and Home resume behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Completed assistant messages expose a visible save-to-artifact action in basic and enhanced chat message widgets
+- [x] #2 The save action creates a local Chatbook artifact through the app local_chatbook_service with bounded provenance metadata
+- [x] #3 Missing local Chatbook service or create failure surfaces an honest recovery notification without deleting the message
+- [x] #4 Focused regressions verify success and failure paths plus the widget affordance
+- [x] #5 Repo tracked QA evidence records automated evidence residual risk and Phase 2.2 exit decision
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing regressions for assistant message save-to-artifact affordance and action handler success and failure paths
+2. Implement the smallest ChatMessage and ChatMessageEnhanced save action affordance
+3. Route the action through local_chatbook_service.create_chatbook with bounded Console provenance metadata
+4. Record Phase 2.2 QA evidence and update the product-maturity tracker
+5. Run focused chat event/widget regressions and adjacent Product Maturity checks
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented assistant-only save-to-artifact actions in ChatMessage and ChatMessageEnhanced. Routed the action through app.local_chatbook_service.create_chatbook with bounded Console provenance metadata and recoverable notifications for missing service or create failures. Added focused red-green regressions for widget affordance, success, missing-service, and failure paths, plus Phase 2.2 QA evidence and tracker updates.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-9.2 - Product-Maturity-Phase-2.2-Console-Chatbook-Artifact-Save-Contract.md
+++ b/backlog/tasks/task-9.2 - Product-Maturity-Phase-2.2-Console-Chatbook-Artifact-Save-Contract.md
@@ -4,7 +4,7 @@ title: 'Product Maturity Phase 2.2: Console Chatbook Artifact Save Contract'
 status: Done
 assignee: []
 created_date: '2026-05-05 21:30'
-updated_date: '2026-05-05 21:36'
+updated_date: '2026-05-05 21:56'
 labels:
   - product-maturity
   - phase-2-core-agentic-loop
@@ -42,4 +42,6 @@ Prove Console can create a local Chatbook artifact record from a completed assis
 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented assistant-only save-to-artifact actions in ChatMessage and ChatMessageEnhanced. Routed the action through app.local_chatbook_service.create_chatbook with bounded Console provenance metadata and recoverable notifications for missing service or create failures. Added focused red-green regressions for widget affordance, success, missing-service, and failure paths, plus Phase 2.2 QA evidence and tracker updates.
+
+PR review remediation moved Chatbook artifact creation onto a Textual thread worker with call_from_thread notifications, excluded System messages from save eligibility, removed raw message content from artifact-action logging, and preserved valid falsey provenance values. Added red-green regressions for all four review items.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Event_Handlers/Chat_Events/chat_events.py
+++ b/tldw_chatbook/Event_Handlers/Chat_Events/chat_events.py
@@ -3,6 +3,7 @@
 #
 # Imports
 import logging
+import asyncio
 import inspect
 import json
 import os
@@ -95,6 +96,13 @@ def _simple_metadata_value(value: Any) -> Optional[Union[str, int, float, bool]]
     return None
 
 
+def _is_console_chatbook_artifact_eligible(
+    action_widget: Union[ChatMessage, ChatMessageEnhanced],
+    message_role: str,
+) -> bool:
+    return action_widget.has_class("-ai") and str(message_role or "").strip().lower() != "system"
+
+
 def _console_chatbook_artifact_title(message_text: str) -> str:
     for line in str(message_text or "").splitlines():
         title = " ".join(line.strip().lstrip("#>*-` ").split())
@@ -121,6 +129,9 @@ def _console_chatbook_artifact_metadata(
     message_role: str,
 ) -> dict[str, Any]:
     content = str(message_text or "")
+    conversation_id = getattr(app, "current_chat_conversation_id", None)
+    if conversation_id is None:
+        conversation_id = getattr(app, "current_conversation_id", None)
     metadata: dict[str, Any] = {
         "artifact_source": "console",
         "artifact_kind": "assistant-response",
@@ -129,17 +140,26 @@ def _console_chatbook_artifact_metadata(
         "content_truncated": len(content) > MAX_CONSOLE_CHATBOOK_ARTIFACT_CONTENT_CHARS,
     }
     optional_values = {
-        "conversation_id": getattr(app, "current_chat_conversation_id", None)
-        or getattr(app, "current_conversation_id", None),
+        "conversation_id": conversation_id,
         "message_id": getattr(action_widget, "message_id_internal", None),
         "provider": getattr(app, "current_provider", None),
         "model": getattr(app, "current_model", None),
     }
     for key, value in optional_values.items():
         simple_value = _simple_metadata_value(value)
-        if simple_value:
-            metadata[key] = simple_value
+        if simple_value is None:
+            continue
+        if isinstance(simple_value, str) and not simple_value.strip():
+            continue
+        metadata[key] = simple_value
     return metadata
+
+
+def _run_console_chatbook_create(create_chatbook: Any, payload: dict[str, Any]) -> Any:
+    result = create_chatbook(**payload)
+    if inspect.isawaitable(result):
+        return asyncio.run(result)
+    return result
 
 
 async def _save_console_chatbook_artifact(
@@ -148,7 +168,7 @@ async def _save_console_chatbook_artifact(
     message_text: str,
     message_role: str,
 ) -> None:
-    if not action_widget.has_class("-ai"):
+    if not _is_console_chatbook_artifact_eligible(action_widget, message_role):
         app.notify("Only assistant responses can be saved as Chatbook artifacts.", severity="warning", timeout=5)
         return
 
@@ -159,20 +179,39 @@ async def _save_console_chatbook_artifact(
         return
 
     title = _console_chatbook_artifact_title(message_text)
-    try:
-        result = create_chatbook(
-            name=title,
-            description=_console_chatbook_artifact_description(message_text),
-            tags=["console", "artifact"],
-            categories=["Console", "Artifacts"],
-            metadata=_console_chatbook_artifact_metadata(app, action_widget, message_text, message_role),
-        )
-        if inspect.isawaitable(result):
-            await result
-        app.notify(f"Saved response as Chatbook artifact: {title}", severity="information", timeout=4)
-    except Exception as exc:
-        loguru_logger.error("Failed to save Console response as Chatbook artifact: %s", exc, exc_info=True)
-        app.notify(f"Failed to save Chatbook artifact: {exc}", severity="error", timeout=7)
+    payload = {
+        "name": title,
+        "description": _console_chatbook_artifact_description(message_text),
+        "tags": ["console", "artifact"],
+        "categories": ["Console", "Artifacts"],
+        "metadata": _console_chatbook_artifact_metadata(app, action_widget, message_text, message_role),
+    }
+
+    def save_worker() -> None:
+        try:
+            _run_console_chatbook_create(create_chatbook, payload)
+            app.call_from_thread(
+                app.notify,
+                f"Saved response as Chatbook artifact: {title}",
+                severity="information",
+                timeout=4,
+            )
+        except Exception as exc:
+            loguru_logger.error("Failed to save Console response as Chatbook artifact", exc_info=True)
+            app.call_from_thread(
+                app.notify,
+                f"Failed to save Chatbook artifact: {exc}",
+                severity="error",
+                timeout=7,
+            )
+
+    app.run_worker(
+        save_worker,
+        name="console-chatbook-artifact-save",
+        group="chat-artifacts",
+        description="Save Console response as Chatbook artifact",
+        thread=True,
+    )
 
 ########################################################################################################################
 #
@@ -1224,7 +1263,7 @@ async def handle_chat_action_button_pressed(app: 'TldwCli', button: Button, acti
         app.set_timer(1.5, lambda: setattr(button, "label", get_char(EMOJI_COPY, FALLBACK_COPY)))
 
     elif "artifact-button" in button_classes:
-        logging.info("Action: Save artifact clicked for %s message: '%s...'", message_role, message_text[:50])
+        logging.info("Action: Save artifact clicked for %s message", message_role)
         await _save_console_chatbook_artifact(app, action_widget, message_text, message_role)
 
     elif "note-button" in button_classes:

--- a/tldw_chatbook/Event_Handlers/Chat_Events/chat_events.py
+++ b/tldw_chatbook/Event_Handlers/Chat_Events/chat_events.py
@@ -3,6 +3,7 @@
 #
 # Imports
 import logging
+import inspect
 import json
 import os
 import time
@@ -55,6 +56,10 @@ if TYPE_CHECKING:
 #
 # Security Functions:
 
+MAX_CONSOLE_CHATBOOK_ARTIFACT_CONTENT_CHARS = 20_000
+MAX_CONSOLE_CHATBOOK_ARTIFACT_TITLE_CHARS = 80
+MAX_CONSOLE_CHATBOOK_ARTIFACT_DESCRIPTION_CHARS = 280
+
 def safe_json_loads(json_str: str, max_size: int = 1024 * 1024) -> Optional[Union[dict, list]]:
     """
     Safely parse JSON with size limits to prevent DoS attacks.
@@ -82,6 +87,92 @@ def safe_json_loads(json_str: str, max_size: int = 1024 * 1024) -> Optional[Unio
     except Exception as e:
         loguru_logger.error(f"Unexpected error parsing JSON: {e}")
         return None
+
+
+def _simple_metadata_value(value: Any) -> Optional[Union[str, int, float, bool]]:
+    if isinstance(value, (str, int, float, bool)):
+        return value
+    return None
+
+
+def _console_chatbook_artifact_title(message_text: str) -> str:
+    for line in str(message_text or "").splitlines():
+        title = " ".join(line.strip().lstrip("#>*-` ").split())
+        if title:
+            if len(title) > MAX_CONSOLE_CHATBOOK_ARTIFACT_TITLE_CHARS:
+                return title[: MAX_CONSOLE_CHATBOOK_ARTIFACT_TITLE_CHARS - 3].rstrip() + "..."
+            return title
+    return "Console response artifact"
+
+
+def _console_chatbook_artifact_description(message_text: str) -> str:
+    preview = " ".join(str(message_text or "").split())
+    if len(preview) > MAX_CONSOLE_CHATBOOK_ARTIFACT_DESCRIPTION_CHARS:
+        preview = preview[: MAX_CONSOLE_CHATBOOK_ARTIFACT_DESCRIPTION_CHARS - 3].rstrip() + "..."
+    if not preview:
+        return "Saved from Console assistant response."
+    return f"Saved from Console assistant response. Preview: {preview}"
+
+
+def _console_chatbook_artifact_metadata(
+    app: "TldwCli",
+    action_widget: Union[ChatMessage, ChatMessageEnhanced],
+    message_text: str,
+    message_role: str,
+) -> dict[str, Any]:
+    content = str(message_text or "")
+    metadata: dict[str, Any] = {
+        "artifact_source": "console",
+        "artifact_kind": "assistant-response",
+        "message_role": str(message_role or "Assistant"),
+        "content": content[:MAX_CONSOLE_CHATBOOK_ARTIFACT_CONTENT_CHARS],
+        "content_truncated": len(content) > MAX_CONSOLE_CHATBOOK_ARTIFACT_CONTENT_CHARS,
+    }
+    optional_values = {
+        "conversation_id": getattr(app, "current_chat_conversation_id", None)
+        or getattr(app, "current_conversation_id", None),
+        "message_id": getattr(action_widget, "message_id_internal", None),
+        "provider": getattr(app, "current_provider", None),
+        "model": getattr(app, "current_model", None),
+    }
+    for key, value in optional_values.items():
+        simple_value = _simple_metadata_value(value)
+        if simple_value:
+            metadata[key] = simple_value
+    return metadata
+
+
+async def _save_console_chatbook_artifact(
+    app: "TldwCli",
+    action_widget: Union[ChatMessage, ChatMessageEnhanced],
+    message_text: str,
+    message_role: str,
+) -> None:
+    if not action_widget.has_class("-ai"):
+        app.notify("Only assistant responses can be saved as Chatbook artifacts.", severity="warning", timeout=5)
+        return
+
+    service = getattr(app, "local_chatbook_service", None)
+    create_chatbook = getattr(service, "create_chatbook", None)
+    if not callable(create_chatbook):
+        app.notify("Local Chatbook artifact service is unavailable.", severity="warning", timeout=5)
+        return
+
+    title = _console_chatbook_artifact_title(message_text)
+    try:
+        result = create_chatbook(
+            name=title,
+            description=_console_chatbook_artifact_description(message_text),
+            tags=["console", "artifact"],
+            categories=["Console", "Artifacts"],
+            metadata=_console_chatbook_artifact_metadata(app, action_widget, message_text, message_role),
+        )
+        if inspect.isawaitable(result):
+            await result
+        app.notify(f"Saved response as Chatbook artifact: {title}", severity="information", timeout=4)
+    except Exception as exc:
+        loguru_logger.error("Failed to save Console response as Chatbook artifact: %s", exc, exc_info=True)
+        app.notify(f"Failed to save Chatbook artifact: {exc}", severity="error", timeout=7)
 
 ########################################################################################################################
 #
@@ -1131,6 +1222,10 @@ async def handle_chat_action_button_pressed(app: 'TldwCli', button: Button, acti
         app.notify("Message content copied to clipboard.", severity="information", timeout=2)
         button.label = get_char(EMOJI_COPIED, FALLBACK_COPIED) + "Copied"
         app.set_timer(1.5, lambda: setattr(button, "label", get_char(EMOJI_COPY, FALLBACK_COPY)))
+
+    elif "artifact-button" in button_classes:
+        logging.info("Action: Save artifact clicked for %s message: '%s...'", message_role, message_text[:50])
+        await _save_console_chatbook_artifact(app, action_widget, message_text, message_role)
 
     elif "note-button" in button_classes:
         logging.info("Action: Create Note clicked for %s message: '%s...'", message_role, message_text[:50])

--- a/tldw_chatbook/Widgets/Chat_Widgets/chat_message.py
+++ b/tldw_chatbook/Widgets/Chat_Widgets/chat_message.py
@@ -191,6 +191,7 @@ class ChatMessage(Widget):
                     thumb_down_label = "👎✓" if self.feedback == "2;" else "👎"
                     yield Button(thumb_up_label, classes="action-button thumb-up-button", id="thumb-up", tooltip="Mark as helpful")
                     yield Button(thumb_down_label, classes="action-button thumb-down-button", id="thumb-down", tooltip="Mark as unhelpful")
+                    yield Button("💾", classes="action-button artifact-button", id="save-artifact", tooltip="Save response as Chatbook artifact")
                     yield Button("🔄", classes="action-button regenerate-button", id="regenerate", tooltip="Regenerate response") # Emoji for regenerate
                     yield Button("↪️", id="continue-response-button", classes="action-button continue-button", tooltip="Continue response")
 

--- a/tldw_chatbook/Widgets/Chat_Widgets/chat_message.py
+++ b/tldw_chatbook/Widgets/Chat_Widgets/chat_message.py
@@ -191,7 +191,8 @@ class ChatMessage(Widget):
                     thumb_down_label = "👎✓" if self.feedback == "2;" else "👎"
                     yield Button(thumb_up_label, classes="action-button thumb-up-button", id="thumb-up", tooltip="Mark as helpful")
                     yield Button(thumb_down_label, classes="action-button thumb-down-button", id="thumb-down", tooltip="Mark as unhelpful")
-                    yield Button("💾", classes="action-button artifact-button", id="save-artifact", tooltip="Save response as Chatbook artifact")
+                    if str(self.role or "").strip().lower() != "system":
+                        yield Button("💾", classes="action-button artifact-button", id="save-artifact", tooltip="Save response as Chatbook artifact")
                     yield Button("🔄", classes="action-button regenerate-button", id="regenerate", tooltip="Regenerate response") # Emoji for regenerate
                     yield Button("↪️", id="continue-response-button", classes="action-button continue-button", tooltip="Continue response")
 

--- a/tldw_chatbook/Widgets/Chat_Widgets/chat_message_enhanced.py
+++ b/tldw_chatbook/Widgets/Chat_Widgets/chat_message_enhanced.py
@@ -334,6 +334,7 @@ class ChatMessageEnhanced(Widget):
                     thumb_down_label = "👎✓" if self.feedback == "2;" else "👎"
                     yield Button(thumb_up_label, classes="action-button thumb-up-button", id="thumb-up", tooltip="Mark as helpful")
                     yield Button(thumb_down_label, classes="action-button thumb-down-button", id="thumb-down", tooltip="Mark as unhelpful")
+                    yield Button("💾", classes="action-button artifact-button", id="save-artifact", tooltip="Save response as Chatbook artifact")
                     yield Button("🔄", classes="action-button regenerate-button", id="regenerate", tooltip="Regenerate response")
                     yield Button("↪️", id="continue-response-button", classes="action-button continue-button", tooltip="Continue response")
                     yield Button("💡", classes="action-button suggest-response-button", id="suggest-response", tooltip="Suggest a response")

--- a/tldw_chatbook/Widgets/Chat_Widgets/chat_message_enhanced.py
+++ b/tldw_chatbook/Widgets/Chat_Widgets/chat_message_enhanced.py
@@ -334,7 +334,8 @@ class ChatMessageEnhanced(Widget):
                     thumb_down_label = "👎✓" if self.feedback == "2;" else "👎"
                     yield Button(thumb_up_label, classes="action-button thumb-up-button", id="thumb-up", tooltip="Mark as helpful")
                     yield Button(thumb_down_label, classes="action-button thumb-down-button", id="thumb-down", tooltip="Mark as unhelpful")
-                    yield Button("💾", classes="action-button artifact-button", id="save-artifact", tooltip="Save response as Chatbook artifact")
+                    if str(self.role or "").strip().lower() != "system":
+                        yield Button("💾", classes="action-button artifact-button", id="save-artifact", tooltip="Save response as Chatbook artifact")
                     yield Button("🔄", classes="action-button regenerate-button", id="regenerate", tooltip="Regenerate response")
                     yield Button("↪️", id="continue-response-button", classes="action-button continue-button", tooltip="Continue response")
                     yield Button("💡", classes="action-button suggest-response-button", id="suggest-response", tooltip="Suggest a response")


### PR DESCRIPTION
## Summary

- add assistant-only save-to-artifact actions to basic and enhanced Console chat messages
- route the action through `local_chatbook_service.create_chatbook` with bounded Console provenance metadata
- add recovery notifications for missing local Chatbook service and create failures without deleting the source response
- record Phase 2.2 QA evidence, roadmap updates, and Backlog task closeout

## Verification

- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Event_Handlers/Chat_Events/test_chat_events.py Tests/Widgets/test_chat_message_enhanced.py Tests/Widgets/test_chat_message_artifact_actions.py -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_keeps_console_launch_disabled_without_chatbooks Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_launches_latest_local_chatbook_in_console Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_sanitizes_chatbook_metadata_before_console_launch Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_uses_numeric_id_tie_break_for_latest_chatbook Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_distinguishes_chatbook_service_failure_from_empty_state Tests/UI/test_product_maturity_phase1_harness.py::test_product_maturity_tracker_links_phase_one_harness_and_tasks -q`
- `git diff --check`
