### PR TITLE
Preserve citations in Chatbook exports

### DIFF
--- a/Tests/Chatbooks/test_chatbook_creator.py
+++ b/Tests/Chatbooks/test_chatbook_creator.py
@@ -18,6 +18,7 @@ from tldw_chatbook.Chatbooks.chatbook_models import (
     ChatbookContent, Chatbook, ChatbookVersion
 )
 from tldw_chatbook.Chatbooks.chatbook_creator import ChatbookCreator
+from tldw_chatbook.Chatbooks.chatbook_importer import ChatbookImporter
 
 
 class TestChatbookCreator:
@@ -375,6 +376,237 @@ class TestChatbookCreator:
             assert conversation_item["metadata"]["citation_message_count"] == 1
             assert conversation_item["metadata"]["evidence_source_count"] == 1
             assert conversation_item["metadata"]["evidence_snippet_count"] == 1
+
+    @patch('tldw_chatbook.Chatbooks.chatbook_creator.CharactersRAGDB')
+    def test_create_chatbook_hydrates_citation_artifacts_from_rag_context_store(
+        self,
+        mock_chacha_db,
+        chatbook_creator,
+        tmp_path,
+    ):
+        """Production-shaped DB messages hydrate citation artifacts from the RAG context store."""
+        mock_db_instance = MagicMock()
+        mock_chacha_db.return_value = mock_db_instance
+        timestamp = datetime.now().isoformat()
+        mock_db_instance.get_conversation_by_id.return_value = {
+            'id': 'conv-rag',
+            'title': 'RAG Conversation',
+            'created_at': timestamp,
+            'updated_at': timestamp,
+            'character_id': None,
+        }
+        mock_db_instance.get_messages_for_conversation.return_value = [
+            {
+                'id': 'msg-rag',
+                'conversation_id': 'conv-rag',
+                'sender': 'assistant',
+                'content': 'Answer grounded by an incident note. [S1]',
+                'timestamp': timestamp,
+            },
+        ]
+        rag_store_path = chatbook_creator.temp_dir.parent.parent / "tldw_chatbook_chat_rag_context.json"
+        rag_store_path.parent.mkdir(parents=True, exist_ok=True)
+        rag_store_path.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "conversations": {
+                        "conv-rag": {
+                            "msg-rag": {
+                                "conversation_id": "conv-rag",
+                                "message_id": "msg-rag",
+                                "rag_context": {
+                                    "citation_validation": {
+                                        "status": "validated",
+                                        "cited_evidence_ids": ["S1"],
+                                    },
+                                    "evidence_bundle": {
+                                        "bundle_id": "library-rag:store",
+                                        "query": "stored evidence",
+                                        "references": [
+                                            {
+                                                "evidence_id": "S1",
+                                                "source_id": "note-store",
+                                                "source_type": "note",
+                                                "title": "Stored Incident",
+                                                "snippet": "Stored snippet from the RAG context store.",
+                                                "authority_label": "Local Library",
+                                                "status": "available",
+                                            }
+                                        ],
+                                    },
+                                },
+                                "citations": [
+                                    {
+                                        "id": "cite-1",
+                                        "evidence_id": "S1",
+                                        "source_id": "note-store",
+                                        "quote": "Answer grounded by an incident note. [S1]",
+                                    }
+                                ],
+                            }
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        output_path = tmp_path / "rag_store_chatbook.zip"
+
+        success, _, _ = chatbook_creator.create_chatbook(
+            name="RAG Store Chatbook",
+            description="Export with stored citations",
+            content_selections={ContentType.CONVERSATION: ["conv-rag"]},
+            output_path=output_path,
+        )
+
+        assert success is True
+        with zipfile.ZipFile(output_path, 'r') as zf:
+            conversation = json.loads(zf.read('content/conversations/conversation_conv-rag.json'))
+            exported = conversation["messages"][0]
+            assert exported["citation_validation"]["status"] == "validated"
+            assert exported["evidence_bundle"]["bundle_id"] == "library-rag:store"
+            assert exported["citations"][0]["source_id"] == "note-store"
+
+    @patch('tldw_chatbook.Chatbooks.chatbook_creator.CharactersRAGDB')
+    def test_create_chatbook_sanitizes_citation_report_path_and_markdown(
+        self,
+        mock_chacha_db,
+        chatbook_creator,
+        tmp_path,
+    ):
+        """Unsafe conversation IDs and Markdown content stay contained and escaped."""
+        mock_db_instance = MagicMock()
+        mock_chacha_db.return_value = mock_db_instance
+        unsafe_conv_id = "../evil<script>"
+        timestamp = datetime.now().isoformat()
+        mock_db_instance.get_conversation_by_id.return_value = {
+            'id': unsafe_conv_id,
+            'title': '<script>alert(1)</script> [bad]',
+            'created_at': timestamp,
+            'updated_at': timestamp,
+            'character_id': None,
+        }
+        mock_db_instance.get_messages_for_conversation.return_value = [
+            {
+                'id': 'msg-unsafe',
+                'sender': 'assistant',
+                'message': 'Uses evidence. [S1]',
+                'timestamp': timestamp,
+                'metadata': {
+                    'citation_validation': {'status': '<b>validated</b>', 'cited_evidence_ids': ['S1']},
+                    'evidence_bundle': {
+                        'bundle_id': 'bundle<script>',
+                        'query': '<img src=x onerror=alert(1)>',
+                        'source': '<b>Library</b>',
+                        'references': [
+                            {
+                                'evidence_id': 'S1',
+                                'source_id': 'note<script>',
+                                'source_type': 'note',
+                                'title': '<i>Incident</i>',
+                                'snippet': '<script>alert(1)</script> Root cause.',
+                                'authority_label': 'Local <Library>',
+                                'status': 'available',
+                            }
+                        ],
+                    },
+                },
+            },
+        ]
+
+        output_path = tmp_path / "unsafe_chatbook.zip"
+
+        success, _, _ = chatbook_creator.create_chatbook(
+            name="Unsafe Chatbook",
+            description="Export with unsafe content",
+            content_selections={ContentType.CONVERSATION: [unsafe_conv_id]},
+            output_path=output_path,
+        )
+
+        assert success is True
+        with zipfile.ZipFile(output_path, 'r') as zf:
+            names = zf.namelist()
+            assert all(".." not in name for name in names)
+            assert all("<script>" not in name for name in names)
+            report_name = next(name for name in names if name.endswith("_citations.md"))
+            assert report_name.startswith("content/conversations/")
+            report_text = zf.read(report_name).decode("utf-8")
+            assert "<script>" not in report_text
+            assert "&lt;script&gt;alert(1)&lt;/script&gt;" in report_text
+            assert "&lt;img src=x onerror=alert(1)&gt;" in report_text
+
+    @patch('tldw_chatbook.Chatbooks.chatbook_creator.CharactersRAGDB')
+    def test_create_chatbook_bounds_large_citation_reports(
+        self,
+        mock_chacha_db,
+        chatbook_creator,
+        tmp_path,
+    ):
+        """Large citation exports keep full JSON but bound the readable Markdown report."""
+        mock_db_instance = MagicMock()
+        mock_chacha_db.return_value = mock_db_instance
+        timestamp = datetime.now().isoformat()
+        mock_db_instance.get_conversation_by_id.return_value = {
+            'id': 'conv-large',
+            'title': 'Large Citation Chat',
+            'created_at': timestamp,
+            'updated_at': timestamp,
+            'character_id': None,
+        }
+        references = [
+            {
+                'evidence_id': f'S{i}',
+                'source_id': f'note-{i}',
+                'source_type': 'note',
+                'title': f'Note {i}',
+                'snippet': f'Snippet {i}',
+                'authority_label': 'Local Library',
+                'status': 'available',
+            }
+            for i in range(1, 75)
+        ]
+        mock_db_instance.get_messages_for_conversation.return_value = [
+            {
+                'id': 'msg-large',
+                'sender': 'assistant',
+                'message': 'Large answer. [S1]',
+                'timestamp': timestamp,
+                'metadata': {
+                    'citation_validation': {'status': 'validated', 'cited_evidence_ids': ['S1']},
+                    'evidence_bundle': {
+                        'bundle_id': 'library-rag:large',
+                        'query': 'large query',
+                        'references': references,
+                    },
+                },
+            },
+        ]
+
+        output_path = tmp_path / "large_citations.zip"
+
+        success, _, _ = chatbook_creator.create_chatbook(
+            name="Large Citation Chatbook",
+            description="Export with many references",
+            content_selections={ContentType.CONVERSATION: ["conv-large"]},
+            output_path=output_path,
+        )
+
+        assert success is True
+        with zipfile.ZipFile(output_path, 'r') as zf:
+            conversation = json.loads(zf.read('content/conversations/conversation_conv-large.json'))
+            assert len(conversation["messages"][0]["evidence_bundle"]["references"]) == 74
+            report_text = zf.read(
+                'content/conversations/conversation_conv-large_citations.md'
+            ).decode("utf-8")
+            assert "Report truncated:" in report_text
+            assert "Snippet 1" in report_text
+            assert "Snippet 74" not in report_text
+            manifest_data = json.loads(zf.read('manifest.json'))
+            item = next(item for item in manifest_data["content_items"] if item["id"] == "conv-large")
+            assert item["metadata"]["citation_report_truncated"] is True
+            assert item["metadata"]["evidence_source_count"] == 74
     
     @patch('zipfile.ZipFile')
     def test_create_chatbook_zip_error(self, mock_zipfile, chatbook_creator, tmp_path):
@@ -395,6 +627,106 @@ class TestChatbookCreator:
         assert success is False
         assert "error" in message.lower()
         assert dependency_info["auto_included"] == []
+
+    @patch('tldw_chatbook.Chatbooks.chatbook_importer.get_user_data_dir')
+    @patch('tldw_chatbook.Chatbooks.chatbook_importer.CharactersRAGDB')
+    def test_import_chatbook_persists_conversation_citation_payloads(
+        self,
+        mock_chacha_db,
+        mock_get_user_data_dir,
+        temp_db_paths,
+        tmp_path,
+    ):
+        """Import preserves exported citation fields in the conversation RAG context store."""
+        user_data_dir = tmp_path / "user-data"
+        mock_get_user_data_dir.return_value = user_data_dir
+
+        mock_db_instance = MagicMock()
+        mock_chacha_db.return_value = mock_db_instance
+        mock_db_instance.get_conversation_by_name.return_value = []
+        mock_db_instance.add_conversation.return_value = "new-conv"
+        mock_db_instance.add_message.return_value = "new-msg"
+        mock_db_instance.get_message_by_id.return_value = {
+            "id": "new-msg",
+            "conversation_id": "new-conv",
+        }
+
+        timestamp = datetime.now().isoformat()
+        manifest = ChatbookManifest(
+            version=ChatbookVersion.V1,
+            name="Imported Citation Chatbook",
+            description="Import with citations",
+        )
+        manifest.content_items.append(
+            ContentItem(
+                id="conv-import",
+                type=ContentType.CONVERSATION,
+                title="Imported Conversation",
+                created_at=datetime.fromisoformat(timestamp),
+                updated_at=datetime.fromisoformat(timestamp),
+                file_path="content/conversations/conversation_conv-import.json",
+            )
+        )
+        manifest.total_conversations = 1
+        chatbook_path = tmp_path / "import_citations.zip"
+        conversation_payload = {
+            "id": "conv-import",
+            "name": "Imported Conversation",
+            "created_at": timestamp,
+            "updated_at": timestamp,
+            "messages": [
+                {
+                    "id": "old-msg",
+                    "role": "assistant",
+                    "content": "Imported answer. [S1]",
+                    "timestamp": timestamp,
+                    "citation_validation": {
+                        "status": "validated",
+                        "cited_evidence_ids": ["S1"],
+                    },
+                    "evidence_bundle": {
+                        "bundle_id": "library-rag:import",
+                        "query": "import evidence",
+                        "references": [
+                            {
+                                "evidence_id": "S1",
+                                "source_id": "note-import",
+                                "source_type": "note",
+                                "title": "Import Note",
+                                "snippet": "Imported evidence snippet.",
+                                "authority_label": "Local Library",
+                                "status": "available",
+                            }
+                        ],
+                    },
+                    "citations": [
+                        {
+                            "evidence_id": "S1",
+                            "source_id": "note-import",
+                            "quote": "Imported answer. [S1]",
+                        }
+                    ],
+                }
+            ],
+        }
+        with zipfile.ZipFile(chatbook_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("manifest.json", json.dumps(manifest.to_dict()))
+            zf.writestr(
+                "content/conversations/conversation_conv-import.json",
+                json.dumps(conversation_payload),
+            )
+
+        importer = ChatbookImporter(temp_db_paths)
+        success, message = importer.import_chatbook(chatbook_path)
+
+        assert success is True, message
+        rag_store = json.loads(
+            (user_data_dir / "tldw_chatbook_chat_rag_context.json").read_text(encoding="utf-8")
+        )
+        record = rag_store["conversations"]["new-conv"]["new-msg"]
+        assert record["rag_context"]["citation_validation"]["status"] == "validated"
+        assert record["rag_context"]["evidence_bundle"]["bundle_id"] == "library-rag:import"
+        assert record["citations"][0]["source_id"] == "note-import"
     
     def test_chatbook_with_media_settings(self, chatbook_creator, tmp_path):
         """Test creating chatbook with media settings."""

--- a/Tests/Chatbooks/test_chatbook_creator.py
+++ b/Tests/Chatbooks/test_chatbook_creator.py
@@ -266,6 +266,115 @@ class TestChatbookCreator:
         assert success is True
         assert output_path.exists()
         assert dependency_info["missing_dependencies"] == []
+
+    @patch('tldw_chatbook.Chatbooks.chatbook_creator.CharactersRAGDB')
+    def test_create_chatbook_preserves_conversation_citation_artifacts(
+        self,
+        mock_chacha_db,
+        chatbook_creator,
+        tmp_path,
+    ):
+        """Conversation exports preserve citation/evidence payloads and readable snippets."""
+        mock_db_instance = MagicMock()
+        mock_chacha_db.return_value = mock_db_instance
+        timestamp = datetime.now().isoformat()
+        mock_db_instance.get_conversation_by_id.return_value = {
+            'id': 'conv-1',
+            'title': 'Incident Chat',
+            'created_at': timestamp,
+            'updated_at': timestamp,
+            'character_id': None,
+        }
+        mock_db_instance.get_messages_for_conversation.return_value = [
+            {
+                'id': 'm-user',
+                'sender': 'user',
+                'message': 'What caused the outage?',
+                'timestamp': timestamp,
+            },
+            {
+                'id': 'm-ai',
+                'sender': 'assistant',
+                'message': 'An expired credential caused the outage. [S1]',
+                'timestamp': timestamp,
+                'metadata': {
+                    'citation_validation': {
+                        'status': 'validated',
+                        'cited_evidence_ids': ['S1'],
+                        'unknown_citation_ids': [],
+                        'uncited_evidence_ids': [],
+                        'citations': [
+                            {
+                                'evidence_id': 'S1',
+                                'source_id': 'note-incident',
+                                'status': 'validated',
+                                'quote': 'An expired credential caused the outage. [S1]',
+                            }
+                        ],
+                    },
+                    'evidence_bundle': {
+                        'bundle_id': 'library-rag:incident',
+                        'query': 'What caused the outage?',
+                        'source': 'Library Search/RAG',
+                        'status': 'available',
+                        'references': [
+                            {
+                                'evidence_id': 'S1',
+                                'source_id': 'note-incident',
+                                'source_type': 'note',
+                                'title': 'Incident Review',
+                                'snippet': 'Expired credential caused the outage during deploy.',
+                                'authority_label': 'Local Library',
+                                'status': 'available',
+                            }
+                        ],
+                    },
+                },
+            },
+        ]
+
+        output_path = tmp_path / "incident_chatbook.zip"
+
+        success, _, dependency_info = chatbook_creator.create_chatbook(
+            name="Incident Chatbook",
+            description="Export with citations",
+            content_selections={ContentType.CONVERSATION: ["conv-1"]},
+            output_path=output_path,
+        )
+
+        assert success is True
+        assert dependency_info["missing_dependencies"] == []
+
+        with zipfile.ZipFile(output_path, 'r') as zf:
+            conversation = json.loads(zf.read('content/conversations/conversation_conv-1.json'))
+            assistant_message = conversation["messages"][1]
+            assert assistant_message["citation_validation"]["status"] == "validated"
+            assert assistant_message["citation_validation"]["cited_evidence_ids"] == ["S1"]
+            assert assistant_message["evidence_bundle"]["bundle_id"] == "library-rag:incident"
+            assert (
+                assistant_message["evidence_bundle"]["references"][0]["snippet"]
+                == "Expired credential caused the outage during deploy."
+            )
+
+            report_text = zf.read(
+                'content/conversations/conversation_conv-1_citations.md'
+            ).decode("utf-8")
+            assert "# Citations and Evidence: Incident Chat" in report_text
+            assert "Citation status: validated" in report_text
+            assert "Expired credential caused the outage during deploy." in report_text
+
+            manifest_data = json.loads(zf.read('manifest.json'))
+            conversation_item = next(
+                item
+                for item in manifest_data["content_items"]
+                if item["id"] == "conv-1" and item["type"] == "conversation"
+            )
+            assert conversation_item["metadata"]["citation_report_path"] == (
+                "content/conversations/conversation_conv-1_citations.md"
+            )
+            assert conversation_item["metadata"]["citation_message_count"] == 1
+            assert conversation_item["metadata"]["evidence_source_count"] == 1
+            assert conversation_item["metadata"]["evidence_snippet_count"] == 1
     
     @patch('zipfile.ZipFile')
     def test_create_chatbook_zip_error(self, mock_zipfile, chatbook_creator, tmp_path):

--- a/backlog/tasks/task-60.4.4 - Post-release-citation-and-snippet-carry-through-tranche.md
+++ b/backlog/tasks/task-60.4.4 - Post-release-citation-and-snippet-carry-through-tranche.md
@@ -54,6 +54,8 @@ Console-saved Chatbook artifact preservation slice added. Saved assistant respon
 PR review hardening added for the artifact preservation slice. Citation summary text now preserves falsy-but-valid values, caps evidence reference counting on resume paths, and is sanitized at Home/Artifacts payload boundaries before reaching Console live-work rendering.
 
 Exported Chatbook ZIP preservation slice added. Conversation exports now retain JSON-safe message-level `citation_validation`, `evidence_bundle`, and citation payloads in the conversation JSON, emit a per-conversation Markdown citation/evidence report with readable snippets and source details, and advertise report paths plus citation/source/snippet counts through the manifest content-item metadata. Regression coverage verifies machine-checkable JSON preservation, readable snippet reports, and manifest metadata.
+
+PR review hardening added for exported Chatbook ZIP preservation. Conversation export filenames now use validated safe path components, citation reports escape user-controlled Markdown/HTML text, production-shaped DB message rows hydrate citation artifacts from the chat RAG context sidecar, imported Chatbooks persist exported citation payloads back into the same sidecar, and readable citation reports are bounded with explicit truncation metadata while full evidence remains in conversation JSON.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-60.4.4 - Post-release-citation-and-snippet-carry-through-tranche.md
+++ b/backlog/tasks/task-60.4.4 - Post-release-citation-and-snippet-carry-through-tranche.md
@@ -21,7 +21,7 @@ Carry retrieved snippets and citations from Library/Search/RAG into Console answ
 <!-- AC:BEGIN -->
 - [ ] #1 Citation and snippet carry-through scope references TASK-60.3 actual-use audit evidence.
 - [ ] #2 Retrieved evidence keeps source identity, snippet text, and authority labels through Console responses and saved artifacts.
-- [ ] #3 Exported Chatbooks preserve citations/snippets in a user-readable and machine-checkable form.
+- [x] #3 Exported Chatbooks preserve citations/snippets in a user-readable and machine-checkable form.
 - [ ] #4 QA verifies source-to-answer-to-artifact carry-through with actual app use before completion.
 <!-- AC:END -->
 
@@ -49,9 +49,11 @@ Console evidence staging slice added. Console staged context and the Run Inspect
 
 Answer-level citation injection slice added. Staged evidence context now includes explicit citation instructions, available/blocked evidence state, and stable `[S#]` source labels. Assistant responses are parsed for citation markers and validated against the staged evidence bundle on both streaming and non-streaming completion paths, attaching validated, unknown, uncited, blocked, stale, missing, or insufficient-evidence metadata to the generated message widget for the later persistence and export slices.
 
-Console-saved Chatbook artifact preservation slice added. Saved assistant response metadata now carries bounded JSON-safe `citation_validation` and staged `evidence_bundle` payloads when present. Artifacts and Home resume paths expose compact citation/evidence summary fields for Console launch payloads so grounded saved answers retain validation status, cited labels, bundle identity, source count, and snippet count. Full exported Chatbook ZIP preservation and actual app QA remain follow-up work for this task.
+Console-saved Chatbook artifact preservation slice added. Saved assistant response metadata now carries bounded JSON-safe `citation_validation` and staged `evidence_bundle` payloads when present. Artifacts and Home resume paths expose compact citation/evidence summary fields for Console launch payloads so grounded saved answers retain validation status, cited labels, bundle identity, source count, and snippet count. Actual app QA remains follow-up work for this task.
 
 PR review hardening added for the artifact preservation slice. Citation summary text now preserves falsy-but-valid values, caps evidence reference counting on resume paths, and is sanitized at Home/Artifacts payload boundaries before reaching Console live-work rendering.
+
+Exported Chatbook ZIP preservation slice added. Conversation exports now retain JSON-safe message-level `citation_validation`, `evidence_bundle`, and citation payloads in the conversation JSON, emit a per-conversation Markdown citation/evidence report with readable snippets and source details, and advertise report paths plus citation/source/snippet counts through the manifest content-item metadata. Regression coverage verifies machine-checkable JSON preservation, readable snippet reports, and manifest metadata.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/tldw_chatbook/Chatbooks/chatbook_creator.py
+++ b/tldw_chatbook/Chatbooks/chatbook_creator.py
@@ -12,6 +12,8 @@ import json
 import shutil
 import tempfile
 import zipfile
+import hashlib
+import html
 from collections.abc import Mapping
 from datetime import datetime
 from pathlib import Path
@@ -23,18 +25,24 @@ from .chatbook_models import (
     ContentItem, ContentType, ChatbookVersion, Relationship
 )
 from .error_handler import ChatbookErrorHandler, ChatbookErrorType, safe_chatbook_operation
+from ..Chat.chat_conversation_service import ChatConversationService
 from ..DB.ChaChaNotes_DB import CharactersRAGDB
 from ..DB.Client_Media_DB_v2 import MediaDatabase
 from ..DB.Prompts_DB import PromptsDatabase
 from ..DB.RAG_Indexing_DB import RAGIndexingDB
 from ..DB.Evals_DB import EvalsDB
 from ..DB.Subscriptions_DB import SubscriptionsDB
+from ..Utils.input_validation import sanitize_string
+from ..Utils.path_validation import validate_filename
 from ..Utils.text import sanitize_filename
 from ..Utils.paths import get_user_data_dir
 
 
 CITATION_MESSAGE_EXPORT_KEYS = ("citation_validation", "evidence_bundle", "citations")
 MAX_CITATION_REPORT_SNIPPET_CHARS = 1000
+MAX_CITATION_REPORT_MESSAGES = 100
+MAX_CITATION_REPORT_REFERENCES_PER_MESSAGE = 50
+MAX_CITATION_REPORT_TOTAL_REFERENCES = 200
 
 
 class ChatbookCreator:
@@ -273,6 +281,10 @@ class ChatbookCreator:
             return
             
         db = CharactersRAGDB(db_path, "chatbook_creator")
+        conversation_service = ChatConversationService(
+            db,
+            rag_context_store_path=get_user_data_dir() / "tldw_chatbook_chat_rag_context.json",
+        )
         conv_dir = work_dir / "content" / "conversations"
         conv_dir.mkdir(parents=True, exist_ok=True)
         logger.info(f"ChatbookCreator._collect_conversations: Created conversations directory at {conv_dir}")
@@ -286,8 +298,10 @@ class ChatbookCreator:
                     logger.warning(f"ChatbookCreator._collect_conversations: Conversation {conv_id} not found")
                     continue
                 
-                # Get all messages
-                messages = db.get_messages_for_conversation(conv_id)
+                # Get DB messages and merge any sidecar RAG/citation context.
+                db_messages = db.get_messages_for_conversation(conv_id)
+                context_messages = conversation_service.get_messages_with_context(conv_id)
+                messages = self._merge_message_context(db_messages, context_messages)
                 logger.debug(f"ChatbookCreator._collect_conversations: Found {len(messages) if messages else 0} messages for conversation {conv_id}")
                 
                 # Create conversation data
@@ -303,11 +317,15 @@ class ChatbookCreator:
                 exported_messages = []
                 citation_messages = []
                 for msg in messages:
+                    timestamp = msg.get('timestamp') or msg.get('created_at') or datetime.now().isoformat()
+                    if hasattr(timestamp, 'isoformat'):
+                        timestamp = timestamp.isoformat()
+                    message_id = msg.get('id')
                     message_data = {
-                        "id": msg['id'],
-                        "role": msg['sender'],
+                        "id": message_id,
+                        "role": msg.get('role') or msg.get('sender'),
                         "content": msg['message'] if 'message' in msg else msg.get('content', ''),
-                        "timestamp": msg['timestamp'] if isinstance(msg['timestamp'], str) else msg['timestamp'].isoformat()
+                        "timestamp": timestamp,
                     }
                     citation_payload = self._message_citation_export_payload(msg)
                     if citation_payload:
@@ -318,7 +336,7 @@ class ChatbookCreator:
                 title = conv.get('title', conv.get('conversation_name', 'Untitled'))
                 citation_metadata: dict[str, Any] = {}
                 if citation_messages:
-                    citation_report_path = self._write_conversation_citation_report(
+                    citation_report_path, citation_report_metadata = self._write_conversation_citation_report(
                         conv_dir,
                         str(conv_id),
                         title,
@@ -328,6 +346,7 @@ class ChatbookCreator:
                         citation_messages,
                         citation_report_path,
                     )
+                    citation_metadata.update(citation_report_metadata)
 
                 conv_data = {
                     "id": conv['id'],
@@ -339,7 +358,7 @@ class ChatbookCreator:
                 }
                 
                 # Write conversation file
-                conv_file = conv_dir / f"conversation_{conv_id}.json"
+                conv_file = self._conversation_export_path(conv_dir, str(conv_id), ".json")
                 with open(conv_file, 'w', encoding='utf-8') as f:
                     json.dump(conv_data, f, indent=2, ensure_ascii=False)
                 
@@ -354,7 +373,7 @@ class ChatbookCreator:
                     created_at=datetime.fromisoformat(conv_data['created_at']),
                     updated_at=datetime.fromisoformat(conv_data['updated_at']),
                     metadata=citation_metadata,
-                    file_path=f"content/conversations/conversation_{conv_id}.json"
+                    file_path=f"content/conversations/{conv_file.name}"
                 ))
                 
                 # Track character dependency if present
@@ -365,18 +384,58 @@ class ChatbookCreator:
                 logger.error(f"Error collecting conversation {conv_id}: {e}")
 
     @staticmethod
+    def _merge_message_context(
+        db_messages: list[Mapping[str, Any]],
+        context_messages: list[Mapping[str, Any]],
+    ) -> list[dict[str, Any]]:
+        context_by_id = {str(message.get("id")): message for message in context_messages}
+        merged_messages: list[dict[str, Any]] = []
+        for message in db_messages:
+            merged = dict(message)
+            context = context_by_id.get(str(message.get("id")))
+            if context:
+                if context.get("rag_context") is not None:
+                    merged["rag_context"] = context.get("rag_context")
+                if context.get("citations") is not None:
+                    merged["citations"] = context.get("citations")
+            merged_messages.append(merged)
+        return merged_messages
+
+    @staticmethod
     def _message_citation_export_payload(message: Mapping[str, Any]) -> dict[str, Any]:
         """Return JSON-safe citation/evidence payloads attached to an exported message."""
         metadata = message.get("metadata") if isinstance(message.get("metadata"), Mapping) else {}
+        rag_context = message.get("rag_context") if isinstance(message.get("rag_context"), Mapping) else {}
         payload: dict[str, Any] = {}
         for key in CITATION_MESSAGE_EXPORT_KEYS:
             value = message.get(key)
             if value is None:
                 value = metadata.get(key)
+            if value is None:
+                value = rag_context.get(key)
             if not ChatbookCreator._has_exportable_citation_value(value):
                 continue
             payload[key] = ChatbookCreator._json_safe_payload(value)
         return payload
+
+    @staticmethod
+    def _conversation_export_path(conv_dir: Path, conv_id: str, suffix: str) -> Path:
+        filename = f"conversation_{ChatbookCreator._safe_conversation_file_id(conv_id)}{suffix}"
+        validate_filename(filename)
+        return conv_dir / filename
+
+    @staticmethod
+    def _safe_conversation_file_id(conv_id: str) -> str:
+        candidate = sanitize_filename(str(conv_id)).strip().strip(".")
+        if candidate:
+            filename = f"conversation_{candidate}.json"
+            try:
+                validate_filename(filename)
+                return candidate
+            except ValueError:
+                pass
+        digest = hashlib.sha256(str(conv_id).encode("utf-8")).hexdigest()[:12]
+        return f"id-{digest}"
 
     @staticmethod
     def _has_exportable_citation_value(value: Any) -> bool:
@@ -442,78 +501,124 @@ class ChatbookCreator:
         conv_id: str,
         title: str,
         citation_messages: list[dict[str, Any]],
-    ) -> str:
+    ) -> tuple[str, dict[str, Any]]:
         """Write a human-readable citation/source report for exported conversations."""
-        report_file = conv_dir / f"conversation_{conv_id}_citations.md"
+        report_file = self._conversation_export_path(conv_dir, conv_id, "_citations.md")
+        report_metadata: dict[str, Any] = {}
+        total_references_written = 0
+        truncated = len(citation_messages) > MAX_CITATION_REPORT_MESSAGES
         with open(report_file, 'w', encoding='utf-8') as f:
-            f.write(f"# Citations and Evidence: {title}\n\n")
-            for message in citation_messages:
-                self._write_message_citation_report_section(f, message)
-        return f"content/conversations/{report_file.name}"
+            f.write(f"# Citations and Evidence: {self._markdown_report_text(title)}\n\n")
+            for message in citation_messages[:MAX_CITATION_REPORT_MESSAGES]:
+                references_remaining = MAX_CITATION_REPORT_TOTAL_REFERENCES - total_references_written
+                if references_remaining <= 0:
+                    truncated = True
+                    break
+                written, section_truncated = self._write_message_citation_report_section(
+                    f,
+                    message,
+                    references_remaining=references_remaining,
+                )
+                total_references_written += written
+                truncated = truncated or section_truncated
+            if truncated:
+                f.write(
+                    "Report truncated: full citation and evidence payloads remain "
+                    "available in the conversation JSON.\n"
+                )
+        if truncated:
+            report_metadata["citation_report_truncated"] = True
+        return f"content/conversations/{report_file.name}", report_metadata
 
     @staticmethod
-    def _write_message_citation_report_section(handle: Any, message: Mapping[str, Any]) -> None:
-        message_id = message.get("id", "unknown")
+    def _write_message_citation_report_section(
+        handle: Any,
+        message: Mapping[str, Any],
+        *,
+        references_remaining: int,
+    ) -> tuple[int, bool]:
+        message_id = ChatbookCreator._markdown_report_text(message.get("id", "unknown"))
         handle.write(f"## Message {message_id}\n\n")
-        handle.write(f"Role: {message.get('role', 'unknown')}\n\n")
+        handle.write(f"Role: {ChatbookCreator._markdown_report_text(message.get('role', 'unknown'))}\n\n")
 
         validation = message.get("citation_validation")
         if isinstance(validation, Mapping):
             status = validation.get("status")
             if status is not None:
-                handle.write(f"Citation status: {status}\n")
+                handle.write(f"Citation status: {ChatbookCreator._markdown_report_text(status)}\n")
             cited_ids = validation.get("cited_evidence_ids")
             if isinstance(cited_ids, list) and cited_ids:
-                handle.write(f"Cited evidence: {', '.join(str(item) for item in cited_ids)}\n")
+                handle.write(
+                    "Cited evidence: "
+                    f"{', '.join(ChatbookCreator._markdown_report_text(item) for item in cited_ids)}\n"
+                )
             unknown_ids = validation.get("unknown_citation_ids")
             if isinstance(unknown_ids, list) and unknown_ids:
-                handle.write(f"Unknown evidence: {', '.join(str(item) for item in unknown_ids)}\n")
+                handle.write(
+                    "Unknown evidence: "
+                    f"{', '.join(ChatbookCreator._markdown_report_text(item) for item in unknown_ids)}\n"
+                )
             handle.write("\n")
 
         evidence_bundle = message.get("evidence_bundle")
         if not isinstance(evidence_bundle, Mapping):
-            return
+            return 0, False
 
         bundle_id = evidence_bundle.get("bundle_id")
         query = evidence_bundle.get("query")
         source = evidence_bundle.get("source")
         if bundle_id is not None:
-            handle.write(f"Evidence bundle: {bundle_id}\n")
+            handle.write(f"Evidence bundle: {ChatbookCreator._markdown_report_text(bundle_id)}\n")
         if source is not None:
-            handle.write(f"Source: {source}\n")
+            handle.write(f"Source: {ChatbookCreator._markdown_report_text(source)}\n")
         if query is not None:
-            handle.write(f"Query: {query}\n")
+            handle.write(f"Query: {ChatbookCreator._markdown_report_text(query)}\n")
         handle.write("\n")
 
         references = evidence_bundle.get("references")
         if not isinstance(references, list) or not references:
-            return
+            return 0, False
 
         handle.write("### Sources\n\n")
-        for reference in references:
+        reference_limit = min(
+            len(references),
+            references_remaining,
+            MAX_CITATION_REPORT_REFERENCES_PER_MESSAGE,
+        )
+        references_written = 0
+        for reference in references[:reference_limit]:
             if not isinstance(reference, Mapping):
                 continue
-            evidence_id = reference.get("evidence_id", "unknown")
-            title = reference.get("title", "Untitled source")
-            source_type = reference.get("source_type", "source")
-            authority = reference.get("authority_label", "unknown authority")
-            status = reference.get("status", "unknown")
+            evidence_id = ChatbookCreator._markdown_report_text(reference.get("evidence_id", "unknown"))
+            title = ChatbookCreator._markdown_report_text(reference.get("title", "Untitled source"))
+            source_type = ChatbookCreator._markdown_report_text(reference.get("source_type", "source"))
+            authority = ChatbookCreator._markdown_report_text(reference.get("authority_label", "unknown authority"))
+            status = ChatbookCreator._markdown_report_text(reference.get("status", "unknown"))
             handle.write(f"- {evidence_id} | {source_type} | {title} | {authority} | {status}\n")
             source_id = reference.get("source_id")
             if source_id is not None:
-                handle.write(f"  - Source id: {source_id}\n")
+                handle.write(f"  - Source id: {ChatbookCreator._markdown_report_text(source_id)}\n")
             snippet = ChatbookCreator._citation_report_snippet(reference.get("snippet"))
             if snippet:
                 handle.write(f"  - Snippet: {snippet}\n")
+            references_written += 1
         handle.write("\n")
+        section_truncated = len(references) > reference_limit
+        return references_written, section_truncated
 
     @staticmethod
     def _citation_report_snippet(value: Any) -> str:
         raw = "" if value is None else str(value)
         text = " ".join(raw.split())
         if len(text) > MAX_CITATION_REPORT_SNIPPET_CHARS:
-            return text[: MAX_CITATION_REPORT_SNIPPET_CHARS - 3].rstrip() + "..."
-        return text
+            text = text[: MAX_CITATION_REPORT_SNIPPET_CHARS - 3].rstrip() + "..."
+        return ChatbookCreator._markdown_report_text(text, max_length=MAX_CITATION_REPORT_SNIPPET_CHARS)
+
+    @staticmethod
+    def _markdown_report_text(value: Any, *, max_length: int = MAX_CITATION_REPORT_SNIPPET_CHARS) -> str:
+        raw = "" if value is None else str(value)
+        text = " ".join(sanitize_string(raw, max_length=max_length).split())
+        return html.escape(text, quote=False).replace("|", "\\|")
     
     def _collect_notes(
         self,

--- a/tldw_chatbook/Chatbooks/chatbook_creator.py
+++ b/tldw_chatbook/Chatbooks/chatbook_creator.py
@@ -12,6 +12,7 @@ import json
 import shutil
 import tempfile
 import zipfile
+from collections.abc import Mapping
 from datetime import datetime
 from pathlib import Path
 from typing import List, Dict, Any, Optional, Set, Tuple
@@ -30,6 +31,10 @@ from ..DB.Evals_DB import EvalsDB
 from ..DB.Subscriptions_DB import SubscriptionsDB
 from ..Utils.text import sanitize_filename
 from ..Utils.paths import get_user_data_dir
+
+
+CITATION_MESSAGE_EXPORT_KEYS = ("citation_validation", "evidence_bundle", "citations")
+MAX_CITATION_REPORT_SNIPPET_CHARS = 1000
 
 
 class ChatbookCreator:
@@ -295,21 +300,42 @@ class ChatbookCreator:
                 if hasattr(last_modified, 'isoformat'):
                     last_modified = last_modified.isoformat()
                     
+                exported_messages = []
+                citation_messages = []
+                for msg in messages:
+                    message_data = {
+                        "id": msg['id'],
+                        "role": msg['sender'],
+                        "content": msg['message'] if 'message' in msg else msg.get('content', ''),
+                        "timestamp": msg['timestamp'] if isinstance(msg['timestamp'], str) else msg['timestamp'].isoformat()
+                    }
+                    citation_payload = self._message_citation_export_payload(msg)
+                    if citation_payload:
+                        message_data.update(citation_payload)
+                        citation_messages.append(message_data)
+                    exported_messages.append(message_data)
+
+                title = conv.get('title', conv.get('conversation_name', 'Untitled'))
+                citation_metadata: dict[str, Any] = {}
+                if citation_messages:
+                    citation_report_path = self._write_conversation_citation_report(
+                        conv_dir,
+                        str(conv_id),
+                        title,
+                        citation_messages,
+                    )
+                    citation_metadata = self._conversation_citation_export_metadata(
+                        citation_messages,
+                        citation_report_path,
+                    )
+
                 conv_data = {
                     "id": conv['id'],
-                    "name": conv.get('title', conv.get('conversation_name', 'Untitled')),
+                    "name": title,
                     "created_at": created_at,
                     "updated_at": last_modified,
                     "character_id": conv.get('character_id'),
-                    "messages": [
-                        {
-                            "id": msg['id'],
-                            "role": msg['sender'],
-                            "content": msg['message'] if 'message' in msg else msg.get('content', ''),
-                            "timestamp": msg['timestamp'] if isinstance(msg['timestamp'], str) else msg['timestamp'].isoformat()
-                        }
-                        for msg in messages
-                    ]
+                    "messages": exported_messages
                 }
                 
                 # Write conversation file
@@ -324,9 +350,10 @@ class ChatbookCreator:
                 manifest.content_items.append(ContentItem(
                     id=conv_id,
                     type=ContentType.CONVERSATION,
-                    title=conv.get('title', conv.get('conversation_name', 'Untitled')),
+                    title=title,
                     created_at=datetime.fromisoformat(conv_data['created_at']),
                     updated_at=datetime.fromisoformat(conv_data['updated_at']),
+                    metadata=citation_metadata,
                     file_path=f"content/conversations/conversation_{conv_id}.json"
                 ))
                 
@@ -336,6 +363,157 @@ class ChatbookCreator:
                     
             except Exception as e:
                 logger.error(f"Error collecting conversation {conv_id}: {e}")
+
+    @staticmethod
+    def _message_citation_export_payload(message: Mapping[str, Any]) -> dict[str, Any]:
+        """Return JSON-safe citation/evidence payloads attached to an exported message."""
+        metadata = message.get("metadata") if isinstance(message.get("metadata"), Mapping) else {}
+        payload: dict[str, Any] = {}
+        for key in CITATION_MESSAGE_EXPORT_KEYS:
+            value = message.get(key)
+            if value is None:
+                value = metadata.get(key)
+            if not ChatbookCreator._has_exportable_citation_value(value):
+                continue
+            payload[key] = ChatbookCreator._json_safe_payload(value)
+        return payload
+
+    @staticmethod
+    def _has_exportable_citation_value(value: Any) -> bool:
+        if value is None:
+            return False
+        if isinstance(value, (str, bytes, Mapping, list, tuple, set)):
+            return bool(value)
+        return True
+
+    @staticmethod
+    def _json_safe_payload(value: Any) -> Any:
+        to_payload = getattr(value, "to_payload", None)
+        if callable(to_payload):
+            return ChatbookCreator._json_safe_payload(to_payload())
+
+        model_dump = getattr(value, "model_dump", None)
+        if callable(model_dump):
+            return ChatbookCreator._json_safe_payload(model_dump(mode="json", exclude_none=True))
+
+        if isinstance(value, Mapping):
+            return {
+                str(key): ChatbookCreator._json_safe_payload(nested_value)
+                for key, nested_value in value.items()
+            }
+        if isinstance(value, (list, tuple, set)):
+            return [ChatbookCreator._json_safe_payload(item) for item in value]
+        if value is None or isinstance(value, (str, int, float, bool)):
+            return value
+        return str(value)
+
+    @staticmethod
+    def _conversation_citation_export_metadata(
+        citation_messages: list[dict[str, Any]],
+        citation_report_path: str,
+    ) -> dict[str, Any]:
+        evidence_source_count = 0
+        evidence_snippet_count = 0
+        for message in citation_messages:
+            evidence_bundle = message.get("evidence_bundle")
+            if not isinstance(evidence_bundle, Mapping):
+                continue
+            references = evidence_bundle.get("references")
+            if not isinstance(references, list):
+                continue
+            evidence_source_count += len(references)
+            evidence_snippet_count += sum(
+                1
+                for reference in references
+                if isinstance(reference, Mapping)
+                and ChatbookCreator._citation_report_snippet(reference.get("snippet"))
+            )
+
+        return {
+            "citation_report_path": citation_report_path,
+            "citation_message_count": len(citation_messages),
+            "evidence_source_count": evidence_source_count,
+            "evidence_snippet_count": evidence_snippet_count,
+        }
+
+    def _write_conversation_citation_report(
+        self,
+        conv_dir: Path,
+        conv_id: str,
+        title: str,
+        citation_messages: list[dict[str, Any]],
+    ) -> str:
+        """Write a human-readable citation/source report for exported conversations."""
+        report_file = conv_dir / f"conversation_{conv_id}_citations.md"
+        with open(report_file, 'w', encoding='utf-8') as f:
+            f.write(f"# Citations and Evidence: {title}\n\n")
+            for message in citation_messages:
+                self._write_message_citation_report_section(f, message)
+        return f"content/conversations/{report_file.name}"
+
+    @staticmethod
+    def _write_message_citation_report_section(handle: Any, message: Mapping[str, Any]) -> None:
+        message_id = message.get("id", "unknown")
+        handle.write(f"## Message {message_id}\n\n")
+        handle.write(f"Role: {message.get('role', 'unknown')}\n\n")
+
+        validation = message.get("citation_validation")
+        if isinstance(validation, Mapping):
+            status = validation.get("status")
+            if status is not None:
+                handle.write(f"Citation status: {status}\n")
+            cited_ids = validation.get("cited_evidence_ids")
+            if isinstance(cited_ids, list) and cited_ids:
+                handle.write(f"Cited evidence: {', '.join(str(item) for item in cited_ids)}\n")
+            unknown_ids = validation.get("unknown_citation_ids")
+            if isinstance(unknown_ids, list) and unknown_ids:
+                handle.write(f"Unknown evidence: {', '.join(str(item) for item in unknown_ids)}\n")
+            handle.write("\n")
+
+        evidence_bundle = message.get("evidence_bundle")
+        if not isinstance(evidence_bundle, Mapping):
+            return
+
+        bundle_id = evidence_bundle.get("bundle_id")
+        query = evidence_bundle.get("query")
+        source = evidence_bundle.get("source")
+        if bundle_id is not None:
+            handle.write(f"Evidence bundle: {bundle_id}\n")
+        if source is not None:
+            handle.write(f"Source: {source}\n")
+        if query is not None:
+            handle.write(f"Query: {query}\n")
+        handle.write("\n")
+
+        references = evidence_bundle.get("references")
+        if not isinstance(references, list) or not references:
+            return
+
+        handle.write("### Sources\n\n")
+        for reference in references:
+            if not isinstance(reference, Mapping):
+                continue
+            evidence_id = reference.get("evidence_id", "unknown")
+            title = reference.get("title", "Untitled source")
+            source_type = reference.get("source_type", "source")
+            authority = reference.get("authority_label", "unknown authority")
+            status = reference.get("status", "unknown")
+            handle.write(f"- {evidence_id} | {source_type} | {title} | {authority} | {status}\n")
+            source_id = reference.get("source_id")
+            if source_id is not None:
+                handle.write(f"  - Source id: {source_id}\n")
+            snippet = ChatbookCreator._citation_report_snippet(reference.get("snippet"))
+            if snippet:
+                handle.write(f"  - Snippet: {snippet}\n")
+        handle.write("\n")
+
+    @staticmethod
+    def _citation_report_snippet(value: Any) -> str:
+        raw = "" if value is None else str(value)
+        text = " ".join(raw.split())
+        if len(text) > MAX_CITATION_REPORT_SNIPPET_CHARS:
+            return text[: MAX_CITATION_REPORT_SNIPPET_CHARS - 3].rstrip() + "..."
+        return text
     
     def _collect_notes(
         self,

--- a/tldw_chatbook/Chatbooks/chatbook_importer.py
+++ b/tldw_chatbook/Chatbooks/chatbook_importer.py
@@ -13,7 +13,7 @@ import shutil
 import zipfile
 from datetime import datetime
 from pathlib import Path
-from typing import List, Dict, Any, Optional, Tuple, Set
+from typing import List, Dict, Any, Optional, Tuple, Set, Mapping
 from enum import Enum
 from loguru import logger
 
@@ -23,12 +23,15 @@ from .chatbook_models import (
 )
 from .conflict_resolver import ConflictResolver, ConflictResolution
 from .error_handler import ChatbookErrorHandler, ChatbookErrorType, safe_chatbook_operation
+from ..Chat.chat_conversation_service import ChatConversationService
 from ..DB.ChaChaNotes_DB import CharactersRAGDB
 from ..DB.Client_Media_DB_v2 import MediaDatabase
 from ..DB.Prompts_DB import PromptsDatabase
 from ..DB.RAG_Indexing_DB import RAGIndexingDB
 from ..DB.Evals_DB import EvalsDB
 from ..Character_Chat.character_card_formats import detect_and_parse_character_card
+from ..Utils.path_validation import validate_filename
+from ..Utils.paths import get_user_data_dir
 
 
 class ImportStatus:
@@ -301,6 +304,10 @@ class ChatbookImporter:
             return
             
         db = CharactersRAGDB(db_path, "chatbook_importer")
+        conversation_service = ChatConversationService(
+            db,
+            rag_context_store_path=get_user_data_dir() / "tldw_chatbook_chat_rag_context.json",
+        )
         conv_dir = extract_dir / "content" / "conversations"
         logger.info(f"ChatbookImporter._import_conversations: Looking for conversations in {conv_dir}")
         
@@ -310,7 +317,7 @@ class ChatbookImporter:
             
             try:
                 # Find conversation file
-                conv_file = conv_dir / f"conversation_{conv_id}.json"
+                conv_file = self._conversation_file_path(extract_dir, conv_dir, manifest, conv_id)
                 if not conv_file.exists():
                     logger.warning(f"ChatbookImporter._import_conversations: Conversation file not found: {conv_file.name}")
                     status.add_warning(f"Conversation file not found: {conv_file.name}")
@@ -370,7 +377,14 @@ class ChatbookImporter:
                             'content': msg['content'],
                             'timestamp': msg.get('timestamp', datetime.now().isoformat())
                         }
-                        db.add_message(msg_dict)
+                        new_message_id = db.add_message(msg_dict)
+                        if new_message_id:
+                            self._persist_imported_message_citation_context(
+                                conversation_service,
+                                str(new_conv_id),
+                                str(new_message_id),
+                                msg,
+                            )
                     
                     status.successful_items += 1
                     logger.info(f"ChatbookImporter._import_conversations: Successfully imported conversation: {conv_name}")
@@ -386,6 +400,60 @@ class ChatbookImporter:
                     "ChatbookImporter._import_conversations: Error importing conversation {}",
                     conv_id,
                 )
+
+    @staticmethod
+    def _conversation_file_path(
+        extract_dir: Path,
+        conv_dir: Path,
+        manifest: ChatbookManifest,
+        conv_id: str,
+    ) -> Path:
+        for item in manifest.content_items:
+            if item.id == conv_id and item.type == ContentType.CONVERSATION and item.file_path:
+                return ChatbookImporter._safe_manifest_relative_path(extract_dir, item.file_path)
+        fallback_filename = f"conversation_{conv_id}.json"
+        validate_filename(fallback_filename)
+        return conv_dir / fallback_filename
+
+    @staticmethod
+    def _safe_manifest_relative_path(base_dir: Path, relative_path: str) -> Path:
+        path = Path(relative_path)
+        if path.is_absolute():
+            raise ValueError("Chatbook manifest file paths must be relative")
+        for part in path.parts:
+            validate_filename(part)
+        resolved_base = base_dir.resolve()
+        resolved_path = (resolved_base / path).resolve()
+        resolved_path.relative_to(resolved_base)
+        return resolved_path
+
+    @staticmethod
+    def _persist_imported_message_citation_context(
+        conversation_service: ChatConversationService,
+        conversation_id: str,
+        message_id: str,
+        message_payload: Mapping[str, Any],
+    ) -> None:
+        rag_context = {}
+        exported_rag_context = message_payload.get("rag_context")
+        if isinstance(exported_rag_context, Mapping):
+            rag_context.update(dict(exported_rag_context))
+        for key in ("citation_validation", "evidence_bundle"):
+            value = message_payload.get(key)
+            if value is not None:
+                rag_context[key] = value
+
+        citations = message_payload.get("citations")
+        citation_items = citations if isinstance(citations, list) else []
+        if not rag_context and not citation_items:
+            return
+
+        conversation_service.record_message_rag_context(
+            conversation_id,
+            message_id,
+            rag_context=rag_context,
+            citations=[item for item in citation_items if isinstance(item, Mapping)],
+        )
     
     def _import_notes(
         self,


### PR DESCRIPTION
## Summary
- preserve message-level citation validation, evidence bundles, and citation payloads in exported conversation JSON
- add per-conversation Markdown citation/evidence reports with readable snippets and source details
- expose citation report paths and citation/source/snippet counts in manifest item metadata
- update TASK-60.4.4 tracking for exported Chatbook preservation

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chatbooks Tests/Chat/test_answer_citations.py Tests/UI/test_post_release_ux_hci_validation_plan.py --tb=short
- git diff --check

Result: 138 passed, 1 skipped, 1 existing requests dependency warning; diff check clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves citations and evidence in Chatbook exports with per-conversation Markdown reports, and hardens paths and report rendering. Hydrates and persists citation context via the chat RAG sidecar, and exposes report metadata in the manifest, satisfying TASK-60.4.4 AC #3.

- **New Features**
  - Exported conversation JSON includes `citation_validation`, `evidence_bundle`, and `citations` per message (JSON-safe).
  - Hydrates citation context from the chat RAG sidecar (`tldw_chatbook_chat_rag_context.json`) when DB rows lack metadata; importer persists these fields via `ChatConversationService`.
  - Generates `conversation_<id>_citations.md` with readable snippets and source details; bounds large reports and sets `citation_report_truncated`.
  - Adds manifest metadata: `citation_report_path`, `citation_message_count`, `evidence_source_count`, `evidence_snippet_count`.

- **Bug Fixes**
  - Validates and sanitizes conversation filenames and manifest `file_path` values (no traversal), and escapes Markdown/HTML in reports; unsafe IDs fall back to a hashed suffix.

<sup>Written for commit 9325adf8c645e65b6858d26becf9a1c5c16fcaf8. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/358?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

