### PR TITLE
Add Chat Sync v2 outbox producer

### DIFF
--- a/Tests/Chat/test_console_chat_store.py
+++ b/Tests/Chat/test_console_chat_store.py
@@ -185,7 +185,15 @@ class FakeChatSyncProducer:
 
     def enqueue_chat_message(self, **kwargs):
         self.enqueued.append(kwargs)
-        return {"status": "enqueued", "outbox_entry": {"outbox_id": len(self.enqueued)}}
+        return {
+            "status": "enqueued",
+            "outbox_entry": {
+                "outbox_id": len(self.enqueued),
+                "envelope": {
+                    "payload_hash": f"hash:{kwargs['role']}:{kwargs['content']}",
+                },
+            },
+        }
 
 
 class FailingChatSyncProducer:
@@ -351,11 +359,54 @@ def test_store_enqueues_selected_variant_with_restore_metadata():
     assert updated.variants is not None
     assert sync_producer.enqueued[-1]["message_id"] == "msg-1"
     assert sync_producer.enqueued[-1]["content"] == "second"
+    assert sync_producer.enqueued[-1]["base_version"] == "hash:assistant:first"
     assert sync_producer.enqueued[-1]["sequence"] == 1
     assert sync_producer.enqueued[-1]["variant_turn_id"] == updated.variants.turn_id
     assert sync_producer.enqueued[-1]["variant_index"] == 1
     assert sync_producer.enqueued[-1]["variant_count"] == 2
     assert sync_producer.enqueued[-1]["selected_variant_id"] == updated.variants.current.id
+
+
+def test_store_sequences_only_sync_eligible_messages():
+    persistence = FakePersistence()
+    sync_producer = FakeChatSyncProducer()
+    store = ConsoleChatStore(
+        persistence=persistence,
+        sync_v2_chat_producer=sync_producer,
+        sync_v2_server_profile_id="server-a",
+    )
+    session = store.ensure_session(title="Chat 1")
+    store.append_message(
+        session.id,
+        role=ConsoleMessageRole.SYSTEM,
+        content="visible only",
+        persist=False,
+    )
+    failed = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="",
+        persist=True,
+    )
+    store.append_stream_chunk(failed.id, "partial")
+    store.mark_message_failed(failed.id)
+
+    first_synced = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content="hello",
+        persist=True,
+    )
+    second_synced = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content="again",
+        persist=True,
+    )
+
+    assert first_synced.persisted_message_id == "msg-2"
+    assert second_synced.persisted_message_id == "msg-3"
+    assert [entry["sequence"] for entry in sync_producer.enqueued] == [1, 2]
 
 
 def test_store_updates_persisted_streaming_assistant_content_and_status():

--- a/Tests/Chat/test_console_chat_store.py
+++ b/Tests/Chat/test_console_chat_store.py
@@ -179,6 +179,20 @@ class FakePersistence:
         return True
 
 
+class FakeChatSyncProducer:
+    def __init__(self):
+        self.enqueued = []
+
+    def enqueue_chat_message(self, **kwargs):
+        self.enqueued.append(kwargs)
+        return {"status": "enqueued", "outbox_entry": {"outbox_id": len(self.enqueued)}}
+
+
+class FailingChatSyncProducer:
+    def enqueue_chat_message(self, **kwargs):
+        raise RuntimeError("sync unavailable")
+
+
 def test_store_can_persist_user_and_assistant_messages_through_adapter():
     persistence = FakePersistence()
     store = ConsoleChatStore(persistence=persistence)
@@ -193,6 +207,155 @@ def test_store_can_persist_user_and_assistant_messages_through_adapter():
     assert persistence.created_messages[0]["content"] == "hello"
     assert persistence.created_messages[0]["image_data"] is None
     assert persistence.created_messages[0]["image_mime_type"] is None
+
+
+def test_store_enqueues_chat_sync_after_user_message_is_durable():
+    persistence = FakePersistence()
+    sync_producer = FakeChatSyncProducer()
+    store = ConsoleChatStore(
+        persistence=persistence,
+        sync_v2_chat_producer=sync_producer,
+        sync_v2_server_profile_id="server-a",
+        sync_v2_authenticated_principal_id="user-a",
+    )
+    session = store.ensure_session(title="Chat 1")
+
+    message = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content="hello",
+        persist=True,
+    )
+
+    assert message.persisted_message_id == "msg-1"
+    assert sync_producer.enqueued == [
+        {
+            "server_profile_id": "server-a",
+            "authenticated_principal_id": "user-a",
+            "workspace_scope": None,
+            "conversation_id": "conv-1",
+            "message_id": "msg-1",
+            "role": "user",
+            "content": "hello",
+            "parent_message_id": None,
+            "sequence": 1,
+            "variant_turn_id": None,
+            "variant_index": None,
+            "variant_count": None,
+            "selected_variant_id": None,
+            "base_version": None,
+            "entity_version": None,
+        }
+    ]
+
+
+def test_store_enqueues_streaming_assistant_only_after_completion():
+    persistence = FakePersistence()
+    sync_producer = FakeChatSyncProducer()
+    store = ConsoleChatStore(
+        persistence=persistence,
+        sync_v2_chat_producer=sync_producer,
+        sync_v2_server_profile_id="server-a",
+    )
+    session = store.ensure_session(title="Chat 1")
+    store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content="hello?",
+        persist=True,
+    )
+    sync_producer.enqueued.clear()
+    assistant = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="",
+        persist=True,
+    )
+
+    store.append_stream_chunk(assistant.id, "hel")
+    store.append_stream_chunk(assistant.id, "lo")
+
+    assert sync_producer.enqueued == []
+
+    completed = store.mark_message_complete(assistant.id)
+
+    assert completed.persisted_message_id == "msg-2"
+    assert sync_producer.enqueued[-1]["message_id"] == "msg-2"
+    assert sync_producer.enqueued[-1]["role"] == "assistant"
+    assert sync_producer.enqueued[-1]["content"] == "hello"
+    assert sync_producer.enqueued[-1]["parent_message_id"] == "msg-1"
+    assert sync_producer.enqueued[-1]["sequence"] == 2
+
+
+def test_store_does_not_enqueue_failed_assistant_final_content():
+    persistence = FakePersistence()
+    sync_producer = FakeChatSyncProducer()
+    store = ConsoleChatStore(
+        persistence=persistence,
+        sync_v2_chat_producer=sync_producer,
+        sync_v2_server_profile_id="server-a",
+    )
+    session = store.ensure_session(title="Chat 1")
+    assistant = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="",
+        persist=True,
+    )
+
+    store.append_stream_chunk(assistant.id, "partial")
+    store.mark_message_failed(assistant.id)
+
+    assert sync_producer.enqueued == []
+
+
+def test_store_persists_chat_when_sync_enqueue_fails():
+    persistence = FakePersistence()
+    store = ConsoleChatStore(
+        persistence=persistence,
+        sync_v2_chat_producer=FailingChatSyncProducer(),
+        sync_v2_server_profile_id="server-a",
+    )
+    session = store.ensure_session(title="Chat 1")
+
+    message = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content="hello",
+        persist=True,
+    )
+
+    assert message.persisted_message_id == "msg-1"
+    assert persistence.created_messages[0]["content"] == "hello"
+
+
+def test_store_enqueues_selected_variant_with_restore_metadata():
+    persistence = FakePersistence()
+    sync_producer = FakeChatSyncProducer()
+    store = ConsoleChatStore(
+        persistence=persistence,
+        sync_v2_chat_producer=sync_producer,
+        sync_v2_server_profile_id="server-a",
+    )
+    session = store.ensure_session(title="Chat 1")
+    message = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="first",
+        persist=True,
+    )
+    sync_producer.enqueued.clear()
+
+    updated = store.add_variant(message.id, "second")
+
+    assert updated.variants is not None
+    assert sync_producer.enqueued[-1]["message_id"] == "msg-1"
+    assert sync_producer.enqueued[-1]["content"] == "second"
+    assert sync_producer.enqueued[-1]["sequence"] == 1
+    assert sync_producer.enqueued[-1]["variant_turn_id"] == updated.variants.turn_id
+    assert sync_producer.enqueued[-1]["variant_index"] == 1
+    assert sync_producer.enqueued[-1]["variant_count"] == 2
+    assert sync_producer.enqueued[-1]["selected_variant_id"] == updated.variants.current.id
 
 
 def test_store_updates_persisted_streaming_assistant_content_and_status():

--- a/Tests/Sync_Interop/test_chat_outbox_producer.py
+++ b/Tests/Sync_Interop/test_chat_outbox_producer.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import json
+
+from tldw_chatbook.Sync_Interop.chat_outbox_producer import ChatSyncV2OutboxProducer
+from tldw_chatbook.Sync_Interop.crypto import decrypt_sync_payload, generate_dataset_key
+from tldw_chatbook.Sync_Interop.sync_state_repository import SyncStateRepository
+
+
+def test_chat_producer_enqueues_encrypted_message_and_updates_summary(tmp_path) -> None:
+    dataset_key = generate_dataset_key()
+    repo = _local_first_repo(tmp_path)
+    producer = ChatSyncV2OutboxProducer(
+        state_repository=repo,
+        dataset_keys={"dataset-1": dataset_key},
+    )
+
+    result = producer.enqueue_chat_message(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope=None,
+        conversation_id="conversation-1",
+        message_id="message-2",
+        role="assistant",
+        content="Private answer",
+        parent_message_id="message-1",
+        sequence=2,
+        variant_turn_id="turn-1",
+        variant_index=1,
+        variant_count=2,
+        selected_variant_id="variant-2",
+        entity_version=3,
+    )
+
+    entries = repo.list_pending_sync_v2_outbox_envelopes(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope=None,
+        dataset_id="dataset-1",
+    )
+    summary = repo.get_sync_v2_profile_summary(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope=None,
+    )
+    envelope = entries[0]["envelope"]
+
+    assert result["status"] == "enqueued"
+    assert len(entries) == 1
+    assert entries[0]["domain"] == "chat"
+    assert summary["outbox"]["pending"] == 1
+    assert summary["outbox"]["by_domain"]["chat"]["pending"] == 1
+    serialized = json.dumps(envelope)
+    assert "Private answer" not in serialized
+    assert envelope["stable_key"] == "conversation-1:message-2"
+    assert envelope["routing_metadata"] == {
+        "conversation_id": "conversation-1",
+        "entity_kind": "message",
+        "parent_message_id": "message-1",
+        "selected_variant_id": "variant-2",
+        "sequence": 2,
+        "variant_count": 2,
+        "variant_index": 1,
+        "variant_turn_id": "turn-1",
+    }
+    assert _decrypt_payload(envelope["payload_ciphertext"], dataset_key) == {
+        "content": "Private answer",
+        "role": "assistant",
+    }
+
+    producer.enqueue_chat_message(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope=None,
+        conversation_id="conversation-1",
+        message_id="message-2",
+        role="assistant",
+        content="Private answer",
+        parent_message_id="message-1",
+        sequence=2,
+        variant_turn_id="turn-1",
+        variant_index=1,
+        variant_count=2,
+        selected_variant_id="variant-2",
+        entity_version=3,
+    )
+    assert len(
+        repo.list_pending_sync_v2_outbox_envelopes(
+            server_profile_id="server-a",
+            authenticated_principal_id="user-a",
+            workspace_scope=None,
+            dataset_id="dataset-1",
+        )
+    ) == 1
+
+
+def test_chat_producer_skips_without_local_first_profile_or_dataset_key(tmp_path) -> None:
+    repo = SyncStateRepository(tmp_path / "sync_state.db")
+    repo.set_sync_v2_profile_state(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope=None,
+        profile_mode="server_frontend",
+        device_id="device-1",
+        dataset_id="dataset-1",
+    )
+    producer = ChatSyncV2OutboxProducer(state_repository=repo, dataset_keys={})
+
+    result = producer.enqueue_chat_message(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope=None,
+        conversation_id="conversation-1",
+        message_id="message-1",
+        role="user",
+        content="No sync",
+    )
+
+    assert result == {"status": "skipped", "reason": "profile_not_local_first"}
+    assert repo.list_sync_v2_outbox_entries(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope=None,
+        dataset_id="dataset-1",
+    ) == []
+
+
+def _local_first_repo(tmp_path) -> SyncStateRepository:
+    repo = SyncStateRepository(tmp_path / "sync_state.db")
+    repo.set_sync_v2_profile_state(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope=None,
+        profile_mode="local_first",
+        device_id="device-1",
+        dataset_id="dataset-1",
+    )
+    return repo
+
+
+def _decrypt_payload(payload_ciphertext: str, dataset_key: bytes) -> dict:
+    return decrypt_sync_payload(json.loads(payload_ciphertext), key=dataset_key)

--- a/Tests/Sync_Interop/test_envelope_applier.py
+++ b/Tests/Sync_Interop/test_envelope_applier.py
@@ -109,6 +109,38 @@ def test_chat_applier_appends_by_stable_id_and_conflicts_on_hash_mismatch() -> N
     assert store.conflicts[-1]["domain"] == "chat"
 
 
+def test_chat_applier_allows_versioned_message_update() -> None:
+    dataset_key = generate_dataset_key()
+    builder = SyncEnvelopeBuilder(dataset_id="dataset-1", device_id="device-1", dataset_key=dataset_key)
+    store = RecordingLocalStore()
+    applier = SyncEnvelopeApplier(dataset_key=dataset_key, local_store=store)
+
+    original = builder.build_chat_message(
+        conversation_id="conversation-1",
+        message_id="message-1",
+        role="assistant",
+        content="first",
+    )
+    updated = builder.build_chat_message(
+        conversation_id="conversation-1",
+        message_id="message-1",
+        role="assistant",
+        content="second",
+        base_version=original.payload_hash,
+    )
+
+    first = applier.apply(original)
+    second = applier.apply(updated)
+
+    assert first["status"] == "applied"
+    assert second["status"] == "applied"
+    assert store.chat_messages["conversation-1:message-1"] == {
+        "content": "second",
+        "role": "assistant",
+    }
+    assert store.conflicts == []
+
+
 def test_workspace_and_source_cache_appliers_route_to_local_store() -> None:
     dataset_key = generate_dataset_key()
     builder = SyncEnvelopeBuilder(dataset_id="dataset-1", device_id="device-1", dataset_key=dataset_key)

--- a/Tests/Sync_Interop/test_envelope_builder.py
+++ b/Tests/Sync_Interop/test_envelope_builder.py
@@ -52,6 +52,45 @@ def test_chat_message_uses_stable_message_identity() -> None:
     }
 
 
+def test_chat_message_preserves_restore_metadata_without_plaintext_leak() -> None:
+    dataset_key = generate_dataset_key()
+    builder = SyncEnvelopeBuilder(dataset_id="dataset-1", device_id="device-1", dataset_key=dataset_key)
+
+    envelope = builder.build_chat_message(
+        conversation_id="conversation-1",
+        message_id="message-2",
+        role="assistant",
+        content="private regenerated answer",
+        parent_message_id="message-1",
+        sequence=2,
+        variant_turn_id="turn-1",
+        variant_index=1,
+        variant_count=2,
+        selected_variant_id="variant-2",
+        base_version="v1",
+        entity_version="v2",
+    )
+
+    serialized = envelope.model_dump_json()
+    assert "private regenerated answer" not in serialized
+    assert envelope.base_version == "v1"
+    assert envelope.entity_version == "v2"
+    assert envelope.routing_metadata == {
+        "conversation_id": "conversation-1",
+        "entity_kind": "message",
+        "parent_message_id": "message-1",
+        "selected_variant_id": "variant-2",
+        "sequence": 2,
+        "variant_count": 2,
+        "variant_index": 1,
+        "variant_turn_id": "turn-1",
+    }
+    assert decrypt_sync_payload_json(envelope.payload_ciphertext, dataset_key) == {
+        "content": "private regenerated answer",
+        "role": "assistant",
+    }
+
+
 def test_workspace_source_ref_add_remove_maps_to_link_unlink() -> None:
     builder = SyncEnvelopeBuilder(
         dataset_id="dataset-1",

--- a/backlog/tasks/task-70.2 - Add-Chat-Sync-v2-outbox-producer-plan.md
+++ b/backlog/tasks/task-70.2 - Add-Chat-Sync-v2-outbox-producer-plan.md
@@ -14,10 +14,12 @@ documentation:
 modified_files:
 - tldw_chatbook/Sync_Interop/chat_outbox_producer.py
 - tldw_chatbook/Sync_Interop/envelope_builder.py
+- tldw_chatbook/Sync_Interop/domain_adapters/chat.py
 - tldw_chatbook/Sync_Interop/__init__.py
 - tldw_chatbook/Chat/console_chat_store.py
 - Tests/Sync_Interop/test_chat_outbox_producer.py
 - Tests/Sync_Interop/test_envelope_builder.py
+- Tests/Sync_Interop/test_envelope_applier.py
 - Tests/Chat/test_console_chat_store.py
 ---
 
@@ -54,6 +56,8 @@ Extended `SyncEnvelopeBuilder.build_chat_message()` with restore-compatible clea
 
 Wired `ConsoleChatStore` to an optional injected Chat producer after durable local persistence succeeds. User messages enqueue immediately after persistence; assistant messages enqueue only when complete. Streaming chunks, failed assistant sends, stopped assistant sends, empty/pending messages, and producer exceptions do not block local chat persistence or create misleading final-message envelopes. Regenerated variants enqueue the selected variant content with variant metadata.
 
+PR review follow-up added Google-style public API docstrings, preserved Loguru structured exception context with `logger.bind()`, made sequence metadata count only sync-eligible persisted complete messages, and added versioned Chat message update semantics. The store now tracks the last enqueued payload hash per stable message key and passes it as `base_version` for changed content, while `ChatSyncAdapter` applies updates when `base_version` matches the current local hash and still conflicts on divergent changes.
+
 Verification:
 - Red tests failed on the missing Chat producer module and missing ConsoleChatStore Sync v2 enqueue contract.
 - `../../.venv/bin/python -m pytest -q Tests/Sync_Interop/test_chat_outbox_producer.py Tests/Sync_Interop/test_envelope_builder.py Tests/Chat/test_console_chat_store.py --tb=short` passed with 27 tests.
@@ -62,6 +66,13 @@ Verification:
 - `../../.venv/bin/python -m pytest -q Tests/UI/test_product_maturity_phase1_harness.py::test_backlog_task_frontmatter_ids_are_unique --tb=short` passed with 1 test.
 - `../../.venv/bin/python -m compileall tldw_chatbook/Sync_Interop/chat_outbox_producer.py tldw_chatbook/Sync_Interop/envelope_builder.py tldw_chatbook/Chat/console_chat_store.py` passed.
 - `git diff --check` passed.
+- `git rebase origin/dev` reported the branch was up to date because `origin/dev` is already an ancestor of the stacked roadmap branch.
+- `../../.venv/bin/python -m pytest -q Tests/Sync_Interop/test_chat_outbox_producer.py Tests/Sync_Interop/test_envelope_builder.py Tests/Sync_Interop/test_envelope_applier.py Tests/Chat/test_console_chat_store.py --tb=short` passed with 33 tests after PR review fixes.
+- `../../.venv/bin/python -m pytest -q Tests/Sync_Interop/test_local_first_sync_service.py Tests/Sync_Interop/test_restore_service.py Tests/Sync_Interop/test_sync_state_repository.py --tb=short` passed with 61 tests after PR review fixes.
+- `../../.venv/bin/python -m pytest -q Tests/Chat/test_console_chat_controller.py Tests/Chat/test_console_chat_store.py --tb=short` passed with 44 tests after PR review fixes.
+- `../../.venv/bin/python -m pytest -q Tests/UI/test_product_maturity_phase1_harness.py::test_backlog_task_frontmatter_ids_are_unique --tb=short` passed with 1 test after PR review fixes.
+- `../../.venv/bin/python -m compileall tldw_chatbook/Sync_Interop/chat_outbox_producer.py tldw_chatbook/Sync_Interop/envelope_builder.py tldw_chatbook/Sync_Interop/domain_adapters/chat.py tldw_chatbook/Chat/console_chat_store.py` passed after PR review fixes.
+- `git diff --check` passed after PR review fixes.
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 

--- a/backlog/tasks/task-70.2 - Add-Chat-Sync-v2-outbox-producer-plan.md
+++ b/backlog/tasks/task-70.2 - Add-Chat-Sync-v2-outbox-producer-plan.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-70.2
 title: Add Chat Sync v2 outbox producer plan
-status: To Do
+status: Done
 labels:
 - sync
 - sync-v2
@@ -11,6 +11,14 @@ priority: high
 parent_task_id: TASK-70
 documentation:
 - Docs/superpowers/specs/2026-05-26-chatbook-sync-v2-completion-roadmap-design.md
+modified_files:
+- tldw_chatbook/Sync_Interop/chat_outbox_producer.py
+- tldw_chatbook/Sync_Interop/envelope_builder.py
+- tldw_chatbook/Sync_Interop/__init__.py
+- tldw_chatbook/Chat/console_chat_store.py
+- Tests/Sync_Interop/test_chat_outbox_producer.py
+- Tests/Sync_Interop/test_envelope_builder.py
+- Tests/Chat/test_console_chat_store.py
 ---
 
 ## Description
@@ -21,24 +29,53 @@ Implement the Chat Sync v2 content-producing path so conversation and message ch
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 User and assistant Chat messages enqueue ordered Sync v2 envelopes only after they represent durable local message state.
-- [ ] #2 Conversation identity, message roles, parentage, ordering, and message variants have restore-compatible metadata.
-- [ ] #3 Streaming, failed-send, and regenerated-message cases do not produce misleading final-message envelopes.
-- [ ] #4 Tests cover local-first success, envelope shape, ordering, variants, and pending profile summary counts.
+- [x] #1 User and assistant Chat messages enqueue ordered Sync v2 envelopes only after they represent durable local message state.
+- [x] #2 Conversation identity, message roles, parentage, ordering, and message variants have restore-compatible metadata.
+- [x] #3 Streaming, failed-send, and regenerated-message cases do not produce misleading final-message envelopes.
+- [x] #4 Tests cover local-first success, envelope shape, ordering, variants, and pending profile summary counts.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing tests for a pure Chat Sync v2 outbox producer and ConsoleChatStore post-durable-message enqueue hooks.
+2. Extend the Chat envelope builder with restore metadata for parentage, transcript ordering, and selected regenerated variants while keeping message content encrypted.
+3. Implement `ChatSyncV2OutboxProducer` using the same local-first profile and dataset-key readiness contract as the Notes producer.
+4. Wire `ConsoleChatStore` to an injected producer only after messages have durable persisted IDs and complete status, leaving streaming, stopped, and failed assistant content unsynced.
+5. Run focused Chat/Sync verification and diff hygiene.
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Added `ChatSyncV2OutboxProducer` as the Chat content-producing Sync v2 boundary. The producer reads the active local-first profile from `SyncStateRepository`, requires device/dataset identity plus an in-memory dataset key, encrypts chat message role/content, and persists deterministic pending outbox envelopes through the existing durable outbox API. Non-local-first, unconfigured, missing-identity, or missing-key profiles return explicit skipped states and do not dispatch remote sync.
+
+Extended `SyncEnvelopeBuilder.build_chat_message()` with restore-compatible clear routing metadata for conversation identity, parent message, transcript sequence, selected variant ID, variant turn ID, selected variant index, and variant count. Message content remains encrypted and does not appear in serialized envelope JSON.
+
+Wired `ConsoleChatStore` to an optional injected Chat producer after durable local persistence succeeds. User messages enqueue immediately after persistence; assistant messages enqueue only when complete. Streaming chunks, failed assistant sends, stopped assistant sends, empty/pending messages, and producer exceptions do not block local chat persistence or create misleading final-message envelopes. Regenerated variants enqueue the selected variant content with variant metadata.
+
+Verification:
+- Red tests failed on the missing Chat producer module and missing ConsoleChatStore Sync v2 enqueue contract.
+- `../../.venv/bin/python -m pytest -q Tests/Sync_Interop/test_chat_outbox_producer.py Tests/Sync_Interop/test_envelope_builder.py Tests/Chat/test_console_chat_store.py --tb=short` passed with 27 tests.
+- `../../.venv/bin/python -m pytest -q Tests/Sync_Interop/test_local_first_sync_service.py Tests/Sync_Interop/test_restore_service.py Tests/Sync_Interop/test_sync_state_repository.py --tb=short` passed with 61 tests.
+- `../../.venv/bin/python -m pytest -q Tests/Chat/test_console_chat_controller.py Tests/Chat/test_console_chat_store.py --tb=short` passed with 43 tests.
+- `../../.venv/bin/python -m pytest -q Tests/UI/test_product_maturity_phase1_harness.py::test_backlog_task_frontmatter_ids_are_unique --tb=short` passed with 1 test.
+- `../../.venv/bin/python -m compileall tldw_chatbook/Sync_Interop/chat_outbox_producer.py tldw_chatbook/Sync_Interop/envelope_builder.py tldw_chatbook/Chat/console_chat_store.py` passed.
+- `git diff --check` passed.
 
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
+`TASK-70.2` adds the Chat Sync v2 producer and durable Console store hook needed for ordered, encrypted local-first Chat message outbox entries. The slice remains opt-in through injected producer/profile context and does not add background sync, automatic dispatch, or UI/config wiring.
 
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria completed
+- [x] #2 Tests and verification recorded
+- [x] #3 Documentation updated in task record
+- [x] #4 No background sync or automatic dispatch added
 <!-- DOD:END -->

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field, replace
-from typing import Protocol
+from typing import Any, Protocol
 from uuid import uuid4
+
+from loguru import logger
 
 from tldw_chatbook.Chat.console_chat_models import (
     ConsoleChatMessage,
@@ -51,6 +53,13 @@ class ConsoleChatPersistence(Protocol):
         """Update persisted message content."""
 
 
+class ConsoleChatSyncProducer(Protocol):
+    """Sync v2 producer surface used after durable local Chat writes."""
+
+    def enqueue_chat_message(self, **kwargs: Any) -> dict[str, Any]:
+        """Enqueue a Chat message into the Sync v2 local outbox."""
+
+
 @dataclass
 class ConsoleChatSession:
     """A native Console chat session."""
@@ -69,9 +78,17 @@ class ConsoleChatStore:
         *,
         persistence: ConsoleChatPersistence | None = None,
         workspace_context: ConsoleWorkspaceContext | None = None,
+        sync_v2_chat_producer: ConsoleChatSyncProducer | None = None,
+        sync_v2_server_profile_id: str | None = None,
+        sync_v2_authenticated_principal_id: str | None = None,
+        sync_v2_workspace_scope: str | None = None,
     ) -> None:
         self.persistence = persistence
         self.workspace_context = workspace_context or ConsoleWorkspaceContext()
+        self.sync_v2_chat_producer = sync_v2_chat_producer
+        self.sync_v2_server_profile_id = sync_v2_server_profile_id
+        self.sync_v2_authenticated_principal_id = sync_v2_authenticated_principal_id
+        self.sync_v2_workspace_scope = sync_v2_workspace_scope
         self.active_session_id: str | None = None
         self._sessions: dict[str, ConsoleChatSession] = {}
         self._messages_by_session: dict[str, list[ConsoleChatMessage]] = {}
@@ -323,6 +340,7 @@ class ConsoleChatStore:
             feedback=None,
         )
         self._pending_persistence_message_ids.discard(message.id)
+        self._enqueue_sync_v2_message_if_ready(message)
 
     def _persist_existing_message(self, message: ConsoleChatMessage) -> None:
         if self.persistence is None:
@@ -340,6 +358,7 @@ class ConsoleChatStore:
             update_parent=False,
             update_feedback=False,
         )
+        self._enqueue_sync_v2_message_if_ready(message)
 
     def _persist_pending_message_if_ready(self, message: ConsoleChatMessage) -> None:
         if (
@@ -350,6 +369,88 @@ class ConsoleChatStore:
             return
         session_id = self._message_session_index[message.id]
         self._persist_new_message(session_id=session_id, message=message)
+
+    def _enqueue_sync_v2_message_if_ready(self, message: ConsoleChatMessage) -> None:
+        if (
+            self.sync_v2_chat_producer is None
+            or self.sync_v2_server_profile_id is None
+            or message.persisted_message_id is None
+            or message.status != "complete"
+            or not message.content
+        ):
+            return
+        session_id = self._message_session_index.get(message.id)
+        if session_id is None:
+            return
+        session = self._sessions.get(session_id)
+        conversation_id = session.persisted_conversation_id if session is not None else None
+        if conversation_id is None:
+            return
+        variant_metadata = self._sync_variant_metadata(message)
+        try:
+            self.sync_v2_chat_producer.enqueue_chat_message(
+                server_profile_id=self.sync_v2_server_profile_id,
+                authenticated_principal_id=self.sync_v2_authenticated_principal_id,
+                workspace_scope=self.sync_v2_workspace_scope,
+                conversation_id=conversation_id,
+                message_id=message.persisted_message_id,
+                role=message.role.value,
+                content=message.content,
+                parent_message_id=self._previous_persisted_message_id(message),
+                sequence=self._sync_message_sequence(message),
+                variant_turn_id=variant_metadata["variant_turn_id"],
+                variant_index=variant_metadata["variant_index"],
+                variant_count=variant_metadata["variant_count"],
+                selected_variant_id=variant_metadata["selected_variant_id"],
+                base_version=None,
+                entity_version=None,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to enqueue Sync v2 chat message after local mutation",
+                server_profile_id=self.sync_v2_server_profile_id,
+                authenticated_principal_id=self.sync_v2_authenticated_principal_id,
+                workspace_scope=self.sync_v2_workspace_scope,
+                conversation_id=conversation_id,
+                message_id=message.persisted_message_id,
+            )
+
+    def _sync_message_sequence(self, message: ConsoleChatMessage) -> int | None:
+        session_id = self._message_session_index.get(message.id)
+        if session_id is None:
+            return None
+        for index, candidate in enumerate(self._messages_by_session.get(session_id, []), start=1):
+            if candidate.id == message.id:
+                return index
+        return None
+
+    def _previous_persisted_message_id(self, message: ConsoleChatMessage) -> str | None:
+        session_id = self._message_session_index.get(message.id)
+        if session_id is None:
+            return None
+        previous: str | None = None
+        for candidate in self._messages_by_session.get(session_id, []):
+            if candidate.id == message.id:
+                return previous
+            if candidate.persisted_message_id is not None:
+                previous = candidate.persisted_message_id
+        return None
+
+    @staticmethod
+    def _sync_variant_metadata(message: ConsoleChatMessage) -> dict[str, str | int | None]:
+        if message.variants is None:
+            return {
+                "variant_turn_id": None,
+                "variant_index": None,
+                "variant_count": None,
+                "selected_variant_id": None,
+            }
+        return {
+            "variant_turn_id": message.variants.turn_id,
+            "variant_index": message.variants.selected_index,
+            "variant_count": len(message.variants.variants),
+            "selected_variant_id": message.variants.current.id,
+        }
 
     def _session_or_raise(self, session_id: str) -> ConsoleChatSession:
         try:

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -83,6 +83,19 @@ class ConsoleChatStore:
         sync_v2_authenticated_principal_id: str | None = None,
         sync_v2_workspace_scope: str | None = None,
     ) -> None:
+        """Initialize the Console chat store.
+
+        Args:
+            persistence: Optional durable Chat persistence adapter.
+            workspace_context: Current workspace and staged-source policy context.
+            sync_v2_chat_producer: Optional Sync v2 producer called after durable,
+                complete local Chat message writes.
+            sync_v2_server_profile_id: Optional server profile scope for Chat outbox
+                entries. If missing, Sync v2 enqueue is disabled.
+            sync_v2_authenticated_principal_id: Optional authenticated principal scope
+                for Chat outbox entries.
+            sync_v2_workspace_scope: Optional workspace scope for Chat outbox entries.
+        """
         self.persistence = persistence
         self.workspace_context = workspace_context or ConsoleWorkspaceContext()
         self.sync_v2_chat_producer = sync_v2_chat_producer
@@ -96,6 +109,7 @@ class ConsoleChatStore:
         self._pending_persistence_message_ids: set[str] = set()
         self._stream_chunks_by_message: dict[str, list[str]] = {}
         self._stream_materialized_counts: dict[str, int] = {}
+        self._sync_v2_message_versions: dict[str, str] = {}
 
     def ensure_session(
         self,
@@ -387,8 +401,9 @@ class ConsoleChatStore:
         if conversation_id is None:
             return
         variant_metadata = self._sync_variant_metadata(message)
+        stable_key = f"{conversation_id}:{message.persisted_message_id}"
         try:
-            self.sync_v2_chat_producer.enqueue_chat_message(
+            result = self.sync_v2_chat_producer.enqueue_chat_message(
                 server_profile_id=self.sync_v2_server_profile_id,
                 authenticated_principal_id=self.sync_v2_authenticated_principal_id,
                 workspace_scope=self.sync_v2_workspace_scope,
@@ -402,27 +417,38 @@ class ConsoleChatStore:
                 variant_index=variant_metadata["variant_index"],
                 variant_count=variant_metadata["variant_count"],
                 selected_variant_id=variant_metadata["selected_variant_id"],
-                base_version=None,
+                base_version=self._sync_v2_message_versions.get(stable_key),
                 entity_version=None,
             )
+            self._record_sync_v2_message_version(stable_key, result)
         except Exception:
-            logger.exception(
-                "Failed to enqueue Sync v2 chat message after local mutation",
+            logger.bind(
                 server_profile_id=self.sync_v2_server_profile_id,
                 authenticated_principal_id=self.sync_v2_authenticated_principal_id,
                 workspace_scope=self.sync_v2_workspace_scope,
                 conversation_id=conversation_id,
                 message_id=message.persisted_message_id,
-            )
+            ).exception("Failed to enqueue Sync v2 chat message after local mutation")
 
     def _sync_message_sequence(self, message: ConsoleChatMessage) -> int | None:
         session_id = self._message_session_index.get(message.id)
         if session_id is None:
             return None
-        for index, candidate in enumerate(self._messages_by_session.get(session_id, []), start=1):
+        sequence = 0
+        for candidate in self._messages_by_session.get(session_id, []):
+            if self._is_sync_eligible_message(candidate):
+                sequence += 1
             if candidate.id == message.id:
-                return index
+                return sequence if self._is_sync_eligible_message(candidate) else None
         return None
+
+    @staticmethod
+    def _is_sync_eligible_message(message: ConsoleChatMessage) -> bool:
+        return (
+            message.persisted_message_id is not None
+            and message.status == "complete"
+            and bool(message.content)
+        )
 
     def _previous_persisted_message_id(self, message: ConsoleChatMessage) -> str | None:
         session_id = self._message_session_index.get(message.id)
@@ -451,6 +477,19 @@ class ConsoleChatStore:
             "variant_count": len(message.variants.variants),
             "selected_variant_id": message.variants.current.id,
         }
+
+    def _record_sync_v2_message_version(self, stable_key: str, result: dict[str, Any]) -> None:
+        if result.get("status") != "enqueued":
+            return
+        entry = result.get("outbox_entry")
+        if not isinstance(entry, dict):
+            return
+        envelope = entry.get("envelope")
+        if not isinstance(envelope, dict):
+            return
+        payload_hash = envelope.get("payload_hash")
+        if isinstance(payload_hash, str) and payload_hash:
+            self._sync_v2_message_versions[stable_key] = payload_hash
 
     def _session_or_raise(self, session_id: str) -> ConsoleChatSession:
         try:

--- a/tldw_chatbook/Sync_Interop/__init__.py
+++ b/tldw_chatbook/Sync_Interop/__init__.py
@@ -1,6 +1,7 @@
 """Server sync transport interoperability services."""
 
 from .key_recovery_service import SyncKeyRecoveryService
+from .chat_outbox_producer import ChatSyncV2OutboxProducer
 from .local_first_sync_service import LocalFirstSyncService
 from .notes_outbox_producer import NotesSyncV2OutboxProducer
 from .restore_service import SyncRestoreService
@@ -10,6 +11,7 @@ from .sync_state_repository import SyncStateRepository
 
 __all__ = [
     "LocalFirstSyncService",
+    "ChatSyncV2OutboxProducer",
     "NotesSyncV2OutboxProducer",
     "ServerSyncService",
     "SyncBackend",

--- a/tldw_chatbook/Sync_Interop/chat_outbox_producer.py
+++ b/tldw_chatbook/Sync_Interop/chat_outbox_producer.py
@@ -1,0 +1,130 @@
+"""Produce Sync v2 outbox envelopes for local Chat mutations."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from tldw_chatbook.Sync_Interop.envelope_builder import SyncEnvelopeBuilder
+from tldw_chatbook.Sync_Interop.sync_state import is_local_first_sync_profile_mode
+
+
+class ChatSyncV2OutboxProducer:
+    """Convert successful local Chat writes into durable Sync v2 outbox entries."""
+
+    def __init__(
+        self,
+        *,
+        state_repository: Any,
+        dataset_keys: Mapping[str, bytes] | None = None,
+    ) -> None:
+        self.state_repository = state_repository
+        self.dataset_keys = dict(dataset_keys or {})
+
+    def enqueue_chat_message(
+        self,
+        *,
+        server_profile_id: str,
+        authenticated_principal_id: str | None = None,
+        workspace_scope: str | None = None,
+        conversation_id: str,
+        message_id: str,
+        role: str,
+        content: str,
+        parent_message_id: str | None = None,
+        sequence: int | None = None,
+        variant_turn_id: str | None = None,
+        variant_index: int | None = None,
+        variant_count: int | None = None,
+        selected_variant_id: str | None = None,
+        base_version: str | int | None = None,
+        entity_version: str | int | None = None,
+    ) -> dict[str, Any]:
+        """Persist an encrypted Chat message envelope when Sync v2 is ready."""
+
+        profile = self._sync_ready_profile(
+            server_profile_id=server_profile_id,
+            authenticated_principal_id=authenticated_principal_id,
+            workspace_scope=workspace_scope,
+        )
+        if profile["status"] != "ready":
+            return profile
+
+        envelope = self._builder(profile).build_chat_message(
+            conversation_id=conversation_id,
+            message_id=message_id,
+            role=role,
+            content=content,
+            parent_message_id=parent_message_id,
+            sequence=sequence,
+            variant_turn_id=variant_turn_id,
+            variant_index=variant_index,
+            variant_count=variant_count,
+            selected_variant_id=selected_variant_id,
+            base_version=base_version,
+            entity_version=entity_version,
+        )
+        return self._enqueue(
+            profile=profile,
+            server_profile_id=server_profile_id,
+            authenticated_principal_id=authenticated_principal_id,
+            workspace_scope=workspace_scope,
+            envelope=envelope,
+        )
+
+    def _sync_ready_profile(
+        self,
+        *,
+        server_profile_id: str,
+        authenticated_principal_id: str | None,
+        workspace_scope: str | None,
+    ) -> dict[str, Any]:
+        profile = self.state_repository.get_sync_v2_profile_state(
+            server_profile_id=server_profile_id,
+            authenticated_principal_id=authenticated_principal_id,
+            workspace_scope=workspace_scope,
+        )
+        if profile is None:
+            return {"status": "skipped", "reason": "profile_not_configured"}
+        if not is_local_first_sync_profile_mode(profile.get("profile_mode")):
+            return {"status": "skipped", "reason": "profile_not_local_first"}
+
+        device_id = profile.get("device_id")
+        dataset_id = profile.get("dataset_id")
+        if not device_id or not dataset_id:
+            return {"status": "skipped", "reason": "profile_missing_dataset_identity"}
+        dataset_key = self.dataset_keys.get(str(dataset_id))
+        if dataset_key is None:
+            return {"status": "skipped", "reason": "dataset_key_unavailable"}
+
+        return {
+            "status": "ready",
+            "device_id": str(device_id),
+            "dataset_id": str(dataset_id),
+            "dataset_key": dataset_key,
+        }
+
+    @staticmethod
+    def _builder(profile: Mapping[str, Any]) -> SyncEnvelopeBuilder:
+        return SyncEnvelopeBuilder(
+            dataset_id=str(profile["dataset_id"]),
+            device_id=str(profile["device_id"]),
+            dataset_key=profile["dataset_key"],
+        )
+
+    def _enqueue(
+        self,
+        *,
+        profile: Mapping[str, Any],
+        server_profile_id: str,
+        authenticated_principal_id: str | None,
+        workspace_scope: str | None,
+        envelope: Any,
+    ) -> dict[str, Any]:
+        entry = self.state_repository.enqueue_sync_v2_outbox_envelope(
+            server_profile_id=server_profile_id,
+            authenticated_principal_id=authenticated_principal_id,
+            workspace_scope=workspace_scope,
+            dataset_id=str(profile["dataset_id"]),
+            envelope=envelope,
+        )
+        return {"status": "enqueued", "outbox_entry": entry}

--- a/tldw_chatbook/Sync_Interop/chat_outbox_producer.py
+++ b/tldw_chatbook/Sync_Interop/chat_outbox_producer.py
@@ -39,7 +39,29 @@ class ChatSyncV2OutboxProducer:
         base_version: str | int | None = None,
         entity_version: str | int | None = None,
     ) -> dict[str, Any]:
-        """Persist an encrypted Chat message envelope when Sync v2 is ready."""
+        """Persist an encrypted Chat message envelope when Sync v2 is ready.
+
+        Args:
+            server_profile_id: Server profile that owns the outbox source scope.
+            authenticated_principal_id: Optional authenticated principal scope.
+            workspace_scope: Optional workspace scope for scoped outbox entries.
+            conversation_id: Durable local conversation ID that owns the message.
+            message_id: Durable local message ID.
+            role: Chat role for the message, such as ``user`` or ``assistant``.
+            content: Message content encrypted into the envelope payload.
+            parent_message_id: Optional previous durable message ID for restore continuity.
+            sequence: Optional 1-based order among sync-eligible messages.
+            variant_turn_id: Optional turn ID shared by regenerated variants.
+            variant_index: Optional selected variant index.
+            variant_count: Optional total available variant count for the turn.
+            selected_variant_id: Optional selected variant ID.
+            base_version: Optional previous payload hash for versioned updates.
+            entity_version: Optional explicit entity version after the mutation.
+
+        Returns:
+            A status mapping. Enqueued results include the durable outbox entry;
+            skipped results include a reason describing the missing prerequisite.
+        """
 
         profile = self._sync_ready_profile(
             server_profile_id=server_profile_id,

--- a/tldw_chatbook/Sync_Interop/domain_adapters/chat.py
+++ b/tldw_chatbook/Sync_Interop/domain_adapters/chat.py
@@ -10,7 +10,7 @@ from ._helpers import call_if_present, decrypt_envelope_payload
 
 
 class ChatSyncAdapter:
-    """Apply append-only chat message envelopes."""
+    """Apply versioned chat message envelopes."""
 
     def apply(
         self,
@@ -25,11 +25,12 @@ class ChatSyncAdapter:
         if current_hash == envelope.payload_hash:
             return {"status": "noop"}
         if current_hash and current_hash != envelope.payload_hash:
-            return record_conflict(
-                envelope,
-                conflict_type="chat_message_hash_mismatch",
-                message="A chat message with this stable ID already has different content.",
-            )
+            if envelope.base_version != current_hash:
+                return record_conflict(
+                    envelope,
+                    conflict_type="chat_message_hash_mismatch",
+                    message="A chat message with this stable ID already has different content.",
+                )
         payload = decrypt_envelope_payload(envelope, dataset_key=dataset_key)
         call_if_present(local_store, "append_chat_message", stable_key, payload, envelope.payload_hash)
         return {"status": "applied"}

--- a/tldw_chatbook/Sync_Interop/envelope_builder.py
+++ b/tldw_chatbook/Sync_Interop/envelope_builder.py
@@ -115,6 +115,25 @@ class SyncEnvelopeBuilder:
         base_version: str | int | None = None,
         entity_version: str | int | None = None,
     ) -> SyncV2Envelope:
+        """Build an encrypted Chat message upsert envelope.
+
+        Args:
+            conversation_id: Stable conversation identifier that owns the message.
+            message_id: Stable message identifier within the conversation.
+            role: Chat role stored with the message payload.
+            content: Message content encrypted into the private payload.
+            parent_message_id: Optional previous message ID for transcript restore order.
+            sequence: Optional 1-based order among sync-eligible transcript messages.
+            variant_turn_id: Optional regenerated-turn identifier shared by variants.
+            variant_index: Optional currently selected variant index.
+            variant_count: Optional number of available variants for the message.
+            selected_variant_id: Optional selected variant identifier.
+            base_version: Optional previous payload hash for versioned updates.
+            entity_version: Optional explicit entity version after this mutation.
+
+        Returns:
+            A Sync v2 envelope with encrypted Chat content and clear routing metadata.
+        """
         stable_key = f"{conversation_id}:{message_id}"
         routing_metadata: dict[str, Any] = {
             "conversation_id": conversation_id,

--- a/tldw_chatbook/Sync_Interop/envelope_builder.py
+++ b/tldw_chatbook/Sync_Interop/envelope_builder.py
@@ -106,10 +106,32 @@ class SyncEnvelopeBuilder:
         message_id: str,
         role: str,
         content: str,
+        parent_message_id: str | None = None,
+        sequence: int | None = None,
+        variant_turn_id: str | None = None,
+        variant_index: int | None = None,
+        variant_count: int | None = None,
+        selected_variant_id: str | None = None,
         base_version: str | int | None = None,
         entity_version: str | int | None = None,
     ) -> SyncV2Envelope:
         stable_key = f"{conversation_id}:{message_id}"
+        routing_metadata: dict[str, Any] = {
+            "conversation_id": conversation_id,
+            "entity_kind": "message",
+        }
+        if parent_message_id is not None:
+            routing_metadata["parent_message_id"] = parent_message_id
+        if sequence is not None:
+            routing_metadata["sequence"] = sequence
+        if variant_turn_id is not None:
+            routing_metadata["variant_turn_id"] = variant_turn_id
+        if variant_index is not None:
+            routing_metadata["variant_index"] = variant_index
+        if variant_count is not None:
+            routing_metadata["variant_count"] = variant_count
+        if selected_variant_id is not None:
+            routing_metadata["selected_variant_id"] = selected_variant_id
         return self._encrypted_envelope(
             domain="chat",
             entity_id=message_id,
@@ -117,7 +139,7 @@ class SyncEnvelopeBuilder:
             stable_key=stable_key,
             payload={"content": content, "role": role},
             payload_clear={},
-            routing_metadata={"conversation_id": conversation_id, "entity_kind": "message"},
+            routing_metadata=routing_metadata,
             base_version=base_version,
             entity_version=entity_version,
         )


### PR DESCRIPTION
## Summary
- Add a Chat Sync v2 outbox producer for encrypted local-first chat message envelopes.
- Extend chat envelope routing metadata with conversation identity, parentage, sequence, and selected variant details.
- Wire ConsoleChatStore to an optional producer only after durable completed message persistence, leaving streaming/failed/stopped content unsynced.

## Verification
- ../../.venv/bin/python -m pytest -q Tests/Sync_Interop/test_chat_outbox_producer.py Tests/Sync_Interop/test_envelope_builder.py Tests/Chat/test_console_chat_store.py --tb=short
- ../../.venv/bin/python -m pytest -q Tests/Sync_Interop/test_local_first_sync_service.py Tests/Sync_Interop/test_restore_service.py Tests/Sync_Interop/test_sync_state_repository.py --tb=short
- ../../.venv/bin/python -m pytest -q Tests/Chat/test_console_chat_controller.py Tests/Chat/test_console_chat_store.py --tb=short
- ../../.venv/bin/python -m pytest -q Tests/UI/test_product_maturity_phase1_harness.py::test_backlog_task_frontmatter_ids_are_unique --tb=short
- ../../.venv/bin/python -m compileall tldw_chatbook/Sync_Interop/chat_outbox_producer.py tldw_chatbook/Sync_Interop/envelope_builder.py tldw_chatbook/Chat/console_chat_store.py
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a local-first Chat Sync v2 outbox producer and wires `ConsoleChatStore` to enqueue encrypted chat messages only after durable persistence. Extends routing metadata and adds versioned updates to meet `TASK-70.2`.

- **New Features**
  - Added `ChatSyncV2OutboxProducer` to create encrypted outbox envelopes when a local-first profile and dataset key are available.
  - Extended `SyncEnvelopeBuilder.build_chat_message()` with restore metadata for conversation, parentage, ordering, and variants; content stays encrypted.
  - Updated `ConsoleChatStore` to enqueue only on completed, persisted messages; sequences only sync‑eligible messages; tracks and passes `base_version` via the last enqueued `payload_hash`; logs producer errors without blocking local writes.
  - `ChatSyncAdapter` now applies versioned message updates when `base_version` matches and still conflicts on divergent content.

<sup>Written for commit 0c8f41a2f6331f90b00df1e34f41c2332be80c21. Summary will update on new commits. <a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/371?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

