### PR TITLE
Plan Gate 1.6 Library-native Search/RAG

### DIFF
--- a/Docs/superpowers/plans/2026-05-07-gate-1-6-library-native-search-rag.md
+++ b/Docs/superpowers/plans/2026-05-07-gate-1-6-library-native-search-rag.md
@@ -1,0 +1,372 @@
+# Gate 1.6 Library-Native Search/RAG Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Library Search/RAG a real destination-native retrieval workflow with source scope, query input, retrieval status, evidence/results, citations/snippets, and Console handoff.
+
+**Architecture:** Keep Library as the owner of deliberate retrieval. Add pure display-state and adapter contracts first, then mount a Library-native Search/RAG panel inside the existing three-pane Library shell. Reuse existing Search/RAG result normalization and Console live-work handoff seams; do not embed the full legacy `SearchRAGWindow` inside Library.
+
+**Tech Stack:** Python 3.12, Textual, pytest, Backlog.md, existing `LibraryScreen`, `SearchRAGWindow` helper seams, `ChatHandoffPayload`, `ConsoleLiveWorkLaunch`, `DestinationRecoveryState`, and RAG optional-dependency policy/recovery helpers.
+
+---
+
+## Source Of Truth
+
+- Binding design gate: `Docs/superpowers/specs/2026-05-06-screen-design-adaptation-audit-design.md`
+- Binding layout contract: `Docs/superpowers/specs/2026-05-06-destination-layout-ia-contracts-design.md`
+- Current roadmap: `Docs/superpowers/trackers/product-maturity-roadmap.md`
+- Parent backlog gate: `TASK-10.8`
+- Child execution slices: `TASK-10.8.1` through `TASK-10.8.5`
+
+Gate 1.6 is required because Gate 1 only made the `Search/RAG` Library mode selectable. The finished gate must let users query Library-owned sources deliberately, inspect evidence and source authority, and move cited snippets into Console without knowing the legacy `search` route.
+
+## Scope
+
+Included:
+
+- Library-native Search/RAG display-state contracts for source scope, query mode, retrieval status, evidence rows, citations/snippets, blocked states, and Console handoff action state.
+- Source scope selectors and recovery states for notes, media, conversations, Workspaces, and Collections so later source adapters can attach without changing the user-facing model.
+- A Library-owned Search/RAG panel mounted inside `#library-source-detail` / `#library-source-inspector` when mode is `search`.
+- Retrieval adapter seam that can use a fake local service in tests and later wrap current local/server RAG services without UI thread mutation.
+- Result/evidence normalization that preserves source IDs, scores, snippets, citations, provenance, runtime backend, and recovery copy.
+- Console handoff from Library Search/RAG results with staged evidence and source authority preserved.
+- Console-initiated RAG against Library sources as a visible staged retrieval seam, not a hidden prompt-only shortcut.
+- QA evidence and roadmap/backlog tracking for Gate 1.6 closeout.
+
+Excluded:
+
+- Replacing or deleting the legacy `SearchRAGWindow`.
+- Full embeddings/indexing management redesign.
+- Full Workspaces and Collections implementation. Gate 1.6 can expose scope selectors and empty/recovery states, but deeper Workspaces/Collections gates remain separate.
+- Server parity beyond the adapter contract and recoverable blocked/server-required states.
+- Artifact/Chatbook save changes beyond preserving retrieved evidence in the existing Console handoff path.
+
+## File Structure
+
+### Create
+
+- `tldw_chatbook/Library/__init__.py`
+- `tldw_chatbook/Library/library_rag_state.py`
+  - Pure dataclasses/builders for Library Search/RAG source scope, query controls, retrieval status, evidence rows, citation/snippet display, and action states.
+- `tldw_chatbook/Library/library_rag_service.py`
+  - Adapter protocol and normalization seam for local/server retrieval services.
+- `tldw_chatbook/Widgets/Library/__init__.py`
+- `tldw_chatbook/Widgets/Library/library_search_rag_panel.py`
+  - Textual widgets for source scope, query input, results/evidence list, and inspector detail.
+- `Tests/Library/test_library_rag_state.py`
+- `Tests/Library/test_library_rag_service.py`
+- `Tests/UI/test_product_maturity_gate16_library_search_rag.py`
+- `Docs/superpowers/qa/product-maturity/phase-3/2026-05-07-gate-1-6-library-native-search-rag.md`
+
+### Modify
+
+- `tldw_chatbook/UI/Screens/library_screen.py`
+  - Mount Library-native Search/RAG mode and route query/result/Console actions.
+- `tldw_chatbook/UI/Views/RAGSearch/search_handoff.py`
+  - Reuse or extract citation/snippet metadata normalization if needed.
+- `tldw_chatbook/Chat/console_live_work.py`
+  - Add only small payload/action helpers if Library RAG evidence needs clearer Console status text.
+- `tldw_chatbook/UI/Screens/chat_screen.py`
+  - Add Console-initiated Library RAG staged retrieval only if a focused seam is needed.
+- `tldw_chatbook/css/features/_library.tcss` or existing Library TCSS source
+  - Add source TCSS for Search/RAG panel regions. Do not edit generated CSS directly.
+- `tldw_chatbook/css/tldw_cli_modular.tcss`
+  - Regenerate with `tldw_chatbook/css/build_css.py` after source TCSS changes.
+- `Docs/superpowers/trackers/product-maturity-roadmap.md`
+- `Docs/superpowers/qa/product-maturity/phase-3/README.md`
+- `backlog/tasks/task-10 - Product-Maturity-Phase-3-Knowledge-And-Study-Workflows.md`
+- `backlog/tasks/task-10.8*.md`
+
+### Read Before Editing
+
+- `tldw_chatbook/UI/Screens/library_screen.py`
+- `tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py`
+- `tldw_chatbook/UI/Views/RAGSearch/search_handoff.py`
+- `tldw_chatbook/UI/Views/RAGSearch/search_result.py`
+- `tldw_chatbook/UI/Views/RAGSearch/search_event_handlers.py`
+- `tldw_chatbook/Chat/console_live_work.py`
+- `tldw_chatbook/Chat/chat_handoff_models.py`
+- `tldw_chatbook/UI/Screens/chat_screen.py`
+- `Tests/UI/test_product_maturity_phase3_library_contract_layout.py`
+- `Tests/UI/test_product_maturity_gate1_core_loop_screen_adaptation.py`
+- `Tests/UI/test_search_handoffs.py`
+- `Tests/UI/test_ux_audit_smoke.py`
+
+Use:
+
+```bash
+PY=.venv/bin/python
+```
+
+## Risk Controls
+
+- Do not embed `SearchRAGWindow` inside Library. Gate 1.6 is destination-native.
+- Keep route ID `library` stable and preserve existing `#library-mode-search`, `#library-source-browser`, `#library-source-detail`, and `#library-source-inspector` selectors.
+- Do not hide optional dependency blockers behind transient notifications; render persistent recovery copy with owner and next action.
+- Do not query or mutate Textual UI from worker threads. Worker results must be applied on the message thread.
+- Avoid exact paragraph assertions in UI tests. Prefer selectors, disabled/enabled state, payload fields, and durable labels.
+- Preserve existing Search/RAG handoff tests and current legacy `SearchRAGWindow` reachability until the native flow proves parity.
+
+---
+
+### Task 1: Gate 1.6.1 Library Search/RAG Display-State Contracts
+
+Backlog: `TASK-10.8.1`
+
+**Files:**
+- Create: `tldw_chatbook/Library/__init__.py`
+- Create: `tldw_chatbook/Library/library_rag_state.py`
+- Create: `Tests/Library/test_library_rag_state.py`
+- Test: `Tests/UI/test_product_maturity_phase3_library_contract_layout.py`
+
+- [ ] **Step 1: Run current Library baseline**
+
+```bash
+$PY -m pytest -q Tests/UI/test_product_maturity_phase3_library_contract_layout.py Tests/UI/test_product_maturity_gate1_core_loop_screen_adaptation.py::test_library_core_loop_modes_are_actionable_without_leaving_library --tb=short
+```
+
+Expected: pass with existing warnings only.
+
+- [ ] **Step 2: Add pure state red tests**
+
+Create tests for:
+
+- `LibraryRagScopeState.from_source_counts(notes=2, media=1, conversations=0, workspaces=0, collections=0)` exposes `Source Scope: All local sources`, selectable source types, and clear empty state when all counts are zero.
+- `LibraryRagQueryState.from_values(query="", mode="rag")` blocks execution with recovery copy.
+- `LibraryRagResultRow.from_result(...)` preserves title, snippet, score, source ID, citation labels, and provenance metadata.
+- `LibraryRagPanelState.from_values(...)` marks retrieval status as `ready`, `searching`, `blocked`, or `empty` with user-visible next action.
+
+Expected before implementation: import failure for `tldw_chatbook.Library.library_rag_state`.
+
+- [ ] **Step 3: Implement minimal dataclasses**
+
+Implement frozen dataclasses:
+
+- `LibraryRagScopeState`
+- `LibraryRagQueryState`
+- `LibraryRagResultRow`
+- `LibraryRagActionState`
+- `LibraryRagPanelState`
+
+Keep these pure, non-Textual, and tolerant of loose app/test seam values.
+
+- [ ] **Step 4: Verify and commit**
+
+```bash
+$PY -m pytest -q Tests/Library/test_library_rag_state.py Tests/UI/test_product_maturity_phase3_library_contract_layout.py --tb=short
+git diff --check
+git add tldw_chatbook/Library/__init__.py tldw_chatbook/Library/library_rag_state.py Tests/Library/test_library_rag_state.py
+git commit -m "Add Library Search RAG display state contracts"
+```
+
+### Task 2: Gate 1.6.2 Library-Native Search/RAG Panel
+
+Backlog: `TASK-10.8.2`
+
+**Files:**
+- Create: `tldw_chatbook/Widgets/Library/__init__.py`
+- Create: `tldw_chatbook/Widgets/Library/library_search_rag_panel.py`
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py`
+- Create/modify: `Tests/UI/test_product_maturity_gate16_library_search_rag.py`
+
+- [ ] **Step 1: Add mounted red tests**
+
+Add tests proving that pressing `#library-mode-search` keeps the user inside Library and mounts:
+
+- `#library-search-rag-panel`
+- `#library-rag-source-scope`
+- `#library-rag-query-input`
+- `#library-rag-run-query`
+- `#library-rag-results`
+- `#library-rag-inspector`
+- `#library-rag-use-in-console`
+
+Also assert legacy `#search-rag-container` is not mounted inside Library.
+Keep the existing `Search/RAG` compatibility route action available and tested, but do not make it the primary Library mode experience.
+
+- [ ] **Step 2: Implement panel widget**
+
+`LibrarySearchRagPanel` should compose source scope, query input, run button, result/evidence area, and inspector using `LibraryRagPanelState`.
+
+- [ ] **Step 3: Wire Library mode**
+
+When `_active_mode == "search"`, `LibraryScreen` should render the native panel in the existing Library detail/inspector shell. Keep `#library-open-search` available as a fallback route button, but the mode itself must be usable without route navigation.
+
+- [ ] **Step 4: Verify and commit**
+
+```bash
+$PY -m pytest -q Tests/UI/test_product_maturity_gate16_library_search_rag.py Tests/UI/test_product_maturity_phase3_library_contract_layout.py --tb=short
+git diff --check
+git add tldw_chatbook/Widgets/Library/__init__.py tldw_chatbook/Widgets/Library/library_search_rag_panel.py tldw_chatbook/UI/Screens/library_screen.py Tests/UI/test_product_maturity_gate16_library_search_rag.py
+git commit -m "Mount Library native Search RAG panel"
+```
+
+### Task 3: Gate 1.6.3 Retrieval Adapter And Evidence Results
+
+Backlog: `TASK-10.8.3`
+
+**Files:**
+- Create: `tldw_chatbook/Library/library_rag_service.py`
+- Create: `Tests/Library/test_library_rag_service.py`
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py`
+- Modify: `Tests/UI/test_product_maturity_gate16_library_search_rag.py`
+
+- [ ] **Step 1: Add adapter red tests**
+
+Cover:
+
+- normalizing local service results into `LibraryRagResultRow`
+- preserving `citations`, `source_id`, `chunk_id`, `score`, `snippet`, `document_title`
+- returning `DestinationRecoveryState` when dependencies are unavailable
+- returning policy-blocked recovery when runtime source is incompatible
+
+- [ ] **Step 2: Implement adapter protocol**
+
+Create `LibraryRagSearchService` seam with async `search(query, scope, mode)` and a normalizer. In tests, use `app_instance.library_rag_search_service` fake first. If absent, return a recoverable unavailable state rather than calling the legacy widget directly.
+
+- [ ] **Step 3: Wire query execution**
+
+`LibraryScreen` should run retrieval in a worker, set status to `searching`, then apply results on the Textual message thread. Empty results should show a visible no-results state with recovery suggestions.
+
+- [ ] **Step 4: Verify and commit**
+
+```bash
+$PY -m pytest -q Tests/Library/test_library_rag_service.py Tests/UI/test_product_maturity_gate16_library_search_rag.py Tests/UI/test_disabled_action_recovery_tooltips.py --tb=short
+git diff --check
+git add tldw_chatbook/Library/library_rag_service.py tldw_chatbook/UI/Screens/library_screen.py Tests/Library/test_library_rag_service.py Tests/UI/test_product_maturity_gate16_library_search_rag.py
+git commit -m "Add Library RAG retrieval adapter"
+```
+
+### Task 4: Gate 1.6.4 Console Handoff And Console-Initiated RAG
+
+Backlog: `TASK-10.8.4`
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py`
+- Modify: `tldw_chatbook/UI/Views/RAGSearch/search_handoff.py`
+- Modify: `tldw_chatbook/Chat/console_live_work.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`
+- Modify: `Tests/UI/test_product_maturity_gate16_library_search_rag.py`
+- Modify: `Tests/UI/test_console_internals_decomposition.py`
+- Test: `Tests/UI/test_search_handoffs.py`
+
+- [ ] **Step 1: Add handoff red tests**
+
+Assert that selecting a Library RAG result and pressing `#library-rag-use-in-console` calls `open_console_for_live_work` with:
+
+- `source="Library Search/RAG"`
+- `target_id` tied to the selected result/source
+- payload fields for `query`, `source_id`, `chunk_id`, `snippet`, `citations`, `score`, and `runtime_backend`
+- recovery copy: `Review citations before sending.`
+
+- [ ] **Step 2: Add Console-invoked RAG red test**
+
+Add a mounted Console test proving a Console RAG action can request Library retrieval against visible Library source scope and shows retrieval state in `#console-run-inspector` or staged context. Keep this as a seam test; do not implement full conversational retrieval rewriting.
+
+- [ ] **Step 3: Implement handoff builders**
+
+Reuse `build_search_chat_handoff_payload` metadata rules where possible. Add a Library-specific builder only if the payload needs Library source scope fields that legacy Search/RAG does not expose.
+
+- [ ] **Step 4: Wire Console action**
+
+Expose a minimal Console RAG invocation seam that stages a Library RAG query/result with visible status. If runtime support is missing, render a blocked state with owner and next action.
+
+- [ ] **Step 5: Verify and commit**
+
+```bash
+$PY -m pytest -q Tests/UI/test_product_maturity_gate16_library_search_rag.py Tests/UI/test_console_internals_decomposition.py Tests/UI/test_search_handoffs.py Tests/UI/test_console_live_work_handoffs.py --tb=short
+git diff --check
+git add tldw_chatbook/UI/Screens/library_screen.py tldw_chatbook/UI/Views/RAGSearch/search_handoff.py tldw_chatbook/Chat/console_live_work.py tldw_chatbook/UI/Screens/chat_screen.py Tests/UI/test_product_maturity_gate16_library_search_rag.py Tests/UI/test_console_internals_decomposition.py
+git commit -m "Stage Library RAG evidence in Console"
+```
+
+### Task 5: Gate 1.6.5 QA Closeout And Tracking
+
+Backlog: `TASK-10.8.5`
+
+**Files:**
+- Create: `Docs/superpowers/qa/product-maturity/phase-3/2026-05-07-gate-1-6-library-native-search-rag.md`
+- Modify: `Docs/superpowers/qa/product-maturity/phase-3/README.md`
+- Modify: `Docs/superpowers/trackers/product-maturity-roadmap.md`
+- Modify: `backlog/tasks/task-10 - Product-Maturity-Phase-3-Knowledge-And-Study-Workflows.md`
+- Modify: `backlog/tasks/task-10.8*.md`
+- Test: `Tests/UI/test_product_maturity_gate16_library_search_rag.py`
+
+- [ ] **Step 1: Add evidence tracking red test**
+
+Add a test that verifies the Gate 1.6 QA evidence doc exists, includes `## Scope`, `## Walkthrough`, `## Verification`, `## Residual Risk`, and records selectors for `#library-search-rag-panel`, `#library-rag-query-input`, `#library-rag-results`, `#library-rag-use-in-console`, and Console staged evidence.
+
+- [ ] **Step 2: Run focused verification**
+
+```bash
+$PY -m pytest -q Tests/Library/test_library_rag_state.py Tests/Library/test_library_rag_service.py Tests/UI/test_product_maturity_gate16_library_search_rag.py Tests/UI/test_product_maturity_phase3_library_contract_layout.py Tests/UI/test_product_maturity_gate1_core_loop_screen_adaptation.py Tests/UI/test_search_handoffs.py Tests/UI/test_console_internals_decomposition.py Tests/UI/test_console_live_work_handoffs.py --tb=short
+```
+
+Expected: pass with known warnings only.
+
+- [ ] **Step 3: Perform manual QA walkthrough**
+
+Run:
+
+```bash
+$PY -m tldw_chatbook.app
+```
+
+Walk through:
+
+- Open Library.
+- Switch to Search/RAG mode.
+- Verify source scope, query input, retrieval status, evidence/results, citations/snippets, and inspector detail.
+- Run a query with fake/local indexed data or verify the setup blocker if dependencies/indexes are unavailable.
+- Stage a selected result into Console and verify the staged context preserves source authority and citations/snippets.
+- Start from Console and invoke Library RAG, verifying retrieval state or a recoverable blocker.
+
+- [ ] **Step 4: Update tracking and commit**
+
+```bash
+git add Docs/superpowers/qa/product-maturity/phase-3/2026-05-07-gate-1-6-library-native-search-rag.md Docs/superpowers/qa/product-maturity/phase-3/README.md Docs/superpowers/trackers/product-maturity-roadmap.md "backlog/tasks/task-10 - Product-Maturity-Phase-3-Knowledge-And-Study-Workflows.md" backlog/tasks/task-10.8*
+git commit -m "Record Gate 1.6 Library Search RAG verification"
+```
+
+### Task 6: Final PR Verification
+
+**Files:**
+- Read: all modified files
+- Verify: focused suite and diff hygiene
+
+- [ ] **Step 1: Run the full Gate 1.6 focused suite**
+
+```bash
+$PY -m pytest -q Tests/Library/test_library_rag_state.py Tests/Library/test_library_rag_service.py Tests/UI/test_product_maturity_gate16_library_search_rag.py Tests/UI/test_product_maturity_phase3_library_contract_layout.py Tests/UI/test_product_maturity_gate1_core_loop_screen_adaptation.py Tests/UI/test_search_handoffs.py Tests/UI/test_ux_audit_smoke.py Tests/UI/test_console_internals_decomposition.py Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_disabled_action_recovery_tooltips.py --tb=short
+```
+
+- [ ] **Step 2: Run diff hygiene**
+
+```bash
+git diff --check
+git status --short --branch
+```
+
+- [ ] **Step 3: Self-review against binding specs**
+
+Confirm:
+
+- Library Search/RAG is usable inside Library without knowing the legacy `search` route.
+- Index/source/model blockers are visible before query execution.
+- Results expose snippets, citations/provenance, confidence/score where available, and source authority.
+- Console handoff preserves staged evidence.
+- Console-initiated RAG has visible retrieval state or explicit recovery.
+- Workspaces/Collections deeper behavior remains documented residual risk if not implemented in this gate.
+
+- [ ] **Step 4: Prepare PR summary**
+
+```markdown
+## Summary
+- Added Library-native Search/RAG state, panel, retrieval adapter, and evidence result contracts.
+- Preserved citations/snippets and source authority through Library-to-Console handoff.
+- Recorded Gate 1.6 QA evidence and roadmap/backlog tracking.
+
+## Verification
+- `$PY -m pytest -q Tests/Library/test_library_rag_state.py Tests/Library/test_library_rag_service.py Tests/UI/test_product_maturity_gate16_library_search_rag.py ... --tb=short`
+- `git diff --check`
+```

--- a/Docs/superpowers/trackers/product-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/product-maturity-roadmap.md
@@ -1,7 +1,7 @@
 # Product Maturity Roadmap
 
 Date: 2026-05-07
-Status: Phase 1 verified; Phase 2 verified; Phase 3.0 verified; Phase 3.1 verified; Phase 3.2 verified; Phase 3.3 verified; Phase 3.4 verified; Gate 1 / Phase 3.5 verified; Gate 1.5 / Phase 3.6 verified; Phase 3.7 verified
+Status: Phase 1 verified; Phase 2 verified; Phase 3.0 verified; Phase 3.1 verified; Phase 3.2 verified; Phase 3.3 verified; Phase 3.4 verified; Gate 1 / Phase 3.5 verified; Gate 1.5 / Phase 3.6 verified; Phase 3.7 verified; Gate 1.6 / Phase 3.8 planned
 Source Branch: `dev`
 Source Spec: `Docs/superpowers/specs/2026-05-05-product-maturity-phased-roadmap-design.md`
 Layout Contract Spec: `Docs/superpowers/specs/2026-05-06-destination-layout-ia-contracts-design.md`
@@ -34,6 +34,7 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 - Gate 1 / Phase 3.5 verifies the core product-loop screen adaptation: Home dashboard regions, Console agentic shell regions, and actionable Library modes are mounted and usable enough to continue into required Gate 1.5 and Gate 1.6 follow-ups.
 - Gate 1.5 / Phase 3.6 verifies the Console internals decomposition gate: Console now mounts native workbench components for controls, staged context, transcript/session, composer, run inspector, approvals, RAG/source state, and Chatbook artifact actions while retaining focused compatibility coverage for existing chat behavior.
 - Phase 3.7 verifies the next source-selected Study generation contract: queued server study-pack jobs can be observed into completed pack metadata and visible reusable Study dashboard state.
+- Gate 1.6 / Phase 3.8 is now planned as a tracked Library-native Search/RAG gate so retrieval can move from selectable mode/legacy route reachability to source-scoped query, evidence, citations/snippets, recovery, and Console handoff.
 
 ## Post-UX Roadmap Handoff
 
@@ -92,6 +93,12 @@ Product Maturity Phase 1 and Phase 2 are not reopened by default. Their existing
   - Phase 3.6.4: Console Run Inspector Approvals Tools And Artifacts - `TASK-10.6.4`
   - Phase 3.6.5: Console Internals QA Closeout - `TASK-10.6.5`
 - Phase 3.7: Source Study-Pack Completion Reuse - `TASK-10.7`
+- Phase 3.8 / Gate 1.6: Library Native Search/RAG - `TASK-10.8`
+  - Phase 3.8.1: Library Search/RAG Display-State Contracts - `TASK-10.8.1`
+  - Phase 3.8.2: Library Native Search/RAG Panel - `TASK-10.8.2`
+  - Phase 3.8.3: Retrieval Adapter And Evidence Results - `TASK-10.8.3`
+  - Phase 3.8.4: Console RAG Handoff And Invocation - `TASK-10.8.4`
+  - Phase 3.8.5: Library Search/RAG QA Closeout - `TASK-10.8.5`
 - Phase 4: Agent Configuration And Execution - `TASK-11`
 - Phase 5: Server-Parity And Live Integrations - `TASK-12`
 - Phase 6: Release Hardening And Documentation - `TASK-13`
@@ -114,6 +121,7 @@ Product Maturity Phase 1 and Phase 2 are not reopened by default. Their existing
 | Gate 1 / Phase 3.5 | `Docs/superpowers/qa/product-maturity/phase-3/2026-05-06-gate-1-core-product-loop-screen-adaptation.md` | verified |
 | Gate 1.5 / Phase 3.6 | `Docs/superpowers/qa/product-maturity/phase-3/2026-05-07-gate-1-5-console-internals-decomposition.md` | verified |
 | Phase 3.7 | `Docs/superpowers/qa/product-maturity/phase-3/2026-05-07-phase-3-7-source-study-pack-completion-reuse.md` | verified |
+| Gate 1.6 / Phase 3.8 | `Docs/superpowers/plans/2026-05-07-gate-1-6-library-native-search-rag.md` | planned |
 
 ## Phase Overview
 
@@ -121,7 +129,7 @@ Product Maturity Phase 1 and Phase 2 are not reopened by default. Their existing
 | --- | --- | --- | --- | --- | --- |
 | Phase 1: QA Baseline And Usability Guardrails | Establish clean-run usability guardrails before feature depth. | verified | `TASK-8`, Phase 1.1 (`TASK-8.1`), Phase 1.2 (`TASK-8.2`), Phase 1.3 (`TASK-8.3`), Phase 1.4 (`TASK-8.4`), Phase 1.5 (`TASK-8.5`), Phase 1.6 (`TASK-8.6`), Phase 1.7 (`TASK-8.7`) | `phase-1/` | Closed; full grounded generation and Artifact/Chatbook persistence move to Phase 2. |
 | Phase 2: Core Agentic Loop | Complete source/question to grounded Console to Artifact/Chatbook loop. | verified | `TASK-9`, Phase 2.1 (`TASK-9.1`), Phase 2.2 (`TASK-9.2`), Phase 2.3 (`TASK-9.3`), Phase 2.4 (`TASK-9.4`), Phase 2.5 (`TASK-9.5`) | `phase-2/2026-05-05-phase-2-1-grounded-console-response-contract.md`, `phase-2/2026-05-05-phase-2-2-console-chatbook-artifact-save-contract.md`, `phase-2/2026-05-05-phase-2-3-saved-chatbook-artifact-reopen-contract.md`, `phase-2/2026-05-05-phase-2-4-home-chatbook-artifact-resume-contract.md`, `phase-2/2026-05-06-phase-2-5-core-loop-closeout-replay.md` | Closed for the local core loop; live provider generation, full `.chatbook` export packaging, and full artifact history picking remain later-phase risks. |
-| Phase 3: Knowledge And Study Workflows | Mature ingest, organize, retrieve, study, and reuse workflows. | in-progress; Phase 3.0 verified; Phase 3.1 verified; Phase 3.2 verified; Phase 3.3 verified; Phase 3.4 verified; Gate 1 / Phase 3.5 verified; Gate 1.5 / Phase 3.6 verified; Phase 3.7 verified | `TASK-10`, Phase 3.0 (`TASK-10.0`), Phase 3.1 (`TASK-10.1`), Phase 3.2 (`TASK-10.2`), Phase 3.3 (`TASK-10.3`), Phase 3.4 (`TASK-10.4`), Gate 1 / Phase 3.5 (`TASK-10.5`), Gate 1.5 / Phase 3.6 (`TASK-10.6`), Phase 3.7 (`TASK-10.7`) | `phase-3/2026-05-06-phase-3-0-destination-layout-contracts.md`, `phase-3/2026-05-06-phase-3-1-library-study-entry.md`, `phase-3/2026-05-06-phase-3-2-library-source-study-context.md`, `phase-3/2026-05-06-phase-3-3-library-contract-layout.md`, `phase-3/2026-05-07-phase-3-4-source-study-generation.md`, `phase-3/2026-05-06-gate-1-core-product-loop-screen-adaptation.md`, `phase-3/2026-05-07-gate-1-5-console-internals-decomposition.md`, `phase-3/2026-05-07-phase-3-7-source-study-pack-completion-reuse.md` | Layout contracts, Library Study entry, Library source context, Library contract layout shell, source-selected server study-pack job launch, core Home/Console/Library screen adaptation, Console-native internals, and completed study-pack reuse state are verified; full server job history, direct generated deck selection, Gate 1.6 Library-native Search/RAG with citations/snippets, Workspaces, Collections-in-Library, and deeper Import/Export/Search/RAG study flows remain. Post-UX roadmap execution should continue under TASK-10 unless the tracker explicitly creates a rebaseline child task for UX/UI deltas. |
+| Phase 3: Knowledge And Study Workflows | Mature ingest, organize, retrieve, study, and reuse workflows. | in-progress; Phase 3.0 verified; Phase 3.1 verified; Phase 3.2 verified; Phase 3.3 verified; Phase 3.4 verified; Gate 1 / Phase 3.5 verified; Gate 1.5 / Phase 3.6 verified; Phase 3.7 verified; Gate 1.6 / Phase 3.8 planned | `TASK-10`, Phase 3.0 (`TASK-10.0`), Phase 3.1 (`TASK-10.1`), Phase 3.2 (`TASK-10.2`), Phase 3.3 (`TASK-10.3`), Phase 3.4 (`TASK-10.4`), Gate 1 / Phase 3.5 (`TASK-10.5`), Gate 1.5 / Phase 3.6 (`TASK-10.6`), Phase 3.7 (`TASK-10.7`), Gate 1.6 / Phase 3.8 (`TASK-10.8`) | `phase-3/2026-05-06-phase-3-0-destination-layout-contracts.md`, `phase-3/2026-05-06-phase-3-1-library-study-entry.md`, `phase-3/2026-05-06-phase-3-2-library-source-study-context.md`, `phase-3/2026-05-06-phase-3-3-library-contract-layout.md`, `phase-3/2026-05-07-phase-3-4-source-study-generation.md`, `phase-3/2026-05-06-gate-1-core-product-loop-screen-adaptation.md`, `phase-3/2026-05-07-gate-1-5-console-internals-decomposition.md`, `phase-3/2026-05-07-phase-3-7-source-study-pack-completion-reuse.md`, `Docs/superpowers/plans/2026-05-07-gate-1-6-library-native-search-rag.md` | Layout contracts, Library Study entry, Library source context, Library contract layout shell, source-selected server study-pack job launch, core Home/Console/Library screen adaptation, Console-native internals, and completed study-pack reuse state are verified; Gate 1.6 is planned for Library-native Search/RAG with citations/snippets. Full server job history, direct generated deck selection, Workspaces, Collections-in-Library, and deeper Import/Export/Search/RAG study flows remain. Post-UX roadmap execution should continue under TASK-10 unless the tracker explicitly creates a rebaseline child task for UX/UI deltas. |
 | Phase 4: Agent Configuration And Execution | Mature Personas, Skills, MCP, ACP, Schedules, and Workflows. | planned | `TASK-11` | not-started | Depends on service adapters and runtime readiness. The post-UX roadmap maps controlled agent configuration and run loops to TASK-11. |
 | Phase 5: Server-Parity And Live Integrations | Close high-value `tldw_server2` parity gaps. | planned | `TASK-12` | not-started | Requires parity inventory. The post-UX roadmap requires parity to be prioritized by workflow value rather than endpoint count. |
 | Phase 6: Release Hardening And Documentation | Reach release-candidate usability. | planned | `TASK-13` | not-started | Depends on earlier phase evidence. The post-UX roadmap public-roadmap and release-readiness refresh belongs under TASK-13. |
@@ -249,3 +257,9 @@ Status: verified
 Status: verified
 
 - `Docs/superpowers/qa/product-maturity/phase-3/2026-05-07-phase-3-7-source-study-pack-completion-reuse.md`
+
+## Gate 1.6 / Phase 3.8 Plan
+
+Status: planned
+
+- `Docs/superpowers/plans/2026-05-07-gate-1-6-library-native-search-rag.md`

--- a/Tests/UI/test_product_maturity_phase3_layout_contracts.py
+++ b/Tests/UI/test_product_maturity_phase3_layout_contracts.py
@@ -14,8 +14,17 @@ PHASE_3_README = Path("Docs/superpowers/qa/product-maturity/phase-3/README.md")
 PHASE_3_0_EVIDENCE = Path(
     "Docs/superpowers/qa/product-maturity/phase-3/2026-05-06-phase-3-0-destination-layout-contracts.md"
 )
+GATE16_PLAN = Path(
+    "Docs/superpowers/plans/2026-05-07-gate-1-6-library-native-search-rag.md"
+)
+TASK_10 = Path(
+    "backlog/tasks/task-10 - Product-Maturity-Phase-3-Knowledge-And-Study-Workflows.md"
+)
 TASK_10_0 = Path(
     "backlog/tasks/task-10.0 - Product-Maturity-Phase-3.0-Destination-Layout-And-IA-Contracts.md"
+)
+TASK_10_8 = Path(
+    "backlog/tasks/task-10.8 - Product-Maturity-Phase-3.8-Gate-1.6-Library-Native-Search-RAG.md"
 )
 PROMPT_MANIFEST = Path("Docs/Design/destination-layout-image-reference-prompts.md")
 
@@ -189,6 +198,35 @@ def test_phase30_tracker_records_layout_contract_gate() -> None:
     assert "Layout Contract Spec: `Docs/superpowers/specs/2026-05-06-destination-layout-ia-contracts-design.md`" in tracker
     assert "Phase 3.0: Destination Layout And IA Contracts - `TASK-10.0`" in tracker
     assert "destination layout and IA contracts must be approved" in tracker
+
+
+def test_phase3_gate16_library_rag_plan_and_tasks_are_tracked() -> None:
+    tracker = _text(TRACKER)
+    parent_task = _text(TASK_10)
+    plan = _text(GATE16_PLAN)
+    task = _text(TASK_10_8)
+
+    assert "Gate 1.6 / Phase 3.8" in tracker
+    assert "TASK-10.8" in tracker
+    assert GATE16_PLAN.as_posix() in tracker
+    assert "TASK-10.8" in parent_task
+    assert "Gate 1.6" in parent_task
+    assert "Library-native Search/RAG" in plan
+    for required_section in (
+        "## Source Of Truth",
+        "## Scope",
+        "## File Structure",
+        "## Risk Controls",
+        "### Task 1: Gate 1.6.1 Library Search/RAG Display-State Contracts",
+        "### Task 5: Gate 1.6.5 QA Closeout And Tracking",
+    ):
+        assert required_section in plan
+    for child_task in ("TASK-10.8.1", "TASK-10.8.2", "TASK-10.8.3", "TASK-10.8.4", "TASK-10.8.5"):
+        assert child_task in plan
+        assert child_task in tracker
+    assert "status: To Do" in task
+    for ac_number in range(1, 5):
+        assert f"- [ ] #{ac_number}" in task
 
 
 def test_phase30_qa_evidence_is_verified() -> None:

--- a/backlog/tasks/task-10 - Product-Maturity-Phase-3-Knowledge-And-Study-Workflows.md
+++ b/backlog/tasks/task-10 - Product-Maturity-Phase-3-Knowledge-And-Study-Workflows.md
@@ -42,4 +42,6 @@ Continued Phase 3 with TASK-10.5. Gate 1 now adapts Home Console and Library int
 Continued Phase 3 with TASK-10.7. Queued server source study-pack jobs now observe bounded completion status and surface ready pack metadata as reusable Study dashboard state. Parent remains open for full server job history direct generated deck selection conversation message-level selection Workspaces Library Collections citations/snippets and deeper Import/Export Search/RAG workflows.
 
 Closed Gate 1.5 with TASK-10.6. Console now uses native workbench internals for provider/model controls, staged context, transcript/session, composer, run inspector, approvals, RAG/source state, and Chatbook artifact actions instead of presenting a full embedded legacy Chat screen. Parent remains open for Gate 1.6 Library-native Search/RAG with citations/snippets, Workspaces, Library Collections, and deeper Import/Export/Search/RAG study workflows.
+
+Planned Gate 1.6 with TASK-10.8. The Library-native Search/RAG gate is split into display-state contracts, a Library-owned Search/RAG panel, retrieval adapter and evidence normalization, Console handoff/Console-invoked RAG seams, and QA closeout. Parent remains open for execution of TASK-10.8 and later Workspaces, Library Collections, and deeper Import/Export/Search/RAG study workflows.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-10.8 - Product-Maturity-Phase-3.8-Gate-1.6-Library-Native-Search-RAG.md
+++ b/backlog/tasks/task-10.8 - Product-Maturity-Phase-3.8-Gate-1.6-Library-Native-Search-RAG.md
@@ -1,0 +1,44 @@
+---
+id: TASK-10.8
+title: 'Product Maturity Phase 3.8: Gate 1.6 Library Native Search/RAG'
+status: To Do
+assignee: []
+created_date: '2026-05-07 12:00'
+labels:
+  - product-maturity
+  - phase-3-knowledge-study
+  - gate-1-6-library-rag
+dependencies:
+  - TASK-10.6
+  - TASK-10.7
+parent_task_id: TASK-10
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Plan and execute the required Gate 1.6 Library-native Search/RAG workflow so users can retrieve cited source evidence from Library and continue into Console without relying on the legacy Search/RAG route.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Library Search/RAG mode exposes source scope query input retrieval status evidence/results citations/snippets and setup/error recovery inside the Library shell.
+- [ ] #2 Library Search/RAG results can stage evidence into Console with source authority citations/snippets and recovery copy preserved.
+- [ ] #3 Console can invoke RAG against Library sources with visible retrieval state or explicit recovery.
+- [ ] #4 Focused automated and QA walkthrough evidence prove the workflow is usable rather than only selectable.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Gate 1.6 is split into child tasks so retrieval state, Library UI, adapter behavior, Console handoff, and QA closeout can ship in reviewable slices:
+
+1. TASK-10.8.1: Library Search/RAG display-state contracts.
+2. TASK-10.8.2: Library-native Search/RAG panel.
+3. TASK-10.8.3: Retrieval adapter and evidence results.
+4. TASK-10.8.4: Console handoff and Console-initiated RAG.
+5. TASK-10.8.5: QA closeout and tracking.
+
+Primary implementation plan: `Docs/superpowers/plans/2026-05-07-gate-1-6-library-native-search-rag.md`.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-10.8.1 - Gate-1.6.1-Library-Search-RAG-display-state-contracts.md
+++ b/backlog/tasks/task-10.8.1 - Gate-1.6.1-Library-Search-RAG-display-state-contracts.md
@@ -1,0 +1,31 @@
+---
+id: TASK-10.8.1
+title: 'Gate 1.6.1: Library Search/RAG display-state contracts'
+status: To Do
+assignee: []
+created_date: '2026-05-07 12:00'
+labels:
+  - product-maturity
+  - phase-3-knowledge-study
+  - gate-1-6-library-rag
+dependencies:
+  - TASK-10.7
+documentation:
+  - Docs/superpowers/specs/2026-05-06-screen-design-adaptation-audit-design.md
+  - Docs/superpowers/plans/2026-05-07-gate-1-6-library-native-search-rag.md
+parent_task_id: TASK-10.8
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create pure Library Search/RAG display-state contracts for source scope query state retrieval status evidence rows citations snippets actions and recovery copy.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Pure state builders expose notes media conversations Workspaces and Collections source scope query mode retrieval status result rows citations snippets and action disabled reasons without Textual dependencies.
+- [ ] #2 Empty query no source missing index and unavailable dependency states produce visible recovery copy with owner and next action.
+- [ ] #3 Unit tests cover valid results malformed values empty states and blocked states.
+<!-- AC:END -->

--- a/backlog/tasks/task-10.8.2 - Gate-1.6.2-Library-native-Search-RAG-panel.md
+++ b/backlog/tasks/task-10.8.2 - Gate-1.6.2-Library-native-Search-RAG-panel.md
@@ -1,0 +1,32 @@
+---
+id: TASK-10.8.2
+title: 'Gate 1.6.2: Library native Search/RAG panel'
+status: To Do
+assignee: []
+created_date: '2026-05-07 12:00'
+labels:
+  - product-maturity
+  - phase-3-knowledge-study
+  - gate-1-6-library-rag
+dependencies:
+  - TASK-10.8.1
+documentation:
+  - Docs/superpowers/specs/2026-05-06-destination-layout-ia-contracts-design.md
+  - Docs/superpowers/plans/2026-05-07-gate-1-6-library-native-search-rag.md
+parent_task_id: TASK-10.8
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Mount a Library-owned Search/RAG panel inside the existing Library three-pane shell instead of routing users to or embedding the legacy Search/RAG window.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Search/RAG mode mounts source scope query input run action evidence/results and retrieval inspector inside Library.
+- [ ] #2 Switching into Search/RAG mode preserves the Library source browser detail and inspector shell selectors.
+- [ ] #3 The legacy Search/RAG container is not embedded inside Library.
+- [ ] #4 The existing standalone Search/RAG compatibility route action remains available and tested.
+<!-- AC:END -->

--- a/backlog/tasks/task-10.8.3 - Gate-1.6.3-Retrieval-adapter-and-evidence-results.md
+++ b/backlog/tasks/task-10.8.3 - Gate-1.6.3-Retrieval-adapter-and-evidence-results.md
@@ -1,0 +1,30 @@
+---
+id: TASK-10.8.3
+title: 'Gate 1.6.3: Retrieval adapter and evidence results'
+status: To Do
+assignee: []
+created_date: '2026-05-07 12:00'
+labels:
+  - product-maturity
+  - phase-3-knowledge-study
+  - gate-1-6-library-rag
+dependencies:
+  - TASK-10.8.2
+documentation:
+  - Docs/superpowers/plans/2026-05-07-gate-1-6-library-native-search-rag.md
+parent_task_id: TASK-10.8
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a retrieval adapter seam for Library Search/RAG that normalizes local or server results into cited evidence rows and persistent recovery states.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Adapter normalizes query results with source id chunk id snippet citations score runtime backend and provenance metadata.
+- [ ] #2 Missing dependency unavailable service policy-denied empty result and failed retrieval states render persistent recovery instead of transient alerts.
+- [ ] #3 Retrieval results are applied to Textual UI on the message thread and covered by focused tests.
+<!-- AC:END -->

--- a/backlog/tasks/task-10.8.4 - Gate-1.6.4-Console-RAG-handoff-and-invocation.md
+++ b/backlog/tasks/task-10.8.4 - Gate-1.6.4-Console-RAG-handoff-and-invocation.md
@@ -1,0 +1,31 @@
+---
+id: TASK-10.8.4
+title: 'Gate 1.6.4: Console RAG handoff and invocation'
+status: To Do
+assignee: []
+created_date: '2026-05-07 12:00'
+labels:
+  - product-maturity
+  - phase-3-knowledge-study
+  - gate-1-6-library-rag
+dependencies:
+  - TASK-10.8.3
+documentation:
+  - Docs/superpowers/plans/2026-05-07-gate-1-6-library-native-search-rag.md
+parent_task_id: TASK-10.8
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Preserve Library Search/RAG evidence when users continue into Console and expose a Console-owned way to invoke RAG against Library sources with visible retrieval state.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Library Search/RAG results stage into Console with query source authority citations snippets score and recovery copy preserved.
+- [ ] #2 Console can invoke Library RAG or show a recoverable blocked state when retrieval is unavailable.
+- [ ] #3 Existing Search/RAG handoff and Console live-work tests remain green.
+- [ ] #4 Library handoff actions remain disabled with specific reason copy until a query and usable evidence are available.
+<!-- AC:END -->

--- a/backlog/tasks/task-10.8.5 - Gate-1.6.5-Library-Search-RAG-QA-closeout.md
+++ b/backlog/tasks/task-10.8.5 - Gate-1.6.5-Library-Search-RAG-QA-closeout.md
@@ -1,0 +1,30 @@
+---
+id: TASK-10.8.5
+title: 'Gate 1.6.5: Library Search/RAG QA closeout'
+status: To Do
+assignee: []
+created_date: '2026-05-07 12:00'
+labels:
+  - product-maturity
+  - phase-3-knowledge-study
+  - gate-1-6-library-rag
+dependencies:
+  - TASK-10.8.4
+documentation:
+  - Docs/superpowers/plans/2026-05-07-gate-1-6-library-native-search-rag.md
+parent_task_id: TASK-10.8
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replay and document Gate 1.6 Library-native Search/RAG after the native retrieval panel and Console evidence handoff are implemented.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 QA evidence verifies Library Search/RAG query execution setup/error states evidence review and Console handoff.
+- [ ] #2 Focused regression suite covers state contracts retrieval adapter mounted Library UI Search/RAG handoff and Console live-work compatibility.
+- [ ] #3 Product maturity roadmap parent TASK-10 and TASK-10.8 record Gate 1.6 verified or document accepted residual risks.
+<!-- AC:END -->


### PR DESCRIPTION
## Summary
- Add the Gate 1.6 Library-native Search/RAG implementation plan after the completed UX/UI and Phase 3.7 work.
- Create TASK-10.8 and child tasks for display-state contracts, Library panel, retrieval adapter/evidence, Console handoff, and QA closeout.
- Update the product maturity roadmap and parent TASK-10, with a regression that keeps the plan/task mapping tracked.

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_product_maturity_phase3_layout_contracts.py::test_phase3_gate16_library_rag_plan_and_tasks_are_tracked --tb=short
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_product_maturity_phase3_layout_contracts.py --tb=short
- git diff --check
- git diff --cached --check