### PR TITLE
Fix Console paste threshold review follow-ups

### DIFF
--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -668,7 +668,7 @@ async def test_settings_console_behavior_saves_paste_threshold(monkeypatch):
         screen = _active_destination_screen(host)
         threshold = screen.query_one("#settings-console-paste-collapse-threshold", Input)
 
-        assert threshold.restrict == "[0-9]*"
+        assert threshold.restrict == r"^[0-9]*$"
         threshold.value = "120"
         screen.handle_console_paste_threshold_changed(Input.Changed(threshold, threshold.value))
         assert "Unsaved" in _visible_text(screen)

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -275,7 +275,7 @@ class SettingsScreen(BaseAppScreen):
     def _collapse_large_pastes_button_label(self) -> str:
         return "Enabled" if self._collapse_large_pastes_enabled() else "Disabled"
 
-    def _paste_collapse_threshold_value(self) -> object:
+    def _paste_collapse_threshold_value(self) -> int | str:
         draft = self._settings_drafts.get(SettingsCategoryId.CONSOLE_BEHAVIOR)
         if draft is not None and "paste_collapse_threshold" in draft.values:
             return draft.values["paste_collapse_threshold"]
@@ -1646,7 +1646,7 @@ class SettingsScreen(BaseAppScreen):
                     id="settings-console-paste-collapse-threshold",
                     classes="settings-compact-input",
                     placeholder=str(DEFAULT_CONSOLE_PASTE_COLLAPSE_THRESHOLD),
-                    restrict="[0-9]*",
+                    restrict=r"^[0-9]*$",
                 )
             yield Static(
                 "Normal typing stays literal. The canonical message payload is preserved.",


### PR DESCRIPTION
## Summary
- Match the Settings paste threshold Input restrict regex requested in PR #387 review.
- Narrow _paste_collapse_threshold_value() to int | str.
- Update the Settings regression assertion to lock the requested regex.

## Verification
- python -m pytest -q Tests/test_config_console_defaults.py Tests/UI/test_settings_configuration_hub.py Tests/UI/test_console_internals_decomposition.py::test_console_paste_threshold_can_be_configured_from_app_config Tests/UI/test_console_internals_decomposition.py::test_console_paste_under_threshold_remains_literal Tests/UI/test_console_internals_decomposition.py::test_console_large_paste_collapse_can_be_disabled_from_config --tb=short
- git diff --check

Follow-up for review comments on merged PR #387.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Console paste threshold input by anchoring the digits-only regex and narrowing the value type. Follow-up on review feedback from PR #387.

- **Bug Fixes**
  - Use restrict pattern r"^[0-9]*$" for the paste threshold input.
  - Narrow _paste_collapse_threshold_value() to int | str and update the test to assert the new regex.

<sup>Written for commit 7f8d89a65a729437f2873d2537548d135828b5f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/392?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

