### PR TITLE
Accept canonical Sync v2 local-first profile mode

### DIFF
--- a/Tests/Sync_Interop/test_key_recovery_service.py
+++ b/Tests/Sync_Interop/test_key_recovery_service.py
@@ -163,6 +163,12 @@ async def test_key_recovery_service_accepts_canonical_local_first_sync_mode(tmp_
 
     assert result["key_recovery_configured"] is True
     assert server.calls[0]["dataset_id"] == "dataset-1"
+    profile = repo.get_sync_v2_profile_state(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-1",
+    )
+    assert profile["profile_mode"] == "local_first_sync"
 
 
 async def test_key_recovery_service_requires_local_first_profile_device_dataset_and_key(tmp_path):

--- a/Tests/Sync_Interop/test_key_recovery_service.py
+++ b/Tests/Sync_Interop/test_key_recovery_service.py
@@ -144,6 +144,27 @@ async def test_key_recovery_service_wraps_dataset_key_and_stores_sanitized_metad
     assert dataset_key.hex() not in serialized_metadata
 
 
+async def test_key_recovery_service_accepts_canonical_local_first_sync_mode(tmp_path):
+    dataset_key = generate_dataset_key()
+    repo = _repo_with_profile(tmp_path, profile_mode="local_first_sync")
+    server = FakeRecoveryServer()
+    service = SyncKeyRecoveryService(
+        server_service=server,
+        state_repository=repo,
+        dataset_keys={"dataset-1": dataset_key},
+    )
+
+    result = await service.configure_recovery(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-1",
+        recovery_secret="correct horse battery staple",
+    )
+
+    assert result["key_recovery_configured"] is True
+    assert server.calls[0]["dataset_id"] == "dataset-1"
+
+
 async def test_key_recovery_service_requires_local_first_profile_device_dataset_and_key(tmp_path):
     server = FakeRecoveryServer()
     service = SyncKeyRecoveryService(

--- a/Tests/Sync_Interop/test_local_first_sync_service.py
+++ b/Tests/Sync_Interop/test_local_first_sync_service.py
@@ -197,6 +197,29 @@ async def test_local_first_sync_once_pushes_pulls_applies_and_persists_cursor(tm
     )["dataset_cursors"]["sync_v2"] == "9"
 
 
+async def test_local_first_sync_once_accepts_canonical_profile_mode(tmp_path):
+    dataset_key = generate_dataset_key()
+    repo = _repo_with_profile(tmp_path, profile_mode="local_first_sync")
+    store = RecordingLocalStore()
+    server = FakeLocalFirstServer()
+    service = LocalFirstSyncService(
+        server_service=server,
+        state_repository=repo,
+        local_store=store,
+        dataset_keys={"dataset-1": dataset_key},
+    )
+
+    result = await service.sync_once(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-1",
+        domains=["notes"],
+    )
+
+    assert result["dataset_id"] == "dataset-1"
+    assert server.calls[-1][0] == "pull"
+
+
 async def test_local_first_sync_once_chunks_pushes_by_server_max_batch_size(tmp_path):
     dataset_key = generate_dataset_key()
     builder = SyncEnvelopeBuilder(

--- a/Tests/Sync_Interop/test_server_sync_service.py
+++ b/Tests/Sync_Interop/test_server_sync_service.py
@@ -426,7 +426,7 @@ async def test_server_sync_service_runs_sync_v2_no_content_dry_run_and_persists_
     assert result["pushed_envelopes"] == 0
     assert result["pulled_envelopes"] == 0
     assert result["next_cursor"] == "6"
-    assert profile["profile_mode"] == "local_first"
+    assert profile["profile_mode"] == "local_first_sync"
     assert profile["dataset_cursors"] == {"notes": "4", "sync_v2": "6"}
     assert cursor.cursor == "6"
     assert client.calls[0] == ("get_sync_v2_capabilities",)
@@ -442,6 +442,29 @@ async def test_server_sync_service_runs_sync_v2_no_content_dry_run_and_persists_
     assert [call.kwargs["action_id"] for call in policy.require_allowed.call_args_list] == [
         "sync.v2.dry_run.server"
     ]
+
+
+@pytest.mark.asyncio
+async def test_server_sync_service_preserves_requested_sync_v2_profile_mode(tmp_path):
+    client = FakeSyncClient()
+    repo = SyncStateRepository(tmp_path / "sync_state.db")
+    service = ServerSyncService(client=client, state_repository=repo)
+
+    await service.run_v2_dry_run(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-1",
+        display_name="Laptop",
+        domains=["notes"],
+        profile_mode="local_first",
+    )
+
+    profile = repo.get_sync_v2_profile_state(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-1",
+    )
+    assert profile["profile_mode"] == "local_first"
 
 
 @pytest.mark.asyncio

--- a/Tests/Sync_Interop/test_sync_scope_service.py
+++ b/Tests/Sync_Interop/test_sync_scope_service.py
@@ -306,3 +306,22 @@ async def test_sync_scope_service_delegates_local_first_mode_to_sync_v2_dry_run(
             },
         )
     ]
+
+
+@pytest.mark.asyncio
+async def test_sync_scope_service_delegates_canonical_local_first_sync_mode_to_dry_run():
+    server = FakeSyncService()
+    scope = SyncScopeService(server_service=server)
+
+    result = await scope.prepare_sync_v2_profile_mode(
+        profile_mode="local_first_sync",
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-1",
+        display_name="Laptop",
+        domains=["notes"],
+    )
+
+    assert result["profile_mode"] == "local_first_sync"
+    assert result["device_id"] == "device-1"
+    assert server.calls[0][0] == "run_v2_dry_run"

--- a/Tests/Sync_Interop/test_sync_scope_service.py
+++ b/Tests/Sync_Interop/test_sync_scope_service.py
@@ -303,6 +303,7 @@ async def test_sync_scope_service_delegates_local_first_mode_to_sync_v2_dry_run(
                 "client_version": "0.1.0",
                 "scope_type": "personal",
                 "encryption_policy": "client_private_v1",
+                "profile_mode": "local_first",
             },
         )
     ]
@@ -325,3 +326,4 @@ async def test_sync_scope_service_delegates_canonical_local_first_sync_mode_to_d
     assert result["profile_mode"] == "local_first_sync"
     assert result["device_id"] == "device-1"
     assert server.calls[0][0] == "run_v2_dry_run"
+    assert server.calls[0][1]["profile_mode"] == "local_first_sync"

--- a/Tests/Sync_Interop/test_sync_state.py
+++ b/Tests/Sync_Interop/test_sync_state.py
@@ -47,6 +47,15 @@ def test_sync_profile_state_tracks_sync_v2_device_dataset_and_cursors() -> None:
     assert state.dataset_cursors == {"notes": "cursor-1", "chat": "cursor-2"}
 
 
+def test_sync_profile_state_accepts_canonical_local_first_sync_mode() -> None:
+    state = SyncProfileState(
+        server_profile_id="server-a",
+        profile_mode="local_first_sync",
+    )
+
+    assert state.profile_mode == SyncV2ProfileMode.LOCAL_FIRST_SYNC
+
+
 def test_sync_profile_state_store_isolates_same_server_by_workspace_id() -> None:
     store = SyncProfileStateStore()
 

--- a/Tests/Sync_Interop/test_sync_state_repository.py
+++ b/Tests/Sync_Interop/test_sync_state_repository.py
@@ -236,6 +236,31 @@ def test_sync_v2_profile_state_persists_device_dataset_cursors_and_metadata(tmp_
     assert stored["dry_run_metadata"] == {"pulled_envelopes": 0}
 
 
+def test_sync_v2_profile_state_persists_canonical_local_first_sync_mode(tmp_path):
+    db_path = tmp_path / "sync_state.db"
+    repo = SyncStateRepository(db_path)
+
+    repo.set_sync_v2_profile_state(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-1",
+        profile_mode="local_first_sync",
+        device_id="device-1",
+        dataset_id="dataset-1",
+        dataset_cursors={"notes": "cursor-1"},
+    )
+    repo.close()
+
+    reopened = SyncStateRepository(db_path)
+    stored = reopened.get_sync_v2_profile_state(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-1",
+    )
+
+    assert stored["profile_mode"] == "local_first_sync"
+
+
 def test_sync_v2_schema_migration_updates_legacy_schema_version(tmp_path):
     db_path = tmp_path / "sync_state.db"
     with sqlite3.connect(db_path) as conn:

--- a/backlog/tasks/task-59 - Add-Chatbook-Sync-v2-profile-orchestration.md
+++ b/backlog/tasks/task-59 - Add-Chatbook-Sync-v2-profile-orchestration.md
@@ -1,0 +1,51 @@
+---
+id: TASK-59
+title: Add Chatbook Sync v2 profile orchestration
+status: Done
+labels:
+- sync
+- orchestration
+- chatbook
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the next Chatbook sync-engine slice after the already-present Sync v2 API client methods. Add explicit sync profile modes, dataset/device/cursor state, outbox/inbox/conflict summaries, and server_sync_service orchestration for capabilities, register, enroll, push, pull, and readiness without changing local-only behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Chatbook accepts the canonical `local_first_sync` Sync v2 profile mode from the server sync-engine plan.
+- [x] #2 Existing `local_first` profile records continue to work as a compatibility alias.
+- [x] #3 Local-first sync and key recovery services recognize both canonical and legacy profile-mode spellings.
+- [x] #4 Focused Sync_Interop and tldw_api sync client tests pass, with verification recorded.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Verified that the broad Chatbook Sync v2 API client/profile/encryption/local-first/restore substrate was already present on current `origin/dev`: `Tests/tldw_api/test_sync_client.py` passed with 9 tests and `Tests/Sync_Interop` passed with 122 tests before this patch.
+
+Aligned profile mode handling with the server sync-engine plan by adding canonical `local_first_sync` support while preserving existing `local_first` records as a compatibility alias. The scope router now returns the requested canonical mode for `prepare_sync_v2_profile_mode`, and local-first sync plus key-recovery services accept both spellings.
+
+Verification: `../../.venv/bin/python -m pytest Tests/Sync_Interop/test_sync_state.py Tests/Sync_Interop/test_sync_state_repository.py Tests/Sync_Interop/test_sync_scope_service.py Tests/Sync_Interop/test_local_first_sync_service.py Tests/Sync_Interop/test_key_recovery_service.py -q` passed with 66 tests.
+Verification: `../../.venv/bin/python -m pytest Tests/Sync_Interop Tests/tldw_api/test_sync_client.py -q` passed with 136 tests.
+Verification: `git diff --check` passed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added canonical `local_first_sync` profile-mode support for Chatbook Sync v2 while keeping `local_first` compatibility. Profile state, repository persistence, scope preparation, local-first sync execution, and key-recovery setup now recognize the canonical mode used by the sync-engine plan.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant or not required
+- [x] #4 Final summary added
+- [x] #5 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-59 - Add-Chatbook-Sync-v2-profile-orchestration.md
+++ b/backlog/tasks/task-59 - Add-Chatbook-Sync-v2-profile-orchestration.md
@@ -33,6 +33,7 @@ Aligned profile mode handling with the server sync-engine plan by adding canonic
 Verification: `../../.venv/bin/python -m pytest Tests/Sync_Interop/test_sync_state.py Tests/Sync_Interop/test_sync_state_repository.py Tests/Sync_Interop/test_sync_scope_service.py Tests/Sync_Interop/test_local_first_sync_service.py Tests/Sync_Interop/test_key_recovery_service.py -q` passed with 66 tests.
 Verification: `../../.venv/bin/python -m pytest Tests/Sync_Interop Tests/tldw_api/test_sync_client.py -q` passed with 136 tests.
 Verification: `git diff --check` passed.
+Review follow-up: addressed PR #320 Qodo/Gemini feedback by giving `is_local_first_sync_profile_mode` a Google-style public docstring, passing normalized profile modes from `SyncScopeService` into `ServerSyncService.run_v2_dry_run`, defaulting direct dry-runs to canonical `local_first_sync`, preserving explicit legacy `local_first` requests, and preserving stored canonical mode during key recovery. Verification: `../../.venv/bin/python -m pytest Tests/Sync_Interop/test_sync_state.py Tests/Sync_Interop/test_sync_state_repository.py Tests/Sync_Interop/test_sync_scope_service.py Tests/Sync_Interop/test_server_sync_service.py Tests/Sync_Interop/test_local_first_sync_service.py Tests/Sync_Interop/test_key_recovery_service.py -q` passed with 92 tests; `../../.venv/bin/python -m pytest Tests/Sync_Interop Tests/tldw_api/test_sync_client.py -q` passed with 137 tests; `git diff --check` passed.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/tldw_chatbook/Sync_Interop/key_recovery_service.py
+++ b/tldw_chatbook/Sync_Interop/key_recovery_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from tldw_chatbook.Sync_Interop.crypto import wrap_dataset_key_for_recovery
+from tldw_chatbook.Sync_Interop.sync_state import is_local_first_sync_profile_mode
 
 
 class SyncKeyRecoveryService:
@@ -40,7 +41,7 @@ class SyncKeyRecoveryService:
         )
         if profile is None:
             raise ValueError("local_first Sync v2 profile is required")
-        if profile.get("profile_mode") != "local_first":
+        if not is_local_first_sync_profile_mode(profile.get("profile_mode")):
             raise ValueError("key recovery setup requires a local_first Sync v2 profile")
 
         dataset_id = profile.get("dataset_id")

--- a/tldw_chatbook/Sync_Interop/key_recovery_service.py
+++ b/tldw_chatbook/Sync_Interop/key_recovery_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from tldw_chatbook.Sync_Interop.crypto import wrap_dataset_key_for_recovery
-from tldw_chatbook.Sync_Interop.sync_state import is_local_first_sync_profile_mode
+from tldw_chatbook.Sync_Interop.sync_state import SyncV2ProfileMode, is_local_first_sync_profile_mode
 
 
 class SyncKeyRecoveryService:
@@ -43,6 +43,7 @@ class SyncKeyRecoveryService:
             raise ValueError("local_first Sync v2 profile is required")
         if not is_local_first_sync_profile_mode(profile.get("profile_mode")):
             raise ValueError("key recovery setup requires a local_first Sync v2 profile")
+        profile_mode = str(profile.get("profile_mode") or SyncV2ProfileMode.LOCAL_FIRST_SYNC.value)
 
         dataset_id = profile.get("dataset_id")
         device_id = profile.get("device_id")
@@ -89,7 +90,7 @@ class SyncKeyRecoveryService:
             server_profile_id=server_profile_id,
             authenticated_principal_id=authenticated_principal_id,
             workspace_scope=workspace_scope,
-            profile_mode="local_first",
+            profile_mode=profile_mode,
             device_id=resolved_device_id,
             dataset_id=resolved_dataset_id,
             dataset_cursors=dict(profile.get("dataset_cursors") or {}),

--- a/tldw_chatbook/Sync_Interop/local_first_sync_service.py
+++ b/tldw_chatbook/Sync_Interop/local_first_sync_service.py
@@ -7,6 +7,7 @@ import json
 from typing import Any, Mapping
 
 from tldw_chatbook.Sync_Interop.envelope_applier import SyncEnvelopeApplier
+from tldw_chatbook.Sync_Interop.sync_state import is_local_first_sync_profile_mode
 from tldw_chatbook.Sync_Interop.validation import (
     validate_pull_pagination_state,
     validate_push_response_scope,
@@ -71,7 +72,7 @@ class LocalFirstSyncService:
         )
         if profile is None:
             raise ValueError("local_first Sync v2 profile is required")
-        if profile.get("profile_mode") != "local_first":
+        if not is_local_first_sync_profile_mode(profile.get("profile_mode")):
             raise ValueError("sync_once requires a local_first Sync v2 profile")
 
         dataset_id = profile.get("dataset_id")

--- a/tldw_chatbook/Sync_Interop/server_sync_service.py
+++ b/tldw_chatbook/Sync_Interop/server_sync_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Optional
 
+from tldw_chatbook.Sync_Interop.sync_state import SyncV2ProfileMode
 from tldw_chatbook.Sync_Interop.validation import (
     validate_outgoing_envelope_scope,
     validate_pull_pagination_state,
@@ -142,6 +143,7 @@ class ServerSyncService:
         client_version: str | None = None,
         scope_type: str = "personal",
         encryption_policy: str = "client_private_v1",
+        profile_mode: str = SyncV2ProfileMode.LOCAL_FIRST_SYNC.value,
     ) -> dict[str, Any]:
         """Negotiate Sync v2 state without sending or applying content envelopes.
 
@@ -154,6 +156,7 @@ class ServerSyncService:
             client_version: Optional Chatbook client version to advertise.
             scope_type: Dataset scope type requested from the server.
             encryption_policy: Sync v2 encryption policy requested for the dataset.
+            profile_mode: Sync v2 profile mode to persist with the negotiated state.
 
         Returns:
             Dry-run summary with negotiated device, dataset, domain, cursor, and key setup state.
@@ -295,7 +298,7 @@ class ServerSyncService:
             server_profile_id=server_profile_id,
             authenticated_principal_id=authenticated_principal_id,
             workspace_scope=workspace_scope,
-            profile_mode="local_first",
+            profile_mode=profile_mode,
             device_id=device_id,
             dataset_id=dataset_id,
             dataset_cursors=dataset_cursors,

--- a/tldw_chatbook/Sync_Interop/sync_scope_service.py
+++ b/tldw_chatbook/Sync_Interop/sync_scope_service.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from tldw_chatbook.runtime_policy.server_parity_models import SyncIdentityMapEntry
 
-from .sync_state import SyncV2ProfileMode
+from .sync_state import SyncV2ProfileMode, is_local_first_sync_profile_mode
 from .sync_mirror_report import build_sync_mirror_report
 from .sync_readiness import (
     DEFAULT_SYNC_ELIGIBILITY_REGISTRY,
@@ -263,6 +263,8 @@ class SyncScopeService:
 
         if display_name is None:
             raise ValueError("display_name is required for local-first Sync v2 dry-run")
+        if not is_local_first_sync_profile_mode(normalized_mode):
+            raise ValueError(f"Invalid Sync v2 profile mode: {profile_mode}")
         service = self._require_server_service(SyncBackend.SERVER)
         result = await self._maybe_await(
             service.run_v2_dry_run(
@@ -279,7 +281,7 @@ class SyncScopeService:
         if not isinstance(result, dict):
             result = {"result": result}
         record = dict(result)
-        record.setdefault("profile_mode", normalized_mode.value)
+        record["profile_mode"] = normalized_mode.value
         record.setdefault("local_sync_enabled", True)
         record.setdefault("server_frontend", False)
         record.setdefault("sync_dataset_created", bool(record.get("dataset_id")))

--- a/tldw_chatbook/Sync_Interop/sync_scope_service.py
+++ b/tldw_chatbook/Sync_Interop/sync_scope_service.py
@@ -276,6 +276,7 @@ class SyncScopeService:
                 client_version=client_version,
                 scope_type=scope_type,
                 encryption_policy=encryption_policy,
+                profile_mode=normalized_mode.value,
             )
         )
         if not isinstance(result, dict):

--- a/tldw_chatbook/Sync_Interop/sync_state.py
+++ b/tldw_chatbook/Sync_Interop/sync_state.py
@@ -29,6 +29,7 @@ class SyncV2ProfileMode(str, Enum):
 
     LOCAL_ONLY = "local_only"
     LOCAL_FIRST = "local_first"
+    LOCAL_FIRST_SYNC = "local_first_sync"
     SERVER_FRONTEND = "server_frontend"
 
 
@@ -64,6 +65,20 @@ class SyncProfileState:
             raise ValueError("server_profile_id is required")
         if not isinstance(self.profile_mode, SyncV2ProfileMode):
             self.profile_mode = SyncV2ProfileMode(str(self.profile_mode))
+
+
+LOCAL_FIRST_SYNC_PROFILE_MODES = {
+    SyncV2ProfileMode.LOCAL_FIRST.value,
+    SyncV2ProfileMode.LOCAL_FIRST_SYNC.value,
+}
+
+
+def is_local_first_sync_profile_mode(profile_mode: SyncV2ProfileMode | str | None) -> bool:
+    """Return whether a profile mode enables local-first Sync v2 behavior."""
+
+    if isinstance(profile_mode, SyncV2ProfileMode):
+        return profile_mode.value in LOCAL_FIRST_SYNC_PROFILE_MODES
+    return str(profile_mode or "") in LOCAL_FIRST_SYNC_PROFILE_MODES
 
 
 class SyncProfileStateStore:

--- a/tldw_chatbook/Sync_Interop/sync_state.py
+++ b/tldw_chatbook/Sync_Interop/sync_state.py
@@ -74,7 +74,14 @@ LOCAL_FIRST_SYNC_PROFILE_MODES = {
 
 
 def is_local_first_sync_profile_mode(profile_mode: SyncV2ProfileMode | str | None) -> bool:
-    """Return whether a profile mode enables local-first Sync v2 behavior."""
+    """Return whether a profile mode enables local-first Sync v2 behavior.
+
+    Args:
+        profile_mode: Profile mode enum or serialized mode value to check.
+
+    Returns:
+        True when the mode represents local-first Sync v2 behavior.
+    """
 
     if isinstance(profile_mode, SyncV2ProfileMode):
         return profile_mode.value in LOCAL_FIRST_SYNC_PROFILE_MODES

--- a/tldw_chatbook/Sync_Interop/sync_state_repository.py
+++ b/tldw_chatbook/Sync_Interop/sync_state_repository.py
@@ -27,7 +27,7 @@ _MAPPING_STATUSES = {
 _BOTH_SIDE_STATUSES = {"confirmed", "stale", "conflict"}
 _LOCAL_NULL_ALLOWED = {"candidate", "orphaned_remote", "unsupported"}
 _REMOTE_NULL_ALLOWED = {"candidate", "orphaned_local", "unsupported"}
-_SYNC_V2_PROFILE_MODES = {"local_only", "local_first", "server_frontend"}
+_SYNC_V2_PROFILE_MODES = {"local_only", "local_first", "local_first_sync", "server_frontend"}
 _SYNC_V2_OUTBOX_STATUSES = {"pending", "dispatched"}
 SYNC_STATE_SCHEMA_VERSION = 2
 


### PR DESCRIPTION
## Summary
- Adds `local_first_sync` as the canonical Sync v2 local-first profile mode while preserving existing `local_first` records as a compatibility alias.
- Updates scope preparation, local-first sync execution, and key recovery checks to accept both spellings.
- Tracks the Chatbook sync-engine continuation in `TASK-59`.

## Test Plan
- [x] `../../.venv/bin/python -m pytest Tests/Sync_Interop/test_sync_state.py Tests/Sync_Interop/test_sync_state_repository.py Tests/Sync_Interop/test_sync_scope_service.py Tests/Sync_Interop/test_local_first_sync_service.py Tests/Sync_Interop/test_key_recovery_service.py -q`
- [x] `../../.venv/bin/python -m pytest Tests/Sync_Interop Tests/tldw_api/test_sync_client.py -q`
- [x] `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts the canonical Sync v2 local-first profile mode local_first_sync and keeps local_first as a compatibility alias. Defaults dry-run to the canonical mode while preserving explicit legacy requests; aligns with TASK-59.

- **New Features**
  - Added `LOCAL_FIRST_SYNC` enum and `is_local_first_sync_profile_mode` helper.
  - Scope preparation validates, normalizes, and passes the canonical mode to server dry-run.
  - Server dry-run defaults to `local_first_sync` and persists the requested mode (canonical or legacy).
  - Local-first sync, key recovery, and repository persistence accept both spellings and preserve the stored mode.

<sup>Written for commit e1ee899ce9725a2e9300e1614c223f6b649ef081. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/320?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

