### PR TITLE
Operationalize post-UX roadmap handoff

### DIFF
--- a/Docs/Product_Roadmap.md
+++ b/Docs/Product_Roadmap.md
@@ -1,0 +1,45 @@
+# Chatbook Product Roadmap
+
+Chatbook is evolving into a local-first agentic knowledge console: a place to ingest sources, reason over them, configure controlled agentic work, monitor progress, and preserve useful outputs as durable artifacts.
+
+This roadmap is directional. It describes current priorities and likely future areas, not delivery dates or commitments.
+
+## Now: Reliability And Product Confidence
+
+Current focus:
+
+- first-run setup and configuration clarity.
+- stable layouts across terminal sizes.
+- keyboard-first navigation and focus behavior.
+- understandable empty, error, and blocked states.
+- clear local, server, workspace, and runtime authority labels.
+- repeatable QA coverage for core workflows.
+
+## Next: Complete Workflow Loops
+
+Next focus:
+
+- ask grounded questions over selected sources.
+- turn answers into reusable Chatbooks and artifacts.
+- organize knowledge with Workspaces and Collections.
+- generate and reuse flashcards, quizzes, reports, and study outputs.
+- configure personas, skills, tools, schedules, and workflows.
+- launch and monitor controlled agent work through Console.
+- recover cleanly when providers, runtimes, or optional capabilities are missing.
+
+## Later: Server-Backed And Live Capabilities
+
+Longer-term focus:
+
+- richer source and RAG integration.
+- server-assisted watchlists and collections.
+- live status updates for running work.
+- import and sync paths for sources, personas, skills, and artifacts.
+- clearer collaboration between local and remote runtimes.
+- documented residual gaps where local mode remains the better default.
+
+## Always: Local-First Control
+
+Across every area, Chatbook should keep source authority, runtime readiness, approvals, recovery paths, and generated outputs visible.
+
+Console remains the live work surface. Other areas prepare, inspect, organize, resume, or preserve work.

--- a/Docs/superpowers/qa/product-maturity/post-ux/README.md
+++ b/Docs/superpowers/qa/product-maturity/post-ux/README.md
@@ -1,0 +1,21 @@
+# Post-UX Product Rebaseline QA
+
+This folder stores post-UX rebaseline evidence created after the current UX/UI and destination layout-contract work is complete.
+
+Use this folder only for:
+
+- changed screens.
+- changed workflows.
+- changed layout contracts.
+- discovered regressions.
+- revalidation of verified Phase 1/2 behavior affected by UX/UI changes.
+
+Do not recreate Product Maturity Phase 1 or Phase 2 evidence here unless a post-UX replay finds a regression or the tracker explicitly requests a rebaseline gate.
+
+Every evidence file must link:
+
+- the pre-UX baseline evidence.
+- the UX/UI or layout-contract change being revalidated.
+- the affected Backlog task.
+- the pass/fail decision.
+- any P0/P1 findings and follow-up owner.

--- a/Docs/superpowers/qa/product-maturity/post-ux/walkthrough-template.md
+++ b/Docs/superpowers/qa/product-maturity/post-ux/walkthrough-template.md
@@ -1,0 +1,46 @@
+# Post-UX Rebaseline Evidence
+
+Date:
+Branch/Commit:
+Post-UX Roadmap Stage:
+Affected Backlog Task:
+Changed Screen/Workflow/Layout Contract:
+
+## Pre-UX Baseline Evidence
+
+- Existing tracker entry:
+- Existing QA artifact:
+- Existing test command:
+
+## Post-UX Delta
+
+- What changed:
+- Why this needs revalidation:
+- Screens or workflows exercised:
+
+## Automated Evidence
+
+- Command:
+- Result:
+- Notes:
+
+## Running-App Walkthrough
+
+- Environment:
+- Terminal size:
+- Entry path:
+- Steps:
+- Result:
+
+## Visual/Focus Notes
+
+## Empty/Error/Recovery Notes
+
+## Regression Decision
+
+- [ ] Revalidated with no regression
+- [ ] Regression found and fixed
+- [ ] Regression found and accepted with owner/follow-up
+- [ ] Not applicable because no affected UX/UI delta exists
+
+## Residual Risk

--- a/Docs/superpowers/trackers/product-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/product-maturity-roadmap.md
@@ -31,6 +31,24 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 - Phase 3.2 verifies Library-originated Study entry preserves visible source context in Study without changing deck or quiz service scope away from global or workspace.
 - Phase 3.3 verifies the Library destination layout shell against the approved contract: mode bar, source browser, detail, inspector, authority, and existing Library actions remain visible across compact, default, and large terminal sizes.
 
+## Post-UX Roadmap Handoff
+
+Source Spec: `Docs/superpowers/specs/2026-05-06-post-ux-product-roadmap-design.md`
+Status: pending UX/UI completion and tracker activation
+
+This post-UX roadmap is a planning overlay for work that starts after the current UX/UI and destination layout-contract work is complete. It does not create a parallel task tree.
+
+Product Maturity Phase 1 and Phase 2 are not reopened by default. Their existing QA evidence is the pre-UX baseline. New post-UX evidence should record only changed screens, changed workflows, changed layout contracts, or discovered regressions.
+
+| Post-UX Roadmap Stage | Existing Backlog Owner | Execution Rule |
+| --- | --- | --- |
+| Post-UX Reliability Rebaseline | `TASK-10` only if Phase 3 UX/UI deltas require a distinct gate | Revalidate deltas against verified Phase 1/2 evidence; do not recreate Phase 1/2 child tasks. |
+| Source, Knowledge, And Artifact Loops | `TASK-10` | Continue Phase 3 under existing Knowledge/Study ownership. |
+| Controlled Agent Configuration And Run Loops | `TASK-11` | Create PR-sized child tasks under Phase 4 when ready. |
+| Monitoring And Cross-Loop Recovery | `TASK-10` or `TASK-11` based on the concrete workflow owner | Do not create standalone recovery rewrites without a workflow gate. |
+| Server Parity And Live Integrations | `TASK-12` | Prioritize parity by workflow value, not endpoint count. |
+| Release Hardening And Distribution | `TASK-13` | Use only after earlier workflow gates have QA evidence. |
+
 ## Severity Policy
 
 | Priority | Taxonomy | Exit Rule |
@@ -86,10 +104,10 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 | --- | --- | --- | --- | --- | --- |
 | Phase 1: QA Baseline And Usability Guardrails | Establish clean-run usability guardrails before feature depth. | verified | `TASK-8`, Phase 1.1 (`TASK-8.1`), Phase 1.2 (`TASK-8.2`), Phase 1.3 (`TASK-8.3`), Phase 1.4 (`TASK-8.4`), Phase 1.5 (`TASK-8.5`), Phase 1.6 (`TASK-8.6`), Phase 1.7 (`TASK-8.7`) | `phase-1/` | Closed; full grounded generation and Artifact/Chatbook persistence move to Phase 2. |
 | Phase 2: Core Agentic Loop | Complete source/question to grounded Console to Artifact/Chatbook loop. | verified | `TASK-9`, Phase 2.1 (`TASK-9.1`), Phase 2.2 (`TASK-9.2`), Phase 2.3 (`TASK-9.3`), Phase 2.4 (`TASK-9.4`), Phase 2.5 (`TASK-9.5`) | `phase-2/2026-05-05-phase-2-1-grounded-console-response-contract.md`, `phase-2/2026-05-05-phase-2-2-console-chatbook-artifact-save-contract.md`, `phase-2/2026-05-05-phase-2-3-saved-chatbook-artifact-reopen-contract.md`, `phase-2/2026-05-05-phase-2-4-home-chatbook-artifact-resume-contract.md`, `phase-2/2026-05-06-phase-2-5-core-loop-closeout-replay.md` | Closed for the local core loop; live provider generation, full `.chatbook` export packaging, and full artifact history picking remain later-phase risks. |
-| Phase 3: Knowledge And Study Workflows | Mature ingest, organize, retrieve, study, and reuse workflows. | in-progress; Phase 3.0 verified; Phase 3.1 verified; Phase 3.2 verified; Phase 3.3 verified | `TASK-10`, Phase 3.0 (`TASK-10.0`), Phase 3.1 (`TASK-10.1`), Phase 3.2 (`TASK-10.2`), Phase 3.3 (`TASK-10.3`) | `phase-3/2026-05-06-phase-3-0-destination-layout-contracts.md`, `phase-3/2026-05-06-phase-3-1-library-study-entry.md`, `phase-3/2026-05-06-phase-3-2-library-source-study-context.md`, `phase-3/2026-05-06-phase-3-3-library-contract-layout.md` | Layout contracts, Library Study entry, Library source context, and the Library contract layout shell are verified; actual source-selected study generation, Workspaces, Collections, and deeper Import/Export/Search/RAG study flows remain. |
-| Phase 4: Agent Configuration And Execution | Mature Personas, Skills, MCP, ACP, Schedules, and Workflows. | planned | `TASK-11` | not-started | Depends on service adapters and runtime readiness. |
-| Phase 5: Server-Parity And Live Integrations | Close high-value `tldw_server2` parity gaps. | planned | `TASK-12` | not-started | Requires parity inventory. |
-| Phase 6: Release Hardening And Documentation | Reach release-candidate usability. | planned | `TASK-13` | not-started | Depends on earlier phase evidence. |
+| Phase 3: Knowledge And Study Workflows | Mature ingest, organize, retrieve, study, and reuse workflows. | in-progress; Phase 3.0 verified; Phase 3.1 verified; Phase 3.2 verified; Phase 3.3 verified | `TASK-10`, Phase 3.0 (`TASK-10.0`), Phase 3.1 (`TASK-10.1`), Phase 3.2 (`TASK-10.2`), Phase 3.3 (`TASK-10.3`) | `phase-3/2026-05-06-phase-3-0-destination-layout-contracts.md`, `phase-3/2026-05-06-phase-3-1-library-study-entry.md`, `phase-3/2026-05-06-phase-3-2-library-source-study-context.md`, `phase-3/2026-05-06-phase-3-3-library-contract-layout.md` | Layout contracts, Library Study entry, Library source context, and the Library contract layout shell are verified; actual source-selected study generation, Workspaces, Collections, and deeper Import/Export/Search/RAG study flows remain. Post-UX roadmap execution should continue under TASK-10 unless the tracker explicitly creates a rebaseline child task for UX/UI deltas. |
+| Phase 4: Agent Configuration And Execution | Mature Personas, Skills, MCP, ACP, Schedules, and Workflows. | planned | `TASK-11` | not-started | Depends on service adapters and runtime readiness. The post-UX roadmap maps controlled agent configuration and run loops to TASK-11. |
+| Phase 5: Server-Parity And Live Integrations | Close high-value `tldw_server2` parity gaps. | planned | `TASK-12` | not-started | Requires parity inventory. The post-UX roadmap requires parity to be prioritized by workflow value rather than endpoint count. |
+| Phase 6: Release Hardening And Documentation | Reach release-candidate usability. | planned | `TASK-13` | not-started | Depends on earlier phase evidence. The post-UX roadmap public-roadmap and release-readiness refresh belongs under TASK-13. |
 
 ## Phase 1.1 Evidence
 

--- a/Tests/UI/test_post_ux_product_roadmap_handoff.py
+++ b/Tests/UI/test_post_ux_product_roadmap_handoff.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 
@@ -24,7 +25,8 @@ def test_post_ux_spec_preserves_tracker_handoff_rules():
     assert "Relationship To Existing Roadmaps" in text
     assert "Verified work reuse rule" in text
     assert "Operational handoff rule" in text
-    assert "`TASK-10` through `TASK-13`" in text
+    for task_id in ("TASK-10", "TASK-11", "TASK-12", "TASK-13"):
+        assert task_id in text
     assert "Post-UX Reliability Rebaseline" in text
     assert "not reimplemented" in text
 
@@ -41,6 +43,7 @@ def test_product_tracker_maps_post_ux_roadmap_to_existing_tasks():
         "Post-UX Reliability Rebaseline",
         "Source, Knowledge, And Artifact Loops",
         "Controlled Agent Configuration And Run Loops",
+        "Monitoring And Cross-Loop Recovery",
         "Server Parity And Live Integrations",
         "Release Hardening And Distribution",
     ):
@@ -76,5 +79,12 @@ def test_public_roadmap_is_directional_and_commitment_free():
     assert "Next: Complete Workflow Loops" in text
     assert "Later: Server-Backed And Live Capabilities" in text
     assert "Always: Local-First Control" in text
-    forbidden = ("ETA", "deadline", "will ship on", "TASK-", "Phase 1.1", "Phase 2.5")
-    assert not any(term in text for term in forbidden)
+    forbidden_patterns = (
+        r"\bETA\b",
+        r"\bdeadline\b",
+        r"\bwill\s+ship\s+on\b",
+        r"\bTASK-",
+        r"\bPhase\s+1\.1\b",
+        r"\bPhase\s+2\.5\b",
+    )
+    assert not any(re.search(pattern, text, flags=re.IGNORECASE) for pattern in forbidden_patterns)

--- a/Tests/UI/test_post_ux_product_roadmap_handoff.py
+++ b/Tests/UI/test_post_ux_product_roadmap_handoff.py
@@ -1,0 +1,80 @@
+"""Post-UX product roadmap handoff documentation regressions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SPEC = Path("Docs/superpowers/specs/2026-05-06-post-ux-product-roadmap-design.md")
+TRACKER = Path("Docs/superpowers/trackers/product-maturity-roadmap.md")
+BACKLOG_POINTER = Path("backlog/docs/product-maturity-roadmap.md")
+PUBLIC_ROADMAP = Path("Docs/Product_Roadmap.md")
+POST_UX_QA_README = Path("Docs/superpowers/qa/product-maturity/post-ux/README.md")
+POST_UX_QA_TEMPLATE = Path("Docs/superpowers/qa/product-maturity/post-ux/walkthrough-template.md")
+
+
+def _text(path: Path) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def test_post_ux_spec_preserves_tracker_handoff_rules():
+    text = _text(SPEC)
+
+    assert "Relationship To Existing Roadmaps" in text
+    assert "Verified work reuse rule" in text
+    assert "Operational handoff rule" in text
+    assert "`TASK-10` through `TASK-13`" in text
+    assert "Post-UX Reliability Rebaseline" in text
+    assert "not reimplemented" in text
+
+
+def test_product_tracker_maps_post_ux_roadmap_to_existing_tasks():
+    text = _text(TRACKER)
+
+    assert "Post-UX Roadmap Handoff" in text
+    assert "Docs/superpowers/specs/2026-05-06-post-ux-product-roadmap-design.md" in text
+    assert "Product Maturity Phase 1 and Phase 2 are not reopened" in text
+    for task_id in ("TASK-10", "TASK-11", "TASK-12", "TASK-13"):
+        assert task_id in text
+    for stage in (
+        "Post-UX Reliability Rebaseline",
+        "Source, Knowledge, And Artifact Loops",
+        "Controlled Agent Configuration And Run Loops",
+        "Server Parity And Live Integrations",
+        "Release Hardening And Distribution",
+    ):
+        assert stage in text
+
+
+def test_backlog_pointer_names_execution_source_of_truth():
+    text = _text(BACKLOG_POINTER)
+
+    assert "2026-05-06-post-ux-product-roadmap-design.md" in text
+    assert "canonical product-maturity tracker" in text
+    assert "Do not create a parallel phase tree" in text
+
+
+def test_post_ux_qa_scaffold_is_delta_focused():
+    readme = _text(POST_UX_QA_README)
+    template = _text(POST_UX_QA_TEMPLATE)
+
+    assert "changed screens" in readme
+    assert "changed workflows" in readme
+    assert "changed layout contracts" in readme
+    assert "discovered regressions" in readme
+    assert "Pre-UX Baseline Evidence" in template
+    assert "Post-UX Delta" in template
+    assert "Regression Decision" in template
+
+
+def test_public_roadmap_is_directional_and_commitment_free():
+    text = _text(PUBLIC_ROADMAP)
+
+    assert "local-first agentic knowledge console" in text
+    assert "Now: Reliability And Product Confidence" in text
+    assert "Next: Complete Workflow Loops" in text
+    assert "Later: Server-Backed And Live Capabilities" in text
+    assert "Always: Local-First Control" in text
+    forbidden = ("ETA", "deadline", "will ship on", "TASK-", "Phase 1.1", "Phase 2.5")
+    assert not any(term in text for term in forbidden)

--- a/backlog/docs/product-maturity-roadmap.md
+++ b/backlog/docs/product-maturity-roadmap.md
@@ -8,6 +8,12 @@ The canonical product-maturity tracker lives at:
 
 `Docs/superpowers/trackers/product-maturity-roadmap.md`
 
+The post-UX roadmap design lives at:
+
+`Docs/superpowers/specs/2026-05-06-post-ux-product-roadmap-design.md`
+
+The canonical product-maturity tracker remains the execution source of truth. Do not create a parallel phase tree from the post-UX roadmap; map new child tasks to the existing product-maturity parent tasks unless the tracker explicitly supersedes them.
+
 Durable QA evidence lives at:
 
 `Docs/superpowers/qa/product-maturity/`


### PR DESCRIPTION
## Summary
- Add post-UX roadmap handoff contract tests for tracker mapping, QA scaffold, and public roadmap alignment.
- Map the post-UX roadmap into the existing product-maturity tracker and backlog pointer without creating a parallel task tree.
- Add delta-focused post-UX QA scaffold plus a public directional Chatbook product roadmap.

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_post_ux_product_roadmap_handoff.py --tb=short: 5 passed
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_product_maturity_phase1_harness.py Tests/UI/test_product_maturity_phase3_layout_contracts.py --tb=short: 18 passed
- git diff --check: clean

## Notes
- TASK-10 through TASK-13 parent tasks were inspected and left unchanged because the tracker mapping refines sequencing without conflicting with their existing descriptions or acceptance criteria.