### PR TITLE
Fix Console provider review findings

### DIFF
--- a/Tests/Chat/test_console_provider_endpoints.py
+++ b/Tests/Chat/test_console_provider_endpoints.py
@@ -1,0 +1,64 @@
+from tldw_chatbook.Chat.console_provider_endpoints import (
+    normalize_generic_endpoint_for_compare,
+    safe_endpoint_display,
+)
+
+
+def test_safe_endpoint_display_redacts_schemeless_credentials_and_query_tokens() -> None:
+    display = safe_endpoint_display("user:secret@127.0.0.1:9999/v1?token=unit-test-token")
+
+    assert display == "127.0.0.1:9999/v1"
+    assert "user" not in display
+    assert "secret" not in display
+    assert "token" not in display
+    assert "unit-test-token" not in display
+
+
+def test_safe_endpoint_display_strips_query_secret_from_url() -> None:
+    display = safe_endpoint_display("https://api.example.test/v1?api_key=unit-test-token")
+
+    assert display == "https://api.example.test/v1"
+    assert "api_key" not in display
+    assert "unit-test-token" not in display
+
+
+def test_safe_endpoint_display_does_not_return_malformed_secret_input() -> None:
+    display = safe_endpoint_display("http://[::1?api_key=unit-test-token")
+
+    assert display == "invalid endpoint"
+    assert "unit-test-token" not in display
+
+
+def test_normalize_generic_endpoint_for_compare_handles_schemeless_credentials() -> None:
+    normalized = normalize_generic_endpoint_for_compare(
+        "user:secret@127.0.0.1:9999/v1?token=unit-test-token"
+    )
+
+    assert normalized == "127.0.0.1:9999/v1"
+
+
+def test_safe_endpoint_display_rejects_schemeless_single_label_token() -> None:
+    display = safe_endpoint_display("unit-test-key")
+
+    assert display == "invalid endpoint"
+    assert "unit-test-key" not in display
+
+
+def test_safe_endpoint_display_rejects_single_label_token_with_scheme() -> None:
+    display = safe_endpoint_display("http://unit-test-key")
+
+    assert display == "invalid endpoint"
+    assert "unit-test-key" not in display
+
+
+def test_normalize_generic_endpoint_for_compare_rejects_single_label_token() -> None:
+    normalized = normalize_generic_endpoint_for_compare("unit-test-key")
+
+    assert normalized == "invalid endpoint"
+    assert "unit-test-key" not in normalized
+
+
+def test_safe_endpoint_display_allows_schemeless_single_label_host_with_port() -> None:
+    display = safe_endpoint_display("local-service:9090/v1")
+
+    assert display == "local-service:9090/v1"

--- a/Tests/Chat/test_console_provider_gateway.py
+++ b/Tests/Chat/test_console_provider_gateway.py
@@ -443,6 +443,29 @@ async def test_resolve_for_send_blocks_generic_base_url_override_that_differs_fr
 
 
 @pytest.mark.asyncio
+async def test_resolve_for_send_ignores_cloud_session_base_url_without_configured_endpoint() -> None:
+    gateway = ConsoleProviderGateway(
+        config_provider=lambda: {
+            "api_settings": {"openai": {"api_key": "unit-test-key", "model": "gpt-4.1"}},
+        },
+        environ={},
+    )
+
+    resolved = await gateway.resolve_for_send(
+        ConsoleProviderSelection(
+            provider="openai",
+            explicit_model="gpt-4.1",
+            base_url="http://127.0.0.1:9999/v1",
+        )
+    )
+
+    assert resolved.ready is True
+    assert resolved.readiness_key == "openai"
+    assert resolved.execution_key == "openai"
+    assert "save the endpoint in Settings" not in resolved.visible_copy
+
+
+@pytest.mark.asyncio
 async def test_resolve_for_send_accepts_generic_base_url_matching_config_with_trailing_slash() -> None:
     gateway = ConsoleProviderGateway(
         config_provider=lambda: {"api_settings": {"ollama": {"api_url": "http://127.0.0.1:11434"}}},

--- a/Tests/Chat/test_console_provider_support.py
+++ b/Tests/Chat/test_console_provider_support.py
@@ -30,6 +30,34 @@ def test_aliases_resolve_to_readiness_and_execution_keys() -> None:
         assert identity.is_supported is True
 
 
+def test_normalized_handler_key_resolves_to_hyphenated_execution_key() -> None:
+    identity = resolve_console_provider_identity(
+        "custom_openai_api",
+        handler_keys={"custom-openai-api"},
+    )
+
+    assert identity == ConsoleProviderIdentity(
+        display_key="custom_openai_api",
+        readiness_key="custom",
+        execution_key="custom-openai-api",
+        is_supported=True,
+    )
+
+
+def test_numbered_normalized_handler_key_resolves_to_hyphenated_execution_key() -> None:
+    identity = resolve_console_provider_identity(
+        "custom_openai_api_2",
+        handler_keys={"custom-openai-api-2"},
+    )
+
+    assert identity == ConsoleProviderIdentity(
+        display_key="custom_openai_api_2",
+        readiness_key="custom_2",
+        execution_key="custom-openai-api-2",
+        is_supported=True,
+    )
+
+
 def test_direct_console_provider_keys_are_not_generic_adapter() -> None:
     for provider in DIRECT_CONSOLE_PROVIDER_KEYS:
         identity = resolve_console_provider_identity(provider)

--- a/tldw_chatbook/Chat/console_provider_endpoints.py
+++ b/tldw_chatbook/Chat/console_provider_endpoints.py
@@ -3,15 +3,44 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from ipaddress import ip_address
 from urllib.parse import urlparse, urlunparse
 
 
 UNSAVED_ENDPOINT_COPY = "Provider blocked: save the endpoint in Settings before using it from Console."
+URL_BASED_PROVIDER_KEYS = frozenset(
+    {
+        "aphrodite",
+        "custom",
+        "custom_2",
+        "koboldcpp",
+        "llama_cpp",
+        "local_llamacpp",
+        "local_llamafile",
+        "local_ollama",
+        "local_vllm",
+        "ollama",
+        "oobabooga",
+        "tabbyapi",
+        "vllm",
+    }
+)
+_ENDPOINT_SETTING_KEYS = ("api_url", "base_url", "api_base", "api_endpoint", "endpoint")
+_URL_PROVIDER_SETTING_KEYS = ("api_url", "base_url", "api_base")
+_INVALID_ENDPOINT_DISPLAY = "invalid endpoint"
 
 
 def first_configured_endpoint(provider_settings: Mapping[str, object]) -> str | None:
-    """Return the first configured provider endpoint from known config aliases."""
-    for key in ("api_url", "base_url", "api_base", "api_endpoint", "endpoint"):
+    """Return the first configured provider endpoint from known config aliases.
+
+    Args:
+        provider_settings: Provider-specific configuration mapping.
+
+    Returns:
+        The first non-empty endpoint string, or ``None`` when no endpoint is
+        configured.
+    """
+    for key in _ENDPOINT_SETTING_KEYS:
         value = provider_settings.get(key)
         if not isinstance(value, str):
             continue
@@ -21,8 +50,32 @@ def first_configured_endpoint(provider_settings: Mapping[str, object]) -> str | 
     return None
 
 
+def provider_uses_endpoint(provider_key: str, provider_settings: Mapping[str, object]) -> bool:
+    """Return whether a provider should validate saved endpoint overrides.
+
+    Args:
+        provider_key: Normalized provider readiness key.
+        provider_settings: Provider-specific configuration mapping.
+
+    Returns:
+        ``True`` when the provider is known to use endpoint URLs or has a saved
+        base URL setting.
+    """
+    return provider_key in URL_BASED_PROVIDER_KEYS or any(
+        key in provider_settings for key in _URL_PROVIDER_SETTING_KEYS
+    )
+
+
 def generic_endpoint_differs(base_url: str | None, provider_settings: Mapping[str, object]) -> bool:
-    """Return whether a session endpoint differs from the persisted provider endpoint."""
+    """Return whether a session endpoint differs from the persisted endpoint.
+
+    Args:
+        base_url: Session-selected provider endpoint.
+        provider_settings: Provider-specific configuration mapping.
+
+    Returns:
+        ``True`` when both values normalize to different endpoint identities.
+    """
     selected_base_url = normalize_generic_endpoint_for_compare(base_url)
     if not selected_base_url:
         return False
@@ -33,60 +86,124 @@ def generic_endpoint_differs(base_url: str | None, provider_settings: Mapping[st
 
 
 def unsaved_endpoint_copy(base_url: str | None, provider_settings: Mapping[str, object]) -> str:
-    """Return actionable recovery copy with safe selected/saved endpoint details."""
+    """Return actionable recovery copy with safe endpoint details.
+
+    Args:
+        base_url: Session-selected provider endpoint.
+        provider_settings: Provider-specific configuration mapping.
+
+    Returns:
+        User-visible recovery copy that omits credentials, query strings, and
+        fragments from endpoint values.
+    """
     selected = safe_endpoint_display(base_url) or "selected session endpoint"
     configured = safe_endpoint_display(first_configured_endpoint(provider_settings)) or "not saved"
     return f"{UNSAVED_ENDPOINT_COPY} Selected endpoint: {selected}. Saved endpoint: {configured}."
 
 
 def safe_endpoint_display(url: str | None) -> str:
-    """Return a credential-free endpoint label safe for user-visible UI."""
-    raw_url = str(url or "").strip()
-    if not raw_url:
-        return ""
-    try:
-        parsed = urlparse(raw_url)
-    except ValueError:
-        return raw_url.rstrip("/")
-    if parsed.scheme and parsed.netloc:
-        scheme = parsed.scheme.lower()
-        hostname = parsed.hostname
-        if not hostname:
-            return raw_url.rstrip("/")
-        host = hostname.lower()
-        if ":" in host and not host.startswith("["):
-            host = f"[{host}]"
-        try:
-            port = parsed.port
-        except ValueError:
-            return raw_url.rstrip("/")
-        netloc = f"{host}:{port}" if port is not None else host
-        return urlunparse((scheme, netloc, parsed.path.rstrip("/"), "", "", "")).rstrip("/")
-    return raw_url.rstrip("/")
+    """Return a credential-free endpoint label safe for user-visible UI.
+
+    Args:
+        url: Raw endpoint value from config or user input.
+
+    Returns:
+        A host/path endpoint label with user info, query strings, and fragments
+        removed. Malformed endpoints return ``"invalid endpoint"`` instead of
+        echoing raw input.
+    """
+    parsed_endpoint = _parse_http_endpoint(url)
+    if parsed_endpoint is None:
+        return "" if not str(url or "").strip() else _INVALID_ENDPOINT_DISPLAY
+    return _format_endpoint(parsed_endpoint, drop_default_port=False)
 
 
 def normalize_generic_endpoint_for_compare(url: str | None) -> str:
-    """Normalize a generic provider endpoint for stable comparison."""
-    raw_url = str(url or "").strip()
+    """Normalize a generic provider endpoint for stable comparison.
+
+    Args:
+        url: Raw endpoint value from config or user input.
+
+    Returns:
+        Normalized endpoint identity. Empty input returns an empty string, while
+        malformed input returns a non-secret invalid sentinel.
+    """
+    parsed_endpoint = _parse_http_endpoint(url)
+    if parsed_endpoint is None:
+        return "" if not str(url or "").strip() else _INVALID_ENDPOINT_DISPLAY
+    return _format_endpoint(parsed_endpoint, drop_default_port=True)
+
+
+def _parse_http_endpoint(url: str | None) -> tuple[bool, str, str, int | None, str] | None:
+    raw_value = str(url or "")
+    raw_url = raw_value.strip()
     if not raw_url:
-        return ""
+        return None
+    has_unsafe_character = any(
+        character.isspace() or ord(character) < 32 or ord(character) == 127
+        for character in raw_value
+    )
+    if has_unsafe_character:
+        return None
+    has_scheme = "://" in raw_url
+    candidate = raw_url if has_scheme else f"http://{raw_url}"
     try:
-        parsed = urlparse(raw_url)
-    except ValueError:
-        return raw_url.rstrip("/")
-    if parsed.scheme and parsed.netloc:
+        parsed = urlparse(candidate)
         scheme = parsed.scheme.lower()
         hostname = parsed.hostname
-        if not hostname:
-            return raw_url.rstrip("/")
-        host = hostname.lower()
-        try:
-            port = parsed.port
-        except ValueError:
-            return raw_url.rstrip("/")
-        default_port = (scheme == "http" and port == 80) or (scheme == "https" and port == 443)
-        if ":" in host and not host.startswith("["):
-            host = f"[{host}]"
-        netloc = host if default_port or port is None else f"{host}:{port}"
-        return urlunparse((scheme, netloc, parsed.path.rstrip("/"), "", "", ""))
-    return raw_url.rstrip("/")
+        port = parsed.port
+    except ValueError:
+        return None
+    if scheme not in {"http", "https"} or not hostname:
+        return None
+    hostname = hostname.lower()
+    if not _is_allowed_endpoint_host(hostname, has_scheme=has_scheme, port=port):
+        return None
+    path = parsed.path.rstrip("/")
+    return (has_scheme, scheme, hostname, port, path)
+
+
+def _is_allowed_endpoint_host(hostname: str, *, has_scheme: bool, port: int | None) -> bool:
+    if hostname == "localhost":
+        return True
+    try:
+        ip_address(hostname)
+        return True
+    except ValueError:
+        pass
+    if _is_dotted_dns_name(hostname):
+        return True
+    return not has_scheme and port is not None
+
+
+def _is_dotted_dns_name(hostname: str) -> bool:
+    hostname = hostname.rstrip(".")
+    if "." not in hostname or len(hostname) > 253:
+        return False
+    labels = hostname.split(".")
+    return all(_is_dns_label(label) for label in labels)
+
+
+def _is_dns_label(label: str) -> bool:
+    return (
+        1 <= len(label) <= 63
+        and label[0].isalnum()
+        and label[-1].isalnum()
+        and all(character.isascii() and (character.isalnum() or character == "-") for character in label)
+    )
+
+
+def _format_endpoint(
+    endpoint: tuple[bool, str, str, int | None, str],
+    *,
+    drop_default_port: bool,
+) -> str:
+    has_scheme, scheme, hostname, port, path = endpoint
+    host = hostname
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    default_port = (scheme == "http" and port == 80) or (scheme == "https" and port == 443)
+    netloc = host if port is None or (drop_default_port and default_port) else f"{host}:{port}"
+    if has_scheme:
+        return urlunparse((scheme, netloc, path, "", "", "")).rstrip("/")
+    return f"{netloc}{path}".rstrip("/")

--- a/tldw_chatbook/Chat/console_provider_gateway.py
+++ b/tldw_chatbook/Chat/console_provider_gateway.py
@@ -24,6 +24,7 @@ from tldw_chatbook.Chat.Chat_Deps import (
 from tldw_chatbook.Chat.console_chat_models import ConsoleProviderSelection
 from tldw_chatbook.Chat.console_provider_endpoints import (
     generic_endpoint_differs,
+    provider_uses_endpoint,
     unsaved_endpoint_copy,
 )
 from tldw_chatbook.Chat.console_provider_support import resolve_console_provider_identity
@@ -43,7 +44,16 @@ _EMPTY_RESPONSE = object()
 
 
 def safe_provider_error_copy(provider: str, exc: BaseException) -> str:
-    """Return safe user-visible provider failure copy without raw exception text."""
+    """Return safe user-visible provider failure copy.
+
+    Args:
+        provider: Provider name associated with the failed request.
+        exc: Exception raised by the provider adapter.
+
+    Returns:
+        Redacted user-facing error text that categorizes the failure without
+        including raw exception content.
+    """
     category = "unexpected provider error"
     if isinstance(exc, ChatAuthenticationError):
         category = "authentication failed"
@@ -61,7 +71,14 @@ def safe_provider_error_copy(provider: str, exc: BaseException) -> str:
 
 
 def normalize_llamacpp_base_url(api_url: str | None) -> str:
-    """Return the llama.cpp origin root used before appending OpenAI paths."""
+    """Return the llama.cpp origin root used before appending OpenAI paths.
+
+    Args:
+        api_url: User or config-provided llama.cpp endpoint.
+
+    Returns:
+        Normalized origin/base path for llama.cpp HTTP calls.
+    """
     raw_url = str(api_url or "").strip()
     if not raw_url:
         return DEFAULT_LLAMACPP_BASE_URL
@@ -98,7 +115,19 @@ def normalize_llamacpp_base_url(api_url: str | None) -> str:
 
 @dataclass(frozen=True)
 class LlamaCppProviderConfig:
-    """Configuration needed to resolve a llama.cpp-compatible provider."""
+    """Configuration needed to resolve a llama.cpp-compatible provider.
+
+    Attributes:
+        base_url: llama.cpp server base URL.
+        explicit_model: Session-selected model, when present.
+        configured_model: Provider-configured fallback model.
+        temperature: Optional sampling temperature.
+        top_p: Optional nucleus sampling value.
+        min_p: Optional min-p sampling value.
+        top_k: Optional top-k sampling value.
+        max_tokens: Optional response token limit.
+        streaming: Whether streaming responses are requested.
+    """
 
     base_url: str = DEFAULT_LLAMACPP_BASE_URL
     explicit_model: str | None = None
@@ -113,7 +142,25 @@ class LlamaCppProviderConfig:
 
 @dataclass(frozen=True)
 class ConsoleProviderResolution:
-    """Provider readiness result used by Console send and recovery UI."""
+    """Provider readiness result used by Console send and recovery UI.
+
+    Attributes:
+        provider: Display provider selected for the session.
+        base_url: Session endpoint value, when applicable.
+        model: Model selected for the request.
+        ready: Whether the provider has enough configuration to send.
+        visible_copy: User-visible blocker or recovery copy.
+        readiness_key: Normalized key used for readiness checks.
+        execution_key: Provider key passed to ``chat_api_call``.
+        api_key: Resolved API key, omitted from repr output.
+        api_key_source: Human-readable source of the resolved API key.
+        temperature: Optional sampling temperature.
+        top_p: Optional nucleus sampling value.
+        min_p: Optional min-p sampling value.
+        top_k: Optional top-k sampling value.
+        max_tokens: Optional response token limit.
+        streaming: Whether streaming responses are requested.
+    """
 
     provider: str
     base_url: str
@@ -161,7 +208,21 @@ def build_llamacpp_chat_payload(
     top_k: int | None = None,
     max_tokens: int | None = None,
 ) -> dict[str, Any]:
-    """Build the OpenAI-compatible llama.cpp chat completion payload."""
+    """Build the OpenAI-compatible llama.cpp chat completion payload.
+
+    Args:
+        model: Model identifier to send to llama.cpp.
+        messages: OpenAI-compatible chat messages.
+        stream: Whether llama.cpp should stream chunks.
+        temperature: Optional sampling temperature.
+        top_p: Optional nucleus sampling value.
+        min_p: Optional min-p sampling value.
+        top_k: Optional top-k sampling value.
+        max_tokens: Optional response token limit.
+
+    Returns:
+        Request payload for the llama.cpp chat completions endpoint.
+    """
     payload: dict[str, Any] = {
         "model": model,
         "messages": list(messages),
@@ -181,7 +242,15 @@ def build_llamacpp_chat_payload(
 
 
 class ConsoleProviderGateway:
-    """Resolve Console providers and stream chat responses."""
+    """Resolve Console providers and stream chat responses.
+
+    Args:
+        http_client: Optional HTTP client for llama.cpp probes and calls.
+        config_provider: Callable returning the current app configuration.
+        environ: Optional environment mapping for provider readiness checks.
+        chat_api_call_fn: Optional replacement for ``chat_api_call`` in tests.
+        safe_error_copy: Optional error redaction callback.
+    """
 
     def __init__(
         self,
@@ -200,12 +269,23 @@ class ConsoleProviderGateway:
         self._safe_error_copy = safe_error_copy or safe_provider_error_copy
 
     async def aclose(self) -> None:
-        """Close the owned HTTP client, leaving injected clients to their owner."""
+        """Close the owned HTTP client.
+
+        Returns:
+            ``None``. Injected HTTP clients are left open for their owner.
+        """
         if self._owns_http_client:
             await self.http_client.aclose()
 
     async def resolve_llamacpp(self, config: LlamaCppProviderConfig) -> ConsoleProviderResolution:
-        """Resolve llama.cpp readiness and the effective model."""
+        """Resolve llama.cpp readiness and the effective model.
+
+        Args:
+            config: llama.cpp provider configuration and sampling settings.
+
+        Returns:
+            Provider resolution indicating whether llama.cpp can be used.
+        """
         model = config.explicit_model or config.configured_model
         base_url = normalize_llamacpp_base_url(config.base_url)
         if not validate_url(base_url):
@@ -279,7 +359,15 @@ class ConsoleProviderGateway:
         )
 
     async def resolve_for_send(self, selection: ConsoleProviderSelection) -> ConsoleProviderResolution:
-        """Resolve the provider selected by Console before sending."""
+        """Resolve the provider selected by Console before sending.
+
+        Args:
+            selection: Current Console provider, model, endpoint, and sampling
+                settings.
+
+        Returns:
+            Provider resolution used to either send or render recovery copy.
+        """
         if not selection.provider.strip():
             return self._blocked_resolution(
                 selection,
@@ -339,7 +427,10 @@ class ConsoleProviderGateway:
                 execution_key=identity.execution_key,
             )
 
-        if generic_endpoint_differs(selection.base_url, provider_settings):
+        if (
+            provider_uses_endpoint(identity.readiness_key, provider_settings)
+            and generic_endpoint_differs(selection.base_url, provider_settings)
+        ):
             return self._blocked_resolution(
                 selection,
                 provider=selection.provider,
@@ -390,7 +481,21 @@ class ConsoleProviderGateway:
         top_k: int | None = None,
         max_tokens: int | None = None,
     ) -> AsyncIterator[str]:
-        """Stream OpenAI-compatible chat completion content chunks from llama.cpp."""
+        """Stream OpenAI-compatible chat completion chunks from llama.cpp.
+
+        Args:
+            base_url: llama.cpp server endpoint.
+            model: Model identifier to send.
+            messages: OpenAI-compatible chat messages.
+            temperature: Optional sampling temperature.
+            top_p: Optional nucleus sampling value.
+            min_p: Optional min-p sampling value.
+            top_k: Optional top-k sampling value.
+            max_tokens: Optional response token limit.
+
+        Yields:
+            Assistant-visible content chunks.
+        """
         normalized_base_url = normalize_llamacpp_base_url(base_url)
         if not validate_url(normalized_base_url):
             raise ValueError("invalid llama.cpp base URL")
@@ -455,7 +560,21 @@ class ConsoleProviderGateway:
         top_k: int | None = None,
         max_tokens: int | None = None,
     ) -> str:
-        """Request a non-streaming OpenAI-compatible chat completion."""
+        """Request a non-streaming OpenAI-compatible chat completion.
+
+        Args:
+            base_url: llama.cpp server endpoint.
+            model: Model identifier to send.
+            messages: OpenAI-compatible chat messages.
+            temperature: Optional sampling temperature.
+            top_p: Optional nucleus sampling value.
+            min_p: Optional min-p sampling value.
+            top_k: Optional top-k sampling value.
+            max_tokens: Optional response token limit.
+
+        Returns:
+            Assistant-visible completion text.
+        """
         normalized_base_url = normalize_llamacpp_base_url(base_url)
         if not validate_url(normalized_base_url):
             raise ValueError("invalid llama.cpp base URL")
@@ -481,7 +600,15 @@ class ConsoleProviderGateway:
         resolution: ConsoleProviderResolution,
         messages: list[Mapping[str, Any]],
     ) -> AsyncIterator[str]:
-        """Dispatch streaming for a resolved Console provider."""
+        """Dispatch streaming for a resolved Console provider.
+
+        Args:
+            resolution: Provider resolution produced by ``resolve_for_send``.
+            messages: OpenAI-compatible chat messages.
+
+        Yields:
+            Assistant-visible content chunks.
+        """
         if not resolution.ready or not resolution.model:
             return
         if resolution.provider in {"llama_cpp", "local_llamacpp"}:
@@ -567,7 +694,14 @@ class ConsoleProviderGateway:
 
     @staticmethod
     def normalize_provider_response(response: Any) -> Iterator[str]:
-        """Yield safe assistant-visible chunks from generic provider output."""
+        """Yield safe assistant-visible chunks from generic provider output.
+
+        Args:
+            response: Raw return value from ``chat_api_call``.
+
+        Yields:
+            Assistant-visible text chunks or normalized fallback copy.
+        """
         content = _content_from_provider_item(response)
         if isinstance(content, str):
             yield content if content else NO_PROVIDER_CONTENT_COPY

--- a/tldw_chatbook/Chat/console_provider_support.py
+++ b/tldw_chatbook/Chat/console_provider_support.py
@@ -28,7 +28,16 @@ _EXECUTION_TO_READINESS_ALIASES = {
 
 @dataclass(frozen=True)
 class ConsoleProviderIdentity:
-    """Resolved Console provider identities for config, readiness, and send."""
+    """Resolved Console provider identities for config, readiness, and send.
+
+    Attributes:
+        display_key: Normalized provider key used by Console controls.
+        readiness_key: Provider key used for configuration/readiness lookup.
+        execution_key: Provider key passed to ``chat_api_call``.
+        is_supported: Whether Console can send through this provider.
+        uses_direct_llama_path: Whether the provider bypasses the generic
+            adapter and uses the direct llama.cpp path.
+    """
 
     display_key: str
     readiness_key: str
@@ -52,7 +61,17 @@ def resolve_console_provider_identity(
     *,
     handler_keys: Collection[str] | None = None,
 ) -> ConsoleProviderIdentity:
-    """Resolve Console provider display, readiness, and execution keys."""
+    """Resolve Console provider display, readiness, and execution keys.
+
+    Args:
+        provider: Raw provider name from config or Console controls.
+        handler_keys: Optional ``chat_api_call`` handler keys for deterministic
+            tests or side-effect-free callers.
+
+    Returns:
+        Resolved provider identity describing display, readiness, and execution
+        keys plus whether the provider is supported.
+    """
     raw_provider = (provider or "").strip()
     display_key = provider_config_key(raw_provider)
     exact_key = raw_provider.lower()
@@ -68,10 +87,18 @@ def resolve_console_provider_identity(
         )
 
     handlers = _handler_keys(handler_keys)
-    readiness_key = _EXECUTION_TO_READINESS_ALIASES.get(exact_key, display_key)
+    normalized_handler_keys = {
+        provider_config_key(handler_key): handler_key for handler_key in handlers
+    }
+    handler_exact_key = (
+        exact_key
+        if exact_key in handlers
+        else normalized_handler_keys.get(display_key, exact_key)
+    )
+    readiness_key = _EXECUTION_TO_READINESS_ALIASES.get(handler_exact_key, display_key)
     execution_key = _READINESS_TO_EXECUTION_ALIASES.get(readiness_key)
     if execution_key is None:
-        execution_key = exact_key if exact_key in handlers else readiness_key
+        execution_key = handler_exact_key if handler_exact_key in handlers else readiness_key
 
     return ConsoleProviderIdentity(
         display_key=display_key,
@@ -85,7 +112,16 @@ def resolve_console_provider_identity(
 def supported_console_provider_readiness_keys(
     handler_keys: Collection[str] | None = None,
 ) -> frozenset[str]:
-    """Return readiness keys supported by Console provider execution."""
+    """Return readiness keys supported by Console provider execution.
+
+    Args:
+        handler_keys: Optional ``chat_api_call`` handler keys for deterministic
+            tests or side-effect-free callers.
+
+    Returns:
+        Set of normalized readiness keys whose providers can be sent from
+        Console.
+    """
     handlers = _handler_keys(handler_keys)
     return frozenset(
         resolve_console_provider_identity(

--- a/tldw_chatbook/Chat/console_session_settings.py
+++ b/tldw_chatbook/Chat/console_session_settings.py
@@ -12,7 +12,9 @@ from tldw_chatbook.Chat.console_provider_support import (
     supported_console_provider_readiness_keys,
 )
 from tldw_chatbook.Chat.console_provider_endpoints import (
+    URL_BASED_PROVIDER_KEYS,
     generic_endpoint_differs,
+    provider_uses_endpoint,
     safe_endpoint_display,
     unsaved_endpoint_copy,
 )
@@ -63,23 +65,6 @@ INVALID_LLAMACPP_BASE_URL_COPY = (
 )
 TokenCounter = Callable[[Sequence[Mapping[str, str]], str, str], int]
 TokenLimitResolver = Callable[[str, str], int]
-URL_BASED_PROVIDER_KEYS = frozenset(
-    {
-        "aphrodite",
-        "custom",
-        "custom_2",
-        "koboldcpp",
-        "llama_cpp",
-        "local_llamacpp",
-        "local_llamafile",
-        "local_ollama",
-        "local_vllm",
-        "ollama",
-        "oobabooga",
-        "tabbyapi",
-        "vllm",
-    }
-)
 CONSOLE_MODEL_TOKEN_LIMITS = {
     "gpt-4": 8192,
     "gpt-4-32k": 32768,
@@ -569,9 +554,7 @@ def _default_base_url(provider_key: str, provider_settings: Mapping[str, object]
 
 
 def _is_url_based_provider(provider_key: str, provider_settings: Mapping[str, object]) -> bool:
-    return provider_key in URL_BASED_PROVIDER_KEYS or any(
-        key in provider_settings for key in ("api_url", "base_url", "api_base")
-    )
+    return provider_uses_endpoint(provider_key, provider_settings)
 
 
 def _valid_base_url(provider_key: str, base_url: str) -> bool:


### PR DESCRIPTION
## Summary
- Fixes the PR #391 review findings missed before merge.
- Redacts endpoint userinfo, query strings, fragments, and malformed secret-bearing endpoint input before rendering Console endpoint copy.
- Resolves normalized provider select values like `custom_openai_api` back to hyphenated `chat_api_call` handler keys.
- Aligns gateway endpoint mismatch blocking with the settings readiness URL-provider guard so cloud providers are not falsely blocked by session `base_url`.
- Adds Google-style docstrings to the new public provider helper/gateway APIs.

## Verification
- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Chat/test_console_provider_endpoints.py Tests/Chat/test_console_provider_support.py Tests/Chat/test_console_provider_gateway.py Tests/Chat/test_console_session_settings.py Tests/Chat/test_provider_readiness.py Tests/UI/test_console_internals_decomposition.py Tests/UI/test_console_native_chat_flow.py Tests/UI/test_console_session_settings.py`
  - 274 passed, 8 warnings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Console provider review findings to make endpoint handling safer and provider resolution correct. Prevents false blocking for cloud providers when a session base_url is set.

- **Bug Fixes**
  - Safer endpoint parsing/display: redacts credentials/query/fragment; validates host/IP; rejects single-label tokens and unsafe input; allows schemeless host:port; normalizes IPv6; drops default ports for compare.
  - Resolves normalized provider keys (e.g., `custom_openai_api`, `custom_openai_api_2`) to hyphenated execution keys (`custom-openai-api`, `custom-openai-api-2`).
  - Blocks on endpoint mismatch only for URL-based providers or when a base URL is saved; ignores cloud session `base_url` when no endpoint is configured.

- **Refactors**
  - Extracted `provider_uses_endpoint` and shared `URL_BASED_PROVIDER_KEYS`; reused in `console_session_settings`.
  - Added clear docstrings to provider gateway/support helpers, endpoint utilities, and llama.cpp APIs.

<sup>Written for commit 5b7a27372fbbd45183fdd8f38b73673a6a16649d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/393?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

