### PR TITLE
Add workspace operating context foundation

### DIFF
--- a/Docs/superpowers/plans/2026-05-20-workspace-operating-context-implementation.md
+++ b/Docs/superpowers/plans/2026-05-20-workspace-operating-context-implementation.md
@@ -123,7 +123,7 @@ Every visible UI task below must complete this gate before the screen can be cal
 - Test: `Tests/Workspaces/test_workspace_models.py`
 - Test: `Tests/Workspaces/test_workspace_eligibility.py`
 
-- [ ] **Step 1: Write model validation tests**
+- [x] **Step 1: Write model validation tests**
 
 ```python
 def test_workspace_record_requires_non_empty_identity() -> None:
@@ -140,7 +140,7 @@ def test_workspace_membership_supports_multi_workspace_visibility() -> None:
     assert membership.workspace_id == "ws-a"
 ```
 
-- [ ] **Step 2: Write eligibility tests**
+- [x] **Step 2: Write eligibility tests**
 
 ```python
 def test_cross_workspace_note_is_visible_but_not_context_eligible() -> None:
@@ -156,13 +156,13 @@ def test_cross_workspace_note_is_visible_but_not_context_eligible() -> None:
     assert "Copy or link" in result.recovery_copy
 ```
 
-- [ ] **Step 3: Run tests and confirm they fail**
+- [x] **Step 3: Run tests and confirm they fail**
 
 Run: `python -m pytest -q Tests/Workspaces/test_workspace_models.py Tests/Workspaces/test_workspace_eligibility.py --tb=short`
 
 Expected: fail because `tldw_chatbook.Workspaces` does not exist.
 
-- [ ] **Step 4: Implement minimal models**
+- [x] **Step 4: Implement minimal models**
 
 Use dataclasses and literal-safe enums. Keep validation in constructors or small helpers.
 
@@ -178,7 +178,7 @@ class WorkspaceAuthority(str, Enum):
     RUNTIME_MISSING = "runtime-missing"
 ```
 
-- [ ] **Step 5: Implement pure eligibility decisions**
+- [x] **Step 5: Implement pure eligibility decisions**
 
 Rules:
 
@@ -187,13 +187,13 @@ Rules:
 - Global conversations are visible in Console but not silently converted into workspace conversations.
 - Cross-workspace use returns a recovery path: copy/link into the active workspace.
 
-- [ ] **Step 6: Run focused tests**
+- [x] **Step 6: Run focused tests**
 
 Run: `python -m pytest -q Tests/Workspaces/test_workspace_models.py Tests/Workspaces/test_workspace_eligibility.py --tb=short`
 
 Expected: pass.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add tldw_chatbook/Workspaces Tests/Workspaces/test_workspace_models.py Tests/Workspaces/test_workspace_eligibility.py
@@ -209,7 +209,7 @@ git commit -m "feat: add workspace operating context models"
 - Test: `Tests/Workspaces/test_workspace_registry_service.py`
 - Test: `Tests/UI/test_screen_navigation.py`
 
-- [ ] **Step 1: Write persistence tests**
+- [x] **Step 1: Write persistence tests**
 
 ```python
 def test_registry_persists_active_workspace(tmp_path: Path) -> None:
@@ -223,7 +223,7 @@ def test_registry_persists_active_workspace(tmp_path: Path) -> None:
     assert reloaded.get_active_workspace().workspace_id == "ws-a"
 ```
 
-- [ ] **Step 2: Write membership tests**
+- [x] **Step 2: Write membership tests**
 
 ```python
 def test_registry_links_note_without_hiding_other_workspaces(tmp_path: Path) -> None:
@@ -234,13 +234,13 @@ def test_registry_links_note_without_hiding_other_workspaces(tmp_path: Path) -> 
     assert {m.workspace_id for m in service.get_item_memberships("note", "note-1")} == {"ws-a", "ws-b"}
 ```
 
-- [ ] **Step 3: Run tests and confirm they fail**
+- [x] **Step 3: Run tests and confirm they fail**
 
 Run: `python -m pytest -q Tests/Workspaces/test_workspace_registry_service.py --tb=short`
 
 Expected: fail because storage/service are missing.
 
-- [ ] **Step 4: Implement `WorkspaceDB`**
+- [x] **Step 4: Implement `WorkspaceDB`**
 
 Use `BaseDB` for path handling and a local schema version table scoped to this DB. Minimum schema:
 
@@ -258,7 +258,7 @@ CREATE TABLE IF NOT EXISTS workspace_records (
 );
 ```
 
-- [ ] **Step 5: Implement `LocalWorkspaceRegistryService`**
+- [x] **Step 5: Implement `LocalWorkspaceRegistryService`**
 
 Service responsibilities:
 
@@ -269,17 +269,17 @@ Service responsibilities:
 - Store runtime binding metadata without secrets.
 - Return deterministic ordering for UI lists.
 
-- [ ] **Step 6: Wire app-owned service**
+- [x] **Step 6: Wire app-owned service**
 
 In `tldw_chatbook/app.py`, instantiate `WorkspaceDB` and `LocalWorkspaceRegistryService` next to existing local DB/service setup. Expose as `self.workspace_registry_service`.
 
-- [ ] **Step 7: Run focused tests**
+- [x] **Step 7: Run focused tests**
 
 Run: `python -m pytest -q Tests/Workspaces/test_workspace_registry_service.py Tests/UI/test_screen_navigation.py --tb=short`
 
 Expected: pass.
 
-- [ ] **Step 8: Commit**
+- [x] **Step 8: Commit**
 
 ```bash
 git add tldw_chatbook/DB/Workspace_DB.py tldw_chatbook/Workspaces/registry_service.py tldw_chatbook/app.py Tests/Workspaces/test_workspace_registry_service.py Tests/UI/test_screen_navigation.py

--- a/Docs/superpowers/plans/2026-05-20-workspace-operating-context-implementation.md
+++ b/Docs/superpowers/plans/2026-05-20-workspace-operating-context-implementation.md
@@ -1,0 +1,797 @@
+# Workspace Operating Context Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build Chatbook's local-first workspace operating-context model so Console can expose real workspace state, global Library/Notes visibility remains intact, and later local-to-server handoff has a safe package boundary.
+
+**Architecture:** Add a focused `Workspaces` domain package with pure models, eligibility rules, local registry persistence, manifest creation, and dry-run handoff services before wiring UI actions. Console consumes the active workspace as operating context; Library, Notes, Artifacts, and search remain global browsers that display workspace membership and gate only active-context actions.
+
+**Tech Stack:** Python 3.11+, Textual, SQLite via existing DB patterns, dataclasses/enums, existing `Sync_Interop` envelope seams, pytest mounted UI tests, textual-web/CDP or actual terminal screenshot approval.
+
+---
+
+## Source Documents
+
+- `Docs/superpowers/specs/2026-05-20-workspace-operating-context-handoff-prd-design.md`
+- `Docs/superpowers/handoffs/2026-05-08-ui-screenshot-approval-workflow-handoff.md`
+- `Docs/superpowers/specs/2026-05-02-agentic-terminal-design-system-design.md`
+- `Docs/superpowers/specs/2026-05-06-destination-layout-ia-contracts-design.md`
+- `Docs/superpowers/trackers/product-maturity-roadmap.md`
+- Adjacent server issues: `rmusser01/tldw_server#1526`, `#1440`, `#1528`
+
+## Non-Negotiable Scope Rules
+
+- Do not hide Library, Notes, Artifacts, or conversations when the active workspace changes.
+- Do not stage, manipulate, RAG-ground, or agent-edit cross-workspace items unless the user explicitly copies or links them into the active workspace.
+- Do not add a top-level Workspaces destination in v1.
+- Do not implement background write sync in this tranche.
+- Do not recreate ACP sessions, containers, VMs, or git worktrees automatically; v1 describes and validates runtime bindings only.
+- Do not claim a UI state is visually approved without an actual rendered PNG screenshot and explicit user approval.
+- Do not use generated SVGs, ASCII diagrams, geometry dumps, or code layouts as approval evidence.
+
+## File Responsibility Map
+
+### New Workspace Domain
+
+- Create: `tldw_chatbook/Workspaces/__init__.py`
+  - Export stable workspace domain APIs.
+- Create: `tldw_chatbook/Workspaces/models.py`
+  - Own `WorkspaceRecord`, `WorkspaceMembership`, `WorkspaceRuntimeBinding`, `WorkspaceManifest`, authority/sync/eligibility enums, and transfer policy values.
+- Create: `tldw_chatbook/Workspaces/eligibility.py`
+  - Pure active-context eligibility decisions. This module must never filter browse/search results.
+- Create: `tldw_chatbook/Workspaces/registry_service.py`
+  - App-facing local workspace registry service: create/list/update/archive workspaces, active workspace selection, membership lookup, and runtime binding lookup.
+- Create: `tldw_chatbook/Workspaces/display_state.py`
+  - Console/Library/Notes presentation state builders so UI copy remains deterministic and testable.
+- Create: `tldw_chatbook/Workspaces/manifest.py`
+  - Build local workspace handoff manifests with copy/reference/redaction/audit classification.
+- Create: `tldw_chatbook/Workspaces/handoff_service.py`
+  - Dry-run local-to-server and server-to-local preflight. First concrete handoff target is ACP task/run packages.
+
+### Persistence
+
+- Create: `tldw_chatbook/DB/Workspace_DB.py`
+  - Local SQLite store for workspace registry tables. Use `BaseDB` path handling.
+  - Tables: `workspace_records`, `workspace_memberships`, `workspace_runtime_bindings`, `workspace_handoff_audit`.
+  - Keep secrets out of stored runtime binding metadata.
+- Modify: `tldw_chatbook/app.py`
+  - Instantiate `WorkspaceDB` and `LocalWorkspaceRegistryService`.
+  - Expose a stable app attribute such as `workspace_registry_service`.
+  - Preserve existing `pending_console_launch` and `pending_notes_workspace_context` behavior.
+
+### Existing Anchors To Reuse
+
+- Modify: `tldw_chatbook/Chat/chat_persistence_service.py`
+  - Keep existing `scope_type` and `workspace_id` inputs.
+  - Add workspace existence/eligibility validation at the service boundary after registry exists.
+- Modify: `tldw_chatbook/DB/ChaChaNotes_DB.py`
+  - Do not add new workspace registry tables here unless a later implementation proves cross-table transactional coupling is required.
+  - Reuse existing conversation `scope_type` and `workspace_id` columns.
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`
+  - Replace the single left tray composition with a two-section Console context rail.
+  - Keep route IDs and Console transcript/composer behavior intact.
+- Modify: `tldw_chatbook/Widgets/Console/console_staged_context.py`
+  - Keep current staged-context section as the top half of the new rail.
+- Create: `tldw_chatbook/Widgets/Console/console_workspace_context.py`
+  - Render `Convos & Workspaces` workspace summary, conversation list, disabled switcher/action affordances, and recovery copy.
+- Modify: `tldw_chatbook/Widgets/Console/__init__.py`
+  - Export the new Console workspace widget.
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py`
+  - Display workspace membership tags and active-context eligibility for visible sources without filtering global Library results.
+- Modify: `tldw_chatbook/UI/Screens/notes_screen.py`
+  - Display workspace membership tags and active-context eligibility while keeping cross-workspace notes visible/editable.
+- Modify: `tldw_chatbook/UI/Screens/artifacts_screen.py`
+  - Display artifact workspace membership and active-context eligibility once manifest packaging reaches artifacts.
+- Modify: `tldw_chatbook/UX_Interop/server_parity_contracts.py`
+  - Reuse `WorkspaceIsolationContract` and `FutureSyncStatusContract`; do not replace them with a parallel contract shape.
+- Modify: `tldw_chatbook/Sync_Interop/envelope_builder.py`
+  - Extend only when manifest/handoff tasks need explicit workspace package envelopes. Existing `build_workspace_source_ref()` remains the first anchor.
+
+### Tests
+
+- Create: `Tests/Workspaces/test_workspace_models.py`
+- Create: `Tests/Workspaces/test_workspace_eligibility.py`
+- Create: `Tests/Workspaces/test_workspace_registry_service.py`
+- Create: `Tests/Workspaces/test_workspace_display_state.py`
+- Create: `Tests/Workspaces/test_workspace_manifest.py`
+- Create: `Tests/Workspaces/test_workspace_handoff_service.py`
+- Create: `Tests/UI/test_console_workspace_context_rail.py`
+- Create: `Tests/UI/test_library_workspace_visibility.py`
+- Create: `Tests/UI/test_notes_workspace_visibility.py`
+- Modify: `Tests/UI/test_chat_screen_state.py`
+- Modify: `Tests/UI/test_destination_visual_parity_correction.py`
+- Modify: `Tests/Sync_Interop/test_envelope_builder.py`
+
+## UI Approval Gate Template
+
+Every visible UI task below must complete this gate before the screen can be called approved:
+
+- [ ] Start the real app or a focused harness with production TCSS.
+- [ ] Prefer textual-web/CDP for browser-observed screenshots. If textual-web does not show the real state, use an actual terminal screenshot.
+- [ ] Capture a PNG screenshot from the rendered app surface.
+- [ ] Inspect the screenshot locally and reject it if it shows a loader, wrong screen, crash, blank state, or truncated core workflow.
+- [ ] Show the screenshot path to the user and wait for explicit approval.
+- [ ] Archive approved screenshots under `Docs/superpowers/qa/product-maturity/phase-4/actual-visual-captures/` unless the active roadmap phase specifies a newer folder.
+- [ ] Record screenshot path, approval state, verification commands, and residual risks in the task notes or QA summary.
+
+## Task 1: Workspace Models And Eligibility Rules
+
+**Files:**
+- Create: `tldw_chatbook/Workspaces/__init__.py`
+- Create: `tldw_chatbook/Workspaces/models.py`
+- Create: `tldw_chatbook/Workspaces/eligibility.py`
+- Test: `Tests/Workspaces/test_workspace_models.py`
+- Test: `Tests/Workspaces/test_workspace_eligibility.py`
+
+- [ ] **Step 1: Write model validation tests**
+
+```python
+def test_workspace_record_requires_non_empty_identity() -> None:
+    with pytest.raises(ValueError, match="workspace_id"):
+        WorkspaceRecord(workspace_id="", name="Research")
+
+def test_workspace_membership_supports_multi_workspace_visibility() -> None:
+    membership = WorkspaceMembership(
+        workspace_id="ws-a",
+        item_type="note",
+        item_id="note-1",
+        role="source",
+    )
+    assert membership.workspace_id == "ws-a"
+```
+
+- [ ] **Step 2: Write eligibility tests**
+
+```python
+def test_cross_workspace_note_is_visible_but_not_context_eligible() -> None:
+    result = evaluate_workspace_eligibility(
+        active_workspace_id="ws-a",
+        item_workspace_ids=("ws-b",),
+        item_type="note",
+        operation="stage_in_console",
+    )
+
+    assert result.visible is True
+    assert result.active_context_eligible is False
+    assert "Copy or link" in result.recovery_copy
+```
+
+- [ ] **Step 3: Run tests and confirm they fail**
+
+Run: `python -m pytest -q Tests/Workspaces/test_workspace_models.py Tests/Workspaces/test_workspace_eligibility.py --tb=short`
+
+Expected: fail because `tldw_chatbook.Workspaces` does not exist.
+
+- [ ] **Step 4: Implement minimal models**
+
+Use dataclasses and literal-safe enums. Keep validation in constructors or small helpers.
+
+```python
+class WorkspaceAuthority(str, Enum):
+    LOCAL_ONLY = "local-only"
+    SERVER_BACKED = "server-backed"
+    SYNCING_TO_SERVER = "syncing-to-server"
+    SYNCING_FROM_SERVER = "syncing-from-server"
+    CONFLICT = "conflict"
+    DETACHED = "detached"
+    REMOTE_ONLY = "remote-only"
+    RUNTIME_MISSING = "runtime-missing"
+```
+
+- [ ] **Step 5: Implement pure eligibility decisions**
+
+Rules:
+
+- Browse/search visibility is always true for user-owned items.
+- Active-context operations require active workspace membership.
+- Global conversations are visible in Console but not silently converted into workspace conversations.
+- Cross-workspace use returns a recovery path: copy/link into the active workspace.
+
+- [ ] **Step 6: Run focused tests**
+
+Run: `python -m pytest -q Tests/Workspaces/test_workspace_models.py Tests/Workspaces/test_workspace_eligibility.py --tb=short`
+
+Expected: pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tldw_chatbook/Workspaces Tests/Workspaces/test_workspace_models.py Tests/Workspaces/test_workspace_eligibility.py
+git commit -m "feat: add workspace operating context models"
+```
+
+## Task 2: Local Workspace Registry Persistence
+
+**Files:**
+- Create: `tldw_chatbook/DB/Workspace_DB.py`
+- Modify: `tldw_chatbook/Workspaces/registry_service.py`
+- Modify: `tldw_chatbook/app.py`
+- Test: `Tests/Workspaces/test_workspace_registry_service.py`
+- Test: `Tests/UI/test_screen_navigation.py`
+
+- [ ] **Step 1: Write persistence tests**
+
+```python
+def test_registry_persists_active_workspace(tmp_path: Path) -> None:
+    db = WorkspaceDB(tmp_path / "workspaces.sqlite", client_id="client-1")
+    service = LocalWorkspaceRegistryService(db)
+
+    service.create_workspace(workspace_id="ws-a", name="Local Research")
+    service.set_active_workspace("ws-a")
+
+    reloaded = LocalWorkspaceRegistryService(WorkspaceDB(tmp_path / "workspaces.sqlite", client_id="client-1"))
+    assert reloaded.get_active_workspace().workspace_id == "ws-a"
+```
+
+- [ ] **Step 2: Write membership tests**
+
+```python
+def test_registry_links_note_without_hiding_other_workspaces(tmp_path: Path) -> None:
+    service = build_test_registry(tmp_path)
+    service.link_membership("ws-a", item_type="note", item_id="note-1", role="source")
+    service.link_membership("ws-b", item_type="note", item_id="note-1", role="reference")
+
+    assert {m.workspace_id for m in service.get_item_memberships("note", "note-1")} == {"ws-a", "ws-b"}
+```
+
+- [ ] **Step 3: Run tests and confirm they fail**
+
+Run: `python -m pytest -q Tests/Workspaces/test_workspace_registry_service.py --tb=short`
+
+Expected: fail because storage/service are missing.
+
+- [ ] **Step 4: Implement `WorkspaceDB`**
+
+Use `BaseDB` for path handling and a local schema version table scoped to this DB. Minimum schema:
+
+```sql
+CREATE TABLE IF NOT EXISTS workspace_records (
+    workspace_id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    authority TEXT NOT NULL,
+    sync_status TEXT NOT NULL,
+    active INTEGER NOT NULL DEFAULT 0,
+    archived INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+```
+
+- [ ] **Step 5: Implement `LocalWorkspaceRegistryService`**
+
+Service responsibilities:
+
+- Normalize IDs/names.
+- Create a default local workspace only when explicitly requested by the caller.
+- Set one active workspace per client.
+- Link/unlink memberships idempotently.
+- Store runtime binding metadata without secrets.
+- Return deterministic ordering for UI lists.
+
+- [ ] **Step 6: Wire app-owned service**
+
+In `tldw_chatbook/app.py`, instantiate `WorkspaceDB` and `LocalWorkspaceRegistryService` next to existing local DB/service setup. Expose as `self.workspace_registry_service`.
+
+- [ ] **Step 7: Run focused tests**
+
+Run: `python -m pytest -q Tests/Workspaces/test_workspace_registry_service.py Tests/UI/test_screen_navigation.py --tb=short`
+
+Expected: pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tldw_chatbook/DB/Workspace_DB.py tldw_chatbook/Workspaces/registry_service.py tldw_chatbook/app.py Tests/Workspaces/test_workspace_registry_service.py Tests/UI/test_screen_navigation.py
+git commit -m "feat: persist local workspace registry"
+```
+
+## Task 3: Console Context Rail Read-Only Shell
+
+**Files:**
+- Create: `tldw_chatbook/Workspaces/display_state.py`
+- Create: `tldw_chatbook/Widgets/Console/console_workspace_context.py`
+- Modify: `tldw_chatbook/Widgets/Console/__init__.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`
+- Test: `Tests/Workspaces/test_workspace_display_state.py`
+- Test: `Tests/UI/test_console_workspace_context_rail.py`
+- QA: `Docs/superpowers/qa/product-maturity/phase-4/actual-visual-captures/`
+
+- [ ] **Step 1: Write display-state tests**
+
+```python
+def test_console_workspace_state_explains_missing_service() -> None:
+    state = build_console_workspace_state(
+        registry_service=None,
+        current_conversation=None,
+    )
+
+    assert state.heading == "Convos & Workspaces"
+    assert state.workspace_label == "No workspace selected"
+    assert state.change_workspace_enabled is False
+    assert "service not ready" in state.recovery_copy.lower()
+```
+
+- [ ] **Step 2: Write mounted UI tests**
+
+Assert `#console-staged-context-tray` still exists and the new rail exposes:
+
+- `#console-workspace-context`
+- `#console-active-workspace`
+- `#console-workspace-conversations`
+- `#console-change-workspace`
+- Disabled recovery copy when service is missing.
+
+- [ ] **Step 3: Run tests and confirm they fail**
+
+Run: `python -m pytest -q Tests/Workspaces/test_workspace_display_state.py Tests/UI/test_console_workspace_context_rail.py --tb=short`
+
+Expected: fail because new display state/widget are missing.
+
+- [ ] **Step 4: Implement display state and widget**
+
+`ConsoleWorkspaceContextTray` renders:
+
+- `Convos & Workspaces`
+- Active workspace name/authority/sync/runtime.
+- Conversation list for the active workspace.
+- Disabled `Change workspace` until switch behavior is implemented.
+- `New conversation` action only when registry and active workspace are ready.
+
+- [ ] **Step 5: Compose two-section left rail**
+
+In `ChatScreen.compose_content()`, wrap `ConsoleStagedContextTray` and `ConsoleWorkspaceContextTray` in a vertical left rail. Keep the existing left rail width ratio smaller than transcript and inspector because it is context/status, not the primary work area.
+
+- [ ] **Step 6: Run focused tests**
+
+Run: `python -m pytest -q Tests/Workspaces/test_workspace_display_state.py Tests/UI/test_console_workspace_context_rail.py Tests/UI/test_destination_visual_parity_correction.py::test_console_screen_uses_terminal_native_workbench_layout --tb=short`
+
+Expected: pass.
+
+- [ ] **Step 7: Capture actual screenshots**
+
+Capture at least:
+
+- Console with no workspace service ready.
+- Console with an active local workspace and empty conversation list.
+- Console with active workspace conversations.
+
+Use textual-web/CDP or actual terminal screenshot. Do not continue until the user approves the rendered screenshots.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tldw_chatbook/Workspaces/display_state.py tldw_chatbook/Widgets/Console/console_workspace_context.py tldw_chatbook/Widgets/Console/__init__.py tldw_chatbook/UI/Screens/chat_screen.py Tests/Workspaces/test_workspace_display_state.py Tests/UI/test_console_workspace_context_rail.py Docs/superpowers/qa/product-maturity/phase-4
+git commit -m "feat: add console workspace context rail"
+```
+
+## Task 4: Active Workspace Selection And Workspace Conversations
+
+**Files:**
+- Modify: `tldw_chatbook/Workspaces/registry_service.py`
+- Modify: `tldw_chatbook/Chat/chat_persistence_service.py`
+- Modify: `tldw_chatbook/Widgets/Console/console_workspace_context.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`
+- Modify: `tldw_chatbook/Widgets/Chat_Widgets/chat_shell_bar.py`
+- Test: `Tests/Workspaces/test_workspace_registry_service.py`
+- Test: `Tests/UI/test_chat_screen_state.py`
+- Test: `Tests/UI/test_console_workspace_context_rail.py`
+
+- [ ] **Step 1: Write conversation-scope regression tests**
+
+```python
+def test_workspace_conversation_requires_existing_workspace(tmp_path: Path) -> None:
+    registry = build_test_registry(tmp_path)
+    service = ChatPersistenceService(db=chat_db, workspace_registry=registry)
+
+    with pytest.raises(ValueError, match="Unknown workspace"):
+        service.create_conversation(scope_type="workspace", workspace_id="missing")
+```
+
+- [ ] **Step 2: Write active switch tests**
+
+Mounted Console tests should prove selecting workspace B changes eligible conversation rows in `Convos & Workspaces` but does not affect Library/Notes browse state.
+
+- [ ] **Step 3: Run tests and confirm they fail**
+
+Run: `python -m pytest -q Tests/UI/test_chat_screen_state.py Tests/UI/test_console_workspace_context_rail.py --tb=short`
+
+Expected: fail because selection is not wired.
+
+- [ ] **Step 4: Add service APIs**
+
+Add:
+
+- `list_workspace_conversations(workspace_id)`
+- `set_active_workspace(workspace_id)`
+- `get_active_workspace_context()`
+- `fork_conversation_into_workspace(conversation_id, target_workspace_id)` as a service stub that records intent but does not silently mutate global conversations.
+
+- [ ] **Step 5: Wire Console actions**
+
+`Change workspace` may open a lightweight selection overlay/list only after the registry exists. If no workspace exists, show `Create a workspace in Library > Workspaces before switching`.
+
+- [ ] **Step 6: Run focused tests**
+
+Run: `python -m pytest -q Tests/Workspaces/test_workspace_registry_service.py Tests/UI/test_chat_screen_state.py Tests/UI/test_console_workspace_context_rail.py --tb=short`
+
+Expected: pass.
+
+- [ ] **Step 7: Capture actual screenshots**
+
+Capture:
+
+- Workspace switch list.
+- Active workspace changed.
+- Global conversation shown as global, not silently workspace-bound.
+
+Wait for user approval before calling the Console workspace switcher visually approved.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tldw_chatbook/Workspaces/registry_service.py tldw_chatbook/Chat/chat_persistence_service.py tldw_chatbook/Widgets/Console/console_workspace_context.py tldw_chatbook/UI/Screens/chat_screen.py tldw_chatbook/Widgets/Chat_Widgets/chat_shell_bar.py Tests/Workspaces/test_workspace_registry_service.py Tests/UI/test_chat_screen_state.py Tests/UI/test_console_workspace_context_rail.py Docs/superpowers/qa/product-maturity/phase-4
+git commit -m "feat: wire active workspace conversations"
+```
+
+## Task 5: Library And Notes Global Visibility With Context Eligibility
+
+**Files:**
+- Create: `tldw_chatbook/Workspaces/item_context.py`
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py`
+- Modify: `tldw_chatbook/UI/Screens/notes_screen.py`
+- Modify: `tldw_chatbook/Widgets/Note_Widgets/notes_sidebar_left.py`
+- Modify: `tldw_chatbook/Widgets/Note_Widgets/notes_sidebar_right.py`
+- Test: `Tests/UI/test_library_workspace_visibility.py`
+- Test: `Tests/UI/test_notes_workspace_visibility.py`
+- Test: `Tests/UI/test_notes_screen.py`
+
+- [ ] **Step 1: Write Library visibility tests**
+
+```python
+async def test_library_shows_cross_workspace_item_but_disables_staging(app) -> None:
+    registry = app.workspace_registry_service
+    registry.create_workspace(workspace_id="ws-a", name="A")
+    registry.create_workspace(workspace_id="ws-b", name="B")
+    registry.set_active_workspace("ws-a")
+    registry.link_membership("ws-b", item_type="note", item_id="note-b", role="source")
+
+    # Mount Library and select note-b.
+    assert screen.query_one("#library-note-workspace-badge").renderable == "Workspace: B"
+    assert screen.query_one("#library-use-in-console").disabled is True
+```
+
+- [ ] **Step 2: Write Notes visibility tests**
+
+Assert a note from workspace B remains visible and editable while active workspace A is selected, but `Use in Console` is disabled with copy/link recovery copy.
+
+- [ ] **Step 3: Run tests and confirm they fail**
+
+Run: `python -m pytest -q Tests/UI/test_library_workspace_visibility.py Tests/UI/test_notes_workspace_visibility.py --tb=short`
+
+Expected: fail because membership badges and eligibility gates do not exist.
+
+- [ ] **Step 4: Implement item context helpers**
+
+`item_context.py` should convert item IDs into:
+
+- `workspace_ids`
+- `workspace_labels`
+- `active_context_eligible`
+- `eligibility_reason`
+- `recovery_copy`
+
+Do not filter item lists in this helper.
+
+- [ ] **Step 5: Wire Library**
+
+Library should keep all local Notes/Media/Conversations visible. Add badges and disabled active-context action states. `Search/RAG` can search globally, but `Use in Console` must respect active workspace eligibility.
+
+- [ ] **Step 6: Wire Notes**
+
+Notes should keep global browse/edit behavior. Workspace badges and disabled `Use in Chat` recovery copy must be visible in right-side or detail context.
+
+- [ ] **Step 7: Run focused tests**
+
+Run: `python -m pytest -q Tests/UI/test_library_workspace_visibility.py Tests/UI/test_notes_workspace_visibility.py Tests/UI/test_notes_screen.py --tb=short`
+
+Expected: pass.
+
+- [ ] **Step 8: Capture actual screenshots**
+
+Capture:
+
+- Library showing a cross-workspace source with disabled staging.
+- Notes showing a cross-workspace note still editable but not stageable.
+- Console after attempting a blocked cross-workspace staging action, showing recovery copy.
+
+Wait for user approval before closing this UI task.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add tldw_chatbook/Workspaces/item_context.py tldw_chatbook/UI/Screens/library_screen.py tldw_chatbook/UI/Screens/notes_screen.py tldw_chatbook/Widgets/Note_Widgets/notes_sidebar_left.py tldw_chatbook/Widgets/Note_Widgets/notes_sidebar_right.py Tests/UI/test_library_workspace_visibility.py Tests/UI/test_notes_workspace_visibility.py Tests/UI/test_notes_screen.py Docs/superpowers/qa/product-maturity/phase-4
+git commit -m "feat: show workspace eligibility in library and notes"
+```
+
+## Task 6: Workspace Manifest And User-Visible Audit
+
+**Files:**
+- Modify: `tldw_chatbook/Workspaces/models.py`
+- Modify: `tldw_chatbook/Workspaces/manifest.py`
+- Modify: `tldw_chatbook/Workspaces/registry_service.py`
+- Test: `Tests/Workspaces/test_workspace_manifest.py`
+- Test: `Tests/Sync_Interop/test_envelope_builder.py`
+
+- [ ] **Step 1: Write manifest tests**
+
+```python
+def test_manifest_classifies_copy_reference_and_local_only_sources() -> None:
+    manifest = build_workspace_manifest(
+        workspace=workspace,
+        memberships=memberships,
+        source_policy=StaticSourcePolicy({
+            "file-1": "copy",
+            "remote-1": "reference",
+            "secret-1": "local-only",
+        }),
+    )
+
+    assert manifest.sources["file-1"].transfer_mode == "copy"
+    assert manifest.sources["remote-1"].transfer_mode == "reference"
+    assert manifest.sources["secret-1"].blocked_reason == "local_only"
+    assert manifest.audit.redactions
+```
+
+- [ ] **Step 2: Run tests and confirm they fail**
+
+Run: `python -m pytest -q Tests/Workspaces/test_workspace_manifest.py --tb=short`
+
+Expected: fail because manifest builder does not exist.
+
+- [ ] **Step 3: Implement manifest builder**
+
+Manifest must include:
+
+- Workspace identity and authority.
+- Source, conversation, note, artifact, ACP run, MCP/tool, schedule, workflow, runtime binding summaries.
+- Transfer mode per source: `copy`, `reference`, `metadata-only`, `local-only`.
+- Redaction report.
+- User-visible audit summary.
+- Non-restorable runtime binding list.
+
+- [ ] **Step 4: Extend sync envelope only if required**
+
+If manifest packages need an envelope, add a small builder method to `SyncEnvelopeBuilder`. Do not alter existing note/chat/source cache envelope behavior.
+
+- [ ] **Step 5: Run focused tests**
+
+Run: `python -m pytest -q Tests/Workspaces/test_workspace_manifest.py Tests/Sync_Interop/test_envelope_builder.py --tb=short`
+
+Expected: pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/Workspaces/models.py tldw_chatbook/Workspaces/manifest.py tldw_chatbook/Workspaces/registry_service.py tldw_chatbook/Sync_Interop/envelope_builder.py Tests/Workspaces/test_workspace_manifest.py Tests/Sync_Interop/test_envelope_builder.py
+git commit -m "feat: build workspace handoff manifests"
+```
+
+## Task 7: ACP Task/Run Package Handoff Dry Run
+
+**Files:**
+- Modify: `tldw_chatbook/Workspaces/handoff_service.py`
+- Modify: `tldw_chatbook/MCP/unified_control_plane_service.py`
+- Modify: `tldw_chatbook/UI/Screens/acp_screen.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`
+- Test: `Tests/Workspaces/test_workspace_handoff_service.py`
+- Test: `Tests/MCP/test_unified_control_plane_service.py`
+- Test: `Tests/UI/test_console_live_work_handoffs.py`
+
+- [ ] **Step 1: Write ACP package dry-run tests**
+
+```python
+def test_acp_handoff_preflight_includes_task_run_and_required_sources() -> None:
+    result = handoff_service.preflight_acp_run_package(
+        workspace_id="ws-a",
+        acp_run_id="run-1",
+    )
+
+    assert result.status == "ready"
+    assert result.primary_target == "acp_task_run"
+    assert result.audit.user_visible is True
+    assert "run-1" in result.manifest.acp_runs
+```
+
+- [ ] **Step 2: Write blocked runtime tests**
+
+Assert missing ACP runtime returns `runtime-missing` and clear recovery copy, not a false ready state.
+
+- [ ] **Step 3: Run tests and confirm they fail**
+
+Run: `python -m pytest -q Tests/Workspaces/test_workspace_handoff_service.py Tests/UI/test_console_live_work_handoffs.py --tb=short`
+
+Expected: fail because ACP package preflight is not implemented.
+
+- [ ] **Step 4: Implement dry-run preflight**
+
+The first implementation creates no server records. It returns a manifest, transfer plan, audit details, and blocked runtime reasons.
+
+- [ ] **Step 5: Wire ACP/Console UI states**
+
+ACP and Console may expose `Prepare handoff` only when a package is available. The action opens a preflight summary; it does not perform background sync.
+
+- [ ] **Step 6: Run focused tests**
+
+Run: `python -m pytest -q Tests/Workspaces/test_workspace_handoff_service.py Tests/MCP/test_unified_control_plane_service.py Tests/UI/test_console_live_work_handoffs.py --tb=short`
+
+Expected: pass.
+
+- [ ] **Step 7: Capture actual screenshots**
+
+Capture:
+
+- ACP run package preflight ready state.
+- ACP runtime missing blocked state.
+- Console live-work handoff summary.
+
+Wait for user approval before marking this UI flow accepted.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tldw_chatbook/Workspaces/handoff_service.py tldw_chatbook/MCP/unified_control_plane_service.py tldw_chatbook/UI/Screens/acp_screen.py tldw_chatbook/UI/Screens/chat_screen.py Tests/Workspaces/test_workspace_handoff_service.py Tests/MCP/test_unified_control_plane_service.py Tests/UI/test_console_live_work_handoffs.py Docs/superpowers/qa/product-maturity/phase-4
+git commit -m "feat: add acp workspace handoff preflight"
+```
+
+## Task 8: Manual Server Handoff Boundary
+
+**Files:**
+- Modify: `tldw_chatbook/Workspaces/handoff_service.py`
+- Create: `tldw_chatbook/tldw_api/workspace_handoff_schemas.py`
+- Modify: `tldw_chatbook/tldw_api/__init__.py`
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`
+- Test: `Tests/Workspaces/test_workspace_handoff_service.py`
+- Test: `Tests/tldw_api/test_workspace_handoff_schemas.py`
+
+- [ ] **Step 1: Write manual handoff schema tests**
+
+```python
+def test_server_handoff_request_preserves_copy_and_reference_modes() -> None:
+    request = WorkspaceHandoffRequest.model_validate({
+        "workspace_id": "ws-a",
+        "direction": "local-to-server",
+        "sources": [
+            {"source_id": "file-1", "transfer_mode": "copy"},
+            {"source_id": "url-1", "transfer_mode": "reference"},
+        ],
+    })
+
+    assert [source.transfer_mode for source in request.sources] == ["copy", "reference"]
+```
+
+- [ ] **Step 2: Run tests and confirm they fail**
+
+Run: `python -m pytest -q Tests/tldw_api/test_workspace_handoff_schemas.py Tests/Workspaces/test_workspace_handoff_service.py --tb=short`
+
+Expected: fail because schemas and manual handoff boundary are missing.
+
+- [ ] **Step 3: Add schemas and service boundary**
+
+Add request/response schemas only. Do not start background sync. Do not assume server endpoint names until server API is confirmed.
+
+- [ ] **Step 4: Add UI preflight copy**
+
+Console/Library can show `Manual handoff prepared` and export/copy manifest JSON. If server transport is unavailable, show `Server handoff transport not configured`.
+
+- [ ] **Step 5: Run focused tests**
+
+Run: `python -m pytest -q Tests/tldw_api/test_workspace_handoff_schemas.py Tests/Workspaces/test_workspace_handoff_service.py --tb=short`
+
+Expected: pass.
+
+- [ ] **Step 6: Capture actual screenshots**
+
+Capture:
+
+- Manual handoff preflight summary.
+- Server transport unavailable state.
+- Manifest audit details expanded.
+
+Wait for user approval before closing the UI flow.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tldw_chatbook/Workspaces/handoff_service.py tldw_chatbook/tldw_api/workspace_handoff_schemas.py tldw_chatbook/tldw_api/__init__.py tldw_chatbook/UI/Screens/library_screen.py tldw_chatbook/UI/Screens/chat_screen.py Tests/tldw_api/test_workspace_handoff_schemas.py Tests/Workspaces/test_workspace_handoff_service.py Docs/superpowers/qa/product-maturity/phase-4
+git commit -m "feat: define manual workspace handoff boundary"
+```
+
+## Task 9: Cross-Screen Actual-Use QA And Closeout
+
+**Files:**
+- Create: `Docs/superpowers/qa/product-maturity/phase-4/workspace-operating-context-qa.md`
+- Modify: `Docs/superpowers/trackers/product-maturity-roadmap.md`
+- Modify: relevant `backlog/tasks/task-*.md` implementation notes
+- Test: `Tests/UI/test_product_maturity_phase3_layout_contracts.py`
+- Test: `Tests/UI/test_post_release_ux_hci_validation_plan.py`
+
+- [ ] **Step 1: Write QA checklist before running it**
+
+The QA document must include:
+
+- Console active workspace switch.
+- Console staged context eligibility.
+- Library global search with workspace badges.
+- Notes cross-workspace edit plus blocked staging.
+- Artifacts Chatbook membership and resume.
+- ACP task/run package preflight.
+- Manual server handoff preflight.
+- Keyboard-only path through affected controls.
+
+- [ ] **Step 2: Run automated closeout suite**
+
+Run: `python -m pytest -q Tests/Workspaces Tests/UI/test_console_workspace_context_rail.py Tests/UI/test_library_workspace_visibility.py Tests/UI/test_notes_workspace_visibility.py Tests/UI/test_product_maturity_phase3_layout_contracts.py Tests/UI/test_post_release_ux_hci_validation_plan.py --tb=short`
+
+Expected: pass.
+
+- [ ] **Step 3: Run actual-use walkthrough**
+
+Use textual-web/CDP or actual terminal screenshots. Record each screenshot path and whether the user approved it.
+
+- [ ] **Step 4: Update roadmap and backlog**
+
+Only mark tasks Done when:
+
+- Acceptance criteria are checked.
+- Automated tests pass.
+- Actual rendered screenshots are approved for changed UI states.
+- QA note records what was verified and what remains uncertain.
+
+- [ ] **Step 5: Run final hygiene**
+
+Run: `git diff --check`
+
+Expected: no whitespace errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Docs/superpowers/qa/product-maturity/phase-4/workspace-operating-context-qa.md Docs/superpowers/trackers/product-maturity-roadmap.md backlog/tasks
+git commit -m "docs: close workspace operating context QA"
+```
+
+## Recommended PR Slicing
+
+1. `PR A - Workspace domain foundation`: Tasks 1 and 2.
+2. `PR B - Console workspace context rail`: Task 3.
+3. `PR C - Active workspace conversations`: Task 4.
+4. `PR D - Global visibility with eligibility gates`: Task 5.
+5. `PR E - Manifest and ACP package preflight`: Tasks 6 and 7.
+6. `PR F - Manual server handoff boundary`: Task 8.
+7. `PR G - QA closeout`: Task 9.
+
+Do not batch UI PRs unless the user approves screenshots for every affected screen before merge.
+
+## Final Verification Commands
+
+Run these before marking the implementation tranche complete:
+
+```bash
+python -m pytest -q Tests/Workspaces --tb=short
+python -m pytest -q Tests/UI/test_console_workspace_context_rail.py Tests/UI/test_library_workspace_visibility.py Tests/UI/test_notes_workspace_visibility.py --tb=short
+python -m pytest -q Tests/UI/test_product_maturity_phase3_layout_contracts.py Tests/UI/test_post_release_ux_hci_validation_plan.py --tb=short
+python -m pytest -q Tests/Sync_Interop/test_envelope_builder.py Tests/MCP/test_unified_control_plane_service.py --tb=short
+git diff --check
+```
+
+Expected: all pytest commands pass and `git diff --check` reports no whitespace errors.
+
+## Residual Risks To Track
+
+- Existing Notes workspace services are server-oriented. The local registry must not accidentally make server workspace APIs look ready when only local metadata exists.
+- A separate `WorkspaceDB` avoids bloating `ChaChaNotes_DB.py`, but cross-DB transactions are not atomic. If later implementation needs atomic conversation plus workspace membership writes, promote those specific writes through a service-level transaction boundary or migrate narrowly.
+- Source copy/reference policy needs server policy confirmation before real upload.
+- ACP task/run packages can be preflighted before runtime recreation is safe; do not overpromise resume semantics.
+- User-visible audit can be verbose. UI should collapse details but keep export/reveal paths available.

--- a/Docs/superpowers/specs/2026-05-20-workspace-operating-context-handoff-prd-design.md
+++ b/Docs/superpowers/specs/2026-05-20-workspace-operating-context-handoff-prd-design.md
@@ -1,0 +1,402 @@
+# Workspace Operating Context And Handoff PRD
+
+Date: 2026-05-20
+Status: Draft PRD for user review
+Primary Repo: `tldw_chatbook`
+Adjacent Repo: `rmusser01/tldw_server`
+Scope: Product and architecture contract for Chatbook workspaces as portable operating contexts, including Console UX implications, local/server sync, and handoff boundaries.
+
+## Summary
+
+`tldw_chatbook` needs a canonical workspace model before the Console left rail can safely expose a real workspace switcher.
+
+The requested Console change is visually small: split the left panel into an upper `Staged Context` section and a lower `Convos & Workspaces` section. The underlying product requirement is larger. A workspace is not just a filter. It is the operating context that binds source material, conversations, notes, artifacts, ACP sessions, tool/runtime state, git worktrees, and sandbox/container/VM filesystem bindings.
+
+This PRD defines the target model and the phased path. The current Console implementation should pause on functional workspace switching until this contract is approved. A visual shell can be implemented first only if it stays honest about unavailable workspace switching.
+
+## Inputs
+
+- `Docs/superpowers/specs/2026-05-02-new-user-first-run-shell-ux-design.md`
+- `Docs/superpowers/specs/2026-05-02-agentic-terminal-design-system-design.md`
+- `Docs/superpowers/specs/2026-05-06-destination-layout-ia-contracts-design.md`
+- `Docs/superpowers/specs/2026-04-19-chat-conversations-parity-vertical-design.md`
+- `tldw_chatbook/Chat/chat_persistence_service.py`
+- `tldw_chatbook/Chat/server_chat_conversation_service.py`
+- `tldw_chatbook/UI/Screens/notes_scope_models.py`
+- `tldw_chatbook/UX_Interop/server_parity_contracts.py`
+- `tldw_server` issue [#1526: Product roadmap: canonical workspace and server-backed workspace record](https://github.com/rmusser01/tldw_server/issues/1526)
+- `tldw_server` issue [#1440: Track prototype workspace collaboration productionization](https://github.com/rmusser01/tldw_server/issues/1440)
+- `tldw_server` issue [#1528: Product roadmap: connector and MCP pack productization](https://github.com/rmusser01/tldw_server/issues/1528)
+- `tldw_server2/apps/packages/ui/src/store/workspace.ts`
+- `tldw_server2/apps/packages/ui/src/components/Option/ChatWorkspace/*`
+- `tldw_server2/tldw_Server_API/app/core/Agent_Orchestration/models.py`
+- `tldw_server2/tools/tldw-agent/internal/workspace/session.go`
+
+## Current Evidence And Gaps
+
+The existing codebase already has partial seams, but not a complete workspace operating-context model.
+
+Current useful anchors:
+
+- `ChatPersistenceService.create_conversation()` accepts `scope_type` and `workspace_id`.
+- `ServerChatConversationService.delete_conversation()` can pass `scope_type` and `workspace_id` to the server.
+- Notes has explicit `ScopeType.WORKSPACE` state plus selected workspace, workspace note, source, and artifact identifiers.
+- `WorkspaceIsolationContract` and `FutureSyncStatusContract` already model workspace isolation and future sync status at the server-parity contract layer.
+- The current Console left rail is a single `ConsoleStagedContextTray`, so there is a clear widget seam for a two-section rail.
+- `tldw_server` issue #1526 explicitly frames workspace as the product unit for sources, chats, notes, generated artifacts, task-agent runs, decisions, and review history.
+
+Current gaps:
+
+- Chatbook does not yet have a single local workspace registry that owns workspace identity and lifecycle.
+- Workspace membership is not consistently enforced across conversations, sources, artifacts, notes, ACP, MCP, schedules, workflows, and Chatbooks.
+- Sync/handoff is not implemented. Existing contracts describe future sync state but do not perform local/server migration.
+- Runtime bindings are not portable. A local path, git worktree, container, VM, or ACP session cannot currently be moved as a safe, user-visible package.
+- Console can show staged context, but it cannot yet truthfully switch the current operating workspace.
+
+## Recommended Initial Product Decisions
+
+These decisions keep the first implementation useful without overreaching.
+
+- Do not add a new top-level `Workspaces` destination in v1. Expose workspace context in Console and deeper workspace management under Library until the model proves it needs a dedicated destination.
+- Start with manual push/pull handoff. Background write sync should remain deferred until conflict handling and replay safety are proven.
+- Treat moving a conversation between workspaces as a fork with provenance, not a silent reassignment.
+- Make v1 runtime bindings metadata-first. Local filesystem and git worktree bindings can be described and validated; ACP sessions, containers, and VMs should be inspect-only until recreation safety is designed.
+- Ship the Console `Convos & Workspaces` rail as read-only first if the persistence model is not ready. Disabled controls must explain what is missing.
+
+## Problem Statement
+
+The current Chatbook Console is becoming the primary agentic control surface. Users now need a way to understand and switch the current operating context without leaving Console.
+
+The risk is building a narrow UI selector that looks like a workspace switcher but does not actually protect workspace boundaries. If a workspace owns conversations, sources, ACP sessions, git worktrees, and runtime state, then switching the workspace affects:
+
+- which conversations are visible and resumable.
+- which Library/RAG sources can be staged.
+- which Chatbooks and artifacts are in scope.
+- which ACP sessions and tool permissions are valid.
+- which git worktree or sandbox filesystem the agent may read or edit.
+- whether data is local-only, server-backed, syncing, conflicted, or portable.
+
+Without a product contract, UI work can create false affordances, leak data across workspaces, or make local/server handoff impossible to reason about.
+
+## Goals
+
+- Define `Workspace` as Chatbook's portable operating-context package.
+- Keep Console as the primary live work surface while giving it visible workspace context.
+- Support future local-to-server and server-to-local handoff of active work.
+- Preserve strict conversation and source isolation by workspace.
+- Make local, server, syncing, conflict, detached, and unavailable states visible.
+- Align Chatbook with the `tldw_server` canonical workspace roadmap instead of inventing a second model.
+- Decompose the work into PR-sized phases with screenshot-based UX approval gates.
+
+## Non-Goals
+
+- Do not implement full real-time collaboration in this PRD.
+- Do not wire a functional workspace switcher before workspace persistence and isolation rules exist.
+- Do not replace the current Console transcript/composer work.
+- Do not move all workspace management into Console. Console displays and uses the active workspace; Library, ACP, MCP, Artifacts, and Settings retain their own ownership boundaries.
+- Do not make ACP runtime setup a Settings concern. ACP owns runtime/session setup; Settings owns global defaults.
+- Do not collapse MCP tools into generic settings. MCP remains server-first with tool bundles scoped by workspace policy later.
+- Do not make server sync mandatory for local-first use.
+
+## Product Model
+
+### Workspace
+
+A workspace is a named operating context containing or referencing:
+
+- Library sources: files, media, notes, conversations, snippets, citations, imports, and search/RAG evidence.
+- Conversations: global or workspace-scoped chat sessions, including active drafts and message variants.
+- Artifacts: Chatbooks, generated outputs, reports, datasets, and saved deliverables.
+- Notes and study state: workspace notes, flashcards, quizzes, and study packs.
+- ACP state: agent sessions, task runs, approvals, review history, and runtime readiness.
+- MCP/tool state: enabled servers, workspace-scoped tools, trusted paths, and policies.
+- Filesystem/runtime bindings: local directory, git repository, git worktree, sandbox/container/VM root, or remote runtime binding.
+- Sync metadata: local identity, server identity, version, authority, conflict state, and handoff history.
+
+### Conversation Scope
+
+Conversation scope must remain explicit:
+
+| Scope | Meaning |
+| --- | --- |
+| `global` | General Console conversation, not bound to a workspace. |
+| `workspace` | Conversation belongs to exactly one workspace and must not appear in another workspace's conversation list. |
+
+Existing Chatbook code already has `scope_type` and `workspace_id` seams in chat persistence and server conversation deletion. The PRD treats those as compatibility anchors, not a complete workspace implementation.
+
+### Workspace Authority
+
+Every workspace has one visible authority state:
+
+| Authority | Meaning |
+| --- | --- |
+| `local-only` | Workspace exists only in this Chatbook instance. |
+| `server-backed` | Workspace has a durable server identity and can be resumed from server. |
+| `syncing-to-server` | Local package is uploading or reconciling to server. |
+| `syncing-from-server` | Server package is materializing locally. |
+| `conflict` | Local and server state disagree and need user choice. |
+| `detached` | Local workspace was once server-backed but cannot verify the server identity. |
+| `remote-only` | Server workspace is visible but not materialized locally. |
+| `runtime-missing` | Metadata exists, but the ACP/runtime/filesystem binding cannot be restored. |
+
+## Console UX Contract
+
+The Console left rail should become a two-section context rail.
+
+```text
++------------------------------------------+
+| Staged Context                           |
+| No live work item is staged.             |
+| Attach Library, runs, Artifacts, or RAG. |
+| [Open Library]                           |
++------------------------------------------+
+| Convos & Workspaces                      |
+| Workspace: Local Research                |
+| Authority: local-only | Sync: Not set    |
+| Runtime: local fs | ACP: none            |
+|                                          |
+| Conversations                            |
+| > Chat 1                  workspace      |
+|   API migration notes     2h ago         |
+|   Untitled draft          unsaved        |
+|                                          |
+| [Change workspace] [New conversation]    |
++------------------------------------------+
+```
+
+### Section Behavior
+
+`Staged Context` remains the fast answer to "what will this send/use right now?"
+
+`Convos & Workspaces` answers:
+
+- What workspace am I operating in?
+- Is this workspace local, server-backed, syncing, or conflicted?
+- Which conversations are available in this workspace?
+- Is the current conversation global or workspace-bound?
+- What runtime or ACP binding will the agent use?
+
+### Immediate UI Boundary
+
+A shell-only PR may split the rail and show read-only workspace/conversation metadata. It must not pretend to support true workspace switching.
+
+Until the workspace model exists:
+
+- `Change workspace` should be disabled or open an explanatory unavailable state.
+- Conversation rows should come only from currently trustworthy session metadata.
+- Any missing workspace service must render as `No workspace selected` or `Workspace service not ready`, not as a fake default workspace.
+- Screenshot approval is required before this shell ships.
+
+## Handoff Model
+
+### Local To Server
+
+When a user hands off an active local workspace to a server:
+
+1. Chatbook builds a workspace manifest.
+2. Chatbook validates what can be transferred, referenced, redacted, or must remain local.
+3. The user sees a preflight summary: sources, conversations, artifacts, ACP sessions, runtime bindings, secrets omitted, and conflicts.
+4. Chatbook creates or upserts a server workspace record.
+5. Transfer proceeds in resumable stages.
+6. The active Console context changes to `syncing-to-server`, then `server-backed` or `conflict`.
+7. Any untransferable runtime binding becomes an explicit recovery item.
+
+### Server To Local
+
+When a user pulls a server workspace into Chatbook:
+
+1. Chatbook fetches the workspace manifest and compatibility metadata.
+2. The user chooses materialization scope: metadata only, sources and conversations, or full local package where supported.
+3. Chatbook maps remote sources to local references or downloads copies according to policy.
+4. Runtime bindings are recreated only if safe and explicitly approved.
+5. The workspace enters `syncing-from-server`, then `server-backed`, `runtime-missing`, or `conflict`.
+
+### Round Trip
+
+Round-trip handoff is allowed only when identity and version checks pass:
+
+- local workspace id.
+- server workspace id.
+- manifest version.
+- content hashes or stable external references.
+- conversation scope keys.
+- ACP/session/run lineage.
+- source membership lineage.
+
+If checks fail, the user must choose merge, fork, replace local, replace server, or cancel.
+
+## Workspace Manifest
+
+The manifest is the portability contract. It should be versioned and serializable.
+
+Minimum fields:
+
+- `manifest_version`
+- `workspace_id`
+- `server_workspace_id`
+- `display_name`
+- `description`
+- `authority_state`
+- `created_at`
+- `updated_at`
+- `owner`
+- `source_memberships`
+- `conversation_memberships`
+- `artifact_memberships`
+- `note_memberships`
+- `study_memberships`
+- `acp_session_bindings`
+- `mcp_policy_bindings`
+- `runtime_bindings`
+- `sync_state`
+- `conflict_state`
+- `redaction_report`
+- `handoff_history`
+
+Runtime bindings must not contain raw secrets. Environment variables, keys, tokens, private filesystem paths, and server credentials need explicit redaction or pointer semantics.
+
+## Data And Service Boundaries
+
+### Chatbook Local
+
+Chatbook owns:
+
+- local workspace cache and local-only workspace records.
+- local conversation association.
+- local source and artifact references.
+- user-visible sync state.
+- local runtime binding inspection.
+- export/import package creation.
+
+### Server
+
+The server owns:
+
+- canonical server workspace records.
+- server-side workspace authorization.
+- team ownership, retention, audit, and governance later.
+- server-side source/artifact/task membership.
+- server-backed ACP task/session state.
+- sharing and collaborator flows.
+
+### ACP
+
+ACP owns:
+
+- ACP workspace/session runtime setup.
+- agent task/run state.
+- branch/session/runtime payload validation.
+- execution-specific recovery.
+
+Console may inspect or follow ACP state, but it should not become the ACP setup surface.
+
+### MCP
+
+MCP owns:
+
+- server/tool lifecycle.
+- workspace-specific tool bundles.
+- trusted path and governance policy.
+
+Console may show tool readiness and use tools in context, but MCP server management stays in MCP.
+
+## Security And Privacy Requirements
+
+- Workspace export/handoff must show a redaction report before transfer.
+- Secrets and credentials are never embedded directly in a workspace manifest.
+- Filesystem paths must be classified as portable, local-only, or unsafe.
+- Server workspace reads and writes must enforce exact workspace scope.
+- ACP runtime payloads must be validated before local execution.
+- Cross-workspace reads and writes default to denied.
+- Audit events are required for server handoff, server pull, share, conflict resolution, and runtime binding recreation.
+
+## Error And Recovery States
+
+Every workspace-aware surface needs visible recovery for:
+
+- server unreachable.
+- server auth expired.
+- workspace not found.
+- workspace archived or deleted.
+- missing local source file.
+- missing local git worktree.
+- dirty or conflicted git worktree.
+- unavailable sandbox/container/VM runtime.
+- ACP session cannot resume.
+- MCP tool disabled by policy.
+- conversation belongs to another workspace.
+- source exists but embeddings/RAG index are not ready.
+- partial transfer interrupted.
+- manifest version unsupported.
+
+## Phased Implementation Plan
+
+### Phase 0: PRD And Decision Record
+
+- Approve this PRD.
+- Add a decision record for Chatbook's workspace model and server alignment.
+- Decide whether Chatbook introduces a top-level Workspaces destination later or keeps workspace management distributed under Library/Console/Home.
+
+### Phase 1: Console Context Rail Shell
+
+- Split Console left rail into `Staged Context` and `Convos & Workspaces`.
+- Show current conversation scope and read-only workspace/session metadata.
+- Keep workspace switching disabled unless a real service is present.
+- Add screenshot approval gate for the rendered Console.
+
+### Phase 2: Local Workspace Registry
+
+- Add local workspace records and service APIs.
+- Associate conversations, source refs, notes, and artifacts with workspace ids.
+- Support create, rename, archive, delete, switch, and list operations.
+- Enforce global vs workspace conversation filtering.
+
+### Phase 3: Workspace Package Manifest
+
+- Define export/import manifest schema.
+- Add dry-run validation for missing files, unsupported source refs, and redacted values.
+- Add local package export/import with no server requirement.
+
+### Phase 4: Server Bridge
+
+- Add server workspace identity mapping.
+- Add local-to-server and server-to-local dry-run flows.
+- Add resumable handoff status and conflict reporting.
+- Keep write sync disabled until conflict semantics are proven.
+
+### Phase 5: ACP, MCP, And Runtime Bindings
+
+- Add ACP session/run bindings to the manifest.
+- Add git worktree and sandbox/container/VM binding descriptors.
+- Add MCP policy/tool bundle references.
+- Require explicit user approval before recreating executable/runtime bindings.
+
+### Phase 6: UX Closeout And Cross-Screen QA
+
+- Verify Home, Console, Library, Artifacts, ACP, MCP, Schedules, Workflows, and Skills against the same active workspace.
+- Verify local-only, server-backed, syncing, conflict, and runtime-missing states.
+- Capture actual Textual Web/CDP screenshots for every affected screen before approval.
+
+## Testing And QA Requirements
+
+- Unit tests for manifest validation, redaction, scope filtering, and conflict classification.
+- Service tests for local workspace CRUD and conversation/source/artifact membership.
+- Mounted Textual tests for the Console context rail shell.
+- Contract tests for local/server authority labels and disabled-action recovery copy.
+- Integration tests for local export/import dry runs.
+- Later server integration tests for handoff preflight and interrupted-transfer resume.
+- Actual CDP screenshots for every UI approval gate.
+
+## Remaining Open Questions
+
+1. After v1 proves out, should Chatbook promote workspace management to a top-level destination or keep it distributed across Console, Library, Home, and Settings?
+2. Should local-to-server handoff copy source content, upload references, or support both depending on source type and policy?
+3. What is the first server-backed handoff target: source/conversation metadata only, full Chatbook packages, or ACP task/run packages?
+4. What audit detail must be visible to users versus stored only for diagnostics?
+5. How should shared or collaborator workspaces map to local-only Chatbook profiles when the user is offline?
+
+## Approval Gate
+
+Implementation should not resume on workspace switching until this PRD is reviewed and approved.
+
+If only the visual left-rail split is approved first, it must ship as a read-only shell with honest disabled states and actual screenshot approval.

--- a/Docs/superpowers/specs/2026-05-20-workspace-operating-context-handoff-prd-design.md
+++ b/Docs/superpowers/specs/2026-05-20-workspace-operating-context-handoff-prd-design.md
@@ -49,6 +49,7 @@ Current gaps:
 
 - Chatbook does not yet have a single local workspace registry that owns workspace identity and lifecycle.
 - Workspace membership is not consistently enforced across conversations, sources, artifacts, notes, ACP, MCP, schedules, workflows, and Chatbooks.
+- Chatbook does not yet distinguish item visibility from active-context eligibility. Workspace switching must not make Notes or Library items disappear.
 - Sync/handoff is not implemented. Existing contracts describe future sync state but do not perform local/server migration.
 - Runtime bindings are not portable. A local path, git worktree, container, VM, or ACP session cannot currently be moved as a safe, user-visible package.
 - Console can show staged context, but it cannot yet truthfully switch the current operating workspace.
@@ -58,10 +59,28 @@ Current gaps:
 These decisions keep the first implementation useful without overreaching.
 
 - Do not add a new top-level `Workspaces` destination in v1. Expose workspace context in Console and deeper workspace management under Library until the model proves it needs a dedicated destination.
+- Workspace switching changes active-context eligibility, not Library or Notes visibility. Users can still see, search, open, and edit items from other workspaces, but cannot stage them into the active Console context unless they belong to the current workspace or are explicitly copied/linked into it.
 - Start with manual push/pull handoff. Background write sync should remain deferred until conflict handling and replay safety are proven.
+- Support both source-content copy and source-reference upload in local-to-server handoff. The default should depend on source type, source location, server policy, and user choice.
+- Make the first server-backed handoff target ACP task/run packages, because this is the highest-value portable operating-context use case.
 - Treat moving a conversation between workspaces as a fork with provenance, not a silent reassignment.
 - Make v1 runtime bindings metadata-first. Local filesystem and git worktree bindings can be described and validated; ACP sessions, containers, and VMs should be inspect-only until recreation safety is designed.
+- Expose audit and diagnostic detail to users by default. The UI may collapse verbose details, but it should not hide them behind developer-only logs. Secrets still require explicit redaction/reveal handling.
+- Shared or collaborator workspace packages should degrade to a single-user local workspace when offline.
 - Ship the Console `Convos & Workspaces` rail as read-only first if the persistence model is not ready. Disabled controls must explain what is missing.
+
+## Workspace Unification Model
+
+Workspace unification should happen through a shared registry and shared context contract, not by turning every screen into a workspace screen.
+
+The unified model has four layers:
+
+1. `Workspace Registry`: the durable list of local and server-backed workspace records, membership tags, authority state, sync state, and runtime bindings.
+2. `Active Workspace Context`: the current operating workspace used by Console, ACP, MCP, Workflows, Schedules, and context staging.
+3. `Global Item Browser`: Library, Notes, Artifacts, and search surfaces can show all user-owned items with workspace tags and eligibility badges.
+4. `Context Eligibility Gate`: actions that involve the active Console context, agent manipulation, RAG staging, ACP runs, or tool use are allowed only when the selected item belongs to the active workspace or is explicitly copied/linked into it.
+
+If a future top-level `Workspaces` destination is added, it should be a management and status surface over the same registry: workspace list, sync health, memberships, handoff actions, audit logs, and runtime bindings. It must not become a second Library or a second Console.
 
 ## Problem Statement
 
@@ -69,9 +88,9 @@ The current Chatbook Console is becoming the primary agentic control surface. Us
 
 The risk is building a narrow UI selector that looks like a workspace switcher but does not actually protect workspace boundaries. If a workspace owns conversations, sources, ACP sessions, git worktrees, and runtime state, then switching the workspace affects:
 
-- which conversations are visible and resumable.
-- which Library/RAG sources can be staged.
-- which Chatbooks and artifacts are in scope.
+- which conversations are eligible for the active Console context.
+- which Library/RAG sources can be staged, not which sources can be viewed.
+- which Chatbooks and artifacts can be used by the active workspace.
 - which ACP sessions and tool permissions are valid.
 - which git worktree or sandbox filesystem the agent may read or edit.
 - whether data is local-only, server-backed, syncing, conflicted, or portable.
@@ -83,7 +102,7 @@ Without a product contract, UI work can create false affordances, leak data acro
 - Define `Workspace` as Chatbook's portable operating-context package.
 - Keep Console as the primary live work surface while giving it visible workspace context.
 - Support future local-to-server and server-to-local handoff of active work.
-- Preserve strict conversation and source isolation by workspace.
+- Preserve global visibility and search across Library, Notes, Artifacts, and conversations while enforcing strict active-context eligibility by workspace.
 - Make local, server, syncing, conflict, detached, and unavailable states visible.
 - Align Chatbook with the `tldw_server` canonical workspace roadmap instead of inventing a second model.
 - Decompose the work into PR-sized phases with screenshot-based UX approval gates.
@@ -123,6 +142,26 @@ Conversation scope must remain explicit:
 | `workspace` | Conversation belongs to exactly one workspace and must not appear in another workspace's conversation list. |
 
 Existing Chatbook code already has `scope_type` and `workspace_id` seams in chat persistence and server conversation deletion. The PRD treats those as compatibility anchors, not a complete workspace implementation.
+
+### Visibility Versus Context Eligibility
+
+Workspace switching must not hide user-owned content from Library, Notes, Artifacts, or global search.
+
+Items have workspace membership metadata:
+
+- `workspace_ids`: zero, one, or many workspace memberships.
+- `workspace_labels`: display labels for each membership.
+- `active_context_eligible`: whether the item can be staged, manipulated, or used by the current Console workspace.
+- `eligibility_reason`: user-facing explanation when the item is visible but not eligible.
+
+Examples:
+
+- A user in Workspace A can search, open, and edit a Note from Workspace B in Notes.
+- The same Note cannot be added to Workspace A's active Console context unless the user explicitly copies or links it into Workspace A.
+- Library can show all media and documents with workspace tags.
+- Console staging, agent edits, RAG grounding, ACP runs, and tool actions are limited to the active workspace.
+
+Cross-workspace items should show disabled active-context actions with recovery copy such as `Belongs to Workspace B. Copy or link into Workspace A before staging.`
 
 ### Workspace Authority
 
@@ -175,6 +214,7 @@ The Console left rail should become a two-section context rail.
 - Which conversations are available in this workspace?
 - Is the current conversation global or workspace-bound?
 - What runtime or ACP binding will the agent use?
+- Are visible Library/Notes/Artifact items eligible for the active Console context?
 
 ### Immediate UI Boundary
 
@@ -185,6 +225,7 @@ Until the workspace model exists:
 - `Change workspace` should be disabled or open an explanatory unavailable state.
 - Conversation rows should come only from currently trustworthy session metadata.
 - Any missing workspace service must render as `No workspace selected` or `Workspace service not ready`, not as a fake default workspace.
+- Library and Notes should continue to show all items. Workspace tags and eligibility states should be added before any active-context restrictions are enforced.
 - Screenshot approval is required before this shell ships.
 
 ## Handoff Model
@@ -194,19 +235,28 @@ Until the workspace model exists:
 When a user hands off an active local workspace to a server:
 
 1. Chatbook builds a workspace manifest.
-2. Chatbook validates what can be transferred, referenced, redacted, or must remain local.
+2. Chatbook validates what can be copied, referenced, redacted, or must remain local.
 3. The user sees a preflight summary: sources, conversations, artifacts, ACP sessions, runtime bindings, secrets omitted, and conflicts.
 4. Chatbook creates or upserts a server workspace record.
 5. Transfer proceeds in resumable stages.
 6. The active Console context changes to `syncing-to-server`, then `server-backed` or `conflict`.
 7. Any untransferable runtime binding becomes an explicit recovery item.
 
+The v1 server-backed handoff target is ACP task/run packages. Source and conversation metadata should be included when required to make the ACP package intelligible, but the first proof should optimize around preserving task/run operating context.
+
+Source transfer supports both modes:
+
+- `copy`: upload source content or a portable bundle to the server when policy allows.
+- `reference`: upload a stable source reference, pointer, or metadata-only binding when copying is unnecessary, disallowed, or too expensive.
+
+The handoff preflight must show which mode each source uses.
+
 ### Server To Local
 
 When a user pulls a server workspace into Chatbook:
 
 1. Chatbook fetches the workspace manifest and compatibility metadata.
-2. The user chooses materialization scope: metadata only, sources and conversations, or full local package where supported.
+2. The user chooses materialization scope: metadata only, references, copied source content, or full local package where supported.
 3. Chatbook maps remote sources to local references or downloads copies according to policy.
 4. Runtime bindings are recreated only if safe and explicitly approved.
 5. The workspace enters `syncing-from-server`, then `server-backed`, `runtime-missing`, or `conflict`.
@@ -255,6 +305,8 @@ Minimum fields:
 
 Runtime bindings must not contain raw secrets. Environment variables, keys, tokens, private filesystem paths, and server credentials need explicit redaction or pointer semantics.
 
+Membership fields should not be interpreted as browse filters. They determine active-context eligibility and provenance display. Browsing and search remain global by default unless the user applies an explicit workspace filter.
+
 ## Data And Service Boundaries
 
 ### Chatbook Local
@@ -264,6 +316,8 @@ Chatbook owns:
 - local workspace cache and local-only workspace records.
 - local conversation association.
 - local source and artifact references.
+- cross-workspace Library/Notes/Artifacts browsing with workspace membership labels.
+- active-context eligibility checks for Console staging and agent manipulation.
 - user-visible sync state.
 - local runtime binding inspection.
 - export/import package creation.
@@ -303,11 +357,12 @@ Console may show tool readiness and use tools in context, but MCP server managem
 ## Security And Privacy Requirements
 
 - Workspace export/handoff must show a redaction report before transfer.
+- All audit and diagnostic detail should be user-accessible by default through expandable UI, logs, or export. Diagnostic detail should not be developer-only.
 - Secrets and credentials are never embedded directly in a workspace manifest.
 - Filesystem paths must be classified as portable, local-only, or unsafe.
 - Server workspace reads and writes must enforce exact workspace scope.
 - ACP runtime payloads must be validated before local execution.
-- Cross-workspace reads and writes default to denied.
+- Cross-workspace Console context use and agent manipulation default to denied. Direct user browsing and editing in Library/Notes can remain available when normal item permissions allow it.
 - Audit events are required for server handoff, server pull, share, conflict resolution, and runtime binding recreation.
 
 ## Error And Recovery States
@@ -325,6 +380,7 @@ Every workspace-aware surface needs visible recovery for:
 - ACP session cannot resume.
 - MCP tool disabled by policy.
 - conversation belongs to another workspace.
+- visible item belongs to another workspace and is not active-context eligible.
 - source exists but embeddings/RAG index are not ready.
 - partial transfer interrupted.
 - manifest version unsupported.
@@ -335,7 +391,7 @@ Every workspace-aware surface needs visible recovery for:
 
 - Approve this PRD.
 - Add a decision record for Chatbook's workspace model and server alignment.
-- Decide whether Chatbook introduces a top-level Workspaces destination later or keeps workspace management distributed under Library/Console/Home.
+- Record that workspace unification is a shared registry plus active workspace context, with a possible later top-level management surface only if v1 proves it is needed.
 
 ### Phase 1: Console Context Rail Shell
 
@@ -349,7 +405,8 @@ Every workspace-aware surface needs visible recovery for:
 - Add local workspace records and service APIs.
 - Associate conversations, source refs, notes, and artifacts with workspace ids.
 - Support create, rename, archive, delete, switch, and list operations.
-- Enforce global vs workspace conversation filtering.
+- Add workspace membership labels in Library, Notes, Artifacts, and conversation browsing.
+- Enforce active-context eligibility without hiding cross-workspace Library or Notes items.
 
 ### Phase 3: Workspace Package Manifest
 
@@ -360,7 +417,8 @@ Every workspace-aware surface needs visible recovery for:
 ### Phase 4: Server Bridge
 
 - Add server workspace identity mapping.
-- Add local-to-server and server-to-local dry-run flows.
+- Add local-to-server and server-to-local dry-run flows with both copy and reference transfer modes.
+- Make ACP task/run packages the first server-backed handoff target.
 - Add resumable handoff status and conflict reporting.
 - Keep write sync disabled until conflict semantics are proven.
 
@@ -375,11 +433,12 @@ Every workspace-aware surface needs visible recovery for:
 
 - Verify Home, Console, Library, Artifacts, ACP, MCP, Schedules, Workflows, and Skills against the same active workspace.
 - Verify local-only, server-backed, syncing, conflict, and runtime-missing states.
+- Verify switching workspaces does not hide Library or Notes items, and that cross-workspace items remain viewable/editable while active-context actions are blocked with recovery copy.
 - Capture actual Textual Web/CDP screenshots for every affected screen before approval.
 
 ## Testing And QA Requirements
 
-- Unit tests for manifest validation, redaction, scope filtering, and conflict classification.
+- Unit tests for manifest validation, redaction, membership tagging, active-context eligibility, and conflict classification.
 - Service tests for local workspace CRUD and conversation/source/artifact membership.
 - Mounted Textual tests for the Console context rail shell.
 - Contract tests for local/server authority labels and disabled-action recovery copy.
@@ -387,13 +446,22 @@ Every workspace-aware surface needs visible recovery for:
 - Later server integration tests for handoff preflight and interrupted-transfer resume.
 - Actual CDP screenshots for every UI approval gate.
 
-## Remaining Open Questions
+## Resolved Decisions From User Review
 
-1. After v1 proves out, should Chatbook promote workspace management to a top-level destination or keep it distributed across Console, Library, Home, and Settings?
-2. Should local-to-server handoff copy source content, upload references, or support both depending on source type and policy?
-3. What is the first server-backed handoff target: source/conversation metadata only, full Chatbook packages, or ACP task/run packages?
-4. What audit detail must be visible to users versus stored only for diagnostics?
-5. How should shared or collaborator workspaces map to local-only Chatbook profiles when the user is offline?
+- Workspace switching must not hide Notes, Library items, Artifacts, or conversation records from global browse/search. Workspace tags and active-context eligibility replace hard filtering.
+- Unified workspace behavior comes from a shared Workspace Registry, Active Workspace Context, Global Item Browser, and Context Eligibility Gate. A future top-level Workspaces screen would manage the same registry rather than replacing Console or Library.
+- Local-to-server handoff supports both copied source content and uploaded source references, depending on source type and policy.
+- The first server-backed handoff target is ACP task/run packages.
+- Audit and diagnostic details should be visible to users by default, with expandable presentation and export paths.
+- Shared or collaborator workspaces map to single-user local workspaces when offline.
+
+## Remaining Deferred Questions
+
+1. Which source types default to copy versus reference in the first server bridge?
+2. What is the first UI for copying or linking a visible cross-workspace item into the active workspace?
+3. Which ACP task/run fields are required for a minimally useful server-backed handoff package?
+4. What exact redaction controls are required for user-visible audit exports?
+5. How should multi-workspace membership be displayed in compact terminal widths?
 
 ## Approval Gate
 

--- a/Tests/UI/test_screen_navigation.py
+++ b/Tests/UI/test_screen_navigation.py
@@ -96,6 +96,7 @@ from tldw_chatbook.MCP_Governance_Interop import MCPGovernanceScopeService, Serv
 from tldw_chatbook.User_Governance_Interop import ServerUserGovernanceService, UserGovernanceScopeService
 from tldw_chatbook.Web_Clipper_Interop import ServerWebClipperService, WebClipperScopeService
 from tldw_chatbook.Web_Scraping_Interop import ServerWebScrapingService, WebScrapingScopeService
+from tldw_chatbook.Workspaces import LocalWorkspaceRegistryService
 from tldw_chatbook.Writing_Interop import LocalWritingService, ServerWritingService, WritingScopeService
 from tldw_chatbook.Subscriptions import (
     LocalWatchlistsService,
@@ -287,13 +288,15 @@ def _build_test_app() -> TldwCli:
                                                     with patch("tldw_chatbook.app.get_research_db_path", return_value=":memory:"):
                                                         with patch("tldw_chatbook.app.get_writing_db_path", return_value=":memory:"):
                                                             with patch("tldw_chatbook.app.get_user_data_dir", return_value=user_data_dir):
-                                                                return TldwCli()
+                                                                with patch("tldw_chatbook.app.get_workspaces_db_path", return_value=user_data_dir / "workspaces.sqlite"):
+                                                                    return TldwCli()
 
 
 def test_app_uses_screen_navigation_and_wires_media_services():
     app = _build_test_app()
 
     assert app._use_screen_navigation is True
+    assert isinstance(app.workspace_registry_service, LocalWorkspaceRegistryService)
     assert isinstance(app.local_media_reading_service, LocalMediaReadingService)
     assert isinstance(app.server_media_reading_service, ServerMediaReadingService)
     assert isinstance(app.media_reading_scope_service, MediaReadingScopeService)

--- a/Tests/Workspaces/test_workspace_eligibility.py
+++ b/Tests/Workspaces/test_workspace_eligibility.py
@@ -1,0 +1,78 @@
+"""Workspace active-context eligibility tests."""
+
+from __future__ import annotations
+
+from tldw_chatbook.Workspaces import (
+    WorkspaceOperation,
+    evaluate_workspace_eligibility,
+)
+
+
+def test_cross_workspace_note_is_visible_but_not_context_eligible() -> None:
+    result = evaluate_workspace_eligibility(
+        active_workspace_id="ws-a",
+        item_workspace_ids=("ws-b",),
+        item_type="note",
+        operation=WorkspaceOperation.STAGE_IN_CONSOLE,
+    )
+
+    assert result.visible is True
+    assert result.active_context_eligible is False
+    assert result.reason_code == "cross_workspace"
+    assert "Copy or link" in result.recovery_copy
+    assert "ws-a" in result.recovery_copy
+
+
+def test_global_browse_and_search_remain_visible_without_workspace() -> None:
+    for operation in (WorkspaceOperation.BROWSE, WorkspaceOperation.SEARCH):
+        result = evaluate_workspace_eligibility(
+            active_workspace_id=None,
+            item_workspace_ids=(),
+            item_type="media",
+            operation=operation,
+        )
+
+        assert result.visible is True
+        assert result.active_context_eligible is True
+        assert result.reason_code == "visible"
+
+
+def test_active_context_operation_requires_active_workspace_membership() -> None:
+    result = evaluate_workspace_eligibility(
+        active_workspace_id="ws-a",
+        item_workspace_ids=("ws-a", "ws-b"),
+        item_type="artifact",
+        operation=WorkspaceOperation.RAG_GROUND,
+    )
+
+    assert result.visible is True
+    assert result.active_context_eligible is True
+    assert result.reason_code == "active_workspace_match"
+
+
+def test_active_context_operation_without_workspace_has_recovery_copy() -> None:
+    result = evaluate_workspace_eligibility(
+        active_workspace_id=None,
+        item_workspace_ids=("ws-a",),
+        item_type="conversation",
+        operation=WorkspaceOperation.AGENT_MANIPULATE,
+    )
+
+    assert result.visible is True
+    assert result.active_context_eligible is False
+    assert result.reason_code == "no_active_workspace"
+    assert "Select an active workspace" in result.recovery_copy
+
+
+def test_global_item_is_not_silently_converted_to_active_context() -> None:
+    result = evaluate_workspace_eligibility(
+        active_workspace_id="ws-a",
+        item_workspace_ids=(),
+        item_type="conversation",
+        operation=WorkspaceOperation.STAGE_IN_CONSOLE,
+    )
+
+    assert result.visible is True
+    assert result.active_context_eligible is False
+    assert result.reason_code == "not_in_active_workspace"
+    assert "Copy or link" in result.recovery_copy

--- a/Tests/Workspaces/test_workspace_models.py
+++ b/Tests/Workspaces/test_workspace_models.py
@@ -66,6 +66,8 @@ def test_workspace_runtime_binding_strips_secret_metadata() -> None:
         metadata={
             "branch": "dev",
             "api_key": "should-not-persist",
+            "api-key": "should-not-persist",
+            "privateKey": "should-not-persist",
             "nested": {"token": "also-secret", "safe": "value"},
         },
     )

--- a/Tests/Workspaces/test_workspace_models.py
+++ b/Tests/Workspaces/test_workspace_models.py
@@ -1,0 +1,87 @@
+"""Workspace operating-context model tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from tldw_chatbook.Workspaces import (
+    RuntimeBindingKind,
+    RuntimeBindingStatus,
+    WorkspaceAuthority,
+    WorkspaceMembership,
+    WorkspaceRecord,
+    WorkspaceRuntimeBinding,
+    WorkspaceSyncStatus,
+    WorkspaceTransferPolicy,
+)
+
+
+def test_workspace_record_requires_non_empty_identity() -> None:
+    with pytest.raises(ValueError, match="workspace_id"):
+        WorkspaceRecord(workspace_id="", name="Research")
+
+    with pytest.raises(ValueError, match="name"):
+        WorkspaceRecord(workspace_id="ws-a", name="")
+
+
+def test_workspace_record_validates_authority_and_sync_status() -> None:
+    record = WorkspaceRecord(
+        workspace_id="ws-a",
+        name="Research",
+        authority=WorkspaceAuthority.LOCAL_ONLY,
+        sync_status=WorkspaceSyncStatus.NOT_CONFIGURED,
+    )
+
+    assert record.workspace_id == "ws-a"
+    assert record.authority is WorkspaceAuthority.LOCAL_ONLY
+    assert record.sync_status is WorkspaceSyncStatus.NOT_CONFIGURED
+
+
+def test_workspace_membership_supports_multi_workspace_visibility() -> None:
+    first = WorkspaceMembership(
+        workspace_id="ws-a",
+        item_type="note",
+        item_id="note-1",
+        role="source",
+    )
+    second = WorkspaceMembership(
+        workspace_id="ws-b",
+        item_type="note",
+        item_id="note-1",
+        role="reference",
+    )
+
+    assert {first.workspace_id, second.workspace_id} == {"ws-a", "ws-b"}
+    assert first.transfer_policy is WorkspaceTransferPolicy.REFERENCE
+
+
+def test_workspace_runtime_binding_strips_secret_metadata() -> None:
+    binding = WorkspaceRuntimeBinding(
+        workspace_id="ws-a",
+        binding_id="binding-1",
+        binding_kind=RuntimeBindingKind.LOCAL_FILESYSTEM,
+        label="Local project",
+        locator="/tmp/project",
+        status=RuntimeBindingStatus.READY,
+        metadata={
+            "branch": "dev",
+            "api_key": "should-not-persist",
+            "nested": {"token": "also-secret", "safe": "value"},
+        },
+    )
+
+    assert binding.metadata == {"branch": "dev", "nested": {"safe": "value"}}
+
+
+def test_workspace_membership_requires_required_fields() -> None:
+    with pytest.raises(ValueError, match="item_id"):
+        WorkspaceMembership(workspace_id="ws-a", item_type="note", item_id="")
+
+    with pytest.raises(ValueError, match="workspace_id"):
+        WorkspaceRuntimeBinding(
+            workspace_id="",
+            binding_id="binding-1",
+            binding_kind=RuntimeBindingKind.ACP_SESSION,
+            label="Run",
+            locator="acp://run/1",
+        )

--- a/Tests/Workspaces/test_workspace_registry_service.py
+++ b/Tests/Workspaces/test_workspace_registry_service.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import inspect
 from pathlib import Path
+
+import pytest
 
 from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
 from tldw_chatbook.Workspaces import (
@@ -10,6 +13,10 @@ from tldw_chatbook.Workspaces import (
     RuntimeBindingKind,
     RuntimeBindingStatus,
     WorkspaceRuntimeBinding,
+)
+from tldw_chatbook.Workspaces.registry_service import (
+    WorkspaceNotFound,
+    WorkspaceRegistryServiceError,
 )
 
 
@@ -78,3 +85,114 @@ def test_registry_lists_workspaces_deterministically(tmp_path: Path) -> None:
         "ws-b",
         "ws-a",
     ]
+
+
+def test_registry_list_workspaces_uses_constant_sql() -> None:
+    source = inspect.getsource(LocalWorkspaceRegistryService.list_workspaces)
+
+    assert "where_clause" not in source
+    assert 'f"""' not in source
+
+
+def test_registry_normalizes_workspace_ids_at_service_boundary(tmp_path: Path) -> None:
+    service = build_test_registry(tmp_path)
+    service.create_workspace(workspace_id=" ws-a ", name="Workspace A")
+    service.create_workspace(workspace_id="ws-b", name="Workspace B")
+
+    service.set_active_workspace(" ws-a ")
+    service.link_membership(" ws-a ", item_type=" note ", item_id=" note-1 ", role=" source ")
+
+    active = service.get_active_workspace()
+
+    assert active is not None
+    assert active.workspace_id == "ws-a"
+    assert service.get_workspace(" ws-a ") is not None
+    memberships = service.get_item_memberships(" note ", " note-1 ")
+    assert len(memberships) == 1
+    assert memberships[0].workspace_id == "ws-a"
+
+
+def test_registry_rejects_archived_active_workspace_without_clearing_current(
+    tmp_path: Path,
+) -> None:
+    db = WorkspaceDB(tmp_path / "workspaces.sqlite", client_id="client-1")
+    service = LocalWorkspaceRegistryService(db)
+    service.create_workspace(workspace_id="ws-a", name="Workspace A")
+    service.create_workspace(workspace_id="ws-b", name="Workspace B")
+    service.set_active_workspace("ws-a")
+    with db.transaction() as conn:
+        conn.execute(
+            """
+            UPDATE workspace_records
+            SET archived = ?
+            WHERE workspace_id = ?
+            """,
+            (1, "ws-b"),
+        )
+
+    with pytest.raises(WorkspaceNotFound):
+        service.set_active_workspace("ws-b")
+
+    active = service.get_active_workspace()
+
+    assert active is not None
+    assert active.workspace_id == "ws-a"
+
+
+def test_link_membership_uses_unique_membership_lookup() -> None:
+    source = inspect.getsource(LocalWorkspaceRegistryService.link_membership)
+
+    assert "get_item_memberships" not in source
+    assert "workspace_id = ?" in source
+    assert "item_type = ?" in source
+    assert "item_id = ?" in source
+    assert "role = ?" in source
+
+
+def test_registry_wraps_non_json_runtime_binding_metadata(tmp_path: Path) -> None:
+    service = build_test_registry(tmp_path)
+    service.create_workspace(workspace_id="ws-a", name="Workspace A")
+
+    with pytest.raises(WorkspaceRegistryServiceError, match="JSON-serializable"):
+        service.save_runtime_binding(
+            WorkspaceRuntimeBinding(
+                workspace_id="ws-a",
+                binding_id="binding-1",
+                binding_kind=RuntimeBindingKind.GIT_WORKTREE,
+                label="Repo",
+                locator="/tmp/repo",
+                status=RuntimeBindingStatus.INSPECT_ONLY,
+                metadata={"bad": object()},
+            )
+        )
+
+
+def test_registry_tolerates_corrupt_runtime_binding_metadata(tmp_path: Path) -> None:
+    db = WorkspaceDB(tmp_path / "workspaces.sqlite", client_id="client-1")
+    service = LocalWorkspaceRegistryService(db)
+    service.create_workspace(workspace_id="ws-a", name="Workspace A")
+    service.save_runtime_binding(
+        WorkspaceRuntimeBinding(
+            workspace_id="ws-a",
+            binding_id="binding-1",
+            binding_kind=RuntimeBindingKind.GIT_WORKTREE,
+            label="Repo",
+            locator="/tmp/repo",
+            status=RuntimeBindingStatus.INSPECT_ONLY,
+            metadata={"branch": "dev"},
+        )
+    )
+    with db.transaction() as conn:
+        conn.execute(
+            """
+            UPDATE workspace_runtime_bindings
+            SET metadata_json = ?
+            WHERE binding_id = ?
+            """,
+            ("{not-json", "binding-1"),
+        )
+
+    bindings = service.list_runtime_bindings(" ws-a ")
+
+    assert len(bindings) == 1
+    assert bindings[0].metadata == {}

--- a/Tests/Workspaces/test_workspace_registry_service.py
+++ b/Tests/Workspaces/test_workspace_registry_service.py
@@ -1,0 +1,80 @@
+"""Local workspace registry persistence tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
+from tldw_chatbook.Workspaces import (
+    LocalWorkspaceRegistryService,
+    RuntimeBindingKind,
+    RuntimeBindingStatus,
+    WorkspaceRuntimeBinding,
+)
+
+
+def build_test_registry(tmp_path: Path) -> LocalWorkspaceRegistryService:
+    return LocalWorkspaceRegistryService(
+        WorkspaceDB(tmp_path / "workspaces.sqlite", client_id="client-1")
+    )
+
+
+def test_registry_persists_active_workspace(tmp_path: Path) -> None:
+    service = build_test_registry(tmp_path)
+
+    service.create_workspace(workspace_id="ws-a", name="Local Research")
+    service.set_active_workspace("ws-a")
+
+    reloaded = build_test_registry(tmp_path)
+    active = reloaded.get_active_workspace()
+
+    assert active is not None
+    assert active.workspace_id == "ws-a"
+    assert active.active is True
+
+
+def test_registry_links_note_without_hiding_other_workspaces(tmp_path: Path) -> None:
+    service = build_test_registry(tmp_path)
+    service.create_workspace(workspace_id="ws-a", name="Workspace A")
+    service.create_workspace(workspace_id="ws-b", name="Workspace B")
+
+    service.link_membership("ws-a", item_type="note", item_id="note-1", role="source")
+    service.link_membership("ws-b", item_type="note", item_id="note-1", role="reference")
+
+    memberships = service.get_item_memberships("note", "note-1")
+
+    assert {membership.workspace_id for membership in memberships} == {"ws-a", "ws-b"}
+
+
+def test_registry_persists_runtime_bindings_without_secrets(tmp_path: Path) -> None:
+    service = build_test_registry(tmp_path)
+    service.create_workspace(workspace_id="ws-a", name="Workspace A")
+
+    service.save_runtime_binding(
+        WorkspaceRuntimeBinding(
+            workspace_id="ws-a",
+            binding_id="binding-1",
+            binding_kind=RuntimeBindingKind.GIT_WORKTREE,
+            label="Repo",
+            locator="/tmp/repo",
+            status=RuntimeBindingStatus.INSPECT_ONLY,
+            metadata={"branch": "dev", "token": "secret"},
+        )
+    )
+
+    bindings = service.list_runtime_bindings("ws-a")
+
+    assert len(bindings) == 1
+    assert bindings[0].metadata == {"branch": "dev"}
+
+
+def test_registry_lists_workspaces_deterministically(tmp_path: Path) -> None:
+    service = build_test_registry(tmp_path)
+
+    service.create_workspace(workspace_id="ws-b", name="B")
+    service.create_workspace(workspace_id="ws-a", name="A")
+
+    assert [workspace.workspace_id for workspace in service.list_workspaces()] == [
+        "ws-b",
+        "ws-a",
+    ]

--- a/backlog/tasks/task-61 - PRD-Workspace-operating-context-and-handoff-model.md
+++ b/backlog/tasks/task-61 - PRD-Workspace-operating-context-and-handoff-model.md
@@ -44,12 +44,14 @@ Define the product and architecture contract for Chatbook workspaces as portable
 - Grounded the PRD in existing Chatbook seams for conversation scope, Notes workspace state, server parity workspace contracts, and the current Console staged-context rail.
 - Linked the related `tldw_server` roadmap issues for canonical workspace records, prototype workspace collaboration, and MCP/connector workspace handoff.
 - Defined the immediate Console left-rail split as a read-only shell unless a real workspace registry/switching service exists, preserving screenshot approval gates for later UI implementation.
+- Revised the PRD after user review so workspace switching does not hide Library/Notes/Artifact items; instead, workspace tags remain visible globally while active Console context actions are gated by workspace eligibility.
+- Captured user decisions that server handoff supports both copy and reference modes, ACP task/run packages are the first server-backed target, audit detail is user-visible by default, and offline shared workspaces degrade to single-user local workspaces.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Drafted and verified the PRD for workspace operating contexts and local/server handoff. No application behavior was changed.
+Drafted and verified the PRD for workspace operating contexts and local/server handoff, then revised it to preserve global item visibility while gating active Console context use by workspace membership. No application behavior was changed.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-61 - PRD-Workspace-operating-context-and-handoff-model.md
+++ b/backlog/tasks/task-61 - PRD-Workspace-operating-context-and-handoff-model.md
@@ -1,0 +1,57 @@
+---
+id: TASK-61
+title: 'PRD: Workspace operating context and handoff model'
+status: Done
+labels:
+- ux
+- prd
+- workspaces
+references:
+- Docs/superpowers/specs/2026-05-20-workspace-operating-context-handoff-prd-design.md
+- https://github.com/rmusser01/tldw_server/issues/1526
+- https://github.com/rmusser01/tldw_server/issues/1440
+- https://github.com/rmusser01/tldw_server/issues/1528
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Define the product and architecture contract for Chatbook workspaces as portable operating contexts that can move between local and server instances while preserving sources, conversations, artifacts, notes, ACP sessions, runs, worktrees, and sandbox/runtime bindings.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Spec defines workspace identity, lifecycle, local/server authority, sync/handoff states, and bundle membership.
+- [x] #2 Spec maps Console left-rail UX requirements without implementing unapproved workspace switching behavior.
+- [x] #3 Spec links the relevant tldw_server workspace roadmap issues and existing Chatbook parity contracts.
+- [x] #4 Spec decomposes follow-up work into PR-sized phases with QA and screenshot approval gates.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Review current Chatbook shell, Console, conversation parity, and server parity workspace contracts.
+2. Review tldw_server workspace roadmap issues and adjacent workspace/prototype/MCP context.
+3. Draft a PRD/spec that defines the workspace operating-context product model, sync/handoff states, data ownership, Console UX implications, and phased implementation boundaries.
+4. Add follow-up phases and QA gates that preserve screenshot approval for future UI work.
+5. Run focused documentation verification and mark the task complete with implementation notes.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added `Docs/superpowers/specs/2026-05-20-workspace-operating-context-handoff-prd-design.md` as the workspace operating-context PRD.
+- Grounded the PRD in existing Chatbook seams for conversation scope, Notes workspace state, server parity workspace contracts, and the current Console staged-context rail.
+- Linked the related `tldw_server` roadmap issues for canonical workspace records, prototype workspace collaboration, and MCP/connector workspace handoff.
+- Defined the immediate Console left-rail split as a read-only shell unless a real workspace registry/switching service exists, preserving screenshot approval gates for later UI implementation.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Drafted and verified the PRD for workspace operating contexts and local/server handoff. No application behavior was changed.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/backlog/tasks/task-62 - Plan-workspace-operating-context-implementation.md
+++ b/backlog/tasks/task-62 - Plan-workspace-operating-context-implementation.md
@@ -1,0 +1,52 @@
+---
+id: TASK-62
+title: Plan workspace operating context implementation
+status: Done
+labels:
+- ux
+- plan
+- workspaces
+references:
+- Docs/superpowers/specs/2026-05-20-workspace-operating-context-handoff-prd-design.md
+- Docs/superpowers/plans/2026-05-20-workspace-operating-context-implementation.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create a staged implementation plan for the approved workspace operating context PRD, including Console context rail, local workspace registry, global item visibility with context eligibility, package manifests, server handoff, ACP task/run package targets, and QA gates.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Implementation plan is saved under Docs/superpowers/plans and references the workspace operating context PRD.
+- [x] #2 Plan decomposes work into PR-sized phases with TDD steps, file-level pointers, and verification commands.
+- [x] #3 Plan preserves the global browse/search visibility rule while gating active Console context use by workspace eligibility.
+- [x] #4 Plan includes screenshot/CDP approval gates for all UI-facing tasks.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Re-read the approved workspace PRD and current Chatbook workspace-related seams.
+2. Map file responsibilities for local workspace models, registry service, eligibility gate, Console rail widgets, manifest schemas, and handoff adapters.
+3. Write a staged implementation plan with PR-sized tasks and TDD steps.
+4. Include UI screenshot/CDP approval gates for Console, Library, Notes, and any cross-screen state changes.
+5. Run focused documentation and Backlog verification, then mark the planning task Done.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Created `Docs/superpowers/plans/2026-05-20-workspace-operating-context-implementation.md` as a PR-sized implementation plan for the approved workspace operating-context PRD. The plan defines new workspace domain, persistence, eligibility, Console rail, Library/Notes visibility, manifest, ACP package handoff, manual server handoff, and QA closeout slices. It keeps global browse/search visible while gating active Console context operations by workspace eligibility, and it requires actual rendered screenshot/CDP approval for each UI-facing phase.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implementation plan completed and linked from this task.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/backlog/tasks/task-63 - Implement-workspace-domain-foundation.md
+++ b/backlog/tasks/task-63 - Implement-workspace-domain-foundation.md
@@ -1,0 +1,53 @@
+---
+id: TASK-63
+title: Implement workspace domain foundation
+status: Done
+labels:
+- workspaces
+- foundation
+- pr-a
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement PR A from the workspace operating context plan: local workspace models, eligibility rules, registry persistence, and app-owned service wiring needed before Console workspace UI work can begin.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Workspace domain models validate required identity, authority, membership, runtime binding, and eligibility fields.
+- [x] #2 Eligibility rules preserve global browse/search visibility while blocking active Console context operations for cross-workspace items with recovery copy.
+- [x] #3 Local workspace registry persists workspace records, active workspace, memberships, and runtime bindings without storing secrets.
+- [x] #4 The app exposes an app-owned workspace_registry_service without changing existing pending Console or Notes workspace context behavior.
+- [x] #5 Focused workspace foundation tests and relevant screen navigation smoke tests pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Review existing DB/service/app setup seams for workspace-friendly integration points.
+2. Write failing tests for workspace models and eligibility rules, then implement the smallest domain package to pass.
+3. Write failing tests for local workspace registry persistence, memberships, runtime binding redaction, and app-owned service wiring.
+4. Implement `WorkspaceDB` and `LocalWorkspaceRegistryService` using existing `BaseDB` and app service patterns.
+5. Run focused tests, update task acceptance criteria/notes, and commit PR A changes.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Added the `tldw_chatbook.Workspaces` foundation package with validated workspace records, memberships, runtime bindings, secret metadata scrubbing, and pure active-context eligibility rules.
+- Added `WorkspaceDB` plus `LocalWorkspaceRegistryService` for local workspace records, active workspace persistence, item memberships, and runtime binding persistence.
+- Wired `workspace_registry_service` into `TldwCli` through a new configurable `workspaces_db_path` while preserving existing pending Console and Notes workspace state.
+- Verification: `python -m pytest -q Tests/Workspaces/test_workspace_models.py Tests/Workspaces/test_workspace_eligibility.py Tests/Workspaces/test_workspace_registry_service.py Tests/UI/test_screen_navigation.py --tb=short`
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+PR A foundation is implemented: workspace domain models, active-context eligibility, local registry persistence, and app-owned service wiring are in place for later Console/Library UI slices.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/tldw_chatbook/DB/Workspace_DB.py
+++ b/tldw_chatbook/DB/Workspace_DB.py
@@ -1,0 +1,123 @@
+"""SQLite persistence for local workspace operating contexts."""
+
+from __future__ import annotations
+
+from contextlib import closing, contextmanager
+from pathlib import Path
+import sqlite3
+from typing import Iterator, Union
+
+from .base_db import BaseDB
+
+
+class WorkspaceDB(BaseDB):
+    """Database wrapper for local workspace registry state."""
+
+    _CURRENT_SCHEMA_VERSION = 1
+
+    def __init__(self, db_path: Union[str, Path], client_id: str = "default") -> None:
+        super().__init__(db_path, client_id)
+
+    def _get_connection(self) -> sqlite3.Connection:
+        conn = super()._get_connection()
+        conn.execute("PRAGMA foreign_keys = ON")
+        return conn
+
+    @contextmanager
+    def connection(self) -> Iterator[sqlite3.Connection]:
+        """Open a connection with row factory and foreign keys enabled."""
+
+        with closing(self._get_connection()) as conn:
+            yield conn
+
+    @contextmanager
+    def transaction(self) -> Iterator[sqlite3.Connection]:
+        """Open a write transaction that rolls back on failure."""
+
+        with closing(self._get_connection()) as conn:
+            conn.execute("BEGIN")
+            try:
+                yield conn
+            except Exception:
+                conn.rollback()
+                raise
+            else:
+                conn.commit()
+
+    def _initialize_schema(self) -> None:
+        """Initialize the local workspace registry schema."""
+
+        with self.connection() as conn:
+            conn.executescript(
+                """
+                PRAGMA foreign_keys = ON;
+
+                CREATE TABLE IF NOT EXISTS schema_version (
+                    version INTEGER PRIMARY KEY NOT NULL
+                );
+                INSERT OR IGNORE INTO schema_version (version) VALUES (1);
+
+                CREATE TABLE IF NOT EXISTS workspace_records (
+                    workspace_id TEXT PRIMARY KEY,
+                    name TEXT NOT NULL,
+                    description TEXT NOT NULL DEFAULT '',
+                    authority TEXT NOT NULL,
+                    sync_status TEXT NOT NULL,
+                    active INTEGER NOT NULL DEFAULT 0,
+                    archived INTEGER NOT NULL DEFAULT 0,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS workspace_memberships (
+                    membership_id TEXT PRIMARY KEY,
+                    workspace_id TEXT NOT NULL,
+                    item_type TEXT NOT NULL,
+                    item_id TEXT NOT NULL,
+                    role TEXT NOT NULL DEFAULT 'source',
+                    transfer_policy TEXT NOT NULL,
+                    title TEXT NOT NULL DEFAULT '',
+                    created_at TEXT NOT NULL,
+                    FOREIGN KEY(workspace_id)
+                        REFERENCES workspace_records(workspace_id)
+                        ON DELETE CASCADE,
+                    UNIQUE(workspace_id, item_type, item_id, role)
+                );
+
+                CREATE TABLE IF NOT EXISTS workspace_runtime_bindings (
+                    binding_id TEXT PRIMARY KEY,
+                    workspace_id TEXT NOT NULL,
+                    binding_kind TEXT NOT NULL,
+                    label TEXT NOT NULL,
+                    locator TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    metadata_json TEXT NOT NULL DEFAULT '{}',
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    FOREIGN KEY(workspace_id)
+                        REFERENCES workspace_records(workspace_id)
+                        ON DELETE CASCADE
+                );
+
+                CREATE TABLE IF NOT EXISTS workspace_handoff_audit (
+                    audit_id TEXT PRIMARY KEY,
+                    workspace_id TEXT NOT NULL,
+                    direction TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    summary TEXT NOT NULL DEFAULT '',
+                    manifest_json TEXT NOT NULL DEFAULT '{}',
+                    created_at TEXT NOT NULL,
+                    FOREIGN KEY(workspace_id)
+                        REFERENCES workspace_records(workspace_id)
+                        ON DELETE CASCADE
+                );
+                """
+            )
+            conn.commit()
+
+    def get_schema_version(self) -> int:
+        """Return the initialized schema version."""
+
+        with self.connection() as conn:
+            row = conn.execute("SELECT MAX(version) FROM schema_version").fetchone()
+        return int(row[0] or 0) if row is not None else 0

--- a/tldw_chatbook/Workspaces/__init__.py
+++ b/tldw_chatbook/Workspaces/__init__.py
@@ -1,0 +1,31 @@
+"""Workspace operating-context APIs."""
+
+from .eligibility import evaluate_workspace_eligibility
+from .models import (
+    RuntimeBindingKind,
+    RuntimeBindingStatus,
+    WorkspaceAuthority,
+    WorkspaceEligibility,
+    WorkspaceMembership,
+    WorkspaceOperation,
+    WorkspaceRecord,
+    WorkspaceRuntimeBinding,
+    WorkspaceSyncStatus,
+    WorkspaceTransferPolicy,
+)
+from .registry_service import LocalWorkspaceRegistryService
+
+__all__ = [
+    "LocalWorkspaceRegistryService",
+    "RuntimeBindingKind",
+    "RuntimeBindingStatus",
+    "WorkspaceAuthority",
+    "WorkspaceEligibility",
+    "WorkspaceMembership",
+    "WorkspaceOperation",
+    "WorkspaceRecord",
+    "WorkspaceRuntimeBinding",
+    "WorkspaceSyncStatus",
+    "WorkspaceTransferPolicy",
+    "evaluate_workspace_eligibility",
+]

--- a/tldw_chatbook/Workspaces/eligibility.py
+++ b/tldw_chatbook/Workspaces/eligibility.py
@@ -1,0 +1,87 @@
+"""Pure workspace active-context eligibility rules."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from .models import WorkspaceEligibility, WorkspaceOperation
+
+
+_ACTIVE_CONTEXT_OPERATIONS = {
+    WorkspaceOperation.STAGE_IN_CONSOLE,
+    WorkspaceOperation.RAG_GROUND,
+    WorkspaceOperation.AGENT_MANIPULATE,
+    WorkspaceOperation.TOOL_USE,
+}
+
+
+def evaluate_workspace_eligibility(
+    *,
+    active_workspace_id: str | None,
+    item_workspace_ids: Iterable[str],
+    item_type: str,
+    operation: WorkspaceOperation | str,
+) -> WorkspaceEligibility:
+    """Evaluate visibility and active-context eligibility for one item operation.
+
+    Workspace switching must never hide user-owned Library/Notes/Artifact records.
+    The gating applies only when the item would be staged into the active Console
+    context or manipulated by an agent/runtime.
+    """
+
+    normalized_operation = _normalize_operation(operation)
+    workspace_ids = tuple(_normalize_workspace_ids(item_workspace_ids))
+
+    if normalized_operation not in _ACTIVE_CONTEXT_OPERATIONS:
+        return WorkspaceEligibility(
+            visible=True,
+            active_context_eligible=True,
+            reason_code="visible",
+        )
+
+    active_id = active_workspace_id.strip() if active_workspace_id else ""
+    if not active_id:
+        return WorkspaceEligibility(
+            visible=True,
+            active_context_eligible=False,
+            reason_code="no_active_workspace",
+            recovery_copy=(
+                "Select an active workspace before using this item in Console."
+            ),
+        )
+
+    if active_id in workspace_ids:
+        return WorkspaceEligibility(
+            visible=True,
+            active_context_eligible=True,
+            reason_code="active_workspace_match",
+        )
+
+    reason_code = "cross_workspace" if workspace_ids else "not_in_active_workspace"
+    return WorkspaceEligibility(
+        visible=True,
+        active_context_eligible=False,
+        reason_code=reason_code,
+        recovery_copy=(
+            f"Copy or link this {item_type} into workspace {active_id} before "
+            "using it in Console."
+        ),
+    )
+
+
+def _normalize_operation(operation: WorkspaceOperation | str) -> WorkspaceOperation:
+    try:
+        return operation if isinstance(operation, WorkspaceOperation) else WorkspaceOperation(operation)
+    except ValueError as exc:
+        raise ValueError("operation is invalid") from exc
+
+
+def _normalize_workspace_ids(workspace_ids: Iterable[str]) -> tuple[str, ...]:
+    normalized: list[str] = []
+    for workspace_id in workspace_ids:
+        if not isinstance(workspace_id, str):
+            continue
+        value = workspace_id.strip()
+        if value:
+            normalized.append(value)
+    return tuple(dict.fromkeys(normalized))

--- a/tldw_chatbook/Workspaces/eligibility.py
+++ b/tldw_chatbook/Workspaces/eligibility.py
@@ -27,6 +27,19 @@ def evaluate_workspace_eligibility(
     Workspace switching must never hide user-owned Library/Notes/Artifact records.
     The gating applies only when the item would be staged into the active Console
     context or manipulated by an agent/runtime.
+
+    Args:
+        active_workspace_id: Currently selected workspace id, if any.
+        item_workspace_ids: Workspace ids associated with the visible item.
+        item_type: Human-readable item type used in recovery copy.
+        operation: Operation being attempted against the item.
+
+    Returns:
+        A `WorkspaceEligibility` decision preserving visibility and describing
+        whether the active-context operation may proceed.
+
+    Raises:
+        ValueError: If `operation` is not a supported `WorkspaceOperation`.
     """
 
     normalized_operation = _normalize_operation(operation)

--- a/tldw_chatbook/Workspaces/models.py
+++ b/tldw_chatbook/Workspaces/models.py
@@ -1,0 +1,248 @@
+"""Workspace operating-context domain models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Mapping
+
+
+class WorkspaceAuthority(str, Enum):
+    """Source of authority for a workspace record."""
+
+    LOCAL_ONLY = "local-only"
+    SERVER_BACKED = "server-backed"
+    SYNCING_TO_SERVER = "syncing-to-server"
+    SYNCING_FROM_SERVER = "syncing-from-server"
+    CONFLICT = "conflict"
+    DETACHED = "detached"
+    REMOTE_ONLY = "remote-only"
+    RUNTIME_MISSING = "runtime-missing"
+
+
+class WorkspaceSyncStatus(str, Enum):
+    """Current local/server sync state for a workspace."""
+
+    NOT_CONFIGURED = "not-configured"
+    READY = "ready"
+    SYNCING = "syncing"
+    BLOCKED = "blocked"
+    CONFLICT = "conflict"
+
+
+class WorkspaceTransferPolicy(str, Enum):
+    """How an item should move during an explicit handoff."""
+
+    COPY = "copy"
+    REFERENCE = "reference"
+    METADATA_ONLY = "metadata-only"
+    LOCAL_ONLY = "local-only"
+
+
+class RuntimeBindingKind(str, Enum):
+    """Runtime resource type attached to a workspace."""
+
+    LOCAL_FILESYSTEM = "local-filesystem"
+    GIT_WORKTREE = "git-worktree"
+    CONTAINER = "container"
+    VM = "vm"
+    REMOTE_RUNTIME = "remote-runtime"
+    ACP_SESSION = "acp-session"
+
+
+class RuntimeBindingStatus(str, Enum):
+    """Readiness state for a runtime binding."""
+
+    READY = "ready"
+    MISSING = "missing"
+    INSPECT_ONLY = "inspect-only"
+    BLOCKED = "blocked"
+
+
+class WorkspaceOperation(str, Enum):
+    """Workspace-sensitive operations used by eligibility checks."""
+
+    BROWSE = "browse"
+    SEARCH = "search"
+    OPEN = "open"
+    EDIT = "edit"
+    STAGE_IN_CONSOLE = "stage_in_console"
+    RAG_GROUND = "rag_ground"
+    AGENT_MANIPULATE = "agent_manipulate"
+    TOOL_USE = "tool_use"
+
+
+_SECRET_METADATA_PARTS = (
+    "api_key",
+    "apikey",
+    "credential",
+    "password",
+    "private_key",
+    "secret",
+    "token",
+)
+
+
+def utc_now_iso() -> str:
+    """Return a stable UTC timestamp string for registry records."""
+
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass(frozen=True)
+class WorkspaceRecord:
+    """One user-visible workspace."""
+
+    workspace_id: str
+    name: str
+    description: str = ""
+    authority: WorkspaceAuthority | str = WorkspaceAuthority.LOCAL_ONLY
+    sync_status: WorkspaceSyncStatus | str = WorkspaceSyncStatus.NOT_CONFIGURED
+    active: bool = False
+    archived: bool = False
+    created_at: str = field(default_factory=utc_now_iso)
+    updated_at: str = field(default_factory=utc_now_iso)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "workspace_id", _required_text(self.workspace_id, "workspace_id"))
+        object.__setattr__(self, "name", _required_text(self.name, "name"))
+        object.__setattr__(self, "description", _optional_text(self.description))
+        object.__setattr__(
+            self,
+            "authority",
+            _coerce_enum(self.authority, WorkspaceAuthority, "authority"),
+        )
+        object.__setattr__(
+            self,
+            "sync_status",
+            _coerce_enum(self.sync_status, WorkspaceSyncStatus, "sync_status"),
+        )
+
+
+@dataclass(frozen=True)
+class WorkspaceMembership:
+    """Association between a visible item and a workspace."""
+
+    workspace_id: str
+    item_type: str
+    item_id: str
+    role: str = "source"
+    transfer_policy: WorkspaceTransferPolicy | str = WorkspaceTransferPolicy.REFERENCE
+    title: str = ""
+    created_at: str = field(default_factory=utc_now_iso)
+    membership_id: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "workspace_id", _required_text(self.workspace_id, "workspace_id"))
+        object.__setattr__(self, "item_type", _required_text(self.item_type, "item_type"))
+        object.__setattr__(self, "item_id", _required_text(self.item_id, "item_id"))
+        object.__setattr__(self, "role", _required_text(self.role, "role"))
+        object.__setattr__(self, "title", _optional_text(self.title))
+        object.__setattr__(
+            self,
+            "transfer_policy",
+            _coerce_enum(self.transfer_policy, WorkspaceTransferPolicy, "transfer_policy"),
+        )
+        if self.membership_id is not None:
+            object.__setattr__(
+                self,
+                "membership_id",
+                _required_text(self.membership_id, "membership_id"),
+            )
+
+
+@dataclass(frozen=True)
+class WorkspaceRuntimeBinding:
+    """Runtime resource associated with a workspace."""
+
+    workspace_id: str
+    binding_id: str
+    binding_kind: RuntimeBindingKind | str
+    label: str
+    locator: str
+    status: RuntimeBindingStatus | str = RuntimeBindingStatus.INSPECT_ONLY
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    created_at: str = field(default_factory=utc_now_iso)
+    updated_at: str = field(default_factory=utc_now_iso)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "workspace_id", _required_text(self.workspace_id, "workspace_id"))
+        object.__setattr__(self, "binding_id", _required_text(self.binding_id, "binding_id"))
+        object.__setattr__(self, "label", _required_text(self.label, "label"))
+        object.__setattr__(self, "locator", _required_text(self.locator, "locator"))
+        object.__setattr__(
+            self,
+            "binding_kind",
+            _coerce_enum(self.binding_kind, RuntimeBindingKind, "binding_kind"),
+        )
+        object.__setattr__(
+            self,
+            "status",
+            _coerce_enum(self.status, RuntimeBindingStatus, "status"),
+        )
+        object.__setattr__(self, "metadata", scrub_secret_metadata(dict(self.metadata)))
+
+
+@dataclass(frozen=True)
+class WorkspaceEligibility:
+    """Decision for a workspace-sensitive item operation."""
+
+    visible: bool
+    active_context_eligible: bool
+    reason_code: str
+    recovery_copy: str = ""
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "reason_code", _required_text(self.reason_code, "reason_code"))
+        object.__setattr__(self, "recovery_copy", _optional_text(self.recovery_copy))
+
+
+def scrub_secret_metadata(value: Mapping[str, Any]) -> dict[str, Any]:
+    """Return metadata with secret-looking keys removed recursively."""
+
+    scrubbed: dict[str, Any] = {}
+    for key, item in value.items():
+        if _is_secret_metadata_key(str(key)):
+            continue
+        scrubbed[str(key)] = _scrub_metadata_value(item)
+    return scrubbed
+
+
+def _scrub_metadata_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return scrub_secret_metadata(value)
+    if isinstance(value, list):
+        return [_scrub_metadata_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_scrub_metadata_value(item) for item in value)
+    return value
+
+
+def _is_secret_metadata_key(key: str) -> bool:
+    key_lower = key.lower()
+    return any(part in key_lower for part in _SECRET_METADATA_PARTS)
+
+
+def _required_text(value: str, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be text")
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{field_name} is required")
+    return normalized
+
+
+def _optional_text(value: str | None) -> str:
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise ValueError("text value must be text")
+    return value.strip()
+
+
+def _coerce_enum(value: Any, enum_type: type[Enum], field_name: str) -> Any:
+    try:
+        return value if isinstance(value, enum_type) else enum_type(value)
+    except ValueError as exc:
+        raise ValueError(f"{field_name} is invalid") from exc

--- a/tldw_chatbook/Workspaces/models.py
+++ b/tldw_chatbook/Workspaces/models.py
@@ -220,8 +220,15 @@ def _scrub_metadata_value(value: Any) -> Any:
 
 
 def _is_secret_metadata_key(key: str) -> bool:
-    key_lower = key.lower()
-    return any(part in key_lower for part in _SECRET_METADATA_PARTS)
+    key_normalized = _normalize_metadata_key(key)
+    return any(
+        _normalize_metadata_key(part) in key_normalized
+        for part in _SECRET_METADATA_PARTS
+    )
+
+
+def _normalize_metadata_key(key: str) -> str:
+    return "".join(character for character in key.lower() if character.isalnum())
 
 
 def _required_text(value: str, field_name: str) -> str:

--- a/tldw_chatbook/Workspaces/registry_service.py
+++ b/tldw_chatbook/Workspaces/registry_service.py
@@ -1,0 +1,437 @@
+"""Local workspace registry service."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import json
+import sqlite3
+from uuid import uuid4
+
+from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
+
+from .models import (
+    RuntimeBindingKind,
+    RuntimeBindingStatus,
+    WorkspaceAuthority,
+    WorkspaceMembership,
+    WorkspaceRecord,
+    WorkspaceRuntimeBinding,
+    WorkspaceSyncStatus,
+    WorkspaceTransferPolicy,
+    scrub_secret_metadata,
+    utc_now_iso,
+)
+
+
+_STORAGE_FAILURE_MESSAGE = "Workspace registry storage failed."
+
+
+class WorkspaceRegistryServiceError(Exception):
+    """Base exception for workspace registry failures."""
+
+
+class WorkspaceNotFound(WorkspaceRegistryServiceError):
+    """Raised when a workspace operation targets a missing workspace."""
+
+
+class DuplicateWorkspace(WorkspaceRegistryServiceError):
+    """Raised when a workspace id already exists."""
+
+
+class LocalWorkspaceRegistryService:
+    """SQLite-backed local workspace registry."""
+
+    def __init__(
+        self,
+        db: WorkspaceDB,
+        *,
+        id_factory: Callable[[], str] | None = None,
+        now_factory: Callable[[], str] | None = None,
+    ) -> None:
+        self.db = db
+        self._id_factory = id_factory or (lambda: f"workspace-link-{uuid4().hex}")
+        self._now_factory = now_factory or utc_now_iso
+
+    def create_workspace(
+        self,
+        *,
+        workspace_id: str,
+        name: str,
+        description: str = "",
+        authority: WorkspaceAuthority | str = WorkspaceAuthority.LOCAL_ONLY,
+        sync_status: WorkspaceSyncStatus | str = WorkspaceSyncStatus.NOT_CONFIGURED,
+    ) -> WorkspaceRecord:
+        """Create a local workspace record."""
+
+        now = self._now_factory()
+        record = WorkspaceRecord(
+            workspace_id=workspace_id,
+            name=name,
+            description=description,
+            authority=authority,
+            sync_status=sync_status,
+            created_at=now,
+            updated_at=now,
+        )
+        try:
+            with self.db.transaction() as conn:
+                conn.execute(
+                    """
+                    INSERT INTO workspace_records (
+                        workspace_id,
+                        name,
+                        description,
+                        authority,
+                        sync_status,
+                        active,
+                        archived,
+                        created_at,
+                        updated_at
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        record.workspace_id,
+                        record.name,
+                        record.description,
+                        record.authority.value,
+                        record.sync_status.value,
+                        int(record.active),
+                        int(record.archived),
+                        record.created_at,
+                        record.updated_at,
+                    ),
+                )
+        except sqlite3.IntegrityError as exc:
+            raise DuplicateWorkspace(record.workspace_id) from exc
+        except sqlite3.Error as exc:
+            raise WorkspaceRegistryServiceError(_STORAGE_FAILURE_MESSAGE) from exc
+        created = self.get_workspace(record.workspace_id)
+        if created is None:
+            raise WorkspaceRegistryServiceError("Workspace creation failed.")
+        return created
+
+    def list_workspaces(self, *, include_archived: bool = False) -> tuple[WorkspaceRecord, ...]:
+        """List local workspaces in stable creation order."""
+
+        where_clause = "" if include_archived else "WHERE archived = 0"
+        try:
+            with self.db.connection() as conn:
+                rows = conn.execute(
+                    f"""
+                    SELECT *
+                    FROM workspace_records
+                    {where_clause}
+                    ORDER BY created_at ASC, workspace_id ASC
+                    """
+                ).fetchall()
+        except sqlite3.Error as exc:
+            raise WorkspaceRegistryServiceError(_STORAGE_FAILURE_MESSAGE) from exc
+        return tuple(_workspace_from_row(row) for row in rows)
+
+    def get_workspace(self, workspace_id: str) -> WorkspaceRecord | None:
+        """Return one workspace record if it exists."""
+
+        try:
+            with self.db.connection() as conn:
+                row = conn.execute(
+                    """
+                    SELECT *
+                    FROM workspace_records
+                    WHERE workspace_id = ?
+                    """,
+                    (workspace_id,),
+                ).fetchone()
+        except sqlite3.Error as exc:
+            raise WorkspaceRegistryServiceError(_STORAGE_FAILURE_MESSAGE) from exc
+        return _workspace_from_row(row) if row is not None else None
+
+    def set_active_workspace(self, workspace_id: str) -> WorkspaceRecord:
+        """Set exactly one active workspace."""
+
+        if self.get_workspace(workspace_id) is None:
+            raise WorkspaceNotFound(workspace_id)
+        now = self._now_factory()
+        try:
+            with self.db.transaction() as conn:
+                conn.execute("UPDATE workspace_records SET active = 0")
+                conn.execute(
+                    """
+                    UPDATE workspace_records
+                    SET active = 1,
+                        updated_at = ?
+                    WHERE workspace_id = ?
+                    """,
+                    (now, workspace_id),
+                )
+        except sqlite3.Error as exc:
+            raise WorkspaceRegistryServiceError(_STORAGE_FAILURE_MESSAGE) from exc
+        active = self.get_active_workspace()
+        if active is None:
+            raise WorkspaceRegistryServiceError("Active workspace update failed.")
+        return active
+
+    def get_active_workspace(self) -> WorkspaceRecord | None:
+        """Return the active workspace if one is selected."""
+
+        try:
+            with self.db.connection() as conn:
+                row = conn.execute(
+                    """
+                    SELECT *
+                    FROM workspace_records
+                    WHERE active = 1
+                        AND archived = 0
+                    ORDER BY updated_at DESC, workspace_id ASC
+                    LIMIT 1
+                    """
+                ).fetchone()
+        except sqlite3.Error as exc:
+            raise WorkspaceRegistryServiceError(_STORAGE_FAILURE_MESSAGE) from exc
+        return _workspace_from_row(row) if row is not None else None
+
+    def link_membership(
+        self,
+        workspace_id: str,
+        *,
+        item_type: str,
+        item_id: str,
+        role: str = "source",
+        transfer_policy: WorkspaceTransferPolicy | str = WorkspaceTransferPolicy.REFERENCE,
+        title: str = "",
+    ) -> WorkspaceMembership:
+        """Link a visible item to a workspace without hiding other memberships."""
+
+        if self.get_workspace(workspace_id) is None:
+            raise WorkspaceNotFound(workspace_id)
+        membership = WorkspaceMembership(
+            membership_id=self._id_factory(),
+            workspace_id=workspace_id,
+            item_type=item_type,
+            item_id=item_id,
+            role=role,
+            transfer_policy=transfer_policy,
+            title=title,
+            created_at=self._now_factory(),
+        )
+        try:
+            with self.db.transaction() as conn:
+                conn.execute(
+                    """
+                    INSERT OR IGNORE INTO workspace_memberships (
+                        membership_id,
+                        workspace_id,
+                        item_type,
+                        item_id,
+                        role,
+                        transfer_policy,
+                        title,
+                        created_at
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        membership.membership_id,
+                        membership.workspace_id,
+                        membership.item_type,
+                        membership.item_id,
+                        membership.role,
+                        membership.transfer_policy.value,
+                        membership.title,
+                        membership.created_at,
+                    ),
+                )
+        except sqlite3.Error as exc:
+            raise WorkspaceRegistryServiceError(_STORAGE_FAILURE_MESSAGE) from exc
+        memberships = self.get_item_memberships(item_type, item_id)
+        for existing in memberships:
+            if existing.workspace_id == workspace_id and existing.role == role:
+                return existing
+        raise WorkspaceRegistryServiceError("Workspace membership link failed.")
+
+    def get_item_memberships(
+        self,
+        item_type: str,
+        item_id: str,
+    ) -> tuple[WorkspaceMembership, ...]:
+        """Return all workspace memberships for one visible item."""
+
+        try:
+            with self.db.connection() as conn:
+                rows = conn.execute(
+                    """
+                    SELECT *
+                    FROM workspace_memberships
+                    WHERE item_type = ?
+                        AND item_id = ?
+                    ORDER BY created_at ASC, workspace_id ASC, role ASC
+                    """,
+                    (item_type, item_id),
+                ).fetchall()
+        except sqlite3.Error as exc:
+            raise WorkspaceRegistryServiceError(_STORAGE_FAILURE_MESSAGE) from exc
+        return tuple(_membership_from_row(row) for row in rows)
+
+    def list_workspace_memberships(
+        self,
+        workspace_id: str,
+    ) -> tuple[WorkspaceMembership, ...]:
+        """Return item memberships for a workspace."""
+
+        try:
+            with self.db.connection() as conn:
+                rows = conn.execute(
+                    """
+                    SELECT *
+                    FROM workspace_memberships
+                    WHERE workspace_id = ?
+                    ORDER BY created_at ASC, item_type ASC, item_id ASC, role ASC
+                    """,
+                    (workspace_id,),
+                ).fetchall()
+        except sqlite3.Error as exc:
+            raise WorkspaceRegistryServiceError(_STORAGE_FAILURE_MESSAGE) from exc
+        return tuple(_membership_from_row(row) for row in rows)
+
+    def save_runtime_binding(
+        self,
+        binding: WorkspaceRuntimeBinding,
+    ) -> WorkspaceRuntimeBinding:
+        """Create or update a workspace runtime binding."""
+
+        if self.get_workspace(binding.workspace_id) is None:
+            raise WorkspaceNotFound(binding.workspace_id)
+        safe_binding = WorkspaceRuntimeBinding(
+            workspace_id=binding.workspace_id,
+            binding_id=binding.binding_id,
+            binding_kind=binding.binding_kind,
+            label=binding.label,
+            locator=binding.locator,
+            status=binding.status,
+            metadata=scrub_secret_metadata(binding.metadata),
+            created_at=binding.created_at,
+            updated_at=self._now_factory(),
+        )
+        try:
+            with self.db.transaction() as conn:
+                conn.execute(
+                    """
+                    INSERT INTO workspace_runtime_bindings (
+                        binding_id,
+                        workspace_id,
+                        binding_kind,
+                        label,
+                        locator,
+                        status,
+                        metadata_json,
+                        created_at,
+                        updated_at
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(binding_id) DO UPDATE SET
+                        workspace_id = excluded.workspace_id,
+                        binding_kind = excluded.binding_kind,
+                        label = excluded.label,
+                        locator = excluded.locator,
+                        status = excluded.status,
+                        metadata_json = excluded.metadata_json,
+                        updated_at = excluded.updated_at
+                    """,
+                    (
+                        safe_binding.binding_id,
+                        safe_binding.workspace_id,
+                        safe_binding.binding_kind.value,
+                        safe_binding.label,
+                        safe_binding.locator,
+                        safe_binding.status.value,
+                        json.dumps(safe_binding.metadata, sort_keys=True),
+                        safe_binding.created_at,
+                        safe_binding.updated_at,
+                    ),
+                )
+        except sqlite3.Error as exc:
+            raise WorkspaceRegistryServiceError(_STORAGE_FAILURE_MESSAGE) from exc
+        stored = self.get_runtime_binding(safe_binding.binding_id)
+        if stored is None:
+            raise WorkspaceRegistryServiceError("Runtime binding save failed.")
+        return stored
+
+    def get_runtime_binding(self, binding_id: str) -> WorkspaceRuntimeBinding | None:
+        """Return one runtime binding if it exists."""
+
+        try:
+            with self.db.connection() as conn:
+                row = conn.execute(
+                    """
+                    SELECT *
+                    FROM workspace_runtime_bindings
+                    WHERE binding_id = ?
+                    """,
+                    (binding_id,),
+                ).fetchone()
+        except sqlite3.Error as exc:
+            raise WorkspaceRegistryServiceError(_STORAGE_FAILURE_MESSAGE) from exc
+        return _runtime_binding_from_row(row) if row is not None else None
+
+    def list_runtime_bindings(
+        self,
+        workspace_id: str,
+    ) -> tuple[WorkspaceRuntimeBinding, ...]:
+        """Return runtime bindings for a workspace."""
+
+        try:
+            with self.db.connection() as conn:
+                rows = conn.execute(
+                    """
+                    SELECT *
+                    FROM workspace_runtime_bindings
+                    WHERE workspace_id = ?
+                    ORDER BY created_at ASC, binding_id ASC
+                    """,
+                    (workspace_id,),
+                ).fetchall()
+        except sqlite3.Error as exc:
+            raise WorkspaceRegistryServiceError(_STORAGE_FAILURE_MESSAGE) from exc
+        return tuple(_runtime_binding_from_row(row) for row in rows)
+
+
+def _workspace_from_row(row: sqlite3.Row) -> WorkspaceRecord:
+    return WorkspaceRecord(
+        workspace_id=row["workspace_id"],
+        name=row["name"],
+        description=row["description"],
+        authority=WorkspaceAuthority(row["authority"]),
+        sync_status=WorkspaceSyncStatus(row["sync_status"]),
+        active=bool(row["active"]),
+        archived=bool(row["archived"]),
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+def _membership_from_row(row: sqlite3.Row) -> WorkspaceMembership:
+    return WorkspaceMembership(
+        membership_id=row["membership_id"],
+        workspace_id=row["workspace_id"],
+        item_type=row["item_type"],
+        item_id=row["item_id"],
+        role=row["role"],
+        transfer_policy=WorkspaceTransferPolicy(row["transfer_policy"]),
+        title=row["title"],
+        created_at=row["created_at"],
+    )
+
+
+def _runtime_binding_from_row(row: sqlite3.Row) -> WorkspaceRuntimeBinding:
+    metadata = json.loads(row["metadata_json"] or "{}")
+    return WorkspaceRuntimeBinding(
+        workspace_id=row["workspace_id"],
+        binding_id=row["binding_id"],
+        binding_kind=RuntimeBindingKind(row["binding_kind"]),
+        label=row["label"],
+        locator=row["locator"],
+        status=RuntimeBindingStatus(row["status"]),
+        metadata=metadata,
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )

--- a/tldw_chatbook/Workspaces/registry_service.py
+++ b/tldw_chatbook/Workspaces/registry_service.py
@@ -7,6 +7,8 @@ import json
 import sqlite3
 from uuid import uuid4
 
+from loguru import logger
+
 from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
 
 from .models import (
@@ -18,7 +20,6 @@ from .models import (
     WorkspaceRuntimeBinding,
     WorkspaceSyncStatus,
     WorkspaceTransferPolicy,
-    scrub_secret_metadata,
     utc_now_iso,
 )
 
@@ -114,17 +115,24 @@ class LocalWorkspaceRegistryService:
     def list_workspaces(self, *, include_archived: bool = False) -> tuple[WorkspaceRecord, ...]:
         """List local workspaces in stable creation order."""
 
-        where_clause = "" if include_archived else "WHERE archived = 0"
+        if include_archived:
+            query = """
+                SELECT *
+                FROM workspace_records
+                ORDER BY created_at ASC, workspace_id ASC
+                """
+            params: tuple[object, ...] = ()
+        else:
+            query = """
+                SELECT *
+                FROM workspace_records
+                WHERE archived = ?
+                ORDER BY created_at ASC, workspace_id ASC
+                """
+            params = (0,)
         try:
             with self.db.connection() as conn:
-                rows = conn.execute(
-                    f"""
-                    SELECT *
-                    FROM workspace_records
-                    {where_clause}
-                    ORDER BY created_at ASC, workspace_id ASC
-                    """
-                ).fetchall()
+                rows = conn.execute(query, params).fetchall()
         except sqlite3.Error as exc:
             raise WorkspaceRegistryServiceError(_STORAGE_FAILURE_MESSAGE) from exc
         return tuple(_workspace_from_row(row) for row in rows)
@@ -132,6 +140,7 @@ class LocalWorkspaceRegistryService:
     def get_workspace(self, workspace_id: str) -> WorkspaceRecord | None:
         """Return one workspace record if it exists."""
 
+        safe_workspace_id = _normalize_required_text(workspace_id, "workspace_id")
         try:
             with self.db.connection() as conn:
                 row = conn.execute(
@@ -140,7 +149,7 @@ class LocalWorkspaceRegistryService:
                     FROM workspace_records
                     WHERE workspace_id = ?
                     """,
-                    (workspace_id,),
+                    (safe_workspace_id,),
                 ).fetchone()
         except sqlite3.Error as exc:
             raise WorkspaceRegistryServiceError(_STORAGE_FAILURE_MESSAGE) from exc
@@ -149,8 +158,10 @@ class LocalWorkspaceRegistryService:
     def set_active_workspace(self, workspace_id: str) -> WorkspaceRecord:
         """Set exactly one active workspace."""
 
-        if self.get_workspace(workspace_id) is None:
-            raise WorkspaceNotFound(workspace_id)
+        safe_workspace_id = _normalize_required_text(workspace_id, "workspace_id")
+        target_workspace = self.get_workspace(safe_workspace_id)
+        if target_workspace is None or target_workspace.archived:
+            raise WorkspaceNotFound(safe_workspace_id)
         now = self._now_factory()
         try:
             with self.db.transaction() as conn:
@@ -162,7 +173,7 @@ class LocalWorkspaceRegistryService:
                         updated_at = ?
                     WHERE workspace_id = ?
                     """,
-                    (now, workspace_id),
+                    (now, safe_workspace_id),
                 )
         except sqlite3.Error as exc:
             raise WorkspaceRegistryServiceError(_STORAGE_FAILURE_MESSAGE) from exc
@@ -202,11 +213,12 @@ class LocalWorkspaceRegistryService:
     ) -> WorkspaceMembership:
         """Link a visible item to a workspace without hiding other memberships."""
 
-        if self.get_workspace(workspace_id) is None:
-            raise WorkspaceNotFound(workspace_id)
+        safe_workspace_id = _normalize_required_text(workspace_id, "workspace_id")
+        if self.get_workspace(safe_workspace_id) is None:
+            raise WorkspaceNotFound(safe_workspace_id)
         membership = WorkspaceMembership(
             membership_id=self._id_factory(),
-            workspace_id=workspace_id,
+            workspace_id=safe_workspace_id,
             item_type=item_type,
             item_id=item_id,
             role=role,
@@ -243,10 +255,28 @@ class LocalWorkspaceRegistryService:
                 )
         except sqlite3.Error as exc:
             raise WorkspaceRegistryServiceError(_STORAGE_FAILURE_MESSAGE) from exc
-        memberships = self.get_item_memberships(item_type, item_id)
-        for existing in memberships:
-            if existing.workspace_id == workspace_id and existing.role == role:
-                return existing
+        try:
+            with self.db.connection() as conn:
+                row = conn.execute(
+                    """
+                    SELECT *
+                    FROM workspace_memberships
+                    WHERE workspace_id = ?
+                        AND item_type = ?
+                        AND item_id = ?
+                        AND role = ?
+                    """,
+                    (
+                        membership.workspace_id,
+                        membership.item_type,
+                        membership.item_id,
+                        membership.role,
+                    ),
+                ).fetchone()
+        except sqlite3.Error as exc:
+            raise WorkspaceRegistryServiceError(_STORAGE_FAILURE_MESSAGE) from exc
+        if row is not None:
+            return _membership_from_row(row)
         raise WorkspaceRegistryServiceError("Workspace membership link failed.")
 
     def get_item_memberships(
@@ -256,6 +286,8 @@ class LocalWorkspaceRegistryService:
     ) -> tuple[WorkspaceMembership, ...]:
         """Return all workspace memberships for one visible item."""
 
+        safe_item_type = _normalize_required_text(item_type, "item_type")
+        safe_item_id = _normalize_required_text(item_id, "item_id")
         try:
             with self.db.connection() as conn:
                 rows = conn.execute(
@@ -266,7 +298,7 @@ class LocalWorkspaceRegistryService:
                         AND item_id = ?
                     ORDER BY created_at ASC, workspace_id ASC, role ASC
                     """,
-                    (item_type, item_id),
+                    (safe_item_type, safe_item_id),
                 ).fetchall()
         except sqlite3.Error as exc:
             raise WorkspaceRegistryServiceError(_STORAGE_FAILURE_MESSAGE) from exc
@@ -278,6 +310,7 @@ class LocalWorkspaceRegistryService:
     ) -> tuple[WorkspaceMembership, ...]:
         """Return item memberships for a workspace."""
 
+        safe_workspace_id = _normalize_required_text(workspace_id, "workspace_id")
         try:
             with self.db.connection() as conn:
                 rows = conn.execute(
@@ -287,7 +320,7 @@ class LocalWorkspaceRegistryService:
                     WHERE workspace_id = ?
                     ORDER BY created_at ASC, item_type ASC, item_id ASC, role ASC
                     """,
-                    (workspace_id,),
+                    (safe_workspace_id,),
                 ).fetchall()
         except sqlite3.Error as exc:
             raise WorkspaceRegistryServiceError(_STORAGE_FAILURE_MESSAGE) from exc
@@ -308,10 +341,11 @@ class LocalWorkspaceRegistryService:
             label=binding.label,
             locator=binding.locator,
             status=binding.status,
-            metadata=scrub_secret_metadata(binding.metadata),
+            metadata=binding.metadata,
             created_at=binding.created_at,
             updated_at=self._now_factory(),
         )
+        metadata_json = _metadata_to_json(safe_binding.metadata)
         try:
             with self.db.transaction() as conn:
                 conn.execute(
@@ -344,7 +378,7 @@ class LocalWorkspaceRegistryService:
                         safe_binding.label,
                         safe_binding.locator,
                         safe_binding.status.value,
-                        json.dumps(safe_binding.metadata, sort_keys=True),
+                        metadata_json,
                         safe_binding.created_at,
                         safe_binding.updated_at,
                     ),
@@ -359,6 +393,7 @@ class LocalWorkspaceRegistryService:
     def get_runtime_binding(self, binding_id: str) -> WorkspaceRuntimeBinding | None:
         """Return one runtime binding if it exists."""
 
+        safe_binding_id = _normalize_required_text(binding_id, "binding_id")
         try:
             with self.db.connection() as conn:
                 row = conn.execute(
@@ -367,7 +402,7 @@ class LocalWorkspaceRegistryService:
                     FROM workspace_runtime_bindings
                     WHERE binding_id = ?
                     """,
-                    (binding_id,),
+                    (safe_binding_id,),
                 ).fetchone()
         except sqlite3.Error as exc:
             raise WorkspaceRegistryServiceError(_STORAGE_FAILURE_MESSAGE) from exc
@@ -379,6 +414,7 @@ class LocalWorkspaceRegistryService:
     ) -> tuple[WorkspaceRuntimeBinding, ...]:
         """Return runtime bindings for a workspace."""
 
+        safe_workspace_id = _normalize_required_text(workspace_id, "workspace_id")
         try:
             with self.db.connection() as conn:
                 rows = conn.execute(
@@ -388,7 +424,7 @@ class LocalWorkspaceRegistryService:
                     WHERE workspace_id = ?
                     ORDER BY created_at ASC, binding_id ASC
                     """,
-                    (workspace_id,),
+                    (safe_workspace_id,),
                 ).fetchall()
         except sqlite3.Error as exc:
             raise WorkspaceRegistryServiceError(_STORAGE_FAILURE_MESSAGE) from exc
@@ -423,7 +459,7 @@ def _membership_from_row(row: sqlite3.Row) -> WorkspaceMembership:
 
 
 def _runtime_binding_from_row(row: sqlite3.Row) -> WorkspaceRuntimeBinding:
-    metadata = json.loads(row["metadata_json"] or "{}")
+    metadata = _metadata_from_json(row["metadata_json"], binding_id=row["binding_id"])
     return WorkspaceRuntimeBinding(
         workspace_id=row["workspace_id"],
         binding_id=row["binding_id"],
@@ -435,3 +471,33 @@ def _runtime_binding_from_row(row: sqlite3.Row) -> WorkspaceRuntimeBinding:
         created_at=row["created_at"],
         updated_at=row["updated_at"],
     )
+
+
+def _metadata_to_json(metadata: dict[str, object]) -> str:
+    try:
+        return json.dumps(metadata, sort_keys=True)
+    except (TypeError, ValueError) as exc:
+        raise WorkspaceRegistryServiceError(
+            "Runtime binding metadata must be JSON-serializable."
+        ) from exc
+
+
+def _metadata_from_json(value: str, *, binding_id: str) -> dict[str, object]:
+    try:
+        decoded = json.loads(value or "{}")
+    except json.JSONDecodeError:
+        logger.warning(
+            "Invalid workspace runtime binding metadata JSON; using empty metadata",
+            binding_id=binding_id,
+        )
+        return {}
+    return decoded if isinstance(decoded, dict) else {}
+
+
+def _normalize_required_text(value: str, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be text")
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{field_name} is required")
+    return normalized

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -72,6 +72,7 @@ from .config import (
     get_research_db_path,
     get_subscriptions_db_path,
     get_user_data_dir,
+    get_workspaces_db_path,
     get_writing_db_path,
 )
 from .Logging_Config import configure_application_logging
@@ -93,6 +94,7 @@ from tldw_chatbook.Chat.server_chat_loop_service import ServerChatLoopService
 from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
 from tldw_chatbook.DB.Library_Collections_DB import LibraryCollectionsDB
 from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
+from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
 from tldw_chatbook.config import CLI_APP_CLIENT_ID
 from tldw_chatbook.Chat import (
     ChatConversationScopeService,
@@ -315,6 +317,7 @@ from tldw_chatbook.MCP_Governance_Interop import MCPGovernanceScopeService, Serv
 from tldw_chatbook.User_Governance_Interop import ServerUserGovernanceService, UserGovernanceScopeService
 from tldw_chatbook.Web_Clipper_Interop import ServerWebClipperService, WebClipperScopeService
 from tldw_chatbook.Web_Scraping_Interop import ServerWebScrapingService, WebScrapingScopeService
+from tldw_chatbook.Workspaces import LocalWorkspaceRegistryService
 from tldw_chatbook.Writing_Interop import LocalWritingService, ServerWritingService, WritingScopeService
 from tldw_chatbook.Subscriptions import (
     LocalWatchlistsService,
@@ -1520,6 +1523,7 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
             policy_enforcer=self.service_policy_enforcer,
         )
         self._wire_library_collections_services()
+        self._wire_workspace_registry_services()
         self._wire_prompt_chatbook_services()
         self._wire_watchlists_and_notifications_services()
         self._wire_writing_services()
@@ -1911,6 +1915,23 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
             self.local_library_collections_db = None
             self.local_library_collections_service = None
             self.library_collections_service = None
+
+    def _wire_workspace_registry_services(self) -> None:
+        try:
+            self.local_workspace_db = WorkspaceDB(
+                get_workspaces_db_path(),
+                CLI_APP_CLIENT_ID,
+            )
+            self.workspace_registry_service = LocalWorkspaceRegistryService(
+                self.local_workspace_db,
+            )
+        except Exception:
+            logger.warning(
+                "Local workspace registry service unavailable during app wiring",
+                exc_info=True,
+            )
+            self.local_workspace_db = None
+            self.workspace_registry_service = None
 
     def _build_chatbook_db_paths(self) -> dict[str, str]:
         return {

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -1450,6 +1450,8 @@ research_db_path = "~/.local/share/tldw_cli/tldw_chatbook_research.db"
 writing_db_path = "~/.local/share/tldw_cli/tldw_chatbook_writing.db"
 # Path to the local Library Collections database.
 library_collections_db_path = "~/.local/share/tldw_cli/tldw_chatbook_library_collections.db"
+# Path to the local Workspaces database.
+workspaces_db_path = "~/.local/share/tldw_cli/tldw_chatbook_workspaces.db"
 USER_DB_BASE_DIR = "~/.local/share/tldw_cli/"
 
 # Database integrity checking
@@ -3296,6 +3298,15 @@ def get_library_collections_db_path() -> Path:
     else:
         user_dir = get_user_data_dir()
         db_path = user_dir / "tldw_chatbook_library_collections.db"
+    return db_path
+
+def get_workspaces_db_path() -> Path:
+    custom_path = get_cli_setting("database", "workspaces_db_path", None)
+    if custom_path and custom_path != DEFAULT_CONFIG_FROM_TOML.get("database", {}).get("workspaces_db_path"):
+        db_path = validate_path_simple(Path(str(custom_path)).expanduser(), require_exists=False).resolve()
+    else:
+        user_dir = get_user_data_dir()
+        db_path = user_dir / "tldw_chatbook_workspaces.db"
     return db_path
 
 def get_subscriptions_db_path() -> Path:


### PR DESCRIPTION
## Summary
- Adds validated workspace operating-context models, runtime binding secret scrubbing, and pure active-context eligibility rules.
- Adds local WorkspaceDB persistence and LocalWorkspaceRegistryService for active workspace, memberships, and runtime bindings.
- Wires app-owned workspace_registry_service and records PR A task/plan state.

## Test Plan
- [x] python -m pytest -q Tests/Workspaces/test_workspace_models.py Tests/Workspaces/test_workspace_eligibility.py Tests/Workspaces/test_workspace_registry_service.py Tests/UI/test_screen_navigation.py --tb=short
- [x] git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lays the foundation for workspace operating context: validated models, pure eligibility rules, and a local registry with SQLite persistence to support an active workspace in Console. Adds a hardened, app-owned `LocalWorkspaceRegistryService` with secret-scrubbed runtime bindings to prepare for the workspace switcher per the PRD.

- **New Features**
  - Added `tldw_chatbook/Workspaces` domain with validated models and enums (authority, sync, transfer).
  - Implemented `evaluate_workspace_eligibility` to keep global browse/search visible and gate active-context ops with reason codes and recovery copy.
  - Added `WorkspaceDB` (SQLite) and `LocalWorkspaceRegistryService` to persist workspaces, memberships, runtime bindings; secrets are scrubbed. Hardened with typed errors (`WorkspaceNotFound`, `DuplicateWorkspace`), stricter validation, idempotent operations, and transaction-safe writes.
  - App wiring: new `get_workspaces_db_path` config and service import; tests cover models, eligibility, and registry.

- **Migration**
  - No breaking changes; a local `tldw_chatbook_workspaces.db` is created automatically (configurable via `get_workspaces_db_path`).
  - No UI changes yet; enables the upcoming Console workspace switcher defined in the PRD.

<sup>Written for commit 1643dc4176847b492f811f279196872d8676b78f. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/337?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

