### PR TITLE
Plan Chatbook Sync v2 completion roadmap

### DIFF
--- a/Docs/superpowers/specs/2026-05-26-chatbook-sync-v2-completion-roadmap-design.md
+++ b/Docs/superpowers/specs/2026-05-26-chatbook-sync-v2-completion-roadmap-design.md
@@ -233,7 +233,7 @@ Every implementation child task should use:
 Recommended common commands:
 
 ```bash
-python -m pytest -q Tests/Sync_Interop --tb=short
+python -m pytest -q Tests/Sync_Tests --tb=short
 python -m pytest -q Tests/UI/test_product_maturity_phase1_harness.py::test_backlog_task_frontmatter_ids_are_unique --tb=short
 git diff --check
 ```

--- a/Docs/superpowers/specs/2026-05-26-chatbook-sync-v2-completion-roadmap-design.md
+++ b/Docs/superpowers/specs/2026-05-26-chatbook-sync-v2-completion-roadmap-design.md
@@ -1,0 +1,263 @@
+# Chatbook Sync v2 Completion Roadmap
+
+Date: 2026-05-26
+Status: Draft implementation roadmap
+Owner: `TASK-70`
+Scope: Plan the remaining Sync v2 work from the current read-only/dry-run baseline to reliable manual local-first sync, then staged workspace/background expansion.
+
+## Summary
+
+Chatbook already has a substantial Sync v2 substrate: profile state, encrypted envelopes, restore services, recovery-key handling, outbox persistence, profile summary display, and read-only write-sync promotion labels. The remaining product gap is not another status banner. The missing step is a safe, user-visible path that produces real local changes into the Sync v2 outbox and lets a user manually sync them without silent mutation.
+
+The first implementation milestone is intentionally small:
+
+- Active server profile only.
+- Personal dataset only.
+- Manual sync only.
+- Notes and Chat messages only.
+- Explicit preview, run, conflict, restore, and recovery evidence before any background automation.
+
+Workspace-scoped datasets, ACP package handoff, background sync, broad domain coverage, and collaboration remain later phases. They should reuse the same safety model after manual Notes and Chat sync proves reliable.
+
+## Current Baseline
+
+Completed foundations already provide these anchors:
+
+- `TASK-15` through `TASK-59` established Sync v2 client dry-run, envelope, encryption, restore, recovery, outbox, runtime-policy, validation, and profile orchestration foundations.
+- `TASK-59.1` added the Sync v2 profile summary contract.
+- `TASK-60.4.2` shipped display-only write-sync promotion labels across relevant surfaces while explicitly not adding write replay, approval buttons, outbox drain, or server mutation.
+- `TASK-69` surfaced read-only Sync v2 profile status in Library Collections.
+- `Docs/superpowers/specs/2026-05-20-workspace-operating-context-handoff-prd-design.md` defines workspace visibility versus active-context eligibility and keeps background write sync deferred until manual push/pull is proven.
+
+Current gap:
+
+- User-created Notes and Chat message changes do not yet have a complete, product-approved path from local mutation to outbox envelope to manual push/pull result to restore verification.
+
+## Product Principles
+
+1. Sync must be source-honest. The UI must distinguish dry-run, staged outgoing work, pushed work, pulled work, conflict, blocked, and restored states.
+2. Manual sync comes before automation. No scheduled/background mutation loop ships until users can safely preview, execute, recover, and audit manual sync.
+3. Domain producers are explicit. Notes and Chat message changes must each own their outbox production contract instead of relying on a generic database diff.
+4. Restore compatibility is part of the first milestone. A sync path is incomplete if a second device or repaired install cannot reconstruct the same Notes and Chat content.
+5. Workspace switching does not hide Library or Notes items. Workspace-specific sync can come later; this milestone targets the active server profile personal dataset.
+6. Conflict visibility beats silent resolution. Automatic resolution can be added only after the conflict object, user copy, retry path, and rollback evidence exist.
+
+## First Milestone
+
+### Included
+
+- Notes outbox producer for user-created/edited/deleted note records in the active profile personal dataset.
+- Chat message outbox producer for conversation/message mutations in the active profile personal dataset.
+- Manual sync execution path that previews outgoing work, runs push/pull through existing Sync v2 services, and reports outcome.
+- Conflict and partial-failure display states that reuse existing profile summary/status foundations.
+- Restore/new-device verification for Notes and Chat messages.
+- Actual app QA evidence for Settings, Library/Collections, Console, and any manual sync control surface touched.
+
+### Excluded
+
+- Background or scheduled sync.
+- Workspace-scoped datasets.
+- Real-time collaboration.
+- ACP task/run package sync.
+- MCP/tool runtime sync.
+- Full Library/media/RAG/artifact domain sync.
+- Silent merge or hidden conflict resolution.
+- Server identity migration between unrelated profiles.
+
+## Architecture Boundaries
+
+### Domain Outbox Producers
+
+Each included domain gets a small producer boundary:
+
+| Domain | Producer responsibility | Non-responsibility |
+| --- | --- | --- |
+| Notes | Convert note create/update/delete into encrypted Sync v2 envelopes with stable local identity, domain scope, idempotency, and restore metadata. | UI layout, server transport, conflict review UI. |
+| Chat | Convert conversation/message changes into ordered envelopes that preserve conversation identity, message parentage, variants, and restore continuity. | Chat rendering, LLM streaming, agent runtime orchestration. |
+
+Producer requirements:
+
+- Run inside the same local transaction boundary as the user-visible mutation when feasible, or record a durable recovery marker if enqueue happens after the mutation.
+- Use stable `client_envelope_id` and domain-qualified `source_scope_key` values.
+- Avoid exposing plaintext in logs, status labels, or task notes.
+- Keep local-first success independent of server availability.
+- Produce deterministic dry-run evidence for tests.
+
+### Manual Sync Execution
+
+Manual sync is a user-controlled workflow:
+
+1. Preflight reads profile summary and pending domain counts.
+2. Preview shows outgoing/incoming/conflict expectations using safe labels.
+3. User explicitly starts sync.
+4. Push runs first for retained outgoing envelopes.
+5. Pull applies accepted remote envelopes only after local validation passes.
+6. Status updates show success, partial success, conflict, blocked, or failed.
+7. Failed or conflicted outgoing work remains visible and retryable.
+
+Manual sync must not:
+
+- Auto-run on app launch.
+- Hide partial push failures after a successful pull.
+- Advance cursors after failed apply.
+- Convert dry-run labels into mutation controls before the execution path exists.
+
+### Conflict And Recovery
+
+Conflict review needs to expose:
+
+- Domain.
+- Item label.
+- Local version summary.
+- Remote version summary.
+- Cause.
+- Safe user actions: keep local, accept remote, duplicate/fork, retry later, or inspect raw audit where available.
+
+For the first milestone, a conflict can block completion as long as it is durable, visible, and recoverable. A polished merge editor is not required before the first manual sync path lands.
+
+### Restore Compatibility
+
+Restore/new-device validation must prove:
+
+- Notes restored from synced envelopes retain title/body/status/deletion semantics.
+- Chat conversations restore message order, roles, parentage, and variants needed for resumed conversation continuity.
+- Recovery-key restore can decrypt selected envelopes without persisting recovered secrets inappropriately.
+- Restore failure stops before applying partial corrupt state.
+
+## Phased Plan
+
+### Phase 0: Roadmap And Task Split
+
+Deliver this spec and Backlog child tasks. No runtime behavior changes.
+
+Exit evidence:
+
+- Spec is committed.
+- Child tasks are created with PR-sized acceptance criteria.
+- Current baseline and exclusions are explicit.
+
+### Phase 1: Notes Producer
+
+Implement the first content-producing path for Notes.
+
+Exit evidence:
+
+- Note create/update/delete can enqueue retained Sync v2 envelopes.
+- Local note operations still succeed when no server is reachable.
+- Tests prove envelope shape, idempotency, encryption boundary, and profile summary pending counts.
+
+### Phase 2: Chat Producer
+
+Implement Chat conversation/message outbox production.
+
+Exit evidence:
+
+- User and assistant messages can enqueue ordered Sync v2 envelopes.
+- Conversation identity, message order, variants, and restore metadata are preserved.
+- Streaming or failed-send paths do not enqueue misleading complete-message envelopes.
+
+### Phase 3: Manual Sync Control Surface
+
+Add the manual sync preview/run/result path.
+
+Exit evidence:
+
+- Users can preview pending Notes/Chat work and explicitly run sync.
+- UI reports success, partial success, conflict, blocked, and failure states.
+- No background sync is introduced.
+
+### Phase 4: Conflict Review And Recovery
+
+Make conflict states actionable enough for manual use.
+
+Exit evidence:
+
+- Conflicts are listed with domain/item/cause.
+- Users have clear recovery actions.
+- Partial push failures remain visible until resolved.
+
+### Phase 5: Restore/New-Device QA
+
+Validate that synced Notes and Chat messages survive restore.
+
+Exit evidence:
+
+- A clean local profile can restore selected Notes and Chat envelopes.
+- Recovery-key flow is covered.
+- Actual app QA verifies users can understand what was restored and what failed.
+
+### Phase 6: Manual Sync Closeout Gate
+
+Run an actual-use QA pass before considering broader promotion.
+
+Exit evidence:
+
+- Manual Notes+Chat sync works end-to-end against a local/server test target.
+- Settings, Library/Collections, and Console agree on status.
+- Remaining gaps are filed as separate tasks.
+
+### Later Phases
+
+Later work should only start after the manual closeout gate:
+
+- Workspace-scoped datasets and eligibility-aware sync.
+- ACP task/run package sync and handoff.
+- Library/media/RAG/artifact domain producers.
+- Scheduled/background sync.
+- Collaboration/shared workspace semantics.
+
+## Backlog Child Tasks
+
+This roadmap is split into these immediate child tasks:
+
+- `TASK-70.1`: Add Notes Sync v2 outbox producer plan.
+- `TASK-70.2`: Add Chat Sync v2 outbox producer plan.
+- `TASK-70.3`: Add manual Sync v2 preview and execution plan.
+- `TASK-70.4`: Add Sync v2 conflict review and recovery plan.
+- `TASK-70.5`: Add Sync v2 Notes and Chat restore QA plan.
+- `TASK-70.6`: Close out manual Sync v2 milestone with actual-use QA.
+
+Each child task should be implemented in its own PR unless review shows two adjacent slices are too small to validate independently.
+
+## Verification Strategy
+
+Every implementation child task should use:
+
+- A failing regression before implementation.
+- Focused unit tests for pure envelope/status logic.
+- Integration tests for local database, outbox, transport, and restore behavior.
+- Mounted Textual tests for visible control states.
+- Actual app QA through CDP/textual-web screenshots for any visible Settings, Library, Console, or Home surface.
+- `git diff --check` before PR.
+
+Recommended common commands:
+
+```bash
+python -m pytest -q Tests/Sync_Interop --tb=short
+python -m pytest -q Tests/UI/test_product_maturity_phase1_harness.py::test_backlog_task_frontmatter_ids_are_unique --tb=short
+git diff --check
+```
+
+## Risks
+
+- Notes and Chat may have different local transaction seams, so a shared producer abstraction could become too generic too early.
+- Chat streaming can create partial message states; producers must avoid syncing incomplete assistant messages as final content.
+- Backlog task IDs can drift during parallel PR work. Roadmap tasks should run the frontmatter uniqueness guard before merge.
+- Manual sync UI could accidentally imply background sync is enabled. Copy and control labels must remain explicit.
+- Restore validation can pass technically while still being confusing to users. Actual-use QA is required before milestone closeout.
+
+## Open Questions
+
+- Which server test target should be canonical for manual sync closeout: local `tldw_server`, `tldw_server2`, or a mocked Sync v2 API harness?
+- Should Notes delete sync as tombstones only, or should the first milestone support undelete/recovery metadata?
+- Which Chat message variant model is canonical for restore when regenerated assistant messages exist?
+- Where should the primary manual sync action live first: Settings Sync Safety, Library Collections, Home status, or a dedicated Sync modal?
+- What audit detail is safe to expose by default without leaking note/chat plaintext?
+
+## Approval Gate
+
+This roadmap is approved for implementation only when:
+
+- The user accepts the milestone scope and exclusions.
+- Child tasks are reviewed as PR-sized.
+- The first child task starts with Notes producer tests rather than UI polish.

--- a/Tests/Chat/test_console_chat_store.py
+++ b/Tests/Chat/test_console_chat_store.py
@@ -179,6 +179,28 @@ class FakePersistence:
         return True
 
 
+class FakeChatSyncProducer:
+    def __init__(self):
+        self.enqueued = []
+
+    def enqueue_chat_message(self, **kwargs):
+        self.enqueued.append(kwargs)
+        return {
+            "status": "enqueued",
+            "outbox_entry": {
+                "outbox_id": len(self.enqueued),
+                "envelope": {
+                    "payload_hash": f"hash:{kwargs['role']}:{kwargs['content']}",
+                },
+            },
+        }
+
+
+class FailingChatSyncProducer:
+    def enqueue_chat_message(self, **kwargs):
+        raise RuntimeError("sync unavailable")
+
+
 def test_store_can_persist_user_and_assistant_messages_through_adapter():
     persistence = FakePersistence()
     store = ConsoleChatStore(persistence=persistence)
@@ -193,6 +215,198 @@ def test_store_can_persist_user_and_assistant_messages_through_adapter():
     assert persistence.created_messages[0]["content"] == "hello"
     assert persistence.created_messages[0]["image_data"] is None
     assert persistence.created_messages[0]["image_mime_type"] is None
+
+
+def test_store_enqueues_chat_sync_after_user_message_is_durable():
+    persistence = FakePersistence()
+    sync_producer = FakeChatSyncProducer()
+    store = ConsoleChatStore(
+        persistence=persistence,
+        sync_v2_chat_producer=sync_producer,
+        sync_v2_server_profile_id="server-a",
+        sync_v2_authenticated_principal_id="user-a",
+    )
+    session = store.ensure_session(title="Chat 1")
+
+    message = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content="hello",
+        persist=True,
+    )
+
+    assert message.persisted_message_id == "msg-1"
+    assert sync_producer.enqueued == [
+        {
+            "server_profile_id": "server-a",
+            "authenticated_principal_id": "user-a",
+            "workspace_scope": None,
+            "conversation_id": "conv-1",
+            "message_id": "msg-1",
+            "role": "user",
+            "content": "hello",
+            "parent_message_id": None,
+            "sequence": 1,
+            "variant_turn_id": None,
+            "variant_index": None,
+            "variant_count": None,
+            "selected_variant_id": None,
+            "base_version": None,
+            "entity_version": None,
+        }
+    ]
+
+
+def test_store_enqueues_streaming_assistant_only_after_completion():
+    persistence = FakePersistence()
+    sync_producer = FakeChatSyncProducer()
+    store = ConsoleChatStore(
+        persistence=persistence,
+        sync_v2_chat_producer=sync_producer,
+        sync_v2_server_profile_id="server-a",
+    )
+    session = store.ensure_session(title="Chat 1")
+    store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content="hello?",
+        persist=True,
+    )
+    sync_producer.enqueued.clear()
+    assistant = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="",
+        persist=True,
+    )
+
+    store.append_stream_chunk(assistant.id, "hel")
+    store.append_stream_chunk(assistant.id, "lo")
+
+    assert sync_producer.enqueued == []
+
+    completed = store.mark_message_complete(assistant.id)
+
+    assert completed.persisted_message_id == "msg-2"
+    assert sync_producer.enqueued[-1]["message_id"] == "msg-2"
+    assert sync_producer.enqueued[-1]["role"] == "assistant"
+    assert sync_producer.enqueued[-1]["content"] == "hello"
+    assert sync_producer.enqueued[-1]["parent_message_id"] == "msg-1"
+    assert sync_producer.enqueued[-1]["sequence"] == 2
+
+
+def test_store_does_not_enqueue_failed_assistant_final_content():
+    persistence = FakePersistence()
+    sync_producer = FakeChatSyncProducer()
+    store = ConsoleChatStore(
+        persistence=persistence,
+        sync_v2_chat_producer=sync_producer,
+        sync_v2_server_profile_id="server-a",
+    )
+    session = store.ensure_session(title="Chat 1")
+    assistant = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="",
+        persist=True,
+    )
+
+    store.append_stream_chunk(assistant.id, "partial")
+    store.mark_message_failed(assistant.id)
+
+    assert sync_producer.enqueued == []
+
+
+def test_store_persists_chat_when_sync_enqueue_fails():
+    persistence = FakePersistence()
+    store = ConsoleChatStore(
+        persistence=persistence,
+        sync_v2_chat_producer=FailingChatSyncProducer(),
+        sync_v2_server_profile_id="server-a",
+    )
+    session = store.ensure_session(title="Chat 1")
+
+    message = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content="hello",
+        persist=True,
+    )
+
+    assert message.persisted_message_id == "msg-1"
+    assert persistence.created_messages[0]["content"] == "hello"
+
+
+def test_store_enqueues_selected_variant_with_restore_metadata():
+    persistence = FakePersistence()
+    sync_producer = FakeChatSyncProducer()
+    store = ConsoleChatStore(
+        persistence=persistence,
+        sync_v2_chat_producer=sync_producer,
+        sync_v2_server_profile_id="server-a",
+    )
+    session = store.ensure_session(title="Chat 1")
+    message = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="first",
+        persist=True,
+    )
+    sync_producer.enqueued.clear()
+
+    updated = store.add_variant(message.id, "second")
+
+    assert updated.variants is not None
+    assert sync_producer.enqueued[-1]["message_id"] == "msg-1"
+    assert sync_producer.enqueued[-1]["content"] == "second"
+    assert sync_producer.enqueued[-1]["base_version"] == "hash:assistant:first"
+    assert sync_producer.enqueued[-1]["sequence"] == 1
+    assert sync_producer.enqueued[-1]["variant_turn_id"] == updated.variants.turn_id
+    assert sync_producer.enqueued[-1]["variant_index"] == 1
+    assert sync_producer.enqueued[-1]["variant_count"] == 2
+    assert sync_producer.enqueued[-1]["selected_variant_id"] == updated.variants.current.id
+
+
+def test_store_sequences_only_sync_eligible_messages():
+    persistence = FakePersistence()
+    sync_producer = FakeChatSyncProducer()
+    store = ConsoleChatStore(
+        persistence=persistence,
+        sync_v2_chat_producer=sync_producer,
+        sync_v2_server_profile_id="server-a",
+    )
+    session = store.ensure_session(title="Chat 1")
+    store.append_message(
+        session.id,
+        role=ConsoleMessageRole.SYSTEM,
+        content="visible only",
+        persist=False,
+    )
+    failed = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="",
+        persist=True,
+    )
+    store.append_stream_chunk(failed.id, "partial")
+    store.mark_message_failed(failed.id)
+
+    first_synced = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content="hello",
+        persist=True,
+    )
+    second_synced = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content="again",
+        persist=True,
+    )
+
+    assert first_synced.persisted_message_id == "msg-2"
+    assert second_synced.persisted_message_id == "msg-3"
+    assert [entry["sequence"] for entry in sync_producer.enqueued] == [1, 2]
 
 
 def test_store_updates_persisted_streaming_assistant_content_and_status():

--- a/Tests/Notes/test_notes_scope_service.py
+++ b/Tests/Notes/test_notes_scope_service.py
@@ -153,6 +153,28 @@ class FakeLocalNotes:
         return {"deleted": len(self.manual_links) != before, "edge_id": edge_id}
 
 
+class FakeNotesSyncV2Producer:
+    def __init__(self):
+        self.upserts = []
+        self.deletes = []
+
+    def enqueue_note_upsert(self, **kwargs):
+        self.upserts.append(kwargs)
+        return {"status": "enqueued"}
+
+    def enqueue_note_delete(self, **kwargs):
+        self.deletes.append(kwargs)
+        return {"status": "enqueued"}
+
+
+class FailingNotesSyncV2Producer:
+    def enqueue_note_upsert(self, **kwargs):
+        raise RuntimeError("outbox unavailable")
+
+    def enqueue_note_delete(self, **kwargs):
+        raise RuntimeError("outbox unavailable")
+
+
 class FakeServerNotes:
     def __init__(self):
         self.saved_ids = []
@@ -512,6 +534,270 @@ async def test_scope_service_routes_local_note_save_to_local_service():
             "expected_version": 3,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_scope_service_enqueues_local_note_upsert_after_successful_save():
+    local = FakeLocalNotes()
+    producer = FakeNotesSyncV2Producer()
+    scope_service = NotesScopeService(
+        local_notes_service=local,
+        server_service=FakeServerNotes(),
+        sync_v2_notes_producer=producer,
+    )
+
+    result = await scope_service.save_note(
+        scope=ScopeType.LOCAL_NOTE,
+        user_id="user-1",
+        note_id="local-1",
+        title="Local",
+        content="Body",
+        version=3,
+        sync_v2_profile={
+            "server_profile_id": "server-a",
+            "authenticated_principal_id": "user-a",
+            "workspace_scope": None,
+        },
+    )
+
+    assert result is True
+    assert producer.upserts == [
+        {
+            "server_profile_id": "server-a",
+            "authenticated_principal_id": "user-a",
+            "workspace_scope": None,
+            "note_id": "local-1",
+            "title": "Local",
+            "content": "Body",
+            "status": "active",
+            "tag_ids": None,
+            "base_version": 3,
+            "entity_version": 4,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_scope_service_does_not_enqueue_local_note_upsert_after_failed_save():
+    class FailingLocalNotes(FakeLocalNotes):
+        def update_note(self, user_id, note_id, update_data, expected_version):
+            super().update_note(user_id, note_id, update_data, expected_version)
+            return False
+
+    producer = FakeNotesSyncV2Producer()
+    scope_service = NotesScopeService(
+        local_notes_service=FailingLocalNotes(),
+        server_service=FakeServerNotes(),
+        sync_v2_notes_producer=producer,
+    )
+
+    result = await scope_service.save_note(
+        scope=ScopeType.LOCAL_NOTE,
+        user_id="user-1",
+        note_id="local-1",
+        title="Local",
+        content="Body",
+        version=3,
+        sync_v2_profile={
+            "server_profile_id": "server-a",
+            "authenticated_principal_id": "user-a",
+            "workspace_scope": None,
+        },
+    )
+
+    assert result is False
+    assert producer.upserts == []
+
+
+@pytest.mark.asyncio
+async def test_scope_service_local_save_survives_sync_v2_enqueue_failure():
+    scope_service = NotesScopeService(
+        local_notes_service=FakeLocalNotes(),
+        server_service=FakeServerNotes(),
+        sync_v2_notes_producer=FailingNotesSyncV2Producer(),
+    )
+
+    result = await scope_service.save_note(
+        scope=ScopeType.LOCAL_NOTE,
+        user_id="user-1",
+        note_id="local-1",
+        title="Local",
+        content="Body",
+        version=3,
+        sync_v2_profile={
+            "server_profile_id": "server-a",
+            "authenticated_principal_id": "user-a",
+            "workspace_scope": None,
+        },
+    )
+
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_scope_service_does_not_enqueue_local_note_upsert_after_failed_create():
+    class FailingCreateLocalNotes(FakeLocalNotes):
+        def add_note(self, user_id, title, content, note_id=None):
+            super().add_note(user_id, title, content, note_id=note_id)
+            return None
+
+    producer = FakeNotesSyncV2Producer()
+    scope_service = NotesScopeService(
+        local_notes_service=FailingCreateLocalNotes(),
+        server_service=FakeServerNotes(),
+        sync_v2_notes_producer=producer,
+    )
+
+    result = await scope_service.save_note(
+        scope=ScopeType.LOCAL_NOTE,
+        user_id="user-1",
+        title="Local",
+        content="Body",
+        sync_v2_profile={
+            "server_profile_id": "server-a",
+            "authenticated_principal_id": "user-a",
+            "workspace_scope": None,
+        },
+    )
+
+    assert result is None
+    assert producer.upserts == []
+
+
+@pytest.mark.asyncio
+async def test_scope_service_passes_keywords_to_sync_v2_note_upsert():
+    producer = FakeNotesSyncV2Producer()
+    scope_service = NotesScopeService(
+        local_notes_service=FakeLocalNotes(),
+        server_service=FakeServerNotes(),
+        sync_v2_notes_producer=producer,
+    )
+
+    result = await scope_service.save_note(
+        scope=ScopeType.LOCAL_NOTE,
+        user_id="user-1",
+        note_id="local-1",
+        title="Local",
+        content="Body",
+        version=3,
+        keywords=["project", "draft"],
+        sync_v2_profile={
+            "server_profile_id": "server-a",
+            "authenticated_principal_id": "user-a",
+            "workspace_scope": None,
+        },
+    )
+
+    assert result["keywords"] == ["project", "draft"]
+    assert producer.upserts[0]["tag_ids"] == ["project", "draft"]
+
+
+@pytest.mark.asyncio
+async def test_scope_service_ignores_incomplete_sync_v2_profile_after_local_save():
+    producer = FakeNotesSyncV2Producer()
+    scope_service = NotesScopeService(
+        local_notes_service=FakeLocalNotes(),
+        server_service=FakeServerNotes(),
+        sync_v2_notes_producer=producer,
+    )
+
+    result = await scope_service.save_note(
+        scope=ScopeType.LOCAL_NOTE,
+        user_id="user-1",
+        note_id="local-1",
+        title="Local",
+        content="Body",
+        version=3,
+        sync_v2_profile={"authenticated_principal_id": "user-a"},
+    )
+
+    assert result is True
+    assert producer.upserts == []
+
+
+@pytest.mark.asyncio
+async def test_scope_service_ignores_invalid_sync_v2_profile_after_local_save():
+    producer = FakeNotesSyncV2Producer()
+    scope_service = NotesScopeService(
+        local_notes_service=FakeLocalNotes(),
+        server_service=FakeServerNotes(),
+        sync_v2_notes_producer=producer,
+    )
+
+    result = await scope_service.save_note(
+        scope=ScopeType.LOCAL_NOTE,
+        user_id="user-1",
+        note_id="local-1",
+        title="Local",
+        content="Body",
+        version=3,
+        sync_v2_profile={
+            "server_profile_id": "server-a\x00",
+            "authenticated_principal_id": "user-a",
+            "workspace_scope": None,
+        },
+    )
+
+    assert result is True
+    assert producer.upserts == []
+
+
+@pytest.mark.asyncio
+async def test_scope_service_enqueues_local_note_delete_after_successful_delete():
+    local = FakeLocalNotes()
+    producer = FakeNotesSyncV2Producer()
+    scope_service = NotesScopeService(
+        local_notes_service=local,
+        server_service=FakeServerNotes(),
+        sync_v2_notes_producer=producer,
+    )
+
+    result = await scope_service.delete_note(
+        scope=ScopeType.LOCAL_NOTE,
+        user_id="user-1",
+        note_id="local-1",
+        version=3,
+        sync_v2_profile={
+            "server_profile_id": "server-a",
+            "authenticated_principal_id": "user-a",
+            "workspace_scope": None,
+        },
+    )
+
+    assert result is True
+    assert producer.deletes == [
+        {
+            "server_profile_id": "server-a",
+            "authenticated_principal_id": "user-a",
+            "workspace_scope": None,
+            "note_id": "local-1",
+            "base_version": 3,
+            "entity_version": 4,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_scope_service_local_delete_survives_sync_v2_enqueue_failure():
+    scope_service = NotesScopeService(
+        local_notes_service=FakeLocalNotes(),
+        server_service=FakeServerNotes(),
+        sync_v2_notes_producer=FailingNotesSyncV2Producer(),
+    )
+
+    result = await scope_service.delete_note(
+        scope=ScopeType.LOCAL_NOTE,
+        user_id="user-1",
+        note_id="local-1",
+        version=3,
+        sync_v2_profile={
+            "server_profile_id": "server-a",
+            "authenticated_principal_id": "user-a",
+            "workspace_scope": None,
+        },
+    )
+
+    assert result is True
 
 
 @pytest.mark.asyncio

--- a/Tests/Sync_Interop/test_chat_outbox_producer.py
+++ b/Tests/Sync_Interop/test_chat_outbox_producer.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import json
+
+from tldw_chatbook.Sync_Interop.chat_outbox_producer import ChatSyncV2OutboxProducer
+from tldw_chatbook.Sync_Interop.crypto import decrypt_sync_payload, generate_dataset_key
+from tldw_chatbook.Sync_Interop.sync_state_repository import SyncStateRepository
+
+
+def test_chat_producer_enqueues_encrypted_message_and_updates_summary(tmp_path) -> None:
+    dataset_key = generate_dataset_key()
+    repo = _local_first_repo(tmp_path)
+    producer = ChatSyncV2OutboxProducer(
+        state_repository=repo,
+        dataset_keys={"dataset-1": dataset_key},
+    )
+
+    result = producer.enqueue_chat_message(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope=None,
+        conversation_id="conversation-1",
+        message_id="message-2",
+        role="assistant",
+        content="Private answer",
+        parent_message_id="message-1",
+        sequence=2,
+        variant_turn_id="turn-1",
+        variant_index=1,
+        variant_count=2,
+        selected_variant_id="variant-2",
+        entity_version=3,
+    )
+
+    entries = repo.list_pending_sync_v2_outbox_envelopes(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope=None,
+        dataset_id="dataset-1",
+    )
+    summary = repo.get_sync_v2_profile_summary(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope=None,
+    )
+    envelope = entries[0]["envelope"]
+
+    assert result["status"] == "enqueued"
+    assert len(entries) == 1
+    assert entries[0]["domain"] == "chat"
+    assert summary["outbox"]["pending"] == 1
+    assert summary["outbox"]["by_domain"]["chat"]["pending"] == 1
+    serialized = json.dumps(envelope)
+    assert "Private answer" not in serialized
+    assert envelope["stable_key"] == "conversation-1:message-2"
+    assert envelope["routing_metadata"] == {
+        "conversation_id": "conversation-1",
+        "entity_kind": "message",
+        "parent_message_id": "message-1",
+        "selected_variant_id": "variant-2",
+        "sequence": 2,
+        "variant_count": 2,
+        "variant_index": 1,
+        "variant_turn_id": "turn-1",
+    }
+    assert _decrypt_payload(envelope["payload_ciphertext"], dataset_key) == {
+        "content": "Private answer",
+        "role": "assistant",
+    }
+
+    producer.enqueue_chat_message(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope=None,
+        conversation_id="conversation-1",
+        message_id="message-2",
+        role="assistant",
+        content="Private answer",
+        parent_message_id="message-1",
+        sequence=2,
+        variant_turn_id="turn-1",
+        variant_index=1,
+        variant_count=2,
+        selected_variant_id="variant-2",
+        entity_version=3,
+    )
+    assert len(
+        repo.list_pending_sync_v2_outbox_envelopes(
+            server_profile_id="server-a",
+            authenticated_principal_id="user-a",
+            workspace_scope=None,
+            dataset_id="dataset-1",
+        )
+    ) == 1
+
+
+def test_chat_producer_skips_without_local_first_profile_or_dataset_key(tmp_path) -> None:
+    repo = SyncStateRepository(tmp_path / "sync_state.db")
+    repo.set_sync_v2_profile_state(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope=None,
+        profile_mode="server_frontend",
+        device_id="device-1",
+        dataset_id="dataset-1",
+    )
+    producer = ChatSyncV2OutboxProducer(state_repository=repo, dataset_keys={})
+
+    result = producer.enqueue_chat_message(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope=None,
+        conversation_id="conversation-1",
+        message_id="message-1",
+        role="user",
+        content="No sync",
+    )
+
+    assert result == {"status": "skipped", "reason": "profile_not_local_first"}
+    assert repo.list_sync_v2_outbox_entries(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope=None,
+        dataset_id="dataset-1",
+    ) == []
+
+
+def _local_first_repo(tmp_path) -> SyncStateRepository:
+    repo = SyncStateRepository(tmp_path / "sync_state.db")
+    repo.set_sync_v2_profile_state(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope=None,
+        profile_mode="local_first",
+        device_id="device-1",
+        dataset_id="dataset-1",
+    )
+    return repo
+
+
+def _decrypt_payload(payload_ciphertext: str, dataset_key: bytes) -> dict:
+    return decrypt_sync_payload(json.loads(payload_ciphertext), key=dataset_key)

--- a/Tests/Sync_Interop/test_envelope_applier.py
+++ b/Tests/Sync_Interop/test_envelope_applier.py
@@ -109,6 +109,38 @@ def test_chat_applier_appends_by_stable_id_and_conflicts_on_hash_mismatch() -> N
     assert store.conflicts[-1]["domain"] == "chat"
 
 
+def test_chat_applier_allows_versioned_message_update() -> None:
+    dataset_key = generate_dataset_key()
+    builder = SyncEnvelopeBuilder(dataset_id="dataset-1", device_id="device-1", dataset_key=dataset_key)
+    store = RecordingLocalStore()
+    applier = SyncEnvelopeApplier(dataset_key=dataset_key, local_store=store)
+
+    original = builder.build_chat_message(
+        conversation_id="conversation-1",
+        message_id="message-1",
+        role="assistant",
+        content="first",
+    )
+    updated = builder.build_chat_message(
+        conversation_id="conversation-1",
+        message_id="message-1",
+        role="assistant",
+        content="second",
+        base_version=original.payload_hash,
+    )
+
+    first = applier.apply(original)
+    second = applier.apply(updated)
+
+    assert first["status"] == "applied"
+    assert second["status"] == "applied"
+    assert store.chat_messages["conversation-1:message-1"] == {
+        "content": "second",
+        "role": "assistant",
+    }
+    assert store.conflicts == []
+
+
 def test_workspace_and_source_cache_appliers_route_to_local_store() -> None:
     dataset_key = generate_dataset_key()
     builder = SyncEnvelopeBuilder(dataset_id="dataset-1", device_id="device-1", dataset_key=dataset_key)

--- a/Tests/Sync_Interop/test_envelope_builder.py
+++ b/Tests/Sync_Interop/test_envelope_builder.py
@@ -52,6 +52,45 @@ def test_chat_message_uses_stable_message_identity() -> None:
     }
 
 
+def test_chat_message_preserves_restore_metadata_without_plaintext_leak() -> None:
+    dataset_key = generate_dataset_key()
+    builder = SyncEnvelopeBuilder(dataset_id="dataset-1", device_id="device-1", dataset_key=dataset_key)
+
+    envelope = builder.build_chat_message(
+        conversation_id="conversation-1",
+        message_id="message-2",
+        role="assistant",
+        content="private regenerated answer",
+        parent_message_id="message-1",
+        sequence=2,
+        variant_turn_id="turn-1",
+        variant_index=1,
+        variant_count=2,
+        selected_variant_id="variant-2",
+        base_version="v1",
+        entity_version="v2",
+    )
+
+    serialized = envelope.model_dump_json()
+    assert "private regenerated answer" not in serialized
+    assert envelope.base_version == "v1"
+    assert envelope.entity_version == "v2"
+    assert envelope.routing_metadata == {
+        "conversation_id": "conversation-1",
+        "entity_kind": "message",
+        "parent_message_id": "message-1",
+        "selected_variant_id": "variant-2",
+        "sequence": 2,
+        "variant_count": 2,
+        "variant_index": 1,
+        "variant_turn_id": "turn-1",
+    }
+    assert decrypt_sync_payload_json(envelope.payload_ciphertext, dataset_key) == {
+        "content": "private regenerated answer",
+        "role": "assistant",
+    }
+
+
 def test_workspace_source_ref_add_remove_maps_to_link_unlink() -> None:
     builder = SyncEnvelopeBuilder(
         dataset_id="dataset-1",

--- a/Tests/Sync_Interop/test_notes_outbox_producer.py
+++ b/Tests/Sync_Interop/test_notes_outbox_producer.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import json
+
+from tldw_chatbook.Sync_Interop.crypto import decrypt_sync_payload, generate_dataset_key
+from tldw_chatbook.Sync_Interop.notes_outbox_producer import NotesSyncV2OutboxProducer
+from tldw_chatbook.Sync_Interop.sync_state_repository import SyncStateRepository
+
+
+def test_notes_producer_enqueues_encrypted_note_upsert_and_updates_summary(tmp_path) -> None:
+    dataset_key = generate_dataset_key()
+    repo = _local_first_repo(tmp_path, dataset_key=dataset_key)
+    producer = NotesSyncV2OutboxProducer(
+        state_repository=repo,
+        dataset_keys={"dataset-1": dataset_key},
+    )
+
+    result = producer.enqueue_note_upsert(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope=None,
+        note_id="note-1",
+        title="Private title",
+        content="Private body",
+        status="active",
+        entity_version=1,
+    )
+
+    entries = repo.list_pending_sync_v2_outbox_envelopes(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope=None,
+        dataset_id="dataset-1",
+    )
+    summary = repo.get_sync_v2_profile_summary(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope=None,
+    )
+    envelope = entries[0]["envelope"]
+
+    assert result["status"] == "enqueued"
+    assert len(entries) == 1
+    assert entries[0]["domain"] == "notes"
+    assert summary["outbox"]["pending"] == 1
+    assert summary["outbox"]["by_domain"]["notes"]["pending"] == 1
+    serialized = json.dumps(entries[0]["envelope"])
+    assert "Private title" not in serialized
+    assert "Private body" not in serialized
+    assert envelope["payload_clear"] == {"status": "active"}
+    assert envelope["routing_metadata"] == {"entity_kind": "note"}
+    assert _decrypt_payload(envelope["payload_ciphertext"], dataset_key) == {
+        "body": "Private body",
+        "title": "Private title",
+    }
+
+    producer.enqueue_note_upsert(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope=None,
+        note_id="note-1",
+        title="Private title",
+        content="Private body",
+        status="active",
+        entity_version=1,
+    )
+    assert len(
+        repo.list_pending_sync_v2_outbox_envelopes(
+            server_profile_id="server-a",
+            authenticated_principal_id="user-a",
+            workspace_scope=None,
+            dataset_id="dataset-1",
+        )
+    ) == 1
+
+
+def test_notes_producer_enqueues_delete_without_plaintext_payload(tmp_path) -> None:
+    dataset_key = generate_dataset_key()
+    repo = _local_first_repo(tmp_path, dataset_key=dataset_key)
+    producer = NotesSyncV2OutboxProducer(
+        state_repository=repo,
+        dataset_keys={"dataset-1": dataset_key},
+    )
+
+    result = producer.enqueue_note_delete(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope=None,
+        note_id="note-1",
+        base_version=3,
+        entity_version=4,
+    )
+
+    entries = repo.list_pending_sync_v2_outbox_envelopes(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope=None,
+        dataset_id="dataset-1",
+    )
+    envelope = entries[0]["envelope"]
+
+    assert result["status"] == "enqueued"
+    assert envelope["operation"] == "delete"
+    assert envelope["payload_ciphertext"] is None
+    assert envelope["payload_clear"] == {"deleted": True}
+    assert envelope["base_version"] == 3
+    assert envelope["entity_version"] == 4
+
+
+def test_notes_producer_skips_without_local_first_profile_or_dataset_key(tmp_path) -> None:
+    repo = SyncStateRepository(tmp_path / "sync_state.db")
+    repo.set_sync_v2_profile_state(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope=None,
+        profile_mode="server_frontend",
+        device_id="device-1",
+        dataset_id="dataset-1",
+    )
+    producer = NotesSyncV2OutboxProducer(state_repository=repo, dataset_keys={})
+
+    result = producer.enqueue_note_upsert(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope=None,
+        note_id="note-1",
+        title="Local only",
+        content="No sync",
+    )
+
+    assert result == {"status": "skipped", "reason": "profile_not_local_first"}
+    assert repo.list_sync_v2_outbox_entries(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope=None,
+        dataset_id="dataset-1",
+    ) == []
+
+
+def _local_first_repo(tmp_path, *, dataset_key: bytes) -> SyncStateRepository:
+    del dataset_key
+    repo = SyncStateRepository(tmp_path / "sync_state.db")
+    repo.set_sync_v2_profile_state(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope=None,
+        profile_mode="local_first",
+        device_id="device-1",
+        dataset_id="dataset-1",
+    )
+    return repo
+
+
+def _decrypt_payload(payload_ciphertext: str, dataset_key: bytes) -> dict:
+    return decrypt_sync_payload(json.loads(payload_ciphertext), key=dataset_key)

--- a/backlog/tasks/task-70 - Plan-Chatbook-Sync-v2-completion-roadmap.md
+++ b/backlog/tasks/task-70 - Plan-Chatbook-Sync-v2-completion-roadmap.md
@@ -1,0 +1,71 @@
+---
+id: TASK-70
+title: Plan Chatbook Sync v2 completion roadmap
+status: Done
+labels:
+- sync
+- sync-v2
+- planning
+- local-first
+- roadmap
+priority: high
+documentation:
+- backlog/tasks/task-59.1 - Add-Chatbook-Sync-v2-profile-summary.md
+- backlog/tasks/task-69 - Surface-Chatbook-Sync-v2-profile-status.md
+- backlog/tasks/task-60.4.2 - Post-release-write-sync-promotion-tranche.md
+- Docs/superpowers/specs/2026-05-20-workspace-operating-context-handoff-prd-design.md
+- Docs/superpowers/plans/2026-05-22-post-release-deferred-feature-tranches.md
+- Docs/superpowers/specs/2026-05-26-chatbook-sync-v2-completion-roadmap-design.md
+modified_files:
+- backlog/tasks/task-70 - Plan-Chatbook-Sync-v2-completion-roadmap.md
+- backlog/tasks/task-70.1 - Add-Notes-Sync-v2-outbox-producer-plan.md
+- backlog/tasks/task-70.2 - Add-Chat-Sync-v2-outbox-producer-plan.md
+- backlog/tasks/task-70.3 - Add-manual-Sync-v2-preview-and-execution-plan.md
+- backlog/tasks/task-70.4 - Add-Sync-v2-conflict-review-and-recovery-plan.md
+- backlog/tasks/task-70.5 - Add-Sync-v2-Notes-and-Chat-restore-QA-plan.md
+- backlog/tasks/task-70.6 - Close-out-manual-Sync-v2-milestone-with-actual-use-QA.md
+- Docs/superpowers/specs/2026-05-26-chatbook-sync-v2-completion-roadmap-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Design and track the complete Chatbook Sync v2 roadmap through polished multi-device sync: content-producing outbox paths, manual sync execution, restore/new-device flows, conflict review, user-private encryption/key recovery, scheduled/background sync, workspace-scoped datasets, and major-domain coverage. The first implementation milestone is manual reliable sync for the active server profile's personal dataset, covering both Notes and Chat messages before workspace-scoped datasets or background automation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Define the first content-producing Sync v2 scope and explicitly exclude background automation until manual sync is safe.
+- [x] #2 Design the client-side boundaries for Notes outbox production, manual sync execution, conflict/status reporting, and restore compatibility.
+- [x] #3 Break the effort into Backlog child tasks suitable for separate PRs after the spec is approved.
+- [x] #4 Record design decisions, verification strategy, risks, and open questions in a committed spec document.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Re-read the current Sync v2 display-only baseline and workspace handoff PRD.
+2. Draft a roadmap spec that identifies the first manual Notes+Chat milestone, exclusions, phases, risks, and verification gates.
+3. Create child Backlog tasks for PR-sized implementation slices.
+4. Run focused documentation/backlog verification and diff hygiene.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Created the Chatbook Sync v2 completion roadmap spec and split the next work into child tasks for Notes outbox production, Chat outbox production, manual sync execution, conflict recovery, restore QA, and manual milestone closeout. The plan keeps write sync manual and active-profile/personal-dataset-only until Notes and Chat content-producing paths are verified with restore and actual-use QA evidence.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+`TASK-70` now records the Sync v2 completion path from the current read-only/dry-run baseline to reliable manual Notes+Chat sync, with background/workspace/broader-domain sync intentionally deferred behind QA gates.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Roadmap spec committed
+- [x] #3 Child tasks created
+- [x] #4 Verification recorded
+<!-- DOD:END -->

--- a/backlog/tasks/task-70.1 - Add-Notes-Sync-v2-outbox-producer-plan.md
+++ b/backlog/tasks/task-70.1 - Add-Notes-Sync-v2-outbox-producer-plan.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-70.1
 title: Add Notes Sync v2 outbox producer plan
-status: To Do
+status: Done
 labels:
 - sync
 - sync-v2
@@ -11,6 +11,13 @@ priority: high
 parent_task_id: TASK-70
 documentation:
 - Docs/superpowers/specs/2026-05-26-chatbook-sync-v2-completion-roadmap-design.md
+modified_files:
+- tldw_chatbook/Sync_Interop/notes_outbox_producer.py
+- tldw_chatbook/Sync_Interop/envelope_builder.py
+- tldw_chatbook/Sync_Interop/__init__.py
+- tldw_chatbook/Notes/notes_scope_service.py
+- Tests/Sync_Interop/test_notes_outbox_producer.py
+- Tests/Notes/test_notes_scope_service.py
 ---
 
 ## Description
@@ -21,24 +28,55 @@ Implement the first content-producing Sync v2 path for Notes so local note creat
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Notes create, update, and delete operations enqueue Sync v2 outbox envelopes for the active server profile personal dataset.
-- [ ] #2 Local Notes operations remain successful and recoverable when the server is unavailable.
-- [ ] #3 Tests cover envelope identity, domain scope, idempotency, encryption boundary, and pending profile summary counts.
-- [ ] #4 No background sync, automatic push, or broad domain sync is introduced.
+- [x] #1 Notes create, update, and delete operations enqueue Sync v2 outbox envelopes for the active server profile personal dataset.
+- [x] #2 Local Notes operations remain successful and recoverable when the server is unavailable.
+- [x] #3 Tests cover envelope identity, domain scope, idempotency, encryption boundary, and pending profile summary counts.
+- [x] #4 No background sync, automatic push, or broad domain sync is introduced.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing tests for a pure Notes Sync v2 outbox producer and NotesScopeService post-success enqueue hooks.
+2. Add a note delete envelope builder while preserving existing encrypted note upsert behavior.
+3. Implement a small NotesSyncV2OutboxProducer that reads the configured local-first profile, requires a dataset key, builds Notes envelopes, and persists them to the durable outbox.
+4. Wire local Notes create/update/delete paths to the producer only when an explicit Sync v2 profile context and producer are injected.
+5. Run focused Sync/Notes verification and diff hygiene.
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Added `NotesSyncV2OutboxProducer` as the first content-producing Notes Sync v2 boundary. The producer reads the active local-first profile from `SyncStateRepository`, requires device/dataset identity and an in-memory dataset key, encrypts note title/body upserts, builds clear delete tombstone envelopes, and persists them through the existing durable outbox API. Non-local-first, unconfigured, or missing-key profiles return explicit skipped states and do not dispatch remote sync.
+
+Extended `SyncEnvelopeBuilder` with `build_note_delete()` and wired `NotesScopeService` local save/delete paths to call an injected producer only after successful local mutations. The hook is opt-in, preserves existing local note behavior by default, and does not add background sync, automatic push/pull, or broad domain sync.
+
+PR review follow-up isolated best-effort enqueue failures from primary local note operations, validated Sync v2 profile scope strings through centralized text validation/sanitization utilities, propagated note keywords to outbox `tag_ids`, and expanded public producer docstrings to Google-style `Args`/`Returns` coverage.
+
+Verification:
+- Red tests failed on the missing producer module and missing `NotesScopeService` producer injection.
+- `../../.venv/bin/python -m pytest -q Tests/Sync_Interop/test_notes_outbox_producer.py Tests/Notes/test_notes_scope_service.py::test_scope_service_enqueues_local_note_upsert_after_successful_save Tests/Notes/test_notes_scope_service.py::test_scope_service_does_not_enqueue_local_note_upsert_after_failed_save Tests/Notes/test_notes_scope_service.py::test_scope_service_does_not_enqueue_local_note_upsert_after_failed_create Tests/Notes/test_notes_scope_service.py::test_scope_service_ignores_incomplete_sync_v2_profile_after_local_save Tests/Notes/test_notes_scope_service.py::test_scope_service_enqueues_local_note_delete_after_successful_delete --tb=short` passed with 8 tests.
+- `../../.venv/bin/python -m pytest -q Tests/Sync_Interop/test_notes_outbox_producer.py Tests/Sync_Interop/test_envelope_builder.py Tests/Sync_Interop/test_sync_state_repository.py Tests/Notes/test_notes_scope_service.py --tb=short` passed with 56 tests.
+- `../../.venv/bin/python -m pytest -q Tests/Sync_Interop/test_local_first_sync_service.py Tests/Sync_Interop/test_restore_service.py --tb=short` passed with 42 tests.
+- `../../.venv/bin/python -m pytest -q Tests/UI/test_product_maturity_phase1_harness.py::test_backlog_task_frontmatter_ids_are_unique --tb=short` passed with 1 test.
+- `../../.venv/bin/python -m compileall tldw_chatbook/Sync_Interop/notes_outbox_producer.py tldw_chatbook/Sync_Interop/envelope_builder.py tldw_chatbook/Notes/notes_scope_service.py` passed.
+- `../../.venv/bin/python -m pytest -q Tests/Notes/test_notes_scope_service.py::test_scope_service_local_save_survives_sync_v2_enqueue_failure Tests/Notes/test_notes_scope_service.py::test_scope_service_passes_keywords_to_sync_v2_note_upsert Tests/Notes/test_notes_scope_service.py::test_scope_service_ignores_invalid_sync_v2_profile_after_local_save Tests/Notes/test_notes_scope_service.py::test_scope_service_local_delete_survives_sync_v2_enqueue_failure --tb=short` passed with 4 tests.
+- `../../.venv/bin/python -m pytest -q Tests/Sync_Interop/test_notes_outbox_producer.py Tests/Notes/test_notes_scope_service.py --tb=short` passed with 33 tests.
+- `git diff --check` passed.
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+`TASK-70.1` adds the first Notes content-producing Sync v2 path. Local Notes create/update/delete can now produce durable pending outbox envelopes when an active local-first profile and dataset key are explicitly provided, while all remote dispatch and background sync remain out of scope.
 
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests and verification recorded
+- [x] #3 Documentation updated in task record
+- [x] #4 No background sync or automatic dispatch added
 <!-- DOD:END -->

--- a/backlog/tasks/task-70.1 - Add-Notes-Sync-v2-outbox-producer-plan.md
+++ b/backlog/tasks/task-70.1 - Add-Notes-Sync-v2-outbox-producer-plan.md
@@ -1,0 +1,44 @@
+---
+id: TASK-70.1
+title: Add Notes Sync v2 outbox producer plan
+status: To Do
+labels:
+- sync
+- sync-v2
+- notes
+- local-first
+priority: high
+parent_task_id: TASK-70
+documentation:
+- Docs/superpowers/specs/2026-05-26-chatbook-sync-v2-completion-roadmap-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the first content-producing Sync v2 path for Notes so local note create, update, and delete operations can enqueue durable encrypted outbox envelopes for manual sync without requiring server availability.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Notes create, update, and delete operations enqueue Sync v2 outbox envelopes for the active server profile personal dataset.
+- [ ] #2 Local Notes operations remain successful and recoverable when the server is unavailable.
+- [ ] #3 Tests cover envelope identity, domain scope, idempotency, encryption boundary, and pending profile summary counts.
+- [ ] #4 No background sync, automatic push, or broad domain sync is introduced.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/backlog/tasks/task-70.2 - Add-Chat-Sync-v2-outbox-producer-plan.md
+++ b/backlog/tasks/task-70.2 - Add-Chat-Sync-v2-outbox-producer-plan.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-70.2
 title: Add Chat Sync v2 outbox producer plan
-status: To Do
+status: Done
 labels:
 - sync
 - sync-v2
@@ -11,6 +11,16 @@ priority: high
 parent_task_id: TASK-70
 documentation:
 - Docs/superpowers/specs/2026-05-26-chatbook-sync-v2-completion-roadmap-design.md
+modified_files:
+- tldw_chatbook/Sync_Interop/chat_outbox_producer.py
+- tldw_chatbook/Sync_Interop/envelope_builder.py
+- tldw_chatbook/Sync_Interop/domain_adapters/chat.py
+- tldw_chatbook/Sync_Interop/__init__.py
+- tldw_chatbook/Chat/console_chat_store.py
+- Tests/Sync_Interop/test_chat_outbox_producer.py
+- Tests/Sync_Interop/test_envelope_builder.py
+- Tests/Sync_Interop/test_envelope_applier.py
+- Tests/Chat/test_console_chat_store.py
 ---
 
 ## Description
@@ -21,24 +31,62 @@ Implement the Chat Sync v2 content-producing path so conversation and message ch
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 User and assistant Chat messages enqueue ordered Sync v2 envelopes only after they represent durable local message state.
-- [ ] #2 Conversation identity, message roles, parentage, ordering, and message variants have restore-compatible metadata.
-- [ ] #3 Streaming, failed-send, and regenerated-message cases do not produce misleading final-message envelopes.
-- [ ] #4 Tests cover local-first success, envelope shape, ordering, variants, and pending profile summary counts.
+- [x] #1 User and assistant Chat messages enqueue ordered Sync v2 envelopes only after they represent durable local message state.
+- [x] #2 Conversation identity, message roles, parentage, ordering, and message variants have restore-compatible metadata.
+- [x] #3 Streaming, failed-send, and regenerated-message cases do not produce misleading final-message envelopes.
+- [x] #4 Tests cover local-first success, envelope shape, ordering, variants, and pending profile summary counts.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing tests for a pure Chat Sync v2 outbox producer and ConsoleChatStore post-durable-message enqueue hooks.
+2. Extend the Chat envelope builder with restore metadata for parentage, transcript ordering, and selected regenerated variants while keeping message content encrypted.
+3. Implement `ChatSyncV2OutboxProducer` using the same local-first profile and dataset-key readiness contract as the Notes producer.
+4. Wire `ConsoleChatStore` to an injected producer only after messages have durable persisted IDs and complete status, leaving streaming, stopped, and failed assistant content unsynced.
+5. Run focused Chat/Sync verification and diff hygiene.
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Added `ChatSyncV2OutboxProducer` as the Chat content-producing Sync v2 boundary. The producer reads the active local-first profile from `SyncStateRepository`, requires device/dataset identity plus an in-memory dataset key, encrypts chat message role/content, and persists deterministic pending outbox envelopes through the existing durable outbox API. Non-local-first, unconfigured, missing-identity, or missing-key profiles return explicit skipped states and do not dispatch remote sync.
+
+Extended `SyncEnvelopeBuilder.build_chat_message()` with restore-compatible clear routing metadata for conversation identity, parent message, transcript sequence, selected variant ID, variant turn ID, selected variant index, and variant count. Message content remains encrypted and does not appear in serialized envelope JSON.
+
+Wired `ConsoleChatStore` to an optional injected Chat producer after durable local persistence succeeds. User messages enqueue immediately after persistence; assistant messages enqueue only when complete. Streaming chunks, failed assistant sends, stopped assistant sends, empty/pending messages, and producer exceptions do not block local chat persistence or create misleading final-message envelopes. Regenerated variants enqueue the selected variant content with variant metadata.
+
+PR review follow-up added Google-style public API docstrings, preserved Loguru structured exception context with `logger.bind()`, made sequence metadata count only sync-eligible persisted complete messages, and added versioned Chat message update semantics. The store now tracks the last enqueued payload hash per stable message key and passes it as `base_version` for changed content, while `ChatSyncAdapter` applies updates when `base_version` matches the current local hash and still conflicts on divergent changes.
+
+Verification:
+- Red tests failed on the missing Chat producer module and missing ConsoleChatStore Sync v2 enqueue contract.
+- `../../.venv/bin/python -m pytest -q Tests/Sync_Interop/test_chat_outbox_producer.py Tests/Sync_Interop/test_envelope_builder.py Tests/Chat/test_console_chat_store.py --tb=short` passed with 27 tests.
+- `../../.venv/bin/python -m pytest -q Tests/Sync_Interop/test_local_first_sync_service.py Tests/Sync_Interop/test_restore_service.py Tests/Sync_Interop/test_sync_state_repository.py --tb=short` passed with 61 tests.
+- `../../.venv/bin/python -m pytest -q Tests/Chat/test_console_chat_controller.py Tests/Chat/test_console_chat_store.py --tb=short` passed with 43 tests.
+- `../../.venv/bin/python -m pytest -q Tests/UI/test_product_maturity_phase1_harness.py::test_backlog_task_frontmatter_ids_are_unique --tb=short` passed with 1 test.
+- `../../.venv/bin/python -m compileall tldw_chatbook/Sync_Interop/chat_outbox_producer.py tldw_chatbook/Sync_Interop/envelope_builder.py tldw_chatbook/Chat/console_chat_store.py` passed.
+- `git diff --check` passed.
+- `git rebase origin/dev` reported the branch was up to date because `origin/dev` is already an ancestor of the stacked roadmap branch.
+- `../../.venv/bin/python -m pytest -q Tests/Sync_Interop/test_chat_outbox_producer.py Tests/Sync_Interop/test_envelope_builder.py Tests/Sync_Interop/test_envelope_applier.py Tests/Chat/test_console_chat_store.py --tb=short` passed with 33 tests after PR review fixes.
+- `../../.venv/bin/python -m pytest -q Tests/Sync_Interop/test_local_first_sync_service.py Tests/Sync_Interop/test_restore_service.py Tests/Sync_Interop/test_sync_state_repository.py --tb=short` passed with 61 tests after PR review fixes.
+- `../../.venv/bin/python -m pytest -q Tests/Chat/test_console_chat_controller.py Tests/Chat/test_console_chat_store.py --tb=short` passed with 44 tests after PR review fixes.
+- `../../.venv/bin/python -m pytest -q Tests/UI/test_product_maturity_phase1_harness.py::test_backlog_task_frontmatter_ids_are_unique --tb=short` passed with 1 test after PR review fixes.
+- `../../.venv/bin/python -m compileall tldw_chatbook/Sync_Interop/chat_outbox_producer.py tldw_chatbook/Sync_Interop/envelope_builder.py tldw_chatbook/Sync_Interop/domain_adapters/chat.py tldw_chatbook/Chat/console_chat_store.py` passed after PR review fixes.
+- `git diff --check` passed after PR review fixes.
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+`TASK-70.2` adds the Chat Sync v2 producer and durable Console store hook needed for ordered, encrypted local-first Chat message outbox entries. The slice remains opt-in through injected producer/profile context and does not add background sync, automatic dispatch, or UI/config wiring.
 
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests and verification recorded
+- [x] #3 Documentation updated in task record
+- [x] #4 No background sync or automatic dispatch added
 <!-- DOD:END -->

--- a/backlog/tasks/task-70.2 - Add-Chat-Sync-v2-outbox-producer-plan.md
+++ b/backlog/tasks/task-70.2 - Add-Chat-Sync-v2-outbox-producer-plan.md
@@ -1,0 +1,44 @@
+---
+id: TASK-70.2
+title: Add Chat Sync v2 outbox producer plan
+status: To Do
+labels:
+- sync
+- sync-v2
+- chat
+- local-first
+priority: high
+parent_task_id: TASK-70
+documentation:
+- Docs/superpowers/specs/2026-05-26-chatbook-sync-v2-completion-roadmap-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the Chat Sync v2 content-producing path so conversation and message changes can be represented as ordered encrypted outbox envelopes that preserve resumed-chat continuity.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 User and assistant Chat messages enqueue ordered Sync v2 envelopes only after they represent durable local message state.
+- [ ] #2 Conversation identity, message roles, parentage, ordering, and message variants have restore-compatible metadata.
+- [ ] #3 Streaming, failed-send, and regenerated-message cases do not produce misleading final-message envelopes.
+- [ ] #4 Tests cover local-first success, envelope shape, ordering, variants, and pending profile summary counts.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/backlog/tasks/task-70.3 - Add-manual-Sync-v2-preview-and-execution-plan.md
+++ b/backlog/tasks/task-70.3 - Add-manual-Sync-v2-preview-and-execution-plan.md
@@ -1,0 +1,44 @@
+---
+id: TASK-70.3
+title: Add manual Sync v2 preview and execution plan
+status: To Do
+labels:
+- sync
+- sync-v2
+- manual-sync
+- ux
+priority: high
+parent_task_id: TASK-70
+documentation:
+- Docs/superpowers/specs/2026-05-26-chatbook-sync-v2-completion-roadmap-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a manual Sync v2 workflow that lets users preview pending Notes and Chat work, explicitly start sync, and understand success, partial success, blocked, failed, or conflicted outcomes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Users can preview outgoing Notes and Chat work before any mutation request is sent to the server.
+- [ ] #2 Users must explicitly start manual sync; no app-launch, scheduled, or background mutation loop is introduced.
+- [ ] #3 Push, pull, partial failure, conflict, blocked, and success outcomes are visible in user-facing copy and profile status.
+- [ ] #4 Actual app QA screenshots verify the visible manual sync workflow in every touched surface.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/backlog/tasks/task-70.4 - Add-Sync-v2-conflict-review-and-recovery-plan.md
+++ b/backlog/tasks/task-70.4 - Add-Sync-v2-conflict-review-and-recovery-plan.md
@@ -1,0 +1,44 @@
+---
+id: TASK-70.4
+title: Add Sync v2 conflict review and recovery plan
+status: To Do
+labels:
+- sync
+- sync-v2
+- conflicts
+- recovery
+priority: high
+parent_task_id: TASK-70
+documentation:
+- Docs/superpowers/specs/2026-05-26-chatbook-sync-v2-completion-roadmap-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make Sync v2 conflict and partial-failure states actionable enough for manual Notes and Chat sync users to inspect, recover, retry, or defer without losing local-first control.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Conflicts display domain, item label, cause, local summary, remote summary, and safe recovery options.
+- [ ] #2 Partial push failures remain durable and visible until resolved.
+- [ ] #3 Retry, keep-local, accept-remote, duplicate/fork, and defer-later states are modeled or explicitly marked unavailable.
+- [ ] #4 Tests cover conflict persistence, user-facing mapping, and no cursor advancement after failed apply.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/backlog/tasks/task-70.5 - Add-Sync-v2-Notes-and-Chat-restore-QA-plan.md
+++ b/backlog/tasks/task-70.5 - Add-Sync-v2-Notes-and-Chat-restore-QA-plan.md
@@ -1,0 +1,44 @@
+---
+id: TASK-70.5
+title: Add Sync v2 Notes and Chat restore QA plan
+status: To Do
+labels:
+- sync
+- sync-v2
+- restore
+- qa
+priority: high
+parent_task_id: TASK-70
+documentation:
+- Docs/superpowers/specs/2026-05-26-chatbook-sync-v2-completion-roadmap-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Validate that manually synced Notes and Chat messages can be restored onto a clean or repaired Chatbook profile with correct content, ordering, identity, and recovery-key behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Notes restore preserves title, body, status, deletion/tombstone behavior, and profile ownership.
+- [ ] #2 Chat restore preserves conversation identity, message order, roles, parentage, and variants required for continuity.
+- [ ] #3 Recovery-key restore decrypts selected envelopes without persisting recovered secrets incorrectly.
+- [ ] #4 Restore failure stops before applying corrupt or partial user-visible state.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/backlog/tasks/task-70.6 - Close-out-manual-Sync-v2-milestone-with-actual-use-QA.md
+++ b/backlog/tasks/task-70.6 - Close-out-manual-Sync-v2-milestone-with-actual-use-QA.md
@@ -1,0 +1,44 @@
+---
+id: TASK-70.6
+title: Close out manual Sync v2 milestone with actual-use QA
+status: To Do
+labels:
+- sync
+- sync-v2
+- qa
+- milestone
+priority: high
+parent_task_id: TASK-70
+documentation:
+- Docs/superpowers/specs/2026-05-26-chatbook-sync-v2-completion-roadmap-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Run the milestone closeout pass proving manual Notes and Chat Sync v2 works end-to-end, remains understandable in the app, and is ready to unblock later workspace, ACP package, and background-sync planning.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Manual Notes and Chat sync is exercised end-to-end against the approved local/server test target.
+- [ ] #2 Settings, Library/Collections, Console, and Home status agree on pending, success, conflict, blocked, and recovery states.
+- [ ] #3 Actual CDP/textual-web screenshots and workflow notes prove the UI is usable, not just mounted.
+- [ ] #4 Remaining gaps are filed as follow-up tasks before any background/workspace/broader-domain sync starts.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/backlog/tasks/task-71 - Console-native-chat-core.md
+++ b/backlog/tasks/task-71 - Console-native-chat-core.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-69
+id: TASK-71
 title: Console native chat core
 status: Done
 assignee: []

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field, replace
-from typing import Protocol
+from typing import Any, Protocol
 from uuid import uuid4
+
+from loguru import logger
 
 from tldw_chatbook.Chat.console_chat_models import (
     ConsoleChatMessage,
@@ -51,6 +53,13 @@ class ConsoleChatPersistence(Protocol):
         """Update persisted message content."""
 
 
+class ConsoleChatSyncProducer(Protocol):
+    """Sync v2 producer surface used after durable local Chat writes."""
+
+    def enqueue_chat_message(self, **kwargs: Any) -> dict[str, Any]:
+        """Enqueue a Chat message into the Sync v2 local outbox."""
+
+
 @dataclass
 class ConsoleChatSession:
     """A native Console chat session."""
@@ -69,9 +78,30 @@ class ConsoleChatStore:
         *,
         persistence: ConsoleChatPersistence | None = None,
         workspace_context: ConsoleWorkspaceContext | None = None,
+        sync_v2_chat_producer: ConsoleChatSyncProducer | None = None,
+        sync_v2_server_profile_id: str | None = None,
+        sync_v2_authenticated_principal_id: str | None = None,
+        sync_v2_workspace_scope: str | None = None,
     ) -> None:
+        """Initialize the Console chat store.
+
+        Args:
+            persistence: Optional durable Chat persistence adapter.
+            workspace_context: Current workspace and staged-source policy context.
+            sync_v2_chat_producer: Optional Sync v2 producer called after durable,
+                complete local Chat message writes.
+            sync_v2_server_profile_id: Optional server profile scope for Chat outbox
+                entries. If missing, Sync v2 enqueue is disabled.
+            sync_v2_authenticated_principal_id: Optional authenticated principal scope
+                for Chat outbox entries.
+            sync_v2_workspace_scope: Optional workspace scope for Chat outbox entries.
+        """
         self.persistence = persistence
         self.workspace_context = workspace_context or ConsoleWorkspaceContext()
+        self.sync_v2_chat_producer = sync_v2_chat_producer
+        self.sync_v2_server_profile_id = sync_v2_server_profile_id
+        self.sync_v2_authenticated_principal_id = sync_v2_authenticated_principal_id
+        self.sync_v2_workspace_scope = sync_v2_workspace_scope
         self.active_session_id: str | None = None
         self._sessions: dict[str, ConsoleChatSession] = {}
         self._messages_by_session: dict[str, list[ConsoleChatMessage]] = {}
@@ -79,6 +109,7 @@ class ConsoleChatStore:
         self._pending_persistence_message_ids: set[str] = set()
         self._stream_chunks_by_message: dict[str, list[str]] = {}
         self._stream_materialized_counts: dict[str, int] = {}
+        self._sync_v2_message_versions: dict[str, str] = {}
 
     def ensure_session(
         self,
@@ -323,6 +354,7 @@ class ConsoleChatStore:
             feedback=None,
         )
         self._pending_persistence_message_ids.discard(message.id)
+        self._enqueue_sync_v2_message_if_ready(message)
 
     def _persist_existing_message(self, message: ConsoleChatMessage) -> None:
         if self.persistence is None:
@@ -340,6 +372,7 @@ class ConsoleChatStore:
             update_parent=False,
             update_feedback=False,
         )
+        self._enqueue_sync_v2_message_if_ready(message)
 
     def _persist_pending_message_if_ready(self, message: ConsoleChatMessage) -> None:
         if (
@@ -350,6 +383,113 @@ class ConsoleChatStore:
             return
         session_id = self._message_session_index[message.id]
         self._persist_new_message(session_id=session_id, message=message)
+
+    def _enqueue_sync_v2_message_if_ready(self, message: ConsoleChatMessage) -> None:
+        if (
+            self.sync_v2_chat_producer is None
+            or self.sync_v2_server_profile_id is None
+            or message.persisted_message_id is None
+            or message.status != "complete"
+            or not message.content
+        ):
+            return
+        session_id = self._message_session_index.get(message.id)
+        if session_id is None:
+            return
+        session = self._sessions.get(session_id)
+        conversation_id = session.persisted_conversation_id if session is not None else None
+        if conversation_id is None:
+            return
+        variant_metadata = self._sync_variant_metadata(message)
+        stable_key = f"{conversation_id}:{message.persisted_message_id}"
+        try:
+            result = self.sync_v2_chat_producer.enqueue_chat_message(
+                server_profile_id=self.sync_v2_server_profile_id,
+                authenticated_principal_id=self.sync_v2_authenticated_principal_id,
+                workspace_scope=self.sync_v2_workspace_scope,
+                conversation_id=conversation_id,
+                message_id=message.persisted_message_id,
+                role=message.role.value,
+                content=message.content,
+                parent_message_id=self._previous_persisted_message_id(message),
+                sequence=self._sync_message_sequence(message),
+                variant_turn_id=variant_metadata["variant_turn_id"],
+                variant_index=variant_metadata["variant_index"],
+                variant_count=variant_metadata["variant_count"],
+                selected_variant_id=variant_metadata["selected_variant_id"],
+                base_version=self._sync_v2_message_versions.get(stable_key),
+                entity_version=None,
+            )
+            self._record_sync_v2_message_version(stable_key, result)
+        except Exception:
+            logger.bind(
+                server_profile_id=self.sync_v2_server_profile_id,
+                authenticated_principal_id=self.sync_v2_authenticated_principal_id,
+                workspace_scope=self.sync_v2_workspace_scope,
+                conversation_id=conversation_id,
+                message_id=message.persisted_message_id,
+            ).exception("Failed to enqueue Sync v2 chat message after local mutation")
+
+    def _sync_message_sequence(self, message: ConsoleChatMessage) -> int | None:
+        session_id = self._message_session_index.get(message.id)
+        if session_id is None:
+            return None
+        sequence = 0
+        for candidate in self._messages_by_session.get(session_id, []):
+            if self._is_sync_eligible_message(candidate):
+                sequence += 1
+            if candidate.id == message.id:
+                return sequence if self._is_sync_eligible_message(candidate) else None
+        return None
+
+    @staticmethod
+    def _is_sync_eligible_message(message: ConsoleChatMessage) -> bool:
+        return (
+            message.persisted_message_id is not None
+            and message.status == "complete"
+            and bool(message.content)
+        )
+
+    def _previous_persisted_message_id(self, message: ConsoleChatMessage) -> str | None:
+        session_id = self._message_session_index.get(message.id)
+        if session_id is None:
+            return None
+        previous: str | None = None
+        for candidate in self._messages_by_session.get(session_id, []):
+            if candidate.id == message.id:
+                return previous
+            if candidate.persisted_message_id is not None:
+                previous = candidate.persisted_message_id
+        return None
+
+    @staticmethod
+    def _sync_variant_metadata(message: ConsoleChatMessage) -> dict[str, str | int | None]:
+        if message.variants is None:
+            return {
+                "variant_turn_id": None,
+                "variant_index": None,
+                "variant_count": None,
+                "selected_variant_id": None,
+            }
+        return {
+            "variant_turn_id": message.variants.turn_id,
+            "variant_index": message.variants.selected_index,
+            "variant_count": len(message.variants.variants),
+            "selected_variant_id": message.variants.current.id,
+        }
+
+    def _record_sync_v2_message_version(self, stable_key: str, result: dict[str, Any]) -> None:
+        if result.get("status") != "enqueued":
+            return
+        entry = result.get("outbox_entry")
+        if not isinstance(entry, dict):
+            return
+        envelope = entry.get("envelope")
+        if not isinstance(envelope, dict):
+            return
+        payload_hash = envelope.get("payload_hash")
+        if isinstance(payload_hash, str) and payload_hash:
+            self._sync_v2_message_versions[stable_key] = payload_hash
 
     def _session_or_raise(self, session_id: str) -> ConsoleChatSession:
         try:

--- a/tldw_chatbook/Notes/notes_scope_service.py
+++ b/tldw_chatbook/Notes/notes_scope_service.py
@@ -7,6 +7,10 @@ from __future__ import annotations
 from enum import Enum
 from typing import Any, Mapping, Optional, Sequence
 
+from loguru import logger
+
+from tldw_chatbook.Utils.input_validation import sanitize_string, validate_text_input
+
 
 class ScopeType(str, Enum):
     LOCAL_NOTE = "local_note"
@@ -49,11 +53,13 @@ class NotesScopeService:
         server_service: Any,
         policy_enforcer: Any = None,
         sync_scope_service: Any = None,
+        sync_v2_notes_producer: Any = None,
     ):
         self.local_notes_service = local_notes_service
         self.server_service = server_service
         self.policy_enforcer = policy_enforcer
         self.sync_scope_service = sync_scope_service
+        self.sync_v2_notes_producer = sync_v2_notes_producer
 
     def _normalize_scope(self, scope: ScopeType | str) -> ScopeType:
         if isinstance(scope, ScopeType):
@@ -416,6 +422,7 @@ class NotesScopeService:
         user_id: Optional[str] = None,
         workspace_id: Optional[str] = None,
         keywords: Optional[Sequence[str]] = None,
+        sync_v2_profile: Optional[Mapping[str, Any]] = None,
     ) -> Any:
         normalized_scope = self._normalize_scope(scope)
         self._enforce_policy(
@@ -433,6 +440,17 @@ class NotesScopeService:
                     {"title": title, "content": content},
                     version,
                 )
+                if updated:
+                    self._enqueue_local_note_upsert(
+                        sync_v2_profile=sync_v2_profile,
+                        note_id=str(note_id),
+                        title=title,
+                        content=content,
+                        status="active",
+                        tag_ids=self._tag_ids_for_sync_v2(keywords),
+                        base_version=version,
+                        entity_version=(version + 1) if version is not None else None,
+                    )
                 if keywords is None:
                     return updated
                 if not updated:
@@ -453,6 +471,18 @@ class NotesScopeService:
                 title,
                 content,
                 note_id=note_id,
+            )
+            if not created_note_id:
+                return created_note_id
+            self._enqueue_local_note_upsert(
+                sync_v2_profile=sync_v2_profile,
+                note_id=str(created_note_id),
+                title=title,
+                content=content,
+                status="active",
+                tag_ids=self._tag_ids_for_sync_v2(keywords),
+                base_version=None,
+                entity_version=1,
             )
             if keywords is None:
                 return created_note_id
@@ -494,15 +524,24 @@ class NotesScopeService:
         version: int,
         user_id: Optional[str] = None,
         workspace_id: Optional[str] = None,
+        sync_v2_profile: Optional[Mapping[str, Any]] = None,
     ) -> Any:
         normalized_scope = self._normalize_scope(scope)
         self._enforce_policy(self._note_action_id(normalized_scope, "delete"))
         if normalized_scope == ScopeType.LOCAL_NOTE:
-            return self.local_notes_service.soft_delete_note(
+            deleted = self.local_notes_service.soft_delete_note(
                 self._require_user_id(user_id),
                 note_id,
                 version,
             )
+            if deleted:
+                self._enqueue_local_note_delete(
+                    sync_v2_profile=sync_v2_profile,
+                    note_id=str(note_id),
+                    base_version=version,
+                    entity_version=version + 1,
+                )
+            return deleted
         if normalized_scope == ScopeType.SERVER_NOTE:
             return await self.server_service.delete_server_note(note_id, version)
         return await self.server_service.delete_workspace_note(
@@ -510,6 +549,130 @@ class NotesScopeService:
             note_id,
             version,
         )
+
+    def _enqueue_local_note_upsert(
+        self,
+        *,
+        sync_v2_profile: Optional[Mapping[str, Any]],
+        note_id: str,
+        title: str,
+        content: str,
+        status: str,
+        tag_ids: Optional[list[str]],
+        base_version: Optional[int],
+        entity_version: Optional[int],
+    ) -> None:
+        profile_scope = self._sync_v2_profile_scope(sync_v2_profile)
+        if self.sync_v2_notes_producer is None or profile_scope is None:
+            return
+        try:
+            self.sync_v2_notes_producer.enqueue_note_upsert(
+                server_profile_id=profile_scope["server_profile_id"],
+                authenticated_principal_id=profile_scope["authenticated_principal_id"],
+                workspace_scope=profile_scope["workspace_scope"],
+                note_id=note_id,
+                title=title,
+                content=content,
+                status=status,
+                tag_ids=tag_ids,
+                base_version=base_version,
+                entity_version=entity_version,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to enqueue Sync v2 note upsert after local mutation",
+                server_profile_id=profile_scope["server_profile_id"],
+                authenticated_principal_id=profile_scope["authenticated_principal_id"],
+                workspace_scope=profile_scope["workspace_scope"],
+                note_id=note_id,
+                base_version=base_version,
+                entity_version=entity_version,
+            )
+
+    def _enqueue_local_note_delete(
+        self,
+        *,
+        sync_v2_profile: Optional[Mapping[str, Any]],
+        note_id: str,
+        base_version: int,
+        entity_version: int,
+    ) -> None:
+        profile_scope = self._sync_v2_profile_scope(sync_v2_profile)
+        if self.sync_v2_notes_producer is None or profile_scope is None:
+            return
+        try:
+            self.sync_v2_notes_producer.enqueue_note_delete(
+                server_profile_id=profile_scope["server_profile_id"],
+                authenticated_principal_id=profile_scope["authenticated_principal_id"],
+                workspace_scope=profile_scope["workspace_scope"],
+                note_id=note_id,
+                base_version=base_version,
+                entity_version=entity_version,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to enqueue Sync v2 note delete after local mutation",
+                server_profile_id=profile_scope["server_profile_id"],
+                authenticated_principal_id=profile_scope["authenticated_principal_id"],
+                workspace_scope=profile_scope["workspace_scope"],
+                note_id=note_id,
+                base_version=base_version,
+                entity_version=entity_version,
+            )
+
+    @staticmethod
+    def _sync_v2_profile_scope(
+        sync_v2_profile: Optional[Mapping[str, Any]],
+    ) -> dict[str, Any] | None:
+        if not sync_v2_profile:
+            return None
+        server_profile_id = NotesScopeService._validated_sync_v2_scope_text(
+            sync_v2_profile.get("server_profile_id")
+        )
+        if not server_profile_id:
+            return None
+        authenticated_principal_id = NotesScopeService._validated_sync_v2_scope_text(
+            sync_v2_profile.get("authenticated_principal_id"),
+            allow_none=True,
+        )
+        workspace_scope = NotesScopeService._validated_sync_v2_scope_text(
+            sync_v2_profile.get("workspace_scope"),
+            allow_none=True,
+        )
+        if sync_v2_profile.get("authenticated_principal_id") and authenticated_principal_id is None:
+            return None
+        if sync_v2_profile.get("workspace_scope") and workspace_scope is None:
+            return None
+        return {
+            "server_profile_id": server_profile_id,
+            "authenticated_principal_id": authenticated_principal_id,
+            "workspace_scope": workspace_scope,
+        }
+
+    @staticmethod
+    def _validated_sync_v2_scope_text(
+        value: Any,
+        *,
+        allow_none: bool = False,
+    ) -> str | None:
+        if value is None:
+            return None if allow_none else ""
+        raw = str(value)
+        stripped = raw.strip()
+        if not stripped:
+            return None if allow_none else ""
+        sanitized = sanitize_string(stripped, max_length=200).strip()
+        if sanitized != stripped:
+            return None if allow_none else ""
+        if not validate_text_input(sanitized, max_length=200, allow_html=False):
+            return None if allow_none else ""
+        return sanitized
+
+    @staticmethod
+    def _tag_ids_for_sync_v2(keywords: Optional[Sequence[str]]) -> Optional[list[str]]:
+        if keywords is None:
+            return None
+        return NotesScopeService._normalize_keywords(keywords)
 
     async def search_notes(
         self,

--- a/tldw_chatbook/Sync_Interop/__init__.py
+++ b/tldw_chatbook/Sync_Interop/__init__.py
@@ -2,6 +2,7 @@
 
 from .key_recovery_service import SyncKeyRecoveryService
 from .local_first_sync_service import LocalFirstSyncService
+from .notes_outbox_producer import NotesSyncV2OutboxProducer
 from .restore_service import SyncRestoreService
 from .server_sync_service import ServerSyncService
 from .sync_scope_service import SyncBackend, SyncScopeService
@@ -9,6 +10,7 @@ from .sync_state_repository import SyncStateRepository
 
 __all__ = [
     "LocalFirstSyncService",
+    "NotesSyncV2OutboxProducer",
     "ServerSyncService",
     "SyncBackend",
     "SyncKeyRecoveryService",

--- a/tldw_chatbook/Sync_Interop/__init__.py
+++ b/tldw_chatbook/Sync_Interop/__init__.py
@@ -1,6 +1,7 @@
 """Server sync transport interoperability services."""
 
 from .key_recovery_service import SyncKeyRecoveryService
+from .chat_outbox_producer import ChatSyncV2OutboxProducer
 from .local_first_sync_service import LocalFirstSyncService
 from .notes_outbox_producer import NotesSyncV2OutboxProducer
 from .restore_service import SyncRestoreService
@@ -10,6 +11,7 @@ from .sync_state_repository import SyncStateRepository
 
 __all__ = [
     "LocalFirstSyncService",
+    "ChatSyncV2OutboxProducer",
     "NotesSyncV2OutboxProducer",
     "ServerSyncService",
     "SyncBackend",

--- a/tldw_chatbook/Sync_Interop/chat_outbox_producer.py
+++ b/tldw_chatbook/Sync_Interop/chat_outbox_producer.py
@@ -1,0 +1,152 @@
+"""Produce Sync v2 outbox envelopes for local Chat mutations."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from tldw_chatbook.Sync_Interop.envelope_builder import SyncEnvelopeBuilder
+from tldw_chatbook.Sync_Interop.sync_state import is_local_first_sync_profile_mode
+
+
+class ChatSyncV2OutboxProducer:
+    """Convert successful local Chat writes into durable Sync v2 outbox entries."""
+
+    def __init__(
+        self,
+        *,
+        state_repository: Any,
+        dataset_keys: Mapping[str, bytes] | None = None,
+    ) -> None:
+        self.state_repository = state_repository
+        self.dataset_keys = dict(dataset_keys or {})
+
+    def enqueue_chat_message(
+        self,
+        *,
+        server_profile_id: str,
+        authenticated_principal_id: str | None = None,
+        workspace_scope: str | None = None,
+        conversation_id: str,
+        message_id: str,
+        role: str,
+        content: str,
+        parent_message_id: str | None = None,
+        sequence: int | None = None,
+        variant_turn_id: str | None = None,
+        variant_index: int | None = None,
+        variant_count: int | None = None,
+        selected_variant_id: str | None = None,
+        base_version: str | int | None = None,
+        entity_version: str | int | None = None,
+    ) -> dict[str, Any]:
+        """Persist an encrypted Chat message envelope when Sync v2 is ready.
+
+        Args:
+            server_profile_id: Server profile that owns the outbox source scope.
+            authenticated_principal_id: Optional authenticated principal scope.
+            workspace_scope: Optional workspace scope for scoped outbox entries.
+            conversation_id: Durable local conversation ID that owns the message.
+            message_id: Durable local message ID.
+            role: Chat role for the message, such as ``user`` or ``assistant``.
+            content: Message content encrypted into the envelope payload.
+            parent_message_id: Optional previous durable message ID for restore continuity.
+            sequence: Optional 1-based order among sync-eligible messages.
+            variant_turn_id: Optional turn ID shared by regenerated variants.
+            variant_index: Optional selected variant index.
+            variant_count: Optional total available variant count for the turn.
+            selected_variant_id: Optional selected variant ID.
+            base_version: Optional previous payload hash for versioned updates.
+            entity_version: Optional explicit entity version after the mutation.
+
+        Returns:
+            A status mapping. Enqueued results include the durable outbox entry;
+            skipped results include a reason describing the missing prerequisite.
+        """
+
+        profile = self._sync_ready_profile(
+            server_profile_id=server_profile_id,
+            authenticated_principal_id=authenticated_principal_id,
+            workspace_scope=workspace_scope,
+        )
+        if profile["status"] != "ready":
+            return profile
+
+        envelope = self._builder(profile).build_chat_message(
+            conversation_id=conversation_id,
+            message_id=message_id,
+            role=role,
+            content=content,
+            parent_message_id=parent_message_id,
+            sequence=sequence,
+            variant_turn_id=variant_turn_id,
+            variant_index=variant_index,
+            variant_count=variant_count,
+            selected_variant_id=selected_variant_id,
+            base_version=base_version,
+            entity_version=entity_version,
+        )
+        return self._enqueue(
+            profile=profile,
+            server_profile_id=server_profile_id,
+            authenticated_principal_id=authenticated_principal_id,
+            workspace_scope=workspace_scope,
+            envelope=envelope,
+        )
+
+    def _sync_ready_profile(
+        self,
+        *,
+        server_profile_id: str,
+        authenticated_principal_id: str | None,
+        workspace_scope: str | None,
+    ) -> dict[str, Any]:
+        profile = self.state_repository.get_sync_v2_profile_state(
+            server_profile_id=server_profile_id,
+            authenticated_principal_id=authenticated_principal_id,
+            workspace_scope=workspace_scope,
+        )
+        if profile is None:
+            return {"status": "skipped", "reason": "profile_not_configured"}
+        if not is_local_first_sync_profile_mode(profile.get("profile_mode")):
+            return {"status": "skipped", "reason": "profile_not_local_first"}
+
+        device_id = profile.get("device_id")
+        dataset_id = profile.get("dataset_id")
+        if not device_id or not dataset_id:
+            return {"status": "skipped", "reason": "profile_missing_dataset_identity"}
+        dataset_key = self.dataset_keys.get(str(dataset_id))
+        if dataset_key is None:
+            return {"status": "skipped", "reason": "dataset_key_unavailable"}
+
+        return {
+            "status": "ready",
+            "device_id": str(device_id),
+            "dataset_id": str(dataset_id),
+            "dataset_key": dataset_key,
+        }
+
+    @staticmethod
+    def _builder(profile: Mapping[str, Any]) -> SyncEnvelopeBuilder:
+        return SyncEnvelopeBuilder(
+            dataset_id=str(profile["dataset_id"]),
+            device_id=str(profile["device_id"]),
+            dataset_key=profile["dataset_key"],
+        )
+
+    def _enqueue(
+        self,
+        *,
+        profile: Mapping[str, Any],
+        server_profile_id: str,
+        authenticated_principal_id: str | None,
+        workspace_scope: str | None,
+        envelope: Any,
+    ) -> dict[str, Any]:
+        entry = self.state_repository.enqueue_sync_v2_outbox_envelope(
+            server_profile_id=server_profile_id,
+            authenticated_principal_id=authenticated_principal_id,
+            workspace_scope=workspace_scope,
+            dataset_id=str(profile["dataset_id"]),
+            envelope=envelope,
+        )
+        return {"status": "enqueued", "outbox_entry": entry}

--- a/tldw_chatbook/Sync_Interop/domain_adapters/chat.py
+++ b/tldw_chatbook/Sync_Interop/domain_adapters/chat.py
@@ -10,7 +10,7 @@ from ._helpers import call_if_present, decrypt_envelope_payload
 
 
 class ChatSyncAdapter:
-    """Apply append-only chat message envelopes."""
+    """Apply versioned chat message envelopes."""
 
     def apply(
         self,
@@ -25,11 +25,12 @@ class ChatSyncAdapter:
         if current_hash == envelope.payload_hash:
             return {"status": "noop"}
         if current_hash and current_hash != envelope.payload_hash:
-            return record_conflict(
-                envelope,
-                conflict_type="chat_message_hash_mismatch",
-                message="A chat message with this stable ID already has different content.",
-            )
+            if envelope.base_version != current_hash:
+                return record_conflict(
+                    envelope,
+                    conflict_type="chat_message_hash_mismatch",
+                    message="A chat message with this stable ID already has different content.",
+                )
         payload = decrypt_envelope_payload(envelope, dataset_key=dataset_key)
         call_if_present(local_store, "append_chat_message", stable_key, payload, envelope.payload_hash)
         return {"status": "applied"}

--- a/tldw_chatbook/Sync_Interop/envelope_builder.py
+++ b/tldw_chatbook/Sync_Interop/envelope_builder.py
@@ -79,6 +79,26 @@ class SyncEnvelopeBuilder:
             entity_version=entity_version,
         )
 
+    def build_note_delete(
+        self,
+        *,
+        note_id: str,
+        base_version: str | int | None = None,
+        entity_version: str | int | None = None,
+    ) -> SyncV2Envelope:
+        clear = {"deleted": True}
+        return self._clear_envelope(
+            domain="notes",
+            entity_id=note_id,
+            operation="delete",
+            stable_key=note_id,
+            payload_clear=clear,
+            routing_metadata={"entity_kind": "note"},
+            payload_hash=self._payload_hash(clear),
+            base_version=base_version,
+            entity_version=entity_version,
+        )
+
     def build_chat_message(
         self,
         *,
@@ -204,6 +224,7 @@ class SyncEnvelopeBuilder:
         payload_clear: Mapping[str, Any],
         routing_metadata: Mapping[str, Any],
         payload_hash: str,
+        base_version: str | int | None = None,
         entity_version: str | int | None = None,
         encryption_policy: str = "client_private_v1",
     ) -> SyncV2Envelope:
@@ -216,6 +237,7 @@ class SyncEnvelopeBuilder:
             operation=operation,
             adapter_version=self.adapter_version,
             stable_key=stable_key,
+            base_version=base_version,
             entity_version=entity_version or payload_hash,
             routing_metadata=dict(routing_metadata),
             payload_clear=dict(payload_clear),

--- a/tldw_chatbook/Sync_Interop/envelope_builder.py
+++ b/tldw_chatbook/Sync_Interop/envelope_builder.py
@@ -106,10 +106,51 @@ class SyncEnvelopeBuilder:
         message_id: str,
         role: str,
         content: str,
+        parent_message_id: str | None = None,
+        sequence: int | None = None,
+        variant_turn_id: str | None = None,
+        variant_index: int | None = None,
+        variant_count: int | None = None,
+        selected_variant_id: str | None = None,
         base_version: str | int | None = None,
         entity_version: str | int | None = None,
     ) -> SyncV2Envelope:
+        """Build an encrypted Chat message upsert envelope.
+
+        Args:
+            conversation_id: Stable conversation identifier that owns the message.
+            message_id: Stable message identifier within the conversation.
+            role: Chat role stored with the message payload.
+            content: Message content encrypted into the private payload.
+            parent_message_id: Optional previous message ID for transcript restore order.
+            sequence: Optional 1-based order among sync-eligible transcript messages.
+            variant_turn_id: Optional regenerated-turn identifier shared by variants.
+            variant_index: Optional currently selected variant index.
+            variant_count: Optional number of available variants for the message.
+            selected_variant_id: Optional selected variant identifier.
+            base_version: Optional previous payload hash for versioned updates.
+            entity_version: Optional explicit entity version after this mutation.
+
+        Returns:
+            A Sync v2 envelope with encrypted Chat content and clear routing metadata.
+        """
         stable_key = f"{conversation_id}:{message_id}"
+        routing_metadata: dict[str, Any] = {
+            "conversation_id": conversation_id,
+            "entity_kind": "message",
+        }
+        if parent_message_id is not None:
+            routing_metadata["parent_message_id"] = parent_message_id
+        if sequence is not None:
+            routing_metadata["sequence"] = sequence
+        if variant_turn_id is not None:
+            routing_metadata["variant_turn_id"] = variant_turn_id
+        if variant_index is not None:
+            routing_metadata["variant_index"] = variant_index
+        if variant_count is not None:
+            routing_metadata["variant_count"] = variant_count
+        if selected_variant_id is not None:
+            routing_metadata["selected_variant_id"] = selected_variant_id
         return self._encrypted_envelope(
             domain="chat",
             entity_id=message_id,
@@ -117,7 +158,7 @@ class SyncEnvelopeBuilder:
             stable_key=stable_key,
             payload={"content": content, "role": role},
             payload_clear={},
-            routing_metadata={"conversation_id": conversation_id, "entity_kind": "message"},
+            routing_metadata=routing_metadata,
             base_version=base_version,
             entity_version=entity_version,
         )

--- a/tldw_chatbook/Sync_Interop/notes_outbox_producer.py
+++ b/tldw_chatbook/Sync_Interop/notes_outbox_producer.py
@@ -1,0 +1,191 @@
+"""Produce Sync v2 outbox envelopes for local Notes mutations."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from tldw_chatbook.Sync_Interop.envelope_builder import SyncEnvelopeBuilder
+from tldw_chatbook.Sync_Interop.sync_state import is_local_first_sync_profile_mode
+
+
+class NotesSyncV2OutboxProducer:
+    """Convert successful local Notes writes into durable Sync v2 outbox entries.
+
+    Args:
+        state_repository: Repository that owns Sync v2 profile state and durable
+            local outbox persistence.
+        dataset_keys: Mapping of dataset IDs to in-memory dataset keys used to
+            encrypt private Notes payloads before persistence.
+    """
+
+    def __init__(
+        self,
+        *,
+        state_repository: Any,
+        dataset_keys: Mapping[str, bytes] | None = None,
+    ) -> None:
+        self.state_repository = state_repository
+        self.dataset_keys = dict(dataset_keys or {})
+
+    def enqueue_note_upsert(
+        self,
+        *,
+        server_profile_id: str,
+        authenticated_principal_id: str | None = None,
+        workspace_scope: str | None = None,
+        note_id: str,
+        title: str,
+        content: str,
+        status: str | None = None,
+        tag_ids: list[str] | None = None,
+        base_version: str | int | None = None,
+        entity_version: str | int | None = None,
+    ) -> dict[str, Any]:
+        """Persist an encrypted Notes upsert envelope when Sync v2 is ready.
+
+        Args:
+            server_profile_id: Server profile that owns the outbox source scope.
+            authenticated_principal_id: Optional authenticated principal scope.
+            workspace_scope: Optional workspace scope for scoped outbox entries.
+            note_id: Local Notes entity ID.
+            title: Note title to encrypt into the payload.
+            content: Note body to encrypt into the payload.
+            status: Optional clear-text note status metadata.
+            tag_ids: Optional clear-text tag identifiers for routing/metadata.
+            base_version: Optional source entity version before the mutation.
+            entity_version: Optional source entity version after the mutation.
+
+        Returns:
+            A status mapping. Enqueued results include the durable outbox entry;
+            skipped results include a reason describing the missing prerequisite.
+        """
+
+        profile = self._sync_ready_profile(
+            server_profile_id=server_profile_id,
+            authenticated_principal_id=authenticated_principal_id,
+            workspace_scope=workspace_scope,
+        )
+        if profile["status"] != "ready":
+            return profile
+
+        builder = self._builder(profile)
+        envelope = builder.build_note_upsert(
+            note_id=note_id,
+            title=title,
+            body=content,
+            status=status,
+            tag_ids=tag_ids,
+            base_version=base_version,
+            entity_version=entity_version,
+        )
+        return self._enqueue(
+            profile=profile,
+            server_profile_id=server_profile_id,
+            authenticated_principal_id=authenticated_principal_id,
+            workspace_scope=workspace_scope,
+            envelope=envelope,
+        )
+
+    def enqueue_note_delete(
+        self,
+        *,
+        server_profile_id: str,
+        authenticated_principal_id: str | None = None,
+        workspace_scope: str | None = None,
+        note_id: str,
+        base_version: str | int | None = None,
+        entity_version: str | int | None = None,
+    ) -> dict[str, Any]:
+        """Persist a Notes delete tombstone envelope when Sync v2 is ready.
+
+        Args:
+            server_profile_id: Server profile that owns the outbox source scope.
+            authenticated_principal_id: Optional authenticated principal scope.
+            workspace_scope: Optional workspace scope for scoped outbox entries.
+            note_id: Local Notes entity ID.
+            base_version: Optional source entity version before the delete.
+            entity_version: Optional source entity version after the delete.
+
+        Returns:
+            A status mapping. Enqueued results include the durable outbox entry;
+            skipped results include a reason describing the missing prerequisite.
+        """
+
+        profile = self._sync_ready_profile(
+            server_profile_id=server_profile_id,
+            authenticated_principal_id=authenticated_principal_id,
+            workspace_scope=workspace_scope,
+        )
+        if profile["status"] != "ready":
+            return profile
+
+        envelope = self._builder(profile).build_note_delete(
+            note_id=note_id,
+            base_version=base_version,
+            entity_version=entity_version,
+        )
+        return self._enqueue(
+            profile=profile,
+            server_profile_id=server_profile_id,
+            authenticated_principal_id=authenticated_principal_id,
+            workspace_scope=workspace_scope,
+            envelope=envelope,
+        )
+
+    def _sync_ready_profile(
+        self,
+        *,
+        server_profile_id: str,
+        authenticated_principal_id: str | None,
+        workspace_scope: str | None,
+    ) -> dict[str, Any]:
+        profile = self.state_repository.get_sync_v2_profile_state(
+            server_profile_id=server_profile_id,
+            authenticated_principal_id=authenticated_principal_id,
+            workspace_scope=workspace_scope,
+        )
+        if profile is None:
+            return {"status": "skipped", "reason": "profile_not_configured"}
+        if not is_local_first_sync_profile_mode(profile.get("profile_mode")):
+            return {"status": "skipped", "reason": "profile_not_local_first"}
+
+        device_id = profile.get("device_id")
+        dataset_id = profile.get("dataset_id")
+        if not device_id or not dataset_id:
+            return {"status": "skipped", "reason": "profile_missing_dataset_identity"}
+        dataset_key = self.dataset_keys.get(str(dataset_id))
+        if dataset_key is None:
+            return {"status": "skipped", "reason": "dataset_key_unavailable"}
+
+        return {
+            "status": "ready",
+            "device_id": str(device_id),
+            "dataset_id": str(dataset_id),
+            "dataset_key": dataset_key,
+        }
+
+    @staticmethod
+    def _builder(profile: Mapping[str, Any]) -> SyncEnvelopeBuilder:
+        return SyncEnvelopeBuilder(
+            dataset_id=str(profile["dataset_id"]),
+            device_id=str(profile["device_id"]),
+            dataset_key=profile["dataset_key"],
+        )
+
+    def _enqueue(
+        self,
+        *,
+        profile: Mapping[str, Any],
+        server_profile_id: str,
+        authenticated_principal_id: str | None,
+        workspace_scope: str | None,
+        envelope: Any,
+    ) -> dict[str, Any]:
+        entry = self.state_repository.enqueue_sync_v2_outbox_envelope(
+            server_profile_id=server_profile_id,
+            authenticated_principal_id=authenticated_principal_id,
+            workspace_scope=workspace_scope,
+            dataset_id=str(profile["dataset_id"]),
+            envelope=envelope,
+        )
+        return {"status": "enqueued", "outbox_entry": entry}


### PR DESCRIPTION
## Summary
- Adds the Chatbook Sync v2 completion roadmap spec from the current read-only/dry-run baseline to manual Notes + Chat sync.
- Creates TASK-70 and child tasks TASK-70.1 through TASK-70.6 for PR-sized implementation slices.
- Fixes a pre-existing Backlog task-id collision by renumbering Console native chat core from TASK-69 to TASK-71.

## Verification
- ../../.venv/bin/python -m pytest -q Tests/UI/test_product_maturity_phase1_harness.py::test_backlog_task_frontmatter_ids_are_unique --tb=short
- git diff --cached --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends Sync v2 manual outbox to Chat. Local Notes and Chat writes now enqueue encrypted envelopes for manual sync, and skip enqueue when the profile or dataset key isn’t ready. Updated the Sync v2 completion roadmap doc to clarify manual sync scope and staged rollout.

- **New Features**
  - Added `ChatSyncV2OutboxProducer` to create encrypted chat message envelopes with sequencing, parent/variant metadata, and pending counts; supports versioned updates via `base_version`.
  - Updated `ChatSyncAdapter` to allow safe message updates when `base_version` matches the current hash; otherwise records a conflict.
  - Wired `ConsoleChatStore` to enqueue after durable local writes; failures are swallowed to keep local UX responsive.
  - Extended `SyncEnvelopeBuilder` with `build_note_delete` and richer `build_chat_message` (parent, sequence, variants, `base_version`/`entity_version`); exported via `tldw_chatbook.Sync_Interop`. Added tests for chat/notes encryption, idempotency/versioning, delete shape, and enqueue/skip behavior. No background/scheduled sync added.

- **Bug Fixes**
  - Renumbered backlog task from `TASK-69` to `TASK-71` to resolve an ID collision.

<sup>Written for commit 3922a5823f073416791083e0f051bd6a5999a3a1. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/369?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

