### PR TITLE
Add Console provider sweep regressions

### DIFF
--- a/Docs/superpowers/qa/product-maturity/screen-qa/console/provider-parity/notes.md
+++ b/Docs/superpowers/qa/product-maturity/screen-qa/console/provider-parity/notes.md
@@ -20,6 +20,7 @@ User approval: approved in Codex thread after reviewing the actual rendered scre
 - A temporary textual-web harness initially reused the already-active Console session through `ensure_session(...)`, so the base URL override scenario did not apply the unsaved endpoint. The harness was corrected to create a fresh session for that scenario before recapturing the approved screenshot.
 - Production gateway behavior already blocked differing generic base URL overrides; no production code change was needed for the screenshot correction.
 - The stale early generic screenshot in this folder is not approval evidence and should not be staged for the provider-parity closeout.
+- Follow-up provider-sweep regressions now assert every `chat_api_call()` handler key resolves through Console provider support, Console settings' static execution-key list stays aligned with `API_CALL_HANDLERS`, and the send gateway does not route any supported handler key to the old WIP/unsupported-provider recovery copy.
 
 ## Verification
 
@@ -29,6 +30,8 @@ User approval: approved in Codex thread after reviewing the actual rendered scre
 - Result: `121 passed, 8 warnings`
 - `python -m pytest -q Tests/UI/test_console_internals_decomposition.py Tests/UI/test_console_session_settings.py --tb=short`
 - Result: `132 passed, 1 warning`
+- `python -m pytest -q Tests/Chat/test_console_provider_support.py::test_all_chat_api_call_handlers_resolve_to_supported_console_identity Tests/Chat/test_console_session_settings.py::test_settings_execution_provider_keys_match_chat_api_handlers Tests/Chat/test_console_provider_gateway.py::test_resolve_for_send_all_chat_api_handlers_are_console_supported --tb=short`
+- Result: `3 passed, 1 warning`
 - `git diff --check`
 - Result: clean
 

--- a/Tests/Chat/test_console_provider_gateway.py
+++ b/Tests/Chat/test_console_provider_gateway.py
@@ -20,6 +20,7 @@ from tldw_chatbook.Chat.console_provider_gateway import (
     build_llamacpp_chat_payload,
     safe_provider_error_copy,
 )
+from tldw_chatbook.Chat.console_provider_support import resolve_console_provider_identity
 
 
 def test_llamacpp_payload_includes_supported_sampling_params() -> None:
@@ -386,6 +387,50 @@ async def test_resolve_for_send_openai_uses_env_key_and_execution_key() -> None:
     assert resolved.api_key_source == "env:OPENAI_API_KEY"
     assert "sk-test-secret" not in resolved.visible_copy
     assert "sk-test-secret" not in repr(resolved)
+
+
+@pytest.mark.asyncio
+async def test_resolve_for_send_all_chat_api_handlers_are_console_supported() -> None:
+    from tldw_chatbook.Chat.Chat_Functions import API_CALL_HANDLERS
+    from tldw_chatbook.Chat.provider_readiness import PROVIDERS_REQUIRING_API_KEY_KEYS
+
+    handler_keys = frozenset(API_CALL_HANDLERS)
+    api_settings: dict[str, dict[str, str]] = {}
+    for provider in handler_keys:
+        identity = resolve_console_provider_identity(
+            provider,
+            handler_keys=handler_keys,
+        )
+        settings = api_settings.setdefault(
+            identity.readiness_key,
+            {"model": f"{identity.readiness_key}-model"},
+        )
+        if identity.readiness_key in PROVIDERS_REQUIRING_API_KEY_KEYS:
+            settings["api_key"] = f"test-key-for-{identity.readiness_key}"
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, json={"status": "ok"}))
+    ) as client:
+        gateway = ConsoleProviderGateway(
+            http_client=client,
+            config_provider=lambda: {"api_settings": api_settings},
+            environ={},
+        )
+
+        for provider in sorted(handler_keys):
+            identity = resolve_console_provider_identity(
+                provider,
+                handler_keys=handler_keys,
+            )
+            resolved = await gateway.resolve_for_send(
+                ConsoleProviderSelection(provider=provider, explicit_model="console-sweep-model")
+            )
+
+            assert resolved.ready is True, provider
+            assert resolved.readiness_key == identity.readiness_key, provider
+            assert resolved.execution_key == identity.execution_key, provider
+            assert "not available in Console yet" not in resolved.visible_copy
+            assert "WIP" not in resolved.visible_copy
 
 
 @pytest.mark.asyncio

--- a/Tests/Chat/test_console_provider_support.py
+++ b/Tests/Chat/test_console_provider_support.py
@@ -79,6 +79,21 @@ def test_all_chat_api_call_handlers_are_known_to_console_support() -> None:
     assert "custom_2" in keys
 
 
+def test_all_chat_api_call_handlers_resolve_to_supported_console_identity() -> None:
+    from tldw_chatbook.Chat.Chat_Functions import API_CALL_HANDLERS
+
+    handler_keys = frozenset(API_CALL_HANDLERS)
+
+    for handler_key in sorted(handler_keys):
+        identity = resolve_console_provider_identity(
+            handler_key,
+            handler_keys=handler_keys,
+        )
+
+        assert identity.is_supported is True, handler_key
+        assert identity.execution_key in handler_keys, handler_key
+
+
 def test_supported_readiness_key_sweep_deduplicates_aliases() -> None:
     keys = supported_console_provider_readiness_keys(
         handler_keys={

--- a/Tests/Chat/test_console_session_settings.py
+++ b/Tests/Chat/test_console_session_settings.py
@@ -3,6 +3,7 @@ import inspect
 
 import tldw_chatbook.Chat.console_session_settings as session_settings
 from tldw_chatbook.Chat.console_session_settings import (
+    CONSOLE_SETTINGS_EXECUTION_PROVIDER_KEYS,
     ConsoleSettingsContextEstimate,
     ConsoleSessionSettings,
     build_console_context_estimate,
@@ -51,6 +52,12 @@ def test_readiness_does_not_import_gateway_or_config_runtime_modules(monkeypatch
     )
 
     assert readiness.label == "Missing key"
+
+
+def test_settings_execution_provider_keys_match_chat_api_handlers() -> None:
+    from tldw_chatbook.Chat.Chat_Functions import API_CALL_HANDLERS
+
+    assert CONSOLE_SETTINGS_EXECUTION_PROVIDER_KEYS == frozenset(API_CALL_HANDLERS)
 
 
 def test_default_settings_prefers_chat_defaults_and_provider_config() -> None:


### PR DESCRIPTION
## Summary
- Add provider-support regression coverage proving every chat_api_call handler key resolves to a supported Console identity.
- Add Settings drift coverage so the Console settings execution-provider set stays aligned with API_CALL_HANDLERS.
- Add gateway sweep coverage proving supported handlers do not fall back to old WIP/unsupported-provider recovery copy.
- Update Console provider-parity QA notes with the new regression evidence.

## Verification
- python -m pytest -q Tests/Chat/test_console_provider_support.py::test_all_chat_api_call_handlers_resolve_to_supported_console_identity Tests/Chat/test_console_session_settings.py::test_settings_execution_provider_keys_match_chat_api_handlers Tests/Chat/test_console_provider_gateway.py::test_resolve_for_send_all_chat_api_handlers_are_console_supported --tb=short
- python -m pytest -q Tests/Chat/test_console_provider_support.py Tests/Chat/test_console_session_settings.py Tests/Chat/test_console_provider_gateway.py Tests/UI/test_console_native_chat_flow.py --tb=short
- git diff --check

## Screenshots
- Not applicable: regression/QA-only change; no rendered UI changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add provider-sweep regression tests to ensure every `chat_api_call` handler maps to a supported Console provider, settings stay in sync with `API_CALL_HANDLERS`, and the send gateway never falls back to WIP/unsupported copy. Update provider-parity QA notes with the new evidence.

- **New Features**
  - Tests: identity resolution for all handler keys, settings-key drift guard, and gateway sweep to block WIP/unsupported copy.
  - Docs: updated provider-parity notes with verification and pass results.

<sup>Written for commit b03c4e61df8ddecd3a7dc377a00f0f18d5a4c95a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/395?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

