### PR TITLE
Add Library RAG evidence bundles

### DIFF
--- a/Tests/UI/test_product_maturity_gate16_library_search_rag.py
+++ b/Tests/UI/test_product_maturity_gate16_library_search_rag.py
@@ -291,6 +291,11 @@ async def test_library_search_rag_run_query_renders_service_results_and_calls_sc
                     "chunk_id": "chunk-7",
                     "runtime_backend": "local-fts",
                     "citations": [{"label": "Incident Review p.2"}],
+                    "provenance": {
+                        "source_type": "note",
+                        "workspace_ids": ("workspace-a",),
+                        "active_workspace_id": "workspace-a",
+                    },
                 }
             ],
             "runtime_backend": "local-fts",
@@ -344,6 +349,11 @@ async def test_library_search_rag_selected_result_launches_console_live_work() -
                     "chunk_id": "chunk-7",
                     "runtime_backend": "local-fts",
                     "citations": [{"label": "Incident Review p.2"}],
+                    "provenance": {
+                        "source_type": "note",
+                        "workspace_ids": ("workspace-a",),
+                        "active_workspace_id": "workspace-a",
+                    },
                 }
             ],
             "runtime_backend": "local-fts",
@@ -376,27 +386,27 @@ async def test_library_search_rag_selected_result_launches_console_live_work() -
         screen.query_one("#library-rag-use-in-console", Button).press()
         await pilot.pause(0.1)
 
-    app.open_console_for_live_work.assert_called_once_with(
-        source="Library Search/RAG",
-        title="Incident Review",
-        payload={
-            "target_id": "local:library-rag:note-42:chunk-7",
-            "result_id": "note-42:chunk-7",
-            "query": query,
-            "title": "Incident Review",
-            "source_id": "note-42",
-            "chunk_id": "chunk-7",
-            "snippet": "Expired credential caused the incident.",
-            "citations": ["Incident Review p.2"],
-            "score": 0.93,
-            "runtime_backend": "local-fts",
-            "source_authority": "local",
-            "source_selector_state": "local",
-        },
-        status="staged",
-        recovery="Review citations before sending.",
-        action_label="Review evidence in Console",
-    )
+    app.open_console_for_live_work.assert_called_once()
+    launch_kwargs = app.open_console_for_live_work.call_args.kwargs
+    assert launch_kwargs["source"] == "Library Search/RAG"
+    assert launch_kwargs["title"] == "Incident Review"
+    assert launch_kwargs["status"] == "staged"
+    assert launch_kwargs["recovery"] == "Review citations before sending."
+    assert launch_kwargs["action_label"] == "Review evidence in Console"
+    payload = launch_kwargs["payload"]
+    assert payload["target_id"] == "local:library-rag:note-42:chunk-7"
+    assert payload["snippet"] == "Expired credential caused the incident."
+    evidence_bundle = payload["evidence_bundle"]
+    evidence_reference = evidence_bundle["references"][0]
+    assert evidence_bundle["query"] == query
+    assert evidence_bundle["status"] == "available"
+    assert evidence_reference["evidence_id"] == "S1"
+    assert evidence_reference["source_id"] == "note-42"
+    assert evidence_reference["source_type"] == "note"
+    assert evidence_reference["snippet"] == "Expired credential caused the incident."
+    assert evidence_reference["authority_label"] == "Workspace: workspace-a"
+    assert evidence_reference["metadata"]["active_context_eligible"] is True
+    assert evidence_reference["metadata"]["global_browse_visible"] is True
     app.open_chat_with_handoff.assert_not_called()
 
 
@@ -442,26 +452,31 @@ async def test_library_search_rag_server_result_launches_server_console_live_wor
         screen.query_one("#library-rag-use-in-console", Button).press()
         await pilot.pause(0.1)
 
-    app.open_console_for_live_work.assert_called_once_with(
-        source="Library Search/RAG",
-        title="Server Incident Review",
-        payload={
-            "target_id": "server:library-rag:server-note-42:chunk-9",
-            "result_id": "server-note-42:chunk-9",
-            "query": query,
-            "title": "Server Incident Review",
-            "source_id": "server-note-42",
-            "chunk_id": "chunk-9",
-            "snippet": "Server retrieval found the authoritative incident record.",
-            "citations": ["Server Incident Review p.4"],
-            "score": 0.88,
-            "runtime_backend": "server-rag",
-            "source_authority": "server",
-            "source_selector_state": "server",
-        },
-        status="staged",
-        recovery="Review citations before sending.",
-        action_label="Review evidence in Console",
+    app.open_console_for_live_work.assert_called_once()
+    launch_kwargs = app.open_console_for_live_work.call_args.kwargs
+    assert launch_kwargs["source"] == "Library Search/RAG"
+    assert launch_kwargs["title"] == "Server Incident Review"
+    assert launch_kwargs["status"] == "staged"
+    assert launch_kwargs["recovery"] == "Review citations before sending."
+    assert launch_kwargs["action_label"] == "Review evidence in Console"
+    payload = launch_kwargs["payload"]
+    assert payload["target_id"] == "server:library-rag:server-note-42:chunk-9"
+    assert payload["result_id"] == "server-note-42:chunk-9"
+    assert payload["query"] == query
+    assert payload["title"] == "Server Incident Review"
+    assert payload["source_id"] == "server-note-42"
+    assert payload["chunk_id"] == "chunk-9"
+    assert payload["snippet"] == "Server retrieval found the authoritative incident record."
+    assert payload["citations"] == ["Server Incident Review p.4"]
+    assert payload["score"] == 0.88
+    assert payload["runtime_backend"] == "server-rag"
+    assert payload["source_authority"] == "server"
+    assert payload["source_selector_state"] == "server"
+    evidence_reference = payload["evidence_bundle"]["references"][0]
+    assert evidence_reference["source_owner"] == "server"
+    assert evidence_reference["authority_label"] == "Source authority: server"
+    assert evidence_reference["snippet"] == (
+        "Server retrieval found the authoritative incident record."
     )
     app.open_chat_with_handoff.assert_not_called()
 

--- a/Tests/UI/test_search_handoffs.py
+++ b/Tests/UI/test_search_handoffs.py
@@ -238,6 +238,40 @@ def test_library_rag_evidence_bundle_marks_empty_results_missing():
     assert payload["metadata"]["blocked_reference_count"] == 0
 
 
+@pytest.mark.parametrize("status", ("stale", "unknown"))
+def test_library_rag_evidence_bundle_preserves_non_missing_reference_status(status):
+    bundle = build_library_rag_evidence_bundle(
+        {
+            "title": "Indexed source",
+            "snippet": "Existing evidence has a non-ready state.",
+            "source_id": f"{status}-source",
+            "evidence_status": status,
+        },
+        query=f"Show {status} evidence",
+    )
+
+    payload = bundle.to_payload()
+    reference = payload["references"][0]
+    assert payload["status"] == status
+    assert reference["status"] == status
+
+
+def test_library_rag_evidence_bundle_drops_out_of_range_scores():
+    payload = build_library_rag_console_live_work_payload(
+        {
+            "title": "Out of range score",
+            "snippet": "Score should not prevent staging evidence.",
+            "source_id": "note-99",
+            "score": 1.5,
+        },
+        query="Can this evidence stage?",
+    )
+
+    reference = payload["evidence_bundle"]["references"][0]
+    assert payload["score"] is None
+    assert "score" not in reference
+
+
 def test_library_rag_console_payload_uses_shared_validation_for_unsafe_text():
     result = {
         "result_id": "note-42:chunk-7",

--- a/Tests/UI/test_search_handoffs.py
+++ b/Tests/UI/test_search_handoffs.py
@@ -16,6 +16,7 @@ from tldw_chatbook.UI.Views.RAGSearch import search_rag_window
 from tldw_chatbook.UI.SearchWindow import SearchWindow
 from tldw_chatbook.UI.Views.RAGSearch.search_rag_window import SearchRAGWindow
 from tldw_chatbook.UI.Views.RAGSearch.search_handoff import (
+    build_library_rag_evidence_bundle,
     build_library_rag_console_live_work_payload,
 )
 from tldw_chatbook.UI.Views.RAGSearch.search_result import SearchResult
@@ -127,7 +128,23 @@ def test_library_rag_console_payload_preserves_evidence_fields():
         query="Why did the incident happen?",
     )
 
-    assert payload == {
+    assert {
+        key: payload[key]
+        for key in (
+            "target_id",
+            "result_id",
+            "query",
+            "title",
+            "source_id",
+            "chunk_id",
+            "snippet",
+            "citations",
+            "score",
+            "runtime_backend",
+            "source_authority",
+            "source_selector_state",
+        )
+    } == {
         "target_id": "local:library-rag:note-42:chunk-7",
         "result_id": "note-42:chunk-7",
         "query": "Why did the incident happen?",
@@ -141,6 +158,84 @@ def test_library_rag_console_payload_preserves_evidence_fields():
         "source_authority": "local",
         "source_selector_state": "local",
     }
+    bundle = payload["evidence_bundle"]
+    reference = bundle["references"][0]
+    assert bundle["query"] == "Why did the incident happen?"
+    assert bundle["status"] == "available"
+    assert reference["evidence_id"] == "S1"
+    assert reference["source_id"] == "note-42"
+    assert reference["snippet"] == "Expired credential caused the incident."
+    assert reference["authority_label"] == "Source authority: local"
+    assert reference["metadata"]["active_context_eligible"] is True
+    assert reference["metadata"]["global_browse_visible"] is True
+
+
+def test_library_rag_evidence_bundle_blocks_cross_workspace_context():
+    bundle = build_library_rag_evidence_bundle(
+        {
+            "result_id": "note-42:chunk-7",
+            "title": "Workspace B Note",
+            "snippet": "Workspace B evidence remains visible.",
+            "source_id": "note-42",
+            "chunk_id": "chunk-7",
+            "source_type": "note",
+            "runtime_backend": "local-fts",
+            "workspace_ids": ("workspace-b",),
+            "active_workspace_id": "workspace-a",
+        },
+        query="Can I use this in Workspace A?",
+    )
+
+    payload = bundle.to_payload()
+    reference = payload["references"][0]
+    assert payload["status"] == "blocked"
+    assert reference["status"] == "blocked"
+    assert reference["workspace_id"] == "workspace-b"
+    assert reference["authority_label"] == (
+        "Workspace: workspace-b (blocked for active workspace workspace-a)"
+    )
+    assert reference["metadata"]["global_browse_visible"] is True
+    assert reference["metadata"]["active_context_eligible"] is False
+    assert reference["metadata"]["eligibility_reason"] == "cross_workspace"
+    assert reference["metadata"]["active_workspace_id"] == "workspace-a"
+
+
+def test_library_rag_evidence_bundle_preserves_provenance_identity():
+    bundle = build_library_rag_evidence_bundle(
+        {
+            "title": "Server Transcript",
+            "snippet": "The server transcript contains the source evidence.",
+            "provenance": {
+                "source_id": "media-9",
+                "chunk_id": "chunk-3",
+                "source_type": "media",
+                "runtime_backend": "server-rag",
+            },
+        },
+        query="What does the transcript say?",
+    )
+
+    payload = bundle.to_payload()
+    reference = payload["references"][0]
+    assert reference["source_id"] == "media-9"
+    assert reference["source_type"] == "media"
+    assert reference["source_owner"] == "server"
+    assert reference["content_ref"] == "server:library-rag:media-9:chunk-3"
+    assert reference["metadata"]["chunk_id"] == "chunk-3"
+    assert reference["metadata"]["runtime_backend"] == "server-rag"
+
+
+def test_library_rag_evidence_bundle_marks_empty_results_missing():
+    bundle = build_library_rag_evidence_bundle(
+        [],
+        query="What evidence is available?",
+    )
+
+    payload = bundle.to_payload()
+    assert payload["status"] == "missing"
+    assert payload["references"] == []
+    assert payload["metadata"]["eligible_reference_count"] == 0
+    assert payload["metadata"]["blocked_reference_count"] == 0
 
 
 def test_library_rag_console_payload_uses_shared_validation_for_unsafe_text():

--- a/backlog/tasks/task-60.4.4 - Post-release-citation-and-snippet-carry-through-tranche.md
+++ b/backlog/tasks/task-60.4.4 - Post-release-citation-and-snippet-carry-through-tranche.md
@@ -42,6 +42,8 @@ Carry retrieved snippets and citations from Library/Search/RAG into Console answ
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Epic setup started. Added `Docs/superpowers/specs/2026-05-23-citation-snippet-carry-through-epic-design.md` to define the stacked PR model, evidence/citation contracts, answer-level citation injection scope, persistence/export requirements, and QA gates. The implementation remains split across sub-PRs so each seam can be tested and reviewed independently.
+
+Library/Search-RAG evidence bundle slice added. `build_library_rag_console_live_work_payload()` now attaches a serialized `EvidenceBundle` that preserves query, source identity, snippets, citation labels, local/server authority, workspace visibility, and active-context eligibility. Regression coverage verifies local and server Console handoff payloads, cross-workspace blocked evidence, and provenance-only source identity fallback before the later Console staging and answer-citation slices.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/tldw_chatbook/UI/Views/RAGSearch/search_handoff.py
+++ b/tldw_chatbook/UI/Views/RAGSearch/search_handoff.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+import math
 from typing import Any
 from urllib.parse import quote
 
@@ -138,6 +139,42 @@ def _library_rag_source_authority(runtime_backend: Any) -> str:
     return "server" if backend.startswith("server") or "server" in backend else "local"
 
 
+def _library_rag_runtime_backend(result: Any) -> str:
+    return (
+        _validated_payload_text(
+            _result_or_provenance_value(result, "runtime_backend")
+        )
+        or "local"
+    )
+
+
+def _library_rag_target_id(*, source_authority: str, result_id: str) -> str:
+    return f"{source_authority}:library-rag:{_safe_target_part(result_id)}"
+
+
+def _library_rag_title(result: Any) -> str:
+    return _validated_payload_text(
+        _result_or_provenance_value(result, "title")
+        or _result_or_provenance_value(result, "document_title")
+        or _result_or_provenance_value(result, "source_title")
+        or "",
+        fallback="Untitled source",
+    )
+
+
+def _library_rag_score(result: Any) -> float | None:
+    value = _result_or_provenance_value(result, "score")
+    if value in (None, ""):
+        return None
+    try:
+        score = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(score) or score < 0 or score > 1:
+        return None
+    return score
+
+
 def _text_tuple(value: Any) -> tuple[str, ...]:
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
         raw_values = value
@@ -268,6 +305,14 @@ def _library_rag_result_sequence(results: Any) -> tuple[Any, ...]:
     return (results,)
 
 
+def _library_rag_bundle_status(references: Sequence[EvidenceReference]) -> str:
+    statuses = {reference.status for reference in references}
+    for status in ("available", "blocked", "stale", "unknown", "missing"):
+        if status in statuses:
+            return status
+    return "missing"
+
+
 def build_library_rag_evidence_bundle(
     results: Any,
     *,
@@ -291,12 +336,7 @@ def build_library_rag_evidence_bundle(
     references: list[EvidenceReference] = []
     for index, result in enumerate(_library_rag_result_sequence(results), start=1):
         result_id = _library_rag_result_id(result)
-        runtime_backend = (
-            _validated_payload_text(
-                _result_or_provenance_value(result, "runtime_backend")
-            )
-            or "local"
-        )
+        runtime_backend = _library_rag_runtime_backend(result)
         source_authority = _library_rag_source_authority(runtime_backend)
         source_id = _validated_payload_text(
             _result_or_provenance_value(result, "source_id"),
@@ -317,7 +357,10 @@ def build_library_rag_evidence_bundle(
             result,
             active_context_eligible=active_context_eligible,
         )
-        target_id = f"{source_authority}:library-rag:{_safe_target_part(result_id)}"
+        target_id = _library_rag_target_id(
+            source_authority=source_authority,
+            result_id=result_id,
+        )
         metadata = {
             **_result_provenance(result),
             "result_id": result_id,
@@ -337,12 +380,7 @@ def build_library_rag_evidence_bundle(
                 evidence_id=f"S{index}",
                 source_id=source_id,
                 source_type=_library_rag_source_type(result),
-                title=_validated_payload_text(
-                    _result_value(result, "title")
-                    or _result_value(result, "document_title")
-                    or "",
-                    fallback="Untitled source",
-                ),
+                title=_library_rag_title(result),
                 snippet=_validated_payload_text(
                     _result_value(result, "snippet"),
                     max_length=LIBRARY_RAG_PAYLOAD_SNIPPET_MAX_LENGTH,
@@ -358,16 +396,14 @@ def build_library_rag_evidence_bundle(
                 source_owner=source_authority,
                 content_ref=target_id,
                 status=status,
-                score=_result_value(result, "score"),
+                score=_library_rag_score(result),
                 metadata=metadata,
             )
         )
 
     available_count = sum(reference.status == "available" for reference in references)
     blocked_count = sum(reference.status == "blocked" for reference in references)
-    bundle_status = (
-        "available" if available_count else ("blocked" if blocked_count else "missing")
-    )
+    bundle_status = _library_rag_bundle_status(references)
     first_runtime_backend = (
         str(references[0].metadata.get("runtime_backend") or "")
         if references
@@ -408,24 +444,19 @@ def build_library_rag_console_live_work_payload(
         so downstream Console flows can preserve snippets and authority labels.
     """
     result_id = _library_rag_result_id(result)
-    runtime_backend = (
-        _validated_payload_text(_result_or_provenance_value(result, "runtime_backend"))
-        or "local"
-    )
+    runtime_backend = _library_rag_runtime_backend(result)
     source_authority = _library_rag_source_authority(runtime_backend)
     return {
-        "target_id": f"{source_authority}:library-rag:{_safe_target_part(result_id)}",
+        "target_id": _library_rag_target_id(
+            source_authority=source_authority,
+            result_id=result_id,
+        ),
         "result_id": result_id,
         "query": _validated_payload_text(
             query,
             max_length=LIBRARY_RAG_PAYLOAD_QUERY_MAX_LENGTH,
         ),
-        "title": _validated_payload_text(
-            _result_value(result, "title")
-            or _result_value(result, "document_title")
-            or "",
-            fallback="Untitled source",
-        ),
+        "title": _library_rag_title(result),
         "source_id": _validated_payload_text(
             _result_or_provenance_value(result, "source_id"),
             max_length=LIBRARY_RAG_PAYLOAD_ID_MAX_LENGTH,
@@ -439,7 +470,7 @@ def build_library_rag_console_live_work_payload(
             max_length=LIBRARY_RAG_PAYLOAD_SNIPPET_MAX_LENGTH,
         ),
         "citations": _library_rag_citation_labels(result),
-        "score": _result_value(result, "score"),
+        "score": _library_rag_score(result),
         "runtime_backend": runtime_backend,
         "source_authority": source_authority,
         "source_selector_state": source_authority,

--- a/tldw_chatbook/UI/Views/RAGSearch/search_handoff.py
+++ b/tldw_chatbook/UI/Views/RAGSearch/search_handoff.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from typing import Any
 from urllib.parse import quote
 
+from ....Chat.citation_evidence_models import (
+    EVIDENCE_STATUSES,
+    EvidenceBundle,
+    EvidenceReference,
+)
 from ....Chat.chat_handoff_models import ChatHandoffPayload
 from ....Utils.input_validation import sanitize_string, validate_text_input
 
@@ -31,10 +37,22 @@ def _metadata_for_result(result: dict[str, Any]) -> dict[str, Any]:
     return metadata
 
 
+def _result_provenance(result: Any) -> dict[str, Any]:
+    provenance = _result_value(result, "provenance", {})
+    return dict(provenance) if isinstance(provenance, Mapping) else {}
+
+
 def _result_value(result: Any, key: str, default: Any = None) -> Any:
     if isinstance(result, dict):
         return result.get(key, default)
     return getattr(result, key, default)
+
+
+def _result_or_provenance_value(result: Any, key: str, default: Any = None) -> Any:
+    value = _result_value(result, key, None)
+    if value not in (None, ""):
+        return value
+    return _result_provenance(result).get(key, default)
 
 
 def _validated_payload_text(
@@ -63,17 +81,17 @@ def _safe_target_part(value: Any) -> str:
 
 def _library_rag_result_id(result: Any) -> str:
     explicit_result_id = _validated_payload_text(
-        _result_value(result, "result_id"),
+        _result_or_provenance_value(result, "result_id"),
         max_length=LIBRARY_RAG_PAYLOAD_ID_MAX_LENGTH,
     )
     if explicit_result_id:
         return explicit_result_id
     source_id = _validated_payload_text(
-        _result_value(result, "source_id"),
+        _result_or_provenance_value(result, "source_id"),
         max_length=LIBRARY_RAG_PAYLOAD_ID_MAX_LENGTH,
     )
     chunk_id = _validated_payload_text(
-        _result_value(result, "chunk_id"),
+        _result_or_provenance_value(result, "chunk_id"),
         max_length=LIBRARY_RAG_PAYLOAD_ID_MAX_LENGTH,
     )
     if source_id and chunk_id:
@@ -120,6 +138,255 @@ def _library_rag_source_authority(runtime_backend: Any) -> str:
     return "server" if backend.startswith("server") or "server" in backend else "local"
 
 
+def _text_tuple(value: Any) -> tuple[str, ...]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        raw_values = value
+    elif value not in (None, ""):
+        raw_values = (value,)
+    else:
+        raw_values = ()
+    normalized: list[str] = []
+    for raw_value in raw_values:
+        text = _validated_payload_text(
+            raw_value,
+            max_length=LIBRARY_RAG_PAYLOAD_ID_MAX_LENGTH,
+        )
+        if text:
+            normalized.append(text)
+    return tuple(dict.fromkeys(normalized))
+
+
+def _library_rag_workspace_ids(result: Any) -> tuple[str, ...]:
+    workspace_ids = _text_tuple(_result_or_provenance_value(result, "workspace_ids"))
+    workspace_id = _validated_payload_text(
+        _result_or_provenance_value(result, "workspace_id"),
+        max_length=LIBRARY_RAG_PAYLOAD_ID_MAX_LENGTH,
+    )
+    if workspace_id:
+        workspace_ids = (*workspace_ids, workspace_id)
+    return tuple(dict.fromkeys(workspace_ids))
+
+
+def _library_rag_active_workspace_id(result: Any) -> str:
+    return _validated_payload_text(
+        _result_or_provenance_value(result, "active_workspace_id"),
+        max_length=LIBRARY_RAG_PAYLOAD_ID_MAX_LENGTH,
+    )
+
+
+def _coerce_optional_bool(value: Any) -> bool | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    text = str(value).strip().lower()
+    if text in {"1", "true", "yes", "y", "enabled", "eligible"}:
+        return True
+    if text in {"0", "false", "no", "n", "disabled", "blocked", "ineligible"}:
+        return False
+    return None
+
+
+def _library_rag_active_context_state(result: Any) -> tuple[bool, str]:
+    explicit_eligible = _coerce_optional_bool(
+        _result_or_provenance_value(result, "active_context_eligible")
+    )
+    explicit_reason = _validated_payload_text(
+        _result_or_provenance_value(result, "eligibility_reason"),
+        max_length=LIBRARY_RAG_PAYLOAD_ID_MAX_LENGTH,
+    )
+    if explicit_eligible is not None:
+        return explicit_eligible, explicit_reason or (
+            "explicit_eligible" if explicit_eligible else "explicit_blocked"
+        )
+
+    workspace_ids = _library_rag_workspace_ids(result)
+    if not workspace_ids:
+        return True, "unscoped"
+
+    active_workspace_id = _library_rag_active_workspace_id(result)
+    if not active_workspace_id:
+        return False, "no_active_workspace"
+    if active_workspace_id in workspace_ids:
+        return True, "active_workspace_match"
+    return False, "cross_workspace"
+
+
+def _library_rag_evidence_status(result: Any, *, active_context_eligible: bool) -> str:
+    if not active_context_eligible:
+        return "blocked"
+    raw_status = _validated_payload_text(
+        _result_or_provenance_value(result, "evidence_status")
+        or _result_or_provenance_value(result, "status"),
+        max_length=LIBRARY_RAG_PAYLOAD_ID_MAX_LENGTH,
+    ).lower()
+    return raw_status if raw_status in EVIDENCE_STATUSES else "available"
+
+
+def _library_rag_source_type(result: Any) -> str:
+    return _validated_payload_text(
+        _result_or_provenance_value(result, "source_type")
+        or _result_or_provenance_value(result, "item_type")
+        or _result_or_provenance_value(result, "type"),
+        fallback="library-rag",
+        max_length=LIBRARY_RAG_PAYLOAD_ID_MAX_LENGTH,
+    )
+
+
+def _library_rag_authority_label(
+    *,
+    result: Any,
+    source_authority: str,
+    workspace_ids: tuple[str, ...],
+    active_workspace_id: str,
+    active_context_eligible: bool,
+) -> str:
+    explicit_label = _validated_payload_text(
+        _result_or_provenance_value(result, "authority_label"),
+        max_length=LIBRARY_RAG_PAYLOAD_TEXT_MAX_LENGTH,
+    )
+    if explicit_label:
+        return explicit_label
+    if workspace_ids:
+        workspace_label = f"Workspace: {', '.join(workspace_ids)}"
+        if not active_context_eligible and active_workspace_id:
+            return f"{workspace_label} (blocked for active workspace {active_workspace_id})"
+        if not active_context_eligible:
+            return f"{workspace_label} (blocked until a workspace is active)"
+        return workspace_label
+    return f"Source authority: {source_authority}"
+
+
+def _library_rag_result_sequence(results: Any) -> tuple[Any, ...]:
+    if isinstance(results, Sequence) and not isinstance(
+        results,
+        (str, bytes, bytearray, Mapping),
+    ):
+        return tuple(results)
+    if results is None:
+        return ()
+    return (results,)
+
+
+def build_library_rag_evidence_bundle(
+    results: Any,
+    *,
+    query: Any,
+) -> EvidenceBundle:
+    """Build a durable evidence bundle from Library Search/RAG results.
+
+    Args:
+        results: One result row or a sequence of result rows from Library Search/RAG.
+        query: User query that produced the evidence.
+
+    Returns:
+        EvidenceBundle preserving source identity, snippets, source authority,
+        workspace eligibility, and active-context availability status.
+    """
+
+    query_text = _validated_payload_text(
+        query,
+        max_length=LIBRARY_RAG_PAYLOAD_QUERY_MAX_LENGTH,
+    )
+    references: list[EvidenceReference] = []
+    for index, result in enumerate(_library_rag_result_sequence(results), start=1):
+        result_id = _library_rag_result_id(result)
+        runtime_backend = (
+            _validated_payload_text(
+                _result_or_provenance_value(result, "runtime_backend")
+            )
+            or "local"
+        )
+        source_authority = _library_rag_source_authority(runtime_backend)
+        source_id = _validated_payload_text(
+            _result_or_provenance_value(result, "source_id"),
+            fallback=result_id,
+            max_length=LIBRARY_RAG_PAYLOAD_ID_MAX_LENGTH,
+        )
+        chunk_id = _validated_payload_text(
+            _result_or_provenance_value(result, "chunk_id"),
+            max_length=LIBRARY_RAG_PAYLOAD_ID_MAX_LENGTH,
+        )
+        workspace_ids = _library_rag_workspace_ids(result)
+        active_workspace_id = _library_rag_active_workspace_id(result)
+        (
+            active_context_eligible,
+            eligibility_reason,
+        ) = _library_rag_active_context_state(result)
+        status = _library_rag_evidence_status(
+            result,
+            active_context_eligible=active_context_eligible,
+        )
+        target_id = f"{source_authority}:library-rag:{_safe_target_part(result_id)}"
+        metadata = {
+            **_result_provenance(result),
+            "result_id": result_id,
+            "chunk_id": chunk_id,
+            "citations": _library_rag_citation_labels(result),
+            "runtime_backend": runtime_backend,
+            "source_authority": source_authority,
+            "source_selector_state": source_authority,
+            "workspace_ids": workspace_ids,
+            "active_workspace_id": active_workspace_id,
+            "global_browse_visible": True,
+            "active_context_eligible": active_context_eligible,
+            "eligibility_reason": eligibility_reason,
+        }
+        references.append(
+            EvidenceReference(
+                evidence_id=f"S{index}",
+                source_id=source_id,
+                source_type=_library_rag_source_type(result),
+                title=_validated_payload_text(
+                    _result_value(result, "title")
+                    or _result_value(result, "document_title")
+                    or "",
+                    fallback="Untitled source",
+                ),
+                snippet=_validated_payload_text(
+                    _result_value(result, "snippet"),
+                    max_length=LIBRARY_RAG_PAYLOAD_SNIPPET_MAX_LENGTH,
+                ),
+                authority_label=_library_rag_authority_label(
+                    result=result,
+                    source_authority=source_authority,
+                    workspace_ids=workspace_ids,
+                    active_workspace_id=active_workspace_id,
+                    active_context_eligible=active_context_eligible,
+                ),
+                workspace_id=workspace_ids[0] if workspace_ids else None,
+                source_owner=source_authority,
+                content_ref=target_id,
+                status=status,
+                score=_result_value(result, "score"),
+                metadata=metadata,
+            )
+        )
+
+    available_count = sum(reference.status == "available" for reference in references)
+    blocked_count = sum(reference.status == "blocked" for reference in references)
+    bundle_status = (
+        "available" if available_count else ("blocked" if blocked_count else "missing")
+    )
+    first_runtime_backend = (
+        str(references[0].metadata.get("runtime_backend") or "")
+        if references
+        else ""
+    )
+    return EvidenceBundle(
+        bundle_id=f"library-rag:{_safe_target_part(query_text or 'evidence')}",
+        query=query_text,
+        references=tuple(references),
+        status=bundle_status,
+        metadata={
+            "runtime_backend": first_runtime_backend,
+            "eligible_reference_count": available_count,
+            "blocked_reference_count": blocked_count,
+            "global_browse_visible": True,
+        },
+    )
+
+
 def build_library_rag_console_live_work_payload(
     result: Any,
     *,
@@ -137,11 +404,13 @@ def build_library_rag_console_live_work_payload(
     Returns:
         A sanitized Console live-work payload containing a stable target ID,
         evidence metadata, citation labels, runtime authority, and source
-        selector state.
+        selector state. The payload also includes a serialized `EvidenceBundle`
+        so downstream Console flows can preserve snippets and authority labels.
     """
     result_id = _library_rag_result_id(result)
     runtime_backend = (
-        _validated_payload_text(_result_value(result, "runtime_backend")) or "local"
+        _validated_payload_text(_result_or_provenance_value(result, "runtime_backend"))
+        or "local"
     )
     source_authority = _library_rag_source_authority(runtime_backend)
     return {
@@ -158,11 +427,11 @@ def build_library_rag_console_live_work_payload(
             fallback="Untitled source",
         ),
         "source_id": _validated_payload_text(
-            _result_value(result, "source_id"),
+            _result_or_provenance_value(result, "source_id"),
             max_length=LIBRARY_RAG_PAYLOAD_ID_MAX_LENGTH,
         ),
         "chunk_id": _validated_payload_text(
-            _result_value(result, "chunk_id"),
+            _result_or_provenance_value(result, "chunk_id"),
             max_length=LIBRARY_RAG_PAYLOAD_ID_MAX_LENGTH,
         ),
         "snippet": _validated_payload_text(
@@ -174,6 +443,10 @@ def build_library_rag_console_live_work_payload(
         "runtime_backend": runtime_backend,
         "source_authority": source_authority,
         "source_selector_state": source_authority,
+        "evidence_bundle": build_library_rag_evidence_bundle(
+            result,
+            query=query,
+        ).to_payload(),
     }
 
 


### PR DESCRIPTION
## Summary
- Build serialized EvidenceBundle payloads for Library Search/RAG Console handoffs.
- Preserve source identity, snippets, citation labels, local/server authority, workspace visibility, and active-context eligibility.
- Cover local/server handoff payloads, cross-workspace blocked evidence, provenance-only source identity fallback, and empty-result missing bundles.

## Verification
- ../../.venv/bin/python -m pytest -q Tests/UI/test_product_maturity_gate16_library_search_rag.py Tests/UI/test_search_handoffs.py Tests/Chat/test_citation_evidence_models.py --tb=short
- git diff --check

Stacked PR targeting the citation/snippet epic branch. No rendered UI changes in this slice.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds serialized evidence bundles for Library Search/RAG and attaches them to Console handoffs to preserve snippets, citations, and source identity across contexts. Normalizes scores, computes active-context eligibility with reasons, and keeps UI unchanged.

- **New Features**
  - Added `build_library_rag_evidence_bundle()` to build an `EvidenceBundle` from one or many results, preserving query, snippet, citation labels, source id/type, `source_owner` (local/server), workspace ids, and provenance. Computes eligibility with reason codes, sets status (`available`, `blocked`, `stale`, `unknown`), builds authority labels (workspace-aware), includes eligible/blocked counts and `global_browse_visible`, supports provenance-only identity, and returns a `missing` bundle for empty results. Validates/normalizes scores and drops out-of-range values.
  - Updated `build_library_rag_console_live_work_payload()` to include `evidence_bundle` while keeping stable target/result IDs and existing fields. Uses shared normalization for title/query/source fields and scores, and preserves runtime authority and selector state.

<sup>Written for commit e313d144d41bbba03c38b81288762094ff9bc155. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/354?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

