### PR TITLE
Normalize Notes widget focus states

### DIFF
--- a/Docs/superpowers/qa/non-obscuring-focus-selection/audit-inventory.md
+++ b/Docs/superpowers/qa/non-obscuring-focus-selection/audit-inventory.md
@@ -87,10 +87,10 @@ Scope: PR 1 foundation plus app-wide inventory
 | `EmojiButton.emoji_button:focus` | `tldw_chatbook/Widgets/emoji_picker.py` | Emoji picker | button | compact button focus needs review | two-cue non-obscuring focus | PR 14 compact widget focus | source contract |
 | `PathBreadcrumbs .breadcrumb-button:focus` | `tldw_chatbook/Widgets/enhanced_file_picker.py` | File picker | breadcrumb button | compact button focus needs review | two-cue non-obscuring focus | PR 14 compact widget focus | source contract |
 | `ModelCardViewer .file-item.selected` | `tldw_chatbook/Widgets/HuggingFace/model_card_viewer.py` | HuggingFace model card | selected row | selected row needs review | readable selected row | PR 15 model-card focus | inline source contract |
-| `NotesToolbar Button.toggle.active` | `tldw_chatbook/Widgets/Note_Widgets/notes_toolbar.py` | Notes toolbar | active toggle | active fill needs review | active plus focus contract | Deferred PR 4+ | not yet migrated |
-| `NotesEditorWidget:focus` | `tldw_chatbook/Widgets/Note_Widgets/notes_editor_widget.py` | Notes editor | custom input | local focus style needs review | non-obscuring editor focus | Deferred PR 4+ | not yet migrated |
-| `SyncProgressWidget.active` | `tldw_chatbook/Widgets/Note_Widgets/notes_sync_widget.py` | Notes sync | active progress | active state needs review | readable active progress state | Deferred PR 4+ | not yet migrated |
-| `SyncProgressSection.active` | `tldw_chatbook/Widgets/Note_Widgets/notes_sync_widget_improved.py` | Notes sync | active progress | active state needs review | readable active progress state | Deferred PR 4+ | not yet migrated |
+| `NotesToolbar Button.toggle.active` | `tldw_chatbook/Widgets/Note_Widgets/notes_toolbar.py` | Notes toolbar | active toggle | active fill needs review | active plus focus contract | PR 16 notes widget focus | inline source contract |
+| `NotesEditorWidget:focus` | `tldw_chatbook/Widgets/Note_Widgets/notes_editor_widget.py` | Notes editor | custom input | local focus style needs review | non-obscuring editor focus | PR 16 notes widget focus | inline source contract |
+| `SyncProgressWidget.active` | `tldw_chatbook/Widgets/Note_Widgets/notes_sync_widget.py` | Notes sync | active progress | active state needs review | readable active progress state | PR 16 notes widget focus | inline source contract |
+| `SyncProgressSection.active` | `tldw_chatbook/Widgets/Note_Widgets/notes_sync_widget_improved.py` | Notes sync | active progress | active state needs review | readable active progress state | PR 16 notes widget focus | inline source contract |
 
 ## Audit Notes
 

--- a/Tests/UI/test_non_obscuring_focus_contract.py
+++ b/Tests/UI/test_non_obscuring_focus_contract.py
@@ -38,6 +38,10 @@ RAG_SEARCH_WINDOW = ROOT / "tldw_chatbook/UI/Views/RAGSearch/search_rag_window.p
 EMOJI_PICKER = ROOT / "tldw_chatbook/Widgets/emoji_picker.py"
 ENHANCED_FILE_PICKER = ROOT / "tldw_chatbook/Widgets/enhanced_file_picker.py"
 MODEL_CARD_VIEWER = ROOT / "tldw_chatbook/Widgets/HuggingFace/model_card_viewer.py"
+NOTES_TOOLBAR = ROOT / "tldw_chatbook/Widgets/Note_Widgets/notes_toolbar.py"
+NOTES_EDITOR = ROOT / "tldw_chatbook/Widgets/Note_Widgets/notes_editor_widget.py"
+NOTES_SYNC = ROOT / "tldw_chatbook/Widgets/Note_Widgets/notes_sync_widget.py"
+NOTES_SYNC_IMPROVED = ROOT / "tldw_chatbook/Widgets/Note_Widgets/notes_sync_widget_improved.py"
 
 
 def css_blocks(text: str, selector: str) -> list[str]:
@@ -538,6 +542,48 @@ def test_huggingface_model_card_selected_file_row_is_readable():
         "ModelCardViewer .file-item.selected:hover",
     ):
         assert_readable_inline_selected_state_contract(css_block(text, selector))
+
+
+def test_notes_toolbar_active_toggle_uses_readable_active_contract():
+    text = NOTES_TOOLBAR.read_text(encoding="utf-8")
+    assert_readable_inline_selected_state_contract(
+        css_block(text, "NotesToolbar Button.toggle.active")
+    )
+
+
+def test_notes_editor_focus_uses_stable_thin_input_contract():
+    from tldw_chatbook.Widgets.Note_Widgets.notes_editor_widget import NotesEditorWidget
+
+    text = NotesEditorWidget.DEFAULT_CSS
+    base = css_block(text, "NotesEditorWidget")
+    focus = css_block(text, "NotesEditorWidget:focus")
+    assert_stable_solid_border_geometry(base, focus)
+    assert "outline: heavy" not in focus
+    assert "border: solid $surface-lighten-1;" in focus
+    assert "border-bottom: solid $surface-lighten-1;" in focus
+    assert "background: $surface;" in focus
+    assert "color: $text;" in focus
+    assert "$primary" not in focus
+    assert "$accent" not in focus
+    assert "$error" not in focus
+    assert "$warning" not in focus
+
+
+def test_notes_sync_progress_active_states_are_readable():
+    for path, selector in (
+        (NOTES_SYNC, "SyncProgressWidget.active"),
+        (NOTES_SYNC_IMPROVED, "SyncProgressSection.active"),
+    ):
+        block = css_block(path.read_text(encoding="utf-8"), selector)
+        assert "display: block;" in block
+        assert "outline: heavy" not in block
+        assert "$primary" not in block
+        assert "$accent" not in block
+        assert "$warning" not in block
+        assert "$error" not in block
+        assert "background: $surface;" in block
+        assert "border: solid $surface-lighten-1;" in block
+        assert "color: $text;" in block
 
 
 def test_search_rag_query_input_focus_targets_rendered_input_without_jitter():

--- a/tldw_chatbook/Widgets/Note_Widgets/notes_editor_widget.py
+++ b/tldw_chatbook/Widgets/Note_Widgets/notes_editor_widget.py
@@ -26,12 +26,16 @@ class NotesEditorWidget(TextArea):
     DEFAULT_CSS = """
     NotesEditorWidget {
         height: 100%;
-        border: none;
+        border: solid transparent;
+        border-bottom: solid transparent;
         padding: 1;
     }
     
     NotesEditorWidget:focus {
-        border: none;
+        border: solid $surface-lighten-1;
+        border-bottom: solid $surface-lighten-1;
+        background: $surface;
+        color: $text;
     }
     
     NotesEditorWidget.preview-mode {

--- a/tldw_chatbook/Widgets/Note_Widgets/notes_sync_widget.py
+++ b/tldw_chatbook/Widgets/Note_Widgets/notes_sync_widget.py
@@ -79,6 +79,9 @@ class SyncProgressWidget(Container):
     
     SyncProgressWidget.active {
         display: block;
+        background: $surface;
+        border: solid $surface-lighten-1;
+        color: $text;
     }
     
     #sync-progress-bar {

--- a/tldw_chatbook/Widgets/Note_Widgets/notes_sync_widget_improved.py
+++ b/tldw_chatbook/Widgets/Note_Widgets/notes_sync_widget_improved.py
@@ -184,6 +184,9 @@ class SyncProgressSection(Container):
     
     SyncProgressSection.active {
         display: block;
+        background: $surface;
+        border: solid $surface-lighten-1;
+        color: $text;
     }
     
     .progress-header {

--- a/tldw_chatbook/Widgets/Note_Widgets/notes_toolbar.py
+++ b/tldw_chatbook/Widgets/Note_Widgets/notes_toolbar.py
@@ -82,7 +82,9 @@ class NotesToolbar(Horizontal):
     }
     
     NotesToolbar Button.toggle.active {
-        background: $primary;
+        background: $surface;
+        color: $text;
+        text-style: bold underline;
     }
     
     .toolbar-separator {


### PR DESCRIPTION
## Summary

- Normalize Notes toolbar active toggle styling away from primary fill and into readable text plus underline treatment.
- Give the Notes editor stable non-obscuring focus geometry using standalone-safe Textual theme tokens.
- Give legacy and improved Notes sync active progress containers readable surface, border, and text states.
- Add non-obscuring focus contract coverage for the Notes selectors and update the audit inventory rows.

## Verification

- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_non_obscuring_focus_contract.py::test_notes_toolbar_active_toggle_uses_readable_active_contract Tests/UI/test_non_obscuring_focus_contract.py::test_notes_editor_focus_uses_stable_thin_input_contract Tests/UI/test_non_obscuring_focus_contract.py::test_notes_sync_progress_active_states_are_readable -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Widgets/test_notes_widgets.py -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_non_obscuring_focus_contract.py Tests/UI/test_focus_accessibility.py -q`
- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m py_compile tldw_chatbook/Widgets/Note_Widgets/notes_toolbar.py tldw_chatbook/Widgets/Note_Widgets/notes_editor_widget.py tldw_chatbook/Widgets/Note_Widgets/notes_sync_widget.py tldw_chatbook/Widgets/Note_Widgets/notes_sync_widget_improved.py`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize Notes widget focus and active states to non-obscuring, readable styles using Textual theme tokens. Improves accessibility and visual consistency across toolbar, editor, and sync progress.

- **Bug Fixes**
  - Toolbar: replace primary fill with surface background + text and bold underline on `Button.toggle.active`.
  - Editor: add stable thin focus border (`$surface-lighten-1`), surface background, and text color; remove heavy outline.
  - Sync progress: readable active states in both widgets with surface background, light border, and text color.
  - Tests/docs: add focus/readability contract tests and update the audit inventory to reference this PR.

<sup>Written for commit c7413f3d282cdb06e772a536d1476994f3739c5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

