### PR TITLE
Make Phase 4 verification commands portable

### DIFF
--- a/Docs/superpowers/qa/product-maturity/phase-4/2026-05-12-phase-4-agent-execution-planning.md
+++ b/Docs/superpowers/qa/product-maturity/phase-4/2026-05-12-phase-4-agent-execution-planning.md
@@ -19,6 +19,6 @@ Phase 4 is ready for sequential execution. `TASK-11.1` is verified for planning 
 
 ## Verification
 
-- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_product_maturity_phase4_agent_execution_plan.py Tests/UI/test_product_maturity_phase3_layout_contracts.py Tests/UI/test_post_ux_product_roadmap_handoff.py --tb=short`
-- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_product_maturity_phase1_harness.py::test_backlog_task_frontmatter_ids_are_unique --tb=short`
+- `python -m pytest -q Tests/UI/test_product_maturity_phase4_agent_execution_plan.py Tests/UI/test_product_maturity_phase3_layout_contracts.py Tests/UI/test_post_ux_product_roadmap_handoff.py --tb=short`
+- `python -m pytest -q Tests/UI/test_product_maturity_phase1_harness.py::test_backlog_task_frontmatter_ids_are_unique --tb=short`
 - `git diff --check`


### PR DESCRIPTION
## Summary
- replace machine-specific absolute virtualenv paths in Phase 4 planning evidence with portable `python -m pytest` commands

## Verification
- `python -m pytest -q Tests/UI/test_product_maturity_phase4_agent_execution_plan.py Tests/UI/test_product_maturity_phase3_layout_contracts.py Tests/UI/test_post_ux_product_roadmap_handoff.py --tb=short`
- `python -m pytest -q Tests/UI/test_product_maturity_phase1_harness.py::test_backlog_task_frontmatter_ids_are_unique --tb=short`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated Phase 4 verification steps to use portable `python -m pytest` commands instead of machine-specific virtualenv paths, so anyone can run the tests on any machine or in CI. Docs-only change; no behavior impact.

<sup>Written for commit 0111dfa25924b774c587b415a38f30c6d0a3f4d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

