### PR TITLE
Add Console Save as action regression

### DIFF
--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -467,6 +467,34 @@ async def test_console_selected_message_copy_action_uses_app_clipboard():
 
 
 @pytest.mark.asyncio
+async def test_console_selected_message_save_as_action_opens_modal():
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+        store = console._ensure_console_chat_store()
+        session = store.ensure_session()
+        message = store.append_message(
+            session.id,
+            role=ConsoleMessageRole.ASSISTANT,
+            content="answer",
+        )
+        await console._sync_native_console_chat_ui()
+
+        transcript = console.query_one("#console-native-transcript", ConsoleTranscript)
+        transcript.select_message(message.id)
+        await console._sync_native_console_chat_ui()
+        await _wait_for_selector(console, pilot, f"#console-message-action-save-as-{message.id}")
+
+        await pilot.click(f"#console-message-action-save-as-{message.id}")
+        await _wait_for_selector(app.screen_stack[-1], pilot, "#console-save-as-modal")
+
+    assert console._last_console_action.action_id == "save-as"
+
+
+@pytest.mark.asyncio
 async def test_console_failed_stream_renders_inline_retry_and_recovers():
     gateway = FailThenRecoverGateway()
     app = _build_test_app()

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -489,7 +489,7 @@ async def test_console_selected_message_save_as_action_opens_modal():
         await _wait_for_selector(console, pilot, f"#console-message-action-save-as-{message.id}")
 
         await pilot.click(f"#console-message-action-save-as-{message.id}")
-        await _wait_for_selector(app.screen_stack[-1], pilot, "#console-save-as-modal")
+        await _wait_for_selector(app, pilot, "#console-save-as-modal")
 
     assert console._last_console_action.action_id == "save-as"
 


### PR DESCRIPTION
## Summary
- Adds a mounted Console regression that selects an assistant transcript message and activates the Save as... action.
- Verifies the action opens the Console Save as modal through the real ChatScreen message-action path.

## Test Plan
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chat/test_console_chat_models.py Tests/Chat/test_console_provider_gateway.py Tests/Chat/test_console_chat_store.py Tests/Chat/test_console_chat_controller.py Tests/Chat/test_console_message_actions.py Tests/UI/test_console_native_chat_flow.py Tests/UI/test_console_native_transcript.py Tests/UI/test_console_workspace_context_rail.py Tests/UI/test_console_internals_decomposition.py --tb=short
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a UI regression test that selects an assistant transcript message and triggers the Save as action to verify the Console Save as modal opens through the real message-action path. Stabilizes the modal wait by waiting for "#console-save-as-modal" on the app, and asserts the last console action id is "save-as" to prevent regressions.

<sup>Written for commit ebd05c3a39da487bd9382b38b77a3f868793b1fb. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/361?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

