### PR TITLE
Add citation evidence contract models

### DIFF
--- a/Docs/superpowers/specs/2026-05-23-citation-snippet-carry-through-epic-design.md
+++ b/Docs/superpowers/specs/2026-05-23-citation-snippet-carry-through-epic-design.md
@@ -180,6 +180,11 @@ CitationRef(
 )
 ```
 
+The contract accepts `text` as an input alias for both `EvidenceReference.snippet` and
+`CitationRef.quote` so existing RAG citation models can be adapted without lossy field
+renames. Serialized payloads keep `snippet` for source evidence and `quote` for answer
+citations because those two fields have different user-facing meanings downstream.
+
 Status values should include at least:
 
 - `available`

--- a/Tests/Chat/test_citation_evidence_models.py
+++ b/Tests/Chat/test_citation_evidence_models.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tldw_chatbook.Chat.citation_evidence_models import (
+    CitationRef,
+    EvidenceBundle,
+    EvidenceReference,
+    EVIDENCE_SNIPPET_CHAR_LIMIT,
+)
+
+
+def test_evidence_bundle_round_trip_preserves_source_authority_and_json_payload() -> None:
+    reference = EvidenceReference(
+        evidence_id="S1",
+        source_id="note-1",
+        source_type="note",
+        title="Release notes",
+        snippet="The feature is enabled by default.",
+        authority_label="Workspace: Research",
+        workspace_id="workspace-a",
+        source_owner="local",
+        content_ref="local:note:note-1",
+        score=0.87,
+        metadata={"page": 2, "token": "secret-value"},
+    )
+    bundle = EvidenceBundle(
+        bundle_id="bundle-1",
+        query="Is the feature enabled?",
+        references=(reference,),
+    )
+
+    payload = bundle.to_payload()
+    json.dumps(payload)
+    restored = EvidenceBundle.from_payload(payload)
+
+    assert payload["references"][0]["metadata"] == {"page": 2}
+    assert restored.references[0].evidence_id == "S1"
+    assert restored.references[0].authority_label == "Workspace: Research"
+    assert restored.references[0].workspace_id == "workspace-a"
+    assert restored.references[0].source_owner == "local"
+    assert restored.references[0].content_ref == "local:note:note-1"
+    assert restored.available_references()[0].source_id == "note-1"
+
+
+def test_evidence_reference_truncates_large_snippets_without_losing_original_count() -> None:
+    long_snippet = "x" * (EVIDENCE_SNIPPET_CHAR_LIMIT + 25)
+
+    reference = EvidenceReference(
+        evidence_id="S1",
+        source_id="note-1",
+        source_type="note",
+        title="Large source",
+        snippet=long_snippet,
+        authority_label="Local Library",
+    )
+
+    payload = reference.to_payload()
+
+    assert len(payload["snippet"]) == EVIDENCE_SNIPPET_CHAR_LIMIT
+    assert payload["snippet_truncated"] is True
+    assert payload["original_snippet_char_count"] == len(long_snippet)
+
+
+def test_evidence_contract_rejects_unsupported_metadata_payloads() -> None:
+    with pytest.raises(TypeError, match="unsupported metadata value"):
+        EvidenceReference(
+            evidence_id="S1",
+            source_id="note-1",
+            source_type="note",
+            title="Bad metadata",
+            snippet="snippet",
+            authority_label="Local Library",
+            metadata={"callback": object()},
+        ).to_payload()
+
+
+def test_citation_ref_validates_against_bundle_and_rejects_unknown_status() -> None:
+    bundle = EvidenceBundle(
+        bundle_id="bundle-1",
+        query="question",
+        references=(
+            EvidenceReference(
+                evidence_id="S1",
+                source_id="note-1",
+                source_type="note",
+                title="Release notes",
+                snippet="The feature is enabled.",
+                authority_label="Local Library",
+            ),
+        ),
+    )
+    citation = CitationRef(
+        evidence_id="S1",
+        source_id="note-1",
+        quote="The feature is enabled.",
+        status="validated",
+    )
+
+    assert citation.to_payload()["status"] == "validated"
+    assert citation.validate_against(bundle).status == "validated"
+    assert CitationRef(evidence_id="S2", source_id="note-2", status="validated").validate_against(bundle).status == "unknown"
+
+    with pytest.raises(ValueError, match="Unsupported citation status"):
+        CitationRef(evidence_id="S1", source_id="note-1", status="trusted")

--- a/Tests/Chat/test_citation_evidence_models.py
+++ b/Tests/Chat/test_citation_evidence_models.py
@@ -64,6 +64,19 @@ def test_evidence_reference_truncates_large_snippets_without_losing_original_cou
     assert payload["original_snippet_char_count"] == len(long_snippet)
 
 
+def test_evidence_reference_rejects_out_of_range_scores() -> None:
+    with pytest.raises(ValueError, match="less than or equal to 1"):
+        EvidenceReference(
+            evidence_id="S1",
+            source_id="note-1",
+            source_type="note",
+            title="Bad score",
+            snippet="snippet",
+            authority_label="Local Library",
+            score=1.25,
+        )
+
+
 def test_evidence_contract_rejects_unsupported_metadata_payloads() -> None:
     with pytest.raises(TypeError, match="unsupported metadata value"):
         EvidenceReference(
@@ -105,3 +118,91 @@ def test_citation_ref_validates_against_bundle_and_rejects_unknown_status() -> N
 
     with pytest.raises(ValueError, match="Unsupported citation status"):
         CitationRef(evidence_id="S1", source_id="note-1", status="trusted")
+
+
+def test_evidence_payload_round_trip_preserves_falsy_json_identifiers() -> None:
+    restored = EvidenceReference.from_payload(
+        {
+            "evidence_id": 0,
+            "source_id": 0,
+            "source_type": "note",
+            "title": "Zero identifiers",
+            "snippet": "snippet",
+            "authority_label": "Local Library",
+        }
+    )
+    citation = CitationRef.from_payload({"evidence_id": 0, "source_id": 0, "status": "validated"})
+
+    assert restored.evidence_id == "0"
+    assert restored.source_id == "0"
+    assert citation.evidence_id == "0"
+    assert citation.source_id == "0"
+
+
+def test_metadata_payload_omits_nulls_preserves_token_metrics_and_serializes_sets() -> None:
+    reference = EvidenceReference(
+        evidence_id="S1",
+        source_id="note-1",
+        source_type="note",
+        title="Token metrics",
+        snippet="snippet",
+        authority_label="Local Library",
+        metadata={
+            "token": "secret-token",
+            "access_token": "secret-access-token",
+            "total_tokens": 42,
+            "prompt_tokens": 7,
+            "tags": {"beta", "alpha"},
+        },
+    )
+    bundle = EvidenceBundle(bundle_id="bundle-1", query="query", references=(reference,), metadata=None)
+    citation = CitationRef(evidence_id="S1", source_id="note-1", metadata=None)
+
+    metadata = bundle.to_payload()["references"][0]["metadata"]
+
+    assert metadata["total_tokens"] == 42
+    assert metadata["prompt_tokens"] == 7
+    assert sorted(metadata["tags"]) == ["alpha", "beta"]
+    assert "token" not in metadata
+    assert "access_token" not in metadata
+    assert bundle.to_payload()["metadata"] == {}
+    assert citation.to_payload()["metadata"] == {}
+
+
+def test_blocked_evidence_status_remains_visible_when_validating_citation() -> None:
+    bundle = EvidenceBundle(
+        bundle_id="bundle-1",
+        query="query",
+        references=(
+            EvidenceReference(
+                evidence_id="S1",
+                source_id="note-1",
+                source_type="note",
+                title="Blocked source",
+                snippet="snippet",
+                authority_label="Workspace: Other",
+                status="blocked",
+            ),
+        ),
+    )
+
+    citation = CitationRef(evidence_id="S1", source_id="note-1", status="validated")
+
+    assert citation.validate_against(bundle).status == "blocked"
+
+
+def test_text_aliases_are_accepted_for_rag_citation_compatibility() -> None:
+    reference = EvidenceReference(
+        evidence_id="S1",
+        source_id="note-1",
+        source_type="note",
+        title="Release notes",
+        text="The feature is enabled.",
+        authority_label="Local Library",
+    )
+    citation = CitationRef(evidence_id="S1", source_id="note-1", text="The feature is enabled.")
+
+    assert reference.snippet == "The feature is enabled."
+    assert EvidenceReference.from_payload({**reference.to_payload(), "text": "ignored"}).snippet == "The feature is enabled."
+    assert citation.quote == "The feature is enabled."
+    assert CitationRef.from_payload({"evidence_id": "S1", "source_id": "note-1", "text": "Alias"}).quote == "Alias"

--- a/tldw_chatbook/Chat/citation_evidence_models.py
+++ b/tldw_chatbook/Chat/citation_evidence_models.py
@@ -2,57 +2,180 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field, replace
 from typing import Any, Mapping
+
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, ValidationInfo, field_validator, model_validator
 
 
 EVIDENCE_SNIPPET_CHAR_LIMIT = 4_000
-SECRET_METADATA_KEYS = frozenset({"credential", "credential_source", "token", "secret", "api_key", "password"})
+EXACT_SECRET_METADATA_KEYS = frozenset({"token"})
+TOKEN_SECRET_SUFFIXES = ("_token",)
+SUBSTRING_SECRET_METADATA_KEYS = frozenset({"credential", "secret", "api_key", "password"})
 
 EVIDENCE_STATUSES = frozenset({"available", "blocked", "missing", "stale", "unknown"})
-CITATION_STATUSES = frozenset({"validated", "unknown", "stale", "missing", "uncited"})
+CITATION_STATUSES = frozenset({"validated", "blocked", "unknown", "stale", "missing", "uncited"})
 
 
-@dataclass(frozen=True)
-class EvidenceReference:
-    """A durable reference to one source snippet that can ground an answer."""
+class EvidenceReference(BaseModel):
+    """A durable reference to one source snippet that can ground an answer.
+
+    Attributes:
+        evidence_id: Stable citation label such as ``S1``.
+        source_id: Source-system identifier for the referenced item.
+        source_type: Source kind, for example ``note`` or ``media``.
+        title: Human-readable source title.
+        snippet: Text excerpt used as evidence.
+        authority_label: User-visible local/server/workspace authority label.
+        workspace_id: Optional workspace owner or eligibility scope.
+        source_owner: Owner category for the source.
+        content_ref: Optional durable source reference string.
+        status: Evidence availability state.
+        score: Optional retrieval score between 0 and 1.
+        metadata: JSON-safe auxiliary metadata.
+        snippet_truncated: Whether ``snippet`` was truncated for payload safety.
+        original_snippet_char_count: Original snippet character count before truncation.
+    """
+
+    model_config = ConfigDict(frozen=True, populate_by_name=True)
 
     evidence_id: str
     source_id: str
     source_type: str
     title: str
-    snippet: str
+    snippet: str = Field(validation_alias=AliasChoices("snippet", "text"))
     authority_label: str
     workspace_id: str | None = None
     source_owner: str = "local"
     content_ref: str | None = None
     status: str = "available"
-    score: float | None = None
-    metadata: Mapping[str, Any] = field(default_factory=dict)
+    score: float | None = Field(default=None, ge=0, le=1)
+    metadata: Mapping[str, Any] = Field(default_factory=dict)
     snippet_truncated: bool = False
     original_snippet_char_count: int | None = None
 
-    def __post_init__(self) -> None:
-        for field_name in ("evidence_id", "source_id", "source_type", "title", "authority_label"):
-            object.__setattr__(self, field_name, _required_text(field_name, getattr(self, field_name)))
+    @field_validator("evidence_id", "source_id", "source_type", "title", "authority_label", mode="before")
+    @classmethod
+    def _normalize_required_text(cls, value: Any, info: ValidationInfo) -> str:
+        """Normalize and validate required text fields.
 
-        snippet = str(self.snippet or "")
-        original_count = self.original_snippet_char_count if self.original_snippet_char_count is not None else len(snippet)
-        truncated = bool(self.snippet_truncated) or len(snippet) > EVIDENCE_SNIPPET_CHAR_LIMIT
-        if len(snippet) > EVIDENCE_SNIPPET_CHAR_LIMIT:
-            snippet = snippet[:EVIDENCE_SNIPPET_CHAR_LIMIT]
+        Args:
+            value: Raw value provided by callers or deserialized payloads.
+            info: Pydantic field metadata for the field being validated.
 
+        Returns:
+            Non-empty stripped text.
+
+        Raises:
+            ValueError: If the normalized field value is empty.
+        """
+
+        return _required_text(info.field_name, value)
+
+    @field_validator("snippet", mode="before")
+    @classmethod
+    def _normalize_snippet(cls, value: Any) -> str:
+        """Normalize source snippets to text.
+
+        Args:
+            value: Raw snippet text.
+
+        Returns:
+            String snippet text, or an empty string for ``None``.
+        """
+
+        return _text_or_empty(value)
+
+    @field_validator("workspace_id", "content_ref", mode="before")
+    @classmethod
+    def _normalize_optional_text(cls, value: Any) -> str | None:
+        """Normalize optional text fields.
+
+        Args:
+            value: Raw optional value.
+
+        Returns:
+            Stripped text, or ``None`` when no value is present.
+        """
+
+        return _optional_text(value)
+
+    @field_validator("source_owner", mode="before")
+    @classmethod
+    def _normalize_source_owner(cls, value: Any) -> str:
+        """Normalize the source-owner field.
+
+        Args:
+            value: Raw source owner value.
+
+        Returns:
+            Stripped source owner, defaulting to ``local``.
+        """
+
+        return _text_or_default(value, "local")
+
+    @field_validator("status", mode="before")
+    @classmethod
+    def _validate_evidence_status(cls, value: Any) -> str:
+        """Validate evidence status.
+
+        Args:
+            value: Raw status value.
+
+        Returns:
+            Normalized evidence status.
+
+        Raises:
+            ValueError: If the status is not supported.
+        """
+
+        return _validate_status("evidence", value, EVIDENCE_STATUSES)
+
+    @field_validator("metadata", mode="before")
+    @classmethod
+    def _normalize_metadata(cls, value: Any) -> Mapping[str, Any]:
+        """Normalize metadata to a mapping.
+
+        Args:
+            value: Raw metadata value.
+
+        Returns:
+            Metadata mapping, or an empty mapping for absent metadata.
+
+        Raises:
+            ValueError: If metadata is present but not mapping-like.
+        """
+
+        return _metadata_mapping(value)
+
+    @model_validator(mode="after")
+    def _apply_snippet_limits(self) -> "EvidenceReference":
+        """Apply the snippet truncation contract.
+
+        Returns:
+            The validated evidence reference with snippet truncation metadata.
+        """
+
+        original_count = (
+            self.original_snippet_char_count
+            if self.original_snippet_char_count is not None
+            else len(self.snippet)
+        )
+        truncated = self.snippet_truncated or len(self.snippet) > EVIDENCE_SNIPPET_CHAR_LIMIT
+        snippet = self.snippet[:EVIDENCE_SNIPPET_CHAR_LIMIT]
         object.__setattr__(self, "snippet", snippet)
         object.__setattr__(self, "snippet_truncated", truncated)
         object.__setattr__(self, "original_snippet_char_count", original_count)
-        object.__setattr__(self, "source_owner", _text_or_default(self.source_owner, "local"))
-        object.__setattr__(self, "status", _validate_status("evidence", self.status, EVIDENCE_STATUSES))
-
-        if self.score is not None and not 0 <= float(self.score) <= 1:
-            raise ValueError("score must be between 0 and 1")
+        return self
 
     def to_payload(self) -> dict[str, Any]:
-        """Return a JSON-safe payload with sensitive metadata removed."""
+        """Serialize the reference for handoffs, persistence, or export.
+
+        Returns:
+            JSON-safe dictionary with sensitive metadata removed.
+
+        Raises:
+            TypeError: If nested metadata contains unsupported values.
+        """
 
         payload = {
             "evidence_id": self.evidence_id,
@@ -74,51 +197,170 @@ class EvidenceReference:
 
     @classmethod
     def from_payload(cls, payload: Mapping[str, Any]) -> "EvidenceReference":
-        """Rebuild a reference from its serialized payload."""
+        """Deserialize an evidence reference payload.
+
+        Args:
+            payload: Serialized evidence reference payload.
+
+        Returns:
+            Validated evidence reference.
+
+        Raises:
+            ValueError: If required fields or statuses are invalid.
+        """
 
         return cls(
-            evidence_id=str(payload.get("evidence_id") or ""),
-            source_id=str(payload.get("source_id") or ""),
-            source_type=str(payload.get("source_type") or ""),
-            title=str(payload.get("title") or ""),
-            snippet=str(payload.get("snippet") or ""),
-            authority_label=str(payload.get("authority_label") or ""),
-            workspace_id=_optional_text(payload.get("workspace_id")),
-            source_owner=str(payload.get("source_owner") or "local"),
-            content_ref=_optional_text(payload.get("content_ref")),
-            status=str(payload.get("status") or "available"),
+            evidence_id=payload.get("evidence_id"),
+            source_id=payload.get("source_id"),
+            source_type=payload.get("source_type"),
+            title=payload.get("title"),
+            snippet=_payload_value(payload, "snippet", fallback_key="text", default=""),
+            authority_label=payload.get("authority_label"),
+            workspace_id=payload.get("workspace_id"),
+            source_owner=_payload_value(payload, "source_owner", default="local"),
+            content_ref=payload.get("content_ref"),
+            status=_payload_value(payload, "status", default="available"),
             score=payload.get("score"),
-            metadata=payload.get("metadata") if isinstance(payload.get("metadata"), Mapping) else {},
+            metadata=payload.get("metadata"),
             snippet_truncated=bool(payload.get("snippet_truncated", False)),
             original_snippet_char_count=payload.get("original_snippet_char_count"),
         )
 
 
-@dataclass(frozen=True)
-class EvidenceBundle:
-    """A set of source snippets staged together for one grounded interaction."""
+class EvidenceBundle(BaseModel):
+    """A set of source snippets staged together for one grounded interaction.
+
+    Attributes:
+        bundle_id: Stable identifier for the evidence group.
+        query: User query or retrieval query that produced the evidence.
+        references: Evidence references in citation-label order.
+        source: User-visible source of the evidence bundle.
+        status: Bundle-level availability state.
+        metadata: JSON-safe auxiliary metadata.
+    """
+
+    model_config = ConfigDict(frozen=True, populate_by_name=True)
 
     bundle_id: str
     query: str
-    references: tuple[EvidenceReference, ...] = field(default_factory=tuple)
+    references: tuple[EvidenceReference, ...] = Field(default_factory=tuple)
     source: str = "Library Search/RAG"
     status: str = "available"
-    metadata: Mapping[str, Any] = field(default_factory=dict)
+    metadata: Mapping[str, Any] = Field(default_factory=dict)
 
-    def __post_init__(self) -> None:
-        object.__setattr__(self, "bundle_id", _required_text("bundle_id", self.bundle_id))
-        object.__setattr__(self, "query", str(self.query or ""))
-        object.__setattr__(self, "source", _text_or_default(self.source, "Library Search/RAG"))
-        object.__setattr__(self, "references", tuple(self.references or ()))
-        object.__setattr__(self, "status", _validate_status("evidence", self.status, EVIDENCE_STATUSES))
+    @field_validator("bundle_id", mode="before")
+    @classmethod
+    def _normalize_bundle_id(cls, value: Any) -> str:
+        """Normalize and validate the bundle identifier.
+
+        Args:
+            value: Raw bundle id.
+
+        Returns:
+            Non-empty stripped bundle id.
+
+        Raises:
+            ValueError: If the bundle id is empty.
+        """
+
+        return _required_text("bundle_id", value)
+
+    @field_validator("query", mode="before")
+    @classmethod
+    def _normalize_query(cls, value: Any) -> str:
+        """Normalize the bundle query.
+
+        Args:
+            value: Raw query value.
+
+        Returns:
+            Query text, or an empty string for ``None``.
+        """
+
+        return _text_or_empty(value)
+
+    @field_validator("source", mode="before")
+    @classmethod
+    def _normalize_source(cls, value: Any) -> str:
+        """Normalize the bundle source label.
+
+        Args:
+            value: Raw source label.
+
+        Returns:
+            Source label, defaulting to ``Library Search/RAG``.
+        """
+
+        return _text_or_default(value, "Library Search/RAG")
+
+    @field_validator("references", mode="before")
+    @classmethod
+    def _normalize_references(cls, value: Any) -> tuple[Any, ...]:
+        """Normalize references into a tuple.
+
+        Args:
+            value: Raw iterable of references.
+
+        Returns:
+            Tuple of reference-like values for Pydantic validation.
+        """
+
+        if value is None:
+            return ()
+        return tuple(value)
+
+    @field_validator("status", mode="before")
+    @classmethod
+    def _validate_evidence_status(cls, value: Any) -> str:
+        """Validate bundle status.
+
+        Args:
+            value: Raw status value.
+
+        Returns:
+            Normalized evidence status.
+
+        Raises:
+            ValueError: If the status is not supported.
+        """
+
+        return _validate_status("evidence", value, EVIDENCE_STATUSES)
+
+    @field_validator("metadata", mode="before")
+    @classmethod
+    def _normalize_metadata(cls, value: Any) -> Mapping[str, Any]:
+        """Normalize metadata to a mapping.
+
+        Args:
+            value: Raw metadata value.
+
+        Returns:
+            Metadata mapping, or an empty mapping for absent metadata.
+
+        Raises:
+            ValueError: If metadata is present but not mapping-like.
+        """
+
+        return _metadata_mapping(value)
 
     def available_references(self) -> tuple[EvidenceReference, ...]:
-        """Return references eligible to ground model output."""
+        """Return references eligible to ground model output.
+
+        Returns:
+            Tuple of references whose status is ``available``.
+        """
 
         return tuple(reference for reference in self.references if reference.status == "available")
 
     def reference_by_id(self, evidence_id: str) -> EvidenceReference | None:
-        """Return one reference by stable citation label."""
+        """Return one reference by stable citation label.
+
+        Args:
+            evidence_id: Citation label to look up.
+
+        Returns:
+            Matching evidence reference, or ``None`` when absent.
+        """
 
         for reference in self.references:
             if reference.evidence_id == evidence_id:
@@ -126,9 +368,16 @@ class EvidenceBundle:
         return None
 
     def to_payload(self) -> dict[str, Any]:
-        """Return a JSON-safe payload for handoffs, persistence, and export."""
+        """Serialize the bundle for handoffs, persistence, or export.
 
-        return {
+        Returns:
+            JSON-safe dictionary with sensitive metadata removed.
+
+        Raises:
+            TypeError: If nested metadata contains unsupported values.
+        """
+
+        payload = {
             "bundle_id": self.bundle_id,
             "query": self.query,
             "source": self.source,
@@ -136,18 +385,29 @@ class EvidenceBundle:
             "metadata": _metadata_payload(self.metadata),
             "references": [reference.to_payload() for reference in self.references],
         }
+        return _without_none(payload)
 
     @classmethod
     def from_payload(cls, payload: Mapping[str, Any]) -> "EvidenceBundle":
-        """Rebuild a bundle from its serialized payload."""
+        """Deserialize an evidence bundle payload.
+
+        Args:
+            payload: Serialized evidence bundle payload.
+
+        Returns:
+            Validated evidence bundle.
+
+        Raises:
+            ValueError: If required fields or statuses are invalid.
+        """
 
         references = payload.get("references") if isinstance(payload.get("references"), list) else []
         return cls(
-            bundle_id=str(payload.get("bundle_id") or ""),
-            query=str(payload.get("query") or ""),
-            source=str(payload.get("source") or "Library Search/RAG"),
-            status=str(payload.get("status") or "available"),
-            metadata=payload.get("metadata") if isinstance(payload.get("metadata"), Mapping) else {},
+            bundle_id=payload.get("bundle_id"),
+            query=_payload_value(payload, "query", default=""),
+            source=_payload_value(payload, "source", default="Library Search/RAG"),
+            status=_payload_value(payload, "status", default="available"),
+            metadata=payload.get("metadata"),
             references=tuple(
                 EvidenceReference.from_payload(reference)
                 for reference in references
@@ -156,73 +416,186 @@ class EvidenceBundle:
         )
 
 
-@dataclass(frozen=True)
-class CitationRef:
-    """A model-output citation marker validated against an evidence bundle."""
+class CitationRef(BaseModel):
+    """A model-output citation marker validated against an evidence bundle.
+
+    Attributes:
+        evidence_id: Stable citation label referenced by the answer.
+        source_id: Source-system identifier expected for the evidence label.
+        quote: Optional answer quote associated with the citation marker.
+        status: Validation status for the citation marker.
+        metadata: JSON-safe auxiliary metadata.
+    """
+
+    model_config = ConfigDict(frozen=True, populate_by_name=True)
 
     evidence_id: str
     source_id: str
-    quote: str = ""
+    quote: str = Field(default="", validation_alias=AliasChoices("quote", "text"))
     status: str = "validated"
-    metadata: Mapping[str, Any] = field(default_factory=dict)
+    metadata: Mapping[str, Any] = Field(default_factory=dict)
 
-    def __post_init__(self) -> None:
-        object.__setattr__(self, "evidence_id", _required_text("evidence_id", self.evidence_id))
-        object.__setattr__(self, "source_id", _required_text("source_id", self.source_id))
-        object.__setattr__(self, "quote", str(self.quote or ""))
-        object.__setattr__(self, "status", _validate_status("citation", self.status, CITATION_STATUSES))
+    @field_validator("evidence_id", "source_id", mode="before")
+    @classmethod
+    def _normalize_required_text(cls, value: Any, info: ValidationInfo) -> str:
+        """Normalize and validate required text fields.
+
+        Args:
+            value: Raw value provided by callers or deserialized payloads.
+            info: Pydantic field metadata for the field being validated.
+
+        Returns:
+            Non-empty stripped text.
+
+        Raises:
+            ValueError: If the normalized field value is empty.
+        """
+
+        return _required_text(info.field_name, value)
+
+    @field_validator("quote", mode="before")
+    @classmethod
+    def _normalize_quote(cls, value: Any) -> str:
+        """Normalize citation quote text.
+
+        Args:
+            value: Raw quote value.
+
+        Returns:
+            Quote text, or an empty string for ``None``.
+        """
+
+        return _text_or_empty(value)
+
+    @field_validator("status", mode="before")
+    @classmethod
+    def _validate_citation_status(cls, value: Any) -> str:
+        """Validate citation status.
+
+        Args:
+            value: Raw status value.
+
+        Returns:
+            Normalized citation status.
+
+        Raises:
+            ValueError: If the status is not supported.
+        """
+
+        return _validate_status("citation", value, CITATION_STATUSES)
+
+    @field_validator("metadata", mode="before")
+    @classmethod
+    def _normalize_metadata(cls, value: Any) -> Mapping[str, Any]:
+        """Normalize metadata to a mapping.
+
+        Args:
+            value: Raw metadata value.
+
+        Returns:
+            Metadata mapping, or an empty mapping for absent metadata.
+
+        Raises:
+            ValueError: If metadata is present but not mapping-like.
+        """
+
+        return _metadata_mapping(value)
 
     def validate_against(self, bundle: EvidenceBundle) -> "CitationRef":
-        """Return a trusted citation only when the evidence id and source id match."""
+        """Validate the citation against an evidence bundle.
+
+        Args:
+            bundle: Evidence bundle that should contain the cited evidence.
+
+        Returns:
+            This citation when valid, or a copied citation with a downgraded
+            status when the evidence is absent, blocked, stale, or mismatched.
+        """
 
         reference = bundle.reference_by_id(self.evidence_id)
         if reference is None or reference.source_id != self.source_id:
-            return replace(self, status="unknown")
+            return self.model_copy(update={"status": "unknown"})
         if reference.status != "available":
-            return replace(self, status=reference.status if reference.status in CITATION_STATUSES else "unknown")
+            return self.model_copy(update={"status": reference.status})
         return self
 
     def to_payload(self) -> dict[str, Any]:
-        """Return a JSON-safe citation payload."""
+        """Serialize the citation reference.
 
-        return {
+        Returns:
+            JSON-safe dictionary with sensitive metadata removed.
+
+        Raises:
+            TypeError: If nested metadata contains unsupported values.
+        """
+
+        payload = {
             "evidence_id": self.evidence_id,
             "source_id": self.source_id,
             "quote": self.quote,
             "status": self.status,
             "metadata": _metadata_payload(self.metadata),
         }
+        return _without_none(payload)
 
     @classmethod
     def from_payload(cls, payload: Mapping[str, Any]) -> "CitationRef":
-        """Rebuild a citation ref from its serialized payload."""
+        """Deserialize a citation reference payload.
+
+        Args:
+            payload: Serialized citation reference payload.
+
+        Returns:
+            Validated citation reference.
+
+        Raises:
+            ValueError: If required fields or statuses are invalid.
+        """
 
         return cls(
-            evidence_id=str(payload.get("evidence_id") or ""),
-            source_id=str(payload.get("source_id") or ""),
-            quote=str(payload.get("quote") or ""),
-            status=str(payload.get("status") or "validated"),
-            metadata=payload.get("metadata") if isinstance(payload.get("metadata"), Mapping) else {},
+            evidence_id=payload.get("evidence_id"),
+            source_id=payload.get("source_id"),
+            quote=_payload_value(payload, "quote", fallback_key="text", default=""),
+            status=_payload_value(payload, "status", default="validated"),
+            metadata=payload.get("metadata"),
         )
 
 
+def _payload_value(
+    payload: Mapping[str, Any],
+    key: str,
+    *,
+    fallback_key: str | None = None,
+    default: Any = None,
+) -> Any:
+    if key in payload:
+        return payload[key]
+    if fallback_key is not None and fallback_key in payload:
+        return payload[fallback_key]
+    return default
+
+
 def _validate_status(kind: str, value: Any, allowed: frozenset[str]) -> str:
-    status = str(value or "").strip().lower()
+    status = _text_or_empty(value).strip().lower()
     if status not in allowed:
         raise ValueError(f"Unsupported {kind} status: {value!r}")
     return status
 
 
 def _required_text(field_name: str, value: Any) -> str:
-    text = str(value or "").strip()
+    text = _text_or_empty(value).strip()
     if not text:
         raise ValueError(f"{field_name} is required")
     return text
 
 
 def _optional_text(value: Any) -> str | None:
-    text = str(value or "").strip()
+    text = _text_or_empty(value).strip()
     return text or None
+
+
+def _text_or_empty(value: Any) -> str:
+    return "" if value is None else str(value)
 
 
 def _text_or_default(value: Any, default: str) -> str:
@@ -233,15 +606,25 @@ def _without_none(payload: Mapping[str, Any]) -> dict[str, Any]:
     return {key: value for key, value in payload.items() if value is not None}
 
 
+def _metadata_mapping(value: Any) -> Mapping[str, Any]:
+    if value is None:
+        return {}
+    if isinstance(value, Mapping):
+        return dict(value)
+    raise ValueError("metadata must be a mapping")
+
+
 def _metadata_payload(value: Any) -> Any:
     if value is None:
-        return None
+        return {}
     if isinstance(value, Mapping):
         return {
             str(key): _metadata_payload(item)
             for key, item in value.items()
             if item is not None and not _is_secret_metadata_key(str(key))
         }
+    if isinstance(value, set):
+        return [_metadata_payload(item) for item in sorted(value, key=str) if item is not None]
     if isinstance(value, (list, tuple)):
         return [_metadata_payload(item) for item in value if item is not None]
     if isinstance(value, (str, int, float, bool)):
@@ -251,4 +634,8 @@ def _metadata_payload(value: Any) -> Any:
 
 def _is_secret_metadata_key(key: str) -> bool:
     normalized = key.lower()
-    return any(secret_key in normalized for secret_key in SECRET_METADATA_KEYS)
+    return (
+        normalized in EXACT_SECRET_METADATA_KEYS
+        or normalized.endswith(TOKEN_SECRET_SUFFIXES)
+        or any(secret_key in normalized for secret_key in SUBSTRING_SECRET_METADATA_KEYS)
+    )

--- a/tldw_chatbook/Chat/citation_evidence_models.py
+++ b/tldw_chatbook/Chat/citation_evidence_models.py
@@ -1,0 +1,254 @@
+"""Evidence and citation contracts for source-grounded Console answers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from typing import Any, Mapping
+
+
+EVIDENCE_SNIPPET_CHAR_LIMIT = 4_000
+SECRET_METADATA_KEYS = frozenset({"credential", "credential_source", "token", "secret", "api_key", "password"})
+
+EVIDENCE_STATUSES = frozenset({"available", "blocked", "missing", "stale", "unknown"})
+CITATION_STATUSES = frozenset({"validated", "unknown", "stale", "missing", "uncited"})
+
+
+@dataclass(frozen=True)
+class EvidenceReference:
+    """A durable reference to one source snippet that can ground an answer."""
+
+    evidence_id: str
+    source_id: str
+    source_type: str
+    title: str
+    snippet: str
+    authority_label: str
+    workspace_id: str | None = None
+    source_owner: str = "local"
+    content_ref: str | None = None
+    status: str = "available"
+    score: float | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    snippet_truncated: bool = False
+    original_snippet_char_count: int | None = None
+
+    def __post_init__(self) -> None:
+        for field_name in ("evidence_id", "source_id", "source_type", "title", "authority_label"):
+            object.__setattr__(self, field_name, _required_text(field_name, getattr(self, field_name)))
+
+        snippet = str(self.snippet or "")
+        original_count = self.original_snippet_char_count if self.original_snippet_char_count is not None else len(snippet)
+        truncated = bool(self.snippet_truncated) or len(snippet) > EVIDENCE_SNIPPET_CHAR_LIMIT
+        if len(snippet) > EVIDENCE_SNIPPET_CHAR_LIMIT:
+            snippet = snippet[:EVIDENCE_SNIPPET_CHAR_LIMIT]
+
+        object.__setattr__(self, "snippet", snippet)
+        object.__setattr__(self, "snippet_truncated", truncated)
+        object.__setattr__(self, "original_snippet_char_count", original_count)
+        object.__setattr__(self, "source_owner", _text_or_default(self.source_owner, "local"))
+        object.__setattr__(self, "status", _validate_status("evidence", self.status, EVIDENCE_STATUSES))
+
+        if self.score is not None and not 0 <= float(self.score) <= 1:
+            raise ValueError("score must be between 0 and 1")
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return a JSON-safe payload with sensitive metadata removed."""
+
+        payload = {
+            "evidence_id": self.evidence_id,
+            "source_id": self.source_id,
+            "source_type": self.source_type,
+            "title": self.title,
+            "snippet": self.snippet,
+            "authority_label": self.authority_label,
+            "workspace_id": self.workspace_id,
+            "source_owner": self.source_owner,
+            "content_ref": self.content_ref,
+            "status": self.status,
+            "score": self.score,
+            "metadata": _metadata_payload(self.metadata),
+            "snippet_truncated": self.snippet_truncated,
+            "original_snippet_char_count": self.original_snippet_char_count,
+        }
+        return _without_none(payload)
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, Any]) -> "EvidenceReference":
+        """Rebuild a reference from its serialized payload."""
+
+        return cls(
+            evidence_id=str(payload.get("evidence_id") or ""),
+            source_id=str(payload.get("source_id") or ""),
+            source_type=str(payload.get("source_type") or ""),
+            title=str(payload.get("title") or ""),
+            snippet=str(payload.get("snippet") or ""),
+            authority_label=str(payload.get("authority_label") or ""),
+            workspace_id=_optional_text(payload.get("workspace_id")),
+            source_owner=str(payload.get("source_owner") or "local"),
+            content_ref=_optional_text(payload.get("content_ref")),
+            status=str(payload.get("status") or "available"),
+            score=payload.get("score"),
+            metadata=payload.get("metadata") if isinstance(payload.get("metadata"), Mapping) else {},
+            snippet_truncated=bool(payload.get("snippet_truncated", False)),
+            original_snippet_char_count=payload.get("original_snippet_char_count"),
+        )
+
+
+@dataclass(frozen=True)
+class EvidenceBundle:
+    """A set of source snippets staged together for one grounded interaction."""
+
+    bundle_id: str
+    query: str
+    references: tuple[EvidenceReference, ...] = field(default_factory=tuple)
+    source: str = "Library Search/RAG"
+    status: str = "available"
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "bundle_id", _required_text("bundle_id", self.bundle_id))
+        object.__setattr__(self, "query", str(self.query or ""))
+        object.__setattr__(self, "source", _text_or_default(self.source, "Library Search/RAG"))
+        object.__setattr__(self, "references", tuple(self.references or ()))
+        object.__setattr__(self, "status", _validate_status("evidence", self.status, EVIDENCE_STATUSES))
+
+    def available_references(self) -> tuple[EvidenceReference, ...]:
+        """Return references eligible to ground model output."""
+
+        return tuple(reference for reference in self.references if reference.status == "available")
+
+    def reference_by_id(self, evidence_id: str) -> EvidenceReference | None:
+        """Return one reference by stable citation label."""
+
+        for reference in self.references:
+            if reference.evidence_id == evidence_id:
+                return reference
+        return None
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return a JSON-safe payload for handoffs, persistence, and export."""
+
+        return {
+            "bundle_id": self.bundle_id,
+            "query": self.query,
+            "source": self.source,
+            "status": self.status,
+            "metadata": _metadata_payload(self.metadata),
+            "references": [reference.to_payload() for reference in self.references],
+        }
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, Any]) -> "EvidenceBundle":
+        """Rebuild a bundle from its serialized payload."""
+
+        references = payload.get("references") if isinstance(payload.get("references"), list) else []
+        return cls(
+            bundle_id=str(payload.get("bundle_id") or ""),
+            query=str(payload.get("query") or ""),
+            source=str(payload.get("source") or "Library Search/RAG"),
+            status=str(payload.get("status") or "available"),
+            metadata=payload.get("metadata") if isinstance(payload.get("metadata"), Mapping) else {},
+            references=tuple(
+                EvidenceReference.from_payload(reference)
+                for reference in references
+                if isinstance(reference, Mapping)
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class CitationRef:
+    """A model-output citation marker validated against an evidence bundle."""
+
+    evidence_id: str
+    source_id: str
+    quote: str = ""
+    status: str = "validated"
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "evidence_id", _required_text("evidence_id", self.evidence_id))
+        object.__setattr__(self, "source_id", _required_text("source_id", self.source_id))
+        object.__setattr__(self, "quote", str(self.quote or ""))
+        object.__setattr__(self, "status", _validate_status("citation", self.status, CITATION_STATUSES))
+
+    def validate_against(self, bundle: EvidenceBundle) -> "CitationRef":
+        """Return a trusted citation only when the evidence id and source id match."""
+
+        reference = bundle.reference_by_id(self.evidence_id)
+        if reference is None or reference.source_id != self.source_id:
+            return replace(self, status="unknown")
+        if reference.status != "available":
+            return replace(self, status=reference.status if reference.status in CITATION_STATUSES else "unknown")
+        return self
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return a JSON-safe citation payload."""
+
+        return {
+            "evidence_id": self.evidence_id,
+            "source_id": self.source_id,
+            "quote": self.quote,
+            "status": self.status,
+            "metadata": _metadata_payload(self.metadata),
+        }
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, Any]) -> "CitationRef":
+        """Rebuild a citation ref from its serialized payload."""
+
+        return cls(
+            evidence_id=str(payload.get("evidence_id") or ""),
+            source_id=str(payload.get("source_id") or ""),
+            quote=str(payload.get("quote") or ""),
+            status=str(payload.get("status") or "validated"),
+            metadata=payload.get("metadata") if isinstance(payload.get("metadata"), Mapping) else {},
+        )
+
+
+def _validate_status(kind: str, value: Any, allowed: frozenset[str]) -> str:
+    status = str(value or "").strip().lower()
+    if status not in allowed:
+        raise ValueError(f"Unsupported {kind} status: {value!r}")
+    return status
+
+
+def _required_text(field_name: str, value: Any) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(f"{field_name} is required")
+    return text
+
+
+def _optional_text(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _text_or_default(value: Any, default: str) -> str:
+    return _optional_text(value) or default
+
+
+def _without_none(payload: Mapping[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in payload.items() if value is not None}
+
+
+def _metadata_payload(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, Mapping):
+        return {
+            str(key): _metadata_payload(item)
+            for key, item in value.items()
+            if item is not None and not _is_secret_metadata_key(str(key))
+        }
+    if isinstance(value, (list, tuple)):
+        return [_metadata_payload(item) for item in value if item is not None]
+    if isinstance(value, (str, int, float, bool)):
+        return value
+    raise TypeError(f"unsupported metadata value: {type(value).__name__}")
+
+
+def _is_secret_metadata_key(key: str) -> bool:
+    normalized = key.lower()
+    return any(secret_key in normalized for secret_key in SECRET_METADATA_KEYS)


### PR DESCRIPTION
## Summary
- Adds pure citation/evidence contract models for the TASK-60.4.4 epic.
- Covers evidence references, evidence bundles, citation refs, JSON-safe payloads, secret stripping, unsupported metadata rejection, snippet truncation, and citation validation.
- Keeps this slice contract-only: no UI, prompt, persistence, or export behavior changes.

## Verification
- ../../.venv/bin/python -m pytest -q Tests/Chat/test_citation_evidence_models.py --tb=short
- ../../.venv/bin/python -m pytest -q Tests/Chat/test_citation_evidence_models.py Tests/UI/test_chat_first_handoffs.py Tests/Chat/test_chat_conversation_service.py --tb=short
- ../../.venv/bin/python -m compileall tldw_chatbook/Chat/citation_evidence_models.py
- git diff --cached --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds contract-only models for citations and evidence with strict, JSON-safe payloads and validation for grounded answers. Supports Linear TASK-60.4.4 without changing UI, prompts, persistence, or exports.

- **New Features**
  - Implemented `EvidenceReference`, `EvidenceBundle`, and `CitationRef` as frozen `pydantic` models.
  - Accepted `text` as an input alias for evidence `snippet` and citation `quote`; payloads preserve `snippet`/`quote`.
  - Enforced 4,000-char snippet limit with truncation flags and original length.
  - Expanded metadata handling: strip secret keys (`token`, `*_token`, and keys containing `secret`/`credential`/`api_key`/`password`); reject unsupported types; serialize sets; omit nulls.
  - Strengthened validation: status sets for evidence/citations, score range checks, citation validation downgrades to `blocked`/`stale`/`missing`/`unknown`; tests cover round-trips (incl. falsy IDs), truncation, metadata, aliases, and validation.

<sup>Written for commit 8a171d174acd7892d98673f0e55aa398a69a2a6d. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/353?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

