### PR TITLE
Clarify Schedules inspector digest state

### DIFF
--- a/Tests/UI/test_console_live_work_handoffs.py
+++ b/Tests/UI/test_console_live_work_handoffs.py
@@ -1369,6 +1369,8 @@ async def test_schedules_destination_routes_latest_digest_output_to_console():
         assert "Console launch available" in text
         assert "Console recovery unavailable" not in text
         assert "Console can launch latest reading digest output: Morning Digest Output." in text
+        assert "State: digest output available" in text
+        assert "State: ready" not in text
 
         await pilot.click("#schedules-follow-in-console")
         await pilot.pause(0.1)

--- a/tldw_chatbook/UI/Screens/schedules_screen.py
+++ b/tldw_chatbook/UI/Screens/schedules_screen.py
@@ -165,10 +165,7 @@ class SchedulesScreen(BaseAppScreen):
         if latest_console_item is not None:
             return f"State: {self._status_text(getattr(latest_console_item, 'status', None))}"
         if self._latest_console_launch_kwargs is not None:
-            return (
-                "State: "
-                f"{self._status_text(self._latest_console_launch_kwargs.get('status'), fallback='ready')}"
-            )
+            return "State: digest output available"
         return "State: blocked"
 
     def _retry_backoff_summary(self, latest_console_item) -> str:


### PR DESCRIPTION
## Summary
- Removes the remaining generic `State: ready` inspector label from the Schedules digest-output path.
- Keeps active run inspector state sourced from the active item status, while digest output now renders `State: digest output available`.
- Adds regression coverage so digest output cannot reintroduce generic `State: ready`.

## Verification
- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_console_live_work_handoffs.py -k "schedules_destination_routes_latest_digest_output_to_console or schedules_inspector_state_matches_active_run_status or schedules_destination_routes_latest_active_run_to_console or schedules_destination_keeps_console_follow_disabled_without_active_run" --tb=short`
- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_destination_shells.py -k schedules --tb=short`
- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_destination_visual_parity_correction.py -k schedules --tb=short`
- `git diff --check origin/dev..HEAD`