### PR TITLE
Add Phase 3.1 Library study entry

### DIFF
--- a/Docs/superpowers/qa/product-maturity/phase-3/2026-05-06-phase-3-1-library-study-entry.md
+++ b/Docs/superpowers/qa/product-maturity/phase-3/2026-05-06-phase-3-1-library-study-entry.md
@@ -1,0 +1,84 @@
+# Phase 3.1 Library Study Entry
+
+Date: 2026-05-06
+Task: TASK-10.1
+Branch: codex/product-maturity-phase3-1-knowledge-entry
+Workflow: Library -> Study Dashboard / Flashcards / Quizzes
+
+## What Was Verified
+
+Phase 3.1 starts Knowledge and Study workflow depth by making Study, Flashcards, and Quizzes visibly reachable from Library instead of relying on hidden routes or prior knowledge.
+
+Verified contract:
+
+- Library exposes a `Knowledge workflow` section near source, import/export, and Search/RAG entry points.
+- Library shows dedicated `Study Dashboard`, `Flashcards`, and `Quizzes` controls with beginner-readable tooltips.
+- Flashcards and Quizzes preserve the requested Study section through `open_study_screen(initial_section=...)`.
+- Study consumes the pending initial section and clears it so later Study opens do not unexpectedly reuse stale routing state.
+
+## Automated Evidence
+
+Initial red run:
+
+```bash
+.venv/bin/python -m pytest Tests/UI/test_product_maturity_phase3_knowledge_entry.py -q
+```
+
+Result:
+
+- `5 failed, 3 warnings in 10.94s`.
+- Failures were expected: Library had no Knowledge workflow controls, Study did not consume a pending initial section, `open_study_screen` did not accept `initial_section`, and Phase 3.1 evidence did not exist yet.
+
+Focused behavior verification:
+
+```bash
+.venv/bin/python -m pytest Tests/UI/test_product_maturity_phase3_knowledge_entry.py::test_library_surfaces_study_workflow_entry_points Tests/UI/test_product_maturity_phase3_knowledge_entry.py::test_library_study_entry_buttons_preserve_requested_section Tests/UI/test_product_maturity_phase3_knowledge_entry.py::test_study_screen_consumes_pending_initial_section Tests/UI/test_product_maturity_phase3_knowledge_entry.py::test_tldwcli_open_study_screen_accepts_initial_section -q
+```
+
+Result:
+
+- `4 passed, 1 warning in 8.05s`.
+
+Closeout tracking verification:
+
+```bash
+.venv/bin/python -m pytest Tests/UI/test_product_maturity_phase3_knowledge_entry.py -q
+```
+
+Result:
+
+- `6 passed, 1 warning in 6.51s`.
+
+Broader adjacent verification:
+
+```bash
+.venv/bin/python -m pytest Tests/UI/test_product_maturity_phase3_knowledge_entry.py Tests/UI/test_destination_shells.py::test_library_exposes_source_sections_and_import_export_boundary Tests/UI/test_destination_shells.py::test_destination_action_buttons_emit_compatibility_routes Tests/UI/test_study_dashboard.py -q
+```
+
+Result:
+
+- `22 passed, 1 warning in 16.95s`.
+
+## Manual Walkthrough
+
+Mounted Library walkthrough verified the entry points are visible even when Library source services are unavailable. This matters for first-time and empty/error states: the user can still discover Study, Flashcards, and Quizzes while source population remains blocked or empty.
+
+## Visual/Focus Notes
+
+- The new controls are grouped under `Knowledge workflow`, which distinguishes study derivatives from source browsing and Search/RAG.
+- Buttons retain Textual focusable controls and explicit tooltips rather than adding passive copy only.
+- The first slice intentionally keeps the Study destination under Library instead of adding a new top-level nav item, preserving the current shell IA while making flashcards and quizzes visible in the product model.
+
+## Defects Found
+
+No P0/P1 defects found.
+
+## Residual Risk
+
+- This slice routes to Study, Flashcards, and Quizzes but does not yet generate flashcards or quizzes directly from selected Library sources.
+- Workspaces and Collections remain later Phase 3 gates.
+- Import/Export progress and recovery are still covered only by existing entry-point routing and need deeper Phase 3 validation.
+
+## Exit Decision
+
+Pass for Phase 3.1. Library now exposes the first visible Knowledge and Study workflow entry points and preserves the requested Study section for Flashcards and Quizzes.

--- a/Docs/superpowers/qa/product-maturity/phase-3/README.md
+++ b/Docs/superpowers/qa/product-maturity/phase-3/README.md
@@ -1,0 +1,11 @@
+# Product Maturity Phase 3 QA Evidence
+
+Phase 3 tracks knowledge and study workflows:
+
+`ingest/select material -> organize/retrieve -> study derivative -> reuse in Console`
+
+Each child gate should record whether the tested slice completes a full workflow or intentionally stops at a narrower contract with explicit residual risk.
+
+## Evidence
+
+- `2026-05-06-phase-3-1-library-study-entry.md`

--- a/Docs/superpowers/trackers/product-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/product-maturity-roadmap.md
@@ -1,7 +1,7 @@
 # Product Maturity Roadmap
 
 Date: 2026-05-06
-Status: Phase 1 verified; Phase 2 verified
+Status: Phase 1 verified; Phase 2 verified; Phase 3.1 verified
 Source Branch: `dev`
 Source Spec: `Docs/superpowers/specs/2026-05-05-product-maturity-phased-roadmap-design.md`
 
@@ -25,6 +25,7 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 - Phase 2.3 verifies the next core-agentic-loop contract: Console-saved Chatbook artifact records can be recognized in Artifacts and reopened into Console with visible saved-response provenance.
 - Phase 2.4 verifies the next core-agentic-loop contract: Home can surface a Console-saved Chatbook artifact as resumable work and route it to Artifacts or Console.
 - Phase 2.5 verifies the complete local core-loop closeout: source/question context can reach Console, save to a Chatbook artifact, reopen through Artifacts, and resume from Home without manual state reconstruction.
+- Phase 3.1 verifies the first Knowledge/Study entry contract: Library visibly routes users to Study Dashboard, Flashcards, and Quizzes while preserving the requested Study section.
 
 ## Severity Policy
 
@@ -52,6 +53,7 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 - Phase 2.4: Home Chatbook Artifact Resume Contract - `TASK-9.4`
 - Phase 2.5: Core Loop Closeout Replay - `TASK-9.5`
 - Phase 3: Knowledge And Study Workflows - `TASK-10`
+- Phase 3.1: Library Study Entry - `TASK-10.1`
 - Phase 4: Agent Configuration And Execution - `TASK-11`
 - Phase 5: Server-Parity And Live Integrations - `TASK-12`
 - Phase 6: Release Hardening And Documentation - `TASK-13`
@@ -66,6 +68,7 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 | Phase 2.3 | `Docs/superpowers/qa/product-maturity/phase-2/2026-05-05-phase-2-3-saved-chatbook-artifact-reopen-contract.md` | verified |
 | Phase 2.4 | `Docs/superpowers/qa/product-maturity/phase-2/2026-05-05-phase-2-4-home-chatbook-artifact-resume-contract.md` | verified |
 | Phase 2.5 | `Docs/superpowers/qa/product-maturity/phase-2/2026-05-06-phase-2-5-core-loop-closeout-replay.md` | verified |
+| Phase 3.1 | `Docs/superpowers/qa/product-maturity/phase-3/2026-05-06-phase-3-1-library-study-entry.md` | verified |
 
 ## Phase Overview
 
@@ -73,7 +76,7 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 | --- | --- | --- | --- | --- | --- |
 | Phase 1: QA Baseline And Usability Guardrails | Establish clean-run usability guardrails before feature depth. | verified | `TASK-8`, Phase 1.1 (`TASK-8.1`), Phase 1.2 (`TASK-8.2`), Phase 1.3 (`TASK-8.3`), Phase 1.4 (`TASK-8.4`), Phase 1.5 (`TASK-8.5`), Phase 1.6 (`TASK-8.6`), Phase 1.7 (`TASK-8.7`) | `phase-1/` | Closed; full grounded generation and Artifact/Chatbook persistence move to Phase 2. |
 | Phase 2: Core Agentic Loop | Complete source/question to grounded Console to Artifact/Chatbook loop. | verified | `TASK-9`, Phase 2.1 (`TASK-9.1`), Phase 2.2 (`TASK-9.2`), Phase 2.3 (`TASK-9.3`), Phase 2.4 (`TASK-9.4`), Phase 2.5 (`TASK-9.5`) | `phase-2/2026-05-05-phase-2-1-grounded-console-response-contract.md`, `phase-2/2026-05-05-phase-2-2-console-chatbook-artifact-save-contract.md`, `phase-2/2026-05-05-phase-2-3-saved-chatbook-artifact-reopen-contract.md`, `phase-2/2026-05-05-phase-2-4-home-chatbook-artifact-resume-contract.md`, `phase-2/2026-05-06-phase-2-5-core-loop-closeout-replay.md` | Closed for the local core loop; live provider generation, full `.chatbook` export packaging, and full artifact history picking remain later-phase risks. |
-| Phase 3: Knowledge And Study Workflows | Mature ingest, organize, retrieve, study, and reuse workflows. | planned | `TASK-10` | not-started | Depends on Phase 2 core loop and later task slicing. |
+| Phase 3: Knowledge And Study Workflows | Mature ingest, organize, retrieve, study, and reuse workflows. | in-progress | `TASK-10`, Phase 3.1 (`TASK-10.1`) | `phase-3/2026-05-06-phase-3-1-library-study-entry.md` | Library Study entry is verified; source-selected study generation, Workspaces, Collections, and deeper Import/Export/Search/RAG study flows remain. |
 | Phase 4: Agent Configuration And Execution | Mature Personas, Skills, MCP, ACP, Schedules, and Workflows. | planned | `TASK-11` | not-started | Depends on service adapters and runtime readiness. |
 | Phase 5: Server-Parity And Live Integrations | Close high-value `tldw_server2` parity gaps. | planned | `TASK-12` | not-started | Requires parity inventory. |
 | Phase 6: Release Hardening And Documentation | Reach release-candidate usability. | planned | `TASK-13` | not-started | Depends on earlier phase evidence. |
@@ -152,3 +155,9 @@ Status: verified
 Status: verified
 
 - `Docs/superpowers/qa/product-maturity/phase-2/2026-05-06-phase-2-5-core-loop-closeout-replay.md`
+
+## Phase 3.1 Evidence
+
+Status: verified
+
+- `Docs/superpowers/qa/product-maturity/phase-3/2026-05-06-phase-3-1-library-study-entry.md`

--- a/Tests/UI/test_product_maturity_phase3_knowledge_entry.py
+++ b/Tests/UI/test_product_maturity_phase3_knowledge_entry.py
@@ -1,0 +1,145 @@
+"""Product maturity Phase 3.1 Library knowledge entry contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from textual.widgets import Button
+
+from Tests.UI.test_destination_shells import (
+    DestinationHarness,
+    _active_destination_screen,
+    _build_test_app,
+    _visible_text,
+)
+from Tests.UI.test_study_dashboard import _build_app_instance as _build_study_app_instance
+from Tests.UI.test_study_dashboard import StudyDashboardTestApp
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TRACKER = Path("Docs/superpowers/trackers/product-maturity-roadmap.md")
+PHASE_3_README = Path("Docs/superpowers/qa/product-maturity/phase-3/README.md")
+PHASE_3_1_EVIDENCE = Path(
+    "Docs/superpowers/qa/product-maturity/phase-3/2026-05-06-phase-3-1-library-study-entry.md"
+)
+TASK_10 = Path("backlog/tasks/task-10 - Product-Maturity-Phase-3-Knowledge-And-Study-Workflows.md")
+TASK_10_1 = Path(
+    "backlog/tasks/task-10.1 - Product-Maturity-Phase-3.1-Library-Study-Entry.md"
+)
+
+
+def _text(path: Path) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_library_surfaces_study_workflow_entry_points() -> None:
+    app = _build_test_app()
+    host = DestinationHarness(app, "library")
+
+    async with host.run_test(size=(160, 40)) as pilot:
+        await pilot.pause(0.2)
+        screen = _active_destination_screen(host)
+        visible_text = _visible_text(screen)
+
+        assert "Knowledge workflow" in visible_text
+
+        expected_tooltips = {
+            "#library-open-study": "Open the Study dashboard for due cards, decks, quizzes, and resume actions.",
+            "#library-open-flashcards": "Open flashcards for selected or imported Library material.",
+            "#library-open-quizzes": "Open quizzes for selected or imported Library material.",
+        }
+        expected_labels = {
+            "#library-open-study": "Study Dashboard",
+            "#library-open-flashcards": "Flashcards",
+            "#library-open-quizzes": "Quizzes",
+        }
+        for selector, tooltip in expected_tooltips.items():
+            button = screen.query_one(selector, Button)
+            assert str(button.label) == expected_labels[selector]
+            assert str(button.tooltip) == tooltip
+
+
+@pytest.mark.asyncio
+async def test_library_study_entry_buttons_preserve_requested_section() -> None:
+    app = _build_test_app()
+    app.open_study_screen = Mock()
+    host = DestinationHarness(app, "library")
+
+    async with host.run_test(size=(160, 40)) as pilot:
+        await pilot.pause(0.2)
+
+        await pilot.click("#library-open-flashcards")
+        await pilot.pause(0.1)
+        app.open_study_screen.assert_called_with(initial_section="flashcards")
+
+        await pilot.click("#library-open-quizzes")
+        await pilot.pause(0.1)
+        app.open_study_screen.assert_called_with(initial_section="quizzes")
+
+
+@pytest.mark.asyncio
+async def test_study_screen_consumes_pending_initial_section() -> None:
+    app_instance = _build_study_app_instance()
+    app_instance.pending_study_initial_section = "quizzes"
+    app = StudyDashboardTestApp(app_instance)
+
+    async with app.run_test() as pilot:
+        await pilot.pause(0.3)
+
+        assert app.screen.current_section == "quizzes"
+        assert getattr(app_instance, "pending_study_initial_section", None) is None
+
+
+def test_tldwcli_open_study_screen_accepts_initial_section() -> None:
+    from tldw_chatbook.Constants import TAB_STUDY
+    from tldw_chatbook.app import TldwCli
+
+    app = object.__new__(TldwCli)
+    app.pending_study_scope_context = None
+    app.pending_study_initial_section = None
+    app.post_message = Mock()
+
+    TldwCli.open_study_screen(app, initial_section="flashcards")
+
+    assert app.pending_study_initial_section == "flashcards"
+    assert app.post_message.call_args.args[0].screen_name == TAB_STUDY
+
+
+def test_pending_study_initial_section_overrides_restored_section() -> None:
+    from tldw_chatbook.UI.Screens.study_screen import StudyScreen
+
+    app_instance = _build_study_app_instance()
+    app_instance.pending_study_initial_section = "quizzes"
+    screen = StudyScreen(app_instance=app_instance)
+
+    screen.restore_state({"study_section": "flashcards"})
+    screen._apply_pending_initial_section()
+
+    assert screen.current_section == "quizzes"
+
+
+def test_phase_3_1_library_study_entry_evidence_is_tracked() -> None:
+    tracker = _text(TRACKER)
+    readme = _text(PHASE_3_README)
+    evidence = _text(PHASE_3_1_EVIDENCE)
+    parent_task = _text(TASK_10)
+    task = _text(TASK_10_1)
+
+    assert "Phase 3.1" in tracker
+    assert "TASK-10.1" in tracker
+    assert PHASE_3_1_EVIDENCE.name in tracker
+    assert PHASE_3_1_EVIDENCE.name in readme
+    assert "Library Study Entry" in evidence
+    assert "Library -> Study Dashboard / Flashcards / Quizzes" in evidence
+    assert "No P0/P1 defects found" in evidence
+    assert "Tests/UI/test_product_maturity_phase3_knowledge_entry.py" in evidence
+    assert "status: In Progress" in parent_task
+    assert "Product Maturity Phase 3.1: Library Study Entry" in task
+    assert "status: Done" in task
+    assert "- [x] #1" in task
+    assert "- [x] #2" in task
+    assert "- [x] #3" in task
+    assert "- [x] #4" in task

--- a/backlog/tasks/task-10 - Product-Maturity-Phase-3-Knowledge-And-Study-Workflows.md
+++ b/backlog/tasks/task-10 - Product-Maturity-Phase-3-Knowledge-And-Study-Workflows.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-10
 title: 'Product Maturity Phase 3: Knowledge And Study Workflows'
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-05-05 15:11'
+updated_date: '2026-05-06 01:15'
 labels:
   - product-maturity
   - phase-3-knowledge-study
@@ -24,3 +25,9 @@ Mature ingest, organize, retrieve, study, and reuse workflows across Library, Wo
 - [ ] #3 Repo-tracked QA evidence exists under Docs/superpowers/qa/product-maturity/.
 - [ ] #4 P0/P1 findings are fixed or explicitly accepted according to the spec severity policy.
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Started Phase 3 with TASK-10.1 as the first PR-sized Knowledge and Study workflow gate. Parent remains open until later Phase 3 child gates verify import/export Search/RAG Workspaces flashcards quizzes and collections workflows end to end.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-10.1 - Product-Maturity-Phase-3.1-Library-Study-Entry.md
+++ b/backlog/tasks/task-10.1 - Product-Maturity-Phase-3.1-Library-Study-Entry.md
@@ -1,0 +1,44 @@
+---
+id: TASK-10.1
+title: 'Product Maturity Phase 3.1: Library Study Entry'
+status: Done
+assignee: []
+created_date: '2026-05-06 01:15'
+updated_date: '2026-05-06 01:16'
+labels:
+  - product-maturity
+  - phase-3-knowledge-study
+dependencies: []
+parent_task_id: TASK-10
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make Library expose the first Knowledge and Study workflow entry points so users can move from source material into Study Dashboard flashcards and quizzes without knowing hidden routes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Library shows a Knowledge workflow section with Study Dashboard Flashcards and Quizzes entry points.
+- [x] #2 Library study entry buttons route to Study with the requested initial section preserved.
+- [x] #3 Study consumes a pending initial section and clears it after use.
+- [x] #4 Repo-tracked QA evidence and product-maturity roadmap record the Phase 3.1 decision.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing mounted Library and Study routing regressions for Phase 3.1 knowledge entry points.
+2. Add Library Knowledge workflow controls for Study Dashboard Flashcards and Quizzes.
+3. Thread an initial Study section through open_study_screen and StudyScreen.
+4. Add Phase 3.1 QA evidence and update roadmap README and Backlog task state.
+5. Run focused Library Study and product-maturity tracking verification before closing the slice.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented Phase 3.1 Library Study entry. Library now includes a Knowledge workflow section with Study Dashboard Flashcards and Quizzes controls, routes those controls through open_study_screen(initial_section=...), and StudyScreen consumes and clears the pending initial section. Added mounted UI and task-tracking regressions plus Phase 3.1 QA evidence and roadmap updates.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -309,6 +309,26 @@ class LibraryScreen(BaseAppScreen):
                     tooltip="Open source import and export tools.",
                 )
                 yield Button("Search/RAG", id="library-open-search", tooltip="Search or ask over indexed sources.")
+                yield Static("Knowledge workflow", classes="destination-section")
+                yield Static(
+                    "Turn Library material into study sessions, flashcards, and quizzes.",
+                    id="library-study-purpose",
+                )
+                yield Button(
+                    "Study Dashboard",
+                    id="library-open-study",
+                    tooltip="Open the Study dashboard for due cards, decks, quizzes, and resume actions.",
+                )
+                yield Button(
+                    "Flashcards",
+                    id="library-open-flashcards",
+                    tooltip="Open flashcards for selected or imported Library material.",
+                )
+                yield Button(
+                    "Quizzes",
+                    id="library-open-quizzes",
+                    tooltip="Open quizzes for selected or imported Library material.",
+                )
                 yield Static("Local Library snapshot", classes="destination-section")
                 if not self._library_loaded:
                     yield Static(
@@ -385,6 +405,25 @@ class LibraryScreen(BaseAppScreen):
     @on(Button.Pressed, "#library-open-search")
     def open_search(self) -> None:
         self.post_message(NavigateToScreen("search"))
+
+    def _open_study_section(self, initial_section: str = "dashboard") -> None:
+        open_study_screen = getattr(self.app_instance, "open_study_screen", None)
+        if callable(open_study_screen):
+            open_study_screen(initial_section=initial_section)
+            return
+        self.post_message(NavigateToScreen("study"))
+
+    @on(Button.Pressed, "#library-open-study")
+    def open_study(self) -> None:
+        self._open_study_section("dashboard")
+
+    @on(Button.Pressed, "#library-open-flashcards")
+    def open_flashcards(self) -> None:
+        self._open_study_section("flashcards")
+
+    @on(Button.Pressed, "#library-open-quizzes")
+    def open_quizzes(self) -> None:
+        self._open_study_section("quizzes")
 
     @on(Button.Pressed, "#library-use-in-console")
     def use_in_console(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/UI/Screens/study_screen.py
+++ b/tldw_chatbook/UI/Screens/study_screen.py
@@ -59,6 +59,7 @@ class StudyScreen(BaseAppScreen):
         "course": "Create course outlines and study sequences.",
         "learning_map": "Open the learning map for relationships across study material.",
     }
+    _VALID_INITIAL_SECTIONS = frozenset({"dashboard", *_SECTION_TO_VIEW.keys()})
 
     def __init__(self, app_instance, **kwargs):
         super().__init__(app_instance, "study", **kwargs)
@@ -74,6 +75,7 @@ class StudyScreen(BaseAppScreen):
         self._dashboard_due_count: int = 0
         self._recent_deck_titles: list[str] = []
         self._recent_quiz_titles: list[str] = []
+        self._pending_initial_section = self._consume_pending_initial_section()
 
     @property
     def current_scope(self) -> StudyScopeState:
@@ -174,6 +176,22 @@ class StudyScreen(BaseAppScreen):
             return None
         self.app_instance.pending_study_scope_context = None
         return pending
+
+    def _consume_pending_initial_section(self) -> Optional[str]:
+        pending = getattr(self.app_instance, "pending_study_initial_section", None)
+        if pending is None:
+            return None
+        self.app_instance.pending_study_initial_section = None
+        normalized = str(pending or "").strip()
+        if normalized in self._VALID_INITIAL_SECTIONS:
+            return normalized
+        return None
+
+    def _apply_pending_initial_section(self) -> None:
+        if self._pending_initial_section is None:
+            return
+        self.current_section = self._pending_initial_section
+        self._pending_initial_section = None
 
     def _current_scope_context(self) -> StudyScopeContext:
         return self.scope_state.as_context()
@@ -626,6 +644,7 @@ class StudyScreen(BaseAppScreen):
         if self.current_study_session:
             if hasattr(study_window, 'restore_session'):
                 await study_window.restore_session(self.current_study_session)
+        self._apply_pending_initial_section()
         self._apply_section_layout()
         self.sync_shell_from_window()
 

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -1396,6 +1396,7 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
         self.pending_chat_handoff: Optional[ChatHandoffPayload] = None
         self.pending_console_launch: Optional[ConsoleLiveWorkLaunch | Dict[str, Any]] = None
         self.pending_study_scope_context: Optional[StudyScopeContext] = None
+        self.pending_study_initial_section: Optional[str] = None
         self.pending_notes_workspace_context: Optional[Dict[str, Any]] = None
         self.home_active_work_adapter = UnavailableHomeActiveWorkAdapter()
         self.loguru_logger = loguru_logger
@@ -1640,8 +1641,14 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
             app_config=self.app_config,
         )
 
-    def open_study_screen(self, scope_context: Optional[StudyScopeContext] = None) -> None:
+    def open_study_screen(
+        self,
+        scope_context: Optional[StudyScopeContext] = None,
+        *,
+        initial_section: Optional[str] = None,
+    ) -> None:
         self.pending_study_scope_context = scope_context
+        self.pending_study_initial_section = initial_section
         self.post_message(NavigateToScreen(TAB_STUDY))
 
     def open_notes_workspace(


### PR DESCRIPTION
## Summary

- Add Phase 3.1 Library Knowledge workflow entry points for Study Dashboard, Flashcards, and Quizzes.
- Preserve requested Study sections through `open_study_screen(initial_section=...)`, including saved-state override behavior.
- Add Phase 3 QA evidence, roadmap tracking, and Backlog task `TASK-10.1`.

## Test Plan

- [x] `.venv/bin/python -m pytest Tests/UI/test_product_maturity_phase3_knowledge_entry.py Tests/UI/test_destination_shells.py::test_library_exposes_source_sections_and_import_export_boundary Tests/UI/test_destination_shells.py::test_destination_action_buttons_emit_compatibility_routes Tests/UI/test_study_dashboard.py -q`
- [x] `.venv/bin/python -m pytest Tests/UI/test_product_maturity_phase3_knowledge_entry.py -q`
- [x] `git diff --check`
