### PR TITLE
Add Console CDP QA ticket

### DIFF
--- a/backlog/tasks/task-74 - CDP-QA-Console-composer-paste-workflow-from-current-dev.md
+++ b/backlog/tasks/task-74 - CDP-QA-Console-composer-paste-workflow-from-current-dev.md
@@ -1,0 +1,46 @@
+---
+id: TASK-74
+title: 'CDP QA: Console composer paste workflow from current dev'
+status: To Do
+labels:
+- qa
+- console
+- cdp
+- ux
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify the current-dev Console composer paste workflow through actual textual-web/CDP use so the visible input, paste-collapse token, unfurl flow, and normal typing behavior are proven in the rendered app after the paste-threshold merge.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 CDP/browser-driven QA is run against a clean current-dev app instance, not a mockup, SVG, or static layout render.
+- [ ] #2 Actual screenshots are captured for Console baseline, visible typed input, collapsed large paste token, first-click Unfurl prompt, second-click expanded paste text, and normal typing over the threshold remaining literal.
+- [ ] #3 QA notes record exact commands, browser/CDP URL, app commit SHA, environment, and any failed or uncertain observations.
+- [ ] #4 The walkthrough verifies that only paste/insert chunks over the configured threshold collapse, while normal typing remains visible and literal.
+- [ ] #5 Any observed Console composer regression is either fixed in the same follow-up PR with focused regression coverage or logged as a separate Backlog task with severity and reproduction steps.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] Current-dev SHA and clean worktree state are recorded before QA begins.
+- [ ] CDP/browser screenshots are attached or linked from durable QA notes.
+- [ ] The rendered app is verified for visual usability and functional behavior, not only selector presence or clickability.
+- [ ] Focused automated regression coverage is added for any bug fixed during the ticket.
+- [ ] Task notes identify residual risks and the next follow-up if the workflow is not fully usable.
+<!-- DOD:END -->


### PR DESCRIPTION
## Summary
- Adds TASK-74 for a narrow Console composer paste workflow CDP QA pass from current dev.
- Requires actual textual-web/CDP screenshots for baseline, typed input, collapsed paste, Unfurl, expanded paste, and normal typing over threshold.
- Records DoD expectations for rendered usability, command provenance, screenshots, residual risks, and follow-up task creation for any discovered regression.

## Test Plan
- [x] /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_product_maturity_phase1_harness.py::test_backlog_task_frontmatter_ids_are_unique --tb=short
- [x] git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds TASK-74 to run CDP/browser QA on the Console composer paste workflow in current dev. The task defines required screenshots, acceptance criteria for paste-collapse threshold, unfurl, and normal typing, plus DoD for provenance, usability checks, and follow-up bug tracking.

<sup>Written for commit 6bcda6c562e40df6c6b31d650727c8e5e34bec93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

