### PR TITLE
Move Console transcript and composer to native surface

### DIFF
--- a/Tests/UI/test_chat_screen_state.py
+++ b/Tests/UI/test_chat_screen_state.py
@@ -22,6 +22,33 @@ class EmptyChatLog:
         return []
 
 
+class QueryResult(list):
+    def first(self):
+        return self[0]
+
+
+class FakeChatLog:
+    children = []
+
+    def __init__(self, messages=()):
+        self.messages = list(messages)
+        self.mount = AsyncMock()
+        self.scroll_end = Mock()
+        self.display = False
+
+    def query(self, _selector):
+        return list(self.messages)
+
+
+class FakeMessageWidget:
+    def __init__(self, *, message_id, role, message_text):
+        self.message_id_internal = message_id
+        self.role = role
+        self.message_text = message_text
+        self.timestamp = None
+        self.image_data = None
+
+
 class TestChatSessionDataSerialization:
     def test_chat_session_data_round_trip_preserves_runtime_discovery_fields(self):
         session_data = ChatSessionData(
@@ -463,4 +490,73 @@ def test_extract_messages_clears_messages_when_direct_chat_log_lookup_succeeds()
     screen._extract_and_save_messages(tab_state)
 
     assert tab_state.messages == []
+    screen.chat_window.query.assert_not_called()
+
+
+def test_extract_messages_prefers_active_session_chat_log_over_first_matching_log():
+    app = Mock()
+    app.query_one = Mock(side_effect=LookupError("direct lookup unavailable"))
+    screen = ChatScreen(app)
+
+    inactive_log = FakeChatLog(
+        [FakeMessageWidget(message_id="inactive", role="user", message_text="wrong tab")]
+    )
+    active_log = FakeChatLog(
+        [FakeMessageWidget(message_id="active", role="user", message_text="active tab")]
+    )
+    screen.chat_window = Mock()
+    screen.chat_window.query = Mock(return_value=QueryResult([inactive_log, active_log]))
+
+    active_session = Mock()
+    active_session.get_chat_log.return_value = active_log
+    screen._get_active_chat_session = Mock(return_value=active_session)
+
+    tab_state = TabState(tab_id="active-tab", title="Active")
+
+    screen._extract_and_save_messages(tab_state)
+
+    assert [message.content for message in tab_state.messages] == ["active tab"]
+    screen.chat_window.query.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_restore_messages_prefers_active_session_chat_log_over_first_matching_log():
+    app = Mock()
+    app.query_one = Mock(side_effect=LookupError("direct lookup unavailable"))
+    screen = ChatScreen(app)
+    screen.chat_state = ChatScreenState(
+        tabs=[
+            TabState(
+                tab_id="active-tab",
+                title="Active",
+                is_active=True,
+                messages=[
+                    MessageData(
+                        message_id="msg-active",
+                        role="user",
+                        content="restore into active tab",
+                        timestamp=datetime(2026, 5, 7, 1, 0, 0),
+                    )
+                ],
+            )
+        ],
+        active_tab_id="active-tab",
+        tab_order=["active-tab"],
+    )
+
+    inactive_log = FakeChatLog()
+    active_log = FakeChatLog()
+    screen.chat_window = Mock()
+    screen.chat_window.hide_empty_state = Mock()
+    screen.chat_window.query = Mock(return_value=QueryResult([inactive_log, active_log]))
+
+    active_session = Mock()
+    active_session.get_chat_log.return_value = active_log
+    screen._get_active_chat_session = Mock(return_value=active_session)
+
+    await screen._restore_messages()
+
+    active_log.mount.assert_awaited_once()
+    inactive_log.mount.assert_not_awaited()
+    active_log.scroll_end.assert_called_once_with(animate=False)
     screen.chat_window.query.assert_not_called()

--- a/Tests/UI/test_chat_window_enhanced.py
+++ b/Tests/UI/test_chat_window_enhanced.py
@@ -460,7 +460,7 @@ class TestChatWindowShellBarMounting:
                 assert children.index(task_surface) < children.index(tab_container)
 
     @pytest.mark.asyncio
-    async def test_chat_screen_receives_live_active_session_message_in_mounted_tree(self):
+    async def test_chat_screen_receives_live_active_session_message_from_native_console_tabs(self):
         app = _ChatScreenShellSyncTestApp()
 
         with patch.object(ChatScreen, "_load_sidebar_state", lambda self: None), patch.object(
@@ -484,10 +484,8 @@ class TestChatWindowShellBarMounting:
                 await pilot.pause()
 
                 screen = pilot.app.screen
-                chat_window = screen.query_one(ChatWindowEnhanced)
-                tab_container = chat_window.query_one(ChatTabContainer)
-                shell_bar = chat_window.get_shell_bar()
-                shell_label = chat_window.query_one("#chat-shell-context", Static)
+                tab_container = screen.query_one("#console-chat-tabs", ChatTabContainer)
+                composer_status = screen.query_one("#console-composer-status", Static)
 
                 tab_container._publish_active_session_changed(
                     ChatSessionData(
@@ -502,17 +500,13 @@ class TestChatWindowShellBarMounting:
                 )
                 await pilot.pause()
 
-                rendered_label = str(shell_label.render())
+                rendered_label = str(composer_status.render())
 
-                assert shell_bar is not None
-                assert shell_bar.context.backend_label == "Server"
-                assert shell_bar.context.scope_label == "Workspace: workspace-42"
-                assert shell_bar.context.assistant_label == "Persona: study.coach"
-                assert shell_bar.context.session_label == "Session: Live Persona Session"
-                assert "Server" in rendered_label
-                assert "Workspace: workspace-42" in rendered_label
-                assert "Persona: study.coach" in rendered_label
-                assert "Session: Live Persona Session" in rendered_label
+                assert len(screen.query(ChatWindowEnhanced)) == 0
+                assert "Live Persona Session" in rendered_label
+                assert "server" in rendered_label
+                assert "workspace-42" in rendered_label
+                assert "study.coach" in rendered_label
 
 
 class TestChatScreenConversationParity:

--- a/Tests/UI/test_console_internals_decomposition.py
+++ b/Tests/UI/test_console_internals_decomposition.py
@@ -1,13 +1,15 @@
 import pytest
-from textual.widgets import Button, Input, Select
+from textual.widgets import Button, Input, Select, Static
 
 from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
 from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
     ConsoleHarness,
     _visible_text,
 )
+from tldw_chatbook.Chat.chat_models import ChatSessionData
 from tldw_chatbook.Chat.console_live_work import ConsoleLiveWorkLaunch
 from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+from tldw_chatbook.Widgets.Console import ConsoleComposerBar
 from tldw_chatbook.Widgets.compact_model_bar import CompactModelBar
 
 
@@ -53,6 +55,38 @@ async def test_console_gate15_keeps_existing_chat_send_control_reachable():
         assert console.query_one("#console-stop-generation", Button)
         assert console.query_one("#console-attach-context", Button)
         assert console.query_one("#console-save-chatbook", Button)
+
+
+@pytest.mark.asyncio
+async def test_console_composer_status_renders_session_metadata_as_plain_text():
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.sync_session_data(
+            ChatSessionData(
+                tab_id="metadata",
+                title="[red]Injected[/red]",
+                runtime_backend="[blue]server[/blue]",
+                assistant_id="[green]persona[/green]",
+                scope_type="workspace",
+                workspace_id="[yellow]workspace[/yellow]",
+            )
+        )
+        await pilot.pause()
+
+        status = console.query_one("#console-composer-status", Static)
+        rendered = status.render()
+        plain = getattr(rendered, "plain", str(rendered))
+
+        assert "[red]Injected[/red]" in plain
+        assert "[blue]server[/blue]" in plain
+        assert "[green]persona[/green]" in plain
+        assert "[yellow]workspace[/yellow]" in plain
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_internals_decomposition.py
+++ b/Tests/UI/test_console_internals_decomposition.py
@@ -12,10 +12,6 @@ from tldw_chatbook.Widgets.compact_model_bar import CompactModelBar
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(
-    reason="Gate 1.5 Task 2/3 will replace the full legacy ChatWindowEnhanced chrome.",
-    strict=True,
-)
 async def test_console_gate15_does_not_mount_full_legacy_chat_window_chrome():
     app = _build_test_app()
     host = ConsoleHarness(app)
@@ -34,10 +30,6 @@ async def test_console_gate15_does_not_mount_full_legacy_chat_window_chrome():
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(
-    reason="Gate 1.5 Task 3 will expose a native Console composer.",
-    strict=True,
-)
 async def test_console_gate15_keeps_existing_chat_send_control_reachable():
     app = _build_test_app()
     host = ConsoleHarness(app)
@@ -48,6 +40,9 @@ async def test_console_gate15_keeps_existing_chat_send_control_reachable():
 
         text = _visible_text(console)
         assert "Send" in text
+        assert "Stop" in text
+        assert "Attach" in text
+        assert "Save Chatbook" in text
         send_controls = [
             button
             for button in console.query(Button)
@@ -55,6 +50,9 @@ async def test_console_gate15_keeps_existing_chat_send_control_reachable():
             or button.has_class("console-send-button")
         ]
         assert send_controls
+        assert console.query_one("#console-stop-generation", Button)
+        assert console.query_one("#console-attach-context", Button)
+        assert console.query_one("#console-save-chatbook", Button)
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_product_maturity_gate1_core_loop_screen_adaptation.py
+++ b/Tests/UI/test_product_maturity_gate1_core_loop_screen_adaptation.py
@@ -186,7 +186,7 @@ async def test_console_core_loop_exposes_agentic_shell_regions():
 
     async with host.run_test(size=(140, 42)) as pilot:
         console = host.screen_stack[-1]
-        await _wait_for_selector(console, pilot, "#chat-window")
+        await _wait_for_selector(console, pilot, "#console-session-surface")
 
         for selector in (
             "#console-shell",
@@ -197,11 +197,13 @@ async def test_console_core_loop_exposes_agentic_shell_regions():
             "#console-staged-context-tray",
             "#console-transcript-region",
             "#console-run-inspector",
-            "#console-composer-region",
-            "#chat-window",
+            "#console-session-surface",
+            "#console-chat-tabs",
+            "#console-native-composer",
         ):
             assert console.query_one(selector)
 
+        assert len(console.query("#chat-window")) == 0
         text = _visible_text(console)
         assert "Console" in text
         assert "Live work" in text
@@ -210,19 +212,20 @@ async def test_console_core_loop_exposes_agentic_shell_regions():
 
 
 @pytest.mark.asyncio
-async def test_console_chat_window_instance_survives_screen_recompose():
+async def test_console_native_session_surface_survives_screen_recompose():
     app = _build_test_app()
     host = ConsoleHarness(app)
 
     async with host.run_test(size=(140, 42)) as pilot:
         console = host.screen_stack[-1]
-        await _wait_for_selector(console, pilot, "#chat-window")
-        chat_window = console.query_one("#chat-window")
+        await _wait_for_selector(console, pilot, "#console-session-surface")
+        session_surface = console.query_one("#console-session-surface")
 
         console.refresh(recompose=True)
-        await _wait_for_selector(console, pilot, "#chat-window")
+        await _wait_for_selector(console, pilot, "#console-session-surface")
 
-        assert console.query_one("#chat-window") is chat_window
+        assert console.query_one("#console-session-surface") is session_surface
+        assert len(console.query("#chat-window")) == 0
 
 
 @pytest.mark.asyncio

--- a/backlog/tasks/task-10.6 - Product-Maturity-Phase-3.6-Gate-1.5-Console-Internals-Decomposition.md
+++ b/backlog/tasks/task-10.6 - Product-Maturity-Phase-3.6-Gate-1.5-Console-Internals-Decomposition.md
@@ -53,4 +53,6 @@ Detailed step-by-step implementation instructions live in `Docs/superpowers/plan
 Completed TASK-10.6.1. Console display-state contracts now exist as pure non-Textual dataclasses with focused tests, and strict xfailed mounted guardrails document the remaining embedded legacy ChatWindowEnhanced chrome for later Gate 1.5 slices.
 
 Completed TASK-10.6.2. Console now owns visible provider/model/persona/RAG/source controls and staged-context rendering outside the transcript region while preserving the legacy chat surface for compatibility until the transcript/composer replacement slices.
+
+Completed TASK-10.6.3. Console now mounts a native transcript/session surface and native composer action row instead of embedding the full `ChatWindowEnhanced` chrome; chat tabs, handoff draft text, state restoration seams, and direct `ChatWindowEnhanced` compatibility tests remain covered by focused regressions.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-10.6.3 - Gate-1.5.3-Console-native-transcript-and-composer-surface.md
+++ b/backlog/tasks/task-10.6.3 - Gate-1.5.3-Console-native-transcript-and-composer-surface.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-10.6.3
 title: 'Gate 1.5.3: Console native transcript and composer surface'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-05-07 03:37'
 labels:
@@ -26,7 +26,22 @@ Replace the embedded ChatWindowEnhanced main surface with Console-owned transcri
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Console transcript/event stream is a native region and no longer contains the full legacy ChatWindowEnhanced container.
-- [ ] #2 Console composer is a native action row with send stop attach and save-Chatbook affordances wired through existing chat handlers or documented compatibility adapters.
-- [ ] #3 Basic chat tabs session state handoff draft text and streaming fallback regressions continue to pass.
+- [x] #1 Console transcript/event stream is a native region and no longer contains the full legacy ChatWindowEnhanced container.
+- [x] #2 Console composer is a native action row with send stop attach and save-Chatbook affordances wired through existing chat handlers or documented compatibility adapters.
+- [x] #3 Basic chat tabs session state handoff draft text and streaming fallback regressions continue to pass.
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Convert the existing Gate 1.5.3 xfail coverage into deterministic failing regressions for a Console-native transcript/session surface and composer.
+2. Add Console-owned session and composer widgets that reuse the existing tab/session chat handlers instead of duplicating chat behavior.
+3. Update `ChatScreen` to mount the native surface, query it through compatibility seams, and keep state/handoff restoration working without a mounted full `ChatWindowEnhanced`.
+4. Run focused Console/chat regressions, fix only migration-caused failures, and record QA evidence in the task notes.
+
+## Implementation Notes
+
+Moved the Console transcript from the full embedded `ChatWindowEnhanced` container to a cached `ConsoleSessionSurface` that hosts `ChatTabContainer` and task cards directly. Added `ConsoleComposerBar` with native send, stop, attach, and Save Chatbook compatibility affordances; send/stop/attach route through active chat-session handlers and Save Chatbook reports the current Artifacts/Chatbooks ownership seam.
+
+Updated `ChatScreen` state/handoff compatibility seams so native Console tabs are discoverable through `_get_tab_container()`, active-session changes remain visible in composer status, and save/restore paths no longer require a mounted legacy chat window. Updated mounted regressions and the Gate 1 core-loop contract to assert native Console selectors and absence of `#chat-window`.
+
+Verification: baseline red was observed by removing the Gate 1.5.3 xfails; final focused runs passed with `83 passed` for Console/chat state coverage, `70 passed` for Gate 1.5 verification, and `git diff --check` passed.

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -10,12 +10,12 @@ import toml
 from pathlib import Path
 
 from textual.app import ComposeResult
-from textual.containers import Container, Horizontal, Vertical
+from textual.containers import Container, Horizontal, Vertical, VerticalScroll
 from textual.widgets import Button, Static, TextArea, Select, Collapsible, Input
 from textual.events import Key
 from textual import on
 from textual.reactive import reactive
-from textual.css.query import QueryError
+from textual.css.query import NoMatches, QueryError
 
 from ..Navigation.base_app_screen import BaseAppScreen
 from .chat_screen_state import ChatScreenState, TabState, MessageData, TaskResumeState
@@ -532,15 +532,15 @@ class ChatScreen(BaseAppScreen):
         """Get the ChatTabContainer widget."""
         try:
             return self.query_one("#console-chat-tabs", ChatTabContainer)
-        except Exception:
+        except NoMatches:
             pass
 
         try:
-            if self.chat_window and hasattr(self.chat_window, '_tab_container'):
-                return self.chat_window._tab_container
-            if self.chat_window:
+            if isinstance(self.chat_window, ChatWindowEnhanced):
+                if self.chat_window._tab_container is not None:
+                    return self.chat_window._tab_container
                 return self.chat_window.query_one("ChatTabContainer")
-        except Exception:
+        except NoMatches:
             return None
         return None
 
@@ -561,6 +561,76 @@ class ChatScreen(BaseAppScreen):
     def _chat_query_scope(self):
         """Prefer the legacy chat window when present, else the native Console tree."""
         return self.chat_window or self
+
+    def _get_active_chat_input(self) -> Optional[TextArea]:
+        """Return the active session input before falling back to legacy single-chat input."""
+        session = self._get_active_chat_session()
+        if session is not None:
+            get_chat_input = getattr(session, "get_chat_input", None)
+            if callable(get_chat_input):
+                try:
+                    chat_input = get_chat_input()
+                    if chat_input is not None:
+                        return chat_input
+                except QueryError:
+                    logger.debug("Active session chat input was not mounted")
+
+        try:
+            return self._chat_query_scope().query_one("#chat-input", TextArea)
+        except QueryError:
+            return None
+
+    def _get_active_chat_log(self):
+        """Return the active session chat log before falling back to legacy chat logs."""
+        session = self._get_active_chat_session()
+        if session is not None:
+            get_chat_log = getattr(session, "get_chat_log", None)
+            if callable(get_chat_log):
+                try:
+                    chat_log = get_chat_log()
+                    if chat_log is not None:
+                        return chat_log
+                except QueryError:
+                    logger.debug("Active session chat log was not mounted")
+
+            session_data = getattr(session, "session_data", None)
+            tab_id = getattr(session_data, "tab_id", None)
+            if tab_id:
+                try:
+                    return session.query_one(f"#chat-log-{tab_id}", VerticalScroll)
+                except QueryError:
+                    logger.debug(f"Active session chat log for tab {tab_id} was not mounted")
+
+        return None
+
+    @staticmethod
+    def _first_query_result(containers: Any) -> Any:
+        if hasattr(containers, "first"):
+            return containers.first()
+        return containers[0]
+
+    def _find_chat_log_container(self, selectors: list[str]):
+        """Find the correct chat log, preferring the active tab over DOM order."""
+        active_log = self._get_active_chat_log()
+        if active_log is not None:
+            return active_log
+
+        try:
+            return self.app_instance.query_one("#chat-log", VerticalScroll)
+        except (LookupError, QueryError):
+            pass
+
+        for selector in selectors:
+            try:
+                containers = self._chat_query_scope().query(selector)
+            except QueryError as e:
+                logger.debug(f"Could not find chat log with {selector}: {e}")
+                continue
+            if containers:
+                logger.debug(f"Found chat log container with selector: {selector}")
+                return self._first_query_result(containers)
+
+        return None
 
     def _session_data_for_handoff(self, payload: ChatHandoffPayload) -> ChatSessionData:
         title_item_type = payload.item_type.replace("-", " ").title()
@@ -995,11 +1065,7 @@ class ChatScreen(BaseAppScreen):
             if tab_container and tab_container.active_session_id:
                 active_tab = self.chat_state.get_tab_by_id(tab_container.active_session_id)
                 if active_tab:
-                    session = self._get_active_chat_session()
-                    if session is not None and hasattr(session, "get_chat_input"):
-                        input_widget = session.get_chat_input()
-                    else:
-                        input_widget = self._chat_query_scope().query_one("#chat-input", TextArea)
+                    input_widget = self._get_active_chat_input()
                     if input_widget:
                         active_tab.input_text = input_widget.text
                         logger.debug(f"Saved input text for tab {tab_container.active_session_id}: '{input_widget.text[:50]}...'")
@@ -1019,18 +1085,8 @@ class ChatScreen(BaseAppScreen):
             active_tab = self.chat_state.get_active_tab()
             if active_tab and active_tab.input_text:
                 logger.info(f"Restoring input text: '{active_tab.input_text[:50]}...'")
-                
-                # Try to find the input widget
-                try:
-                    session = self._get_active_chat_session()
-                    if session is not None and hasattr(session, "get_chat_input"):
-                        input_widget = session.get_chat_input()
-                    else:
-                        input_widget = self._chat_query_scope().query_one("#chat-input", TextArea)
-                except Exception:
-                    # Try alternate query
-                    input_widget = self._chat_query_scope().query_one("#chat-input")
-                
+                input_widget = self._get_active_chat_input()
+
                 if input_widget and hasattr(input_widget, 'load_text'):
                     input_widget.load_text(active_tab.input_text)
                     logger.info(f"Successfully restored input text to widget")
@@ -1278,35 +1334,12 @@ class ChatScreen(BaseAppScreen):
                 return
                 
             logger.info(f"Restoring {len(active_tab.messages)} messages to chat log")
-            
-            # Import required classes
-            from textual.containers import VerticalScroll
-            
-            # Find the chat log container (it's a VerticalScroll)
-            chat_log = None
+
             log_selectors = [
                 "#chat-log",
                 ".chat-log",
             ]
-            
-            # Try the direct approach first
-            try:
-                chat_log = self.app_instance.query_one("#chat-log", VerticalScroll)
-                logger.debug("Found chat log for restoration via app_instance")
-            except Exception:
-                pass
-            
-            # If not found, try other approaches
-            if not chat_log:
-                for selector in log_selectors:
-                    try:
-                        containers = self._chat_query_scope().query(selector)
-                        if containers:
-                            chat_log = containers.first()
-                            logger.debug(f"Found chat log container for restoration: {selector}")
-                            break
-                    except Exception as e:
-                        logger.debug(f"Could not find chat log with {selector}: {e}")
+            chat_log = self._find_chat_log_container(log_selectors)
             
             if not chat_log:
                 logger.warning("Could not find chat log container to restore messages")
@@ -1414,19 +1447,9 @@ class ChatScreen(BaseAppScreen):
         """Try to save input text directly from the chat input TextArea only."""
         try:
             # Be specific - only look for the chat input TextArea, not system prompt or other TextAreas
-            chat_input = None
-            
-            # Try to find the specific chat input by ID first
-            try:
-                session = self._get_active_chat_session()
-                if session is not None and hasattr(session, "get_chat_input"):
-                    chat_input = session.get_chat_input()
-                else:
-                    chat_input = self._chat_query_scope().query_one("#chat-input", TextArea)
+            chat_input = self._get_active_chat_input()
+            if chat_input:
                 logger.debug("Found chat input by #chat-input ID")
-            except Exception:
-                # If not found by ID, try other selectors but be careful
-                pass
             
             if not chat_input:
                 # Look for TextAreas but filter out system prompt and other non-chat inputs
@@ -1482,35 +1505,14 @@ class ChatScreen(BaseAppScreen):
         try:
             # Import message widget classes
             from ...Widgets.Chat_Widgets.chat_message_enhanced import ChatMessageEnhanced
-            from textual.containers import VerticalScroll
-            
-            # Try to find the chat log container (it's a VerticalScroll)
-            chat_log = None
+
             log_selectors = [
                 "#chat-log",
                 ".chat-log",
                 "#chat-messages-container",
                 ".chat-messages"
             ]
-            
-            # First try the direct approach used in Chat_Window_Enhanced
-            try:
-                chat_log = self.app_instance.query_one("#chat-log", VerticalScroll)
-                logger.debug("Found chat log via app_instance.query_one")
-            except Exception:
-                pass
-            
-            # If not found, try other selectors
-            if not chat_log:
-                for selector in log_selectors:
-                    try:
-                        containers = self._chat_query_scope().query(selector)
-                        if containers:
-                            chat_log = containers.first()
-                            logger.debug(f"Found chat log container with selector: {selector}")
-                            break
-                    except Exception as e:
-                        logger.debug(f"Could not find chat log with {selector}: {e}")
+            chat_log = self._find_chat_log_container(log_selectors)
             
             if not chat_log:
                 logger.warning("Could not find chat log container to save messages")

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -31,7 +31,13 @@ from ...Chat.console_live_work import (
 from ...Utils.chat_diagnostics import ChatDiagnostics
 from ...state.ui_state import UIState
 from ...Widgets.Chat_Widgets.chat_tab_container import ChatTabContainer
-from ...Widgets.Console import ConsoleControlBar, ConsoleStagedContextTray
+from ...Widgets.Chat_Widgets.chat_task_cards import ChatTaskCards
+from ...Widgets.Console import (
+    ConsoleComposerBar,
+    ConsoleControlBar,
+    ConsoleSessionSurface,
+    ConsoleStagedContextTray,
+)
 from ...Widgets.compact_model_bar import CompactModelBar
 
 # Import the existing chat window to reuse its functionality
@@ -143,6 +149,20 @@ class ChatScreen(BaseAppScreen):
     def on_chat_temperature_changed(self, event: Input.Changed) -> None:
         """Mirror sidebar temperature changes into the compact shell controls."""
         self._sync_compact_shell_controls(temperature=event.value)
+
+    @on(Select.Changed, "#compact-api-provider")
+    def on_console_compact_provider_changed(self, event: Select.Changed) -> None:
+        """Mirror native compact provider changes into Console-owned labels."""
+        if not _is_empty_select_value(event.value):
+            self._console_control_provider = str(event.value)
+        self._sync_console_control_bar()
+
+    @on(Select.Changed, "#compact-api-model")
+    def on_console_compact_model_changed(self, event: Select.Changed) -> None:
+        """Mirror native compact model changes into Console-owned labels."""
+        if not _is_empty_select_value(event.value):
+            self._console_control_model = str(event.value)
+        self._sync_console_control_bar()
     
     
     # Reactive property for sidebar state persistence
@@ -151,6 +171,7 @@ class ChatScreen(BaseAppScreen):
     def __init__(self, app_instance: 'TldwCli', **kwargs):
         super().__init__(app_instance, "chat", **kwargs)
         self.chat_window: Optional[ChatWindowEnhanced] = None
+        self.console_session_surface: Optional[ConsoleSessionSurface] = None
         self.chat_state = ChatScreenState()
         self._state_dirty = False
         self._diagnostics_run = False
@@ -170,6 +191,15 @@ class ChatScreen(BaseAppScreen):
                 classes="window",
             )
         return self.chat_window
+
+    def _ensure_console_session_surface(self) -> ConsoleSessionSurface:
+        if self.console_session_surface is None:
+            self.console_session_surface = ConsoleSessionSurface(
+                self.app_instance,
+                id="console-session-surface",
+                classes="console-region",
+            )
+        return self.console_session_surface
 
     def _consume_pending_console_launch(self) -> Optional[ConsoleLiveWorkLaunch]:
         """Accept one-shot live-work launch context from another destination."""
@@ -324,22 +354,8 @@ class ChatScreen(BaseAppScreen):
                         else:
                             yield from self._render_console_live_work_source_readiness()
                 with Vertical(id="console-transcript-region", classes="console-region"):
-                    yield Static(
-                        "Transcript",
-                        id="console-transcript-title",
-                        classes="destination-section",
-                    )
-                    yield self._ensure_chat_window()
-                with Vertical(id="console-composer-region", classes="console-region"):
-                    yield Static(
-                        "Composer",
-                        id="console-composer-title",
-                        classes="destination-section",
-                    )
-                    yield Static(
-                        "Gate 1 keeps the existing chat composer in the transcript surface.",
-                        id="console-composer-summary",
-                    )
+                    yield self._ensure_console_session_surface()
+                yield ConsoleComposerBar(id="console-native-composer", classes="console-region ds-panel")
     
     def on_mount(self) -> None:
         """Run diagnostics when first mounted (only once)."""
@@ -348,7 +364,7 @@ class ChatScreen(BaseAppScreen):
         
         if not self._diagnostics_run and self.chat_window:
             self._diagnostics_run = True
-            # Run diagnostic in the background
+            # Run diagnostic in the background for the legacy direct widget only.
             self.set_timer(0.5, self._run_diagnostic)
         
         # Restore collapsible states after mount
@@ -370,54 +386,53 @@ class ChatScreen(BaseAppScreen):
             # Create fresh state object
             self.chat_state = ChatScreenState()
             self.chat_state.last_saved = datetime.now()
+
+            # Save UI preferences even when Console no longer mounts the legacy chat window.
+            self.chat_state.left_sidebar_collapsed = getattr(
+                self.app_instance, 'chat_sidebar_collapsed', False
+            )
+            self.chat_state.right_sidebar_collapsed = getattr(
+                self.app_instance, 'chat_right_sidebar_collapsed', False
+            )
+
+            # Try to detect and save from different chat interface types.
+            tab_container = self._get_tab_container()
             
-            if self.chat_window:
-                # Save UI preferences
-                self.chat_state.left_sidebar_collapsed = getattr(
-                    self.app_instance, 'chat_sidebar_collapsed', False
-                )
-                self.chat_state.right_sidebar_collapsed = getattr(
-                    self.app_instance, 'chat_right_sidebar_collapsed', False
-                )
-                
-                # Try to detect and save from different chat interface types
-                tab_container = self._get_tab_container()
-                
-                if tab_container and hasattr(tab_container, 'sessions'):
-                    # Tabbed interface detected
-                    logger.debug(f"Detected tabbed interface with {len(tab_container.sessions)} tabs")
-                    
-                    # Save all tab sessions
-                    self._save_tab_sessions(tab_container)
-                    
-                    # Save active tab
-                    self.chat_state.active_tab_id = tab_container.active_session_id
-                    
-                    # Save tab order
-                    if hasattr(tab_container, 'tab_bar') and tab_container.tab_bar:
-                        self.chat_state.tab_order = tab_container.tab_bar.get_tab_ids()
-                    
-                    # Also save messages for the active session
-                    if tab_container.active_session_id:
-                        active_tab = self.chat_state.get_tab_by_id(tab_container.active_session_id)
-                        if active_tab:
-                            self._extract_and_save_messages(active_tab)
-                else:
-                    # Non-tabbed interface - try to save single chat state
-                    logger.debug("Detected non-tabbed chat interface")
-                    self._save_non_tabbed_state()
-                
-                # Always try to save current input text directly
-                self._save_direct_input_text()
-                
-                # Save sidebar settings (system prompt, temperature, etc.)
-                self._save_sidebar_settings()
-                
-                # Save scroll positions
-                self._save_scroll_positions()
-                
-                # Save pending attachments
-                self._save_attachments()
+            if tab_container and hasattr(tab_container, 'sessions'):
+                # Tabbed interface detected
+                logger.debug(f"Detected tabbed interface with {len(tab_container.sessions)} tabs")
+
+                # Save all tab sessions
+                self._save_tab_sessions(tab_container)
+
+                # Save active tab
+                self.chat_state.active_tab_id = tab_container.active_session_id
+
+                # Save tab order
+                if hasattr(tab_container, 'tab_bar') and tab_container.tab_bar:
+                    self.chat_state.tab_order = tab_container.tab_bar.get_tab_ids()
+
+                # Also save messages for the active session
+                if tab_container.active_session_id:
+                    active_tab = self.chat_state.get_tab_by_id(tab_container.active_session_id)
+                    if active_tab:
+                        self._extract_and_save_messages(active_tab)
+            elif self.chat_window:
+                # Non-tabbed legacy direct widget - try to save single chat state
+                logger.debug("Detected non-tabbed chat interface")
+                self._save_non_tabbed_state()
+
+            # Always try to save current input text directly
+            self._save_direct_input_text()
+
+            # Save sidebar settings (system prompt, temperature, etc.) when available.
+            self._save_sidebar_settings()
+
+            # Save scroll positions
+            self._save_scroll_positions()
+
+            # Save pending attachments
+            self._save_attachments()
             
             # Convert to dict for storage
             state['chat_state'] = self.chat_state.to_dict()
@@ -464,8 +479,8 @@ class ChatScreen(BaseAppScreen):
     
     async def _perform_state_restoration(self) -> None:
         """Perform actual state restoration after UI is ready."""
-        if not self.chat_window:
-            logger.warning("Chat window not ready for restoration")
+        if not self.chat_window and not self._get_tab_container():
+            logger.warning("Console chat surface not ready for restoration")
             # Try again in a moment
             self.set_timer(0.2, self._perform_state_restoration)
             return
@@ -516,11 +531,36 @@ class ChatScreen(BaseAppScreen):
     def _get_tab_container(self):
         """Get the ChatTabContainer widget."""
         try:
+            return self.query_one("#console-chat-tabs", ChatTabContainer)
+        except Exception:
+            pass
+
+        try:
             if self.chat_window and hasattr(self.chat_window, '_tab_container'):
                 return self.chat_window._tab_container
-            return self.chat_window.query_one("ChatTabContainer")
-        except:
+            if self.chat_window:
+                return self.chat_window.query_one("ChatTabContainer")
+        except Exception:
             return None
+        return None
+
+    def _get_active_chat_session(self):
+        """Return the active native/legacy chat session widget when available."""
+        tab_container = self._get_tab_container()
+        if not tab_container:
+            return None
+        get_active_session = getattr(tab_container, "get_active_session", None)
+        if callable(get_active_session):
+            return get_active_session()
+        active_session_id = getattr(tab_container, "active_session_id", None)
+        sessions = getattr(tab_container, "sessions", {})
+        if active_session_id and active_session_id in sessions:
+            return sessions[active_session_id]
+        return None
+
+    def _chat_query_scope(self):
+        """Prefer the legacy chat window when present, else the native Console tree."""
+        return self.chat_window or self
 
     def _session_data_for_handoff(self, payload: ChatHandoffPayload) -> ChatSessionData:
         title_item_type = payload.item_type.replace("-", " ").title()
@@ -587,6 +627,66 @@ class ChatScreen(BaseAppScreen):
         set_draft_text = getattr(session, "set_draft_text", None)
         if callable(set_draft_text):
             set_draft_text(payload.default_prompt())
+
+    @on(Button.Pressed, "#console-send-message")
+    async def handle_console_send_message(self, event: Button.Pressed) -> None:
+        """Route the Console composer send action through the active chat session."""
+        event.stop()
+        session = self._get_active_chat_session()
+        if session is None:
+            self.app_instance.notify("No active Console chat session is available.", severity="error")
+            return
+        handler = getattr(session, "handle_send_stop_button", None)
+        if not callable(handler):
+            self.app_instance.notify("Console send is unavailable for this session.", severity="error")
+            return
+        result = handler(event)
+        if inspect.isawaitable(result):
+            await result
+
+    @on(Button.Pressed, "#console-stop-generation")
+    async def handle_console_stop_generation(self, event: Button.Pressed) -> None:
+        """Route the Console stop action through tab-aware chat stop handling."""
+        event.stop()
+        session = self._get_active_chat_session()
+        if session is None:
+            self.app_instance.notify("No active Console chat session is available.", severity="error")
+            return
+        from tldw_chatbook.Event_Handlers.Chat_Events import chat_events_tabs
+
+        await chat_events_tabs.handle_stop_chat_generation_pressed_with_tabs(
+            self.app_instance,
+            event,
+            session.session_data,
+        )
+        update_button = getattr(session, "_update_button_state", None)
+        if callable(update_button):
+            update_button()
+
+    @on(Button.Pressed, "#console-attach-context")
+    async def handle_console_attach_context(self, event: Button.Pressed) -> None:
+        """Route the Console attach affordance through the active chat session adapter."""
+        event.stop()
+        session = self._get_active_chat_session()
+        if session is None:
+            self.app_instance.notify("No active Console chat session is available.", severity="error")
+            return
+        handler = getattr(session, "handle_attach_button", None)
+        if not callable(handler):
+            self.app_instance.notify("Console attachment is unavailable for this session.", severity="warning")
+            return
+        result = handler(event)
+        if inspect.isawaitable(result):
+            await result
+
+    @on(Button.Pressed, "#console-save-chatbook")
+    def handle_console_save_chatbook(self, event: Button.Pressed) -> None:
+        """Expose the current Chatbook save seam without inventing export behavior."""
+        event.stop()
+        self.app_instance.notify(
+            "Save Chatbook is still owned by Artifacts/Chatbooks; this Console button is a compatibility adapter.",
+            severity="information",
+        )
 
     def _get_shell_bar(self):
         """Get the mounted combined chat shell bar."""
@@ -721,6 +821,11 @@ class ChatScreen(BaseAppScreen):
         """Push the live active session contract into the mounted shell bar."""
         shell_bar = self._get_shell_bar()
         if not shell_bar:
+            try:
+                composer = self.query_one("#console-native-composer", ConsoleComposerBar)
+                composer.sync_session_data(session_data)
+            except QueryError:
+                pass
             logger.debug("No shell bar available for live session sync")
             return
 
@@ -890,7 +995,11 @@ class ChatScreen(BaseAppScreen):
             if tab_container and tab_container.active_session_id:
                 active_tab = self.chat_state.get_tab_by_id(tab_container.active_session_id)
                 if active_tab:
-                    input_widget = self.chat_window.query_one("#chat-input", TextArea)
+                    session = self._get_active_chat_session()
+                    if session is not None and hasattr(session, "get_chat_input"):
+                        input_widget = session.get_chat_input()
+                    else:
+                        input_widget = self._chat_query_scope().query_one("#chat-input", TextArea)
                     if input_widget:
                         active_tab.input_text = input_widget.text
                         logger.debug(f"Saved input text for tab {tab_container.active_session_id}: '{input_widget.text[:50]}...'")
@@ -913,10 +1022,14 @@ class ChatScreen(BaseAppScreen):
                 
                 # Try to find the input widget
                 try:
-                    input_widget = self.chat_window.query_one("#chat-input", TextArea)
+                    session = self._get_active_chat_session()
+                    if session is not None and hasattr(session, "get_chat_input"):
+                        input_widget = session.get_chat_input()
+                    else:
+                        input_widget = self._chat_query_scope().query_one("#chat-input", TextArea)
                 except Exception:
                     # Try alternate query
-                    input_widget = self.chat_window.query_one("#chat-input")
+                    input_widget = self._chat_query_scope().query_one("#chat-input")
                 
                 if input_widget and hasattr(input_widget, 'load_text'):
                     input_widget.load_text(active_tab.input_text)
@@ -952,6 +1065,10 @@ class ChatScreen(BaseAppScreen):
     def _save_sidebar_settings(self) -> None:
         """Save sidebar settings including system prompt, temperature, etc."""
         try:
+            if not self.chat_window:
+                logger.debug("Legacy chat sidebar is not mounted; sidebar settings already live in Console controls")
+                return
+
             active_tab = self.chat_state.get_active_tab()
             if not active_tab:
                 # Create default tab if none exists
@@ -1047,6 +1164,10 @@ class ChatScreen(BaseAppScreen):
     async def _restore_sidebar_settings(self) -> None:
         """Restore sidebar settings including system prompt, temperature, etc."""
         try:
+            if not self.chat_window:
+                logger.debug("Legacy chat sidebar is not mounted; skipping sidebar restore")
+                return
+
             active_tab = self.chat_state.get_active_tab()
             if not active_tab:
                 logger.debug("No active tab to restore sidebar settings from")
@@ -1179,7 +1300,7 @@ class ChatScreen(BaseAppScreen):
             if not chat_log:
                 for selector in log_selectors:
                     try:
-                        containers = self.chat_window.query(selector)
+                        containers = self._chat_query_scope().query(selector)
                         if containers:
                             chat_log = containers.first()
                             logger.debug(f"Found chat log container for restoration: {selector}")
@@ -1297,7 +1418,11 @@ class ChatScreen(BaseAppScreen):
             
             # Try to find the specific chat input by ID first
             try:
-                chat_input = self.chat_window.query_one("#chat-input", TextArea)
+                session = self._get_active_chat_session()
+                if session is not None and hasattr(session, "get_chat_input"):
+                    chat_input = session.get_chat_input()
+                else:
+                    chat_input = self._chat_query_scope().query_one("#chat-input", TextArea)
                 logger.debug("Found chat input by #chat-input ID")
             except Exception:
                 # If not found by ID, try other selectors but be careful
@@ -1305,7 +1430,7 @@ class ChatScreen(BaseAppScreen):
             
             if not chat_input:
                 # Look for TextAreas but filter out system prompt and other non-chat inputs
-                text_areas = self.chat_window.query("TextArea")
+                text_areas = self._chat_query_scope().query("TextArea")
                 logger.debug(f"Found {len(text_areas)} TextArea widgets total")
                 
                 for text_area in text_areas:
@@ -1379,7 +1504,7 @@ class ChatScreen(BaseAppScreen):
             if not chat_log:
                 for selector in log_selectors:
                     try:
-                        containers = self.chat_window.query(selector)
+                        containers = self._chat_query_scope().query(selector)
                         if containers:
                             chat_log = containers.first()
                             logger.debug(f"Found chat log container with selector: {selector}")
@@ -1460,6 +1585,13 @@ class ChatScreen(BaseAppScreen):
 
     def sync_task_resume_state(self) -> None:
         """Push the current task resume state into the chat window when available."""
+        try:
+            task_cards = self.query_one("#console-task-surface", ChatTaskCards)
+            task_cards.sync_state(self.chat_state.task_resume_state)
+            return
+        except QueryError:
+            pass
+
         if self.chat_window:
             self.chat_window.sync_task_resume_state(self.chat_state.task_resume_state)
     

--- a/tldw_chatbook/Widgets/Console/__init__.py
+++ b/tldw_chatbook/Widgets/Console/__init__.py
@@ -1,9 +1,13 @@
 """Console-native widgets."""
 
 from .console_control_bar import ConsoleControlBar
+from .console_composer_bar import ConsoleComposerBar
+from .console_session_surface import ConsoleSessionSurface
 from .console_staged_context import ConsoleStagedContextTray
 
 __all__ = [
+    "ConsoleComposerBar",
     "ConsoleControlBar",
+    "ConsoleSessionSurface",
     "ConsoleStagedContextTray",
 ]

--- a/tldw_chatbook/Widgets/Console/console_composer_bar.py
+++ b/tldw_chatbook/Widgets/Console/console_composer_bar.py
@@ -44,6 +44,7 @@ class ConsoleComposerBar(Horizontal):
             self.DEFAULT_STATUS,
             id="console-composer-status",
             classes="console-composer-status",
+            markup=False,
         )
         yield Button(
             "Send",

--- a/tldw_chatbook/Widgets/Console/console_composer_bar.py
+++ b/tldw_chatbook/Widgets/Console/console_composer_bar.py
@@ -1,0 +1,72 @@
+"""Console-native composer action row."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from textual.app import ComposeResult
+from textual.containers import Horizontal
+from textual.css.query import NoMatches
+from textual.widgets import Button, Static
+
+
+class ConsoleComposerBar(Horizontal):
+    """Expose Console-owned composer actions while reusing active chat sessions."""
+
+    DEFAULT_STATUS = "Use the active session input below. Actions route through the active chat session."
+
+    def sync_session_data(self, session_data: Any | None) -> None:
+        """Refresh composer status copy from the active chat session contract."""
+        if session_data is None:
+            status = self.DEFAULT_STATUS
+        else:
+            title = getattr(session_data, "title", None) or "Untitled session"
+            backend = getattr(session_data, "runtime_backend", None) or "local"
+            assistant = getattr(session_data, "assistant_id", None) or getattr(
+                session_data,
+                "character_name",
+                None,
+            ) or "General"
+            workspace = getattr(session_data, "workspace_id", None) or "global"
+            status = (
+                f"Active session: {title} | Backend: {backend} | "
+                f"Assistant: {assistant} | Scope: {workspace}"
+            )
+
+        try:
+            self.query_one("#console-composer-status", Static).update(status)
+        except NoMatches:
+            return
+
+    def compose(self) -> ComposeResult:
+        yield Static("Composer", id="console-composer-title", classes="destination-section")
+        yield Static(
+            self.DEFAULT_STATUS,
+            id="console-composer-status",
+            classes="console-composer-status",
+        )
+        yield Button(
+            "Send",
+            id="console-send-message",
+            classes="destination-action-button console-send-button",
+            variant="primary",
+            tooltip="Send the active Console session draft.",
+        )
+        yield Button(
+            "Stop",
+            id="console-stop-generation",
+            classes="destination-action-button console-stop-button",
+            tooltip="Stop generation in the active Console session.",
+        )
+        yield Button(
+            "Attach",
+            id="console-attach-context",
+            classes="destination-action-button console-attach-button",
+            tooltip="Attach files or context through the active Console session.",
+        )
+        yield Button(
+            "Save Chatbook",
+            id="console-save-chatbook",
+            classes="destination-action-button console-save-chatbook-button",
+            tooltip="Compatibility adapter: save Chatbook export is still owned by Artifacts/Chatbooks.",
+        )

--- a/tldw_chatbook/Widgets/Console/console_composer_bar.py
+++ b/tldw_chatbook/Widgets/Console/console_composer_bar.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from rich.markup import escape
 from textual.app import ComposeResult
 from textual.containers import Horizontal
 from textual.css.query import NoMatches
@@ -34,7 +35,7 @@ class ConsoleComposerBar(Horizontal):
             )
 
         try:
-            self.query_one("#console-composer-status", Static).update(status)
+            self.query_one("#console-composer-status", Static).update(escape(status))
         except NoMatches:
             return
 
@@ -44,7 +45,6 @@ class ConsoleComposerBar(Horizontal):
             self.DEFAULT_STATUS,
             id="console-composer-status",
             classes="console-composer-status",
-            markup=False,
         )
         yield Button(
             "Send",

--- a/tldw_chatbook/Widgets/Console/console_session_surface.py
+++ b/tldw_chatbook/Widgets/Console/console_session_surface.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from textual.app import ComposeResult
 from textual.containers import Vertical
+from textual.css.query import NoMatches
 from textual.widgets import Static
 
 from tldw_chatbook.Widgets.Chat_Widgets.chat_tab_container import ChatTabContainer
@@ -37,6 +38,6 @@ class ConsoleSessionSurface(Vertical):
             return self.tab_container
         try:
             self.tab_container = self.query_one("#console-chat-tabs", ChatTabContainer)
-        except Exception:
+        except NoMatches:
             return None
         return self.tab_container

--- a/tldw_chatbook/Widgets/Console/console_session_surface.py
+++ b/tldw_chatbook/Widgets/Console/console_session_surface.py
@@ -1,0 +1,42 @@
+"""Console-native chat session surface."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.widgets import Static
+
+from tldw_chatbook.Widgets.Chat_Widgets.chat_tab_container import ChatTabContainer
+from tldw_chatbook.Widgets.Chat_Widgets.chat_task_cards import ChatTaskCards
+
+
+class ConsoleSessionSurface(Vertical):
+    """Host Console transcript/event stream sessions without legacy chat chrome."""
+
+    def __init__(self, app_instance: Any, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.app_instance = app_instance
+        self.tab_container: ChatTabContainer | None = None
+
+    def compose(self) -> ComposeResult:
+        yield Static(
+            "Transcript / Event Stream",
+            id="console-transcript-title",
+            classes="destination-section",
+        )
+        yield ChatTaskCards(id="console-task-surface")
+        self.tab_container = ChatTabContainer(self.app_instance, id="console-chat-tabs")
+        self.tab_container.enhanced_mode = True
+        yield self.tab_container
+
+    def get_tab_container(self) -> ChatTabContainer | None:
+        """Return the mounted Console tab container when available."""
+        if self.tab_container is not None:
+            return self.tab_container
+        try:
+            self.tab_container = self.query_one("#console-chat-tabs", ChatTabContainer)
+        except Exception:
+            return None
+        return self.tab_container


### PR DESCRIPTION
## Summary
- Replace the Console embedded legacy ChatWindowEnhanced surface with a cached native ConsoleSessionSurface hosting ChatTabContainer.
- Add a native Console composer action row with send, stop, attach, and Save Chatbook compatibility affordances.
- Update Console/chat regressions and backlog task notes for TASK-10.6.3.

## Test Plan
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_console_internals_decomposition.py Tests/UI/test_product_maturity_gate1_core_loop_screen_adaptation.py::test_console_core_loop_exposes_agentic_shell_regions Tests/UI/test_product_maturity_gate1_core_loop_screen_adaptation.py::test_console_native_session_surface_survives_screen_recompose Tests/UI/test_chat_window_enhanced.py Tests/UI/test_chat_first_handoffs.py Tests/UI/test_chat_tab_container.py --tb=short
- git diff --check