### PR TITLE
Add Phase 2.4 Home artifact resume contract

### DIFF
--- a/Docs/superpowers/qa/product-maturity/phase-2/2026-05-05-phase-2-4-home-chatbook-artifact-resume-contract.md
+++ b/Docs/superpowers/qa/product-maturity/phase-2/2026-05-05-phase-2-4-home-chatbook-artifact-resume-contract.md
@@ -1,0 +1,93 @@
+# Phase 2.4 Home Chatbook Artifact Resume Contract
+
+Date: 2026-05-05
+Task: TASK-9.4
+Branch: codex/product-maturity-phase2-4-home-artifact-resume
+Workflow: Console-saved Chatbook artifact -> Home active work -> Artifacts details or Console resume
+
+## What Was Verified
+
+Phase 2.4 verifies the final Home-resume seam for the Phase 2 core loop: a Console-saved local Chatbook artifact can appear on Home as resumable work and route back to Artifacts or Console without manual state reconstruction.
+
+Verified contract:
+
+- `LocalChatbookService.list_home_artifact_snapshot(...)` returns a synchronous latest-first snapshot of Console-saved assistant-response Chatbook artifacts.
+- Home active-work input includes only the latest Console-saved Chatbook artifact when the local Chatbook service exposes one.
+- Home renders the saved artifact as active work with `Open details` and `Open in Console` controls.
+- `Open details` routes the artifact target to Artifacts.
+- `Open in Console` launches the artifact with Chatbook id, record id, tags, categories, file path, source metadata, conversation id, message id, provider, model, content preview, and truncation status.
+- Missing or failing Chatbook snapshot state fails closed without removing existing notification or W+C Home behavior.
+
+## Automated Evidence
+
+Initial red run:
+
+```bash
+.venv/bin/python -m pytest Tests/Chatbooks/test_local_chatbook_service.py::test_local_chatbook_service_home_artifact_snapshot_lists_latest_console_saved_artifacts Tests/Home/test_active_work_adapter.py::test_local_notification_adapter_maps_console_saved_chatbook_to_active_work Tests/Home/test_active_work_adapter.py::test_local_notification_adapter_opens_console_saved_chatbook_details_and_console Tests/UI/test_screen_navigation.py::test_app_initializes_watchlists_and_notifications_services -q
+```
+
+Result:
+
+- `4 failed, 10 warnings in 10.69s`.
+- Failures were expected: the local Chatbook service had no synchronous Home snapshot, the Home adapter did not accept a Chatbook service, and app wiring did not pass the local Chatbook service into Home.
+
+Focused green verification:
+
+```bash
+.venv/bin/python -m pytest Tests/Chatbooks/test_local_chatbook_service.py::test_local_chatbook_service_home_artifact_snapshot_lists_latest_console_saved_artifacts Tests/Home/test_active_work_adapter.py::test_local_notification_adapter_maps_console_saved_chatbook_to_active_work Tests/Home/test_active_work_adapter.py::test_local_notification_adapter_opens_console_saved_chatbook_details_and_console Tests/UI/test_screen_navigation.py::test_app_initializes_watchlists_and_notifications_services -q
+```
+
+Result:
+
+- `4 passed, 8 warnings in 5.20s`.
+
+Home visible-control verification:
+
+```bash
+.venv/bin/python -m pytest Tests/UI/test_home_screen.py::test_home_saved_chatbook_artifact_resume_controls_pass_artifact_target Tests/Home/test_active_work_adapter.py::test_local_notification_adapter_maps_console_saved_chatbook_to_active_work Tests/Home/test_active_work_adapter.py::test_local_notification_adapter_opens_console_saved_chatbook_details_and_console -q
+```
+
+Result:
+
+- `3 passed, 8 warnings in 6.13s`.
+
+Latest-only and fail-closed guardrail verification:
+
+```bash
+.venv/bin/python -m pytest Tests/Home/test_active_work_adapter.py::test_local_notification_adapter_maps_only_latest_console_saved_chatbook_to_active_work Tests/Home/test_active_work_adapter.py::test_local_notification_adapter_fails_closed_when_chatbook_snapshot_unavailable -q
+```
+
+Result:
+
+- `2 passed in 0.23s`.
+
+Broader focused verification:
+
+```bash
+.venv/bin/python -m pytest Tests/Chatbooks/test_local_chatbook_service.py Tests/Home/test_active_work_adapter.py Tests/UI/test_home_screen.py Tests/UI/test_screen_navigation.py::test_app_initializes_watchlists_and_notifications_services Tests/UI/test_product_maturity_phase1_harness.py -q
+```
+
+Result:
+
+- `49 passed, 8 warnings in 26.93s`.
+
+## Defects Fixed
+
+- `workflow-degradation`: Home had no way to surface a newly saved Console Chatbook artifact as resumable work after Phase 2.3 proved Artifacts could reopen it.
+- `recognition`: The user had to remember to go to Artifacts manually; Home did not expose the saved artifact in its active-work model.
+
+## UX Notes
+
+- The saved artifact uses the existing Home active-work model instead of adding a new dashboard section.
+- Details route to Artifacts, which remains the authority for generated outputs and Chatbooks.
+- Console launch reuses the existing Home control path and preserves the saved-response provenance needed by Console status cards.
+
+## Residual Risk
+
+- Home currently surfaces the latest Console-saved Chatbook artifact, not a full artifact history picker.
+- Full `.chatbook` export packaging remains outside this gate.
+- Phase 2 should still receive a final closeout replay that walks the full source/question -> grounded answer -> save -> Home resume path in one test or QA artifact.
+
+## Exit Decision
+
+Pass for Phase 2.4. Home can now resume the latest Console-saved Chatbook artifact through Artifacts or Console. Phase 2 should continue with a closeout replay of the complete core loop.

--- a/Docs/superpowers/qa/product-maturity/phase-2/2026-05-05-phase-2-4-home-chatbook-artifact-resume-contract.md
+++ b/Docs/superpowers/qa/product-maturity/phase-2/2026-05-05-phase-2-4-home-chatbook-artifact-resume-contract.md
@@ -71,6 +71,22 @@ Result:
 
 - `49 passed, 8 warnings in 26.93s`.
 
+PR review fix verification:
+
+```bash
+.venv/bin/python -m pytest Tests/Home/test_active_work_adapter.py Tests/Home/test_dashboard_state.py Tests/Chatbooks/test_local_chatbook_service.py Tests/UI/test_home_screen.py Tests/UI/test_screen_navigation.py::test_app_initializes_watchlists_and_notifications_services Tests/UI/test_product_maturity_phase1_harness.py -q
+```
+
+Result:
+
+- `65 passed, 8 warnings in 33.20s`.
+
+Review comments addressed:
+
+- Home Chatbook artifact snapshot refresh now runs off the Home compose path and uses a cached snapshot for dashboard rendering.
+- Mixed W+C plus Chatbook active work now exposes dedicated Chatbook detail and Console controls so the saved artifact remains reachable.
+- Console launch payload fields are sanitized, path-validated, and length-bounded before they are rendered by Console live-work status rows.
+
 ## Defects Fixed
 
 - `workflow-degradation`: Home had no way to surface a newly saved Console Chatbook artifact as resumable work after Phase 2.3 proved Artifacts could reopen it.

--- a/Docs/superpowers/qa/product-maturity/phase-2/README.md
+++ b/Docs/superpowers/qa/product-maturity/phase-2/README.md
@@ -11,3 +11,4 @@ Each child gate should record whether the tested slice completes the full loop o
 - `2026-05-05-phase-2-1-grounded-console-response-contract.md`
 - `2026-05-05-phase-2-2-console-chatbook-artifact-save-contract.md`
 - `2026-05-05-phase-2-3-saved-chatbook-artifact-reopen-contract.md`
+- `2026-05-05-phase-2-4-home-chatbook-artifact-resume-contract.md`

--- a/Docs/superpowers/trackers/product-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/product-maturity-roadmap.md
@@ -1,7 +1,7 @@
 # Product Maturity Roadmap
 
 Date: 2026-05-05
-Status: Phase 1 verified; Phase 2.3 verified
+Status: Phase 1 verified; Phase 2.4 verified
 Source Branch: `dev`
 Source Spec: `Docs/superpowers/specs/2026-05-05-product-maturity-phased-roadmap-design.md`
 
@@ -23,6 +23,7 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 - Phase 2.1 verifies the first core-agentic-loop contract: staged Search/RAG context reaches the model-bound Console request and remains staged when send is blocked before generation starts.
 - Phase 2.2 verifies the next core-agentic-loop contract: completed assistant responses can create local Chatbook artifact records with bounded Console provenance and recoverable failure notifications.
 - Phase 2.3 verifies the next core-agentic-loop contract: Console-saved Chatbook artifact records can be recognized in Artifacts and reopened into Console with visible saved-response provenance.
+- Phase 2.4 verifies the next core-agentic-loop contract: Home can surface a Console-saved Chatbook artifact as resumable work and route it to Artifacts or Console.
 
 ## Severity Policy
 
@@ -47,6 +48,7 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 - Phase 2.1: Grounded Console Response Contract - `TASK-9.1`
 - Phase 2.2: Console Chatbook Artifact Save Contract - `TASK-9.2`
 - Phase 2.3: Saved Chatbook Artifact Reopen Contract - `TASK-9.3`
+- Phase 2.4: Home Chatbook Artifact Resume Contract - `TASK-9.4`
 - Phase 3: Knowledge And Study Workflows - `TASK-10`
 - Phase 4: Agent Configuration And Execution - `TASK-11`
 - Phase 5: Server-Parity And Live Integrations - `TASK-12`
@@ -60,13 +62,14 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 | Phase 2.1 | `Docs/superpowers/qa/product-maturity/phase-2/2026-05-05-phase-2-1-grounded-console-response-contract.md` | verified |
 | Phase 2.2 | `Docs/superpowers/qa/product-maturity/phase-2/2026-05-05-phase-2-2-console-chatbook-artifact-save-contract.md` | verified |
 | Phase 2.3 | `Docs/superpowers/qa/product-maturity/phase-2/2026-05-05-phase-2-3-saved-chatbook-artifact-reopen-contract.md` | verified |
+| Phase 2.4 | `Docs/superpowers/qa/product-maturity/phase-2/2026-05-05-phase-2-4-home-chatbook-artifact-resume-contract.md` | verified |
 
 ## Phase Overview
 
 | Phase | Goal | Status | Backlog Tasks | QA Evidence | Residual Risk |
 | --- | --- | --- | --- | --- | --- |
 | Phase 1: QA Baseline And Usability Guardrails | Establish clean-run usability guardrails before feature depth. | verified | `TASK-8`, Phase 1.1 (`TASK-8.1`), Phase 1.2 (`TASK-8.2`), Phase 1.3 (`TASK-8.3`), Phase 1.4 (`TASK-8.4`), Phase 1.5 (`TASK-8.5`), Phase 1.6 (`TASK-8.6`), Phase 1.7 (`TASK-8.7`) | `phase-1/` | Closed; full grounded generation and Artifact/Chatbook persistence move to Phase 2. |
-| Phase 2: Core Agentic Loop | Complete source/question to grounded Console to Artifact/Chatbook loop. | in-progress | `TASK-9`, Phase 2.1 (`TASK-9.1`), Phase 2.2 (`TASK-9.2`), Phase 2.3 (`TASK-9.3`) | `phase-2/2026-05-05-phase-2-1-grounded-console-response-contract.md`, `phase-2/2026-05-05-phase-2-2-console-chatbook-artifact-save-contract.md`, `phase-2/2026-05-05-phase-2-3-saved-chatbook-artifact-reopen-contract.md` | Grounded request, local Chatbook artifact save, and Artifacts reopen contracts verified; Home resume remains. |
+| Phase 2: Core Agentic Loop | Complete source/question to grounded Console to Artifact/Chatbook loop. | in-progress | `TASK-9`, Phase 2.1 (`TASK-9.1`), Phase 2.2 (`TASK-9.2`), Phase 2.3 (`TASK-9.3`), Phase 2.4 (`TASK-9.4`) | `phase-2/2026-05-05-phase-2-1-grounded-console-response-contract.md`, `phase-2/2026-05-05-phase-2-2-console-chatbook-artifact-save-contract.md`, `phase-2/2026-05-05-phase-2-3-saved-chatbook-artifact-reopen-contract.md`, `phase-2/2026-05-05-phase-2-4-home-chatbook-artifact-resume-contract.md` | Grounded request, local Chatbook artifact save, Artifacts reopen, and Home resume contracts verified; full closeout replay remains. |
 | Phase 3: Knowledge And Study Workflows | Mature ingest, organize, retrieve, study, and reuse workflows. | planned | `TASK-10` | not-started | Depends on Phase 2 core loop and later task slicing. |
 | Phase 4: Agent Configuration And Execution | Mature Personas, Skills, MCP, ACP, Schedules, and Workflows. | planned | `TASK-11` | not-started | Depends on service adapters and runtime readiness. |
 | Phase 5: Server-Parity And Live Integrations | Close high-value `tldw_server2` parity gaps. | planned | `TASK-12` | not-started | Requires parity inventory. |
@@ -134,3 +137,9 @@ Status: verified
 Status: verified
 
 - `Docs/superpowers/qa/product-maturity/phase-2/2026-05-05-phase-2-3-saved-chatbook-artifact-reopen-contract.md`
+
+## Phase 2.4 Evidence
+
+Status: verified
+
+- `Docs/superpowers/qa/product-maturity/phase-2/2026-05-05-phase-2-4-home-chatbook-artifact-resume-contract.md`

--- a/Tests/Chatbooks/test_local_chatbook_service.py
+++ b/Tests/Chatbooks/test_local_chatbook_service.py
@@ -51,3 +51,43 @@ async def test_local_chatbook_service_lists_with_query_limit_and_offset(tmp_path
     results = await service.list_chatbooks(q="pack", limit=1, offset=1)
 
     assert [item["name"] for item in results] == ["Beta Pack"]
+
+
+@pytest.mark.asyncio
+async def test_local_chatbook_service_home_artifact_snapshot_lists_latest_console_saved_artifacts(tmp_path):
+    service = LocalChatbookService(db_paths={}, registry_path=tmp_path / "chatbooks.json")
+    await service.create_chatbook(
+        name="Generic Pack",
+        description="Imported pack",
+        metadata={"artifact_source": "import"},
+    )
+    older = await service.create_chatbook(
+        name="Older Console Answer",
+        description="Saved from Console assistant response.",
+        metadata={
+            "artifact_source": "console",
+            "artifact_kind": "assistant-response",
+            "message_id": "msg-old",
+            "content": "Older saved answer.",
+            "content_truncated": False,
+        },
+    )
+    newer = await service.create_chatbook(
+        name="Newer Console Answer",
+        description="Saved from Console assistant response.",
+        metadata={
+            "artifact_source": "console",
+            "artifact_kind": "assistant-response",
+            "message_id": "msg-new",
+            "content": "Newer saved answer.",
+            "content_truncated": False,
+        },
+    )
+
+    snapshot = service.list_home_artifact_snapshot(limit=2)
+
+    assert [record["chatbook_id"] for record in snapshot] == [
+        newer["chatbook_id"],
+        older["chatbook_id"],
+    ]
+    assert snapshot[0]["metadata"]["message_id"] == "msg-new"

--- a/Tests/Home/test_active_work_adapter.py
+++ b/Tests/Home/test_active_work_adapter.py
@@ -262,6 +262,7 @@ def test_local_notification_adapter_maps_console_saved_chatbook_to_active_work()
 
     service = FakeChatbookService()
     adapter = LocalNotificationHomeActiveWorkAdapter(chatbook_service=service)
+    adapter.refresh_chatbook_artifact_snapshot()
 
     dashboard_input = adapter.build_dashboard_input(
         providers_models={"OpenAI": ["gpt-4.1"]},
@@ -306,6 +307,7 @@ def test_local_notification_adapter_maps_only_latest_console_saved_chatbook_to_a
     adapter = LocalNotificationHomeActiveWorkAdapter(
         chatbook_service=FakeChatbookService()
     )
+    adapter.refresh_chatbook_artifact_snapshot()
 
     dashboard_input = adapter.build_dashboard_input(
         providers_models={"OpenAI": ["gpt-4.1"]},
@@ -347,6 +349,7 @@ def test_local_notification_adapter_opens_console_saved_chatbook_details_and_con
     adapter = LocalNotificationHomeActiveWorkAdapter(
         chatbook_service=FakeChatbookService()
     )
+    adapter.refresh_chatbook_artifact_snapshot()
 
     detail_result = adapter.handle_control(
         HomeControlAction.OPEN_DETAILS,
@@ -373,11 +376,15 @@ def test_local_notification_adapter_opens_console_saved_chatbook_details_and_con
         "Review this Chatbook artifact in Console or return to Home."
     )
     assert console_result.console_launch.action_label == "Open Chatbook artifact"
+    assert console_result.console_launch.payload is not None
+    assert console_result.console_launch.payload["file_path"].endswith(
+        "/grounded-answer.chatbook"
+    )
     assert console_result.console_launch.payload == {
         "target_id": "local:chatbook:77",
         "chatbook_id": 77,
         "record_id": "77",
-        "file_path": "/tmp/grounded-answer.chatbook",
+        "file_path": console_result.console_launch.payload["file_path"],
         "description": "Saved from Console assistant response.",
         "tags": "console, artifact",
         "categories": "Console, Artifacts",
@@ -416,6 +423,7 @@ def test_local_notification_adapter_bounds_console_saved_chatbook_preview():
     adapter = LocalNotificationHomeActiveWorkAdapter(
         chatbook_service=FakeChatbookService()
     )
+    adapter.refresh_chatbook_artifact_snapshot()
 
     result = adapter.handle_control(
         HomeControlAction.OPEN_IN_CONSOLE,
@@ -428,6 +436,129 @@ def test_local_notification_adapter_bounds_console_saved_chatbook_preview():
     assert payload is not None
     assert payload["content_preview"] == "x" * 1000
     assert payload["content_truncated"] is True
+
+
+def test_local_notification_adapter_sanitizes_console_saved_chatbook_payload_text():
+    class FakeChatbookService:
+        def list_home_artifact_snapshot(self, *, limit=20):
+            return [
+                {
+                    "chatbook_id": 77,
+                    "id": "77",
+                    "name": "Unsafe Answer",
+                    "description": "<script>alert('x')</script>\nDescription",
+                    "file_path": "../../secret.chatbook",
+                    "tags": ["safe", "<script>tag</script>"],
+                    "categories": ["Console\nArtifacts"],
+                    "metadata": {
+                        "artifact_source": "console",
+                        "artifact_kind": "assistant-response",
+                        "provider": "OpenAI\n<script>",
+                        "model": "gpt-4.1",
+                        "content": "<script>alert('x')</script>\nGrounded answer body.",
+                        "content_truncated": False,
+                    },
+                },
+            ]
+
+    adapter = LocalNotificationHomeActiveWorkAdapter(
+        chatbook_service=FakeChatbookService()
+    )
+    adapter.refresh_chatbook_artifact_snapshot()
+
+    result = adapter.handle_control(
+        HomeControlAction.OPEN_IN_CONSOLE,
+        target_id="local:chatbook:77",
+        target_route="chat",
+    )
+
+    assert result.console_launch is not None
+    payload = result.console_launch.payload
+    assert payload is not None
+    assert payload["file_path"] is None
+    assert "<script" not in str(payload["description"]).lower()
+    assert "<script" not in str(payload["tags"]).lower()
+    assert "\n" not in str(payload["categories"])
+    assert "<script" not in str(payload.get("provider", "")).lower()
+    assert "<script" not in str(payload["content_preview"]).lower()
+
+
+def test_local_notification_adapter_bounds_console_saved_chatbook_payload_fields():
+    class FakeChatbookService:
+        def list_home_artifact_snapshot(self, *, limit=20):
+            return [
+                {
+                    "chatbook_id": 77,
+                    "id": "77",
+                    "name": "Large Answer",
+                    "description": "d" * 1500,
+                    "file_path": f"/tmp/{'f' * 2500}.chatbook",
+                    "tags": ["t" * 1500],
+                    "categories": ["c" * 1500],
+                    "metadata": {
+                        "artifact_source": "console",
+                        "artifact_kind": "assistant-response",
+                        "provider": "p" * 300,
+                        "model": "m" * 300,
+                        "content": "body",
+                    },
+                },
+            ]
+
+    adapter = LocalNotificationHomeActiveWorkAdapter(
+        chatbook_service=FakeChatbookService()
+    )
+    adapter.refresh_chatbook_artifact_snapshot()
+
+    result = adapter.handle_control(
+        HomeControlAction.OPEN_IN_CONSOLE,
+        target_id="local:chatbook:77",
+        target_route="chat",
+    )
+
+    assert result.console_launch is not None
+    payload = result.console_launch.payload
+    assert payload is not None
+    assert len(str(payload["description"])) <= 1000
+    assert len(str(payload["file_path"])) <= 2000
+    assert len(str(payload["tags"])) <= 1000
+    assert len(str(payload["categories"])) <= 1000
+    assert len(str(payload["provider"])) <= 256
+    assert len(str(payload["model"])) <= 256
+
+
+def test_local_notification_adapter_dashboard_build_uses_cached_chatbook_snapshot():
+    class FakeChatbookService:
+        def __init__(self):
+            self.calls = 0
+
+        def list_home_artifact_snapshot(self, *, limit=20):
+            self.calls += 1
+            return [
+                {
+                    "chatbook_id": 77,
+                    "name": "Grounded Answer",
+                    "metadata": {
+                        "artifact_source": "console",
+                        "artifact_kind": "assistant-response",
+                    },
+                },
+            ]
+
+    service = FakeChatbookService()
+    adapter = LocalNotificationHomeActiveWorkAdapter(chatbook_service=service)
+    adapter.refresh_chatbook_artifact_snapshot()
+    assert service.calls == 1
+
+    dashboard_input = adapter.build_dashboard_input(
+        providers_models={"OpenAI": ["gpt-4.1"]},
+        has_recent_work=False,
+    )
+
+    assert service.calls == 1
+    assert [item.item_id for item in dashboard_input.active_work_items] == [
+        "local:chatbook:77"
+    ]
 
 
 def test_local_notification_adapter_fails_closed_when_chatbook_snapshot_unavailable():
@@ -451,6 +582,7 @@ def test_local_notification_adapter_fails_closed_when_chatbook_snapshot_unavaila
         watchlist_service=FakeWatchlistsService(),
         chatbook_service=BrokenChatbookService(),
     )
+    adapter.refresh_chatbook_artifact_snapshot()
 
     dashboard_input = adapter.build_dashboard_input(
         providers_models={"OpenAI": ["gpt-4.1"]},

--- a/Tests/Home/test_active_work_adapter.py
+++ b/Tests/Home/test_active_work_adapter.py
@@ -8,6 +8,7 @@ from tldw_chatbook.Home.active_work_adapter import (
     LocalNotificationHomeActiveWorkAdapter,
     UnavailableHomeActiveWorkAdapter,
 )
+from tldw_chatbook.Home.dashboard_state import HomeActiveWorkItem
 
 
 def test_unavailable_home_adapter_builds_dashboard_input_from_runtime_context():
@@ -231,6 +232,234 @@ def test_local_notification_adapter_opens_local_watchlist_run_in_console():
     }
     assert missing_result.status is HomeControlResultStatus.UNAVAILABLE
     assert missing_result.console_launch is None
+
+
+def test_local_notification_adapter_maps_console_saved_chatbook_to_active_work():
+    class FakeChatbookService:
+        def __init__(self):
+            self.calls = []
+
+        def list_home_artifact_snapshot(self, *, limit=20):
+            self.calls.append({"limit": limit})
+            return [
+                {
+                    "chatbook_id": 77,
+                    "id": "77",
+                    "name": "Grounded Answer",
+                    "description": "Saved from Console assistant response.",
+                    "metadata": {
+                        "artifact_source": "console",
+                        "artifact_kind": "assistant-response",
+                        "message_id": "msg-456",
+                        "provider": "OpenAI",
+                        "model": "gpt-4.1",
+                        "content": "Grounded answer body.",
+                        "content_truncated": False,
+                    },
+                    "updated_at": "2026-05-05T20:00:00Z",
+                },
+            ]
+
+    service = FakeChatbookService()
+    adapter = LocalNotificationHomeActiveWorkAdapter(chatbook_service=service)
+
+    dashboard_input = adapter.build_dashboard_input(
+        providers_models={"OpenAI": ["gpt-4.1"]},
+        has_recent_work=False,
+    )
+
+    assert service.calls == [{"limit": 20}]
+    assert dashboard_input.active_work_items == (
+        HomeActiveWorkItem(
+            item_id="local:chatbook:77",
+            title="Grounded Answer",
+            source="Artifacts",
+            status="ready",
+            detail_route="artifacts",
+            console_available=True,
+        ),
+    )
+
+
+def test_local_notification_adapter_maps_only_latest_console_saved_chatbook_to_active_work():
+    class FakeChatbookService:
+        def list_home_artifact_snapshot(self, *, limit=20):
+            return [
+                {
+                    "chatbook_id": 78,
+                    "name": "Latest Grounded Answer",
+                    "metadata": {
+                        "artifact_source": "console",
+                        "artifact_kind": "assistant-response",
+                    },
+                },
+                {
+                    "chatbook_id": 77,
+                    "name": "Older Grounded Answer",
+                    "metadata": {
+                        "artifact_source": "console",
+                        "artifact_kind": "assistant-response",
+                    },
+                },
+            ]
+
+    adapter = LocalNotificationHomeActiveWorkAdapter(
+        chatbook_service=FakeChatbookService()
+    )
+
+    dashboard_input = adapter.build_dashboard_input(
+        providers_models={"OpenAI": ["gpt-4.1"]},
+        has_recent_work=False,
+    )
+
+    assert [item.item_id for item in dashboard_input.active_work_items] == [
+        "local:chatbook:78"
+    ]
+
+
+def test_local_notification_adapter_opens_console_saved_chatbook_details_and_console():
+    class FakeChatbookService:
+        def list_home_artifact_snapshot(self, *, limit=20):
+            return [
+                {
+                    "chatbook_id": 77,
+                    "id": "77",
+                    "name": "Grounded Answer",
+                    "description": "Saved from Console assistant response.",
+                    "file_path": "/tmp/grounded-answer.chatbook",
+                    "tags": ["console", "artifact"],
+                    "categories": ["Console", "Artifacts"],
+                    "metadata": {
+                        "artifact_source": "console",
+                        "artifact_kind": "assistant-response",
+                        "conversation_id": "conv-123",
+                        "message_id": "msg-456",
+                        "message_role": "Assistant",
+                        "provider": "OpenAI",
+                        "model": "gpt-4.1",
+                        "content": "Grounded answer body.",
+                        "content_truncated": False,
+                    },
+                    "updated_at": "2026-05-05T20:00:00Z",
+                },
+            ]
+
+    adapter = LocalNotificationHomeActiveWorkAdapter(
+        chatbook_service=FakeChatbookService()
+    )
+
+    detail_result = adapter.handle_control(
+        HomeControlAction.OPEN_DETAILS,
+        target_id="local:chatbook:77",
+        target_route="artifacts",
+    )
+    console_result = adapter.handle_control(
+        HomeControlAction.OPEN_IN_CONSOLE,
+        target_id="local:chatbook:77",
+        target_route="chat",
+    )
+
+    assert detail_result.status is HomeControlResultStatus.HANDLED
+    assert detail_result.target_id == "local:chatbook:77"
+    assert detail_result.target_route == "artifacts"
+    assert detail_result.message == "Opening Artifacts for Grounded Answer."
+
+    assert console_result.status is HomeControlResultStatus.HANDLED
+    assert console_result.console_launch is not None
+    assert console_result.console_launch.source == "artifacts"
+    assert console_result.console_launch.title == "Grounded Answer"
+    assert console_result.console_launch.status == "ready"
+    assert console_result.console_launch.recovery == (
+        "Review this Chatbook artifact in Console or return to Home."
+    )
+    assert console_result.console_launch.action_label == "Open Chatbook artifact"
+    assert console_result.console_launch.payload == {
+        "target_id": "local:chatbook:77",
+        "chatbook_id": 77,
+        "record_id": "77",
+        "file_path": "/tmp/grounded-answer.chatbook",
+        "description": "Saved from Console assistant response.",
+        "tags": "console, artifact",
+        "categories": "Console, Artifacts",
+        "updated_at": "2026-05-05T20:00:00Z",
+        "artifact_source": "console",
+        "artifact_kind": "assistant-response",
+        "conversation_id": "conv-123",
+        "message_id": "msg-456",
+        "message_role": "Assistant",
+        "provider": "OpenAI",
+        "model": "gpt-4.1",
+        "content_preview": "Grounded answer body.",
+        "content_truncated": False,
+    }
+
+
+def test_local_notification_adapter_bounds_console_saved_chatbook_preview():
+    long_content = "x" * 1500
+
+    class FakeChatbookService:
+        def list_home_artifact_snapshot(self, *, limit=20):
+            return [
+                {
+                    "chatbook_id": 77,
+                    "id": "77",
+                    "name": "Long Answer",
+                    "metadata": {
+                        "artifact_source": "console",
+                        "artifact_kind": "assistant-response",
+                        "content": long_content,
+                        "content_truncated": False,
+                    },
+                },
+            ]
+
+    adapter = LocalNotificationHomeActiveWorkAdapter(
+        chatbook_service=FakeChatbookService()
+    )
+
+    result = adapter.handle_control(
+        HomeControlAction.OPEN_IN_CONSOLE,
+        target_id="local:chatbook:77",
+        target_route="chat",
+    )
+
+    assert result.console_launch is not None
+    payload = result.console_launch.payload
+    assert payload is not None
+    assert payload["content_preview"] == "x" * 1000
+    assert payload["content_truncated"] is True
+
+
+def test_local_notification_adapter_fails_closed_when_chatbook_snapshot_unavailable():
+    class FakeWatchlistsService:
+        def list_home_run_snapshot(self, *, limit=20):
+            return [
+                {
+                    "id": "local:watchlist_run:5",
+                    "title": "Daily Feed",
+                    "status": "running",
+                    "target_route": "watchlists",
+                    "console_available": True,
+                },
+            ]
+
+    class BrokenChatbookService:
+        def list_home_artifact_snapshot(self, *, limit=20):
+            raise RuntimeError("chatbook registry unavailable")
+
+    adapter = LocalNotificationHomeActiveWorkAdapter(
+        watchlist_service=FakeWatchlistsService(),
+        chatbook_service=BrokenChatbookService(),
+    )
+
+    dashboard_input = adapter.build_dashboard_input(
+        providers_models={"OpenAI": ["gpt-4.1"]},
+        has_recent_work=True,
+    )
+
+    assert [item.item_id for item in dashboard_input.active_work_items] == [
+        "local:watchlist_run:5"
+    ]
 
 
 def test_local_notification_adapter_fails_closed_when_watchlist_snapshot_unavailable():

--- a/Tests/Home/test_dashboard_state.py
+++ b/Tests/Home/test_dashboard_state.py
@@ -209,6 +209,40 @@ def test_dashboard_summary_exposes_active_work_item_context_and_targets():
     assert controls_by_id["home-open-in-console"].target_id == "run-1"
 
 
+def test_dashboard_summary_keeps_chatbook_artifact_reachable_when_mixed_with_watchlist_run():
+    dashboard = summarize_home_dashboard(
+        HomeDashboardInput(
+            model_ready=True,
+            has_library_content=True,
+            active_work_items=(
+                HomeActiveWorkItem(
+                    item_id="local:watchlist_run:5",
+                    title="Daily feed",
+                    source="W+C",
+                    status="running",
+                    detail_route="watchlists",
+                    console_available=True,
+                ),
+                HomeActiveWorkItem(
+                    item_id="local:chatbook:77",
+                    title="Grounded Answer",
+                    source="Artifacts",
+                    status="ready",
+                    detail_route="artifacts",
+                    console_available=True,
+                ),
+            ),
+        )
+    )
+
+    controls_by_id = {control.control_id: control for control in dashboard.controls}
+    assert controls_by_id["home-open-details"].target_id == "local:watchlist_run:5"
+    assert controls_by_id["home-open-in-console"].target_id == "local:watchlist_run:5"
+    assert controls_by_id["home-open-chatbook-details"].target_id == "local:chatbook:77"
+    assert controls_by_id["home-open-chatbook-details"].target_route == "artifacts"
+    assert controls_by_id["home-open-chatbook-in-console"].target_id == "local:chatbook:77"
+
+
 def test_dashboard_item_statuses_gate_matching_controls():
     dashboard = summarize_home_dashboard(
         HomeDashboardInput(

--- a/Tests/UI/test_home_screen.py
+++ b/Tests/UI/test_home_screen.py
@@ -372,6 +372,51 @@ async def test_home_active_work_item_controls_pass_target_id_to_runtime_hooks():
     )
 
 
+@pytest.mark.asyncio
+async def test_home_saved_chatbook_artifact_resume_controls_pass_artifact_target():
+    app = _build_test_app()
+    app._home_dashboard_test_input = HomeDashboardInput(
+        model_ready=True,
+        has_library_content=True,
+        active_work_items=(
+            HomeActiveWorkItem(
+                item_id="local:chatbook:77",
+                title="Grounded Answer",
+                source="Artifacts",
+                status="ready",
+                detail_route="artifacts",
+                console_available=True,
+            ),
+        ),
+    )
+    app.open_active_home_item_details = Mock()
+    app.open_active_home_item_in_console = Mock()
+    host = HomeHarness(app, [])
+
+    async with host.run_test(size=(160, 40)) as pilot:
+        await pilot.pause(0.1)
+        home = _active_home_screen(host)
+
+        active_work_text = str(home.query_one("#home-active-work-body").renderable)
+        assert "Grounded Answer" in active_work_text
+        assert "Artifacts" in active_work_text
+        assert "ready" in active_work_text
+
+        await pilot.click("#home-open-details")
+        await pilot.pause(0.1)
+        await pilot.click("#home-open-in-console")
+        await pilot.pause(0.1)
+
+    app.open_active_home_item_details.assert_called_once_with(
+        target_id="local:chatbook:77",
+        target_route="artifacts",
+    )
+    app.open_active_home_item_in_console.assert_called_once_with(
+        target_id="local:chatbook:77",
+        target_route="chat",
+    )
+
+
 def test_app_detail_hook_delegates_to_adapter_and_navigates_handled_route():
     app = _build_test_app()
     adapter = RecordingHomeActiveWorkAdapter(

--- a/Tests/UI/test_home_screen.py
+++ b/Tests/UI/test_home_screen.py
@@ -417,6 +417,56 @@ async def test_home_saved_chatbook_artifact_resume_controls_pass_artifact_target
     )
 
 
+@pytest.mark.asyncio
+async def test_home_mixed_active_work_exposes_chatbook_artifact_resume_controls():
+    app = _build_test_app()
+    app._home_dashboard_test_input = HomeDashboardInput(
+        model_ready=True,
+        has_library_content=True,
+        active_work_items=(
+            HomeActiveWorkItem(
+                item_id="local:watchlist_run:5",
+                title="Daily Feed",
+                source="W+C",
+                status="running",
+                detail_route="watchlists",
+                console_available=True,
+            ),
+            HomeActiveWorkItem(
+                item_id="local:chatbook:77",
+                title="Grounded Answer",
+                source="Artifacts",
+                status="ready",
+                detail_route="artifacts",
+                console_available=True,
+            ),
+        ),
+    )
+    app.open_active_home_item_details = Mock()
+    app.open_active_home_item_in_console = Mock()
+    host = HomeHarness(app, [])
+
+    async with host.run_test(size=(160, 40)) as pilot:
+        await pilot.pause(0.1)
+        home = _active_home_screen(host)
+
+        assert len(home.query("#home-open-chatbook-details")) == 1
+        assert len(home.query("#home-open-chatbook-in-console")) == 1
+        await pilot.click("#home-open-chatbook-details")
+        await pilot.pause(0.1)
+        await pilot.click("#home-open-chatbook-in-console")
+        await pilot.pause(0.1)
+
+    app.open_active_home_item_details.assert_called_once_with(
+        target_id="local:chatbook:77",
+        target_route="artifacts",
+    )
+    app.open_active_home_item_in_console.assert_called_once_with(
+        target_id="local:chatbook:77",
+        target_route="chat",
+    )
+
+
 def test_app_detail_hook_delegates_to_adapter_and_navigates_handled_route():
     app = _build_test_app()
     adapter = RecordingHomeActiveWorkAdapter(

--- a/Tests/UI/test_product_maturity_phase1_harness.py
+++ b/Tests/UI/test_product_maturity_phase1_harness.py
@@ -19,6 +19,7 @@ PROTOCOL = PHASE_1_ROOT / "walkthrough-protocol.md"
 TEMPLATE = PHASE_1_ROOT / "walkthrough-template.md"
 SMOKE = PHASE_1_ROOT / "2026-05-05-phase-1-1-harness-smoke.md"
 PHASE_2_3_EVIDENCE = PHASE_2_ROOT / "2026-05-05-phase-2-3-saved-chatbook-artifact-reopen-contract.md"
+PHASE_2_4_EVIDENCE = PHASE_2_ROOT / "2026-05-05-phase-2-4-home-chatbook-artifact-resume-contract.md"
 PHASE_1_2_PLAN = Path("Docs/superpowers/plans/2026-05-05-product-maturity-phase-1-2-first-run-walkthrough.md")
 BACKLOG_TASKS = Path("backlog/tasks")
 
@@ -195,6 +196,23 @@ def test_product_maturity_phase_two_three_evidence_links_task_and_tracker() -> N
     assert "Saved Chatbook Artifact Reopen Contract" in evidence
     assert "Home resume controls for saved artifacts" in evidence
     assert "Artifacts identifies Console-saved Chatbook artifact records" in task
+
+
+def test_product_maturity_phase_two_four_evidence_links_task_and_tracker() -> None:
+    tracker = _text(TRACKER)
+    readme = _text(PHASE_2_README)
+    evidence = _text(PHASE_2_4_EVIDENCE)
+    task = _task_text_by_id("TASK-9.4")
+
+    phase_two_row = _phase_row(tracker, "Phase 2: Core Agentic Loop")
+
+    assert "Phase 2.4" in tracker
+    assert "TASK-9.4" in phase_two_row[3]
+    assert PHASE_2_4_EVIDENCE.name in phase_two_row[4]
+    assert PHASE_2_4_EVIDENCE.name in readme
+    assert "Home Chatbook Artifact Resume Contract" in evidence
+    assert "closeout replay" in evidence
+    assert "Home active-work input includes the latest Console-saved Chatbook artifact" in task
 
 
 def test_phase_one_one_smoke_evidence_records_harness_only_boundary() -> None:

--- a/Tests/UI/test_screen_navigation.py
+++ b/Tests/UI/test_screen_navigation.py
@@ -349,6 +349,7 @@ def test_app_initializes_watchlists_and_notifications_services():
     assert isinstance(app.home_active_work_adapter, LocalNotificationHomeActiveWorkAdapter)
     assert app.home_active_work_adapter.notification_service is app.client_notifications_service
     assert app.home_active_work_adapter.watchlist_service is app.local_watchlists_service
+    assert app.home_active_work_adapter.chatbook_service is app.local_chatbook_service
     assert isinstance(app.server_outputs_service, ServerOutputsService)
     assert isinstance(app.outputs_scope_service, OutputsScopeService)
     assert isinstance(app.local_research_service, LocalResearchService)

--- a/backlog/tasks/task-9.4 - Product-Maturity-Phase-2.4-Home-Chatbook-Artifact-Resume-Contract.md
+++ b/backlog/tasks/task-9.4 - Product-Maturity-Phase-2.4-Home-Chatbook-Artifact-Resume-Contract.md
@@ -4,7 +4,7 @@ title: 'Product Maturity Phase 2.4: Home Chatbook Artifact Resume Contract'
 status: Done
 assignee: []
 created_date: '2026-05-05 23:14'
-updated_date: '2026-05-05 23:38'
+updated_date: '2026-05-06 00:05'
 labels:
   - product-maturity
   - phase-2-core-agentic-loop
@@ -44,4 +44,6 @@ Prove Home can surface a recently saved Console Chatbook artifact as resumable w
 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented Home resume support for the latest Console-saved Chatbook artifact by adding a synchronous local Chatbook Home snapshot, mapping the latest artifact into Home active work, routing details to Artifacts, and launching Console with bounded provenance payloads. Added focused Chatbook service, Home adapter, Home screen, app-wiring, tracker, and QA evidence tests. Verification: 49 focused tests passed with 8 warnings.
+
+Review fix pass addressed PR #258 comments: Home now refreshes the Chatbook artifact snapshot off the compose path, mixed W+C plus Chatbook active work exposes dedicated Chatbook controls, and Console launch payload fields are sanitized, path-validated, and bounded before rendering. Verification: 65 focused tests passed with 8 warnings.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-9.4 - Product-Maturity-Phase-2.4-Home-Chatbook-Artifact-Resume-Contract.md
+++ b/backlog/tasks/task-9.4 - Product-Maturity-Phase-2.4-Home-Chatbook-Artifact-Resume-Contract.md
@@ -1,0 +1,47 @@
+---
+id: TASK-9.4
+title: 'Product Maturity Phase 2.4: Home Chatbook Artifact Resume Contract'
+status: Done
+assignee: []
+created_date: '2026-05-05 23:14'
+updated_date: '2026-05-05 23:38'
+labels:
+  - product-maturity
+  - phase-2-core-agentic-loop
+dependencies: []
+parent_task_id: TASK-9
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Prove Home can surface a recently saved Console Chatbook artifact as resumable work and route it back to Artifacts or Console without manual state reconstruction.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Home active-work input includes the latest Console-saved Chatbook artifact when the local Chatbook service has one.
+- [x] #2 Home renders the saved artifact as resumable work with Open details and Open in Console controls.
+- [x] #3 Home Open details routes to Artifacts for the saved Chatbook artifact.
+- [x] #4 Home Open in Console launches the saved artifact with Chatbook id, record id, and Console provenance.
+- [x] #5 Missing or failing local Chatbook service remains fail-closed without hiding existing notification or W+C Home behavior.
+- [x] #6 QA evidence and product-maturity tracker record the Phase 2.4 exit decision and remaining Phase 2 risk.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing adapter and app-wiring regressions for Home surfacing the latest Console-saved Chatbook artifact.
+2. Extend the Home active-work adapter to accept the local Chatbook service and map the latest Console-saved artifact into a Home active-work item.
+3. Add handled Home detail and Console control responses for local Chatbook artifact targets.
+4. Wire the app Home adapter to the existing local Chatbook service.
+5. Record Phase 2.4 QA evidence and update the Phase 2 roadmap tracking.
+6. Run focused Home adapter, Home screen, app wiring, and product-maturity tracker verification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented Home resume support for the latest Console-saved Chatbook artifact by adding a synchronous local Chatbook Home snapshot, mapping the latest artifact into Home active work, routing details to Artifacts, and launching Console with bounded provenance payloads. Added focused Chatbook service, Home adapter, Home screen, app-wiring, tracker, and QA evidence tests. Verification: 49 focused tests passed with 8 warnings.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chatbooks/local_chatbook_service.py
+++ b/tldw_chatbook/Chatbooks/local_chatbook_service.py
@@ -130,6 +130,42 @@ class LocalChatbookService:
             ]
         return records[int(offset) : int(offset) + int(limit)]
 
+    @staticmethod
+    def _is_console_saved_artifact(record: dict[str, Any]) -> bool:
+        metadata = record.get("metadata") if isinstance(record.get("metadata"), dict) else {}
+        return (
+            str(metadata.get("artifact_source") or "").strip().lower() == "console"
+            and str(metadata.get("artifact_kind") or "").strip().lower() == "assistant-response"
+        )
+
+    @classmethod
+    def _home_artifact_sort_key(cls, record: dict[str, Any]) -> tuple[float, int]:
+        timestamp = str(record.get("updated_at") or record.get("created_at") or "").strip()
+        try:
+            normalized = timestamp[:-1] + "+00:00" if timestamp.endswith("Z") else timestamp
+            parsed = datetime.fromisoformat(normalized)
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            timestamp_value = parsed.timestamp()
+        except (TypeError, ValueError):
+            timestamp_value = 0.0
+        try:
+            chatbook_id = int(record.get("chatbook_id") or record.get("id") or 0)
+        except (TypeError, ValueError):
+            chatbook_id = 0
+        return timestamp_value, chatbook_id
+
+    def list_home_artifact_snapshot(self, *, limit: int = 20) -> list[dict[str, Any]]:
+        """Return latest Console-saved Chatbook artifacts for synchronous Home rendering."""
+        registry = self._load_registry()
+        records = [
+            self._record_copy(record)
+            for record in registry["records"]
+            if self._is_console_saved_artifact(record)
+        ]
+        records.sort(key=self._home_artifact_sort_key, reverse=True)
+        return records[: int(limit)]
+
     async def get_chatbook(self, chatbook_id: int | str) -> dict[str, Any]:
         registry = self._load_registry()
         return self._record_copy(self._find_record(registry, chatbook_id))

--- a/tldw_chatbook/Home/active_work_adapter.py
+++ b/tldw_chatbook/Home/active_work_adapter.py
@@ -24,6 +24,7 @@ _HOME_WATCHLIST_RUN_STATUSES = frozenset(
         "error",
     }
 )
+_MAX_CHATBOOK_ARTIFACT_PREVIEW_CHARS = 1000
 
 
 class HomeControlAction(StrEnum):
@@ -153,9 +154,11 @@ class LocalNotificationHomeActiveWorkAdapter(UnavailableHomeActiveWorkAdapter):
         *,
         notification_service: Any | None = None,
         watchlist_service: Any | None = None,
+        chatbook_service: Any | None = None,
     ):
         self.notification_service = notification_service
         self.watchlist_service = watchlist_service
+        self.chatbook_service = chatbook_service
 
     def build_dashboard_input(
         self,
@@ -170,7 +173,12 @@ class LocalNotificationHomeActiveWorkAdapter(UnavailableHomeActiveWorkAdapter):
         return replace(
             dashboard_input,
             notification_count=self._unread_notification_count(),
-            active_work_items=tuple(self._local_watchlist_run_items()),
+            active_work_items=tuple(
+                [
+                    *self._local_watchlist_run_items(),
+                    *self._local_chatbook_artifact_items(),
+                ]
+            ),
         )
 
     def handle_control(
@@ -207,6 +215,35 @@ class LocalNotificationHomeActiveWorkAdapter(UnavailableHomeActiveWorkAdapter):
                         status=str(_mapping_value(run, "status") or "pending").strip().lower(),
                         recovery="Review the W+C run details or retry from W+C.",
                         action_label="Open W+C run",
+                    ),
+                )
+        if action is HomeControlAction.OPEN_DETAILS and _is_local_chatbook_id(target_id):
+            record = self._local_chatbook_artifact_by_id(str(target_id))
+            if record is not None:
+                title = self._chatbook_title(record)
+                return HomeControlResult(
+                    action=action,
+                    status=HomeControlResultStatus.HANDLED,
+                    message=f"Opening Artifacts for {title}.",
+                    target_route=target_route or "artifacts",
+                    target_id=target_id,
+                )
+        if action is HomeControlAction.OPEN_IN_CONSOLE and _is_local_chatbook_id(target_id):
+            record = self._local_chatbook_artifact_by_id(str(target_id))
+            if record is not None:
+                title = self._chatbook_title(record)
+                return HomeControlResult(
+                    action=action,
+                    status=HomeControlResultStatus.HANDLED,
+                    message=f"Opening Console for {title}.",
+                    target_id=target_id,
+                    console_launch=HomeConsoleLaunch(
+                        source="artifacts",
+                        title=title,
+                        payload=self._chatbook_console_payload(record, str(target_id)),
+                        status="ready",
+                        recovery="Review this Chatbook artifact in Console or return to Home.",
+                        action_label="Open Chatbook artifact",
                     ),
                 )
         return super().handle_control(
@@ -263,6 +300,24 @@ class LocalNotificationHomeActiveWorkAdapter(UnavailableHomeActiveWorkAdapter):
             )
         return items
 
+    def _local_chatbook_artifact_items(self) -> list[HomeActiveWorkItem]:
+        items: list[HomeActiveWorkItem] = []
+        for record in self._local_chatbook_artifacts()[:1]:
+            item_id = self._local_chatbook_item_id(record)
+            if not item_id:
+                continue
+            items.append(
+                HomeActiveWorkItem(
+                    item_id=item_id,
+                    title=self._chatbook_title(record),
+                    source="Artifacts",
+                    status="ready",
+                    detail_route="artifacts",
+                    console_available=True,
+                )
+            )
+        return items
+
     def _local_watchlist_run_by_id(self, target_id: str) -> Any | None:
         if self.watchlist_service is None:
             return None
@@ -273,6 +328,29 @@ class LocalNotificationHomeActiveWorkAdapter(UnavailableHomeActiveWorkAdapter):
             return None
         return next(
             (run for run in runs if self._local_watchlist_run_item_id(run) == target_id),
+            None,
+        )
+
+    def _local_chatbook_artifacts(self) -> list[Any]:
+        if self.chatbook_service is None:
+            return []
+        list_snapshot = getattr(self.chatbook_service, "list_home_artifact_snapshot", None)
+        if not callable(list_snapshot):
+            return []
+        try:
+            records = list_snapshot(limit=20)
+        except Exception as e:
+            logger.warning(f"Failed to fetch local Chatbook artifacts for Home: {e}")
+            return []
+        return [record for record in records if isinstance(record, Mapping)]
+
+    def _local_chatbook_artifact_by_id(self, target_id: str) -> Any | None:
+        return next(
+            (
+                record
+                for record in self._local_chatbook_artifacts()
+                if self._local_chatbook_item_id(record) == target_id
+            ),
             None,
         )
 
@@ -302,6 +380,35 @@ class LocalNotificationHomeActiveWorkAdapter(UnavailableHomeActiveWorkAdapter):
             or "Watchlist run"
         )
 
+    @staticmethod
+    def _local_chatbook_item_id(record: Any) -> str:
+        chatbook_id = _mapping_value(record, "chatbook_id") or _mapping_value(record, "id")
+        return f"local:chatbook:{chatbook_id}" if chatbook_id not in (None, "") else ""
+
+    @staticmethod
+    def _chatbook_title(record: Any) -> str:
+        return str(
+            _mapping_value(record, "name")
+            or _mapping_value(record, "title")
+            or "Untitled Chatbook"
+        )
+
+    @classmethod
+    def _chatbook_console_payload(cls, record: Any, target_id: str) -> Mapping[str, Any]:
+        chatbook_id = _mapping_value(record, "chatbook_id") or _mapping_value(record, "id")
+        payload: dict[str, Any] = {
+            "target_id": target_id,
+            "chatbook_id": chatbook_id,
+            "record_id": str(_mapping_value(record, "id") or ""),
+            "file_path": str(_mapping_value(record, "file_path") or ""),
+            "description": str(_mapping_value(record, "description") or ""),
+            "tags": _csv(_mapping_value(record, "tags")),
+            "categories": _csv(_mapping_value(record, "categories")),
+            "updated_at": str(_mapping_value(record, "updated_at") or ""),
+        }
+        payload.update(_console_metadata_payload(_mapping_value(record, "metadata")))
+        return payload
+
 
 def _notification_is_unread(notification: Any) -> bool:
     if isinstance(notification, Mapping):
@@ -317,3 +424,44 @@ def _mapping_value(value: Any, key: str) -> Any:
 
 def _is_local_watchlist_run_id(value: str | None) -> bool:
     return bool(value and str(value).startswith("local:watchlist_run:"))
+
+
+def _is_local_chatbook_id(value: str | None) -> bool:
+    return bool(value and str(value).startswith("local:chatbook:"))
+
+
+def _csv(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (list, tuple)):
+        text = ", ".join(str(item) for item in value if str(item).strip())
+        return text or None
+    return str(value)
+
+
+def _console_metadata_payload(metadata: Any) -> dict[str, Any]:
+    if not isinstance(metadata, Mapping):
+        return {}
+    if str(metadata.get("artifact_source") or "").strip().lower() != "console":
+        return {}
+    if str(metadata.get("artifact_kind") or "").strip().lower() != "assistant-response":
+        return {}
+
+    payload: dict[str, Any] = {
+        "artifact_source": "console",
+        "artifact_kind": "assistant-response",
+    }
+    for key in ("conversation_id", "message_id", "message_role", "provider", "model"):
+        value = metadata.get(key)
+        if value is not None:
+            payload[key] = value
+    if metadata.get("content") is not None:
+        content = str(metadata.get("content"))
+        payload["content_preview"] = content[:_MAX_CHATBOOK_ARTIFACT_PREVIEW_CHARS]
+        payload["content_truncated"] = (
+            bool(metadata.get("content_truncated"))
+            or len(content) > _MAX_CHATBOOK_ARTIFACT_PREVIEW_CHARS
+        )
+    return payload

--- a/tldw_chatbook/Home/active_work_adapter.py
+++ b/tldw_chatbook/Home/active_work_adapter.py
@@ -2,12 +2,19 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, replace
 from enum import StrEnum
+from html import escape as html_escape
+from pathlib import Path
+from threading import RLock
 from typing import Any, Mapping, Protocol, runtime_checkable
 
 from loguru import logger
+from rich.markup import escape
 
+from tldw_chatbook.Utils.input_validation import sanitize_string, validate_text_input
+from tldw_chatbook.Utils.path_validation import validate_path
 from .dashboard_state import HomeActiveWorkItem, HomeDashboardInput
 
 
@@ -25,6 +32,10 @@ _HOME_WATCHLIST_RUN_STATUSES = frozenset(
     }
 )
 _MAX_CHATBOOK_ARTIFACT_PREVIEW_CHARS = 1000
+_MAX_CHATBOOK_FILE_PATH_CHARS = 2000
+_MAX_CHATBOOK_PAYLOAD_TEXT_CHARS = 1000
+_MAX_CHATBOOK_METADATA_TEXT_CHARS = 256
+_DANGEROUS_TEXT_PATTERNS = ("<script", "</script", "javascript:", "onclick=", "onerror=")
 
 
 class HomeControlAction(StrEnum):
@@ -159,6 +170,31 @@ class LocalNotificationHomeActiveWorkAdapter(UnavailableHomeActiveWorkAdapter):
         self.notification_service = notification_service
         self.watchlist_service = watchlist_service
         self.chatbook_service = chatbook_service
+        self._chatbook_artifact_snapshot: tuple[Mapping[str, Any], ...] = ()
+        self._chatbook_artifact_snapshot_lock = RLock()
+
+    def refresh_chatbook_artifact_snapshot(self, *, limit: int = 20) -> None:
+        """Refresh cached local Chatbook artifacts off the Home compose path."""
+        if self.chatbook_service is None:
+            self._set_chatbook_artifact_snapshot(())
+            return
+        list_snapshot = getattr(self.chatbook_service, "list_home_artifact_snapshot", None)
+        if not callable(list_snapshot):
+            self._set_chatbook_artifact_snapshot(())
+            return
+        try:
+            records = list_snapshot(limit=limit)
+        except Exception as e:
+            logger.warning(f"Failed to fetch local Chatbook artifacts for Home: {e}")
+            self._set_chatbook_artifact_snapshot(())
+            return
+        self._set_chatbook_artifact_snapshot(
+            tuple(record for record in records if isinstance(record, Mapping))
+        )
+
+    def _set_chatbook_artifact_snapshot(self, records: tuple[Mapping[str, Any], ...]) -> None:
+        with self._chatbook_artifact_snapshot_lock:
+            self._chatbook_artifact_snapshot = records
 
     def build_dashboard_input(
         self,
@@ -332,17 +368,8 @@ class LocalNotificationHomeActiveWorkAdapter(UnavailableHomeActiveWorkAdapter):
         )
 
     def _local_chatbook_artifacts(self) -> list[Any]:
-        if self.chatbook_service is None:
-            return []
-        list_snapshot = getattr(self.chatbook_service, "list_home_artifact_snapshot", None)
-        if not callable(list_snapshot):
-            return []
-        try:
-            records = list_snapshot(limit=20)
-        except Exception as e:
-            logger.warning(f"Failed to fetch local Chatbook artifacts for Home: {e}")
-            return []
-        return [record for record in records if isinstance(record, Mapping)]
+        with self._chatbook_artifact_snapshot_lock:
+            return list(self._chatbook_artifact_snapshot)
 
     def _local_chatbook_artifact_by_id(self, target_id: str) -> Any | None:
         return next(
@@ -387,10 +414,10 @@ class LocalNotificationHomeActiveWorkAdapter(UnavailableHomeActiveWorkAdapter):
 
     @staticmethod
     def _chatbook_title(record: Any) -> str:
-        return str(
-            _mapping_value(record, "name")
-            or _mapping_value(record, "title")
-            or "Untitled Chatbook"
+        return _safe_payload_text(
+            _mapping_value(record, "name") or _mapping_value(record, "title"),
+            fallback="Untitled Chatbook",
+            max_length=_MAX_CHATBOOK_PAYLOAD_TEXT_CHARS,
         )
 
     @classmethod
@@ -399,12 +426,21 @@ class LocalNotificationHomeActiveWorkAdapter(UnavailableHomeActiveWorkAdapter):
         payload: dict[str, Any] = {
             "target_id": target_id,
             "chatbook_id": chatbook_id,
-            "record_id": str(_mapping_value(record, "id") or ""),
-            "file_path": str(_mapping_value(record, "file_path") or ""),
-            "description": str(_mapping_value(record, "description") or ""),
+            "record_id": _safe_payload_text(
+                _mapping_value(record, "id"),
+                max_length=_MAX_CHATBOOK_METADATA_TEXT_CHARS,
+            ),
+            "file_path": _safe_file_path(_mapping_value(record, "file_path")),
+            "description": _safe_payload_text(
+                _mapping_value(record, "description"),
+                max_length=_MAX_CHATBOOK_PAYLOAD_TEXT_CHARS,
+            ),
             "tags": _csv(_mapping_value(record, "tags")),
             "categories": _csv(_mapping_value(record, "categories")),
-            "updated_at": str(_mapping_value(record, "updated_at") or ""),
+            "updated_at": _safe_payload_text(
+                _mapping_value(record, "updated_at"),
+                max_length=_MAX_CHATBOOK_METADATA_TEXT_CHARS,
+            ),
         }
         payload.update(_console_metadata_payload(_mapping_value(record, "metadata")))
         return payload
@@ -434,34 +470,96 @@ def _csv(value: Any) -> str | None:
     if value is None:
         return None
     if isinstance(value, str):
-        return value
+        return _safe_payload_text(value, max_length=_MAX_CHATBOOK_PAYLOAD_TEXT_CHARS) or None
     if isinstance(value, (list, tuple)):
-        text = ", ".join(str(item) for item in value if str(item).strip())
+        text = ", ".join(
+            _safe_payload_text(item, max_length=_MAX_CHATBOOK_PAYLOAD_TEXT_CHARS)
+            for item in value
+            if str(item).strip()
+        )
+        text = _safe_payload_text(text, max_length=_MAX_CHATBOOK_PAYLOAD_TEXT_CHARS)
         return text or None
-    return str(value)
+    return _safe_payload_text(value, max_length=_MAX_CHATBOOK_PAYLOAD_TEXT_CHARS) or None
+
+
+def _safe_payload_text(
+    value: Any,
+    *,
+    fallback: str = "",
+    max_length: int = _MAX_CHATBOOK_PAYLOAD_TEXT_CHARS,
+    single_line: bool = True,
+) -> str:
+    text = sanitize_string(str(value or ""), max_length=max_length).strip()
+    if single_line:
+        text = " ".join(text.split())
+    if not text:
+        return fallback
+    if not validate_text_input(text, max_length=max_length, allow_html=False):
+        for pattern in _DANGEROUS_TEXT_PATTERNS:
+            replacement = pattern.rstrip(":=").replace("=", "")
+            text = re.sub(re.escape(pattern), replacement, text, flags=re.IGNORECASE)
+        if not validate_text_input(text, max_length=max_length, allow_html=False):
+            return fallback
+    return escape(html_escape(text, quote=False))
+
+
+def _safe_metadata_value(value: Any, *, max_length: int = _MAX_CHATBOOK_METADATA_TEXT_CHARS) -> Any | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value
+    text = _safe_payload_text(value, max_length=max_length)
+    return text or None
+
+
+def _safe_file_path(value: Any) -> str | None:
+    text = sanitize_string(str(value or ""), max_length=_MAX_CHATBOOK_FILE_PATH_CHARS).strip()
+    if not text:
+        return None
+    text = " ".join(text.split())
+    try:
+        path = Path(text).expanduser()
+        base_directory = path.parent if path.is_absolute() else Path.cwd()
+        validated = validate_path(path, base_directory)
+    except ValueError:
+        logger.warning(f"Rejected unsafe Chatbook artifact file path for Home payload: {text!r}")
+        return None
+    return _safe_payload_text(
+        str(validated),
+        max_length=_MAX_CHATBOOK_FILE_PATH_CHARS,
+    ) or None
 
 
 def _console_metadata_payload(metadata: Any) -> dict[str, Any]:
     if not isinstance(metadata, Mapping):
         return {}
-    if str(metadata.get("artifact_source") or "").strip().lower() != "console":
+    artifact_source = _safe_metadata_value(metadata.get("artifact_source"), max_length=128)
+    artifact_kind = _safe_metadata_value(metadata.get("artifact_kind"), max_length=128)
+    if str(artifact_source or "").strip().lower() != "console":
         return {}
-    if str(metadata.get("artifact_kind") or "").strip().lower() != "assistant-response":
+    if str(artifact_kind or "").strip().lower() != "assistant-response":
         return {}
 
     payload: dict[str, Any] = {
-        "artifact_source": "console",
-        "artifact_kind": "assistant-response",
+        "artifact_source": artifact_source,
+        "artifact_kind": artifact_kind,
     }
     for key in ("conversation_id", "message_id", "message_role", "provider", "model"):
-        value = metadata.get(key)
+        value = _safe_metadata_value(metadata.get(key))
         if value is not None:
             payload[key] = value
     if metadata.get("content") is not None:
-        content = str(metadata.get("content"))
-        payload["content_preview"] = content[:_MAX_CHATBOOK_ARTIFACT_PREVIEW_CHARS]
+        content = sanitize_string(
+            str(metadata.get("content")),
+            max_length=_MAX_CHATBOOK_ARTIFACT_PREVIEW_CHARS,
+        )
+        payload["content_preview"] = _safe_payload_text(
+            content,
+            max_length=_MAX_CHATBOOK_ARTIFACT_PREVIEW_CHARS,
+            single_line=False,
+        )
         payload["content_truncated"] = (
             bool(metadata.get("content_truncated"))
-            or len(content) > _MAX_CHATBOOK_ARTIFACT_PREVIEW_CHARS
+            or len(str(metadata.get("content"))) > _MAX_CHATBOOK_ARTIFACT_PREVIEW_CHARS
         )
     return payload

--- a/tldw_chatbook/Home/dashboard_state.py
+++ b/tldw_chatbook/Home/dashboard_state.py
@@ -138,6 +138,7 @@ def build_home_controls(state: HomeDashboardInput) -> tuple[HomeControl, ...]:
     running_item = _first_item_for_status(state, _RUNNING_STATUSES)
     paused_item = _first_item_for_status(state, _PAUSED_STATUSES)
     failed_item = _first_item_for_status(state, _FAILED_STATUSES)
+    chatbook_item = _first_chatbook_artifact_item(state)
     detail_item = (
         approval_item
         or failed_item
@@ -224,6 +225,26 @@ def build_home_controls(state: HomeDashboardInput) -> tuple[HomeControl, ...]:
                     console_item.item_id if console_item else None,
                 )
             )
+            if chatbook_item is not None and chatbook_item != console_item:
+                controls.append(
+                    HomeControl(
+                        "home-open-chatbook-in-console",
+                        "Open Chatbook in Console",
+                        "chat",
+                        "chatbook_console",
+                        chatbook_item.item_id,
+                    )
+                )
+        if chatbook_item is not None and chatbook_item != detail_item:
+            controls.append(
+                HomeControl(
+                    "home-open-chatbook-details",
+                    "Open Chatbook details",
+                    chatbook_item.detail_route,
+                    "chatbook_details",
+                    chatbook_item.item_id,
+                )
+            )
     return tuple(controls)
 
 
@@ -272,6 +293,17 @@ def _first_item_for_status(
     statuses: frozenset[str],
 ) -> HomeActiveWorkItem | None:
     return next((item for item in state.active_work_items if _normalized_status(item) in statuses), None)
+
+
+def _first_chatbook_artifact_item(state: HomeDashboardInput) -> HomeActiveWorkItem | None:
+    return next(
+        (
+            item
+            for item in state.active_work_items
+            if item.item_id.startswith("local:chatbook:")
+        ),
+        None,
+    )
 
 
 def _pending_approval_count(state: HomeDashboardInput) -> int:

--- a/tldw_chatbook/UI/Screens/home_screen.py
+++ b/tldw_chatbook/UI/Screens/home_screen.py
@@ -1,6 +1,6 @@
 """Home dashboard screen for the master shell."""
 
-from textual import on
+from textual import on, work
 from textual.app import ComposeResult
 from textual.containers import Vertical
 from textual.widgets import Button, Static
@@ -23,11 +23,15 @@ HOME_CONTROL_METHODS = {
     "home-retry": "retry_active_home_item",
     "home-open-details": "open_active_home_item_details",
     "home-open-in-console": "open_active_home_item_in_console",
+    "home-open-chatbook-details": "open_active_home_item_details",
+    "home-open-chatbook-in-console": "open_active_home_item_in_console",
 }
 
 HOME_CONTROL_METHODS_WITH_TARGET_ROUTE = {
     "home-open-details",
     "home-open-in-console",
+    "home-open-chatbook-details",
+    "home-open-chatbook-in-console",
 }
 
 
@@ -37,6 +41,23 @@ class HomeScreen(BaseAppScreen):
     def __init__(self, app_instance, **kwargs):
         super().__init__(app_instance, "home", **kwargs)
         self._current_dashboard: HomeDashboard | None = None
+
+    def on_mount(self) -> None:
+        super().on_mount()
+        self._refresh_home_chatbook_artifact_snapshot()
+
+    @work(exclusive=True, thread=True)
+    def _refresh_home_chatbook_artifact_snapshot(self) -> None:
+        adapter = getattr(self.app_instance, "home_active_work_adapter", None)
+        refresh_snapshot = getattr(adapter, "refresh_chatbook_artifact_snapshot", None)
+        if not callable(refresh_snapshot):
+            return
+        refresh_snapshot()
+        self.app.call_from_thread(self._refresh_after_chatbook_artifact_snapshot)
+
+    def _refresh_after_chatbook_artifact_snapshot(self) -> None:
+        if self.is_mounted:
+            self.refresh(recompose=True)
 
     def _build_dashboard_input(self) -> HomeDashboardInput:
         test_override = getattr(self.app_instance, "_home_dashboard_test_input", None)

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -2085,6 +2085,7 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
         self.home_active_work_adapter = LocalNotificationHomeActiveWorkAdapter(
             notification_service=self.client_notifications_service,
             watchlist_service=self.local_watchlists_service,
+            chatbook_service=self.local_chatbook_service,
         )
         self.notification_dispatch_service = NotificationDispatchService(
             store=self.client_notifications_db,


### PR DESCRIPTION
## Summary
- Adds Home active-work resume support for the latest Console-saved Chatbook artifact.
- Adds a synchronous local Chatbook Home snapshot plus Home controls that route details to Artifacts or launch Console with bounded provenance payloads.
- Records TASK-9.4 QA evidence and updates the product-maturity tracker.

## Verification
- `.venv/bin/python -m pytest Tests/Chatbooks/test_local_chatbook_service.py Tests/Home/test_active_work_adapter.py Tests/UI/test_home_screen.py Tests/UI/test_screen_navigation.py::test_app_initializes_watchlists_and_notifications_services Tests/UI/test_product_maturity_phase1_harness.py -q` -> 49 passed, 8 warnings
- `git diff --check`