### PR TITLE
Compact Console message action labels

### DIFF
--- a/Tests/Chat/test_console_message_actions.py
+++ b/Tests/Chat/test_console_message_actions.py
@@ -19,7 +19,7 @@ def test_assistant_message_actions_include_required_order():
         "Regen",
         "Cont",
         "Feedback",
-        "Del",
+        "X",
     ]
 
 
@@ -40,7 +40,7 @@ def test_streaming_assistant_message_shows_completed_actions_disabled_with_reaso
         "Regen",
         "Cont",
         "Feedback",
-        "Del",
+        "X",
     ]
     assert all(action.enabled is False for action in actions)
     assert all(action.disabled_reason for action in actions)
@@ -67,7 +67,7 @@ def test_pending_assistant_message_shows_completed_actions_disabled_with_reasons
         "Regen",
         "Cont",
         "Feedback",
-        "Del",
+        "X",
     ]
     assert all(action.enabled is False for action in actions)
     assert all(action.disabled_reason for action in actions)
@@ -88,13 +88,9 @@ def test_action_labels_fit_compact_terminal_width_budget():
     service = ConsoleMessageActionService()
     message = ConsoleChatMessage(role=ConsoleMessageRole.ASSISTANT, content="answer")
 
-    labels = [
-        replacement
-        for action in service.available_actions(message)
-        for replacement in (["Good", "Bad"] if action.action_id == "feedback" else [action.label])
-    ]
+    labels = service.plain_action_labels(message)
 
-    assert " ".join(labels) == "Copy Edit Save Regen Cont Good Bad Del"
+    assert " ".join(labels) == "Copy Edit Save Regen Cont Good Bad X"
     assert len(" ".join(labels)) <= 40
 
 
@@ -118,8 +114,37 @@ def test_variant_action_labels_use_symbolic_navigation():
         "Regen",
         "Cont",
         "Feedback",
-        "Del",
+        "X",
     ]
+
+
+def test_variant_action_labels_fit_compact_terminal_width_budget():
+    service = ConsoleMessageActionService()
+    message = ConsoleChatMessage(role=ConsoleMessageRole.ASSISTANT, content="first", id="m1")
+    message.variants = ConsoleVariantSet.from_contents(
+        turn_id="turn-1",
+        contents=["first", "second"],
+        selected_index=1,
+    )
+
+    labels = service.plain_action_labels(message)
+
+    assert " ".join(labels) == "Copy Edit Save < > Regen Cont Good Bad X"
+    assert len(" ".join(labels)) <= 40
+
+
+def test_failed_action_labels_include_retry_inside_terminal_width_budget():
+    service = ConsoleMessageActionService()
+    message = ConsoleChatMessage(
+        role=ConsoleMessageRole.ASSISTANT,
+        content="failed",
+        status="failed",
+    )
+
+    labels = service.plain_action_labels(message)
+
+    assert " ".join(labels) == "Copy Edit Save Try Regen Cont Good Bad X"
+    assert len(" ".join(labels)) <= 40
 
 
 def test_copy_action_returns_clipboard_text():

--- a/Tests/Chat/test_console_message_actions.py
+++ b/Tests/Chat/test_console_message_actions.py
@@ -16,10 +16,10 @@ def test_assistant_message_actions_include_required_order():
         "Copy",
         "Edit",
         "Save",
-        "Regenerate",
-        "Continue",
+        "Regen",
+        "Cont",
         "Feedback",
-        "Delete",
+        "Del",
     ]
 
 
@@ -37,10 +37,10 @@ def test_streaming_assistant_message_shows_completed_actions_disabled_with_reaso
         "Copy",
         "Edit",
         "Save",
-        "Regenerate",
-        "Continue",
+        "Regen",
+        "Cont",
         "Feedback",
-        "Delete",
+        "Del",
     ]
     assert all(action.enabled is False for action in actions)
     assert all(action.disabled_reason for action in actions)
@@ -64,10 +64,10 @@ def test_pending_assistant_message_shows_completed_actions_disabled_with_reasons
         "Copy",
         "Edit",
         "Save",
-        "Regenerate",
-        "Continue",
+        "Regen",
+        "Cont",
         "Feedback",
-        "Delete",
+        "Del",
     ]
     assert all(action.enabled is False for action in actions)
     assert all(action.disabled_reason for action in actions)
@@ -82,6 +82,44 @@ def test_unavailable_save_destinations_are_explicit_wip():
     note = next(destination for destination in destinations if destination.label == "Note")
     assert note.available is False
     assert "WIP" in note.reason
+
+
+def test_action_labels_fit_compact_terminal_width_budget():
+    service = ConsoleMessageActionService()
+    message = ConsoleChatMessage(role=ConsoleMessageRole.ASSISTANT, content="answer")
+
+    labels = [
+        replacement
+        for action in service.available_actions(message)
+        for replacement in (["Good", "Bad"] if action.action_id == "feedback" else [action.label])
+    ]
+
+    assert " ".join(labels) == "Copy Edit Save Regen Cont Good Bad Del"
+    assert len(" ".join(labels)) <= 40
+
+
+def test_variant_action_labels_use_symbolic_navigation():
+    service = ConsoleMessageActionService()
+    message = ConsoleChatMessage(role=ConsoleMessageRole.ASSISTANT, content="first", id="m1")
+    message.variants = ConsoleVariantSet.from_contents(
+        turn_id="turn-1",
+        contents=["first", "second"],
+        selected_index=1,
+    )
+
+    actions = service.available_actions(message)
+
+    assert [action.label for action in actions] == [
+        "Copy",
+        "Edit",
+        "Save",
+        "<",
+        ">",
+        "Regen",
+        "Cont",
+        "Feedback",
+        "Del",
+    ]
 
 
 def test_copy_action_returns_clipboard_text():

--- a/Tests/UI/test_console_native_transcript.py
+++ b/Tests/UI/test_console_native_transcript.py
@@ -107,8 +107,24 @@ def test_console_transcript_selected_message_shows_action_row():
 
     plain = transcript.to_plain_text(width=80)
 
-    assert "Copy Edit Save Regenerate Continue Good Bad Delete" in plain
+    assert "Copy Edit Save Regen Cont Good Bad Del" in plain
     assert "|" not in plain
+
+
+def test_console_transcript_action_row_stays_within_terminal_width_budget():
+    message = ConsoleChatMessage(role=ConsoleMessageRole.ASSISTANT, content="answer", id="m1")
+    transcript = ConsoleTranscript()
+    transcript.set_messages([message])
+    transcript.select_message("m1")
+
+    action_row = next(
+        line
+        for line in transcript.to_plain_text(width=48).splitlines()
+        if line.startswith("Copy")
+    )
+
+    assert action_row == "Copy Edit Save Regen Cont Good Bad Del"
+    assert len(action_row) <= 40
 
 
 def test_console_transcript_variant_navigation_changes_displayed_content():
@@ -128,8 +144,8 @@ def test_console_transcript_variant_navigation_changes_displayed_content():
     rendered = transcript.to_plain_text(width=80)
     assert "second" in rendered
     assert "first" not in rendered
-    assert "Prev" in rendered
-    assert "Next" in rendered
+    assert " < " in f" {rendered} "
+    assert " > " in f" {rendered} "
 
 
 @pytest.mark.asyncio
@@ -144,7 +160,7 @@ async def test_console_transcript_keyboard_selects_messages_and_enter_shows_acti
 
     assert "Copy" in text
     assert "Save" in text
-    assert "Regenerate" in text
+    assert "Regen" in text
     assert "|" not in text
 
 
@@ -158,7 +174,7 @@ async def test_console_transcript_click_selects_message_and_shows_actions():
 
     assert "Copy" in text
     assert "Save" in text
-    assert "Regenerate" in text
+    assert "Regen" in text
     assert "|" not in text
 
 
@@ -191,7 +207,7 @@ async def test_console_transcript_action_buttons_have_stable_ids():
 
     assert "Copy" in text
     assert "Save" in text
-    assert "Regenerate" in text
+    assert "Regen" in text
     assert "|" not in text
 
 

--- a/Tests/UI/test_console_native_transcript.py
+++ b/Tests/UI/test_console_native_transcript.py
@@ -107,7 +107,7 @@ def test_console_transcript_selected_message_shows_action_row():
 
     plain = transcript.to_plain_text(width=80)
 
-    assert "Copy Edit Save Regen Cont Good Bad Del" in plain
+    assert "Copy Edit Save Regen Cont Good Bad X" in plain
     assert "|" not in plain
 
 
@@ -123,7 +123,7 @@ def test_console_transcript_action_row_stays_within_terminal_width_budget():
         if line.startswith("Copy")
     )
 
-    assert action_row == "Copy Edit Save Regen Cont Good Bad Del"
+    assert action_row == "Copy Edit Save Regen Cont Good Bad X"
     assert len(action_row) <= 40
 
 
@@ -146,6 +146,47 @@ def test_console_transcript_variant_navigation_changes_displayed_content():
     assert "first" not in rendered
     assert " < " in f" {rendered} "
     assert " > " in f" {rendered} "
+
+
+def test_console_transcript_variant_action_row_stays_within_terminal_width_budget():
+    message = ConsoleChatMessage(role=ConsoleMessageRole.ASSISTANT, content="first", id="m1")
+    message.variants = ConsoleVariantSet.from_contents(
+        turn_id="turn-1",
+        contents=["first", "second"],
+    )
+    transcript = ConsoleTranscript()
+    transcript.set_messages([message])
+    transcript.select_message("m1")
+
+    action_row = next(
+        line
+        for line in transcript.to_plain_text(width=48).splitlines()
+        if line.startswith("Copy")
+    )
+
+    assert action_row == "Copy Edit Save < > Regen Cont Good Bad X"
+    assert len(action_row) <= 40
+
+
+def test_console_transcript_failed_action_row_includes_retry_without_exceeding_budget():
+    message = ConsoleChatMessage(
+        role=ConsoleMessageRole.ASSISTANT,
+        content="failed",
+        id="m1",
+        status="failed",
+    )
+    transcript = ConsoleTranscript()
+    transcript.set_messages([message])
+    transcript.select_message("m1")
+
+    action_row = next(
+        line
+        for line in transcript.to_plain_text(width=48).splitlines()
+        if line.startswith("Copy")
+    )
+
+    assert action_row == "Copy Edit Save Try Regen Cont Good Bad X"
+    assert len(action_row) <= 40
 
 
 @pytest.mark.asyncio

--- a/tldw_chatbook/Chat/console_message_actions.py
+++ b/tldw_chatbook/Chat/console_message_actions.py
@@ -49,10 +49,10 @@ class ConsoleMessageActionService:
         ("copy", "Copy"),
         ("edit", "Edit"),
         ("save-as", "Save"),
-        ("regenerate", "Regenerate"),
-        ("continue", "Continue"),
+        ("regenerate", "Regen"),
+        ("continue", "Cont"),
         ("feedback", "Feedback"),
-        ("delete", "Delete"),
+        ("delete", "Del"),
     )
 
     def __init__(self, *, available_save_destinations: set[str] | None = None) -> None:
@@ -67,12 +67,12 @@ class ConsoleMessageActionService:
                 ("copy", "Copy"),
                 ("edit", "Edit"),
                 ("save-as", "Save"),
-                ("variant-previous", "Prev"),
-                ("variant-next", "Next"),
-                ("regenerate", "Regenerate"),
-                ("continue", "Continue"),
+                ("variant-previous", "<"),
+                ("variant-next", ">"),
+                ("regenerate", "Regen"),
+                ("continue", "Cont"),
                 ("feedback", "Feedback"),
-                ("delete", "Delete"),
+                ("delete", "Del"),
             ]
         if message.status == "failed":
             return [
@@ -80,10 +80,10 @@ class ConsoleMessageActionService:
                 ConsoleMessageAction("edit", "Edit"),
                 ConsoleMessageAction("save-as", "Save"),
                 ConsoleMessageAction("retry", "Retry"),
-                ConsoleMessageAction("regenerate", "Regenerate"),
-                ConsoleMessageAction("continue", "Continue"),
+                ConsoleMessageAction("regenerate", "Regen"),
+                ConsoleMessageAction("continue", "Cont"),
                 ConsoleMessageAction("feedback", "Feedback"),
-                ConsoleMessageAction("delete", "Delete"),
+                ConsoleMessageAction("delete", "Del"),
             ]
         return [
             ConsoleMessageAction(

--- a/tldw_chatbook/Chat/console_message_actions.py
+++ b/tldw_chatbook/Chat/console_message_actions.py
@@ -45,6 +45,8 @@ class ConsoleSaveDestination:
 class ConsoleMessageActionService:
     """Resolve and dispatch safe Console selected-message actions."""
 
+    FEEDBACK_PLAIN_LABELS: tuple[str, str] = ("Good", "Bad")
+
     _COMPLETED_ACTIONS: tuple[tuple[str, str], ...] = (
         ("copy", "Copy"),
         ("edit", "Edit"),
@@ -52,7 +54,7 @@ class ConsoleMessageActionService:
         ("regenerate", "Regen"),
         ("continue", "Cont"),
         ("feedback", "Feedback"),
-        ("delete", "Del"),
+        ("delete", "X"),
     )
 
     def __init__(self, *, available_save_destinations: set[str] | None = None) -> None:
@@ -72,18 +74,18 @@ class ConsoleMessageActionService:
                 ("regenerate", "Regen"),
                 ("continue", "Cont"),
                 ("feedback", "Feedback"),
-                ("delete", "Del"),
+                ("delete", "X"),
             ]
         if message.status == "failed":
             return [
                 ConsoleMessageAction("copy", "Copy"),
                 ConsoleMessageAction("edit", "Edit"),
                 ConsoleMessageAction("save-as", "Save"),
-                ConsoleMessageAction("retry", "Retry"),
+                ConsoleMessageAction("retry", "Try"),
                 ConsoleMessageAction("regenerate", "Regen"),
                 ConsoleMessageAction("continue", "Cont"),
                 ConsoleMessageAction("feedback", "Feedback"),
-                ConsoleMessageAction("delete", "Del"),
+                ConsoleMessageAction("delete", "X"),
             ]
         return [
             ConsoleMessageAction(
@@ -94,6 +96,25 @@ class ConsoleMessageActionService:
             )
             for action_id, label in completed_actions
         ]
+
+    def plain_action_labels(self, message: ConsoleChatMessage) -> list[str]:
+        """Return terminal-width labels for a message action row."""
+        return self.expand_plain_action_labels(self.available_actions(message))
+
+    def plain_action_row(self, message: ConsoleChatMessage) -> str:
+        """Return a terminal-readable action row for plain transcript exports."""
+        return " ".join(self.plain_action_labels(message))
+
+    @classmethod
+    def expand_plain_action_labels(cls, actions: list[ConsoleMessageAction]) -> list[str]:
+        """Expand grouped UI actions into the labels shown in plain text."""
+        labels: list[str] = []
+        for action in actions:
+            if action.action_id == "feedback":
+                labels.extend(cls.FEEDBACK_PLAIN_LABELS)
+            else:
+                labels.append(action.label)
+        return labels
 
     def save_as_destinations(self, message: ConsoleChatMessage) -> list[ConsoleSaveDestination]:
         """Return Save as destinations, including explicit WIP/unavailable entries."""

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -15,7 +15,7 @@ from tldw_chatbook.Chat.console_chat_models import ConsoleChatMessage
 from tldw_chatbook.Chat.console_message_actions import ConsoleMessageAction, ConsoleMessageActionService
 
 
-CONSOLE_TRANSCRIPT_ACTION_ROW = "Copy Edit Save Regenerate Continue Good Bad Delete"
+CONSOLE_TRANSCRIPT_ACTION_ROW = "Copy Edit Save Regen Cont Good Bad Del"
 CONSOLE_TRANSCRIPT_RULE = "─" * 200
 EMPTY_TRANSCRIPT_COPY = "Ready. Ask a question, run a command, or attach context."
 _ACTION_TOOLTIPS = {
@@ -253,7 +253,7 @@ class ConsoleTranscript(VerticalScroll):
     @staticmethod
     def _plain_action_row(message: ConsoleChatMessage) -> str:
         if message.variants is not None:
-            return "Copy Edit Save Prev Next Regenerate Continue Good Bad Delete"
+            return "Copy Edit Save < > Regen Cont Good Bad Del"
         return CONSOLE_TRANSCRIPT_ACTION_ROW
 
     @staticmethod

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -15,13 +15,13 @@ from tldw_chatbook.Chat.console_chat_models import ConsoleChatMessage
 from tldw_chatbook.Chat.console_message_actions import ConsoleMessageAction, ConsoleMessageActionService
 
 
-CONSOLE_TRANSCRIPT_ACTION_ROW = "Copy Edit Save Regen Cont Good Bad Del"
 CONSOLE_TRANSCRIPT_RULE = "─" * 200
 EMPTY_TRANSCRIPT_COPY = "Ready. Ask a question, run a command, or attach context."
 _ACTION_TOOLTIPS = {
     "copy": "Copy this message to the clipboard.",
     "edit": "Edit this message before continuing the thread.",
     "save-as": "Choose a destination for this message, such as Chatbook or Note.",
+    "retry": "Retry the failed response.",
     "regenerate": "Generate another assistant variant for this turn.",
     "continue": "Continue and extend the selected message.",
     "feedback-up": "Mark this response as helpful.",
@@ -252,9 +252,7 @@ class ConsoleTranscript(VerticalScroll):
 
     @staticmethod
     def _plain_action_row(message: ConsoleChatMessage) -> str:
-        if message.variants is not None:
-            return "Copy Edit Save < > Regen Cont Good Bad Del"
-        return CONSOLE_TRANSCRIPT_ACTION_ROW
+        return ConsoleMessageActionService().plain_action_row(message)
 
     @staticmethod
     def _action_button(message: ConsoleChatMessage, action: ConsoleMessageAction) -> Button:


### PR DESCRIPTION
## Summary
- Compact the Console selected-message action row labels so the row fits better in the terminal transcript.
- Use symbolic variant navigation labels while preserving action IDs and full explanatory tooltips.
- Add regression coverage for the action label width budget and variant action labels.

## Test Plan
- [x] /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Chat/test_console_message_actions.py Tests/UI/test_console_native_transcript.py Tests/UI/test_console_internals_decomposition.py Tests/UI/test_console_session_settings.py Tests/UI/test_console_persistent_rails.py -q
- [x] git diff --check

## Notes
- Focused suite result: 181 passed, 8 warnings.
- Warnings are existing dependency/deprecation warnings from requests and SWIG objects.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compact the Console selected-message action row to better fit narrow terminals by shortening labels (Regenerate→Regen, Continue→Cont, Delete→X, Retry→Try) and using "<"/">" for variant navigation. Action IDs are unchanged; added a tooltip for retry; centralized plain action-row rendering in the message action service; and tests enforce the 40-char width and label set across Chat and UI transcripts.

<sup>Written for commit 329486531404885acb4f561c9ab8ef3198fcdb94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/380?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

