### PR TITLE
Verify source-selected Study generation

### DIFF
--- a/Docs/superpowers/qa/product-maturity/phase-3/2026-05-07-phase-3-4-source-study-generation.md
+++ b/Docs/superpowers/qa/product-maturity/phase-3/2026-05-07-phase-3-4-source-study-generation.md
@@ -1,0 +1,80 @@
+# Product Maturity Phase 3.4 Source-Selected Study Generation
+
+Date: 2026-05-07
+Task: TASK-10.4
+Branch: codex/product-maturity-phase3-4-source-study-generation
+Workflow: Library -> Study Dashboard -> Generate Source Study Pack
+
+## What Was Verified
+
+Phase 3.4 verifies the first source-selected Study generation action after the Phase 3.2 source-context handoff.
+
+Verified contract:
+
+- Library-originated Study context carries concrete note and media source items alongside the visible source titles and summary.
+- Study Dashboard can launch a server-backed study-pack generation job from the selected Library source items.
+- The generation request uses the current server runtime mode and preserves workspace routing when a workspace scope exists.
+- Local mode keeps the generation action disabled and explains that server mode is required.
+- Conversation records remain visible in the material context but are not sent as study-pack source items until message-level selection exists.
+
+## Automated Evidence
+
+Initial red run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_product_maturity_phase3_source_study_generation.py -q
+```
+
+Result:
+
+- Failed during collection because `StudySourceItem` did not exist.
+
+Focused verification:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_product_maturity_phase3_source_study_generation.py -q
+```
+
+Result:
+
+- `4 passed, 1 warning`.
+
+Adjacent Phase 3 verification:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_product_maturity_phase3_source_study_generation.py Tests/UI/test_product_maturity_phase3_library_study_context.py Tests/UI/test_product_maturity_phase3_library_contract_layout.py Tests/UI/test_study_dashboard.py -q
+```
+
+Result:
+
+- `23 passed, 1 warning`.
+
+Study scope regression verification:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_study_screen.py Tests/UI/test_study_flashcards_screen.py Tests/UI/test_study_quizzes_screen.py -q
+```
+
+Result:
+
+- `54 passed, 1 warning`.
+
+## UX Notes
+
+- The Study Dashboard now has an explicit source-pack generation action only when source items are present.
+- Server mode gives a direct queued-job path instead of requiring users to reconstruct the source selection in another surface.
+- Local mode avoids a false affordance by keeping the action disabled with a server-mode requirement.
+
+## Defects Found
+
+No P0/P1 defects found.
+
+## Residual Risk
+
+- This slice verifies job launch, not completed study-pack polling, review, or generated deck/quiz reuse.
+- Conversation source records are still material context only; message-level source selection is needed before they can safely become study-pack `message` source items.
+- Workspaces, Collections, Import/Export, and Search/RAG-to-study generation remain later Phase 3 gates.
+
+## Exit Decision
+
+Pass for Phase 3.4. A user can enter Study from Library sources and queue server source-selected study-pack generation with honest local-mode recovery.

--- a/Docs/superpowers/qa/product-maturity/phase-3/README.md
+++ b/Docs/superpowers/qa/product-maturity/phase-3/README.md
@@ -20,3 +20,4 @@ Phase 3.0 records destination layout and IA contracts before additional Phase 3 
 - `2026-05-06-phase-3-1-library-study-entry.md`
 - `2026-05-06-phase-3-2-library-source-study-context.md`
 - `2026-05-06-phase-3-3-library-contract-layout.md`
+- `2026-05-07-phase-3-4-source-study-generation.md`

--- a/Docs/superpowers/trackers/product-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/product-maturity-roadmap.md
@@ -1,7 +1,7 @@
 # Product Maturity Roadmap
 
-Date: 2026-05-06
-Status: Phase 1 verified; Phase 2 verified; Phase 3.0 verified; Phase 3.1 verified; Phase 3.2 verified; Phase 3.3 verified
+Date: 2026-05-07
+Status: Phase 1 verified; Phase 2 verified; Phase 3.0 verified; Phase 3.1 verified; Phase 3.2 verified; Phase 3.3 verified; Phase 3.4 verified
 Source Branch: `dev`
 Source Spec: `Docs/superpowers/specs/2026-05-05-product-maturity-phased-roadmap-design.md`
 Layout Contract Spec: `Docs/superpowers/specs/2026-05-06-destination-layout-ia-contracts-design.md`
@@ -30,6 +30,7 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 - Phase 3.1 verifies the first Knowledge/Study entry contract: Library visibly routes users to Study Dashboard, Flashcards, and Quizzes while preserving the requested Study section.
 - Phase 3.2 verifies Library-originated Study entry preserves visible source context in Study without changing deck or quiz service scope away from global or workspace.
 - Phase 3.3 verifies the Library destination layout shell against the approved contract: mode bar, source browser, detail, inspector, authority, and existing Library actions remain visible across compact, default, and large terminal sizes.
+- Phase 3.4 verifies the first source-selected Study generation contract: Library-selected note and media source items carry into Study Dashboard and can queue a server study-pack generation job with local-mode recovery.
 
 ## Post-UX Roadmap Handoff
 
@@ -79,6 +80,7 @@ Product Maturity Phase 1 and Phase 2 are not reopened by default. Their existing
 - Phase 3.1: Library Study Entry - `TASK-10.1`
 - Phase 3.2: Library Source Study Context - `TASK-10.2`
 - Phase 3.3: Library Contract Layout Shell - `TASK-10.3`
+- Phase 3.4: Source-Selected Study Generation - `TASK-10.4`
 - Phase 4: Agent Configuration And Execution - `TASK-11`
 - Phase 5: Server-Parity And Live Integrations - `TASK-12`
 - Phase 6: Release Hardening And Documentation - `TASK-13`
@@ -97,6 +99,7 @@ Product Maturity Phase 1 and Phase 2 are not reopened by default. Their existing
 | Phase 3.1 | `Docs/superpowers/qa/product-maturity/phase-3/2026-05-06-phase-3-1-library-study-entry.md` | verified |
 | Phase 3.2 | `Docs/superpowers/qa/product-maturity/phase-3/2026-05-06-phase-3-2-library-source-study-context.md` | verified |
 | Phase 3.3 | `Docs/superpowers/qa/product-maturity/phase-3/2026-05-06-phase-3-3-library-contract-layout.md` | verified |
+| Phase 3.4 | `Docs/superpowers/qa/product-maturity/phase-3/2026-05-07-phase-3-4-source-study-generation.md` | verified |
 
 ## Phase Overview
 
@@ -104,7 +107,7 @@ Product Maturity Phase 1 and Phase 2 are not reopened by default. Their existing
 | --- | --- | --- | --- | --- | --- |
 | Phase 1: QA Baseline And Usability Guardrails | Establish clean-run usability guardrails before feature depth. | verified | `TASK-8`, Phase 1.1 (`TASK-8.1`), Phase 1.2 (`TASK-8.2`), Phase 1.3 (`TASK-8.3`), Phase 1.4 (`TASK-8.4`), Phase 1.5 (`TASK-8.5`), Phase 1.6 (`TASK-8.6`), Phase 1.7 (`TASK-8.7`) | `phase-1/` | Closed; full grounded generation and Artifact/Chatbook persistence move to Phase 2. |
 | Phase 2: Core Agentic Loop | Complete source/question to grounded Console to Artifact/Chatbook loop. | verified | `TASK-9`, Phase 2.1 (`TASK-9.1`), Phase 2.2 (`TASK-9.2`), Phase 2.3 (`TASK-9.3`), Phase 2.4 (`TASK-9.4`), Phase 2.5 (`TASK-9.5`) | `phase-2/2026-05-05-phase-2-1-grounded-console-response-contract.md`, `phase-2/2026-05-05-phase-2-2-console-chatbook-artifact-save-contract.md`, `phase-2/2026-05-05-phase-2-3-saved-chatbook-artifact-reopen-contract.md`, `phase-2/2026-05-05-phase-2-4-home-chatbook-artifact-resume-contract.md`, `phase-2/2026-05-06-phase-2-5-core-loop-closeout-replay.md` | Closed for the local core loop; live provider generation, full `.chatbook` export packaging, and full artifact history picking remain later-phase risks. |
-| Phase 3: Knowledge And Study Workflows | Mature ingest, organize, retrieve, study, and reuse workflows. | in-progress; Phase 3.0 verified; Phase 3.1 verified; Phase 3.2 verified; Phase 3.3 verified | `TASK-10`, Phase 3.0 (`TASK-10.0`), Phase 3.1 (`TASK-10.1`), Phase 3.2 (`TASK-10.2`), Phase 3.3 (`TASK-10.3`) | `phase-3/2026-05-06-phase-3-0-destination-layout-contracts.md`, `phase-3/2026-05-06-phase-3-1-library-study-entry.md`, `phase-3/2026-05-06-phase-3-2-library-source-study-context.md`, `phase-3/2026-05-06-phase-3-3-library-contract-layout.md` | Layout contracts, Library Study entry, Library source context, and the Library contract layout shell are verified; actual source-selected study generation, Workspaces, Collections, and deeper Import/Export/Search/RAG study flows remain. Post-UX roadmap execution should continue under TASK-10 unless the tracker explicitly creates a rebaseline child task for UX/UI deltas. |
+| Phase 3: Knowledge And Study Workflows | Mature ingest, organize, retrieve, study, and reuse workflows. | in-progress; Phase 3.0 verified; Phase 3.1 verified; Phase 3.2 verified; Phase 3.3 verified; Phase 3.4 verified | `TASK-10`, Phase 3.0 (`TASK-10.0`), Phase 3.1 (`TASK-10.1`), Phase 3.2 (`TASK-10.2`), Phase 3.3 (`TASK-10.3`), Phase 3.4 (`TASK-10.4`) | `phase-3/2026-05-06-phase-3-0-destination-layout-contracts.md`, `phase-3/2026-05-06-phase-3-1-library-study-entry.md`, `phase-3/2026-05-06-phase-3-2-library-source-study-context.md`, `phase-3/2026-05-06-phase-3-3-library-contract-layout.md`, `phase-3/2026-05-07-phase-3-4-source-study-generation.md` | Layout contracts, Library Study entry, Library source context, Library contract layout shell, and source-selected server study-pack job launch are verified; completed study-pack polling/reuse, Workspaces, Collections, and deeper Import/Export/Search/RAG study flows remain. Post-UX roadmap execution should continue under TASK-10 unless the tracker explicitly creates a rebaseline child task for UX/UI deltas. |
 | Phase 4: Agent Configuration And Execution | Mature Personas, Skills, MCP, ACP, Schedules, and Workflows. | planned | `TASK-11` | not-started | Depends on service adapters and runtime readiness. The post-UX roadmap maps controlled agent configuration and run loops to TASK-11. |
 | Phase 5: Server-Parity And Live Integrations | Close high-value `tldw_server2` parity gaps. | planned | `TASK-12` | not-started | Requires parity inventory. The post-UX roadmap requires parity to be prioritized by workflow value rather than endpoint count. |
 | Phase 6: Release Hardening And Documentation | Reach release-candidate usability. | planned | `TASK-13` | not-started | Depends on earlier phase evidence. The post-UX roadmap public-roadmap and release-readiness refresh belongs under TASK-13. |
@@ -207,3 +210,9 @@ Status: verified
 Status: verified
 
 - `Docs/superpowers/qa/product-maturity/phase-3/2026-05-06-phase-3-3-library-contract-layout.md`
+
+## Phase 3.4 Evidence
+
+Status: verified
+
+- `Docs/superpowers/qa/product-maturity/phase-3/2026-05-07-phase-3-4-source-study-generation.md`

--- a/Tests/UI/test_product_maturity_phase3_source_study_generation.py
+++ b/Tests/UI/test_product_maturity_phase3_source_study_generation.py
@@ -1,0 +1,218 @@
+"""Product maturity Phase 3.4 source-selected Study generation contract."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from textual.widgets import Button, Static
+
+from Tests.UI.test_destination_shells import (
+    DestinationHarness,
+    StaticLibraryConversationScopeService,
+    StaticLibraryMediaScopeService,
+    StaticLibraryNotesScopeService,
+    _build_test_app,
+    _wait_for_library_snapshot,
+)
+from Tests.UI.test_study_dashboard import (
+    DashboardStudyScopeService,
+    StudyDashboardTestApp,
+    _build_app_instance,
+)
+from tldw_chatbook.UI.Screens.study_scope_models import (
+    MATERIAL_SOURCE_LIBRARY,
+    MATERIAL_TITLE_LIBRARY_SOURCES,
+    StudyScopeContext,
+    StudySourceItem,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TRACKER = Path("Docs/superpowers/trackers/product-maturity-roadmap.md")
+PHASE_3_README = Path("Docs/superpowers/qa/product-maturity/phase-3/README.md")
+PHASE_3_4_EVIDENCE = Path(
+    "Docs/superpowers/qa/product-maturity/phase-3/2026-05-07-phase-3-4-source-study-generation.md"
+)
+TASK_10 = Path("backlog/tasks/task-10 - Product-Maturity-Phase-3-Knowledge-And-Study-Workflows.md")
+TASK_10_4 = Path(
+    "backlog/tasks/task-10.4 - Product-Maturity-Phase-3.4-Source-Selected-Study-Generation.md"
+)
+
+
+class RecordingSourceStudyService(DashboardStudyScopeService):
+    """Dashboard service stub that records source-selected study pack jobs."""
+
+    async def create_study_pack_job(
+        self,
+        *,
+        mode=None,
+        title,
+        source_items,
+        workspace_id=None,
+    ):
+        self.calls.append(
+            (
+                "create_study_pack_job",
+                mode,
+                title,
+                workspace_id,
+                source_items,
+            )
+        )
+        return {"job": {"id": 42, "status": "queued"}}
+
+
+async def _wait_for_source_generation_call(
+    service: RecordingSourceStudyService,
+    pilot,
+    *,
+    timeout: float = 1.0,
+) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if any(call[0] == "create_study_pack_job" for call in service.calls):
+            return
+        await pilot.pause(0.01)
+    raise AssertionError(f"Timed out waiting for study pack generation call: {service.calls}")
+
+
+def _text(path: Path) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def _static_text(widget: Static) -> str:
+    return str(widget.render())
+
+
+@pytest.mark.asyncio
+async def test_library_source_context_carries_study_pack_source_items() -> None:
+    app = _build_test_app()
+    app.notes_scope_service = StaticLibraryNotesScopeService(
+        [{"title": "Research Note", "id": "note-1"}]
+    )
+    app.media_reading_scope_service = StaticLibraryMediaScopeService(
+        [{"title": "Transcript A", "id": "media-1"}]
+    )
+    app.chat_conversation_scope_service = StaticLibraryConversationScopeService(
+        [{"title": "Planning Chat", "id": "chat-1"}]
+    )
+    app.open_study_screen = Mock()
+    host = DestinationHarness(app, "library")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = host.screen_stack[-1]
+        await _wait_for_library_snapshot(screen, pilot)
+        await pilot.click("#library-open-study")
+        await pilot.pause(0.1)
+
+    scope_context = app.open_study_screen.call_args.args[0]
+
+    assert scope_context.source_items == (
+        StudySourceItem(source_type="note", source_id="note-1", label="Research Note"),
+        StudySourceItem(source_type="media", source_id="media-1", label="Transcript A"),
+    )
+    assert scope_context.material_titles == (
+        "Research Note",
+        "Transcript A",
+        "Planning Chat",
+    )
+
+
+@pytest.mark.asyncio
+async def test_server_study_dashboard_launches_source_selected_study_pack_job() -> None:
+    service = RecordingSourceStudyService()
+    app_instance = _build_app_instance()
+    app_instance.study_scope_service = service
+    app_instance.current_runtime_backend = "server"
+    app_instance.runtime_backend = "server"
+    app_instance.notify = Mock()
+    app_instance.pending_study_scope_context = StudyScopeContext(
+        material_source=MATERIAL_SOURCE_LIBRARY,
+        material_title=MATERIAL_TITLE_LIBRARY_SOURCES,
+        material_summary="Local Library source snapshot staged for Study.",
+        material_titles=("Research Note", "Transcript A"),
+        source_items=(
+            StudySourceItem(source_type="note", source_id="note-1", label="Research Note"),
+            StudySourceItem(source_type="media", source_id="media-1", label="Transcript A"),
+        ),
+    )
+    app = StudyDashboardTestApp(app_instance)
+
+    async with app.run_test() as pilot:
+        await pilot.pause(0.3)
+        generate_button = app.screen.query_one("#study-generate-source-pack", Button)
+
+        assert generate_button.disabled is False
+        assert "selected Library sources" in str(generate_button.tooltip)
+
+        await pilot.click("#study-generate-source-pack")
+        await _wait_for_source_generation_call(service, pilot)
+
+        status = app.screen.query_one("#study-source-generation-status", Static)
+
+        assert "queued" in _static_text(status).lower()
+        assert "42" in _static_text(status)
+
+    assert (
+        "create_study_pack_job",
+        "server",
+        "Local Library Sources",
+        None,
+        [
+            {"source_type": "note", "source_id": "note-1", "label": "Research Note", "locator": {}},
+            {"source_type": "media", "source_id": "media-1", "label": "Transcript A", "locator": {}},
+        ],
+    ) in service.calls
+    app_instance.notify.assert_called_with("Study pack generation queued.", severity="information")
+
+
+@pytest.mark.asyncio
+async def test_local_study_dashboard_explains_source_generation_server_requirement() -> None:
+    service = RecordingSourceStudyService()
+    app_instance = _build_app_instance()
+    app_instance.study_scope_service = service
+    app_instance.pending_study_scope_context = StudyScopeContext(
+        material_source=MATERIAL_SOURCE_LIBRARY,
+        material_title=MATERIAL_TITLE_LIBRARY_SOURCES,
+        material_summary="Local Library source snapshot staged for Study.",
+        material_titles=("Research Note",),
+        source_items=(StudySourceItem(source_type="note", source_id="note-1", label="Research Note"),),
+    )
+    app = StudyDashboardTestApp(app_instance)
+
+    async with app.run_test() as pilot:
+        await pilot.pause(0.3)
+        generate_button = app.screen.query_one("#study-generate-source-pack", Button)
+        status = app.screen.query_one("#study-source-generation-status", Static)
+
+        assert generate_button.disabled is True
+        assert "server mode" in str(generate_button.tooltip).lower()
+        assert "server mode" in _static_text(status).lower()
+
+    assert not any(call[0] == "create_study_pack_job" for call in service.calls)
+
+
+def test_phase_3_4_source_study_generation_evidence_is_tracked() -> None:
+    tracker = _text(TRACKER)
+    readme = _text(PHASE_3_README)
+    evidence = _text(PHASE_3_4_EVIDENCE)
+    parent_task = _text(TASK_10)
+    task = _text(TASK_10_4)
+
+    assert "Phase 3.4" in tracker
+    assert "TASK-10.4" in tracker
+    assert PHASE_3_4_EVIDENCE.name in tracker
+    assert PHASE_3_4_EVIDENCE.name in readme
+    assert "Source-Selected Study Generation" in evidence
+    assert "Library -> Study Dashboard -> Generate Source Study Pack" in evidence
+    assert "No P0/P1 defects found" in evidence
+    assert "Tests/UI/test_product_maturity_phase3_source_study_generation.py" in evidence
+    assert "status: In Progress" in parent_task
+    assert "TASK-10.4" in parent_task
+    assert "Product Maturity Phase 3.4: Source-Selected Study Generation" in task
+    assert "status: Done" in task
+    for ac_number in range(1, 5):
+        assert f"- [x] #{ac_number}" in task

--- a/Tests/UI/test_product_maturity_phase3_source_study_generation.py
+++ b/Tests/UI/test_product_maturity_phase3_source_study_generation.py
@@ -48,11 +48,11 @@ class RecordingSourceStudyService(DashboardStudyScopeService):
     async def create_study_pack_job(
         self,
         *,
-        mode=None,
-        title,
-        source_items,
-        workspace_id=None,
-    ):
+        mode: str | None = None,
+        title: str,
+        source_items: list[dict[str, object]],
+        workspace_id: str | None = None,
+    ) -> dict[str, object]:
         self.calls.append(
             (
                 "create_study_pack_job",
@@ -69,7 +69,7 @@ async def _wait_for_source_generation_call(
     service: RecordingSourceStudyService,
     pilot,
     *,
-    timeout: float = 1.0,
+    timeout: float = 5.0,
 ) -> None:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:

--- a/backlog/tasks/task-10 - Product-Maturity-Phase-3-Knowledge-And-Study-Workflows.md
+++ b/backlog/tasks/task-10 - Product-Maturity-Phase-3-Knowledge-And-Study-Workflows.md
@@ -34,4 +34,6 @@ Started Phase 3 with TASK-10.1 as the first PR-sized Knowledge and Study workflo
 Continued Phase 3 with TASK-10.2. Library source context now carries into Study Dashboard Flashcards and Quizzes without changing deck/quiz service scope. Parent remains open for source-selected generation Workspaces Collections Import/Export Search/RAG and Console reuse gates.
 
 Continued Phase 3 with TASK-10.3. The Library destination now exposes the approved Phase 3.0 layout shell with mode bar source browser source detail and inspector regions across compact default and large terminal sizes. Parent remains open for source-selected study generation Workspaces Collections and deeper Import/Export Search/RAG workflows.
+
+Continued Phase 3 with TASK-10.4. Library-selected note and media source items now carry into Study Dashboard and can queue a server study-pack generation job with local-mode recovery. Parent remains open for completed study-pack polling/reuse conversation message-level selection Workspaces Collections and deeper Import/Export Search/RAG workflows.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-10.4 - Product-Maturity-Phase-3.4-Source-Selected-Study-Generation.md
+++ b/backlog/tasks/task-10.4 - Product-Maturity-Phase-3.4-Source-Selected-Study-Generation.md
@@ -1,0 +1,45 @@
+---
+id: TASK-10.4
+title: 'Product Maturity Phase 3.4: Source-Selected Study Generation'
+status: Done
+assignee: []
+created_date: '2026-05-07 00:00'
+updated_date: '2026-05-07 00:00'
+labels:
+  - product-maturity
+  - phase-3-knowledge-study
+  - study-generation
+dependencies: []
+parent_task_id: TASK-10
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Allow a user who enters Study from visible Library sources to launch a server-backed study-pack generation job from those concrete source items, while keeping local-mode recovery honest.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Library-originated Study context carries concrete note and media source items for generation while preserving visible source titles.
+- [x] #2 Study Dashboard in server mode can queue a study-pack generation job from selected Library source items.
+- [x] #3 Local mode explains the server-mode requirement and does not dispatch generation.
+- [x] #4 Repo-tracked QA evidence, roadmap, and parent task notes record the Phase 3.4 verification and residual risk.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a failing Phase 3.4 product-maturity regression for Library source item handoff, server generation dispatch, local-mode recovery, and tracking evidence.
+2. Extend Study scope models so concrete source items can survive Library to Study navigation and saved state.
+3. Extract eligible note and media source items from the Library snapshot without treating conversation records as message IDs.
+4. Add a Study Dashboard generation action that queues server study-pack generation from the selected source items and reports unavailable local/runtime states.
+5. Record Phase 3.4 QA evidence and update the tracker, README, and parent task notes.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the Phase 3.4 source-selected Study generation gate. Library now carries concrete note and media source items into Study along with the existing visible material titles. Study Dashboard exposes a source study-pack generation action that queues `create_study_pack_job` in server mode using those source items, reports queued job status, and keeps local mode disabled with a clear server requirement. Conversation records remain visible in the material context but are not sent as study-pack source items until message-level selection exists.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -25,6 +25,7 @@ from .study_scope_models import (
     MATERIAL_SOURCE_LIBRARY,
     MATERIAL_TITLE_LIBRARY_SOURCES,
     StudyScopeContext,
+    StudySourceItem,
 )
 
 
@@ -271,6 +272,34 @@ class LibraryScreen(BaseAppScreen):
             for record in self._local_source_records[source_type]
         ]
 
+    @classmethod
+    def _source_record_id(cls, record: Mapping[str, Any]) -> str | None:
+        for key in ("id", "uuid", "record_id", "backing_id", "source_id"):
+            value = cls._safe_text(record.get(key), max_length=128)
+            if value:
+                return value
+        return None
+
+    def _study_source_items(self) -> tuple[StudySourceItem, ...]:
+        source_items: list[StudySourceItem] = []
+        source_type_map = {
+            "notes": "note",
+            "media": "media",
+        }
+        for source_type, study_source_type in source_type_map.items():
+            for record in self._local_source_records[source_type]:
+                source_id = self._source_record_id(record)
+                if not source_id:
+                    continue
+                source_items.append(
+                    StudySourceItem(
+                        source_type=study_source_type,
+                        source_id=source_id,
+                        label=self._source_title(source_type, record),
+                    )
+                )
+        return tuple(source_items)
+
     def _source_count_metadata(self) -> dict[str, int | None]:
         metadata: dict[str, int | None] = {}
         for source_type in ("notes", "media", "conversations"):
@@ -302,6 +331,7 @@ class LibraryScreen(BaseAppScreen):
             material_title=MATERIAL_TITLE_LIBRARY_SOURCES,
             material_summary=self._source_snapshot_body(),
             material_titles=tuple(material_titles),
+            source_items=self._study_source_items(),
             return_hint=MATERIAL_SOURCE_LIBRARY,
         )
 

--- a/tldw_chatbook/UI/Screens/study_scope_models.py
+++ b/tldw_chatbook/UI/Screens/study_scope_models.py
@@ -23,7 +23,15 @@ class StudyScopeType(str, Enum):
 
 @dataclass(frozen=True)
 class StudySourceItem:
-    """Concrete source item that can back server-side study generation."""
+    """Concrete source item that can back server-side study generation.
+
+    Attributes:
+        source_type: Stable source category, such as ``note`` or ``media``.
+        source_id: Stable identifier for the selected source record.
+        label: Optional user-facing source label.
+        excerpt_text: Optional source excerpt for generation context.
+        locator: Optional structured locator metadata for the source.
+    """
 
     source_type: str
     source_id: str
@@ -32,6 +40,12 @@ class StudySourceItem:
     locator: dict[str, Any] = field(default_factory=dict)
 
     def as_payload(self) -> dict[str, Any]:
+        """Return the server study-pack generation payload.
+
+        Returns:
+            Dictionary containing the source identity plus optional label,
+            excerpt, and locator metadata.
+        """
         payload: dict[str, Any] = {
             "source_type": self.source_type,
             "source_id": self.source_id,

--- a/tldw_chatbook/UI/Screens/study_scope_models.py
+++ b/tldw_chatbook/UI/Screens/study_scope_models.py
@@ -4,19 +4,44 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Optional
+from typing import Any, Optional
 
 
 MATERIAL_SOURCE_LIBRARY = "library"
 MATERIAL_TITLE_LIBRARY_SOURCES = "Local Library Sources"
 STUDY_MATERIAL_TITLES_LIMIT = 10
+STUDY_SOURCE_ITEMS_LIMIT = 25
 STUDY_MATERIAL_TITLE_LENGTH_LIMIT = 160
 STUDY_MATERIAL_SUMMARY_LENGTH_LIMIT = 1000
+STUDY_SOURCE_ID_LENGTH_LIMIT = 128
 
 
 class StudyScopeType(str, Enum):
     GLOBAL = "global"
     WORKSPACE = "workspace"
+
+
+@dataclass(frozen=True)
+class StudySourceItem:
+    """Concrete source item that can back server-side study generation."""
+
+    source_type: str
+    source_id: str
+    label: Optional[str] = None
+    excerpt_text: Optional[str] = None
+    locator: dict[str, Any] = field(default_factory=dict)
+
+    def as_payload(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "source_type": self.source_type,
+            "source_id": self.source_id,
+        }
+        if self.label:
+            payload["label"] = self.label
+        if self.excerpt_text:
+            payload["excerpt_text"] = self.excerpt_text
+        payload["locator"] = dict(self.locator or {})
+        return payload
 
 
 @dataclass(frozen=True)
@@ -31,6 +56,7 @@ class StudyScopeContext:
     material_title: Optional[str] = None
     material_summary: Optional[str] = None
     material_titles: tuple[str, ...] = field(default_factory=tuple)
+    source_items: tuple[StudySourceItem, ...] = field(default_factory=tuple)
 
 
 @dataclass
@@ -48,6 +74,7 @@ class StudyScopeState:
     material_title: Optional[str] = None
     material_summary: Optional[str] = None
     material_titles: tuple[str, ...] = field(default_factory=tuple)
+    source_items: tuple[StudySourceItem, ...] = field(default_factory=tuple)
 
     def as_context(self) -> StudyScopeContext:
         return StudyScopeContext(
@@ -59,4 +86,5 @@ class StudyScopeState:
             material_title=self.material_title,
             material_summary=self.material_summary,
             material_titles=self.material_titles,
+            source_items=self.source_items,
         )

--- a/tldw_chatbook/UI/Screens/study_screen.py
+++ b/tldw_chatbook/UI/Screens/study_screen.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 import hashlib
 from inspect import isawaitable
 import re
@@ -35,9 +36,12 @@ from .study_scope_models import (
     STUDY_MATERIAL_SUMMARY_LENGTH_LIMIT,
     STUDY_MATERIAL_TITLE_LENGTH_LIMIT,
     STUDY_MATERIAL_TITLES_LIMIT,
+    STUDY_SOURCE_ID_LENGTH_LIMIT,
+    STUDY_SOURCE_ITEMS_LIMIT,
     StudyScopeContext,
     StudyScopeState,
     StudyScopeType,
+    StudySourceItem,
 )
 
 
@@ -174,6 +178,7 @@ class StudyScreen(BaseAppScreen):
                 scope_state.material_title,
                 scope_state.material_summary,
                 scope_state.material_titles,
+                scope_state.source_items,
             )
         ):
             return None
@@ -185,6 +190,11 @@ class StudyScreen(BaseAppScreen):
             scope_state.material_summary or "",
             str(len(scope_state.material_titles)),
             *scope_state.material_titles[:STUDY_MATERIAL_TITLES_LIMIT],
+            str(len(scope_state.source_items)),
+            *(
+                f"{item.source_type}:{item.source_id}:{item.label or ''}"
+                for item in scope_state.source_items[:STUDY_SOURCE_ITEMS_LIMIT]
+            ),
         )
         for part in parts:
             digest.update(part.encode("utf-8", errors="ignore"))
@@ -213,6 +223,48 @@ class StudyScreen(BaseAppScreen):
             if clean_title:
                 cleaned.append(clean_title)
             if len(cleaned) >= STUDY_MATERIAL_TITLES_LIMIT:
+                break
+        return tuple(cleaned)
+
+    def _clean_source_items(self, source_items: tuple[StudySourceItem, ...]) -> tuple[StudySourceItem, ...]:
+        cleaned: list[StudySourceItem] = []
+        for item in source_items:
+            if not isinstance(item, StudySourceItem):
+                continue
+            source_type = self._clean_material_text(item.source_type, max_length=32)
+            if source_type not in {"note", "media", "message"}:
+                continue
+            source_id = self._clean_material_text(
+                item.source_id,
+                max_length=STUDY_SOURCE_ID_LENGTH_LIMIT,
+            )
+            if not source_id:
+                continue
+            label = self._clean_material_text(
+                item.label,
+                max_length=STUDY_MATERIAL_TITLE_LENGTH_LIMIT,
+            ) or None
+            excerpt_text = self._clean_material_text(
+                item.excerpt_text,
+                max_length=STUDY_MATERIAL_SUMMARY_LENGTH_LIMIT,
+            ) or None
+            locator: dict[str, Any] = {}
+            if isinstance(item.locator, Mapping):
+                for key, value in item.locator.items():
+                    clean_key = self._clean_material_text(key, max_length=64)
+                    clean_value = self._clean_material_text(value, max_length=160)
+                    if clean_key and clean_value:
+                        locator[clean_key] = clean_value
+            cleaned.append(
+                StudySourceItem(
+                    source_type=source_type,
+                    source_id=source_id,
+                    label=label,
+                    excerpt_text=excerpt_text,
+                    locator=locator,
+                )
+            )
+            if len(cleaned) >= STUDY_SOURCE_ITEMS_LIMIT:
                 break
         return tuple(cleaned)
 
@@ -251,6 +303,7 @@ class StudyScreen(BaseAppScreen):
             )
             or None,
             material_titles=self._clean_material_titles(tuple(scope_context.material_titles or ())),
+            source_items=self._clean_source_items(tuple(scope_context.source_items or ())),
         )
 
     def _consume_pending_scope_context(self) -> Optional[StudyScopeContext]:
@@ -422,6 +475,114 @@ class StudyScreen(BaseAppScreen):
             topic = str(self.current_study_session.get("topic") or "session").strip()
             summary = f"{section}: {topic}"
         self.study_dashboard.update_resume_action(summary)
+        self.study_dashboard.update_source_generation_action(**self._source_generation_dashboard_state())
+
+    def _source_generation_dashboard_state(self) -> dict[str, Any]:
+        if not self.scope_state.source_items:
+            return {
+                "enabled": False,
+                "status": "Source generation is unavailable until Study has selected source items.",
+                "tooltip": "Open Study from selected Library sources in server mode to generate a study pack.",
+            }
+        if self.scope_state.error_message:
+            return {
+                "enabled": False,
+                "status": self.scope_state.error_message,
+                "tooltip": self.scope_state.error_message,
+            }
+        if self._runtime_backend() != "server":
+            return {
+                "enabled": False,
+                "status": "Source generation requires server mode.",
+                "tooltip": "Switch to server mode to generate a study pack from selected Library sources.",
+            }
+        return {
+            "enabled": True,
+            "status": f"{len(self.scope_state.source_items)} selected source items ready for study-pack generation.",
+            "tooltip": "Generate a server study pack from the selected Library sources.",
+        }
+
+    def _source_study_pack_title(self) -> str:
+        return self.scope_state.material_title or "Selected Source Study Pack"
+
+    def _source_items_payload(self) -> list[dict[str, Any]]:
+        return [item.as_payload() for item in self.scope_state.source_items]
+
+    async def _generate_source_study_pack(self) -> None:
+        if self.study_dashboard is not None and self.study_dashboard.is_mounted:
+            self.study_dashboard.update_source_generation_action(
+                enabled=False,
+                status="Queuing source study-pack generation...",
+                tooltip="Source study-pack generation is already queued.",
+            )
+
+        state = self._source_generation_dashboard_state()
+        if not state["enabled"]:
+            if self.study_dashboard is not None and self.study_dashboard.is_mounted:
+                self.study_dashboard.update_source_generation_action(**state)
+            notify = getattr(self.app_instance, "notify", None)
+            if callable(notify):
+                notify(state["status"], severity="warning")
+            return
+
+        study_service = getattr(self.app_instance, "study_scope_service", None)
+        create_job = getattr(study_service, "create_study_pack_job", None)
+        if not callable(create_job):
+            status = "Study pack generation is unavailable in this runtime."
+            if self.study_dashboard is not None and self.study_dashboard.is_mounted:
+                self.study_dashboard.update_source_generation_action(
+                    enabled=False,
+                    status=status,
+                    tooltip=status,
+                )
+            notify = getattr(self.app_instance, "notify", None)
+            if callable(notify):
+                notify(status, severity="warning")
+            return
+
+        try:
+            result = await self._maybe_await(
+                create_job(
+                    mode=self._runtime_backend(),
+                    title=self._source_study_pack_title(),
+                    workspace_id=(
+                        self.scope_state.workspace_id
+                        if self.scope_state.scope_type == StudyScopeType.WORKSPACE
+                        else None
+                    ),
+                    source_items=self._source_items_payload(),
+                )
+            )
+        except Exception:
+            logger.error("Failed to queue source study-pack generation", exc_info=True)
+            status = "Failed to queue source study-pack generation."
+            if self.study_dashboard is not None and self.study_dashboard.is_mounted:
+                self.study_dashboard.update_source_generation_action(
+                    enabled=True,
+                    status=status,
+                    tooltip="Retry source study-pack generation.",
+                )
+            notify = getattr(self.app_instance, "notify", None)
+            if callable(notify):
+                notify(status, severity="error")
+            return
+
+        job = result.get("job") if isinstance(result, dict) else None
+        job_id = job.get("id") if isinstance(job, dict) else None
+        job_status = str(job.get("status") or "queued") if isinstance(job, dict) else "queued"
+        if job_id is not None:
+            status = f"Study pack generation {job_status}: job {job_id}."
+        else:
+            status = f"Study pack generation {job_status}."
+        if self.study_dashboard is not None and self.study_dashboard.is_mounted:
+            self.study_dashboard.update_source_generation_action(
+                enabled=True,
+                status=status,
+                tooltip="Generate another server study pack from the selected Library sources.",
+            )
+        notify = getattr(self.app_instance, "notify", None)
+        if callable(notify):
+            notify("Study pack generation queued.", severity="information")
 
     def _status_text_from_window(self, widget_id: str) -> str:
         study_window = self.study_window_widget
@@ -786,12 +947,20 @@ class StudyScreen(BaseAppScreen):
                     "material_title": self.scope_state.material_title,
                     "material_summary": self.scope_state.material_summary,
                     "material_titles": list(self.scope_state.material_titles),
+                    "source_items": [item.as_payload() for item in self.scope_state.source_items],
                 },
                 "study_section": self.current_section,
                 "current_study_session": self.current_study_session,
             }
         )
         return state
+
+    @staticmethod
+    def _restored_source_item_locator(item: dict[str, Any]) -> dict[str, Any]:
+        locator = item.get("locator")
+        if isinstance(locator, Mapping):
+            return dict(locator)
+        return {}
 
     def restore_state(self, state: dict[str, Any]) -> None:
         super().restore_state(state)
@@ -807,6 +976,17 @@ class StudyScreen(BaseAppScreen):
                     material_title=saved_scope.get("material_title"),
                     material_summary=saved_scope.get("material_summary"),
                     material_titles=tuple(saved_scope.get("material_titles") or ()),
+                    source_items=tuple(
+                        StudySourceItem(
+                            source_type=str(item.get("source_type") or ""),
+                            source_id=str(item.get("source_id") or ""),
+                            label=item.get("label"),
+                            excerpt_text=item.get("excerpt_text"),
+                            locator=self._restored_source_item_locator(item),
+                        )
+                        for item in list(saved_scope.get("source_items") or [])
+                        if isinstance(item, dict)
+                    ),
                 )
             )
             self._effective_scope_key = self._scope_key(self.scope_state)
@@ -904,6 +1084,10 @@ class StudyScreen(BaseAppScreen):
     @on(Button.Pressed, "#study-open-quizzes")
     def handle_dashboard_open_quizzes(self) -> None:
         self.activate_section("quizzes")
+
+    @on(Button.Pressed, "#study-generate-source-pack")
+    def handle_generate_source_pack(self) -> None:
+        self.run_worker(self._generate_source_study_pack(), exclusive=True)
 
     @on(Button.Pressed, "#study-resume-last")
     def handle_resume_last_session(self) -> None:

--- a/tldw_chatbook/UI/Screens/study_screen.py
+++ b/tldw_chatbook/UI/Screens/study_screen.py
@@ -554,7 +554,7 @@ class StudyScreen(BaseAppScreen):
                 )
             )
         except Exception:
-            logger.error("Failed to queue source study-pack generation", exc_info=True)
+            logger.exception("Failed to queue source study-pack generation")
             status = "Failed to queue source study-pack generation."
             if self.study_dashboard is not None and self.study_dashboard.is_mounted:
                 self.study_dashboard.update_source_generation_action(

--- a/tldw_chatbook/Widgets/Study/study_dashboard.py
+++ b/tldw_chatbook/Widgets/Study/study_dashboard.py
@@ -138,6 +138,13 @@ class StudyDashboard(Widget):
         status: str,
         tooltip: str,
     ) -> None:
+        """Update the source-pack generation action state.
+
+        Args:
+            enabled: Whether the generation button should be interactive.
+            status: Status text shown beside the generation action.
+            tooltip: Tooltip explaining the current action state.
+        """
         if not self.is_mounted:
             return
         button = self.query_one("#study-generate-source-pack", Button)

--- a/tldw_chatbook/Widgets/Study/study_dashboard.py
+++ b/tldw_chatbook/Widgets/Study/study_dashboard.py
@@ -12,6 +12,9 @@ RESUME_DISABLED_TOOLTIP = (
     "No study session to resume. Open flashcards or quizzes to start a session."
 )
 RESUME_ENABLED_TOOLTIP = "Resume the most recent study session."
+SOURCE_GENERATION_DISABLED_TOOLTIP = (
+    "Open Study from selected Library sources in server mode to generate a study pack."
+)
 
 
 class StudyDashboard(Widget):
@@ -85,6 +88,17 @@ class StudyDashboard(Widget):
                 )
                 yield Button("Open flashcards", id="study-open-flashcards")
                 yield Button("Open quizzes", id="study-open-quizzes")
+                yield Button(
+                    "Generate source pack",
+                    id="study-generate-source-pack",
+                    disabled=True,
+                    tooltip=SOURCE_GENERATION_DISABLED_TOOLTIP,
+                )
+            yield Static(
+                "Source generation is unavailable until Study has selected source items.",
+                id="study-source-generation-status",
+                classes="study-dashboard-meta",
+            )
 
     def update_scope_summary(self, summary: str) -> None:
         if self.is_mounted:
@@ -116,3 +130,17 @@ class StudyDashboard(Widget):
             button.label = "Resume last session"
             button.disabled = True
             button.tooltip = RESUME_DISABLED_TOOLTIP
+
+    def update_source_generation_action(
+        self,
+        *,
+        enabled: bool,
+        status: str,
+        tooltip: str,
+    ) -> None:
+        if not self.is_mounted:
+            return
+        button = self.query_one("#study-generate-source-pack", Button)
+        button.disabled = not enabled
+        button.tooltip = tooltip
+        self.query_one("#study-source-generation-status", Static).update(status)


### PR DESCRIPTION
## Summary
- Add Phase 3.4 source-selected Study generation: Library note/media source items now carry into Study alongside material context.
- Add a Study Dashboard source-pack generation action that queues server study-pack jobs and keeps local mode disabled with a clear server requirement.
- Record TASK-10.4, tracker, and QA evidence for the new product-maturity gate.

## Test Plan
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_product_maturity_phase3_source_study_generation.py -q`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_product_maturity_phase3_source_study_generation.py Tests/UI/test_product_maturity_phase3_library_study_context.py Tests/UI/test_product_maturity_phase3_library_contract_layout.py Tests/UI/test_study_dashboard.py -q`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_study_screen.py Tests/UI/test_study_flashcards_screen.py Tests/UI/test_study_quizzes_screen.py -q`
- [x] `git diff --check`
