### PR TITLE
Close resolved Watchlists loading follow-up

### DIFF
--- a/backlog/tasks/task-60.6 - Fix-Watchlists-destination-indefinite-local-snapshot-loading-state.md
+++ b/backlog/tasks/task-60.6 - Fix-Watchlists-destination-indefinite-local-snapshot-loading-state.md
@@ -41,7 +41,7 @@ Ensure the Watchlists destination resolves its local snapshot load into an actio
 - Verified the issue is already resolved on current `origin/dev` after the Watchlists screen QA work.
 - Current Watchlists destination coverage includes empty local snapshots, service failure recovery copy, timeout-to-recovery behavior, distinct initial loading copy, policy-denied recovery selectors, disabled Console attach state, and deterministic polling via `_wait_for_wc_snapshot`.
 - No production code change was needed; the task is closed as verified by the focused Watchlists destination regression slice.
-- Verification: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_destination_shells.py -k 'watchlists_collections' --tb=short` returned `13 passed, 89 deselected`.
+- Verification: python -m pytest -q Tests/UI/test_destination_shells.py -k 'watchlists_collections' --tb=short returned 13 passed, 89 deselected.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-60.6 - Fix-Watchlists-destination-indefinite-local-snapshot-loading-state.md
+++ b/backlog/tasks/task-60.6 - Fix-Watchlists-destination-indefinite-local-snapshot-loading-state.md
@@ -1,14 +1,14 @@
 ---
 id: TASK-60.6
 title: Fix Watchlists destination indefinite local snapshot loading state
-status: To Do
+status: Done
 assignee: []
-created_date: '2026-05-20 15:16'
+created_date: 2026-05-20 15:16
 labels:
-  - ux
-  - hci
-  - qa
-  - screens
+- ux
+- hci
+- qa
+- screens
 dependencies: []
 parent_task_id: TASK-60
 priority: high
@@ -22,8 +22,29 @@ Ensure the Watchlists destination resolves its local snapshot load into an actio
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Watchlists screen leaves loading state deterministically in an empty local profile.
-- [ ] #2 Watchlists screen shows an actionable empty or service error state instead of permanent loading copy.
-- [ ] #3 Open and Console controls reflect actual run availability.
-- [ ] #4 Mounted regression waits deterministically without fixed sleeps.
+- [x] #1 Watchlists screen leaves loading state deterministically in an empty local profile.
+- [x] #2 Watchlists screen shows an actionable empty or service error state instead of permanent loading copy.
+- [x] #3 Open and Console controls reflect actual run availability.
+- [x] #4 Mounted regression waits deterministically without fixed sleeps.
 <!-- AC:END -->
+
+## Implementation Plan
+<!-- SECTION:PLAN:BEGIN -->
+1. Re-check current merged `dev` before editing because Watchlists screen QA was already completed in a later PR.
+2. Inspect Watchlists destination tests and screen loading/error/empty-state code paths.
+3. Run the focused Watchlists destination regression slice to verify empty, error, timeout, control-state, and deterministic wait coverage.
+4. If the bug still reproduces, add a failing regression and implement the smallest fix; otherwise close the stale follow-up with verification evidence.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+- Verified the issue is already resolved on current `origin/dev` after the Watchlists screen QA work.
+- Current Watchlists destination coverage includes empty local snapshots, service failure recovery copy, timeout-to-recovery behavior, distinct initial loading copy, policy-denied recovery selectors, disabled Console attach state, and deterministic polling via `_wait_for_wc_snapshot`.
+- No production code change was needed; the task is closed as verified by the focused Watchlists destination regression slice.
+- Verification: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_destination_shells.py -k 'watchlists_collections' --tb=short` returned `13 passed, 89 deselected`.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Closed as already fixed on current `dev`; focused mounted Watchlists destination regressions pass and cover the original indefinite loading failure mode.
+<!-- SECTION:FINAL_SUMMARY:END -->


### PR DESCRIPTION
## Summary
- Mark TASK-60.6 done after verifying the Watchlists loading-state issue is already resolved on current dev.
- Record existing deterministic regression coverage for empty, service-error, timeout, disabled-control, and handoff states.
- No production code changed.

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_destination_shells.py -k 'watchlists_collections' --tb=short
- git diff --check

## Notes
- This is backlog/task hygiene only; no visible UI changed, so no new screenshot approval is required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks TASK-60.6 as Done after verifying the Watchlists destination indefinite loading bug is already fixed on current dev, and updates the task doc with checked acceptance criteria, an implementation plan, and test evidence. Documents deterministic regression coverage (empty profile, service error, timeout-to-recovery, distinct initial loading copy, policy-denied recovery selectors, disabled Console attach, and polling via `_wait_for_wc_snapshot`); no production code or UI changes.

<sup>Written for commit c1d6c1014b513d63dadcc45dfca0a558a1c70cf8. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/344?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

