### PR TITLE
Plan post-release UX/HCI validation

### DIFF
--- a/Docs/superpowers/plans/2026-05-17-post-release-ux-hci-functional-validation.md
+++ b/Docs/superpowers/plans/2026-05-17-post-release-ux-hci-functional-validation.md
@@ -1,0 +1,182 @@
+# Post-Release UX/HCI Functional Validation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Re-audit the rendered app as an actual user, verify every top-level screen and cross-screen workflow, and convert discovered breakage into prioritized correction work before advancing deferred feature implementation.
+
+**Architecture:** Treat current Phase 3-6 closeout as a historical baseline, not proof that the app is currently usable. The next tranche starts with evidence capture and actual-use validation, then turns findings into P0/P1/P2/P3 correction tasks and only then plans deferred features such as ACP runtime launch, write sync, Workspaces, and citation/snippet carry-through.
+
+**Tech Stack:** Python 3.11+, Textual, textual-web/CDP when available, actual terminal screenshots when textual-web is insufficient, pytest documentation regressions, Backlog.md.
+
+---
+
+## File Structure
+
+- Create: `Docs/superpowers/qa/product-maturity/post-release-ux-hci/README.md` for the audit index and current acceptance status.
+- Create: `Docs/superpowers/qa/product-maturity/post-release-ux-hci/walkthrough-template.md` for reusable screen and workflow evidence.
+- Create: `Docs/superpowers/qa/product-maturity/post-release-ux-hci/<date>-<screen-or-workflow>.md` for each completed audit slice.
+- Modify: `Docs/superpowers/trackers/product-maturity-roadmap.md` to list `TASK-60` and child tasks as the active post-release validation tranche.
+- Modify: `backlog/tasks/task-60*.md` as audit evidence is produced and follow-up tasks are created.
+- Test: `Tests/UI/test_post_release_ux_hci_validation_plan.py` to prevent the audit from becoming untracked prose.
+
+## Task 1: Create Actual-Screen Audit Harness
+
+**Files:**
+- Create: `Docs/superpowers/qa/product-maturity/post-release-ux-hci/README.md`
+- Create: `Docs/superpowers/qa/product-maturity/post-release-ux-hci/walkthrough-template.md`
+- Modify: `backlog/tasks/task-60.1 - Post-release-actual-screen-UX-HCI-audit-harness.md`
+- Test: `Tests/UI/test_post_release_ux_hci_validation_plan.py`
+
+- [ ] **Step 1: Write the failing documentation regression**
+
+Add a test that asserts the plan, tracker, parent task, and audit-template files require actual rendered screenshots, actual-use verification, NN/g heuristic notes, CDP/textual-web or terminal evidence, severity classification, and user approval before a screen is accepted.
+
+- [ ] **Step 2: Run the focused regression and confirm failure**
+
+Run: `python -m pytest -q Tests/UI/test_post_release_ux_hci_validation_plan.py --tb=short`
+
+Expected: FAIL because the QA index/template do not exist yet.
+
+- [ ] **Step 3: Create the audit harness docs**
+
+The template must include these required fields:
+
+- Screen or workflow name
+- Evidence method: textual-web/CDP, browser automation, terminal screenshot, or manual screenshot path
+- Actual screenshot path
+- Screenshot approval state: pending, approved, rejected
+- Primary user goal
+- Steps attempted
+- What worked
+- What broke
+- NN/g heuristic findings
+- Keyboard/focus findings
+- Empty/error/setup-state findings
+- Cross-screen handoff findings
+- P0/P1/P2/P3 severity decisions
+- Follow-up Backlog task links
+
+- [ ] **Step 4: Verify the harness regression passes**
+
+Run: `python -m pytest -q Tests/UI/test_post_release_ux_hci_validation_plan.py --tb=short`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the harness slice**
+
+Commit message: `docs: add post-release UX HCI audit harness`
+
+## Task 2: Audit Every Top-Level Screen By Actual Use
+
+**Files:**
+- Create: `Docs/superpowers/qa/product-maturity/post-release-ux-hci/<date>-screen-<destination>.md`
+- Modify: `backlog/tasks/task-60.2 - Post-release-top-level-screen-functionality-audit.md`
+- Modify: `Docs/superpowers/trackers/product-maturity-roadmap.md`
+
+- [ ] **Step 1: Start from a clean launch**
+
+Run the app from the current branch with the same Python used by the repo virtual environment. Prefer textual-web and CDP for browser-observed screenshots. If textual-web cannot capture the real terminal rendering, use an actual terminal screenshot.
+
+- [ ] **Step 2: Capture and review each screen**
+
+Required destinations: Home, Console, Library, Artifacts, Personas, Watchlists, Schedules, Workflows, MCP, ACP, Skills, Settings.
+
+For each destination, record the actual screenshot, whether the user approved it, the visible IA/layout issues, whether primary controls work, whether blocked states explain recovery, and whether keyboard/focus behavior supports fast use.
+
+- [ ] **Step 3: Create follow-up tasks for every P0/P1**
+
+P0 means the screen blocks basic use. P1 means a core workflow is seriously degraded. Do not close the screen audit while P0/P1 findings are only prose.
+
+- [ ] **Step 4: Update task evidence**
+
+Update `TASK-60.2` with the audit evidence index, completion state, and remaining findings.
+
+- [ ] **Step 5: Commit the screen-audit slice**
+
+Commit message: `docs: record post-release screen UX audit`
+
+## Task 3: Validate Cross-Screen Workflows End-To-End
+
+**Files:**
+- Create: `Docs/superpowers/qa/product-maturity/post-release-ux-hci/<date>-workflow-<name>.md`
+- Modify: `backlog/tasks/task-60.3 - Post-release-cross-screen-workflow-validation.md`
+- Modify: `Docs/superpowers/trackers/product-maturity-roadmap.md`
+
+- [ ] **Step 1: Select the minimum required workflows**
+
+Required workflows:
+
+- Home active work opens details and routes relevant work into Console or shows a clear blocked state.
+- Library Search/RAG produces evidence or a recoverable blocked state, then hands context into Console where appropriate.
+- Console can accept visible composer input, preserve pasted/collapsed text behavior, send or clearly block, and save/resume a Chatbook artifact.
+- Artifacts and Chatbooks can reopen or resume into Console without dead controls.
+- Personas, Skills, MCP, ACP, Watchlists, Schedules, and Workflows handoffs into Console are verified or explicitly classified as blocked future work with user-visible recovery copy.
+
+- [ ] **Step 2: Drive each workflow in the actual app**
+
+Use CDP/textual-web/browser automation where possible, but record actual screenshots for visual acceptance. Use terminal screenshots when browser rendering cannot prove the state.
+
+- [ ] **Step 3: Record power-user friction**
+
+For at least five repeated-use workflows, record shortcuts, repeated steps, state persistence, missing batch actions, recovery paths, and whether the workflow supports fast repeated use.
+
+- [ ] **Step 4: Create correction tasks**
+
+Every P0/P1 workflow failure must have a Backlog task with concrete acceptance criteria before `TASK-60.3` can be closed.
+
+- [ ] **Step 5: Commit the workflow-validation slice**
+
+Commit message: `docs: record post-release workflow validation`
+
+## Task 4: Convert Deferred Features Into Evidence-Gated Tranches
+
+**Files:**
+- Modify: `Docs/superpowers/trackers/product-maturity-roadmap.md`
+- Modify: `Docs/Product_Roadmap.md`
+- Modify: `backlog/tasks/task-60.4 - Post-release-deferred-feature-tranche-planning.md`
+- Create: new Backlog child tasks only after audit evidence justifies their order.
+
+- [ ] **Step 1: Read the audit findings before feature planning**
+
+Do not prioritize deferred feature implementation ahead of unresolved P0/P1 usability failures.
+
+- [ ] **Step 2: Create staged tranches**
+
+Required deferred tranches:
+
+- ACP runtime launch.
+- Write sync promotion from dry-run/read-only surfacing to explicitly approved write behavior.
+- Workspaces and deeper Library organization, including Library-owned collection membership and deeper Import/Export.
+- Citation/snippet carry-through into Chat responses, artifacts, and exported Chatbooks.
+- Optional dependency installation/recovery and package metadata polish.
+
+- [ ] **Step 3: Link each tranche to evidence**
+
+Each tranche must name the audit finding or residual-risk evidence that justifies it, plus the screens/workflows it affects.
+
+- [ ] **Step 4: Commit the deferred-feature planning slice**
+
+Commit message: `docs: plan post-release deferred feature tranches`
+
+## Task 5: Close The Tracking PR
+
+**Files:**
+- Modify: `Docs/superpowers/trackers/product-maturity-roadmap.md`
+- Modify: `backlog/tasks/task-60*.md`
+- Test: `Tests/UI/test_post_release_ux_hci_validation_plan.py`
+
+- [ ] **Step 1: Run focused verification**
+
+Run: `python -m pytest -q Tests/UI/test_post_release_ux_hci_validation_plan.py Tests/UI/test_post_ux_product_roadmap_handoff.py Tests/UI/test_product_maturity_phase6_release_closeout.py --tb=short`
+
+- [ ] **Step 2: Run diff hygiene**
+
+Run: `git diff --check`
+
+- [ ] **Step 3: Update implementation notes**
+
+Record what was planned, what was intentionally deferred, and why actual-use validation gates future work.
+
+- [ ] **Step 4: Open PR against `dev`**
+
+The PR body must state that this does not certify the app as usable. It creates the next validation tranche because the current app may still be visually or functionally broken despite prior mounted-test closeout.

--- a/Docs/superpowers/qa/product-maturity/post-release-ux-hci/README.md
+++ b/Docs/superpowers/qa/product-maturity/post-release-ux-hci/README.md
@@ -1,0 +1,54 @@
+# Post-Release UX/HCI Functional Validation
+
+Status: planned; `TASK-60` active
+
+This index exists because prior mounted layout checks and phase closeout evidence are not enough to prove the app is usable. Each top-level destination and cross-screen workflow must be driven in the actual app, evaluated from a senior UX/HCI perspective, and backed by real rendered screenshots before acceptance.
+
+## Evidence Rules
+
+- Actual screenshots are required for screen approval. Do not use generated SVGs, code-layout renderings, or ASCII-only mockups as approval evidence.
+- Prefer textual-web with CDP/browser automation when it exposes the real Textual UI. Use an actual terminal screenshot when browser rendering is unavailable, misleading, or insufficient.
+- Screen acceptance requires both visual approval and actual-use functionality evidence.
+- A screen that renders but has dead controls, invisible input, broken focus, unclear recovery, or unusable cross-screen handoffs is not accepted.
+- P0/P1 findings require Backlog follow-up tasks before the related audit task can close.
+
+## Required Screens
+
+| Screen | Evidence Status | Screenshot Approval | Functionality Status | Follow-Up |
+| --- | --- | --- | --- | --- |
+| Home | pending | pending | pending | `TASK-60.2` |
+| Console | pending | pending | pending | `TASK-60.2` |
+| Library | pending | pending | pending | `TASK-60.2` |
+| Artifacts | pending | pending | pending | `TASK-60.2` |
+| Personas | pending | pending | pending | `TASK-60.2` |
+| Watchlists | pending | pending | pending | `TASK-60.2` |
+| Schedules | pending | pending | pending | `TASK-60.2` |
+| Workflows | pending | pending | pending | `TASK-60.2` |
+| MCP | pending | pending | pending | `TASK-60.2` |
+| ACP | pending | pending | pending | `TASK-60.2` |
+| Skills | pending | pending | pending | `TASK-60.2` |
+| Settings | pending | pending | pending | `TASK-60.2` |
+
+## Required Cross-Screen Workflows
+
+| Workflow | Evidence Status | Acceptance Gate |
+| --- | --- | --- |
+| Home active work to details and Console | pending | actual-use handoff or clear blocked recovery |
+| Library Search/RAG to Console context | pending | evidence handoff or clear blocked recovery |
+| Console composer, send/block, Chatbook save/resume | pending | visible input and recoverable send/save path |
+| Artifacts/Chatbooks to Console resume | pending | no dead controls |
+| Personas/Skills/MCP/ACP context to Console | pending | verified handoff or honest blocked future work |
+| Watchlists/Schedules/Workflows runs to Console | pending | verified handoff or honest blocked future work |
+
+## Severity Rules
+
+| Severity | Meaning | Close Rule |
+| --- | --- | --- |
+| P0 | Blocks basic use or makes a primary screen unusable. | Must be fixed before the screen/workflow can be accepted. |
+| P1 | Seriously degrades a core workflow or creates misleading state. | Must be fixed or linked to an accepted follow-up task before closeout. |
+| P2 | Confusing, inefficient, or weak recovery, but usable. | May remain with explicit residual risk and follow-up. |
+| P3 | Polish that does not hide status, recovery, or user control. | May remain as backlog polish. |
+
+## Required Template
+
+Use `walkthrough-template.md` for every screen and workflow evidence file.

--- a/Docs/superpowers/qa/product-maturity/post-release-ux-hci/walkthrough-template.md
+++ b/Docs/superpowers/qa/product-maturity/post-release-ux-hci/walkthrough-template.md
@@ -1,0 +1,73 @@
+# Post-Release UX/HCI Walkthrough Evidence
+
+## Metadata
+
+- Task:
+- Screen or workflow:
+- Date:
+- Branch:
+- App command:
+- Evidence method: textual-web/CDP, browser automation, terminal screenshot, or manual screenshot
+- Actual screenshot path:
+- Screenshot approval: pending / approved / rejected
+- Reviewer:
+
+## User Goal
+
+Describe the user goal in plain language.
+
+## Steps Attempted
+
+1. 
+
+## What Worked
+
+- 
+
+## What Broke Or Slowed The Workflow
+
+- 
+
+## Nielsen Norman Heuristic Findings
+
+- Visibility of system status:
+- Match between system and real world:
+- User control and freedom:
+- Consistency and standards:
+- Error prevention:
+- Recognition rather than recall:
+- Flexibility and efficiency of use:
+- Aesthetic and minimalist design:
+- Error recognition, diagnosis, and recovery:
+- Help and documentation:
+
+## Keyboard And Focus Findings
+
+- 
+
+## Empty Error Setup State Findings
+
+- 
+
+## Cross-Screen Handoff Findings
+
+- 
+
+## Power-User Repetition Findings
+
+- Shortcuts:
+- Batch actions:
+- State persistence:
+- Recovery paths:
+- Repeated-use friction:
+
+## Severity Decisions
+
+| Finding | Severity | Follow-Up Task | Decision |
+| --- | --- | --- | --- |
+
+## Acceptance Decision
+
+- Accepted: no
+- Reason:
+- Required follow-up before acceptance:

--- a/Docs/superpowers/trackers/product-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/product-maturity-roadmap.md
@@ -61,6 +61,22 @@ Product Maturity Phase 1 and Phase 2 are not reopened by default. Their existing
 | Server Parity And Live Integrations | `TASK-12` | Prioritize parity by workflow value, not endpoint count. |
 | Release Hardening And Distribution | `TASK-13` | Use only after earlier workflow gates have QA evidence. |
 
+## Post-Release UX/HCI Functional Validation
+
+Source Plan: `Docs/superpowers/plans/2026-05-17-post-release-ux-hci-functional-validation.md`
+Status: planned; `TASK-60` active
+
+This tranche reopens validation only where evidence must come from actual app use. It does not invalidate the historical Phase 3-6 closeout evidence, but it treats that evidence as insufficient for current usability certification when the rendered app may still be visually or functionally broken.
+
+Acceptance requires actual screenshots, actual-use functionality evidence, and cross-screen workflow validation. Screens that merely render, mount, or expose clickable controls are not accepted unless the user can complete or recover from the intended workflow.
+
+| Post-Release Track | Backlog Owner | Validation Rule |
+| --- | --- | --- |
+| Actual-screen UX/HCI audit harness | `TASK-60.1` | Define screenshot, CDP/textual-web, NN/g, severity, and approval evidence before auditing screens. |
+| Top-level screen functionality audit | `TASK-60.2` | Home, Console, Library, Artifacts, Personas, Watchlists, Schedules, Workflows, MCP, ACP, Skills, and Settings require rendered screenshot approval plus actual-use evidence. |
+| Cross-screen workflow validation | `TASK-60.3` | Validate handoffs into Console, Library/RAG to Console, Chatbook save/resume, agent configuration paths, and run-control paths end-to-end. |
+| Deferred feature tranche planning | `TASK-60.4` | Plan ACP runtime launch, write sync, Workspaces/Library depth, citation/snippet carry-through, and optional dependency/package polish only after audit findings are known. |
+
 ## Severity Policy
 
 | Priority | Taxonomy | Exit Rule |
@@ -127,6 +143,11 @@ Product Maturity Phase 1 and Phase 2 are not reopened by default. Their existing
   - Phase 6.5: Recovery Setup And Documentation Alignment - `TASK-13.5`
   - Phase 6.6: Packaging Configuration And Data-Safety Validation - `TASK-13.6`
   - Phase 6.7: Public Roadmap Release Closeout - `TASK-13.7`
+- Post-Release UX/HCI Functional Validation - `TASK-60`
+  - Actual-Screen UX/HCI Audit Harness - `TASK-60.1`
+  - Top-Level Screen Functionality Audit - `TASK-60.2`
+  - Cross-Screen Workflow Validation - `TASK-60.3`
+  - Deferred Feature Tranche Planning - `TASK-60.4`
 
 ## QA Evidence Index
 

--- a/Tests/UI/test_post_release_ux_hci_validation_plan.py
+++ b/Tests/UI/test_post_release_ux_hci_validation_plan.py
@@ -1,0 +1,142 @@
+"""Post-release UX/HCI functional validation tracking regressions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLAN = Path("Docs/superpowers/plans/2026-05-17-post-release-ux-hci-functional-validation.md")
+TRACKER = Path("Docs/superpowers/trackers/product-maturity-roadmap.md")
+QA_README = Path("Docs/superpowers/qa/product-maturity/post-release-ux-hci/README.md")
+QA_TEMPLATE = Path("Docs/superpowers/qa/product-maturity/post-release-ux-hci/walkthrough-template.md")
+TASK_60 = Path("backlog/tasks/task-60 - Post-release-UX-HCI-and-functionality-validation-tranche.md")
+CHILD_TASKS = {
+    "TASK-60.1": Path(
+        "backlog/tasks/task-60.1 - Post-release-actual-screen-UX-HCI-audit-harness.md"
+    ),
+    "TASK-60.2": Path(
+        "backlog/tasks/task-60.2 - Post-release-top-level-screen-functionality-audit.md"
+    ),
+    "TASK-60.3": Path(
+        "backlog/tasks/task-60.3 - Post-release-cross-screen-workflow-validation.md"
+    ),
+    "TASK-60.4": Path(
+        "backlog/tasks/task-60.4 - Post-release-deferred-feature-tranche-planning.md"
+    ),
+}
+REQUIRED_SCREENS = (
+    "Home",
+    "Console",
+    "Library",
+    "Artifacts",
+    "Personas",
+    "Watchlists",
+    "Schedules",
+    "Workflows",
+    "MCP",
+    "ACP",
+    "Skills",
+    "Settings",
+)
+
+
+def _text(path: Path) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def test_post_release_validation_plan_requires_actual_app_use() -> None:
+    plan = _text(PLAN)
+
+    for required in (
+        "Re-audit the rendered app as an actual user",
+        "textual-web/CDP",
+        "actual terminal screenshots",
+        "actual-use validation",
+        "P0/P1/P2/P3",
+        "Do not prioritize deferred feature implementation ahead of unresolved P0/P1",
+    ):
+        assert required in plan
+
+    for screen in REQUIRED_SCREENS:
+        assert screen in plan
+
+    for workflow in (
+        "Home active work",
+        "Library Search/RAG",
+        "Console can accept visible composer input",
+        "Artifacts and Chatbooks",
+        "Personas, Skills, MCP, ACP, Watchlists, Schedules, and Workflows",
+    ):
+        assert workflow in plan
+
+
+def test_post_release_qa_harness_requires_real_screenshots_and_approval() -> None:
+    readme = _text(QA_README)
+    template = _text(QA_TEMPLATE)
+
+    for required in (
+        "Actual screenshots are required",
+        "Do not use generated SVGs",
+        "textual-web with CDP/browser automation",
+        "actual terminal screenshot",
+        "A screen that renders but has dead controls",
+        "P0/P1 findings require Backlog follow-up tasks",
+    ):
+        assert required in readme
+
+    for screen in REQUIRED_SCREENS:
+        assert f"| {screen} | pending | pending | pending | `TASK-60.2` |" in readme
+
+    for required_field in (
+        "Evidence method:",
+        "Actual screenshot path:",
+        "Screenshot approval:",
+        "Nielsen Norman Heuristic Findings",
+        "Keyboard And Focus Findings",
+        "Cross-Screen Handoff Findings",
+        "Power-User Repetition Findings",
+        "Severity Decisions",
+        "Accepted: no",
+    ):
+        assert required_field in template
+
+
+def test_post_release_backlog_tasks_track_screens_workflows_and_deferred_features() -> None:
+    parent = _text(TASK_60)
+
+    assert "status: To Do" in parent
+    assert "actual rendered screenshot audit" in parent
+    assert "Cross-screen workflows are validated end-to-end" in parent
+    assert "No screen is marked accepted without actual screenshot approval" in parent
+
+    for task_id, path in CHILD_TASKS.items():
+        task = _text(path)
+        assert f"id: {task_id}" in task
+        assert "parent_task_id: TASK-60" in task
+        assert "<!-- AC:BEGIN -->" in task
+
+    assert "status: Done" in _text(CHILD_TASKS["TASK-60.1"])
+    for task_id in ("TASK-60.2", "TASK-60.3", "TASK-60.4"):
+        assert "status: To Do" in _text(CHILD_TASKS[task_id])
+
+    assert "forbids SVG/code-layout substitutes" in _text(CHILD_TASKS["TASK-60.1"])
+    assert "Home, Console, Library, Artifacts, Personas, Watchlists" in _text(
+        CHILD_TASKS["TASK-60.2"]
+    )
+    assert "At least five power-user repeated workflows" in _text(CHILD_TASKS["TASK-60.3"])
+    assert "ACP runtime launch, write sync promotion, Workspaces/Library depth" in _text(
+        CHILD_TASKS["TASK-60.4"]
+    )
+
+
+def test_product_maturity_tracker_lists_post_release_validation_tranche() -> None:
+    tracker = _text(TRACKER)
+
+    assert "Post-Release UX/HCI Functional Validation" in tracker
+    assert "TASK-60" in tracker
+    for task_id in CHILD_TASKS:
+        assert task_id in tracker
+    assert "actual screenshots" in tracker
+    assert "actual-use functionality evidence" in tracker
+    assert "cross-screen workflow validation" in tracker

--- a/backlog/tasks/task-60 - Post-release-UX-HCI-and-functionality-validation-tranche.md
+++ b/backlog/tasks/task-60 - Post-release-UX-HCI-and-functionality-validation-tranche.md
@@ -1,0 +1,42 @@
+---
+id: TASK-60
+title: Post-release UX/HCI and functionality validation tranche
+status: To Do
+labels:
+- ux
+- hci
+- qa
+- post-release
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Track the post-release correction pass required after Phase 3-6 closeout. The goal is to verify the actual rendered app, screen functionality, and cross-screen workflows before treating deferred feature work as implementation-ready.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Every top-level destination has an actual rendered screenshot audit entry, not just mounted layout assertions.
+- [ ] #2 Each destination has an actual-use validation checklist covering primary controls, empty/error/setup states, keyboard/focus behavior, and recovery paths.
+- [ ] #3 Cross-screen workflows are validated end-to-end with direct app use, including Home to Console, Library/RAG to Console, Artifacts/Chatbooks to Console, Watchlists/Schedules/Workflows handoffs, Personas/Skills/MCP/ACP context paths, and Settings recovery paths.
+- [ ] #4 Findings are prioritized into P0/P1/P2/P3 with ownership and follow-up task links.
+- [ ] #5 No screen is marked accepted without actual screenshot approval and recorded functionality evidence.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/backlog/tasks/task-60.1 - Post-release-actual-screen-UX-HCI-audit-harness.md
+++ b/backlog/tasks/task-60.1 - Post-release-actual-screen-UX-HCI-audit-harness.md
@@ -1,0 +1,59 @@
+---
+id: TASK-60.1
+title: Post-release actual-screen UX/HCI audit harness
+status: Done
+labels:
+- ux
+- hci
+- qa
+- screenshots
+priority: high
+parent_task_id: TASK-60
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create the repeatable audit protocol for rendered screenshots, CDP/textual-web or terminal evidence capture, Nielsen Norman heuristic review, and user-approved screen acceptance gates.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Audit protocol names the exact tool paths for actual screenshots and forbids SVG/code-layout substitutes for screen approval.
+- [x] #2 Protocol maps each top-level destination to evidence fields for rendered screenshot, visible defects, NN/g heuristic findings, keyboard/focus findings, and acceptance status.
+- [x] #3 Protocol defines severity rules for P0/P1/P2/P3 findings and requires follow-up Backlog tasks for unresolved P0/P1 items.
+- [x] #4 Protocol includes a QA walkthrough requirement proving the screen is usable, not merely rendered or clickable.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add documentation regression coverage for the post-release UX/HCI audit plan.
+2. Create the QA index and walkthrough template requiring actual screenshots, actual-use evidence, NN/g findings, severity decisions, and approval state.
+3. Update the product maturity tracker with the active post-release validation tranche.
+4. Run focused verification and diff hygiene.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Created the post-release UX/HCI audit harness and tracking guardrails. Added a QA index and reusable walkthrough template that require actual rendered screenshots, actual-use functionality evidence, Nielsen Norman heuristic findings, keyboard/focus review, cross-screen handoff notes, severity classification, and follow-up task links. Added tracker coverage for TASK-60 and child tasks so current app usability validation is tracked separately from historical Phase 3-6 closeout evidence.
+
+Verification: `python -m pytest -q Tests/UI/test_post_release_ux_hci_validation_plan.py Tests/UI/test_post_ux_product_roadmap_handoff.py Tests/UI/test_product_maturity_phase6_release_closeout.py --tb=short` passed with 11 tests.
+Verification: `git diff --check` passed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added the post-release UX/HCI audit harness for actual rendered screenshots, actual-use validation, NN/g findings, severity decisions, and user approval gates.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests or verification recorded
+- [x] #3 Documentation updated when relevant or not required
+- [x] #4 Final summary added
+- [x] #5 Known skips or blockers documented
+<!-- DOD:END -->

--- a/backlog/tasks/task-60.2 - Post-release-top-level-screen-functionality-audit.md
+++ b/backlog/tasks/task-60.2 - Post-release-top-level-screen-functionality-audit.md
@@ -1,0 +1,42 @@
+---
+id: TASK-60.2
+title: Post-release top-level screen functionality audit
+status: To Do
+labels:
+- ux
+- hci
+- qa
+- screens
+priority: high
+parent_task_id: TASK-60
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Drive each top-level destination as a user and verify the primary controls, setup states, empty states, error states, focus behavior, and visual layout against the approved Textual-native direction.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Home, Console, Library, Artifacts, Personas, Watchlists, Schedules, Workflows, MCP, ACP, Skills, and Settings each have actual-use evidence recorded.
+- [ ] #2 Every screen audit identifies what works, what is broken, what is confusing, and whether fast repeated use is supported.
+- [ ] #3 Every screen has a rendered screenshot approval status and unresolved findings are linked to Backlog follow-up tasks.
+- [ ] #4 No screen is accepted if primary actions render but do not complete a user-visible workflow or recovery path.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/backlog/tasks/task-60.3 - Post-release-cross-screen-workflow-validation.md
+++ b/backlog/tasks/task-60.3 - Post-release-cross-screen-workflow-validation.md
@@ -1,0 +1,43 @@
+---
+id: TASK-60.3
+title: Post-release cross-screen workflow validation
+status: To Do
+labels:
+- ux
+- hci
+- qa
+- workflows
+priority: high
+parent_task_id: TASK-60
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Validate end-to-end product workflows across destinations using the actual app, with special focus on handoffs into Console as the agentic control surface.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Home active work can open details and route relevant work into Console or shows a clear blocked state.
+- [ ] #2 Library Search/RAG can produce evidence or a recoverable blocked state, then hand off context into Console where appropriate.
+- [ ] #3 Artifacts and Chatbooks can be opened, resumed, or clearly blocked from Home/Artifacts/Console without dead controls.
+- [ ] #4 Personas, Skills, MCP, ACP, Watchlists, Schedules, and Workflows handoffs into Console are verified or explicitly classified as blocked future work with user-visible recovery copy.
+- [ ] #5 At least five power-user repeated workflows are timed qualitatively for friction, shortcuts, state persistence, and recovery paths.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/backlog/tasks/task-60.4 - Post-release-deferred-feature-tranche-planning.md
+++ b/backlog/tasks/task-60.4 - Post-release-deferred-feature-tranche-planning.md
@@ -1,0 +1,41 @@
+---
+id: TASK-60.4
+title: Post-release deferred feature tranche planning
+status: To Do
+labels:
+- roadmap
+- planning
+- post-release
+priority: medium
+parent_task_id: TASK-60
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Convert verified residual risks from Phase 3-6 closeout into staged implementation tranches after the actual-use audit establishes what is currently broken.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 ACP runtime launch, write sync promotion, Workspaces/Library depth, citation/snippet carry-through, and optional dependency/package polish each have a staged follow-up tranche.
+- [ ] #2 Each tranche references evidence from the actual-use audit before implementation work is prioritized.
+- [ ] #3 Feature planning does not mask P0/P1 usability breakage discovered by the audit.
+- [ ] #4 The product maturity roadmap distinguishes verified shipped behavior from deferred future work and newly discovered broken behavior.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- creates TASK-60 and child tasks for post-release actual-screen UX/HCI validation
- adds a plan and QA harness requiring real screenshots, actual-use evidence, NN/g findings, severity classification, and screenshot approval
- updates the product maturity tracker so deferred feature planning is gated behind actual app-use validation
- adds regression coverage to keep this validation tranche tracked

## Verification
- python -m pytest -q Tests/UI/test_post_release_ux_hci_validation_plan.py Tests/UI/test_post_ux_product_roadmap_handoff.py Tests/UI/test_product_maturity_phase6_release_closeout.py --tb=short
- git diff --check

## Scope note
This PR does not certify the current app as usable. It creates the next validation tranche because the rendered app may still be visually or functionally broken despite prior mounted-test closeout.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Creates a post-release UX/HCI validation tranche that requires real screenshots and actual-use evidence before accepting screens or planning deferred features. Adds a QA harness, docs, and tests to track screen/workflow audits and gate roadmap work behind resolved P0/P1 issues.

- **New Features**
  - Added plan: Docs/superpowers/plans/2026-05-17-post-release-ux-hci-functional-validation.md.
  - Added QA index and walkthrough template with required fields (screenshot path, approval, NN/g notes, severity, follow-ups).
  - Updated product maturity tracker to gate deferred features until audits complete.
  - Added regression tests to enforce evidence rules and task tracking.
  - Created backlog tasks `TASK-60` and `TASK-60.1`–`TASK-60.4` for harness, top-level screen audits, cross-screen workflows, and deferred-feature planning.

<sup>Written for commit b2a25e3bfbc36b0ee3560c358fdc39df9894db0e. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/336?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

