### PR TITLE
Plan post-release deferred feature tranches

### DIFF
--- a/Docs/Product_Roadmap.md
+++ b/Docs/Product_Roadmap.md
@@ -23,6 +23,16 @@ Some capabilities remain intentionally source-honest rather than overpromised:
 - Optional dependency groups must be installed before advanced media, RAG, MCP, or web capabilities are available.
 - Missing providers, missing sources, missing runtimes, and unavailable optional features should show the responsible surface and a recovery path.
 
+## Deferred Tranche Gates
+
+These areas are tracked as staged future work after the post-release actual-use audit. They are not counted as shipped behavior until each tranche has its own implementation evidence and actual app QA:
+
+- ACP runtime launch for task/run package handoff.
+- write sync promotion with explicit preview, conflict, rollback, and authority controls.
+- Workspaces and Library depth, including workspace ownership labels, Collections membership, and deeper Import/Export without hiding cross-workspace Library items.
+- citation and snippet carry-through from Library/Search-RAG into Console answers, Artifacts, and exported Chatbooks.
+- optional dependency and package polish for clearer advanced-feature recovery paths.
+
 ## Now: Reliability And Product Confidence
 
 Current focus:

--- a/Docs/superpowers/plans/2026-05-22-post-release-deferred-feature-tranches.md
+++ b/Docs/superpowers/plans/2026-05-22-post-release-deferred-feature-tranches.md
@@ -1,0 +1,117 @@
+# Post-Release Deferred Feature Tranches
+
+Date: 2026-05-22
+Owner: `TASK-60.4`
+Evidence source: `Docs/superpowers/qa/product-maturity/post-release-ux-hci/2026-05-22-cross-screen-workflow-validation.md`
+
+## Purpose
+
+This plan converts verified residual risks from the post-release actual-use audit into staged follow-up work. It does not approve broad implementation on its own; it makes the remaining future work visible, ordered, and testable.
+
+No deferred implementation starts before open P0/P1 usability defects are triaged. Verified shipped behavior stays separate from deferred future work so roadmap status cannot imply that blocked service depth is already complete.
+
+## Evidence Gate
+
+All tranches below use `TASK-60.3` actual-use audit evidence as their entry condition:
+
+- Home, Console, Library/Search-RAG, Artifacts/Chatbooks, Personas, Skills, Watchlists, Schedules, Workflows, ACP, MCP, and Settings were exercised through mounted Textual regressions and documented workflow evidence.
+- No unresolved P0/P1 cross-screen workflow findings remain for the verified local-first scope.
+- Service-depth gaps are recoverable or future-scoped, not hidden as shipped behavior.
+- Each tranche must add actual-use QA evidence before completion; mounted assertions alone are not enough.
+
+## Tranche 1: ACP Runtime Launch
+
+Backlog owner: `TASK-60.4.1`
+Audit evidence: ACP runtime payloads remain recoverably blocked because the UI can expose ACP session intent, but there is no real ACP-compatible runtime launch path yet.
+
+Scope:
+
+- Launch or attach to an ACP runtime from the ACP destination and Console handoff surfaces.
+- Keep unavailable runtime states source-honest until launch support exists.
+- Preserve Console as the task/run control surface once an ACP package is active.
+- Validate ACP task/run package handoff as the first server-backed handoff target.
+
+Exit evidence:
+
+- Actual app QA proves an ACP task/run package can move from local planning into an ACP runtime or present a precise recovery path.
+- Home, Console, and ACP agree on runtime status and active-work controls.
+
+## Tranche 2: Write Sync Promotion
+
+Backlog owner: `TASK-60.4.2`
+Audit evidence: write sync remains deferred; current sync-related surfaces are intentionally read-only or dry-run so users are not misled into thinking mutation replay is safe.
+
+Scope:
+
+- Promote write sync only after dry-run, conflict, rollback, and authority labels are understandable.
+- Gate mutation replay behind explicit user review.
+- Preserve local-first control if server sync is unavailable or rejected.
+- Keep source, artifact, workspace, and collection authority visible across Library, Home, Settings, and Console.
+
+Exit evidence:
+
+- Actual app QA proves users can preview, approve, recover, or abort write-sync operations without silent mutation.
+- Test fixtures cover conflict and rollback recovery paths.
+
+## Tranche 3: Workspaces And Library Depth
+
+Backlog owner: `TASK-60.4.3`
+Audit evidence: Workspace switching must not hide Library items. Users must be able to view and search all Library and Notes items while only the active workspace controls context eligibility, source authority, and Console manipulation.
+
+Scope:
+
+- Deepen workspace membership, Collections membership, and source authority without removing global Library visibility.
+- Make Import/Export depth work under Library, not Artifacts.
+- Show workspace ownership tags and eligibility states on Library items.
+- Preserve single-user local workspace behavior for offline/shared-workspace fallback.
+
+Exit evidence:
+
+- Actual app QA proves users can view/edit/search across workspaces while only active-workspace items can be staged into Console context.
+- Collections membership and deeper Import/Export are visible in Library and do not regress existing local Collections management.
+
+## Tranche 4: Citation And Snippet Carry-Through
+
+Backlog owner: `TASK-60.4.4`
+Audit evidence: citation/snippet carry-through remains downstream future work; Library/Search-RAG can stage evidence, but downstream Chat answers, Artifacts, and exported Chatbooks still need durable source attribution.
+
+Scope:
+
+- Carry retrieved snippets, citations, and source authority from Library/Search-RAG into Console responses.
+- Preserve citations/snippets in saved Artifacts and exported Chatbooks.
+- Keep citation data readable to users and structured enough for future replay/export tooling.
+- Avoid implying grounded answers when no source evidence is attached.
+
+Exit evidence:
+
+- Actual app QA proves source evidence survives the path from Library query to Console answer to saved Chatbook.
+- Tests verify missing-source and stale-source recovery states.
+
+## Tranche 5: Optional Dependency And Package Polish
+
+Backlog owner: `TASK-60.4.5`
+Audit evidence: optional dependency recovery remains source-honest; unavailable advanced features can identify missing setup, but install paths and package metadata still need polish.
+
+Scope:
+
+- Make missing dependency groups and recovery commands visible where optional media, RAG, MCP, web, or server features are unavailable.
+- Clarify baseline local-first install versus advanced extras.
+- Keep packaging metadata and setup docs aligned with the real optional feature matrix.
+- Avoid presenting missing optional features as core app failure.
+
+Exit evidence:
+
+- Actual app QA proves missing optional features show the responsible dependency group and recovery action.
+- Packaging and setup docs pass focused regression checks without machine-specific paths.
+
+## Priority Rule
+
+The tranches are ordered by workflow unlock and risk:
+
+1. ACP runtime launch unlocks the first server-backed task/run package handoff.
+2. Write sync promotion is safety-critical and must remain gated until mutation recovery is clear.
+3. Workspaces and Library depth clarifies source authority for the operating context.
+4. Citation and snippet carry-through increases answer trust and artifact durability.
+5. Optional dependency and package polish improves recovery and contributor readiness without masking core workflow defects.
+
+If future audits discover new P0/P1 defects, pause these tranches and address the usability breakage first.

--- a/Docs/superpowers/trackers/product-maturity-roadmap.md
+++ b/Docs/superpowers/trackers/product-maturity-roadmap.md
@@ -64,7 +64,8 @@ Product Maturity Phase 1 and Phase 2 are not reopened by default. Their existing
 ## Post-Release UX/HCI Functional Validation
 
 Source Plan: `Docs/superpowers/plans/2026-05-17-post-release-ux-hci-functional-validation.md`
-Status: in progress; `TASK-60.3` verified; `TASK-60.4` pending
+Deferred Tranche Plan: `Docs/superpowers/plans/2026-05-22-post-release-deferred-feature-tranches.md`
+Status: verified; `TASK-60.1` through `TASK-60.6` done; deferred tranches tracked under `TASK-60.4`
 
 This tranche reopens validation only where evidence must come from actual app use. It does not invalidate the historical Phase 3-6 closeout evidence, but it treats that evidence as insufficient for current usability certification when the rendered app may still be visually or functionally broken.
 
@@ -75,9 +76,19 @@ Acceptance requires actual screenshots, actual-use functionality evidence, and c
 | Actual-screen UX/HCI audit harness | `TASK-60.1` | Define screenshot, CDP/textual-web, NN/g, severity, and approval evidence before auditing screens. |
 | Top-level screen functionality audit | `TASK-60.2` | Home, Console, Library, Artifacts, Personas, Watchlists, Schedules, Workflows, MCP, ACP, Skills, and Settings require rendered screenshot approval plus actual-use evidence. |
 | Cross-screen workflow validation | `TASK-60.3` | Verified handoffs into Console, Library/RAG to Console, Chatbook save/resume, agent configuration paths, and run-control paths; future service-depth gaps are classified for `TASK-60.4`. |
-| Deferred feature tranche planning | `TASK-60.4` | Plan ACP runtime launch, write sync, Workspaces/Library depth, citation/snippet carry-through, and optional dependency/package polish only after audit findings are known. |
+| Deferred feature tranche planning | `TASK-60.4` | Planned ACP runtime launch, write sync, Workspaces/Library depth, citation/snippet carry-through, and optional dependency/package polish from actual-use evidence without masking P0/P1 defects. |
 | Personas loading recovery | `TASK-60.5` | Resolve indefinite Personas local behavior-context loading before accepting the Personas destination. |
 | Watchlists loading recovery | `TASK-60.6` | Resolve indefinite Watchlists local snapshot loading before accepting the Watchlists destination. |
+
+Deferred follow-up tranches:
+
+| Deferred Tranche | Backlog Owner | Evidence Boundary |
+| --- | --- | --- |
+| Post-release ACP runtime launch tranche | `TASK-60.4.1` | ACP runtime payloads remain recoverably blocked until a real ACP runtime can launch or attach and report status. |
+| Post-release write sync promotion tranche | `TASK-60.4.2` | Write sync remains deferred until preview, conflict, rollback, and mutation authority are visible and testable. |
+| Post-release Workspaces and Library depth tranche | `TASK-60.4.3` | Workspace switching must preserve global Library visibility while limiting Console context manipulation to eligible workspace items. |
+| Post-release citation and snippet carry-through tranche | `TASK-60.4.4` | Library/Search-RAG evidence is verified at the handoff seam, but downstream citation/snippet carry-through into Chat, Artifacts, and exports remains future work. |
+| Post-release optional dependency and packaging polish tranche | `TASK-60.4.5` | Optional dependency recovery remains source-honest, but package metadata and install-path polish need a dedicated follow-up. |
 
 ## Severity Policy
 
@@ -150,6 +161,11 @@ Acceptance requires actual screenshots, actual-use functionality evidence, and c
   - Top-Level Screen Functionality Audit - `TASK-60.2`
   - Cross-Screen Workflow Validation - `TASK-60.3`
   - Deferred Feature Tranche Planning - `TASK-60.4`
+    - ACP Runtime Launch Tranche - `TASK-60.4.1`
+    - Write Sync Promotion Tranche - `TASK-60.4.2`
+    - Workspaces And Library Depth Tranche - `TASK-60.4.3`
+    - Citation And Snippet Carry-Through Tranche - `TASK-60.4.4`
+    - Optional Dependency And Packaging Polish Tranche - `TASK-60.4.5`
   - Personas Loading Recovery - `TASK-60.5`
   - Watchlists Loading Recovery - `TASK-60.6`
 

--- a/Tests/UI/test_post_release_ux_hci_validation_plan.py
+++ b/Tests/UI/test_post_release_ux_hci_validation_plan.py
@@ -13,6 +13,9 @@ QA_TEMPLATE = Path("Docs/superpowers/qa/product-maturity/post-release-ux-hci/wal
 WORKFLOW_EVIDENCE = Path(
     "Docs/superpowers/qa/product-maturity/post-release-ux-hci/2026-05-22-cross-screen-workflow-validation.md"
 )
+DEFERRED_TRANCHE_PLAN = Path(
+    "Docs/superpowers/plans/2026-05-22-post-release-deferred-feature-tranches.md"
+)
 TASK_60 = Path("backlog/tasks/task-60 - Post-release-UX-HCI-and-functionality-validation-tranche.md")
 CHILD_TASKS = {
     "TASK-60.1": Path(
@@ -47,6 +50,13 @@ REQUIRED_SCREENS = (
     "ACP",
     "Skills",
     "Settings",
+)
+DEFERRED_TRANCHE_TASK_TITLES = (
+    "Post-release ACP runtime launch tranche",
+    "Post-release write sync promotion tranche",
+    "Post-release Workspaces and Library depth tranche",
+    "Post-release citation and snippet carry-through tranche",
+    "Post-release optional dependency and packaging polish tranche",
 )
 
 
@@ -127,7 +137,7 @@ def test_post_release_qa_harness_requires_real_screenshots_and_approval() -> Non
 def test_post_release_backlog_tasks_track_screens_workflows_and_deferred_features() -> None:
     parent = _text(TASK_60)
 
-    assert "status: To Do" in parent
+    assert "status: Done" in parent
     assert "actual rendered screenshot audit" in parent
     assert "Cross-screen workflows are validated end-to-end" in parent
     assert "No screen is marked accepted without actual screenshot approval" in parent
@@ -142,7 +152,7 @@ def test_post_release_backlog_tasks_track_screens_workflows_and_deferred_feature
         "TASK-60.1": "Done",
         "TASK-60.2": "Done",
         "TASK-60.3": "Done",
-        "TASK-60.4": "To Do",
+        "TASK-60.4": "Done",
         "TASK-60.5": "Done",
         "TASK-60.6": "Done",
     }
@@ -164,6 +174,14 @@ def test_post_release_backlog_tasks_track_screens_workflows_and_deferred_feature
         CHILD_TASKS["TASK-60.6"]
     )
 
+    backlog_text = "\n\n".join(
+        path.read_text(encoding="utf-8") for path in (REPO_ROOT / "backlog/tasks").glob("*.md")
+    )
+    for title in DEFERRED_TRANCHE_TASK_TITLES:
+        assert f"title: {title}" in backlog_text
+    assert "TASK-60.3" in backlog_text
+    assert "actual-use audit evidence" in backlog_text
+
 
 def test_product_maturity_tracker_lists_post_release_validation_tranche() -> None:
     tracker = _text(TRACKER)
@@ -172,9 +190,12 @@ def test_product_maturity_tracker_lists_post_release_validation_tranche() -> Non
     assert "TASK-60" in tracker
     for task_id in CHILD_TASKS:
         assert task_id in tracker
+    for title in DEFERRED_TRANCHE_TASK_TITLES:
+        assert title in tracker
     assert "actual screenshots" in tracker
     assert "actual-use functionality evidence" in tracker
     assert "cross-screen workflow validation" in tracker
+    assert str(DEFERRED_TRANCHE_PLAN) in tracker
 
 
 def test_post_release_cross_screen_workflow_evidence_records_verification() -> None:
@@ -196,3 +217,34 @@ def test_post_release_cross_screen_workflow_evidence_records_verification() -> N
         assert required in evidence
 
     assert "2026-05-22-cross-screen-workflow-validation.md" in readme
+
+
+def test_post_release_deferred_tranche_plan_prioritizes_audited_future_work() -> None:
+    plan = _text(DEFERRED_TRANCHE_PLAN)
+
+    for required in (
+        "TASK-60.4",
+        str(WORKFLOW_EVIDENCE),
+        "No deferred implementation starts before open P0/P1 usability defects are triaged",
+        "Verified shipped behavior stays separate from deferred future work",
+        "actual-use audit evidence",
+    ):
+        assert required in plan
+
+    for required_tranche in (
+        "ACP Runtime Launch",
+        "Write Sync Promotion",
+        "Workspaces And Library Depth",
+        "Citation And Snippet Carry-Through",
+        "Optional Dependency And Package Polish",
+    ):
+        assert required_tranche in plan
+
+    for required_evidence in (
+        "ACP runtime payloads remain recoverably blocked",
+        "write sync remains deferred",
+        "Workspace switching must not hide Library items",
+        "citation/snippet carry-through remains downstream future work",
+        "optional dependency recovery remains source-honest",
+    ):
+        assert required_evidence in plan

--- a/Tests/UI/test_post_ux_product_roadmap_handoff.py
+++ b/Tests/UI/test_post_ux_product_roadmap_handoff.py
@@ -78,6 +78,12 @@ def test_public_roadmap_is_directional_and_commitment_free():
     assert "Now: Reliability And Product Confidence" in text
     assert "Next: Complete Workflow Loops" in text
     assert "Later: Server-Backed And Live Capabilities" in text
+    assert "Deferred Tranche Gates" in text
+    assert "ACP runtime launch" in text
+    assert "write sync promotion" in text
+    assert "Workspaces and Library depth" in text
+    assert "citation and snippet carry-through" in text
+    assert "optional dependency and package polish" in text
     assert "Always: Local-First Control" in text
     forbidden_patterns = (
         r"\bETA\b",

--- a/backlog/tasks/task-60 - Post-release-UX-HCI-and-functionality-validation-tranche.md
+++ b/backlog/tasks/task-60 - Post-release-UX-HCI-and-functionality-validation-tranche.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-60
 title: Post-release UX/HCI and functionality validation tranche
-status: To Do
+status: Done
 labels:
 - ux
 - hci
@@ -18,23 +18,27 @@ Track the post-release correction pass required after Phase 3-6 closeout. The go
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Every top-level destination has an actual rendered screenshot audit entry, not just mounted layout assertions.
-- [ ] #2 Each destination has an actual-use validation checklist covering primary controls, empty/error/setup states, keyboard/focus behavior, and recovery paths.
-- [ ] #3 Cross-screen workflows are validated end-to-end with direct app use, including Home to Console, Library/RAG to Console, Artifacts/Chatbooks to Console, Watchlists/Schedules/Workflows handoffs, Personas/Skills/MCP/ACP context paths, and Settings recovery paths.
-- [ ] #4 Findings are prioritized into P0/P1/P2/P3 with ownership and follow-up task links.
-- [ ] #5 No screen is marked accepted without actual screenshot approval and recorded functionality evidence.
+- [x] #1 Every top-level destination has an actual rendered screenshot audit entry, not just mounted layout assertions.
+- [x] #2 Each destination has an actual-use validation checklist covering primary controls, empty/error/setup states, keyboard/focus behavior, and recovery paths.
+- [x] #3 Cross-screen workflows are validated end-to-end with direct app use, including Home to Console, Library/RAG to Console, Artifacts/Chatbooks to Console, Watchlists/Schedules/Workflows handoffs, Personas/Skills/MCP/ACP context paths, and Settings recovery paths.
+- [x] #4 Findings are prioritized into P0/P1/P2/P3 with ownership and follow-up task links.
+- [x] #5 No screen is marked accepted without actual screenshot approval and recorded functionality evidence.
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+- `TASK-60.1` established the post-release actual-screen audit harness requiring real screenshots, CDP/textual-web evidence, NN/g review, and explicit approval before a screen can be accepted.
+- `TASK-60.2` completed the top-level screen functionality audit evidence index for Home, Console, Library, Artifacts, Personas, Watchlists, Schedules, Workflows, MCP, ACP, Skills, and Settings.
+- `TASK-60.3` added cross-screen workflow validation evidence covering Home-to-Console, Library/RAG-to-Console, Artifacts/Chatbooks resume, Personas/Skills attach paths, and Watchlists/Schedules/Workflows handoffs.
+- `TASK-60.5` and `TASK-60.6` closed the Personas and Watchlists indefinite loading risks.
+- `TASK-60.4` converted remaining recoverable service-depth gaps into staged follow-up tranches without treating deferred work as shipped behavior.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Closed the post-release UX/HCI and functionality validation tranche. Actual screenshot approval, functionality evidence, cross-screen workflow validation, and deferred feature tranche planning are now recorded; no unresolved P0/P1 findings remain for this validation scope.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-60.4 - Post-release-deferred-feature-tranche-planning.md
+++ b/backlog/tasks/task-60.4 - Post-release-deferred-feature-tranche-planning.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-60.4
 title: Post-release deferred feature tranche planning
-status: To Do
+status: Done
 labels:
 - roadmap
 - planning
@@ -18,22 +18,35 @@ Convert verified residual risks from Phase 3-6 closeout into staged implementati
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 ACP runtime launch, write sync promotion, Workspaces/Library depth, citation/snippet carry-through, and optional dependency/package polish each have a staged follow-up tranche.
-- [ ] #2 Each tranche references evidence from the actual-use audit before implementation work is prioritized.
-- [ ] #3 Feature planning does not mask P0/P1 usability breakage discovered by the audit.
-- [ ] #4 The product maturity roadmap distinguishes verified shipped behavior from deferred future work and newly discovered broken behavior.
+- [x] #1 ACP runtime launch, write sync promotion, Workspaces/Library depth, citation/snippet carry-through, and optional dependency/package polish each have a staged follow-up tranche.
+- [x] #2 Each tranche references evidence from the actual-use audit before implementation work is prioritized.
+- [x] #3 Feature planning does not mask P0/P1 usability breakage discovered by the audit.
+- [x] #4 The product maturity roadmap distinguishes verified shipped behavior from deferred future work and newly discovered broken behavior.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add regression coverage requiring the deferred tranche plan, public roadmap gate wording, tracked follow-up tasks, and completed post-release validation status.
+2. Create follow-up tranche tasks for ACP runtime launch, write sync promotion, Workspaces/Library depth, citation/snippet carry-through, and optional dependency/package polish.
+3. Write the deferred tranche plan from `TASK-60.3` actual-use audit evidence and explicitly preserve the P0/P1 usability gate.
+4. Update the product maturity tracker and public roadmap so verified shipped behavior stays distinct from deferred future work.
+5. Close `TASK-60.4` and parent `TASK-60` only after focused documentation regressions pass.
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+- Added `Docs/superpowers/plans/2026-05-22-post-release-deferred-feature-tranches.md` to stage the five deferred feature tranches from `TASK-60.3` actual-use audit evidence.
+- Created follow-up tranche tasks `TASK-60.4.1` through `TASK-60.4.5` for ACP runtime launch, write sync promotion, Workspaces/Library depth, citation/snippet carry-through, and optional dependency/package polish.
+- Updated `Docs/superpowers/trackers/product-maturity-roadmap.md` and `Docs/Product_Roadmap.md` so verified shipped behavior, recoverably blocked behavior, and deferred future work stay distinct.
+- Added regression coverage for the tranche plan, follow-up task titles, roadmap gates, and completed post-release validation status.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Closed deferred feature tranche planning. The remaining high-value future work is now staged, evidence-linked, and gated behind unresolved P0/P1 usability defects instead of being treated as already shipped behavior.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-60.4.1 - Post-release-ACP-runtime-launch-tranche.md
+++ b/backlog/tasks/task-60.4.1 - Post-release-ACP-runtime-launch-tranche.md
@@ -1,0 +1,42 @@
+---
+id: TASK-60.4.1
+title: Post-release ACP runtime launch tranche
+status: To Do
+labels:
+- post-release
+- acp
+- runtime
+- ux
+priority: medium
+parent_task_id: TASK-60.4
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Plan and implement the ACP runtime launch path only after the post-release actual-use audit evidence shows ACP remains recoverably blocked rather than broken by UI affordance.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 ACP launch requirements are derived from TASK-60.3 actual-use audit evidence.
+- [ ] #2 ACP unavailable states remain source-honest until a real runtime can be launched.
+- [ ] #3 Console, ACP, Home, and relevant handoff surfaces expose consistent runtime readiness and recovery copy.
+- [ ] #4 QA verifies the ACP task/run package path with actual app use before completion.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/backlog/tasks/task-60.4.2 - Post-release-write-sync-promotion-tranche.md
+++ b/backlog/tasks/task-60.4.2 - Post-release-write-sync-promotion-tranche.md
@@ -1,0 +1,42 @@
+---
+id: TASK-60.4.2
+title: Post-release write sync promotion tranche
+status: To Do
+labels:
+- post-release
+- sync
+- safety
+- ux
+priority: medium
+parent_task_id: TASK-60.4
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Promote write sync only after the dry-run and audit evidence prove the user can understand authority, conflicts, recovery, and rollback before mutations are enabled.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Write sync scope references TASK-60.3 actual-use audit evidence and existing dry-run sync foundations.
+- [ ] #2 Mutation replay remains gated behind explicit user review, rollback, and conflict visibility.
+- [ ] #3 Library, Collections, Workspaces, and Settings expose consistent sync authority labels before writes are available.
+- [ ] #4 QA validates write-sync promotion with actual app use and non-destructive safety fixtures before completion.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/backlog/tasks/task-60.4.3 - Post-release-Workspaces-and-Library-depth-tranche.md
+++ b/backlog/tasks/task-60.4.3 - Post-release-Workspaces-and-Library-depth-tranche.md
@@ -1,0 +1,42 @@
+---
+id: TASK-60.4.3
+title: Post-release Workspaces and Library depth tranche
+status: To Do
+labels:
+- post-release
+- workspaces
+- library
+- ux
+priority: medium
+parent_task_id: TASK-60.4
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Deepen the Workspaces and Library model after the audit confirms the current local surfaces are usable but workspace membership, Collections membership, Import/Export depth, and cross-workspace source authority need product depth.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Workspace and Library depth requirements reference TASK-60.3 actual-use audit evidence.
+- [ ] #2 Workspace switching never hides Library or Notes items; it only changes context eligibility, authority labels, and handoff availability.
+- [ ] #3 Collections membership, deeper Import/Export, and workspace source authority are staged without regressing global search/view access.
+- [ ] #4 QA verifies cross-workspace view/edit/search behavior and Console-context restrictions with actual app use before completion.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/backlog/tasks/task-60.4.4 - Post-release-citation-and-snippet-carry-through-tranche.md
+++ b/backlog/tasks/task-60.4.4 - Post-release-citation-and-snippet-carry-through-tranche.md
@@ -1,0 +1,42 @@
+---
+id: TASK-60.4.4
+title: Post-release citation and snippet carry-through tranche
+status: To Do
+labels:
+- post-release
+- rag
+- citations
+- ux
+priority: medium
+parent_task_id: TASK-60.4
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Carry retrieved snippets and citations from Library/Search/RAG into Console answers, Artifacts, exported Chatbooks, and downstream saved work only after source authority is visible and testable end-to-end.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Citation and snippet carry-through scope references TASK-60.3 actual-use audit evidence.
+- [ ] #2 Retrieved evidence keeps source identity, snippet text, and authority labels through Console responses and saved artifacts.
+- [ ] #3 Exported Chatbooks preserve citations/snippets in a user-readable and machine-checkable form.
+- [ ] #4 QA verifies source-to-answer-to-artifact carry-through with actual app use before completion.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/backlog/tasks/task-60.4.5 - Post-release-optional-dependency-and-packaging-polish-tranche.md
+++ b/backlog/tasks/task-60.4.5 - Post-release-optional-dependency-and-packaging-polish-tranche.md
@@ -1,0 +1,42 @@
+---
+id: TASK-60.4.5
+title: Post-release optional dependency and packaging polish tranche
+status: To Do
+labels:
+- post-release
+- packaging
+- dependencies
+- ux
+priority: medium
+parent_task_id: TASK-60.4
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Improve optional dependency recovery and package metadata after the audit confirms the app is source-honest but users still need clearer install, unavailable-feature, and recovery paths.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Optional dependency and packaging polish scope references TASK-60.3 actual-use audit evidence.
+- [ ] #2 Unavailable optional features identify the missing dependency group and safe recovery command without implying broken core functionality.
+- [ ] #3 Package metadata and setup docs distinguish local-first baseline from advanced media, RAG, MCP, server, and web capability extras.
+- [ ] #4 QA verifies missing-dependency recovery copy and package/install paths before completion.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- add the post-release deferred feature tranche plan from TASK-60.3 actual-use audit evidence
- create follow-up backlog tasks for ACP runtime launch, write sync promotion, Workspaces/Library depth, citation/snippet carry-through, and optional dependency/package polish
- update the product maturity tracker and public roadmap so deferred future work remains distinct from verified shipped behavior
- close TASK-60.4 and parent TASK-60 as validation/planning complete

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_post_release_ux_hci_validation_plan.py Tests/UI/test_post_ux_product_roadmap_handoff.py Tests/UI/test_product_maturity_phase6_release_closeout.py --tb=short
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Plan and gate the post-release deferred feature tranches from `TASK-60.3` audit evidence, creating `TASK-60.4.1`–`TASK-60.4.5` for ACP runtime launch, write sync promotion, Workspaces/Library depth, citation/snippet carry-through, and optional dependency/package polish. Update the product maturity tracker and `Docs/Product_Roadmap.md` to keep deferred work separate from shipped behavior, add the tranche plan document, update tests to enforce these gates, and mark `TASK-60` and `TASK-60.4` as Done.

<sup>Written for commit 4aba8267aea32eb0364822070c8ead20641c67e1. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/347?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

