### PR TITLE
Add Phase 2.3 saved artifact reopen contract

### DIFF
--- a/Docs/superpowers/qa/product-maturity/phase-2/2026-05-05-phase-2-3-saved-chatbook-artifact-reopen-contract.md
+++ b/Docs/superpowers/qa/product-maturity/phase-2/2026-05-05-phase-2-3-saved-chatbook-artifact-reopen-contract.md
@@ -1,0 +1,74 @@
+# Phase 2.3 Saved Chatbook Artifact Reopen Contract
+
+Date: 2026-05-05
+Task: TASK-9.3
+Branch: codex/product-maturity-phase2-3-artifact-reopen-contract
+Workflow: Console-saved Chatbook artifact -> Artifacts provenance -> Console reopen payload
+
+## What Was Verified
+
+Phase 2.3 verifies the next narrow Phase 2 gate: a local Chatbook artifact record created from Console metadata can be recognized in Artifacts and reopened into Console with enough saved-response provenance to review the artifact without manual reconstruction.
+
+Verified contract:
+
+- Artifacts still selects the latest local Chatbook record from the local Chatbook service.
+- Console-saved Chatbook metadata is identified by `artifact_source=console` and `artifact_kind=assistant-response`.
+- Artifacts shows saved-response provenance before launch, including provider/model authority when present.
+- Artifacts shows a bounded saved response preview before launch.
+- Launching the artifact into Console preserves Chatbook id, record id, file path, tags, categories, source metadata, conversation id, message id, provider, model, bounded content preview, and truncation status.
+- Empty local Chatbook state and local Chatbook service failure recovery remain unchanged.
+- Newly exposed provenance strings are sanitized with the same no-script/no-event-handler boundary as existing Chatbook fields.
+
+## Automated Evidence
+
+Initial red run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_reopens_console_saved_chatbook_with_provenance -q
+```
+
+Result:
+
+- `1 failed, 3 warnings in 10.91s`.
+- Failure was expected: Artifacts displayed only the generic Chatbook description and did not show `OpenAI / gpt-4.1` or carry Console metadata into the launch payload.
+
+Focused green verification:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_reopens_console_saved_chatbook_with_provenance -q
+```
+
+Result:
+
+- `1 passed, 1 warning in 7.87s`.
+
+Focused sanitization verification:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_reopens_console_saved_chatbook_with_provenance Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_sanitizes_chatbook_metadata_before_console_launch -q
+```
+
+Result:
+
+- `2 passed, 1 warning in 6.94s`.
+
+## Defects Fixed
+
+- `workflow-degradation`: Artifacts could launch a generic latest Chatbook but discarded Console-saved artifact provenance, so the user could not tell whether the launched artifact was the saved response they intended to reopen.
+- `recognition`: Artifacts did not expose provider/model authority or saved response preview for Console-created artifacts.
+
+## UX Notes
+
+- The design stays text-first and terminal-native: Artifacts adds concise provenance rows rather than a new selector or full artifact browser.
+- The saved response content is bounded as `content_preview` so Console status cards do not render unbounded message bodies.
+- The existing latest-artifact behavior remains intact; multi-artifact selection is intentionally outside this gate.
+
+## Residual Risk
+
+- This gate verifies the latest Console-saved artifact visibility and Console reopen payload, not a full multi-artifact picker.
+- Home resume/open controls for newly saved artifacts remain unverified.
+- Full `.chatbook` export packaging remains outside this gate; the local registry record is the authority used here.
+
+## Exit Decision
+
+Pass for Phase 2.3. Artifacts can now recognize and reopen a Console-saved Chatbook artifact with visible provenance. Phase 2 should continue with Home resume controls for saved artifacts.

--- a/Docs/superpowers/qa/product-maturity/phase-2/2026-05-05-phase-2-3-saved-chatbook-artifact-reopen-contract.md
+++ b/Docs/superpowers/qa/product-maturity/phase-2/2026-05-05-phase-2-3-saved-chatbook-artifact-reopen-contract.md
@@ -24,7 +24,7 @@ Verified contract:
 Initial red run:
 
 ```bash
-/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_reopens_console_saved_chatbook_with_provenance -q
+.venv/bin/python -m pytest Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_reopens_console_saved_chatbook_with_provenance -q
 ```
 
 Result:
@@ -35,7 +35,7 @@ Result:
 Focused green verification:
 
 ```bash
-/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_reopens_console_saved_chatbook_with_provenance -q
+.venv/bin/python -m pytest Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_reopens_console_saved_chatbook_with_provenance -q
 ```
 
 Result:
@@ -45,7 +45,7 @@ Result:
 Focused sanitization verification:
 
 ```bash
-/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_reopens_console_saved_chatbook_with_provenance Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_sanitizes_chatbook_metadata_before_console_launch -q
+.venv/bin/python -m pytest Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_reopens_console_saved_chatbook_with_provenance Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_sanitizes_chatbook_metadata_before_console_launch -q
 ```
 
 Result:

--- a/Docs/superpowers/qa/product-maturity/phase-2/README.md
+++ b/Docs/superpowers/qa/product-maturity/phase-2/README.md
@@ -10,3 +10,4 @@ Each child gate should record whether the tested slice completes the full loop o
 
 - `2026-05-05-phase-2-1-grounded-console-response-contract.md`
 - `2026-05-05-phase-2-2-console-chatbook-artifact-save-contract.md`
+- `2026-05-05-phase-2-3-saved-chatbook-artifact-reopen-contract.md`

--- a/Docs/superpowers/trackers/product-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/product-maturity-roadmap.md
@@ -1,7 +1,7 @@
 # Product Maturity Roadmap
 
 Date: 2026-05-05
-Status: Phase 1 verified; Phase 2.2 verified
+Status: Phase 1 verified; Phase 2.3 verified
 Source Branch: `dev`
 Source Spec: `Docs/superpowers/specs/2026-05-05-product-maturity-phased-roadmap-design.md`
 
@@ -22,6 +22,7 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 - Phase 1.7 verifies the remaining narrow core-loop proof gate: Search/RAG result context can stage into Console with visible local source authority.
 - Phase 2.1 verifies the first core-agentic-loop contract: staged Search/RAG context reaches the model-bound Console request and remains staged when send is blocked before generation starts.
 - Phase 2.2 verifies the next core-agentic-loop contract: completed assistant responses can create local Chatbook artifact records with bounded Console provenance and recoverable failure notifications.
+- Phase 2.3 verifies the next core-agentic-loop contract: Console-saved Chatbook artifact records can be recognized in Artifacts and reopened into Console with visible saved-response provenance.
 
 ## Severity Policy
 
@@ -45,6 +46,7 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 - Phase 2: Core Agentic Loop - `TASK-9`
 - Phase 2.1: Grounded Console Response Contract - `TASK-9.1`
 - Phase 2.2: Console Chatbook Artifact Save Contract - `TASK-9.2`
+- Phase 2.3: Saved Chatbook Artifact Reopen Contract - `TASK-9.3`
 - Phase 3: Knowledge And Study Workflows - `TASK-10`
 - Phase 4: Agent Configuration And Execution - `TASK-11`
 - Phase 5: Server-Parity And Live Integrations - `TASK-12`
@@ -57,13 +59,14 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 | Phase 1 | `Docs/superpowers/qa/product-maturity/phase-1/` | verified |
 | Phase 2.1 | `Docs/superpowers/qa/product-maturity/phase-2/2026-05-05-phase-2-1-grounded-console-response-contract.md` | verified |
 | Phase 2.2 | `Docs/superpowers/qa/product-maturity/phase-2/2026-05-05-phase-2-2-console-chatbook-artifact-save-contract.md` | verified |
+| Phase 2.3 | `Docs/superpowers/qa/product-maturity/phase-2/2026-05-05-phase-2-3-saved-chatbook-artifact-reopen-contract.md` | verified |
 
 ## Phase Overview
 
 | Phase | Goal | Status | Backlog Tasks | QA Evidence | Residual Risk |
 | --- | --- | --- | --- | --- | --- |
 | Phase 1: QA Baseline And Usability Guardrails | Establish clean-run usability guardrails before feature depth. | verified | `TASK-8`, Phase 1.1 (`TASK-8.1`), Phase 1.2 (`TASK-8.2`), Phase 1.3 (`TASK-8.3`), Phase 1.4 (`TASK-8.4`), Phase 1.5 (`TASK-8.5`), Phase 1.6 (`TASK-8.6`), Phase 1.7 (`TASK-8.7`) | `phase-1/` | Closed; full grounded generation and Artifact/Chatbook persistence move to Phase 2. |
-| Phase 2: Core Agentic Loop | Complete source/question to grounded Console to Artifact/Chatbook loop. | in-progress | `TASK-9`, Phase 2.1 (`TASK-9.1`), Phase 2.2 (`TASK-9.2`) | `phase-2/2026-05-05-phase-2-1-grounded-console-response-contract.md`, `phase-2/2026-05-05-phase-2-2-console-chatbook-artifact-save-contract.md` | Grounded request and local Chatbook artifact save contracts verified; newly saved artifact visibility, reopen, and Home resume remain. |
+| Phase 2: Core Agentic Loop | Complete source/question to grounded Console to Artifact/Chatbook loop. | in-progress | `TASK-9`, Phase 2.1 (`TASK-9.1`), Phase 2.2 (`TASK-9.2`), Phase 2.3 (`TASK-9.3`) | `phase-2/2026-05-05-phase-2-1-grounded-console-response-contract.md`, `phase-2/2026-05-05-phase-2-2-console-chatbook-artifact-save-contract.md`, `phase-2/2026-05-05-phase-2-3-saved-chatbook-artifact-reopen-contract.md` | Grounded request, local Chatbook artifact save, and Artifacts reopen contracts verified; Home resume remains. |
 | Phase 3: Knowledge And Study Workflows | Mature ingest, organize, retrieve, study, and reuse workflows. | planned | `TASK-10` | not-started | Depends on Phase 2 core loop and later task slicing. |
 | Phase 4: Agent Configuration And Execution | Mature Personas, Skills, MCP, ACP, Schedules, and Workflows. | planned | `TASK-11` | not-started | Depends on service adapters and runtime readiness. |
 | Phase 5: Server-Parity And Live Integrations | Close high-value `tldw_server2` parity gaps. | planned | `TASK-12` | not-started | Requires parity inventory. |
@@ -125,3 +128,9 @@ Status: verified
 Status: verified
 
 - `Docs/superpowers/qa/product-maturity/phase-2/2026-05-05-phase-2-2-console-chatbook-artifact-save-contract.md`
+
+## Phase 2.3 Evidence
+
+Status: verified
+
+- `Docs/superpowers/qa/product-maturity/phase-2/2026-05-05-phase-2-3-saved-chatbook-artifact-reopen-contract.md`

--- a/Tests/UI/test_console_live_work_handoffs.py
+++ b/Tests/UI/test_console_live_work_handoffs.py
@@ -1461,6 +1461,75 @@ async def test_artifacts_destination_launches_latest_local_chatbook_in_console()
 
 
 @pytest.mark.asyncio
+async def test_artifacts_destination_reopens_console_saved_chatbook_with_provenance():
+    app = _build_test_app()
+    app.local_chatbook_service = StaticLocalChatbookService(
+        (
+            {
+                "chatbook_id": 77,
+                "id": "77",
+                "name": "Grounded Answer",
+                "description": "Saved from Console assistant response. Preview: Grounded answer body.",
+                "file_path": "/tmp/grounded-answer.chatbook",
+                "tags": ["console", "artifact"],
+                "categories": ["Console", "Artifacts"],
+                "metadata": {
+                    "artifact_source": "console",
+                    "artifact_kind": "assistant-response",
+                    "conversation_id": "conv-123",
+                    "message_id": "msg-456",
+                    "message_role": "Assistant",
+                    "provider": "OpenAI",
+                    "model": "gpt-4.1",
+                    "content": "Grounded answer body from saved artifact.",
+                    "content_truncated": False,
+                },
+                "updated_at": "2026-05-05T20:00:00Z",
+            },
+        )
+    )
+    app.open_console_for_live_work = Mock()
+    host = DestinationHarness(app, "artifacts")
+
+    async with host.run_test(size=(180, 40)) as pilot:
+        await pilot.pause(0.1)
+        screen = _active_console_screen(host)
+        text = _screen_static_text(screen)
+
+        assert "Console can launch latest Chatbook artifact: Grounded Answer." in text
+        assert "Saved from Console assistant response." in text
+        assert "OpenAI / gpt-4.1" in text
+        assert "Grounded answer body from saved artifact." in text
+
+        await pilot.click("#artifacts-use-in-console")
+        await pilot.pause(0.1)
+
+    app.open_console_for_live_work.assert_called_once()
+    launch_kwargs = app.open_console_for_live_work.call_args.kwargs
+    assert launch_kwargs["source"] == "artifacts"
+    assert launch_kwargs["title"] == "Grounded Answer"
+    assert launch_kwargs["payload"] == {
+        "target_id": "local:chatbook:77",
+        "chatbook_id": 77,
+        "record_id": "77",
+        "file_path": "/tmp/grounded-answer.chatbook",
+        "description": "Saved from Console assistant response. Preview: Grounded answer body.",
+        "tags": "console, artifact",
+        "categories": "Console, Artifacts",
+        "updated_at": "2026-05-05T20:00:00Z",
+        "artifact_source": "console",
+        "artifact_kind": "assistant-response",
+        "conversation_id": "conv-123",
+        "message_id": "msg-456",
+        "message_role": "Assistant",
+        "provider": "OpenAI",
+        "model": "gpt-4.1",
+        "content_preview": "Grounded answer body from saved artifact.",
+        "content_truncated": False,
+    }
+
+
+@pytest.mark.asyncio
 async def test_artifacts_destination_sanitizes_chatbook_metadata_before_console_launch():
     app = _build_test_app()
     app.local_chatbook_service = StaticLocalChatbookService(
@@ -1473,6 +1542,17 @@ async def test_artifacts_destination_sanitizes_chatbook_metadata_before_console_
                 "file_path": "/tmp/<script>bad</script>.chatbook\x00",
                 "tags": ["safe", "<script>tag</script>"],
                 "categories": ["onclick=bad", "Library"],
+                "metadata": {
+                    "artifact_source": "console",
+                    "artifact_kind": "assistant-response",
+                    "conversation_id": "conv-<script>bad</script>",
+                    "message_id": "msg-onclick=bad",
+                    "message_role": "Assistant",
+                    "provider": "javascript:alert(1)",
+                    "model": "onerror=bad",
+                    "content": "<script>bad</script> onerror=bad",
+                    "content_truncated": False,
+                },
                 "updated_at": "2026-05-03T20:00:00Z",
             },
         )

--- a/Tests/UI/test_product_maturity_phase1_harness.py
+++ b/Tests/UI/test_product_maturity_phase1_harness.py
@@ -13,9 +13,12 @@ BACKLOG_DOC = Path("backlog/docs/product-maturity-roadmap.md")
 QA_ROOT = Path("Docs/superpowers/qa/product-maturity")
 PHASE_1_ROOT = QA_ROOT / "phase-1"
 PHASE_1_README = PHASE_1_ROOT / "README.md"
+PHASE_2_ROOT = QA_ROOT / "phase-2"
+PHASE_2_README = PHASE_2_ROOT / "README.md"
 PROTOCOL = PHASE_1_ROOT / "walkthrough-protocol.md"
 TEMPLATE = PHASE_1_ROOT / "walkthrough-template.md"
 SMOKE = PHASE_1_ROOT / "2026-05-05-phase-1-1-harness-smoke.md"
+PHASE_2_3_EVIDENCE = PHASE_2_ROOT / "2026-05-05-phase-2-3-saved-chatbook-artifact-reopen-contract.md"
 PHASE_1_2_PLAN = Path("Docs/superpowers/plans/2026-05-05-product-maturity-phase-1-2-first-run-walkthrough.md")
 BACKLOG_TASKS = Path("backlog/tasks")
 
@@ -175,6 +178,23 @@ def test_product_maturity_phase_one_two_plan_scopes_first_run_walkthrough() -> N
     assert PHASE_1_2_PLAN.name in readme
     assert "Phase 1.2 clean first-run status: verified" in readme
     assert "2026-05-05-phase-1-2-first-run-walkthrough.md" in readme
+
+
+def test_product_maturity_phase_two_three_evidence_links_task_and_tracker() -> None:
+    tracker = _text(TRACKER)
+    readme = _text(PHASE_2_README)
+    evidence = _text(PHASE_2_3_EVIDENCE)
+    task = _task_text_by_id("TASK-9.3")
+
+    phase_two_row = _phase_row(tracker, "Phase 2: Core Agentic Loop")
+
+    assert "Phase 2.3" in tracker
+    assert "TASK-9.3" in phase_two_row[3]
+    assert PHASE_2_3_EVIDENCE.name in phase_two_row[4]
+    assert PHASE_2_3_EVIDENCE.name in readme
+    assert "Saved Chatbook Artifact Reopen Contract" in evidence
+    assert "Home resume controls for saved artifacts" in evidence
+    assert "Artifacts identifies Console-saved Chatbook artifact records" in task
 
 
 def test_phase_one_one_smoke_evidence_records_harness_only_boundary() -> None:

--- a/backlog/tasks/task-9.3 - Product-Maturity-Phase-2.3-Saved-Chatbook-Artifact-Reopen-Contract.md
+++ b/backlog/tasks/task-9.3 - Product-Maturity-Phase-2.3-Saved-Chatbook-Artifact-Reopen-Contract.md
@@ -1,0 +1,45 @@
+---
+id: TASK-9.3
+title: 'Product Maturity Phase 2.3: Saved Chatbook Artifact Reopen Contract'
+status: Done
+assignee: []
+created_date: '2026-05-05 22:21'
+updated_date: '2026-05-05 22:25'
+labels:
+  - product-maturity
+  - phase-2-core-agentic-loop
+dependencies: []
+parent_task_id: TASK-9
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Prove that a Chatbook artifact record created from Console can be discovered in Artifacts and reopened into Console with saved-response provenance, while leaving Home resume as a separate remaining Phase 2 risk.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Artifacts identifies Console-saved Chatbook artifact records from local Chatbook metadata.
+- [x] #2 Artifacts shows saved-response provenance or source authority before launch so the user understands what will reopen.
+- [x] #3 Launching the saved artifact routes into Console with record id, Chatbook id, and saved-response provenance sufficient to resume or review without manual state reconstruction.
+- [x] #4 Empty-state and service-failure recovery remain honest and existing Artifacts launch behavior does not regress.
+- [x] #5 QA evidence and product-maturity tracker record the Phase 2.3 exit decision and remaining Home resume risk.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a failing Artifacts destination regression for Console-saved Chatbook metadata visibility and Console reopen payload provenance.
+2. Implement the smallest safe Artifacts metadata mapping and provenance copy needed to pass the regression.
+3. Preserve existing latest-chatbook launch selection, sanitization, empty-state, and service-failure behavior.
+4. Record Phase 2.3 QA evidence and update the product-maturity tracker and Phase 2 README.
+5. Run focused Artifacts/Console handoff tests, tracker tests, and diff hygiene before closing the task.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented Phase 2.3 saved Chatbook artifact reopen contract. Artifacts now recognizes Console-saved Chatbook metadata, surfaces provider/model provenance and bounded saved-response preview, and carries sanitized provenance into the Console launch payload while preserving existing latest-chatbook, empty-state, service-failure, and sanitization behavior. Added focused Artifacts/Console regression coverage, Phase 2.3 QA evidence, roadmap tracking, and a product-maturity tracker regression.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/artifacts_screen.py
+++ b/tldw_chatbook/UI/Screens/artifacts_screen.py
@@ -123,6 +123,58 @@ class ArtifactsScreen(BaseAppScreen):
         return text or None
 
     @classmethod
+    def _safe_metadata_value(cls, value: Any, *, max_length: int = 1000) -> str | int | float | bool | None:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, (int, float)):
+            return value
+        text = cls._safe_text(value, max_length=max_length)
+        return text or None
+
+    @classmethod
+    def _console_saved_artifact_payload(cls, metadata: Any) -> dict[str, Any]:
+        if not isinstance(metadata, Mapping):
+            return {}
+
+        artifact_source = cls._safe_metadata_value(metadata.get("artifact_source"), max_length=128)
+        artifact_kind = cls._safe_metadata_value(metadata.get("artifact_kind"), max_length=128)
+        if str(artifact_source or "").strip().lower() != "console":
+            return {}
+        if str(artifact_kind or "").strip().lower() != "assistant-response":
+            return {}
+
+        payload: dict[str, Any] = {
+            "artifact_source": artifact_source,
+            "artifact_kind": artifact_kind,
+        }
+        for key in ("conversation_id", "message_id", "message_role", "provider", "model"):
+            if (safe_value := cls._safe_metadata_value(metadata.get(key), max_length=256)) is not None:
+                payload[key] = safe_value
+
+        if (content_preview := cls._safe_metadata_value(metadata.get("content"), max_length=1000)) is not None:
+            payload["content_preview"] = content_preview
+        content_truncated = metadata.get("content_truncated")
+        if isinstance(content_truncated, bool):
+            payload["content_truncated"] = content_truncated
+        elif "content_preview" in payload:
+            payload["content_truncated"] = False
+        return payload
+
+    @staticmethod
+    def _console_saved_artifact_provenance(payload: Mapping[str, Any]) -> str | None:
+        if str(payload.get("artifact_source") or "").strip().lower() != "console":
+            return None
+        provider = str(payload.get("provider") or "").strip()
+        model = str(payload.get("model") or "").strip()
+        if provider and model:
+            return f"Saved from Console assistant response via {provider} / {model}."
+        if provider:
+            return f"Saved from Console assistant response via {provider}."
+        if model:
+            return f"Saved from Console assistant response using {model}."
+        return "Saved from Console assistant response."
+
+    @classmethod
     def _datetime_sort_key(cls, value: Any) -> float:
         text = cls._text(value)
         if not text:
@@ -166,6 +218,7 @@ class ArtifactsScreen(BaseAppScreen):
             "categories": cls._csv(record.get("categories")),
             "updated_at": cls._safe_text(record.get("updated_at")),
         }
+        payload.update(cls._console_saved_artifact_payload(record.get("metadata")))
         return {
             "source": "artifacts",
             "title": title,
@@ -220,6 +273,8 @@ class ArtifactsScreen(BaseAppScreen):
                     title = str(launch_kwargs["title"])
                     payload = launch_kwargs.get("payload") or {}
                     description = str(payload.get("description") or "").strip()
+                    provenance = self._console_saved_artifact_provenance(payload)
+                    content_preview = str(payload.get("content_preview") or "").strip()
                     yield Static("Console launch available", classes="destination-section")
                     yield Static(
                         Text.from_markup(
@@ -232,6 +287,16 @@ class ArtifactsScreen(BaseAppScreen):
                         yield Static(
                             Text.from_markup(escape_markup(description)),
                             id="artifacts-chatbook-description",
+                        )
+                    if provenance:
+                        yield Static(
+                            Text.from_markup(escape_markup(provenance)),
+                            id="artifacts-chatbook-provenance",
+                        )
+                    if content_preview:
+                        yield Static(
+                            Text.from_markup(f"Preview: {escape_markup(content_preview)}"),
+                            id="artifacts-chatbook-content-preview",
                         )
                     yield Button(
                         Text.from_markup(f"Launch {escape_markup(title)} in Console"),


### PR DESCRIPTION
Summary
- Recognize Console-saved Chatbook metadata in Artifacts and surface provider/model plus bounded saved-response preview before launch.
- Carry sanitized Console provenance into the Artifacts -> Console launch payload while preserving generic latest-Chatbook behavior and recovery states.
- Add Phase 2.3 QA evidence, tracker updates, Backlog task TASK-9.3, and tracker regression coverage.

Verification
- RED: /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_reopens_console_saved_chatbook_with_provenance -q (1 failed, expected missing provenance)
- GREEN: /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_reopens_console_saved_chatbook_with_provenance -q (1 passed, 1 warning)
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_keeps_console_launch_disabled_without_chatbooks Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_launches_latest_local_chatbook_in_console Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_reopens_console_saved_chatbook_with_provenance Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_sanitizes_chatbook_metadata_before_console_launch Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_uses_numeric_id_tie_break_for_latest_chatbook Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_distinguishes_chatbook_service_failure_from_empty_state Tests/UI/test_product_maturity_phase1_harness.py -q (13 passed, 1 warning)
- git diff --check