### PR TITLE
Address startup and transcript lag

### DIFF
--- a/Docs/superpowers/plans/2026-05-28-performance-lag-remediation.md
+++ b/Docs/superpowers/plans/2026-05-28-performance-lag-remediation.md
@@ -1,0 +1,676 @@
+# Performance Lag Remediation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce perceived lag in tldw_chatbook by removing eager startup work, preserving mounted UI state where safe, and replacing full transcript remounts with incremental updates.
+
+**Architecture:** Keep the existing Textual screen architecture, but move heavyweight work behind lazy boundaries and add narrow performance guardrails before each change. Treat startup, navigation, and streaming transcript updates as separate surfaces with separate regression tests so each fix can land independently. Avoid assuming Textual `Screen` instances can be safely reused; prove lifecycle behavior first and prefer data/state caching when screen reuse is unsafe.
+
+**Tech Stack:** Python 3.11+, Textual, pytest, Loguru, SQLite, existing tldw_chatbook UI and service modules.
+
+## Closeout Status
+
+Implemented in `codex/performance-lag-remediation` and closed under `TASK-72`. The work covered the planned guardrails, lazy optional dependency checks, lazy app/splash imports, cacheable destination navigation, incremental native console transcript updates, deferred nonessential startup services, metric log gating, Notes duplicate-load removal, and final measurement/verification documentation.
+
+Conditional audit items that did not require extra code changes are recorded in the task notes and closeout artifact: Prometheus registry instrumentation was not gated because the observed high-volume issue was Loguru metric emission, and Search/RAG/Media duplicate-load work did not show the same duplicate owner problem found in Notes during the focused destination pass.
+
+---
+
+## Baseline Evidence
+
+Current local measurements from the performance review:
+
+- `import tldw_chatbook.app`: about 4.5 seconds.
+- `TldwCli()` construction after import: about 0.04 seconds.
+- Headless startup to `_ui_ready`: about 6.5 seconds.
+- Route switches on small local data: about 0.26 to 0.61 seconds.
+- Local DBs are small, so the current lag is not primarily local database volume.
+
+The remediation target is not one giant refactor. Each task below should be a separate PR-sized slice with its own tests and before/after measurements.
+
+## File Map
+
+- `tldw_chatbook/Utils/optional_deps.py`: make embeddings/RAG dependency checks truly lazy.
+- `tldw_chatbook/Event_Handlers/embeddings_events.py`: preserve explicit embeddings checks on real embeddings actions.
+- `tldw_chatbook/app.py`: reduce top-level imports, introduce lazy screen resolution, reduce destination remount cost, defer nonessential startup services, reduce noisy global select logging.
+- `tldw_chatbook/UI/Navigation/screen_registry.py`: new lazy route-to-screen registry, if needed.
+- `tldw_chatbook/UI/Navigation/main_navigation.py`: keep route message contract unchanged.
+- `tldw_chatbook/Widgets/Console/console_transcript.py`: replace full transcript remount refreshes with keyed incremental updates.
+- `tldw_chatbook/UI/Screens/chat_screen.py`: avoid unconditional transcript refresh when native console state has not changed.
+- `tldw_chatbook/Metrics/metrics_logger.py`: gate normal Loguru metric log emission behind config/env/debug settings.
+- `tldw_chatbook/Metrics/metrics.py`: evaluate Prometheus metrics registry overhead separately from log-volume reduction.
+- `tldw_chatbook/Utils/Splash_Screens/__init__.py`: stop importing every splash effect on package import, if import profiling still shows this as material after the first two tasks.
+- `Tests/Performance/test_app_startup_performance.py`: new structural and optional timed startup/import guardrails.
+- `Tests/UI/test_screen_navigation.py`: navigation behavior and cache reuse coverage.
+- `Tests/UI/test_console_native_transcript.py`: transcript incremental update and large-transcript behavior coverage.
+- `Tests/Utils/test_optional_deps.py`: lazy dependency behavior coverage.
+
+## Definition Of Done
+
+- Performance work is represented by Backlog.md task files before implementation starts, and every task moved to Done has completed acceptance criteria, implementation notes, and verification evidence.
+- Import, startup, navigation, and transcript-refresh measurements are captured before and after the work.
+- No embeddings/RAG heavyweight dependency check runs during `import tldw_chatbook.app` unless explicitly requested by env/config.
+- Common destination navigation avoids unnecessary reload/remount work while preserving explicit cache invalidation on profile, runtime-policy, and context changes.
+- Native console transcript updates do not remount the entire message list for appends, streaming content updates, or selection changes.
+- Initial `_ui_ready` is not blocked by TTS/STTS, media cleanup, DB-size polling, or other nonessential startup work.
+- Normal user interactions do not emit high-volume INFO/METRIC logs unless debug/performance logging is enabled.
+- Existing UI smoke tests and focused performance regression tests pass.
+
+---
+
+## Task A: Create Backlog Tracking Tasks
+
+**Files:**
+
+- Created: `backlog/tasks/task-72 - Performance-lag-remediation.md`
+- Optional create: child tasks in `backlog/tasks/` if this plan is split across several PRs.
+
+- [x] **Step 1: Create the parent task**
+
+  Created `TASK-72` in `To Do` status:
+
+  Equivalent CLI command:
+
+  ```bash
+  backlog task create "Performance lag remediation" -d "Reduce startup, navigation, and console transcript lag by removing eager work and adding performance guardrails." --ac "Startup and navigation measurements are captured before and after remediation,Embeddings and heavy optional dependencies are not checked during plain app import,Console transcript updates avoid full transcript remounts during streaming,Nonessential startup services do not block UI readiness,Focused UI and performance tests pass"
+  ```
+
+- [ ] **Step 2: Move the task to In Progress before code changes**
+
+  Run:
+
+  ```bash
+  backlog task edit <id> -s "In Progress"
+  ```
+
+- [ ] **Step 3: Add this plan to the task**
+
+  Add a concise implementation plan that points to this document and lists the first implementation slice. Do not paste the whole plan into the task; use the task file for current-slice status and closeout notes.
+
+- [ ] **Step 4: Split child tasks only when a slice is too large for one PR**
+
+  If needed, create child tasks in dependency order:
+
+  - performance guardrails and lazy optional deps
+  - lazy app import graph
+  - transcript incremental rendering
+  - deferred startup work
+  - destination load deduplication
+
+  Keep each child task independently testable. Do not reference future child task ids until they exist.
+
+---
+
+## Task 0: Add Performance Guardrails
+
+**Files:**
+
+- Create: `Tests/Performance/test_app_startup_performance.py`
+- Modify: `pyproject.toml` only if the existing `performance` marker needs adjustment.
+
+- [ ] **Step 1: Add an isolated subprocess helper**
+
+  Add a helper that runs Python snippets in a subprocess with isolated config and data paths. The helper must set:
+
+  ```python
+  env = {
+      **os.environ,
+      "TLDW_TEST_MODE": "1",
+      "XDG_DATA_HOME": str(tmp_path / "data"),
+      "XDG_CONFIG_HOME": str(tmp_path / "config"),
+      "HOME": str(tmp_path / "home"),
+  }
+  ```
+
+  This is required because pytest's autouse fixture only patches the parent process. Subprocess probes must not read or write the real user config or DBs.
+
+- [ ] **Step 2: Add phase-specific structural import guards**
+
+  Add separate subprocess guards instead of one broad guard:
+
+  1. Optional dependency guard for Task 1:
+
+  ```python
+  OPTIONAL_DEPS_IMPORT_GUARDS = (
+      "torch",
+      "transformers",
+      "chromadb",
+      "sentence_transformers",
+  )
+  ```
+
+  This guard imports `tldw_chatbook.Utils.optional_deps`.
+
+  2. App import graph guard for Task 2:
+
+  ```python
+  APP_IMPORT_GUARDS = (
+      "tldw_chatbook.UI.Evals.evals_window_v3",
+      "tldw_chatbook.UI.STTS_Window",
+      "tldw_chatbook.UI.SearchWindow",
+      "tldw_chatbook.UI.MediaWindow_v2",
+  )
+  ```
+
+  This guard imports `tldw_chatbook.app`.
+
+  Avoid asserting `scipy` is absent in the Task 1 guard unless the failing import path proves it comes from embeddings checks. `scipy` may also arrive through other eager feature imports and belongs in the Task 2 analysis.
+
+- [ ] **Step 3: Mark guards honestly until their slice lands**
+
+  Do not land permanently failing tests. Use `pytest.mark.xfail(strict=True, reason="...")` for a guard until the corresponding remediation task is implemented, or land the guard in the same PR as the fix.
+
+- [ ] **Step 4: Add optional timed smoke probe**
+
+  Add a `pytest.mark.performance` test that records:
+
+  - import duration
+  - `TldwCli()` init duration
+  - `run_test()` entry duration
+  - time until `_ui_ready`
+  - route switch timings for `library`, `notes`, `media`, `search`, `settings`, and `chat`
+
+  Keep hard assertions conservative at first. The structural import guard should be the required CI signal; exact timing can be informational or marked performance until the fixes stabilize.
+
+- [ ] **Step 5: Run the new tests and record the expected failures**
+
+  Run:
+
+  ```bash
+  .venv/bin/python -m pytest Tests/Performance/test_app_startup_performance.py -q
+  ```
+
+  Expected before implementation: phase-specific guards are either xfailed or fail for the known eager import paths. Timed output should be recorded as baseline evidence, not treated as a stable CI budget yet.
+
+- [ ] **Step 6: Commit only after at least one remediation task makes each guard meaningful**
+
+  Do not land a permanently failing guard. Either mark expected-fail with a clear reason in the first PR or land it together with Task 1.
+
+---
+
+## Task 1: Make Embeddings And Optional Dependency Checks Truly Lazy
+
+**Files:**
+
+- Modify: `tldw_chatbook/Utils/optional_deps.py`
+- Modify: `tldw_chatbook/Event_Handlers/embeddings_events.py`
+- Test: `Tests/Utils/test_optional_deps.py`
+- Test: `Tests/Performance/test_app_startup_performance.py`
+
+- [ ] **Step 1: Write the failing lazy-import test**
+
+  Add a test that imports `tldw_chatbook.Utils.optional_deps` in the isolated subprocess helper from Task 0 and asserts the subprocess output/logs do not include:
+
+  - `Checking embeddings dependencies early`
+  - imports of `torch`, `transformers`, `chromadb`, or `sentence_transformers`
+
+- [ ] **Step 2: Keep explicit eager mode test coverage**
+
+  Add or update coverage so `TLDW_EAGER_DEPENDENCY_CHECK=true` still calls `initialize_dependency_checks()` and checks configured dependencies. Use isolated subprocess envs for eager-mode coverage too, because import-time behavior is the behavior under test.
+
+- [ ] **Step 3: Remove the unconditional embeddings check**
+
+  In `optional_deps.py`, remove this import-time block:
+
+  ```python
+  if 'PYTEST_CURRENT_TEST' not in os.environ:
+      logger.info("Checking embeddings dependencies early to ensure UI loads correctly...")
+      check_embeddings_rag_deps()
+  ```
+
+  Keep `check_embeddings_rag_deps()`, `force_recheck_embeddings()`, and explicit event-handler calls intact.
+
+- [ ] **Step 4: Represent unknown dependency state explicitly**
+
+  If any UI needs to distinguish "not checked yet" from "checked and missing", add a small status helper rather than reading `DEPENDENCIES_AVAILABLE["embeddings_rag"]` as final truth before a check has run.
+
+- [ ] **Step 5: Verify explicit embeddings actions still check dependencies**
+
+  Run:
+
+  ```bash
+  .venv/bin/python -m pytest Tests/Utils/test_optional_deps.py Tests/RAG/simplified/test_embeddings_wrapper.py -q
+  ```
+
+- [ ] **Step 6: Re-run the relevant performance guards**
+
+  Run:
+
+  ```bash
+  .venv/bin/python -m pytest Tests/Performance/test_app_startup_performance.py -q
+  ```
+
+  Expected after this task: the optional-deps guard passes. The app import graph guard may still xfail until Task 2 because `app.py` still eagerly imports screen and feature modules.
+
+---
+
+## Task 2: Lazy-Load Application Screens And Heavy Feature Windows
+
+**Files:**
+
+- Create: `tldw_chatbook/UI/Navigation/screen_registry.py`
+- Modify: `tldw_chatbook/app.py`
+- Test: `Tests/UI/test_screen_navigation.py`
+- Test: `Tests/Performance/test_app_startup_performance.py`
+
+- [ ] **Step 1: Inventory app import ownership before moving imports**
+
+  Classify top-level imports in `tldw_chatbook/app.py` into:
+
+  - needed for `TldwCli` class definition or compose-time shell chrome
+  - needed only when resolving a destination screen
+  - needed only when handling a specific event
+  - unused legacy window imports
+
+  Do not move imports blindly. Some services are used during `TldwCli.__init__`; those should be delayed only when the owning initialization path is also delayed and tested.
+
+- [ ] **Step 2: Add a lazy screen registry test**
+
+  In `Tests/UI/test_screen_navigation.py`, add a test that resolves every visible shell destination route and verifies it returns the same screen class name as today.
+
+  The test should not require importing all screen modules during `import tldw_chatbook.app`.
+
+- [ ] **Step 3: Create a lazy screen target data structure**
+
+  In `screen_registry.py`, define route entries that store:
+
+  - screen name
+  - canonical tab id
+  - module path
+  - class name
+
+  Add a loader that imports the module only when the route is requested.
+
+- [ ] **Step 4: Move destination screen imports out of app module import time**
+
+  In `app.py`, remove top-level imports for heavyweight screen modules where possible and replace `_resolve_screen_navigation_target()` internals with the lazy registry.
+
+  Keep lightweight constants and message classes at module import time.
+
+- [ ] **Step 5: Move legacy feature-window imports behind their use sites**
+
+  `app.py` also imports legacy windows and feature windows that are not required for a plain app import, including Evals, STTS, Search, Media, and Chatbooks windows. Move these behind their use sites or remove them if they are no longer used.
+
+- [ ] **Step 6: Preserve current route aliases**
+
+  Ensure existing route aliases still work:
+
+  - `chat`
+  - `library`
+  - `notes`
+  - `media`
+  - `search`
+  - `settings`
+  - all routes covered by `SHELL_DESTINATION_ORDER`
+
+- [ ] **Step 7: Add structural import assertions**
+
+  Update the performance guard to assert that these are not loaded after plain app import:
+
+  - `tldw_chatbook.UI.Evals.evals_window_v3`
+  - `tldw_chatbook.UI.STTS_Window`
+  - media/search/admin windows not needed for the startup route
+
+- [ ] **Step 8: Verify navigation and import behavior**
+
+  Run:
+
+  ```bash
+  .venv/bin/python -m pytest Tests/UI/test_screen_navigation.py Tests/UI/test_master_shell_navigation.py Tests/Performance/test_app_startup_performance.py -q
+  ```
+
+  Expected after this task: plain import gets materially faster, and route resolution still reaches every destination.
+
+---
+
+## Task 3: Reduce Destination Remount Cost Safely
+
+**Files:**
+
+- Modify: `tldw_chatbook/app.py`
+- Potentially modify: destination-specific services or state holders after measurement.
+- Test: `Tests/UI/test_screen_navigation.py`
+- Test: `Tests/UI/test_product_maturity_phase1_navigation_smoke.py`
+
+- [ ] **Step 1: Run a Textual lifecycle spike**
+
+  Before implementing caching, write a small local experiment or focused test that answers whether a previously switched-away `Screen` instance can be safely reattached with current Textual behavior. Record the result in the task implementation notes.
+
+- [ ] **Step 2: Write the remount-cost regression test**
+
+  Add coverage that navigates `chat -> library -> chat` and verifies the second `chat` navigation avoids the expensive work identified by measurement. Prefer asserting against load counters, preserved state snapshots, or cached service data instead of asserting raw `Screen` object identity.
+
+- [ ] **Step 3: Choose the lowest-risk caching strategy**
+
+  Choose in this order:
+
+  1. Destination data/service cache with explicit invalidation.
+  2. Persistent destination content mounted inside a stable shell, if Textual supports it cleanly.
+  3. Reuse `Screen` instances only if the lifecycle spike proves this is safe.
+
+  This repository guidance says caches should be cleared on context switch, so every cache must define invalidation for profile changes, runtime-policy source changes, workspace/context changes, and explicit refresh actions.
+
+- [ ] **Step 4: Add a cache policy only for the chosen strategy**
+
+  Add a small allowlist for destinations where cache reuse is expected:
+
+  ```python
+  CACHEABLE_SCREEN_ROUTES = {
+      TAB_CHAT,
+      TAB_LIBRARY,
+      TAB_NOTES,
+      TAB_MEDIA,
+      TAB_SEARCH,
+      TAB_SETTINGS,
+  }
+  ```
+
+  Do not cache modal/transient screens.
+
+- [ ] **Step 5: Implement the selected reuse path**
+
+  If the lifecycle spike proves screen reuse is safe, add app helpers that:
+
+  - return cached screens for cacheable routes
+  - create fresh screens for non-cacheable routes
+  - invalidate cached screens on runtime-policy or profile changes
+  - preserve current `save_state()` / `restore_state()` compatibility
+
+  If screen reuse is not safe, implement only destination data/state caching in this task and leave screen reuse out of scope.
+
+- [ ] **Step 6: Measure route switch deltas**
+
+  Run the performance probe from Task 0 and compare the route timings with the baseline.
+
+  Target after this task on small local data:
+
+  - repeat navigation does not rerun the expensive data loads discovered by the probe
+  - no visible duplicate screen mount/load work in logs
+  - route timings improve or remain stable without stale data
+
+- [ ] **Step 7: Verify smoke navigation**
+
+  Run:
+
+  ```bash
+  .venv/bin/python -m pytest Tests/UI/test_screen_navigation.py Tests/UI/test_product_maturity_phase1_navigation_smoke.py -q
+  ```
+
+---
+
+## Task 4: Incrementalize Native Console Transcript Rendering
+
+**Files:**
+
+- Modify: `tldw_chatbook/Widgets/Console/console_transcript.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`
+- Test: `Tests/UI/test_console_native_transcript.py`
+- Test: `Tests/UI/test_console_native_chat_flow.py`
+- Test: `Tests/UI/test_console_internals_decomposition.py`
+
+- [ ] **Step 1: Introduce row-level test seams**
+
+  Add or expose a test-friendly way to observe transcript reconciliation, such as stable row ids, render signatures, or an internal update counter. Avoid tests that depend on arbitrary Textual child widget object identity.
+
+- [ ] **Step 2: Write append preservation test**
+
+  In `test_console_native_transcript.py`, mount a transcript with many messages, append one message, refresh, and assert existing message rows were not rebuilt according to the row-level seam from Step 1.
+
+- [ ] **Step 3: Write streaming update test**
+
+  Mount a transcript with an assistant message, update only that message content/status, refresh, and assert unrelated rows were not remounted.
+
+- [ ] **Step 4: Write selection update test**
+
+  Select one message, then another, and assert only the previous and new selected rows/action rows changed.
+
+- [ ] **Step 5: Add row identity and signatures**
+
+  In `ConsoleTranscript`, track row objects by message id and a render signature such as:
+
+  - role
+  - content
+  - status
+  - selected state
+  - variant selection state
+  - available actions state, if needed
+
+- [ ] **Step 6: Replace whole-list `remove_children()` refresh**
+
+  Replace `refresh_messages()` with an incremental reconciler:
+
+  - remove rows for deleted message ids
+  - mount rows for new message ids
+  - update or replace only rows whose signature changed
+  - update the empty state only when the transcript transitions between empty and non-empty
+
+- [ ] **Step 7: Skip transcript refresh when nothing changed**
+
+  In `chat_screen.py`, store a lightweight native transcript fingerprint before calling `refresh_messages()`. If the active session id and message signatures are unchanged, skip the refresh.
+
+- [ ] **Step 8: Keep the legacy fallback behavior intact**
+
+  The legacy chat-log fallback can remain full-rendered for now because the native transcript is the main path. Do not expand this task into a full legacy chat rewrite.
+
+- [ ] **Step 9: Verify transcript behavior**
+
+  Run:
+
+  ```bash
+  .venv/bin/python -m pytest Tests/UI/test_console_native_transcript.py Tests/UI/test_console_native_chat_flow.py Tests/UI/test_console_internals_decomposition.py -q
+  ```
+
+  Expected after this task: streaming and long-chat updates no longer scale with total transcript length on every poll.
+
+---
+
+## Task 5: Move Nonessential Startup Work To Idle Or First Use
+
+**Files:**
+
+- Modify: `tldw_chatbook/app.py`
+- Potentially create: `tldw_chatbook/Services/startup_tasks.py`
+- Test: `Tests/Performance/test_app_startup_performance.py`
+- Test: focused UI tests for TTS/STTS controls if present.
+
+- [ ] **Step 1: Write readiness ordering test**
+
+  Add a test that patches TTS/STTS initialization to sleep or record calls and asserts `_ui_ready` can become true before those optional services finish.
+
+- [ ] **Step 2: Defer TTS/STTS initialization**
+
+  Replace awaited startup initialization with an idle/background initializer:
+
+  - create safe handler placeholders synchronously so existing controls can query service state without attribute errors
+  - create real handler objects lazily
+  - initialize on first use or after `_ui_ready`
+  - expose a "not ready yet" state to controls if needed
+  - do not block app readiness on failures
+
+- [ ] **Step 3: Add service-state tests for deferred TTS/STTS**
+
+  Add focused tests that assert TTS/STTS controls, events, or command paths handle the placeholder state correctly before the real service has initialized.
+
+- [ ] **Step 4: Defer DB-size initial update**
+
+  Keep the footer widget, but schedule the first `db_status_manager.update_db_sizes()` after readiness or on a short idle timer. The footer can show a pending/unknown value until then.
+
+- [ ] **Step 5: Defer media cleanup**
+
+  Keep periodic cleanup, but avoid `call_later(self.perform_media_cleanup)` immediately after startup. Use one of:
+
+  - a delayed timer after `_ui_ready`
+  - first visit to media/settings cleanup UI
+  - manual cleanup only when `cleanup_on_startup` is false
+
+  Preserve the user-configured cleanup policy, but stop running it in the initial responsiveness window.
+
+- [ ] **Step 6: Move splash completion before optional work**
+
+  Ensure splash removal and `_ui_ready = True` are based on essential UI mount/binding only, not optional services.
+
+- [ ] **Step 7: Verify startup readiness**
+
+  Run:
+
+  ```bash
+  .venv/bin/python -m pytest Tests/Performance/test_app_startup_performance.py Tests/UI/test_product_maturity_phase1_first_run.py -q
+  ```
+
+  Expected after this task: `total_to_ready_s` falls, even if deferred tasks continue after readiness.
+
+---
+
+## Task 6: Reduce Normal Logging And Metric Overhead
+
+**Files:**
+
+- Modify: `tldw_chatbook/Metrics/metrics_logger.py`
+- Inspect, then modify only if measured: `tldw_chatbook/Metrics/metrics.py`
+- Modify: `tldw_chatbook/app.py`
+- Modify: high-volume call sites only if metrics remain noisy after central gating.
+- Test: new focused tests in `Tests/Utils/` or `Tests/Performance/test_app_startup_performance.py`
+
+- [ ] **Step 1: Add metric gating tests**
+
+  Verify metric logging can be disabled for normal runs and enabled explicitly through env/config.
+
+  Suggested env name:
+
+  ```text
+  TLDW_METRICS_LOGGING=1
+  ```
+
+- [ ] **Step 2: Gate Loguru metric emission**
+
+  In `metrics_logger.py`, make `_log_metric()` return early unless metrics logging is enabled. Keep counters/histograms callable so instrumentation sites do not need broad changes.
+
+- [ ] **Step 3: Measure Prometheus registry overhead separately**
+
+  Startup code also calls `tldw_chatbook.Metrics.metrics` functions. Do not disable Prometheus metrics as part of Loguru log-volume cleanup unless profiling shows registry/label overhead is material. If it is material, add a separate config/env gate with tests.
+
+- [ ] **Step 4: Lower select-change logging**
+
+  In `app.py:on_select_changed`, change the always-on INFO log to DEBUG. Remove the duplicate `conv-char-character-select` branch while staying behaviorally equivalent.
+
+- [ ] **Step 5: Avoid token-counter work from synthetic mount select events**
+
+  If initial widget population fires `Select.Changed` events, guard token-counter updates so they run only after `_ui_ready` and only for real Chat provider/model changes.
+
+- [ ] **Step 6: Verify log volume reduction**
+
+  Run the startup/navigation probe and compare stderr/log size with the baseline. Normal route switching should not produce a flood of path-validation and metric lines.
+
+- [ ] **Step 7: Run focused tests**
+
+  Run:
+
+  ```bash
+  .venv/bin/python -m pytest Tests/UI/test_screen_navigation.py Tests/Performance/test_app_startup_performance.py -q
+  ```
+
+---
+
+## Task 7: Audit And Deduplicate Destination Mount Data Loading
+
+**Files:**
+
+- Modify after measurement, likely:
+  - `tldw_chatbook/UI/Notes_Window.py`
+  - `tldw_chatbook/Notes/Notes_Library.py`
+  - Search/RAG destination screen modules
+  - Media destination screen modules
+- Test:
+  - `Tests/UI/test_destination_shells.py`
+  - `Tests/UI/test_product_maturity_gate16_library_search_rag.py`
+  - screen-specific Notes/Media/Search tests.
+
+- [ ] **Step 1: Instrument destination mount load counts**
+
+  Add test-only counters, monkeypatch spies, or scoped instrumentation around notes list loads, RAG profile loads, media select initialization, and search history loads. Avoid leaving permanent noisy instrumentation in normal UI paths.
+
+- [ ] **Step 2: Write duplicate-load regression tests**
+
+  For each heavy destination, navigate to the route once and assert initial data population happens once unless explicitly refreshed by the user. Use the isolated `run_test()` environment from the existing UI harness so tests do not depend on the developer's real local DB size.
+
+- [ ] **Step 3: Fix Notes duplicate list loading**
+
+  Remove duplicated Notes population paths between screen `on_mount` and `NotesTabInitializer.on_tab_shown()`. Keep one owner for initial load and one explicit refresh path.
+
+- [ ] **Step 4: Fix Search/RAG initial load duplication**
+
+  Load RAG profiles/search history once per mounted destination or cache them behind a short-lived service/state object. Do not check embeddings dependencies as part of rendering static Search UI.
+
+- [ ] **Step 5: Fix Media mount churn**
+
+  Avoid repeated config/path validation and synthetic select-change side effects on media route mount. Cache stable config-derived options for the mounted screen lifetime.
+
+- [ ] **Step 6: Verify each destination remains refreshable**
+
+  Manual or automated explicit refresh actions should still reload data. The fix is to remove accidental duplicate initial loads, not to make data stale.
+
+- [ ] **Step 7: Run focused destination tests**
+
+  Run:
+
+  ```bash
+  .venv/bin/python -m pytest Tests/UI/test_destination_shells.py Tests/UI/test_product_maturity_gate16_library_search_rag.py -q
+  ```
+
+---
+
+## Task 8: Closeout Measurement And Release Notes
+
+**Files:**
+
+- Modify: `Docs/superpowers/qa/performance/2026-05-28-lag-remediation-closeout.md`
+- Potentially modify: `README.md` or relevant docs if startup/config behavior changes.
+
+- [ ] **Step 1: Capture final performance measurements**
+
+  Run the same probe used in the initial review:
+
+  ```bash
+  .venv/bin/python -X importtime -c "import tldw_chatbook.app"
+  .venv/bin/python -m pytest Tests/Performance/test_app_startup_performance.py -q
+  ```
+
+- [ ] **Step 2: Compare before/after**
+
+  Record:
+
+  - import duration
+  - time to `_ui_ready`
+  - route switch timings
+  - long transcript append/update timing
+  - log volume during startup/navigation
+
+- [ ] **Step 3: Run final focused suite**
+
+  Run:
+
+  ```bash
+  .venv/bin/python -m pytest Tests/Utils/test_optional_deps.py Tests/UI/test_screen_navigation.py Tests/UI/test_console_native_transcript.py Tests/UI/test_console_native_chat_flow.py Tests/UI/test_console_internals_decomposition.py Tests/Performance/test_app_startup_performance.py -q
+  ```
+
+- [ ] **Step 4: Run broader suite or agreed CI subset**
+
+  If full local pytest is too slow, run the largest relevant UI subset and document any skipped optional-dependency suites.
+
+- [ ] **Step 5: Document known residual risks**
+
+  Include:
+
+  - Textual screen caching limitations, if any.
+  - Any remaining screen-specific mount cost.
+  - Whether splash-screen auto-discovery still contributes material startup time.
+  - Whether representative test-user data still shows lag after architectural fixes.
+
+- [ ] **Step 6: Close Backlog task hygiene**
+
+  Before marking the Backlog task Done:
+
+  - check every acceptance criterion in the task file
+  - add implementation notes with modified files, measurement deltas, and known residual risks
+  - run the focused verification suite or document why a broader suite could not be run
+  - update task status to Done with the Backlog CLI

--- a/Docs/superpowers/qa/performance/2026-05-28-lag-remediation-closeout.md
+++ b/Docs/superpowers/qa/performance/2026-05-28-lag-remediation-closeout.md
@@ -1,0 +1,57 @@
+# 2026-05-28 Performance Lag Remediation Closeout
+
+## Scope
+
+This closeout covers TASK-72 remediation for perceived lag during import, startup readiness, route switching, console transcript updates, and high-volume metric logging.
+
+## Baseline
+
+Measurements from the approved plan:
+
+- Plain `import tldw_chatbook.app`: about 4.5 seconds.
+- `TldwCli()` construction after import: about 0.04 seconds.
+- Headless startup to `_ui_ready`: about 6.5 seconds.
+- Route switches on small local data: about 0.26 to 0.61 seconds.
+
+## After Measurements
+
+Fresh isolated local probe with `TLDW_TEST_MODE=1`, temporary config/data paths, splash disabled for the UI run, and startup media cleanup disabled for the UI run:
+
+- Plain `import tldw_chatbook.app`: 4.365 seconds.
+- Patched test-app construction: 0.057 seconds.
+- `run_test()` to `_ui_ready`: 0.492 seconds.
+- Route switches:
+  - library: 0.286 seconds.
+  - notes: 0.274 seconds.
+  - media: 0.547 seconds.
+  - search: 0.373 seconds.
+  - settings: 0.360 seconds.
+  - chat: 0.341 seconds.
+- Captured stderr log volume:
+  - import probe: 93 lines, 0 `METRIC` lines.
+  - UI startup/navigation probe: 153 lines, 0 `METRIC` lines.
+
+## Changes Verified
+
+- Optional dependency checks no longer run heavyweight embeddings/RAG checks during plain optional-deps import unless `TLDW_EAGER_DEPENDENCY_CHECK=true`.
+- Plain app import no longer loads guarded legacy feature windows or splash effect modules.
+- Common destination screens are lazily resolved and allowlisted routes reuse cached screen instances.
+- TTS/STTS initialization, DB-size initial update, and startup media cleanup no longer block `_ui_ready`.
+- Native Console transcript updates reconcile rows incrementally and skip unchanged native transcript refreshes.
+- Normal metric logging is disabled unless `TLDW_METRICS_LOGGING=1`.
+- Notes screen navigation refreshes scope once per entry instead of through duplicate screen and tab-initializer owners.
+
+## Verification
+
+- `Tests/Performance/test_app_startup_performance.py Tests/UI/test_product_maturity_phase1_first_run.py`: 18 passed.
+- `Tests/UI/test_screen_navigation.py Tests/Performance/test_app_startup_performance.py Tests/Utils/test_metrics_logger.py`: 40 passed.
+- `Tests/UI/test_destination_shells.py Tests/UI/test_product_maturity_gate16_library_search_rag.py`: 119 passed.
+- Final focused suite: `Tests/Utils/test_optional_deps.py Tests/Utils/test_metrics_logger.py Tests/Utils/test_startup_polish_regressions.py Tests/UI/test_screen_navigation.py Tests/UI/test_console_native_transcript.py Tests/UI/test_console_native_chat_flow.py Tests/UI/test_console_internals_decomposition.py Tests/Performance/test_app_startup_performance.py`: 212 passed.
+- Static checks: targeted `py_compile` passed and `git diff --check` reported no whitespace errors.
+
+## Residual Risks
+
+- Plain app import is only modestly improved. It still imports broad non-splash subsystems, including chunking/ingestion paths, during `tldw_chatbook.app` import.
+- Splash effect discovery is now lazy, but splash card definitions and the SplashScreen widget still remain in the app import graph.
+- Startup measurements use the existing test harness with patched local services, not a real large user database.
+- Long transcript behavior is verified structurally through row reconciliation and refresh-skip tests; no stable wall-clock transcript budget was added in this slice.

--- a/Tests/Performance/test_app_startup_performance.py
+++ b/Tests/Performance/test_app_startup_performance.py
@@ -1,0 +1,257 @@
+"""Performance guardrails for startup and import-time behavior."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+async def _wait_until(
+    condition,
+    *,
+    pause,
+    timeout_seconds: float = 3.0,
+    interval_seconds: float = 0.05,
+) -> None:
+    """Wait for a test-app condition without sleeping the host process."""
+
+    deadline = asyncio.get_running_loop().time() + timeout_seconds
+    while asyncio.get_running_loop().time() < deadline:
+        if condition():
+            return
+        await pause(interval_seconds)
+    if condition():
+        return
+    raise AssertionError(f"condition was not met within {timeout_seconds:.1f}s")
+
+
+def _run_isolated_python(
+    tmp_path: Path,
+    code: str,
+    *,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run a Python snippet with isolated Chatbook config/data directories."""
+
+    data_home = tmp_path / "data"
+    config_home = tmp_path / "config"
+    home = tmp_path / "home"
+    for path in (data_home, config_home, home):
+        path.mkdir(parents=True, exist_ok=True)
+
+    env = {
+        **os.environ,
+        "TLDW_TEST_MODE": "1",
+        "XDG_DATA_HOME": str(data_home),
+        "XDG_CONFIG_HOME": str(config_home),
+        "HOME": str(home),
+        "PYTHONPATH": str(REPO_ROOT),
+    }
+    env.pop("PYTEST_CURRENT_TEST", None)
+    if extra_env:
+        env.update(extra_env)
+
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(code)],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_optional_deps_import_does_not_eagerly_check_embeddings(tmp_path: Path) -> None:
+    """Importing optional_deps should not import heavyweight embeddings packages."""
+
+    result = _run_isolated_python(
+        tmp_path,
+        """
+        import json
+        import sys
+
+        import tldw_chatbook.Utils.optional_deps  # noqa: F401
+
+        guards = ("torch", "transformers", "chromadb", "sentence_transformers")
+        print(json.dumps({"loaded": [name for name in guards if name in sys.modules]}))
+        """,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["loaded"] == []
+    assert "Checking embeddings dependencies early" not in result.stderr
+
+
+def test_optional_deps_eager_env_still_initializes_dependency_checks(tmp_path: Path) -> None:
+    """Explicit eager dependency mode should still run dependency initialization."""
+
+    result = _run_isolated_python(
+        tmp_path,
+        """
+        import json
+
+        import tldw_chatbook.Utils.optional_deps as optional_deps
+
+        print(json.dumps({"initialized": optional_deps._initialized}))
+        """,
+        extra_env={"TLDW_EAGER_DEPENDENCY_CHECK": "true"},
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["initialized"] is True
+    assert "Eager dependency checking enabled via TLDW_EAGER_DEPENDENCY_CHECK" in result.stderr
+
+
+def test_app_import_does_not_load_legacy_feature_windows(tmp_path: Path) -> None:
+    """Plain app import should not load heavy destination/legacy windows."""
+
+    result = _run_isolated_python(
+        tmp_path,
+        """
+        import json
+        import sys
+
+        import tldw_chatbook.app  # noqa: F401
+
+        guards = (
+            "tldw_chatbook.UI.Evals.evals_window_v3",
+            "tldw_chatbook.UI.STTS_Window",
+            "tldw_chatbook.UI.SearchWindow",
+            "tldw_chatbook.UI.MediaWindow_v2",
+            "tldw_chatbook.Utils.Splash_Screens.classic.glitch_reveal",
+            "tldw_chatbook.Utils.Splash_Screens.tech.code_scroll",
+        )
+        print(json.dumps({"loaded": [name for name in guards if name in sys.modules]}))
+        """,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["loaded"] == []
+
+
+@pytest.mark.asyncio
+async def test_ui_ready_before_nonessential_startup_services_finish(monkeypatch) -> None:
+    """Optional audio/DB/cleanup startup work should not gate initial UI readiness."""
+
+    from Tests.UI.test_screen_navigation import _build_test_app
+    from tldw_chatbook.Utils.db_status_manager import DBStatusManager
+    from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import TTSEventHandler
+    from tldw_chatbook.Event_Handlers.STTS_Events.stts_events import STTSEventHandler
+    from tldw_chatbook.app import TldwCli
+
+    tts_started = asyncio.Event()
+    stts_started = asyncio.Event()
+    db_size_started = asyncio.Event()
+    media_cleanup_started = asyncio.Event()
+    release_optional_work = asyncio.Event()
+
+    async def blocked_tts_init(self) -> None:
+        tts_started.set()
+        await release_optional_work.wait()
+
+    async def blocked_stts_init(self) -> None:
+        stts_started.set()
+        await release_optional_work.wait()
+
+    async def blocked_db_size_update(self) -> None:
+        db_size_started.set()
+        await release_optional_work.wait()
+
+    async def blocked_media_cleanup(self) -> None:
+        media_cleanup_started.set()
+        await release_optional_work.wait()
+
+    def test_cli_setting(section: str, key: str | None = None, default=None):
+        if section == "splash_screen" and key == "enabled":
+            return False
+        if section == "media_cleanup" and key == "enabled":
+            return True
+        if section == "media_cleanup" and key == "cleanup_on_startup":
+            return True
+        return default
+
+    monkeypatch.setattr(TTSEventHandler, "initialize_tts", blocked_tts_init)
+    monkeypatch.setattr(STTSEventHandler, "initialize_stts", blocked_stts_init)
+    monkeypatch.setattr(DBStatusManager, "update_db_sizes", blocked_db_size_update)
+    monkeypatch.setattr(TldwCli, "perform_media_cleanup", blocked_media_cleanup)
+    monkeypatch.setattr("tldw_chatbook.app.get_cli_setting", test_cli_setting)
+
+    app = _build_test_app()
+
+    async with app.run_test(size=(120, 36)) as pilot:
+        try:
+            await _wait_until(lambda: app._ui_ready, pause=pilot.pause)
+            await _wait_until(
+                lambda: (
+                    tts_started.is_set()
+                    and stts_started.is_set()
+                    and db_size_started.is_set()
+                ),
+                pause=pilot.pause,
+            )
+            assert app._ui_ready is True
+
+            await asyncio.sleep(0.2)
+            assert media_cleanup_started.is_set() is False
+        finally:
+            release_optional_work.set()
+            await pilot.pause(0.05)
+
+
+@pytest.mark.asyncio
+async def test_tts_handler_initializes_on_first_use(monkeypatch) -> None:
+    """TTS event paths can initialize the handler lazily after startup."""
+
+    from Tests.UI.test_screen_navigation import _build_test_app
+    from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import TTSEventHandler
+
+    initialized = asyncio.Event()
+
+    async def initialize_tts(self) -> None:
+        initialized.set()
+
+    monkeypatch.setattr(TTSEventHandler, "initialize_tts", initialize_tts)
+
+    app = _build_test_app()
+
+    assert app._tts_handler is None
+    handler = await app._ensure_tts_handler()
+
+    assert initialized.is_set()
+    assert handler is app._tts_handler
+
+
+@pytest.mark.asyncio
+async def test_stts_handler_initializes_on_first_use(monkeypatch) -> None:
+    """S/TT/S command paths can initialize the handler lazily after startup."""
+
+    from Tests.UI.test_screen_navigation import _build_test_app
+    from tldw_chatbook.Event_Handlers.STTS_Events.stts_events import STTSEventHandler
+
+    initialized = asyncio.Event()
+
+    async def initialize_stts(self) -> None:
+        initialized.set()
+
+    monkeypatch.setattr(STTSEventHandler, "initialize_stts", initialize_stts)
+
+    app = _build_test_app()
+
+    assert app._stts_handler is None
+    handler = await app._ensure_stts_handler()
+
+    assert initialized.is_set()
+    assert handler is app._stts_handler

--- a/Tests/TTS/test_stts_export_security.py
+++ b/Tests/TTS/test_stts_export_security.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_chatbook.Event_Handlers.STTS_Events.stts_events import STTSEventHandler
+
+
+class NotifyCaptureApp:
+    def __init__(self) -> None:
+        self.notifications: list[SimpleNamespace] = []
+
+    def notify(self, message: str, *, severity: str = "information") -> None:
+        self.notifications.append(SimpleNamespace(message=message, severity=severity))
+
+
+@pytest.mark.asyncio
+async def test_stts_export_current_audio_validates_destination_path(tmp_path):
+    app = NotifyCaptureApp()
+    handler = STTSEventHandler(app=app)
+    handler._current_audio_file = tmp_path / "source.wav"
+    handler._current_audio_file.write_bytes(b"audio")
+
+    target_path = tmp_path / "export.wav"
+
+    await handler.export_current_audio(target_path)
+
+    assert target_path.read_bytes() == b"audio"
+    assert app.notifications[-1].severity == "information"
+
+
+@pytest.mark.asyncio
+async def test_stts_export_current_audio_rejects_dangerous_destination_path(tmp_path):
+    app = NotifyCaptureApp()
+    handler = STTSEventHandler(app=app)
+    handler._current_audio_file = tmp_path / "source.wav"
+    handler._current_audio_file.write_bytes(b"audio")
+
+    target_path = tmp_path / "bad;name.wav"
+
+    await handler.export_current_audio(target_path)
+
+    assert not target_path.exists()
+    assert app.notifications[-1].severity == "error"
+    assert "dangerous pattern" in app.notifications[-1].message

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -264,6 +264,23 @@ def test_console_transcript_sync_timer_polls_at_coarse_interval(monkeypatch):
     assert captured["interval"] >= 0.15
 
 
+def test_console_transcript_fingerprint_tolerates_empty_variant_container():
+    screen = ChatScreen(_build_test_app())
+    message = SimpleNamespace(
+        id="m1",
+        role=ConsoleMessageRole.ASSISTANT,
+        content="answer",
+        status="complete",
+        turn_id="turn-1",
+        persisted_message_id=None,
+        variants=SimpleNamespace(selected_index=0, variants=None),
+    )
+
+    fingerprint = screen._native_console_transcript_fingerprint([message])
+
+    assert fingerprint[1][0][-1] == (0, ())
+
+
 def test_console_provider_selection_reads_local_llamacpp_configured_model():
     app = _build_test_app()
     app.chat_api_provider_value = "local_llamacpp"

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -683,6 +683,44 @@ async def test_console_selected_message_copy_action_uses_app_clipboard():
 
 
 @pytest.mark.asyncio
+async def test_console_sync_skips_transcript_refresh_when_messages_unchanged(monkeypatch):
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+        store = console._ensure_console_chat_store()
+        session = store.ensure_session()
+        message = store.append_message(
+            session.id,
+            role=ConsoleMessageRole.ASSISTANT,
+            content="answer",
+        )
+
+        transcript = console.query_one("#console-native-transcript", ConsoleTranscript)
+        original_refresh = transcript.refresh_messages
+        refresh_calls = 0
+
+        async def counted_refresh():
+            nonlocal refresh_calls
+            refresh_calls += 1
+            await original_refresh()
+
+        monkeypatch.setattr(transcript, "refresh_messages", counted_refresh)
+
+        await console._sync_native_console_chat_ui()
+        assert refresh_calls == 1
+
+        await console._sync_native_console_chat_ui()
+        assert refresh_calls == 1
+
+        store.add_variant(message.id, "updated answer")
+        await console._sync_native_console_chat_ui()
+        assert refresh_calls == 2
+
+
+@pytest.mark.asyncio
 async def test_console_selected_message_save_as_action_opens_modal():
     app = _build_test_app()
     host = ConsoleHarness(app)

--- a/Tests/UI/test_console_native_transcript.py
+++ b/Tests/UI/test_console_native_transcript.py
@@ -174,6 +174,27 @@ async def test_console_transcript_selection_update_preserves_message_rows():
 
 
 @pytest.mark.asyncio
+async def test_console_transcript_removes_build_counts_for_stale_rows():
+    app = MutableTranscriptHarness()
+    removed = ConsoleChatMessage(role=ConsoleMessageRole.USER, content="remove me", id="m-removed")
+    kept = ConsoleChatMessage(role=ConsoleMessageRole.ASSISTANT, content="keep me", id="m-kept")
+
+    async with app.run_test(size=(100, 32)):
+        transcript = app.query_one("#console-native-transcript", ConsoleTranscript)
+        transcript.set_messages([removed, kept])
+        await transcript.refresh_messages()
+        assert "message:m-removed" in transcript.row_build_counts()
+
+        transcript.set_messages([kept])
+        await transcript.refresh_messages()
+        build_counts = transcript.row_build_counts()
+
+    assert "rule:m-removed" not in build_counts
+    assert "message:m-removed" not in build_counts
+    assert "message:m-kept" in build_counts
+
+
+@pytest.mark.asyncio
 async def test_console_transcript_empty_state_accepts_setup_copy():
     app = EmptyTranscriptHarness()
 

--- a/Tests/UI/test_console_native_transcript.py
+++ b/Tests/UI/test_console_native_transcript.py
@@ -194,6 +194,26 @@ async def test_console_transcript_removes_build_counts_for_stale_rows():
     assert "message:m-kept" in build_counts
 
 
+def test_console_transcript_compose_resets_build_count_bookkeeping():
+    transcript = ConsoleTranscript()
+    transcript._row_build_counts["message:stale"] = 3
+    transcript.set_messages(
+        [
+            ConsoleChatMessage(
+                role=ConsoleMessageRole.USER,
+                content="current",
+                id="m-current",
+            )
+        ]
+    )
+
+    list(transcript.compose())
+
+    build_counts = transcript.row_build_counts()
+    assert "message:stale" not in build_counts
+    assert build_counts["message:m-current"] == 1
+
+
 @pytest.mark.asyncio
 async def test_console_transcript_empty_state_accepts_setup_copy():
     app = EmptyTranscriptHarness()

--- a/Tests/UI/test_console_native_transcript.py
+++ b/Tests/UI/test_console_native_transcript.py
@@ -34,6 +34,11 @@ class EmptyTranscriptHarness(App):
         yield ConsoleTranscript(id="console-native-transcript")
 
 
+class MutableTranscriptHarness(App):
+    def compose(self) -> ComposeResult:
+        yield ConsoleTranscript(id="console-native-transcript")
+
+
 class SaveAsModalHarness(App):
     def on_mount(self) -> None:
         self.push_screen(
@@ -82,6 +87,90 @@ def test_console_transcript_widget_rules_are_long_enough_to_clip_full_width():
     renderable = getattr(first_rule, "renderable", "")
 
     assert len(str(renderable)) >= 160
+
+
+@pytest.mark.asyncio
+async def test_console_transcript_append_preserves_existing_message_rows():
+    app = MutableTranscriptHarness()
+    messages = [
+        ConsoleChatMessage(role=ConsoleMessageRole.USER, content=f"message {index}", id=f"m{index}")
+        for index in range(12)
+    ]
+
+    async with app.run_test(size=(100, 32)):
+        transcript = app.query_one("#console-native-transcript", ConsoleTranscript)
+        transcript.set_messages(messages)
+        await transcript.refresh_messages()
+        before_counts = transcript.row_build_counts()
+
+        transcript.set_messages(
+            messages
+            + [ConsoleChatMessage(role=ConsoleMessageRole.ASSISTANT, content="new answer", id="m-new")]
+        )
+        await transcript.refresh_messages()
+        after_counts = transcript.row_build_counts()
+
+    for message in messages:
+        assert after_counts[f"message:{message.id}"] == before_counts[f"message:{message.id}"]
+    assert after_counts["message:m-new"] == 1
+
+
+@pytest.mark.asyncio
+async def test_console_transcript_streaming_update_preserves_unrelated_message_rows():
+    app = MutableTranscriptHarness()
+    user = ConsoleChatMessage(role=ConsoleMessageRole.USER, content="prompt", id="m-user")
+    assistant = ConsoleChatMessage(
+        role=ConsoleMessageRole.ASSISTANT,
+        content="partial",
+        id="m-assistant",
+        status="streaming",
+    )
+    trailing = ConsoleChatMessage(role=ConsoleMessageRole.USER, content="next", id="m-next")
+
+    async with app.run_test(size=(100, 32)):
+        transcript = app.query_one("#console-native-transcript", ConsoleTranscript)
+        transcript.set_messages([user, assistant, trailing])
+        await transcript.refresh_messages()
+        before_counts = transcript.row_build_counts()
+
+        assistant.content = "partial response"
+        transcript.set_messages([user, assistant, trailing])
+        await transcript.refresh_messages()
+        after_counts = transcript.row_build_counts()
+        rendered = transcript.query_one("#console-message-m-assistant", Static)
+
+    assert after_counts["message:m-user"] == before_counts["message:m-user"]
+    assert after_counts["message:m-next"] == before_counts["message:m-next"]
+    assert after_counts["message:m-assistant"] == before_counts["message:m-assistant"]
+    assert "partial response" in str(rendered.renderable)
+
+
+@pytest.mark.asyncio
+async def test_console_transcript_selection_update_preserves_message_rows():
+    app = MutableTranscriptHarness()
+    messages = [
+        ConsoleChatMessage(role=ConsoleMessageRole.USER, content="prompt", id="m-user"),
+        ConsoleChatMessage(role=ConsoleMessageRole.ASSISTANT, content="answer", id="m-assistant"),
+        ConsoleChatMessage(role=ConsoleMessageRole.USER, content="followup", id="m-followup"),
+    ]
+
+    async with app.run_test(size=(100, 32)):
+        transcript = app.query_one("#console-native-transcript", ConsoleTranscript)
+        transcript.set_messages(messages)
+        await transcript.refresh_messages()
+
+        transcript.selected_message_id = "m-user"
+        await transcript.refresh_messages()
+        before_counts = transcript.row_build_counts()
+
+        transcript.selected_message_id = "m-assistant"
+        await transcript.refresh_messages()
+        after_counts = transcript.row_build_counts()
+
+    for message in messages:
+        assert after_counts[f"message:{message.id}"] == before_counts[f"message:{message.id}"]
+    assert "actions:m-user" not in transcript.row_render_signatures()
+    assert "actions:m-assistant" in transcript.row_render_signatures()
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_home_screen.py
+++ b/Tests/UI/test_home_screen.py
@@ -228,11 +228,12 @@ async def test_home_empty_state_inspector_explains_selected_primary_action():
         assert "Import Library sources" in selected_text
         assert "Destination: Library" in selected_text
         assert "Enter: Open Library" in selected_text
-        assert "Ctrl+P: Search commands" in selected_text
+        assert "Ctrl+P" not in selected_text
 
         hint_text = str(home.query_one("#home-action-hints").renderable)
         assert "Enter open selected" in hint_text
         assert "Tab switch pane" in hint_text
+        assert "Ctrl+P" not in hint_text
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_screen_navigation.py
+++ b/Tests/UI/test_screen_navigation.py
@@ -105,7 +105,7 @@ from tldw_chatbook.Subscriptions import (
 )
 from tldw_chatbook.Translation_Interop import ServerTranslationService, TranslationScopeService
 from tldw_chatbook.Voice_Assistant_Interop import ServerVoiceAssistantService, VoiceAssistantScopeService
-from tldw_chatbook.Constants import ALL_TABS, TAB_CCP, TAB_CHAT, TAB_NOTES
+from tldw_chatbook.Constants import ALL_TABS, TAB_CCP, TAB_CHAT, TAB_NOTES, TAB_SUBSCRIPTIONS
 from tldw_chatbook.UI.Navigation.base_app_screen import BaseAppScreen
 from tldw_chatbook.UI.Navigation.main_navigation import MainNavigationBar
 from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
@@ -130,7 +130,11 @@ PRIMARY_ROUTE_IDS = [
 ]
 
 
-def test_master_shell_route_inventory_has_known_legacy_routes():
+def test_master_shell_route_inventory_has_known_legacy_routes(monkeypatch):
+    monkeypatch.setattr(
+        "tldw_chatbook.Utils.optional_deps.check_subscriptions_deps",
+        lambda: True,
+    )
     expected_legacy_routes = {
         "chat",
         "notes",
@@ -353,6 +357,46 @@ def test_lazy_screen_registry_resolves_visible_shell_destinations():
         resolved[destination.primary_route] = screen_class.__name__ if screen_class else None
 
     assert resolved == expected_class_names
+
+
+def test_optional_screen_registry_route_skips_import_when_dependency_guard_fails(monkeypatch):
+    from tldw_chatbook.UI.Navigation import screen_registry
+
+    imported_modules = []
+
+    def fake_import_module(module_name):
+        imported_modules.append(module_name)
+        if module_name == "tldw_chatbook.Utils.optional_deps":
+            return SimpleNamespace(check_subscriptions_deps=lambda: False)
+        raise AssertionError(f"Optional screen should not import when dependencies are missing: {module_name}")
+
+    monkeypatch.setattr(screen_registry, "import_module", fake_import_module)
+
+    screen_name, canonical_tab, screen_class = screen_registry.resolve_screen_target("subscriptions")
+
+    assert screen_name == "subscriptions"
+    assert canonical_tab == TAB_SUBSCRIPTIONS
+    assert screen_class is None
+    assert imported_modules == ["tldw_chatbook.Utils.optional_deps"]
+
+
+def test_optional_screen_registry_route_handles_import_error(monkeypatch):
+    from tldw_chatbook.UI.Navigation import screen_registry
+
+    def fake_import_module(module_name):
+        if module_name == "tldw_chatbook.Utils.optional_deps":
+            return SimpleNamespace(check_subscriptions_deps=lambda: True)
+        if module_name == "tldw_chatbook.UI.Screens.subscription_screen":
+            raise ImportError("missing optional subscription dependency")
+        raise AssertionError(f"Unexpected import: {module_name}")
+
+    monkeypatch.setattr(screen_registry, "import_module", fake_import_module)
+
+    screen_name, canonical_tab, screen_class = screen_registry.resolve_screen_target("subscriptions")
+
+    assert screen_name == "subscriptions"
+    assert canonical_tab == TAB_SUBSCRIPTIONS
+    assert screen_class is None
 
 
 def test_conversation_route_uses_library_conversation_context():
@@ -827,7 +871,11 @@ async def test_main_navigation_route_ids_match_shell_destinations():
 
 
 @pytest.mark.asyncio
-async def test_screen_navigation_routes_reach_real_app_handler():
+async def test_screen_navigation_routes_reach_real_app_handler(monkeypatch):
+    monkeypatch.setattr(
+        "tldw_chatbook.Utils.optional_deps.check_subscriptions_deps",
+        lambda: True,
+    )
     app = _build_test_app()
     captured_destinations = []
 

--- a/Tests/UI/test_screen_navigation.py
+++ b/Tests/UI/test_screen_navigation.py
@@ -105,7 +105,7 @@ from tldw_chatbook.Subscriptions import (
 )
 from tldw_chatbook.Translation_Interop import ServerTranslationService, TranslationScopeService
 from tldw_chatbook.Voice_Assistant_Interop import ServerVoiceAssistantService, VoiceAssistantScopeService
-from tldw_chatbook.Constants import ALL_TABS
+from tldw_chatbook.Constants import ALL_TABS, TAB_CCP, TAB_CHAT, TAB_NOTES
 from tldw_chatbook.UI.Navigation.base_app_screen import BaseAppScreen
 from tldw_chatbook.UI.Navigation.main_navigation import MainNavigationBar
 from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
@@ -220,6 +220,87 @@ def test_ccp_default_tab_initializes_before_reactive_watcher_runs():
     assert app._ui_ready is False
 
 
+@pytest.mark.asyncio
+async def test_ccp_character_select_change_dispatches_once(monkeypatch):
+    app = _build_test_app()
+    app.current_tab = TAB_CCP
+    calls = []
+
+    async def fake_character_select_changed(_app, value):
+        calls.append(value)
+
+    monkeypatch.setattr(
+        "tldw_chatbook.app.ccp_handlers.handle_ccp_character_select_changed",
+        fake_character_select_changed,
+    )
+
+    await app.on_select_changed(
+        SimpleNamespace(
+            select=SimpleNamespace(id="conv-char-character-select"),
+            value="character-1",
+        )
+    )
+
+    assert calls == ["character-1"]
+
+
+@pytest.mark.asyncio
+async def test_chat_select_change_before_ui_ready_skips_token_counter(monkeypatch):
+    app = _build_test_app()
+    app.current_tab = TAB_CHAT
+    app._ui_ready = False
+    calls = []
+
+    async def fake_update_token_counter(_app):
+        calls.append("updated")
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Event_Handlers.Chat_Events.chat_token_events.update_chat_token_counter",
+        fake_update_token_counter,
+    )
+
+    await app.on_select_changed(
+        SimpleNamespace(
+            select=SimpleNamespace(id="chat-api-provider"),
+            value="OpenAI",
+        )
+    )
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_notes_screen_navigation_refreshes_scope_once_per_entry(monkeypatch):
+    from tldw_chatbook.UI.Screens.notes_screen import NotesScreen
+
+    app = _build_test_app()
+    refresh_calls = []
+
+    async def fake_refresh_current_scope(self):
+        refresh_calls.append(self)
+
+    monkeypatch.setattr(NotesScreen, "refresh_current_scope", fake_refresh_current_scope)
+    monkeypatch.setattr(
+        "tldw_chatbook.app.get_cli_setting",
+        lambda section, key=None, default=None: False
+        if section == "splash_screen" and key == "enabled"
+        else default,
+    )
+
+    async with app.run_test(size=(160, 40)) as pilot:
+        await pilot.pause(0.1)
+
+        await app.handle_screen_navigation(NavigateToScreen(TAB_NOTES))
+        await pilot.pause(0.1)
+        assert len(refresh_calls) == 1
+
+        await app.handle_screen_navigation(NavigateToScreen(TAB_CHAT))
+        await pilot.pause(0.1)
+        await app.handle_screen_navigation(NavigateToScreen(TAB_NOTES))
+        await pilot.pause(0.1)
+        assert len(refresh_calls) == 2
+
+
 def test_all_master_shell_primary_routes_resolve_before_nav_exposure():
     app = _build_test_app()
     expected_routes = {
@@ -247,6 +328,33 @@ def test_all_master_shell_primary_routes_resolve_before_nav_exposure():
     assert unresolved == []
 
 
+def test_lazy_screen_registry_resolves_visible_shell_destinations():
+    from tldw_chatbook.UI.Navigation.screen_registry import resolve_screen_target
+    from tldw_chatbook.UI.Navigation.shell_destinations import SHELL_DESTINATION_ORDER
+
+    expected_class_names = {
+        "home": "HomeScreen",
+        "chat": "ChatScreen",
+        "library": "LibraryScreen",
+        "artifacts": "ArtifactsScreen",
+        "personas": "PersonasScreen",
+        "watchlists_collections": "WatchlistsCollectionsScreen",
+        "schedules": "SchedulesScreen",
+        "workflows": "WorkflowsScreen",
+        "mcp": "MCPScreen",
+        "acp": "ACPScreen",
+        "skills": "SkillsScreen",
+        "settings": "SettingsScreen",
+    }
+
+    resolved = {}
+    for destination in SHELL_DESTINATION_ORDER:
+        _screen_name, _tab_id, screen_class = resolve_screen_target(destination.primary_route)
+        resolved[destination.primary_route] = screen_class.__name__ if screen_class else None
+
+    assert resolved == expected_class_names
+
+
 def test_conversation_route_uses_library_conversation_context():
     app = _build_test_app()
 
@@ -265,6 +373,51 @@ def test_legacy_tools_settings_route_uses_mcp_context():
     assert screen_name == "tools_settings"
     assert current_tab == "mcp"
     assert screen_class.__name__ == "MCPScreen"
+
+
+@pytest.mark.asyncio
+async def test_cacheable_screen_navigation_reuses_constructed_screen_instance(monkeypatch):
+    app = _build_test_app()
+    constructed = {"chat": 0, "library": 0}
+
+    class FakeChatScreen:
+        screen_name = "chat"
+
+        def __init__(self, app_instance):
+            self.app_instance = app_instance
+            constructed["chat"] += 1
+
+    class FakeLibraryScreen:
+        screen_name = "library"
+
+        def __init__(self, app_instance):
+            self.app_instance = app_instance
+            constructed["library"] += 1
+
+    def fake_resolve(target):
+        if target == "chat":
+            return "chat", "chat", FakeChatScreen
+        if target == "library":
+            return "library", "library", FakeLibraryScreen
+        return target, target, None
+
+    switched_screens = []
+
+    async def fake_switch_screen(screen):
+        switched_screens.append(screen)
+
+    monkeypatch.setattr(app, "_resolve_screen_navigation_target", fake_resolve)
+    monkeypatch.setattr(app, "switch_screen", fake_switch_screen)
+
+    async with app.run_test(size=(160, 40)) as pilot:
+        await pilot.pause(0.1)
+
+        await app.handle_screen_navigation(NavigateToScreen("chat"))
+        await app.handle_screen_navigation(NavigateToScreen("library"))
+        await app.handle_screen_navigation(NavigateToScreen("chat"))
+
+    assert constructed == {"chat": 1, "library": 1}
+    assert switched_screens[0] is switched_screens[2]
 
 
 def _build_test_app(configured_default: str | None = None) -> TldwCli:

--- a/Tests/Utils/test_metrics_logger.py
+++ b/Tests/Utils/test_metrics_logger.py
@@ -1,0 +1,41 @@
+"""Focused coverage for normal metric log-volume controls."""
+
+from __future__ import annotations
+
+from loguru import logger
+
+from tldw_chatbook.Metrics import metrics_logger
+
+
+def _capture_metric_output(action) -> list[str]:
+    messages: list[str] = []
+    sink_id = logger.add(lambda message: messages.append(str(message)), level="METRIC")
+    try:
+        action()
+    finally:
+        logger.remove(sink_id)
+    return messages
+
+
+def test_metric_logging_disabled_by_default(monkeypatch) -> None:
+    """Normal runs should not emit high-volume METRIC log lines."""
+
+    monkeypatch.delenv("TLDW_METRICS_LOGGING", raising=False)
+
+    messages = _capture_metric_output(
+        lambda: metrics_logger.log_counter("unit_metric_disabled")
+    )
+
+    assert messages == []
+
+
+def test_metric_logging_enabled_by_env(monkeypatch) -> None:
+    """Explicit metric logging opt-in should preserve existing METRIC output."""
+
+    monkeypatch.setenv("TLDW_METRICS_LOGGING", "1")
+
+    messages = _capture_metric_output(
+        lambda: metrics_logger.log_counter("unit_metric_enabled")
+    )
+
+    assert any("unit_metric_enabled" in message for message in messages)

--- a/Tests/Utils/test_optional_deps.py
+++ b/Tests/Utils/test_optional_deps.py
@@ -83,6 +83,34 @@ def test_optional_feature_metadata_groups_release_capabilities_without_core_inst
     assert "web" in groups["Web access"]
 
 
+def test_subscriptions_deps_require_beautifulsoup_for_route_import(monkeypatch):
+    """The subscriptions route guard blocks imports when BeautifulSoup is absent."""
+    from tldw_chatbook.Utils import optional_deps
+
+    optional_deps.reset_dependency_checks()
+    seen: list[tuple[str, str]] = []
+
+    def fake_check_dependency(module_name: str, feature_name: str | None = None) -> bool:
+        dependency_key = feature_name or module_name
+        seen.append((module_name, dependency_key))
+        is_available = module_name != "bs4"
+        optional_deps.DEPENDENCIES_AVAILABLE[dependency_key] = is_available
+        return is_available
+
+    monkeypatch.setattr(optional_deps, "check_dependency", fake_check_dependency)
+
+    assert optional_deps.check_subscriptions_deps() is False
+    assert ("bs4", "beautifulsoup4") in seen
+    assert optional_deps.DEPENDENCIES_AVAILABLE["subscriptions"] is False
+
+
+def test_subscriptions_extra_declares_beautifulsoup_dependency():
+    """The install extra matches the route guard's BeautifulSoup dependency."""
+    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+    assert "beautifulsoup4" in pyproject["project"]["optional-dependencies"]["subscriptions"]
+
+
 def test_unavailable_feature_handler():
     """Test that unavailable feature handlers work correctly."""
     from tldw_chatbook.Utils.optional_deps import create_unavailable_feature_handler

--- a/backlog/tasks/task-72 - Performance-lag-remediation.md
+++ b/backlog/tasks/task-72 - Performance-lag-remediation.md
@@ -1,0 +1,68 @@
+---
+id: TASK-72
+title: Performance lag remediation
+status: Done
+assignee: []
+created_date: ''
+updated_date: 2026-05-28 23:58
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Reduce startup, navigation, and console transcript lag by removing eager work and adding performance guardrails.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Startup and navigation measurements are captured before and after remediation
+- [x] #2 Embeddings and heavy optional dependencies are not checked during plain app import
+- [x] #3 Console transcript updates avoid full transcript remounts during streaming
+- [x] #4 Nonessential startup services do not block UI readiness
+- [x] #5 Focused UI and performance tests pass
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add subprocess startup/import guards for optional dependency checks and app import graph behavior.
+2. Remove import-time embeddings dependency checks while preserving explicit eager dependency mode.
+3. Lazy-load screen route resolution and legacy feature windows that are not needed for plain app import.
+4. Add safe repeat-navigation reuse for allowlisted destination screens with context-change invalidation.
+5. Incrementalize native Console transcript reconciliation and skip unchanged transcript refresh polls.
+6. Defer nonessential startup services and startup cleanup work so UI readiness is not blocked.
+7. Gate high-volume metrics/logging overhead behind explicit enablement.
+8. Capture before/after measurement deltas and run focused UI/performance verification before closing the task.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the approved performance-lag remediation in the isolated worktree. Added subprocess startup/import guards and removed the import-time embeddings/RAG dependency check while preserving explicit `TLDW_EAGER_DEPENDENCY_CHECK=true` behavior. Added lazy screen route resolution, lazy `UI.Screens` exports, and lazy splash effect discovery so guarded legacy feature windows and splash effect modules are not loaded during plain app import.
+
+Added allowlisted destination screen caching with invalidation on runtime/workspace context changes, and fixed Notes navigation so initial scope refresh has one owner per entry. Incrementalized `ConsoleTranscript` row reconciliation, added row signatures/build counters for tests, and skipped unchanged native transcript refreshes in `ChatScreen`. Deferred TTS/STTS initialization, DB-size polling, token-count timers, and startup media cleanup until after UI readiness or first use. Gated normal metric log emission behind `TLDW_METRICS_LOGGING` and lowered high-volume select-change logging.
+
+Captured before/after measurements in `Docs/superpowers/qa/performance/2026-05-28-lag-remediation-closeout.md`. Baseline was about 4.5s import, 6.5s to `_ui_ready`, and 0.26s-0.61s route switches. After remediation, isolated probes measured 4.365s app import, 0.492s to `_ui_ready`, route switches of 0.274s-0.547s, and 0 `METRIC` log lines during import/startup probes. Residual risks are documented in the closeout: plain app import remains broad, splash card definitions still stay in the app import graph, large user DBs were not replayed, and transcript wall-clock budgets remain structural rather than timed.
+
+Modified files include `tldw_chatbook/app.py`, `tldw_chatbook/UI/Navigation/screen_registry.py`, `tldw_chatbook/UI/Screens/__init__.py`, `tldw_chatbook/UI/Screens/chat_screen.py`, `tldw_chatbook/UI/Screens/notes_screen.py`, `tldw_chatbook/Widgets/Console/console_transcript.py`, `tldw_chatbook/Utils/optional_deps.py`, `tldw_chatbook/Utils/Splash_Screens/__init__.py`, `tldw_chatbook/Widgets/splash_screen.py`, `tldw_chatbook/Metrics/metrics_logger.py`, focused UI/performance/unit tests, and the performance plan/closeout docs.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Reduced the critical startup path and repeat-interaction lag by lazy-loading heavy modules, deferring nonessential services until after readiness or first use, reusing cacheable destination screens safely, removing duplicate Notes refresh ownership, and making native Console transcript refreshes keyed/incremental instead of full-list remounts. Focused verification passed for the startup, route navigation, destination smoke, metrics gating, and console transcript suites; static checks passed with targeted `py_compile` and `git diff --check`.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Acceptance criteria are checked off.
+- [x] #2 Implementation plan is added after the task moves to In Progress.
+- [x] #3 Focused automated tests cover changed behavior.
+- [x] #4 Static analysis / formatting checks are run or documented if not applicable.
+- [x] #5 Relevant docs or QA artifacts are updated.
+- [x] #6 Implementation notes summarize approach, modified files, measurement deltas, and residual risks.
+- [x] #7 Self-review completed.
+- [x] #8 Task status is set to Done via Backlog CLI only after all DoD items are complete.
+<!-- DOD:END -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,6 +257,7 @@ subscriptions = [
     "markdown",  # For HTML generation from markdown
     "schedule",  # For scheduled tasks
     "feedparser",  # For RSS feed parsing
+    "beautifulsoup4", # HTML parsing for subscription monitors
     "cryptography", # Security.py
     "defusedxml",  # For safe XML parsing
     "tqdm",

--- a/tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py
+++ b/tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py
@@ -777,8 +777,16 @@ class STTSEventHandler:
         
         try:
             import shutil
-            shutil.copy2(self._current_audio_file, target_path)
-            self.app.notify(f"Audio exported to {target_path}", severity="information")
+            from tldw_chatbook.Utils.path_validation import validate_filename, validate_path_simple
+
+            target_path = Path(target_path)
+            validate_path_simple(target_path, require_exists=False)
+            validated_parent = validate_path_simple(target_path.parent, require_exists=True).resolve()
+            validated_filename = validate_filename(target_path.name)
+            validated_target_path = validated_parent / validated_filename
+
+            shutil.copy2(self._current_audio_file, validated_target_path)
+            self.app.notify(f"Audio exported to {validated_target_path}", severity="information")
         except Exception as e:
             logger.error(f"Failed to export audio: {e}")
             self.app.notify(f"Failed to export audio: {e}", severity="error")

--- a/tldw_chatbook/Metrics/metrics_logger.py
+++ b/tldw_chatbook/Metrics/metrics_logger.py
@@ -22,6 +22,7 @@ from loguru import logger
 LabelValue = Union[str, int, float, bool]
 LabelDict = Dict[str, LabelValue]
 _METRICS_LOGGING_TRUTHY = {"1", "true", "yes", "on"}
+_metrics_enabled_cache: bool | None = None
 
 # 2. (Gold Standard) Define a custom "METRIC" level for powerful filtering
 # This allows separating metrics from regular application logs at the sink level.
@@ -31,7 +32,12 @@ logger.level("METRIC", no=25, color="<blue>", icon="📊")
 def is_metrics_logging_enabled() -> bool:
     """Return whether high-volume Loguru metric lines should be emitted."""
 
-    return os.environ.get("TLDW_METRICS_LOGGING", "").lower() in _METRICS_LOGGING_TRUTHY
+    global _metrics_enabled_cache
+    if "PYTEST_CURRENT_TEST" in os.environ:
+        return os.environ.get("TLDW_METRICS_LOGGING", "").lower() in _METRICS_LOGGING_TRUTHY
+    if _metrics_enabled_cache is None:
+        _metrics_enabled_cache = os.environ.get("TLDW_METRICS_LOGGING", "").lower() in _METRICS_LOGGING_TRUTHY
+    return _metrics_enabled_cache
 
 
 def _log_metric(

--- a/tldw_chatbook/Metrics/metrics_logger.py
+++ b/tldw_chatbook/Metrics/metrics_logger.py
@@ -2,6 +2,7 @@
 #
 # Imports
 import functools
+import os
 import sys
 import time
 from datetime import datetime, timezone
@@ -20,10 +21,17 @@ from loguru import logger
 # 1. Refined Type Hinting for clarity and correctness
 LabelValue = Union[str, int, float, bool]
 LabelDict = Dict[str, LabelValue]
+_METRICS_LOGGING_TRUTHY = {"1", "true", "yes", "on"}
 
 # 2. (Gold Standard) Define a custom "METRIC" level for powerful filtering
 # This allows separating metrics from regular application logs at the sink level.
 logger.level("METRIC", no=25, color="<blue>", icon="📊")
+
+
+def is_metrics_logging_enabled() -> bool:
+    """Return whether high-volume Loguru metric lines should be emitted."""
+
+    return os.environ.get("TLDW_METRICS_LOGGING", "").lower() in _METRICS_LOGGING_TRUTHY
 
 
 def _log_metric(
@@ -35,6 +43,9 @@ def _log_metric(
     """
     Private helper to log a structured metric using idiomatic loguru binding.
     """
+    if not is_metrics_logging_enabled():
+        return
+
     # 3. Bind each piece of data to the top level for a flatter, queryable JSON
     bound_logger = logger.bind(
         event=metric_name,

--- a/tldw_chatbook/UI/Navigation/screen_registry.py
+++ b/tldw_chatbook/UI/Navigation/screen_registry.py
@@ -1,0 +1,88 @@
+"""Lazy screen route registry for app shell navigation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import import_module
+
+from tldw_chatbook.Constants import TAB_CCP, TAB_LLM, TAB_MCP, TAB_SUBSCRIPTIONS
+
+
+@dataclass(frozen=True)
+class ScreenRoute:
+    """Screen target metadata that defers importing the screen class."""
+
+    screen_name: str
+    canonical_tab: str
+    module_path: str
+    class_name: str
+
+    def load_screen_class(self) -> type:
+        module = import_module(self.module_path)
+        return getattr(module, self.class_name)
+
+
+_SCREEN_ROUTES: dict[str, ScreenRoute] = {
+    "home": ScreenRoute("home", "home", "tldw_chatbook.UI.Screens.home_screen", "HomeScreen"),
+    "chat": ScreenRoute("chat", "chat", "tldw_chatbook.UI.Screens.chat_screen", "ChatScreen"),
+    "library": ScreenRoute("library", "library", "tldw_chatbook.UI.Screens.library_screen", "LibraryScreen"),
+    "artifacts": ScreenRoute("artifacts", "artifacts", "tldw_chatbook.UI.Screens.artifacts_screen", "ArtifactsScreen"),
+    "personas": ScreenRoute("personas", "personas", "tldw_chatbook.UI.Screens.personas_screen", "PersonasScreen"),
+    "watchlists_collections": ScreenRoute(
+        "watchlists_collections",
+        "watchlists_collections",
+        "tldw_chatbook.UI.Screens.watchlists_collections_screen",
+        "WatchlistsCollectionsScreen",
+    ),
+    "schedules": ScreenRoute("schedules", "schedules", "tldw_chatbook.UI.Screens.schedules_screen", "SchedulesScreen"),
+    "workflows": ScreenRoute("workflows", "workflows", "tldw_chatbook.UI.Screens.workflows_screen", "WorkflowsScreen"),
+    "mcp": ScreenRoute("mcp", TAB_MCP, "tldw_chatbook.UI.Screens.mcp_screen", "MCPScreen"),
+    "acp": ScreenRoute("acp", "acp", "tldw_chatbook.UI.Screens.acp_screen", "ACPScreen"),
+    "skills": ScreenRoute("skills", "skills", "tldw_chatbook.UI.Screens.skills_screen", "SkillsScreen"),
+    "settings": ScreenRoute("settings", "settings", "tldw_chatbook.UI.Screens.settings_screen", "SettingsScreen"),
+    "ingest": ScreenRoute("ingest", "ingest", "tldw_chatbook.UI.Screens.media_ingest_screen", "MediaIngestScreen"),
+    "coding": ScreenRoute("coding", "coding", "tldw_chatbook.UI.Screens.coding_screen", "CodingScreen"),
+    "conversation": ScreenRoute(
+        "conversation",
+        "conversation",
+        "tldw_chatbook.UI.Screens.library_conversations_screen",
+        "LibraryConversationsScreen",
+    ),
+    "ccp": ScreenRoute("ccp", TAB_CCP, "tldw_chatbook.UI.Screens.conversation_screen", "ConversationScreen"),
+    "media": ScreenRoute("media", "media", "tldw_chatbook.UI.Screens.media_screen", "MediaScreen"),
+    "notes": ScreenRoute("notes", "notes", "tldw_chatbook.UI.Screens.notes_screen", "NotesScreen"),
+    "search": ScreenRoute("search", "search", "tldw_chatbook.UI.Screens.search_screen", "SearchScreen"),
+    "evals": ScreenRoute("evals", "evals", "tldw_chatbook.UI.Screens.evals_screen", "EvalsScreen"),
+    "tools_settings": ScreenRoute("tools_settings", TAB_MCP, "tldw_chatbook.UI.Screens.mcp_screen", "MCPScreen"),
+    "llm": ScreenRoute("llm", TAB_LLM, "tldw_chatbook.UI.Screens.llm_screen", "LLMScreen"),
+    "customize": ScreenRoute("customize", "customize", "tldw_chatbook.UI.Screens.customize_screen", "CustomizeScreen"),
+    "logs": ScreenRoute("logs", "logs", "tldw_chatbook.UI.Screens.logs_screen", "LogsScreen"),
+    "stats": ScreenRoute("stats", "stats", "tldw_chatbook.UI.Screens.stats_screen", "StatsScreen"),
+    "stts": ScreenRoute("stts", "stts", "tldw_chatbook.UI.Screens.stts_screen", "STTSScreen"),
+    "study": ScreenRoute("study", "study", "tldw_chatbook.UI.Screens.study_screen", "StudyScreen"),
+    "writing": ScreenRoute("writing", "writing", "tldw_chatbook.UI.Screens.writing_screen", "WritingScreen"),
+    "research": ScreenRoute("research", "research", "tldw_chatbook.UI.Screens.research_screen", "ResearchScreen"),
+    "chatbooks": ScreenRoute("chatbooks", "chatbooks", "tldw_chatbook.UI.Screens.chatbooks_screen", "ChatbooksScreen"),
+    "subscriptions": ScreenRoute(
+        "subscriptions",
+        TAB_SUBSCRIPTIONS,
+        "tldw_chatbook.UI.Screens.subscription_screen",
+        "SubscriptionScreen",
+    ),
+}
+
+_SCREEN_ALIASES = {
+    TAB_CCP: "ccp",
+    TAB_LLM: "llm",
+    "subscription": "subscriptions",
+}
+
+
+def resolve_screen_target(target: str) -> tuple[str, str, type | None]:
+    """Resolve a navigation target to a screen route without importing unrelated screens."""
+
+    route_id = _SCREEN_ALIASES.get(target, target)
+    route = _SCREEN_ROUTES.get(route_id)
+    if route is None:
+        return route_id, route_id, None
+    return route.screen_name, route.canonical_tab, route.load_screen_class()

--- a/tldw_chatbook/UI/Navigation/screen_registry.py
+++ b/tldw_chatbook/UI/Navigation/screen_registry.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from importlib import import_module
 
+from loguru import logger
+
 from tldw_chatbook.Constants import TAB_CCP, TAB_LLM, TAB_MCP, TAB_SUBSCRIPTIONS
 
 
@@ -16,10 +18,35 @@ class ScreenRoute:
     canonical_tab: str
     module_path: str
     class_name: str
+    dependency_check: str | None = None
 
-    def load_screen_class(self) -> type:
-        module = import_module(self.module_path)
-        return getattr(module, self.class_name)
+    def dependencies_available(self) -> bool:
+        """Return whether optional dependencies for this route are available."""
+
+        if self.dependency_check is None:
+            return True
+        try:
+            optional_deps = import_module("tldw_chatbook.Utils.optional_deps")
+            check = getattr(optional_deps, self.dependency_check)
+        except (ImportError, AttributeError) as exc:
+            logger.warning(
+                f"Optional dependency guard unavailable for route {self.screen_name}: {exc}"
+            )
+            return False
+        return bool(check())
+
+    def load_screen_class(self) -> type | None:
+        """Load the screen class, returning None when an optional screen is unavailable."""
+
+        if not self.dependencies_available():
+            logger.warning(f"Screen route unavailable due to missing dependencies: {self.screen_name}")
+            return None
+        try:
+            module = import_module(self.module_path)
+            return getattr(module, self.class_name)
+        except (ImportError, AttributeError) as exc:
+            logger.warning(f"Screen route unavailable: {self.screen_name}: {exc}")
+            return None
 
 
 _SCREEN_ROUTES: dict[str, ScreenRoute] = {
@@ -68,6 +95,7 @@ _SCREEN_ROUTES: dict[str, ScreenRoute] = {
         TAB_SUBSCRIPTIONS,
         "tldw_chatbook.UI.Screens.subscription_screen",
         "SubscriptionScreen",
+        dependency_check="check_subscriptions_deps",
     ),
 }
 

--- a/tldw_chatbook/UI/Screens/__init__.py
+++ b/tldw_chatbook/UI/Screens/__init__.py
@@ -1,18 +1,29 @@
-"""Application screens for screen-based navigation."""
+"""Application screens for screen-based navigation.
 
-from .chat_screen import ChatScreen
-from .media_ingest_screen import MediaIngestScreen
-from .coding_screen import CodingScreen
-from .conversation_screen import ConversationScreen
-from .media_screen import MediaScreen
-from .notes_screen import NotesScreen
-from .search_screen import SearchScreen
-from .evals_screen import EvalsScreen
-from .tools_settings_screen import ToolsSettingsScreen
-from .llm_screen import LLMScreen
-from .customize_screen import CustomizeScreen
-from .logs_screen import LogsScreen
-from .stats_screen import StatsScreen
+Screen classes are exported lazily so importing lightweight screen-adjacent
+modules does not import every destination screen during app startup.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+
+
+_SCREEN_EXPORTS = {
+    "ChatScreen": ".chat_screen",
+    "MediaIngestScreen": ".media_ingest_screen",
+    "CodingScreen": ".coding_screen",
+    "ConversationScreen": ".conversation_screen",
+    "MediaScreen": ".media_screen",
+    "NotesScreen": ".notes_screen",
+    "SearchScreen": ".search_screen",
+    "EvalsScreen": ".evals_screen",
+    "ToolsSettingsScreen": ".tools_settings_screen",
+    "LLMScreen": ".llm_screen",
+    "CustomizeScreen": ".customize_screen",
+    "LogsScreen": ".logs_screen",
+    "StatsScreen": ".stats_screen",
+}
 
 __all__ = [
     'ChatScreen',
@@ -29,3 +40,13 @@ __all__ = [
     'LogsScreen',
     'StatsScreen',
 ]
+
+
+def __getattr__(name: str):
+    if name not in _SCREEN_EXPORTS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module = import_module(_SCREEN_EXPORTS[name], __name__)
+    screen_class = getattr(module, name)
+    globals()[name] = screen_class
+    return screen_class

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -451,6 +451,7 @@ class ChatScreen(BaseAppScreen):
         self._last_console_action: ConsoleActionResult | None = None
         self._console_transcript_sync_timer: Any | None = None
         self._console_sync_in_progress = False
+        self._last_native_transcript_refresh_key: tuple[int, tuple[Any, ...]] | None = None
         self._console_guidance_dismissed = False
         self.ui_state = UIState()
         self._load_sidebar_state()
@@ -2225,6 +2226,8 @@ class ChatScreen(BaseAppScreen):
             result = close()
             if inspect.isawaitable(result):
                 await result
+        self._console_provider_gateway = None
+        self._console_chat_controller = None
         super().on_unmount()
     
     def save_state(self) -> Dict[str, Any]:
@@ -2578,6 +2581,37 @@ class ChatScreen(BaseAppScreen):
             return []
         return store.messages_for_session(store.active_session_id)
 
+    def _native_console_transcript_fingerprint(self, messages: list[Any]) -> tuple[Any, ...]:
+        """Return a lightweight signature for native transcript refresh skipping."""
+        store = self._ensure_console_chat_store()
+        message_signatures = []
+        for message in messages:
+            variants = getattr(message, "variants", None)
+            variant_signature = None
+            if variants is not None:
+                variant_signature = (
+                    getattr(variants, "selected_index", None),
+                    tuple(
+                        (
+                            getattr(variant, "id", None),
+                            getattr(variant, "content", ""),
+                        )
+                        for variant in getattr(variants, "variants", ())
+                    ),
+                )
+            message_signatures.append(
+                (
+                    getattr(message, "id", None),
+                    getattr(getattr(message, "role", None), "value", getattr(message, "role", None)),
+                    getattr(message, "content", ""),
+                    getattr(message, "status", None),
+                    getattr(message, "turn_id", None),
+                    getattr(message, "persisted_message_id", None),
+                    variant_signature,
+                )
+            )
+        return (store.active_session_id, tuple(message_signatures))
+
     async def _sync_native_console_transcript_to_legacy_surface(self) -> None:
         """Temporary bridge: render native Console messages in the existing surface."""
         try:
@@ -2585,9 +2619,16 @@ class ChatScreen(BaseAppScreen):
         except QueryError:
             transcript = None
 
+        messages = self._native_console_messages()
         if transcript is not None:
-            transcript.set_messages(self._native_console_messages())
-            await transcript.refresh_messages()
+            transcript.set_messages(messages)
+            refresh_key = (
+                id(transcript),
+                self._native_console_transcript_fingerprint(messages),
+            )
+            if refresh_key != self._last_native_transcript_refresh_key:
+                await transcript.refresh_messages()
+                self._last_native_transcript_refresh_key = refresh_key
             self._sync_console_transcript_guidance()
             return
 
@@ -2595,7 +2636,6 @@ class ChatScreen(BaseAppScreen):
         if chat_log is None:
             return
 
-        messages = self._native_console_messages()
         chat_log.remove_children()
         for message in messages:
             role_label = str(message.role.value if hasattr(message.role, "value") else message.role)

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -2596,7 +2596,7 @@ class ChatScreen(BaseAppScreen):
                             getattr(variant, "id", None),
                             getattr(variant, "content", ""),
                         )
-                        for variant in getattr(variants, "variants", ())
+                        for variant in (getattr(variants, "variants", None) or ())
                     ),
                 )
             message_signatures.append(

--- a/tldw_chatbook/UI/Screens/home_screen.py
+++ b/tldw_chatbook/UI/Screens/home_screen.py
@@ -153,8 +153,7 @@ class HomeScreen(BaseAppScreen):
                 f"{dashboard.next_action.label}\n"
                 f"{dashboard.next_action.reason}\n"
                 f"Destination: {_home_route_label(dashboard.next_action.target_route)}\n"
-                f"Enter: Open {_home_route_label(dashboard.next_action.target_route)}\n"
-                "Ctrl+P: Search commands"
+                f"Enter: Open {_home_route_label(dashboard.next_action.target_route)}"
             )
         )
         next_action_copy = section_text("next_best_action")
@@ -182,7 +181,7 @@ class HomeScreen(BaseAppScreen):
                 classes="ds-panel",
             )
             yield Static(
-                "Keys: Enter open selected | Tab switch pane | Ctrl+P command palette",
+                "Keys: Enter open selected | Tab switch pane",
                 id="home-action-hints",
                 classes="destination-status-row",
             )

--- a/tldw_chatbook/UI/Screens/notes_screen.py
+++ b/tldw_chatbook/UI/Screens/notes_screen.py
@@ -164,6 +164,7 @@ class NotesScreen(BaseAppScreen):
             "sources": [],
             "artifacts": [],
         }
+        self._skip_next_resume_refresh = False
         logger.debug("NotesScreen initialized with scope-aware state")
 
     def compose_content(self) -> ComposeResult:
@@ -2655,10 +2656,15 @@ class NotesScreen(BaseAppScreen):
         logger.info("NotesScreen mounted")
         self._consume_pending_workspace_return_context()
         await self.refresh_current_scope()
+        self._skip_next_resume_refresh = True
         self._update_scope_context_ui()
 
     async def on_screen_resume(self) -> None:
         self._consume_pending_workspace_return_context()
+        if self._skip_next_resume_refresh:
+            self._skip_next_resume_refresh = False
+            self._update_scope_context_ui()
+            return
         await self.refresh_current_scope()
         self._update_scope_context_ui()
 

--- a/tldw_chatbook/Utils/Splash_Screens/__init__.py
+++ b/tldw_chatbook/Utils/Splash_Screens/__init__.py
@@ -5,11 +5,8 @@ This module automatically discovers and loads all effect classes
 from subdirectories, making them available through a central registry.
 """
 
-import os
 import importlib
-import pkgutil
 from pathlib import Path
-from typing import Dict, Type, List
 
 from loguru import logger
 
@@ -26,8 +23,10 @@ __all__ = [
     'load_all_effects',
 ]
 
+_effects_loaded = False
 
-def load_all_effects():
+
+def load_all_effects(force: bool = False):
     """
     Automatically discover and load all effect modules from subdirectories.
     
@@ -35,6 +34,10 @@ def load_all_effects():
     and imports any Python modules found, which should register their effects
     using the @register_effect decorator.
     """
+    global _effects_loaded
+    if _effects_loaded and not force:
+        return 0
+
     # Get the current package directory
     package_dir = Path(__file__).parent
     
@@ -64,13 +67,6 @@ def load_all_effects():
             except Exception as e:
                 logger.error(f"Failed to load effect module '{full_module_name}': {e}")
     
+    _effects_loaded = True
     logger.info(f"Loaded {loaded_count} effect modules, {len(EFFECTS_REGISTRY)} effects registered")
     return loaded_count
-
-
-# Auto-load all effects when this module is imported
-try:
-    load_all_effects()
-except Exception as e:
-    logger.error(f"Failed to auto-load effects: {e}")
-    # Don't fail the import if auto-loading fails

--- a/tldw_chatbook/Utils/optional_deps.py
+++ b/tldw_chatbook/Utils/optional_deps.py
@@ -303,7 +303,7 @@ OPTIONAL_FEATURES: dict[str, OptionalFeatureInfo] = {
     ),
     "subscriptions": _feature(
         "subscriptions", "Subscriptions and scheduled feeds", AREA_WATCHLISTS,
-        ("markdown", "schedule", "feedparser", "cryptography"),
+        ("markdown", "schedule", "feedparser", "beautifulsoup4", "cryptography"),
         "Watchlists", "Subscriptions/watchlists", OWNER_WATCHLISTS,
     ),
     "transcription_faster_whisper": _feature(
@@ -878,10 +878,17 @@ def check_subscriptions_deps() -> bool:
     markdown_available = check_dependency('markdown')
     schedule_available = check_dependency('schedule')
     feedparser_available = check_dependency('feedparser')
+    beautifulsoup_available = check_dependency('bs4', 'beautifulsoup4')
     defusedxml_available = check_dependency('defusedxml')
     
     # All are needed for subscriptions to work properly
-    subscriptions_available = markdown_available and schedule_available and feedparser_available and defusedxml_available
+    subscriptions_available = (
+        markdown_available
+        and schedule_available
+        and feedparser_available
+        and beautifulsoup_available
+        and defusedxml_available
+    )
     DEPENDENCIES_AVAILABLE['subscriptions'] = subscriptions_available
     
     if subscriptions_available:
@@ -894,6 +901,8 @@ def check_subscriptions_deps() -> bool:
             missing.append("schedule")
         if not feedparser_available:
             missing.append("feedparser")
+        if not beautifulsoup_available:
+            missing.append("beautifulsoup4")
         if not defusedxml_available:
             missing.append("defusedxml")
         logger.warning(f"⚠️ Subscriptions dependencies missing: {', '.join(missing)}")

--- a/tldw_chatbook/Utils/optional_deps.py
+++ b/tldw_chatbook/Utils/optional_deps.py
@@ -1117,12 +1117,6 @@ else:
         except Exception as e:
             logger.debug(f"Could not check config for eager_dependency_check: {e}")
 
-# Always check embeddings dependencies eagerly since they're critical for the UI
-# This ensures the embeddings window loads correctly
-if 'PYTEST_CURRENT_TEST' not in os.environ:
-    logger.info("Checking embeddings dependencies early to ensure UI loads correctly...")
-    check_embeddings_rag_deps()
-
 if eager_check:
     initialize_dependency_checks()
     _initialized = True

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -314,6 +314,7 @@ class ConsoleTranscript(VerticalScroll):
         for stale_key in [key for key in self._row_widgets if key not in desired_key_set]:
             stale_widget = self._row_widgets.pop(stale_key)
             self._row_signatures.pop(stale_key, None)
+            self._row_build_counts.pop(stale_key, None)
             await stale_widget.remove()
 
         previous_widget: Widget | None = None

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -120,6 +120,7 @@ class ConsoleTranscript(VerticalScroll):
     def compose(self) -> ComposeResult:
         self._row_widgets.clear()
         self._row_signatures.clear()
+        self._row_build_counts.clear()
         for row in self._transcript_rows():
             widget = self._build_row_widget(row, track=True)
             self._row_widgets[row.key] = widget

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Iterable
+from dataclasses import dataclass
+from typing import Iterable, Literal
 
 from textual.app import ComposeResult
 from textual.containers import Horizontal, VerticalScroll
@@ -47,6 +48,16 @@ def _message_body(message: ConsoleChatMessage) -> str:
     return content
 
 
+@dataclass(frozen=True)
+class _TranscriptRow:
+    key: str
+    kind: Literal["rule", "message", "actions", "empty"]
+    signature: tuple
+    message: ConsoleChatMessage | None = None
+    selected: bool = False
+    renderable: str = ""
+
+
 class ConsoleTranscriptMessage(Static):
     """Clickable native Console transcript message row."""
 
@@ -64,6 +75,17 @@ class ConsoleTranscriptMessage(Static):
         )
         if selected:
             self.styles.border = ("solid", "grey")
+
+    def sync_message(self, message: ConsoleChatMessage, *, selected: bool = False) -> None:
+        """Update row content and selection styling without remounting the row."""
+        self.message_id = message.id
+        self.update(f"{_message_role_label(message)}\n{_message_body(message)}")
+        if selected:
+            self.add_class("console-transcript-message-selected")
+            self.styles.border = ("solid", "grey")
+        else:
+            self.remove_class("console-transcript-message-selected")
+            self.styles.border = ("none", "grey")
 
     def on_click(self, event: Click) -> None:
         event.stop()
@@ -91,9 +113,18 @@ class ConsoleTranscript(VerticalScroll):
         self.selected_message_id: str | None = None
         self._refresh_lock = asyncio.Lock()
         self.empty_state_copy = EMPTY_TRANSCRIPT_COPY
+        self._row_widgets: dict[str, Widget] = {}
+        self._row_signatures: dict[str, tuple] = {}
+        self._row_build_counts: dict[str, int] = {}
 
     def compose(self) -> ComposeResult:
-        yield from self._message_widgets()
+        self._row_widgets.clear()
+        self._row_signatures.clear()
+        for row in self._transcript_rows():
+            widget = self._build_row_widget(row, track=True)
+            self._row_widgets[row.key] = widget
+            self._row_signatures[row.key] = row.signature
+            yield widget
 
     def set_messages(self, messages: Iterable[ConsoleChatMessage]) -> None:
         """Replace transcript messages and refresh mounted rows when possible."""
@@ -112,11 +143,17 @@ class ConsoleTranscript(VerticalScroll):
             self.call_later(self.refresh_messages)
 
     async def refresh_messages(self) -> None:
-        """Rebuild mounted message rows from the current transcript state."""
+        """Reconcile mounted message rows from the current transcript state."""
         async with self._refresh_lock:
-            await self.remove_children()
-            for widget in self._message_widgets():
-                await self.mount(widget)
+            await self._reconcile_rows(self._transcript_rows())
+
+    def row_build_counts(self) -> dict[str, int]:
+        """Return row build counts for focused reconciliation tests."""
+        return dict(self._row_build_counts)
+
+    def row_render_signatures(self) -> dict[str, tuple]:
+        """Return active row signatures for focused reconciliation tests."""
+        return dict(self._row_signatures)
 
     def select_message(self, message_id: str) -> None:
         """Select one message and show its contextual action row."""
@@ -217,28 +254,167 @@ class ConsoleTranscript(VerticalScroll):
     def _message_by_id(self, message_id: str) -> ConsoleChatMessage | None:
         return next((message for message in self._messages if message.id == message_id), None)
 
-    def _message_widgets(self) -> list[Widget]:
-        widgets: list[Widget] = []
+    def _transcript_rows(self) -> list[_TranscriptRow]:
+        rows: list[_TranscriptRow] = []
         for message in self._messages:
-            widgets.append(Static(CONSOLE_TRANSCRIPT_RULE, classes="console-transcript-rule"))
-            widgets.append(
-                ConsoleTranscriptMessage(
-                    message,
-                    selected=message.id == self.selected_message_id,
+            selected = message.id == self.selected_message_id
+            rows.append(
+                _TranscriptRow(
+                    key=f"rule:{message.id}",
+                    kind="rule",
+                    signature=("rule", message.id),
+                    renderable=CONSOLE_TRANSCRIPT_RULE,
                 )
             )
-            if message.id == self.selected_message_id:
-                widgets.append(self._action_row(message))
+            rows.append(
+                _TranscriptRow(
+                    key=f"message:{message.id}",
+                    kind="message",
+                    signature=self._message_row_signature(message, selected=selected),
+                    message=message,
+                    selected=selected,
+                )
+            )
+            if selected:
+                rows.append(
+                    _TranscriptRow(
+                        key=f"actions:{message.id}",
+                        kind="actions",
+                        signature=self._action_row_signature(message),
+                        message=message,
+                    )
+                )
         if self._messages:
-            widgets.append(Static(CONSOLE_TRANSCRIPT_RULE, classes="console-transcript-rule"))
-        else:
-            widgets.append(
-                Static(
-                    self.empty_state_copy,
-                    classes="console-transcript-empty-state",
+            rows.append(
+                _TranscriptRow(
+                    key="rule:end",
+                    kind="rule",
+                    signature=("rule", "end"),
+                    renderable=CONSOLE_TRANSCRIPT_RULE,
                 )
             )
-        return widgets
+        else:
+            rows.append(
+                _TranscriptRow(
+                    key="empty",
+                    kind="empty",
+                    signature=("empty", self.empty_state_copy),
+                    renderable=self.empty_state_copy,
+                )
+            )
+        return rows
+
+    def _message_widgets(self) -> list[Widget]:
+        return [self._build_row_widget(row, track=False) for row in self._transcript_rows()]
+
+    async def _reconcile_rows(self, rows: list[_TranscriptRow]) -> None:
+        desired_keys = [row.key for row in rows]
+        desired_key_set = set(desired_keys)
+
+        for stale_key in [key for key in self._row_widgets if key not in desired_key_set]:
+            stale_widget = self._row_widgets.pop(stale_key)
+            self._row_signatures.pop(stale_key, None)
+            await stale_widget.remove()
+
+        previous_widget: Widget | None = None
+        for index, row in enumerate(rows):
+            widget = self._row_widgets.get(row.key)
+            if widget is None:
+                widget = self._build_row_widget(row, track=True)
+                if previous_widget is None:
+                    await self.mount(widget, before=0 if self.children else None)
+                else:
+                    await self.mount(widget, after=previous_widget)
+                self._row_widgets[row.key] = widget
+                self._row_signatures[row.key] = row.signature
+            elif self._row_signatures.get(row.key) != row.signature:
+                updated_widget = self._update_row_widget(widget, row)
+                if updated_widget is widget:
+                    self._row_signatures[row.key] = row.signature
+                else:
+                    await widget.remove()
+                    widget = updated_widget
+                    if previous_widget is None:
+                        await self.mount(widget, before=0 if self.children else None)
+                    else:
+                        await self.mount(widget, after=previous_widget)
+                    self._row_widgets[row.key] = widget
+                    self._row_signatures[row.key] = row.signature
+
+            if previous_widget is None:
+                self.move_child(widget, before=0)
+            else:
+                self.move_child(widget, after=previous_widget)
+            previous_widget = widget
+
+    def _build_row_widget(self, row: _TranscriptRow, *, track: bool) -> Widget:
+        if track:
+            self._row_build_counts[row.key] = self._row_build_counts.get(row.key, 0) + 1
+        if row.kind == "rule":
+            return Static(
+                row.renderable,
+                id=self._row_widget_id(row),
+                classes="console-transcript-rule",
+            )
+        if row.kind == "empty":
+            return Static(
+                row.renderable,
+                id=self._row_widget_id(row),
+                classes="console-transcript-empty-state",
+            )
+        if row.kind == "message" and row.message is not None:
+            return ConsoleTranscriptMessage(row.message, selected=row.selected)
+        if row.kind == "actions" and row.message is not None:
+            return self._action_row(row.message)
+        raise ValueError(f"Unsupported transcript row: {row}")
+
+    def _update_row_widget(self, widget: Widget, row: _TranscriptRow) -> Widget:
+        if row.kind == "message" and row.message is not None and isinstance(widget, ConsoleTranscriptMessage):
+            widget.sync_message(row.message, selected=row.selected)
+            return widget
+        if row.kind == "empty" and isinstance(widget, Static):
+            widget.update(row.renderable)
+            return widget
+        return self._build_row_widget(row, track=True)
+
+    @staticmethod
+    def _row_widget_id(row: _TranscriptRow) -> str:
+        return "console-transcript-row-" + row.key.replace(":", "-")
+
+    @staticmethod
+    def _message_row_signature(message: ConsoleChatMessage, *, selected: bool) -> tuple:
+        variants_signature = None
+        if message.variants is not None:
+            variants_signature = (
+                message.variants.selected_index,
+                tuple(variant.id for variant in message.variants.variants),
+            )
+        return (
+            "message",
+            _message_role_label(message),
+            _message_body(message),
+            message.status,
+            selected,
+            variants_signature,
+        )
+
+    @staticmethod
+    def _action_row_signature(message: ConsoleChatMessage) -> tuple:
+        actions = []
+        for action in ConsoleMessageActionService().available_actions(message):
+            if action.action_id == "feedback":
+                actions.append(("feedback-up", "Good", True, ""))
+                actions.append(("feedback-down", "Bad", True, ""))
+                continue
+            actions.append(
+                (
+                    action.action_id,
+                    action.label,
+                    action.enabled,
+                    action.disabled_reason or "",
+                )
+            )
+        return ("actions", message.id, tuple(actions))
 
     def _action_row(self, message: ConsoleChatMessage) -> Horizontal:
         buttons: list[Button] = []
@@ -248,7 +424,7 @@ class ConsoleTranscript(VerticalScroll):
                 buttons.append(self._action_button(message, ConsoleMessageAction("feedback-down", "Bad")))
                 continue
             buttons.append(self._action_button(message, action))
-        return Horizontal(*buttons, classes="console-transcript-action-row")
+        return Horizontal(*buttons, id=f"console-message-actions-{message.id}", classes="console-transcript-action-row")
 
     @staticmethod
     def _plain_action_row(message: ConsoleChatMessage) -> str:

--- a/tldw_chatbook/Widgets/splash_screen.py
+++ b/tldw_chatbook/Widgets/splash_screen.py
@@ -31,9 +31,6 @@ from ..Utils.Splash import get_ascii_art, get_splash_card_config
 from ..Utils.Splash_Screens import load_all_effects, get_effect_class
 from ..Utils.Splash_Screens.card_definitions import get_all_card_definitions
 
-# Load all effects on module import
-load_all_effects()
-
 
 class SplashScreen(Container):
     """Customizable splash screen widget with animation support."""
@@ -266,6 +263,7 @@ class SplashScreen(Container):
         logger.debug(f"Starting animation with effect: {effect_type}")
         
         if effect_type:
+            load_all_effects()
             # Get the effect class from the registry
             effect_class = get_effect_class(effect_type)
             

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -202,42 +202,11 @@ from .LLM_Calls.LLM_API_Calls_Local import (
     chat_with_ollama, chat_with_custom_openai, chat_with_custom_openai_2, chat_with_local_llm
 )
 from tldw_chatbook.config import get_chachanotes_db_path, settings, get_chachanotes_db_lazy
-from .UI.Chat_Window import ChatWindow
-from .UI.Chat_Window_Enhanced import ChatWindowEnhanced
-from .UI.Conv_Char_Window import CCPWindow
-from .UI.Logs_Window import LogsWindow
-from .UI.Stats_Window import StatsWindow
-from .UI.MediaIngestWindowRebuilt import MediaIngestWindowRebuilt as MediaIngestWindow
 from .UI.Navigation.main_navigation import NavigateToScreen
-from .UI.Screens.acp_screen import ACPScreen
-from .UI.Screens.artifacts_screen import ArtifactsScreen
-from .UI.Screens.chat_screen import ChatScreen
-from .UI.Screens.home_screen import HomeScreen
-from .UI.Screens.library_conversations_screen import LibraryConversationsScreen
-from .UI.Screens.library_screen import LibraryScreen
-from .UI.Screens.mcp_screen import MCPScreen
-from .UI.Screens.media_ingest_screen import MediaIngestScreen
-from .UI.Screens.coding_screen import CodingScreen
-from .UI.Screens.conversation_screen import ConversationScreen
-from .UI.Screens.media_screen import MediaScreen
-from .UI.Screens.notes_screen import NotesScreen
-from .UI.Screens.personas_screen import PersonasScreen
-from .UI.Screens.schedules_screen import SchedulesScreen
+from .UI.Navigation.screen_registry import resolve_screen_target
 from .UI.Screens.notes_scope_models import WorkspaceSubview
-from .UI.Screens.search_screen import SearchScreen
-from .UI.Screens.evals_screen import EvalsScreen
-from .UI.Screens.settings_screen import SettingsScreen
-from .UI.Screens.skills_screen import SkillsScreen
-from .UI.Screens.llm_screen import LLMScreen
-from .UI.Screens.customize_screen import CustomizeScreen
-from .UI.Screens.logs_screen import LogsScreen
-from .UI.Screens.stats_screen import StatsScreen
 from .UI.Screens.media_runtime_state import MediaRuntimeState
 from .UI.Screens.study_scope_models import StudyScopeContext
-from .UI.Screens.watchlists_collections_screen import WatchlistsCollectionsScreen
-from .UI.Screens.workflows_screen import WorkflowsScreen
-from .UI.Screens.writing_screen import WritingScreen
-from .UI.Screens.research_screen import ResearchScreen
 # Ingest UI has been rebuilt to use an internal TabbedContent (local/remote)
 # The legacy per-view navigation (ingest-nav-*/ingest-view-*) is not used anymore.
 # Keep these as empty to avoid wiring legacy handlers.
@@ -247,17 +216,9 @@ INGEST_VIEW_IDS: list[str] = []
 from .UI.Tools_Settings_Window import ToolsSettingsWindow
 from .UI.LLM_Management_Window import LLMManagementWindow
 from .UI.Customize_Window import CustomizeWindow
-# Using pragmatic V2 Evals window
-from .UI.Evals.evals_window_v3 import EvalsWindowV3 as EvalsWindow
-from .UI.Coding_Window import CodingWindow
-from .UI.STTS_Window import STTSWindow
-from .UI.Study_Window import StudyWindow
-from .UI.Chatbooks_Window import ChatbooksWindow
 from .UI.Tab_Bar import TabBar
 from .UI.Tab_Links import TabLinks
 from .UI.Tab_Dropdown import TabDropdown
-from .UI.MediaWindow_v2 import MediaWindow as MediaWindow_v2
-from .UI.SearchWindow import SearchWindow
 from tldw_chatbook.Chat_Grammars_Interop import (
     ChatGrammarsScopeService,
     LocalChatGrammarsService,
@@ -365,25 +326,28 @@ from tldw_chatbook.Audio_Services_Interop import (
     ServerAudioServicesService,
 )
 from .Evals.eval_orchestrator import EvaluationOrchestrator
-from .UI.SearchWindow import ( # Import new constants from SearchWindow.py
-    SEARCH_VIEW_RAG_QA,
-    SEARCH_NAV_RAG_QA,
-    SEARCH_NAV_RAG_CHAT,
-    SEARCH_NAV_RAG_MANAGEMENT,
-    SEARCH_NAV_WEB_SEARCH,
-    SEARCH_NAV_EMBEDDINGS_CREATE,
-    SEARCH_NAV_EMBEDDINGS_MANAGE
-)
 API_IMPORTS_SUCCESSFUL = True
 
-# Try to import SubscriptionWindow if dependencies are available
-SubscriptionWindow = None
-try:
-    from .UI.SubscriptionWindow import SubscriptionWindow
-    SUBSCRIPTIONS_AVAILABLE = True
-except ImportError as e:
-    logger.warning(f"Subscriptions feature unavailable: {e}")
-    SUBSCRIPTIONS_AVAILABLE = False
+SEARCH_VIEW_RAG_QA = "search-view-rag-qa"
+SEARCH_NAV_RAG_QA = "search-nav-rag-qa"
+SEARCH_NAV_RAG_CHAT = "search-nav-rag-chat"
+SEARCH_NAV_RAG_MANAGEMENT = "search-nav-rag-management"
+SEARCH_NAV_WEB_SEARCH = "search-nav-web-search"
+SEARCH_NAV_EMBEDDINGS_CREATE = "search-nav-embeddings-create"
+SEARCH_NAV_EMBEDDINGS_MANAGE = "search-nav-embeddings-manage"
+
+CACHEABLE_SCREEN_ROUTES = {
+    TAB_CHAT,
+    TAB_LIBRARY,
+    TAB_NOTES,
+    TAB_MEDIA,
+    TAB_SEARCH,
+    TAB_SETTINGS,
+}
+
+DEFERRED_AUDIO_SERVICE_DELAY_SECONDS = 0.1
+DEFERRED_DB_SIZE_UPDATE_DELAY_SECONDS = 0.1
+DEFERRED_MEDIA_CLEANUP_DELAY_SECONDS = 5.0
 #
 #######################################################################################################################
 #
@@ -1377,6 +1341,7 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
         
         # Tab switching optimization
         self._initialized_tabs = set()  # Track which tabs have been initialized
+        self._screen_cache: dict[str, Any] = {}
         
         # Reduce logging in production
         if not os.environ.get("TLDW_DEBUG"):
@@ -1535,6 +1500,12 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
         self.loguru_logger.debug(f"ULTRA EARLY APP INIT: self._media_types_for_ui VALUE: {self._media_types_for_ui}")
         self.loguru_logger.debug(f"ULTRA EARLY APP INIT: self._media_types_for_ui TYPE: {type(self._media_types_for_ui)}")
 
+        self._tts_handler = None
+        self._stts_handler = None
+        self._tts_initialization_task: asyncio.Task | None = None
+        self._stts_initialization_task: asyncio.Task | None = None
+        self._deferred_startup_tasks: set[asyncio.Task] = set()
+
         self._ui_ready = False  # Track if UI is fully composed
         self._shutting_down = False  # Track if app is shutting down
 
@@ -1671,6 +1642,7 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
         workspace_id: str,
         subview: WorkspaceSubview = WorkspaceSubview.DETAILS,
     ) -> None:
+        self.invalidate_screen_cache()
         self.pending_notes_workspace_context = {
             "workspace_id": workspace_id,
             "subview": subview,
@@ -2786,9 +2758,11 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
                 )
                 if callable(invalidate_for_server_switch):
                     invalidate_for_server_switch(previous_server_id, updated_state.active_server_id)
+                self.invalidate_screen_cache()
             else:
                 self.current_runtime_backend = normalized_backend
                 self.runtime_backend = normalized_backend
+                self.invalidate_screen_cache()
 
         resolved_backend = normalized_backend
         runtime_state = getattr(getattr(self, "runtime_policy", None), "state", None)
@@ -3183,66 +3157,42 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
 
     def _resolve_screen_navigation_target(self, target: str):
         """Normalize navigation aliases to a routed screen id and canonical current_tab value."""
-        from .UI.Screens.stts_screen import STTSScreen
-        from .UI.Screens.study_screen import StudyScreen
-        from .UI.Screens.chatbooks_screen import ChatbooksScreen
-        from .UI.Screens.subscription_screen import SubscriptionScreen
+        return resolve_screen_target(target)
 
-        screen_aliases = {
-            TAB_CCP: "ccp",
-            TAB_LLM: "llm",
-            "subscription": "subscriptions",
-        }
-        canonical_screen = screen_aliases.get(target, target)
+    def invalidate_screen_cache(self, routes: set[str] | None = None) -> None:
+        """Clear cached destination screens after context changes."""
+        cache = getattr(self, "_screen_cache", None)
+        if not cache:
+            return
+        if routes is None:
+            cache.clear()
+            logger.debug("Cleared all cached destination screens")
+            return
+        for route in routes:
+            cache.pop(route, None)
+        logger.debug(f"Cleared cached destination screens: {sorted(routes)}")
 
-        tab_aliases = {
-            "ccp": TAB_CCP,
-            "conversation": "conversation",
-            TAB_CCP: TAB_CCP,
-            "llm": TAB_LLM,
-            TAB_LLM: TAB_LLM,
-            "subscription": TAB_SUBSCRIPTIONS,
-            "subscriptions": TAB_SUBSCRIPTIONS,
-            "tools_settings": "mcp",
-        }
-        canonical_tab = tab_aliases.get(target, tab_aliases.get(canonical_screen, canonical_screen))
+    def _get_or_create_navigation_screen(self, screen_name: str, screen_class: type):
+        """Return a cached screen for allowlisted routes, otherwise build a fresh screen."""
+        if screen_name not in CACHEABLE_SCREEN_ROUTES:
+            return screen_class(self)
 
-        screen_map = {
-            "home": HomeScreen,
-            "chat": ChatScreen,
-            "library": LibraryScreen,
-            "artifacts": ArtifactsScreen,
-            "personas": PersonasScreen,
-            "watchlists_collections": WatchlistsCollectionsScreen,
-            "schedules": SchedulesScreen,
-            "workflows": WorkflowsScreen,
-            "mcp": MCPScreen,
-            "acp": ACPScreen,
-            "skills": SkillsScreen,
-            "settings": SettingsScreen,
-            "ingest": MediaIngestScreen,
-            "coding": CodingScreen,
-            "conversation": LibraryConversationsScreen,
-            "ccp": ConversationScreen,
-            "media": MediaScreen,
-            "notes": NotesScreen,
-            "search": SearchScreen,
-            "evals": EvalsScreen,
-            "tools_settings": MCPScreen,
-            "llm": LLMScreen,
-            "customize": CustomizeScreen,
-            "logs": LogsScreen,
-            "stats": StatsScreen,
-            "stts": STTSScreen,
-            "study": StudyScreen,
-            "writing": WritingScreen,
-            "research": ResearchScreen,
-            "chatbooks": ChatbooksScreen,
-            "subscription": SubscriptionScreen,
-            "subscriptions": SubscriptionScreen,
-        }
+        cache = getattr(self, "_screen_cache", None)
+        if cache is None:
+            cache = self._screen_cache = {}
 
-        return canonical_screen, canonical_tab, screen_map.get(canonical_screen)
+        cached_screen = cache.get(screen_name)
+        if cached_screen is not None:
+            try:
+                if cached_screen is self.screen:
+                    return screen_class(self)
+            except Exception:
+                pass
+            return cached_screen
+
+        new_screen = screen_class(self)
+        cache[screen_name] = new_screen
+        return new_screen
 
     def _valid_startup_route_ids(self) -> set[str]:
         """Return route ids allowed in startup config during the shell migration."""
@@ -3306,8 +3256,7 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
             if previous_tab == TAB_NOTES and previous_tab != current_tab_value:
                 await self._notes_tab_initializer.on_tab_hidden()
 
-            # Create a fresh screen instance (per Textual best practices)
-            new_screen = screen_class(self)
+            new_screen = self._get_or_create_navigation_screen(screen_name, screen_class)
             
             # Restore state if available
             if hasattr(self, '_screen_states') and screen_name in self._screen_states:
@@ -3332,9 +3281,6 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
             # Keep current_tab aligned to canonical tab ids even when routing uses aliases.
             self.current_tab = current_tab_value
 
-            if current_tab_value == TAB_NOTES and previous_tab != current_tab_value:
-                await self._notes_tab_initializer.on_tab_shown()
-            
             logger.info(f"Successfully switched to {screen_name} screen")
         else:
             logger.error(f"Unknown screen requested: {requested_screen}")
@@ -3373,8 +3319,9 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
     async def handle_tts_request_event(self, event: TTSRequestEvent) -> None:
         """Handle TTS generation request."""
         self.loguru_logger.info(f"TTS request received for text: '{event.text[:50]}...'")
-        if self._tts_handler:
-            await self._tts_handler.handle_tts_request(event)
+        handler = await self._ensure_tts_handler()
+        if handler:
+            await handler.handle_tts_request(event)
         else:
             self.loguru_logger.error("TTS handler not initialized")
             await self.post_message(
@@ -3478,15 +3425,17 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
     @on(TTSPlaybackEvent)
     async def handle_tts_playback_event(self, event: TTSPlaybackEvent) -> None:
         """Handle TTS playback control."""
-        if self._tts_handler:
-            await self._tts_handler.handle_tts_playback(event)
+        handler = await self._ensure_tts_handler()
+        if handler:
+            await handler.handle_tts_playback(event)
     
     @on(STTSPlaygroundGenerateEvent)
     async def handle_stts_playground_generate_event(self, event: STTSPlaygroundGenerateEvent) -> None:
         """Handle S/TT/S playground generation request."""
         self.loguru_logger.info(f"S/TT/S generation request: provider={event.provider}, model={event.model}")
-        if self._stts_handler:
-            await self._stts_handler.handle_playground_generate(event)
+        handler = await self._ensure_stts_handler()
+        if handler:
+            await handler.handle_playground_generate(event)
         else:
             self.loguru_logger.error("S/TT/S handler not initialized")
             self.notify("S/TT/S service not available", severity="error")
@@ -3494,14 +3443,16 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
     @on(STTSSettingsSaveEvent)
     async def handle_stts_settings_save_event(self, event: STTSSettingsSaveEvent) -> None:
         """Handle S/TT/S settings save."""
-        if self._stts_handler:
-            await self._stts_handler.handle_settings_save(event)
+        handler = await self._ensure_stts_handler()
+        if handler:
+            await handler.handle_settings_save(event)
     
     @on(STTSAudioBookGenerateEvent)
     async def handle_stts_audiobook_generate_event(self, event: STTSAudioBookGenerateEvent) -> None:
         """Handle audiobook generation request."""
-        if self._stts_handler:
-            await self._stts_handler.handle_audiobook_generate(event)
+        handler = await self._ensure_stts_handler()
+        if handler:
+            await handler.handle_audiobook_generate(event)
 
     def switch_ccp_center_view(self, view_name: str) -> None:
         """Switch the center pane view in the CCP tab."""
@@ -4360,7 +4311,9 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
         if screen_class is None:
             resolved_screen_name = TAB_CHAT
             resolved_tab = TAB_CHAT
-            screen_class = ChatScreen
+            _, _, screen_class = self._resolve_screen_navigation_target(TAB_CHAT)
+            if screen_class is None:
+                raise RuntimeError("Unable to resolve default chat screen")
 
         await self.push_screen(screen_class(self))
         self.current_tab = resolved_tab
@@ -4422,38 +4375,9 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
                      labels={"phase": "widget_binding"}, 
                      documentation="Duration of post-mount phase in seconds")
 
-        # Initialize TTS service
-        phase_start = time.perf_counter()
-        try:
-            self.loguru_logger.info("Initializing TTS service...")
-            # Create TTS event handler instance
-            self._tts_handler = TTSEventHandler()
-            self._tts_handler.app = self  # Set app reference for posting messages
-            await self._tts_handler.initialize_tts()
-            self.loguru_logger.info("TTS service initialized successfully")
-        except Exception as e:
-            self.loguru_logger.error(f"Failed to initialize TTS service: {e}")
-            self._tts_handler = None
-        log_histogram("app_post_mount_phase_duration_seconds", time.perf_counter() - phase_start,
-                     labels={"phase": "tts_init"}, 
-                     documentation="Duration of post-mount phase in seconds")
-        
-        # Initialize S/TT/S service
-        phase_start = time.perf_counter()
-        try:
-            self.loguru_logger.info("Initializing S/TT/S service...")
-            # Create S/TT/S event handler instance
-            self._stts_handler = STTSEventHandler(app=self)
-            await self._stts_handler.initialize_stts()
-            # Copy some methods to app instance for convenience
-            self.play_current_audio = self._stts_handler.play_current_audio
-            self.export_current_audio = self._stts_handler.export_current_audio
-            self.loguru_logger.info("S/TT/S service initialized successfully")
-        except Exception as e:
-            self.loguru_logger.error(f"Failed to initialize S/TT/S service: {e}")
-            self._stts_handler = None
-        log_histogram("app_post_mount_phase_duration_seconds", time.perf_counter() - phase_start,
-                     labels={"phase": "stts_init"}, 
+        # TTS/STTS services are initialized after readiness or on first use.
+        log_histogram("app_post_mount_phase_duration_seconds", 0.0,
+                     labels={"phase": "audio_services_deferred"},
                      documentation="Duration of post-mount phase in seconds")
 
         # Set initial tab now that other bindings might be ready
@@ -4504,30 +4428,8 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
         self.current_tab = self._resolve_initial_shell_route()
         self.loguru_logger.info(f"Initial tab set to: {self.current_tab}")
 
-        # --- DB Size Indicator Setup ---
-        try:
-            # Query for the AppFooterStatus widget instance
-            self._db_size_status_widget = self.query_one(AppFooterStatus)
-            # Or use ID: self._db_size_status_widget = self.query_one("#app-footer-status", AppFooterStatus)
-            self.loguru_logger.info("AppFooterStatus widget instance acquired.")
-
-            await self.db_status_manager.update_db_sizes()  # Initial population
-            self.db_status_manager.start_periodic_updates(120)  # Update every 2 minutes
-            self.loguru_logger.info("DB size update timer started for AppFooterStatus (interval: 2 minutes).")
-            
-            # Start token count updates
-            # Initial update after a short delay to ensure UI is ready
-            # Initial update after a short delay
-            self.set_timer(0.5, self.update_token_count_display)
-            # REDUCED FREQUENCY: Update token count less frequently to improve performance
-            # Changed from 3 seconds to 10 seconds - tokens don't change that often
-            self._token_count_update_timer = self.set_interval(10, lambda: self.call_after_refresh(self.update_token_count_display))
-            self.loguru_logger.info("Token count update timer started (10s interval).")
-        except QueryError:
-            self.loguru_logger.error("Failed to find AppFooterStatus widget for DB size display.")
-        except Exception as e_db_size:
-            self.loguru_logger.error(f"Error setting up DB size indicator with AppFooterStatus: {e_db_size}", exc_info=True)
-        # --- End DB Size Indicator Setup ---
+        # Footer status population is scheduled after readiness so DB-size
+        # polling cannot hold the first interactive frame.
 
         # Initialize chat settings sidebar mode
         try:
@@ -4587,8 +4489,7 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
             # Final memory usage
             log_resource_usage()
             
-        # Schedule media cleanup if enabled
-        self.schedule_media_cleanup()
+        self._schedule_deferred_startup_work()
 
 
     async def update_db_sizes(self) -> None:
@@ -4598,6 +4499,177 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
     async def update_token_count_display(self) -> None:
         """Updates the token count in the footer when on Chat tab."""
         await self.db_status_manager.update_token_count_display()
+
+    def _create_deferred_startup_task(
+        self,
+        coroutine,
+        *,
+        name: str,
+    ) -> asyncio.Task:
+        """Schedule nonessential startup work without blocking UI readiness."""
+
+        task = asyncio.create_task(coroutine, name=name)
+        self._deferred_startup_tasks.add(task)
+
+        def on_done(completed: asyncio.Task) -> None:
+            self._deferred_startup_tasks.discard(completed)
+            if completed.cancelled():
+                self.loguru_logger.debug(f"Deferred startup task cancelled: {name}")
+                return
+            try:
+                completed.result()
+            except Exception as exc:
+                self.loguru_logger.error(
+                    f"Deferred startup task failed: {name}: {exc}",
+                    exc_info=True,
+                )
+
+        task.add_done_callback(on_done)
+        return task
+
+    def _schedule_deferred_startup_work(self) -> None:
+        """Start nonessential services after the first interactive UI frame."""
+
+        self.set_timer(
+            DEFERRED_DB_SIZE_UPDATE_DELAY_SECONDS,
+            self._schedule_footer_status_updates,
+        )
+        self.set_timer(
+            DEFERRED_AUDIO_SERVICE_DELAY_SECONDS,
+            self._start_deferred_audio_service_initialization,
+        )
+        self.schedule_media_cleanup()
+
+    def _schedule_footer_status_updates(self) -> None:
+        """Wire footer DB/token status updates after UI readiness."""
+
+        try:
+            self._db_size_status_widget = self.query_one(AppFooterStatus)
+            self.loguru_logger.info("AppFooterStatus widget instance acquired.")
+
+            self.set_timer(
+                DEFERRED_DB_SIZE_UPDATE_DELAY_SECONDS,
+                self.update_db_sizes,
+            )
+            self.db_status_manager.start_periodic_updates(120)
+            self.loguru_logger.info("DB size update timer started for AppFooterStatus (interval: 2 minutes).")
+
+            self.set_timer(0.5, self.update_token_count_display)
+            self._token_count_update_timer = self.set_interval(
+                10,
+                lambda: self.call_after_refresh(self.update_token_count_display),
+            )
+            self.loguru_logger.info("Token count update timer started (10s interval).")
+        except QueryError:
+            self.loguru_logger.error("Failed to find AppFooterStatus widget for DB size display.")
+        except Exception as e_db_size:
+            self.loguru_logger.error(
+                f"Error setting up DB size indicator with AppFooterStatus: {e_db_size}",
+                exc_info=True,
+            )
+
+    def _start_deferred_audio_service_initialization(self) -> None:
+        """Kick off TTS/STTS initialization after startup readiness."""
+
+        self._schedule_tts_initialization()
+        self._schedule_stts_initialization()
+
+    def _schedule_tts_initialization(self) -> None:
+        if self._tts_handler is not None:
+            return
+        if self._tts_initialization_task and not self._tts_initialization_task.done():
+            return
+        self._tts_initialization_task = self._create_deferred_startup_task(
+            self._initialize_tts_service(),
+            name="deferred_tts_initialization",
+        )
+
+    def _schedule_stts_initialization(self) -> None:
+        if self._stts_handler is not None:
+            return
+        if self._stts_initialization_task and not self._stts_initialization_task.done():
+            return
+        self._stts_initialization_task = self._create_deferred_startup_task(
+            self._initialize_stts_service(),
+            name="deferred_stts_initialization",
+        )
+
+    async def _initialize_tts_service(self):
+        """Initialize the TTS handler outside the startup critical path."""
+
+        phase_start = time.perf_counter()
+        try:
+            self.loguru_logger.info("Initializing TTS service...")
+            handler = TTSEventHandler()
+            handler.app = self
+            await handler.initialize_tts()
+            self._tts_handler = handler
+            self.loguru_logger.info("TTS service initialized successfully")
+        except Exception as e:
+            self.loguru_logger.error(f"Failed to initialize TTS service: {e}")
+            self._tts_handler = None
+        finally:
+            log_histogram("app_post_mount_phase_duration_seconds", time.perf_counter() - phase_start,
+                         labels={"phase": "tts_init_deferred"},
+                         documentation="Duration of post-mount phase in seconds")
+        return self._tts_handler
+
+    async def _initialize_stts_service(self):
+        """Initialize the S/TT/S handler outside the startup critical path."""
+
+        phase_start = time.perf_counter()
+        try:
+            self.loguru_logger.info("Initializing S/TT/S service...")
+            handler = STTSEventHandler(app=self)
+            await handler.initialize_stts()
+            self._stts_handler = handler
+            self.loguru_logger.info("S/TT/S service initialized successfully")
+        except Exception as e:
+            self.loguru_logger.error(f"Failed to initialize S/TT/S service: {e}")
+            self._stts_handler = None
+        finally:
+            log_histogram("app_post_mount_phase_duration_seconds", time.perf_counter() - phase_start,
+                         labels={"phase": "stts_init_deferred"},
+                         documentation="Duration of post-mount phase in seconds")
+        return self._stts_handler
+
+    async def _ensure_tts_handler(self):
+        """Return an initialized TTS handler, initializing on first use if needed."""
+
+        if self._tts_handler is not None:
+            return self._tts_handler
+        if self._tts_initialization_task and not self._tts_initialization_task.done():
+            await self._tts_initialization_task
+            return self._tts_handler
+        return await self._initialize_tts_service()
+
+    async def _ensure_stts_handler(self):
+        """Return an initialized S/TT/S handler, initializing on first use if needed."""
+
+        if self._stts_handler is not None:
+            return self._stts_handler
+        if self._stts_initialization_task and not self._stts_initialization_task.done():
+            await self._stts_initialization_task
+            return self._stts_handler
+        return await self._initialize_stts_service()
+
+    async def play_current_audio(self) -> None:
+        """Play the current S/TT/S audio after lazy service initialization."""
+
+        handler = await self._ensure_stts_handler()
+        if handler is None:
+            self.notify("S/TT/S service not available", severity="error")
+            return
+        await handler.play_current_audio()
+
+    async def export_current_audio(self, target_path: Path) -> None:
+        """Export the current S/TT/S audio after lazy service initialization."""
+
+        handler = await self._ensure_stts_handler()
+        if handler is None:
+            self.notify("S/TT/S service not available", severity="error")
+            return
+        await handler.export_current_audio(target_path)
 
 
     async def on_shutdown_request(self) -> None:  # Use the imported ShutdownRequest
@@ -4641,6 +4713,15 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
         
         # Stop all background services and threads
         try:
+            deferred_tasks = [
+                task for task in getattr(self, "_deferred_startup_tasks", set())
+                if not task.done()
+            ]
+            for task in deferred_tasks:
+                task.cancel()
+            if deferred_tasks:
+                await asyncio.gather(*deferred_tasks, return_exceptions=True)
+
             # Stop audio player if it exists
             if hasattr(self, 'audio_player'):
                 try:
@@ -5042,6 +5123,8 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
         elif new_tab == TAB_MEDIA:
             def activate_media_initial_view():
                 try:
+                    from .UI.MediaWindow_v2 import MediaWindow as MediaWindow_v2
+
                     media_window = self.query_one(MediaWindow_v2)
                     media_window.activate_initial_view()
                 except QueryError:
@@ -5314,6 +5397,8 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
     def _initialize_video_models(self) -> None:
         """Initialize models for the video ingestion window."""
         try:
+            from .UI.MediaIngestWindowRebuilt import MediaIngestWindowRebuilt as MediaIngestWindow
+
             ingest_window = self.query_one("#ingest-window", MediaIngestWindow)
             # New ingest window doesn't need model initialization
             self.log.debug("New ingest window loaded")
@@ -5323,6 +5408,8 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
     def _initialize_audio_models(self) -> None:
         """Initialize models for the audio ingestion window."""
         try:
+            from .UI.MediaIngestWindowRebuilt import MediaIngestWindowRebuilt as MediaIngestWindow
+
             ingest_window = self.query_one("#ingest-window", MediaIngestWindow)
             # New ingest window doesn't need model initialization
             self.log.debug("New ingest window loaded")
@@ -5331,6 +5418,8 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
 
     async def save_current_note(self) -> bool:
         """Saves the currently selected note's title and content to the database."""
+        from .UI.Screens.notes_screen import NotesScreen
+
         if isinstance(self.screen, NotesScreen):
             return await self.screen._save_current_note()
         if not self.notes_service or not self.current_selected_note_id or self.current_selected_note_version is None:
@@ -6129,12 +6218,7 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
         """Handles changes in Select widgets if specific actions are needed beyond watchers."""
         select_id = event.select.id
         current_active_tab = self.current_tab
-        self.loguru_logger.info(f"Select changed: {select_id} = {event.value}, current tab = {current_active_tab}")
-
-        if select_id == "conv-char-character-select" and current_active_tab == TAB_CCP:
-            await ccp_handlers.handle_ccp_character_select_changed(self, event.value)
-
-        current_active_tab = self.current_tab
+        self.loguru_logger.debug(f"Select changed: {select_id} = {event.value}, current tab = {current_active_tab}")
 
         if select_id == "conv-char-character-select" and current_active_tab == TAB_CCP:
             await ccp_handlers.handle_ccp_character_select_changed(self, event.value)
@@ -6157,18 +6241,20 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
             self.loguru_logger.debug(f"chat-api-provider change event (handled in ChatScreen): {event.value}")
             
             # Update token counter when provider changes
-            try:
-                from .Event_Handlers.Chat_Events.chat_token_events import update_chat_token_counter
-                await update_chat_token_counter(self)
-            except Exception as e:
-                self.loguru_logger.debug(f"Could not update token counter on provider change: {e}")
+            if self._ui_ready:
+                try:
+                    from .Event_Handlers.Chat_Events.chat_token_events import update_chat_token_counter
+                    await update_chat_token_counter(self)
+                except Exception as e:
+                    self.loguru_logger.debug(f"Could not update token counter on provider change: {e}")
         elif select_id == "chat-api-model" and current_active_tab == TAB_CHAT:
             # Update token counter when model changes
-            try:
-                from .Event_Handlers.Chat_Events.chat_token_events import update_chat_token_counter
-                await update_chat_token_counter(self)
-            except Exception as e:
-                self.loguru_logger.debug(f"Could not update token counter on model change: {e}")
+            if self._ui_ready:
+                try:
+                    from .Event_Handlers.Chat_Events.chat_token_events import update_chat_token_counter
+                    await update_chat_token_counter(self)
+                except Exception as e:
+                    self.loguru_logger.debug(f"Could not update token counter on model change: {e}")
         elif select_id == "chat-conversation-search-character-filter-select" and current_active_tab == TAB_CHAT:
             self.loguru_logger.debug("Character filter changed in chat tab, triggering conversation search")
             await chat_handlers.perform_chat_conversation_search(self)
@@ -6628,8 +6714,13 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
             
             # Run cleanup on startup if configured
             if cleanup_on_startup:
-                self.loguru_logger.info("Running media cleanup on startup")
-                self.call_later(self.perform_media_cleanup)
+                self.loguru_logger.info(
+                    "Scheduling media cleanup after startup idle delay"
+                )
+                self._media_cleanup_startup_timer = self.set_timer(
+                    DEFERRED_MEDIA_CLEANUP_DELAY_SECONDS,
+                    self.perform_media_cleanup,
+                )
             
             # Schedule periodic cleanup
             cleanup_interval_seconds = cleanup_interval_hours * 3600


### PR DESCRIPTION
## Summary
- Lazy-load optional dependency checks, screen route resolution, UI screen exports, and splash effects to reduce eager startup work.
- Defer TTS/STTS, DB-size polling, token timers, and media cleanup until after UI readiness or first use.
- Add cacheable destination screen reuse, Notes duplicate-refresh removal, incremental Console transcript reconciliation, and metric log gating.
- Address review feedback: validate S/TT/S audio export paths, guard optional subscription route imports, clean transcript build-count bookkeeping, handle `variants=None`, and cache the metrics env lookup.

## Measurements
- Baseline: about 4.5s app import, about 6.5s to `_ui_ready`, and 0.26s-0.61s route switches.
- After isolated probe: 4.365s app import, 0.492s to `_ui_ready`, 0.274s-0.547s route switches, and 0 `METRIC` lines during import/startup probes.
- Residual risk: plain app import remains broad; see `Docs/superpowers/qa/performance/2026-05-28-lag-remediation-closeout.md`.

## Test Plan
- [x] `.venv/bin/python -m pytest Tests/Utils/test_optional_deps.py Tests/Utils/test_metrics_logger.py Tests/Utils/test_startup_polish_regressions.py Tests/UI/test_screen_navigation.py Tests/UI/test_console_native_transcript.py Tests/UI/test_console_native_chat_flow.py Tests/UI/test_console_internals_decomposition.py Tests/Performance/test_app_startup_performance.py Tests/TTS/test_stts_export_security.py -q` (`219 passed, 9 warnings`)
- [x] `.venv/bin/python -m pytest Tests/UI/test_destination_shells.py Tests/UI/test_product_maturity_gate16_library_search_rag.py -q` (`119 passed, 1 warning`)
- [x] `.venv/bin/python -m py_compile tldw_chatbook/app.py tldw_chatbook/Metrics/metrics_logger.py tldw_chatbook/UI/Screens/notes_screen.py tldw_chatbook/Utils/Splash_Screens/__init__.py tldw_chatbook/Widgets/splash_screen.py tldw_chatbook/Widgets/Console/console_transcript.py tldw_chatbook/UI/Screens/chat_screen.py tldw_chatbook/UI/Navigation/screen_registry.py tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py`
- [x] `git diff --check`