### PR TITLE
Add Notes Sync v2 outbox producer

### DIFF
--- a/Tests/Notes/test_notes_scope_service.py
+++ b/Tests/Notes/test_notes_scope_service.py
@@ -153,6 +153,20 @@ class FakeLocalNotes:
         return {"deleted": len(self.manual_links) != before, "edge_id": edge_id}
 
 
+class FakeNotesSyncV2Producer:
+    def __init__(self):
+        self.upserts = []
+        self.deletes = []
+
+    def enqueue_note_upsert(self, **kwargs):
+        self.upserts.append(kwargs)
+        return {"status": "enqueued"}
+
+    def enqueue_note_delete(self, **kwargs):
+        self.deletes.append(kwargs)
+        return {"status": "enqueued"}
+
+
 class FakeServerNotes:
     def __init__(self):
         self.saved_ids = []
@@ -510,6 +524,166 @@ async def test_scope_service_routes_local_note_save_to_local_service():
             "note_id": "local-1",
             "update_data": {"title": "Local", "content": "Body"},
             "expected_version": 3,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_scope_service_enqueues_local_note_upsert_after_successful_save():
+    local = FakeLocalNotes()
+    producer = FakeNotesSyncV2Producer()
+    scope_service = NotesScopeService(
+        local_notes_service=local,
+        server_service=FakeServerNotes(),
+        sync_v2_notes_producer=producer,
+    )
+
+    result = await scope_service.save_note(
+        scope=ScopeType.LOCAL_NOTE,
+        user_id="user-1",
+        note_id="local-1",
+        title="Local",
+        content="Body",
+        version=3,
+        sync_v2_profile={
+            "server_profile_id": "server-a",
+            "authenticated_principal_id": "user-a",
+            "workspace_scope": None,
+        },
+    )
+
+    assert result is True
+    assert producer.upserts == [
+        {
+            "server_profile_id": "server-a",
+            "authenticated_principal_id": "user-a",
+            "workspace_scope": None,
+            "note_id": "local-1",
+            "title": "Local",
+            "content": "Body",
+            "status": "active",
+            "base_version": 3,
+            "entity_version": 4,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_scope_service_does_not_enqueue_local_note_upsert_after_failed_save():
+    class FailingLocalNotes(FakeLocalNotes):
+        def update_note(self, user_id, note_id, update_data, expected_version):
+            super().update_note(user_id, note_id, update_data, expected_version)
+            return False
+
+    producer = FakeNotesSyncV2Producer()
+    scope_service = NotesScopeService(
+        local_notes_service=FailingLocalNotes(),
+        server_service=FakeServerNotes(),
+        sync_v2_notes_producer=producer,
+    )
+
+    result = await scope_service.save_note(
+        scope=ScopeType.LOCAL_NOTE,
+        user_id="user-1",
+        note_id="local-1",
+        title="Local",
+        content="Body",
+        version=3,
+        sync_v2_profile={
+            "server_profile_id": "server-a",
+            "authenticated_principal_id": "user-a",
+            "workspace_scope": None,
+        },
+    )
+
+    assert result is False
+    assert producer.upserts == []
+
+
+@pytest.mark.asyncio
+async def test_scope_service_does_not_enqueue_local_note_upsert_after_failed_create():
+    class FailingCreateLocalNotes(FakeLocalNotes):
+        def add_note(self, user_id, title, content, note_id=None):
+            super().add_note(user_id, title, content, note_id=note_id)
+            return None
+
+    producer = FakeNotesSyncV2Producer()
+    scope_service = NotesScopeService(
+        local_notes_service=FailingCreateLocalNotes(),
+        server_service=FakeServerNotes(),
+        sync_v2_notes_producer=producer,
+    )
+
+    result = await scope_service.save_note(
+        scope=ScopeType.LOCAL_NOTE,
+        user_id="user-1",
+        title="Local",
+        content="Body",
+        sync_v2_profile={
+            "server_profile_id": "server-a",
+            "authenticated_principal_id": "user-a",
+            "workspace_scope": None,
+        },
+    )
+
+    assert result is None
+    assert producer.upserts == []
+
+
+@pytest.mark.asyncio
+async def test_scope_service_ignores_incomplete_sync_v2_profile_after_local_save():
+    producer = FakeNotesSyncV2Producer()
+    scope_service = NotesScopeService(
+        local_notes_service=FakeLocalNotes(),
+        server_service=FakeServerNotes(),
+        sync_v2_notes_producer=producer,
+    )
+
+    result = await scope_service.save_note(
+        scope=ScopeType.LOCAL_NOTE,
+        user_id="user-1",
+        note_id="local-1",
+        title="Local",
+        content="Body",
+        version=3,
+        sync_v2_profile={"authenticated_principal_id": "user-a"},
+    )
+
+    assert result is True
+    assert producer.upserts == []
+
+
+@pytest.mark.asyncio
+async def test_scope_service_enqueues_local_note_delete_after_successful_delete():
+    local = FakeLocalNotes()
+    producer = FakeNotesSyncV2Producer()
+    scope_service = NotesScopeService(
+        local_notes_service=local,
+        server_service=FakeServerNotes(),
+        sync_v2_notes_producer=producer,
+    )
+
+    result = await scope_service.delete_note(
+        scope=ScopeType.LOCAL_NOTE,
+        user_id="user-1",
+        note_id="local-1",
+        version=3,
+        sync_v2_profile={
+            "server_profile_id": "server-a",
+            "authenticated_principal_id": "user-a",
+            "workspace_scope": None,
+        },
+    )
+
+    assert result is True
+    assert producer.deletes == [
+        {
+            "server_profile_id": "server-a",
+            "authenticated_principal_id": "user-a",
+            "workspace_scope": None,
+            "note_id": "local-1",
+            "base_version": 3,
+            "entity_version": 4,
         }
     ]
 

--- a/Tests/Notes/test_notes_scope_service.py
+++ b/Tests/Notes/test_notes_scope_service.py
@@ -167,6 +167,14 @@ class FakeNotesSyncV2Producer:
         return {"status": "enqueued"}
 
 
+class FailingNotesSyncV2Producer:
+    def enqueue_note_upsert(self, **kwargs):
+        raise RuntimeError("outbox unavailable")
+
+    def enqueue_note_delete(self, **kwargs):
+        raise RuntimeError("outbox unavailable")
+
+
 class FakeServerNotes:
     def __init__(self):
         self.saved_ids = []
@@ -562,6 +570,7 @@ async def test_scope_service_enqueues_local_note_upsert_after_successful_save():
             "title": "Local",
             "content": "Body",
             "status": "active",
+            "tag_ids": None,
             "base_version": 3,
             "entity_version": 4,
         }
@@ -601,6 +610,31 @@ async def test_scope_service_does_not_enqueue_local_note_upsert_after_failed_sav
 
 
 @pytest.mark.asyncio
+async def test_scope_service_local_save_survives_sync_v2_enqueue_failure():
+    scope_service = NotesScopeService(
+        local_notes_service=FakeLocalNotes(),
+        server_service=FakeServerNotes(),
+        sync_v2_notes_producer=FailingNotesSyncV2Producer(),
+    )
+
+    result = await scope_service.save_note(
+        scope=ScopeType.LOCAL_NOTE,
+        user_id="user-1",
+        note_id="local-1",
+        title="Local",
+        content="Body",
+        version=3,
+        sync_v2_profile={
+            "server_profile_id": "server-a",
+            "authenticated_principal_id": "user-a",
+            "workspace_scope": None,
+        },
+    )
+
+    assert result is True
+
+
+@pytest.mark.asyncio
 async def test_scope_service_does_not_enqueue_local_note_upsert_after_failed_create():
     class FailingCreateLocalNotes(FakeLocalNotes):
         def add_note(self, user_id, title, content, note_id=None):
@@ -631,6 +665,34 @@ async def test_scope_service_does_not_enqueue_local_note_upsert_after_failed_cre
 
 
 @pytest.mark.asyncio
+async def test_scope_service_passes_keywords_to_sync_v2_note_upsert():
+    producer = FakeNotesSyncV2Producer()
+    scope_service = NotesScopeService(
+        local_notes_service=FakeLocalNotes(),
+        server_service=FakeServerNotes(),
+        sync_v2_notes_producer=producer,
+    )
+
+    result = await scope_service.save_note(
+        scope=ScopeType.LOCAL_NOTE,
+        user_id="user-1",
+        note_id="local-1",
+        title="Local",
+        content="Body",
+        version=3,
+        keywords=["project", "draft"],
+        sync_v2_profile={
+            "server_profile_id": "server-a",
+            "authenticated_principal_id": "user-a",
+            "workspace_scope": None,
+        },
+    )
+
+    assert result["keywords"] == ["project", "draft"]
+    assert producer.upserts[0]["tag_ids"] == ["project", "draft"]
+
+
+@pytest.mark.asyncio
 async def test_scope_service_ignores_incomplete_sync_v2_profile_after_local_save():
     producer = FakeNotesSyncV2Producer()
     scope_service = NotesScopeService(
@@ -647,6 +709,33 @@ async def test_scope_service_ignores_incomplete_sync_v2_profile_after_local_save
         content="Body",
         version=3,
         sync_v2_profile={"authenticated_principal_id": "user-a"},
+    )
+
+    assert result is True
+    assert producer.upserts == []
+
+
+@pytest.mark.asyncio
+async def test_scope_service_ignores_invalid_sync_v2_profile_after_local_save():
+    producer = FakeNotesSyncV2Producer()
+    scope_service = NotesScopeService(
+        local_notes_service=FakeLocalNotes(),
+        server_service=FakeServerNotes(),
+        sync_v2_notes_producer=producer,
+    )
+
+    result = await scope_service.save_note(
+        scope=ScopeType.LOCAL_NOTE,
+        user_id="user-1",
+        note_id="local-1",
+        title="Local",
+        content="Body",
+        version=3,
+        sync_v2_profile={
+            "server_profile_id": "server-a\x00",
+            "authenticated_principal_id": "user-a",
+            "workspace_scope": None,
+        },
     )
 
     assert result is True
@@ -686,6 +775,29 @@ async def test_scope_service_enqueues_local_note_delete_after_successful_delete(
             "entity_version": 4,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_scope_service_local_delete_survives_sync_v2_enqueue_failure():
+    scope_service = NotesScopeService(
+        local_notes_service=FakeLocalNotes(),
+        server_service=FakeServerNotes(),
+        sync_v2_notes_producer=FailingNotesSyncV2Producer(),
+    )
+
+    result = await scope_service.delete_note(
+        scope=ScopeType.LOCAL_NOTE,
+        user_id="user-1",
+        note_id="local-1",
+        version=3,
+        sync_v2_profile={
+            "server_profile_id": "server-a",
+            "authenticated_principal_id": "user-a",
+            "workspace_scope": None,
+        },
+    )
+
+    assert result is True
 
 
 @pytest.mark.asyncio

--- a/Tests/Sync_Interop/test_notes_outbox_producer.py
+++ b/Tests/Sync_Interop/test_notes_outbox_producer.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import json
+
+from tldw_chatbook.Sync_Interop.crypto import decrypt_sync_payload, generate_dataset_key
+from tldw_chatbook.Sync_Interop.notes_outbox_producer import NotesSyncV2OutboxProducer
+from tldw_chatbook.Sync_Interop.sync_state_repository import SyncStateRepository
+
+
+def test_notes_producer_enqueues_encrypted_note_upsert_and_updates_summary(tmp_path) -> None:
+    dataset_key = generate_dataset_key()
+    repo = _local_first_repo(tmp_path, dataset_key=dataset_key)
+    producer = NotesSyncV2OutboxProducer(
+        state_repository=repo,
+        dataset_keys={"dataset-1": dataset_key},
+    )
+
+    result = producer.enqueue_note_upsert(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope=None,
+        note_id="note-1",
+        title="Private title",
+        content="Private body",
+        status="active",
+        entity_version=1,
+    )
+
+    entries = repo.list_pending_sync_v2_outbox_envelopes(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope=None,
+        dataset_id="dataset-1",
+    )
+    summary = repo.get_sync_v2_profile_summary(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope=None,
+    )
+    envelope = entries[0]["envelope"]
+
+    assert result["status"] == "enqueued"
+    assert len(entries) == 1
+    assert entries[0]["domain"] == "notes"
+    assert summary["outbox"]["pending"] == 1
+    assert summary["outbox"]["by_domain"]["notes"]["pending"] == 1
+    serialized = json.dumps(entries[0]["envelope"])
+    assert "Private title" not in serialized
+    assert "Private body" not in serialized
+    assert envelope["payload_clear"] == {"status": "active"}
+    assert envelope["routing_metadata"] == {"entity_kind": "note"}
+    assert _decrypt_payload(envelope["payload_ciphertext"], dataset_key) == {
+        "body": "Private body",
+        "title": "Private title",
+    }
+
+    producer.enqueue_note_upsert(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope=None,
+        note_id="note-1",
+        title="Private title",
+        content="Private body",
+        status="active",
+        entity_version=1,
+    )
+    assert len(
+        repo.list_pending_sync_v2_outbox_envelopes(
+            server_profile_id="server-a",
+            authenticated_principal_id="user-a",
+            workspace_scope=None,
+            dataset_id="dataset-1",
+        )
+    ) == 1
+
+
+def test_notes_producer_enqueues_delete_without_plaintext_payload(tmp_path) -> None:
+    dataset_key = generate_dataset_key()
+    repo = _local_first_repo(tmp_path, dataset_key=dataset_key)
+    producer = NotesSyncV2OutboxProducer(
+        state_repository=repo,
+        dataset_keys={"dataset-1": dataset_key},
+    )
+
+    result = producer.enqueue_note_delete(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope=None,
+        note_id="note-1",
+        base_version=3,
+        entity_version=4,
+    )
+
+    entries = repo.list_pending_sync_v2_outbox_envelopes(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope=None,
+        dataset_id="dataset-1",
+    )
+    envelope = entries[0]["envelope"]
+
+    assert result["status"] == "enqueued"
+    assert envelope["operation"] == "delete"
+    assert envelope["payload_ciphertext"] is None
+    assert envelope["payload_clear"] == {"deleted": True}
+    assert envelope["base_version"] == 3
+    assert envelope["entity_version"] == 4
+
+
+def test_notes_producer_skips_without_local_first_profile_or_dataset_key(tmp_path) -> None:
+    repo = SyncStateRepository(tmp_path / "sync_state.db")
+    repo.set_sync_v2_profile_state(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope=None,
+        profile_mode="server_frontend",
+        device_id="device-1",
+        dataset_id="dataset-1",
+    )
+    producer = NotesSyncV2OutboxProducer(state_repository=repo, dataset_keys={})
+
+    result = producer.enqueue_note_upsert(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope=None,
+        note_id="note-1",
+        title="Local only",
+        content="No sync",
+    )
+
+    assert result == {"status": "skipped", "reason": "profile_not_local_first"}
+    assert repo.list_sync_v2_outbox_entries(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope=None,
+        dataset_id="dataset-1",
+    ) == []
+
+
+def _local_first_repo(tmp_path, *, dataset_key: bytes) -> SyncStateRepository:
+    del dataset_key
+    repo = SyncStateRepository(tmp_path / "sync_state.db")
+    repo.set_sync_v2_profile_state(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope=None,
+        profile_mode="local_first",
+        device_id="device-1",
+        dataset_id="dataset-1",
+    )
+    return repo
+
+
+def _decrypt_payload(payload_ciphertext: str, dataset_key: bytes) -> dict:
+    return decrypt_sync_payload(json.loads(payload_ciphertext), key=dataset_key)

--- a/backlog/tasks/task-70.1 - Add-Notes-Sync-v2-outbox-producer-plan.md
+++ b/backlog/tasks/task-70.1 - Add-Notes-Sync-v2-outbox-producer-plan.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-70.1
 title: Add Notes Sync v2 outbox producer plan
-status: To Do
+status: Done
 labels:
 - sync
 - sync-v2
@@ -11,6 +11,13 @@ priority: high
 parent_task_id: TASK-70
 documentation:
 - Docs/superpowers/specs/2026-05-26-chatbook-sync-v2-completion-roadmap-design.md
+modified_files:
+- tldw_chatbook/Sync_Interop/notes_outbox_producer.py
+- tldw_chatbook/Sync_Interop/envelope_builder.py
+- tldw_chatbook/Sync_Interop/__init__.py
+- tldw_chatbook/Notes/notes_scope_service.py
+- Tests/Sync_Interop/test_notes_outbox_producer.py
+- Tests/Notes/test_notes_scope_service.py
 ---
 
 ## Description
@@ -21,24 +28,51 @@ Implement the first content-producing Sync v2 path for Notes so local note creat
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Notes create, update, and delete operations enqueue Sync v2 outbox envelopes for the active server profile personal dataset.
-- [ ] #2 Local Notes operations remain successful and recoverable when the server is unavailable.
-- [ ] #3 Tests cover envelope identity, domain scope, idempotency, encryption boundary, and pending profile summary counts.
-- [ ] #4 No background sync, automatic push, or broad domain sync is introduced.
+- [x] #1 Notes create, update, and delete operations enqueue Sync v2 outbox envelopes for the active server profile personal dataset.
+- [x] #2 Local Notes operations remain successful and recoverable when the server is unavailable.
+- [x] #3 Tests cover envelope identity, domain scope, idempotency, encryption boundary, and pending profile summary counts.
+- [x] #4 No background sync, automatic push, or broad domain sync is introduced.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing tests for a pure Notes Sync v2 outbox producer and NotesScopeService post-success enqueue hooks.
+2. Add a note delete envelope builder while preserving existing encrypted note upsert behavior.
+3. Implement a small NotesSyncV2OutboxProducer that reads the configured local-first profile, requires a dataset key, builds Notes envelopes, and persists them to the durable outbox.
+4. Wire local Notes create/update/delete paths to the producer only when an explicit Sync v2 profile context and producer are injected.
+5. Run focused Sync/Notes verification and diff hygiene.
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Added `NotesSyncV2OutboxProducer` as the first content-producing Notes Sync v2 boundary. The producer reads the active local-first profile from `SyncStateRepository`, requires device/dataset identity and an in-memory dataset key, encrypts note title/body upserts, builds clear delete tombstone envelopes, and persists them through the existing durable outbox API. Non-local-first, unconfigured, or missing-key profiles return explicit skipped states and do not dispatch remote sync.
+
+Extended `SyncEnvelopeBuilder` with `build_note_delete()` and wired `NotesScopeService` local save/delete paths to call an injected producer only after successful local mutations. The hook is opt-in, preserves existing local note behavior by default, and does not add background sync, automatic push/pull, or broad domain sync.
+
+Verification:
+- Red tests failed on the missing producer module and missing `NotesScopeService` producer injection.
+- `../../.venv/bin/python -m pytest -q Tests/Sync_Interop/test_notes_outbox_producer.py Tests/Notes/test_notes_scope_service.py::test_scope_service_enqueues_local_note_upsert_after_successful_save Tests/Notes/test_notes_scope_service.py::test_scope_service_does_not_enqueue_local_note_upsert_after_failed_save Tests/Notes/test_notes_scope_service.py::test_scope_service_does_not_enqueue_local_note_upsert_after_failed_create Tests/Notes/test_notes_scope_service.py::test_scope_service_ignores_incomplete_sync_v2_profile_after_local_save Tests/Notes/test_notes_scope_service.py::test_scope_service_enqueues_local_note_delete_after_successful_delete --tb=short` passed with 8 tests.
+- `../../.venv/bin/python -m pytest -q Tests/Sync_Interop/test_notes_outbox_producer.py Tests/Sync_Interop/test_envelope_builder.py Tests/Sync_Interop/test_sync_state_repository.py Tests/Notes/test_notes_scope_service.py --tb=short` passed with 52 tests.
+- `../../.venv/bin/python -m pytest -q Tests/Sync_Interop/test_local_first_sync_service.py Tests/Sync_Interop/test_restore_service.py --tb=short` passed with 42 tests.
+- `../../.venv/bin/python -m pytest -q Tests/UI/test_product_maturity_phase1_harness.py::test_backlog_task_frontmatter_ids_are_unique --tb=short` passed with 1 test.
+- `../../.venv/bin/python -m compileall tldw_chatbook/Sync_Interop/notes_outbox_producer.py tldw_chatbook/Sync_Interop/envelope_builder.py tldw_chatbook/Notes/notes_scope_service.py` passed.
+- `git diff --check` passed.
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+`TASK-70.1` adds the first Notes content-producing Sync v2 path. Local Notes create/update/delete can now produce durable pending outbox envelopes when an active local-first profile and dataset key are explicitly provided, while all remote dispatch and background sync remain out of scope.
 
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests and verification recorded
+- [x] #3 Documentation updated in task record
+- [x] #4 No background sync or automatic dispatch added
 <!-- DOD:END -->

--- a/backlog/tasks/task-70.1 - Add-Notes-Sync-v2-outbox-producer-plan.md
+++ b/backlog/tasks/task-70.1 - Add-Notes-Sync-v2-outbox-producer-plan.md
@@ -51,13 +51,17 @@ Added `NotesSyncV2OutboxProducer` as the first content-producing Notes Sync v2 b
 
 Extended `SyncEnvelopeBuilder` with `build_note_delete()` and wired `NotesScopeService` local save/delete paths to call an injected producer only after successful local mutations. The hook is opt-in, preserves existing local note behavior by default, and does not add background sync, automatic push/pull, or broad domain sync.
 
+PR review follow-up isolated best-effort enqueue failures from primary local note operations, validated Sync v2 profile scope strings through centralized text validation/sanitization utilities, propagated note keywords to outbox `tag_ids`, and expanded public producer docstrings to Google-style `Args`/`Returns` coverage.
+
 Verification:
 - Red tests failed on the missing producer module and missing `NotesScopeService` producer injection.
 - `../../.venv/bin/python -m pytest -q Tests/Sync_Interop/test_notes_outbox_producer.py Tests/Notes/test_notes_scope_service.py::test_scope_service_enqueues_local_note_upsert_after_successful_save Tests/Notes/test_notes_scope_service.py::test_scope_service_does_not_enqueue_local_note_upsert_after_failed_save Tests/Notes/test_notes_scope_service.py::test_scope_service_does_not_enqueue_local_note_upsert_after_failed_create Tests/Notes/test_notes_scope_service.py::test_scope_service_ignores_incomplete_sync_v2_profile_after_local_save Tests/Notes/test_notes_scope_service.py::test_scope_service_enqueues_local_note_delete_after_successful_delete --tb=short` passed with 8 tests.
-- `../../.venv/bin/python -m pytest -q Tests/Sync_Interop/test_notes_outbox_producer.py Tests/Sync_Interop/test_envelope_builder.py Tests/Sync_Interop/test_sync_state_repository.py Tests/Notes/test_notes_scope_service.py --tb=short` passed with 52 tests.
+- `../../.venv/bin/python -m pytest -q Tests/Sync_Interop/test_notes_outbox_producer.py Tests/Sync_Interop/test_envelope_builder.py Tests/Sync_Interop/test_sync_state_repository.py Tests/Notes/test_notes_scope_service.py --tb=short` passed with 56 tests.
 - `../../.venv/bin/python -m pytest -q Tests/Sync_Interop/test_local_first_sync_service.py Tests/Sync_Interop/test_restore_service.py --tb=short` passed with 42 tests.
 - `../../.venv/bin/python -m pytest -q Tests/UI/test_product_maturity_phase1_harness.py::test_backlog_task_frontmatter_ids_are_unique --tb=short` passed with 1 test.
 - `../../.venv/bin/python -m compileall tldw_chatbook/Sync_Interop/notes_outbox_producer.py tldw_chatbook/Sync_Interop/envelope_builder.py tldw_chatbook/Notes/notes_scope_service.py` passed.
+- `../../.venv/bin/python -m pytest -q Tests/Notes/test_notes_scope_service.py::test_scope_service_local_save_survives_sync_v2_enqueue_failure Tests/Notes/test_notes_scope_service.py::test_scope_service_passes_keywords_to_sync_v2_note_upsert Tests/Notes/test_notes_scope_service.py::test_scope_service_ignores_invalid_sync_v2_profile_after_local_save Tests/Notes/test_notes_scope_service.py::test_scope_service_local_delete_survives_sync_v2_enqueue_failure --tb=short` passed with 4 tests.
+- `../../.venv/bin/python -m pytest -q Tests/Sync_Interop/test_notes_outbox_producer.py Tests/Notes/test_notes_scope_service.py --tb=short` passed with 33 tests.
 - `git diff --check` passed.
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->

--- a/tldw_chatbook/Notes/notes_scope_service.py
+++ b/tldw_chatbook/Notes/notes_scope_service.py
@@ -49,11 +49,13 @@ class NotesScopeService:
         server_service: Any,
         policy_enforcer: Any = None,
         sync_scope_service: Any = None,
+        sync_v2_notes_producer: Any = None,
     ):
         self.local_notes_service = local_notes_service
         self.server_service = server_service
         self.policy_enforcer = policy_enforcer
         self.sync_scope_service = sync_scope_service
+        self.sync_v2_notes_producer = sync_v2_notes_producer
 
     def _normalize_scope(self, scope: ScopeType | str) -> ScopeType:
         if isinstance(scope, ScopeType):
@@ -416,6 +418,7 @@ class NotesScopeService:
         user_id: Optional[str] = None,
         workspace_id: Optional[str] = None,
         keywords: Optional[Sequence[str]] = None,
+        sync_v2_profile: Optional[Mapping[str, Any]] = None,
     ) -> Any:
         normalized_scope = self._normalize_scope(scope)
         self._enforce_policy(
@@ -433,6 +436,16 @@ class NotesScopeService:
                     {"title": title, "content": content},
                     version,
                 )
+                if updated:
+                    self._enqueue_local_note_upsert(
+                        sync_v2_profile=sync_v2_profile,
+                        note_id=str(note_id),
+                        title=title,
+                        content=content,
+                        status="active",
+                        base_version=version,
+                        entity_version=(version + 1) if version is not None else None,
+                    )
                 if keywords is None:
                     return updated
                 if not updated:
@@ -453,6 +466,17 @@ class NotesScopeService:
                 title,
                 content,
                 note_id=note_id,
+            )
+            if not created_note_id:
+                return created_note_id
+            self._enqueue_local_note_upsert(
+                sync_v2_profile=sync_v2_profile,
+                note_id=str(created_note_id),
+                title=title,
+                content=content,
+                status="active",
+                base_version=None,
+                entity_version=1,
             )
             if keywords is None:
                 return created_note_id
@@ -494,15 +518,24 @@ class NotesScopeService:
         version: int,
         user_id: Optional[str] = None,
         workspace_id: Optional[str] = None,
+        sync_v2_profile: Optional[Mapping[str, Any]] = None,
     ) -> Any:
         normalized_scope = self._normalize_scope(scope)
         self._enforce_policy(self._note_action_id(normalized_scope, "delete"))
         if normalized_scope == ScopeType.LOCAL_NOTE:
-            return self.local_notes_service.soft_delete_note(
+            deleted = self.local_notes_service.soft_delete_note(
                 self._require_user_id(user_id),
                 note_id,
                 version,
             )
+            if deleted:
+                self._enqueue_local_note_delete(
+                    sync_v2_profile=sync_v2_profile,
+                    note_id=str(note_id),
+                    base_version=version,
+                    entity_version=version + 1,
+                )
+            return deleted
         if normalized_scope == ScopeType.SERVER_NOTE:
             return await self.server_service.delete_server_note(note_id, version)
         return await self.server_service.delete_workspace_note(
@@ -510,6 +543,67 @@ class NotesScopeService:
             note_id,
             version,
         )
+
+    def _enqueue_local_note_upsert(
+        self,
+        *,
+        sync_v2_profile: Optional[Mapping[str, Any]],
+        note_id: str,
+        title: str,
+        content: str,
+        status: str,
+        base_version: Optional[int],
+        entity_version: Optional[int],
+    ) -> None:
+        profile_scope = self._sync_v2_profile_scope(sync_v2_profile)
+        if self.sync_v2_notes_producer is None or profile_scope is None:
+            return
+        self.sync_v2_notes_producer.enqueue_note_upsert(
+            server_profile_id=profile_scope["server_profile_id"],
+            authenticated_principal_id=profile_scope["authenticated_principal_id"],
+            workspace_scope=profile_scope["workspace_scope"],
+            note_id=note_id,
+            title=title,
+            content=content,
+            status=status,
+            base_version=base_version,
+            entity_version=entity_version,
+        )
+
+    def _enqueue_local_note_delete(
+        self,
+        *,
+        sync_v2_profile: Optional[Mapping[str, Any]],
+        note_id: str,
+        base_version: int,
+        entity_version: int,
+    ) -> None:
+        profile_scope = self._sync_v2_profile_scope(sync_v2_profile)
+        if self.sync_v2_notes_producer is None or profile_scope is None:
+            return
+        self.sync_v2_notes_producer.enqueue_note_delete(
+            server_profile_id=profile_scope["server_profile_id"],
+            authenticated_principal_id=profile_scope["authenticated_principal_id"],
+            workspace_scope=profile_scope["workspace_scope"],
+            note_id=note_id,
+            base_version=base_version,
+            entity_version=entity_version,
+        )
+
+    @staticmethod
+    def _sync_v2_profile_scope(
+        sync_v2_profile: Optional[Mapping[str, Any]],
+    ) -> dict[str, Any] | None:
+        if not sync_v2_profile:
+            return None
+        server_profile_id = sync_v2_profile.get("server_profile_id")
+        if not server_profile_id:
+            return None
+        return {
+            "server_profile_id": str(server_profile_id),
+            "authenticated_principal_id": sync_v2_profile.get("authenticated_principal_id"),
+            "workspace_scope": sync_v2_profile.get("workspace_scope"),
+        }
 
     async def search_notes(
         self,

--- a/tldw_chatbook/Notes/notes_scope_service.py
+++ b/tldw_chatbook/Notes/notes_scope_service.py
@@ -7,6 +7,10 @@ from __future__ import annotations
 from enum import Enum
 from typing import Any, Mapping, Optional, Sequence
 
+from loguru import logger
+
+from tldw_chatbook.Utils.input_validation import sanitize_string, validate_text_input
+
 
 class ScopeType(str, Enum):
     LOCAL_NOTE = "local_note"
@@ -443,6 +447,7 @@ class NotesScopeService:
                         title=title,
                         content=content,
                         status="active",
+                        tag_ids=self._tag_ids_for_sync_v2(keywords),
                         base_version=version,
                         entity_version=(version + 1) if version is not None else None,
                     )
@@ -475,6 +480,7 @@ class NotesScopeService:
                 title=title,
                 content=content,
                 status="active",
+                tag_ids=self._tag_ids_for_sync_v2(keywords),
                 base_version=None,
                 entity_version=1,
             )
@@ -552,23 +558,36 @@ class NotesScopeService:
         title: str,
         content: str,
         status: str,
+        tag_ids: Optional[list[str]],
         base_version: Optional[int],
         entity_version: Optional[int],
     ) -> None:
         profile_scope = self._sync_v2_profile_scope(sync_v2_profile)
         if self.sync_v2_notes_producer is None or profile_scope is None:
             return
-        self.sync_v2_notes_producer.enqueue_note_upsert(
-            server_profile_id=profile_scope["server_profile_id"],
-            authenticated_principal_id=profile_scope["authenticated_principal_id"],
-            workspace_scope=profile_scope["workspace_scope"],
-            note_id=note_id,
-            title=title,
-            content=content,
-            status=status,
-            base_version=base_version,
-            entity_version=entity_version,
-        )
+        try:
+            self.sync_v2_notes_producer.enqueue_note_upsert(
+                server_profile_id=profile_scope["server_profile_id"],
+                authenticated_principal_id=profile_scope["authenticated_principal_id"],
+                workspace_scope=profile_scope["workspace_scope"],
+                note_id=note_id,
+                title=title,
+                content=content,
+                status=status,
+                tag_ids=tag_ids,
+                base_version=base_version,
+                entity_version=entity_version,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to enqueue Sync v2 note upsert after local mutation",
+                server_profile_id=profile_scope["server_profile_id"],
+                authenticated_principal_id=profile_scope["authenticated_principal_id"],
+                workspace_scope=profile_scope["workspace_scope"],
+                note_id=note_id,
+                base_version=base_version,
+                entity_version=entity_version,
+            )
 
     def _enqueue_local_note_delete(
         self,
@@ -581,14 +600,25 @@ class NotesScopeService:
         profile_scope = self._sync_v2_profile_scope(sync_v2_profile)
         if self.sync_v2_notes_producer is None or profile_scope is None:
             return
-        self.sync_v2_notes_producer.enqueue_note_delete(
-            server_profile_id=profile_scope["server_profile_id"],
-            authenticated_principal_id=profile_scope["authenticated_principal_id"],
-            workspace_scope=profile_scope["workspace_scope"],
-            note_id=note_id,
-            base_version=base_version,
-            entity_version=entity_version,
-        )
+        try:
+            self.sync_v2_notes_producer.enqueue_note_delete(
+                server_profile_id=profile_scope["server_profile_id"],
+                authenticated_principal_id=profile_scope["authenticated_principal_id"],
+                workspace_scope=profile_scope["workspace_scope"],
+                note_id=note_id,
+                base_version=base_version,
+                entity_version=entity_version,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to enqueue Sync v2 note delete after local mutation",
+                server_profile_id=profile_scope["server_profile_id"],
+                authenticated_principal_id=profile_scope["authenticated_principal_id"],
+                workspace_scope=profile_scope["workspace_scope"],
+                note_id=note_id,
+                base_version=base_version,
+                entity_version=entity_version,
+            )
 
     @staticmethod
     def _sync_v2_profile_scope(
@@ -596,14 +626,53 @@ class NotesScopeService:
     ) -> dict[str, Any] | None:
         if not sync_v2_profile:
             return None
-        server_profile_id = sync_v2_profile.get("server_profile_id")
+        server_profile_id = NotesScopeService._validated_sync_v2_scope_text(
+            sync_v2_profile.get("server_profile_id")
+        )
         if not server_profile_id:
             return None
+        authenticated_principal_id = NotesScopeService._validated_sync_v2_scope_text(
+            sync_v2_profile.get("authenticated_principal_id"),
+            allow_none=True,
+        )
+        workspace_scope = NotesScopeService._validated_sync_v2_scope_text(
+            sync_v2_profile.get("workspace_scope"),
+            allow_none=True,
+        )
+        if sync_v2_profile.get("authenticated_principal_id") and authenticated_principal_id is None:
+            return None
+        if sync_v2_profile.get("workspace_scope") and workspace_scope is None:
+            return None
         return {
-            "server_profile_id": str(server_profile_id),
-            "authenticated_principal_id": sync_v2_profile.get("authenticated_principal_id"),
-            "workspace_scope": sync_v2_profile.get("workspace_scope"),
+            "server_profile_id": server_profile_id,
+            "authenticated_principal_id": authenticated_principal_id,
+            "workspace_scope": workspace_scope,
         }
+
+    @staticmethod
+    def _validated_sync_v2_scope_text(
+        value: Any,
+        *,
+        allow_none: bool = False,
+    ) -> str | None:
+        if value is None:
+            return None if allow_none else ""
+        raw = str(value)
+        stripped = raw.strip()
+        if not stripped:
+            return None if allow_none else ""
+        sanitized = sanitize_string(stripped, max_length=200).strip()
+        if sanitized != stripped:
+            return None if allow_none else ""
+        if not validate_text_input(sanitized, max_length=200, allow_html=False):
+            return None if allow_none else ""
+        return sanitized
+
+    @staticmethod
+    def _tag_ids_for_sync_v2(keywords: Optional[Sequence[str]]) -> Optional[list[str]]:
+        if keywords is None:
+            return None
+        return NotesScopeService._normalize_keywords(keywords)
 
     async def search_notes(
         self,

--- a/tldw_chatbook/Sync_Interop/__init__.py
+++ b/tldw_chatbook/Sync_Interop/__init__.py
@@ -2,6 +2,7 @@
 
 from .key_recovery_service import SyncKeyRecoveryService
 from .local_first_sync_service import LocalFirstSyncService
+from .notes_outbox_producer import NotesSyncV2OutboxProducer
 from .restore_service import SyncRestoreService
 from .server_sync_service import ServerSyncService
 from .sync_scope_service import SyncBackend, SyncScopeService
@@ -9,6 +10,7 @@ from .sync_state_repository import SyncStateRepository
 
 __all__ = [
     "LocalFirstSyncService",
+    "NotesSyncV2OutboxProducer",
     "ServerSyncService",
     "SyncBackend",
     "SyncKeyRecoveryService",

--- a/tldw_chatbook/Sync_Interop/envelope_builder.py
+++ b/tldw_chatbook/Sync_Interop/envelope_builder.py
@@ -79,6 +79,26 @@ class SyncEnvelopeBuilder:
             entity_version=entity_version,
         )
 
+    def build_note_delete(
+        self,
+        *,
+        note_id: str,
+        base_version: str | int | None = None,
+        entity_version: str | int | None = None,
+    ) -> SyncV2Envelope:
+        clear = {"deleted": True}
+        return self._clear_envelope(
+            domain="notes",
+            entity_id=note_id,
+            operation="delete",
+            stable_key=note_id,
+            payload_clear=clear,
+            routing_metadata={"entity_kind": "note"},
+            payload_hash=self._payload_hash(clear),
+            base_version=base_version,
+            entity_version=entity_version,
+        )
+
     def build_chat_message(
         self,
         *,
@@ -204,6 +224,7 @@ class SyncEnvelopeBuilder:
         payload_clear: Mapping[str, Any],
         routing_metadata: Mapping[str, Any],
         payload_hash: str,
+        base_version: str | int | None = None,
         entity_version: str | int | None = None,
         encryption_policy: str = "client_private_v1",
     ) -> SyncV2Envelope:
@@ -216,6 +237,7 @@ class SyncEnvelopeBuilder:
             operation=operation,
             adapter_version=self.adapter_version,
             stable_key=stable_key,
+            base_version=base_version,
             entity_version=entity_version or payload_hash,
             routing_metadata=dict(routing_metadata),
             payload_clear=dict(payload_clear),

--- a/tldw_chatbook/Sync_Interop/notes_outbox_producer.py
+++ b/tldw_chatbook/Sync_Interop/notes_outbox_producer.py
@@ -1,0 +1,150 @@
+"""Produce Sync v2 outbox envelopes for local Notes mutations."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from tldw_chatbook.Sync_Interop.envelope_builder import SyncEnvelopeBuilder
+from tldw_chatbook.Sync_Interop.sync_state import is_local_first_sync_profile_mode
+
+
+class NotesSyncV2OutboxProducer:
+    """Convert successful local Notes writes into durable Sync v2 outbox entries."""
+
+    def __init__(
+        self,
+        *,
+        state_repository: Any,
+        dataset_keys: Mapping[str, bytes] | None = None,
+    ) -> None:
+        self.state_repository = state_repository
+        self.dataset_keys = dict(dataset_keys or {})
+
+    def enqueue_note_upsert(
+        self,
+        *,
+        server_profile_id: str,
+        authenticated_principal_id: str | None = None,
+        workspace_scope: str | None = None,
+        note_id: str,
+        title: str,
+        content: str,
+        status: str | None = None,
+        tag_ids: list[str] | None = None,
+        base_version: str | int | None = None,
+        entity_version: str | int | None = None,
+    ) -> dict[str, Any]:
+        profile = self._sync_ready_profile(
+            server_profile_id=server_profile_id,
+            authenticated_principal_id=authenticated_principal_id,
+            workspace_scope=workspace_scope,
+        )
+        if profile["status"] != "ready":
+            return profile
+
+        builder = self._builder(profile)
+        envelope = builder.build_note_upsert(
+            note_id=note_id,
+            title=title,
+            body=content,
+            status=status,
+            tag_ids=tag_ids,
+            base_version=base_version,
+            entity_version=entity_version,
+        )
+        return self._enqueue(
+            profile=profile,
+            server_profile_id=server_profile_id,
+            authenticated_principal_id=authenticated_principal_id,
+            workspace_scope=workspace_scope,
+            envelope=envelope,
+        )
+
+    def enqueue_note_delete(
+        self,
+        *,
+        server_profile_id: str,
+        authenticated_principal_id: str | None = None,
+        workspace_scope: str | None = None,
+        note_id: str,
+        base_version: str | int | None = None,
+        entity_version: str | int | None = None,
+    ) -> dict[str, Any]:
+        profile = self._sync_ready_profile(
+            server_profile_id=server_profile_id,
+            authenticated_principal_id=authenticated_principal_id,
+            workspace_scope=workspace_scope,
+        )
+        if profile["status"] != "ready":
+            return profile
+
+        envelope = self._builder(profile).build_note_delete(
+            note_id=note_id,
+            base_version=base_version,
+            entity_version=entity_version,
+        )
+        return self._enqueue(
+            profile=profile,
+            server_profile_id=server_profile_id,
+            authenticated_principal_id=authenticated_principal_id,
+            workspace_scope=workspace_scope,
+            envelope=envelope,
+        )
+
+    def _sync_ready_profile(
+        self,
+        *,
+        server_profile_id: str,
+        authenticated_principal_id: str | None,
+        workspace_scope: str | None,
+    ) -> dict[str, Any]:
+        profile = self.state_repository.get_sync_v2_profile_state(
+            server_profile_id=server_profile_id,
+            authenticated_principal_id=authenticated_principal_id,
+            workspace_scope=workspace_scope,
+        )
+        if profile is None:
+            return {"status": "skipped", "reason": "profile_not_configured"}
+        if not is_local_first_sync_profile_mode(profile.get("profile_mode")):
+            return {"status": "skipped", "reason": "profile_not_local_first"}
+
+        device_id = profile.get("device_id")
+        dataset_id = profile.get("dataset_id")
+        if not device_id or not dataset_id:
+            return {"status": "skipped", "reason": "profile_missing_dataset_identity"}
+        dataset_key = self.dataset_keys.get(str(dataset_id))
+        if dataset_key is None:
+            return {"status": "skipped", "reason": "dataset_key_unavailable"}
+
+        return {
+            "status": "ready",
+            "device_id": str(device_id),
+            "dataset_id": str(dataset_id),
+            "dataset_key": dataset_key,
+        }
+
+    @staticmethod
+    def _builder(profile: Mapping[str, Any]) -> SyncEnvelopeBuilder:
+        return SyncEnvelopeBuilder(
+            dataset_id=str(profile["dataset_id"]),
+            device_id=str(profile["device_id"]),
+            dataset_key=profile["dataset_key"],
+        )
+
+    def _enqueue(
+        self,
+        *,
+        profile: Mapping[str, Any],
+        server_profile_id: str,
+        authenticated_principal_id: str | None,
+        workspace_scope: str | None,
+        envelope: Any,
+    ) -> dict[str, Any]:
+        entry = self.state_repository.enqueue_sync_v2_outbox_envelope(
+            server_profile_id=server_profile_id,
+            authenticated_principal_id=authenticated_principal_id,
+            workspace_scope=workspace_scope,
+            dataset_id=str(profile["dataset_id"]),
+            envelope=envelope,
+        )
+        return {"status": "enqueued", "outbox_entry": entry}

--- a/tldw_chatbook/Sync_Interop/notes_outbox_producer.py
+++ b/tldw_chatbook/Sync_Interop/notes_outbox_producer.py
@@ -9,7 +9,14 @@ from tldw_chatbook.Sync_Interop.sync_state import is_local_first_sync_profile_mo
 
 
 class NotesSyncV2OutboxProducer:
-    """Convert successful local Notes writes into durable Sync v2 outbox entries."""
+    """Convert successful local Notes writes into durable Sync v2 outbox entries.
+
+    Args:
+        state_repository: Repository that owns Sync v2 profile state and durable
+            local outbox persistence.
+        dataset_keys: Mapping of dataset IDs to in-memory dataset keys used to
+            encrypt private Notes payloads before persistence.
+    """
 
     def __init__(
         self,
@@ -34,6 +41,25 @@ class NotesSyncV2OutboxProducer:
         base_version: str | int | None = None,
         entity_version: str | int | None = None,
     ) -> dict[str, Any]:
+        """Persist an encrypted Notes upsert envelope when Sync v2 is ready.
+
+        Args:
+            server_profile_id: Server profile that owns the outbox source scope.
+            authenticated_principal_id: Optional authenticated principal scope.
+            workspace_scope: Optional workspace scope for scoped outbox entries.
+            note_id: Local Notes entity ID.
+            title: Note title to encrypt into the payload.
+            content: Note body to encrypt into the payload.
+            status: Optional clear-text note status metadata.
+            tag_ids: Optional clear-text tag identifiers for routing/metadata.
+            base_version: Optional source entity version before the mutation.
+            entity_version: Optional source entity version after the mutation.
+
+        Returns:
+            A status mapping. Enqueued results include the durable outbox entry;
+            skipped results include a reason describing the missing prerequisite.
+        """
+
         profile = self._sync_ready_profile(
             server_profile_id=server_profile_id,
             authenticated_principal_id=authenticated_principal_id,
@@ -70,6 +96,21 @@ class NotesSyncV2OutboxProducer:
         base_version: str | int | None = None,
         entity_version: str | int | None = None,
     ) -> dict[str, Any]:
+        """Persist a Notes delete tombstone envelope when Sync v2 is ready.
+
+        Args:
+            server_profile_id: Server profile that owns the outbox source scope.
+            authenticated_principal_id: Optional authenticated principal scope.
+            workspace_scope: Optional workspace scope for scoped outbox entries.
+            note_id: Local Notes entity ID.
+            base_version: Optional source entity version before the delete.
+            entity_version: Optional source entity version after the delete.
+
+        Returns:
+            A status mapping. Enqueued results include the durable outbox entry;
+            skipped results include a reason describing the missing prerequisite.
+        """
+
         profile = self._sync_ready_profile(
             server_profile_id=server_profile_id,
             authenticated_principal_id=authenticated_principal_id,


### PR DESCRIPTION
## Summary
- Add a pure Notes Sync v2 outbox producer for local-first Notes create/update/delete envelopes.
- Add note delete envelope support and opt-in NotesScopeService hooks after successful local mutations.
- Mark TASK-70.1 Done with verification evidence.

## Scope
- No background sync, automatic push/pull, UI changes, or broad domain sync added.
- Producer skips when a local-first profile, dataset identity, or dataset key is unavailable.

## Verification
- ../../.venv/bin/python -m pytest -q Tests/Sync_Interop/test_notes_outbox_producer.py Tests/Notes/test_notes_scope_service.py::test_scope_service_enqueues_local_note_upsert_after_successful_save Tests/Notes/test_notes_scope_service.py::test_scope_service_does_not_enqueue_local_note_upsert_after_failed_save Tests/Notes/test_notes_scope_service.py::test_scope_service_does_not_enqueue_local_note_upsert_after_failed_create Tests/Notes/test_notes_scope_service.py::test_scope_service_ignores_incomplete_sync_v2_profile_after_local_save Tests/Notes/test_notes_scope_service.py::test_scope_service_enqueues_local_note_delete_after_successful_delete --tb=short
- ../../.venv/bin/python -m pytest -q Tests/Sync_Interop/test_notes_outbox_producer.py Tests/Sync_Interop/test_envelope_builder.py Tests/Sync_Interop/test_sync_state_repository.py Tests/Notes/test_notes_scope_service.py --tb=short
- ../../.venv/bin/python -m pytest -q Tests/Sync_Interop/test_local_first_sync_service.py Tests/Sync_Interop/test_restore_service.py --tb=short
- ../../.venv/bin/python -m pytest -q Tests/UI/test_product_maturity_phase1_harness.py::test_backlog_task_frontmatter_ids_are_unique --tb=short
- ../../.venv/bin/python -m compileall tldw_chatbook/Sync_Interop/notes_outbox_producer.py tldw_chatbook/Sync_Interop/envelope_builder.py tldw_chatbook/Notes/notes_scope_service.py
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Notes Sync v2 outbox producer that turns local-first note create/update/delete into durable envelopes. Wires `NotesScopeService` to enqueue on successful local writes with best-effort behavior; skips when the profile is invalid/missing or the dataset key is unavailable. Completes TASK-70.1.

- **New Features**
  - Added `NotesSyncV2OutboxProducer` to enqueue encrypted note upserts and clear delete tombstones for local-first profiles; idempotent on same `entity_version` and updates outbox summary.
  - Extended `SyncEnvelopeBuilder` with `build_note_delete` and `base_version` on clear envelopes.
  - Hooked `NotesScopeService.save_note` and `.delete_note` to enqueue after success; forwards `keywords` to `tag_ids`; local writes still succeed if enqueue fails; no background sync.
  - Skips enqueue when the Sync v2 profile is incomplete/invalid, not local-first, or the dataset key is missing.
  - Added tests for encryption boundaries, idempotency, profile validation, best‑effort failure paths, and scope service hooks.

<sup>Written for commit fcc58a64673d315ae31ae3be353c1fcdf0860560. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/370?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

