### PR TITLE
Close screen QA campaign tracking

### DIFF
--- a/Docs/superpowers/qa/product-maturity/screen-qa/README.md
+++ b/Docs/superpowers/qa/product-maturity/screen-qa/README.md
@@ -18,13 +18,13 @@ This folder tracks actual rendered screenshot approval for the 12 top-level dest
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | 1 | Console | TASK-14.1 | `codex/screen-qa-console` | `console/baseline-2026-05-08-playwright-2048x1280.png` | `console/final-2026-05-08-playwright-console.png` | approved | #287 | merged |
 | 2 | Home | TASK-14.2 | `codex/screen-qa-home` | `home/baseline-2026-05-08-playwright-home.png` | `home/final-2026-05-09-playwright-home-polish2.png` | approved | #288 | merged |
-| 3 | Library | TASK-14.3 | `codex/screen-qa-library` | `library/baseline-2026-05-09-playwright-library.png` | `library/review-2026-05-09-playwright-library-contextual-inspector.png` | approved | pending | pending |
+| 3 | Library | TASK-14.3 | `codex/screen-qa-library-final` | `library/baseline-2026-05-09-playwright-library.png` | `library/review-2026-05-09-playwright-library-contextual-inspector.png` | approved | #290 | merged |
 | 4 | Artifacts | TASK-14.4 | `codex/screen-qa-artifacts` | `artifacts/baseline-2026-05-09-artifacts.png` | `artifacts/final-2026-05-09-artifacts-columns.png` | approved | #292 | merged |
-| 5 | Personas | TASK-14.5 | `codex/screen-qa-personas` | pending | pending | approved | #294/#295 | merged |
+| 5 | Personas | TASK-14.5 | `codex/screen-qa-personas` | `personas/baseline-2026-05-09-personas.png` | `personas/final-2026-05-09-personas.png` | approved | #294/#295 | merged |
 | 6 | Watchlists | TASK-14.6 | `codex/screen-qa-watchlists` | `watchlists/baseline-2026-05-09-watchlists.png` | `watchlists/final-2026-05-09-watchlists.png` | approved | #296 | merged |
 | 7 | Schedules | TASK-14.7 | `codex/screen-qa-schedules` | `schedules/baseline-2026-05-09-schedules.png` | `schedules/final-2026-05-10-schedules.png` | approved | #297/#298 | merged |
 | 8 | Workflows | TASK-14.8 | `codex/screen-qa-workflows` | `workflows/baseline-2026-05-10-workflows.png` | `workflows/final-2026-05-10-workflows.png` | approved | #299 | merged |
 | 9 | MCP | TASK-14.9 | `codex/screen-qa-mcp` | `mcp/baseline-2026-05-10-mcp.png` | `mcp/final-2026-05-10-mcp.png` | approved | #301 | merged |
 | 10 | ACP | TASK-14.10 | `codex/screen-qa-acp` | `acp/baseline-2026-05-10-acp-rerun.png` | `acp/final-2026-05-10-acp-columns.png` | approved | #304 | merged |
 | 11 | Skills | TASK-14.11 | `codex/screen-qa-skills` | `skills/baseline-2026-05-11-skills.png` | `skills/final-2026-05-11-skills.png` | approved | #305 | merged |
-| 12 | Settings | TASK-14.12 | `codex/screen-qa-settings` | `settings/baseline-2026-05-11-settings.png` | `settings/final-2026-05-11-settings.png` | approved | pending | pending |
+| 12 | Settings | TASK-14.12 | `codex/screen-qa-settings` | `settings/baseline-2026-05-11-settings.png` | `settings/final-2026-05-11-settings.png` | approved | #306 | merged |

--- a/Docs/superpowers/qa/product-maturity/screen-qa/settings/notes.md
+++ b/Docs/superpowers/qa/product-maturity/screen-qa/settings/notes.md
@@ -3,7 +3,7 @@
 Date: 2026-05-11
 Branch: `codex/screen-qa-settings`
 Backlog task: TASK-14.12
-Commit: pending
+Commit: PR #306 merge `6baee11e59039340c10e2027567f62922929e968`
 Screen: Settings
 Viewport: 2050x1240 textual-web browser capture
 Launch method: `tldw-serve --host 127.0.0.1 --port 8832` with isolated HOME/XDG config and `default_tab = "settings"`

--- a/backlog/tasks/task-14 - 12-screen-actual-screenshot-QA-campaign.md
+++ b/backlog/tasks/task-14 - 12-screen-actual-screenshot-QA-campaign.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-14
 title: 12-screen actual screenshot QA campaign
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-05-09 03:44'
 updated_date: '2026-05-09 03:45'
@@ -28,9 +28,21 @@ Coordinate the actual rendered screenshot QA campaign for all 12 top-level desti
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Baseline screenshot evidence exists for each of 12 screens
-- [ ] #2 Final screenshot evidence exists for each of 12 screens
-- [ ] #3 User approval is recorded for each screen
-- [ ] #4 One PR is opened and merged per screen
-- [ ] #5 Campaign README and per-screen notes are updated
+- [x] #1 Baseline screenshot evidence exists for each of 12 screens
+- [x] #2 Final screenshot evidence exists for each of 12 screens
+- [x] #3 User approval is recorded for each screen
+- [x] #4 One PR is opened and merged per screen
+- [x] #5 Campaign README and per-screen notes are updated
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Run the 12-screen actual screenshot campaign one top-level destination at a time.
+2. Capture baseline and final actual rendered screenshots for each screen.
+3. Require explicit user approval of the actual final screenshot before opening each screen PR.
+4. Keep per-screen notes, Backlog child tasks, and the campaign README synchronized.
+5. Merge each focused screen PR before advancing unless explicitly overridden.
+
+## Implementation Notes
+
+Completed the 12-screen actual screenshot QA campaign across Console, Home, Library, Artifacts, Personas, Watchlists, Schedules, Workflows, MCP, ACP, Skills, and Settings. Each screen has baseline and final actual screenshot evidence, explicit user approval, focused verification, and a merged PR. Campaign tracking was reconciled after Settings PR #306 merged so the README and child Backlog tasks reflect the final merged state.

--- a/backlog/tasks/task-14.12 - Screen-QA-Settings.md
+++ b/backlog/tasks/task-14.12 - Screen-QA-Settings.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-14.12
 title: 'Screen QA: Settings'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-09 03:46'
 labels:
@@ -34,7 +34,7 @@ Validate and correct the Settings top-level destination screen through actual re
 - [x] #3 Final actual screenshot captured
 - [x] #4 User approval recorded before PR
 - [x] #5 Focused tests pass
-- [ ] #6 PR merged before next screen starts unless user explicitly overrides
+- [x] #6 PR merged before next screen starts unless user explicitly overrides
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -48,3 +48,5 @@ Validate and correct the Settings top-level destination screen through actual re
 ## Implementation Notes
 
 Adapted Settings to a compact three-column workbench with a narrower settings-section column and wider preference-detail and scope-inspector columns. Replaced the unreadable checkbox glyph with a readable button toggle for Console large-paste display, preserved the persisted `console.collapse_large_pastes` setting, and kept MCP/ACP runtime control ownership explicit. Added mounted regressions for the Settings column contract, narrow-left column geometry, Appearance routing, and large-paste toggle persistence. Final actual textual-web screenshot was approved before PR creation.
+
+PR #306 was merged into `dev` at merge commit `6baee11e59039340c10e2027567f62922929e968`.


### PR DESCRIPTION
## Summary
- mark Settings TASK-14.12 complete after PR #306 merged
- reconcile the screen-QA README with Library #290, Personas #294/#295, and Settings #306 merge state
- close the parent TASK-14 campaign now that all 12 screen-QA child tasks are done

## Verification
- rg -n "pending" Docs/superpowers/qa/product-maturity/screen-qa/README.md backlog/tasks/task-14*.md (no matches)
- status scan confirms all TASK-14 child tasks are Done
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes the 12-screen screenshot QA campaign and finalizes tracking.
Updates the Screen QA README and notes to reflect merged PRs for Library (#290), Personas (#294/#295), and Settings (#306), fills baseline/final asset paths, sets `codex/screen-qa-library-final`, and marks TASK-14 and TASK-14.12 as Done with all acceptance criteria met.

<sup>Written for commit e4481c579864a1d1e908970b5d9b02c566dd240b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

