### PR TITLE
Carry Library source context into Study

### DIFF
--- a/Docs/superpowers/qa/product-maturity/phase-3/2026-05-06-phase-3-2-library-source-study-context.md
+++ b/Docs/superpowers/qa/product-maturity/phase-3/2026-05-06-phase-3-2-library-source-study-context.md
@@ -1,0 +1,81 @@
+# Phase 3.2 Library Source Study Context
+
+Date: 2026-05-06
+Task: TASK-10.2
+Branch: codex/product-maturity-phase3-2-library-study-context
+Workflow: Library -> Flashcards / Quizzes with source context
+
+## What Was Verified
+
+Phase 3.2 verifies that Library study entry points do not send users into an ungrounded Study surface when local Library sources are visible. The current Library source snapshot is carried into Study as material context while deck and quiz services continue using the established `global` or `workspace` service scope.
+
+Verified contract:
+
+- Library passes the current local source snapshot into Study when the user opens Study Dashboard, Flashcards, or Quizzes from Library and sources are loaded.
+- The context includes source counts and visible source titles across Notes, Media, and Conversations.
+- Empty or unavailable Library source states preserve Phase 3.1 behavior and open Study with only the requested initial section.
+- Study displays the Library material context in its scope summary and stores the source titles as current study materials.
+- Deck and quiz service calls remain scoped to `global` or `workspace`; no unsupported `library` service scope is introduced.
+
+## Automated Evidence
+
+Initial red run:
+
+```bash
+.venv/bin/python -m pytest Tests/UI/test_product_maturity_phase3_library_study_context.py -q
+```
+
+Result:
+
+- `3 failed, 1 passed, 3 warnings in 10.05s`.
+- Failures were expected: Library did not pass a Study scope context, `StudyScopeContext` had no material context fields, and Phase 3.2 evidence did not exist.
+
+Focused behavior verification:
+
+```bash
+.venv/bin/python -m pytest Tests/UI/test_product_maturity_phase3_library_study_context.py::test_library_flashcards_entry_passes_source_snapshot_context_to_study Tests/UI/test_product_maturity_phase3_library_study_context.py::test_library_empty_state_preserves_plain_study_section_routing Tests/UI/test_product_maturity_phase3_library_study_context.py::test_study_displays_library_material_context_without_changing_service_scope -q
+```
+
+Result:
+
+- `3 passed, 1 warning in 7.95s`.
+
+Closeout tracking verification:
+
+```bash
+.venv/bin/python -m pytest Tests/UI/test_product_maturity_phase3_library_study_context.py -q
+```
+
+Result:
+
+- `4 passed, 1 warning in 9.21s`.
+
+Broader adjacent verification:
+
+```bash
+.venv/bin/python -m pytest Tests/UI/test_product_maturity_phase3_library_study_context.py Tests/UI/test_product_maturity_phase3_knowledge_entry.py Tests/UI/test_destination_shells.py::test_library_destination_lists_local_source_snapshot_from_services Tests/UI/test_destination_shells.py::test_library_destination_empty_state_disables_console_handoff Tests/UI/test_destination_shells.py::test_library_use_in_console_uses_source_snapshot_context Tests/UI/test_study_dashboard.py -q
+```
+
+Result:
+
+- `20 passed, 1 warning in 18.42s`.
+
+## UX Notes
+
+- This preserves beginner orientation: Study now explains that the session is grounded in visible Library sources instead of only saying `Global study`.
+- Power-user speed is preserved: Library Flashcards and Quizzes still jump directly to the requested Study section.
+- The implementation deliberately keeps Library material context separate from service scope. Study services continue querying existing global or workspace decks/quizzes until a later generation/import slice creates study derivatives from the selected material.
+
+## Defects Found
+
+No P0/P1 defects found.
+
+## Residual Risk
+
+- This slice carries Library source context into Study but does not yet generate flashcards or quizzes from that material.
+- Workspaces and Collections are still later Phase 3 gates.
+- Import/Export progress, Search/RAG-to-study generation, and reuse of generated study outputs in Console remain open Phase 3 work.
+
+## Exit Decision
+
+Pass for Phase 3.2. Library-originated Study, Flashcards, and Quizzes opens now preserve visible source context without inventing an unsupported Library service scope.

--- a/Docs/superpowers/qa/product-maturity/phase-3/README.md
+++ b/Docs/superpowers/qa/product-maturity/phase-3/README.md
@@ -9,3 +9,4 @@ Each child gate should record whether the tested slice completes a full workflow
 ## Evidence
 
 - `2026-05-06-phase-3-1-library-study-entry.md`
+- `2026-05-06-phase-3-2-library-source-study-context.md`

--- a/Docs/superpowers/trackers/product-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/product-maturity-roadmap.md
@@ -1,7 +1,7 @@
 # Product Maturity Roadmap
 
 Date: 2026-05-06
-Status: Phase 1 verified; Phase 2 verified; Phase 3.1 verified
+Status: Phase 1 verified; Phase 2 verified; Phase 3.2 verified
 Source Branch: `dev`
 Source Spec: `Docs/superpowers/specs/2026-05-05-product-maturity-phased-roadmap-design.md`
 
@@ -26,6 +26,7 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 - Phase 2.4 verifies the next core-agentic-loop contract: Home can surface a Console-saved Chatbook artifact as resumable work and route it to Artifacts or Console.
 - Phase 2.5 verifies the complete local core-loop closeout: source/question context can reach Console, save to a Chatbook artifact, reopen through Artifacts, and resume from Home without manual state reconstruction.
 - Phase 3.1 verifies the first Knowledge/Study entry contract: Library visibly routes users to Study Dashboard, Flashcards, and Quizzes while preserving the requested Study section.
+- Phase 3.2 verifies Library-originated Study entry preserves visible source context in Study without changing deck or quiz service scope away from global or workspace.
 
 ## Severity Policy
 
@@ -54,6 +55,7 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 - Phase 2.5: Core Loop Closeout Replay - `TASK-9.5`
 - Phase 3: Knowledge And Study Workflows - `TASK-10`
 - Phase 3.1: Library Study Entry - `TASK-10.1`
+- Phase 3.2: Library Source Study Context - `TASK-10.2`
 - Phase 4: Agent Configuration And Execution - `TASK-11`
 - Phase 5: Server-Parity And Live Integrations - `TASK-12`
 - Phase 6: Release Hardening And Documentation - `TASK-13`
@@ -69,6 +71,7 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 | Phase 2.4 | `Docs/superpowers/qa/product-maturity/phase-2/2026-05-05-phase-2-4-home-chatbook-artifact-resume-contract.md` | verified |
 | Phase 2.5 | `Docs/superpowers/qa/product-maturity/phase-2/2026-05-06-phase-2-5-core-loop-closeout-replay.md` | verified |
 | Phase 3.1 | `Docs/superpowers/qa/product-maturity/phase-3/2026-05-06-phase-3-1-library-study-entry.md` | verified |
+| Phase 3.2 | `Docs/superpowers/qa/product-maturity/phase-3/2026-05-06-phase-3-2-library-source-study-context.md` | verified |
 
 ## Phase Overview
 
@@ -76,7 +79,7 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 | --- | --- | --- | --- | --- | --- |
 | Phase 1: QA Baseline And Usability Guardrails | Establish clean-run usability guardrails before feature depth. | verified | `TASK-8`, Phase 1.1 (`TASK-8.1`), Phase 1.2 (`TASK-8.2`), Phase 1.3 (`TASK-8.3`), Phase 1.4 (`TASK-8.4`), Phase 1.5 (`TASK-8.5`), Phase 1.6 (`TASK-8.6`), Phase 1.7 (`TASK-8.7`) | `phase-1/` | Closed; full grounded generation and Artifact/Chatbook persistence move to Phase 2. |
 | Phase 2: Core Agentic Loop | Complete source/question to grounded Console to Artifact/Chatbook loop. | verified | `TASK-9`, Phase 2.1 (`TASK-9.1`), Phase 2.2 (`TASK-9.2`), Phase 2.3 (`TASK-9.3`), Phase 2.4 (`TASK-9.4`), Phase 2.5 (`TASK-9.5`) | `phase-2/2026-05-05-phase-2-1-grounded-console-response-contract.md`, `phase-2/2026-05-05-phase-2-2-console-chatbook-artifact-save-contract.md`, `phase-2/2026-05-05-phase-2-3-saved-chatbook-artifact-reopen-contract.md`, `phase-2/2026-05-05-phase-2-4-home-chatbook-artifact-resume-contract.md`, `phase-2/2026-05-06-phase-2-5-core-loop-closeout-replay.md` | Closed for the local core loop; live provider generation, full `.chatbook` export packaging, and full artifact history picking remain later-phase risks. |
-| Phase 3: Knowledge And Study Workflows | Mature ingest, organize, retrieve, study, and reuse workflows. | in-progress | `TASK-10`, Phase 3.1 (`TASK-10.1`) | `phase-3/2026-05-06-phase-3-1-library-study-entry.md` | Library Study entry is verified; source-selected study generation, Workspaces, Collections, and deeper Import/Export/Search/RAG study flows remain. |
+| Phase 3: Knowledge And Study Workflows | Mature ingest, organize, retrieve, study, and reuse workflows. | in-progress | `TASK-10`, Phase 3.1 (`TASK-10.1`), Phase 3.2 (`TASK-10.2`) | `phase-3/2026-05-06-phase-3-1-library-study-entry.md`, `phase-3/2026-05-06-phase-3-2-library-source-study-context.md` | Library Study entry and Library source context are verified; actual source-selected study generation, Workspaces, Collections, and deeper Import/Export/Search/RAG study flows remain. |
 | Phase 4: Agent Configuration And Execution | Mature Personas, Skills, MCP, ACP, Schedules, and Workflows. | planned | `TASK-11` | not-started | Depends on service adapters and runtime readiness. |
 | Phase 5: Server-Parity And Live Integrations | Close high-value `tldw_server2` parity gaps. | planned | `TASK-12` | not-started | Requires parity inventory. |
 | Phase 6: Release Hardening And Documentation | Reach release-candidate usability. | planned | `TASK-13` | not-started | Depends on earlier phase evidence. |
@@ -161,3 +164,9 @@ Status: verified
 Status: verified
 
 - `Docs/superpowers/qa/product-maturity/phase-3/2026-05-06-phase-3-1-library-study-entry.md`
+
+## Phase 3.2 Evidence
+
+Status: verified
+
+- `Docs/superpowers/qa/product-maturity/phase-3/2026-05-06-phase-3-2-library-source-study-context.md`

--- a/Tests/UI/test_product_maturity_phase3_library_study_context.py
+++ b/Tests/UI/test_product_maturity_phase3_library_study_context.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
+from rich.text import Text
 from textual.widgets import Static
 
 from Tests.UI.test_destination_shells import (
@@ -16,7 +17,14 @@ from Tests.UI.test_destination_shells import (
     _build_test_app,
 )
 from Tests.UI.test_study_dashboard import StudyDashboardTestApp, _build_app_instance
-from tldw_chatbook.UI.Screens.study_scope_models import StudyScopeContext, StudyScopeType
+from tldw_chatbook.UI.Screens.study_screen import StudyScreen
+from tldw_chatbook.UI.Screens.study_scope_models import (
+    MATERIAL_SOURCE_LIBRARY,
+    MATERIAL_TITLE_LIBRARY_SOURCES,
+    STUDY_MATERIAL_TITLES_LIMIT,
+    StudyScopeContext,
+    StudyScopeType,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -70,8 +78,8 @@ async def test_library_flashcards_entry_passes_source_snapshot_context_to_study(
 
     assert isinstance(scope_context, StudyScopeContext)
     assert scope_context.scope_type == StudyScopeType.GLOBAL
-    assert scope_context.material_source == "library"
-    assert scope_context.material_title == "Local Library Sources"
+    assert scope_context.material_source == MATERIAL_SOURCE_LIBRARY
+    assert scope_context.material_title == MATERIAL_TITLE_LIBRARY_SOURCES
     assert scope_context.material_titles == (
         "Research Note",
         "Transcript A",
@@ -104,8 +112,8 @@ async def test_study_displays_library_material_context_without_changing_service_
     app_instance = _build_app_instance()
     app_instance.pending_study_scope_context = StudyScopeContext(
         scope_type=StudyScopeType.GLOBAL,
-        material_source="library",
-        material_title="Local Library Sources",
+        material_source=MATERIAL_SOURCE_LIBRARY,
+        material_title=MATERIAL_TITLE_LIBRARY_SOURCES,
         material_summary="Notes: 1\n  1. Research Note\n\nMedia: 1\n  1. Transcript A",
         material_titles=("Research Note", "Transcript A"),
     )
@@ -149,3 +157,56 @@ def test_phase_3_2_library_study_context_evidence_is_tracked() -> None:
     assert "- [x] #2" in task
     assert "- [x] #3" in task
     assert "- [x] #4" in task
+
+
+def test_study_restored_material_context_is_sanitized_and_escaped_for_markup() -> None:
+    screen = StudyScreen(app_instance=_build_app_instance())
+
+    screen.restore_state(
+        {
+            "study_scope": {
+                "scope_type": "global",
+                "material_source": MATERIAL_SOURCE_LIBRARY,
+                "material_title": "[bold]Unsafe[/bold] <script>alert(1)</script>",
+                "material_summary": "javascript:alert(1)\nSecond line",
+                "material_titles": (
+                    "[red]Styled title[/red]",
+                    "Clickable <script>alert(1)</script>",
+                    "onclick=alert(1)",
+                ),
+            }
+        }
+    )
+
+    summary = screen._scope_summary_text()
+    rendered = Text.from_markup(summary)
+
+    assert rendered.spans == []
+    assert "[bold]Unsafe[/bold]" in rendered.plain
+    assert "[red]Styled title[/red]" in rendered.plain
+    assert "<script" not in rendered.plain.lower()
+    assert "javascript:" not in rendered.plain.lower()
+    assert "onclick=" not in rendered.plain.lower()
+    assert "<script" not in repr(screen.scope_state.material_titles).lower()
+    assert "javascript:" not in str(screen.scope_state.material_summary).lower()
+    assert "onclick=" not in repr(screen.scope_state.material_titles).lower()
+
+
+def test_study_material_context_key_uses_bounded_fingerprint_and_caps_titles() -> None:
+    screen = StudyScreen(app_instance=_build_app_instance())
+    long_titles = tuple(f"Sensitive material title {index} {'x' * 80}" for index in range(25))
+    long_summary = f"Sensitive summary {'y' * 4000}"
+
+    state = screen._derive_scope_state(
+        StudyScopeContext(
+            material_source=MATERIAL_SOURCE_LIBRARY,
+            material_title=MATERIAL_TITLE_LIBRARY_SOURCES,
+            material_summary=long_summary,
+            material_titles=long_titles,
+        )
+    )
+    key = screen._scope_key(state)
+
+    assert len(state.material_titles) <= STUDY_MATERIAL_TITLES_LIMIT
+    assert long_titles[-1] not in repr(key)
+    assert long_summary not in repr(key)

--- a/Tests/UI/test_product_maturity_phase3_library_study_context.py
+++ b/Tests/UI/test_product_maturity_phase3_library_study_context.py
@@ -1,0 +1,151 @@
+"""Product maturity Phase 3.2 Library source study-context contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from textual.widgets import Static
+
+from Tests.UI.test_destination_shells import (
+    DestinationHarness,
+    StaticLibraryConversationScopeService,
+    StaticLibraryMediaScopeService,
+    StaticLibraryNotesScopeService,
+    _build_test_app,
+)
+from Tests.UI.test_study_dashboard import StudyDashboardTestApp, _build_app_instance
+from tldw_chatbook.UI.Screens.study_scope_models import StudyScopeContext, StudyScopeType
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TRACKER = Path("Docs/superpowers/trackers/product-maturity-roadmap.md")
+PHASE_3_README = Path("Docs/superpowers/qa/product-maturity/phase-3/README.md")
+PHASE_3_2_EVIDENCE = Path(
+    "Docs/superpowers/qa/product-maturity/phase-3/2026-05-06-phase-3-2-library-source-study-context.md"
+)
+TASK_10 = Path("backlog/tasks/task-10 - Product-Maturity-Phase-3-Knowledge-And-Study-Workflows.md")
+TASK_10_2 = Path(
+    "backlog/tasks/task-10.2 - Product-Maturity-Phase-3.2-Library-Source-Study-Context.md"
+)
+
+
+def _text(path: Path) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def _static_text(widget: Static) -> str:
+    return str(widget.render())
+
+
+def _seed_library_sources(app) -> None:
+    app.notes_scope_service = StaticLibraryNotesScopeService(
+        [{"title": "Research Note", "id": "note-1"}]
+    )
+    app.media_reading_scope_service = StaticLibraryMediaScopeService(
+        [{"title": "Transcript A", "id": "media-1"}]
+    )
+    app.chat_conversation_scope_service = StaticLibraryConversationScopeService(
+        [{"title": "Planning Chat", "id": "chat-1"}]
+    )
+
+
+@pytest.mark.asyncio
+async def test_library_flashcards_entry_passes_source_snapshot_context_to_study() -> None:
+    app = _build_test_app()
+    _seed_library_sources(app)
+    app.open_study_screen = Mock()
+    host = DestinationHarness(app, "library")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        await pilot.click("#library-open-flashcards")
+        await pilot.pause(0.1)
+
+    app.open_study_screen.assert_called_once()
+    call = app.open_study_screen.call_args
+    assert call.kwargs["initial_section"] == "flashcards"
+    scope_context = call.args[0]
+
+    assert isinstance(scope_context, StudyScopeContext)
+    assert scope_context.scope_type == StudyScopeType.GLOBAL
+    assert scope_context.material_source == "library"
+    assert scope_context.material_title == "Local Library Sources"
+    assert scope_context.material_titles == (
+        "Research Note",
+        "Transcript A",
+        "Planning Chat",
+    )
+    assert "Notes: 1" in scope_context.material_summary
+    assert "Media: 1" in scope_context.material_summary
+    assert "Conversations: 1" in scope_context.material_summary
+
+
+@pytest.mark.asyncio
+async def test_library_empty_state_preserves_plain_study_section_routing() -> None:
+    app = _build_test_app()
+    app.notes_scope_service = StaticLibraryNotesScopeService([])
+    app.media_reading_scope_service = StaticLibraryMediaScopeService([])
+    app.chat_conversation_scope_service = StaticLibraryConversationScopeService([])
+    app.open_study_screen = Mock()
+    host = DestinationHarness(app, "library")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        await pilot.click("#library-open-quizzes")
+        await pilot.pause(0.1)
+
+    app.open_study_screen.assert_called_once_with(initial_section="quizzes")
+
+
+@pytest.mark.asyncio
+async def test_study_displays_library_material_context_without_changing_service_scope() -> None:
+    app_instance = _build_app_instance()
+    app_instance.pending_study_scope_context = StudyScopeContext(
+        scope_type=StudyScopeType.GLOBAL,
+        material_source="library",
+        material_title="Local Library Sources",
+        material_summary="Notes: 1\n  1. Research Note\n\nMedia: 1\n  1. Transcript A",
+        material_titles=("Research Note", "Transcript A"),
+    )
+    app = StudyDashboardTestApp(app_instance)
+
+    async with app.run_test() as pilot:
+        await pilot.pause(0.3)
+
+        scope_summary = app.screen.query_one("#study-scope-summary", Static)
+
+        assert "Global study" in _static_text(scope_summary)
+        assert "Local Library Sources" in _static_text(scope_summary)
+        assert "Research Note" in _static_text(scope_summary)
+        assert "Transcript A" in _static_text(scope_summary)
+        assert app.screen.study_materials == ["Research Note", "Transcript A"]
+
+    assert ("get_due_flashcards", "local", "global", None, 25) in app_instance.study_scope_service.calls
+    assert ("list_decks", "local", "global", None, 3, 0) in app_instance.study_scope_service.calls
+    assert ("list_quizzes", "local", "global", None, None, 3, 0) in app_instance.study_quiz_scope_service.calls
+
+
+def test_phase_3_2_library_study_context_evidence_is_tracked() -> None:
+    tracker = _text(TRACKER)
+    readme = _text(PHASE_3_README)
+    evidence = _text(PHASE_3_2_EVIDENCE)
+    parent_task = _text(TASK_10)
+    task = _text(TASK_10_2)
+
+    assert "Phase 3.2" in tracker
+    assert "TASK-10.2" in tracker
+    assert PHASE_3_2_EVIDENCE.name in tracker
+    assert PHASE_3_2_EVIDENCE.name in readme
+    assert "Library Source Study Context" in evidence
+    assert "Library -> Flashcards / Quizzes with source context" in evidence
+    assert "No P0/P1 defects found" in evidence
+    assert "Tests/UI/test_product_maturity_phase3_library_study_context.py" in evidence
+    assert "status: In Progress" in parent_task
+    assert "Product Maturity Phase 3.2: Library Source Study Context" in task
+    assert "status: Done" in task
+    assert "- [x] #1" in task
+    assert "- [x] #2" in task
+    assert "- [x] #3" in task
+    assert "- [x] #4" in task

--- a/backlog/tasks/task-10 - Product-Maturity-Phase-3-Knowledge-And-Study-Workflows.md
+++ b/backlog/tasks/task-10 - Product-Maturity-Phase-3-Knowledge-And-Study-Workflows.md
@@ -4,7 +4,7 @@ title: 'Product Maturity Phase 3: Knowledge And Study Workflows'
 status: In Progress
 assignee: []
 created_date: '2026-05-05 15:11'
-updated_date: '2026-05-06 01:15'
+updated_date: '2026-05-06 01:34'
 labels:
   - product-maturity
   - phase-3-knowledge-study
@@ -30,4 +30,6 @@ Mature ingest, organize, retrieve, study, and reuse workflows across Library, Wo
 
 <!-- SECTION:NOTES:BEGIN -->
 Started Phase 3 with TASK-10.1 as the first PR-sized Knowledge and Study workflow gate. Parent remains open until later Phase 3 child gates verify import/export Search/RAG Workspaces flashcards quizzes and collections workflows end to end.
+
+Continued Phase 3 with TASK-10.2. Library source context now carries into Study Dashboard Flashcards and Quizzes without changing deck/quiz service scope. Parent remains open for source-selected generation Workspaces Collections Import/Export Search/RAG and Console reuse gates.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-10.2 - Product-Maturity-Phase-3.2-Library-Source-Study-Context.md
+++ b/backlog/tasks/task-10.2 - Product-Maturity-Phase-3.2-Library-Source-Study-Context.md
@@ -41,4 +41,6 @@ Carry visible Library source material into Study Flashcards and Quizzes so users
 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented Phase 3.2 Library source study context. Library now passes the loaded local source snapshot into Study Dashboard Flashcards and Quizzes entry points when sources exist, while empty/unavailable Library states preserve plain section routing. Study scope context/state now carries optional material metadata, displays Library source titles in the Study scope summary, stores them as study materials, and keeps deck/quiz service queries on global or workspace scope. Added focused mounted UI and tracking regressions plus Phase 3.2 QA evidence and roadmap updates.
+
+PR review hardening sanitized and escaped restored Study material context, capped persisted material titles, replaced full material fields in the scope key with a bounded fingerprint, and extracted shared Library material constants.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-10.2 - Product-Maturity-Phase-3.2-Library-Source-Study-Context.md
+++ b/backlog/tasks/task-10.2 - Product-Maturity-Phase-3.2-Library-Source-Study-Context.md
@@ -1,0 +1,44 @@
+---
+id: TASK-10.2
+title: 'Product Maturity Phase 3.2: Library Source Study Context'
+status: Done
+assignee: []
+created_date: '2026-05-06 01:32'
+updated_date: '2026-05-06 01:34'
+labels:
+  - product-maturity
+  - phase-3-knowledge-study
+dependencies: []
+parent_task_id: TASK-10
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Carry visible Library source material into Study Flashcards and Quizzes so users can start study work from Library context instead of navigating to an empty global study surface.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Library Study Flashcards and Quizzes entry points pass the current local Library source snapshot into Study when sources exist.
+- [x] #2 Study displays the Library source context and material titles without changing deck or quiz service queries away from global or workspace scope.
+- [x] #3 Empty or unavailable Library source states still open Study without stale source context while preserving section routing.
+- [x] #4 Repo tracked QA evidence and product maturity tracking record Phase 3.2 residual risks and exit decision.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing Phase 3.2 regressions for Library-to-Study source context handoff, Study context display, service-scope preservation, and tracking evidence.
+2. Extend Study scope context/state with optional Library material context metadata without introducing a new service scope.
+3. Pass the current Library source snapshot into Study entry points when sources are loaded and present.
+4. Display the Library material context in Study dashboard and keep Study material state available for session resume.
+5. Record Phase 3.2 QA evidence, update roadmap/README/task hygiene, and run focused verification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented Phase 3.2 Library source study context. Library now passes the loaded local source snapshot into Study Dashboard Flashcards and Quizzes entry points when sources exist, while empty/unavailable Library states preserve plain section routing. Study scope context/state now carries optional material metadata, displays Library source titles in the Study scope summary, stores them as study materials, and keeps deck/quiz service queries on global or workspace scope. Added focused mounted UI and tracking regressions plus Phase 3.2 QA evidence and roadmap updates.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -21,7 +21,11 @@ from ...Utils.input_validation import sanitize_string, validate_text_input
 from ..Navigation.base_app_screen import BaseAppScreen
 from ..Navigation.main_navigation import NavigateToScreen
 from .destination_recovery import DestinationRecoveryState, policy_denied_recovery_state
-from .study_scope_models import StudyScopeContext
+from .study_scope_models import (
+    MATERIAL_SOURCE_LIBRARY,
+    MATERIAL_TITLE_LIBRARY_SOURCES,
+    StudyScopeContext,
+)
 
 
 logger = logger.bind(module="LibraryScreen")
@@ -294,11 +298,11 @@ class LibraryScreen(BaseAppScreen):
         for source_type in ("notes", "media", "conversations"):
             material_titles.extend(self._source_sample_titles(source_type))
         return StudyScopeContext(
-            material_source="library",
-            material_title="Local Library Sources",
+            material_source=MATERIAL_SOURCE_LIBRARY,
+            material_title=MATERIAL_TITLE_LIBRARY_SOURCES,
             material_summary=self._source_snapshot_body(),
             material_titles=tuple(material_titles),
-            return_hint="library",
+            return_hint=MATERIAL_SOURCE_LIBRARY,
         )
 
     def compose_content(self) -> ComposeResult:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -21,6 +21,7 @@ from ...Utils.input_validation import sanitize_string, validate_text_input
 from ..Navigation.base_app_screen import BaseAppScreen
 from ..Navigation.main_navigation import NavigateToScreen
 from .destination_recovery import DestinationRecoveryState, policy_denied_recovery_state
+from .study_scope_models import StudyScopeContext
 
 
 logger = logger.bind(module="LibraryScreen")
@@ -286,6 +287,20 @@ class LibraryScreen(BaseAppScreen):
             "conversation_titles": self._source_sample_titles("conversations"),
         }
 
+    def _source_study_context(self) -> StudyScopeContext | None:
+        if not self._has_local_sources():
+            return None
+        material_titles: list[str] = []
+        for source_type in ("notes", "media", "conversations"):
+            material_titles.extend(self._source_sample_titles(source_type))
+        return StudyScopeContext(
+            material_source="library",
+            material_title="Local Library Sources",
+            material_summary=self._source_snapshot_body(),
+            material_titles=tuple(material_titles),
+            return_hint="library",
+        )
+
     def compose_content(self) -> ComposeResult:
         has_sources = self._has_local_sources()
         with Vertical(id="library-shell"):
@@ -409,7 +424,11 @@ class LibraryScreen(BaseAppScreen):
     def _open_study_section(self, initial_section: str = "dashboard") -> None:
         open_study_screen = getattr(self.app_instance, "open_study_screen", None)
         if callable(open_study_screen):
-            open_study_screen(initial_section=initial_section)
+            scope_context = self._source_study_context()
+            if scope_context is None:
+                open_study_screen(initial_section=initial_section)
+            else:
+                open_study_screen(scope_context, initial_section=initial_section)
             return
         self.post_message(NavigateToScreen("study"))
 

--- a/tldw_chatbook/UI/Screens/study_scope_models.py
+++ b/tldw_chatbook/UI/Screens/study_scope_models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Optional
 
@@ -20,6 +20,10 @@ class StudyScopeContext:
     workspace_id: Optional[str] = None
     workspace_name: Optional[str] = None
     return_hint: Optional[str] = None
+    material_source: Optional[str] = None
+    material_title: Optional[str] = None
+    material_summary: Optional[str] = None
+    material_titles: tuple[str, ...] = field(default_factory=tuple)
 
 
 @dataclass
@@ -33,6 +37,10 @@ class StudyScopeState:
     backend: str = "local"
     workspace_scope_available: bool = False
     error_message: Optional[str] = None
+    material_source: Optional[str] = None
+    material_title: Optional[str] = None
+    material_summary: Optional[str] = None
+    material_titles: tuple[str, ...] = field(default_factory=tuple)
 
     def as_context(self) -> StudyScopeContext:
         return StudyScopeContext(
@@ -40,4 +48,8 @@ class StudyScopeState:
             workspace_id=self.workspace_id,
             workspace_name=self.workspace_name,
             return_hint=self.return_hint,
+            material_source=self.material_source,
+            material_title=self.material_title,
+            material_summary=self.material_summary,
+            material_titles=self.material_titles,
         )

--- a/tldw_chatbook/UI/Screens/study_scope_models.py
+++ b/tldw_chatbook/UI/Screens/study_scope_models.py
@@ -7,6 +7,13 @@ from enum import Enum
 from typing import Optional
 
 
+MATERIAL_SOURCE_LIBRARY = "library"
+MATERIAL_TITLE_LIBRARY_SOURCES = "Local Library Sources"
+STUDY_MATERIAL_TITLES_LIMIT = 10
+STUDY_MATERIAL_TITLE_LENGTH_LIMIT = 160
+STUDY_MATERIAL_SUMMARY_LENGTH_LIMIT = 1000
+
+
 class StudyScopeType(str, Enum):
     GLOBAL = "global"
     WORKSPACE = "workspace"

--- a/tldw_chatbook/UI/Screens/study_screen.py
+++ b/tldw_chatbook/UI/Screens/study_screen.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import hashlib
 from inspect import isawaitable
+import re
 from typing import Any, Dict, List, Optional
 
 from loguru import logger
+from rich.markup import escape as escape_markup
 from textual import on
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
@@ -13,6 +16,7 @@ from textual.reactive import reactive
 from textual.widgets import Button
 
 from ...Chat.chat_handoff_models import ChatHandoffPayload
+from ...Utils.input_validation import sanitize_string, validate_text_input
 from ..Navigation.base_app_screen import BaseAppScreen
 from ..Study_Window import StudyWindow
 from ...Widgets.Study import QuizSessionWidget, StudyDashboard
@@ -27,7 +31,19 @@ from ...Widgets.Study.quiz_session_widget import (
     QUIZ_START_SELECT_TOOLTIP,
 )
 from .notes_scope_models import WorkspaceSubview
-from .study_scope_models import StudyScopeContext, StudyScopeState, StudyScopeType
+from .study_scope_models import (
+    STUDY_MATERIAL_SUMMARY_LENGTH_LIMIT,
+    STUDY_MATERIAL_TITLE_LENGTH_LIMIT,
+    STUDY_MATERIAL_TITLES_LIMIT,
+    StudyScopeContext,
+    StudyScopeState,
+    StudyScopeType,
+)
+
+
+ScopeKey = tuple[str, Optional[str], str, bool, Optional[str]]
+_HTML_TAG_RE = re.compile(r"<[^>]*>")
+_DANGEROUS_TEXT_RE = re.compile(r"javascript\s*:|\bon(?:click|error)\s*=", re.IGNORECASE)
 
 
 class StudyScreen(BaseAppScreen):
@@ -68,7 +84,7 @@ class StudyScreen(BaseAppScreen):
             self.scope_state = self._derive_scope_state(pending_scope)
         else:
             self.scope_state = StudyScopeState(backend=self._runtime_backend())
-        self._effective_scope_key: tuple[str, Optional[str], str, bool] = self._scope_key(self.scope_state)
+        self._effective_scope_key: ScopeKey = self._scope_key(self.scope_state)
         self.study_dashboard: Optional[StudyDashboard] = None
         self.quiz_session_widget: Optional[QuizSessionWidget] = None
         self.study_window_widget: Optional[StudyWindow] = None
@@ -141,26 +157,64 @@ class StudyScreen(BaseAppScreen):
         return "local"
 
     @staticmethod
-    def _scope_key(scope_state: StudyScopeState) -> tuple[
-        str,
-        Optional[str],
-        str,
-        bool,
-        Optional[str],
-        Optional[str],
-        Optional[str],
-        tuple[str, ...],
-    ]:
+    def _scope_key(scope_state: StudyScopeState) -> ScopeKey:
         return (
             scope_state.scope_type.value,
             scope_state.workspace_id,
             scope_state.backend,
             scope_state.workspace_scope_available,
-            scope_state.material_source,
-            scope_state.material_title,
-            scope_state.material_summary,
-            scope_state.material_titles,
+            StudyScreen._material_context_fingerprint(scope_state),
         )
+
+    @staticmethod
+    def _material_context_fingerprint(scope_state: StudyScopeState) -> Optional[str]:
+        if not any(
+            (
+                scope_state.material_source,
+                scope_state.material_title,
+                scope_state.material_summary,
+                scope_state.material_titles,
+            )
+        ):
+            return None
+
+        digest = hashlib.sha256()
+        parts = (
+            scope_state.material_source or "",
+            scope_state.material_title or "",
+            scope_state.material_summary or "",
+            str(len(scope_state.material_titles)),
+            *scope_state.material_titles[:STUDY_MATERIAL_TITLES_LIMIT],
+        )
+        for part in parts:
+            digest.update(part.encode("utf-8", errors="ignore"))
+            digest.update(b"\0")
+        source = scope_state.material_source or "material"
+        return f"{source}:{len(scope_state.material_titles)}:{digest.hexdigest()[:12]}"
+
+    @staticmethod
+    def _clean_material_text(value: Any, *, max_length: int) -> str:
+        text = sanitize_string(str(value or ""), max_length=max_length).strip()
+        if not text:
+            return ""
+        text = _HTML_TAG_RE.sub("", text)
+        text = _DANGEROUS_TEXT_RE.sub("", text).strip()
+        if not validate_text_input(text, max_length=max_length, allow_html=False):
+            return ""
+        return text
+
+    def _clean_material_titles(self, material_titles: tuple[str, ...]) -> tuple[str, ...]:
+        cleaned: list[str] = []
+        for title in material_titles:
+            clean_title = self._clean_material_text(
+                title,
+                max_length=STUDY_MATERIAL_TITLE_LENGTH_LIMIT,
+            )
+            if clean_title:
+                cleaned.append(clean_title)
+            if len(cleaned) >= STUDY_MATERIAL_TITLES_LIMIT:
+                break
+        return tuple(cleaned)
 
     def _derive_scope_state(self, scope_context: StudyScopeContext) -> StudyScopeState:
         backend = self._runtime_backend()
@@ -181,10 +235,22 @@ class StudyScreen(BaseAppScreen):
             backend=backend,
             workspace_scope_available=workspace_scope_available,
             error_message=error_message,
-            material_source=scope_context.material_source,
-            material_title=scope_context.material_title,
-            material_summary=scope_context.material_summary,
-            material_titles=tuple(str(title) for title in (scope_context.material_titles or ()) if str(title).strip()),
+            material_source=self._clean_material_text(
+                scope_context.material_source,
+                max_length=64,
+            )
+            or None,
+            material_title=self._clean_material_text(
+                scope_context.material_title,
+                max_length=STUDY_MATERIAL_TITLE_LENGTH_LIMIT,
+            )
+            or None,
+            material_summary=self._clean_material_text(
+                scope_context.material_summary,
+                max_length=STUDY_MATERIAL_SUMMARY_LENGTH_LIMIT,
+            )
+            or None,
+            material_titles=self._clean_material_titles(tuple(scope_context.material_titles or ())),
         )
 
     def _consume_pending_scope_context(self) -> Optional[StudyScopeContext]:
@@ -251,16 +317,32 @@ class StudyScreen(BaseAppScreen):
     def _material_context_summary_text(self) -> str | None:
         if not self.scope_state.material_source and not self.scope_state.material_title:
             return None
-        title = self.scope_state.material_title or "Study material"
-        sample_titles = [title for title in self.scope_state.material_titles if title]
+        title = escape_markup(
+            self._clean_material_text(
+                self.scope_state.material_title,
+                max_length=STUDY_MATERIAL_TITLE_LENGTH_LIMIT,
+            )
+            or "Study material"
+        )
+        sample_titles: list[str] = []
+        for raw_title in self.scope_state.material_titles:
+            clean_title = self._clean_material_text(
+                raw_title,
+                max_length=STUDY_MATERIAL_TITLE_LENGTH_LIMIT,
+            )
+            if clean_title:
+                sample_titles.append(escape_markup(clean_title))
         if sample_titles:
             sample_text = ", ".join(sample_titles[:3])
             if len(sample_titles) > 3:
                 sample_text = f"{sample_text}, +{len(sample_titles) - 3} more"
             return f"{title}: {sample_text}"
-        summary = str(self.scope_state.material_summary or "").strip()
+        summary = self._clean_material_text(
+            self.scope_state.material_summary,
+            max_length=STUDY_MATERIAL_SUMMARY_LENGTH_LIMIT,
+        )
         if summary:
-            first_line = summary.splitlines()[0].strip()
+            first_line = escape_markup(summary.splitlines()[0].strip())
             return f"{title}: {first_line}"
         return title
 

--- a/tldw_chatbook/UI/Screens/study_screen.py
+++ b/tldw_chatbook/UI/Screens/study_screen.py
@@ -141,12 +141,25 @@ class StudyScreen(BaseAppScreen):
         return "local"
 
     @staticmethod
-    def _scope_key(scope_state: StudyScopeState) -> tuple[str, Optional[str], str, bool]:
+    def _scope_key(scope_state: StudyScopeState) -> tuple[
+        str,
+        Optional[str],
+        str,
+        bool,
+        Optional[str],
+        Optional[str],
+        Optional[str],
+        tuple[str, ...],
+    ]:
         return (
             scope_state.scope_type.value,
             scope_state.workspace_id,
             scope_state.backend,
             scope_state.workspace_scope_available,
+            scope_state.material_source,
+            scope_state.material_title,
+            scope_state.material_summary,
+            scope_state.material_titles,
         )
 
     def _derive_scope_state(self, scope_context: StudyScopeContext) -> StudyScopeState:
@@ -168,6 +181,10 @@ class StudyScreen(BaseAppScreen):
             backend=backend,
             workspace_scope_available=workspace_scope_available,
             error_message=error_message,
+            material_source=scope_context.material_source,
+            material_title=scope_context.material_title,
+            material_summary=scope_context.material_summary,
+            material_titles=tuple(str(title) for title in (scope_context.material_titles or ()) if str(title).strip()),
         )
 
     def _consume_pending_scope_context(self) -> Optional[StudyScopeContext]:
@@ -221,13 +238,31 @@ class StudyScreen(BaseAppScreen):
         return []
 
     def _scope_summary_text(self) -> str:
+        material_summary = self._material_context_summary_text()
         if self.scope_state.scope_type == StudyScopeType.WORKSPACE:
             workspace_name = self.scope_state.workspace_name or self.scope_state.workspace_id or "Workspace"
             backend = self.scope_state.backend
             if self.scope_state.error_message:
                 return f"Workspace: {workspace_name} | {self.scope_state.error_message}"
-            return f"Workspace: {workspace_name} | Backend: {backend}"
-        return "Global study"
+            base = f"Workspace: {workspace_name} | Backend: {backend}"
+            return f"{base} | {material_summary}" if material_summary else base
+        return f"Global study | {material_summary}" if material_summary else "Global study"
+
+    def _material_context_summary_text(self) -> str | None:
+        if not self.scope_state.material_source and not self.scope_state.material_title:
+            return None
+        title = self.scope_state.material_title or "Study material"
+        sample_titles = [title for title in self.scope_state.material_titles if title]
+        if sample_titles:
+            sample_text = ", ".join(sample_titles[:3])
+            if len(sample_titles) > 3:
+                sample_text = f"{sample_text}, +{len(sample_titles) - 3} more"
+            return f"{title}: {sample_text}"
+        summary = str(self.scope_state.material_summary or "").strip()
+        if summary:
+            first_line = summary.splitlines()[0].strip()
+            return f"{title}: {first_line}"
+        return title
 
     def _apply_section_layout(self) -> None:
         dashboard = self.study_dashboard
@@ -564,6 +599,7 @@ class StudyScreen(BaseAppScreen):
 
         self.scope_state = next_state
         self._effective_scope_key = next_key
+        self.study_materials = list(next_state.material_titles)
 
         if previous_key == next_key and not force_controller_notify:
             return
@@ -664,6 +700,10 @@ class StudyScreen(BaseAppScreen):
                     "workspace_id": self.scope_state.workspace_id,
                     "workspace_name": self.scope_state.workspace_name,
                     "return_hint": self.scope_state.return_hint,
+                    "material_source": self.scope_state.material_source,
+                    "material_title": self.scope_state.material_title,
+                    "material_summary": self.scope_state.material_summary,
+                    "material_titles": list(self.scope_state.material_titles),
                 },
                 "study_section": self.current_section,
                 "current_study_session": self.current_study_session,
@@ -681,6 +721,10 @@ class StudyScreen(BaseAppScreen):
                     workspace_id=saved_scope.get("workspace_id"),
                     workspace_name=saved_scope.get("workspace_name"),
                     return_hint=saved_scope.get("return_hint"),
+                    material_source=saved_scope.get("material_source"),
+                    material_title=saved_scope.get("material_title"),
+                    material_summary=saved_scope.get("material_summary"),
+                    material_titles=tuple(saved_scope.get("material_titles") or ()),
                 )
             )
             self._effective_scope_key = self._scope_key(self.scope_state)


### PR DESCRIPTION
## Summary

- Carry the loaded Library source snapshot into Study Dashboard, Flashcards, and Quizzes entry points when sources exist.
- Extend Study scope context/state with optional material metadata while preserving existing global/workspace deck and quiz service scopes.
- Add Phase 3.2 QA evidence, roadmap/README tracking, and Backlog task closure.

## Test Plan

- [x] `.venv/bin/python -m pytest Tests/UI/test_product_maturity_phase3_library_study_context.py Tests/UI/test_product_maturity_phase3_knowledge_entry.py Tests/UI/test_destination_shells.py::test_library_destination_lists_local_source_snapshot_from_services Tests/UI/test_destination_shells.py::test_library_destination_empty_state_disables_console_handoff Tests/UI/test_destination_shells.py::test_library_use_in_console_uses_source_snapshot_context Tests/UI/test_study_dashboard.py -q`
- [x] `.venv/bin/python -m pytest Tests/UI/test_product_maturity_phase3_library_study_context.py -q`
- [x] `git diff --check`
