### PR TITLE
Surface Sync v2 profile status in Library

### DIFF
--- a/Docs/superpowers/plans/2026-05-22-sync-profile-status-surfacing.md
+++ b/Docs/superpowers/plans/2026-05-22-sync-profile-status-surfacing.md
@@ -1,0 +1,55 @@
+# Sync Profile Status Surfacing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface the merged Sync v2 profile summary in a read-only running-app workflow.
+
+**Architecture:** Add a pure display-state adapter for Sync v2 profile summaries, render it in the existing Library Collections panel, and have `LibraryScreen` load the summary from `SyncScopeService` when an active server scope exists. The UI remains observational: no sync, restore, push, or pull actions are introduced.
+
+**Tech Stack:** Python, Textual widgets, pytest, existing `SyncScopeService` and Library Collections panel/state patterns.
+
+---
+
+### Task 1: Pure Sync Profile Status State
+
+**Files:**
+- Create: `tldw_chatbook/Sync_Interop/sync_profile_status_state.py`
+- Test: `Tests/Sync_Interop/test_sync_profile_status_state.py`
+
+- [ ] **Step 1: Write failing tests** for `not_configured`, `server_frontend`, `pending`, and `attention_required` summary mappings.
+- [ ] **Step 2: Run tests** with `../../.venv/bin/python -m pytest Tests/Sync_Interop/test_sync_profile_status_state.py -q` and confirm import failure.
+- [ ] **Step 3: Implement dataclass mapping** with stable label, detail, severity, pending count, conflict count, dataset/device labels, and read-only copy.
+- [ ] **Step 4: Re-run focused tests** and confirm pass.
+
+### Task 2: Render Status in Library Collections
+
+**Files:**
+- Modify: `tldw_chatbook/Library/library_collections_state.py`
+- Modify: `tldw_chatbook/Widgets/Library/library_collections_panel.py`
+- Test: `Tests/Widgets/test_library_collections_panel.py`
+
+- [ ] **Step 1: Write failing widget test** proving the panel renders the Sync v2 profile label/detail before collection rows.
+- [ ] **Step 2: Run the widget test** and confirm the expected selector is missing.
+- [ ] **Step 3: Add optional profile status to panel state** and render it in `LibraryCollectionsPanel` as a read-only status banner.
+- [ ] **Step 4: Re-run widget and Library state tests** and confirm pass.
+
+### Task 3: Load Summary From App Scope
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py`
+- Test: `Tests/UI/test_product_maturity_phase39_library_collections.py`
+
+- [ ] **Step 1: Write failing mounted UI test** with a fake `sync_scope_service` that returns a summary and tracks that no push/pull methods are invoked.
+- [ ] **Step 2: Run the mounted test** and confirm the profile status is absent.
+- [ ] **Step 3: Load profile summary through `sync_scope_service.get_sync_v2_profile_summary`** using the active server scope, worker-isolated like other repository reads.
+- [ ] **Step 4: Re-run focused UI tests** and confirm pass.
+
+### Task 4: Verification And Task Closeout
+
+**Files:**
+- Modify: `backlog/tasks/task-69 - Surface-Chatbook-Sync-v2-profile-status.md`
+
+- [ ] **Step 1: Run focused tests** for the new state, widget, and mounted UI coverage.
+- [ ] **Step 2: Run broader sync/library slice** with `Tests/Sync_Interop Tests/Library Tests/Widgets/test_library_collections_panel.py Tests/UI/test_product_maturity_phase39_library_collections.py`.
+- [ ] **Step 3: Run compile, diff, and Bandit checks** on touched production files.
+- [ ] **Step 4: Update Backlog notes and commit.**

--- a/Tests/Sync_Interop/test_sync_profile_status_state.py
+++ b/Tests/Sync_Interop/test_sync_profile_status_state.py
@@ -84,7 +84,7 @@ def test_pending_summary_includes_outbox_count_without_implying_write_action() -
     assert display.label == "Sync profile: pending local changes"
     assert display.pending_count == 2
     assert display.detail == (
-        "2 pending local changes are waiting for the next sync pass. No writes start from this view."
+        "2 pending local changes are waiting for the next sync pass."
     )
 
 
@@ -102,5 +102,11 @@ def test_attention_required_summary_prioritizes_conflicts_and_safe_error_copy() 
     assert display.label == "Sync profile: needs attention"
     assert display.conflict_count == 1
     assert display.detail == (
-        "1 sync conflict needs review. Last error is unavailable. No writes start from this view."
+        "1 sync conflict needs review. Last error is unavailable."
     )
+
+
+def test_public_display_adapter_has_google_style_docstrings() -> None:
+    assert "Attributes:" in (SyncProfileStatusDisplay.__doc__ or "")
+    assert "Args:" in (SyncProfileStatusDisplay.from_summary.__doc__ or "")
+    assert "Returns:" in (SyncProfileStatusDisplay.from_summary.__doc__ or "")

--- a/Tests/Sync_Interop/test_sync_profile_status_state.py
+++ b/Tests/Sync_Interop/test_sync_profile_status_state.py
@@ -1,0 +1,106 @@
+"""Sync v2 profile summary display-state contracts."""
+
+from __future__ import annotations
+
+from tldw_chatbook.Sync_Interop.sync_profile_status_state import SyncProfileStatusDisplay
+
+
+def _summary(
+    *,
+    status: str,
+    profile_mode: str = "local_first_sync",
+    pending: int = 0,
+    dispatched: int = 0,
+    conflicts: int = 0,
+    last_error: str | None = None,
+) -> dict[str, object]:
+    return {
+        "status": status,
+        "profile": {
+            "server_profile_id": "server-a",
+            "authenticated_principal_id": "user-a",
+            "workspace_scope": "workspace-1",
+            "profile_mode": profile_mode,
+            "device_id": "device-1",
+            "dataset_id": "dataset-1",
+            "last_error": last_error,
+        },
+        "cursor": {
+            "remote_collection": "dataset-1",
+            "remote_cursor": "remote-42",
+            "profile_cursor": "profile-42",
+        },
+        "outbox": {
+            "pending": pending,
+            "dispatched": dispatched,
+            "by_domain": {"notes": {"pending": pending, "dispatched": dispatched}},
+        },
+        "identity_map": {"total": 3, "confirmed": 3, "by_domain": {"notes": {"confirmed": 3}}},
+        "conflicts": {"count": conflicts, "latest": []},
+        "last_mirror_report": None,
+    }
+
+
+def test_not_configured_summary_maps_to_local_safe_copy() -> None:
+    display = SyncProfileStatusDisplay.from_summary(
+        {
+            "status": "not_configured",
+            "profile": None,
+            "cursor": None,
+            "outbox": {"pending": 0, "dispatched": 0, "by_domain": {}},
+            "identity_map": {"total": 0, "by_domain": {}},
+            "conflicts": {"count": 0, "latest": []},
+            "last_mirror_report": None,
+        }
+    )
+
+    assert display.status == "not_configured"
+    assert display.severity == "neutral"
+    assert display.label == "Sync profile: not configured"
+    assert display.detail == (
+        "No Sync v2 server profile is configured. Local Library data stays on this device."
+    )
+    assert display.read_only_notice == "This view only reads sync state; it does not start sync."
+
+
+def test_server_frontend_summary_maps_to_live_frontend_copy() -> None:
+    display = SyncProfileStatusDisplay.from_summary(
+        _summary(status="server_frontend", profile_mode="server_frontend")
+    )
+
+    assert display.severity == "ready"
+    assert display.label == "Sync profile: server front-end"
+    assert display.detail == (
+        "Using server-a as a live server front-end. Offline mirror sync is not configured."
+    )
+    assert display.dataset_label == "Dataset dataset-1"
+    assert display.device_label == "Device device-1"
+
+
+def test_pending_summary_includes_outbox_count_without_implying_write_action() -> None:
+    display = SyncProfileStatusDisplay.from_summary(_summary(status="pending", pending=2))
+
+    assert display.severity == "pending"
+    assert display.label == "Sync profile: pending local changes"
+    assert display.pending_count == 2
+    assert display.detail == (
+        "2 pending local changes are waiting for the next sync pass. No writes start from this view."
+    )
+
+
+def test_attention_required_summary_prioritizes_conflicts_and_safe_error_copy() -> None:
+    display = SyncProfileStatusDisplay.from_summary(
+        _summary(
+            status="attention_required",
+            pending=1,
+            conflicts=1,
+            last_error="<script>alert(1)</script>",
+        )
+    )
+
+    assert display.severity == "attention"
+    assert display.label == "Sync profile: needs attention"
+    assert display.conflict_count == 1
+    assert display.detail == (
+        "1 sync conflict needs review. Last error is unavailable. No writes start from this view."
+    )

--- a/Tests/UI/test_product_maturity_phase39_library_collections.py
+++ b/Tests/UI/test_product_maturity_phase39_library_collections.py
@@ -351,6 +351,90 @@ async def test_library_collections_surfaces_sync_profile_summary_without_write_s
 
 
 @pytest.mark.asyncio
+async def test_library_collections_does_not_load_sync_profile_summary_in_local_mode() -> None:
+    app = _build_test_app()
+    _seed_library_sources(app)
+    app.runtime_policy = SimpleNamespace(
+        state=RuntimeSourceState(
+            active_source="local",
+            server_configured=True,
+            active_server_id="server-a",
+        )
+    )
+    app.library_collections_service = FakeLibraryCollectionsService(
+        (
+            LibraryCollectionRecord(
+                collection_id="collection-1",
+                name="Research",
+                description="Policy sources",
+                item_count=2,
+                source_authority="local",
+                sync_status="local-only",
+                created_at="2026-05-08T04:00:00Z",
+                updated_at="2026-05-08T04:05:00Z",
+            ),
+        )
+    )
+    sync_scope = FakeSyncProfileSummaryService({"status": "pending"})
+    app.sync_scope_service = sync_scope
+    host = DestinationHarness(app, "library")
+
+    async with host.run_test(size=(170, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_library_snapshot(screen, pilot)
+
+        screen.query_one("#library-mode-collections", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-collections-panel")
+
+        assert len(screen.query("#library-sync-profile-status")) == 0
+        assert sync_scope.summary_calls == []
+        assert sync_scope.push_calls == []
+        assert sync_scope.pull_calls == []
+
+
+@pytest.mark.asyncio
+async def test_library_collections_validates_sync_profile_scope_before_summary_load() -> None:
+    app = _build_test_app()
+    _seed_library_sources(app)
+    app.runtime_policy = SimpleNamespace(
+        state=RuntimeSourceState(
+            active_source="server",
+            server_configured=True,
+            active_server_id="server-a<script>",
+        )
+    )
+    app.library_collections_service = FakeLibraryCollectionsService(
+        (
+            LibraryCollectionRecord(
+                collection_id="collection-1",
+                name="Research",
+                description="Policy sources",
+                item_count=2,
+                source_authority="local",
+                sync_status="local-only",
+                created_at="2026-05-08T04:00:00Z",
+                updated_at="2026-05-08T04:05:00Z",
+            ),
+        )
+    )
+    sync_scope = FakeSyncProfileSummaryService({"status": "pending"})
+    app.sync_scope_service = sync_scope
+    host = DestinationHarness(app, "library")
+
+    async with host.run_test(size=(170, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_library_snapshot(screen, pilot)
+
+        screen.query_one("#library-mode-collections", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-collections-panel")
+
+        assert len(screen.query("#library-sync-profile-status")) == 0
+        assert sync_scope.summary_calls == []
+        assert sync_scope.push_calls == []
+        assert sync_scope.pull_calls == []
+
+
+@pytest.mark.asyncio
 async def test_library_collections_scopes_sync_conflicts_to_selected_collection(tmp_path) -> None:
     app = _build_test_app()
     _activate_server_sync_scope(app)

--- a/Tests/UI/test_product_maturity_phase39_library_collections.py
+++ b/Tests/UI/test_product_maturity_phase39_library_collections.py
@@ -117,6 +117,38 @@ def _activate_server_sync_scope(app) -> None:
     )
 
 
+class FakeSyncProfileSummaryService:
+    def __init__(self, summary: dict[str, object]):
+        self.summary = summary
+        self.summary_calls = []
+        self.push_calls = []
+        self.pull_calls = []
+
+    def get_sync_v2_profile_summary(
+        self,
+        *,
+        server_profile_id: str,
+        authenticated_principal_id: str | None = None,
+        workspace_scope: str | None = None,
+    ):
+        self.summary_calls.append(
+            {
+                "server_profile_id": server_profile_id,
+                "authenticated_principal_id": authenticated_principal_id,
+                "workspace_scope": workspace_scope,
+            }
+        )
+        return dict(self.summary)
+
+    def push_v2_envelopes(self, *args, **kwargs):
+        self.push_calls.append((args, kwargs))
+        raise AssertionError("Library status rendering must not push sync envelopes")
+
+    def pull_v2_envelopes(self, *args, **kwargs):
+        self.pull_calls.append((args, kwargs))
+        raise AssertionError("Library status rendering must not pull sync envelopes")
+
+
 def _seed_library_sources(app) -> None:
     app.notes_scope_service = StaticLibraryNotesScopeService(
         [{"title": "Research Note", "id": "note-1"}]
@@ -247,6 +279,75 @@ async def test_library_collections_surfaces_sync_dry_run_report_without_write_sy
             inspector_text
         )
         assert "No source selected." not in inspector_text
+
+
+@pytest.mark.asyncio
+async def test_library_collections_surfaces_sync_profile_summary_without_write_sync() -> None:
+    app = _build_test_app()
+    _seed_library_sources(app)
+    app.runtime_policy = SimpleNamespace(
+        state=RuntimeSourceState(
+            active_source="server",
+            server_configured=True,
+            active_server_id="server-a",
+        )
+    )
+    app.library_collections_service = FakeLibraryCollectionsService(
+        (
+            LibraryCollectionRecord(
+                collection_id="collection-1",
+                name="Research",
+                description="Policy sources",
+                item_count=2,
+                source_authority="local",
+                sync_status="local-only",
+                created_at="2026-05-08T04:00:00Z",
+                updated_at="2026-05-08T04:05:00Z",
+            ),
+        )
+    )
+    sync_scope = FakeSyncProfileSummaryService(
+        {
+            "status": "pending",
+            "profile": {
+                "server_profile_id": "server-a",
+                "authenticated_principal_id": None,
+                "workspace_scope": None,
+                "profile_mode": "local_first_sync",
+                "device_id": "device-1",
+                "dataset_id": "dataset-1",
+                "last_error": None,
+            },
+            "cursor": None,
+            "outbox": {"pending": 2, "dispatched": 0, "by_domain": {}},
+            "identity_map": {"total": 0, "by_domain": {}},
+            "conflicts": {"count": 0, "latest": []},
+            "last_mirror_report": None,
+        }
+    )
+    app.sync_scope_service = sync_scope
+    host = DestinationHarness(app, "library")
+
+    async with host.run_test(size=(170, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_library_snapshot(screen, pilot)
+
+        screen.query_one("#library-mode-collections", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-sync-profile-status")
+
+        visible = _visible_text(screen)
+        assert "Sync profile: pending local changes" in visible
+        assert "2 pending local changes are waiting for the next sync pass." in visible
+        assert "This view only reads sync state; it does not start sync." in visible
+        assert sync_scope.summary_calls == [
+            {
+                "server_profile_id": "server-a",
+                "authenticated_principal_id": None,
+                "workspace_scope": None,
+            }
+        ]
+        assert sync_scope.push_calls == []
+        assert sync_scope.pull_calls == []
 
 
 @pytest.mark.asyncio

--- a/Tests/Widgets/test_library_collections_panel.py
+++ b/Tests/Widgets/test_library_collections_panel.py
@@ -91,3 +91,53 @@ async def test_library_collections_panel_renders_write_sync_promotion_labels(wid
             "Conflicts: none | Rollback: not required | "
             "Writes stay blocked until review, conflict, and rollback gates are ready."
         )
+
+
+async def test_library_collections_panel_renders_sync_profile_status_banner(widget_pilot):
+    state = LibraryCollectionsPanelState.from_values(
+        collections=(
+            {
+                "collection_id": "collection-1",
+                "name": "Research",
+                "description": "Selected sources",
+                "item_count": 2,
+                "source_authority": "local",
+                "sync_status": "local-only",
+                "created_at": "2026-05-08T03:00:00Z",
+                "updated_at": "2026-05-08T04:00:00Z",
+            },
+        ),
+        selected_collection_id="collection-1",
+        sync_profile_summary={
+            "status": "pending",
+            "profile": {
+                "server_profile_id": "server-a",
+                "authenticated_principal_id": "user-a",
+                "workspace_scope": None,
+                "profile_mode": "local_first_sync",
+                "device_id": "device-1",
+                "dataset_id": "dataset-1",
+                "last_error": None,
+            },
+            "cursor": None,
+            "outbox": {"pending": 2, "dispatched": 1, "by_domain": {}},
+            "identity_map": {"total": 0, "by_domain": {}},
+            "conflicts": {"count": 0, "latest": []},
+            "last_mirror_report": None,
+        },
+    )
+
+    async with await widget_pilot(LibraryCollectionsPanel, state=state) as pilot:
+        await pilot.pause()
+        assert str(pilot.app.query_one("#library-sync-profile-status", Static).renderable) == (
+            "Sync profile: pending local changes"
+        )
+        assert str(pilot.app.query_one("#library-sync-profile-detail", Static).renderable) == (
+            "2 pending local changes are waiting for the next sync pass."
+        )
+        assert str(pilot.app.query_one("#library-sync-profile-read-only", Static).renderable) == (
+            "This view only reads sync state; it does not start sync."
+        )
+        assert pilot.app.query_one("#library-sync-profile-status", Static)._render_markup is False
+        assert pilot.app.query_one("#library-sync-profile-detail", Static)._render_markup is False
+        assert pilot.app.query_one("#library-sync-profile-read-only", Static)._render_markup is False

--- a/backlog/tasks/task-69 - Surface-Chatbook-Sync-v2-profile-status.md
+++ b/backlog/tasks/task-69 - Surface-Chatbook-Sync-v2-profile-status.md
@@ -1,0 +1,59 @@
+---
+id: TASK-69
+title: Surface Chatbook Sync v2 profile status
+status: Done
+labels:
+- sync
+- sync-v2
+- ui-status
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Use the merged Sync v2 profile summary contract in Chatbook running-app workflows so users can see configured mode, pending work, conflicts, cursor identity, and last error without enabling new write-sync controls.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Sync v2 profile status is exposed through a small display-state/service seam that maps repository summary states to user-facing labels and recovery severity.
+- [x] #2 A running-app surface can render local-only, server-frontend, local-first pending, attention-required, and not-configured summaries without triggering sync mutations.
+- [x] #3 Focused tests cover status mapping and prove rendering the summary does not enqueue or push/pull sync work.
+- [x] #4 Verification, touched files, and final outcome are recorded in the Backlog task.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Added `SyncProfileStatusDisplay` as a pure Sync v2 profile summary display-state adapter. It maps repository/service summaries into stable labels, severity, counts, dataset/device labels, safe last-error copy, and an explicit read-only notice.
+
+Extended `LibraryCollectionsPanelState` and `LibraryCollectionsPanel` with an optional Sync profile status banner. The banner renders above the Collection workbench and does not introduce sync mutation controls.
+
+Updated `LibraryScreen` to load `sync_scope_service.get_sync_v2_profile_summary` for the active server profile when the Collections mode snapshot refreshes. The lookup uses the same worker-isolated service-call helper as existing sync dry-run reads and returns no banner when no active server profile is available.
+
+Verification:
+- Red test confirmed `Tests/Sync_Interop/test_sync_profile_status_state.py` failed on the missing display-state module.
+- Red widget test confirmed `LibraryCollectionsPanelState.from_values` rejected `sync_profile_summary` before implementation.
+- Red mounted UI test confirmed the Library Collections screen did not render `#library-sync-profile-status` before the screen-level summary load.
+- `../../.venv/bin/python -m pytest Tests/Sync_Interop/test_sync_profile_status_state.py Tests/Widgets/test_library_collections_panel.py Tests/Library/test_library_collections_state.py Tests/UI/test_product_maturity_phase39_library_collections.py -q` passed with 21 tests.
+- `../../.venv/bin/python -m pytest Tests/Sync_Interop Tests/Library Tests/Widgets/test_library_collections_panel.py Tests/UI/test_product_maturity_phase39_library_collections.py -q` passed with 187 tests.
+- `/usr/bin/env PYTHONPYCACHEPREFIX=/tmp/tldw_chatbook_sync_profile_status_pycache ../../.venv/bin/python -m compileall tldw_chatbook/Sync_Interop/sync_profile_status_state.py tldw_chatbook/Library/library_collections_state.py tldw_chatbook/Widgets/Library/library_collections_panel.py tldw_chatbook/UI/Screens/library_screen.py` passed.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -q -r tldw_chatbook/Sync_Interop/sync_profile_status_state.py tldw_chatbook/Library/library_collections_state.py tldw_chatbook/Widgets/Library/library_collections_panel.py tldw_chatbook/UI/Screens/library_screen.py -f json -o /tmp/bandit_chatbook_sync_profile_status.json` passed.
+- `git diff --check` passed.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Surfaced Sync v2 profile summary status in the Library Collections running-app workflow. Users can now see read-only profile state, pending work, conflict/error attention, and dataset/device identity context without triggering sync writes.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests and verification recorded
+- [x] #3 Documentation updated in task record
+- [x] #4 Final summary added
+- [x] #5 No known blockers
+<!-- DOD:END -->

--- a/backlog/tasks/task-69 - Surface-Chatbook-Sync-v2-profile-status.md
+++ b/backlog/tasks/task-69 - Surface-Chatbook-Sync-v2-profile-status.md
@@ -7,6 +7,16 @@ labels:
 - sync-v2
 - ui-status
 priority: medium
+modified_files:
+- tldw_chatbook/Sync_Interop/sync_profile_status_state.py
+- tldw_chatbook/Sync_Interop/sync_state_repository.py
+- tldw_chatbook/Library/library_collections_state.py
+- tldw_chatbook/Widgets/Library/library_collections_panel.py
+- tldw_chatbook/UI/Screens/library_screen.py
+- Tests/Sync_Interop/test_sync_profile_status_state.py
+- Tests/Library/test_library_collections_state.py
+- Tests/Widgets/test_library_collections_panel.py
+- Tests/UI/test_product_maturity_phase39_library_collections.py
 ---
 
 ## Description
@@ -41,12 +51,39 @@ Verification:
 - `/usr/bin/env PYTHONPYCACHEPREFIX=/tmp/tldw_chatbook_sync_profile_status_pycache ../../.venv/bin/python -m compileall tldw_chatbook/Sync_Interop/sync_profile_status_state.py tldw_chatbook/Library/library_collections_state.py tldw_chatbook/Widgets/Library/library_collections_panel.py tldw_chatbook/UI/Screens/library_screen.py` passed.
 - `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -q -r tldw_chatbook/Sync_Interop/sync_profile_status_state.py tldw_chatbook/Library/library_collections_state.py tldw_chatbook/Widgets/Library/library_collections_panel.py tldw_chatbook/UI/Screens/library_screen.py -f json -o /tmp/bandit_chatbook_sync_profile_status.json` passed.
 - `git diff --check` passed.
+
+PR review follow-up:
+- Validated Sync profile scope values before summary-service calls and gated Library summary loading to server-authoritative runtime state.
+- Disabled Rich markup for Sync profile banner text.
+- Removed duplicated read-only copy from status detail strings because the banner already renders a dedicated read-only notice.
+- Added Google-style docstrings for the public `SyncProfileStatusDisplay` adapter.
+- Removed the duplicate manual dangerous-fragment blacklist and relies on shared input validation with `allow_html=False`.
+
+Review verification:
+- `../../.venv/bin/python -m pytest Tests/Sync_Interop/test_sync_profile_status_state.py Tests/Widgets/test_library_collections_panel.py Tests/UI/test_product_maturity_phase39_library_collections.py::test_library_collections_surfaces_sync_profile_summary_without_write_sync Tests/UI/test_product_maturity_phase39_library_collections.py::test_library_collections_does_not_load_sync_profile_summary_in_local_mode Tests/UI/test_product_maturity_phase39_library_collections.py::test_library_collections_validates_sync_profile_scope_before_summary_load -q` passed with 10 tests.
+- `../../.venv/bin/python -m pytest Tests/Sync_Interop Tests/Library Tests/Widgets/test_library_collections_panel.py Tests/UI/test_product_maturity_phase39_library_collections.py -q` passed with 190 tests.
+- `/usr/bin/env PYTHONPYCACHEPREFIX=/tmp/tldw_chatbook_sync_profile_status_pycache ../../.venv/bin/python -m compileall tldw_chatbook/Sync_Interop/sync_profile_status_state.py tldw_chatbook/Library/library_collections_state.py tldw_chatbook/Widgets/Library/library_collections_panel.py tldw_chatbook/UI/Screens/library_screen.py` passed.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -q -r tldw_chatbook/Sync_Interop/sync_profile_status_state.py tldw_chatbook/Library/library_collections_state.py tldw_chatbook/Widgets/Library/library_collections_panel.py tldw_chatbook/UI/Screens/library_screen.py -f json -o /tmp/bandit_chatbook_sync_profile_status_review.json` passed.
+- `git diff --check` passed.
+
+Rebase follow-up:
+- Rebased `codex/sync-profile-status` onto latest `origin/dev`.
+- Preserved newer write-sync promotion labels/tests from `dev` while keeping Sync profile status tests.
+- Updated Sync v2 profile summary identity/conflict aggregation for the domain-qualified `source_scope_key` shape now present on `dev`.
+
+Rebase verification:
+- `../../.venv/bin/python -m pytest Tests/Sync_Interop/test_sync_profile_status_state.py Tests/Widgets/test_library_collections_panel.py Tests/UI/test_product_maturity_phase39_library_collections.py::test_library_collections_surfaces_sync_profile_summary_without_write_sync Tests/UI/test_product_maturity_phase39_library_collections.py::test_library_collections_does_not_load_sync_profile_summary_in_local_mode Tests/UI/test_product_maturity_phase39_library_collections.py::test_library_collections_validates_sync_profile_scope_before_summary_load -q` passed with 11 tests.
+- `../../.venv/bin/python -m pytest Tests/Sync_Interop/test_sync_scope_service.py::test_sync_scope_service_returns_sync_v2_profile_summary Tests/Sync_Interop/test_sync_state_repository.py::test_sync_v2_profile_summary_aggregates_state_counts_and_status Tests/Sync_Interop/test_sync_state_repository.py::test_sync_v2_profile_summary_scopes_none_principal_and_workspace_exactly -q` passed with 3 tests.
+- `../../.venv/bin/python -m pytest Tests/Sync_Interop Tests/Library Tests/Widgets/test_library_collections_panel.py Tests/UI/test_product_maturity_phase39_library_collections.py -q` passed with 205 tests.
+- `/usr/bin/env PYTHONPYCACHEPREFIX=/tmp/tldw_chatbook_sync_profile_status_pycache ../../.venv/bin/python -m compileall tldw_chatbook/Sync_Interop/sync_profile_status_state.py tldw_chatbook/Sync_Interop/sync_state_repository.py tldw_chatbook/Library/library_collections_state.py tldw_chatbook/Widgets/Library/library_collections_panel.py tldw_chatbook/UI/Screens/library_screen.py` passed.
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -q -r tldw_chatbook/Sync_Interop/sync_profile_status_state.py tldw_chatbook/Sync_Interop/sync_state_repository.py tldw_chatbook/Library/library_collections_state.py tldw_chatbook/Widgets/Library/library_collections_panel.py tldw_chatbook/UI/Screens/library_screen.py -f json -o /tmp/bandit_chatbook_sync_profile_status_rebase.json` reported three pre-existing B608 findings in `sync_state_repository.py` outside this branch's diff; no new Bandit finding is on changed lines.
+- `git diff --check` passed.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Surfaced Sync v2 profile summary status in the Library Collections running-app workflow. Users can now see read-only profile state, pending work, conflict/error attention, and dataset/device identity context without triggering sync writes.
+Surfaced Sync v2 profile summary status in the Library Collections running-app workflow and addressed PR review feedback. Users can see read-only profile state, pending work, conflict/error attention, and dataset/device identity context without triggering sync writes. Review follow-up validates sync scope inputs before summary loads, gates status loading to server runtime state, disables Rich markup for banner text, removes duplicated read-only detail copy, and documents the public display adapter. Rebase follow-up preserved newer write-sync promotion coverage from dev and updated Sync v2 profile summary aggregation to remain compatible with domain-qualified sync scope keys.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_chatbook/Library/library_collections_state.py
+++ b/tldw_chatbook/Library/library_collections_state.py
@@ -8,6 +8,7 @@ import re
 from typing import Any, Mapping, Sequence
 
 from tldw_chatbook.Utils.input_validation import sanitize_string, validate_text_input
+from tldw_chatbook.Sync_Interop.sync_profile_status_state import SyncProfileStatusDisplay
 
 
 LIBRARY_COLLECTIONS_EMPTY_COPY = "Group saved Library items for Search/RAG, Study, and Console."
@@ -356,6 +357,7 @@ class LibraryCollectionsPanelState:
     create_action: LibraryCollectionActionState
     rename_action: LibraryCollectionActionState
     delete_action: LibraryCollectionActionState
+    sync_profile_status: SyncProfileStatusDisplay | None = None
     error_message: str = ""
     recovery_copy: str = ""
 
@@ -369,6 +371,7 @@ class LibraryCollectionsPanelState:
         error_message: Any = "",
         create_name: Any = "",
         rename_name: Any = None,
+        sync_profile_summary: Mapping[str, Any] | None = None,
     ) -> "LibraryCollectionsPanelState":
         records = tuple(
             LibraryCollectionSummary.from_record(record)
@@ -425,6 +428,11 @@ class LibraryCollectionsPanelState:
         create_action = _create_action(create_name, summary_rows)
         rename_action = _rename_action(rename_name, selected_detail, summary_rows)
         delete_action = _delete_action(selected_detail)
+        sync_profile_status = (
+            SyncProfileStatusDisplay.from_summary(sync_profile_summary)
+            if sync_profile_summary is not None
+            else None
+        )
 
         return cls(
             status=requested_status,
@@ -435,6 +443,7 @@ class LibraryCollectionsPanelState:
             create_action=create_action,
             rename_action=rename_action,
             delete_action=delete_action,
+            sync_profile_status=sync_profile_status,
             error_message=error_copy,
             recovery_copy=recovery_copy,
         )

--- a/tldw_chatbook/Sync_Interop/sync_profile_status_state.py
+++ b/tldw_chatbook/Sync_Interop/sync_profile_status_state.py
@@ -1,0 +1,157 @@
+"""Display-state adapter for Sync v2 profile summaries."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from tldw_chatbook.Utils.input_validation import sanitize_string, validate_text_input
+
+
+_DANGEROUS_DISPLAY_FRAGMENTS = ("<script", "javascript:", "onerror=", "onclick=")
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _safe_text(value: Any, fallback: str = "", *, max_length: int = 200) -> str:
+    text = sanitize_string(str(value or ""), max_length=max_length).strip()
+    text = " ".join(text.split())
+    if not text:
+        return fallback
+    lowered = text.lower()
+    if any(fragment in lowered for fragment in _DANGEROUS_DISPLAY_FRAGMENTS):
+        return fallback
+    if not validate_text_input(text, max_length=max_length, allow_html=False):
+        return fallback
+    return text
+
+
+def _count(value: Any) -> int:
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _status(value: Any) -> str:
+    candidate = _safe_text(value, "not_configured", max_length=80).lower()
+    allowed = {
+        "not_configured",
+        "local_only",
+        "server_frontend",
+        "pending",
+        "attention_required",
+        "ready",
+    }
+    return candidate if candidate in allowed else "not_configured"
+
+
+@dataclass(frozen=True)
+class SyncProfileStatusDisplay:
+    """Presentation-safe status derived from a Sync v2 profile summary."""
+
+    status: str
+    severity: str
+    label: str
+    detail: str
+    pending_count: int
+    dispatched_count: int
+    conflict_count: int
+    dataset_label: str
+    device_label: str
+    read_only_notice: str = "This view only reads sync state; it does not start sync."
+
+    @classmethod
+    def from_summary(cls, summary: Mapping[str, Any] | None) -> "SyncProfileStatusDisplay":
+        """Build display state from repository/service summary data."""
+
+        record = _mapping(summary)
+        status = _status(record.get("status"))
+        profile = _mapping(record.get("profile"))
+        outbox = _mapping(record.get("outbox"))
+        conflicts = _mapping(record.get("conflicts"))
+        pending_count = _count(outbox.get("pending"))
+        dispatched_count = _count(outbox.get("dispatched"))
+        conflict_count = _count(conflicts.get("count"))
+        server_profile_id = _safe_text(profile.get("server_profile_id"), "the configured server")
+        dataset_id = _safe_text(profile.get("dataset_id"), "")
+        device_id = _safe_text(profile.get("device_id"), "")
+        last_error = _safe_text(profile.get("last_error"), "unavailable", max_length=240)
+
+        return cls(
+            status=status,
+            severity=_severity(status),
+            label=_label(status),
+            detail=_detail(
+                status,
+                server_profile_id=server_profile_id,
+                pending_count=pending_count,
+                conflict_count=conflict_count,
+                last_error=last_error,
+            ),
+            pending_count=pending_count,
+            dispatched_count=dispatched_count,
+            conflict_count=conflict_count,
+            dataset_label=f"Dataset {dataset_id}" if dataset_id else "Dataset not assigned",
+            device_label=f"Device {device_id}" if device_id else "Device not registered",
+        )
+
+
+def _severity(status: str) -> str:
+    severities = {
+        "attention_required": "attention",
+        "pending": "pending",
+        "ready": "ready",
+        "server_frontend": "ready",
+        "local_only": "neutral",
+        "not_configured": "neutral",
+    }
+    return severities.get(status, "neutral")
+
+
+def _label(status: str) -> str:
+    labels = {
+        "attention_required": "Sync profile: needs attention",
+        "pending": "Sync profile: pending local changes",
+        "ready": "Sync profile: ready",
+        "server_frontend": "Sync profile: server front-end",
+        "local_only": "Sync profile: local-only",
+        "not_configured": "Sync profile: not configured",
+    }
+    return labels.get(status, "Sync profile: not configured")
+
+
+def _detail(
+    status: str,
+    *,
+    server_profile_id: str,
+    pending_count: int,
+    conflict_count: int,
+    last_error: str,
+) -> str:
+    if status == "attention_required":
+        if conflict_count:
+            suffix = "conflict needs" if conflict_count == 1 else "conflicts need"
+            return (
+                f"{conflict_count} sync {suffix} review. "
+                f"Last error is {last_error}. No writes start from this view."
+            )
+        return f"Sync needs attention. Last error is {last_error}. No writes start from this view."
+    if status == "pending":
+        suffix = "change is" if pending_count == 1 else "changes are"
+        return (
+            f"{pending_count} pending local {suffix} waiting for the next sync pass. "
+            "No writes start from this view."
+        )
+    if status == "ready":
+        return "Local-first sync is ready. No writes start from this view."
+    if status == "server_frontend":
+        return (
+            f"Using {server_profile_id} as a live server front-end. "
+            "Offline mirror sync is not configured."
+        )
+    if status == "local_only":
+        return "This profile is local-only. Local Library data stays on this device."
+    return "No Sync v2 server profile is configured. Local Library data stays on this device."

--- a/tldw_chatbook/Sync_Interop/sync_profile_status_state.py
+++ b/tldw_chatbook/Sync_Interop/sync_profile_status_state.py
@@ -8,9 +8,6 @@ from typing import Any, Mapping
 from tldw_chatbook.Utils.input_validation import sanitize_string, validate_text_input
 
 
-_DANGEROUS_DISPLAY_FRAGMENTS = ("<script", "javascript:", "onerror=", "onclick=")
-
-
 def _mapping(value: Any) -> Mapping[str, Any]:
     return value if isinstance(value, Mapping) else {}
 
@@ -19,9 +16,6 @@ def _safe_text(value: Any, fallback: str = "", *, max_length: int = 200) -> str:
     text = sanitize_string(str(value or ""), max_length=max_length).strip()
     text = " ".join(text.split())
     if not text:
-        return fallback
-    lowered = text.lower()
-    if any(fragment in lowered for fragment in _DANGEROUS_DISPLAY_FRAGMENTS):
         return fallback
     if not validate_text_input(text, max_length=max_length, allow_html=False):
         return fallback
@@ -50,7 +44,20 @@ def _status(value: Any) -> str:
 
 @dataclass(frozen=True)
 class SyncProfileStatusDisplay:
-    """Presentation-safe status derived from a Sync v2 profile summary."""
+    """Presentation-safe status derived from a Sync v2 profile summary.
+
+    Attributes:
+        status: Normalized Sync v2 profile status.
+        severity: UI severity token used by the Library status banner.
+        label: Short human-readable banner title.
+        detail: Sanitized status detail copy.
+        pending_count: Count of local outbox changes waiting to sync.
+        dispatched_count: Count of dispatched outbox changes.
+        conflict_count: Count of conflicts that need review.
+        dataset_label: Sanitized dataset label for the active profile.
+        device_label: Sanitized device label for the active profile.
+        read_only_notice: Stable copy explaining the banner does not start sync.
+    """
 
     status: str
     severity: str
@@ -65,7 +72,17 @@ class SyncProfileStatusDisplay:
 
     @classmethod
     def from_summary(cls, summary: Mapping[str, Any] | None) -> "SyncProfileStatusDisplay":
-        """Build display state from repository/service summary data."""
+        """Build display state from repository/service summary data.
+
+        Args:
+            summary: Raw Sync v2 profile summary mapping returned by the repository
+                or service layer. Missing or malformed mappings are treated as not
+                configured.
+
+        Returns:
+            SyncProfileStatusDisplay with normalized counts and sanitized display
+            strings.
+        """
 
         record = _mapping(summary)
         status = _status(record.get("status"))
@@ -134,19 +151,13 @@ def _detail(
     if status == "attention_required":
         if conflict_count:
             suffix = "conflict needs" if conflict_count == 1 else "conflicts need"
-            return (
-                f"{conflict_count} sync {suffix} review. "
-                f"Last error is {last_error}. No writes start from this view."
-            )
-        return f"Sync needs attention. Last error is {last_error}. No writes start from this view."
+            return f"{conflict_count} sync {suffix} review. Last error is {last_error}."
+        return f"Sync needs attention. Last error is {last_error}."
     if status == "pending":
         suffix = "change is" if pending_count == 1 else "changes are"
-        return (
-            f"{pending_count} pending local {suffix} waiting for the next sync pass. "
-            "No writes start from this view."
-        )
+        return f"{pending_count} pending local {suffix} waiting for the next sync pass."
     if status == "ready":
-        return "Local-first sync is ready. No writes start from this view."
+        return "Local-first sync is ready."
     if status == "server_frontend":
         return (
             f"Using {server_profile_id} as a live server front-end. "

--- a/tldw_chatbook/Sync_Interop/sync_state_repository.py
+++ b/tldw_chatbook/Sync_Interop/sync_state_repository.py
@@ -1337,22 +1337,31 @@ class SyncStateRepository(BaseDB):
         authenticated_principal_id: str | None,
         workspace_scope: str | None,
     ) -> dict[str, Any]:
-        scope_prefix = _source_scope_prefix(
-            source_authority="server",
-            server_profile_id=server_profile_id,
-            authenticated_principal_id=authenticated_principal_id,
-            workspace_scope=workspace_scope,
-        )
         summary: dict[str, Any] = {"total": 0, "by_domain": {}}
         with self._get_connection() as conn:
             rows = conn.execute(
                 """
                 SELECT mapping_status, domain, COUNT(*) AS count
                 FROM sync_identity_mappings
-                WHERE source_scope_key LIKE ?
+                WHERE source_authority = 'server'
+                  AND server_profile_id = ?
+                  AND (
+                    authenticated_principal_id = ?
+                    OR (authenticated_principal_id IS NULL AND ? IS NULL)
+                  )
+                  AND (
+                    workspace_scope = ?
+                    OR (workspace_scope IS NULL AND ? IS NULL)
+                  )
                 GROUP BY mapping_status, domain
                 """,
-                (f"{scope_prefix}:%",),
+                (
+                    server_profile_id,
+                    authenticated_principal_id,
+                    authenticated_principal_id,
+                    workspace_scope,
+                    workspace_scope,
+                ),
             ).fetchall()
         for row in rows:
             status = row["mapping_status"]
@@ -1371,11 +1380,14 @@ class SyncStateRepository(BaseDB):
         authenticated_principal_id: str | None,
         workspace_scope: str | None,
     ) -> dict[str, Any]:
-        scope_prefix = _source_scope_prefix(
-            source_authority="server",
-            server_profile_id=server_profile_id,
-            authenticated_principal_id=authenticated_principal_id,
-            workspace_scope=workspace_scope,
+        scope_prefix = ":".join(
+            (
+                "server",
+                server_profile_id,
+                _scope_component(authenticated_principal_id),
+                _scope_component(workspace_scope),
+                "",
+            )
         )
         with self._get_connection() as conn:
             rows = conn.execute(
@@ -1386,7 +1398,7 @@ class SyncStateRepository(BaseDB):
                 ORDER BY conflict_id DESC
                 LIMIT 5
                 """,
-                (f"{scope_prefix}:%",),
+                (f"{scope_prefix}%",),
             ).fetchall()
             count_row = conn.execute(
                 """
@@ -1394,7 +1406,7 @@ class SyncStateRepository(BaseDB):
                 FROM sync_conflict_reports
                 WHERE source_scope_key LIKE ?
                 """,
-                (f"{scope_prefix}:%",),
+                (f"{scope_prefix}%",),
             ).fetchone()
         latest = [dict(row) for row in rows]
         for report in latest:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -259,6 +259,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_collections_records = ()
         self._library_collections_selected_id = ""
         self._library_collections_error = ""
+        self._library_sync_profile_summary: Mapping[str, Any] | None = None
         self._library_collection_name_input = ""
         self._library_collection_description_input = ""
         self._library_collection_pending_delete_id = ""
@@ -644,6 +645,7 @@ class LibraryScreen(BaseAppScreen):
             error_message=self._library_collections_error,
             create_name=self._library_collection_name_input,
             rename_name=self._library_collection_name_input,
+            sync_profile_summary=self._library_sync_profile_summary,
         )
 
     def _collections_inspector_rows(
@@ -1080,6 +1082,7 @@ class LibraryScreen(BaseAppScreen):
         list_collections = getattr(service, "list_collections", None)
         if not callable(list_collections):
             self._library_collections_records = ()
+            self._library_sync_profile_summary = None
             self._library_collections_loaded = True
             self._library_collections_error = "Library Collections are unavailable in this runtime."
             return
@@ -1088,12 +1091,14 @@ class LibraryScreen(BaseAppScreen):
         except Exception:
             logger.warning("Failed to load Library Collections.", exc_info=True)
             self._library_collections_records = ()
+            self._library_sync_profile_summary = None
             self._library_collections_loaded = True
             self._library_collections_error = "Library Collections are unavailable."
             return
         self._library_collections_records = await self._decorate_library_collection_sync_records(
             tuple(records or ())
         )
+        self._library_sync_profile_summary = await self._load_library_sync_profile_summary()
         self._library_collections_loaded = True
         self._library_collections_error = ""
         if (
@@ -1202,6 +1207,31 @@ class LibraryScreen(BaseAppScreen):
                 record_data["sync_status"] = ""
             decorated.append(record_data)
         return tuple(decorated)
+
+    async def _load_library_sync_profile_summary(self) -> Mapping[str, Any] | None:
+        sync_scope_service = getattr(self.app_instance, "sync_scope_service", None)
+        get_summary = getattr(sync_scope_service, "get_sync_v2_profile_summary", None)
+        if not callable(get_summary):
+            return None
+
+        scope_provider = getattr(self.app_instance, "_server_notification_event_scope", None)
+        scope = scope_provider() if callable(scope_provider) else {}
+        server_profile_id = scope.get("server_profile_id") if isinstance(scope, Mapping) else None
+        if not server_profile_id:
+            return None
+
+        try:
+            summary = await self._run_library_service_call(
+                get_summary,
+                server_profile_id=str(server_profile_id),
+                authenticated_principal_id=scope.get("authenticated_principal_id"),
+                workspace_scope=scope.get("workspace_scope"),
+                isolate_in_worker=True,
+            )
+        except Exception:
+            logger.warning("Failed to load Sync v2 profile summary.", exc_info=True)
+            return None
+        return summary if isinstance(summary, Mapping) else None
 
     def _sync_collection_scoped_action_buttons(self) -> None:
         deferred = self._active_mode == "collections"

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -26,7 +26,7 @@ from ...Library.library_rag_service import (
 )
 from ...Library.library_rag_state import LibraryRagPanelState
 from ...runtime_policy.server_event_scope import event_principal_id_from_active_context
-from ...runtime_policy.types import PolicyDeniedError
+from ...runtime_policy.types import PolicyDeniedError, RuntimeSourceState
 from ...Sync_Interop.sync_promotion_state import build_sync_promotion_state
 from ...Sync_Interop.sync_readiness import DEFAULT_SYNC_ELIGIBILITY_REGISTRY, build_sync_readiness_report
 from ...Utils.input_validation import sanitize_string, validate_text_input
@@ -357,6 +357,18 @@ class LibraryScreen(BaseAppScreen):
         if validate_text_input(text, max_length=max_length, allow_html=False):
             return text
         return fallback
+
+    @staticmethod
+    def _safe_sync_scope_text(value: Any, *, max_length: int = 200) -> str | None:
+        """Return a validated Sync scope value or None when unsafe/empty."""
+
+        text = sanitize_string(str(value or ""), max_length=max_length).strip()
+        text = " ".join(text.split())
+        if not text:
+            return None
+        if validate_text_input(text, max_length=max_length, allow_html=False):
+            return text
+        return None
 
     @classmethod
     def _source_title(cls, source_type: str, record: Mapping[str, Any]) -> str:
@@ -1214,18 +1226,38 @@ class LibraryScreen(BaseAppScreen):
         if not callable(get_summary):
             return None
 
+        runtime_policy = getattr(self.app_instance, "runtime_policy", None)
+        runtime_state = getattr(runtime_policy, "state", None)
+        if (
+            not isinstance(runtime_state, RuntimeSourceState)
+            or runtime_state.active_source != "server"
+            or not runtime_state.server_configured
+            or not runtime_state.active_server_id
+        ):
+            return None
+
         scope_provider = getattr(self.app_instance, "_server_notification_event_scope", None)
         scope = scope_provider() if callable(scope_provider) else {}
-        server_profile_id = scope.get("server_profile_id") if isinstance(scope, Mapping) else None
+        scope_mapping = scope if isinstance(scope, Mapping) else {}
+        raw_server_profile_id = scope_mapping.get("server_profile_id", runtime_state.active_server_id)
+        server_profile_id = self._safe_sync_scope_text(raw_server_profile_id)
         if not server_profile_id:
+            return None
+        authenticated_principal_id = self._safe_sync_scope_text(
+            scope_mapping.get("authenticated_principal_id")
+        )
+        if scope_mapping.get("authenticated_principal_id") is not None and authenticated_principal_id is None:
+            return None
+        workspace_scope = self._safe_sync_scope_text(scope_mapping.get("workspace_scope"))
+        if scope_mapping.get("workspace_scope") is not None and workspace_scope is None:
             return None
 
         try:
             summary = await self._run_library_service_call(
                 get_summary,
-                server_profile_id=str(server_profile_id),
-                authenticated_principal_id=scope.get("authenticated_principal_id"),
-                workspace_scope=scope.get("workspace_scope"),
+                server_profile_id=server_profile_id,
+                authenticated_principal_id=authenticated_principal_id,
+                workspace_scope=workspace_scope,
                 isolate_in_worker=True,
             )
         except Exception:

--- a/tldw_chatbook/Widgets/Library/library_collections_panel.py
+++ b/tldw_chatbook/Widgets/Library/library_collections_panel.py
@@ -47,14 +47,17 @@ class LibraryCollectionsPanel(Vertical):
                 yield Static(
                     self.state.sync_profile_status.label,
                     id="library-sync-profile-status",
+                    markup=False,
                 )
                 yield Static(
                     self.state.sync_profile_status.detail,
                     id="library-sync-profile-detail",
+                    markup=False,
                 )
                 yield Static(
                     self.state.sync_profile_status.read_only_notice,
                     id="library-sync-profile-read-only",
+                    markup=False,
                 )
 
         with Horizontal(id="library-collections-workbench"):

--- a/tldw_chatbook/Widgets/Library/library_collections_panel.py
+++ b/tldw_chatbook/Widgets/Library/library_collections_panel.py
@@ -39,6 +39,24 @@ class LibraryCollectionsPanel(Vertical):
         if self.state.status == "empty":
             yield Static(self.state.empty_copy, id="library-collections-empty")
 
+        if self.state.sync_profile_status is not None:
+            with Vertical(
+                id="library-sync-profile-status-banner",
+                classes=f"sync-profile-status {self.state.sync_profile_status.severity}",
+            ):
+                yield Static(
+                    self.state.sync_profile_status.label,
+                    id="library-sync-profile-status",
+                )
+                yield Static(
+                    self.state.sync_profile_status.detail,
+                    id="library-sync-profile-detail",
+                )
+                yield Static(
+                    self.state.sync_profile_status.read_only_notice,
+                    id="library-sync-profile-read-only",
+                )
+
         with Horizontal(id="library-collections-workbench"):
             with Vertical(id="library-collections-list"):
                 yield Static("Collections", classes="destination-section")


### PR DESCRIPTION
## Change summary

This PR surfaces the merged Sync v2 profile summary contract in the Library Collections workflow as a read-only status banner. I added a small pure display-state adapter so raw repository/service summaries map to stable user-facing labels, severity, pending/conflict counts, safe error copy, and dataset/device labels. Library Collections now loads the summary from `SyncScopeService` for the active server profile and renders it without adding push, pull, restore, or other write-sync controls.

## Why this approach

The previous PR made profile status available as a repository/service contract, but users still had no running-app visibility into that state. Library Collections already has the read-only sync dry-run surface, so extending that panel keeps the sync work observable without expanding behavior or implying write sync is enabled. The mounted regression uses a fake sync scope service to prove rendering asks only for the summary and does not call push or pull.

## Test plan

- `../../.venv/bin/python -m pytest Tests/Sync_Interop/test_sync_profile_status_state.py Tests/Widgets/test_library_collections_panel.py Tests/Library/test_library_collections_state.py Tests/UI/test_product_maturity_phase39_library_collections.py -q`
- `../../.venv/bin/python -m pytest Tests/Sync_Interop Tests/Library Tests/Widgets/test_library_collections_panel.py Tests/UI/test_product_maturity_phase39_library_collections.py -q`
- `/usr/bin/env PYTHONPYCACHEPREFIX=/tmp/tldw_chatbook_sync_profile_status_pycache ../../.venv/bin/python -m compileall tldw_chatbook/Sync_Interop/sync_profile_status_state.py tldw_chatbook/Library/library_collections_state.py tldw_chatbook/Widgets/Library/library_collections_panel.py tldw_chatbook/UI/Screens/library_screen.py`
- `/Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/python -m bandit -q -r tldw_chatbook/Sync_Interop/sync_profile_status_state.py tldw_chatbook/Library/library_collections_state.py tldw_chatbook/Widgets/Library/library_collections_panel.py tldw_chatbook/UI/Screens/library_screen.py -f json -o /tmp/bandit_chatbook_sync_profile_status.json`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows the Sync v2 profile summary in Library Collections as a read-only status banner. Loads the summary only in server mode with safe scope validation and never starts sync.

- **New Features**
  - Added SyncProfileStatusDisplay that maps service summaries to UI-safe fields (label, severity, counts, dataset/device labels, sanitized last error, read-only notice).
  - LibraryScreen loads the summary via `sync_scope_service.get_sync_v2_profile_summary` for the active server profile, isolates it in a worker, and never calls push/pull.
  - LibraryCollectionsPanel renders a banner above the list; LibraryCollectionsPanelState.from_values accepts `sync_profile_summary` and builds `sync_profile_status`.

- **Bug Fixes**
  - Validates sync scope inputs and runtime state; loads the summary only in server mode and skips when values are unsafe.
  - Disables Rich markup for banner text and sanitizes all copy with shared validators.
  - Corrects identity/conflict aggregation in `sync_state_repository` to use exact server scope columns and null-safe filters, avoiding cross-scope counts.
  - Tests cover mapping, gating (no load in local mode/invalid scope), and confirm no write sync is triggered.

<sup>Written for commit 25bfd618e7351933e97d2be9a7af6439bce6cf5f. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/350?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

