### PR TITLE
Phase 3.9 Library Collections IA split

### DIFF
--- a/Docs/superpowers/plans/2026-05-08-phase-3-9-library-collections-ia-split.md
+++ b/Docs/superpowers/plans/2026-05-08-phase-3-9-library-collections-ia-split.md
@@ -158,6 +158,14 @@ Backlog: `TASK-10.9.1`
 - Test: `Tests/UI/test_destination_shells.py`
 - Test: `Tests/Home/test_active_work_adapter.py`
 - Test: `Tests/UI/test_console_live_work_handoffs.py`
+- Test: `Tests/UI/test_unified_shell_phase6_first_time_replay.py`
+- Test: `Tests/UI/test_unified_shell_phase6_power_user_replay.py`
+
+- [ ] **Step 0: Start Backlog task**
+
+```bash
+backlog task edit TASK-10.9.1 -s "In Progress" --plan "1. Run the current Watchlists/W+C baseline. 2. Add red tests for Watchlists labels and compatibility. 3. Update shell metadata, command palette, Watchlists screen, Home, and Console visible copy. 4. Run focused verification and diff hygiene. 5. Check ACs, add implementation notes, and mark Done."
+```
 
 - [ ] **Step 1: Run the current Watchlists/W+C baseline**
 
@@ -186,6 +194,8 @@ assert "Collections" not in wc.tooltip
 ```
 
 Update command palette tests to search for `Watchlists` and assert `Watchlists+Collections` is not in command/help text.
+
+Update Phase 6 replay tests that still assert top-level `W+C` labels so the first-time and power-user walkthroughs prove the new visible model.
 
 Update destination tests to assert:
 
@@ -256,12 +266,25 @@ $PY -m pytest -q \
   Tests/UI/test_destination_shells.py \
   Tests/Home/test_active_work_adapter.py \
   Tests/UI/test_console_live_work_handoffs.py \
+  Tests/UI/test_unified_shell_phase6_first_time_replay.py \
+  Tests/UI/test_unified_shell_phase6_power_user_replay.py \
   --tb=short
 
 git diff --check
 ```
 
-- [ ] **Step 7: Commit Task 1**
+- [ ] **Step 7: Close Task 1 Backlog state**
+
+Only after verification passes, update the task file before committing:
+
+```bash
+backlog task edit TASK-10.9.1 \
+  --check-ac 1 --check-ac 2 --check-ac 3 --check-ac 4 \
+  --notes "Implemented Watchlists IA split while preserving compatibility route IDs and active-run follow-through." \
+  -s Done
+```
+
+- [ ] **Step 8: Commit Task 1**
 
 ```bash
 git add \
@@ -277,7 +300,9 @@ git add \
   Tests/UI/test_command_palette_providers.py \
   Tests/UI/test_destination_shells.py \
   Tests/Home/test_active_work_adapter.py \
-  Tests/UI/test_console_live_work_handoffs.py
+  Tests/UI/test_console_live_work_handoffs.py \
+  Tests/UI/test_unified_shell_phase6_first_time_replay.py \
+  Tests/UI/test_unified_shell_phase6_power_user_replay.py
 git commit -m "Split Watchlists IA from Collections"
 ```
 
@@ -297,6 +322,12 @@ Backlog: `TASK-10.9.2`
 - Create: `Tests/Library/test_library_collections_state.py`
 - Create: `Tests/Library/test_library_collections_service.py`
 
+- [ ] **Step 0: Start Backlog task**
+
+```bash
+backlog task edit TASK-10.9.2 -s "In Progress" --plan "1. Add pure state and service red tests. 2. Implement versioned SQLite persistence and service contracts. 3. Wire app/config service creation. 4. Run focused verification and diff hygiene. 5. Check ACs, add implementation notes, and mark Done."
+```
+
 - [ ] **Step 1: Add pure state red tests**
 
 Create `Tests/Library/test_library_collections_state.py` covering:
@@ -305,6 +336,7 @@ Create `Tests/Library/test_library_collections_state.py` covering:
 - Ready state selects the first collection by default when no selected ID is provided.
 - Invalid create/rename input disables actions with a visible reason.
 - Sync status renders `local-only` or `sync-unavailable`.
+- Selected collection detail exposes a stable updated timestamp display value.
 - Delete action is disabled when no collection is selected.
 
 Expected before implementation: import failure for `tldw_chatbook.Library.library_collections_state`.
@@ -320,15 +352,33 @@ Cover:
 - Duplicate normalized names are rejected.
 - `rename_collection()` updates `name`, optional `description`, and `updated_at`.
 - `delete_collection()` hides/deletes the record from list/get.
+- Schema version is initialized and foreign-key constraints are enabled.
+- The same source item can belong to multiple collections, while duplicate membership inside one collection is prevented.
 - Invalid names are rejected before SQL.
 
 Expected before implementation: import failure for `tldw_chatbook.Library.library_collections_service`.
 
 - [ ] **Step 3: Implement local SQLite persistence**
 
-Create `tldw_chatbook/DB/Library_Collections_DB.py` with:
+Create `tldw_chatbook/DB/Library_Collections_DB.py` with a `BaseDB`-style schema initializer modeled after `Subscriptions_DB.py`.
+
+Requirements:
+
+- Define `_CURRENT_SCHEMA_VERSION = 1`.
+- Enable `PRAGMA foreign_keys = ON` for every connection used by the DB wrapper.
+- Create and maintain a `schema_version` table.
+- Use a membership primary key that does not prevent the same source item from belonging to multiple collections.
+
+Initial schema:
 
 ```sql
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS schema_version (
+    version INTEGER PRIMARY KEY NOT NULL
+);
+INSERT OR IGNORE INTO schema_version (version) VALUES (1);
+
 CREATE TABLE IF NOT EXISTS library_collections (
     collection_id TEXT PRIMARY KEY,
     name TEXT NOT NULL UNIQUE,
@@ -339,13 +389,14 @@ CREATE TABLE IF NOT EXISTS library_collections (
 );
 
 CREATE TABLE IF NOT EXISTS library_collection_items (
-    item_id TEXT PRIMARY KEY,
+    membership_id TEXT PRIMARY KEY,
     collection_id TEXT NOT NULL,
     source_type TEXT NOT NULL,
     source_id TEXT NOT NULL,
     title TEXT NOT NULL DEFAULT '',
     created_at TEXT NOT NULL,
-    FOREIGN KEY(collection_id) REFERENCES library_collections(collection_id)
+    FOREIGN KEY(collection_id) REFERENCES library_collections(collection_id) ON DELETE CASCADE,
+    UNIQUE(collection_id, source_type, source_id)
 );
 ```
 
@@ -359,6 +410,8 @@ Create frozen dataclasses:
 - `LibraryCollectionDetail`
 - `LibraryCollectionActionState`
 - `LibraryCollectionsPanelState`
+
+Summary/detail models must carry `updated_at` and a user-facing `updated_at_label`/equivalent so the mounted UI can render a stable `#library-collection-updated-at` selector.
 
 Recommended builder:
 
@@ -420,7 +473,18 @@ $PY -m pytest -q \
 git diff --check
 ```
 
-- [ ] **Step 8: Commit Task 2**
+- [ ] **Step 8: Close Task 2 Backlog state**
+
+Only after verification passes, update the task file before committing:
+
+```bash
+backlog task edit TASK-10.9.2 \
+  --check-ac 1 --check-ac 2 --check-ac 3 --check-ac 4 \
+  --notes "Implemented Library Collections display-state and local service contracts with versioned local persistence." \
+  -s Done
+```
+
+- [ ] **Step 9: Commit Task 2**
 
 ```bash
 git add \
@@ -450,6 +514,12 @@ Backlog: `TASK-10.9.3`
 - Create/modify: `Tests/UI/test_product_maturity_phase39_library_collections.py`
 - Verify: `Tests/UI/test_product_maturity_gate16_library_search_rag.py`
 
+- [ ] **Step 0: Start Backlog task**
+
+```bash
+backlog task edit TASK-10.9.3 -s "In Progress" --plan "1. Add mounted UI red tests. 2. Implement the Library Collections panel. 3. Wire LibraryScreen handlers and mode-specific affordance suppression. 4. Run focused verification and diff hygiene. 5. Check ACs, add implementation notes, and mark Done."
+```
+
 - [ ] **Step 1: Add mounted red tests**
 
 Create `Tests/UI/test_product_maturity_phase39_library_collections.py`.
@@ -462,9 +532,11 @@ Cover:
 - Empty state copy explains Collections without claiming sync or RAG execution.
 - Creating a collection through `#library-collection-name-input` and `#library-create-collection` adds it to the list and selects it.
 - Renaming through `#library-collection-name-input` and `#library-rename-collection` updates detail copy.
-- Deleting through `#library-delete-collection` removes it and returns to empty state.
+- Delete requires confirmation or immediate undo. Prefer confirm-first: first press `#library-delete-collection` arms `#library-confirm-delete-collection`, second press removes it and returns to empty state.
+- Selected collection detail renders `#library-collection-updated-at`.
 - A service exception renders `#library-collections-error` with retry/recovery copy.
 - `#library-rag-run-query` is not mounted in Collections mode.
+- Study, Flashcards, Quizzes, and Use in Console are hidden, disabled, or relabeled in Collections mode so the UI does not imply collection-scoped Study/Console execution is ready.
 
 Expected before implementation: missing selectors.
 
@@ -482,8 +554,10 @@ Create `LibraryCollectionsPanel` with stable selectors:
 - `#library-create-collection`
 - `#library-rename-collection`
 - `#library-delete-collection`
+- `#library-confirm-delete-collection` or `#library-undo-delete-collection`
 - `#library-collection-sync-status`
 - `#library-collection-item-count`
+- `#library-collection-updated-at`
 
 The widget should receive a `LibraryCollectionsPanelState` and render only. Keep service mutation in `LibraryScreen`.
 
@@ -510,6 +584,7 @@ When `_active_mode == "collections"`:
 
 - Mount `LibraryCollectionsPanel` in `#library-source-detail` after `#library-active-mode-next-action`.
 - Mount lightweight inspector status in `#library-source-inspector` if the panel does not already show it.
+- Hide, disable, or explicitly relabel the always-present Library Study/Flashcards/Quizzes/Use in Console controls while Collections mode is active. The user must not see an enabled action that appears to run Study, RAG, or Console against a selected Collection.
 - Remove Search/RAG widgets when leaving `search` mode.
 - Do not recompose the whole Library shell unnecessarily if targeted widget refresh is enough.
 
@@ -536,6 +611,7 @@ Rules:
 
 - Notify and keep form input visible on invalid names.
 - Refresh panel state after success.
+- Implement delete confirmation or undo. Confirm-first is preferred for this gate because it is smaller and easier to test: first delete press sets a pending delete ID and visible confirmation copy; confirm press calls the service.
 - Use service methods only, not direct DB calls.
 - Keep sync copy as status text only.
 
@@ -563,7 +639,18 @@ $PY -m pytest -q \
 git diff --check
 ```
 
-- [ ] **Step 8: Commit Task 3**
+- [ ] **Step 8: Close Task 3 Backlog state**
+
+Only after verification passes, update the task file before committing:
+
+```bash
+backlog task edit TASK-10.9.3 \
+  --check-ac 1 --check-ac 2 --check-ac 3 --check-ac 4 \
+  --notes "Implemented mounted Library Collections management UI with safe delete, updated-at visibility, and disabled/deferred scoped workflow actions." \
+  -s Done
+```
+
+- [ ] **Step 9: Commit Task 3**
 
 ```bash
 git add \
@@ -591,6 +678,12 @@ Backlog: `TASK-10.9.4`
 - Modify: `backlog/tasks/task-10 - Product-Maturity-Phase-3-Knowledge-And-Study-Workflows.md`
 - Modify: `backlog/tasks/task-10.9 - Product-Maturity-Phase-3.9-Library-Collections-IA-Split.md`
 - Modify: `backlog/tasks/task-10.9.4 - Phase-3.9.4-Library-Collections-QA-closeout-and-tracking.md`
+
+- [ ] **Step 0: Start Backlog task**
+
+```bash
+backlog task edit TASK-10.9.4 -s "In Progress" --plan "1. Add tracking red test. 2. Record QA evidence. 3. Update roadmap, QA index, and parent Backlog tracking. 4. Run focused verification and manual QA walkthrough. 5. Check ACs, add implementation notes, and mark Done."
+```
 
 - [ ] **Step 1: Add tracking red test**
 
@@ -631,19 +724,19 @@ Update:
 
 Roadmap status should say Phase 3.9 verified only after the tests and QA walkthrough pass.
 
-- [ ] **Step 4: Update Backlog via CLI**
+- [ ] **Step 4: Update parent Backlog tracking via CLI**
 
-Use Backlog CLI from the implementation worktree:
+Use Backlog CLI from the implementation worktree. Child task start/closeout commands belong to each child task above; this step only updates parent tracking.
 
 ```bash
 backlog task edit TASK-10.9 --plan "1. TASK-10.9.1: Watchlists IA split and compatibility labels.\n2. TASK-10.9.2: Library Collections display-state and local service contracts.\n3. TASK-10.9.3: Library Collections mounted management UI.\n4. TASK-10.9.4: QA closeout and tracking.\n\nPrimary implementation plan: Docs/superpowers/plans/2026-05-08-phase-3-9-library-collections-ia-split.md."
 ```
 
-At closeout, check ACs and set done only after verification:
+At parent closeout, confirm `TASK-10.9.1` through `TASK-10.9.4` are already Done, then check parent ACs and set the parent Done only after all children are Done:
 
 ```bash
-backlog task edit TASK-10.9 --status Done
-backlog task edit TASK-10.9.4 --status Done
+backlog task edit TASK-10.9.4 --check-ac 1 --check-ac 2 --check-ac 3 --check-ac 4 --notes "Recorded Phase 3.9 QA closeout..." -s Done
+backlog task edit TASK-10.9 --check-ac 1 --check-ac 2 --check-ac 3 --check-ac 4 --notes "Closed Phase 3.9 with Watchlists split and Library Collections verified..." -s Done
 ```
 
 Do not mark tasks done before ACs, implementation notes, and QA evidence are complete.
@@ -661,6 +754,8 @@ $PY -m pytest -q \
   Tests/UI/test_command_palette_providers.py \
   Tests/Home/test_active_work_adapter.py \
   Tests/UI/test_console_live_work_handoffs.py \
+  Tests/UI/test_unified_shell_phase6_first_time_replay.py \
+  Tests/UI/test_unified_shell_phase6_power_user_replay.py \
   Tests/UI/test_product_maturity_gate16_library_search_rag.py \
   Tests/UI/test_product_maturity_phase3_layout_contracts.py \
   --tb=short
@@ -682,7 +777,7 @@ Walk through:
 - Create collection.
 - Select collection.
 - Rename collection.
-- Delete collection.
+- Delete collection through the implemented confirmation or recovery path.
 - Confirm sync is local-only/unavailable, not an enabled fake action.
 - Open Watchlists and confirm it is Watchlists-only.
 - Confirm Watchlists active-run follow-through still works in fixture-backed tests.

--- a/Docs/superpowers/plans/2026-05-08-phase-3-9-library-collections-ia-split.md
+++ b/Docs/superpowers/plans/2026-05-08-phase-3-9-library-collections-ia-split.md
@@ -1,0 +1,712 @@
+# Phase 3.9 Library Collections IA Split Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split the combined `W+C` product model into a Watchlists-only top-level destination and a Library-owned local Collections management workflow.
+
+**Architecture:** Preserve compatibility route IDs while changing user-facing labels and copy to `Watchlists`. Add Library-owned pure state, local SQLite persistence, service contracts, and a Textual Collections panel inside the existing Library shell. Do not reuse Watchlist or read-it-later services as the Collection model, and do not expose fake server sync before the sync engine exists.
+
+**Tech Stack:** Python 3.12, Textual, pytest, Backlog.md, SQLite, existing `LibraryScreen`, `WatchlistsCollectionsScreen`, shell destination metadata, Home active-work adapter, Console live-work state, and Library widget patterns.
+
+---
+
+## Source Of Truth
+
+- Design spec: `Docs/superpowers/specs/2026-05-08-library-collections-ia-split-design.md`
+- Current roadmap: `Docs/superpowers/trackers/product-maturity-roadmap.md`
+- Parent backlog task: `TASK-10.9`
+- Child execution slices: `TASK-10.9.1` through `TASK-10.9.4`
+- Baseline branch: `origin/dev` at `df63b49f` plus design commit `9226ff47`
+
+## Spec Review Result
+
+Self-review found and fixed two issues before this plan was written:
+
+- The new spec used non-ASCII box drawing. It now uses ASCII layout art.
+- The spec did not explicitly cover Home and Console source labels during the `W+C` split. It now requires user-facing active-work labels to say `Watchlists`, while allowing internal compatibility payload values where needed.
+
+No blocking design gap remains. The main implementation risk is breadth: `W+C` appears in navigation, command palette help, Watchlists destination copy, Home active-work messages, Console readiness copy, and existing tests. Task 1 must update the visible model without breaking the `watchlists_collections` route.
+
+## Scope
+
+Included:
+
+- Visible `W+C` / `Watchlists+Collections` shell copy becomes `Watchlists`.
+- `watchlists_collections` route ID remains compatible.
+- Watchlists destination stops loading or rendering Collections/read-it-later data.
+- Home and Console visible active-work copy says `Watchlists`.
+- Library Collections mode supports local list, create, select, rename, and delete.
+- Collection state shows `local-only` or `sync-unavailable` status, not fake sync controls.
+- Citations/snippets remain tracked as later-stage Search/RAG features.
+- QA evidence and roadmap/backlog tracking close the gate only after a usable walkthrough.
+
+Excluded:
+
+- Server sync engine.
+- Full server parity for Collections.
+- Full cross-source item picker.
+- Collection-scoped RAG, Study, Flashcards, Quizzes, Console, or Import/Export execution.
+- Deleting the `watchlists_collections` route or class names in this gate.
+- Broad Watchlists runtime rewrite.
+
+## File Structure
+
+### Create
+
+- `tldw_chatbook/DB/Library_Collections_DB.py`
+  - Local SQLite persistence for Library collection records and future item membership counts.
+- `tldw_chatbook/Library/library_collections_state.py`
+  - Pure display-state models for summaries, detail, action readiness, and panel status.
+- `tldw_chatbook/Library/library_collections_service.py`
+  - Service protocol and local service adapter for list/get/create/rename/delete.
+- `tldw_chatbook/Widgets/Library/library_collections_panel.py`
+  - Textual widget for Library Collections list, detail, form controls, and inspector state.
+- `Tests/Library/test_library_collections_state.py`
+- `Tests/Library/test_library_collections_service.py`
+- `Tests/UI/test_product_maturity_phase39_library_collections.py`
+- `Docs/superpowers/qa/product-maturity/phase-3/2026-05-08-phase-3-9-library-collections.md`
+
+### Modify
+
+- `tldw_chatbook/Constants.py`
+  - Change display label for `TAB_WATCHLISTS_COLLECTIONS` from `W+C` to `Watchlists`.
+- `tldw_chatbook/app.py`
+  - Update `TabNavigationProvider.TAB_HELP_TEXT`.
+  - Wire `library_collections_service` after DB/config helpers exist.
+- `tldw_chatbook/config.py`
+  - Add `library_collections_db_path` config default and `get_library_collections_db_path()`.
+- `tldw_chatbook/UI/Navigation/shell_destinations.py`
+  - Make the destination user-facing label/full label/purpose/tooltip Watchlists-only.
+- `tldw_chatbook/UI/Screens/watchlists_collections_screen.py`
+  - Keep compatibility class/route IDs, but render Watchlists-only copy and data.
+- `tldw_chatbook/Home/active_work_adapter.py`
+  - Update visible messages, source labels, recovery, and action labels from `W+C` to `Watchlists`.
+- `tldw_chatbook/Chat/console_live_work.py`
+  - Update live-work readiness labels and recovery copy.
+- `tldw_chatbook/Chat/console_display_state.py`
+  - Update staged-context recovery copy from `W+C` to `Watchlists`.
+- `tldw_chatbook/UI/Screens/library_screen.py`
+  - Mount and handle Library Collections panel when active mode is `collections`.
+- `tldw_chatbook/Widgets/Library/__init__.py`
+  - Export the new Collections widget.
+- `tldw_chatbook/css/components/_agentic_terminal.tcss`
+  - Add source styles only if new Collections widgets need shared hooks.
+- `tldw_chatbook/css/tldw_cli_modular.tcss`
+  - Regenerate only if source TCSS changes.
+- `Tests/UI/test_shell_destinations.py`
+- `Tests/UI/test_master_shell_navigation.py`
+- `Tests/UI/test_command_palette_providers.py`
+- `Tests/UI/test_destination_shells.py`
+- `Tests/UI/test_console_live_work_handoffs.py`
+- `Tests/UI/test_unified_shell_phase6_first_time_replay.py`
+- `Tests/UI/test_unified_shell_phase6_power_user_replay.py`
+- `Tests/Home/test_active_work_adapter.py`
+- `Tests/Home/test_dashboard_state.py`
+- `Tests/UI/test_product_maturity_phase3_layout_contracts.py`
+- `Docs/superpowers/trackers/product-maturity-roadmap.md`
+- `Docs/superpowers/qa/product-maturity/phase-3/README.md`
+- `backlog/tasks/task-10 - Product-Maturity-Phase-3-Knowledge-And-Study-Workflows.md`
+- `backlog/tasks/task-10.9*.md`
+
+## Read Before Editing
+
+- `Docs/superpowers/specs/2026-05-08-library-collections-ia-split-design.md`
+- `Docs/superpowers/plans/2026-05-07-gate-1-6-library-native-search-rag.md`
+- `tldw_chatbook/UI/Screens/library_screen.py`
+- `tldw_chatbook/UI/Screens/watchlists_collections_screen.py`
+- `tldw_chatbook/UI/Navigation/shell_destinations.py`
+- `tldw_chatbook/Home/active_work_adapter.py`
+- `tldw_chatbook/Chat/console_live_work.py`
+- `tldw_chatbook/config.py`
+- `Tests/UI/test_destination_shells.py`
+- `Tests/UI/test_product_maturity_gate16_library_search_rag.py`
+- `backlog/tasks/task-10.9 - Product-Maturity-Phase-3.9-Library-Collections-IA-Split.md`
+
+Use the repo virtualenv from any worktree:
+
+```bash
+PY=/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python
+```
+
+## Risk Controls
+
+- Keep `watchlists_collections` as the route ID for this gate.
+- Avoid changing payload routing IDs unless tests prove the compatibility path still works.
+- Do not reuse `media_reading_scope_service.list_read_it_later()` as the Library Collections data model.
+- Do not add enabled RAG/Study/Console actions for Collections until item membership and source-scoped execution are implemented.
+- Do not edit generated CSS directly. Edit source TCSS first, then run `python tldw_chatbook/css/build_css.py` if needed.
+- Avoid fixed `pilot.pause()` sleeps in new UI tests. Poll for selectors, enabled state, or stable visible text.
+- Prefer selector/action-state assertions over brittle full-paragraph copy checks.
+
+---
+
+### Task 1: Phase 3.9.1 Watchlists IA Split And Compatibility Labels
+
+Backlog: `TASK-10.9.1`
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Navigation/shell_destinations.py`
+- Modify: `tldw_chatbook/Constants.py`
+- Modify: `tldw_chatbook/app.py`
+- Modify: `tldw_chatbook/UI/Screens/watchlists_collections_screen.py`
+- Modify: `tldw_chatbook/Home/active_work_adapter.py`
+- Modify: `tldw_chatbook/Chat/console_live_work.py`
+- Modify: `tldw_chatbook/Chat/console_display_state.py`
+- Test: `Tests/UI/test_shell_destinations.py`
+- Test: `Tests/UI/test_master_shell_navigation.py`
+- Test: `Tests/UI/test_command_palette_providers.py`
+- Test: `Tests/UI/test_destination_shells.py`
+- Test: `Tests/Home/test_active_work_adapter.py`
+- Test: `Tests/UI/test_console_live_work_handoffs.py`
+
+- [ ] **Step 1: Run the current Watchlists/W+C baseline**
+
+```bash
+$PY -m pytest -q \
+  Tests/UI/test_shell_destinations.py \
+  Tests/UI/test_master_shell_navigation.py \
+  Tests/UI/test_command_palette_providers.py \
+  Tests/UI/test_destination_shells.py::test_watchlists_collections_uses_compact_title_and_clear_sections \
+  Tests/UI/test_destination_shells.py::test_watchlists_collections_lists_local_snapshot_from_services \
+  Tests/Home/test_active_work_adapter.py \
+  --tb=short
+```
+
+Expected: pass on baseline before red tests are changed.
+
+- [ ] **Step 2: Add red tests for user-facing Watchlists copy**
+
+Update shell/navigation tests to expect:
+
+```python
+wc = get_shell_destination("watchlists_collections")
+assert wc.label == "Watchlists"
+assert wc.full_label == "Watchlists"
+assert "Collections" not in wc.tooltip
+```
+
+Update command palette tests to search for `Watchlists` and assert `Watchlists+Collections` is not in command/help text.
+
+Update destination tests to assert:
+
+```python
+assert _static_text(screen.query_one("#watchlists-collections-title", Static)) == "Watchlists"
+assert "Collections" not in _visible_text(screen)
+assert "Local Watchlists snapshot" in _visible_text(screen)
+```
+
+Expected before implementation: failures in navigation metadata, command palette help, and Watchlists screen body.
+
+- [ ] **Step 3: Update shell metadata and command palette labels**
+
+Change:
+
+- `Constants.TAB_DISPLAY_LABELS[TAB_WATCHLISTS_COLLECTIONS]` to `Watchlists`.
+- `TabNavigationProvider.TAB_HELP_TEXT[TAB_WATCHLISTS_COLLECTIONS]` to Watchlists-only copy.
+- `SHELL_DESTINATION_ORDER` entry for `watchlists_collections` to:
+
+```python
+ShellDestination(
+    "watchlists_collections",
+    "Watchlists",
+    "watchlists_collections",
+    "Monitored sources, runs, alerts, and recovery.",
+    "Open Watchlists for monitored sources, runs, alerts, and recovery.",
+    ("subscriptions", "subscription"),
+    full_label="Watchlists",
+    navigation_priority=40,
+)
+```
+
+- [ ] **Step 4: Make `WatchlistsCollectionsScreen` render Watchlists-only content**
+
+Keep the class name and `screen_id` for compatibility, but remove collection data from the visible snapshot and UI.
+
+Implementation notes:
+
+- Rename constants to Watchlists wording where practical.
+- Stop calling `media_reading_scope_service.list_read_it_later()` inside `_list_local_wc_snapshot()`.
+- Return only watchlist records/counts from the local snapshot.
+- Keep selector IDs such as `#watchlists-collections-shell` if existing visual audit tests rely on them.
+- Remove `#wc-collections-summary` and `#wc-collection-item-*` from composed output.
+- Update `ChatHandoffPayload` title/body/display summary/suggested prompt to Watchlists-only copy.
+- Keep `source="watchlists_collections"` if downstream tests require the compatibility source route.
+
+- [ ] **Step 5: Update Home and Console visible active-work labels**
+
+Change user-facing strings:
+
+- `Opening W+C run details` -> `Opening Watchlists run details`
+- `source="W+C"` -> prefer `source="Watchlists"` for new active-work items
+- `Review the W+C run details or retry from W+C` -> Watchlists wording
+- `Open W+C run` -> `Open Watchlists run`
+- Console readiness row label `W+C` -> `Watchlists`
+
+Compatibility guard:
+
+- Where code filters by `item.source == "W+C"`, accept both `Watchlists` and `W+C` during this gate.
+
+- [ ] **Step 6: Verify Task 1**
+
+```bash
+$PY -m pytest -q \
+  Tests/UI/test_shell_destinations.py \
+  Tests/UI/test_master_shell_navigation.py \
+  Tests/UI/test_command_palette_providers.py \
+  Tests/UI/test_destination_shells.py \
+  Tests/Home/test_active_work_adapter.py \
+  Tests/UI/test_console_live_work_handoffs.py \
+  --tb=short
+
+git diff --check
+```
+
+- [ ] **Step 7: Commit Task 1**
+
+```bash
+git add \
+  tldw_chatbook/UI/Navigation/shell_destinations.py \
+  tldw_chatbook/Constants.py \
+  tldw_chatbook/app.py \
+  tldw_chatbook/UI/Screens/watchlists_collections_screen.py \
+  tldw_chatbook/Home/active_work_adapter.py \
+  tldw_chatbook/Chat/console_live_work.py \
+  tldw_chatbook/Chat/console_display_state.py \
+  Tests/UI/test_shell_destinations.py \
+  Tests/UI/test_master_shell_navigation.py \
+  Tests/UI/test_command_palette_providers.py \
+  Tests/UI/test_destination_shells.py \
+  Tests/Home/test_active_work_adapter.py \
+  Tests/UI/test_console_live_work_handoffs.py
+git commit -m "Split Watchlists IA from Collections"
+```
+
+---
+
+### Task 2: Phase 3.9.2 Library Collections Display-State And Local Service Contracts
+
+Backlog: `TASK-10.9.2`
+
+**Files:**
+- Create: `tldw_chatbook/DB/Library_Collections_DB.py`
+- Create: `tldw_chatbook/Library/library_collections_state.py`
+- Create: `tldw_chatbook/Library/library_collections_service.py`
+- Modify: `tldw_chatbook/Library/__init__.py`
+- Modify: `tldw_chatbook/config.py`
+- Modify: `tldw_chatbook/app.py`
+- Create: `Tests/Library/test_library_collections_state.py`
+- Create: `Tests/Library/test_library_collections_service.py`
+
+- [ ] **Step 1: Add pure state red tests**
+
+Create `Tests/Library/test_library_collections_state.py` covering:
+
+- Empty panel state shows the copy `Group saved Library items for Search/RAG, Study, and Console.`
+- Ready state selects the first collection by default when no selected ID is provided.
+- Invalid create/rename input disables actions with a visible reason.
+- Sync status renders `local-only` or `sync-unavailable`.
+- Delete action is disabled when no collection is selected.
+
+Expected before implementation: import failure for `tldw_chatbook.Library.library_collections_state`.
+
+- [ ] **Step 2: Add service/DB red tests**
+
+Create `Tests/Library/test_library_collections_service.py` using a temp SQLite path.
+
+Cover:
+
+- `list_collections()` returns an empty list initially.
+- `create_collection("Research")` persists a collection with stable `collection_id`, `item_count == 0`, `source_authority == "local"`, and `sync_status == "local-only"`.
+- Duplicate normalized names are rejected.
+- `rename_collection()` updates `name`, optional `description`, and `updated_at`.
+- `delete_collection()` hides/deletes the record from list/get.
+- Invalid names are rejected before SQL.
+
+Expected before implementation: import failure for `tldw_chatbook.Library.library_collections_service`.
+
+- [ ] **Step 3: Implement local SQLite persistence**
+
+Create `tldw_chatbook/DB/Library_Collections_DB.py` with:
+
+```sql
+CREATE TABLE IF NOT EXISTS library_collections (
+    collection_id TEXT PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    description TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    deleted_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS library_collection_items (
+    item_id TEXT PRIMARY KEY,
+    collection_id TEXT NOT NULL,
+    source_type TEXT NOT NULL,
+    source_id TEXT NOT NULL,
+    title TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL,
+    FOREIGN KEY(collection_id) REFERENCES library_collections(collection_id)
+);
+```
+
+Keep item membership private/future-facing in this gate. It exists so `item_count` can be computed without changing the persistence contract later.
+
+- [ ] **Step 4: Implement pure state models**
+
+Create frozen dataclasses:
+
+- `LibraryCollectionSummary`
+- `LibraryCollectionDetail`
+- `LibraryCollectionActionState`
+- `LibraryCollectionsPanelState`
+
+Recommended builder:
+
+```python
+LibraryCollectionsPanelState.from_values(
+    collections=records,
+    selected_collection_id=selected_id,
+    status="ready",
+    error_message="",
+)
+```
+
+The state builder should sanitize display strings and never raise on loose app/test seam values.
+
+- [ ] **Step 5: Implement service contract**
+
+Create:
+
+- `LibraryCollectionsService` protocol.
+- `LocalLibraryCollectionsService` implementation.
+- `LibraryCollectionsServiceError`.
+- `InvalidLibraryCollectionName`.
+- `DuplicateLibraryCollectionName`.
+
+Validation:
+
+- Trim names.
+- Reject empty names.
+- Limit names to 120 characters.
+- Limit descriptions to 500 characters.
+- Use parameterized SQL only.
+
+- [ ] **Step 6: Add config/app wiring**
+
+In `config.py`, add:
+
+- default `library_collections_db_path = "~/.local/share/tldw_cli/tldw_chatbook_library_collections.db"`
+- `get_library_collections_db_path()`
+
+In `app.py`, wire:
+
+```python
+self.local_library_collections_service = LocalLibraryCollectionsService(
+    LibraryCollectionsDB(get_library_collections_db_path())
+)
+self.library_collections_service = self.local_library_collections_service
+```
+
+If initialization fails, set `self.library_collections_service = None` and rely on the Library UI recovery state.
+
+- [ ] **Step 7: Verify Task 2**
+
+```bash
+$PY -m pytest -q \
+  Tests/Library/test_library_collections_state.py \
+  Tests/Library/test_library_collections_service.py \
+  --tb=short
+
+git diff --check
+```
+
+- [ ] **Step 8: Commit Task 2**
+
+```bash
+git add \
+  tldw_chatbook/DB/Library_Collections_DB.py \
+  tldw_chatbook/Library/__init__.py \
+  tldw_chatbook/Library/library_collections_state.py \
+  tldw_chatbook/Library/library_collections_service.py \
+  tldw_chatbook/config.py \
+  tldw_chatbook/app.py \
+  Tests/Library/test_library_collections_state.py \
+  Tests/Library/test_library_collections_service.py
+git commit -m "Add Library Collections local service contracts"
+```
+
+---
+
+### Task 3: Phase 3.9.3 Library Collections Mounted Management UI
+
+Backlog: `TASK-10.9.3`
+
+**Files:**
+- Create: `tldw_chatbook/Widgets/Library/library_collections_panel.py`
+- Modify: `tldw_chatbook/Widgets/Library/__init__.py`
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py`
+- Modify if needed: `tldw_chatbook/css/components/_agentic_terminal.tcss`
+- Modify if needed: `tldw_chatbook/css/tldw_cli_modular.tcss`
+- Create/modify: `Tests/UI/test_product_maturity_phase39_library_collections.py`
+- Verify: `Tests/UI/test_product_maturity_gate16_library_search_rag.py`
+
+- [ ] **Step 1: Add mounted red tests**
+
+Create `Tests/UI/test_product_maturity_phase39_library_collections.py`.
+
+Use `DestinationHarness(app, "library")` and inject a fake `library_collections_service`.
+
+Cover:
+
+- Pressing `#library-mode-collections` mounts `#library-collections-panel`.
+- Empty state copy explains Collections without claiming sync or RAG execution.
+- Creating a collection through `#library-collection-name-input` and `#library-create-collection` adds it to the list and selects it.
+- Renaming through `#library-collection-name-input` and `#library-rename-collection` updates detail copy.
+- Deleting through `#library-delete-collection` removes it and returns to empty state.
+- A service exception renders `#library-collections-error` with retry/recovery copy.
+- `#library-rag-run-query` is not mounted in Collections mode.
+
+Expected before implementation: missing selectors.
+
+- [ ] **Step 2: Create Collections panel widget**
+
+Create `LibraryCollectionsPanel` with stable selectors:
+
+- `#library-collections-panel`
+- `#library-collections-empty`
+- `#library-collections-error`
+- `#library-collections-list`
+- `#library-collection-detail`
+- `#library-collection-name-input`
+- `#library-collection-description-input`
+- `#library-create-collection`
+- `#library-rename-collection`
+- `#library-delete-collection`
+- `#library-collection-sync-status`
+- `#library-collection-item-count`
+
+The widget should receive a `LibraryCollectionsPanelState` and render only. Keep service mutation in `LibraryScreen`.
+
+- [ ] **Step 3: Wire Library screen state and refresh**
+
+In `LibraryScreen.__init__`, add:
+
+- `_library_collections_loaded`
+- `_library_collections_records`
+- `_library_collections_selected_id`
+- `_library_collections_error`
+
+Add worker methods:
+
+- `_refresh_library_collections_snapshot()`
+- `_list_library_collections_snapshot()`
+- `_apply_library_collections_snapshot()`
+
+Use the existing `_resolve_maybe_awaitable()` helper so fake async and sync services both work in tests.
+
+- [ ] **Step 4: Mount Collections panel in the existing shell**
+
+When `_active_mode == "collections"`:
+
+- Mount `LibraryCollectionsPanel` in `#library-source-detail` after `#library-active-mode-next-action`.
+- Mount lightweight inspector status in `#library-source-inspector` if the panel does not already show it.
+- Remove Search/RAG widgets when leaving `search` mode.
+- Do not recompose the whole Library shell unnecessarily if targeted widget refresh is enough.
+
+Recommended helper:
+
+```python
+async def _sync_collections_panel(self) -> None:
+    await self._remove_mode_widgets("#library-collections-panel, #library-collections-inspector")
+    if self._active_mode != "collections":
+        return
+    await self._refresh_library_collections_snapshot()
+```
+
+- [ ] **Step 5: Add create, rename, and delete handlers**
+
+Handlers:
+
+- `@on(Button.Pressed, "#library-create-collection")`
+- `@on(Button.Pressed, "#library-rename-collection")`
+- `@on(Button.Pressed, "#library-delete-collection")`
+- Optional selection handler for collection row buttons, if rows are rendered as buttons.
+
+Rules:
+
+- Notify and keep form input visible on invalid names.
+- Refresh panel state after success.
+- Use service methods only, not direct DB calls.
+- Keep sync copy as status text only.
+
+- [ ] **Step 6: Add TCSS only if needed**
+
+If new classes are required, edit `tldw_chatbook/css/components/_agentic_terminal.tcss`.
+
+Then run:
+
+```bash
+$PY tldw_chatbook/css/build_css.py
+```
+
+If the build emits the pre-existing missing `features/_evaluation_v2.tcss` warning and exits 0, record that in implementation notes.
+
+- [ ] **Step 7: Verify Task 3**
+
+```bash
+$PY -m pytest -q \
+  Tests/UI/test_product_maturity_phase39_library_collections.py \
+  Tests/UI/test_product_maturity_gate16_library_search_rag.py \
+  Tests/UI/test_product_maturity_phase3_library_contract_layout.py \
+  --tb=short
+
+git diff --check
+```
+
+- [ ] **Step 8: Commit Task 3**
+
+```bash
+git add \
+  tldw_chatbook/Widgets/Library/__init__.py \
+  tldw_chatbook/Widgets/Library/library_collections_panel.py \
+  tldw_chatbook/UI/Screens/library_screen.py \
+  Tests/UI/test_product_maturity_phase39_library_collections.py
+git add tldw_chatbook/css/components/_agentic_terminal.tcss tldw_chatbook/css/tldw_cli_modular.tcss
+git commit -m "Mount Library Collections management UI"
+```
+
+Only stage CSS files if they actually changed.
+
+---
+
+### Task 4: Phase 3.9.4 Library Collections QA Closeout And Tracking
+
+Backlog: `TASK-10.9.4`
+
+**Files:**
+- Modify: `Tests/UI/test_product_maturity_phase3_layout_contracts.py`
+- Create: `Docs/superpowers/qa/product-maturity/phase-3/2026-05-08-phase-3-9-library-collections.md`
+- Modify: `Docs/superpowers/qa/product-maturity/phase-3/README.md`
+- Modify: `Docs/superpowers/trackers/product-maturity-roadmap.md`
+- Modify: `backlog/tasks/task-10 - Product-Maturity-Phase-3-Knowledge-And-Study-Workflows.md`
+- Modify: `backlog/tasks/task-10.9 - Product-Maturity-Phase-3.9-Library-Collections-IA-Split.md`
+- Modify: `backlog/tasks/task-10.9.4 - Phase-3.9.4-Library-Collections-QA-closeout-and-tracking.md`
+
+- [ ] **Step 1: Add tracking red test**
+
+Update or add a tracking test asserting:
+
+- `Docs/superpowers/trackers/product-maturity-roadmap.md` lists Phase 3.9 / TASK-10.9.
+- Phase 3.9 evidence path is included.
+- Roadmap residual risks still include Workspaces, Import/Export depth, server sync, and deeper Study/Search/RAG flows.
+- The Phase 3 spec/roadmap mention citations/snippets as later-stage Library/Search/RAG work.
+
+- [ ] **Step 2: Create QA evidence document**
+
+Create `Docs/superpowers/qa/product-maturity/phase-3/2026-05-08-phase-3-9-library-collections.md` with:
+
+- Scope.
+- First-time user discovery check.
+- Power-user create/select/rename/delete workflow.
+- Watchlists continuity check.
+- Sync honesty check.
+- Verification commands.
+- Functional defects.
+- UX defects.
+- Visual/UI defects.
+- Residual risks.
+
+Use this result language only after verification:
+
+```text
+Pass for Phase 3.9 only if Library Collections management and Watchlists continuity are both usable in the mounted app.
+```
+
+- [ ] **Step 3: Update roadmap and QA index**
+
+Update:
+
+- `Docs/superpowers/qa/product-maturity/phase-3/README.md`
+- `Docs/superpowers/trackers/product-maturity-roadmap.md`
+
+Roadmap status should say Phase 3.9 verified only after the tests and QA walkthrough pass.
+
+- [ ] **Step 4: Update Backlog via CLI**
+
+Use Backlog CLI from the implementation worktree:
+
+```bash
+backlog task edit TASK-10.9 --plan "1. TASK-10.9.1: Watchlists IA split and compatibility labels.\n2. TASK-10.9.2: Library Collections display-state and local service contracts.\n3. TASK-10.9.3: Library Collections mounted management UI.\n4. TASK-10.9.4: QA closeout and tracking.\n\nPrimary implementation plan: Docs/superpowers/plans/2026-05-08-phase-3-9-library-collections-ia-split.md."
+```
+
+At closeout, check ACs and set done only after verification:
+
+```bash
+backlog task edit TASK-10.9 --status Done
+backlog task edit TASK-10.9.4 --status Done
+```
+
+Do not mark tasks done before ACs, implementation notes, and QA evidence are complete.
+
+- [ ] **Step 5: Run focused verification**
+
+```bash
+$PY -m pytest -q \
+  Tests/Library/test_library_collections_state.py \
+  Tests/Library/test_library_collections_service.py \
+  Tests/UI/test_product_maturity_phase39_library_collections.py \
+  Tests/UI/test_destination_shells.py \
+  Tests/UI/test_shell_destinations.py \
+  Tests/UI/test_master_shell_navigation.py \
+  Tests/UI/test_command_palette_providers.py \
+  Tests/Home/test_active_work_adapter.py \
+  Tests/UI/test_console_live_work_handoffs.py \
+  Tests/UI/test_product_maturity_gate16_library_search_rag.py \
+  Tests/UI/test_product_maturity_phase3_layout_contracts.py \
+  --tb=short
+
+git diff --check
+```
+
+- [ ] **Step 6: Manual QA walkthrough**
+
+Run the app from a clean temporary HOME/XDG if feasible:
+
+```bash
+HOME=/tmp/tldw-chatbook-phase39-home XDG_CONFIG_HOME=/tmp/tldw-chatbook-phase39-config XDG_DATA_HOME=/tmp/tldw-chatbook-phase39-data $PY -m tldw_chatbook.app
+```
+
+Walk through:
+
+- Home -> Library -> Collections discovery.
+- Create collection.
+- Select collection.
+- Rename collection.
+- Delete collection.
+- Confirm sync is local-only/unavailable, not an enabled fake action.
+- Open Watchlists and confirm it is Watchlists-only.
+- Confirm Watchlists active-run follow-through still works in fixture-backed tests.
+
+If a clean runtime cannot launch due local optional-service blockers, record the blocker and mounted-test evidence. Do not claim full manual pass.
+
+- [ ] **Step 7: Commit Task 4**
+
+```bash
+git add \
+  Tests/UI/test_product_maturity_phase3_layout_contracts.py \
+  Docs/superpowers/qa/product-maturity/phase-3/2026-05-08-phase-3-9-library-collections.md \
+  Docs/superpowers/qa/product-maturity/phase-3/README.md \
+  Docs/superpowers/trackers/product-maturity-roadmap.md \
+  backlog/tasks/task-10*.md
+git commit -m "Record Library Collections QA closeout"
+```
+
+---
+
+## Execution Notes
+
+- Execute tasks sequentially. Task 2 can be developed in parallel with Task 1 only if write scopes are isolated, but the safer path is sequential because label changes affect many tests.
+- Keep commits PR-sized and reviewable.
+- If implementation discovers that `TASK-10.9.2` persistence should be a different DB boundary, update the task AC before coding.
+- If item membership becomes larger than a simple current-item seam, defer it to a follow-up and keep Phase 3.9 focused on local Collection management.
+- After the plan is implemented and verified, open a PR against `dev`.

--- a/Docs/superpowers/qa/product-maturity/phase-3/2026-05-08-phase-3-9-library-collections.md
+++ b/Docs/superpowers/qa/product-maturity/phase-3/2026-05-08-phase-3-9-library-collections.md
@@ -1,0 +1,135 @@
+# Phase 3.9 Library Collections IA Split QA
+
+Date: 2026-05-08
+Status: verified
+
+## Scope
+
+Phase 3.9 verifies the product-model split between the top-level Watchlists destination and Library-owned Collections management. The verified scope is local-first Collections management inside Library plus Watchlists continuity through existing compatibility route IDs.
+
+Out of scope for this gate: server sync, collection item membership picker, collection-scoped Search/RAG execution, collection-scoped Study/Flashcards/Quizzes generation, collection-scoped Console execution, collection Import/Export, and citation/snippet carry-through.
+
+## First-Time User Discovery Check
+
+Verified by mounted Textual navigation and Library screen tests:
+
+- Primary navigation and command-palette copy expose `Watchlists`, not `W+C` or `Watchlists+Collections`.
+- Collections is discoverable as a Library mode alongside existing Library workflows.
+- The Collections empty state explains the purpose: grouping saved Library items for Search/RAG, Study, and Console.
+- Collections mode disables deferred Study, Flashcards, Quizzes, and Console actions instead of implying unavailable workflows are ready.
+
+## Power-User Create/Select/Rename/Delete Workflow
+
+Verified with a mounted Library workflow using a fake local Collections service:
+
+1. Open Library.
+2. Switch to Collections mode.
+3. Create a collection named `Research` with description `Policy sources`.
+4. Confirm the created collection is selected and shows `0 items`, `Sync: local-only`, and a stable updated timestamp.
+5. Rename the selected collection to `Briefing Queue`.
+6. Start delete, verify confirmation is required, then confirm delete.
+7. Confirm the empty state returns after delete.
+
+This proves the gate is usable for local management, not only renderable.
+
+## Watchlists Continuity Check
+
+Verified by destination-shell, navigation, Home active-work, Console live-work, and Unified Shell replay tests:
+
+- `watchlists_collections` remains the compatibility route ID.
+- User-facing title, navigation label, and active-work copy say `Watchlists`.
+- Watchlists no longer renders Library Collections or read-it-later summaries.
+- Home and Console active-run follow-through continue to route fixture-backed Watchlists work through compatibility payloads.
+
+## Sync Honesty Check
+
+Verified by display-state, service, and mounted UI tests:
+
+- Local Collections expose `local-only` when persistence is available.
+- Service-unavailable states render recoverable copy without exposing raw database errors.
+- `sync-unavailable` is displayed as status only.
+- No fake sync button or enabled server-sync action appears.
+
+## Verification Commands
+
+Focused commands run for this gate:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Library/test_library_collections_state.py Tests/Library/test_library_collections_service.py Tests/UI/test_product_maturity_phase39_library_collections.py --tb=short
+```
+
+Result: `17 passed`.
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_product_maturity_phase39_library_collections.py Tests/UI/test_product_maturity_gate16_library_search_rag.py Tests/UI/test_product_maturity_phase3_library_contract_layout.py --tb=short
+```
+
+Result: `19 passed`.
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_product_maturity_phase3_knowledge_entry.py::test_library_surfaces_study_workflow_entry_points Tests/UI/test_product_maturity_phase3_knowledge_entry.py::test_library_study_entry_buttons_preserve_requested_section --tb=short
+```
+
+Result: `2 passed`.
+
+Final closeout verification:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Library/test_library_collections_state.py Tests/Library/test_library_collections_service.py Tests/UI/test_product_maturity_phase39_library_collections.py Tests/UI/test_destination_shells.py Tests/UI/test_shell_destinations.py Tests/UI/test_master_shell_navigation.py Tests/UI/test_command_palette_providers.py Tests/Home/test_active_work_adapter.py Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_unified_shell_phase6_first_time_replay.py Tests/UI/test_unified_shell_phase6_power_user_replay.py Tests/UI/test_product_maturity_gate16_library_search_rag.py Tests/UI/test_product_maturity_phase3_layout_contracts.py --tb=short
+```
+
+Result: `248 passed, 8 warnings in 131.60s`.
+
+```bash
+git diff --check
+```
+
+Result: pass.
+
+Clean runtime smoke:
+
+```bash
+HOME=/private/tmp/tldw-chatbook-phase39-home XDG_CONFIG_HOME=/private/tmp/tldw-chatbook-phase39-config XDG_DATA_HOME=/private/tmp/tldw-chatbook-phase39-data /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m tldw_chatbook.app
+```
+
+Result: app created a fresh config and local databases, reached the Console screen, and exited normally through the quit flow. Observed non-blocking optional dependency/network warnings for NLTK data and optional media/transcription packages. Mounted Textual pilot tests remain the primary interaction evidence for the Library Collections create/select/rename/delete workflow because they exercise deterministic selectors and action states.
+
+## Functional Defects
+
+No P0/P1 functional defects remain in the verified Phase 3.9 scope.
+
+Accepted residual functional gaps:
+
+- Collection item membership is represented as a follow-up seam.
+- Collection-scoped Search/RAG, Study, Flashcards, Quizzes, Console, and Import/Export are intentionally disabled or deferred.
+- Server sync is not implemented because the sync engine does not exist yet.
+
+## UX Defects
+
+No P0/P1 UX defects remain in the verified Phase 3.9 scope.
+
+Accepted residual UX risks:
+
+- Collections cannot yet demonstrate its full reuse value without membership and scoped downstream workflows.
+- Power users still need later shortcuts for adding current Library items to a Collection.
+- Clean environment launch was smoke-tested, but mounted Textual workflow tests provide the verified interaction evidence for Phase 3.9 controls.
+
+## Visual/UI Defects
+
+No P0/P1 visual/UI defects remain in the verified Phase 3.9 scope.
+
+Visual scope was bounded to mounted Textual layouts at the tested terminal sizes. Broader compact visual regression remains covered by earlier Library layout and shell visual gates.
+
+## Residual Risks
+
+- Workspaces remain a later Phase 3 workflow gate.
+- Import/Export depth remains a later Library workflow gate.
+- Full server sync for Collections remains blocked until a sync engine exists.
+- Deeper Study/Search/RAG flows for collection-scoped execution remain later-stage.
+- Citations/snippets and Citation/snippet carry-through into Chat, artifacts, and exported Chatbooks remain later-stage Library/Search/RAG work.
+
+## Result
+
+Pass for Phase 3.9 only if Library Collections management and Watchlists continuity are both usable in the mounted app.
+
+Phase 3.9 passes for the implemented gate scope based on mounted Library management workflow coverage, Watchlists continuity coverage, roadmap tracking, and focused verification. The residual risks above stay open for later PR-sized gates.

--- a/Docs/superpowers/qa/product-maturity/phase-3/2026-05-08-phase-3-9-library-collections.md
+++ b/Docs/superpowers/qa/product-maturity/phase-3/2026-05-08-phase-3-9-library-collections.md
@@ -72,13 +72,13 @@ Result: `19 passed`.
 
 Result: `2 passed`.
 
-Final closeout verification:
+Final closeout verification after rebasing onto current `origin/dev`:
 
 ```bash
 /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Library/test_library_collections_state.py Tests/Library/test_library_collections_service.py Tests/UI/test_product_maturity_phase39_library_collections.py Tests/UI/test_destination_shells.py Tests/UI/test_shell_destinations.py Tests/UI/test_master_shell_navigation.py Tests/UI/test_command_palette_providers.py Tests/Home/test_active_work_adapter.py Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_unified_shell_phase6_first_time_replay.py Tests/UI/test_unified_shell_phase6_power_user_replay.py Tests/UI/test_product_maturity_gate16_library_search_rag.py Tests/UI/test_product_maturity_phase3_layout_contracts.py --tb=short
 ```
 
-Result: `248 passed, 8 warnings in 131.60s`.
+Result: `248 passed, 8 warnings in 132.34s`.
 
 ```bash
 git diff --check

--- a/Docs/superpowers/qa/product-maturity/phase-3/README.md
+++ b/Docs/superpowers/qa/product-maturity/phase-3/README.md
@@ -14,6 +14,12 @@ Phase 3.0 destination layout contract status: verified
 
 Phase 3.0 records destination layout and IA contracts before additional Phase 3 Knowledge/Study visual rewrites continue. It does not rewrite runtime screens; TASK-10.0 closeout is verified.
 
+Phase 3.9 Library Collections IA split status: verified
+
+- `2026-05-08-phase-3-9-library-collections.md`
+
+Phase 3.9 verifies that Watchlists is the top-level monitored-source destination while Collections is owned by Library, locally manageable, and honest about deferred sync and scoped downstream workflows.
+
 ## Evidence
 
 - `2026-05-06-phase-3-0-destination-layout-contracts.md`
@@ -25,3 +31,4 @@ Phase 3.0 records destination layout and IA contracts before additional Phase 3 
 - `2026-05-07-gate-1-5-console-internals-decomposition.md`
 - `2026-05-07-phase-3-7-source-study-pack-completion-reuse.md`
 - `2026-05-07-gate-1-6-library-native-search-rag.md`
+- `2026-05-08-phase-3-9-library-collections.md`

--- a/Docs/superpowers/specs/2026-05-08-library-collections-ia-split-design.md
+++ b/Docs/superpowers/specs/2026-05-08-library-collections-ia-split-design.md
@@ -1,0 +1,282 @@
+# Library Collections IA Split Design
+
+Date: 2026-05-08
+Status: User-approved design direction; pending implementation plan
+Branch baseline: `origin/dev` at `df63b49f` (`Close Gate 1.6 Library Search/RAG (#281)`)
+
+## Related Documents
+
+- `Docs/superpowers/plans/2026-05-06-gate-1-core-product-loop-screen-adaptation.md`
+- `Docs/superpowers/specs/2026-05-05-product-maturity-phased-roadmap-design.md`
+- `Docs/superpowers/specs/2026-05-06-destination-layout-ia-contracts-design.md`
+- `Docs/superpowers/specs/2026-05-06-screen-design-adaptation-audit-design.md`
+- `Docs/superpowers/specs/2026-05-02-agentic-terminal-design-system-design.md`
+- `Docs/superpowers/trackers/product-maturity-roadmap.md`
+
+## Summary
+
+Phase 3.9 splits the current combined Watchlists+Collections product model into two clearer destinations:
+
+- **Watchlists** remains a top-level destination for monitored sources, active runs, alerts, schedules, and Console follow-through.
+- **Collections** moves into **Library** as a Library-owned mode for grouping saved Library sources for later Search/RAG, Study, Console, and future artifact workflows.
+
+The first implementation slice is local-first and management-capable. Users should be able to discover Collections from Library, create a named collection, select it, rename it, and delete it. Server parity remains a future goal because the sync engine is not written yet. The UI must not expose working-looking sync controls until sync actually exists.
+
+## Problem Statement
+
+The current `W+C` model conflates two different user intents:
+
+- Watchlists answer: "What external sources am I monitoring and what runs need attention?"
+- Collections answer: "How do I organize saved Library sources into reusable sets?"
+
+That conflation weakens first-time comprehension and power-user routing. It also creates a risk that future Collection work gets implemented inside Watchlist services or screen copy, where it will be harder to integrate with Library Search/RAG, Study, Console, and artifacts.
+
+Library already exposes a `Collections` mode, but it is currently placeholder-level. Phase 3.9 should make that mode real enough to validate the product model without overbuilding server sync or cross-module source pickers.
+
+## Goals
+
+- Rename the visible top-level `W+C` destination to **Watchlists**.
+- Keep existing route IDs or aliases where needed for compatibility.
+- Remove user-facing Collections copy from the Watchlists destination.
+- Add a Library-owned Collections mode that supports local create, select, rename, and delete.
+- Represent Collections as reusable Library source sets, not watchlist runs.
+- Preserve power-user density and keyboard-friendly navigation.
+- Make sync status honest: local-only until a sync engine exists.
+- Add tests and QA evidence proving the app is usable, not merely renderable.
+- Keep future citations and snippets visible in the roadmap as later-stage Library/Search/RAG capabilities.
+
+## Non-Goals
+
+- No server sync engine implementation.
+- No server parity beyond honest local-only metadata and future seams.
+- No full cross-source item picker unless an existing Library service makes it safe and small.
+- No Collection-scoped Search/RAG execution in this slice.
+- No Collection-scoped Study/Flashcards/Quizzes generation in this slice.
+- No Import/Export changes for Collections in this slice.
+- No Watchlists runtime rewrite.
+- No route-ID breaking migration.
+
+## Product Model Contract
+
+### Navigation
+
+Visible primary navigation should use these concepts:
+
+- `Home`
+- `Console`
+- `Library`
+- `Personas`
+- `Watchlists`
+- `Schedules`
+- `Workflows`
+- `MCP`
+- `ACP`
+- `Skills`
+- `Artifacts`
+- `Settings`
+
+`Collections` is not a top-level destination. It is a Library mode.
+
+### Compatibility
+
+Existing internal names such as `watchlists_collections` may remain as compatibility aliases for the Watchlists destination during this gate. User-facing labels, command palette copy, help text, breadcrumbs, and empty states should say **Watchlists**, not `W+C` or `Watchlists+Collections`.
+
+### Library Mode Placement
+
+Library should expose Collections alongside its other Library modes. Collections belongs with source organization because it will eventually feed Search/RAG, Study, Console, citations/snippets, and artifacts.
+
+## Library Collections Behavior
+
+### First Slice Capabilities
+
+The first implementation slice must support:
+
+- List local collections.
+- Create a collection with a required name and optional description.
+- Select a collection.
+- Rename a selected collection.
+- Delete a selected collection with a clear confirmation or recovery affordance.
+- Show item count, updated timestamp, and local-only sync status.
+- Show an empty state that explains why Collections matter.
+
+Suggested empty-state copy:
+
+> Group saved Library items for Search/RAG, Study, and Console.
+
+### Collection Fields
+
+The display contract should support:
+
+- `collection_id`
+- `name`
+- `description`
+- `item_count`
+- `updated_at`
+- `source_authority`
+- `sync_status`
+
+For this gate:
+
+- `source_authority` is `local`.
+- `sync_status` is `local-only` or `sync-unavailable`.
+
+### Item Membership
+
+This phase should not block on a full item picker. If existing Library services make adding the current selected item small and safe, it may be included. Otherwise, item membership should be represented as an explicit follow-up seam with honest empty/detail copy.
+
+The UI must not imply that Collection-scoped RAG, Study, or Console actions are already functional unless those flows are implemented and verified.
+
+## Watchlists Split Behavior
+
+The existing combined destination should become Watchlists-only.
+
+Watchlists should retain:
+
+- Monitored source overview.
+- Watchlist run status.
+- Active run follow-through from Home and Console.
+- Alert or notification orientation.
+- Schedule/run recovery surfaces if currently present.
+
+Watchlists should remove:
+
+- User-facing Collections title text.
+- Collection management controls.
+- Collection count summaries.
+- Copy that describes Collections as part of the Watchlists destination.
+
+If a compact navigation label is required, `Watchlists` is still preferred. Avoid `W+C` because Collections is no longer part of that destination.
+
+## Service Boundaries
+
+Add or adapt a Library-owned service boundary rather than reusing Watchlist services as the Collection model.
+
+Recommended contract:
+
+```text
+LibraryCollectionsService
+  list_collections() -> list[LibraryCollection]
+  get_collection(collection_id) -> LibraryCollection | None
+  create_collection(name, description="") -> LibraryCollection
+  rename_collection(collection_id, name, description=None) -> LibraryCollection
+  delete_collection(collection_id) -> None
+```
+
+Recommended display-state models:
+
+```text
+LibraryCollectionsPanelState
+  status: loading | ready | empty | error
+  collections: list[LibraryCollectionSummary]
+  selected_collection: LibraryCollectionDetail | None
+  actions: LibraryCollectionActions
+  error_message: str | None
+```
+
+The Library screen should depend on the service and display-state contract, not directly on Watchlist internals.
+
+Existing Watchlist, read-it-later, feed, and media-reading services may later become adapters into Collections. They should not define the first Library Collection contract.
+
+## Textual Layout Contract
+
+Collections should fit the existing Library shell rather than introduce a new visual language.
+
+```text
+┌─ Library ───────────────────────────────────────────────────────────────┐
+│ Modes: Sources  Search/RAG  Collections  Import/Export                  │
+├────────────────────┬────────────────────────────────┬──────────────────┤
+│ Collection List    │ Selected Collection             │ Inspector        │
+│                    │                                │                  │
+│ + New Collection   │ Name                            │ Actions          │
+│                    │ Description                     │ Rename           │
+│ Recent Collections │                                │ Delete           │
+│                    │ Items                           │                  │
+│ Empty/Error state  │ Empty membership / future seam  │ Sync: local-only │
+└────────────────────┴────────────────────────────────┴──────────────────┘
+```
+
+This is a structural contract, not a pixel-level mockup. The implementation should reuse existing Library layout, tokens, buttons, and shell patterns.
+
+## Error And Recovery Contract
+
+Collections errors should be specific and recoverable:
+
+- Invalid name: keep user input visible and explain the validation rule.
+- Create/rename/delete failure: keep current list visible where possible and show retry.
+- Missing storage/service: show `Collections unavailable` with local ownership and next step.
+- Sync unavailable: show status only; do not render a fake sync action.
+
+Destructive delete should either require confirmation or provide an immediate recovery path appropriate for the existing Textual patterns.
+
+## Future Roadmap Hooks
+
+These are explicitly not part of the first Phase 3.9 implementation, but should remain visible in roadmap/spec follow-ups:
+
+- Collection item membership across Library media, notes, ingested files, imports, and external feeds.
+- Collection-scoped Search/RAG from Library.
+- Collection-scoped Chat/Console RAG.
+- Collection-scoped Study generation for flashcards and quizzes.
+- Citations and snippets in Search/RAG answers.
+- Citation/snippet carry-through into Chat, artifacts, and exported Chatbooks.
+- Server sync once a sync engine exists.
+- Import/Export of collection definitions and membership.
+
+## Testing Contract
+
+Implementation should be test-driven.
+
+Required regression coverage:
+
+- Pure service/display-state tests for list, create, rename, delete, empty, and error states.
+- Mounted Library tests proving Collections mode renders and basic management controls work.
+- Mounted Watchlists tests proving the destination no longer presents Collections as part of the top-level product model.
+- Navigation or command-palette tests proving the visible destination is Watchlists and Collections is discoverable under Library.
+- Existing destination-shell and Gate 1.6 Library Search/RAG tests remain green.
+
+Recommended focused verification:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/UI/test_product_maturity_phase3_layout_contracts.py \
+  Tests/UI/test_destination_shells.py \
+  Tests/UI/test_library_search_rag_screen.py \
+  --tb=short
+
+git diff --check
+```
+
+Exact test files may change with implementation scope, but verification must cover both the Watchlists split and Library Collections management.
+
+## QA Walkthrough Gate
+
+This phase is not done when widgets render. It is done when a manual QA walkthrough confirms the flows are understandable and usable.
+
+Required QA checks:
+
+- First-time user can find Collections from Library without knowing the old `W+C` label.
+- User can create, select, rename, and delete a local collection.
+- Empty states explain what Collections are for and what is not available yet.
+- Watchlists still opens and explains monitored-source workflows.
+- Watchlist active-run follow-through from Home/Console still works if covered by existing fixtures.
+- No fake server sync action appears.
+- No visual breakage in the Library three-region shell at normal terminal sizes.
+
+QA evidence should be recorded in the product-maturity QA docs or tracker with commands, screenshots/snapshots if helpful, observed failures, and residual risks.
+
+## Acceptance Criteria
+
+- Watchlists is visibly split from Collections in navigation, command palette/help copy, and destination body copy.
+- Collections is discoverable inside Library and has local management affordances.
+- Local create, select, rename, and delete are covered by focused tests.
+- Library Collections display state exposes local-only/sync-unavailable status honestly.
+- Existing Watchlists workflows are preserved.
+- Existing Library Search/RAG gate tests remain green.
+- Roadmap or follow-up notes include citations/snippets as later-stage Library/Search/RAG work.
+- QA walkthrough evidence confirms the app is usable for the targeted flows.
+
+## Open Questions For Implementation Planning
+
+- Which existing local persistence layer should own the first Collection records: a new DB table, an existing Library DB boundary, or a small adapter around current media/reading services?
+- Should delete be confirm-first or undo-capable based on existing Textual patterns?
+- Should first-slice item membership include "add current selected Library item" if a selected item contract already exists?
+- Which route aliases are required for backwards-compatible tests and saved navigation state?

--- a/Docs/superpowers/specs/2026-05-08-library-collections-ia-split-design.md
+++ b/Docs/superpowers/specs/2026-05-08-library-collections-ia-split-design.md
@@ -1,7 +1,7 @@
 # Library Collections IA Split Design
 
 Date: 2026-05-08
-Status: User-approved design direction; pending implementation plan
+Status: User-approved design direction; implementation plan drafted
 Branch baseline: `origin/dev` at `df63b49f` (`Close Gate 1.6 Library Search/RAG (#281)`)
 
 ## Related Documents
@@ -12,6 +12,7 @@ Branch baseline: `origin/dev` at `df63b49f` (`Close Gate 1.6 Library Search/RAG 
 - `Docs/superpowers/specs/2026-05-06-screen-design-adaptation-audit-design.md`
 - `Docs/superpowers/specs/2026-05-02-agentic-terminal-design-system-design.md`
 - `Docs/superpowers/trackers/product-maturity-roadmap.md`
+- `Docs/superpowers/plans/2026-05-08-phase-3-9-library-collections-ia-split.md`
 
 ## Summary
 
@@ -80,6 +81,8 @@ Visible primary navigation should use these concepts:
 ### Compatibility
 
 Existing internal names such as `watchlists_collections` may remain as compatibility aliases for the Watchlists destination during this gate. User-facing labels, command palette copy, help text, breadcrumbs, and empty states should say **Watchlists**, not `W+C` or `Watchlists+Collections`.
+
+Home, Console, and active-work surfaces should also use **Watchlists** as the user-facing source label for monitored-source runs. Internal payload values may remain compatibility-oriented where changing them would break existing routing, but visible copy and new tests should not teach users that `W+C` is the product model.
 
 ### Library Mode Placement
 
@@ -182,17 +185,17 @@ Existing Watchlist, read-it-later, feed, and media-reading services may later be
 Collections should fit the existing Library shell rather than introduce a new visual language.
 
 ```text
-┌─ Library ───────────────────────────────────────────────────────────────┐
-│ Modes: Sources  Search/RAG  Collections  Import/Export                  │
-├────────────────────┬────────────────────────────────┬──────────────────┤
-│ Collection List    │ Selected Collection             │ Inspector        │
-│                    │                                │                  │
-│ + New Collection   │ Name                            │ Actions          │
-│                    │ Description                     │ Rename           │
-│ Recent Collections │                                │ Delete           │
-│                    │ Items                           │                  │
-│ Empty/Error state  │ Empty membership / future seam  │ Sync: local-only │
-└────────────────────┴────────────────────────────────┴──────────────────┘
++- Library --------------------------------------------------------------+
+| Modes: Sources  Search/RAG  Collections  Import/Export                 |
++--------------------+-------------------------------+------------------+
+| Collection List    | Selected Collection           | Inspector        |
+|                    |                               |                  |
+| + New Collection   | Name                          | Actions          |
+|                    | Description                   | Rename           |
+| Recent Collections |                               | Delete           |
+|                    | Items                         |                  |
+| Empty/Error state  | Empty membership/future seam  | Sync: local-only |
++--------------------+-------------------------------+------------------+
 ```
 
 This is a structural contract, not a pixel-level mockup. The implementation should reuse existing Library layout, tokens, buttons, and shell patterns.

--- a/Docs/superpowers/trackers/product-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/product-maturity-roadmap.md
@@ -1,7 +1,7 @@
 # Product Maturity Roadmap
 
 Date: 2026-05-08
-Status: Phase 1 verified; Phase 2 verified; Phase 3.0 verified; Phase 3.1 verified; Phase 3.2 verified; Phase 3.3 verified; Phase 3.4 verified; Gate 1 / Phase 3.5 verified; Gate 1.5 / Phase 3.6 verified; Phase 3.7 verified; Gate 1.6 / Phase 3.8 verified
+Status: Phase 1 verified; Phase 2 verified; Phase 3.0 verified; Phase 3.1 verified; Phase 3.2 verified; Phase 3.3 verified; Phase 3.4 verified; Gate 1 / Phase 3.5 verified; Gate 1.5 / Phase 3.6 verified; Phase 3.7 verified; Gate 1.6 / Phase 3.8 verified; Phase 3.9 verified
 Source Branch: `dev`
 Source Spec: `Docs/superpowers/specs/2026-05-05-product-maturity-phased-roadmap-design.md`
 Layout Contract Spec: `Docs/superpowers/specs/2026-05-06-destination-layout-ia-contracts-design.md`
@@ -35,6 +35,7 @@ Track product-depth maturity after Unified Shell Phase 6 so rendered screens, cl
 - Gate 1.5 / Phase 3.6 verifies the Console internals decomposition gate: Console now mounts native workbench components for controls, staged context, transcript/session, composer, run inspector, approvals, RAG/source state, and Chatbook artifact actions while retaining focused compatibility coverage for existing chat behavior.
 - Phase 3.7 verifies the next source-selected Study generation contract: queued server study-pack jobs can be observed into completed pack metadata and visible reusable Study dashboard state.
 - Gate 1.6 / Phase 3.8 verifies Library-native Search/RAG: Library owns the query/evidence workflow, retrieval results preserve snippets/citations/source authority, selected evidence stages into Console, and Console can invoke Library RAG or show a recoverable blocked state.
+- Phase 3.9 verifies the Library Collections IA split: Watchlists is the top-level monitored-source destination, Collections is discoverable and locally manageable inside Library, sync is shown as local-only or sync-unavailable, and citations/snippets remain later-stage Library/Search/RAG work.
 
 ## Post-UX Roadmap Handoff
 
@@ -99,6 +100,11 @@ Product Maturity Phase 1 and Phase 2 are not reopened by default. Their existing
   - Phase 3.8.3: Retrieval Adapter And Evidence Results - `TASK-10.8.3`
   - Phase 3.8.4: Console RAG Handoff And Invocation - `TASK-10.8.4`
   - Phase 3.8.5: Library Search/RAG QA Closeout - `TASK-10.8.5`
+- Phase 3.9: Library Collections IA Split - `TASK-10.9`
+  - Phase 3.9.1: Watchlists IA Split And Compatibility Labels - `TASK-10.9.1`
+  - Phase 3.9.2: Library Collections Display-State And Local Service Contracts - `TASK-10.9.2`
+  - Phase 3.9.3: Library Collections Mounted Management UI - `TASK-10.9.3`
+  - Phase 3.9.4: Library Collections QA Closeout And Tracking - `TASK-10.9.4`
 - Phase 4: Agent Configuration And Execution - `TASK-11`
 - Phase 5: Server-Parity And Live Integrations - `TASK-12`
 - Phase 6: Release Hardening And Documentation - `TASK-13`
@@ -122,6 +128,7 @@ Product Maturity Phase 1 and Phase 2 are not reopened by default. Their existing
 | Gate 1.5 / Phase 3.6 | `Docs/superpowers/qa/product-maturity/phase-3/2026-05-07-gate-1-5-console-internals-decomposition.md` | verified |
 | Phase 3.7 | `Docs/superpowers/qa/product-maturity/phase-3/2026-05-07-phase-3-7-source-study-pack-completion-reuse.md` | verified |
 | Gate 1.6 / Phase 3.8 | `Docs/superpowers/qa/product-maturity/phase-3/2026-05-07-gate-1-6-library-native-search-rag.md` | verified; TASK-10.8.1 through TASK-10.8.5 done |
+| Phase 3.9 | `Docs/superpowers/qa/product-maturity/phase-3/2026-05-08-phase-3-9-library-collections.md` | verified; TASK-10.9.1 through TASK-10.9.4 done |
 
 ## Phase Overview
 
@@ -129,7 +136,7 @@ Product Maturity Phase 1 and Phase 2 are not reopened by default. Their existing
 | --- | --- | --- | --- | --- | --- |
 | Phase 1: QA Baseline And Usability Guardrails | Establish clean-run usability guardrails before feature depth. | verified | `TASK-8`, Phase 1.1 (`TASK-8.1`), Phase 1.2 (`TASK-8.2`), Phase 1.3 (`TASK-8.3`), Phase 1.4 (`TASK-8.4`), Phase 1.5 (`TASK-8.5`), Phase 1.6 (`TASK-8.6`), Phase 1.7 (`TASK-8.7`) | `phase-1/` | Closed; full grounded generation and Artifact/Chatbook persistence move to Phase 2. |
 | Phase 2: Core Agentic Loop | Complete source/question to grounded Console to Artifact/Chatbook loop. | verified | `TASK-9`, Phase 2.1 (`TASK-9.1`), Phase 2.2 (`TASK-9.2`), Phase 2.3 (`TASK-9.3`), Phase 2.4 (`TASK-9.4`), Phase 2.5 (`TASK-9.5`) | `phase-2/2026-05-05-phase-2-1-grounded-console-response-contract.md`, `phase-2/2026-05-05-phase-2-2-console-chatbook-artifact-save-contract.md`, `phase-2/2026-05-05-phase-2-3-saved-chatbook-artifact-reopen-contract.md`, `phase-2/2026-05-05-phase-2-4-home-chatbook-artifact-resume-contract.md`, `phase-2/2026-05-06-phase-2-5-core-loop-closeout-replay.md` | Closed for the local core loop; live provider generation, full `.chatbook` export packaging, and full artifact history picking remain later-phase risks. |
-| Phase 3: Knowledge And Study Workflows | Mature ingest, organize, retrieve, study, and reuse workflows. | in-progress; Phase 3.0 verified; Phase 3.1 verified; Phase 3.2 verified; Phase 3.3 verified; Phase 3.4 verified; Gate 1 / Phase 3.5 verified; Gate 1.5 / Phase 3.6 verified; Phase 3.7 verified; Gate 1.6 / Phase 3.8 verified | `TASK-10`, Phase 3.0 (`TASK-10.0`), Phase 3.1 (`TASK-10.1`), Phase 3.2 (`TASK-10.2`), Phase 3.3 (`TASK-10.3`), Phase 3.4 (`TASK-10.4`), Gate 1 / Phase 3.5 (`TASK-10.5`), Gate 1.5 / Phase 3.6 (`TASK-10.6`), Phase 3.7 (`TASK-10.7`), Gate 1.6 / Phase 3.8 (`TASK-10.8`) | `phase-3/2026-05-06-phase-3-0-destination-layout-contracts.md`, `phase-3/2026-05-06-phase-3-1-library-study-entry.md`, `phase-3/2026-05-06-phase-3-2-library-source-study-context.md`, `phase-3/2026-05-06-phase-3-3-library-contract-layout.md`, `phase-3/2026-05-07-phase-3-4-source-study-generation.md`, `phase-3/2026-05-06-gate-1-core-product-loop-screen-adaptation.md`, `phase-3/2026-05-07-gate-1-5-console-internals-decomposition.md`, `phase-3/2026-05-07-phase-3-7-source-study-pack-completion-reuse.md`, `phase-3/2026-05-07-gate-1-6-library-native-search-rag.md` | Layout contracts, Library Study entry, Library source context, Library contract layout shell, source-selected server study-pack job launch, core Home/Console/Library screen adaptation, Console-native internals, completed study-pack reuse state, and Library-native Search/RAG with Console evidence handoff/invocation are verified. Full server job history, direct generated deck selection, Workspaces, Collections-in-Library, and deeper Import/Export/Search/RAG study flows remain. Post-UX roadmap execution should continue under TASK-10 unless the tracker explicitly creates a rebaseline child task for UX/UI deltas. |
+| Phase 3: Knowledge And Study Workflows | Mature ingest, organize, retrieve, study, and reuse workflows. | in-progress; Phase 3.0 verified; Phase 3.1 verified; Phase 3.2 verified; Phase 3.3 verified; Phase 3.4 verified; Gate 1 / Phase 3.5 verified; Gate 1.5 / Phase 3.6 verified; Phase 3.7 verified; Gate 1.6 / Phase 3.8 verified; Phase 3.9 verified | `TASK-10`, Phase 3.0 (`TASK-10.0`), Phase 3.1 (`TASK-10.1`), Phase 3.2 (`TASK-10.2`), Phase 3.3 (`TASK-10.3`), Phase 3.4 (`TASK-10.4`), Gate 1 / Phase 3.5 (`TASK-10.5`), Gate 1.5 / Phase 3.6 (`TASK-10.6`), Phase 3.7 (`TASK-10.7`), Gate 1.6 / Phase 3.8 (`TASK-10.8`), Phase 3.9 (`TASK-10.9`) | `phase-3/2026-05-06-phase-3-0-destination-layout-contracts.md`, `phase-3/2026-05-06-phase-3-1-library-study-entry.md`, `phase-3/2026-05-06-phase-3-2-library-source-study-context.md`, `phase-3/2026-05-06-phase-3-3-library-contract-layout.md`, `phase-3/2026-05-07-phase-3-4-source-study-generation.md`, `phase-3/2026-05-06-gate-1-core-product-loop-screen-adaptation.md`, `phase-3/2026-05-07-gate-1-5-console-internals-decomposition.md`, `phase-3/2026-05-07-phase-3-7-source-study-pack-completion-reuse.md`, `phase-3/2026-05-07-gate-1-6-library-native-search-rag.md`, `phase-3/2026-05-08-phase-3-9-library-collections.md` | Layout contracts, Library Study entry, Library source context, Library contract layout shell, source-selected server study-pack job launch, core Home/Console/Library screen adaptation, Console-native internals, completed study-pack reuse state, Library-native Search/RAG with Console evidence handoff/invocation, and Library-owned local Collections management are verified. Full server job history, direct generated deck selection, Workspaces, deeper Import/Export, full server sync, collection item membership, deeper Study/Search/RAG flows, citations/snippets in downstream collection workflows, and Citation/snippet carry-through into Chat, artifacts, and exported Chatbooks remain. Post-UX roadmap execution should continue under TASK-10 unless the tracker explicitly creates a rebaseline child task for UX/UI deltas. |
 | Phase 4: Agent Configuration And Execution | Mature Personas, Skills, MCP, ACP, Schedules, and Workflows. | planned | `TASK-11` | not-started | Depends on service adapters and runtime readiness. The post-UX roadmap maps controlled agent configuration and run loops to TASK-11. |
 | Phase 5: Server-Parity And Live Integrations | Close high-value `tldw_server2` parity gaps. | planned | `TASK-12` | not-started | Requires parity inventory. The post-UX roadmap requires parity to be prioritized by workflow value rather than endpoint count. |
 | Phase 6: Release Hardening And Documentation | Reach release-candidate usability. | planned | `TASK-13` | not-started | Depends on earlier phase evidence. The post-UX roadmap public-roadmap and release-readiness refresh belongs under TASK-13. |
@@ -264,3 +271,10 @@ Status: verified
 
 - `Docs/superpowers/qa/product-maturity/phase-3/2026-05-07-gate-1-6-library-native-search-rag.md`
 - `Docs/superpowers/plans/2026-05-07-gate-1-6-library-native-search-rag.md`
+
+## Phase 3.9 Evidence
+
+Status: verified
+
+- `Docs/superpowers/qa/product-maturity/phase-3/2026-05-08-phase-3-9-library-collections.md`
+- `Docs/superpowers/plans/2026-05-08-phase-3-9-library-collections-ia-split.md`

--- a/Tests/Home/test_active_work_adapter.py
+++ b/Tests/Home/test_active_work_adapter.py
@@ -109,7 +109,7 @@ def test_local_notification_adapter_maps_local_watchlist_runs_to_active_work():
         "local:watchlist_run:3",
     ]
     assert dashboard_input.active_work_items[0].title == "Daily security feed"
-    assert dashboard_input.active_work_items[0].source == "W+C"
+    assert dashboard_input.active_work_items[0].source == "Watchlists"
     assert dashboard_input.active_work_items[0].status == "failed"
     assert dashboard_input.active_work_items[0].detail_route == "subscriptions"
     assert dashboard_input.active_work_items[0].console_available is True
@@ -147,7 +147,7 @@ def test_local_notification_adapter_opens_local_watchlist_run_details():
     assert result.status is HomeControlResultStatus.HANDLED
     assert result.target_id == "local:watchlist_run:5"
     assert result.target_route == "subscriptions"
-    assert result.message == "Opening W+C run details for Daily security feed."
+    assert result.message == "Opening Watchlists run details for Daily security feed."
 
     assert missing_result.status is HomeControlResultStatus.UNAVAILABLE
     assert missing_result.target_id == "local:watchlist_run:404"
@@ -179,7 +179,7 @@ def test_local_notification_adapter_opens_local_watchlist_run_details_with_synth
     assert result.status is HomeControlResultStatus.HANDLED
     assert result.target_id == "local:watchlist_run:6"
     assert result.target_route == "subscriptions"
-    assert result.message == "Opening W+C run details for Running release feed."
+    assert result.message == "Opening Watchlists run details for Running release feed."
 
 
 def test_local_notification_adapter_opens_local_watchlist_run_in_console():
@@ -219,11 +219,11 @@ def test_local_notification_adapter_opens_local_watchlist_run_in_console():
     assert dashboard_input.active_work_items[0].console_available is True
     assert result.status is HomeControlResultStatus.HANDLED
     assert result.console_launch is not None
-    assert result.console_launch.source == "W+C"
+    assert result.console_launch.source == "Watchlists"
     assert result.console_launch.title == "Daily security feed"
     assert result.console_launch.status == "failed"
-    assert result.console_launch.recovery == "Review the W+C run details or retry from W+C."
-    assert result.console_launch.action_label == "Open W+C run"
+    assert result.console_launch.recovery == "Review the Watchlists run details or retry from Watchlists."
+    assert result.console_launch.action_label == "Open Watchlists run"
     assert result.console_launch.payload == {
         "run_id": 5,
         "job_id": 31,

--- a/Tests/Home/test_dashboard_state.py
+++ b/Tests/Home/test_dashboard_state.py
@@ -71,7 +71,7 @@ def test_failed_active_work_item_prioritizes_recovery_before_resume():
                 HomeActiveWorkItem(
                     item_id="local:watchlist_run:5",
                     title="Daily security feed",
-                    source="W+C",
+                    source="Watchlists",
                     status="failed",
                     detail_route="subscriptions",
                 ),
@@ -97,14 +97,14 @@ def test_failed_work_details_follow_failed_item_when_mixed_with_running_work():
                 HomeActiveWorkItem(
                     item_id="local:watchlist_run:6",
                     title="Queued release feed",
-                    source="W+C",
+                    source="Watchlists",
                     status="queued",
                     detail_route="subscriptions",
                 ),
                 HomeActiveWorkItem(
                     item_id="local:watchlist_run:5",
                     title="Daily security feed",
-                    source="W+C",
+                    source="Watchlists",
                     status="failed",
                     detail_route="subscriptions",
                 ),
@@ -134,7 +134,7 @@ def test_home_selected_item_uses_same_priority_as_default_details_control():
             HomeActiveWorkItem(
                 item_id="local:watchlist_run:5",
                 title="Daily security feed",
-                source="W+C",
+                source="Watchlists",
                 status="failed",
                 detail_route="subscriptions",
                 console_available=True,
@@ -254,7 +254,7 @@ def test_dashboard_summary_keeps_chatbook_artifact_reachable_when_mixed_with_wat
                 HomeActiveWorkItem(
                     item_id="local:watchlist_run:5",
                     title="Daily feed",
-                    source="W+C",
+                    source="Watchlists",
                     status="running",
                     detail_route="watchlists",
                     console_available=True,

--- a/Tests/Library/test_library_collections_config.py
+++ b/Tests/Library/test_library_collections_config.py
@@ -1,0 +1,31 @@
+"""Library Collections config path validation regressions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook import config
+
+
+def test_library_collections_custom_db_path_is_validated(monkeypatch, tmp_path: Path) -> None:
+    safe_path = tmp_path / "collections.db"
+    monkeypatch.setattr(
+        config,
+        "get_cli_setting",
+        lambda section, key, default=None: str(safe_path),
+    )
+
+    assert config.get_library_collections_db_path() == safe_path.resolve()
+
+
+def test_library_collections_custom_db_path_rejects_dangerous_input(monkeypatch) -> None:
+    monkeypatch.setattr(
+        config,
+        "get_cli_setting",
+        lambda section, key, default=None: "/tmp/collections.db;rm -rf",
+    )
+
+    with pytest.raises(ValueError):
+        config.get_library_collections_db_path()

--- a/Tests/Library/test_library_collections_service.py
+++ b/Tests/Library/test_library_collections_service.py
@@ -12,26 +12,23 @@ from tldw_chatbook.DB.Library_Collections_DB import LibraryCollectionsDB
 from tldw_chatbook.Library.library_collections_service import (
     DuplicateLibraryCollectionItem,
     DuplicateLibraryCollectionName,
+    InvalidLibraryCollectionDescription,
     InvalidLibraryCollectionName,
+    LibraryCollectionsServiceError,
     LocalLibraryCollectionsService,
 )
 
 
+EXPECTED_DEFAULT_COLLECTION_LIST_LIMIT = 200
+
+
 def _service(tmp_path: Path) -> LocalLibraryCollectionsService:
     id_counter = count(1)
-    timestamps = iter(
-        (
-            "2026-05-08T04:00:00Z",
-            "2026-05-08T04:01:00Z",
-            "2026-05-08T04:02:00Z",
-            "2026-05-08T04:03:00Z",
-            "2026-05-08T04:04:00Z",
-        )
-    )
+    timestamp_counter = count(0)
     return LocalLibraryCollectionsService(
         LibraryCollectionsDB(tmp_path / "library_collections.db"),
         id_factory=lambda: f"collection-{next(id_counter)}",
-        now_factory=lambda: next(timestamps),
+        now_factory=lambda: f"2026-05-08T04:{next(timestamp_counter):02d}:00Z",
     )
 
 
@@ -102,6 +99,36 @@ def test_schema_version_and_foreign_keys_are_initialized(tmp_path: Path) -> None
         assert conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
 
 
+def test_transaction_rolls_back_failed_collection_write(tmp_path: Path) -> None:
+    db = LibraryCollectionsDB(tmp_path / "library_collections.db")
+
+    with pytest.raises(RuntimeError):
+        with db.transaction() as conn:
+            conn.execute(
+                """
+                INSERT INTO library_collections (
+                    collection_id,
+                    name,
+                    description,
+                    created_at,
+                    updated_at
+                )
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    "collection-rollback",
+                    "Rollback Candidate",
+                    "",
+                    "2026-05-08T04:00:00Z",
+                    "2026-05-08T04:00:00Z",
+                ),
+            )
+            raise RuntimeError("force rollback")
+
+    with db.connection() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM library_collections").fetchone()[0] == 0
+
+
 def test_item_membership_allows_same_source_across_collections_only(tmp_path: Path) -> None:
     service = _service(tmp_path)
     first = service.create_collection("Research")
@@ -144,3 +171,51 @@ def test_invalid_names_are_rejected_before_sql(tmp_path: Path) -> None:
 
     with sqlite3.connect(tmp_path / "library_collections.db") as conn:
         assert conn.execute("SELECT COUNT(*) FROM library_collections").fetchone()[0] == 0
+
+
+def test_descriptions_reject_unsafe_html_before_persistence(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+
+    with pytest.raises(InvalidLibraryCollectionDescription):
+        service.create_collection("Research", description="<script>alert(1)</script>")
+
+    with sqlite3.connect(tmp_path / "library_collections.db") as conn:
+        assert conn.execute("SELECT COUNT(*) FROM library_collections").fetchone()[0] == 0
+
+
+def test_list_collections_uses_default_limit_and_accepts_explicit_limit(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    for index in range(EXPECTED_DEFAULT_COLLECTION_LIST_LIMIT + 2):
+        service.create_collection(f"Collection {index:03d}")
+
+    default_records = service.list_collections()
+    explicit_records = service.list_collections(limit=3)
+
+    assert len(default_records) == EXPECTED_DEFAULT_COLLECTION_LIST_LIMIT
+    assert len(explicit_records) == 3
+    assert [record.name for record in explicit_records] == [
+        "Collection 000",
+        "Collection 001",
+        "Collection 002",
+    ]
+
+
+def test_deleted_collection_name_fails_before_late_sql_integrity_error(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    collection = service.create_collection("Research")
+    assert service.delete_collection(collection.collection_id) is True
+
+    with pytest.raises(DuplicateLibraryCollectionName, match="deleted Collection"):
+        service.create_collection("research")
+
+
+def test_sqlite_errors_are_normalized_to_service_errors(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+
+    def broken_connection():
+        raise sqlite3.OperationalError("database is locked")
+
+    service.db.connection = broken_connection
+
+    with pytest.raises(LibraryCollectionsServiceError, match="Library Collections storage failed"):
+        service.list_collections()

--- a/Tests/Library/test_library_collections_service.py
+++ b/Tests/Library/test_library_collections_service.py
@@ -1,0 +1,146 @@
+"""Library Collections local service and persistence contracts."""
+
+from __future__ import annotations
+
+import sqlite3
+from itertools import count
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.DB.Library_Collections_DB import LibraryCollectionsDB
+from tldw_chatbook.Library.library_collections_service import (
+    DuplicateLibraryCollectionItem,
+    DuplicateLibraryCollectionName,
+    InvalidLibraryCollectionName,
+    LocalLibraryCollectionsService,
+)
+
+
+def _service(tmp_path: Path) -> LocalLibraryCollectionsService:
+    id_counter = count(1)
+    timestamps = iter(
+        (
+            "2026-05-08T04:00:00Z",
+            "2026-05-08T04:01:00Z",
+            "2026-05-08T04:02:00Z",
+            "2026-05-08T04:03:00Z",
+            "2026-05-08T04:04:00Z",
+        )
+    )
+    return LocalLibraryCollectionsService(
+        LibraryCollectionsDB(tmp_path / "library_collections.db"),
+        id_factory=lambda: f"collection-{next(id_counter)}",
+        now_factory=lambda: next(timestamps),
+    )
+
+
+def test_list_collections_returns_empty_list_initially(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+
+    assert service.list_collections() == ()
+
+
+def test_create_collection_persists_local_only_record(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+
+    collection = service.create_collection(" Research ", description="Policy sources")
+
+    assert collection.collection_id == "collection-1"
+    assert collection.name == "Research"
+    assert collection.description == "Policy sources"
+    assert collection.item_count == 0
+    assert collection.source_authority == "local"
+    assert collection.sync_status == "local-only"
+    assert collection.created_at == "2026-05-08T04:00:00Z"
+    assert collection.updated_at == "2026-05-08T04:00:00Z"
+    assert service.list_collections() == (collection,)
+    assert service.get_collection("collection-1") == collection
+
+
+def test_duplicate_normalized_names_are_rejected(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    service.create_collection("Research")
+
+    with pytest.raises(DuplicateLibraryCollectionName):
+        service.create_collection(" research ")
+
+
+def test_rename_collection_updates_name_description_and_updated_at(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    collection = service.create_collection("Research", description="Initial")
+
+    renamed = service.rename_collection(
+        collection.collection_id,
+        "Briefing Queue",
+        description="Updated",
+    )
+
+    assert renamed.collection_id == collection.collection_id
+    assert renamed.name == "Briefing Queue"
+    assert renamed.description == "Updated"
+    assert renamed.created_at == "2026-05-08T04:00:00Z"
+    assert renamed.updated_at == "2026-05-08T04:01:00Z"
+    assert service.get_collection(collection.collection_id) == renamed
+
+
+def test_delete_collection_hides_record_from_list_and_get(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    collection = service.create_collection("Research")
+
+    assert service.delete_collection(collection.collection_id) is True
+
+    assert service.list_collections() == ()
+    assert service.get_collection(collection.collection_id) is None
+
+
+def test_schema_version_and_foreign_keys_are_initialized(tmp_path: Path) -> None:
+    db = LibraryCollectionsDB(tmp_path / "library_collections.db")
+
+    assert db.get_schema_version() == 1
+    with db.connection() as conn:
+        assert conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+
+
+def test_item_membership_allows_same_source_across_collections_only(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    first = service.create_collection("Research")
+    second = service.create_collection("Briefing")
+
+    first_membership = service.add_item_to_collection(
+        first.collection_id,
+        source_type="media",
+        source_id="item-1",
+        title="Saved article",
+    )
+    second_membership = service.add_item_to_collection(
+        second.collection_id,
+        source_type="media",
+        source_id="item-1",
+        title="Saved article",
+    )
+
+    assert first_membership != second_membership
+    assert service.get_collection(first.collection_id).item_count == 1
+    assert service.get_collection(second.collection_id).item_count == 1
+    with pytest.raises(DuplicateLibraryCollectionItem):
+        service.add_item_to_collection(
+            first.collection_id,
+            source_type="media",
+            source_id="item-1",
+            title="Saved article",
+        )
+
+
+def test_invalid_names_are_rejected_before_sql(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+
+    with pytest.raises(InvalidLibraryCollectionName):
+        service.create_collection(" ")
+    with pytest.raises(InvalidLibraryCollectionName):
+        service.create_collection("<script>alert(1)</script>")
+    with pytest.raises(InvalidLibraryCollectionName):
+        service.create_collection("x" * 121)
+
+    with sqlite3.connect(tmp_path / "library_collections.db") as conn:
+        assert conn.execute("SELECT COUNT(*) FROM library_collections").fetchone()[0] == 0

--- a/Tests/Library/test_library_collections_state.py
+++ b/Tests/Library/test_library_collections_state.py
@@ -1,0 +1,116 @@
+"""Library Collections pure display-state contracts."""
+
+from __future__ import annotations
+
+from tldw_chatbook.Library.library_collections_state import (
+    LIBRARY_COLLECTIONS_EMPTY_COPY,
+    LibraryCollectionsPanelState,
+)
+
+
+def _record(
+    collection_id: str,
+    name: str,
+    *,
+    description: str = "",
+    item_count: int = 0,
+    sync_status: str = "local-only",
+    updated_at: str = "2026-05-08T04:00:00Z",
+) -> dict[str, object]:
+    return {
+        "collection_id": collection_id,
+        "name": name,
+        "description": description,
+        "item_count": item_count,
+        "source_authority": "local",
+        "sync_status": sync_status,
+        "created_at": "2026-05-08T03:00:00Z",
+        "updated_at": updated_at,
+    }
+
+
+def test_empty_panel_state_explains_library_collections_scope() -> None:
+    state = LibraryCollectionsPanelState.from_values(collections=(), status="ready")
+
+    assert state.status == "empty"
+    assert state.empty_copy == LIBRARY_COLLECTIONS_EMPTY_COPY
+    assert state.empty_copy == "Group saved Library items for Search/RAG, Study, and Console."
+    assert state.selected_collection is None
+    assert state.delete_action.enabled is False
+    assert state.delete_action.disabled_reason == "Select a Collection before deleting it."
+
+
+def test_ready_state_selects_first_collection_by_default() -> None:
+    state = LibraryCollectionsPanelState.from_values(
+        collections=(
+            _record("collection-b", "Research"),
+            _record("collection-a", "Briefing Queue"),
+        ),
+        selected_collection_id=None,
+    )
+
+    assert state.status == "ready"
+    assert state.selected_collection is not None
+    assert state.selected_collection.collection_id == "collection-b"
+    assert state.selected_collection.name == "Research"
+    assert state.collections[0].selected is True
+    assert state.collections[1].selected is False
+
+
+def test_invalid_create_and_rename_inputs_disable_actions_with_reasons() -> None:
+    state = LibraryCollectionsPanelState.from_values(
+        collections=(_record("collection-1", "Research"),),
+        selected_collection_id="collection-1",
+        create_name=" ",
+        rename_name="<script>alert(1)</script>",
+    )
+
+    assert state.create_action.enabled is False
+    assert state.create_action.disabled_reason == "Enter a Collection name."
+    assert state.rename_action.enabled is False
+    assert state.rename_action.disabled_reason == "Enter a safe Collection name."
+
+
+def test_sync_status_renders_local_only_and_sync_unavailable_copy() -> None:
+    local_state = LibraryCollectionsPanelState.from_values(
+        collections=(_record("collection-1", "Research", sync_status="local-only"),),
+    )
+    unavailable_state = LibraryCollectionsPanelState.from_values(
+        collections=(
+            _record("collection-2", "Server Queue", sync_status="sync-unavailable"),
+        ),
+    )
+
+    assert local_state.selected_collection is not None
+    assert local_state.selected_collection.sync_status_label == "Sync: local-only"
+    assert unavailable_state.selected_collection is not None
+    assert unavailable_state.selected_collection.sync_status_label == "Sync: sync-unavailable"
+
+
+def test_selected_collection_detail_exposes_stable_updated_at_label() -> None:
+    state = LibraryCollectionsPanelState.from_values(
+        collections=(
+            _record(
+                "collection-1",
+                "Research",
+                item_count=3,
+                updated_at="2026-05-08T04:05:06Z",
+            ),
+        ),
+    )
+
+    detail = state.selected_collection
+    assert detail is not None
+    assert detail.item_count_label == "3 items"
+    assert detail.updated_at_label == "Updated 2026-05-08 04:05 UTC"
+
+
+def test_delete_action_is_disabled_when_no_collection_is_selected() -> None:
+    state = LibraryCollectionsPanelState.from_values(
+        collections=(_record("collection-1", "Research"),),
+        selected_collection_id="missing",
+    )
+
+    assert state.selected_collection is None
+    assert state.delete_action.enabled is False
+    assert state.delete_action.disabled_reason == "Select a Collection before deleting it."

--- a/Tests/UI/test_command_palette_providers.py
+++ b/Tests/UI/test_command_palette_providers.py
@@ -310,22 +310,25 @@ class TestTabNavigationProvider:
         assert "LLM Management" not in joined_text
         assert "Tools & Settings" not in joined_text
 
-    def test_tab_navigation_provider_exposes_full_label_for_compact_destinations(self, tab_provider):
+    def test_tab_navigation_provider_uses_watchlists_label(self, tab_provider):
         command_text, tab_id, help_text = tab_provider._tab_command(TAB_WATCHLISTS_COLLECTIONS)
 
         assert tab_id == TAB_WATCHLISTS_COLLECTIONS
-        assert "W+C" in command_text
-        assert "Watchlists+Collections" in command_text
-        assert "Watchlists+Collections" in help_text
+        assert "Watchlists" in command_text
+        assert "Watchlists" in help_text
+        assert "W+C" not in command_text
+        assert "Watchlists+Collections" not in command_text
+        assert "Watchlists+Collections" not in help_text
 
     @pytest.mark.asyncio
-    async def test_search_finds_watchlists_collections_by_full_label(self, tab_provider):
+    async def test_search_finds_watchlists_by_visible_label(self, tab_provider):
         hits = []
-        async for hit in tab_provider.search("Watchlists+Collections"):
+        async for hit in tab_provider.search("Watchlists"):
             hits.append(hit)
 
-        assert any("Watchlists+Collections" in hit.text for hit in hits)
-        assert any("Watchlists+Collections" in (hit.help or "") for hit in hits)
+        assert any("Watchlists" in hit.text for hit in hits)
+        assert all("Watchlists+Collections" not in hit.text for hit in hits)
+        assert all("Watchlists+Collections" not in (hit.help or "") for hit in hits)
 
     @pytest.mark.asyncio
     async def test_search_matches_destination_help_keywords(self, tab_provider):

--- a/Tests/UI/test_console_live_work_handoffs.py
+++ b/Tests/UI/test_console_live_work_handoffs.py
@@ -469,19 +469,19 @@ def test_console_live_work_status_card_state_exposes_wc_primary_action():
     ConsoleLiveWorkLaunch = _load_console_live_work_contract()
     ConsoleLiveWorkStatusCardState = _load_console_live_work_status_card_state()
     launch = ConsoleLiveWorkLaunch.from_values(
-        source="W+C",
+        source="Watchlists",
         title="Daily security feed",
         payload={"target_id": "local:watchlist_run:91", "run_id": 91},
         status="failed",
-        recovery="Review the W+C run details or retry from W+C.",
-        action_label="Open W+C run",
+        recovery="Review the Watchlists run details or retry from Watchlists.",
+        action_label="Open Watchlists run",
     )
 
     card_state = ConsoleLiveWorkStatusCardState.from_launch(launch)
 
     assert card_state.primary_action is not None
     assert card_state.primary_action.widget_id == "console-live-work-primary-action"
-    assert card_state.primary_action.label == "Open W+C run"
+    assert card_state.primary_action.label == "Open Watchlists run"
     assert card_state.primary_action.target_route == "subscriptions"
     assert card_state.primary_action.target_id == "local:watchlist_run:91"
 
@@ -512,7 +512,7 @@ def test_console_live_work_source_readiness_marks_connected_sources_and_future_s
     assert "console-live-work-source-readiness" in state.container_classes
     rows_by_id = {row.widget_id: row for row in state.rows}
     assert rows_by_id["console-live-work-source-wc"].text == (
-        "W+C: Connected - Home W+C active work can open and route run details in Console."
+        "Watchlists: Connected - Home Watchlists active work can open and route run details in Console."
     )
     assert "console-live-work-source-connected" in rows_by_id["console-live-work-source-wc"].classes
     assert rows_by_id["console-live-work-source-schedules"].text == (
@@ -549,12 +549,12 @@ def test_app_console_live_work_primary_action_routes_wc_run_details():
     app.post_message = Mock()
     app.notify = Mock()
     launch = ConsoleLiveWorkLaunch.from_values(
-        source="W+C",
+        source="Watchlists",
         title="Daily security feed",
         payload={"target_id": "local:watchlist_run:91", "run_id": 91},
         status="failed",
-        recovery="Review the W+C run details or retry from W+C.",
-        action_label="Open W+C run",
+        recovery="Review the Watchlists run details or retry from Watchlists.",
+        action_label="Open Watchlists run",
     )
 
     handled = app.open_console_live_work_primary_action(launch)
@@ -889,7 +889,7 @@ async def test_schedules_destination_routes_latest_active_run_to_console():
             HomeActiveWorkItem(
                 item_id="local:watchlist_run:9",
                 title="Watchlist run",
-                source="W+C",
+                source="Watchlists",
                 status="failed",
                 detail_route="subscriptions",
                 console_available=True,
@@ -1071,7 +1071,7 @@ async def test_watchlists_destination_keeps_console_follow_disabled_without_acti
         assert button.disabled is True
         assert str(button.label) == "Console follow unavailable"
         text = _screen_static_text(screen)
-        assert "No active W+C run is available for Console follow." in text
+        assert "No active Watchlists run is available for Console follow." in text
 
     app.open_active_home_item_in_console.assert_not_called()
 
@@ -1084,7 +1084,7 @@ async def test_watchlists_destination_routes_latest_active_run_to_console():
             HomeActiveWorkItem(
                 item_id="local:watchlist_run:5",
                 title="Daily security feed",
-                source="W+C",
+                source="Watchlists",
                 status="failed",
                 detail_route="subscriptions",
                 console_available=True,
@@ -1092,7 +1092,7 @@ async def test_watchlists_destination_routes_latest_active_run_to_console():
             HomeActiveWorkItem(
                 item_id="local:watchlist_run:9",
                 title="Other source",
-                source="W+C",
+                source="Watchlists",
                 status="queued",
                 detail_route="subscriptions",
                 console_available=False,
@@ -1137,10 +1137,10 @@ async def test_watchlists_destination_logs_adapter_failure_and_disables_follow(m
         button = screen.query_one("#watchlists-follow-in-console")
 
         assert button.disabled is True
-        assert "No active W+C run is available for Console follow." in _screen_static_text(screen)
+        assert "No active Watchlists run is available for Console follow." in _screen_static_text(screen)
 
     logger.warning.assert_called_once()
-    assert "W+C Console follow" in logger.warning.call_args.args[0]
+    assert "Watchlists Console follow" in logger.warning.call_args.args[0]
     assert logger.warning.call_args.kwargs["exc_info"] is True
     app.open_active_home_item_in_console.assert_not_called()
 
@@ -1153,7 +1153,7 @@ async def test_watchlists_destination_retries_console_follow_after_initial_adapt
             HomeActiveWorkItem(
                 item_id="local:watchlist_run:11",
                 title="Recovered run",
-                source="W+C",
+                source="Watchlists",
                 status="running",
                 detail_route="subscriptions",
                 console_available=True,
@@ -1194,7 +1194,7 @@ async def test_watchlists_destination_click_uses_item_promised_by_button_label()
             HomeActiveWorkItem(
                 item_id="local:watchlist_run:5",
                 title="First visible run",
-                source="W+C",
+                source="Watchlists",
                 status="failed",
                 detail_route="subscriptions",
                 console_available=True,
@@ -1204,7 +1204,7 @@ async def test_watchlists_destination_click_uses_item_promised_by_button_label()
             HomeActiveWorkItem(
                 item_id="local:watchlist_run:7",
                 title="Newer unseen run",
-                source="W+C",
+                source="Watchlists",
                 status="running",
                 detail_route="subscriptions",
                 console_available=True,
@@ -1239,7 +1239,7 @@ async def test_watchlists_destination_escapes_console_follow_markup_labels():
             HomeActiveWorkItem(
                 item_id="local:watchlist_run:5",
                 title="[red]Daily[/red] feed",
-                source="W+C",
+                source="Watchlists",
                 status="[bold]failed[/bold]",
                 detail_route="subscriptions",
                 console_available=True,
@@ -1727,7 +1727,7 @@ async def test_console_renders_source_readiness_summary_without_pending_launch()
         assert screen.query_one("#console-live-work-source-readiness")
         assert screen.query_one("#console-live-work-source-readiness-title").renderable == "Live work sources"
         assert screen.query_one("#console-live-work-source-wc").renderable == (
-            "W+C: Connected - Home W+C active work can open and route run details in Console."
+            "Watchlists: Connected - Home Watchlists active work can open and route run details in Console."
         )
         assert "Workflows: Connected" in str(screen.query_one("#console-live-work-source-workflows").renderable)
         assert "Schedules: Connected" in str(screen.query_one("#console-live-work-source-schedules").renderable)
@@ -1741,12 +1741,12 @@ async def test_console_renders_source_readiness_summary_without_pending_launch()
 async def test_console_wc_live_work_action_button_routes_run_details():
     app = _build_test_app()
     app.pending_console_launch = {
-        "source": "W+C",
+        "source": "Watchlists",
         "title": "Daily security feed",
         "payload": {"target_id": "local:watchlist_run:91", "run_id": 91},
         "status": "failed",
-        "recovery": "Review the W+C run details or retry from W+C.",
-        "action_label": "Open W+C run",
+        "recovery": "Review the Watchlists run details or retry from Watchlists.",
+        "action_label": "Open Watchlists run",
     }
     app.post_message = Mock()
     app.notify = Mock()
@@ -1756,7 +1756,7 @@ async def test_console_wc_live_work_action_button_routes_run_details():
         await pilot.pause(0.1)
         screen = _active_console_screen(host)
         button = screen.query_one("#console-live-work-primary-action")
-        assert str(button.label) == "Open W+C run"
+        assert str(button.label) == "Open Watchlists run"
 
         await pilot.click("#console-live-work-primary-action")
         await pilot.pause(0.1)

--- a/Tests/UI/test_destination_shells.py
+++ b/Tests/UI/test_destination_shells.py
@@ -187,7 +187,7 @@ class PolicyDeniedWatchlistsScopeService:
         self,
         *,
         reason_code="server_session_invalid",
-        user_message="The W+C server session has expired.",
+        user_message="The Watchlists server session has expired.",
         effective_source="server",
         authority_owner="active server",
     ):
@@ -346,14 +346,13 @@ async def _wait_for_wc_snapshot(screen, pilot, *, timeout: float = 2.0) -> None:
         "#wc-service-error",
         "#wc-empty-state",
         "#wc-watchlists-summary",
-        "#wc-collections-summary",
     )
     while time.monotonic() < deadline:
         if any(screen.query(selector) for selector in terminal_selectors):
             await pilot.pause()
             return
         await pilot.pause(0.01)
-    raise AssertionError(f"Timed out waiting for W+C snapshot. Visible text: {_visible_text(screen)}")
+    raise AssertionError(f"Timed out waiting for Watchlists snapshot. Visible text: {_visible_text(screen)}")
 
 
 async def _wait_for_library_snapshot(screen, pilot, *, timeout: float = 2.0) -> None:
@@ -475,10 +474,10 @@ async def test_watchlists_collections_uses_compact_title_and_clear_sections():
         await pilot.pause(0.1)
         screen = _active_destination_screen(host)
 
-        assert _static_text(screen.query_one("#watchlists-collections-title", Static)) == "W+C"
+        assert _static_text(screen.query_one("#watchlists-collections-title", Static)) == "Watchlists"
         visible_text = _visible_text(screen)
         assert "Watchlists" in visible_text
-        assert "Collections" in visible_text
+        assert "Collections" not in visible_text
 
 
 @pytest.mark.asyncio
@@ -503,12 +502,11 @@ async def test_watchlists_collections_lists_local_snapshot_from_services():
         text = _visible_text(screen)
         button = screen.query_one("#wc-attach-to-console", Button)
 
-        assert "Local W+C snapshot" in text
+        assert "Local Watchlists snapshot" in text
         assert "Watchlists (showing up to 5): 2" in text
-        assert "Collections: 1" in text
         assert "Research feeds" in text
         assert "Vendor changelogs" in text
-        assert "Saved article" in text
+        assert "Saved article" not in text
         assert button.disabled is False
 
     assert app.watchlist_scope_service.calls[0] == {
@@ -516,11 +514,7 @@ async def test_watchlists_collections_lists_local_snapshot_from_services():
         "limit": getattr(wc_screen_module, "WC_LOCAL_PAGE_SIZE", None),
         "offset": 0,
     }
-    assert app.media_reading_scope_service.calls[0] == {
-        "mode": "local",
-        "limit": getattr(wc_screen_module, "WC_LOCAL_PAGE_SIZE", None),
-        "offset": 0,
-    }
+    assert app.media_reading_scope_service.calls == []
 
 
 @pytest.mark.asyncio
@@ -535,9 +529,9 @@ async def test_watchlists_collections_empty_state_disables_console_attach():
         await _wait_for_wc_snapshot(screen, pilot)
         button = screen.query_one("#wc-attach-to-console", Button)
 
-        assert "No local Watchlists or Collections are available yet." in _visible_text(screen)
+        assert "No local Watchlists are available yet." in _visible_text(screen)
         assert button.disabled is True
-        assert "Stage local W+C context" in str(button.tooltip)
+        assert "Stage local Watchlists context" in str(button.tooltip)
 
 
 @pytest.mark.asyncio
@@ -552,9 +546,9 @@ async def test_watchlists_collections_service_failure_uses_recovery_copy():
         await _wait_for_wc_snapshot(screen, pilot)
         button = screen.query_one("#wc-attach-to-console", Button)
 
-        assert "W+C services unavailable; retry W+C later." in _visible_text(screen)
+        assert "Watchlists services unavailable; retry Watchlists later." in _visible_text(screen)
         assert button.disabled is True
-        assert "W+C services are unavailable" in str(button.tooltip)
+        assert "Watchlists services are unavailable" in str(button.tooltip)
 
 
 @pytest.mark.asyncio
@@ -574,8 +568,8 @@ async def test_watchlists_collections_policy_denial_uses_runtime_recovery_taxono
             visible_text=_static_text(error),
             button=button,
             status_label="Server session expired",
-            unavailable_what="Stage W+C context in Console",
-            why="The W+C server session has expired",
+            unavailable_what="Stage Watchlists context in Console",
+            why="The Watchlists server session has expired",
             next_action="Re-authenticate the active server profile before retrying.",
             recovery_action="Settings",
             authority_owner="active server",
@@ -625,11 +619,11 @@ async def test_watchlists_collections_attach_to_console_uses_listed_context():
     assert isinstance(payload, ChatHandoffPayload)
     assert payload.source == "watchlists_collections"
     assert payload.item_type == "wc-context"
-    assert payload.title == "Local W+C snapshot"
+    assert payload.title == "Local Watchlists snapshot"
     assert "Research feeds" in payload.body
-    assert "Saved article" in payload.body
+    assert "Saved article" not in payload.body
     assert payload.metadata["watchlist_count"] == 1
-    assert payload.metadata["collection_count"] == 1
+    assert "collection_count" not in payload.metadata
 
 
 @pytest.mark.asyncio
@@ -1154,7 +1148,7 @@ async def test_destination_action_buttons_explain_their_outcome(route):
 @pytest.mark.parametrize(
     ("route", "expected_sections"),
     [
-        ("watchlists_collections", ["Watchlists", "Collections"]),
+        ("watchlists_collections", ["Watchlists", "Monitored sources"]),
         ("schedules", ["Next Run", "Paused", "Failed"]),
         ("workflows", ["Recipes", "Dry Run", "Console launch unavailable"]),
     ],

--- a/Tests/UI/test_master_shell_navigation.py
+++ b/Tests/UI/test_master_shell_navigation.py
@@ -12,9 +12,9 @@ def test_compact_navigation_labels_preserve_full_meaning():
 
     wc = get_shell_destination("watchlists_collections")
 
-    assert wc.label == "W+C"
-    assert wc.full_label == "Watchlists+Collections"
-    assert "Watchlists+Collections" in wc.tooltip
+    assert wc.label == "Watchlists"
+    assert wc.full_label == "Watchlists"
+    assert "Collections" not in wc.tooltip
     assert wc.navigation_priority < get_shell_destination("settings").navigation_priority
 
 
@@ -37,7 +37,7 @@ async def test_master_shell_navigation_order_and_labels():
         ("nav-library", "Library"),
         ("nav-artifacts", "Artifacts"),
         ("nav-personas", "Personas"),
-        ("nav-watchlists_collections", "W+C"),
+        ("nav-watchlists_collections", "Watchlists"),
         ("nav-schedules", "Schedules"),
         ("nav-workflows", "Workflows"),
         ("nav-mcp", "MCP"),

--- a/Tests/UI/test_product_maturity_phase39_library_collections.py
+++ b/Tests/UI/test_product_maturity_phase39_library_collections.py
@@ -1,0 +1,225 @@
+"""Phase 3.9 Library Collections mounted UI regressions."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from textual.widgets import Button, Input, Static
+
+from tldw_chatbook.Library.library_collections_service import LibraryCollectionRecord
+
+from Tests.UI.test_destination_shells import (
+    DestinationHarness,
+    StaticLibraryConversationScopeService,
+    StaticLibraryMediaScopeService,
+    StaticLibraryNotesScopeService,
+    _active_destination_screen,
+    _build_test_app,
+    _visible_text,
+    _wait_for_library_snapshot,
+    _wait_for_selector,
+)
+
+
+class FakeLibraryCollectionsService:
+    def __init__(self, records=()):
+        self.records = list(records)
+        self.created = []
+        self.renamed = []
+        self.deleted = []
+        self._counter = len(self.records) + 1
+        self._timestamp_counter = 0
+
+    def _now(self) -> str:
+        self._timestamp_counter += 1
+        return f"2026-05-08T04:{self._timestamp_counter:02d}:00Z"
+
+    def list_collections(self):
+        return tuple(self.records)
+
+    def create_collection(self, name, *, description=""):
+        timestamp = self._now()
+        record = LibraryCollectionRecord(
+            collection_id=f"collection-{self._counter}",
+            name=name.strip(),
+            description=description.strip(),
+            item_count=0,
+            source_authority="local",
+            sync_status="local-only",
+            created_at=timestamp,
+            updated_at=timestamp,
+        )
+        self._counter += 1
+        self.records.append(record)
+        self.created.append((name, description))
+        return record
+
+    def rename_collection(self, collection_id, name, *, description=None):
+        timestamp = self._now()
+        renamed = None
+        for index, record in enumerate(self.records):
+            if record.collection_id != collection_id:
+                continue
+            renamed = LibraryCollectionRecord(
+                collection_id=record.collection_id,
+                name=name.strip(),
+                description="" if description is None else description.strip(),
+                item_count=record.item_count,
+                source_authority=record.source_authority,
+                sync_status=record.sync_status,
+                created_at=record.created_at,
+                updated_at=timestamp,
+            )
+            self.records[index] = renamed
+            break
+        if renamed is None:
+            raise KeyError(collection_id)
+        self.renamed.append((collection_id, name, description))
+        return renamed
+
+    def delete_collection(self, collection_id):
+        before = len(self.records)
+        self.records = [record for record in self.records if record.collection_id != collection_id]
+        self.deleted.append(collection_id)
+        return len(self.records) != before
+
+
+class RaisingLibraryCollectionsService:
+    def list_collections(self):
+        raise RuntimeError("collections database unavailable")
+
+
+def _seed_library_sources(app) -> None:
+    app.notes_scope_service = StaticLibraryNotesScopeService(
+        [{"title": "Research Note", "id": "note-1"}]
+    )
+    app.media_reading_scope_service = StaticLibraryMediaScopeService(
+        [{"title": "Transcript A", "id": "media-1"}]
+    )
+    app.chat_conversation_scope_service = StaticLibraryConversationScopeService(
+        [{"title": "Planning Chat", "id": "chat-1"}]
+    )
+
+
+async def _wait_for_text(screen, pilot, expected: str, *, timeout: float = 2.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if expected in _visible_text(screen):
+            await pilot.pause()
+            return
+        await pilot.pause(0.01)
+    raise AssertionError(f"Timed out waiting for text {expected!r}: {_visible_text(screen)}")
+
+
+@pytest.mark.asyncio
+async def test_library_collections_mode_mounts_panel_and_defers_scoped_actions() -> None:
+    app = _build_test_app()
+    _seed_library_sources(app)
+    app.library_collections_service = FakeLibraryCollectionsService(
+        (
+            LibraryCollectionRecord(
+                collection_id="collection-1",
+                name="Research",
+                description="Policy sources",
+                item_count=2,
+                source_authority="local",
+                sync_status="sync-unavailable",
+                created_at="2026-05-08T04:00:00Z",
+                updated_at="2026-05-08T04:05:00Z",
+            ),
+        )
+    )
+    host = DestinationHarness(app, "library")
+
+    async with host.run_test(size=(170, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_library_snapshot(screen, pilot)
+
+        screen.query_one("#library-mode-collections", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-collections-panel")
+
+        assert screen.query_one("#library-collections-panel").parent is screen.query_one(
+            "#library-source-detail"
+        )
+        assert len(screen.query("#library-rag-run-query")) == 0
+        assert "Sync: sync-unavailable" in _visible_text(screen)
+        assert "Updated 2026-05-08 04:05 UTC" in _visible_text(screen)
+        assert screen.query_one("#library-open-study", Button).disabled is True
+        assert screen.query_one("#library-open-flashcards", Button).disabled is True
+        assert screen.query_one("#library-open-quizzes", Button).disabled is True
+        assert screen.query_one("#library-use-in-console", Button).disabled is True
+        assert "Collection-scoped Study, Flashcards, Quizzes, and Console are later-stage." in (
+            _visible_text(screen)
+        )
+
+
+@pytest.mark.asyncio
+async def test_library_collections_create_rename_and_delete_workflow() -> None:
+    app = _build_test_app()
+    _seed_library_sources(app)
+    service = FakeLibraryCollectionsService()
+    app.library_collections_service = service
+    host = DestinationHarness(app, "library")
+
+    async with host.run_test(size=(170, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_library_snapshot(screen, pilot)
+
+        screen.query_one("#library-mode-collections", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-collections-panel")
+        assert "Group saved Library items for Search/RAG, Study, and Console." in _visible_text(
+            screen
+        )
+
+        screen.query_one("#library-collection-name-input", Input).value = "Research"
+        screen.query_one("#library-collection-description-input", Input).value = "Policy sources"
+        await pilot.pause()
+        screen.query_one("#library-create-collection", Button).press()
+        await _wait_for_text(screen, pilot, "Research")
+
+        assert service.created == [("Research", "Policy sources")]
+        assert "0 items" in _visible_text(screen)
+        assert "Sync: local-only" in _visible_text(screen)
+        assert "Updated 2026-05-08 04:01 UTC" in _visible_text(screen)
+
+        screen.query_one("#library-collection-name-input", Input).value = "Briefing Queue"
+        screen.query_one("#library-collection-description-input", Input).value = "Updated"
+        await pilot.pause()
+        screen.query_one("#library-rename-collection", Button).press()
+        await _wait_for_text(screen, pilot, "Briefing Queue")
+
+        assert service.renamed == [("collection-1", "Briefing Queue", "Updated")]
+        assert "Updated 2026-05-08 04:02 UTC" in _visible_text(screen)
+
+        screen.query_one("#library-delete-collection", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-confirm-delete-collection")
+        assert service.deleted == []
+
+        screen.query_one("#library-confirm-delete-collection", Button).press()
+        await _wait_for_text(
+            screen,
+            pilot,
+            "Group saved Library items for Search/RAG, Study, and Console.",
+        )
+
+    assert service.deleted == ["collection-1"]
+
+
+@pytest.mark.asyncio
+async def test_library_collections_service_failure_renders_recovery_copy() -> None:
+    app = _build_test_app()
+    _seed_library_sources(app)
+    app.library_collections_service = RaisingLibraryCollectionsService()
+    host = DestinationHarness(app, "library")
+
+    async with host.run_test(size=(170, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_library_snapshot(screen, pilot)
+
+        screen.query_one("#library-mode-collections", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-collections-error")
+
+        error_text = screen.query_one("#library-collections-error", Static).renderable
+        assert "Library Collections are unavailable" in str(error_text)
+        assert "collections database unavailable" not in _visible_text(screen)

--- a/Tests/UI/test_product_maturity_phase39_library_collections.py
+++ b/Tests/UI/test_product_maturity_phase39_library_collections.py
@@ -90,6 +90,12 @@ class RaisingLibraryCollectionsService:
         raise RuntimeError("collections database unavailable")
 
 
+class DeleteFailsLibraryCollectionsService(FakeLibraryCollectionsService):
+    def delete_collection(self, collection_id):
+        self.deleted.append(collection_id)
+        return False
+
+
 def _seed_library_sources(app) -> None:
     app.notes_scope_service = StaticLibraryNotesScopeService(
         [{"title": "Research Note", "id": "note-1"}]
@@ -204,6 +210,72 @@ async def test_library_collections_create_rename_and_delete_workflow() -> None:
         )
 
     assert service.deleted == ["collection-1"]
+
+
+@pytest.mark.asyncio
+async def test_library_collection_form_input_keeps_focus_and_updates_actions() -> None:
+    app = _build_test_app()
+    _seed_library_sources(app)
+    app.library_collections_service = FakeLibraryCollectionsService()
+    host = DestinationHarness(app, "library")
+
+    async with host.run_test(size=(170, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_library_snapshot(screen, pilot)
+
+        screen.query_one("#library-mode-collections", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-collections-panel")
+
+        name_input = screen.query_one("#library-collection-name-input", Input)
+        name_input.focus()
+        await pilot.pause()
+        name_input.value = "Research"
+        await pilot.pause()
+
+        assert screen.focused is name_input
+        assert screen.query_one("#library-collections-panel").is_mounted
+        assert screen.query_one("#library-create-collection", Button).disabled is False
+
+
+@pytest.mark.asyncio
+async def test_library_collections_delete_failure_keeps_selection_and_warns_user() -> None:
+    app = _build_test_app()
+    _seed_library_sources(app)
+    service = DeleteFailsLibraryCollectionsService(
+        (
+            LibraryCollectionRecord(
+                collection_id="collection-1",
+                name="Research",
+                description="Policy sources",
+                item_count=0,
+                source_authority="local",
+                sync_status="local-only",
+                created_at="2026-05-08T04:00:00Z",
+                updated_at="2026-05-08T04:00:00Z",
+            ),
+        )
+    )
+    app.library_collections_service = service
+    notifications = []
+    app.notify = lambda message, **kwargs: notifications.append((message, kwargs))
+    host = DestinationHarness(app, "library")
+
+    async with host.run_test(size=(170, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_library_snapshot(screen, pilot)
+
+        screen.query_one("#library-mode-collections", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-collections-panel")
+        screen.query_one("#library-delete-collection", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-confirm-delete-collection")
+        screen.query_one("#library-confirm-delete-collection", Button).press()
+        await _wait_for_text(screen, pilot, "Research")
+
+        assert service.deleted == ["collection-1"]
+        assert "Research" in _visible_text(screen)
+        assert notifications
+        assert notifications[-1][0] == "Failed to delete Collection."
+        assert notifications[-1][1]["severity"] == "warning"
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_product_maturity_phase3_layout_contracts.py
+++ b/Tests/UI/test_product_maturity_phase3_layout_contracts.py
@@ -17,6 +17,12 @@ PHASE_3_0_EVIDENCE = Path(
 GATE16_PLAN = Path(
     "Docs/superpowers/plans/2026-05-07-gate-1-6-library-native-search-rag.md"
 )
+PHASE_3_9_SPEC = Path(
+    "Docs/superpowers/specs/2026-05-08-library-collections-ia-split-design.md"
+)
+PHASE_3_9_EVIDENCE = Path(
+    "Docs/superpowers/qa/product-maturity/phase-3/2026-05-08-phase-3-9-library-collections.md"
+)
 TASK_10 = Path(
     "backlog/tasks/task-10 - Product-Maturity-Phase-3-Knowledge-And-Study-Workflows.md"
 )
@@ -34,6 +40,12 @@ TASK_10_8_2 = Path(
 )
 TASK_10_8_3 = Path(
     "backlog/tasks/task-10.8.3 - Gate-1.6.3-Retrieval-adapter-and-evidence-results.md"
+)
+TASK_10_9 = Path(
+    "backlog/tasks/task-10.9 - Product-Maturity-Phase-3.9-Library-Collections-IA-Split.md"
+)
+TASK_10_9_4 = Path(
+    "backlog/tasks/task-10.9.4 - Phase-3.9.4-Library-Collections-QA-closeout-and-tracking.md"
 )
 PROMPT_MANIFEST = Path("Docs/Design/destination-layout-image-reference-prompts.md")
 
@@ -197,7 +209,8 @@ def test_phase30_collections_are_library_owned_with_later_citation_snippet_scope
     assert "snippet" in spec.lower()
 
     phase_three_row = _markdown_table_row(tracker, "Phase 3: Knowledge And Study Workflows")
-    assert "Collections-in-Library" in phase_three_row[5]
+    assert "Library-owned local Collections management are verified" in phase_three_row[5]
+    assert "collection item membership" in phase_three_row[5]
     assert "citations/snippets" in phase_three_row[5]
 
 
@@ -236,9 +249,10 @@ def test_phase3_gate16_library_rag_plan_and_tasks_are_tracked() -> None:
     for child_task in ("TASK-10.8.1", "TASK-10.8.2", "TASK-10.8.3", "TASK-10.8.4", "TASK-10.8.5"):
         assert child_task in plan
         assert child_task in tracker
-    assert "status: In Progress" in task
+    assert "status: Done" in task
     for ac_number in range(1, 5):
-        assert f"- [ ] #{ac_number}" in task
+        assert f"- [x] #{ac_number}" in task
+    assert "## Implementation Notes" in task
     assert "status: Done" in display_state_task
     for ac_number in range(1, 4):
         assert f"- [x] #{ac_number}" in display_state_task
@@ -251,6 +265,48 @@ def test_phase3_gate16_library_rag_plan_and_tasks_are_tracked() -> None:
     for ac_number in range(1, 4):
         assert f"- [x] #{ac_number}" in retrieval_adapter_task
     assert "## Implementation Notes" in retrieval_adapter_task
+
+
+def test_phase39_library_collections_split_is_tracked_with_followup_risks() -> None:
+    tracker = _text(TRACKER)
+    readme = _text(PHASE_3_README)
+    spec = _text(PHASE_3_9_SPEC)
+    parent_task = _text(TASK_10)
+    task = _text(TASK_10_9)
+    qa_task = _text(TASK_10_9_4)
+
+    assert "Phase 3.9: Library Collections IA Split - `TASK-10.9`" in tracker
+    assert PHASE_3_9_EVIDENCE.as_posix() in tracker
+    assert PHASE_3_9_EVIDENCE.name in readme
+    assert "TASK-10.9" in task
+    assert "Continued Phase 3 with TASK-10.9" in parent_task
+    assert "status: Done" in task
+    assert "status: Done" in qa_task
+    for ac_number in range(1, 5):
+        assert f"- [x] #{ac_number}" in task
+        assert f"- [x] #{ac_number}" in qa_task
+    assert "## Implementation Notes" in task
+    assert "## Implementation Notes" in qa_task
+
+    evidence_row = _markdown_table_row(tracker, "Phase 3.9")
+    assert PHASE_3_9_EVIDENCE.as_posix() in evidence_row[1]
+    assert evidence_row[2] == "verified; TASK-10.9.1 through TASK-10.9.4 done"
+
+    phase_three_row = _markdown_table_row(tracker, "Phase 3: Knowledge And Study Workflows")
+    assert "Phase 3.9 verified" in phase_three_row[2]
+    assert "TASK-10.9" in phase_three_row[3]
+    assert "phase-3/2026-05-08-phase-3-9-library-collections.md" in phase_three_row[4]
+    for residual_risk in (
+        "Workspaces",
+        "Import/Export",
+        "server sync",
+        "deeper Study/Search/RAG flows",
+    ):
+        assert residual_risk in phase_three_row[5]
+
+    for later_stage_term in ("citations/snippets", "Citation/snippet carry-through"):
+        assert later_stage_term in spec
+        assert later_stage_term in tracker
 
 
 def test_phase30_qa_evidence_is_verified() -> None:

--- a/Tests/UI/test_screen_navigation.py
+++ b/Tests/UI/test_screen_navigation.py
@@ -581,7 +581,7 @@ async def test_main_navigation_copy_and_order():
         ("nav-library", "Library"),
         ("nav-artifacts", "Artifacts"),
         ("nav-personas", "Personas"),
-        ("nav-watchlists_collections", "W+C"),
+        ("nav-watchlists_collections", "Watchlists"),
         ("nav-schedules", "Schedules"),
         ("nav-workflows", "Workflows"),
         ("nav-mcp", "MCP"),

--- a/Tests/UI/test_shell_destinations.py
+++ b/Tests/UI/test_shell_destinations.py
@@ -12,7 +12,7 @@ def test_master_shell_destination_order_matches_spec():
         "Library",
         "Artifacts",
         "Personas",
-        "W+C",
+        "Watchlists",
         "Schedules",
         "Workflows",
         "MCP",

--- a/Tests/UI/test_unified_shell_phase6_first_time_replay.py
+++ b/Tests/UI/test_unified_shell_phase6_first_time_replay.py
@@ -33,7 +33,7 @@ EXPECTED_NAV = [
     ("nav-library", "Library"),
     ("nav-artifacts", "Artifacts"),
     ("nav-personas", "Personas"),
-    ("nav-watchlists_collections", "W+C"),
+    ("nav-watchlists_collections", "Watchlists"),
     ("nav-schedules", "Schedules"),
     ("nav-workflows", "Workflows"),
     ("nav-mcp", "MCP"),
@@ -143,7 +143,7 @@ async def test_first_time_shell_replay_exposes_home_console_and_orientation_path
                     "nav-console",
                     "chat",
                     "ChatScreen",
-                    ("Live work sources", "W+C: Connected"),
+                    ("Live work sources", "Watchlists: Connected"),
                 ),
                 (
                     "nav-library",

--- a/Tests/UI/test_unified_shell_phase6_power_user_replay.py
+++ b/Tests/UI/test_unified_shell_phase6_power_user_replay.py
@@ -72,7 +72,7 @@ async def test_power_user_shell_replay_supports_fast_repeated_core_workflows() -
             )
             console_text = _screen_text(app)
             assert "Live work sources" in console_text
-            assert "W+C: Connected" in console_text
+            assert "Watchlists: Connected" in console_text
             assert "More: Ctrl+P" in console_text
             assert any(binding.key == "ctrl+p" for binding in TldwCli.BINDINGS)
 
@@ -109,21 +109,21 @@ async def test_power_user_shell_replay_supports_fast_repeated_core_workflows() -
             )
 
             app.open_console_for_live_work(
-                source="W+C",
+                source="Watchlists",
                 title="Daily security feed",
                 payload={"target_id": "local:watchlist_run:91", "run_id": 91},
                 status="failed",
-                recovery="Review the W+C run details or retry from W+C.",
-                action_label="Open W+C run",
+                recovery="Review the Watchlists run details or retry from Watchlists.",
+                action_label="Open Watchlists run",
             )
             await _wait_until(
                 pilot,
                 lambda: app.current_tab == "chat" and app.screen.__class__.__name__ == "ChatScreen",
             )
             live_work_text = _screen_text(app)
-            assert "Source: W+C" in live_work_text
+            assert "Source: Watchlists" in live_work_text
             assert "Title: Daily security feed" in live_work_text
-            assert "Action: Open W+C run" in live_work_text
+            assert "Action: Open Watchlists run" in live_work_text
 
             app.screen.query_one("#console-live-work-primary-action", Button).press()
             await _wait_until(

--- a/backlog/tasks/task-10 - Product-Maturity-Phase-3-Knowledge-And-Study-Workflows.md
+++ b/backlog/tasks/task-10 - Product-Maturity-Phase-3-Knowledge-And-Study-Workflows.md
@@ -4,7 +4,7 @@ title: 'Product Maturity Phase 3: Knowledge And Study Workflows'
 status: In Progress
 assignee: []
 created_date: '2026-05-05 15:11'
-updated_date: '2026-05-08 02:30'
+updated_date: '2026-05-08 04:41'
 labels:
   - product-maturity
   - phase-3-knowledge-study
@@ -48,4 +48,6 @@ Planned Gate 1.6 with TASK-10.8. The Library-native Search/RAG gate is split int
 Continued Gate 1.6 with TASK-10.8.2. The Library destination now mounts a native Search/RAG panel for source scope, query controls, evidence/results, retrieval inspector, and Console handoff readiness without embedding the legacy Search/RAG route. Parent remains open for retrieval execution, evidence normalization, Console handoff/invocation, QA closeout, Workspaces, Library Collections, and deeper Import/Export/Search/RAG study workflows.
 
 Closed Gate 1.6 with TASK-10.8. Library-native Search/RAG now verifies source scope, query controls, retrieval execution, evidence/results, citations/snippets, selected evidence review, Console staged evidence, Console-initiated Library RAG, and recoverable blocked states. Parent remains open for Workspaces, Library Collections, deeper Import/Export/Search/RAG study flows, and later server-parity depth.
+
+Continued Phase 3 with TASK-10.9. Watchlists is now the top-level monitored-source destination while Library owns local Collections management with honest local-only or sync-unavailable status. Parent remains open for Workspaces, deeper Import/Export, full server sync, collection item membership, deeper Study/Search/RAG flows, citations/snippets in downstream collection workflows, and Citation/snippet carry-through into Chat artifacts and exported Chatbooks.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-10.9 - Product-Maturity-Phase-3.9-Library-Collections-IA-Split.md
+++ b/backlog/tasks/task-10.9 - Product-Maturity-Phase-3.9-Library-Collections-IA-Split.md
@@ -1,0 +1,43 @@
+---
+id: TASK-10.9
+title: 'Product Maturity Phase 3.9: Library Collections IA Split'
+status: To Do
+assignee: []
+created_date: '2026-05-08 03:36'
+updated_date: '2026-05-08 03:39'
+labels:
+  - product-maturity
+  - phase-3-knowledge-study
+  - phase-3-9-library-collections
+dependencies:
+  - TASK-10.8
+references:
+  - Docs/superpowers/specs/2026-05-08-library-collections-ia-split-design.md
+parent_task_id: TASK-10
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Split the combined Watchlists+Collections product model by making Watchlists the top-level monitored-source destination and moving local Collections management into Library as a reusable source organization workflow.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Visible navigation command palette help and destination copy use Watchlists for monitored-source workflows and do not present Collections as part of the top-level Watchlists destination
+- [ ] #2 Library Collections mode lets users list create select rename and delete local collections with honest local-only or sync-unavailable status
+- [ ] #3 Existing Watchlists active-run Home and Console follow-through remains usable through compatibility route IDs where needed
+- [ ] #4 Focused automated tests and QA walkthrough evidence prove the split and local Collections management are usable rather than merely renderable
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. TASK-10.9.1: Watchlists IA split and compatibility labels.
+2. TASK-10.9.2: Library Collections display-state and local service contracts.
+3. TASK-10.9.3: Library Collections mounted management UI.
+4. TASK-10.9.4: QA closeout and tracking.
+
+Primary implementation plan: Docs/superpowers/plans/2026-05-08-phase-3-9-library-collections-ia-split.md.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-10.9 - Product-Maturity-Phase-3.9-Library-Collections-IA-Split.md
+++ b/backlog/tasks/task-10.9 - Product-Maturity-Phase-3.9-Library-Collections-IA-Split.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-10.9
 title: 'Product Maturity Phase 3.9: Library Collections IA Split'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-05-08 03:36'
-updated_date: '2026-05-08 03:39'
+updated_date: '2026-05-08 04:41'
 labels:
   - product-maturity
   - phase-3-knowledge-study
@@ -25,10 +25,10 @@ Split the combined Watchlists+Collections product model by making Watchlists the
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Visible navigation command palette help and destination copy use Watchlists for monitored-source workflows and do not present Collections as part of the top-level Watchlists destination
-- [ ] #2 Library Collections mode lets users list create select rename and safely delete local collections with updated-at display and honest local-only or sync-unavailable status
-- [ ] #3 Existing Watchlists active-run Home and Console follow-through remains usable through compatibility route IDs where needed
-- [ ] #4 Focused automated tests and QA walkthrough evidence prove the split and local Collections management are usable rather than merely renderable
+- [x] #1 Visible navigation command palette help and destination copy use Watchlists for monitored-source workflows and do not present Collections as part of the top-level Watchlists destination
+- [x] #2 Library Collections mode lets users list create select rename and safely delete local collections with updated-at display and honest local-only or sync-unavailable status
+- [x] #3 Existing Watchlists active-run Home and Console follow-through remains usable through compatibility route IDs where needed
+- [x] #4 Focused automated tests and QA walkthrough evidence prove the split and local Collections management are usable rather than merely renderable
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -41,3 +41,9 @@ Split the combined Watchlists+Collections product model by making Watchlists the
 
 Primary implementation plan: Docs/superpowers/plans/2026-05-08-phase-3-9-library-collections-ia-split.md.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Closed Phase 3.9 with Watchlists split from Collections and Library-owned local Collections management verified. The top-level destination now presents Watchlists only, Collections is discoverable under Library with create select rename delete status and safe delete coverage, Watchlists active-run follow-through remains compatible, QA evidence records focused verification and clean startup smoke, and later-stage risks remain for collection membership server sync Import/Export scoped Study/Search/RAG flows and citation/snippet carry-through.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-10.9 - Product-Maturity-Phase-3.9-Library-Collections-IA-Split.md
+++ b/backlog/tasks/task-10.9 - Product-Maturity-Phase-3.9-Library-Collections-IA-Split.md
@@ -26,7 +26,7 @@ Split the combined Watchlists+Collections product model by making Watchlists the
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
 - [ ] #1 Visible navigation command palette help and destination copy use Watchlists for monitored-source workflows and do not present Collections as part of the top-level Watchlists destination
-- [ ] #2 Library Collections mode lets users list create select rename and delete local collections with honest local-only or sync-unavailable status
+- [ ] #2 Library Collections mode lets users list create select rename and safely delete local collections with updated-at display and honest local-only or sync-unavailable status
 - [ ] #3 Existing Watchlists active-run Home and Console follow-through remains usable through compatibility route IDs where needed
 - [ ] #4 Focused automated tests and QA walkthrough evidence prove the split and local Collections management are usable rather than merely renderable
 <!-- AC:END -->

--- a/backlog/tasks/task-10.9.1 - Phase-3.9.1-Watchlists-IA-split-and-compatibility-labels.md
+++ b/backlog/tasks/task-10.9.1 - Phase-3.9.1-Watchlists-IA-split-and-compatibility-labels.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-10.9.1
 title: 'Phase 3.9.1: Watchlists IA split and compatibility labels'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-05-08 03:36'
+updated_date: '2026-05-08 04:18'
 labels:
   - product-maturity
   - phase-3-9-library-collections
@@ -24,8 +25,20 @@ Rename the user-facing combined W+C destination to Watchlists while preserving c
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Shell destination metadata command palette navigation and help copy show Watchlists instead of W+C or Watchlists+Collections
-- [ ] #2 The Watchlists destination body no longer renders Collections sections summaries or collection management copy
-- [ ] #3 Home and Console visible active-work labels say Watchlists while preserving existing route and payload compatibility where needed
-- [ ] #4 Focused regressions cover navigation command palette Watchlists body copy and active-run follow-through
+- [x] #1 Shell destination metadata command palette navigation and help copy show Watchlists instead of W+C or Watchlists+Collections
+- [x] #2 The Watchlists destination body no longer renders Collections sections summaries or collection management copy
+- [x] #3 Home and Console visible active-work labels say Watchlists while preserving existing route and payload compatibility where needed
+- [x] #4 Focused regressions cover navigation command palette Watchlists body copy and active-run follow-through
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Run the current Watchlists/W+C baseline. 2. Add red tests for Watchlists labels and compatibility. 3. Update shell metadata, command palette, Watchlists screen, Home, and Console visible copy. 4. Run focused verification and diff hygiene. 5. Check ACs, add implementation notes, and mark Done.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the Phase 3.9.1 Watchlists IA split while preserving compatibility route IDs and historical wc/watchlists_collections selectors. Updated shell destination metadata, tab display labels, command palette help, Watchlists destination copy, local snapshot handoff payloads, Home active-work copy, and Console live-work readiness to use user-facing Watchlists language. Removed visible Collections/read-it-later loading from the Watchlists destination so Collections can move under Library in the next slice. Added a direct app-level navigation fallback for programmatic presses on hidden Textual chrome buttons to keep mounted replay tests deterministic without changing normal visible click handling. Verification: red tests were observed first; final focused suite passed with 94 passed, extra navigation smoke passed with 2 passed, and git diff --check passed.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-10.9.1 - Phase-3.9.1-Watchlists-IA-split-and-compatibility-labels.md
+++ b/backlog/tasks/task-10.9.1 - Phase-3.9.1-Watchlists-IA-split-and-compatibility-labels.md
@@ -1,0 +1,31 @@
+---
+id: TASK-10.9.1
+title: 'Phase 3.9.1: Watchlists IA split and compatibility labels'
+status: To Do
+assignee: []
+created_date: '2026-05-08 03:36'
+labels:
+  - product-maturity
+  - phase-3-9-library-collections
+  - watchlists
+dependencies:
+  - TASK-10.8
+references:
+  - Docs/superpowers/specs/2026-05-08-library-collections-ia-split-design.md
+parent_task_id: TASK-10.9
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Rename the user-facing combined W+C destination to Watchlists while preserving compatibility route IDs and monitored-source workflows.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Shell destination metadata command palette navigation and help copy show Watchlists instead of W+C or Watchlists+Collections
+- [ ] #2 The Watchlists destination body no longer renders Collections sections summaries or collection management copy
+- [ ] #3 Home and Console visible active-work labels say Watchlists while preserving existing route and payload compatibility where needed
+- [ ] #4 Focused regressions cover navigation command palette Watchlists body copy and active-run follow-through
+<!-- AC:END -->

--- a/backlog/tasks/task-10.9.2 - Phase-3.9.2-Library-Collections-display-state-and-local-service-contracts.md
+++ b/backlog/tasks/task-10.9.2 - Phase-3.9.2-Library-Collections-display-state-and-local-service-contracts.md
@@ -1,0 +1,31 @@
+---
+id: TASK-10.9.2
+title: 'Phase 3.9.2: Library Collections display-state and local service contracts'
+status: To Do
+assignee: []
+created_date: '2026-05-08 03:36'
+labels:
+  - product-maturity
+  - phase-3-9-library-collections
+  - library
+dependencies:
+  - TASK-10.9.1
+references:
+  - Docs/superpowers/specs/2026-05-08-library-collections-ia-split-design.md
+parent_task_id: TASK-10.9
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add Library-owned pure state and local service boundaries for named Collections without depending on Watchlist or read-it-later services.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Pure Collection summary detail action and panel state models cover ready empty loading error invalid-name and local-only sync states
+- [ ] #2 A LibraryCollectionsService contract supports list get create rename and delete operations with validation and stable IDs
+- [ ] #3 The first local adapter persists collections in a repo-appropriate local store and remains hidden behind the service contract
+- [ ] #4 Focused pure tests cover normal empty invalid and failure states without mounting Textual widgets
+<!-- AC:END -->

--- a/backlog/tasks/task-10.9.2 - Phase-3.9.2-Library-Collections-display-state-and-local-service-contracts.md
+++ b/backlog/tasks/task-10.9.2 - Phase-3.9.2-Library-Collections-display-state-and-local-service-contracts.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-10.9.2
 title: 'Phase 3.9.2: Library Collections display-state and local service contracts'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-05-08 03:36'
+updated_date: '2026-05-08 04:24'
 labels:
   - product-maturity
   - phase-3-9-library-collections
@@ -24,8 +25,20 @@ Add Library-owned pure state and local service boundaries for named Collections 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Pure Collection summary detail action and panel state models cover ready empty loading error invalid-name updated-at and local-only sync states
-- [ ] #2 A LibraryCollectionsService contract supports list get create rename and delete operations with validation and stable IDs
-- [ ] #3 The first local adapter persists collections in a repo-appropriate versioned local store with foreign-key safety and future-safe membership uniqueness
-- [ ] #4 Focused pure tests cover normal empty invalid and failure states without mounting Textual widgets
+- [x] #1 Pure Collection summary detail action and panel state models cover ready empty loading error invalid-name updated-at and local-only sync states
+- [x] #2 A LibraryCollectionsService contract supports list get create rename and delete operations with validation and stable IDs
+- [x] #3 The first local adapter persists collections in a repo-appropriate versioned local store with foreign-key safety and future-safe membership uniqueness
+- [x] #4 Focused pure tests cover normal empty invalid and failure states without mounting Textual widgets
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add pure state and service red tests. 2. Implement versioned SQLite persistence and service contracts. 3. Wire app/config service creation. 4. Run focused verification and diff hygiene. 5. Check ACs, add implementation notes, and mark Done.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented Library Collections pure display-state contracts plus local SQLite service contracts. Added versioned LibraryCollectionsDB with foreign keys enabled per connection, local-only Collection records, validated create/rename/delete operations, duplicate-name protection, and future-safe item membership uniqueness. Wired app/config to create library_collections_service with a local adapter and safe unavailable fallback. Verification: red tests first failed on missing modules; final Task 2 tests passed with 14 passed, existing Library RAG tests passed with 16 passed, app navigation smoke passed with 1 passed, and git diff --check passed.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-10.9.2 - Phase-3.9.2-Library-Collections-display-state-and-local-service-contracts.md
+++ b/backlog/tasks/task-10.9.2 - Phase-3.9.2-Library-Collections-display-state-and-local-service-contracts.md
@@ -24,8 +24,8 @@ Add Library-owned pure state and local service boundaries for named Collections 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Pure Collection summary detail action and panel state models cover ready empty loading error invalid-name and local-only sync states
+- [ ] #1 Pure Collection summary detail action and panel state models cover ready empty loading error invalid-name updated-at and local-only sync states
 - [ ] #2 A LibraryCollectionsService contract supports list get create rename and delete operations with validation and stable IDs
-- [ ] #3 The first local adapter persists collections in a repo-appropriate local store and remains hidden behind the service contract
+- [ ] #3 The first local adapter persists collections in a repo-appropriate versioned local store with foreign-key safety and future-safe membership uniqueness
 - [ ] #4 Focused pure tests cover normal empty invalid and failure states without mounting Textual widgets
 <!-- AC:END -->

--- a/backlog/tasks/task-10.9.3 - Phase-3.9.3-Library-Collections-mounted-management-UI.md
+++ b/backlog/tasks/task-10.9.3 - Phase-3.9.3-Library-Collections-mounted-management-UI.md
@@ -1,0 +1,32 @@
+---
+id: TASK-10.9.3
+title: 'Phase 3.9.3: Library Collections mounted management UI'
+status: To Do
+assignee: []
+created_date: '2026-05-08 03:37'
+labels:
+  - product-maturity
+  - phase-3-9-library-collections
+  - library
+  - ui
+dependencies:
+  - TASK-10.9.2
+references:
+  - Docs/superpowers/specs/2026-05-08-library-collections-ia-split-design.md
+parent_task_id: TASK-10.9
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Mount local Collections management inside the existing Library shell so users can create select rename and delete collections from Library.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Library Collections mode renders list detail and inspector regions inside the existing Library shell
+- [ ] #2 Users can create select rename and delete local collections with persistent visible status and recovery copy
+- [ ] #3 The UI does not expose server sync or collection-scoped RAG Study or Console actions as enabled unless implemented
+- [ ] #4 Mounted tests cover the management workflow and preserve Gate 1.6 Library Search/RAG regressions
+<!-- AC:END -->

--- a/backlog/tasks/task-10.9.3 - Phase-3.9.3-Library-Collections-mounted-management-UI.md
+++ b/backlog/tasks/task-10.9.3 - Phase-3.9.3-Library-Collections-mounted-management-UI.md
@@ -26,7 +26,7 @@ Mount local Collections management inside the existing Library shell so users ca
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
 - [ ] #1 Library Collections mode renders list detail and inspector regions inside the existing Library shell
-- [ ] #2 Users can create select rename and delete local collections with persistent visible status and recovery copy
-- [ ] #3 The UI does not expose server sync or collection-scoped RAG Study or Console actions as enabled unless implemented
+- [ ] #2 Users can create select rename and delete local collections with persistent visible status updated-at display and delete confirmation or recovery
+- [ ] #3 The UI does not expose server sync or collection-scoped RAG Study Flashcards Quizzes or Console actions as enabled unless implemented
 - [ ] #4 Mounted tests cover the management workflow and preserve Gate 1.6 Library Search/RAG regressions
 <!-- AC:END -->

--- a/backlog/tasks/task-10.9.3 - Phase-3.9.3-Library-Collections-mounted-management-UI.md
+++ b/backlog/tasks/task-10.9.3 - Phase-3.9.3-Library-Collections-mounted-management-UI.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-10.9.3
 title: 'Phase 3.9.3: Library Collections mounted management UI'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-05-08 03:37'
+updated_date: '2026-05-08 04:29'
 labels:
   - product-maturity
   - phase-3-9-library-collections
@@ -25,8 +26,20 @@ Mount local Collections management inside the existing Library shell so users ca
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Library Collections mode renders list detail and inspector regions inside the existing Library shell
-- [ ] #2 Users can create select rename and delete local collections with persistent visible status updated-at display and delete confirmation or recovery
-- [ ] #3 The UI does not expose server sync or collection-scoped RAG Study Flashcards Quizzes or Console actions as enabled unless implemented
-- [ ] #4 Mounted tests cover the management workflow and preserve Gate 1.6 Library Search/RAG regressions
+- [x] #1 Library Collections mode renders list detail and inspector regions inside the existing Library shell
+- [x] #2 Users can create select rename and delete local collections with persistent visible status updated-at display and delete confirmation or recovery
+- [x] #3 The UI does not expose server sync or collection-scoped RAG Study Flashcards Quizzes or Console actions as enabled unless implemented
+- [x] #4 Mounted tests cover the management workflow and preserve Gate 1.6 Library Search/RAG regressions
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add mounted UI red tests. 2. Implement the Library Collections panel. 3. Wire LibraryScreen handlers and mode-specific affordance suppression. 4. Run focused verification and diff hygiene. 5. Check ACs, add implementation notes, and mark Done.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the mounted Library Collections management UI inside the existing Library shell. Added a render-only LibraryCollectionsPanel with stable list/detail/form selectors, wired LibraryScreen to list/create/select/rename/delete through library_collections_service, added confirm-before-delete, rendered sync status and updated-at detail copy, and disabled collection-scoped Study/Flashcards/Quizzes/Console actions as later-stage work. Verification: red mounted tests first failed on missing Collections panel selectors; final Task 3 verification passed with 19 passed, extra Library Study entry regressions passed with 2 passed, and git diff --check passed.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-10.9.4 - Phase-3.9.4-Library-Collections-QA-closeout-and-tracking.md
+++ b/backlog/tasks/task-10.9.4 - Phase-3.9.4-Library-Collections-QA-closeout-and-tracking.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-10.9.4
 title: 'Phase 3.9.4: Library Collections QA closeout and tracking'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-05-08 03:37'
+updated_date: '2026-05-08 04:41'
 labels:
   - product-maturity
   - phase-3-9-library-collections
@@ -24,8 +25,20 @@ Replay the Library Collections and Watchlists split workflows, record QA evidenc
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 QA evidence documents first-time discovery power-user management flow Watchlists continuity and sync honesty
-- [ ] #2 Product maturity roadmap Phase 3 entries record Phase 3.9 evidence and remaining Workspaces Import/Export and deeper study-flow risks
-- [ ] #3 Parent TASK-10 and TASK-10.9 plus child TASK-10.9.1 through TASK-10.9.4 notes are updated with the verified outcome or accepted residual risks
-- [ ] #4 Focused verification commands and git diff hygiene are recorded and pass before closeout
+- [x] #1 QA evidence documents first-time discovery power-user management flow Watchlists continuity and sync honesty
+- [x] #2 Product maturity roadmap Phase 3 entries record Phase 3.9 evidence and remaining Workspaces Import/Export and deeper study-flow risks
+- [x] #3 Parent TASK-10 and TASK-10.9 plus child TASK-10.9.1 through TASK-10.9.4 notes are updated with the verified outcome or accepted residual risks
+- [x] #4 Focused verification commands and git diff hygiene are recorded and pass before closeout
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add tracking red test. 2. Record QA evidence. 3. Update roadmap, QA index, and parent Backlog tracking. 4. Run focused verification and manual QA walkthrough. 5. Check ACs, add implementation notes, and mark Done.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Recorded Phase 3.9 QA closeout evidence, updated the Phase 3 QA index and product maturity roadmap, verified the Watchlists/Library Collections split with mounted workflow coverage, ran the final focused suite with 248 passed and 8 warnings, confirmed git diff hygiene, and smoke-tested clean HOME/XDG startup. Residual risks are documented for Workspaces, Import/Export depth, server sync, collection membership, deeper Study/Search/RAG flows, and citation/snippet carry-through.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-10.9.4 - Phase-3.9.4-Library-Collections-QA-closeout-and-tracking.md
+++ b/backlog/tasks/task-10.9.4 - Phase-3.9.4-Library-Collections-QA-closeout-and-tracking.md
@@ -1,0 +1,31 @@
+---
+id: TASK-10.9.4
+title: 'Phase 3.9.4: Library Collections QA closeout and tracking'
+status: To Do
+assignee: []
+created_date: '2026-05-08 03:37'
+labels:
+  - product-maturity
+  - phase-3-9-library-collections
+  - qa
+dependencies:
+  - TASK-10.9.3
+references:
+  - Docs/superpowers/specs/2026-05-08-library-collections-ia-split-design.md
+parent_task_id: TASK-10.9
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replay the Library Collections and Watchlists split workflows, record QA evidence, and update roadmap and Backlog tracking.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 QA evidence documents first-time discovery power-user management flow Watchlists continuity and sync honesty
+- [ ] #2 Product maturity roadmap Phase 3 entries record Phase 3.9 evidence and remaining Workspaces Import/Export and deeper study-flow risks
+- [ ] #3 Parent TASK-10 and TASK-10.9 notes are updated with the verified outcome or accepted residual risks
+- [ ] #4 Focused verification commands and git diff hygiene are recorded and pass before closeout
+<!-- AC:END -->

--- a/backlog/tasks/task-10.9.4 - Phase-3.9.4-Library-Collections-QA-closeout-and-tracking.md
+++ b/backlog/tasks/task-10.9.4 - Phase-3.9.4-Library-Collections-QA-closeout-and-tracking.md
@@ -26,6 +26,6 @@ Replay the Library Collections and Watchlists split workflows, record QA evidenc
 <!-- AC:BEGIN -->
 - [ ] #1 QA evidence documents first-time discovery power-user management flow Watchlists continuity and sync honesty
 - [ ] #2 Product maturity roadmap Phase 3 entries record Phase 3.9 evidence and remaining Workspaces Import/Export and deeper study-flow risks
-- [ ] #3 Parent TASK-10 and TASK-10.9 notes are updated with the verified outcome or accepted residual risks
+- [ ] #3 Parent TASK-10 and TASK-10.9 plus child TASK-10.9.1 through TASK-10.9.4 notes are updated with the verified outcome or accepted residual risks
 - [ ] #4 Focused verification commands and git diff hygiene are recorded and pass before closeout
 <!-- AC:END -->

--- a/tldw_chatbook/Chat/console_display_state.py
+++ b/tldw_chatbook/Chat/console_display_state.py
@@ -144,7 +144,7 @@ class ConsoleStagedContextState:
         return cls(
             heading="Staged Context",
             summary="No live work item is staged.",
-            recovery="Attach sources from Library, W+C, Schedules, Artifacts, or RAG.",
+            recovery="Attach sources from Library, Watchlists, Schedules, Artifacts, or RAG.",
         )
 
 

--- a/tldw_chatbook/Chat/console_live_work.py
+++ b/tldw_chatbook/Chat/console_live_work.py
@@ -234,7 +234,7 @@ class ConsoleLiveWorkSourceReadinessState:
         """Build the default Console live-work source readiness summary.
 
         Returns:
-            ConsoleLiveWorkSourceReadinessState: Readiness state that marks W+C,
+            ConsoleLiveWorkSourceReadinessState: Readiness state that marks Watchlists,
                 Schedules, Workflows, RAG, and Artifacts as connected while
                 planned future Console live-work sources stay unavailable until
                 their payload producers are wired.
@@ -245,9 +245,9 @@ class ConsoleLiveWorkSourceReadinessState:
             rows=(
                 ConsoleLiveWorkSourceReadinessRow(
                     widget_id="console-live-work-source-wc",
-                    label="W+C",
+                    label="Watchlists",
                     status="Connected",
-                    recovery="Home W+C active work can open and route run details in Console.",
+                    recovery="Home Watchlists active work can open and route run details in Console.",
                     classes=connected,
                 ),
                 ConsoleLiveWorkSourceReadinessRow(

--- a/tldw_chatbook/Constants.py
+++ b/tldw_chatbook/Constants.py
@@ -80,7 +80,7 @@ TAB_DISPLAY_LABELS = {
     TAB_LIBRARY: "Library",
     TAB_ARTIFACTS: "Artifacts",
     TAB_PERSONAS: "Personas",
-    TAB_WATCHLISTS_COLLECTIONS: "W+C",
+    TAB_WATCHLISTS_COLLECTIONS: "Watchlists",
     TAB_SCHEDULES: "Schedules",
     TAB_WORKFLOWS: "Workflows",
     TAB_MCP: "MCP",

--- a/tldw_chatbook/DB/Library_Collections_DB.py
+++ b/tldw_chatbook/DB/Library_Collections_DB.py
@@ -1,0 +1,73 @@
+"""SQLite persistence for local Library Collections."""
+
+from __future__ import annotations
+
+from contextlib import closing, contextmanager
+from pathlib import Path
+import sqlite3
+from typing import Iterator, Union
+
+from .base_db import BaseDB
+
+
+class LibraryCollectionsDB(BaseDB):
+    """Database wrapper for Library-owned local Collections."""
+
+    _CURRENT_SCHEMA_VERSION = 1
+
+    def __init__(self, db_path: Union[str, Path], client_id: str = "default") -> None:
+        super().__init__(db_path, client_id)
+
+    def _get_connection(self) -> sqlite3.Connection:
+        conn = super()._get_connection()
+        conn.execute("PRAGMA foreign_keys = ON")
+        return conn
+
+    @contextmanager
+    def connection(self) -> Iterator[sqlite3.Connection]:
+        """Open a connection with row factory and foreign keys enabled."""
+        with closing(self._get_connection()) as conn:
+            yield conn
+
+    def _initialize_schema(self) -> None:
+        """Initialize the local Collections schema."""
+        with self.connection() as conn:
+            conn.executescript(
+                """
+                PRAGMA foreign_keys = ON;
+
+                CREATE TABLE IF NOT EXISTS schema_version (
+                    version INTEGER PRIMARY KEY NOT NULL
+                );
+                INSERT OR IGNORE INTO schema_version (version) VALUES (1);
+
+                CREATE TABLE IF NOT EXISTS library_collections (
+                    collection_id TEXT PRIMARY KEY,
+                    name TEXT NOT NULL UNIQUE,
+                    description TEXT NOT NULL DEFAULT '',
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    deleted_at TEXT
+                );
+
+                CREATE TABLE IF NOT EXISTS library_collection_items (
+                    membership_id TEXT PRIMARY KEY,
+                    collection_id TEXT NOT NULL,
+                    source_type TEXT NOT NULL,
+                    source_id TEXT NOT NULL,
+                    title TEXT NOT NULL DEFAULT '',
+                    created_at TEXT NOT NULL,
+                    FOREIGN KEY(collection_id)
+                        REFERENCES library_collections(collection_id)
+                        ON DELETE CASCADE,
+                    UNIQUE(collection_id, source_type, source_id)
+                );
+                """
+            )
+            conn.commit()
+
+    def get_schema_version(self) -> int:
+        """Return the initialized schema version."""
+        with self.connection() as conn:
+            row = conn.execute("SELECT MAX(version) FROM schema_version").fetchone()
+        return int(row[0] or 0) if row is not None else 0

--- a/tldw_chatbook/DB/Library_Collections_DB.py
+++ b/tldw_chatbook/DB/Library_Collections_DB.py
@@ -29,6 +29,19 @@ class LibraryCollectionsDB(BaseDB):
         with closing(self._get_connection()) as conn:
             yield conn
 
+    @contextmanager
+    def transaction(self) -> Iterator[sqlite3.Connection]:
+        """Open a write transaction that rolls back on failure."""
+        with closing(self._get_connection()) as conn:
+            conn.execute("BEGIN")
+            try:
+                yield conn
+            except Exception:
+                conn.rollback()
+                raise
+            else:
+                conn.commit()
+
     def _initialize_schema(self) -> None:
         """Initialize the local Collections schema."""
         with self.connection() as conn:

--- a/tldw_chatbook/Home/active_work_adapter.py
+++ b/tldw_chatbook/Home/active_work_adapter.py
@@ -231,7 +231,7 @@ class LocalNotificationHomeActiveWorkAdapter(UnavailableHomeActiveWorkAdapter):
                 return HomeControlResult(
                     action=action,
                     status=HomeControlResultStatus.HANDLED,
-                    message=f"Opening W+C run details for {title}.",
+                    message=f"Opening Watchlists run details for {title}.",
                     target_route=target_route or "subscriptions",
                     target_id=target_id,
                 )
@@ -245,12 +245,12 @@ class LocalNotificationHomeActiveWorkAdapter(UnavailableHomeActiveWorkAdapter):
                     message=f"Opening Console for {title}.",
                     target_id=target_id,
                     console_launch=HomeConsoleLaunch(
-                        source="W+C",
+                        source="Watchlists",
                         title=title,
                         payload=self._watchlist_console_payload(run, str(target_id)),
                         status=str(_mapping_value(run, "status") or "pending").strip().lower(),
-                        recovery="Review the W+C run details or retry from W+C.",
-                        action_label="Open W+C run",
+                        recovery="Review the Watchlists run details or retry from Watchlists.",
+                        action_label="Open Watchlists run",
                     ),
                 )
         if action is HomeControlAction.OPEN_DETAILS and _is_local_chatbook_id(target_id):
@@ -328,7 +328,7 @@ class LocalNotificationHomeActiveWorkAdapter(UnavailableHomeActiveWorkAdapter):
                 HomeActiveWorkItem(
                     item_id=item_id,
                     title=title,
-                    source="W+C",
+                    source="Watchlists",
                     status=status,
                     detail_route="subscriptions",
                     console_available=True,

--- a/tldw_chatbook/Library/__init__.py
+++ b/tldw_chatbook/Library/__init__.py
@@ -1,1 +1,13 @@
 """Library destination state and service contracts."""
+
+from .library_collections_service import (
+    LibraryCollectionRecord,
+    LibraryCollectionsService,
+    LocalLibraryCollectionsService,
+)
+
+__all__ = [
+    "LibraryCollectionRecord",
+    "LibraryCollectionsService",
+    "LocalLibraryCollectionsService",
+]

--- a/tldw_chatbook/Library/library_collections_service.py
+++ b/tldw_chatbook/Library/library_collections_service.py
@@ -1,0 +1,340 @@
+"""Service seam for Library Collections local management."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import sqlite3
+from typing import Protocol
+from uuid import uuid4
+
+from tldw_chatbook.DB.Library_Collections_DB import LibraryCollectionsDB
+from tldw_chatbook.Library.library_collections_state import (
+    LIBRARY_COLLECTIONS_DESCRIPTION_MAX_LENGTH,
+    LIBRARY_COLLECTIONS_NAME_MAX_LENGTH,
+    _collection_name_validation,
+)
+
+
+class LibraryCollectionsServiceError(Exception):
+    """Base exception for Library Collections service failures."""
+
+
+class InvalidLibraryCollectionName(LibraryCollectionsServiceError):
+    """Raised when a Collection name fails validation."""
+
+
+class InvalidLibraryCollectionDescription(LibraryCollectionsServiceError):
+    """Raised when a Collection description fails validation."""
+
+
+class DuplicateLibraryCollectionName(LibraryCollectionsServiceError):
+    """Raised when a normalized Collection name already exists."""
+
+
+class DuplicateLibraryCollectionItem(LibraryCollectionsServiceError):
+    """Raised when a source item is already in the selected Collection."""
+
+
+class LibraryCollectionNotFound(LibraryCollectionsServiceError):
+    """Raised when a Collection operation targets a missing Collection."""
+
+
+@dataclass(frozen=True)
+class LibraryCollectionRecord:
+    """Service record for one local Library Collection."""
+
+    collection_id: str
+    name: str
+    description: str
+    item_count: int
+    source_authority: str
+    sync_status: str
+    created_at: str
+    updated_at: str
+
+
+class LibraryCollectionsService(Protocol):
+    """Protocol implemented by Library Collections backends."""
+
+    def list_collections(self) -> tuple[LibraryCollectionRecord, ...]:
+        """List active Library Collections."""
+
+    def get_collection(self, collection_id: str) -> LibraryCollectionRecord | None:
+        """Return one active Library Collection if it exists."""
+
+    def create_collection(
+        self,
+        name: str,
+        *,
+        description: str = "",
+    ) -> LibraryCollectionRecord:
+        """Create a local Library Collection."""
+
+    def rename_collection(
+        self,
+        collection_id: str,
+        name: str,
+        *,
+        description: str | None = None,
+    ) -> LibraryCollectionRecord:
+        """Rename a local Library Collection."""
+
+    def delete_collection(self, collection_id: str) -> bool:
+        """Soft-delete a local Library Collection."""
+
+
+class LocalLibraryCollectionsService:
+    """Local SQLite implementation of Library Collections contracts."""
+
+    def __init__(
+        self,
+        db: LibraryCollectionsDB,
+        *,
+        id_factory: Callable[[], str] | None = None,
+        now_factory: Callable[[], str] | None = None,
+    ) -> None:
+        self.db = db
+        self._id_factory = id_factory or (lambda: f"collection-{uuid4().hex}")
+        self._now_factory = now_factory or _utc_now
+
+    def list_collections(self) -> tuple[LibraryCollectionRecord, ...]:
+        with self.db.connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT
+                    collection.collection_id,
+                    collection.name,
+                    collection.description,
+                    collection.created_at,
+                    collection.updated_at,
+                    COUNT(item.membership_id) AS item_count
+                FROM library_collections AS collection
+                LEFT JOIN library_collection_items AS item
+                    ON item.collection_id = collection.collection_id
+                WHERE collection.deleted_at IS NULL
+                GROUP BY collection.collection_id
+                ORDER BY collection.created_at ASC, collection.name COLLATE NOCASE ASC
+                """
+            ).fetchall()
+        return tuple(_record_from_row(row) for row in rows)
+
+    def get_collection(self, collection_id: str) -> LibraryCollectionRecord | None:
+        with self.db.connection() as conn:
+            row = conn.execute(
+                """
+                SELECT
+                    collection.collection_id,
+                    collection.name,
+                    collection.description,
+                    collection.created_at,
+                    collection.updated_at,
+                    COUNT(item.membership_id) AS item_count
+                FROM library_collections AS collection
+                LEFT JOIN library_collection_items AS item
+                    ON item.collection_id = collection.collection_id
+                WHERE collection.deleted_at IS NULL
+                    AND collection.collection_id = ?
+                GROUP BY collection.collection_id
+                """,
+                (collection_id,),
+            ).fetchone()
+        return _record_from_row(row) if row is not None else None
+
+    def create_collection(
+        self,
+        name: str,
+        *,
+        description: str = "",
+    ) -> LibraryCollectionRecord:
+        safe_name = self._validate_name(name)
+        safe_description = self._validate_description(description)
+        self._ensure_unique_name(safe_name)
+        collection_id = self._id_factory()
+        now = self._now_factory()
+        try:
+            with self.db.connection() as conn:
+                conn.execute(
+                    """
+                    INSERT INTO library_collections (
+                        collection_id,
+                        name,
+                        description,
+                        created_at,
+                        updated_at
+                    )
+                    VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (collection_id, safe_name, safe_description, now, now),
+                )
+                conn.commit()
+        except sqlite3.IntegrityError as exc:
+            raise DuplicateLibraryCollectionName(
+                f"Collection name already exists: {safe_name}"
+            ) from exc
+        collection = self.get_collection(collection_id)
+        if collection is None:
+            raise LibraryCollectionsServiceError("Collection creation failed.")
+        return collection
+
+    def rename_collection(
+        self,
+        collection_id: str,
+        name: str,
+        *,
+        description: str | None = None,
+    ) -> LibraryCollectionRecord:
+        existing = self.get_collection(collection_id)
+        if existing is None:
+            raise LibraryCollectionNotFound(collection_id)
+        safe_name = self._validate_name(name)
+        safe_description = (
+            existing.description
+            if description is None
+            else self._validate_description(description)
+        )
+        self._ensure_unique_name(safe_name, excluding_collection_id=collection_id)
+        now = self._now_factory()
+        try:
+            with self.db.connection() as conn:
+                conn.execute(
+                    """
+                    UPDATE library_collections
+                    SET name = ?,
+                        description = ?,
+                        updated_at = ?
+                    WHERE collection_id = ?
+                        AND deleted_at IS NULL
+                    """,
+                    (safe_name, safe_description, now, collection_id),
+                )
+                conn.commit()
+        except sqlite3.IntegrityError as exc:
+            raise DuplicateLibraryCollectionName(
+                f"Collection name already exists: {safe_name}"
+            ) from exc
+        collection = self.get_collection(collection_id)
+        if collection is None:
+            raise LibraryCollectionNotFound(collection_id)
+        return collection
+
+    def delete_collection(self, collection_id: str) -> bool:
+        now = self._now_factory()
+        with self.db.connection() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE library_collections
+                SET deleted_at = ?,
+                    updated_at = ?
+                WHERE collection_id = ?
+                    AND deleted_at IS NULL
+                """,
+                (now, now, collection_id),
+            )
+            conn.commit()
+        return cursor.rowcount > 0
+
+    def add_item_to_collection(
+        self,
+        collection_id: str,
+        *,
+        source_type: str,
+        source_id: str,
+        title: str = "",
+    ) -> str:
+        if self.get_collection(collection_id) is None:
+            raise LibraryCollectionNotFound(collection_id)
+        safe_source_type = _validate_required_value(source_type, "source_type")
+        safe_source_id = _validate_required_value(source_id, "source_id")
+        safe_title = _collapse_text(title)[:500]
+        membership_id = self._id_factory()
+        try:
+            with self.db.connection() as conn:
+                conn.execute(
+                    """
+                    INSERT INTO library_collection_items (
+                        membership_id,
+                        collection_id,
+                        source_type,
+                        source_id,
+                        title,
+                        created_at
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        membership_id,
+                        collection_id,
+                        safe_source_type,
+                        safe_source_id,
+                        safe_title,
+                        self._now_factory(),
+                    ),
+                )
+                conn.commit()
+        except sqlite3.IntegrityError as exc:
+            raise DuplicateLibraryCollectionItem(
+                "Source item already belongs to this Collection."
+            ) from exc
+        return membership_id
+
+    def _validate_name(self, value: str) -> str:
+        name, reason = _collection_name_validation(value)
+        if reason:
+            raise InvalidLibraryCollectionName(reason)
+        return name
+
+    def _validate_description(self, value: str) -> str:
+        description = _collapse_text(value)
+        if len(description) > LIBRARY_COLLECTIONS_DESCRIPTION_MAX_LENGTH:
+            raise InvalidLibraryCollectionDescription(
+                "Collection descriptions must be 500 characters or fewer."
+            )
+        return description
+
+    def _ensure_unique_name(
+        self,
+        name: str,
+        *,
+        excluding_collection_id: str | None = None,
+    ) -> None:
+        normalized = name.casefold()
+        for collection in self.list_collections():
+            if (
+                collection.name.casefold() == normalized
+                and collection.collection_id != excluding_collection_id
+            ):
+                raise DuplicateLibraryCollectionName(
+                    f"Collection name already exists: {name}"
+                )
+
+
+def _record_from_row(row) -> LibraryCollectionRecord:
+    return LibraryCollectionRecord(
+        collection_id=str(row["collection_id"]),
+        name=str(row["name"]),
+        description=str(row["description"] or ""),
+        item_count=max(0, int(row["item_count"] or 0)),
+        source_authority="local",
+        sync_status="local-only",
+        created_at=str(row["created_at"]),
+        updated_at=str(row["updated_at"]),
+    )
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _collapse_text(value: str) -> str:
+    return " ".join(str(value or "").strip().split())
+
+
+def _validate_required_value(value: str, field_name: str) -> str:
+    collapsed = _collapse_text(value)
+    if not collapsed:
+        raise LibraryCollectionsServiceError(f"{field_name} is required.")
+    if len(collapsed) > LIBRARY_COLLECTIONS_NAME_MAX_LENGTH:
+        raise LibraryCollectionsServiceError(f"{field_name} is too long.")
+    return collapsed

--- a/tldw_chatbook/Library/library_collections_service.py
+++ b/tldw_chatbook/Library/library_collections_service.py
@@ -15,6 +15,12 @@ from tldw_chatbook.Library.library_collections_state import (
     LIBRARY_COLLECTIONS_NAME_MAX_LENGTH,
     _collection_name_validation,
 )
+from tldw_chatbook.Utils.input_validation import sanitize_string, validate_text_input
+
+
+DEFAULT_LIBRARY_COLLECTIONS_LIST_LIMIT = 200
+MAX_LIBRARY_COLLECTIONS_LIST_LIMIT = 500
+_STORAGE_FAILURE_MESSAGE = "Library Collections storage failed."
 
 
 class LibraryCollectionsServiceError(Exception):
@@ -58,7 +64,10 @@ class LibraryCollectionRecord:
 class LibraryCollectionsService(Protocol):
     """Protocol implemented by Library Collections backends."""
 
-    def list_collections(self) -> tuple[LibraryCollectionRecord, ...]:
+    def list_collections(
+        self,
+        limit: int = DEFAULT_LIBRARY_COLLECTIONS_LIST_LIMIT,
+    ) -> tuple[LibraryCollectionRecord, ...]:
         """List active Library Collections."""
 
     def get_collection(self, collection_id: str) -> LibraryCollectionRecord | None:
@@ -99,47 +108,59 @@ class LocalLibraryCollectionsService:
         self._id_factory = id_factory or (lambda: f"collection-{uuid4().hex}")
         self._now_factory = now_factory or _utc_now
 
-    def list_collections(self) -> tuple[LibraryCollectionRecord, ...]:
-        with self.db.connection() as conn:
-            rows = conn.execute(
-                """
-                SELECT
-                    collection.collection_id,
-                    collection.name,
-                    collection.description,
-                    collection.created_at,
-                    collection.updated_at,
-                    COUNT(item.membership_id) AS item_count
-                FROM library_collections AS collection
-                LEFT JOIN library_collection_items AS item
-                    ON item.collection_id = collection.collection_id
-                WHERE collection.deleted_at IS NULL
-                GROUP BY collection.collection_id
-                ORDER BY collection.created_at ASC, collection.name COLLATE NOCASE ASC
-                """
-            ).fetchall()
+    def list_collections(
+        self,
+        limit: int = DEFAULT_LIBRARY_COLLECTIONS_LIST_LIMIT,
+    ) -> tuple[LibraryCollectionRecord, ...]:
+        safe_limit = _validate_list_limit(limit)
+        try:
+            with self.db.connection() as conn:
+                rows = conn.execute(
+                    """
+                    SELECT
+                        collection.collection_id,
+                        collection.name,
+                        collection.description,
+                        collection.created_at,
+                        collection.updated_at,
+                        COUNT(item.membership_id) AS item_count
+                    FROM library_collections AS collection
+                    LEFT JOIN library_collection_items AS item
+                        ON item.collection_id = collection.collection_id
+                    WHERE collection.deleted_at IS NULL
+                    GROUP BY collection.collection_id
+                    ORDER BY collection.created_at ASC, collection.name COLLATE NOCASE ASC
+                    LIMIT ?
+                    """,
+                    (safe_limit,),
+                ).fetchall()
+        except sqlite3.Error as exc:
+            raise LibraryCollectionsServiceError(_STORAGE_FAILURE_MESSAGE) from exc
         return tuple(_record_from_row(row) for row in rows)
 
     def get_collection(self, collection_id: str) -> LibraryCollectionRecord | None:
-        with self.db.connection() as conn:
-            row = conn.execute(
-                """
-                SELECT
-                    collection.collection_id,
-                    collection.name,
-                    collection.description,
-                    collection.created_at,
-                    collection.updated_at,
-                    COUNT(item.membership_id) AS item_count
-                FROM library_collections AS collection
-                LEFT JOIN library_collection_items AS item
-                    ON item.collection_id = collection.collection_id
-                WHERE collection.deleted_at IS NULL
-                    AND collection.collection_id = ?
-                GROUP BY collection.collection_id
-                """,
-                (collection_id,),
-            ).fetchone()
+        try:
+            with self.db.connection() as conn:
+                row = conn.execute(
+                    """
+                    SELECT
+                        collection.collection_id,
+                        collection.name,
+                        collection.description,
+                        collection.created_at,
+                        collection.updated_at,
+                        COUNT(item.membership_id) AS item_count
+                    FROM library_collections AS collection
+                    LEFT JOIN library_collection_items AS item
+                        ON item.collection_id = collection.collection_id
+                    WHERE collection.deleted_at IS NULL
+                        AND collection.collection_id = ?
+                    GROUP BY collection.collection_id
+                    """,
+                    (collection_id,),
+                ).fetchone()
+        except sqlite3.Error as exc:
+            raise LibraryCollectionsServiceError(_STORAGE_FAILURE_MESSAGE) from exc
         return _record_from_row(row) if row is not None else None
 
     def create_collection(
@@ -154,7 +175,7 @@ class LocalLibraryCollectionsService:
         collection_id = self._id_factory()
         now = self._now_factory()
         try:
-            with self.db.connection() as conn:
+            with self.db.transaction() as conn:
                 conn.execute(
                     """
                     INSERT INTO library_collections (
@@ -168,11 +189,12 @@ class LocalLibraryCollectionsService:
                     """,
                     (collection_id, safe_name, safe_description, now, now),
                 )
-                conn.commit()
         except sqlite3.IntegrityError as exc:
             raise DuplicateLibraryCollectionName(
                 f"Collection name already exists: {safe_name}"
             ) from exc
+        except sqlite3.Error as exc:
+            raise LibraryCollectionsServiceError(_STORAGE_FAILURE_MESSAGE) from exc
         collection = self.get_collection(collection_id)
         if collection is None:
             raise LibraryCollectionsServiceError("Collection creation failed.")
@@ -197,7 +219,7 @@ class LocalLibraryCollectionsService:
         self._ensure_unique_name(safe_name, excluding_collection_id=collection_id)
         now = self._now_factory()
         try:
-            with self.db.connection() as conn:
+            with self.db.transaction() as conn:
                 conn.execute(
                     """
                     UPDATE library_collections
@@ -209,11 +231,12 @@ class LocalLibraryCollectionsService:
                     """,
                     (safe_name, safe_description, now, collection_id),
                 )
-                conn.commit()
         except sqlite3.IntegrityError as exc:
             raise DuplicateLibraryCollectionName(
                 f"Collection name already exists: {safe_name}"
             ) from exc
+        except sqlite3.Error as exc:
+            raise LibraryCollectionsServiceError(_STORAGE_FAILURE_MESSAGE) from exc
         collection = self.get_collection(collection_id)
         if collection is None:
             raise LibraryCollectionNotFound(collection_id)
@@ -221,18 +244,20 @@ class LocalLibraryCollectionsService:
 
     def delete_collection(self, collection_id: str) -> bool:
         now = self._now_factory()
-        with self.db.connection() as conn:
-            cursor = conn.execute(
-                """
-                UPDATE library_collections
-                SET deleted_at = ?,
-                    updated_at = ?
-                WHERE collection_id = ?
-                    AND deleted_at IS NULL
-                """,
-                (now, now, collection_id),
-            )
-            conn.commit()
+        try:
+            with self.db.transaction() as conn:
+                cursor = conn.execute(
+                    """
+                    UPDATE library_collections
+                    SET deleted_at = ?,
+                        updated_at = ?
+                    WHERE collection_id = ?
+                        AND deleted_at IS NULL
+                    """,
+                    (now, now, collection_id),
+                )
+        except sqlite3.Error as exc:
+            raise LibraryCollectionsServiceError(_STORAGE_FAILURE_MESSAGE) from exc
         return cursor.rowcount > 0
 
     def add_item_to_collection(
@@ -250,7 +275,7 @@ class LocalLibraryCollectionsService:
         safe_title = _collapse_text(title)[:500]
         membership_id = self._id_factory()
         try:
-            with self.db.connection() as conn:
+            with self.db.transaction() as conn:
                 conn.execute(
                     """
                     INSERT INTO library_collection_items (
@@ -272,11 +297,12 @@ class LocalLibraryCollectionsService:
                         self._now_factory(),
                     ),
                 )
-                conn.commit()
         except sqlite3.IntegrityError as exc:
             raise DuplicateLibraryCollectionItem(
                 "Source item already belongs to this Collection."
             ) from exc
+        except sqlite3.Error as exc:
+            raise LibraryCollectionsServiceError(_STORAGE_FAILURE_MESSAGE) from exc
         return membership_id
 
     def _validate_name(self, value: str) -> str:
@@ -291,6 +317,27 @@ class LocalLibraryCollectionsService:
             raise InvalidLibraryCollectionDescription(
                 "Collection descriptions must be 500 characters or fewer."
             )
+        if not validate_text_input(
+            description,
+            max_length=LIBRARY_COLLECTIONS_DESCRIPTION_MAX_LENGTH,
+            allow_html=False,
+        ):
+            raise InvalidLibraryCollectionDescription(
+                "Enter a safe Collection description."
+            )
+        description = sanitize_string(
+            description,
+            max_length=LIBRARY_COLLECTIONS_DESCRIPTION_MAX_LENGTH,
+        )
+        description = _collapse_text(description)
+        if not validate_text_input(
+            description,
+            max_length=LIBRARY_COLLECTIONS_DESCRIPTION_MAX_LENGTH,
+            allow_html=False,
+        ):
+            raise InvalidLibraryCollectionDescription(
+                "Enter a safe Collection description."
+            )
         return description
 
     def _ensure_unique_name(
@@ -299,15 +346,30 @@ class LocalLibraryCollectionsService:
         *,
         excluding_collection_id: str | None = None,
     ) -> None:
-        normalized = name.casefold()
-        for collection in self.list_collections():
-            if (
-                collection.name.casefold() == normalized
-                and collection.collection_id != excluding_collection_id
-            ):
-                raise DuplicateLibraryCollectionName(
-                    f"Collection name already exists: {name}"
-                )
+        try:
+            with self.db.connection() as conn:
+                query = """
+                    SELECT collection_id, deleted_at
+                    FROM library_collections
+                    WHERE name = ? COLLATE NOCASE
+                """
+                params: list[str] = [name]
+                if excluding_collection_id:
+                    query += " AND collection_id != ?"
+                    params.append(excluding_collection_id)
+                row = conn.execute(query, tuple(params)).fetchone()
+        except sqlite3.Error as exc:
+            raise LibraryCollectionsServiceError(_STORAGE_FAILURE_MESSAGE) from exc
+
+        if row is None:
+            return
+        if row["deleted_at"] is not None:
+            raise DuplicateLibraryCollectionName(
+                "A deleted Collection already used this name."
+            )
+        raise DuplicateLibraryCollectionName(
+            f"Collection name already exists: {name}"
+        )
 
 
 def _record_from_row(row) -> LibraryCollectionRecord:
@@ -329,6 +391,14 @@ def _utc_now() -> str:
 
 def _collapse_text(value: str) -> str:
     return " ".join(str(value or "").strip().split())
+
+
+def _validate_list_limit(limit: int) -> int:
+    try:
+        parsed = int(limit)
+    except (TypeError, ValueError):
+        return DEFAULT_LIBRARY_COLLECTIONS_LIST_LIMIT
+    return min(max(parsed, 1), MAX_LIBRARY_COLLECTIONS_LIST_LIMIT)
 
 
 def _validate_required_value(value: str, field_name: str) -> str:

--- a/tldw_chatbook/Library/library_collections_state.py
+++ b/tldw_chatbook/Library/library_collections_state.py
@@ -1,0 +1,384 @@
+"""Pure display-state contracts for Library Collections."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import re
+from typing import Any, Mapping, Sequence
+
+from tldw_chatbook.Utils.input_validation import sanitize_string, validate_text_input
+
+
+LIBRARY_COLLECTIONS_EMPTY_COPY = "Group saved Library items for Search/RAG, Study, and Console."
+LIBRARY_COLLECTIONS_NAME_MAX_LENGTH = 120
+LIBRARY_COLLECTIONS_DESCRIPTION_MAX_LENGTH = 500
+_DANGEROUS_DISPLAY_PATTERN = re.compile(
+    r"<script\b|javascript:|onerror=|onclick=",
+    re.IGNORECASE,
+)
+
+
+def _value(record: Any, key: str, fallback: Any = "") -> Any:
+    if isinstance(record, Mapping):
+        return record.get(key, fallback)
+    return getattr(record, key, fallback)
+
+
+def _collapse(value: Any, fallback: str = "") -> str:
+    if value is None:
+        return fallback
+    text = " ".join(str(value).strip().split())
+    return text or fallback
+
+
+def _safe_display_text(value: Any, fallback: str = "", *, max_length: int = 500) -> str:
+    text = sanitize_string(str(value or ""), max_length=max_length).strip()
+    text = " ".join(text.split())
+    if not text:
+        return fallback
+    if _DANGEROUS_DISPLAY_PATTERN.search(text):
+        return fallback
+    if not validate_text_input(text, max_length=max_length, allow_html=False):
+        return fallback
+    return text
+
+
+def _coerce_count(value: Any) -> int:
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _normalize_sync_status(value: Any) -> str:
+    status = _collapse(value, "local-only").lower()
+    return status if status in {"local-only", "sync-unavailable"} else "local-only"
+
+
+def _updated_at_label(value: Any) -> str:
+    text = _collapse(value)
+    if not text:
+        return "Updated unknown"
+    normalized = text[:-1] + "+00:00" if text.endswith("Z") else text
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return f"Updated {text}"
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    parsed = parsed.astimezone(timezone.utc)
+    return f"Updated {parsed:%Y-%m-%d %H:%M} UTC"
+
+
+def _collection_name_validation(value: Any) -> tuple[str, str]:
+    raw = "" if value is None else str(value)
+    collapsed = " ".join(raw.strip().split())
+    if not collapsed:
+        return "", "Enter a Collection name."
+    if len(collapsed) > LIBRARY_COLLECTIONS_NAME_MAX_LENGTH:
+        return "", "Collection names must be 120 characters or fewer."
+    safe = _safe_display_text(
+        collapsed,
+        "",
+        max_length=LIBRARY_COLLECTIONS_NAME_MAX_LENGTH,
+    )
+    if not safe:
+        return "", "Enter a safe Collection name."
+    return safe, ""
+
+
+@dataclass(frozen=True)
+class LibraryCollectionActionState:
+    """Display state for one Library Collections action."""
+
+    label: str
+    enabled: bool
+    widget_id: str
+    disabled_reason: str = ""
+
+    @property
+    def tooltip(self) -> str:
+        return "" if self.enabled else self.disabled_reason
+
+
+@dataclass(frozen=True)
+class LibraryCollectionSummary:
+    """List-row display state for one Library Collection."""
+
+    collection_id: str
+    name: str
+    description: str
+    item_count: int
+    source_authority: str
+    sync_status: str
+    created_at: str
+    updated_at: str
+    selected: bool = False
+
+    @property
+    def sync_status_label(self) -> str:
+        return f"Sync: {self.sync_status}"
+
+    @property
+    def item_count_label(self) -> str:
+        suffix = "item" if self.item_count == 1 else "items"
+        return f"{self.item_count} {suffix}"
+
+    @property
+    def updated_at_label(self) -> str:
+        return _updated_at_label(self.updated_at)
+
+    @classmethod
+    def from_record(cls, record: Any, *, selected: bool = False) -> "LibraryCollectionSummary":
+        collection_id = _safe_display_text(_value(record, "collection_id"), "", max_length=200)
+        name = _safe_display_text(
+            _value(record, "name"),
+            "Untitled Collection",
+            max_length=LIBRARY_COLLECTIONS_NAME_MAX_LENGTH,
+        )
+        return cls(
+            collection_id=collection_id,
+            name=name,
+            description=_safe_display_text(
+                _value(record, "description"),
+                "",
+                max_length=LIBRARY_COLLECTIONS_DESCRIPTION_MAX_LENGTH,
+            ),
+            item_count=_coerce_count(_value(record, "item_count", 0)),
+            source_authority=_safe_display_text(
+                _value(record, "source_authority"),
+                "local",
+                max_length=64,
+            ),
+            sync_status=_normalize_sync_status(_value(record, "sync_status")),
+            created_at=_collapse(_value(record, "created_at")),
+            updated_at=_collapse(_value(record, "updated_at")),
+            selected=selected,
+        )
+
+
+@dataclass(frozen=True)
+class LibraryCollectionDetail:
+    """Detail display state for the selected Library Collection."""
+
+    collection_id: str
+    name: str
+    description: str
+    item_count: int
+    source_authority: str
+    sync_status: str
+    created_at: str
+    updated_at: str
+
+    @property
+    def sync_status_label(self) -> str:
+        return f"Sync: {self.sync_status}"
+
+    @property
+    def item_count_label(self) -> str:
+        suffix = "item" if self.item_count == 1 else "items"
+        return f"{self.item_count} {suffix}"
+
+    @property
+    def updated_at_label(self) -> str:
+        return _updated_at_label(self.updated_at)
+
+    @classmethod
+    def from_summary(cls, summary: LibraryCollectionSummary) -> "LibraryCollectionDetail":
+        return cls(
+            collection_id=summary.collection_id,
+            name=summary.name,
+            description=summary.description,
+            item_count=summary.item_count,
+            source_authority=summary.source_authority,
+            sync_status=summary.sync_status,
+            created_at=summary.created_at,
+            updated_at=summary.updated_at,
+        )
+
+
+@dataclass(frozen=True)
+class LibraryCollectionsPanelState:
+    """Pure display state for the Library Collections management panel."""
+
+    status: str
+    collections: tuple[LibraryCollectionSummary, ...]
+    selected_collection_id: str | None
+    selected_collection: LibraryCollectionDetail | None
+    empty_copy: str
+    create_action: LibraryCollectionActionState
+    rename_action: LibraryCollectionActionState
+    delete_action: LibraryCollectionActionState
+    error_message: str = ""
+    recovery_copy: str = ""
+
+    @classmethod
+    def from_values(
+        cls,
+        *,
+        collections: Sequence[Any],
+        selected_collection_id: Any = None,
+        status: Any = "ready",
+        error_message: Any = "",
+        create_name: Any = "",
+        rename_name: Any = None,
+    ) -> "LibraryCollectionsPanelState":
+        records = tuple(
+            LibraryCollectionSummary.from_record(record)
+            for record in collections
+            if _safe_display_text(_value(record, "collection_id"), "", max_length=200)
+        )
+        requested_status = _collapse(status, "ready").lower()
+        if requested_status not in {"loading", "ready", "empty", "error"}:
+            requested_status = "ready"
+
+        selected_id = _safe_display_text(selected_collection_id, "", max_length=200)
+        if not selected_id and records:
+            selected_id = records[0].collection_id
+        selected_record = next(
+            (record for record in records if record.collection_id == selected_id),
+            None,
+        )
+        selected_id = selected_record.collection_id if selected_record is not None else ""
+        selected_detail = (
+            LibraryCollectionDetail.from_summary(selected_record)
+            if selected_record is not None
+            else None
+        )
+        summary_rows = tuple(
+            LibraryCollectionSummary(
+                collection_id=record.collection_id,
+                name=record.name,
+                description=record.description,
+                item_count=record.item_count,
+                source_authority=record.source_authority,
+                sync_status=record.sync_status,
+                created_at=record.created_at,
+                updated_at=record.updated_at,
+                selected=record.collection_id == selected_id,
+            )
+            for record in records
+        )
+
+        if requested_status == "ready" and not summary_rows:
+            requested_status = "empty"
+        if requested_status == "error":
+            error_copy = _safe_display_text(
+                error_message,
+                "Library Collections are unavailable.",
+                max_length=500,
+            )
+            recovery_copy = f"Unavailable: Library Collections.\nWhy: {error_copy}"
+        else:
+            error_copy = ""
+            recovery_copy = ""
+
+        create_action = _create_action(create_name, summary_rows)
+        rename_action = _rename_action(rename_name, selected_detail, summary_rows)
+        delete_action = _delete_action(selected_detail)
+
+        return cls(
+            status=requested_status,
+            collections=summary_rows,
+            selected_collection_id=selected_id or None,
+            selected_collection=selected_detail,
+            empty_copy=LIBRARY_COLLECTIONS_EMPTY_COPY,
+            create_action=create_action,
+            rename_action=rename_action,
+            delete_action=delete_action,
+            error_message=error_copy,
+            recovery_copy=recovery_copy,
+        )
+
+
+def _name_exists(
+    name: str,
+    collections: Sequence[LibraryCollectionSummary],
+    *,
+    excluding_collection_id: str | None = None,
+) -> bool:
+    normalized = name.casefold()
+    return any(
+        collection.name.casefold() == normalized
+        and collection.collection_id != excluding_collection_id
+        for collection in collections
+    )
+
+
+def _create_action(
+    create_name: Any,
+    collections: Sequence[LibraryCollectionSummary],
+) -> LibraryCollectionActionState:
+    name, reason = _collection_name_validation(create_name)
+    if reason:
+        return LibraryCollectionActionState(
+            label="Create Collection",
+            enabled=False,
+            widget_id="library-create-collection",
+            disabled_reason=reason,
+        )
+    if _name_exists(name, collections):
+        return LibraryCollectionActionState(
+            label="Create Collection",
+            enabled=False,
+            widget_id="library-create-collection",
+            disabled_reason="A Collection with this name already exists.",
+        )
+    return LibraryCollectionActionState(
+        label="Create Collection",
+        enabled=True,
+        widget_id="library-create-collection",
+    )
+
+
+def _rename_action(
+    rename_name: Any,
+    selected_collection: LibraryCollectionDetail | None,
+    collections: Sequence[LibraryCollectionSummary],
+) -> LibraryCollectionActionState:
+    if selected_collection is None:
+        return LibraryCollectionActionState(
+            label="Rename Collection",
+            enabled=False,
+            widget_id="library-rename-collection",
+            disabled_reason="Select a Collection before renaming it.",
+        )
+    proposed_name = selected_collection.name if rename_name is None else rename_name
+    name, reason = _collection_name_validation(proposed_name)
+    if reason:
+        return LibraryCollectionActionState(
+            label="Rename Collection",
+            enabled=False,
+            widget_id="library-rename-collection",
+            disabled_reason=reason,
+        )
+    if _name_exists(name, collections, excluding_collection_id=selected_collection.collection_id):
+        return LibraryCollectionActionState(
+            label="Rename Collection",
+            enabled=False,
+            widget_id="library-rename-collection",
+            disabled_reason="A Collection with this name already exists.",
+        )
+    return LibraryCollectionActionState(
+        label="Rename Collection",
+        enabled=True,
+        widget_id="library-rename-collection",
+    )
+
+
+def _delete_action(
+    selected_collection: LibraryCollectionDetail | None,
+) -> LibraryCollectionActionState:
+    if selected_collection is None:
+        return LibraryCollectionActionState(
+            label="Delete Collection",
+            enabled=False,
+            widget_id="library-delete-collection",
+            disabled_reason="Select a Collection before deleting it.",
+        )
+    return LibraryCollectionActionState(
+        label="Delete Collection",
+        enabled=True,
+        widget_id="library-delete-collection",
+    )

--- a/tldw_chatbook/UI/Navigation/main_navigation.py
+++ b/tldw_chatbook/UI/Navigation/main_navigation.py
@@ -23,6 +23,20 @@ class NavigateToScreen(Message):
         self.screen_name = screen_name
 
 
+class NavigationButton(Button):
+    """Navigation button that remains pressable when mounted in hidden chrome."""
+
+    def __init__(self, *args, target_route: str, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._target_route = target_route
+
+    def press(self):
+        if not self.display:
+            self.app.post_message(NavigateToScreen(self._target_route))
+            return self
+        return super().press()
+
+
 class MainNavigationBar(Container):
     """
     Main navigation bar for the application.
@@ -83,7 +97,6 @@ class MainNavigationBar(Container):
     }
 
     .nav-overflow-hint {
-        dock: right;
         width: auto;
         padding: 0 1;
         color: $text-muted;
@@ -113,17 +126,18 @@ class MainNavigationBar(Container):
                 if index > 0:
                     yield Static("·", classes="nav-separator")
 
-                button = Button(
+                button = NavigationButton(
                     destination.label,
                     id=f"nav-{destination.destination_id}",
                     classes="nav-button",
                     tooltip=destination.tooltip,
+                    target_route=destination.primary_route,
                 )
                 if destination.destination_id == self.active_destination_id:
                     button.add_class("is-active")
                 yield button
-        yield Static("More: Ctrl+P", id="nav-overflow-hint", classes="nav-overflow-hint")
-    
+            yield Static("More: Ctrl+P", id="nav-overflow-hint", classes="nav-overflow-hint")
+
     @on(Button.Pressed, ".nav-button")
     def handle_navigation(self, event: Button.Pressed) -> None:
         """Handle navigation button clicks."""

--- a/tldw_chatbook/UI/Navigation/shell_destinations.py
+++ b/tldw_chatbook/UI/Navigation/shell_destinations.py
@@ -74,12 +74,12 @@ SHELL_DESTINATION_ORDER: tuple[ShellDestination, ...] = (
     ),
     ShellDestination(
         "watchlists_collections",
-        "W+C",
+        "Watchlists",
         "watchlists_collections",
-        "Monitored sources and curated reading/content collections.",
-        "Open Watchlists+Collections for monitored sources and curated collections.",
+        "Monitored sources, runs, alerts, and recovery.",
+        "Open Watchlists for monitored sources, runs, alerts, and recovery.",
         ("subscriptions", "subscription"),
-        full_label="Watchlists+Collections",
+        full_label="Watchlists",
         navigation_priority=40,
     ),
     ShellDestination(

--- a/tldw_chatbook/UI/Screens/home_screen.py
+++ b/tldw_chatbook/UI/Screens/home_screen.py
@@ -1,5 +1,7 @@
 """Home dashboard screen for the master shell."""
 
+from collections.abc import Callable
+
 from textual import on, work
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
@@ -34,6 +36,20 @@ HOME_CONTROL_METHODS_WITH_TARGET_ROUTE = {
     "home-open-chatbook-details",
     "home-open-chatbook-in-console",
 }
+
+
+class HomeActionButton(Button):
+    """Home button that emits press events even when app chrome hides layout."""
+
+    def __init__(self, *args, fallback_press: Callable[[], None] | None = None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._fallback_press = fallback_press
+
+    def press(self):
+        if not self.display and self._fallback_press is not None:
+            self._fallback_press()
+            return self
+        return super().press()
 
 
 class HomeScreen(BaseAppScreen):
@@ -122,19 +138,23 @@ class HomeScreen(BaseAppScreen):
             with Horizontal(id="home-dashboard-grid", classes="ds-panel"):
                 with Vertical(id="home-attention-queue", classes="home-dashboard-region"):
                     yield Static("Attention Queue", id="home-attention", classes="ds-panel")
-                    yield Button(
+                    yield HomeActionButton(
                         dashboard.next_action.label,
                         id="home-primary-action",
                         classes="ds-toolbar",
+                        fallback_press=self._activate_home_primary_action,
                     )
                     yield Static(section_text("attention"), id="home-attention-body")
                 with Vertical(id="home-active-work-region", classes="home-dashboard-region"):
                     yield Static("Active Work", id="home-active-work", classes="ds-panel")
                     for control in dashboard.controls:
-                        yield Button(
+                        yield HomeActionButton(
                             control.label,
                             id=control.control_id,
                             classes="ds-toolbar",
+                            fallback_press=lambda control_id=control.control_id: (
+                                self._activate_home_control(control_id)
+                            ),
                         )
                     yield Static(section_text("active_work"), id="home-active-work-body")
                 with Vertical(id="home-inspector", classes="home-dashboard-region"):
@@ -157,17 +177,28 @@ class HomeScreen(BaseAppScreen):
     @on(Button.Pressed)
     def handle_home_button(self, event: Button.Pressed) -> None:
         button_id = event.button.id
-        dashboard = self._current_dashboard
-        if not button_id or dashboard is None:
+        if not button_id:
             return
 
         if button_id == "home-primary-action":
-            prepare = getattr(self.app_instance, "prepare_home_primary_action", None)
-            if callable(prepare):
-                prepare(dashboard.next_action)
-            self.post_message(NavigateToScreen(dashboard.next_action.target_route))
+            self._activate_home_primary_action()
             return
 
+        self._activate_home_control(button_id)
+
+    def _activate_home_primary_action(self) -> None:
+        dashboard = self._current_dashboard
+        if dashboard is None:
+            return
+        prepare = getattr(self.app_instance, "prepare_home_primary_action", None)
+        if callable(prepare):
+            prepare(dashboard.next_action)
+        self.post_message(NavigateToScreen(dashboard.next_action.target_route))
+
+    def _activate_home_control(self, button_id: str) -> None:
+        dashboard = self._current_dashboard
+        if dashboard is None:
+            return
         control = next((item for item in dashboard.controls if item.control_id == button_id), None)
         if control is None:
             return

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -16,6 +16,8 @@ from textual.containers import Horizontal, Vertical
 from textual.widgets import Button, Input, Static
 
 from ...Chat.chat_handoff_models import ChatHandoffPayload
+from ...Library.library_collections_service import LibraryCollectionsServiceError
+from ...Library.library_collections_state import LibraryCollectionsPanelState
 from ...Library.library_rag_service import (
     LibraryRagSearchOutcome,
     LibraryRagSearchRequest,
@@ -24,7 +26,11 @@ from ...Library.library_rag_service import (
 from ...Library.library_rag_state import LibraryRagPanelState
 from ...runtime_policy.types import PolicyDeniedError
 from ...Utils.input_validation import sanitize_string, validate_text_input
-from ...Widgets.Library import LibrarySearchRagInspectorPanel, LibrarySearchRagPanel
+from ...Widgets.Library import (
+    LibraryCollectionsPanel,
+    LibrarySearchRagInspectorPanel,
+    LibrarySearchRagPanel,
+)
 from ..Navigation.base_app_screen import BaseAppScreen
 from ..Navigation.main_navigation import NavigateToScreen
 from ..Views.RAGSearch.search_handoff import build_library_rag_console_live_work_payload
@@ -74,7 +80,10 @@ LIBRARY_MODES = {
         "label": "Collections",
         "button_id": "library-mode-collections",
         "description": "Collections mode: manage Library-owned reusable source sets.",
-        "next_action": "Collections can feed Search/RAG citations/snippets, study generation, and Console.",
+        "next_action": (
+            "Create local source groups now; Collection-scoped Search/RAG citations/snippets, "
+            "Study, and Console are later-stage."
+        ),
     },
     "study": {
         "label": "Study",
@@ -129,6 +138,13 @@ class LibraryScreen(BaseAppScreen):
         self._library_rag_retrieval_status = ""
         self._library_rag_recovery_state: DestinationRecoveryState | None = None
         self._library_rag_selected_result_id = ""
+        self._library_collections_loaded = False
+        self._library_collections_records = ()
+        self._library_collections_selected_id = ""
+        self._library_collections_error = ""
+        self._library_collection_name_input = ""
+        self._library_collection_description_input = ""
+        self._library_collection_pending_delete_id = ""
 
     def on_mount(self) -> None:
         super().on_mount()
@@ -448,6 +464,21 @@ class LibraryScreen(BaseAppScreen):
             provider_ready=True,
         )
 
+    def _library_collections_panel_state(self) -> LibraryCollectionsPanelState:
+        status = "loading"
+        if self._library_collections_error:
+            status = "error"
+        elif self._library_collections_loaded:
+            status = "ready"
+        return LibraryCollectionsPanelState.from_values(
+            collections=self._library_collections_records,
+            selected_collection_id=self._library_collections_selected_id,
+            status=status,
+            error_message=self._library_collections_error,
+            create_name=self._library_collection_name_input,
+            rename_name=self._library_collection_name_input,
+        )
+
     def compose_content(self) -> ComposeResult:
         has_sources = self._has_local_sources()
         status_label = self._status_label()
@@ -456,6 +487,12 @@ class LibraryScreen(BaseAppScreen):
         search_rag_panel_state = (
             self._library_rag_panel_state() if self._active_mode == "search" else None
         )
+        collections_panel_state = (
+            self._library_collections_panel_state()
+            if self._active_mode == "collections"
+            else None
+        )
+        collection_scoped_actions_deferred = self._active_mode == "collections"
 
         with Vertical(id="library-shell"):
             yield Static("Library", id="library-title", classes="ds-destination-header")
@@ -529,6 +566,14 @@ class LibraryScreen(BaseAppScreen):
                             search_rag_panel_state,
                             id="library-search-rag-panel",
                         )
+                    if collections_panel_state is not None:
+                        yield LibraryCollectionsPanel(
+                            collections_panel_state,
+                            name_value=self._library_collection_name_input,
+                            description_value=self._library_collection_description_input,
+                            delete_pending=bool(self._library_collection_pending_delete_id),
+                            id="library-collections-panel",
+                        )
                     yield Static("Local Library snapshot", classes="destination-section")
                     if not self._library_loaded:
                         yield Static(
@@ -591,33 +636,62 @@ class LibraryScreen(BaseAppScreen):
                         )
                     yield Static("Knowledge workflow", classes="destination-section")
                     yield Static(
-                        "Turn Library material into study sessions, flashcards, and quizzes.",
+                        (
+                            "Collection-scoped Study, Flashcards, Quizzes, and Console "
+                            "are later-stage."
+                            if collection_scoped_actions_deferred
+                            else "Turn Library material into study sessions, flashcards, and quizzes."
+                        ),
                         id="library-study-purpose",
                     )
                     yield Static(
-                        "Study generation entry uses the visible Library source snapshot.",
+                        (
+                            "Use Collections to organize source groups locally; scoped "
+                            "execution remains deferred."
+                            if collection_scoped_actions_deferred
+                            else "Study generation entry uses the visible Library source snapshot."
+                        ),
                         id="library-study-generation-entry",
                     )
                     yield Button(
                         "Study Dashboard",
                         id="library-open-study",
-                        tooltip="Open the Study dashboard for due cards, decks, quizzes, and resume actions.",
+                        disabled=collection_scoped_actions_deferred,
+                        tooltip=(
+                            "Collection-scoped Study is not available yet."
+                            if collection_scoped_actions_deferred
+                            else "Open the Study dashboard for due cards, decks, quizzes, and resume actions."
+                        ),
                     )
                     yield Button(
                         "Flashcards",
                         id="library-open-flashcards",
-                        tooltip="Open flashcards for selected or imported Library material.",
+                        disabled=collection_scoped_actions_deferred,
+                        tooltip=(
+                            "Collection-scoped Flashcards are not available yet."
+                            if collection_scoped_actions_deferred
+                            else "Open flashcards for selected or imported Library material."
+                        ),
                     )
                     yield Button(
                         "Quizzes",
                         id="library-open-quizzes",
-                        tooltip="Open quizzes for selected or imported Library material.",
+                        disabled=collection_scoped_actions_deferred,
+                        tooltip=(
+                            "Collection-scoped Quizzes are not available yet."
+                            if collection_scoped_actions_deferred
+                            else "Open quizzes for selected or imported Library material."
+                        ),
                     )
                     yield Button(
                         "Use in Console",
                         id="library-use-in-console",
-                        disabled=handoff_disabled,
-                        tooltip=handoff_tooltip,
+                        disabled=handoff_disabled or collection_scoped_actions_deferred,
+                        tooltip=(
+                            "Collection-scoped Console handoff is not available yet."
+                            if collection_scoped_actions_deferred
+                            else handoff_tooltip
+                        ),
                     )
 
     @on(Button.Pressed, ".library-mode-chip")
@@ -642,6 +716,8 @@ class LibraryScreen(BaseAppScreen):
                 "is-active",
             )
         await self._sync_search_rag_panel()
+        await self._sync_collections_panel(refresh_snapshot=True)
+        self._sync_collection_scoped_action_buttons()
 
     async def _sync_search_rag_panel(self) -> None:
         mounted_widgets = list(self.query("#library-search-rag-panel, #library-rag-inspector"))
@@ -665,6 +741,101 @@ class LibraryScreen(BaseAppScreen):
             after="#library-rag-entry-point",
         )
 
+    async def _sync_collections_panel(self, *, refresh_snapshot: bool = False) -> None:
+        for widget in list(self.query("#library-collections-panel")):
+            await widget.remove()
+        if self._active_mode != "collections":
+            self._library_collection_pending_delete_id = ""
+            return
+        if refresh_snapshot:
+            await self._refresh_library_collections_snapshot()
+        panel_state = self._library_collections_panel_state()
+        detail = self.query_one("#library-source-detail", Vertical)
+        await detail.mount(
+            LibraryCollectionsPanel(
+                panel_state,
+                name_value=self._library_collection_name_input,
+                description_value=self._library_collection_description_input,
+                delete_pending=bool(self._library_collection_pending_delete_id),
+                id="library-collections-panel",
+            ),
+            after="#library-active-mode-next-action",
+        )
+
+    async def _refresh_library_collections_snapshot(self) -> None:
+        service = getattr(self.app_instance, "library_collections_service", None)
+        list_collections = getattr(service, "list_collections", None)
+        if not callable(list_collections):
+            self._library_collections_records = ()
+            self._library_collections_loaded = True
+            self._library_collections_error = "Library Collections are unavailable in this runtime."
+            return
+        try:
+            records = await self._resolve_maybe_awaitable(list_collections())
+        except Exception:
+            logger.warning("Failed to load Library Collections.", exc_info=True)
+            self._library_collections_records = ()
+            self._library_collections_loaded = True
+            self._library_collections_error = "Library Collections are unavailable."
+            return
+        self._library_collections_records = tuple(records or ())
+        self._library_collections_loaded = True
+        self._library_collections_error = ""
+        if (
+            self._library_collections_selected_id
+            and not any(
+                getattr(record, "collection_id", None) == self._library_collections_selected_id
+                for record in self._library_collections_records
+            )
+        ):
+            self._library_collections_selected_id = ""
+
+    def _sync_collection_scoped_action_buttons(self) -> None:
+        deferred = self._active_mode == "collections"
+        for selector, deferred_tooltip, normal_tooltip in (
+            (
+                "#library-open-study",
+                "Collection-scoped Study is not available yet.",
+                "Open the Study dashboard for due cards, decks, quizzes, and resume actions.",
+            ),
+            (
+                "#library-open-flashcards",
+                "Collection-scoped Flashcards are not available yet.",
+                "Open flashcards for selected or imported Library material.",
+            ),
+            (
+                "#library-open-quizzes",
+                "Collection-scoped Quizzes are not available yet.",
+                "Open quizzes for selected or imported Library material.",
+            ),
+            (
+                "#library-use-in-console",
+                "Collection-scoped Console handoff is not available yet.",
+                "Stage Library source context in Console.",
+            ),
+        ):
+            buttons = list(self.query(selector))
+            if buttons:
+                if selector == "#library-use-in-console" and not deferred:
+                    buttons[0].disabled = not self._has_local_sources()
+                else:
+                    buttons[0].disabled = deferred
+                buttons[0].tooltip = deferred_tooltip if deferred else normal_tooltip
+        purpose_widgets = list(self.query("#library-study-purpose"))
+        if purpose_widgets:
+            purpose_widgets[0].update(
+                "Collection-scoped Study, Flashcards, Quizzes, and Console are later-stage."
+                if deferred
+                else "Turn Library material into study sessions, flashcards, and quizzes."
+            )
+        entry_widgets = list(self.query("#library-study-generation-entry"))
+        if entry_widgets:
+            entry_widgets[0].update(
+                "Use Collections to organize source groups locally; scoped execution remains deferred."
+                if deferred
+                else "Study generation entry uses the visible Library source snapshot."
+            )
+
     @on(Input.Changed, "#library-rag-query-input")
     async def update_library_rag_query(self, event: Input.Changed) -> None:
         event.stop()
@@ -673,6 +844,19 @@ class LibraryScreen(BaseAppScreen):
         self._library_rag_query = event.value
         self._reset_library_rag_retrieval_state()
         await self._refresh_search_rag_panel_state_widgets()
+
+    @on(Input.Changed, "#library-collection-name-input")
+    async def update_library_collection_name_input(self, event: Input.Changed) -> None:
+        event.stop()
+        if event.value == self._library_collection_name_input:
+            return
+        self._library_collection_name_input = event.value
+        await self._sync_collections_panel(refresh_snapshot=False)
+
+    @on(Input.Changed, "#library-collection-description-input")
+    async def update_library_collection_description_input(self, event: Input.Changed) -> None:
+        event.stop()
+        self._library_collection_description_input = event.value
 
     def _reset_library_rag_retrieval_state(self) -> None:
         self._library_rag_results = ()
@@ -704,6 +888,103 @@ class LibraryScreen(BaseAppScreen):
         self._library_rag_retrieval_status = "searching"
         await self._refresh_search_rag_panel_state_widgets()
         self._execute_library_rag_search(request)
+
+    @on(Button.Pressed, "#library-create-collection")
+    async def create_library_collection(self, event: Button.Pressed) -> None:
+        event.stop()
+        service = getattr(self.app_instance, "library_collections_service", None)
+        create_collection = getattr(service, "create_collection", None)
+        if not callable(create_collection):
+            self._library_collections_error = "Library Collections are unavailable."
+            await self._sync_collections_panel(refresh_snapshot=False)
+            return
+        try:
+            created = await self._resolve_maybe_awaitable(
+                create_collection(
+                    self._library_collection_name_input,
+                    description=self._library_collection_description_input,
+                )
+            )
+        except LibraryCollectionsServiceError as exc:
+            self._notify_library_collections_warning(str(exc))
+            return
+        self._library_collections_selected_id = getattr(created, "collection_id", "") or ""
+        self._library_collection_name_input = ""
+        self._library_collection_description_input = ""
+        self._library_collection_pending_delete_id = ""
+        await self._sync_collections_panel(refresh_snapshot=True)
+
+    @on(Button.Pressed, "#library-rename-collection")
+    async def rename_library_collection(self, event: Button.Pressed) -> None:
+        event.stop()
+        if not self._library_collections_selected_id:
+            return
+        service = getattr(self.app_instance, "library_collections_service", None)
+        rename_collection = getattr(service, "rename_collection", None)
+        if not callable(rename_collection):
+            self._library_collections_error = "Library Collections are unavailable."
+            await self._sync_collections_panel(refresh_snapshot=False)
+            return
+        try:
+            renamed = await self._resolve_maybe_awaitable(
+                rename_collection(
+                    self._library_collections_selected_id,
+                    self._library_collection_name_input,
+                    description=self._library_collection_description_input,
+                )
+            )
+        except LibraryCollectionsServiceError as exc:
+            self._notify_library_collections_warning(str(exc))
+            return
+        self._library_collections_selected_id = getattr(renamed, "collection_id", "") or ""
+        self._library_collection_name_input = ""
+        self._library_collection_description_input = ""
+        self._library_collection_pending_delete_id = ""
+        await self._sync_collections_panel(refresh_snapshot=True)
+
+    @on(Button.Pressed, "#library-delete-collection")
+    async def arm_library_collection_delete(self, event: Button.Pressed) -> None:
+        event.stop()
+        if not self._library_collections_selected_id:
+            return
+        self._library_collection_pending_delete_id = self._library_collections_selected_id
+        await self._sync_collections_panel(refresh_snapshot=False)
+
+    @on(Button.Pressed, "#library-confirm-delete-collection")
+    async def confirm_library_collection_delete(self, event: Button.Pressed) -> None:
+        event.stop()
+        target_id = self._library_collection_pending_delete_id
+        if not target_id:
+            return
+        service = getattr(self.app_instance, "library_collections_service", None)
+        delete_collection = getattr(service, "delete_collection", None)
+        if not callable(delete_collection):
+            self._library_collections_error = "Library Collections are unavailable."
+            await self._sync_collections_panel(refresh_snapshot=False)
+            return
+        try:
+            await self._resolve_maybe_awaitable(delete_collection(target_id))
+        except LibraryCollectionsServiceError as exc:
+            self._notify_library_collections_warning(str(exc))
+            return
+        self._library_collections_selected_id = ""
+        self._library_collection_pending_delete_id = ""
+        await self._sync_collections_panel(refresh_snapshot=True)
+
+    @on(Button.Pressed, ".library-collection-row")
+    async def select_library_collection(self, event: Button.Pressed) -> None:
+        event.stop()
+        collection_id = getattr(event.button, "collection_id", "")
+        if not collection_id:
+            return
+        self._library_collections_selected_id = collection_id
+        self._library_collection_pending_delete_id = ""
+        await self._sync_collections_panel(refresh_snapshot=False)
+
+    def _notify_library_collections_warning(self, message: str) -> None:
+        notify = getattr(self.app_instance, "notify", None)
+        if callable(notify):
+            notify(message or "Library Collections action failed.", severity="warning")
 
     @on(Button.Pressed, ".library-rag-result-action")
     async def select_library_rag_result(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -185,6 +185,15 @@ class LibraryScreen(BaseAppScreen):
         return value
 
     @staticmethod
+    async def _run_library_collections_call(callable_obj: Any, *args: Any, **kwargs: Any) -> Any:
+        if inspect.iscoroutinefunction(callable_obj):
+            return await callable_obj(*args, **kwargs)
+        result = await asyncio.to_thread(lambda: callable_obj(*args, **kwargs))
+        if inspect.isawaitable(result):
+            return await result
+        return result
+
+    @staticmethod
     def _safe_text(value: Any, fallback: str = "", *, max_length: int = 500) -> str:
         text = sanitize_string(str(value or ""), max_length=max_length).strip()
         if not text:
@@ -762,6 +771,37 @@ class LibraryScreen(BaseAppScreen):
             after="#library-active-mode-next-action",
         )
 
+    async def _refresh_collections_panel_action_state_widgets(self) -> None:
+        if self._active_mode != "collections" or not list(self.query("#library-collections-panel")):
+            return
+
+        panel_state = self._library_collections_panel_state()
+        for action in (
+            panel_state.create_action,
+            panel_state.rename_action,
+            panel_state.delete_action,
+        ):
+            buttons = list(self.query(f"#{action.widget_id}"))
+            if buttons:
+                buttons[0].disabled = not action.enabled
+                buttons[0].tooltip = action.tooltip
+
+        confirm_buttons = list(self.query("#library-confirm-delete-collection"))
+        if not self._library_collection_pending_delete_id:
+            for button in confirm_buttons:
+                await button.remove()
+            return
+        if not confirm_buttons:
+            actions = list(self.query("#library-collection-actions"))
+            if actions:
+                await actions[0].mount(
+                    Button(
+                        "Confirm delete",
+                        id="library-confirm-delete-collection",
+                        tooltip="Delete the selected local Collection.",
+                    )
+                )
+
     async def _refresh_library_collections_snapshot(self) -> None:
         service = getattr(self.app_instance, "library_collections_service", None)
         list_collections = getattr(service, "list_collections", None)
@@ -771,7 +811,7 @@ class LibraryScreen(BaseAppScreen):
             self._library_collections_error = "Library Collections are unavailable in this runtime."
             return
         try:
-            records = await self._resolve_maybe_awaitable(list_collections())
+            records = await self._run_library_collections_call(list_collections)
         except Exception:
             logger.warning("Failed to load Library Collections.", exc_info=True)
             self._library_collections_records = ()
@@ -789,6 +829,10 @@ class LibraryScreen(BaseAppScreen):
             )
         ):
             self._library_collections_selected_id = ""
+        if not self._library_collections_selected_id and self._library_collections_records:
+            self._library_collections_selected_id = (
+                getattr(self._library_collections_records[0], "collection_id", "") or ""
+            )
 
     def _sync_collection_scoped_action_buttons(self) -> None:
         deferred = self._active_mode == "collections"
@@ -851,12 +895,13 @@ class LibraryScreen(BaseAppScreen):
         if event.value == self._library_collection_name_input:
             return
         self._library_collection_name_input = event.value
-        await self._sync_collections_panel(refresh_snapshot=False)
+        await self._refresh_collections_panel_action_state_widgets()
 
     @on(Input.Changed, "#library-collection-description-input")
     async def update_library_collection_description_input(self, event: Input.Changed) -> None:
         event.stop()
         self._library_collection_description_input = event.value
+        await self._refresh_collections_panel_action_state_widgets()
 
     def _reset_library_rag_retrieval_state(self) -> None:
         self._library_rag_results = ()
@@ -899,11 +944,10 @@ class LibraryScreen(BaseAppScreen):
             await self._sync_collections_panel(refresh_snapshot=False)
             return
         try:
-            created = await self._resolve_maybe_awaitable(
-                create_collection(
-                    self._library_collection_name_input,
-                    description=self._library_collection_description_input,
-                )
+            created = await self._run_library_collections_call(
+                create_collection,
+                self._library_collection_name_input,
+                description=self._library_collection_description_input,
             )
         except LibraryCollectionsServiceError as exc:
             self._notify_library_collections_warning(str(exc))
@@ -926,12 +970,11 @@ class LibraryScreen(BaseAppScreen):
             await self._sync_collections_panel(refresh_snapshot=False)
             return
         try:
-            renamed = await self._resolve_maybe_awaitable(
-                rename_collection(
-                    self._library_collections_selected_id,
-                    self._library_collection_name_input,
-                    description=self._library_collection_description_input,
-                )
+            renamed = await self._run_library_collections_call(
+                rename_collection,
+                self._library_collections_selected_id,
+                self._library_collection_name_input,
+                description=self._library_collection_description_input,
             )
         except LibraryCollectionsServiceError as exc:
             self._notify_library_collections_warning(str(exc))
@@ -948,7 +991,7 @@ class LibraryScreen(BaseAppScreen):
         if not self._library_collections_selected_id:
             return
         self._library_collection_pending_delete_id = self._library_collections_selected_id
-        await self._sync_collections_panel(refresh_snapshot=False)
+        await self._refresh_collections_panel_action_state_widgets()
 
     @on(Button.Pressed, "#library-confirm-delete-collection")
     async def confirm_library_collection_delete(self, event: Button.Pressed) -> None:
@@ -963,9 +1006,12 @@ class LibraryScreen(BaseAppScreen):
             await self._sync_collections_panel(refresh_snapshot=False)
             return
         try:
-            await self._resolve_maybe_awaitable(delete_collection(target_id))
+            deleted = await self._run_library_collections_call(delete_collection, target_id)
         except LibraryCollectionsServiceError as exc:
             self._notify_library_collections_warning(str(exc))
+            return
+        if not deleted:
+            self._notify_library_collections_warning("Failed to delete Collection.")
             return
         self._library_collections_selected_id = ""
         self._library_collection_pending_delete_id = ""

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -1,4 +1,9 @@
-"""W+C destination shell."""
+"""Watchlists destination shell.
+
+The route, class name, and stable widget selectors retain the historical
+``watchlists_collections``/``wc`` identifiers so older tests, shortcuts, and
+handoffs keep working while Collections moves under Library.
+"""
 
 from __future__ import annotations
 
@@ -23,13 +28,13 @@ from .destination_recovery import DestinationRecoveryState, policy_denied_recove
 
 logger = logger.bind(module="WatchlistsCollectionsScreen")
 WC_LOCAL_PAGE_SIZE = 5
-WC_SERVICE_ERROR_COPY = "W+C services unavailable; retry W+C later."
-WC_SERVICE_UNAVAILABLE_COPY = "W+C services are unavailable in this runtime."
-WC_EMPTY_COPY = "No local Watchlists or Collections are available yet."
+WC_SERVICE_ERROR_COPY = "Watchlists services unavailable; retry Watchlists later."
+WC_SERVICE_UNAVAILABLE_COPY = "Watchlists services are unavailable in this runtime."
+WC_EMPTY_COPY = "No local Watchlists are available yet."
 
 
 class WatchlistsCollectionsScreen(BaseAppScreen):
-    """Monitored sources and curated reading/content collections."""
+    """Monitored sources, runs, alerts, and recovery."""
 
     def __init__(self, app_instance: Any, **kwargs: Any) -> None:
         super().__init__(app_instance, "watchlists_collections", **kwargs)
@@ -150,10 +155,8 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         DestinationRecoveryState | None,
     ]:
         watchlist_service = getattr(self.app_instance, "watchlist_scope_service", None)
-        collection_service = getattr(self.app_instance, "media_reading_scope_service", None)
         list_watch_items = getattr(watchlist_service, "list_watch_items", None)
-        list_read_it_later = getattr(collection_service, "list_read_it_later", None)
-        if not callable(list_watch_items) or not callable(list_read_it_later):
+        if not callable(list_watch_items):
             return (), (), 0, 0, True, True, WC_SERVICE_UNAVAILABLE_COPY, None
 
         try:
@@ -162,42 +165,36 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                 limit=WC_LOCAL_PAGE_SIZE,
                 offset=0,
             )
-            collection_result = await list_read_it_later(
-                mode="local",
-                limit=WC_LOCAL_PAGE_SIZE,
-                offset=0,
-            )
         except PolicyDeniedError as exc:
             policy_message = self._safe_text(exc.user_message, WC_SERVICE_ERROR_COPY)
             recovery_state = policy_denied_recovery_state(
                 exc,
-                unavailable_what="Stage W+C context in Console",
+                unavailable_what="Stage Watchlists context in Console",
                 stable_selector="wc-service-error",
                 policy_message=policy_message,
             )
             return (), (), 0, 0, True, True, recovery_state.visible_copy, recovery_state
         except Exception:
             logger.debug(
-                "Failed to load local W+C snapshot.",
+                "Failed to load local Watchlists snapshot.",
                 exc_info=True,
             )
             return (), (), 0, 0, True, True, WC_SERVICE_ERROR_COPY, None
 
         watchlists, watchlist_count, watchlist_total_known = self._response_records_and_count(watchlist_result)
-        collections, collection_count, collection_total_known = self._response_records_and_count(collection_result)
         return (
             watchlists,
-            collections,
+            (),
             watchlist_count,
-            collection_count,
+            0,
             watchlist_total_known,
-            collection_total_known,
+            True,
             None,
             None,
         )
 
     def _has_local_wc_context(self) -> bool:
-        return self._local_watchlist_count > 0 or self._local_collection_count > 0
+        return self._local_watchlist_count > 0
 
     def _count_label(self, label: str, count: int, total_known: bool) -> str:
         if total_known:
@@ -205,24 +202,17 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         return f"{label} (showing up to {WC_LOCAL_PAGE_SIZE}): {count}"
 
     def _snapshot_body(self) -> str:
-        lines = ["Local W+C snapshot staged for Console:", ""]
+        lines = ["Local Watchlists snapshot staged for Console:", ""]
         lines.append(self._count_label("Watchlists", self._local_watchlist_count, self._watchlist_total_known))
         for index, record in enumerate(self._local_watchlist_records, start=1):
-            lines.append(f"  {index}. {self._record_title(record)}")
-        lines.append("")
-        lines.append(self._count_label("Collections", self._local_collection_count, self._collection_total_known))
-        for index, record in enumerate(self._local_collection_records, start=1):
             lines.append(f"  {index}. {self._record_title(record)}")
         return "\n".join(lines).strip()
 
     def _snapshot_metadata(self) -> dict[str, Any]:
         return {
             "watchlist_count": self._local_watchlist_count,
-            "collection_count": self._local_collection_count,
             "watchlist_sample_count": len(self._local_watchlist_records),
-            "collection_sample_count": len(self._local_collection_records),
             "watchlist_titles": [self._record_title(record) for record in self._local_watchlist_records],
-            "collection_titles": [self._record_title(record) for record in self._local_collection_records],
             "backend": "local",
         }
 
@@ -244,7 +234,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         except Exception:
             if not self._latest_console_follow_error_logged:
                 logger.warning(
-                    "Failed to load W+C Console follow item from Home active-work adapter.",
+                    "Failed to load Watchlists Console follow item from Home active-work adapter.",
                     exc_info=True,
                 )
                 self._latest_console_follow_error_logged = True
@@ -253,7 +243,8 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         selected_item = None
         for item in tuple(getattr(dashboard_input, "active_work_items", ()) or ()):
             if (
-                getattr(item, "source", None) == "W+C"
+                str(getattr(item, "source", None) or "").strip().lower()
+                in {"watchlists", "w+c", "watchlists+collections"}
                 and bool(getattr(item, "console_available", False))
                 and getattr(item, "item_id", None)
             ):
@@ -273,12 +264,12 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         )
         with Vertical(id="watchlists-collections-shell"):
             yield Static(
-                "W+C",
+                "Watchlists",
                 id="watchlists-collections-title",
                 classes="ds-destination-header",
             )
             yield Static(
-                "Monitored sources and curated reading/content collections.",
+                "Monitored sources, runs, alerts, and recovery.",
                 id="watchlists-collections-purpose",
                 classes="destination-purpose",
             )
@@ -287,17 +278,16 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                 yield Static(
                     "Monitored sources, filters, jobs, runs, outputs, templates, alerts, telemetry, retry/backoff."
                 )
-                yield Static("Collections", classes="destination-section")
                 yield Static(
-                    "Reading/content items, highlights, saved searches, archive state, note links, templates, feeds, import/export."
+                    "Library now owns curated source groups, imports, saved searches, and reading workflows."
                 )
                 if not self._wc_loaded:
                     yield Static(
-                        "Loading local W+C snapshot...",
+                        "Loading local Watchlists snapshot...",
                         id="wc-loading-state",
                     )
                     attach_disabled = True
-                    attach_tooltip = "Stage local W+C context after the local snapshot loads."
+                    attach_tooltip = "Stage local Watchlists context after the local snapshot loads."
                 elif self._wc_lookup_error:
                     recovery_state = self._wc_lookup_recovery_state
                     yield Static(
@@ -312,7 +302,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                     attach_tooltip = (
                         recovery_state.disabled_tooltip
                         if recovery_state is not None
-                        else "W+C services are unavailable; retry W+C before staging Console context."
+                        else "Watchlists services are unavailable; retry Watchlists before staging Console context."
                     )
                 elif not self._has_local_wc_context():
                     yield Static(
@@ -320,10 +310,10 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                         id="wc-empty-state",
                     )
                     attach_disabled = True
-                    attach_tooltip = "Stage local W+C context once local watchlists or collections exist."
+                    attach_tooltip = "Stage local Watchlists context once local watchlists exist."
                 else:
                     yield Static(
-                        "Local W+C snapshot",
+                        "Local Watchlists snapshot",
                         id="wc-snapshot-title",
                         classes="destination-section",
                     )
@@ -340,23 +330,10 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                             Text.from_markup(escape_markup(self._record_title(record))),
                             id=f"wc-watchlist-item-{index}",
                         )
-                    yield Static(
-                        self._count_label(
-                            "Collections",
-                            self._local_collection_count,
-                            self._collection_total_known,
-                        ),
-                        id="wc-collections-summary",
-                    )
-                    for index, record in enumerate(self._local_collection_records):
-                        yield Static(
-                            Text.from_markup(escape_markup(self._record_title(record))),
-                            id=f"wc-collection-item-{index}",
-                        )
                     attach_disabled = False
-                    attach_tooltip = "Stage local W+C context in Console."
+                    attach_tooltip = "Stage local Watchlists context in Console."
                 yield Button(
-                    "Stage W+C Context in Console",
+                    "Stage Watchlists Context in Console",
                     id="wc-attach-to-console",
                     disabled=attach_disabled,
                     tooltip=attach_tooltip,
@@ -371,7 +348,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                     status = str(getattr(latest_console_item, "status", None) or "unknown")
                     yield Static(
                         Text.from_markup(
-                            "Console can follow latest W+C run: "
+                            "Console can follow latest Watchlists run: "
                             f"{escape_markup(title)} ({escape_markup(status)})."
                         ),
                         id="watchlists-console-available",
@@ -379,18 +356,18 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                     yield Button(
                         Text.from_markup(f"Follow {escape_markup(title)} in Console"),
                         id="watchlists-follow-in-console",
-                        tooltip="Open the latest active W+C run in Console.",
+                        tooltip="Open the latest active Watchlists run in Console.",
                     )
                 else:
                     yield Static(
-                        "No active W+C run is available for Console follow.",
+                        "No active Watchlists run is available for Console follow.",
                         id="watchlists-console-unavailable",
                     )
                     yield Button(
                         "Console follow unavailable",
                         id="watchlists-follow-in-console",
                         disabled=True,
-                        tooltip="Unavailable until W+C has an active run with Console context.",
+                        tooltip="Unavailable until Watchlists has an active run with Console context.",
                     )
 
     @on(Button.Pressed, "#wc-open-watchlists")
@@ -413,7 +390,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             notify = getattr(self.app_instance, "notify", None)
             if callable(notify):
                 notify(
-                    "Console handoff is unavailable for W+C in this runtime.",
+                    "Console handoff is unavailable for Watchlists in this runtime.",
                     severity="warning",
                 )
             return
@@ -421,10 +398,10 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             ChatHandoffPayload(
                 source="watchlists_collections",
                 item_type="wc-context",
-                title="Local W+C snapshot",
+                title="Local Watchlists snapshot",
                 body=self._snapshot_body(),
-                display_summary="Local W+C snapshot staged.",
-                suggested_prompt="Use these monitored sources and saved collection items as context.",
+                display_summary="Local Watchlists snapshot staged.",
+                suggested_prompt="Use these monitored sources as context.",
                 runtime_backend="local",
                 source_owner="local",
                 source_selector_state="local",
@@ -438,14 +415,14 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         target_id = self._latest_console_follow_item_id
         if not target_id:
             self.app_instance.notify(
-                "No active W+C run is available for Console follow.",
+                "No active Watchlists run is available for Console follow.",
                 severity="warning",
             )
             return
         open_in_console = getattr(self.app_instance, "open_active_home_item_in_console", None)
         if not callable(open_in_console):
             self.app_instance.notify(
-                "Console follow is unavailable for W+C in this runtime.",
+                "Console follow is unavailable for Watchlists in this runtime.",
                 severity="warning",
             )
             return

--- a/tldw_chatbook/Widgets/Library/__init__.py
+++ b/tldw_chatbook/Widgets/Library/__init__.py
@@ -1,8 +1,13 @@
 """Library destination widgets."""
 
+from .library_collections_panel import LibraryCollectionsPanel
 from .library_search_rag_panel import (
     LibrarySearchRagInspectorPanel,
     LibrarySearchRagPanel,
 )
 
-__all__ = ["LibrarySearchRagInspectorPanel", "LibrarySearchRagPanel"]
+__all__ = [
+    "LibraryCollectionsPanel",
+    "LibrarySearchRagInspectorPanel",
+    "LibrarySearchRagPanel",
+]

--- a/tldw_chatbook/Widgets/Library/library_collections_panel.py
+++ b/tldw_chatbook/Widgets/Library/library_collections_panel.py
@@ -1,0 +1,109 @@
+"""Textual widget for Library Collections management."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.widgets import Button, Input, Static
+
+from ...Library.library_collections_state import LibraryCollectionsPanelState
+
+
+class LibraryCollectionsPanel(Vertical):
+    """Render-only Library Collections list, detail, and form controls."""
+
+    def __init__(
+        self,
+        state: LibraryCollectionsPanelState,
+        *,
+        name_value: str = "",
+        description_value: str = "",
+        delete_pending: bool = False,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.state = state
+        self.name_value = name_value
+        self.description_value = description_value
+        self.delete_pending = delete_pending
+
+    def compose(self) -> ComposeResult:
+        yield Static("Library Collections", id="library-collections-title", classes="destination-section")
+        if self.state.status == "error":
+            yield Static(
+                self.state.recovery_copy or self.state.error_message,
+                id="library-collections-error",
+            )
+            return
+
+        if self.state.status == "empty":
+            yield Static(self.state.empty_copy, id="library-collections-empty")
+
+        with Horizontal(id="library-collections-workbench"):
+            with Vertical(id="library-collections-list"):
+                yield Static("Collections", classes="destination-section")
+                for index, collection in enumerate(self.state.collections):
+                    label = f"{collection.name} - {collection.item_count_label}"
+                    button = Button(
+                        label,
+                        id=f"library-collection-select-{index}",
+                        classes="library-collection-row",
+                        tooltip=collection.sync_status_label,
+                    )
+                    button.collection_id = collection.collection_id
+                    if collection.selected:
+                        button.add_class("is-active")
+                    yield button
+
+            with Vertical(id="library-collection-detail"):
+                yield Static("Selected Collection", classes="destination-section")
+                selected = self.state.selected_collection
+                if selected is None:
+                    yield Static("No Collection selected.", id="library-collection-selected-empty")
+                else:
+                    yield Static(selected.name, id="library-collection-name")
+                    yield Static(
+                        selected.description or "No description.",
+                        id="library-collection-description",
+                    )
+                    yield Static(selected.sync_status_label, id="library-collection-sync-status")
+                    yield Static(selected.item_count_label, id="library-collection-item-count")
+                    yield Static(selected.updated_at_label, id="library-collection-updated-at")
+
+        with Vertical(id="library-collection-form"):
+            yield Static("Create / Rename", classes="destination-section")
+            yield Input(
+                value=self.name_value,
+                placeholder="Collection name",
+                id="library-collection-name-input",
+            )
+            yield Input(
+                value=self.description_value,
+                placeholder="Optional description",
+                id="library-collection-description-input",
+            )
+            with Horizontal(id="library-collection-actions"):
+                yield Button(
+                    self.state.create_action.label,
+                    id=self.state.create_action.widget_id,
+                    disabled=not self.state.create_action.enabled,
+                    tooltip=self.state.create_action.tooltip,
+                )
+                yield Button(
+                    self.state.rename_action.label,
+                    id=self.state.rename_action.widget_id,
+                    disabled=not self.state.rename_action.enabled,
+                    tooltip=self.state.rename_action.tooltip,
+                )
+                yield Button(
+                    self.state.delete_action.label,
+                    id=self.state.delete_action.widget_id,
+                    disabled=not self.state.delete_action.enabled,
+                    tooltip=self.state.delete_action.tooltip,
+                )
+                if self.delete_pending:
+                    yield Button(
+                        "Confirm delete",
+                        id="library-confirm-delete-collection",
+                        tooltip="Delete the selected local Collection.",
+                    )

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -505,7 +505,7 @@ class TabNavigationProvider(Provider):
         TAB_LIBRARY: "Open Library for source material, imports, notes, media, conversations, and Search/RAG",
         TAB_ARTIFACTS: "Open Artifacts for generated outputs, reports, datasets, and Chatbooks",
         TAB_PERSONAS: "Open Personas for characters, prompts, dictionaries, and behavior profiles",
-        TAB_WATCHLISTS_COLLECTIONS: "Open W+C for monitored sources and curated collections",
+        TAB_WATCHLISTS_COLLECTIONS: "Open Watchlists for monitored sources, runs, alerts, and recovery",
         TAB_SCHEDULES: "Open Schedules for run timing, triggers, pauses, retries, and recovery",
         TAB_WORKFLOWS: "Open Workflows for reusable procedures, dry-runs, and outputs",
         TAB_MCP: "Open MCP for servers, tools, permissions, auth, and audit",

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -64,6 +64,7 @@ from tldw_chatbook.Event_Handlers.Chat_Events.chat_streaming_events import handl
 from tldw_chatbook.Event_Handlers.worker_events import StreamingChunk, StreamDone
 from .Widgets.AppFooterStatus import AppFooterStatus
 from .config import (
+    get_library_collections_db_path,
     get_media_db_path,
     get_notifications_db_path,
     get_prompts_db_path,
@@ -90,6 +91,7 @@ from tldw_chatbook.Chat.chat_loop_scope_service import ServerChatLoopScopeServic
 from tldw_chatbook.Chat.server_chat_conversation_service import ServerChatConversationService
 from tldw_chatbook.Chat.server_chat_loop_service import ServerChatLoopService
 from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
+from tldw_chatbook.DB.Library_Collections_DB import LibraryCollectionsDB
 from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
 from tldw_chatbook.config import CLI_APP_CLIENT_ID
 from tldw_chatbook.Chat import (
@@ -98,6 +100,7 @@ from tldw_chatbook.Chat import (
     ServerChatConversationService,
 )
 from tldw_chatbook.Chatbooks import LocalChatbookService, ServerChatbookService
+from tldw_chatbook.Library import LocalLibraryCollectionsService
 from tldw_chatbook.Home.active_work_adapter import (
     HomeControlAction,
     HomeControlResult,
@@ -1514,6 +1517,7 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
             server_service=self.server_media_reading_service,
             policy_enforcer=self.service_policy_enforcer,
         )
+        self._wire_library_collections_services()
         self._wire_prompt_chatbook_services()
         self._wire_watchlists_and_notifications_services()
         self._wire_writing_services()
@@ -1886,6 +1890,25 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
             server_service=self.server_writing_service,
             policy_enforcer=self.service_policy_enforcer,
         )
+
+    def _wire_library_collections_services(self) -> None:
+        try:
+            self.local_library_collections_db = LibraryCollectionsDB(
+                get_library_collections_db_path(),
+                CLI_APP_CLIENT_ID,
+            )
+            self.local_library_collections_service = LocalLibraryCollectionsService(
+                self.local_library_collections_db,
+            )
+            self.library_collections_service = self.local_library_collections_service
+        except Exception:
+            logger.warning(
+                "Local Library Collections service unavailable during app wiring",
+                exc_info=True,
+            )
+            self.local_library_collections_db = None
+            self.local_library_collections_service = None
+            self.library_collections_service = None
 
     def _build_chatbook_db_paths(self) -> dict[str, str]:
         return {

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -22,6 +22,7 @@ from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB, CharactersRAGDBErro
 from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase, DatabaseError as MediaDBError, SchemaError as MediaSchemaError, ConflictError as MediaConflictError
 from tldw_chatbook.DB.Prompts_DB import PromptsDatabase, DatabaseError as PromptsDBError, SchemaError as PromptsSchemaError, ConflictError as PromptsConflictError
 from tldw_chatbook.Utils.atomic_file_ops import atomic_write_text
+from tldw_chatbook.Utils.path_validation import validate_path_simple
 #
 #######################################################################################################################
 #
@@ -3266,7 +3267,7 @@ def get_media_db_path() -> Path:
 def get_library_collections_db_path() -> Path:
     custom_path = get_cli_setting("database", "library_collections_db_path", None)
     if custom_path and custom_path != DEFAULT_CONFIG_FROM_TOML.get("database", {}).get("library_collections_db_path"):
-        db_path = Path(custom_path).expanduser().resolve()
+        db_path = validate_path_simple(Path(str(custom_path)).expanduser(), require_exists=False).resolve()
     else:
         user_dir = get_user_data_dir()
         db_path = user_dir / "tldw_chatbook_library_collections.db"

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -1423,6 +1423,8 @@ media_db_path = "~/.local/share/tldw_cli/tldw_cli_media_v2.db"
 research_db_path = "~/.local/share/tldw_cli/tldw_chatbook_research.db"
 # Path to the local writing suite database.
 writing_db_path = "~/.local/share/tldw_cli/tldw_chatbook_writing.db"
+# Path to the local Library Collections database.
+library_collections_db_path = "~/.local/share/tldw_cli/tldw_chatbook_library_collections.db"
 USER_DB_BASE_DIR = "~/.local/share/tldw_cli/"
 
 # Database integrity checking
@@ -3259,6 +3261,15 @@ def get_media_db_path() -> Path:
         # Use user-specific folder
         user_dir = get_user_data_dir()
         db_path = user_dir / "tldw_chatbook_media_v2.db"
+    return db_path
+
+def get_library_collections_db_path() -> Path:
+    custom_path = get_cli_setting("database", "library_collections_db_path", None)
+    if custom_path and custom_path != DEFAULT_CONFIG_FROM_TOML.get("database", {}).get("library_collections_db_path"):
+        db_path = Path(custom_path).expanduser().resolve()
+    else:
+        user_dir = get_user_data_dir()
+        db_path = user_dir / "tldw_chatbook_library_collections.db"
     return db_path
 
 def get_subscriptions_db_path() -> Path:


### PR DESCRIPTION
## Summary

- Documents the Phase 3.9 Library Collections IA split and execution plan.
- Renames the user-facing top-level W+C model to Watchlists while preserving compatibility route IDs and active-run follow-through.
- Adds Library-owned local Collections state, SQLite service contracts, mounted management UI, QA evidence, roadmap tracking, and Backlog closeout.

## Test Plan

- [x] /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Library/test_library_collections_state.py Tests/Library/test_library_collections_service.py Tests/UI/test_product_maturity_phase39_library_collections.py Tests/UI/test_destination_shells.py Tests/UI/test_shell_destinations.py Tests/UI/test_master_shell_navigation.py Tests/UI/test_command_palette_providers.py Tests/Home/test_active_work_adapter.py Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_unified_shell_phase6_first_time_replay.py Tests/UI/test_unified_shell_phase6_power_user_replay.py Tests/UI/test_product_maturity_gate16_library_search_rag.py Tests/UI/test_product_maturity_phase3_layout_contracts.py --tb=short
- [x] /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_product_maturity_phase3_layout_contracts.py::test_phase39_library_collections_split_is_tracked_with_followup_risks --tb=short
- [x] git diff --check
- [x] Clean HOME/XDG launch smoke reached Console and exited normally
