### PR TITLE
Add Library Search/RAG display-state contracts

### DIFF
--- a/Tests/Library/test_library_rag_state.py
+++ b/Tests/Library/test_library_rag_state.py
@@ -1,0 +1,174 @@
+"""Pure Library Search/RAG display-state contract tests."""
+
+from __future__ import annotations
+
+from tldw_chatbook.Library.library_rag_state import (
+    LibraryRagPanelState,
+    LibraryRagQueryState,
+    LibraryRagResultRow,
+    LibraryRagScopeState,
+)
+
+
+def test_scope_state_exposes_source_counts_and_empty_recovery() -> None:
+    state = LibraryRagScopeState.from_source_counts(
+        notes=2,
+        media=1,
+        conversations=0,
+        workspaces=0,
+        collections=0,
+    )
+
+    assert state.summary_label == "Source Scope: All local sources"
+    assert state.total_count == 3
+    assert state.selectable_source_types == ("notes", "media")
+    assert state.source_count_labels == (
+        "Notes: 2",
+        "Media: 1",
+        "Conversations: 0",
+        "Workspaces: 0",
+        "Collections: 0",
+    )
+    assert not state.is_empty
+    assert state.recovery_copy == ""
+
+    empty_state = LibraryRagScopeState.from_source_counts()
+
+    assert empty_state.is_empty
+    assert empty_state.selectable_source_types == ()
+    assert "No Library sources are available" in empty_state.recovery_copy
+    assert "Owner: Library sources" in empty_state.recovery_copy
+    assert "Next:" in empty_state.recovery_copy
+    assert "Add notes, media, conversations, Workspaces, or Collections" in empty_state.next_action
+
+
+def test_query_state_blocks_empty_queries_with_recovery_copy() -> None:
+    state = LibraryRagQueryState.from_values(query="", mode="rag")
+
+    assert state.query == ""
+    assert state.mode == "rag"
+    assert not state.can_run
+    assert state.disabled_reason == "Enter a Search/RAG query before running retrieval."
+    assert "Enter a question or search terms" in state.recovery_copy
+    assert "Owner: Library Search/RAG" in state.recovery_copy
+    assert "Next:" in state.recovery_copy
+
+    ready_state = LibraryRagQueryState.from_values(query="summarize vector search", mode="search")
+
+    assert ready_state.query == "summarize vector search"
+    assert ready_state.mode == "search"
+    assert ready_state.can_run
+    assert ready_state.recovery_copy == ""
+
+    unsafe_state = LibraryRagQueryState.from_values(
+        query="<script>alert('x')</script>",
+        mode="<script>",
+    )
+
+    assert unsafe_state.query == ""
+    assert unsafe_state.mode == "rag"
+    assert not unsafe_state.can_run
+
+
+def test_result_row_preserves_citations_snippets_and_provenance() -> None:
+    row = LibraryRagResultRow.from_result(
+        {
+            "document_title": "Vector Notes",
+            "snippet": "FTS5 and embeddings can be combined.",
+            "score": "0.87",
+            "source_id": "note-42",
+            "chunk_id": "chunk-7",
+            "citations": [{"label": "Vector Notes p. 4"}, "Appendix A"],
+            "metadata": {"backend": "local", "collection": "research"},
+        }
+    )
+
+    assert row.title == "Vector Notes"
+    assert row.snippet == "FTS5 and embeddings can be combined."
+    assert row.score == 0.87
+    assert row.source_id == "note-42"
+    assert row.chunk_id == "chunk-7"
+    assert row.citation_labels == ("Vector Notes p. 4", "Appendix A")
+    assert row.provenance == {"backend": "local", "collection": "research"}
+    assert row.source_authority_label == "Source: note-42"
+
+    malformed = LibraryRagResultRow.from_result(
+        {"title": "", "snippet": None, "score": "not-a-number"}
+    )
+
+    assert malformed.title == "Untitled result"
+    assert malformed.snippet == ""
+    assert malformed.score is None
+    assert malformed.source_authority_label == "Source: unknown"
+
+    unsafe = LibraryRagResultRow.from_result(
+        {
+            "title": "<script>alert('x')</script>",
+            "snippet": "onclick=alert(1)",
+            "source_id": "javascript:alert(1)",
+        }
+    )
+
+    assert unsafe.title == "Untitled result"
+    assert unsafe.snippet == ""
+    assert unsafe.source_id == ""
+
+    single_mapping_citation = LibraryRagResultRow.from_result(
+        {"title": "Solo Citation", "citations": {"label": "Single mapping citation"}}
+    )
+
+    assert single_mapping_citation.citation_labels == ("Single mapping citation",)
+
+
+def test_panel_state_marks_ready_searching_blocked_and_empty_states() -> None:
+    scope = LibraryRagScopeState.from_source_counts(notes=1)
+    query = LibraryRagQueryState.from_values(query="What is indexed?", mode="rag")
+    result = LibraryRagResultRow.from_result(
+        {"title": "Indexed Note", "snippet": "Index evidence.", "source_id": "note-1"}
+    )
+
+    ready = LibraryRagPanelState.from_values(scope=scope, query=query, results=[result])
+
+    assert ready.status == "ready"
+    assert ready.status_label == "Ready"
+    assert ready.results == (result,)
+    assert ready.run_action.enabled
+    assert ready.console_action.enabled
+
+    searching = LibraryRagPanelState.from_values(scope=scope, query=query, is_searching=True)
+
+    assert searching.status == "searching"
+    assert searching.status_label == "Searching"
+    assert not searching.run_action.enabled
+    assert searching.run_action.disabled_reason == "Search/RAG retrieval is already running."
+
+    blocked = LibraryRagPanelState.from_values(scope=scope, query=LibraryRagQueryState.from_values())
+
+    assert blocked.status == "blocked"
+    assert blocked.status_label == "Blocked"
+    assert not blocked.run_action.enabled
+    assert "Enter a Search/RAG query" in blocked.next_action
+    assert blocked.authority_owner == "Library Search/RAG"
+
+    unavailable = LibraryRagPanelState.from_values(
+        scope=scope,
+        query=query,
+        recovery_copy=(
+            "Missing Library retrieval index. Next: Build or connect an index. "
+            "Owner: embeddings."
+        ),
+    )
+
+    assert unavailable.status == "blocked"
+    assert "Missing Library retrieval index" in unavailable.recovery_copy
+    assert unavailable.run_action.disabled_reason == unavailable.recovery_copy
+
+    empty = LibraryRagPanelState.from_values(
+        scope=LibraryRagScopeState.from_source_counts(),
+        query=query,
+    )
+
+    assert empty.status == "empty"
+    assert empty.status_label == "No sources"
+    assert not empty.run_action.enabled
+    assert "Add notes, media, conversations, Workspaces, or Collections" in empty.next_action

--- a/backlog/tasks/task-10.8.1 - Gate-1.6.1-Library-Search-RAG-display-state-contracts.md
+++ b/backlog/tasks/task-10.8.1 - Gate-1.6.1-Library-Search-RAG-display-state-contracts.md
@@ -1,13 +1,14 @@
 ---
 id: TASK-10.8.1
 title: 'Gate 1.6.1: Library Search/RAG display-state contracts'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-05-07 12:00'
 labels:
   - product-maturity
   - phase-3-knowledge-study
   - gate-1-6-library-rag
+updated_date: '2026-05-07 13:00'
 dependencies:
   - TASK-10.7
 documentation:
@@ -25,7 +26,23 @@ Create pure Library Search/RAG display-state contracts for source scope query st
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Pure state builders expose notes media conversations Workspaces and Collections source scope query mode retrieval status result rows citations snippets and action disabled reasons without Textual dependencies.
-- [ ] #2 Empty query no source missing index and unavailable dependency states produce visible recovery copy with owner and next action.
-- [ ] #3 Unit tests cover valid results malformed values empty states and blocked states.
+- [x] #1 Pure state builders expose notes media conversations Workspaces and Collections source scope query mode retrieval status result rows citations snippets and action disabled reasons without Textual dependencies.
+- [x] #2 Empty query no source missing index and unavailable dependency states produce visible recovery copy with owner and next action.
+- [x] #3 Unit tests cover valid results malformed values empty states and blocked states.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Run the current Library contract-layout baseline and Gate 1 Library mode guardrail.
+2. Add failing pure state tests for Library Search/RAG source scope query state result rows action states and panel statuses.
+3. Implement minimal frozen dataclasses under tldw_chatbook/Library without Textual imports.
+4. Verify the new unit tests and existing Library contract-layout tests.
+5. Run diff hygiene before committing.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added pure Library Search/RAG display-state contracts in tldw_chatbook/Library/library_rag_state.py with scope query result action and panel state dataclasses. Covered source counts for notes media conversations Workspaces and Collections, empty query/source recovery copy, citation/snippet/provenance normalization, malformed result tolerance, and ready searching blocked empty panel status behavior. Added Tests/Library/test_library_rag_state.py and kept existing Library contract-layout guardrails green.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Library/__init__.py
+++ b/tldw_chatbook/Library/__init__.py
@@ -1,0 +1,17 @@
+"""Library-domain display-state contracts and service seams."""
+
+from .library_rag_state import (
+    LibraryRagActionState,
+    LibraryRagPanelState,
+    LibraryRagQueryState,
+    LibraryRagResultRow,
+    LibraryRagScopeState,
+)
+
+__all__ = [
+    "LibraryRagActionState",
+    "LibraryRagPanelState",
+    "LibraryRagQueryState",
+    "LibraryRagResultRow",
+    "LibraryRagScopeState",
+]

--- a/tldw_chatbook/Library/library_rag_state.py
+++ b/tldw_chatbook/Library/library_rag_state.py
@@ -1,0 +1,424 @@
+"""Pure display-state contracts for Library-native Search/RAG."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+from tldw_chatbook.Utils.input_validation import sanitize_string, validate_text_input
+
+
+LIBRARY_RAG_SOURCE_TYPES = ("notes", "media", "conversations", "workspaces", "collections")
+LIBRARY_RAG_SOURCE_LABELS = {
+    "notes": "Notes",
+    "media": "Media",
+    "conversations": "Conversations",
+    "workspaces": "Workspaces",
+    "collections": "Collections",
+}
+LIBRARY_RAG_EMPTY_NEXT_ACTION = (
+    "Add notes, media, conversations, Workspaces, or Collections before running retrieval."
+)
+LIBRARY_RAG_EMPTY_RECOVERY = (
+    "No Library sources are available for Search/RAG. "
+    f"Next: {LIBRARY_RAG_EMPTY_NEXT_ACTION} Owner: Library sources."
+)
+LIBRARY_RAG_EMPTY_QUERY_REASON = "Enter a Search/RAG query before running retrieval."
+LIBRARY_RAG_EMPTY_QUERY_RECOVERY = (
+    "Enter a question or search terms, then run Search/RAG against Library sources. "
+    "Next: Provide a query. Owner: Library Search/RAG."
+)
+LIBRARY_RAG_NO_EVIDENCE_REASON = "Run Search/RAG and select evidence before using Console."
+LIBRARY_RAG_RUNNING_REASON = "Search/RAG retrieval is already running."
+LIBRARY_RAG_WAIT_FOR_RESULTS_REASON = "Wait for retrieval to finish before using Console."
+
+
+def _clean_text(value: Any, fallback: str = "", *, max_length: int = 1000) -> str:
+    text = sanitize_string(str(value or ""), max_length=max_length).strip()
+    if not text:
+        return fallback
+    if not validate_text_input(text, max_length=max_length, allow_html=False):
+        return fallback
+    return text
+
+
+def _coerce_count(value: Any) -> int:
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _coerce_score(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_citation_label(value: Any) -> str:
+    if isinstance(value, Mapping):
+        return _clean_text(
+            value.get("label")
+            or value.get("title")
+            or value.get("citation")
+            or value.get("source")
+        )
+    return _clean_text(value)
+
+
+def _coerce_citation_labels(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, (str, bytes, bytearray, Mapping)):
+        raw_values: Iterable[Any] = (value,)
+    elif isinstance(value, Iterable):
+        raw_values = value
+    else:
+        raw_values = (value,)
+    labels = tuple(label for item in raw_values if (label := _coerce_citation_label(item)))
+    return labels
+
+
+@dataclass(frozen=True)
+class LibraryRagActionState:
+    """One Library Search/RAG action and its disabled-state copy."""
+
+    widget_id: str
+    label: str
+    enabled: bool
+    disabled_reason: str = ""
+    recovery_copy: str = ""
+    authority_owner: str = "Library Search/RAG"
+    classes: str = "destination-action-button library-rag-action"
+
+    @property
+    def tooltip(self) -> str:
+        return "" if self.enabled else self.disabled_reason
+
+
+@dataclass(frozen=True)
+class LibraryRagScopeState:
+    """Display state for Library Search/RAG source scope controls."""
+
+    summary_label: str
+    counts: Mapping[str, int] = field(default_factory=dict)
+    source_count_labels: tuple[str, ...] = ()
+    selectable_source_types: tuple[str, ...] = ()
+    total_count: int = 0
+    is_empty: bool = True
+    recovery_copy: str = LIBRARY_RAG_EMPTY_RECOVERY
+    next_action: str = LIBRARY_RAG_EMPTY_NEXT_ACTION
+    authority_owner: str = "Library sources"
+
+    @classmethod
+    def from_source_counts(
+        cls,
+        *,
+        notes: Any = 0,
+        media: Any = 0,
+        conversations: Any = 0,
+        workspaces: Any = 0,
+        collections: Any = 0,
+    ) -> "LibraryRagScopeState":
+        """Build source-scope display state from loose source counts.
+
+        Args:
+            notes: Count-like value for note sources.
+            media: Count-like value for media sources.
+            conversations: Count-like value for conversation sources.
+            workspaces: Count-like value for workspace scopes.
+            collections: Count-like value for collection scopes.
+
+        Returns:
+            Source-scope display state with normalized non-negative counts,
+            selectable source types, and empty-state recovery copy.
+        """
+        counts = {
+            "notes": _coerce_count(notes),
+            "media": _coerce_count(media),
+            "conversations": _coerce_count(conversations),
+            "workspaces": _coerce_count(workspaces),
+            "collections": _coerce_count(collections),
+        }
+        labels = tuple(
+            f"{LIBRARY_RAG_SOURCE_LABELS[source_type]}: {counts[source_type]}"
+            for source_type in LIBRARY_RAG_SOURCE_TYPES
+        )
+        selectable = tuple(
+            source_type
+            for source_type in LIBRARY_RAG_SOURCE_TYPES
+            if counts[source_type] > 0
+        )
+        total_count = sum(counts.values())
+        is_empty = total_count == 0
+        return cls(
+            summary_label="Source Scope: All local sources",
+            counts=counts,
+            source_count_labels=labels,
+            selectable_source_types=selectable,
+            total_count=total_count,
+            is_empty=is_empty,
+            recovery_copy=LIBRARY_RAG_EMPTY_RECOVERY if is_empty else "",
+            next_action=LIBRARY_RAG_EMPTY_NEXT_ACTION if is_empty else "",
+        )
+
+
+@dataclass(frozen=True)
+class LibraryRagQueryState:
+    """Display state for the Library Search/RAG query controls."""
+
+    query: str = ""
+    mode: str = "rag"
+    can_run: bool = False
+    disabled_reason: str = LIBRARY_RAG_EMPTY_QUERY_REASON
+    recovery_copy: str = LIBRARY_RAG_EMPTY_QUERY_RECOVERY
+    authority_owner: str = "Library Search/RAG"
+
+    @classmethod
+    def from_values(cls, *, query: Any = "", mode: Any = "rag") -> "LibraryRagQueryState":
+        """Build query display state from user-provided query controls.
+
+        Args:
+            query: User-entered query or loose seam value.
+            mode: Requested retrieval mode. Supported values are ``rag`` and
+                ``search``; invalid values fall back to ``rag``.
+
+        Returns:
+            Query display state with sanitized text, normalized mode, runnable
+            state, and recovery copy when execution is blocked.
+        """
+        normalized_query = _clean_text(query, max_length=5000)
+        normalized_mode = _clean_text(mode, "rag", max_length=32).lower()
+        if normalized_mode not in {"rag", "search"}:
+            normalized_mode = "rag"
+        can_run = bool(normalized_query)
+        return cls(
+            query=normalized_query,
+            mode=normalized_mode,
+            can_run=can_run,
+            disabled_reason="" if can_run else LIBRARY_RAG_EMPTY_QUERY_REASON,
+            recovery_copy="" if can_run else LIBRARY_RAG_EMPTY_QUERY_RECOVERY,
+        )
+
+
+@dataclass(frozen=True)
+class LibraryRagResultRow:
+    """One normalized Library Search/RAG evidence row."""
+
+    title: str
+    snippet: str = ""
+    score: float | None = None
+    source_id: str = ""
+    chunk_id: str = ""
+    citation_labels: tuple[str, ...] = ()
+    provenance: Mapping[str, Any] = field(default_factory=dict)
+
+    @property
+    def source_authority_label(self) -> str:
+        return f"Source: {self.source_id or 'unknown'}"
+
+    @classmethod
+    def from_result(cls, result: Mapping[str, Any] | Any) -> "LibraryRagResultRow":
+        """Normalize a retrieval result into a Library evidence row.
+
+        Args:
+            result: Mapping-like retrieval result. Missing, malformed, or
+                unsafe values are tolerated and replaced with safe fallbacks.
+
+        Returns:
+            Evidence row preserving safe title, snippet, score, source ID,
+            chunk ID, citation labels, and provenance metadata.
+        """
+        data: Mapping[str, Any] = result if isinstance(result, Mapping) else {}
+        title = _clean_text(
+            data.get("document_title")
+            or data.get("title")
+            or data.get("source_title")
+            or data.get("name")
+            or data.get("label"),
+            "Untitled result",
+            max_length=240,
+        )
+        snippet = _clean_text(
+            data.get("snippet")
+            or data.get("text")
+            or data.get("content")
+            or data.get("excerpt"),
+            max_length=1000,
+        )
+        source_id = _clean_text(
+            data.get("source_id")
+            or data.get("document_id")
+            or data.get("media_id")
+            or data.get("note_id"),
+            max_length=200,
+        )
+        chunk_id = _clean_text(data.get("chunk_id") or data.get("segment_id"), max_length=200)
+        metadata = data.get("metadata")
+        provenance = dict(metadata) if isinstance(metadata, Mapping) else {}
+        return cls(
+            title=title,
+            snippet=snippet,
+            score=_coerce_score(data.get("score")),
+            source_id=source_id,
+            chunk_id=chunk_id,
+            citation_labels=_coerce_citation_labels(data.get("citations")),
+            provenance=provenance,
+        )
+
+
+@dataclass(frozen=True)
+class LibraryRagPanelState:
+    """Display state for the destination-native Library Search/RAG panel."""
+
+    scope: LibraryRagScopeState
+    query: LibraryRagQueryState
+    status: str
+    status_label: str
+    results: tuple[LibraryRagResultRow, ...] = ()
+    run_action: LibraryRagActionState = field(default_factory=lambda: LibraryRagActionState(
+        widget_id="library-rag-run-query",
+        label="Run Search/RAG",
+        enabled=False,
+        disabled_reason=LIBRARY_RAG_EMPTY_QUERY_REASON,
+        recovery_copy=LIBRARY_RAG_EMPTY_QUERY_RECOVERY,
+    ))
+    console_action: LibraryRagActionState = field(default_factory=lambda: LibraryRagActionState(
+        widget_id="library-rag-use-in-console",
+        label="Use in Console",
+        enabled=False,
+        disabled_reason=LIBRARY_RAG_NO_EVIDENCE_REASON,
+    ))
+    recovery_copy: str = ""
+    next_action: str = ""
+    authority_owner: str = "Library Search/RAG"
+
+    @classmethod
+    def from_values(
+        cls,
+        *,
+        scope: LibraryRagScopeState | None = None,
+        query: LibraryRagQueryState | None = None,
+        results: Sequence[LibraryRagResultRow] | None = None,
+        is_searching: bool = False,
+        recovery_copy: Any = "",
+    ) -> "LibraryRagPanelState":
+        """Build aggregate panel state for the Library Search/RAG surface.
+
+        Args:
+            scope: Source-scope display state. Defaults to an empty Library
+                scope when omitted.
+            query: Query display state. Defaults to an empty blocked query when
+                omitted.
+            results: Normalized retrieval evidence rows to render.
+            is_searching: Whether retrieval is currently in flight.
+            recovery_copy: Optional blocker copy from an index, dependency,
+                policy, or service failure.
+
+        Returns:
+            Panel display state with status, actions, result rows, recovery
+            copy, and next action derived from scope/query/runtime state.
+        """
+        scope_state = scope or LibraryRagScopeState.from_source_counts()
+        query_state = query or LibraryRagQueryState.from_values()
+        result_rows = tuple(results or ())
+        blocked_copy = _clean_text(recovery_copy, max_length=1000)
+
+        if scope_state.is_empty:
+            return cls(
+                scope=scope_state,
+                query=query_state,
+                status="empty",
+                status_label="No sources",
+                results=result_rows,
+                run_action=LibraryRagActionState(
+                    widget_id="library-rag-run-query",
+                    label="Run Search/RAG",
+                    enabled=False,
+                    disabled_reason=scope_state.recovery_copy,
+                    recovery_copy=scope_state.recovery_copy,
+                ),
+                console_action=LibraryRagActionState(
+                    widget_id="library-rag-use-in-console",
+                    label="Use in Console",
+                    enabled=False,
+                    disabled_reason=LIBRARY_RAG_NO_EVIDENCE_REASON,
+                ),
+                recovery_copy=scope_state.recovery_copy,
+                next_action=scope_state.next_action,
+            )
+
+        if not query_state.can_run or blocked_copy:
+            reason = blocked_copy or query_state.disabled_reason
+            return cls(
+                scope=scope_state,
+                query=query_state,
+                status="blocked",
+                status_label="Blocked",
+                results=result_rows,
+                run_action=LibraryRagActionState(
+                    widget_id="library-rag-run-query",
+                    label="Run Search/RAG",
+                    enabled=False,
+                    disabled_reason=reason,
+                    recovery_copy=blocked_copy or query_state.recovery_copy,
+                ),
+                console_action=LibraryRagActionState(
+                    widget_id="library-rag-use-in-console",
+                    label="Use in Console",
+                    enabled=False,
+                    disabled_reason=LIBRARY_RAG_NO_EVIDENCE_REASON,
+                ),
+                recovery_copy=blocked_copy or query_state.recovery_copy,
+                next_action=reason,
+            )
+
+        if is_searching:
+            return cls(
+                scope=scope_state,
+                query=query_state,
+                status="searching",
+                status_label="Searching",
+                results=result_rows,
+                run_action=LibraryRagActionState(
+                    widget_id="library-rag-run-query",
+                    label="Run Search/RAG",
+                    enabled=False,
+                    disabled_reason=LIBRARY_RAG_RUNNING_REASON,
+                ),
+                console_action=LibraryRagActionState(
+                    widget_id="library-rag-use-in-console",
+                    label="Use in Console",
+                    enabled=False,
+                    disabled_reason=LIBRARY_RAG_WAIT_FOR_RESULTS_REASON,
+                ),
+                next_action=LIBRARY_RAG_WAIT_FOR_RESULTS_REASON,
+            )
+
+        return cls(
+            scope=scope_state,
+            query=query_state,
+            status="ready",
+            status_label="Ready",
+            results=result_rows,
+            run_action=LibraryRagActionState(
+                widget_id="library-rag-run-query",
+                label="Run Search/RAG",
+                enabled=True,
+            ),
+            console_action=LibraryRagActionState(
+                widget_id="library-rag-use-in-console",
+                label="Use in Console",
+                enabled=bool(result_rows),
+                disabled_reason="" if result_rows else LIBRARY_RAG_NO_EVIDENCE_REASON,
+            ),
+            next_action=(
+                "Review retrieved evidence and use it in Console."
+                if result_rows
+                else "Run Search/RAG to retrieve Library evidence."
+            ),
+        )


### PR DESCRIPTION
## Summary
- Add pure Library Search/RAG display-state contracts for source scope, query state, evidence rows, action disabled reasons, and panel status.
- Cover empty source/query, missing-index/unavailable recovery copy, citation/snippet/provenance normalization, and malformed result tolerance.
- Mark TASK-10.8.1 done with implementation plan and notes.

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Library/test_library_rag_state.py Tests/UI/test_product_maturity_phase3_library_contract_layout.py Tests/UI/test_product_maturity_gate1_core_loop_screen_adaptation.py::test_library_core_loop_modes_are_actionable_without_leaving_library --tb=short
- git diff --check
- git diff --cached --check