### PR TITLE
Close post-release cross-screen workflow validation

### DIFF
--- a/Docs/superpowers/qa/product-maturity/post-release-ux-hci/2026-05-22-cross-screen-workflow-validation.md
+++ b/Docs/superpowers/qa/product-maturity/post-release-ux-hci/2026-05-22-cross-screen-workflow-validation.md
@@ -1,0 +1,92 @@
+# Post-Release UX/HCI Walkthrough Evidence: Cross-Screen Workflows
+
+## Metadata
+
+- Task: `TASK-60.3`
+- Screen or workflow: Cross-screen workflow validation
+- Date: 2026-05-22
+- Branch: `codex/continue-screen-qa`
+- App command: mounted Textual app regressions against current `origin/dev`; prior screen visuals captured through textual-web/CDP in `actual-screenshots/`
+- Evidence method: focused mounted Textual workflow tests plus existing actual screenshot evidence; no visible UI changed in this slice
+- Actual screenshot path: existing screen captures under `Docs/superpowers/qa/product-maturity/post-release-ux-hci/actual-screenshots/`
+- Screenshot approval: no new screenshot required for this docs/test-only workflow closeout
+- Reviewer: workflow evidence pending PR review
+
+## User Goal
+
+Verify that the top-level destinations work together as a product system, especially when handing context into Console as the primary agentic control surface.
+
+## Steps Attempted
+
+1. Refreshed current `origin/dev` after PR #344 merged.
+2. Reviewed existing post-release screen evidence and stale cross-screen follow-up notes.
+3. Ran focused mounted Textual regressions for Home, Library, Artifacts, Personas, Skills, ACP, Watchlists, Schedules, Workflows, and Console source-readiness paths.
+4. Classified each workflow as complete, recoverably blocked, or future service-depth work with visible recovery copy.
+
+## Workflow Matrix
+
+| Workflow | Status | Evidence | Friction And Recovery | Severity |
+| --- | --- | --- | --- | --- |
+| Home primary action opens target route | Verified | `test_home_primary_action_opens_target_route` | Fast path is one action; clean dashboard remains sparse but routes to Library instead of dead-ending. | P2 residual orientation only |
+| Home active work opens Console with payload | Verified | `test_app_console_hook_opens_console_with_adapter_launch_payload` | Adapter payload preserves source/status/recovery/action metadata for Console. | None |
+| Home mixed Watchlists plus Chatbook controls | Verified | `test_home_mixed_active_work_exposes_chatbook_artifact_resume_controls` | Chatbook remains reachable even when Watchlists active work exists. | None |
+| Library Search/RAG mode and source handoff | Verified/recoverable | `test_library_search_action_switches_to_search_mode_without_route_handoff`, `test_library_use_in_console_uses_source_snapshot_context` | Empty source state blocks safely; populated source snapshot can stage Console context. | None |
+| Artifacts/Chatbook resume to Console | Verified | `test_artifacts_destination_reopens_console_saved_chatbook_with_provenance` | Saved Chatbook provenance is preserved in the Console launch payload. | None |
+| Personas and Skills attach to Console | Verified | `test_personas_attach_to_console_uses_listed_behavior_context`, `test_skills_attach_to_console_uses_listed_skill_context` | Attach paths use selected/listed context and avoid fake handoffs when context is unavailable. | None |
+| ACP session follow into Console | Verified with fixture-backed session payload | `test_acp_session_payload_enables_console_follow_live_work_handoff` | Missing runtime remains an honest blocked state; session payload enables follow. | Future runtime depth |
+| Watchlists, Schedules, Workflows run follow | Verified with adapter-backed run context | `test_watchlists_destination_routes_latest_active_run_to_console`, `test_schedules_destination_routes_latest_active_run_to_console`, `test_workflows_destination_routes_latest_active_run_to_console` | Empty states remain disabled; populated adapter context routes to Console. | None |
+| MCP source readiness in Console | Classified future service-depth | `test_console_renders_source_readiness_summary_without_pending_launch` | Console states MCP is not embedded and directs server management to MCP; no fake Console tool run exists. | Future MCP runtime depth |
+
+## Nielsen Norman Heuristic Findings
+
+- Visibility of system status: strong for handoff readiness; Console shows source readiness and destination screens disable unavailable follow actions.
+- Match between system and real world: source, run, artifact, persona, skill, and ACP session language maps to user-visible product objects.
+- User control and freedom: blocked states keep users in the current destination and explain the recovery path instead of navigating unexpectedly.
+- Consistency and standards: handoff payloads now use shared Console live-work contracts instead of per-screen ad hoc launches.
+- Error prevention: empty, unavailable, or missing-runtime states disable unsafe Console follow actions.
+- Recognition rather than recall: recovery copy names the missing source, runtime, run, or artifact prerequisite.
+- Flexibility and efficiency of use: repeated workflows are single-action once a source/run/artifact exists; service-depth gaps remain explicit future work.
+- Aesthetic and minimalist design: no new UI was introduced; this pass validates existing approved destination shells.
+- Error recognition, diagnosis, and recovery: missing-provider/source/runtime states are visible and preserve user work.
+- Help and documentation: evidence now distinguishes verified workflow support from future MCP/runtime/server depth.
+
+## Power-User Repetition Findings
+
+| Repeated Workflow | Qualitative Timing | Shortcut/State Notes |
+| --- | --- | --- |
+| Home -> Library next action | Fast | One primary action; useful for empty profile onboarding and repeated source import starts. |
+| Home active work -> Console | Fast when adapter context exists | Launch payload preserves action label, recovery, and target route. |
+| Library source -> Console | Moderate | Requires source availability/selection; empty Library blocks honestly. |
+| Artifacts Chatbook -> Console | Fast once artifact exists | Latest/requested Chatbook selection is deterministic. |
+| Watchlists/Schedules/Workflows -> Console | Fast with active adapter item | Empty states are safe but require upstream run creation. |
+| Personas/Skills -> Console | Fast with valid local context | Invalid/empty service states block honestly. |
+
+## Severity Decisions
+
+| Finding | Severity | Follow-Up Task | Decision |
+| --- | --- | --- | --- |
+| MCP configured-server tool execution remains service-depth future work | P2 | `TASK-60.4` | Defer to feature tranche planning because the UI is honest and non-actionable rather than misleading. |
+| ACP real runtime launch remains future service-depth work | P2 | `TASK-60.4` | Fixture-backed session payload proves the Console handoff contract; runtime launch planning remains deferred. |
+| Empty Library Search/RAG cannot produce evidence until sources exist | P2 | `TASK-60.4` | Accept as recoverable blocked state; deeper source/citation/snippet carry-through belongs to deferred feature planning. |
+
+No unresolved P0/P1 findings remain for `TASK-60.3`.
+
+## Verification
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_home_screen.py::test_home_primary_action_opens_target_route Tests/UI/test_home_screen.py::test_app_console_hook_opens_console_with_adapter_launch_payload Tests/UI/test_home_screen.py::test_home_mixed_active_work_exposes_chatbook_artifact_resume_controls Tests/UI/test_destination_shells.py::test_library_use_in_console_uses_source_snapshot_context Tests/UI/test_destination_shells.py::test_library_search_action_switches_to_search_mode_without_route_handoff --tb=short
+```
+
+Result: 5 passed.
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_destination_shells.py::test_personas_attach_to_console_uses_listed_behavior_context Tests/UI/test_destination_shells.py::test_skills_attach_to_console_uses_listed_skill_context Tests/UI/test_destination_shells.py::test_acp_session_payload_enables_console_follow_live_work_handoff Tests/UI/test_console_live_work_handoffs.py::test_schedules_destination_routes_latest_active_run_to_console Tests/UI/test_console_live_work_handoffs.py::test_workflows_destination_routes_latest_active_run_to_console Tests/UI/test_console_live_work_handoffs.py::test_watchlists_destination_routes_latest_active_run_to_console Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_reopens_console_saved_chatbook_with_provenance Tests/UI/test_console_live_work_handoffs.py::test_console_renders_source_readiness_summary_without_pending_launch --tb=short
+```
+
+Result: 8 passed.
+
+## Acceptance Decision
+
+- Accepted: yes for `TASK-60.3` workflow-validation scope.
+- Reason: required handoffs are verified or honestly classified as recoverable/future service-depth work with user-visible copy.
+- Remaining follow-up: `TASK-60.4` plans deferred feature tranches for MCP/ACP runtime depth, Workspaces/Library depth, write sync, and citation/snippet carry-through.

--- a/Docs/superpowers/qa/product-maturity/post-release-ux-hci/README.md
+++ b/Docs/superpowers/qa/product-maturity/post-release-ux-hci/README.md
@@ -16,29 +16,31 @@ This index exists because prior mounted layout checks and phase closeout evidenc
 
 | Screen | Evidence Status | Screenshot Approval | Functionality Status | Follow-Up |
 | --- | --- | --- | --- | --- |
-| Home | recorded | pending | next-best action opens Library | `TASK-60.3` |
-| Console | recorded | pending | visible composer input and blocked-send recovery verified | `TASK-60.3` |
-| Library | recorded | pending | Search/RAG keyboard activation and blocked empty recovery verified | `TASK-60.3` |
-| Artifacts | recorded | pending | empty state and Open Console recovery verified | `TASK-60.3` |
+| Home | recorded | pending | next-best action opens Library; active-work Console payload verified | `TASK-60.3` verified |
+| Console | recorded | pending | visible composer input, blocked-send recovery, and source-readiness summary verified | `TASK-60.3` verified |
+| Library | recorded | pending | Search/RAG mode, blocked empty recovery, and source-to-Console handoff verified | `TASK-60.3` verified |
+| Artifacts | recorded | pending | empty state, Open Console recovery, and Chatbook resume payload verified | `TASK-60.3` verified |
 | Personas | recorded | approved | loading blocker fixed; CCP route approved as destination-native workbench | `TASK-60.5` |
-| Watchlists | recorded | pending | P1 indefinite loading blocks primary run review path | `TASK-60.6` |
-| Schedules | recorded | pending | empty/recovery baseline verified | `TASK-60.3` |
-| Workflows | recorded | pending | empty/recovery baseline verified | `TASK-60.3` |
-| MCP | recorded | pending | local overview and no-server recovery verified | `TASK-60.3` |
-| ACP | recorded | pending | runtime-not-configured recovery verified | `TASK-60.3` |
-| Skills | recorded | pending | empty state and import-not-wired recovery visible | `TASK-60.3` |
+| Watchlists | recorded | pending | deterministic loading recovery and active-run Console follow verified | `TASK-60.6`; `TASK-60.3` verified |
+| Schedules | recorded | pending | empty/recovery baseline and active-run Console follow verified | `TASK-60.3` verified |
+| Workflows | recorded | pending | empty/recovery baseline and active-run Console follow verified | `TASK-60.3` verified |
+| MCP | recorded | pending | local overview and no-server recovery verified; Console source readiness classifies MCP as future service-depth | `TASK-60.3` verified; `TASK-60.4` planning |
+| ACP | recorded | pending | runtime-not-configured recovery and fixture-backed session handoff verified | `TASK-60.3` verified; `TASK-60.4` planning |
+| Skills | recorded | pending | empty state, import-not-wired recovery, and valid-skill Console attach verified | `TASK-60.3` verified |
 | Settings | recorded | pending | preference and scope baseline recorded | `TASK-60.3` |
 
 ## Required Cross-Screen Workflows
 
 | Workflow | Evidence Status | Acceptance Gate |
 | --- | --- | --- |
-| Home active work to details and Console | pending | actual-use handoff or clear blocked recovery |
-| Library Search/RAG to Console context | pending | evidence handoff or clear blocked recovery |
-| Console composer, send/block, Chatbook save/resume | pending | visible input and recoverable send/save path |
-| Artifacts/Chatbooks to Console resume | pending | no dead controls |
-| Personas/Skills/MCP/ACP context to Console | pending | verified handoff or honest blocked future work |
-| Watchlists/Schedules/Workflows runs to Console | pending | verified handoff or honest blocked future work |
+| Home active work to details and Console | verified | actual-use handoff or clear blocked recovery |
+| Library Search/RAG to Console context | verified/recoverable | evidence handoff or clear blocked recovery |
+| Console composer, send/block, Chatbook save/resume | verified/recoverable | visible input and recoverable send/save path |
+| Artifacts/Chatbooks to Console resume | verified | no dead controls |
+| Personas/Skills/MCP/ACP context to Console | verified/recoverable | verified handoff or honest blocked future work |
+| Watchlists/Schedules/Workflows runs to Console | verified | verified handoff or honest blocked future work |
+
+Current workflow evidence: `2026-05-22-cross-screen-workflow-validation.md`.
 
 ## Severity Rules
 

--- a/Docs/superpowers/trackers/product-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/product-maturity-roadmap.md
@@ -64,7 +64,7 @@ Product Maturity Phase 1 and Phase 2 are not reopened by default. Their existing
 ## Post-Release UX/HCI Functional Validation
 
 Source Plan: `Docs/superpowers/plans/2026-05-17-post-release-ux-hci-functional-validation.md`
-Status: in progress; `TASK-60` active
+Status: in progress; `TASK-60.3` verified; `TASK-60.4` pending
 
 This tranche reopens validation only where evidence must come from actual app use. It does not invalidate the historical Phase 3-6 closeout evidence, but it treats that evidence as insufficient for current usability certification when the rendered app may still be visually or functionally broken.
 
@@ -74,7 +74,7 @@ Acceptance requires actual screenshots, actual-use functionality evidence, and c
 | --- | --- | --- |
 | Actual-screen UX/HCI audit harness | `TASK-60.1` | Define screenshot, CDP/textual-web, NN/g, severity, and approval evidence before auditing screens. |
 | Top-level screen functionality audit | `TASK-60.2` | Home, Console, Library, Artifacts, Personas, Watchlists, Schedules, Workflows, MCP, ACP, Skills, and Settings require rendered screenshot approval plus actual-use evidence. |
-| Cross-screen workflow validation | `TASK-60.3` | Validate handoffs into Console, Library/RAG to Console, Chatbook save/resume, agent configuration paths, and run-control paths end-to-end. |
+| Cross-screen workflow validation | `TASK-60.3` | Verified handoffs into Console, Library/RAG to Console, Chatbook save/resume, agent configuration paths, and run-control paths; future service-depth gaps are classified for `TASK-60.4`. |
 | Deferred feature tranche planning | `TASK-60.4` | Plan ACP runtime launch, write sync, Workspaces/Library depth, citation/snippet carry-through, and optional dependency/package polish only after audit findings are known. |
 | Personas loading recovery | `TASK-60.5` | Resolve indefinite Personas local behavior-context loading before accepting the Personas destination. |
 | Watchlists loading recovery | `TASK-60.6` | Resolve indefinite Watchlists local snapshot loading before accepting the Watchlists destination. |

--- a/Tests/UI/test_post_release_ux_hci_validation_plan.py
+++ b/Tests/UI/test_post_release_ux_hci_validation_plan.py
@@ -10,6 +10,9 @@ PLAN = Path("Docs/superpowers/plans/2026-05-17-post-release-ux-hci-functional-va
 TRACKER = Path("Docs/superpowers/trackers/product-maturity-roadmap.md")
 QA_README = Path("Docs/superpowers/qa/product-maturity/post-release-ux-hci/README.md")
 QA_TEMPLATE = Path("Docs/superpowers/qa/product-maturity/post-release-ux-hci/walkthrough-template.md")
+WORKFLOW_EVIDENCE = Path(
+    "Docs/superpowers/qa/product-maturity/post-release-ux-hci/2026-05-22-cross-screen-workflow-validation.md"
+)
 TASK_60 = Path("backlog/tasks/task-60 - Post-release-UX-HCI-and-functionality-validation-tranche.md")
 CHILD_TASKS = {
     "TASK-60.1": Path(
@@ -103,8 +106,8 @@ def test_post_release_qa_harness_requires_real_screenshots_and_approval() -> Non
         )
         columns = matching_rows[0]
         assert len(columns) >= 5, f"{screen} row must include all QA index columns"
-        assert columns[2] == "pending", (
-            f"{screen} row must track pending screenshot approval explicitly"
+        assert columns[2] in {"pending", "approved"}, (
+            f"{screen} row must track screenshot approval explicitly"
         )
 
     for required_field in (
@@ -138,10 +141,10 @@ def test_post_release_backlog_tasks_track_screens_workflows_and_deferred_feature
     expected_statuses = {
         "TASK-60.1": "Done",
         "TASK-60.2": "Done",
-        "TASK-60.3": "To Do",
+        "TASK-60.3": "Done",
         "TASK-60.4": "To Do",
-        "TASK-60.5": "To Do",
-        "TASK-60.6": "To Do",
+        "TASK-60.5": "Done",
+        "TASK-60.6": "Done",
     }
     for task_id, expected_status in expected_statuses.items():
         assert f"status: {expected_status}" in _text(CHILD_TASKS[task_id])
@@ -172,3 +175,24 @@ def test_product_maturity_tracker_lists_post_release_validation_tranche() -> Non
     assert "actual screenshots" in tracker
     assert "actual-use functionality evidence" in tracker
     assert "cross-screen workflow validation" in tracker
+
+
+def test_post_release_cross_screen_workflow_evidence_records_verification() -> None:
+    evidence = _text(WORKFLOW_EVIDENCE)
+    readme = _text(QA_README)
+
+    for required in (
+        "TASK-60.3",
+        "Workflow Matrix",
+        "Home primary action opens target route",
+        "Library Search/RAG mode and source handoff",
+        "Artifacts/Chatbook resume to Console",
+        "Personas and Skills attach to Console",
+        "Watchlists, Schedules, Workflows run follow",
+        "No unresolved P0/P1 findings remain",
+        "Result: 5 passed",
+        "Result: 8 passed",
+    ):
+        assert required in evidence
+
+    assert "2026-05-22-cross-screen-workflow-validation.md" in readme

--- a/backlog/tasks/task-60.3 - Post-release-cross-screen-workflow-validation.md
+++ b/backlog/tasks/task-60.3 - Post-release-cross-screen-workflow-validation.md
@@ -1,14 +1,18 @@
 ---
 id: TASK-60.3
 title: Post-release cross-screen workflow validation
-status: To Do
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-05-22 05:53'
 labels:
-- ux
-- hci
-- qa
-- workflows
-priority: high
+  - ux
+  - hci
+  - qa
+  - workflows
+dependencies: []
 parent_task_id: TASK-60
+priority: high
 ---
 
 ## Description
@@ -19,23 +23,36 @@ Validate end-to-end product workflows across destinations using the actual app, 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Home active work can open details and route relevant work into Console or shows a clear blocked state.
-- [ ] #2 Library Search/RAG can produce evidence or a recoverable blocked state, then hand off context into Console where appropriate.
-- [ ] #3 Artifacts and Chatbooks can be opened, resumed, or clearly blocked from Home/Artifacts/Console without dead controls.
-- [ ] #4 Personas, Skills, MCP, ACP, Watchlists, Schedules, and Workflows handoffs into Console are verified or explicitly classified as blocked future work with user-visible recovery copy.
-- [ ] #5 At least five power-user repeated workflows are timed qualitatively for friction, shortcuts, state persistence, and recovery paths.
+- [x] #1 Home active work can open details and route relevant work into Console or shows a clear blocked state.
+- [x] #2 Library Search/RAG can produce evidence or a recoverable blocked state, then hand off context into Console where appropriate.
+- [x] #3 Artifacts and Chatbooks can be opened, resumed, or clearly blocked from Home/Artifacts/Console without dead controls.
+- [x] #4 Personas, Skills, MCP, ACP, Watchlists, Schedules, and Workflows handoffs into Console are verified or explicitly classified as blocked future work with user-visible recovery copy.
+- [x] #5 At least five power-user repeated workflows are timed qualitatively for friction, shortcuts, state persistence, and recovery paths.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Refresh current dev state and existing post-release QA evidence so the workflow audit starts from real merged behavior.
+2. Run actual app/CDP or mounted-pilot validation for the required cross-screen workflows: Home to Console, Library RAG to Console, Artifacts/Chatbooks resume, and destination handoffs into Console.
+3. Capture evidence files under Docs/superpowers/qa/product-maturity/post-release-ux-hci/ with screenshots only when a visible UI state changes or needs user approval.
+4. Classify each workflow as complete, recoverably blocked, or defective using P0/P1/P2/P3 severity and create follow-up Backlog tasks for unresolved P0/P1 findings.
+5. Run focused regression tests for verified paths and update TASK-60.3 with implementation notes, final summary, AC status, and residual risks.
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+- Added consolidated cross-screen workflow evidence at `Docs/superpowers/qa/product-maturity/post-release-ux-hci/2026-05-22-cross-screen-workflow-validation.md`.
+- Verified Home, Library/Search-RAG, Artifacts/Chatbooks, Personas, Skills, ACP, Watchlists, Schedules, Workflows, and Console source-readiness seams with focused mounted Textual regressions.
+- Updated the post-release QA index and product-maturity tracker so `TASK-60.3` is recorded as verified while MCP/ACP runtime depth, Workspaces/Library depth, write sync, and citation/snippet carry-through stay in `TASK-60.4`.
+- No visible UI changed in this slice, so no new screenshot approval was required; prior actual screenshot evidence remains linked in the screen evidence index.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Closed post-release cross-screen workflow validation. Required handoffs are verified or honestly classified as recoverable/future service-depth work with user-visible copy, and no unresolved P0/P1 workflow findings remain for `TASK-60.3`.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done


### PR DESCRIPTION
## Summary
- Close TASK-60.3 with consolidated cross-screen workflow evidence for Home, Library/RAG, Artifacts/Chatbooks, Personas, Skills, ACP, Watchlists, Schedules, Workflows, and Console source-readiness seams.
- Update the post-release UX/HCI QA index and product-maturity tracker to reflect verified workflow status and leave deeper MCP/ACP/runtime/Workspace/citation planning in TASK-60.4.
- Update the post-release tracking regression to cover the new workflow evidence file and current task states.

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_post_release_ux_hci_validation_plan.py --tb=short
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_home_screen.py::test_home_primary_action_opens_target_route Tests/UI/test_home_screen.py::test_app_console_hook_opens_console_with_adapter_launch_payload Tests/UI/test_home_screen.py::test_home_mixed_active_work_exposes_chatbook_artifact_resume_controls Tests/UI/test_destination_shells.py::test_library_use_in_console_uses_source_snapshot_context Tests/UI/test_destination_shells.py::test_library_search_action_switches_to_search_mode_without_route_handoff Tests/UI/test_destination_shells.py::test_personas_attach_to_console_uses_listed_behavior_context Tests/UI/test_destination_shells.py::test_skills_attach_to_console_uses_listed_skill_context Tests/UI/test_destination_shells.py::test_acp_session_payload_enables_console_follow_live_work_handoff Tests/UI/test_console_live_work_handoffs.py::test_schedules_destination_routes_latest_active_run_to_console Tests/UI/test_console_live_work_handoffs.py::test_workflows_destination_routes_latest_active_run_to_console Tests/UI/test_console_live_work_handoffs.py::test_watchlists_destination_routes_latest_active_run_to_console Tests/UI/test_console_live_work_handoffs.py::test_artifacts_destination_reopens_console_saved_chatbook_with_provenance Tests/UI/test_console_live_work_handoffs.py::test_console_renders_source_readiness_summary_without_pending_launch --tb=short
- git diff --check

## Screenshot note
- No visible UI changed in this PR; it records workflow evidence and tracking state only, so no new screenshot approval is required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes `TASK-60.3` by recording cross-screen workflow evidence and verifying handoffs into Console across Home, Library/RAG, Artifacts/Chatbooks, Personas, Skills, ACP, Watchlists, Schedules, and Workflows. Deeper MCP/ACP runtime work is deferred to `TASK-60.4`.

- **Refactors**
  - Added `Docs/superpowers/qa/product-maturity/post-release-ux-hci/2026-05-22-cross-screen-workflow-validation.md`.
  - Updated the QA index and product-maturity roadmap to reflect verified workflows and future planning.
  - Extended the validation test to assert evidence presence, accept pending/approved screenshot states, and expect `TASK-60.3`/`60.5`/`60.6` as Done.
  - Marked `backlog/tasks/task-60.3` as Done with AC checked and implementation notes.

<sup>Written for commit 4cf3e685e46b63e296653351df9d190c827978ba. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/345?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

