### PR TITLE
Add Impeccable design context

### DIFF
--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,0 +1,277 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-05-28T00:00:00-07:00",
+  "title": "Design System: tldw_chatbook",
+  "extensions": {
+    "colorMeta": {
+      "canvas": {
+        "role": "neutral",
+        "displayName": "Deep Canvas",
+        "canonical": "$background",
+        "tonalRamp": [
+          "oklch(14% 0.03 285)",
+          "oklch(20% 0.035 285)",
+          "oklch(28% 0.04 285)",
+          "oklch(38% 0.045 285)",
+          "oklch(52% 0.05 285)",
+          "oklch(66% 0.035 285)",
+          "oklch(82% 0.02 285)",
+          "oklch(94% 0.01 285)"
+        ]
+      },
+      "panel": {
+        "role": "neutral",
+        "displayName": "Console Panel",
+        "canonical": "$panel",
+        "tonalRamp": [
+          "oklch(10% 0.02 285)",
+          "oklch(16% 0.025 285)",
+          "oklch(24% 0.03 285)",
+          "oklch(34% 0.035 285)",
+          "oklch(48% 0.035 285)",
+          "oklch(64% 0.025 285)",
+          "oklch(80% 0.018 285)",
+          "oklch(94% 0.01 285)"
+        ]
+      },
+      "action-primary": {
+        "role": "primary",
+        "displayName": "Signal Primary",
+        "canonical": "$primary",
+        "tonalRamp": [
+          "oklch(16% 0.08 330)",
+          "oklch(25% 0.12 330)",
+          "oklch(36% 0.16 330)",
+          "oklch(48% 0.20 330)",
+          "oklch(60% 0.22 330)",
+          "oklch(72% 0.16 330)",
+          "oklch(84% 0.08 330)",
+          "oklch(95% 0.03 330)"
+        ]
+      },
+      "focus-accent": {
+        "role": "primary",
+        "displayName": "Focus Phosphor",
+        "canonical": "$accent",
+        "tonalRamp": [
+          "oklch(18% 0.06 110)",
+          "oklch(28% 0.09 110)",
+          "oklch(40% 0.13 110)",
+          "oklch(54% 0.16 110)",
+          "oklch(68% 0.18 110)",
+          "oklch(78% 0.13 110)",
+          "oklch(88% 0.07 110)",
+          "oklch(96% 0.03 110)"
+        ]
+      },
+      "ready-success": {
+        "role": "status",
+        "displayName": "Ready Green",
+        "canonical": "$success",
+        "tonalRamp": [
+          "oklch(18% 0.06 150)",
+          "oklch(28% 0.08 150)",
+          "oklch(40% 0.11 150)",
+          "oklch(52% 0.14 150)",
+          "oklch(64% 0.15 150)",
+          "oklch(76% 0.11 150)",
+          "oklch(88% 0.06 150)",
+          "oklch(96% 0.025 150)"
+        ]
+      },
+      "warning-amber": {
+        "role": "status",
+        "displayName": "Approval Amber",
+        "canonical": "$warning",
+        "tonalRamp": [
+          "oklch(20% 0.05 85)",
+          "oklch(32% 0.08 85)",
+          "oklch(44% 0.11 85)",
+          "oklch(58% 0.14 85)",
+          "oklch(72% 0.15 85)",
+          "oklch(82% 0.10 85)",
+          "oklch(90% 0.055 85)",
+          "oklch(97% 0.02 85)"
+        ]
+      },
+      "blocked-error": {
+        "role": "status",
+        "displayName": "Blocked Red",
+        "canonical": "$error",
+        "tonalRamp": [
+          "oklch(18% 0.06 25)",
+          "oklch(28% 0.09 25)",
+          "oklch(40% 0.12 25)",
+          "oklch(52% 0.15 25)",
+          "oklch(64% 0.16 25)",
+          "oklch(76% 0.11 25)",
+          "oklch(88% 0.06 25)",
+          "oklch(96% 0.025 25)"
+        ]
+      }
+    },
+    "typographyMeta": {
+      "display": {
+        "displayName": "Terminal Display",
+        "purpose": "Rare destination title use inside terminal constraints."
+      },
+      "body": {
+        "displayName": "Terminal Body",
+        "purpose": "Transcript, help text, labels, and dense work surfaces."
+      },
+      "label": {
+        "displayName": "Terminal Label",
+        "purpose": "Badges, authority chips, status labels, shortcuts, and buttons."
+      }
+    },
+    "shadows": [],
+    "motion": [
+      {
+        "name": "state-change-only",
+        "value": "150ms ease-out",
+        "purpose": "Use only when a Textual or web-served surface needs state feedback; no decorative choreography."
+      }
+    ],
+    "breakpoints": [
+      {
+        "name": "compact-terminal",
+        "value": "80x24"
+      },
+      {
+        "name": "default-terminal",
+        "value": "120x36"
+      },
+      {
+        "name": "wide-terminal",
+        "value": "160x48"
+      }
+    ]
+  },
+  "components": [
+    {
+      "name": "Primary Button",
+      "kind": "button",
+      "refersTo": "button-primary",
+      "description": "Primary terminal action, stable in size and bright only when action is earned.",
+      "html": "<button class=\"ds-btn-primary\">Run</button>",
+      "css": ".ds-btn-primary { background: #ff00ff; color: #00ffff; border: 0; min-height: 32px; padding: 0 12px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-weight: 700; transition: background 150ms ease-out, color 150ms ease-out; } .ds-btn-primary:hover { background: #ff4dff; color: #ffffff; } .ds-btn-primary:focus-visible { outline: 3px solid #fefe22; outline-offset: 2px; }"
+    },
+    {
+      "name": "Ghost Button",
+      "kind": "button",
+      "refersTo": "button-ghost",
+      "description": "Secondary utility action for dense toolbars and transcript controls.",
+      "html": "<button class=\"ds-btn-ghost\">Copy</button>",
+      "css": ".ds-btn-ghost { background: #240046; color: #9aa0c8; border: 0; min-height: 28px; padding: 0 10px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-weight: 600; transition: background 150ms ease-out, color 150ms ease-out; } .ds-btn-ghost:hover { background: #32105d; color: #00ffff; } .ds-btn-ghost:focus-visible { outline: 3px solid #fefe22; outline-offset: 2px; }"
+    },
+    {
+      "name": "Form Input",
+      "kind": "input",
+      "refersTo": "field-input",
+      "description": "Compact Textual-style input with visible focus and no dimension shift.",
+      "html": "<label class=\"ds-field\"><span>Provider URL</span><input class=\"ds-input\" value=\"http://127.0.0.1:9099\" /></label>",
+      "css": ".ds-field { display: grid; gap: 6px; color: #00ffff; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-weight: 700; } .ds-input { background: #101010; color: #00ffff; border: 1px solid #ff00ff; min-height: 34px; padding: 0 10px; font-family: inherit; } .ds-input:focus-visible { outline: 3px solid #fefe22; outline-offset: 2px; background: #1a102a; }"
+    },
+    {
+      "name": "Destination Header",
+      "kind": "custom",
+      "refersTo": "destination-header",
+      "description": "Screen contract header with title, purpose, readiness, authority, and primary action.",
+      "html": "<section class=\"ds-destination-header\"><div><strong>Console</strong><span>Live agentic work</span></div><span class=\"ds-badge\">Local</span></section>",
+      "css": ".ds-destination-header { display: flex; align-items: center; justify-content: space-between; gap: 16px; background: #101010; color: #00ffff; border: 2px solid #33ccff; padding: 12px 16px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; } .ds-destination-header div { display: grid; gap: 2px; } .ds-destination-header span { color: #9aa0c8; font-weight: 500; } .ds-badge { background: #240046; color: #39ff14 !important; padding: 2px 8px; font-weight: 700 !important; }"
+    },
+    {
+      "name": "Panel",
+      "kind": "card",
+      "refersTo": "panel",
+      "description": "Flat working region with border-defined structure rather than shadow elevation.",
+      "html": "<section class=\"ds-panel\"><strong>Staged Context</strong><p>3 sources ready for Console.</p></section>",
+      "css": ".ds-panel { background: #101010; color: #00ffff; border: 1px solid #32324a; padding: 12px 16px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; } .ds-panel strong { display: block; margin-bottom: 6px; } .ds-panel p { margin: 0; color: #9aa0c8; }"
+    },
+    {
+      "name": "Status Badge",
+      "kind": "chip",
+      "refersTo": "status-badge",
+      "description": "One-line readable state label. Color supports the label, never replaces it.",
+      "html": "<span class=\"ds-status-badge\">Approval required</span>",
+      "css": ".ds-status-badge { display: inline-flex; align-items: center; min-height: 22px; background: #3a3210; color: #fefe22; border: 1px solid #fefe22; padding: 0 8px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-weight: 700; }"
+    },
+    {
+      "name": "Recovery Callout",
+      "kind": "custom",
+      "refersTo": "recovery-callout",
+      "description": "Blocked-state surface that names owner, problem, impact, and next action.",
+      "html": "<aside class=\"ds-recovery\"><strong>Provider blocked</strong><p>llama.cpp is not reachable at 127.0.0.1:9099.</p><button>Configure provider</button></aside>",
+      "css": ".ds-recovery { background: rgba(254, 254, 34, 0.12); color: #00ffff; border: 1px solid #fefe22; padding: 12px 16px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; } .ds-recovery strong { color: #fefe22; } .ds-recovery p { color: #d7d2a8; } .ds-recovery button { background: #ff00ff; color: #00ffff; border: 0; padding: 6px 10px; font-family: inherit; font-weight: 700; } .ds-recovery button:focus-visible { outline: 3px solid #fefe22; outline-offset: 2px; }"
+    },
+    {
+      "name": "Tab Link",
+      "kind": "nav",
+      "refersTo": "navigation-tab",
+      "description": "Compact destination navigation with visible active state and no hidden workflow state.",
+      "html": "<nav class=\"ds-tabs\"><a>Home</a><a class=\"active\">Console</a><a>Library</a><a>Study</a></nav>",
+      "css": ".ds-tabs { display: flex; gap: 4px; background: #0d0221; padding: 6px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; } .ds-tabs a { color: #9aa0c8; background: #101010; padding: 6px 10px; text-decoration: none; font-weight: 600; } .ds-tabs a:hover { color: #00ffff; background: #240046; } .ds-tabs a.active { color: #0d0221; background: #fefe22; font-weight: 800; } .ds-tabs a:focus-visible { outline: 3px solid #ff00ff; outline-offset: 2px; }"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Neon Workbench",
+    "overview": "This system is a dense terminal workbench for controlled agentic work: cyberpunk in atmosphere, efficient in layout, effective in state exposure, and cozy enough to keep users inside long-running workflows. The interface should feel like a trusted local control room, not a decorative command-line costume. Color and borders exist to reveal state, focus, authority, and recovery.\n\nThe visual model is themeable Textual UI. Semantic variables such as `$background`, `$panel`, `$surface`, `$primary`, `$accent`, `$success`, `$warning`, and `$error` are the source of truth, with `ds-*` aliases documenting product-level roles. Future work should preserve the compact screen grammar: global destination navigation, destination header, local mode bar, primary list or queue, main workspace, optional inspector, and footer status.\n\nReject generic chatbot surfaces, study-only framing, SaaS dashboard tropes, marketing-card layouts, vague \"AI assistant\" language, hidden recovery states, and interfaces that require log reading to understand status. Console is the live work surface; other destinations prepare, inspect, organize, configure, or hand off work.",
+    "keyCharacteristics": [
+      "Terminal-native density with readable labels.",
+      "Themeable semantic tokens, not one hardcoded palette.",
+      "Status and source authority visible before action.",
+      "Flat by default, structured by borders, panels, and tonal layers.",
+      "Keyboard-first focus with no layout shifts on hover or focus."
+    ],
+    "rules": [
+      {
+        "name": "The Semantic First Rule",
+        "body": "Never choose a color because it looks cyberpunk. Choose the token that names the state: focus, ready, running, warning, approval required, blocked, error, workspace, server, local, dry-run, synced, or conflict.",
+        "section": "colors"
+      },
+      {
+        "name": "The Rare Neon Rule",
+        "body": "Bright accent color is earned by state or action. It must not become decoration, background wash, or page mood.",
+        "section": "colors"
+      },
+      {
+        "name": "The Cell Discipline Rule",
+        "body": "Do not simulate web typography inside Textual. Use one-cell rhythm, bold weight, concise copy, and region hierarchy.",
+        "section": "typography"
+      },
+      {
+        "name": "The Label Before Color Rule",
+        "body": "Every important colored state needs readable text. Color supports recognition; labels carry meaning.",
+        "section": "typography"
+      },
+      {
+        "name": "The Flat Control Room Rule",
+        "body": "Surfaces are flat at rest. Use tonal layering, borders, and labeled state instead of drop shadows, blur, or glass effects.",
+        "section": "elevation"
+      },
+      {
+        "name": "The Border Has A Job Rule",
+        "body": "Borders define regions, focus, approval, recovery, or source authority. Decorative borders are forbidden.",
+        "section": "elevation"
+      }
+    ],
+    "dos": [
+      "Do use Textual semantic tokens and `ds-*` aliases for new product UI.",
+      "Do keep Console as the live work surface; destinations prepare, inspect, organize, configure, or hand off work.",
+      "Do expose local, server, workspace, remote-only, dry-run, syncing, synced, conflict, ready, blocked, approval required, and unavailable states as readable labels.",
+      "Do preserve keyboard focus with `outline: heavy $accent` or the theme-aware equivalent.",
+      "Do keep hover and focus states dimensionally stable.",
+      "Do use skeleton states, explicit empty states, and recovery callouts instead of silent disabled controls.",
+      "Do use compact panels and inspectors when they help scan dense work."
+    ],
+    "donts": [
+      "Don't make Chatbook feel like a generic chatbot, a study-only app, a file manager, or a decorative terminal skin.",
+      "Don't use SaaS dashboard tropes, marketing-card layouts, vague \"AI assistant\" language, hidden recovery states, or interfaces that require reading logs to understand status.",
+      "Don't collapse Personas, Skills, MCP, ACP, Schedules, Workflows, Library, Study, and Workspaces into one undifferentiated \"agents\" bucket.",
+      "Don't turn every destination into a live agent console.",
+      "Don't use side-stripe accent borders on cards, list items, callouts, or alerts. If a colored state is needed, use a full border, background tint, status badge, or explicit icon/label.",
+      "Don't use gradient text, decorative glass blur, bouncy motion, or full-saturation accents on inactive states.",
+      "Don't hide why an action is disabled. Give the recovery path in the surface, tooltip, inspector, or command palette."
+    ]
+  }
+}

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -5,7 +5,7 @@ colors:
   canvas: "$background"
   panel: "$panel"
   surface: "$surface"
-  raised-surface: "$surface-lighten-1"
+  raised-surface: "$surface"
   field-surface: "$surface-darken-1"
   text-primary: "$text"
   text-muted: "$text-muted"

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,252 @@
+---
+name: tldw_chatbook
+description: Local-first agentic knowledge console with a terminal-native, cyberpunk-cozy product system.
+colors:
+  canvas: "$background"
+  panel: "$panel"
+  surface: "$surface"
+  raised-surface: "$surface-lighten-1"
+  field-surface: "$surface-darken-1"
+  text-primary: "$text"
+  text-muted: "$text-muted"
+  text-disabled: "$text-disabled"
+  action-primary: "$primary"
+  action-secondary: "$secondary"
+  focus-accent: "$accent"
+  ready-success: "$success"
+  warning-amber: "$warning"
+  blocked-error: "$error"
+  grid-line: "$surface-lighten-1"
+typography:
+  display:
+    fontFamily: "terminal emulator monospace"
+    fontSize: "1 terminal cell"
+    fontWeight: 700
+    lineHeight: 1
+    letterSpacing: "normal"
+  headline:
+    fontFamily: "terminal emulator monospace"
+    fontSize: "1 terminal cell"
+    fontWeight: 700
+    lineHeight: 1
+    letterSpacing: "normal"
+  title:
+    fontFamily: "terminal emulator monospace"
+    fontSize: "1 terminal cell"
+    fontWeight: 700
+    lineHeight: 1
+    letterSpacing: "normal"
+  body:
+    fontFamily: "terminal emulator monospace"
+    fontSize: "1 terminal cell"
+    fontWeight: 400
+    lineHeight: 1
+    letterSpacing: "normal"
+  label:
+    fontFamily: "terminal emulator monospace"
+    fontSize: "1 terminal cell"
+    fontWeight: 700
+    lineHeight: 1
+    letterSpacing: "normal"
+rounded:
+  none: "none"
+  terminal-round: "round"
+  terminal-tall: "tall"
+  terminal-heavy: "heavy"
+spacing:
+  cell-0: "0 cells"
+  cell-1: "1 cell"
+  cell-2: "2 cells"
+  cell-3: "3 cells"
+  cell-5: "5 cells"
+components:
+  button-primary:
+    backgroundColor: "{colors.action-primary}"
+    textColor: "{colors.text-primary}"
+    rounded: "{rounded.none}"
+    padding: "0 1 cell"
+    height: "3 cells"
+  button-primary-focus:
+    backgroundColor: "{colors.action-primary}"
+    textColor: "{colors.text-primary}"
+    rounded: "{rounded.none}"
+    padding: "0 1 cell"
+    height: "3 cells"
+  field-input:
+    backgroundColor: "{colors.field-surface}"
+    textColor: "{colors.text-primary}"
+    rounded: "{rounded.terminal-round}"
+    padding: "0 1 cell"
+    height: "3 cells"
+  destination-header:
+    backgroundColor: "{colors.panel}"
+    textColor: "{colors.text-primary}"
+    rounded: "{rounded.terminal-tall}"
+    padding: "1 2 cells"
+  panel:
+    backgroundColor: "{colors.panel}"
+    textColor: "{colors.text-primary}"
+    rounded: "{rounded.terminal-round}"
+    padding: "1 2 cells"
+  status-badge:
+    backgroundColor: "{colors.raised-surface}"
+    textColor: "{colors.text-primary}"
+    rounded: "{rounded.none}"
+    padding: "0 1 cell"
+    height: "1 cell"
+---
+
+# Design System: tldw_chatbook
+
+## 1. Overview
+
+**Creative North Star: "The Neon Workbench"**
+
+This system is a dense terminal workbench for controlled agentic work: cyberpunk in atmosphere, efficient in layout, effective in state exposure, and cozy enough to keep users inside long-running workflows. The interface should feel like a trusted local control room, not a decorative command-line costume. Color and borders exist to reveal state, focus, authority, and recovery.
+
+The visual model is themeable Textual UI. Semantic variables such as `$background`, `$panel`, `$surface`, `$primary`, `$accent`, `$success`, `$warning`, and `$error` are the source of truth, with `ds-*` aliases documenting product-level roles. Future work should preserve the compact screen grammar: global destination navigation, destination header, local mode bar, primary list or queue, main workspace, optional inspector, and footer status.
+
+Reject generic chatbot surfaces, study-only framing, SaaS dashboard tropes, marketing-card layouts, vague "AI assistant" language, hidden recovery states, and interfaces that require log reading to understand status. Console is the live work surface; other destinations prepare, inspect, organize, configure, or hand off work.
+
+**Key Characteristics:**
+
+- Terminal-native density with readable labels.
+- Themeable semantic tokens, not one hardcoded palette.
+- Status and source authority visible before action.
+- Flat by default, structured by borders, panels, and tonal layers.
+- Keyboard-first focus with no layout shifts on hover or focus.
+
+## 2. Colors
+
+The palette is semantic and restrained: dark terminal surfaces by default, bright action and state colors used only when they explain control, authority, readiness, or recovery.
+
+### Primary
+
+- **Signal Primary** (`$primary`): primary actions, active controls, strong selected rows, and execution affordances.
+- **Focus Phosphor** (`$accent`): focus outlines, active structure, compact section emphasis, and selected input borders.
+
+### Secondary
+
+- **Secondary Circuit** (`$secondary`): secondary action roles and source-role differentiation when `$primary` would overstate importance.
+
+### Tertiary
+
+- **Workspace Glow** (`$ds-authority-workspace`, aliased to `$accent`): workspace-scoped authority, contextual source roles, and staged handoff state.
+
+### Neutral
+
+- **Deep Canvas** (`$background`): root terminal canvas and major unused space.
+- **Console Panel** (`$panel`): headers, footers, primary panel backgrounds, and stable control surfaces.
+- **Raised Surface** (`$surface`, `$surface-lighten-1`): cards, inputs, collapsible headers, toolbars, and list rows.
+- **Grid Line** (`$surface-lighten-1`, `$surface-lighten-2`): panel borders, dividers, table lines, and structural separators.
+- **Readable Text** (`$text`): default foreground.
+- **Dim Telemetry** (`$text-muted`): metadata, footer hints, secondary help, and inactive controls.
+- **Disabled Ghost** (`$text-disabled`): disabled action labels only.
+
+### Named Rules
+
+**The Semantic First Rule.** Never choose a color because it looks cyberpunk. Choose the token that names the state: focus, ready, running, warning, approval required, blocked, error, workspace, server, local, dry-run, synced, or conflict.
+
+**The Rare Neon Rule.** Bright accent color is earned by state or action. It must not become decoration, background wash, or page mood.
+
+## 3. Typography
+
+**Display Font:** terminal emulator monospace
+**Body Font:** terminal emulator monospace
+**Label/Mono Font:** terminal emulator monospace
+
+**Character:** The type system is intentionally mono-forward because Textual renders inside terminal cells. Hierarchy comes from weight, casing restraint, labels, borders, and region placement, not from display fonts or large type.
+
+### Hierarchy
+
+- **Display** (bold, 1 terminal cell, line-height 1): rare destination title use inside headers and splash-adjacent surfaces.
+- **Headline** (bold, 1 terminal cell, line-height 1): destination headers, panel titles, and selected work summaries.
+- **Title** (bold, 1 terminal cell, line-height 1): section titles, collapsible headers, list group labels, and modal titles.
+- **Body** (regular, 1 terminal cell, line-height 1): transcript text, field help, descriptions, and list content. Prose should wrap before it becomes difficult to scan, usually around 65 to 75 characters when a region is prose-heavy.
+- **Label** (bold, 1 terminal cell, normal letter spacing): badges, status labels, authority chips, shortcuts, and button labels.
+
+### Named Rules
+
+**The Cell Discipline Rule.** Do not simulate web typography inside Textual. Use one-cell rhythm, bold weight, concise copy, and region hierarchy.
+
+**The Label Before Color Rule.** Every important colored state needs readable text. Color supports recognition; labels carry meaning.
+
+## 4. Elevation
+
+This system does not use shadow elevation as a primary depth cue. Depth is conveyed through Textual layers: `$background` canvas, `$panel` containers, `$surface` controls, `round` or `tall` borders, compact dividers, and visible focus outlines. Lift is structural, not atmospheric.
+
+### Named Rules
+
+**The Flat Control Room Rule.** Surfaces are flat at rest. Use tonal layering, borders, and labeled state instead of drop shadows, blur, or glass effects.
+
+**The Border Has A Job Rule.** Borders define regions, focus, approval, recovery, or source authority. Decorative borders are forbidden.
+
+## 5. Components
+
+### Buttons
+
+- **Shape:** borderless rectangular Textual buttons by default (`border: none`), with fixed terminal-cell height for stable layout.
+- **Primary:** `$primary` background, `$text` foreground, usually `height: 3` and `padding: 0 1`.
+- **Hover / Focus:** hover changes background only; focus uses `outline: heavy $accent`. Hover and focus must not change dimensions.
+- **Secondary / Ghost / Tertiary:** use `$surface-darken-1`, `$surface`, or `$surface-lighten-2` backgrounds with `$text-muted` for lower priority actions.
+
+### Chips
+
+- **Style:** one-line badges and source-role chips use compact `padding: 0 1`, `$ds-surface-raised` backgrounds, and readable labels.
+- **State:** selected, active, ready, warning, blocked, local, server, workspace, dry-run, and source-role chips must use semantic status or authority tokens.
+
+### Cards / Containers
+
+- **Corner Style:** Textual `round` borders for panels and inspectors; `tall` borders only for high-level destination headers.
+- **Background:** `$panel` for durable regions, `$surface` or `$boost` for active working surfaces.
+- **Shadow Strategy:** no shadows. Use tonal layer changes and borders.
+- **Border:** `$ds-grid-line` for normal panels; `$accent`, `$warning`, `$error`, or `$success` only when the panel state requires it.
+- **Internal Padding:** `1 2` for destination headers and panels, `1` for inspectors and dense inner regions.
+
+### Inputs / Fields
+
+- **Style:** `height: 3`, `width: 100%`, solid `$primary` border or round `$surface-lighten-1` border, with `padding: 0 1`.
+- **Focus:** border or outline shifts to `$accent`; background may use `$accent 10%` for focus visibility.
+- **Error / Disabled:** errors use `$error` border plus `$error 10%` background. Disabled controls use lowered opacity, `$surface-darken-1`, and `$text-disabled`.
+
+### Navigation
+
+- **Style:** top navigation and tab links are compact, theme-aware, and text-labeled. Home and Console remain reachable at supported widths.
+- **Default:** `$panel` background and `$text-muted` labels.
+- **Hover:** `$panel-lighten-1` background and `$text`.
+- **Active:** `$accent` background or `$accent` text with bold weight, depending on whether the nav is button-based or link-based.
+- **Overflow:** use command palette or explicit compact hints, never hidden mystery navigation.
+
+### Destination Header
+
+The destination header is a product contract, not decoration. It carries title, one-line purpose, readiness, authority, primary action, and blocked recovery when needed. It uses `$ds-surface-panel`, `border: tall $ds-action-focus`, `padding: 1 2`, and bold text.
+
+### Recovery Callout
+
+Recovery callouts name owner, problem, impact, and next action. They use `$warning` or `$error` state tokens with a tinted background, but the text must remain explicit enough to work without color.
+
+### Console Transcript
+
+Console transcript messages use compact role/body grammar and full-width terminal rules. Unselected messages stay quiet; selected messages reveal contextual actions. Tool, approval, recovery, stopped, and failed turns follow the same flow instead of becoming separate visual languages.
+
+## 6. Do's and Don'ts
+
+### Do:
+
+- **Do** use Textual semantic tokens and `ds-*` aliases for new product UI.
+- **Do** keep Console as the live work surface; destinations prepare, inspect, organize, configure, or hand off work.
+- **Do** expose local, server, workspace, remote-only, dry-run, syncing, synced, conflict, ready, blocked, approval required, and unavailable states as readable labels.
+- **Do** preserve keyboard focus with `outline: heavy $accent` or the theme-aware equivalent.
+- **Do** keep hover and focus states dimensionally stable.
+- **Do** use skeleton states, explicit empty states, and recovery callouts instead of silent disabled controls.
+- **Do** use compact panels and inspectors when they help scan dense work.
+
+### Don't:
+
+- **Don't** make Chatbook feel like a generic chatbot, a study-only app, a file manager, or a decorative terminal skin.
+- **Don't** use SaaS dashboard tropes, marketing-card layouts, vague "AI assistant" language, hidden recovery states, or interfaces that require reading logs to understand status.
+- **Don't** collapse Personas, Skills, MCP, ACP, Schedules, Workflows, Library, Study, and Workspaces into one undifferentiated "agents" bucket.
+- **Don't** turn every destination into a live agent console.
+- **Don't** use side-stripe accent borders on cards, list items, callouts, or alerts. If a colored state is needed, use a full border, background tint, status badge, or explicit icon/label.
+- **Don't** use gradient text, decorative glass blur, bouncy motion, or full-saturation accents on inactive states.
+- **Don't** hide why an action is disabled. Give the recovery path in the surface, tooltip, inspector, or command palette.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,39 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+Chatbook is for solo builder/operators first: people who work inside a terminal, keep sources local, and want inspectable control over conversations, agents, tools, workflows, and generated outputs. Researchers and students are important expansion users who share the same source-to-output loop, with more emphasis on notes, summaries, flashcards, quizzes, and study artifacts.
+
+## Product Purpose
+
+Chatbook turns local knowledge into controlled agentic work and durable artifacts. Users ingest or select sources, reason over them in Console, configure behavior and tools, monitor execution, recover from blocked states, and preserve useful outputs as reusable Chatbooks, reports, notes, study sets, or other artifacts.
+
+Success means users can complete high-value loops without reconstructing state by hand: ground answers in selected sources, save and reopen outputs, launch controlled work, inspect authority, and understand what is local, server-backed, workspace-scoped, synced, dry-run, or unavailable.
+
+## Brand Personality
+
+Cyberpunk, efficient, effective, cozy.
+
+The product should feel terminal-native and technically sharp, but not hostile. It should keep power-user density and keyboard speed while making state, authority, and recovery legible enough for first-time users.
+
+## Anti-references
+
+Do not make Chatbook feel like a generic chatbot, a study-only app, a file manager, or a decorative terminal skin. Avoid SaaS dashboard tropes, marketing-card layouts, vague "AI assistant" language, hidden recovery states, and interfaces that require reading logs to understand status.
+
+Do not collapse Personas, Skills, MCP, ACP, Schedules, Workflows, Library, Study, and Workspaces into one undifferentiated "agents" bucket. Do not let every destination become a live agent console; Console is the live work surface, while other destinations prepare, inspect, organize, configure, or hand off work.
+
+## Design Principles
+
+1. Console is the live work surface.
+2. Preserve local-first control and make source authority visible.
+3. Keep dense workflows legible, keyboard-first, and recoverable.
+4. Treat Workspaces as global context, not as a buried notes feature.
+5. Make advanced capabilities honest: unavailable, WIP, dry-run, remote-only, and blocked states must be explicit.
+
+## Accessibility & Inclusion
+
+Design for keyboard-first use, readable text labels, and terminal constraints. Important states must be text-labeled; color must never be the only carrier of meaning. Focus, blocked states, approval requirements, source authority, and recovery actions should remain visible at supported terminal sizes. Motion should be optional, restrained, and safe for reduced-motion users.


### PR DESCRIPTION
## Summary

- Add `PRODUCT.md` with the confirmed Chatbook product register, audience, purpose, anti-references, design principles, and accessibility constraints.
- Add `DESIGN.md` in the Impeccable/Stitch-compatible format, grounded in the existing Textual semantic token system and Chat-first Console design direction.
- Add `.impeccable/design.json` sidecar with renderable preview primitives for the live design panel.

## Verification

- `git diff --cached --check`
- `node -e "JSON.parse(require('fs').readFileSync('.impeccable/design.json','utf8')); console.log('design sidecar json ok')"`

Full pytest was not run; this PR only adds design-context documentation and sidecar metadata.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds product and design context for Chatbook plus a renderable Impeccable sidecar to power the live design panel. Establishes semantic tokens, component specs, and previewable HTML/CSS so UI stays consistent and terminal-first.

- **New Features**
  - `PRODUCT.md` with product register, users, purpose, brand, anti-references, principles, and accessibility.
  - `DESIGN.md` (Impeccable/Stitch) aligned to Textual tokens and Console-first design; defines color/typography tokens, rounded/spacing scales, component contracts (buttons, inputs, badges, panels, nav, destination header, recovery), elevation rules, and do/don’ts.
  - `.impeccable/design.json` (schema v2) with semantic color ramps, typography intent, motion and terminal breakpoints, and preview components for the live design panel.

<sup>Written for commit 54fb8f213d5167ac4fcc54e71e53ddbf7872cb36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/383?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

