### PR TITLE
Verify Phase 3.3 Library contract layout

### DIFF
--- a/Docs/superpowers/plans/2026-05-06-product-maturity-phase-3-3-library-contract-layout.md
+++ b/Docs/superpowers/plans/2026-05-06-product-maturity-phase-3-3-library-contract-layout.md
@@ -1,0 +1,110 @@
+# Product Maturity Phase 3.3 Library Contract Layout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Library destination visibly follow the approved Phase 3.0 layout contract while preserving existing Library actions and source snapshot behavior.
+
+**Architecture:** Keep the existing `LibraryScreen` data/service seams and only reshape the composed shell into a contract-aligned header, mode bar, source browser, detail, and inspector. Add mounted regressions that verify the contract essentials across terminal sizes, then record QA and roadmap evidence under the product-maturity Phase 3 tracker.
+
+**Tech Stack:** Python 3.12, Textual, pytest, Backlog.md.
+
+---
+
+### Task 1: Add Library Contract Layout Regression
+
+**Files:**
+- Create: `Tests/UI/test_product_maturity_phase3_library_contract_layout.py`
+- Read: `Docs/superpowers/specs/2026-05-06-destination-layout-ia-contracts-design.md`
+- Read: `Tests/UI/test_destination_shells.py`
+
+- [ ] **Step 1: Write failing mounted tests**
+
+Add tests that mount Library through `DestinationHarness`, seed local source services, and assert:
+
+- `#library-mode-bar` exists and exposes Sources, Search/RAG, Import/Export, Workspaces, Study, Flashcards, and Quizzes.
+- `#library-source-browser`, `#library-source-detail`, and `#library-source-inspector` exist.
+- Existing action selectors remain present: `#library-open-notes`, `#library-open-media`, `#library-open-conversations`, `#library-open-import-export`, `#library-open-search`, `#library-open-study`, `#library-open-flashcards`, `#library-open-quizzes`, and `#library-use-in-console`.
+- Compact, default, and large terminal runs retain the contract essentials.
+
+- [ ] **Step 2: Run the focused red tests**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/UI/test_product_maturity_phase3_library_contract_layout.py --tb=short
+```
+
+Expected before implementation: fail because the Library contract layout selectors do not exist yet.
+
+### Task 2: Reshape LibraryScreen Composition
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py`
+- Test: `Tests/UI/test_product_maturity_phase3_library_contract_layout.py`
+- Test: `Tests/UI/test_product_maturity_phase3_knowledge_entry.py`
+- Test: `Tests/UI/test_product_maturity_phase3_library_study_context.py`
+- Test: `Tests/UI/test_destination_shells.py`
+
+- [ ] **Step 1: Implement the minimal layout structure**
+
+In `LibraryScreen.compose_content()`, keep existing snapshot logic and action handlers, but compose:
+
+- destination header and status row.
+- `#library-mode-bar` with mode labels/actions.
+- `#library-contract-grid`.
+- `#library-source-browser` for Notes, Media, Conversations, and Workspaces scope cue.
+- `#library-source-detail` for source snapshot loading/error/empty/summary records.
+- `#library-source-inspector` for authority, Search/RAG, Study, and Console handoff actions.
+
+- [ ] **Step 2: Run focused green tests**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/UI/test_product_maturity_phase3_library_contract_layout.py Tests/UI/test_product_maturity_phase3_knowledge_entry.py Tests/UI/test_product_maturity_phase3_library_study_context.py Tests/UI/test_destination_shells.py --tb=short
+```
+
+Expected after implementation: pass with only known dependency warnings.
+
+### Task 3: Record Phase 3.3 Evidence And Tracking
+
+**Files:**
+- Create: `Docs/superpowers/qa/product-maturity/phase-3/2026-05-06-phase-3-3-library-contract-layout.md`
+- Modify: `Docs/superpowers/qa/product-maturity/phase-3/README.md`
+- Modify: `Docs/superpowers/trackers/product-maturity-roadmap.md`
+- Modify: `backlog/tasks/task-10 - Product-Maturity-Phase-3-Knowledge-And-Study-Workflows.md`
+- Modify: `backlog/tasks/task-10.3 - Product-Maturity-Phase-3.3-Library-Contract-Layout-Shell.md`
+- Test: `Tests/UI/test_product_maturity_phase3_library_contract_layout.py`
+
+- [ ] **Step 1: Add evidence assertions**
+
+Extend the Phase 3.3 test file to verify QA evidence, roadmap entries, and Backlog task hygiene.
+
+- [ ] **Step 2: Run red evidence tests**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/UI/test_product_maturity_phase3_library_contract_layout.py::test_phase_3_3_library_contract_layout_evidence_is_tracked --tb=short
+```
+
+Expected before docs/tracker updates: fail because evidence and tracker entries are missing.
+
+- [ ] **Step 3: Add QA evidence and tracking updates**
+
+Record the compact/default/large walkthrough, changed seams, focused verification, P0/P1 result, and residual risks.
+
+- [ ] **Step 4: Complete Backlog task hygiene**
+
+Check all `TASK-10.3` acceptance criteria, add implementation notes, and append a concise parent `TASK-10` note that Phase 3.3 closed the Library layout shell gate while deeper source-selected generation and Workspaces/Collections flows remain.
+
+- [ ] **Step 5: Run final verification**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/UI/test_product_maturity_phase3_library_contract_layout.py Tests/UI/test_product_maturity_phase3_knowledge_entry.py Tests/UI/test_product_maturity_phase3_library_study_context.py Tests/UI/test_destination_shells.py Tests/UI/test_product_maturity_phase3_layout_contracts.py --tb=short
+git diff --check
+```
+
+Expected: all tests pass and diff check is clean.

--- a/Docs/superpowers/qa/product-maturity/phase-3/2026-05-06-phase-3-3-library-contract-layout.md
+++ b/Docs/superpowers/qa/product-maturity/phase-3/2026-05-06-phase-3-3-library-contract-layout.md
@@ -1,0 +1,104 @@
+# Product Maturity Phase 3.3 Library Contract Layout Shell
+
+Status: verified
+
+## Scope
+
+Phase 3.3 verifies that the running Library destination exposes the approved Phase 3.0 Library layout contract enough for users to orient and act without knowing legacy route names.
+
+This is a shell layout gate only. It does not implement deeper source-selected generation, full Workspaces management, Collections flows, or new Search/RAG/Import/Export internals.
+
+## Evidence
+
+- Runtime screen: `tldw_chatbook/UI/Screens/library_screen.py`
+- Contract spec: `Docs/superpowers/specs/2026-05-06-destination-layout-ia-contracts-design.md`
+- Regression tests: `Tests/UI/test_product_maturity_phase3_library_contract_layout.py`
+- Related regressions: `Tests/UI/test_product_maturity_phase3_knowledge_entry.py`, `Tests/UI/test_product_maturity_phase3_library_study_context.py`, `Tests/UI/test_destination_shells.py`
+- Backlog task: `TASK-10.3`
+
+## Walkthrough
+
+Mounted Library with local Notes, Media, and Conversations source services.
+
+Verified compact default and large terminal sizes:
+
+- compact: 90x32
+- default: 140x42
+- large: 180x50
+
+Observed contract regions:
+
+- `#library-status-row`
+- `#library-mode-bar`
+- `#library-contract-grid`
+- `#library-source-browser`
+- `#library-source-detail`
+- `#library-source-inspector`
+
+Observed visible contract labels:
+
+- Sources
+- Search/RAG
+- Import/Export
+- Workspaces
+- Study
+- Flashcards
+- Quizzes
+- Source Browser
+- Source Detail / Search Results
+- Source Inspector
+- Authority: local
+
+Observed source snapshot evidence:
+
+- Research Note
+- Transcript A
+- Planning Chat
+
+## Functional Result
+
+Existing Library actions remain reachable and labelled:
+
+- Open Notes
+- Open Media
+- Open Conversations
+- Import/Export Sources
+- Search/RAG
+- Study Dashboard
+- Flashcards
+- Quizzes
+- Use in Console
+
+The first implementation attempt placed action buttons in a wide horizontal mode bar. Focused regression replay caught that several buttons were outside the visible screen region at tested terminal sizes. The final layout uses noninteractive mode labels in the mode bar and keeps route/action buttons in vertical browser and inspector regions.
+
+## Verification
+
+Focused verification:
+
+```bash
+.venv/bin/python -m pytest -q Tests/UI/test_product_maturity_phase3_library_contract_layout.py Tests/UI/test_product_maturity_phase3_knowledge_entry.py Tests/UI/test_product_maturity_phase3_library_study_context.py Tests/UI/test_destination_shells.py --tb=short
+```
+
+Result:
+
+```text
+87 passed, 1 warning
+```
+
+Warning:
+
+- Existing `RequestsDependencyWarning` for `urllib3` / `chardet` / `charset_normalizer` versions.
+
+## Defects
+
+No P0/P1 defects found after the final layout change.
+
+## Residual Risk
+
+- Search/RAG, Import/Export, Workspaces, Flashcards, and Quizzes still route into existing surfaces; their deeper contract implementations remain later Phase 3 child gates.
+- Workspaces are visible as scope language but not yet a full Library-native workspace manager in this slice.
+- Collections remain owned by W+C; Library only exposes Workspaces scope and source material actions.
+
+## Exit Decision
+
+Phase 3.3 Library contract layout shell is verified. Continue Phase 3 with deeper source-selected generation, Search/RAG, Import/Export, Workspaces, and Collections-adjacent workflow gates.

--- a/Docs/superpowers/qa/product-maturity/phase-3/README.md
+++ b/Docs/superpowers/qa/product-maturity/phase-3/README.md
@@ -19,3 +19,4 @@ Phase 3.0 records destination layout and IA contracts before additional Phase 3 
 - `2026-05-06-phase-3-0-destination-layout-contracts.md`
 - `2026-05-06-phase-3-1-library-study-entry.md`
 - `2026-05-06-phase-3-2-library-source-study-context.md`
+- `2026-05-06-phase-3-3-library-contract-layout.md`

--- a/Docs/superpowers/trackers/product-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/product-maturity-roadmap.md
@@ -1,7 +1,7 @@
 # Product Maturity Roadmap
 
 Date: 2026-05-06
-Status: Phase 1 verified; Phase 2 verified; Phase 3.0 verified; Phase 3.1 verified; Phase 3.2 verified
+Status: Phase 1 verified; Phase 2 verified; Phase 3.0 verified; Phase 3.1 verified; Phase 3.2 verified; Phase 3.3 verified
 Source Branch: `dev`
 Source Spec: `Docs/superpowers/specs/2026-05-05-product-maturity-phased-roadmap-design.md`
 Layout Contract Spec: `Docs/superpowers/specs/2026-05-06-destination-layout-ia-contracts-design.md`
@@ -29,6 +29,7 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 - Phase 3.0 verifies the required design gate before additional Phase 3 Knowledge/Study visual rewrites: destination layout and IA contracts must be approved for affected screens or deviations must be reviewed.
 - Phase 3.1 verifies the first Knowledge/Study entry contract: Library visibly routes users to Study Dashboard, Flashcards, and Quizzes while preserving the requested Study section.
 - Phase 3.2 verifies Library-originated Study entry preserves visible source context in Study without changing deck or quiz service scope away from global or workspace.
+- Phase 3.3 verifies the Library destination layout shell against the approved contract: mode bar, source browser, detail, inspector, authority, and existing Library actions remain visible across compact, default, and large terminal sizes.
 
 ## Severity Policy
 
@@ -59,6 +60,7 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 - Phase 3.0: Destination Layout And IA Contracts - `TASK-10.0`
 - Phase 3.1: Library Study Entry - `TASK-10.1`
 - Phase 3.2: Library Source Study Context - `TASK-10.2`
+- Phase 3.3: Library Contract Layout Shell - `TASK-10.3`
 - Phase 4: Agent Configuration And Execution - `TASK-11`
 - Phase 5: Server-Parity And Live Integrations - `TASK-12`
 - Phase 6: Release Hardening And Documentation - `TASK-13`
@@ -76,6 +78,7 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 | Phase 3.0 | `Docs/superpowers/qa/product-maturity/phase-3/2026-05-06-phase-3-0-destination-layout-contracts.md` | verified |
 | Phase 3.1 | `Docs/superpowers/qa/product-maturity/phase-3/2026-05-06-phase-3-1-library-study-entry.md` | verified |
 | Phase 3.2 | `Docs/superpowers/qa/product-maturity/phase-3/2026-05-06-phase-3-2-library-source-study-context.md` | verified |
+| Phase 3.3 | `Docs/superpowers/qa/product-maturity/phase-3/2026-05-06-phase-3-3-library-contract-layout.md` | verified |
 
 ## Phase Overview
 
@@ -83,7 +86,7 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 | --- | --- | --- | --- | --- | --- |
 | Phase 1: QA Baseline And Usability Guardrails | Establish clean-run usability guardrails before feature depth. | verified | `TASK-8`, Phase 1.1 (`TASK-8.1`), Phase 1.2 (`TASK-8.2`), Phase 1.3 (`TASK-8.3`), Phase 1.4 (`TASK-8.4`), Phase 1.5 (`TASK-8.5`), Phase 1.6 (`TASK-8.6`), Phase 1.7 (`TASK-8.7`) | `phase-1/` | Closed; full grounded generation and Artifact/Chatbook persistence move to Phase 2. |
 | Phase 2: Core Agentic Loop | Complete source/question to grounded Console to Artifact/Chatbook loop. | verified | `TASK-9`, Phase 2.1 (`TASK-9.1`), Phase 2.2 (`TASK-9.2`), Phase 2.3 (`TASK-9.3`), Phase 2.4 (`TASK-9.4`), Phase 2.5 (`TASK-9.5`) | `phase-2/2026-05-05-phase-2-1-grounded-console-response-contract.md`, `phase-2/2026-05-05-phase-2-2-console-chatbook-artifact-save-contract.md`, `phase-2/2026-05-05-phase-2-3-saved-chatbook-artifact-reopen-contract.md`, `phase-2/2026-05-05-phase-2-4-home-chatbook-artifact-resume-contract.md`, `phase-2/2026-05-06-phase-2-5-core-loop-closeout-replay.md` | Closed for the local core loop; live provider generation, full `.chatbook` export packaging, and full artifact history picking remain later-phase risks. |
-| Phase 3: Knowledge And Study Workflows | Mature ingest, organize, retrieve, study, and reuse workflows. | in-progress; Phase 3.0 verified; Phase 3.1 verified; Phase 3.2 verified | `TASK-10`, Phase 3.0 (`TASK-10.0`), Phase 3.1 (`TASK-10.1`), Phase 3.2 (`TASK-10.2`) | `phase-3/2026-05-06-phase-3-0-destination-layout-contracts.md`, `phase-3/2026-05-06-phase-3-1-library-study-entry.md`, `phase-3/2026-05-06-phase-3-2-library-source-study-context.md` | Layout contracts, Library Study entry, and Library source context are verified; actual source-selected study generation, Workspaces, Collections, and deeper Import/Export/Search/RAG study flows remain. |
+| Phase 3: Knowledge And Study Workflows | Mature ingest, organize, retrieve, study, and reuse workflows. | in-progress; Phase 3.0 verified; Phase 3.1 verified; Phase 3.2 verified; Phase 3.3 verified | `TASK-10`, Phase 3.0 (`TASK-10.0`), Phase 3.1 (`TASK-10.1`), Phase 3.2 (`TASK-10.2`), Phase 3.3 (`TASK-10.3`) | `phase-3/2026-05-06-phase-3-0-destination-layout-contracts.md`, `phase-3/2026-05-06-phase-3-1-library-study-entry.md`, `phase-3/2026-05-06-phase-3-2-library-source-study-context.md`, `phase-3/2026-05-06-phase-3-3-library-contract-layout.md` | Layout contracts, Library Study entry, Library source context, and the Library contract layout shell are verified; actual source-selected study generation, Workspaces, Collections, and deeper Import/Export/Search/RAG study flows remain. |
 | Phase 4: Agent Configuration And Execution | Mature Personas, Skills, MCP, ACP, Schedules, and Workflows. | planned | `TASK-11` | not-started | Depends on service adapters and runtime readiness. |
 | Phase 5: Server-Parity And Live Integrations | Close high-value `tldw_server2` parity gaps. | planned | `TASK-12` | not-started | Requires parity inventory. |
 | Phase 6: Release Hardening And Documentation | Reach release-candidate usability. | planned | `TASK-13` | not-started | Depends on earlier phase evidence. |
@@ -180,3 +183,9 @@ Status: verified
 Status: verified
 
 - `Docs/superpowers/qa/product-maturity/phase-3/2026-05-06-phase-3-2-library-source-study-context.md`
+
+## Phase 3.3 Evidence
+
+Status: verified
+
+- `Docs/superpowers/qa/product-maturity/phase-3/2026-05-06-phase-3-3-library-contract-layout.md`

--- a/Tests/UI/test_product_maturity_phase3_library_contract_layout.py
+++ b/Tests/UI/test_product_maturity_phase3_library_contract_layout.py
@@ -1,0 +1,146 @@
+"""Product maturity Phase 3.3 Library contract layout shell."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from textual.widgets import Button, Static
+
+from Tests.UI.test_destination_shells import (
+    DestinationHarness,
+    StaticLibraryConversationScopeService,
+    StaticLibraryMediaScopeService,
+    StaticLibraryNotesScopeService,
+    _active_destination_screen,
+    _build_test_app,
+    _wait_for_library_snapshot,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TRACKER = Path("Docs/superpowers/trackers/product-maturity-roadmap.md")
+PHASE_3_README = Path("Docs/superpowers/qa/product-maturity/phase-3/README.md")
+PHASE_3_3_EVIDENCE = Path(
+    "Docs/superpowers/qa/product-maturity/phase-3/2026-05-06-phase-3-3-library-contract-layout.md"
+)
+TASK_10 = Path("backlog/tasks/task-10 - Product-Maturity-Phase-3-Knowledge-And-Study-Workflows.md")
+TASK_10_3 = Path(
+    "backlog/tasks/task-10.3 - Product-Maturity-Phase-3.3-Library-Contract-Layout-Shell.md"
+)
+
+
+def _text(path: Path) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def _rendered_static_text(widget: Static) -> str:
+    renderable = widget.renderable
+    return getattr(renderable, "plain", str(renderable))
+
+
+def _screen_text(screen) -> str:
+    static_text = [
+        _rendered_static_text(widget)
+        for widget in screen.query(Static)
+        if widget.display and hasattr(widget, "renderable")
+    ]
+    button_text = [
+        str(button.label)
+        for button in screen.query(Button)
+        if button.display and button.label is not None
+    ]
+    return " ".join([*static_text, *button_text])
+
+
+def _seed_library_sources(app) -> None:
+    app.notes_scope_service = StaticLibraryNotesScopeService(
+        [{"title": "Research Note", "id": "note-1"}]
+    )
+    app.media_reading_scope_service = StaticLibraryMediaScopeService(
+        [{"title": "Transcript A", "id": "media-1"}]
+    )
+    app.chat_conversation_scope_service = StaticLibraryConversationScopeService(
+        [{"title": "Planning Chat", "id": "chat-1"}]
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("terminal_size", [(90, 32), (140, 42), (180, 50)])
+async def test_library_contract_layout_regions_survive_terminal_sizes(terminal_size) -> None:
+    app = _build_test_app()
+    _seed_library_sources(app)
+    host = DestinationHarness(app, "library")
+
+    async with host.run_test(size=terminal_size) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_library_snapshot(screen, pilot)
+
+        for selector in (
+            "#library-status-row",
+            "#library-mode-bar",
+            "#library-contract-grid",
+            "#library-source-browser",
+            "#library-source-detail",
+            "#library-source-inspector",
+        ):
+            assert screen.query_one(selector)
+
+        visible_text = _screen_text(screen)
+        for label in (
+            "Sources",
+            "Search/RAG",
+            "Import/Export",
+            "Workspaces",
+            "Study",
+            "Flashcards",
+            "Quizzes",
+            "Source Browser",
+            "Source Detail / Search Results",
+            "Source Inspector",
+            "Authority: local",
+            "Research Note",
+            "Transcript A",
+            "Planning Chat",
+        ):
+            assert label in visible_text
+
+        expected_actions = {
+            "#library-open-notes": "Open Notes",
+            "#library-open-media": "Open Media",
+            "#library-open-conversations": "Open Conversations",
+            "#library-open-import-export": "Import/Export Sources",
+            "#library-open-search": "Search/RAG",
+            "#library-open-study": "Study Dashboard",
+            "#library-open-flashcards": "Flashcards",
+            "#library-open-quizzes": "Quizzes",
+            "#library-use-in-console": "Use in Console",
+        }
+        for selector, label in expected_actions.items():
+            button = screen.query_one(selector, Button)
+            assert str(button.label) == label
+
+
+def test_phase_3_3_library_contract_layout_evidence_is_tracked() -> None:
+    tracker = _text(TRACKER)
+    readme = _text(PHASE_3_README)
+    evidence = _text(PHASE_3_3_EVIDENCE)
+    parent_task = _text(TASK_10)
+    task = _text(TASK_10_3)
+
+    assert "Phase 3.3" in tracker
+    assert "TASK-10.3" in tracker
+    assert PHASE_3_3_EVIDENCE.name in tracker
+    assert PHASE_3_3_EVIDENCE.name in readme
+    assert "Library Contract Layout Shell" in evidence
+    assert "compact default and large terminal sizes" in evidence
+    assert "No P0/P1 defects found" in evidence
+    assert "Tests/UI/test_product_maturity_phase3_library_contract_layout.py" in evidence
+    assert "status: In Progress" in parent_task
+    assert "TASK-10.3" in parent_task
+    assert "Library destination now exposes the approved Phase 3.0 layout shell" in parent_task
+    assert "Product Maturity Phase 3.3: Library Contract Layout Shell" in task
+    assert "status: Done" in task
+    for ac_number in range(1, 6):
+        assert f"- [x] #{ac_number}" in task
+    assert "## Implementation Notes" in task

--- a/Tests/UI/test_product_maturity_phase3_library_contract_layout.py
+++ b/Tests/UI/test_product_maturity_phase3_library_contract_layout.py
@@ -9,6 +9,7 @@ from textual.widgets import Button, Static
 
 from Tests.UI.test_destination_shells import (
     DestinationHarness,
+    PolicyDeniedLibraryNotesScopeService,
     StaticLibraryConversationScopeService,
     StaticLibraryMediaScopeService,
     StaticLibraryNotesScopeService,
@@ -67,7 +68,9 @@ def _seed_library_sources(app) -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("terminal_size", [(90, 32), (140, 42), (180, 50)])
-async def test_library_contract_layout_regions_survive_terminal_sizes(terminal_size) -> None:
+async def test_library_contract_layout_regions_survive_terminal_sizes(
+    terminal_size: tuple[int, int],
+) -> None:
     app = _build_test_app()
     _seed_library_sources(app)
     host = DestinationHarness(app, "library")
@@ -121,6 +124,42 @@ async def test_library_contract_layout_regions_survive_terminal_sizes(terminal_s
             assert str(button.label) == label
 
 
+@pytest.mark.asyncio
+async def test_library_status_row_preserves_unavailable_taxonomy() -> None:
+    app = _build_test_app()
+    app.notes_scope_service = None
+    app.media_reading_scope_service = None
+    app.chat_conversation_scope_service = None
+    host = DestinationHarness(app, "library")
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_library_snapshot(screen, pilot)
+
+        status_row = _rendered_static_text(screen.query_one("#library-status-row", Static))
+
+    assert "Unavailable" in status_row
+    assert "Blocked" not in status_row
+
+
+@pytest.mark.asyncio
+async def test_library_status_row_preserves_policy_recovery_status() -> None:
+    app = _build_test_app()
+    app.notes_scope_service = PolicyDeniedLibraryNotesScopeService()
+    app.media_reading_scope_service = StaticLibraryMediaScopeService([])
+    app.chat_conversation_scope_service = StaticLibraryConversationScopeService([])
+    host = DestinationHarness(app, "library")
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_library_snapshot(screen, pilot)
+
+        status_row = _rendered_static_text(screen.query_one("#library-status-row", Static))
+
+    assert "Wrong source" in status_row
+    assert "Blocked" not in status_row
+
+
 def test_phase_3_3_library_contract_layout_evidence_is_tracked() -> None:
     tracker = _text(TRACKER)
     readme = _text(PHASE_3_README)
@@ -132,14 +171,32 @@ def test_phase_3_3_library_contract_layout_evidence_is_tracked() -> None:
     assert "TASK-10.3" in tracker
     assert PHASE_3_3_EVIDENCE.name in tracker
     assert PHASE_3_3_EVIDENCE.name in readme
-    assert "Library Contract Layout Shell" in evidence
-    assert "compact default and large terminal sizes" in evidence
-    assert "No P0/P1 defects found" in evidence
+    for heading in (
+        "## Scope",
+        "## Evidence",
+        "## Walkthrough",
+        "## Functional Result",
+        "## Verification",
+        "## Defects",
+        "## Residual Risk",
+        "## Exit Decision",
+    ):
+        assert heading in evidence
+    for terminal_size in ("90x32", "140x42", "180x50"):
+        assert terminal_size in evidence
+    for selector in (
+        "#library-status-row",
+        "#library-mode-bar",
+        "#library-contract-grid",
+        "#library-source-browser",
+        "#library-source-detail",
+        "#library-source-inspector",
+    ):
+        assert selector in evidence
     assert "Tests/UI/test_product_maturity_phase3_library_contract_layout.py" in evidence
     assert "status: In Progress" in parent_task
     assert "TASK-10.3" in parent_task
-    assert "Library destination now exposes the approved Phase 3.0 layout shell" in parent_task
-    assert "Product Maturity Phase 3.3: Library Contract Layout Shell" in task
+    assert "TASK-10.3" in task
     assert "status: Done" in task
     for ac_number in range(1, 6):
         assert f"- [x] #{ac_number}" in task

--- a/backlog/tasks/task-10 - Product-Maturity-Phase-3-Knowledge-And-Study-Workflows.md
+++ b/backlog/tasks/task-10 - Product-Maturity-Phase-3-Knowledge-And-Study-Workflows.md
@@ -4,7 +4,7 @@ title: 'Product Maturity Phase 3: Knowledge And Study Workflows'
 status: In Progress
 assignee: []
 created_date: '2026-05-05 15:11'
-updated_date: '2026-05-06 01:34'
+updated_date: '2026-05-06 06:27'
 labels:
   - product-maturity
   - phase-3-knowledge-study
@@ -32,4 +32,6 @@ Mature ingest, organize, retrieve, study, and reuse workflows across Library, Wo
 Started Phase 3 with TASK-10.1 as the first PR-sized Knowledge and Study workflow gate. Parent remains open until later Phase 3 child gates verify import/export Search/RAG Workspaces flashcards quizzes and collections workflows end to end.
 
 Continued Phase 3 with TASK-10.2. Library source context now carries into Study Dashboard Flashcards and Quizzes without changing deck/quiz service scope. Parent remains open for source-selected generation Workspaces Collections Import/Export Search/RAG and Console reuse gates.
+
+Continued Phase 3 with TASK-10.3. The Library destination now exposes the approved Phase 3.0 layout shell with mode bar source browser source detail and inspector regions across compact default and large terminal sizes. Parent remains open for source-selected study generation Workspaces Collections and deeper Import/Export Search/RAG workflows.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-10.3 - Product-Maturity-Phase-3.3-Library-Contract-Layout-Shell.md
+++ b/backlog/tasks/task-10.3 - Product-Maturity-Phase-3.3-Library-Contract-Layout-Shell.md
@@ -1,0 +1,50 @@
+---
+id: TASK-10.3
+title: 'Product Maturity Phase 3.3: Library Contract Layout Shell'
+status: Done
+assignee: []
+created_date: '2026-05-06 06:22'
+updated_date: '2026-05-06 06:27'
+labels:
+  - product-maturity
+  - phase-3-knowledge-study
+  - library-ux
+dependencies: []
+documentation:
+  - Docs/superpowers/specs/2026-05-06-destination-layout-ia-contracts-design.md
+  - >-
+    Docs/superpowers/plans/2026-05-06-product-maturity-phase-3-3-library-contract-layout.md
+parent_task_id: TASK-10
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make the Library destination visibly follow the approved Phase 3.0 layout contract so users can distinguish source browsing, Search/RAG, Import/Export, Workspaces, Study, Flashcards, Quizzes, source detail, and Console handoff without relying on legacy route knowledge.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Library exposes a contract-aligned mode bar with Sources Search/RAG Import/Export Workspaces Study Flashcards Quizzes.
+- [x] #2 Library exposes source browser detail and inspector regions with stable selectors.
+- [x] #3 Library keeps existing Notes Media Conversations Import/Export Search/RAG Study Flashcards Quizzes and Use in Console actions reachable and labelled.
+- [x] #4 Focused mounted regression tests verify compact default and large Library layout contract essentials.
+- [x] #5 Repo-tracked QA evidence and roadmap/backlog updates record the Phase 3.3 verification and any residual risk.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add mounted Library contract layout regressions for the Phase 3.0 mode bar source browser detail inspector and existing action selectors.
+2. Reshape LibraryScreen composition only preserving current service snapshot and action handler behavior.
+3. Verify compact default and large Library layout essentials plus existing Phase 3.1 Phase 3.2 and destination-shell regressions.
+4. Record Phase 3.3 QA evidence tracker updates and Backlog task hygiene.
+5. Run focused verification and git diff hygiene before PR.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the Phase 3.3 Library contract layout shell. LibraryScreen now exposes the approved mode bar source browser source detail and source inspector regions while preserving existing Notes Media Conversations Import/Export Search/RAG Study Flashcards Quizzes and Use in Console actions. Focused mounted regressions verify compact default and large terminal layout essentials and caught an intermediate wide-mode-bar out-of-bounds regression; final layout keeps action buttons in vertical regions. Added Phase 3.3 QA evidence roadmap README and Backlog tracking.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -12,7 +12,7 @@ from rich.markup import escape as escape_markup
 from rich.text import Text
 from textual import on, work
 from textual.app import ComposeResult
-from textual.containers import Vertical
+from textual.containers import Horizontal, Vertical
 from textual.widgets import Button, Static
 
 from ...Chat.chat_handoff_models import ChatHandoffPayload
@@ -307,6 +307,16 @@ class LibraryScreen(BaseAppScreen):
 
     def compose_content(self) -> ComposeResult:
         has_sources = self._has_local_sources()
+        status_label = (
+            "Loading"
+            if not self._library_loaded
+            else "Blocked"
+            if self._library_lookup_error
+            else "Ready"
+        )
+        handoff_disabled = True
+        handoff_tooltip = "Stage Library source context after Library finishes loading."
+
         with Vertical(id="library-shell"):
             yield Static("Library", id="library-title", classes="ds-destination-header")
             yield Static(
@@ -314,96 +324,128 @@ class LibraryScreen(BaseAppScreen):
                 id="library-purpose",
                 classes="destination-purpose",
             )
-            with Vertical(id="library-sections", classes="ds-panel"):
-                yield Button("Open Notes", id="library-open-notes", tooltip="Open saved notes and workspaces.")
-                yield Button("Open Media", id="library-open-media", tooltip="Open ingested media and transcripts.")
-                yield Button(
-                    "Open Conversations",
-                    id="library-open-conversations",
-                    tooltip="Open saved conversation browsing inside Library.",
-                )
-                yield Button(
-                    "Import/Export Sources",
-                    id="library-open-import-export",
-                    tooltip="Open source import and export tools.",
-                )
-                yield Button("Search/RAG", id="library-open-search", tooltip="Search or ask over indexed sources.")
-                yield Static("Knowledge workflow", classes="destination-section")
-                yield Static(
-                    "Turn Library material into study sessions, flashcards, and quizzes.",
-                    id="library-study-purpose",
-                )
-                yield Button(
-                    "Study Dashboard",
-                    id="library-open-study",
-                    tooltip="Open the Study dashboard for due cards, decks, quizzes, and resume actions.",
-                )
-                yield Button(
-                    "Flashcards",
-                    id="library-open-flashcards",
-                    tooltip="Open flashcards for selected or imported Library material.",
-                )
-                yield Button(
-                    "Quizzes",
-                    id="library-open-quizzes",
-                    tooltip="Open quizzes for selected or imported Library material.",
-                )
-                yield Static("Local Library snapshot", classes="destination-section")
-                if not self._library_loaded:
+            yield Static(
+                f"Library | Sources, imports, Search/RAG, Workspaces, Study | {status_label} | Local",
+                id="library-status-row",
+                classes="destination-status-row",
+            )
+            with Horizontal(id="library-mode-bar", classes="ds-panel"):
+                yield Static("Modes:", id="library-mode-label", classes="destination-section")
+                yield Static("Sources", id="library-mode-sources", classes="library-mode-chip")
+                yield Static("Search/RAG", id="library-mode-search", classes="library-mode-chip")
+                yield Static("Import/Export", id="library-mode-import-export", classes="library-mode-chip")
+                yield Static("Workspaces", id="library-mode-workspaces", classes="library-mode-chip")
+                yield Static("Study", id="library-mode-study", classes="library-mode-chip")
+                yield Static("Flashcards", id="library-mode-flashcards", classes="library-mode-chip")
+                yield Static("Quizzes", id="library-mode-quizzes", classes="library-mode-chip")
+
+            with Horizontal(id="library-contract-grid", classes="ds-panel"):
+                with Vertical(id="library-source-browser", classes="library-region"):
+                    yield Static("Source Browser", classes="destination-section")
+                    yield Button("Open Notes", id="library-open-notes", tooltip="Open saved notes and workspaces.")
+                    yield Button("Open Media", id="library-open-media", tooltip="Open ingested media and transcripts.")
+                    yield Button(
+                        "Open Conversations",
+                        id="library-open-conversations",
+                        tooltip="Open saved conversation browsing inside Library.",
+                    )
+                    yield Button(
+                        "Import/Export Sources",
+                        id="library-open-import-export",
+                        tooltip="Open source import and export tools.",
+                    )
+                    yield Button("Search/RAG", id="library-open-search", tooltip="Search or ask over indexed sources.")
                     yield Static(
-                        "Loading local Library sources...",
-                        id="library-source-loading",
+                        "Workspaces: all local sources until workspace scoping is selected.",
+                        id="library-workspace-scope",
                     )
-                    handoff_disabled = True
-                    handoff_tooltip = "Stage Library source context after Library finishes loading."
-                elif self._library_lookup_error:
-                    recovery_state = self._library_lookup_recovery_state
-                    yield Static(
-                        self._library_lookup_error,
-                        id=(
-                            recovery_state.stable_selector
-                            if recovery_state is not None
-                            else "library-source-error"
-                        ),
-                    )
-                    handoff_disabled = True
-                    handoff_tooltip = (
-                        recovery_state.disabled_tooltip
-                        if recovery_state is not None
-                        else "Library source services are unavailable; retry Library later."
-                    )
-                elif not has_sources:
-                    yield Static(
-                        LIBRARY_EMPTY_COPY,
-                        id="library-source-empty",
-                    )
-                    handoff_disabled = True
-                    handoff_tooltip = "Stage Library source context after adding notes, media, or conversations."
-                else:
-                    for source_type, label, widget_id in (
-                        ("notes", "Notes", "library-notes-summary"),
-                        ("media", "Media", "library-media-summary"),
-                        ("conversations", "Conversations", "library-conversations-summary"),
-                    ):
+
+                with Vertical(id="library-source-detail", classes="library-region"):
+                    yield Static("Source Detail / Search Results", classes="destination-section")
+                    yield Static("Local Library snapshot", classes="destination-section")
+                    if not self._library_loaded:
                         yield Static(
-                            self._source_count_label(source_type, label),
-                            id=widget_id,
+                            "Loading local Library sources...",
+                            id="library-source-loading",
                         )
-                        for index, record in enumerate(self._local_source_records[source_type]):
+                    elif self._library_lookup_error:
+                        recovery_state = self._library_lookup_recovery_state
+                        yield Static(
+                            self._library_lookup_error,
+                            id=(
+                                recovery_state.stable_selector
+                                if recovery_state is not None
+                                else "library-source-error"
+                            ),
+                        )
+                        handoff_tooltip = (
+                            recovery_state.disabled_tooltip
+                            if recovery_state is not None
+                            else "Library source services are unavailable; retry Library later."
+                        )
+                    elif not has_sources:
+                        yield Static(
+                            LIBRARY_EMPTY_COPY,
+                            id="library-source-empty",
+                        )
+                        handoff_tooltip = "Stage Library source context after adding notes, media, or conversations."
+                    else:
+                        for source_type, label, widget_id in (
+                            ("notes", "Notes", "library-notes-summary"),
+                            ("media", "Media", "library-media-summary"),
+                            ("conversations", "Conversations", "library-conversations-summary"),
+                        ):
                             yield Static(
-                                Text.from_markup(
-                                    escape_markup(self._source_title(source_type, record))
-                                ),
-                                id=f"library-{source_type}-source-{index}",
+                                self._source_count_label(source_type, label),
+                                id=widget_id,
                             )
-                    handoff_disabled = False
-                    handoff_tooltip = "Stage Library source context in Console."
-                yield Button(
-                    "Use in Console",
-                    id="library-use-in-console",
-                    disabled=handoff_disabled,
-                    tooltip=handoff_tooltip,
-                )
+                            for index, record in enumerate(self._local_source_records[source_type]):
+                                yield Static(
+                                    Text.from_markup(
+                                        escape_markup(self._source_title(source_type, record))
+                                    ),
+                                    id=f"library-{source_type}-source-{index}",
+                                )
+                        handoff_disabled = False
+                        handoff_tooltip = "Stage Library source context in Console."
+
+                with Vertical(id="library-source-inspector", classes="library-region"):
+                    yield Static("Source Inspector", classes="destination-section")
+                    yield Static("Authority: local", id="library-source-authority")
+                    yield Static(
+                        "Search/RAG: query selected Library sources or stage evidence in Console.",
+                        id="library-rag-entry-point",
+                    )
+                    yield Static("Knowledge workflow", classes="destination-section")
+                    yield Static(
+                        "Turn Library material into study sessions, flashcards, and quizzes.",
+                        id="library-study-purpose",
+                    )
+                    yield Static(
+                        "Study generation entry uses the visible Library source snapshot.",
+                        id="library-study-generation-entry",
+                    )
+                    yield Button(
+                        "Study Dashboard",
+                        id="library-open-study",
+                        tooltip="Open the Study dashboard for due cards, decks, quizzes, and resume actions.",
+                    )
+                    yield Button(
+                        "Flashcards",
+                        id="library-open-flashcards",
+                        tooltip="Open flashcards for selected or imported Library material.",
+                    )
+                    yield Button(
+                        "Quizzes",
+                        id="library-open-quizzes",
+                        tooltip="Open quizzes for selected or imported Library material.",
+                    )
+                    yield Button(
+                        "Use in Console",
+                        id="library-use-in-console",
+                        disabled=handoff_disabled,
+                        tooltip=handoff_tooltip,
+                    )
 
     @on(Button.Pressed, "#library-open-notes")
     def open_notes(self) -> None:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -305,15 +305,20 @@ class LibraryScreen(BaseAppScreen):
             return_hint=MATERIAL_SOURCE_LIBRARY,
         )
 
+    def _status_label(self) -> str:
+        if not self._library_loaded:
+            return "Loading"
+        if self._library_lookup_recovery_state is not None:
+            return self._library_lookup_recovery_state.status_label
+        if self._library_lookup_error is None:
+            return "Ready"
+        if "unavailable" in self._library_lookup_error.lower():
+            return "Unavailable"
+        return "Blocked"
+
     def compose_content(self) -> ComposeResult:
         has_sources = self._has_local_sources()
-        status_label = (
-            "Loading"
-            if not self._library_loaded
-            else "Blocked"
-            if self._library_lookup_error
-            else "Ready"
-        )
+        status_label = self._status_label()
         handoff_disabled = True
         handoff_tooltip = "Stage Library source context after Library finishes loading."
 


### PR DESCRIPTION
## Summary
- Reshape Library into the approved Phase 3.0 contract shell: mode bar, source browser, source detail, and source inspector.
- Preserve existing Library actions for Notes, Media, Conversations, Import/Export, Search/RAG, Study, Flashcards, Quizzes, and Console handoff.
- Add Phase 3.3 QA evidence, roadmap updates, and Backlog task closeout.

## Test Plan
- [x] `.venv/bin/python -m pytest -q Tests/UI/test_product_maturity_phase3_library_contract_layout.py Tests/UI/test_product_maturity_phase3_knowledge_entry.py Tests/UI/test_product_maturity_phase3_library_study_context.py Tests/UI/test_destination_shells.py Tests/UI/test_product_maturity_phase3_layout_contracts.py --tb=short`
- [x] `git diff --check`

## Notes
- Initial implementation attempt exposed a real usability issue: wide horizontal action buttons became out-of-bounds at tested terminal sizes. Final layout keeps the mode bar as noninteractive labels and places action buttons in vertical regions.