### PR TITLE
Add Sync v2 profile summary

### DIFF
--- a/Tests/Sync_Interop/test_sync_scope_service.py
+++ b/Tests/Sync_Interop/test_sync_scope_service.py
@@ -327,3 +327,37 @@ async def test_sync_scope_service_delegates_canonical_local_first_sync_mode_to_d
     assert result["device_id"] == "device-1"
     assert server.calls[0][0] == "run_v2_dry_run"
     assert server.calls[0][1]["profile_mode"] == "local_first_sync"
+
+
+def test_sync_scope_service_returns_sync_v2_profile_summary(tmp_path):
+    repo = SyncStateRepository(tmp_path / "sync_state.db")
+    repo.set_sync_v2_profile_state(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-1",
+        profile_mode="server_frontend",
+        device_id=None,
+        dataset_id=None,
+    )
+    scope = SyncScopeService(server_service=FakeSyncService(), state_repository=repo)
+
+    summary = scope.get_sync_v2_profile_summary(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-1",
+    )
+
+    assert summary["status"] == "server_frontend"
+    assert summary["profile"]["profile_mode"] == "server_frontend"
+    assert summary["outbox"]["pending"] == 0
+
+
+def test_sync_scope_service_requires_repository_for_sync_v2_profile_summary():
+    scope = SyncScopeService(server_service=FakeSyncService())
+
+    with pytest.raises(ValueError, match="Sync state repository is unavailable"):
+        scope.get_sync_v2_profile_summary(
+            server_profile_id="server-a",
+            authenticated_principal_id="user-a",
+            workspace_scope="workspace-1",
+        )

--- a/Tests/Sync_Interop/test_sync_state_repository.py
+++ b/Tests/Sync_Interop/test_sync_state_repository.py
@@ -629,8 +629,7 @@ def test_sync_v2_profile_summary_aggregates_state_counts_and_status(tmp_path):
     assert summary["outbox"] == {
         "pending": 2,
         "dispatched": 1,
-        "failed": 0,
-        "by_domain": {"notes": {"pending": 2, "dispatched": 1, "failed": 0}},
+        "by_domain": {"notes": {"pending": 2, "dispatched": 1}},
     }
     assert summary["identity_map"] == {
         "total": 2,
@@ -656,10 +655,56 @@ def test_sync_v2_profile_summary_reports_missing_profile(tmp_path):
         "status": "not_configured",
         "profile": None,
         "cursor": None,
-        "outbox": {"pending": 0, "dispatched": 0, "failed": 0, "by_domain": {}},
+        "outbox": {"pending": 0, "dispatched": 0, "by_domain": {}},
         "identity_map": {"total": 0, "by_domain": {}},
         "conflicts": {"count": 0, "latest": []},
         "last_mirror_report": None,
+    }
+
+
+def test_sync_v2_profile_summary_scopes_none_principal_and_workspace_exactly(tmp_path):
+    repo = SyncStateRepository(tmp_path / "sync_state.db")
+    repo.set_sync_v2_profile_state(
+        server_profile_id="server-a",
+        authenticated_principal_id=None,
+        workspace_scope=None,
+        profile_mode="local_first_sync",
+        device_id="device-1",
+        dataset_id="dataset-1",
+    )
+    repo.record_identity_mapping(
+        source_authority="server",
+        server_profile_id="server-a",
+        authenticated_principal_id=None,
+        workspace_scope=None,
+        domain="notes",
+        entity_type="note",
+        local_entity_id="local-note-1",
+        remote_entity_id="remote-note-1",
+        mapping_status="confirmed",
+    )
+    repo.record_identity_mapping(
+        source_authority="server",
+        server_profile_id="server-a",
+        authenticated_principal_id="user-b",
+        workspace_scope="workspace-1",
+        domain="notes",
+        entity_type="note",
+        local_entity_id="local-note-2",
+        remote_entity_id="remote-note-2",
+        mapping_status="confirmed",
+    )
+
+    summary = repo.get_sync_v2_profile_summary(
+        server_profile_id="server-a",
+        authenticated_principal_id=None,
+        workspace_scope=None,
+    )
+
+    assert summary["identity_map"] == {
+        "total": 1,
+        "confirmed": 1,
+        "by_domain": {"notes": {"confirmed": 1}},
     }
 
 

--- a/Tests/Sync_Interop/test_sync_state_repository.py
+++ b/Tests/Sync_Interop/test_sync_state_repository.py
@@ -513,6 +513,156 @@ def test_sync_v2_outbox_persists_pending_entries_and_push_results(tmp_path):
     assert pending_after[1]["last_error"]["error_code"] == "conflict"
 
 
+def test_sync_v2_profile_summary_aggregates_state_counts_and_status(tmp_path):
+    db_path = tmp_path / "sync_state.db"
+    dataset_key = generate_dataset_key()
+    builder = SyncEnvelopeBuilder(
+        dataset_id="dataset-1",
+        device_id="device-1",
+        dataset_key=dataset_key,
+    )
+    pending = builder.build_note_metadata_update(note_id="note-1", status="active")
+    accepted = builder.build_note_metadata_update(note_id="note-2", status="archived")
+    conflicted = builder.build_note_metadata_update(note_id="note-3", status="draft")
+    repo = SyncStateRepository(db_path)
+    report = repo.record_mirror_report(
+        source_authority="server",
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-1",
+        domain="notes",
+        report={"dry_run": True, "write_enabled": False, "mapped_count": 1},
+    )
+    repo.set_sync_v2_profile_state(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-1",
+        profile_mode="local_first_sync",
+        device_id="device-1",
+        dataset_id="dataset-1",
+        dataset_cursors={"sync_v2": "cursor-profile"},
+        capabilities={"max_batch_size": 25},
+        dry_run_metadata={"domains": ["notes", "chat"]},
+        last_error="push_conflicts: 1",
+        last_mirror_report_id=report["report_id"],
+    )
+    repo.set_remote_pull_cursor(
+        source_authority="server",
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-1",
+        domain="sync_v2",
+        remote_collection="dataset-1",
+        cursor="cursor-remote",
+    )
+    repo.record_identity_mapping(
+        source_authority="server",
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-1",
+        domain="notes",
+        entity_type="note",
+        local_entity_id="local-note-1",
+        remote_entity_id="remote-note-1",
+        mapping_status="confirmed",
+    )
+    repo.record_identity_mapping(
+        source_authority="server",
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-1",
+        domain="notes",
+        entity_type="note",
+        local_entity_id="local-note-1",
+        remote_entity_id="remote-note-2",
+        mapping_status="confirmed",
+    )
+    repo.enqueue_sync_v2_outbox_envelope(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-1",
+        dataset_id="dataset-1",
+        envelope=pending,
+    )
+    repo.enqueue_sync_v2_outbox_envelope(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-1",
+        dataset_id="dataset-1",
+        envelope=accepted,
+    )
+    repo.enqueue_sync_v2_outbox_envelope(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-1",
+        dataset_id="dataset-1",
+        envelope=conflicted,
+    )
+    repo.mark_sync_v2_outbox_push_results(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-1",
+        dataset_id="dataset-1",
+        accepted=[{"client_envelope_id": accepted.client_envelope_id}],
+        rejected=[],
+        conflicts=[
+            {
+                "client_envelope_id": conflicted.client_envelope_id,
+                "conflict_id": "conflict-1",
+            }
+        ],
+    )
+
+    summary = repo.get_sync_v2_profile_summary(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-1",
+    )
+
+    assert summary["status"] == "attention_required"
+    assert summary["profile"]["profile_mode"] == "local_first_sync"
+    assert summary["profile"]["device_id"] == "device-1"
+    assert summary["profile"]["dataset_id"] == "dataset-1"
+    assert summary["profile"]["last_error"] == "push_conflicts: 1"
+    assert summary["cursor"]["remote_cursor"] == "cursor-remote"
+    assert summary["cursor"]["profile_cursor"] == "cursor-profile"
+    assert summary["outbox"] == {
+        "pending": 2,
+        "dispatched": 1,
+        "failed": 0,
+        "by_domain": {"notes": {"pending": 2, "dispatched": 1, "failed": 0}},
+    }
+    assert summary["identity_map"] == {
+        "total": 2,
+        "confirmed": 1,
+        "conflict": 1,
+        "by_domain": {"notes": {"confirmed": 1, "conflict": 1}},
+    }
+    assert summary["conflicts"]["count"] == 1
+    assert summary["last_mirror_report"]["report_id"] == report["report_id"]
+    assert summary["last_mirror_report"]["domain"] == "notes"
+
+
+def test_sync_v2_profile_summary_reports_missing_profile(tmp_path):
+    repo = SyncStateRepository(tmp_path / "sync_state.db")
+
+    summary = repo.get_sync_v2_profile_summary(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-1",
+    )
+
+    assert summary == {
+        "status": "not_configured",
+        "profile": None,
+        "cursor": None,
+        "outbox": {"pending": 0, "dispatched": 0, "failed": 0, "by_domain": {}},
+        "identity_map": {"total": 0, "by_domain": {}},
+        "conflicts": {"count": 0, "latest": []},
+        "last_mirror_report": None,
+    }
+
+
 def test_domain_eligibility_defaults_to_not_eligible_and_persists_override(tmp_path):
     db_path = tmp_path / "sync_state.db"
     repo = SyncStateRepository(db_path)

--- a/backlog/tasks/task-60 - Add-Chatbook-Sync-v2-profile-summary.md
+++ b/backlog/tasks/task-60 - Add-Chatbook-Sync-v2-profile-summary.md
@@ -1,0 +1,56 @@
+---
+id: TASK-60
+title: Add Chatbook Sync v2 profile summary
+status: Done
+labels:
+- sync
+- sync-v2
+- client-contract
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a Sync v2 profile summary contract that lets Chatbook report local-first/server-front-end status, dataset/device identity, pending outbox counts, conflict counts, cursor state, key availability, and last error without parsing low-level repository rows.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 `SyncStateRepository` exposes a Sync v2 profile summary for configured and missing profile states.
+- [x] #2 The summary includes profile mode, device/dataset identity, cursor state, outbox counts, identity map counts, conflict counts, last mirror report, and an overall status.
+- [x] #3 `SyncScopeService` exposes the summary through the existing state-repository boundary.
+- [x] #4 Focused Sync interop and API-client tests pass.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Added `get_sync_v2_profile_summary` to `SyncStateRepository` so callers can read one stable status contract instead of inspecting sync profile rows, outbox entries, identity mappings, conflict reports, remote cursors, and mirror reports separately.
+
+The summary status is intentionally presentation-oriented: missing profiles report `not_configured`, server-front-end profiles report `server_frontend`, local-only profiles report `local_only`, pending outbox work reports `pending`, and any last error or durable conflict report reports `attention_required`.
+
+Added `SyncScopeService.get_sync_v2_profile_summary` as the public service seam for app callers that already receive a scope service.
+
+Verification:
+- `../../.venv/bin/python -m pytest Tests/Sync_Interop/test_sync_state_repository.py::test_sync_v2_profile_summary_aggregates_state_counts_and_status Tests/Sync_Interop/test_sync_state_repository.py::test_sync_v2_profile_summary_reports_missing_profile Tests/Sync_Interop/test_sync_scope_service.py::test_sync_scope_service_returns_sync_v2_profile_summary Tests/Sync_Interop/test_sync_scope_service.py::test_sync_scope_service_requires_repository_for_sync_v2_profile_summary -q` passed with 4 tests.
+- `../../.venv/bin/python -m pytest Tests/Sync_Interop Tests/tldw_api/test_sync_client.py -q` passed with 143 tests.
+- `../../.venv/bin/python -m compileall tldw_chatbook/Sync_Interop` passed.
+- `git diff --check` passed.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -q -r tldw_chatbook/Sync_Interop/sync_state_repository.py tldw_chatbook/Sync_Interop/sync_scope_service.py -f json -o /tmp/bandit_chatbook_sync_profile_summary.json` passed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added a Sync v2 profile summary contract for Chatbook local-first/server-front-end status. The repository now aggregates profile metadata, remote cursor state, outbox counts, identity map status counts, conflict counts, and the last mirror report; the scope service exposes that aggregate for app use.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests and verification recorded
+- [x] #3 Documentation updated in task record
+- [x] #4 Final summary added
+- [x] #5 No known blockers
+<!-- DOD:END -->

--- a/backlog/tasks/task-60 - Add-Chatbook-Sync-v2-profile-summary.md
+++ b/backlog/tasks/task-60 - Add-Chatbook-Sync-v2-profile-summary.md
@@ -32,12 +32,19 @@ The summary status is intentionally presentation-oriented: missing profiles repo
 
 Added `SyncScopeService.get_sync_v2_profile_summary` as the public service seam for app callers that already receive a scope service.
 
+PR review follow-up tightened the profile summary implementation so outbox and identity-map counts are aggregated in SQL instead of loading full rows and JSON envelopes. Identity-map aggregation now treats `None` principal/workspace scopes as exact stored buckets instead of wildcard filters, conflict reports have a scope index for summary lookup, the latest conflict list remains newest-first, and the outbox summary only reports supported `pending` and `dispatched` states.
+
 Verification:
 - `../../.venv/bin/python -m pytest Tests/Sync_Interop/test_sync_state_repository.py::test_sync_v2_profile_summary_aggregates_state_counts_and_status Tests/Sync_Interop/test_sync_state_repository.py::test_sync_v2_profile_summary_reports_missing_profile Tests/Sync_Interop/test_sync_scope_service.py::test_sync_scope_service_returns_sync_v2_profile_summary Tests/Sync_Interop/test_sync_scope_service.py::test_sync_scope_service_requires_repository_for_sync_v2_profile_summary -q` passed with 4 tests.
 - `../../.venv/bin/python -m pytest Tests/Sync_Interop Tests/tldw_api/test_sync_client.py -q` passed with 143 tests.
 - `../../.venv/bin/python -m compileall tldw_chatbook/Sync_Interop` passed.
 - `git diff --check` passed.
 - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -q -r tldw_chatbook/Sync_Interop/sync_state_repository.py tldw_chatbook/Sync_Interop/sync_scope_service.py -f json -o /tmp/bandit_chatbook_sync_profile_summary.json` passed.
+- Review follow-up: `../../.venv/bin/python -m pytest Tests/Sync_Interop/test_sync_state_repository.py::test_sync_v2_profile_summary_aggregates_state_counts_and_status Tests/Sync_Interop/test_sync_state_repository.py::test_sync_v2_profile_summary_reports_missing_profile Tests/Sync_Interop/test_sync_state_repository.py::test_sync_v2_profile_summary_scopes_none_principal_and_workspace_exactly Tests/Sync_Interop/test_sync_scope_service.py::test_sync_scope_service_returns_sync_v2_profile_summary Tests/Sync_Interop/test_sync_scope_service.py::test_sync_scope_service_requires_repository_for_sync_v2_profile_summary -q` passed with 5 tests.
+- Review follow-up: `../../.venv/bin/python -m pytest Tests/Sync_Interop Tests/tldw_api/test_sync_client.py -q` passed with 144 tests.
+- Review follow-up: `/usr/bin/env PYTHONPYCACHEPREFIX=/tmp/tldw_chatbook_pycache ../../.venv/bin/python -m compileall tldw_chatbook/Sync_Interop` passed.
+- Review follow-up: `git diff --check` passed.
+- Review follow-up: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -q -r tldw_chatbook/Sync_Interop/sync_state_repository.py tldw_chatbook/Sync_Interop/sync_scope_service.py -f json -o /tmp/bandit_chatbook_sync_profile_summary_review.json` passed.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/tldw_chatbook/Sync_Interop/sync_scope_service.py
+++ b/tldw_chatbook/Sync_Interop/sync_scope_service.py
@@ -295,6 +295,24 @@ class SyncScopeService:
         authenticated_principal_id: str | None = None,
         workspace_scope: str | None = None,
     ) -> dict[str, Any]:
+        """Return the Sync v2 status summary for a configured server profile.
+
+        Args:
+            server_profile_id: Stable configured server profile identifier.
+            authenticated_principal_id: Optional authenticated user or account identity
+                for the profile scope. None is treated as an explicit unscoped
+                principal bucket by the repository.
+            workspace_scope: Optional workspace identifier. None is treated as the
+                explicit non-workspace profile scope by the repository.
+
+        Returns:
+            Summary dictionary from ``SyncStateRepository.get_sync_v2_profile_summary``.
+
+        Raises:
+            ValueError: If the sync state repository is unavailable or the profile scope
+                is invalid.
+        """
+
         repository = self._require_state_repository()
         return repository.get_sync_v2_profile_summary(
             server_profile_id=server_profile_id,

--- a/tldw_chatbook/Sync_Interop/sync_scope_service.py
+++ b/tldw_chatbook/Sync_Interop/sync_scope_service.py
@@ -288,6 +288,20 @@ class SyncScopeService:
         record.setdefault("sync_dataset_created", bool(record.get("dataset_id")))
         return record
 
+    def get_sync_v2_profile_summary(
+        self,
+        *,
+        server_profile_id: str,
+        authenticated_principal_id: str | None = None,
+        workspace_scope: str | None = None,
+    ) -> dict[str, Any]:
+        repository = self._require_state_repository()
+        return repository.get_sync_v2_profile_summary(
+            server_profile_id=server_profile_id,
+            authenticated_principal_id=authenticated_principal_id,
+            workspace_scope=workspace_scope,
+        )
+
     def record_dry_run_mirror_report(
         self,
         *,

--- a/tldw_chatbook/Sync_Interop/sync_state_repository.py
+++ b/tldw_chatbook/Sync_Interop/sync_state_repository.py
@@ -1140,6 +1140,191 @@ class SyncStateRepository(BaseDB):
             "updated_at": row["updated_at"],
         }
 
+    def get_sync_v2_profile_summary(
+        self,
+        *,
+        server_profile_id: str,
+        authenticated_principal_id: str | None,
+        workspace_scope: str | None,
+    ) -> dict[str, Any]:
+        """Return a user-facing Sync v2 status summary for one profile scope."""
+
+        profile = self.get_sync_v2_profile_state(
+            server_profile_id=server_profile_id,
+            authenticated_principal_id=authenticated_principal_id,
+            workspace_scope=workspace_scope,
+        )
+        if profile is None:
+            return _empty_sync_v2_profile_summary()
+
+        dataset_id = profile.get("dataset_id")
+        cursor = None
+        outbox = _empty_outbox_summary()
+        if dataset_id:
+            cursor_record = self.get_remote_pull_cursor(
+                source_authority="server",
+                server_profile_id=server_profile_id,
+                authenticated_principal_id=authenticated_principal_id,
+                workspace_scope=workspace_scope,
+                domain="sync_v2",
+                remote_collection=str(dataset_id),
+            )
+            cursor = {
+                "remote_collection": str(dataset_id),
+                "remote_cursor": cursor_record.cursor,
+                "profile_cursor": dict(profile.get("dataset_cursors") or {}).get("sync_v2"),
+            }
+            outbox = self._sync_v2_outbox_summary(
+                server_profile_id=server_profile_id,
+                authenticated_principal_id=authenticated_principal_id,
+                workspace_scope=workspace_scope,
+                dataset_id=str(dataset_id),
+            )
+
+        identity_map = self._sync_v2_identity_summary(
+            server_profile_id=server_profile_id,
+            authenticated_principal_id=authenticated_principal_id,
+            workspace_scope=workspace_scope,
+        )
+        conflicts = self._sync_v2_conflict_summary(
+            server_profile_id=server_profile_id,
+            authenticated_principal_id=authenticated_principal_id,
+            workspace_scope=workspace_scope,
+        )
+        last_mirror_report = self._get_mirror_report_by_id(profile.get("last_mirror_report_id"))
+
+        return {
+            "status": _sync_v2_profile_status(profile, outbox=outbox, conflicts=conflicts),
+            "profile": {
+                "source_authority": profile["source_authority"],
+                "server_profile_id": profile["server_profile_id"],
+                "authenticated_principal_id": profile["authenticated_principal_id"],
+                "workspace_scope": profile["workspace_scope"],
+                "profile_mode": profile["profile_mode"],
+                "device_id": profile["device_id"],
+                "dataset_id": profile["dataset_id"],
+                "capabilities": profile["capabilities"],
+                "dry_run_metadata": profile["dry_run_metadata"],
+                "last_error": profile["last_error"],
+                "updated_at": profile["updated_at"],
+            },
+            "cursor": cursor,
+            "outbox": outbox,
+            "identity_map": identity_map,
+            "conflicts": conflicts,
+            "last_mirror_report": last_mirror_report,
+        }
+
+    def _sync_v2_outbox_summary(
+        self,
+        *,
+        server_profile_id: str,
+        authenticated_principal_id: str | None,
+        workspace_scope: str | None,
+        dataset_id: str,
+    ) -> dict[str, Any]:
+        entries = self.list_sync_v2_outbox_entries(
+            server_profile_id=server_profile_id,
+            authenticated_principal_id=authenticated_principal_id,
+            workspace_scope=workspace_scope,
+            dataset_id=dataset_id,
+        )
+        summary = _empty_outbox_summary()
+        for entry in entries:
+            status = entry["status"]
+            if status in ("pending", "dispatched", "failed"):
+                summary[status] += 1
+            domain = entry["domain"]
+            domain_summary = summary["by_domain"].setdefault(
+                domain,
+                {"pending": 0, "dispatched": 0, "failed": 0},
+            )
+            if status in domain_summary:
+                domain_summary[status] += 1
+        return summary
+
+    def _sync_v2_identity_summary(
+        self,
+        *,
+        server_profile_id: str,
+        authenticated_principal_id: str | None,
+        workspace_scope: str | None,
+    ) -> dict[str, Any]:
+        mappings = self.list_identity_mappings(
+            source_authority="server",
+            server_profile_id=server_profile_id,
+            authenticated_principal_id=authenticated_principal_id,
+            workspace_scope=workspace_scope,
+        )
+        summary: dict[str, Any] = {"total": len(mappings), "by_domain": {}}
+        for mapping in mappings:
+            summary[mapping.mapping_status] = summary.get(mapping.mapping_status, 0) + 1
+            domain_summary = summary["by_domain"].setdefault(mapping.domain, {})
+            domain_summary[mapping.mapping_status] = domain_summary.get(mapping.mapping_status, 0) + 1
+        return summary
+
+    def _sync_v2_conflict_summary(
+        self,
+        *,
+        server_profile_id: str,
+        authenticated_principal_id: str | None,
+        workspace_scope: str | None,
+    ) -> dict[str, Any]:
+        scope_prefix = _source_scope_prefix(
+            source_authority="server",
+            server_profile_id=server_profile_id,
+            authenticated_principal_id=authenticated_principal_id,
+            workspace_scope=workspace_scope,
+        )
+        with self._get_connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT *
+                FROM sync_conflict_reports
+                WHERE source_scope_key LIKE ?
+                ORDER BY conflict_id DESC
+                LIMIT 5
+                """,
+                (f"{scope_prefix}:%",),
+            ).fetchall()
+            count_row = conn.execute(
+                """
+                SELECT COUNT(*) AS count
+                FROM sync_conflict_reports
+                WHERE source_scope_key LIKE ?
+                """,
+                (f"{scope_prefix}:%",),
+            ).fetchone()
+        latest = [dict(row) for row in rows]
+        for report in latest:
+            report["details"] = json.loads(report["details"])
+        latest.reverse()
+        return {"count": int(count_row["count"] if count_row else 0), "latest": latest}
+
+    def _get_mirror_report_by_id(self, report_id: int | None) -> dict[str, Any] | None:
+        if report_id is None:
+            return None
+        with self._get_connection() as conn:
+            row = conn.execute(
+                """
+                SELECT *
+                FROM mirror_reports
+                WHERE report_id = ?
+                """,
+                (report_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return {
+            "report_id": int(row["report_id"]),
+            "source_scope_key": row["source_scope_key"],
+            "domain": row["domain"],
+            "dry_run": bool(row["dry_run"]),
+            "write_enabled": bool(row["write_enabled"]),
+            "report": json.loads(row["report"]),
+            "created_at": row["created_at"],
+        }
+
     def set_domain_eligibility(
         self,
         *,
@@ -1390,6 +1575,63 @@ def _sync_v2_outbox_scope_key(
         domain="sync_v2",
         entity_type="outbox",
     )
+
+
+def _source_scope_prefix(
+    *,
+    source_authority: SourceAuthority,
+    server_profile_id: str | None,
+    authenticated_principal_id: str | None,
+    workspace_scope: str | None,
+) -> str:
+    if source_authority not in {"local", "server"}:
+        raise ValueError("source_authority must be one of: local, server")
+    if source_authority == "server" and not server_profile_id:
+        raise ValueError("server_profile_id is required for server sync state")
+    return ":".join(
+        [
+            source_authority,
+            server_profile_id or "none",
+            authenticated_principal_id or "none",
+            workspace_scope or "none",
+        ]
+    )
+
+
+def _empty_outbox_summary() -> dict[str, Any]:
+    return {"pending": 0, "dispatched": 0, "failed": 0, "by_domain": {}}
+
+
+def _empty_sync_v2_profile_summary() -> dict[str, Any]:
+    return {
+        "status": "not_configured",
+        "profile": None,
+        "cursor": None,
+        "outbox": _empty_outbox_summary(),
+        "identity_map": {"total": 0, "by_domain": {}},
+        "conflicts": {"count": 0, "latest": []},
+        "last_mirror_report": None,
+    }
+
+
+def _sync_v2_profile_status(
+    profile: Mapping[str, Any],
+    *,
+    outbox: Mapping[str, Any],
+    conflicts: Mapping[str, Any],
+) -> str:
+    if profile.get("last_error"):
+        return "attention_required"
+    if int(conflicts.get("count") or 0) > 0:
+        return "attention_required"
+    if int(outbox.get("pending") or 0) > 0 or int(outbox.get("failed") or 0) > 0:
+        return "pending"
+    profile_mode = profile.get("profile_mode")
+    if profile_mode == "server_frontend":
+        return "server_frontend"
+    if profile_mode == "local_only":
+        return "local_only"
+    return "ready"
 
 
 def _scope_value(value: str | None) -> str:

--- a/tldw_chatbook/Sync_Interop/sync_state_repository.py
+++ b/tldw_chatbook/Sync_Interop/sync_state_repository.py
@@ -135,6 +135,9 @@ class SyncStateRepository(BaseDB):
                     created_at TEXT NOT NULL
                 );
 
+                CREATE INDEX IF NOT EXISTS idx_sync_conflict_scope
+                    ON sync_conflict_reports(source_scope_key, conflict_id);
+
                 CREATE TABLE IF NOT EXISTS sync_profile_state (
                     source_authority TEXT NOT NULL,
                     server_profile_id TEXT NOT NULL,
@@ -1147,7 +1150,26 @@ class SyncStateRepository(BaseDB):
         authenticated_principal_id: str | None,
         workspace_scope: str | None,
     ) -> dict[str, Any]:
-        """Return a user-facing Sync v2 status summary for one profile scope."""
+        """Return a user-facing Sync v2 status summary for one profile scope.
+
+        Args:
+            server_profile_id: Stable configured server profile identifier.
+            authenticated_principal_id: Authenticated user or account identity for the
+                profile scope. A value of None means the profile explicitly stored under
+                the unscoped principal bucket, not a wildcard over all principals.
+            workspace_scope: Optional workspace identifier. A value of None means the
+                profile explicitly stored outside a workspace, not a wildcard over all
+                workspaces.
+
+        Returns:
+            Summary dictionary containing profile metadata, cursor state, outbox counts,
+            identity-map status counts, conflict counts, the last mirror report, and a
+            presentation-oriented status. Missing profiles return a stable
+            ``not_configured`` summary.
+
+        Raises:
+            ValueError: If required server profile scope data is invalid.
+        """
 
         profile = self.get_sync_v2_profile_state(
             server_profile_id=server_profile_id,
@@ -1223,24 +1245,35 @@ class SyncStateRepository(BaseDB):
         workspace_scope: str | None,
         dataset_id: str,
     ) -> dict[str, Any]:
-        entries = self.list_sync_v2_outbox_entries(
+        source_scope_key = _sync_v2_outbox_scope_key(
             server_profile_id=server_profile_id,
             authenticated_principal_id=authenticated_principal_id,
             workspace_scope=workspace_scope,
-            dataset_id=dataset_id,
         )
         summary = _empty_outbox_summary()
-        for entry in entries:
-            status = entry["status"]
-            if status in ("pending", "dispatched", "failed"):
-                summary[status] += 1
-            domain = entry["domain"]
+        with self._get_connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT status, domain, COUNT(*) AS count
+                FROM sync_v2_local_outbox
+                WHERE source_scope_key = ?
+                  AND dataset_id = ?
+                GROUP BY status, domain
+                """,
+                (source_scope_key, dataset_id),
+            ).fetchall()
+        for row in rows:
+            status = row["status"]
+            count = int(row["count"])
+            if status in ("pending", "dispatched"):
+                summary[status] += count
+            domain = row["domain"]
             domain_summary = summary["by_domain"].setdefault(
                 domain,
-                {"pending": 0, "dispatched": 0, "failed": 0},
+                {"pending": 0, "dispatched": 0},
             )
             if status in domain_summary:
-                domain_summary[status] += 1
+                domain_summary[status] += count
         return summary
 
     def _sync_v2_identity_summary(
@@ -1250,17 +1283,31 @@ class SyncStateRepository(BaseDB):
         authenticated_principal_id: str | None,
         workspace_scope: str | None,
     ) -> dict[str, Any]:
-        mappings = self.list_identity_mappings(
+        scope_prefix = _source_scope_prefix(
             source_authority="server",
             server_profile_id=server_profile_id,
             authenticated_principal_id=authenticated_principal_id,
             workspace_scope=workspace_scope,
         )
-        summary: dict[str, Any] = {"total": len(mappings), "by_domain": {}}
-        for mapping in mappings:
-            summary[mapping.mapping_status] = summary.get(mapping.mapping_status, 0) + 1
-            domain_summary = summary["by_domain"].setdefault(mapping.domain, {})
-            domain_summary[mapping.mapping_status] = domain_summary.get(mapping.mapping_status, 0) + 1
+        summary: dict[str, Any] = {"total": 0, "by_domain": {}}
+        with self._get_connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT mapping_status, domain, COUNT(*) AS count
+                FROM sync_identity_mappings
+                WHERE source_scope_key LIKE ?
+                GROUP BY mapping_status, domain
+                """,
+                (f"{scope_prefix}:%",),
+            ).fetchall()
+        for row in rows:
+            status = row["mapping_status"]
+            domain = row["domain"]
+            count = int(row["count"])
+            summary["total"] += count
+            summary[status] = summary.get(status, 0) + count
+            domain_summary = summary["by_domain"].setdefault(domain, {})
+            domain_summary[status] = domain_summary.get(status, 0) + count
         return summary
 
     def _sync_v2_conflict_summary(
@@ -1298,7 +1345,6 @@ class SyncStateRepository(BaseDB):
         latest = [dict(row) for row in rows]
         for report in latest:
             report["details"] = json.loads(report["details"])
-        latest.reverse()
         return {"count": int(count_row["count"] if count_row else 0), "latest": latest}
 
     def _get_mirror_report_by_id(self, report_id: int | None) -> dict[str, Any] | None:
@@ -1599,7 +1645,7 @@ def _source_scope_prefix(
 
 
 def _empty_outbox_summary() -> dict[str, Any]:
-    return {"pending": 0, "dispatched": 0, "failed": 0, "by_domain": {}}
+    return {"pending": 0, "dispatched": 0, "by_domain": {}}
 
 
 def _empty_sync_v2_profile_summary() -> dict[str, Any]:
@@ -1624,7 +1670,7 @@ def _sync_v2_profile_status(
         return "attention_required"
     if int(conflicts.get("count") or 0) > 0:
         return "attention_required"
-    if int(outbox.get("pending") or 0) > 0 or int(outbox.get("failed") or 0) > 0:
+    if int(outbox.get("pending") or 0) > 0:
         return "pending"
     profile_mode = profile.get("profile_mode")
     if profile_mode == "server_frontend":


### PR DESCRIPTION
## Summary
- Add a Sync v2 profile summary contract on SyncStateRepository that aggregates profile metadata, remote cursor state, outbox counts, identity-map status counts, conflict counts, and the last mirror report.
- Expose the summary through SyncScopeService for app-level callers.
- Track the slice in TASK-60.

## Verification
- ../../.venv/bin/python -m pytest Tests/Sync_Interop/test_sync_state_repository.py::test_sync_v2_profile_summary_aggregates_state_counts_and_status Tests/Sync_Interop/test_sync_state_repository.py::test_sync_v2_profile_summary_reports_missing_profile Tests/Sync_Interop/test_sync_scope_service.py::test_sync_scope_service_returns_sync_v2_profile_summary Tests/Sync_Interop/test_sync_scope_service.py::test_sync_scope_service_requires_repository_for_sync_v2_profile_summary -q
- ../../.venv/bin/python -m pytest Tests/Sync_Interop Tests/tldw_api/test_sync_client.py -q
- ../../.venv/bin/python -m compileall tldw_chatbook/Sync_Interop
- git diff --check
- /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -q -r tldw_chatbook/Sync_Interop/sync_state_repository.py tldw_chatbook/Sync_Interop/sync_scope_service.py -f json -o /tmp/bandit_chatbook_sync_profile_summary.json

## Change summary
Human-authored merge rationale required before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Sync v2 profile summary that aggregates profile state, cursors, outbox, identity-map, conflicts, and the last mirror report, and exposes it via the scope service. This gives Chatbook one stable status per profile and satisfies TASK-60.

- **New Features**
  - `SyncStateRepository.get_sync_v2_profile_summary(...)` returns a single object: `status`, `profile`, `cursor`, `outbox`, `identity_map`, `conflicts`, `last_mirror_report`. Missing profiles return `not_configured`. Outbox and identity-map counts are aggregated in SQL; `None` principal/workspace are treated as exact scope buckets; conflict summary returns a total count and the newest five, with a new scope index for faster lookups.
  - Status logic: `attention_required` if `last_error` or conflicts > 0; `pending` if outbox has `pending` > 0; `server_frontend` or `local_only` based on `profile_mode`; else `ready`.
  - `SyncScopeService.get_sync_v2_profile_summary(...)` exposes the summary for app callers and errors if the repository is not configured.

<sup>Written for commit 269ea48e7074dba3e4c7e092a473fc3aab9f3ac5. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/323?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

