### PR TITLE
Polish optional dependency recovery docs

### DIFF
--- a/Docs/Development/release-recovery-setup.md
+++ b/Docs/Development/release-recovery-setup.md
@@ -2,6 +2,22 @@
 
 This guide is the release-candidate recovery reference for setup states that can block core Chatbook workflows. It mirrors the current running app labels and keeps recovery guidance source-honest.
 
+## Local-first baseline
+
+Chatbook's baseline install is local-first. A source checkout installed with `pip install -e .`, or a packaged install with `pip install tldw_chatbook`, should still provide the shell, Home, Console, local conversations, notes, personas, Library browsing, Chatbook artifacts, and Settings.
+
+Missing optional features do not mean Chatbook is broken. They mean the user has opened an advanced capability that requires an optional dependency group. Recovery copy must name the missing group, identify the owning destination, and provide a safe install command without implying that local-first core workflows are unavailable.
+
+## Advanced optional capability groups
+
+| Capability area | Optional group | Source install | Packaged install | Owner |
+| --- | --- | --- | --- | --- |
+| RAG and retrieval | `embeddings_rag` | `pip install -e ".[embeddings_rag]"` | `pip install "tldw_chatbook[embeddings_rag]"` | Library Search/RAG |
+| Media ingestion and transcription | `audio`, `video`, `pdf`, `ebook` | `pip install -e ".[audio,video,pdf,ebook]"` | `pip install "tldw_chatbook[audio,video,pdf,ebook]"` | Library import/media |
+| MCP integration | `mcp` | `pip install -e ".[mcp]"` | `pip install "tldw_chatbook[mcp]"` | MCP destination |
+| Local inference | `local_vllm`, `local_mlx`, `local_transformers` | `pip install -e ".[local_vllm]"` | `pip install "tldw_chatbook[local_vllm]"` | Console/provider setup |
+| Web access | `web` | `pip install -e ".[web]"` | `pip install "tldw_chatbook[web]"` | Web/browser serving |
+
 ## Recovery Matrix
 
 | Blocker | Visible State | Recovery | Documentation |
@@ -10,7 +26,7 @@ This guide is the release-candidate recovery reference for setup states that can
 | Server/local mode | Home shows server sync status such as `Configured; local mode`; server-backed work can show reconnect/auth recovery when active server state requires it. | Local mode is usable without a server. For server-backed work, configure/select the active server and reconnect or authenticate when prompted. | See README `Configuration File` and `Web Server Access`. |
 | ACP runtime setup | ACP shows `Runtime not configured`, `Why: no ACP-compatible runtime is configured.`, and owner `ACP runtime`. | Configure an ACP-compatible runtime in ACP, then start or resume an ACP session before launching or following agent work. | ACP runtime setup remains owned by the ACP destination, not global Settings. |
 | MCP server management | Console shows `MCP: Not wired - Manage servers in MCP.`; MCP shows server/scope inventory and prompts users to inspect runnable tools. | Open MCP to manage servers, scoped tools, permissions, and audit readiness. Install optional MCP support with `pip install -e ".[mcp]"` when MCP dependencies are needed. | See README `Model Context Protocol (MCP) Integration`. |
-| Optional dependency recovery | Disabled feature states name the missing optional dependency group and owner. | Install the matching optional extra, such as `pip install -e ".[embeddings_rag]"` for Search/RAG dependencies or the relevant audio/video/transcription extras for media workflows. | See README `Installation with Optional Features` and `Optional Feature Groups`. |
+| Optional dependency recovery | Disabled feature states name the missing optional dependency group and owner. | Install the matching optional extra, such as `pip install -e ".[embeddings_rag]"` or `pip install "tldw_chatbook[embeddings_rag]"` for Search/RAG dependencies, or the relevant audio/video/transcription extras for media workflows. | See README `Installation with Optional Features` and `Optional Feature Groups`. |
 | Missing-source recovery | Home and Console show `RAG: Missing sources`, `RAG/source: not staged`, or Library source-selection recovery copy. | Add/import Library content, select a source or RAG result, then stage it into Console before asking grounded questions. | Use Library `Sources`, `Search/RAG`, and `Import/Export Sources` modes. |
 
 ## Setup Commands
@@ -28,6 +44,7 @@ Common optional features:
 
 ```bash
 pip install -e ".[embeddings_rag]"
+pip install "tldw_chatbook[embeddings_rag]"
 pip install -e ".[mcp]"
 pip install -e ".[web]"
 ```

--- a/README.md
+++ b/README.md
@@ -36,12 +36,23 @@ tldw-cli --serve
 tldw-serve --port 8080
 ```
 
+### Local-first baseline
+
+The core local-first app installs with `pip install -e .` and includes the Textual shell, Console, local conversations, notes, personas, Library browsing, Chatbook artifacts, and settings. Missing optional extras should be treated as unavailable advanced capabilities, not as a broken core install.
+
+For packaged installs, use:
+
+```bash
+pip install tldw_chatbook
+```
+
 ### Installation with Optional Features
-The application supports several optional feature sets that can be installed based on your needs:
+The application supports several advanced optional capability groups that can be installed based on your needs. Source checkouts use `pip install -e ".[extra]"`; packaged installs use commands such as `pip install "tldw_chatbook[embeddings_rag]"`.
 
 ```bash
 # RAG (Retrieval-Augmented Generation) support
 pip install -e ".[embeddings_rag]"
+pip install "tldw_chatbook[embeddings_rag]"
 
 # Advanced text chunking and language detection
 pip install -e ".[embeddings_rag,chunker]"
@@ -76,32 +87,34 @@ pip install -e ".[dev]"
 
 ### Optional Feature Groups
 
-| Feature Group                  | Enables | Key Dependencies |
-|--------------------------------|---------|------------------|
-| `embeddings_rag`               | Vector search, semantic similarity, hybrid RAG | torch, transformers, sentence-transformers*, chromadb* |
-| `chunker`                      | Advanced text chunking, language detection | nltk, langdetect, jieba, fugashi |
-| `websearch`                    | Web scraping, content extraction | beautifulsoup4, playwright, trafilatura |
-| `coding_map`                   | Code analysis features | grep_ast, pygments |
-| `local_vllm`                   | vLLM inference support | vllm |
-| `local_mlx`                    | MLX inference (Apple Silicon) | mlx-lm |
-| `transcription_faster_whisper` | CPU/CUDA optimized Whisper transcription | faster-whisper |
-| `transcription_lightning_whisper` | Apple Silicon optimized Whisper | lightning-whisper-mlx |
-| `transcription_parakeet`       | Real-time ASR for Apple Silicon | parakeet-mlx |
-| `mlx_whisper`                  | Legacy: Both Apple Silicon transcription providers | lightning-whisper-mlx, parakeet-mlx |
-| `audio`                        | Audio processing with transcription | faster-whisper, soundfile, yt-dlp |
-| `video`                        | Video processing with transcription | faster-whisper, soundfile, yt-dlp |
-| `media_processing`             | Combined audio/video processing | faster-whisper, soundfile, yt-dlp |
-| `pdf`                          | PDF text extraction | pymupdf, docling |
-| `ebook`                        | E-book processing | ebooklib, beautifulsoup4, defusedxml |
-| `nemo`                         | NVIDIA Parakeet ASR models | nemo-toolkit[asr] |
-| `local_transformers`           | HuggingFace transformers | transformers |
-| `mcp`                          | Model Context Protocol integration | mcp |
-| `chatterbox`                   | Chatterbox TTS model support | chatterbox |
-| `local_tts`                    | Local TTS models (Kokoro ONNX) | kokoro-onnx, scipy, pyaudio |
-| `ocr_docext`                   | OCR and document extraction | docext, gradio_client |
-| `debugging`                    | Metrics and telemetry | prometheus-client, opentelemetry-api |
-| `diarization`                  | Speaker diarization for audio | torch, torchaudio, speechbrain |
-| `web`                          | Web server for browser access | textual-serve |
+Advanced optional capability groups:
+
+| Feature Group                  | Capability Area | Enables | Key Dependencies |
+|--------------------------------|-----------------|---------|------------------|
+| `embeddings_rag`               | RAG and retrieval | Vector search, semantic similarity, hybrid RAG | torch, transformers, sentence-transformers*, chromadb* |
+| `chunker`                      | RAG and retrieval | Advanced text chunking, language detection | nltk, langdetect, jieba, fugashi |
+| `websearch`                    | Server/research | Web search and scraping | beautifulsoup4, playwright, trafilatura |
+| `coding_map`                   | Local inference | Code analysis features | grep_ast, pygments |
+| `local_vllm`                   | Local inference | vLLM inference support | vllm |
+| `local_mlx`                    | Local inference | MLX inference (Apple Silicon) | mlx-lm |
+| `transcription_faster_whisper` | Media ingestion and transcription | CPU/CUDA optimized Whisper transcription | faster-whisper |
+| `transcription_lightning_whisper` | Media ingestion and transcription | Apple Silicon optimized Whisper | lightning-whisper-mlx |
+| `transcription_parakeet`       | Media ingestion and transcription | Real-time ASR for Apple Silicon | parakeet-mlx |
+| `mlx_whisper`                  | Media ingestion and transcription | Legacy: Both Apple Silicon transcription providers | lightning-whisper-mlx, parakeet-mlx |
+| `audio`                        | Media ingestion and transcription | Audio processing with transcription | faster-whisper, soundfile, yt-dlp |
+| `video`                        | Media ingestion and transcription | Video processing with transcription | faster-whisper, soundfile, yt-dlp |
+| `media_processing`             | Media ingestion and transcription | Combined audio/video processing | faster-whisper, soundfile, yt-dlp |
+| `pdf`                          | Media ingestion and transcription | PDF text extraction | pymupdf, docling |
+| `ebook`                        | Media ingestion and transcription | E-book processing | ebooklib, beautifulsoup4, defusedxml |
+| `nemo`                         | Media ingestion and transcription | NVIDIA Parakeet ASR models | nemo-toolkit[asr] |
+| `local_transformers`           | Local inference | HuggingFace transformers | transformers |
+| `mcp`                          | MCP integration | Model Context Protocol integration | mcp |
+| `chatterbox`                   | Media ingestion and transcription | Chatterbox TTS model support | chatterbox |
+| `local_tts`                    | Media ingestion and transcription | Local TTS models (Kokoro ONNX) | kokoro-onnx, scipy, pyaudio |
+| `ocr_docext`                   | Media ingestion and transcription | OCR and document extraction | docext, gradio_client |
+| `debugging`                    | Server/research | Metrics and telemetry | prometheus-client, opentelemetry-api |
+| `diarization`                  | Media ingestion and transcription | Speaker diarization for audio | torch, torchaudio, speechbrain |
+| `web`                          | Web access | Web server for browser access | textual-serve |
 
 *Note: `sentence-transformers` and `chromadb` are detected separately and installed automatically when needed.
 

--- a/Tests/UI/test_disabled_action_recovery_tooltips.py
+++ b/Tests/UI/test_disabled_action_recovery_tooltips.py
@@ -118,9 +118,10 @@ async def test_search_rag_missing_embeddings_dependency_exposes_phase_five_recov
         assert "Dependency missing" in recovery_text
         assert "Unavailable: Search/RAG queries." in recovery_text
         assert "Why: Missing optional dependencies: embeddings_rag." in recovery_text
-        assert 'Next: Install with pip install -e ".[embeddings_rag]" and restart.' in recovery_text
+        assert 'pip install -e ".[embeddings_rag]"' in recovery_text
+        assert 'pip install "tldw_chatbook[embeddings_rag]"' in recovery_text
         assert "Recovery: Settings > RAG." in recovery_text
-        assert "Owner: optional dependency." in recovery_text
+        assert "Owner: Library Search/RAG." in recovery_text
 
         search_input = widget.query_one("#search-query-input", Input)
         search_button = widget.query_one("#search-button", Button)
@@ -129,6 +130,7 @@ async def test_search_rag_missing_embeddings_dependency_exposes_phase_five_recov
         assert widget.is_searching is False
         assert "Search/RAG queries" in str(search_button.tooltip)
         assert 'pip install -e ".[embeddings_rag]"' in str(search_button.tooltip)
+        assert 'pip install "tldw_chatbook[embeddings_rag]"' in str(search_button.tooltip)
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_product_maturity_phase1_empty_setup_states.py
+++ b/Tests/UI/test_product_maturity_phase1_empty_setup_states.py
@@ -231,12 +231,14 @@ async def test_optional_dependency_missing_state_exposes_owner_and_setup_action(
         assert "Dependency missing" in recovery_text
         assert "Unavailable: Search/RAG queries." in recovery_text
         assert "Why: Missing optional dependencies: embeddings_rag." in recovery_text
-        assert 'Next: Install with pip install -e ".[embeddings_rag]" and restart.' in recovery_text
+        assert 'pip install -e ".[embeddings_rag]"' in recovery_text
+        assert 'pip install "tldw_chatbook[embeddings_rag]"' in recovery_text
         assert "Recovery: Settings > RAG." in recovery_text
-        assert "Owner: optional dependency." in recovery_text
+        assert "Owner: Library Search/RAG." in recovery_text
         assert search_input.disabled is True
         assert search_button.disabled is True
         assert 'pip install -e ".[embeddings_rag]"' in str(search_button.tooltip)
+        assert 'pip install "tldw_chatbook[embeddings_rag]"' in str(search_button.tooltip)
 
 
 @pytest.mark.parametrize(

--- a/Tests/UI/test_product_maturity_phase6_packaging_data_safety.py
+++ b/Tests/UI/test_product_maturity_phase6_packaging_data_safety.py
@@ -111,15 +111,27 @@ def test_phase6_packaging_config_and_data_safety_source_seams_are_present() -> N
     assert "tldw_chatbook.Config_Files" in package_data
 
     for required_copy in (
+        "Local-first baseline",
+        "Advanced optional capability groups",
         "python3 -m venv .venv",
         "pip install -e .",
         "pip install -e \".[dev]\"",
+        "pip install \"tldw_chatbook[embeddings_rag]\"",
         "tldw-cli",
         "tldw-serve",
         "Configuration File",
         "Environment Variables",
     ):
         assert required_copy in readme
+
+    for optional_area in (
+        "RAG and retrieval",
+        "Media ingestion and transcription",
+        "MCP integration",
+        "Local inference",
+        "Web access",
+    ):
+        assert optional_area in readme
 
     assert "TLDW_CONFIG_PATH" in config
     assert "_get_effective_config_path" in config
@@ -201,10 +213,10 @@ def test_phase6_packaging_config_data_safety_evidence_and_tracking_are_current()
 
     assert EVIDENCE.name in readme
     assert "Phase 6.6 Packaging/configuration/data-safety validation" in readme
-    assert "Status: TASK-13.1 through TASK-13.6 done; TASK-13.7 not started" in readme
+    assert "Status: TASK-13.1 through TASK-13.7 done; Phase 6 verified" in readme
 
     phase6_row = _markdown_table_row(tracker, "Phase 6: Release Hardening And Documentation")
-    assert "in-progress; TASK-13.1 through TASK-13.6 done" in phase6_row[2]
+    assert "verified; TASK-13.1 through TASK-13.7 done" in phase6_row[2]
     assert "TASK-13.6" in phase6_row[3]
     assert EVIDENCE.name in phase6_row[4]
     assert "packaging/configuration/migration/data-safety verified" in phase6_row[5].lower()

--- a/Tests/UI/test_product_maturity_phase6_recovery_docs.py
+++ b/Tests/UI/test_product_maturity_phase6_recovery_docs.py
@@ -254,23 +254,28 @@ def test_phase6_recovery_docs_evidence_and_tracking_are_current() -> None:
         "ACP runtime setup",
         "MCP server management",
         "Optional dependency recovery",
+        "Local-first baseline",
+        "Advanced optional capability groups",
+        "Missing optional features do not mean Chatbook is broken",
         "Missing-source recovery",
         "OPENAI_API_KEY",
         "pip install -e \".[embeddings_rag]\"",
         "pip install -e \".[mcp]\"",
+        "pip install \"tldw_chatbook[embeddings_rag]\"",
     ):
         assert required_phrase in recovery_doc
 
     assert EVIDENCE.name in readme
     assert RECOVERY_DOC.as_posix() in readme
     assert "Phase 6.5 Recovery/setup/documentation alignment" in readme
-    assert "Status: TASK-13.1 through TASK-13.5 done; TASK-13.6 through TASK-13.7 not started" in readme
+    assert "Status: TASK-13.1 through TASK-13.7 done; Phase 6 verified" in readme
 
     phase6_row = _markdown_table_row(tracker, "Phase 6: Release Hardening And Documentation")
-    assert "in-progress; TASK-13.1 through TASK-13.5 done" in phase6_row[2]
+    assert "verified; TASK-13.1 through TASK-13.7 done" in phase6_row[2]
     assert "TASK-13.5" in phase6_row[3]
     assert EVIDENCE.name in phase6_row[4]
-    assert "recovery/setup/documentation alignment verified" in phase6_row[5].lower()
+    assert "recovery/setup/documentation alignment" in phase6_row[5].lower()
+    assert "release hardening complete" in phase6_row[5].lower()
 
     qa_row = _markdown_table_row(tracker, "Phase 6.5")
     assert EVIDENCE.as_posix() in qa_row[1]

--- a/Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py
+++ b/Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py
@@ -431,7 +431,10 @@ def test_phase_five_optional_dependency_recovery_helper_builds_required_fields()
     recovery_state = optional_dependency_recovery_state(
         unavailable_what="Search/RAG queries",
         missing_dependencies=("torch", "sentence-transformers"),
-        install_target='pip install -e ".[embeddings_rag]"',
+        install_targets=(
+            'pip install -e ".[embeddings_rag]"',
+            'pip install "tldw_chatbook[embeddings_rag]"',
+        ),
         stable_selector="search-rag-dependency-missing",
         recovery_action="Settings > RAG",
     )
@@ -439,13 +442,17 @@ def test_phase_five_optional_dependency_recovery_helper_builds_required_fields()
     assert recovery_state.status_label == "Dependency missing"
     assert recovery_state.unavailable_what == "Search/RAG queries"
     assert recovery_state.why == "Missing optional dependencies: torch, sentence-transformers."
-    assert recovery_state.next_action == 'Install with pip install -e ".[embeddings_rag]" and restart.'
+    assert recovery_state.next_action == (
+        'Install with pip install -e ".[embeddings_rag]" for source checkouts or '
+        'pip install "tldw_chatbook[embeddings_rag]" for packaged installs, then restart.'
+    )
     assert recovery_state.recovery_action == "Settings > RAG"
     assert recovery_state.authority_owner == "optional dependency"
     assert recovery_state.stable_selector == "search-rag-dependency-missing"
     assert "Unavailable: Search/RAG queries." in recovery_state.visible_copy
     assert "Why: Missing optional dependencies: torch, sentence-transformers." in recovery_state.visible_copy
-    assert 'Install with pip install -e ".[embeddings_rag]" and restart.' in recovery_state.disabled_tooltip
+    assert 'pip install -e ".[embeddings_rag]"' in recovery_state.disabled_tooltip
+    assert 'pip install "tldw_chatbook[embeddings_rag]"' in recovery_state.disabled_tooltip
 
 
 def test_search_rag_window_imports_without_screens_recovery_cycle():

--- a/Tests/Utils/test_optional_deps.py
+++ b/Tests/Utils/test_optional_deps.py
@@ -3,7 +3,12 @@
 #
 import pytest
 import sys
+import tomllib
+from pathlib import Path
 from unittest.mock import patch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def test_optional_deps_import():
@@ -28,7 +33,8 @@ def test_optional_feature_metadata_exposes_recovery_commands_and_capability_tier
     assert rag.extra == "embeddings_rag"
     assert rag.label == "Library/Search-RAG"
     assert rag.capability_tier == "advanced"
-    assert rag.feature_area == "rag"
+    assert rag.feature_area == "RAG and retrieval"
+    assert rag.owner == "Library Search/RAG"
     assert rag.source_install_command == 'pip install -e ".[embeddings_rag]"'
     assert rag.package_install_command == 'pip install "tldw_chatbook[embeddings_rag]"'
     assert rag.recovery_action == "Settings > RAG"
@@ -36,8 +42,26 @@ def test_optional_feature_metadata_exposes_recovery_commands_and_capability_tier
 
     web = get_optional_feature_info("web")
     assert web.label == "Web server"
-    assert web.feature_area == "web"
+    assert web.feature_area == "Web access"
+    assert web.owner == "Web/browser serving"
     assert web.source_install_command == 'pip install -e ".[web]"'
+
+
+def test_optional_feature_metadata_covers_pyproject_extras():
+    """Every declared optional extra has source-honest recovery metadata."""
+    from tldw_chatbook.Utils.optional_deps import OPTIONAL_FEATURES, get_optional_feature_info
+
+    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    declared_extras = set(pyproject["project"]["optional-dependencies"])
+
+    assert set(OPTIONAL_FEATURES) == declared_extras
+    for extra in declared_extras:
+        info = get_optional_feature_info(extra)
+        assert info.extra == extra
+        assert info.owner != "optional dependency"
+        assert info.feature_area
+        assert info.recovery_action
+        assert info.unavailable_what
 
 
 def test_optional_feature_metadata_groups_release_capabilities_without_core_install():
@@ -49,14 +73,14 @@ def test_optional_feature_metadata_groups_release_capabilities_without_core_inst
 
     groups = optional_feature_groups_by_area()
     assert LOCAL_FIRST_BASELINE_INSTALL_COMMAND == "pip install -e ."
-    assert "rag" in groups
-    assert "media" in groups
-    assert "mcp" in groups
-    assert "server" in groups
-    assert "web" in groups
-    assert "embeddings_rag" in groups["rag"]
-    assert "mcp" in groups["mcp"]
-    assert "web" in groups["web"]
+    assert "RAG and retrieval" in groups
+    assert "Media ingestion and transcription" in groups
+    assert "MCP integration" in groups
+    assert "Local inference" in groups
+    assert "Web access" in groups
+    assert "embeddings_rag" in groups["RAG and retrieval"]
+    assert "mcp" in groups["MCP integration"]
+    assert "web" in groups["Web access"]
 
 
 def test_unavailable_feature_handler():

--- a/Tests/Utils/test_optional_deps.py
+++ b/Tests/Utils/test_optional_deps.py
@@ -20,6 +20,45 @@ def test_optional_deps_import():
     assert callable(create_unavailable_feature_handler)
 
 
+def test_optional_feature_metadata_exposes_recovery_commands_and_capability_tiers():
+    """Optional extras expose source-honest recovery metadata for blocked features."""
+    from tldw_chatbook.Utils.optional_deps import get_optional_feature_info
+
+    rag = get_optional_feature_info("embeddings_rag")
+    assert rag.extra == "embeddings_rag"
+    assert rag.label == "Library/Search-RAG"
+    assert rag.capability_tier == "advanced"
+    assert rag.feature_area == "rag"
+    assert rag.source_install_command == 'pip install -e ".[embeddings_rag]"'
+    assert rag.package_install_command == 'pip install "tldw_chatbook[embeddings_rag]"'
+    assert rag.recovery_action == "Settings > RAG"
+    assert rag.unavailable_what == "Search/RAG queries"
+
+    web = get_optional_feature_info("web")
+    assert web.label == "Web server"
+    assert web.feature_area == "web"
+    assert web.source_install_command == 'pip install -e ".[web]"'
+
+
+def test_optional_feature_metadata_groups_release_capabilities_without_core_install():
+    """The optional matrix separates baseline install from advanced feature groups."""
+    from tldw_chatbook.Utils.optional_deps import (
+        LOCAL_FIRST_BASELINE_INSTALL_COMMAND,
+        optional_feature_groups_by_area,
+    )
+
+    groups = optional_feature_groups_by_area()
+    assert LOCAL_FIRST_BASELINE_INSTALL_COMMAND == "pip install -e ."
+    assert "rag" in groups
+    assert "media" in groups
+    assert "mcp" in groups
+    assert "server" in groups
+    assert "web" in groups
+    assert "embeddings_rag" in groups["rag"]
+    assert "mcp" in groups["mcp"]
+    assert "web" in groups["web"]
+
+
 def test_unavailable_feature_handler():
     """Test that unavailable feature handlers work correctly."""
     from tldw_chatbook.Utils.optional_deps import create_unavailable_feature_handler

--- a/backlog/tasks/task-60.4.5 - Post-release-optional-dependency-and-packaging-polish-tranche.md
+++ b/backlog/tasks/task-60.4.5 - Post-release-optional-dependency-and-packaging-polish-tranche.md
@@ -42,7 +42,9 @@ Improve optional dependency recovery and package metadata after the audit confir
 - Added optional feature metadata helpers in `tldw_chatbook/Utils/optional_deps.py` for capability area, owner, unavailable feature copy, and source/package install commands.
 - Updated Search/RAG recovery copy to use the `embeddings_rag` metadata entry, preserving `Search/RAG queries` as the unavailable feature while exposing safe install actions.
 - Updated README and `Docs/Development/release-recovery-setup.md` with local-first baseline guidance and advanced optional capability group install paths.
+- Addressed PR review by rendering both source-checkout and packaged-install recovery commands, explicitly setting owner metadata for all optional extras, covering every pyproject optional extra in the registry, and adding Google-style docstrings for the new public helpers.
 - Verified with focused optional-dependency, recovery-copy, packaging, and recovery-doc tests: 29 passed.
+  Review follow-up verification: 30 passed.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-60.4.5 - Post-release-optional-dependency-and-packaging-polish-tranche.md
+++ b/backlog/tasks/task-60.4.5 - Post-release-optional-dependency-and-packaging-polish-tranche.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-60.4.5
 title: Post-release optional dependency and packaging polish tranche
-status: To Do
+status: Done
 labels:
 - post-release
 - packaging
@@ -19,22 +19,36 @@ Improve optional dependency recovery and package metadata after the audit confir
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Optional dependency and packaging polish scope references TASK-60.3 actual-use audit evidence.
-- [ ] #2 Unavailable optional features identify the missing dependency group and safe recovery command without implying broken core functionality.
-- [ ] #3 Package metadata and setup docs distinguish local-first baseline from advanced media, RAG, MCP, server, and web capability extras.
-- [ ] #4 QA verifies missing-dependency recovery copy and package/install paths before completion.
+- [x] #1 Optional dependency and packaging polish scope references TASK-60.3 actual-use audit evidence.
+- [x] #2 Unavailable optional features identify the missing dependency group and safe recovery command without implying broken core functionality.
+- [x] #3 Package metadata and setup docs distinguish local-first baseline from advanced media, RAG, MCP, server, and web capability extras.
+- [x] #4 QA verifies missing-dependency recovery copy and package/install paths before completion.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:IMPLEMENTATION_PLAN:BEGIN -->
+1. Add failing focused assertions for optional feature metadata, safe install commands, and local-first/advanced-capability documentation copy.
+2. Centralize optional feature metadata so unavailable states can reuse a single source for dependency group, owner, capability area, and source/package install commands.
+3. Wire Search/RAG missing-dependency recovery through the metadata registry without changing core local-first behavior.
+4. Update README and release recovery setup docs to distinguish baseline installation from optional advanced capability groups.
+5. Run focused optional-dependency, recovery-copy, and packaging documentation verification before marking the task done.
+<!-- SECTION:IMPLEMENTATION_PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+- Scope follows TASK-60.3 audit evidence that optional dependency failures should present recoverable, source-honest states instead of making the product appear broken.
+- Added optional feature metadata helpers in `tldw_chatbook/Utils/optional_deps.py` for capability area, owner, unavailable feature copy, and source/package install commands.
+- Updated Search/RAG recovery copy to use the `embeddings_rag` metadata entry, preserving `Search/RAG queries` as the unavailable feature while exposing safe install actions.
+- Updated README and `Docs/Development/release-recovery-setup.md` with local-first baseline guidance and advanced optional capability group install paths.
+- Verified with focused optional-dependency, recovery-copy, packaging, and recovery-doc tests: 29 passed.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+TASK-60.4.5 completed. Optional dependency metadata now has a central registry, Search/RAG recovery uses the registry, setup docs distinguish the local-first baseline from advanced extras, and focused QA verifies recovery copy plus package/install paths.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py
+++ b/tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py
@@ -495,7 +495,10 @@ class SearchRAGWindow(SearchEventHandlersMixin, Container):
         return optional_dependency_recovery_state(
             unavailable_what=feature.unavailable_what,
             missing_dependencies=(feature.extra,),
-            install_target=feature.source_install_command,
+            install_targets=(
+                feature.source_install_command,
+                feature.package_install_command,
+            ),
             stable_selector="search-rag-dependency-missing",
             recovery_action=feature.recovery_action,
             authority_owner=feature.owner,

--- a/tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py
+++ b/tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py
@@ -489,12 +489,16 @@ class SearchRAGWindow(SearchEventHandlersMixin, Container):
         
 
     def _missing_embeddings_recovery_state(self):
+        from ....Utils.optional_deps import get_optional_feature_info
+
+        feature = get_optional_feature_info("embeddings_rag")
         return optional_dependency_recovery_state(
-            unavailable_what="Search/RAG requires optional embeddings dependencies",
-            missing_dependencies=("embeddings_rag",),
-            install_target='pip install -e ".[embeddings_rag]"',
+            unavailable_what=feature.unavailable_what,
+            missing_dependencies=(feature.extra,),
+            install_target=feature.source_install_command,
             stable_selector="search-rag-dependency-missing",
-            recovery_action="Settings > RAG",
+            recovery_action=feature.recovery_action,
+            authority_owner=feature.owner,
         )
 
     async def on_mount(self) -> None:

--- a/tldw_chatbook/UI/destination_recovery.py
+++ b/tldw_chatbook/UI/destination_recovery.py
@@ -170,7 +170,8 @@ def optional_dependency_recovery_state(
     *,
     unavailable_what: str,
     missing_dependencies: Iterable[str] | str,
-    install_target: str,
+    install_target: str | None = None,
+    install_targets: Iterable[str] | None = None,
     stable_selector: str,
     recovery_action: str,
     authority_owner: str = "optional dependency",
@@ -181,17 +182,39 @@ def optional_dependency_recovery_state(
         unavailable_what: Specific workflow or control blocked by the missing dependency.
         missing_dependencies: Missing package, extra, or feature names.
         install_target: User-facing install command or setup target.
+        install_targets: Optional source/package install commands. When provided, the
+            first command is treated as the source checkout path and the second as the
+            packaged install path.
         stable_selector: Stable widget selector for the rendered recovery state.
         recovery_action: Target setup area or action.
         authority_owner: Owner of the blocker.
 
     Returns:
         Destination recovery state with dependency-specific visible copy and tooltip.
+
+    Raises:
+        ValueError: If neither `install_target` nor `install_targets` is provided.
     """
 
     dependency_names = _dependency_names(missing_dependencies)
     why = f"Missing optional dependencies: {dependency_names}."
-    next_action = f"Install with {install_target} and restart."
+    install_target_list = [
+        str(target).strip()
+        for target in (install_targets or ())
+        if str(target).strip()
+    ]
+    if install_target_list:
+        if len(install_target_list) >= 2:
+            next_action = (
+                f"Install with {install_target_list[0]} for source checkouts or "
+                f"{install_target_list[1]} for packaged installs, then restart."
+            )
+        else:
+            next_action = f"Install with {install_target_list[0]} and restart."
+    elif install_target:
+        next_action = f"Install with {install_target} and restart."
+    else:
+        raise ValueError("install_target or install_targets is required")
     disabled_tooltip = " ".join(
         (
             DestinationRecoveryState._sentence(unavailable_what),

--- a/tldw_chatbook/Utils/optional_deps.py
+++ b/tldw_chatbook/Utils/optional_deps.py
@@ -3,6 +3,7 @@
 #
 import sys
 import importlib.util
+from dataclasses import dataclass
 from typing import Dict, Any, Optional, Callable
 from loguru import logger
 
@@ -98,6 +99,188 @@ MODULES = {}
 
 # Store placeholder functions for unavailable features
 PLACEHOLDERS = {}
+
+LOCAL_FIRST_BASELINE_INSTALL_COMMAND = "pip install -e ."
+LOCAL_FIRST_PACKAGE_INSTALL_COMMAND = "pip install tldw_chatbook"
+
+
+@dataclass(frozen=True)
+class OptionalFeatureInfo:
+    """User-facing metadata for an optional feature group.
+
+    Args:
+        extra: pyproject optional dependency group.
+        label: Human-readable capability label.
+        feature_area: Product area used for release docs and grouping.
+        capability_tier: `baseline` or `advanced` capability tier.
+        package_dependencies: Representative packages installed by the extra.
+        recovery_action: Destination or setup area that owns recovery.
+        unavailable_what: Specific workflow blocked when the extra is missing.
+        owner: User-facing authority owner for recovery copy.
+    """
+
+    extra: str
+    label: str
+    feature_area: str
+    capability_tier: str
+    package_dependencies: tuple[str, ...]
+    recovery_action: str
+    unavailable_what: str
+    owner: str = "optional dependency"
+
+    @property
+    def source_install_command(self) -> str:
+        """Editable/source checkout install command."""
+
+        return f'pip install -e ".[{self.extra}]"'
+
+    @property
+    def package_install_command(self) -> str:
+        """Installed-package recovery command."""
+
+        return f'pip install "tldw_chatbook[{self.extra}]"'
+
+
+OPTIONAL_FEATURES: dict[str, OptionalFeatureInfo] = {
+    "embeddings_rag": OptionalFeatureInfo(
+        extra="embeddings_rag",
+        label="Library/Search-RAG",
+        feature_area="rag",
+        capability_tier="advanced",
+        package_dependencies=("torch", "transformers", "sentence-transformers", "chromadb"),
+        recovery_action="Settings > RAG",
+        unavailable_what="Search/RAG queries",
+    ),
+    "chunker": OptionalFeatureInfo(
+        extra="chunker",
+        label="Advanced chunking",
+        feature_area="rag",
+        capability_tier="advanced",
+        package_dependencies=("nltk", "langdetect", "scikit-learn", "jieba", "fugashi"),
+        recovery_action="Library > Import/Export",
+        unavailable_what="Advanced chunking",
+    ),
+    "websearch": OptionalFeatureInfo(
+        extra="websearch",
+        label="Web search and scraping",
+        feature_area="server",
+        capability_tier="advanced",
+        package_dependencies=("beautifulsoup4", "playwright", "trafilatura"),
+        recovery_action="Search/RAG or server research settings",
+        unavailable_what="Web search",
+    ),
+    "audio": OptionalFeatureInfo(
+        extra="audio",
+        label="Audio ingestion and transcription",
+        feature_area="media",
+        capability_tier="advanced",
+        package_dependencies=("soundfile", "scipy", "yt-dlp", "faster-whisper"),
+        recovery_action="Library > Import/Export",
+        unavailable_what="Audio processing",
+    ),
+    "video": OptionalFeatureInfo(
+        extra="video",
+        label="Video ingestion and transcription",
+        feature_area="media",
+        capability_tier="advanced",
+        package_dependencies=("soundfile", "scipy", "yt-dlp", "faster-whisper"),
+        recovery_action="Library > Import/Export",
+        unavailable_what="Video processing",
+    ),
+    "pdf": OptionalFeatureInfo(
+        extra="pdf",
+        label="PDF processing",
+        feature_area="media",
+        capability_tier="advanced",
+        package_dependencies=("pymupdf", "pymupdf4llm", "docling"),
+        recovery_action="Library > Import/Export",
+        unavailable_what="PDF ingestion",
+    ),
+    "ebook": OptionalFeatureInfo(
+        extra="ebook",
+        label="E-book processing",
+        feature_area="media",
+        capability_tier="advanced",
+        package_dependencies=("ebooklib", "beautifulsoup4", "defusedxml"),
+        recovery_action="Library > Import/Export",
+        unavailable_what="E-book ingestion",
+    ),
+    "mcp": OptionalFeatureInfo(
+        extra="mcp",
+        label="MCP server and client support",
+        feature_area="mcp",
+        capability_tier="advanced",
+        package_dependencies=("mcp[cli]",),
+        recovery_action="MCP",
+        unavailable_what="MCP server/client tools",
+    ),
+    "web": OptionalFeatureInfo(
+        extra="web",
+        label="Web server",
+        feature_area="web",
+        capability_tier="advanced",
+        package_dependencies=("textual-serve",),
+        recovery_action="Web server setup",
+        unavailable_what="Browser access",
+    ),
+    "local_vllm": OptionalFeatureInfo(
+        extra="local_vllm",
+        label="Local vLLM inference",
+        feature_area="server",
+        capability_tier="advanced",
+        package_dependencies=("vllm",),
+        recovery_action="Settings > Models",
+        unavailable_what="Local vLLM inference",
+    ),
+    "local_mlx": OptionalFeatureInfo(
+        extra="local_mlx",
+        label="Local MLX inference",
+        feature_area="server",
+        capability_tier="advanced",
+        package_dependencies=("mlx-lm",),
+        recovery_action="Settings > Models",
+        unavailable_what="Local MLX inference",
+    ),
+    "local_tts": OptionalFeatureInfo(
+        extra="local_tts",
+        label="Local text-to-speech",
+        feature_area="media",
+        capability_tier="advanced",
+        package_dependencies=("kokoro-onnx", "onnxruntime", "pyaudio"),
+        recovery_action="STTS",
+        unavailable_what="Local TTS",
+    ),
+    "ocr_docext": OptionalFeatureInfo(
+        extra="ocr_docext",
+        label="OCR and document extraction",
+        feature_area="media",
+        capability_tier="advanced",
+        package_dependencies=("docext", "gradio_client", "openai"),
+        recovery_action="Library > Import/Export",
+        unavailable_what="OCR/document extraction",
+    ),
+}
+
+
+def get_optional_feature_info(extra: str) -> OptionalFeatureInfo:
+    """Return recovery metadata for a pyproject optional dependency group."""
+
+    try:
+        return OPTIONAL_FEATURES[extra]
+    except KeyError as exc:
+        raise KeyError(f"Unknown optional feature extra: {extra}") from exc
+
+
+def optional_feature_groups_by_area() -> dict[str, tuple[str, ...]]:
+    """Group optional dependency extras by release-facing capability area."""
+
+    grouped: dict[str, list[str]] = {}
+    for extra, info in OPTIONAL_FEATURES.items():
+        grouped.setdefault(info.feature_area, []).append(extra)
+    return {
+        area: tuple(sorted(extras))
+        for area, extras in sorted(grouped.items())
+    }
 
 def check_dependency(module_name: str, feature_name: Optional[str] = None) -> bool:
     """

--- a/tldw_chatbook/Utils/optional_deps.py
+++ b/tldw_chatbook/Utils/optional_deps.py
@@ -141,129 +141,216 @@ class OptionalFeatureInfo:
         return f'pip install "tldw_chatbook[{self.extra}]"'
 
 
+AREA_RAG = "RAG and retrieval"
+AREA_MEDIA = "Media ingestion and transcription"
+AREA_MCP = "MCP integration"
+AREA_LOCAL_INFERENCE = "Local inference"
+AREA_WEB = "Web access"
+AREA_DIAGNOSTICS = "Diagnostics and telemetry"
+AREA_WATCHLISTS = "Watchlists and schedules"
+AREA_VISUALIZATION = "Library visualization"
+AREA_DEVELOPMENT = "Development tooling"
+AREA_ALL = "All optional capabilities"
+
+OWNER_LIBRARY_RAG = "Library Search/RAG"
+OWNER_LIBRARY_MEDIA = "Library import/media"
+OWNER_MCP = "MCP destination"
+OWNER_CONSOLE_PROVIDER = "Console/provider setup"
+OWNER_WEB = "Web/browser serving"
+OWNER_SETTINGS = "Settings"
+OWNER_WATCHLISTS = "Watchlists"
+OWNER_LIBRARY = "Library"
+OWNER_DEVELOPMENT = "Development tooling"
+OWNER_RELEASE = "Release packaging"
+
+
+def _feature(
+    extra: str,
+    label: str,
+    feature_area: str,
+    package_dependencies: tuple[str, ...],
+    recovery_action: str,
+    unavailable_what: str,
+    owner: str,
+) -> OptionalFeatureInfo:
+    return OptionalFeatureInfo(
+        extra=extra,
+        label=label,
+        feature_area=feature_area,
+        capability_tier="advanced",
+        package_dependencies=package_dependencies,
+        recovery_action=recovery_action,
+        unavailable_what=unavailable_what,
+        owner=owner,
+    )
+
+
 OPTIONAL_FEATURES: dict[str, OptionalFeatureInfo] = {
-    "embeddings_rag": OptionalFeatureInfo(
-        extra="embeddings_rag",
-        label="Library/Search-RAG",
-        feature_area="rag",
-        capability_tier="advanced",
-        package_dependencies=("torch", "transformers", "sentence-transformers", "chromadb"),
-        recovery_action="Settings > RAG",
-        unavailable_what="Search/RAG queries",
+    "all-tools": _feature(
+        "all-tools", "All optional tools", AREA_ALL,
+        ("grep_ast", "chromadb", "vllm", "playwright", "faster-whisper", "mcp[cli]"),
+        "Release packaging", "All optional capabilities", OWNER_RELEASE,
     ),
-    "chunker": OptionalFeatureInfo(
-        extra="chunker",
-        label="Advanced chunking",
-        feature_area="rag",
-        capability_tier="advanced",
-        package_dependencies=("nltk", "langdetect", "scikit-learn", "jieba", "fugashi"),
-        recovery_action="Library > Import/Export",
-        unavailable_what="Advanced chunking",
+    "audio": _feature(
+        "audio", "Audio ingestion and transcription", AREA_MEDIA,
+        ("soundfile", "scipy", "yt-dlp", "faster-whisper"),
+        "Library > Import/Export", "Audio processing", OWNER_LIBRARY_MEDIA,
     ),
-    "websearch": OptionalFeatureInfo(
-        extra="websearch",
-        label="Web search and scraping",
-        feature_area="server",
-        capability_tier="advanced",
-        package_dependencies=("beautifulsoup4", "playwright", "trafilatura"),
-        recovery_action="Search/RAG or server research settings",
-        unavailable_what="Web search",
+    "chatterbox": _feature(
+        "chatterbox", "Chatterbox TTS", AREA_MEDIA,
+        ("chatterbox-tts", "torchaudio", "torch"),
+        "STTS", "Chatterbox TTS", OWNER_LIBRARY_MEDIA,
     ),
-    "audio": OptionalFeatureInfo(
-        extra="audio",
-        label="Audio ingestion and transcription",
-        feature_area="media",
-        capability_tier="advanced",
-        package_dependencies=("soundfile", "scipy", "yt-dlp", "faster-whisper"),
-        recovery_action="Library > Import/Export",
-        unavailable_what="Audio processing",
+    "chunker": _feature(
+        "chunker", "Advanced chunking", AREA_RAG,
+        ("nltk", "langdetect", "scikit-learn", "jieba", "fugashi"),
+        "Library > Import/Export", "Advanced chunking", OWNER_LIBRARY_RAG,
     ),
-    "video": OptionalFeatureInfo(
-        extra="video",
-        label="Video ingestion and transcription",
-        feature_area="media",
-        capability_tier="advanced",
-        package_dependencies=("soundfile", "scipy", "yt-dlp", "faster-whisper"),
-        recovery_action="Library > Import/Export",
-        unavailable_what="Video processing",
+    "coding_map": _feature(
+        "coding_map", "Code map analysis", AREA_LOCAL_INFERENCE,
+        ("grep_ast", "pygments", "tqdm"),
+        "Console/provider setup", "Code map analysis", OWNER_CONSOLE_PROVIDER,
     ),
-    "pdf": OptionalFeatureInfo(
-        extra="pdf",
-        label="PDF processing",
-        feature_area="media",
-        capability_tier="advanced",
-        package_dependencies=("pymupdf", "pymupdf4llm", "docling"),
-        recovery_action="Library > Import/Export",
-        unavailable_what="PDF ingestion",
+    "debugging": _feature(
+        "debugging", "Metrics and telemetry", AREA_DIAGNOSTICS,
+        ("prometheus_client", "opentelemetry-api", "opentelemetry-sdk"),
+        "Settings > Diagnostics", "Diagnostics/telemetry", OWNER_SETTINGS,
     ),
-    "ebook": OptionalFeatureInfo(
-        extra="ebook",
-        label="E-book processing",
-        feature_area="media",
-        capability_tier="advanced",
-        package_dependencies=("ebooklib", "beautifulsoup4", "defusedxml"),
-        recovery_action="Library > Import/Export",
-        unavailable_what="E-book ingestion",
+    "dev": _feature(
+        "dev", "Development dependencies", AREA_DEVELOPMENT,
+        ("pytest", "textual-dev", "hypothesis", "build", "twine"),
+        "Development setup", "Development tooling", OWNER_DEVELOPMENT,
     ),
-    "mcp": OptionalFeatureInfo(
-        extra="mcp",
-        label="MCP server and client support",
-        feature_area="mcp",
-        capability_tier="advanced",
-        package_dependencies=("mcp[cli]",),
-        recovery_action="MCP",
-        unavailable_what="MCP server/client tools",
+    "diarization": _feature(
+        "diarization", "Speaker diarization", AREA_MEDIA,
+        ("torch", "torchaudio", "speechbrain", "scikit-learn"),
+        "Library > Import/Export", "Speaker diarization", OWNER_LIBRARY_MEDIA,
     ),
-    "web": OptionalFeatureInfo(
-        extra="web",
-        label="Web server",
-        feature_area="web",
-        capability_tier="advanced",
-        package_dependencies=("textual-serve",),
-        recovery_action="Web server setup",
-        unavailable_what="Browser access",
+    "ebook": _feature(
+        "ebook", "E-book processing", AREA_MEDIA,
+        ("ebooklib", "beautifulsoup4", "defusedxml"),
+        "Library > Import/Export", "E-book ingestion", OWNER_LIBRARY_MEDIA,
     ),
-    "local_vllm": OptionalFeatureInfo(
-        extra="local_vllm",
-        label="Local vLLM inference",
-        feature_area="server",
-        capability_tier="advanced",
-        package_dependencies=("vllm",),
-        recovery_action="Settings > Models",
-        unavailable_what="Local vLLM inference",
+    "embeddings_rag": _feature(
+        "embeddings_rag", "Library/Search-RAG", AREA_RAG,
+        ("torch", "transformers", "sentence-transformers", "chromadb"),
+        "Settings > RAG", "Search/RAG queries", OWNER_LIBRARY_RAG,
     ),
-    "local_mlx": OptionalFeatureInfo(
-        extra="local_mlx",
-        label="Local MLX inference",
-        feature_area="server",
-        capability_tier="advanced",
-        package_dependencies=("mlx-lm",),
-        recovery_action="Settings > Models",
-        unavailable_what="Local MLX inference",
+    "higgs_tts": _feature(
+        "higgs_tts", "Higgs Audio TTS", AREA_MEDIA,
+        ("torch", "torchaudio", "librosa", "soundfile"),
+        "STTS", "Higgs Audio TTS", OWNER_LIBRARY_MEDIA,
     ),
-    "local_tts": OptionalFeatureInfo(
-        extra="local_tts",
-        label="Local text-to-speech",
-        feature_area="media",
-        capability_tier="advanced",
-        package_dependencies=("kokoro-onnx", "onnxruntime", "pyaudio"),
-        recovery_action="STTS",
-        unavailable_what="Local TTS",
+    "local_mlx": _feature(
+        "local_mlx", "Local MLX inference", AREA_LOCAL_INFERENCE,
+        ("mlx-lm",),
+        "Settings > Models", "Local MLX inference", OWNER_CONSOLE_PROVIDER,
     ),
-    "ocr_docext": OptionalFeatureInfo(
-        extra="ocr_docext",
-        label="OCR and document extraction",
-        feature_area="media",
-        capability_tier="advanced",
-        package_dependencies=("docext", "gradio_client", "openai"),
-        recovery_action="Library > Import/Export",
-        unavailable_what="OCR/document extraction",
+    "local_transformers": _feature(
+        "local_transformers", "Local Transformers inference", AREA_LOCAL_INFERENCE,
+        ("transformers",),
+        "Settings > Models", "Local Transformers inference", OWNER_CONSOLE_PROVIDER,
+    ),
+    "local_tts": _feature(
+        "local_tts", "Local text-to-speech", AREA_MEDIA,
+        ("kokoro-onnx", "onnxruntime", "pyaudio"),
+        "STTS", "Local TTS", OWNER_LIBRARY_MEDIA,
+    ),
+    "local_vllm": _feature(
+        "local_vllm", "Local vLLM inference", AREA_LOCAL_INFERENCE,
+        ("vllm",),
+        "Settings > Models", "Local vLLM inference", OWNER_CONSOLE_PROVIDER,
+    ),
+    "mcp": _feature(
+        "mcp", "MCP server and client support", AREA_MCP,
+        ("mcp[cli]",),
+        "MCP", "MCP server/client tools", OWNER_MCP,
+    ),
+    "media_processing": _feature(
+        "media_processing", "Combined media processing", AREA_MEDIA,
+        ("soundfile", "scipy", "yt-dlp", "faster-whisper"),
+        "Library > Import/Export", "Media processing", OWNER_LIBRARY_MEDIA,
+    ),
+    "mindmap": _feature(
+        "mindmap", "Mind map visualization", AREA_VISUALIZATION,
+        ("anytree",),
+        "Library", "Mind map visualization", OWNER_LIBRARY,
+    ),
+    "mlx_whisper": _feature(
+        "mlx_whisper", "Legacy MLX Whisper providers", AREA_MEDIA,
+        ("lightning-whisper-mlx", "parakeet-mlx"),
+        "Library > Import/Export", "MLX transcription", OWNER_LIBRARY_MEDIA,
+    ),
+    "nemo": _feature(
+        "nemo", "NVIDIA NeMo ASR", AREA_MEDIA,
+        ("nemo-toolkit[asr]", "torch", "torchaudio"),
+        "Library > Import/Export", "NVIDIA NeMo ASR", OWNER_LIBRARY_MEDIA,
+    ),
+    "ocr_docext": _feature(
+        "ocr_docext", "OCR and document extraction", AREA_MEDIA,
+        ("docext", "gradio_client", "openai"),
+        "Library > Import/Export", "OCR/document extraction", OWNER_LIBRARY_MEDIA,
+    ),
+    "pdf": _feature(
+        "pdf", "PDF processing", AREA_MEDIA,
+        ("pymupdf", "pymupdf4llm", "docling"),
+        "Library > Import/Export", "PDF ingestion", OWNER_LIBRARY_MEDIA,
+    ),
+    "speech_recording": _feature(
+        "speech_recording", "Speech recording", AREA_MEDIA,
+        ("pyaudio", "sounddevice", "webrtcvad"),
+        "STTS", "Speech recording", OWNER_LIBRARY_MEDIA,
+    ),
+    "subscriptions": _feature(
+        "subscriptions", "Subscriptions and scheduled feeds", AREA_WATCHLISTS,
+        ("markdown", "schedule", "feedparser", "cryptography"),
+        "Watchlists", "Subscriptions/watchlists", OWNER_WATCHLISTS,
+    ),
+    "transcription_faster_whisper": _feature(
+        "transcription_faster_whisper", "Faster Whisper transcription", AREA_MEDIA,
+        ("faster-whisper",),
+        "Library > Import/Export", "Faster Whisper transcription", OWNER_LIBRARY_MEDIA,
+    ),
+    "transcription_lightning_whisper": _feature(
+        "transcription_lightning_whisper", "Lightning Whisper MLX transcription", AREA_MEDIA,
+        ("lightning-whisper-mlx",),
+        "Library > Import/Export", "Lightning Whisper transcription", OWNER_LIBRARY_MEDIA,
+    ),
+    "transcription_parakeet": _feature(
+        "transcription_parakeet", "Parakeet MLX transcription", AREA_MEDIA,
+        ("parakeet-mlx",),
+        "Library > Import/Export", "Parakeet transcription", OWNER_LIBRARY_MEDIA,
+    ),
+    "video": _feature(
+        "video", "Video ingestion and transcription", AREA_MEDIA,
+        ("soundfile", "scipy", "yt-dlp", "faster-whisper"),
+        "Library > Import/Export", "Video processing", OWNER_LIBRARY_MEDIA,
+    ),
+    "web": _feature(
+        "web", "Web server", AREA_WEB,
+        ("textual-serve",),
+        "Web server setup", "Browser access", OWNER_WEB,
+    ),
+    "websearch": _feature(
+        "websearch", "Web search and scraping", AREA_WEB,
+        ("beautifulsoup4", "playwright", "trafilatura"),
+        "Search/RAG or server research settings", "Web search", OWNER_LIBRARY_RAG,
     ),
 }
 
 
 def get_optional_feature_info(extra: str) -> OptionalFeatureInfo:
-    """Return recovery metadata for a pyproject optional dependency group."""
+    """Return recovery metadata for a pyproject optional dependency group.
+
+    Args:
+        extra: Optional dependency extra name from `pyproject.toml`.
+
+    Returns:
+        User-facing metadata for the optional feature group.
+
+    Raises:
+        KeyError: If `extra` is not a known optional dependency group.
+    """
 
     try:
         return OPTIONAL_FEATURES[extra]
@@ -272,7 +359,11 @@ def get_optional_feature_info(extra: str) -> OptionalFeatureInfo:
 
 
 def optional_feature_groups_by_area() -> dict[str, tuple[str, ...]]:
-    """Group optional dependency extras by release-facing capability area."""
+    """Group optional dependency extras by release-facing capability area.
+
+    Returns:
+        Mapping of capability area labels to sorted optional extra names.
+    """
 
     grouped: dict[str, list[str]] = {}
     for extra, info in OPTIONAL_FEATURES.items():


### PR DESCRIPTION
## Summary
- Add central optional-feature metadata for capability area, owner, unavailable copy, and source/package install commands
- Route Search/RAG missing dependency recovery through the metadata registry
- Update README and release recovery setup docs to separate local-first baseline from advanced optional capability groups
- Mark TASK-60.4.5 complete with focused QA evidence

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Utils/test_optional_deps.py Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py::test_phase_five_optional_dependency_recovery_helper_builds_required_fields Tests/UI/test_disabled_action_recovery_tooltips.py::test_search_rag_missing_embeddings_dependency_exposes_phase_five_recovery Tests/UI/test_product_maturity_phase1_empty_setup_states.py::test_optional_dependency_missing_state_exposes_owner_and_setup_action Tests/UI/test_product_maturity_phase6_packaging_data_safety.py Tests/UI/test_product_maturity_phase6_recovery_docs.py::test_phase6_recovery_docs_evidence_and_tracking_are_current --tb=short
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished optional-dependency recovery to show clear owners and both source and packaged install commands, so missing extras don’t imply the core app is broken. Docs now separate the local-first baseline from advanced capability groups; Search/RAG recovery uses the central registry; marks TASK-60.4.5 done.

- **New Features**
  - Added `OptionalFeatureInfo` and `OPTIONAL_FEATURES` in `tldw_chatbook/Utils/optional_deps.py` (area, owner, recovery copy, source/package commands).
  - Provided `optional_feature_groups_by_area()` plus baseline install constants; registry covers all `pyproject.toml` extras.
  - `optional_dependency_recovery_state` accepts `install_targets` to render both paths; Search/RAG uses `get_optional_feature_info("embeddings_rag")` with owner “Library Search/RAG”.

- **Docs**
  - Added “Local-first baseline” and “Advanced optional capability groups”.
  - Show both commands, e.g., `pip install -e ".[embeddings_rag]"` and `pip install "tldw_chatbook[embeddings_rag]"`.
  - Updated recovery guidance and Phase 6 tracking to verified.

<sup>Written for commit 31bbcb3ea6771efc0cd7fa270c4280c16c47cf11. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/360?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

