### PR TITLE
Add Console display state contracts

### DIFF
--- a/Tests/Chat/test_console_display_state.py
+++ b/Tests/Chat/test_console_display_state.py
@@ -26,6 +26,18 @@ def test_console_control_state_exposes_provider_model_and_context_labels():
     assert state.approvals_label == "Approvals: 1 pending"
 
 
+def test_console_control_state_preserves_falsy_labels_and_general_assistant_fallback():
+    state = ConsoleControlState.from_values(
+        provider=0,
+        model=False,
+        persona="",
+    )
+
+    assert state.provider_label == "Provider: 0"
+    assert state.model_label == "Model: False"
+    assert state.persona_label == "Assistant: General"
+
+
 def test_console_staged_context_state_preserves_live_work_payload_provenance():
     launch = ConsoleLiveWorkLaunch.from_values(
         source="Library Search/RAG",
@@ -59,3 +71,17 @@ def test_console_inspector_state_combines_readiness_artifact_and_recovery_rows()
     assert "Configure a provider before sending." in text
     assert "RAG: missing index" in text
     assert "Artifacts: save available after response" in text
+
+
+def test_console_inspector_state_uses_explicit_chatbook_save_capability():
+    state = ConsoleInspectorState.from_values(
+        artifact_status="Chatbook save available",
+        can_save_chatbook=True,
+    )
+
+    label_only_state = ConsoleInspectorState.from_values(
+        artifact_status="Chatbook save available",
+    )
+
+    assert state.can_save_chatbook is True
+    assert label_only_state.can_save_chatbook is False

--- a/Tests/Chat/test_console_display_state.py
+++ b/Tests/Chat/test_console_display_state.py
@@ -1,0 +1,61 @@
+from tldw_chatbook.Chat.console_display_state import (
+    ConsoleControlState,
+    ConsoleInspectorState,
+    ConsoleStagedContextState,
+)
+from tldw_chatbook.Chat.console_live_work import ConsoleLiveWorkLaunch
+
+
+def test_console_control_state_exposes_provider_model_and_context_labels():
+    state = ConsoleControlState.from_values(
+        provider="OpenAI",
+        model="gpt-5.5",
+        persona="Researcher",
+        rag_enabled=True,
+        staged_source_count=3,
+        tool_count=4,
+        approval_count=1,
+    )
+
+    assert state.provider_label == "Provider: OpenAI"
+    assert state.model_label == "Model: gpt-5.5"
+    assert state.persona_label == "Persona: Researcher"
+    assert state.rag_label == "RAG: on"
+    assert state.sources_label == "Sources: 3 staged"
+    assert state.tools_label == "Tools: 4 ready"
+    assert state.approvals_label == "Approvals: 1 pending"
+
+
+def test_console_staged_context_state_preserves_live_work_payload_provenance():
+    launch = ConsoleLiveWorkLaunch.from_values(
+        source="Library Search/RAG",
+        title="Transformer notes",
+        status="ready",
+        recovery="Review citations before sending.",
+        payload={"source_id": "note-1", "citation_count": 2},
+    )
+
+    state = ConsoleStagedContextState.from_live_work(launch)
+
+    assert state.heading == "Staged Context"
+    assert "Transformer notes" in state.summary
+    assert any(row.label == "source_id" and row.value == "note-1" for row in state.rows)
+    assert state.recovery == "Review citations before sending."
+
+
+def test_console_inspector_state_combines_readiness_artifact_and_recovery_rows():
+    state = ConsoleInspectorState.from_values(
+        live_work_title="Daily papers",
+        provider_ready=False,
+        provider_recovery="Configure a provider before sending.",
+        rag_status="missing index",
+        artifact_status="save available after response",
+        approval_count=0,
+    )
+
+    text = state.to_plain_text()
+    assert "Daily papers" in text
+    assert "Provider: blocked" in text
+    assert "Configure a provider before sending." in text
+    assert "RAG: missing index" in text
+    assert "Artifacts: save available after response" in text

--- a/Tests/UI/test_console_internals_decomposition.py
+++ b/Tests/UI/test_console_internals_decomposition.py
@@ -1,0 +1,54 @@
+import pytest
+from textual.widgets import Button
+
+from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+    ConsoleHarness,
+    _visible_text,
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(
+    reason="Gate 1.5 Task 2/3 will replace the full legacy ChatWindowEnhanced chrome.",
+    strict=True,
+)
+async def test_console_gate15_does_not_mount_full_legacy_chat_window_chrome():
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-shell")
+
+        assert console.query_one("#console-control-bar")
+        assert console.query_one("#console-session-surface")
+        assert console.query_one("#console-native-composer")
+
+        assert not console.query("#chat-enhanced-sidebar")
+        assert not console.query("#toggle-chat-left-sidebar")
+        assert not console.query("#chat-main-content")
+
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(
+    reason="Gate 1.5 Task 3 will expose a native Console composer.",
+    strict=True,
+)
+async def test_console_gate15_keeps_existing_chat_send_control_reachable():
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+
+        text = _visible_text(console)
+        assert "Send" in text
+        send_controls = [
+            button
+            for button in console.query(Button)
+            if (button.id or "").startswith("send-stop-chat")
+            or button.has_class("console-send-button")
+        ]
+        assert send_controls

--- a/Tests/UI/test_console_internals_decomposition.py
+++ b/Tests/UI/test_console_internals_decomposition.py
@@ -25,9 +25,9 @@ async def test_console_gate15_does_not_mount_full_legacy_chat_window_chrome():
         assert console.query_one("#console-session-surface")
         assert console.query_one("#console-native-composer")
 
-        assert not console.query("#chat-enhanced-sidebar")
-        assert not console.query("#toggle-chat-left-sidebar")
-        assert not console.query("#chat-main-content")
+        assert len(console.query("#chat-enhanced-sidebar")) == 0
+        assert len(console.query("#toggle-chat-left-sidebar")) == 0
+        assert len(console.query("#chat-main-content")) == 0
 
 
 @pytest.mark.asyncio

--- a/backlog/tasks/task-10.6 - Product-Maturity-Phase-3.6-Gate-1.5-Console-Internals-Decomposition.md
+++ b/backlog/tasks/task-10.6 - Product-Maturity-Phase-3.6-Gate-1.5-Console-Internals-Decomposition.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-10.6
 title: 'Product Maturity Phase 3.6: Gate 1.5 Console Internals Decomposition'
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-05-07 03:36'
+updated_date: '2026-05-07 04:25'
 labels:
   - product-maturity
   - phase-3-knowledge-study
@@ -45,3 +46,9 @@ Gate 1.5 is intentionally split into child tasks so the Console rewrite can proc
 
 Detailed step-by-step implementation instructions live in `Docs/superpowers/plans/2026-05-07-gate-1-5-console-internals-decomposition.md`.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Completed TASK-10.6.1. Console display-state contracts now exist as pure non-Textual dataclasses with focused tests, and strict xfailed mounted guardrails document the remaining embedded legacy ChatWindowEnhanced chrome for later Gate 1.5 slices.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-10.6.1 - Gate-1.5.1-Console-native-display-state-contracts.md
+++ b/backlog/tasks/task-10.6.1 - Gate-1.5.1-Console-native-display-state-contracts.md
@@ -44,5 +44,5 @@ Create pure Console display-state seams and mounted red regressions that define 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Added tldw_chatbook/Chat/console_display_state.py with pure ConsoleControlState ConsoleStagedContextState ConsoleInspectorState and ConsoleDisplayRow contracts. Added unit coverage for provider/model/persona/RAG/source/tool/approval/artifact/recovery labels. Added strict xfailed mounted Console internals guardrails that record the current legacy ChatWindowEnhanced chrome and missing native composer as intentional Gate 1.5 follow-up red states. Existing Gate 1 Console shell handoff and shell-bar baseline remains green.
+Added tldw_chatbook/Chat/console_display_state.py with pure ConsoleControlState ConsoleStagedContextState ConsoleInspectorState and ConsoleDisplayRow contracts. Added unit coverage for provider/model/persona/RAG/source/tool/approval/artifact/recovery labels, including falsy label preservation and explicit Chatbook-save capability state. Added strict xfailed mounted Console internals guardrails that record the current legacy ChatWindowEnhanced chrome and missing native composer as intentional Gate 1.5 follow-up red states. Existing Gate 1 Console shell handoff and shell-bar baseline remains green.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-10.6.1 - Gate-1.5.1-Console-native-display-state-contracts.md
+++ b/backlog/tasks/task-10.6.1 - Gate-1.5.1-Console-native-display-state-contracts.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-10.6.1
 title: 'Gate 1.5.1: Console native display-state contracts'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-05-07 03:37'
+updated_date: '2026-05-07 04:25'
 labels:
   - product-maturity
   - phase-3-knowledge-study
@@ -25,7 +26,23 @@ Create pure Console display-state seams and mounted red regressions that define 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Console display-state helpers expose provider model persona source RAG tool approval artifact and recovery labels without reading widget internals.
-- [ ] #2 Mounted regressions prove the current Console still exposes legacy embedded chrome that Gate 1.5 must remove or isolate.
-- [ ] #3 Existing Gate 1 Console shell tests remain runnable as compatibility guardrails.
+- [x] #1 Console display-state helpers expose provider model persona source RAG tool approval artifact and recovery labels without reading widget internals.
+- [x] #2 Mounted regressions prove the current Console still exposes legacy embedded chrome that Gate 1.5 must remove or isolate.
+- [x] #3 Existing Gate 1 Console shell tests remain runnable as compatibility guardrails.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Run the existing Console Gate 1 shell handoff and shell-bar baseline.
+2. Add failing pure Console display-state tests for provider/model context staged provenance and inspector recovery labels.
+3. Add strict xfailed mounted guardrails documenting the current embedded legacy Console chrome that later Gate 1.5 tasks must remove.
+4. Implement minimal pure dataclasses in tldw_chatbook/Chat/console_display_state.py with no Textual imports.
+5. Run focused display-state and Console shell verification plus diff hygiene.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added tldw_chatbook/Chat/console_display_state.py with pure ConsoleControlState ConsoleStagedContextState ConsoleInspectorState and ConsoleDisplayRow contracts. Added unit coverage for provider/model/persona/RAG/source/tool/approval/artifact/recovery labels. Added strict xfailed mounted Console internals guardrails that record the current legacy ChatWindowEnhanced chrome and missing native composer as intentional Gate 1.5 follow-up red states. Existing Gate 1 Console shell handoff and shell-bar baseline remains green.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_display_state.py
+++ b/tldw_chatbook/Chat/console_display_state.py
@@ -9,7 +9,9 @@ from tldw_chatbook.Chat.console_live_work import ConsoleLiveWorkLaunch
 
 
 def _clean(value: Any, fallback: str) -> str:
-    text = str(value or "").strip()
+    if value is None:
+        return fallback
+    text = str(value).strip()
     return text or fallback
 
 
@@ -52,10 +54,14 @@ class ConsoleControlState:
         tool_count: int = 0,
         approval_count: int = 0,
     ) -> "ConsoleControlState":
+        persona_text = _clean(persona, "")
+        persona_label = (
+            f"Persona: {persona_text}" if persona_text else "Assistant: General"
+        )
         return cls(
             provider_label=f"Provider: {_clean(provider, 'not selected')}",
             model_label=f"Model: {_clean(model, 'not selected')}",
-            persona_label=f"Persona: {_clean(persona, 'Default')}",
+            persona_label=persona_label,
             rag_label=f"RAG: {'on' if rag_enabled else 'off'}",
             sources_label=f"Sources: {staged_source_count} staged",
             tools_label=f"Tools: {tool_count} ready",
@@ -115,6 +121,7 @@ class ConsoleInspectorState:
         rag_status: Any = None,
         artifact_status: Any = None,
         approval_count: int = 0,
+        can_save_chatbook: bool = False,
     ) -> "ConsoleInspectorState":
         provider_status = "ready" if provider_ready else "blocked"
         rows = [
@@ -132,7 +139,7 @@ class ConsoleInspectorState:
         return cls(
             rows=tuple(rows),
             has_pending_approval=approval_count > 0,
-            can_save_chatbook=_clean(artifact_status, "").lower().startswith("chatbook save"),
+            can_save_chatbook=can_save_chatbook,
         )
 
     def to_plain_text(self) -> str:

--- a/tldw_chatbook/Chat/console_display_state.py
+++ b/tldw_chatbook/Chat/console_display_state.py
@@ -1,0 +1,139 @@
+"""Pure display-state contracts for the native Console workbench."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from tldw_chatbook.Chat.console_live_work import ConsoleLiveWorkLaunch
+
+
+def _clean(value: Any, fallback: str) -> str:
+    text = str(value or "").strip()
+    return text or fallback
+
+
+@dataclass(frozen=True)
+class ConsoleDisplayRow:
+    """One user-visible Console display row."""
+
+    label: str
+    value: Any
+    status: str = "ready"
+    recovery: str = ""
+
+    @property
+    def text(self) -> str:
+        suffix = f" - {self.recovery}" if self.recovery else ""
+        return f"{self.label}: {self.value}{suffix}"
+
+
+@dataclass(frozen=True)
+class ConsoleControlState:
+    """Header/control labels for the Console-native workbench chrome."""
+
+    provider_label: str
+    model_label: str
+    persona_label: str
+    rag_label: str
+    sources_label: str
+    tools_label: str
+    approvals_label: str
+
+    @classmethod
+    def from_values(
+        cls,
+        *,
+        provider: Any = None,
+        model: Any = None,
+        persona: Any = None,
+        rag_enabled: bool = False,
+        staged_source_count: int = 0,
+        tool_count: int = 0,
+        approval_count: int = 0,
+    ) -> "ConsoleControlState":
+        return cls(
+            provider_label=f"Provider: {_clean(provider, 'not selected')}",
+            model_label=f"Model: {_clean(model, 'not selected')}",
+            persona_label=f"Persona: {_clean(persona, 'Default')}",
+            rag_label=f"RAG: {'on' if rag_enabled else 'off'}",
+            sources_label=f"Sources: {staged_source_count} staged",
+            tools_label=f"Tools: {tool_count} ready",
+            approvals_label=f"Approvals: {approval_count} pending",
+        )
+
+
+@dataclass(frozen=True)
+class ConsoleStagedContextState:
+    """Display state for the Console staged-context tray."""
+
+    heading: str
+    summary: str
+    rows: tuple[ConsoleDisplayRow, ...] = ()
+    recovery: str = ""
+
+    @classmethod
+    def from_live_work(
+        cls,
+        launch: ConsoleLiveWorkLaunch,
+    ) -> "ConsoleStagedContextState":
+        rows = tuple(
+            ConsoleDisplayRow(label=key, value=value)
+            for key, value in launch.payload_display_items()
+        )
+        return cls(
+            heading="Staged Context",
+            summary=f"{launch.title} ({launch.source}, {launch.status})",
+            rows=rows,
+            recovery=launch.recovery,
+        )
+
+    @classmethod
+    def empty(cls) -> "ConsoleStagedContextState":
+        return cls(
+            heading="Staged Context",
+            summary="No live work item is staged.",
+            recovery="Attach sources from Library, W+C, Schedules, Artifacts, or RAG.",
+        )
+
+
+@dataclass(frozen=True)
+class ConsoleInspectorState:
+    """Display state for Console run/readiness inspection."""
+
+    rows: tuple[ConsoleDisplayRow, ...]
+    has_pending_approval: bool = False
+    can_save_chatbook: bool = False
+
+    @classmethod
+    def from_values(
+        cls,
+        *,
+        live_work_title: Any = None,
+        provider_ready: bool = True,
+        provider_recovery: Any = None,
+        rag_status: Any = None,
+        artifact_status: Any = None,
+        approval_count: int = 0,
+    ) -> "ConsoleInspectorState":
+        provider_status = "ready" if provider_ready else "blocked"
+        rows = [
+            ConsoleDisplayRow("Live work", _clean(live_work_title, "No active work")),
+            ConsoleDisplayRow(
+                "Provider",
+                provider_status,
+                status=provider_status,
+                recovery=_clean(provider_recovery, "") if not provider_ready else "",
+            ),
+            ConsoleDisplayRow("RAG", _clean(rag_status, "not staged")),
+            ConsoleDisplayRow("Artifacts", _clean(artifact_status, "unavailable")),
+            ConsoleDisplayRow("Approvals", f"{approval_count} pending"),
+        ]
+        return cls(
+            rows=tuple(rows),
+            has_pending_approval=approval_count > 0,
+            can_save_chatbook=_clean(artifact_status, "").lower().startswith("chatbook save"),
+        )
+
+    def to_plain_text(self) -> str:
+        return "\n".join(row.text for row in self.rows)


### PR DESCRIPTION
## Summary
- Adds pure Console display-state contracts for control labels, staged context provenance, and inspector recovery rows.
- Adds focused unit coverage for provider/model/persona/RAG/source/tool/approval/artifact labels.
- Adds strict xfailed mounted guardrails documenting the remaining embedded legacy Console chrome for later Gate 1.5 slices.
- Marks TASK-10.6.1 done and moves TASK-10.6 to In Progress.

## Verification
- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_product_maturity_gate1_core_loop_screen_adaptation.py::test_console_core_loop_exposes_agentic_shell_regions Tests/UI/test_chat_first_handoffs.py Tests/UI/test_chat_shell_bar.py --tb=short`
- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chat/test_console_display_state.py --tb=short`
- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chat/test_console_display_state.py Tests/UI/test_console_internals_decomposition.py Tests/UI/test_product_maturity_gate1_core_loop_screen_adaptation.py::test_console_core_loop_exposes_agentic_shell_regions Tests/UI/test_chat_first_handoffs.py Tests/UI/test_chat_shell_bar.py --tb=short`
- `git diff --check`