### PR TITLE
Track 12-screen screenshot QA campaign

### DIFF
--- a/Docs/superpowers/qa/product-maturity/README.md
+++ b/Docs/superpowers/qa/product-maturity/README.md
@@ -10,6 +10,10 @@ Canonical spec:
 
 `Docs/superpowers/specs/2026-05-05-product-maturity-phased-roadmap-design.md`
 
+Subfolder indexes:
+
+- [Screen Screenshot QA Campaign](screen-qa/README.md): actual rendered screenshot approval tracker for the 12 top-level destination screens.
+
 Rules:
 
 - Verify running-app behavior, not only rendered widgets.

--- a/Docs/superpowers/qa/product-maturity/screen-qa/README.md
+++ b/Docs/superpowers/qa/product-maturity/screen-qa/README.md
@@ -1,0 +1,29 @@
+# Screen Screenshot QA Campaign
+
+This folder tracks actual rendered screenshot approval for the 12 top-level destination screens. Geometry dumps and SVG exports are regression evidence only. A screen is approved only after the user approves an actual screenshot from the running app.
+
+## Rules
+
+- Capture screenshots from the running app only.
+- Do not use rendered SVGs, generated mockups, or code layouts for approval.
+- Keep one screen per branch and PR.
+- Do not open a screen PR until the final screenshot has explicit user approval.
+- Record rejected screenshots and follow-up fixes in the target screen's `notes.md`.
+- Prefer `textual-serve` plus browser automation; if using a terminal screenshot fallback, record the reason.
+
+## Tracker
+
+| Order | Screen | Backlog Task | Branch | Baseline | Final | Approved | PR | Merged |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | Console | TASK-14.1 | `codex/screen-qa-console` | pending | pending | pending | pending | pending |
+| 2 | Home | TASK-14.2 | `codex/screen-qa-home` | pending | pending | pending | pending | pending |
+| 3 | Library | TASK-14.3 | `codex/screen-qa-library` | pending | pending | pending | pending | pending |
+| 4 | Artifacts | TASK-14.4 | `codex/screen-qa-artifacts` | pending | pending | pending | pending | pending |
+| 5 | Personas | TASK-14.5 | `codex/screen-qa-personas` | pending | pending | pending | pending | pending |
+| 6 | Watchlists | TASK-14.6 | `codex/screen-qa-watchlists` | pending | pending | pending | pending | pending |
+| 7 | Schedules | TASK-14.7 | `codex/screen-qa-schedules` | pending | pending | pending | pending | pending |
+| 8 | Workflows | TASK-14.8 | `codex/screen-qa-workflows` | pending | pending | pending | pending | pending |
+| 9 | MCP | TASK-14.9 | `codex/screen-qa-mcp` | pending | pending | pending | pending | pending |
+| 10 | ACP | TASK-14.10 | `codex/screen-qa-acp` | pending | pending | pending | pending | pending |
+| 11 | Skills | TASK-14.11 | `codex/screen-qa-skills` | pending | pending | pending | pending | pending |
+| 12 | Settings | TASK-14.12 | `codex/screen-qa-settings` | pending | pending | pending | pending | pending |

--- a/Docs/superpowers/qa/product-maturity/screen-qa/acp/notes.md
+++ b/Docs/superpowers/qa/product-maturity/screen-qa/acp/notes.md
@@ -1,0 +1,38 @@
+# ACP Screenshot QA Notes
+
+Date:
+Branch: `codex/screen-qa-acp`
+Backlog task: TASK-14.10
+Commit:
+Screen: ACP
+Viewport:
+Launch method:
+
+## Baseline Screenshot
+
+- Path:
+- Defects:
+
+## Interaction Smoke
+
+- Goal:
+- Steps:
+- Result:
+
+## Fixes
+
+- Summary:
+
+## Final Screenshot
+
+- Path:
+- User approval: pending
+
+## Verification
+
+- Commands:
+- Results:
+
+## Residual Risks
+
+- None recorded.

--- a/Docs/superpowers/qa/product-maturity/screen-qa/acp/notes.md
+++ b/Docs/superpowers/qa/product-maturity/screen-qa/acp/notes.md
@@ -7,6 +7,8 @@ Commit:
 Screen: ACP
 Viewport:
 Launch method:
+Screenshot method:
+Fallback reason:
 
 ## Baseline Screenshot
 

--- a/Docs/superpowers/qa/product-maturity/screen-qa/artifacts/notes.md
+++ b/Docs/superpowers/qa/product-maturity/screen-qa/artifacts/notes.md
@@ -1,0 +1,38 @@
+# Artifacts Screenshot QA Notes
+
+Date:
+Branch: `codex/screen-qa-artifacts`
+Backlog task: TASK-14.4
+Commit:
+Screen: Artifacts
+Viewport:
+Launch method:
+
+## Baseline Screenshot
+
+- Path:
+- Defects:
+
+## Interaction Smoke
+
+- Goal:
+- Steps:
+- Result:
+
+## Fixes
+
+- Summary:
+
+## Final Screenshot
+
+- Path:
+- User approval: pending
+
+## Verification
+
+- Commands:
+- Results:
+
+## Residual Risks
+
+- None recorded.

--- a/Docs/superpowers/qa/product-maturity/screen-qa/artifacts/notes.md
+++ b/Docs/superpowers/qa/product-maturity/screen-qa/artifacts/notes.md
@@ -7,6 +7,8 @@ Commit:
 Screen: Artifacts
 Viewport:
 Launch method:
+Screenshot method:
+Fallback reason:
 
 ## Baseline Screenshot
 

--- a/Docs/superpowers/qa/product-maturity/screen-qa/console/notes.md
+++ b/Docs/superpowers/qa/product-maturity/screen-qa/console/notes.md
@@ -7,6 +7,8 @@ Commit:
 Screen: Console
 Viewport:
 Launch method:
+Screenshot method:
+Fallback reason:
 
 ## Baseline Screenshot
 

--- a/Docs/superpowers/qa/product-maturity/screen-qa/console/notes.md
+++ b/Docs/superpowers/qa/product-maturity/screen-qa/console/notes.md
@@ -1,0 +1,38 @@
+# Console Screenshot QA Notes
+
+Date:
+Branch: `codex/screen-qa-console`
+Backlog task: TASK-14.1
+Commit:
+Screen: Console
+Viewport:
+Launch method:
+
+## Baseline Screenshot
+
+- Path:
+- Defects:
+
+## Interaction Smoke
+
+- Goal:
+- Steps:
+- Result:
+
+## Fixes
+
+- Summary:
+
+## Final Screenshot
+
+- Path:
+- User approval: pending
+
+## Verification
+
+- Commands:
+- Results:
+
+## Residual Risks
+
+- None recorded.

--- a/Docs/superpowers/qa/product-maturity/screen-qa/home/notes.md
+++ b/Docs/superpowers/qa/product-maturity/screen-qa/home/notes.md
@@ -1,0 +1,38 @@
+# Home Screenshot QA Notes
+
+Date:
+Branch: `codex/screen-qa-home`
+Backlog task: TASK-14.2
+Commit:
+Screen: Home
+Viewport:
+Launch method:
+
+## Baseline Screenshot
+
+- Path:
+- Defects:
+
+## Interaction Smoke
+
+- Goal:
+- Steps:
+- Result:
+
+## Fixes
+
+- Summary:
+
+## Final Screenshot
+
+- Path:
+- User approval: pending
+
+## Verification
+
+- Commands:
+- Results:
+
+## Residual Risks
+
+- None recorded.

--- a/Docs/superpowers/qa/product-maturity/screen-qa/home/notes.md
+++ b/Docs/superpowers/qa/product-maturity/screen-qa/home/notes.md
@@ -7,6 +7,8 @@ Commit:
 Screen: Home
 Viewport:
 Launch method:
+Screenshot method:
+Fallback reason:
 
 ## Baseline Screenshot
 

--- a/Docs/superpowers/qa/product-maturity/screen-qa/library/notes.md
+++ b/Docs/superpowers/qa/product-maturity/screen-qa/library/notes.md
@@ -7,6 +7,8 @@ Commit:
 Screen: Library
 Viewport:
 Launch method:
+Screenshot method:
+Fallback reason:
 
 ## Baseline Screenshot
 

--- a/Docs/superpowers/qa/product-maturity/screen-qa/library/notes.md
+++ b/Docs/superpowers/qa/product-maturity/screen-qa/library/notes.md
@@ -1,0 +1,38 @@
+# Library Screenshot QA Notes
+
+Date:
+Branch: `codex/screen-qa-library`
+Backlog task: TASK-14.3
+Commit:
+Screen: Library
+Viewport:
+Launch method:
+
+## Baseline Screenshot
+
+- Path:
+- Defects:
+
+## Interaction Smoke
+
+- Goal:
+- Steps:
+- Result:
+
+## Fixes
+
+- Summary:
+
+## Final Screenshot
+
+- Path:
+- User approval: pending
+
+## Verification
+
+- Commands:
+- Results:
+
+## Residual Risks
+
+- None recorded.

--- a/Docs/superpowers/qa/product-maturity/screen-qa/mcp/notes.md
+++ b/Docs/superpowers/qa/product-maturity/screen-qa/mcp/notes.md
@@ -1,0 +1,38 @@
+# MCP Screenshot QA Notes
+
+Date:
+Branch: `codex/screen-qa-mcp`
+Backlog task: TASK-14.9
+Commit:
+Screen: MCP
+Viewport:
+Launch method:
+
+## Baseline Screenshot
+
+- Path:
+- Defects:
+
+## Interaction Smoke
+
+- Goal:
+- Steps:
+- Result:
+
+## Fixes
+
+- Summary:
+
+## Final Screenshot
+
+- Path:
+- User approval: pending
+
+## Verification
+
+- Commands:
+- Results:
+
+## Residual Risks
+
+- None recorded.

--- a/Docs/superpowers/qa/product-maturity/screen-qa/mcp/notes.md
+++ b/Docs/superpowers/qa/product-maturity/screen-qa/mcp/notes.md
@@ -7,6 +7,8 @@ Commit:
 Screen: MCP
 Viewport:
 Launch method:
+Screenshot method:
+Fallback reason:
 
 ## Baseline Screenshot
 

--- a/Docs/superpowers/qa/product-maturity/screen-qa/personas/notes.md
+++ b/Docs/superpowers/qa/product-maturity/screen-qa/personas/notes.md
@@ -7,6 +7,8 @@ Commit:
 Screen: Personas
 Viewport:
 Launch method:
+Screenshot method:
+Fallback reason:
 
 ## Baseline Screenshot
 

--- a/Docs/superpowers/qa/product-maturity/screen-qa/personas/notes.md
+++ b/Docs/superpowers/qa/product-maturity/screen-qa/personas/notes.md
@@ -1,0 +1,38 @@
+# Personas Screenshot QA Notes
+
+Date:
+Branch: `codex/screen-qa-personas`
+Backlog task: TASK-14.5
+Commit:
+Screen: Personas
+Viewport:
+Launch method:
+
+## Baseline Screenshot
+
+- Path:
+- Defects:
+
+## Interaction Smoke
+
+- Goal:
+- Steps:
+- Result:
+
+## Fixes
+
+- Summary:
+
+## Final Screenshot
+
+- Path:
+- User approval: pending
+
+## Verification
+
+- Commands:
+- Results:
+
+## Residual Risks
+
+- None recorded.

--- a/Docs/superpowers/qa/product-maturity/screen-qa/schedules/notes.md
+++ b/Docs/superpowers/qa/product-maturity/screen-qa/schedules/notes.md
@@ -7,6 +7,8 @@ Commit:
 Screen: Schedules
 Viewport:
 Launch method:
+Screenshot method:
+Fallback reason:
 
 ## Baseline Screenshot
 

--- a/Docs/superpowers/qa/product-maturity/screen-qa/schedules/notes.md
+++ b/Docs/superpowers/qa/product-maturity/screen-qa/schedules/notes.md
@@ -1,0 +1,38 @@
+# Schedules Screenshot QA Notes
+
+Date:
+Branch: `codex/screen-qa-schedules`
+Backlog task: TASK-14.7
+Commit:
+Screen: Schedules
+Viewport:
+Launch method:
+
+## Baseline Screenshot
+
+- Path:
+- Defects:
+
+## Interaction Smoke
+
+- Goal:
+- Steps:
+- Result:
+
+## Fixes
+
+- Summary:
+
+## Final Screenshot
+
+- Path:
+- User approval: pending
+
+## Verification
+
+- Commands:
+- Results:
+
+## Residual Risks
+
+- None recorded.

--- a/Docs/superpowers/qa/product-maturity/screen-qa/settings/notes.md
+++ b/Docs/superpowers/qa/product-maturity/screen-qa/settings/notes.md
@@ -1,0 +1,38 @@
+# Settings Screenshot QA Notes
+
+Date:
+Branch: `codex/screen-qa-settings`
+Backlog task: TASK-14.12
+Commit:
+Screen: Settings
+Viewport:
+Launch method:
+
+## Baseline Screenshot
+
+- Path:
+- Defects:
+
+## Interaction Smoke
+
+- Goal:
+- Steps:
+- Result:
+
+## Fixes
+
+- Summary:
+
+## Final Screenshot
+
+- Path:
+- User approval: pending
+
+## Verification
+
+- Commands:
+- Results:
+
+## Residual Risks
+
+- None recorded.

--- a/Docs/superpowers/qa/product-maturity/screen-qa/settings/notes.md
+++ b/Docs/superpowers/qa/product-maturity/screen-qa/settings/notes.md
@@ -7,6 +7,8 @@ Commit:
 Screen: Settings
 Viewport:
 Launch method:
+Screenshot method:
+Fallback reason:
 
 ## Baseline Screenshot
 

--- a/Docs/superpowers/qa/product-maturity/screen-qa/skills/notes.md
+++ b/Docs/superpowers/qa/product-maturity/screen-qa/skills/notes.md
@@ -1,0 +1,38 @@
+# Skills Screenshot QA Notes
+
+Date:
+Branch: `codex/screen-qa-skills`
+Backlog task: TASK-14.11
+Commit:
+Screen: Skills
+Viewport:
+Launch method:
+
+## Baseline Screenshot
+
+- Path:
+- Defects:
+
+## Interaction Smoke
+
+- Goal:
+- Steps:
+- Result:
+
+## Fixes
+
+- Summary:
+
+## Final Screenshot
+
+- Path:
+- User approval: pending
+
+## Verification
+
+- Commands:
+- Results:
+
+## Residual Risks
+
+- None recorded.

--- a/Docs/superpowers/qa/product-maturity/screen-qa/skills/notes.md
+++ b/Docs/superpowers/qa/product-maturity/screen-qa/skills/notes.md
@@ -7,6 +7,8 @@ Commit:
 Screen: Skills
 Viewport:
 Launch method:
+Screenshot method:
+Fallback reason:
 
 ## Baseline Screenshot
 

--- a/Docs/superpowers/qa/product-maturity/screen-qa/watchlists/notes.md
+++ b/Docs/superpowers/qa/product-maturity/screen-qa/watchlists/notes.md
@@ -7,6 +7,8 @@ Commit:
 Screen: Watchlists
 Viewport:
 Launch method:
+Screenshot method:
+Fallback reason:
 
 ## Baseline Screenshot
 

--- a/Docs/superpowers/qa/product-maturity/screen-qa/watchlists/notes.md
+++ b/Docs/superpowers/qa/product-maturity/screen-qa/watchlists/notes.md
@@ -1,0 +1,38 @@
+# Watchlists Screenshot QA Notes
+
+Date:
+Branch: `codex/screen-qa-watchlists`
+Backlog task: TASK-14.6
+Commit:
+Screen: Watchlists
+Viewport:
+Launch method:
+
+## Baseline Screenshot
+
+- Path:
+- Defects:
+
+## Interaction Smoke
+
+- Goal:
+- Steps:
+- Result:
+
+## Fixes
+
+- Summary:
+
+## Final Screenshot
+
+- Path:
+- User approval: pending
+
+## Verification
+
+- Commands:
+- Results:
+
+## Residual Risks
+
+- None recorded.

--- a/Docs/superpowers/qa/product-maturity/screen-qa/workflows/notes.md
+++ b/Docs/superpowers/qa/product-maturity/screen-qa/workflows/notes.md
@@ -7,6 +7,8 @@ Commit:
 Screen: Workflows
 Viewport:
 Launch method:
+Screenshot method:
+Fallback reason:
 
 ## Baseline Screenshot
 

--- a/Docs/superpowers/qa/product-maturity/screen-qa/workflows/notes.md
+++ b/Docs/superpowers/qa/product-maturity/screen-qa/workflows/notes.md
@@ -1,0 +1,38 @@
+# Workflows Screenshot QA Notes
+
+Date:
+Branch: `codex/screen-qa-workflows`
+Backlog task: TASK-14.8
+Commit:
+Screen: Workflows
+Viewport:
+Launch method:
+
+## Baseline Screenshot
+
+- Path:
+- Defects:
+
+## Interaction Smoke
+
+- Goal:
+- Steps:
+- Result:
+
+## Fixes
+
+- Summary:
+
+## Final Screenshot
+
+- Path:
+- User approval: pending
+
+## Verification
+
+- Commands:
+- Results:
+
+## Residual Risks
+
+- None recorded.

--- a/backlog/tasks/task-14 - 12-screen-actual-screenshot-QA-campaign.md
+++ b/backlog/tasks/task-14 - 12-screen-actual-screenshot-QA-campaign.md
@@ -16,6 +16,7 @@ documentation:
   - >-
     Docs/superpowers/specs/2026-05-08-destination-visual-parity-correction-design.md
   - Docs/superpowers/trackers/product-maturity-roadmap.md
+  - Docs/superpowers/qa/product-maturity/screen-qa/README.md
 priority: high
 ---
 

--- a/backlog/tasks/task-14 - 12-screen-actual-screenshot-QA-campaign.md
+++ b/backlog/tasks/task-14 - 12-screen-actual-screenshot-QA-campaign.md
@@ -1,0 +1,35 @@
+---
+id: TASK-14
+title: 12-screen actual screenshot QA campaign
+status: To Do
+assignee: []
+created_date: '2026-05-09 03:44'
+updated_date: '2026-05-09 03:45'
+labels:
+  - ux
+  - screen-qa
+  - product-maturity
+dependencies: []
+documentation:
+  - Docs/superpowers/plans/2026-05-08-12-screen-screenshot-qa-campaign.md
+  - Docs/superpowers/specs/2026-05-08-12-screen-screenshot-qa-campaign-design.md
+  - >-
+    Docs/superpowers/specs/2026-05-08-destination-visual-parity-correction-design.md
+  - Docs/superpowers/trackers/product-maturity-roadmap.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Coordinate the actual rendered screenshot QA campaign for all 12 top-level destination screens. This parent tracks the campaign-level evidence and merge sequence; each child screen task owns one focused PR and requires user approval from an actual running-app screenshot before PR creation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Baseline screenshot evidence exists for each of 12 screens
+- [ ] #2 Final screenshot evidence exists for each of 12 screens
+- [ ] #3 User approval is recorded for each screen
+- [ ] #4 One PR is opened and merged per screen
+- [ ] #5 Campaign README and per-screen notes are updated
+<!-- AC:END -->

--- a/backlog/tasks/task-14.1 - Screen-QA-Console.md
+++ b/backlog/tasks/task-14.1 - Screen-QA-Console.md
@@ -1,0 +1,38 @@
+---
+id: TASK-14.1
+title: 'Screen QA: Console'
+status: To Do
+assignee: []
+created_date: '2026-05-09 03:46'
+labels:
+  - ux
+  - screen-qa
+  - product-maturity
+  - screen-console
+dependencies: []
+references:
+  - Docs/superpowers/qa/product-maturity/screen-qa/console/notes.md
+documentation:
+  - Docs/superpowers/plans/2026-05-08-12-screen-screenshot-qa-campaign.md
+  - Docs/superpowers/specs/2026-05-08-12-screen-screenshot-qa-campaign-design.md
+  - >-
+    Docs/superpowers/specs/2026-05-08-destination-visual-parity-correction-design.md
+parent_task_id: TASK-14
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Validate and correct the Console top-level destination screen through actual rendered screenshot QA. This task owns one focused PR for Console; do not claim approval from geometry dumps, SVG exports, mockups, or code layouts. Capture baseline and final screenshots from the running app, exercise one realistic interaction or blocked recovery path, and record explicit user approval before opening the PR.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Baseline actual screenshot captured
+- [ ] #2 Interaction smoke path exercised
+- [ ] #3 Final actual screenshot captured
+- [ ] #4 User approval recorded before PR
+- [ ] #5 Focused tests pass
+- [ ] #6 PR merged before next screen starts unless user explicitly overrides
+<!-- AC:END -->

--- a/backlog/tasks/task-14.10 - Screen-QA-ACP.md
+++ b/backlog/tasks/task-14.10 - Screen-QA-ACP.md
@@ -1,0 +1,38 @@
+---
+id: TASK-14.10
+title: 'Screen QA: ACP'
+status: To Do
+assignee: []
+created_date: '2026-05-09 03:46'
+labels:
+  - ux
+  - screen-qa
+  - product-maturity
+  - screen-acp
+dependencies: []
+references:
+  - Docs/superpowers/qa/product-maturity/screen-qa/acp/notes.md
+documentation:
+  - Docs/superpowers/plans/2026-05-08-12-screen-screenshot-qa-campaign.md
+  - Docs/superpowers/specs/2026-05-08-12-screen-screenshot-qa-campaign-design.md
+  - >-
+    Docs/superpowers/specs/2026-05-08-destination-visual-parity-correction-design.md
+parent_task_id: TASK-14
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Validate and correct the ACP top-level destination screen through actual rendered screenshot QA. This task owns one focused PR for ACP; do not claim approval from geometry dumps, SVG exports, mockups, or code layouts. Capture baseline and final screenshots from the running app, exercise one realistic interaction or blocked recovery path, and record explicit user approval before opening the PR.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Baseline actual screenshot captured
+- [ ] #2 Interaction smoke path exercised
+- [ ] #3 Final actual screenshot captured
+- [ ] #4 User approval recorded before PR
+- [ ] #5 Focused tests pass
+- [ ] #6 PR merged before next screen starts unless user explicitly overrides
+<!-- AC:END -->

--- a/backlog/tasks/task-14.11 - Screen-QA-Skills.md
+++ b/backlog/tasks/task-14.11 - Screen-QA-Skills.md
@@ -1,0 +1,38 @@
+---
+id: TASK-14.11
+title: 'Screen QA: Skills'
+status: To Do
+assignee: []
+created_date: '2026-05-09 03:46'
+labels:
+  - ux
+  - screen-qa
+  - product-maturity
+  - screen-skills
+dependencies: []
+references:
+  - Docs/superpowers/qa/product-maturity/screen-qa/skills/notes.md
+documentation:
+  - Docs/superpowers/plans/2026-05-08-12-screen-screenshot-qa-campaign.md
+  - Docs/superpowers/specs/2026-05-08-12-screen-screenshot-qa-campaign-design.md
+  - >-
+    Docs/superpowers/specs/2026-05-08-destination-visual-parity-correction-design.md
+parent_task_id: TASK-14
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Validate and correct the Skills top-level destination screen through actual rendered screenshot QA. This task owns one focused PR for Skills; do not claim approval from geometry dumps, SVG exports, mockups, or code layouts. Capture baseline and final screenshots from the running app, exercise one realistic interaction or blocked recovery path, and record explicit user approval before opening the PR.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Baseline actual screenshot captured
+- [ ] #2 Interaction smoke path exercised
+- [ ] #3 Final actual screenshot captured
+- [ ] #4 User approval recorded before PR
+- [ ] #5 Focused tests pass
+- [ ] #6 PR merged before next screen starts unless user explicitly overrides
+<!-- AC:END -->

--- a/backlog/tasks/task-14.12 - Screen-QA-Settings.md
+++ b/backlog/tasks/task-14.12 - Screen-QA-Settings.md
@@ -1,0 +1,38 @@
+---
+id: TASK-14.12
+title: 'Screen QA: Settings'
+status: To Do
+assignee: []
+created_date: '2026-05-09 03:46'
+labels:
+  - ux
+  - screen-qa
+  - product-maturity
+  - screen-settings
+dependencies: []
+references:
+  - Docs/superpowers/qa/product-maturity/screen-qa/settings/notes.md
+documentation:
+  - Docs/superpowers/plans/2026-05-08-12-screen-screenshot-qa-campaign.md
+  - Docs/superpowers/specs/2026-05-08-12-screen-screenshot-qa-campaign-design.md
+  - >-
+    Docs/superpowers/specs/2026-05-08-destination-visual-parity-correction-design.md
+parent_task_id: TASK-14
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Validate and correct the Settings top-level destination screen through actual rendered screenshot QA. This task owns one focused PR for Settings; do not claim approval from geometry dumps, SVG exports, mockups, or code layouts. Capture baseline and final screenshots from the running app, exercise one realistic interaction or blocked recovery path, and record explicit user approval before opening the PR.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Baseline actual screenshot captured
+- [ ] #2 Interaction smoke path exercised
+- [ ] #3 Final actual screenshot captured
+- [ ] #4 User approval recorded before PR
+- [ ] #5 Focused tests pass
+- [ ] #6 PR merged before next screen starts unless user explicitly overrides
+<!-- AC:END -->

--- a/backlog/tasks/task-14.2 - Screen-QA-Home.md
+++ b/backlog/tasks/task-14.2 - Screen-QA-Home.md
@@ -1,0 +1,38 @@
+---
+id: TASK-14.2
+title: 'Screen QA: Home'
+status: To Do
+assignee: []
+created_date: '2026-05-09 03:46'
+labels:
+  - ux
+  - screen-qa
+  - product-maturity
+  - screen-home
+dependencies: []
+references:
+  - Docs/superpowers/qa/product-maturity/screen-qa/home/notes.md
+documentation:
+  - Docs/superpowers/plans/2026-05-08-12-screen-screenshot-qa-campaign.md
+  - Docs/superpowers/specs/2026-05-08-12-screen-screenshot-qa-campaign-design.md
+  - >-
+    Docs/superpowers/specs/2026-05-08-destination-visual-parity-correction-design.md
+parent_task_id: TASK-14
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Validate and correct the Home top-level destination screen through actual rendered screenshot QA. This task owns one focused PR for Home; do not claim approval from geometry dumps, SVG exports, mockups, or code layouts. Capture baseline and final screenshots from the running app, exercise one realistic interaction or blocked recovery path, and record explicit user approval before opening the PR.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Baseline actual screenshot captured
+- [ ] #2 Interaction smoke path exercised
+- [ ] #3 Final actual screenshot captured
+- [ ] #4 User approval recorded before PR
+- [ ] #5 Focused tests pass
+- [ ] #6 PR merged before next screen starts unless user explicitly overrides
+<!-- AC:END -->

--- a/backlog/tasks/task-14.3 - Screen-QA-Library.md
+++ b/backlog/tasks/task-14.3 - Screen-QA-Library.md
@@ -1,0 +1,38 @@
+---
+id: TASK-14.3
+title: 'Screen QA: Library'
+status: To Do
+assignee: []
+created_date: '2026-05-09 03:46'
+labels:
+  - ux
+  - screen-qa
+  - product-maturity
+  - screen-library
+dependencies: []
+references:
+  - Docs/superpowers/qa/product-maturity/screen-qa/library/notes.md
+documentation:
+  - Docs/superpowers/plans/2026-05-08-12-screen-screenshot-qa-campaign.md
+  - Docs/superpowers/specs/2026-05-08-12-screen-screenshot-qa-campaign-design.md
+  - >-
+    Docs/superpowers/specs/2026-05-08-destination-visual-parity-correction-design.md
+parent_task_id: TASK-14
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Validate and correct the Library top-level destination screen through actual rendered screenshot QA. This task owns one focused PR for Library; do not claim approval from geometry dumps, SVG exports, mockups, or code layouts. Capture baseline and final screenshots from the running app, exercise one realistic interaction or blocked recovery path, and record explicit user approval before opening the PR.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Baseline actual screenshot captured
+- [ ] #2 Interaction smoke path exercised
+- [ ] #3 Final actual screenshot captured
+- [ ] #4 User approval recorded before PR
+- [ ] #5 Focused tests pass
+- [ ] #6 PR merged before next screen starts unless user explicitly overrides
+<!-- AC:END -->

--- a/backlog/tasks/task-14.4 - Screen-QA-Artifacts.md
+++ b/backlog/tasks/task-14.4 - Screen-QA-Artifacts.md
@@ -1,0 +1,38 @@
+---
+id: TASK-14.4
+title: 'Screen QA: Artifacts'
+status: To Do
+assignee: []
+created_date: '2026-05-09 03:46'
+labels:
+  - ux
+  - screen-qa
+  - product-maturity
+  - screen-artifacts
+dependencies: []
+references:
+  - Docs/superpowers/qa/product-maturity/screen-qa/artifacts/notes.md
+documentation:
+  - Docs/superpowers/plans/2026-05-08-12-screen-screenshot-qa-campaign.md
+  - Docs/superpowers/specs/2026-05-08-12-screen-screenshot-qa-campaign-design.md
+  - >-
+    Docs/superpowers/specs/2026-05-08-destination-visual-parity-correction-design.md
+parent_task_id: TASK-14
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Validate and correct the Artifacts top-level destination screen through actual rendered screenshot QA. This task owns one focused PR for Artifacts; do not claim approval from geometry dumps, SVG exports, mockups, or code layouts. Capture baseline and final screenshots from the running app, exercise one realistic interaction or blocked recovery path, and record explicit user approval before opening the PR.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Baseline actual screenshot captured
+- [ ] #2 Interaction smoke path exercised
+- [ ] #3 Final actual screenshot captured
+- [ ] #4 User approval recorded before PR
+- [ ] #5 Focused tests pass
+- [ ] #6 PR merged before next screen starts unless user explicitly overrides
+<!-- AC:END -->

--- a/backlog/tasks/task-14.5 - Screen-QA-Personas.md
+++ b/backlog/tasks/task-14.5 - Screen-QA-Personas.md
@@ -1,0 +1,38 @@
+---
+id: TASK-14.5
+title: 'Screen QA: Personas'
+status: To Do
+assignee: []
+created_date: '2026-05-09 03:46'
+labels:
+  - ux
+  - screen-qa
+  - product-maturity
+  - screen-personas
+dependencies: []
+references:
+  - Docs/superpowers/qa/product-maturity/screen-qa/personas/notes.md
+documentation:
+  - Docs/superpowers/plans/2026-05-08-12-screen-screenshot-qa-campaign.md
+  - Docs/superpowers/specs/2026-05-08-12-screen-screenshot-qa-campaign-design.md
+  - >-
+    Docs/superpowers/specs/2026-05-08-destination-visual-parity-correction-design.md
+parent_task_id: TASK-14
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Validate and correct the Personas top-level destination screen through actual rendered screenshot QA. This task owns one focused PR for Personas; do not claim approval from geometry dumps, SVG exports, mockups, or code layouts. Capture baseline and final screenshots from the running app, exercise one realistic interaction or blocked recovery path, and record explicit user approval before opening the PR.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Baseline actual screenshot captured
+- [ ] #2 Interaction smoke path exercised
+- [ ] #3 Final actual screenshot captured
+- [ ] #4 User approval recorded before PR
+- [ ] #5 Focused tests pass
+- [ ] #6 PR merged before next screen starts unless user explicitly overrides
+<!-- AC:END -->

--- a/backlog/tasks/task-14.6 - Screen-QA-Watchlists.md
+++ b/backlog/tasks/task-14.6 - Screen-QA-Watchlists.md
@@ -1,0 +1,38 @@
+---
+id: TASK-14.6
+title: 'Screen QA: Watchlists'
+status: To Do
+assignee: []
+created_date: '2026-05-09 03:46'
+labels:
+  - ux
+  - screen-qa
+  - product-maturity
+  - screen-watchlists
+dependencies: []
+references:
+  - Docs/superpowers/qa/product-maturity/screen-qa/watchlists/notes.md
+documentation:
+  - Docs/superpowers/plans/2026-05-08-12-screen-screenshot-qa-campaign.md
+  - Docs/superpowers/specs/2026-05-08-12-screen-screenshot-qa-campaign-design.md
+  - >-
+    Docs/superpowers/specs/2026-05-08-destination-visual-parity-correction-design.md
+parent_task_id: TASK-14
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Validate and correct the Watchlists top-level destination screen through actual rendered screenshot QA. This task owns one focused PR for Watchlists; do not claim approval from geometry dumps, SVG exports, mockups, or code layouts. Capture baseline and final screenshots from the running app, exercise one realistic interaction or blocked recovery path, and record explicit user approval before opening the PR.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Baseline actual screenshot captured
+- [ ] #2 Interaction smoke path exercised
+- [ ] #3 Final actual screenshot captured
+- [ ] #4 User approval recorded before PR
+- [ ] #5 Focused tests pass
+- [ ] #6 PR merged before next screen starts unless user explicitly overrides
+<!-- AC:END -->

--- a/backlog/tasks/task-14.7 - Screen-QA-Schedules.md
+++ b/backlog/tasks/task-14.7 - Screen-QA-Schedules.md
@@ -1,0 +1,38 @@
+---
+id: TASK-14.7
+title: 'Screen QA: Schedules'
+status: To Do
+assignee: []
+created_date: '2026-05-09 03:46'
+labels:
+  - ux
+  - screen-qa
+  - product-maturity
+  - screen-schedules
+dependencies: []
+references:
+  - Docs/superpowers/qa/product-maturity/screen-qa/schedules/notes.md
+documentation:
+  - Docs/superpowers/plans/2026-05-08-12-screen-screenshot-qa-campaign.md
+  - Docs/superpowers/specs/2026-05-08-12-screen-screenshot-qa-campaign-design.md
+  - >-
+    Docs/superpowers/specs/2026-05-08-destination-visual-parity-correction-design.md
+parent_task_id: TASK-14
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Validate and correct the Schedules top-level destination screen through actual rendered screenshot QA. This task owns one focused PR for Schedules; do not claim approval from geometry dumps, SVG exports, mockups, or code layouts. Capture baseline and final screenshots from the running app, exercise one realistic interaction or blocked recovery path, and record explicit user approval before opening the PR.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Baseline actual screenshot captured
+- [ ] #2 Interaction smoke path exercised
+- [ ] #3 Final actual screenshot captured
+- [ ] #4 User approval recorded before PR
+- [ ] #5 Focused tests pass
+- [ ] #6 PR merged before next screen starts unless user explicitly overrides
+<!-- AC:END -->

--- a/backlog/tasks/task-14.8 - Screen-QA-Workflows.md
+++ b/backlog/tasks/task-14.8 - Screen-QA-Workflows.md
@@ -1,0 +1,38 @@
+---
+id: TASK-14.8
+title: 'Screen QA: Workflows'
+status: To Do
+assignee: []
+created_date: '2026-05-09 03:46'
+labels:
+  - ux
+  - screen-qa
+  - product-maturity
+  - screen-workflows
+dependencies: []
+references:
+  - Docs/superpowers/qa/product-maturity/screen-qa/workflows/notes.md
+documentation:
+  - Docs/superpowers/plans/2026-05-08-12-screen-screenshot-qa-campaign.md
+  - Docs/superpowers/specs/2026-05-08-12-screen-screenshot-qa-campaign-design.md
+  - >-
+    Docs/superpowers/specs/2026-05-08-destination-visual-parity-correction-design.md
+parent_task_id: TASK-14
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Validate and correct the Workflows top-level destination screen through actual rendered screenshot QA. This task owns one focused PR for Workflows; do not claim approval from geometry dumps, SVG exports, mockups, or code layouts. Capture baseline and final screenshots from the running app, exercise one realistic interaction or blocked recovery path, and record explicit user approval before opening the PR.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Baseline actual screenshot captured
+- [ ] #2 Interaction smoke path exercised
+- [ ] #3 Final actual screenshot captured
+- [ ] #4 User approval recorded before PR
+- [ ] #5 Focused tests pass
+- [ ] #6 PR merged before next screen starts unless user explicitly overrides
+<!-- AC:END -->

--- a/backlog/tasks/task-14.9 - Screen-QA-MCP.md
+++ b/backlog/tasks/task-14.9 - Screen-QA-MCP.md
@@ -1,0 +1,38 @@
+---
+id: TASK-14.9
+title: 'Screen QA: MCP'
+status: To Do
+assignee: []
+created_date: '2026-05-09 03:46'
+labels:
+  - ux
+  - screen-qa
+  - product-maturity
+  - screen-mcp
+dependencies: []
+references:
+  - Docs/superpowers/qa/product-maturity/screen-qa/mcp/notes.md
+documentation:
+  - Docs/superpowers/plans/2026-05-08-12-screen-screenshot-qa-campaign.md
+  - Docs/superpowers/specs/2026-05-08-12-screen-screenshot-qa-campaign-design.md
+  - >-
+    Docs/superpowers/specs/2026-05-08-destination-visual-parity-correction-design.md
+parent_task_id: TASK-14
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Validate and correct the MCP top-level destination screen through actual rendered screenshot QA. This task owns one focused PR for MCP; do not claim approval from geometry dumps, SVG exports, mockups, or code layouts. Capture baseline and final screenshots from the running app, exercise one realistic interaction or blocked recovery path, and record explicit user approval before opening the PR.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Baseline actual screenshot captured
+- [ ] #2 Interaction smoke path exercised
+- [ ] #3 Final actual screenshot captured
+- [ ] #4 User approval recorded before PR
+- [ ] #5 Focused tests pass
+- [ ] #6 PR merged before next screen starts unless user explicitly overrides
+<!-- AC:END -->


### PR DESCRIPTION
## Summary
- Adds Backlog parent TASK-14 and 12 child tasks for the actual screenshot QA campaign.
- Adds campaign README tracking one PR per top-level screen.
- Adds per-screen notes templates for baseline/final screenshots, interaction smoke, verification, and user approval.

## Verification
- git diff --check origin/dev...HEAD
- backlog task list --parent 14 --plain

No pytest run: this PR is tracker/docs scaffolding only.