### PR TITLE
Align New Ingest mode selector styles

### DIFF
--- a/Tests/UI/test_non_obscuring_focus_contract.py
+++ b/Tests/UI/test_non_obscuring_focus_contract.py
@@ -554,6 +554,8 @@ def test_new_ingest_focus_overrides_defer_to_shared_contracts():
     assert css_blocks(text, ".mode-selector RadioButton") == []
     assert css_blocks(text, ".mode-selector RadioButton:hover") == []
     assert css_blocks(text, ".mode-selector RadioButton.-active") == []
+    assert css_blocks(text, ".mode-description") == []
+    assert css_block(text, "#mode-description")
     mode_button_base = css_block(text, "#mode-selector Button")
     mode_button_active = css_block(text, "#mode-selector Button.active")
     assert "border: round $border;" in mode_button_base

--- a/Tests/UI/test_non_obscuring_focus_contract.py
+++ b/Tests/UI/test_non_obscuring_focus_contract.py
@@ -551,6 +551,15 @@ def test_new_ingest_focus_overrides_defer_to_shared_contracts():
     assert "border: solid $border;" in metadata_input_base
     assert "border: solid $primary;" not in metadata_input_base
 
+    assert css_blocks(text, ".mode-selector RadioButton") == []
+    assert css_blocks(text, ".mode-selector RadioButton:hover") == []
+    assert css_blocks(text, ".mode-selector RadioButton.-active") == []
+    mode_button_base = css_block(text, "#mode-selector Button")
+    mode_button_active = css_block(text, "#mode-selector Button.active")
+    assert "border: round $border;" in mode_button_base
+    assert_readable_selected_state_contract(mode_button_active)
+    assert_no_dominant_selected_geometry(mode_button_active)
+
     widget_focus_selector = re.compile(r"\b(Button|Input|RadioButton)\b.*:focus")
     offenders = [
         selector

--- a/Tests/Widgets/test_unified_processor.py
+++ b/Tests/Widgets/test_unified_processor.py
@@ -7,6 +7,7 @@ import pytest
 from pathlib import Path
 from unittest.mock import Mock, patch, AsyncMock
 from textual.app import App
+from textual.widgets import Button, RadioButton
 
 from tldw_chatbook.Widgets.NewIngest.UnifiedProcessor import (
     UnifiedProcessor,
@@ -190,6 +191,17 @@ async def test_mode_toggle_compose():
         assert toggle.query("#expert-mode")
         assert toggle.query("#mode-description")
 
+        buttons = list(toggle.query("#mode-selector Button"))
+        assert [button.id for button in buttons] == [
+            "simple-mode",
+            "advanced-mode",
+            "expert-mode",
+        ]
+        assert list(toggle.query("#mode-selector RadioButton")) == []
+        assert all(isinstance(button, Button) for button in buttons)
+        assert not any(isinstance(button, RadioButton) for button in buttons)
+        assert toggle.query_one("#simple-mode", Button).has_class("active")
+
 
 @pytest.mark.asyncio
 async def test_mode_toggle_mode_changes():
@@ -205,12 +217,16 @@ async def test_mode_toggle_mode_changes():
         await pilot.pause()
         
         assert toggle.current_mode == ProcessingMode.ADVANCED
+        assert toggle.query_one("#advanced-mode", Button).has_class("active")
+        assert not toggle.query_one("#simple-mode", Button).has_class("active")
         
         # Click expert mode
         await pilot.click("#expert-mode")
         await pilot.pause()
         
         assert toggle.current_mode == ProcessingMode.EXPERT
+        assert toggle.query_one("#expert-mode", Button).has_class("active")
+        assert not toggle.query_one("#advanced-mode", Button).has_class("active")
 
 
 @pytest.mark.asyncio

--- a/Tests/Widgets/test_unified_processor.py
+++ b/Tests/Widgets/test_unified_processor.py
@@ -7,7 +7,7 @@ import pytest
 from pathlib import Path
 from unittest.mock import Mock, patch, AsyncMock
 from textual.app import App
-from textual.widgets import Button, RadioButton
+from textual.widgets import Button, RadioButton, Static
 
 from tldw_chatbook.Widgets.NewIngest.UnifiedProcessor import (
     UnifiedProcessor,
@@ -227,6 +227,13 @@ async def test_mode_toggle_mode_changes():
         assert toggle.current_mode == ProcessingMode.EXPERT
         assert toggle.query_one("#expert-mode", Button).has_class("active")
         assert not toggle.query_one("#advanced-mode", Button).has_class("active")
+
+        toggle.current_mode = "simple"
+        await pilot.pause()
+
+        assert toggle.query_one("#simple-mode", Button).has_class("active")
+        assert not toggle.query_one("#expert-mode", Button).has_class("active")
+        assert toggle.query_one("#mode-description", Static).renderable == "Simple processing mode"
 
 
 @pytest.mark.asyncio

--- a/tldw_chatbook/Widgets/NewIngest/UnifiedProcessor.py
+++ b/tldw_chatbook/Widgets/NewIngest/UnifiedProcessor.py
@@ -126,9 +126,15 @@ class ModeToggle(Widget):
             yield Static("Simple processing mode", id="mode-description")
 
     def on_mount(self) -> None:
+        """Synchronize selected mode state after the widget is mounted."""
         self._sync_mode_buttons()
 
     def watch_current_mode(self, _mode: ProcessingMode) -> None:
+        """Refresh selected mode presentation when the reactive mode changes.
+
+        Args:
+            _mode: Updated processing mode value from the reactive watcher.
+        """
         if self.is_mounted:
             self._sync_mode_buttons()
 
@@ -143,12 +149,17 @@ class ModeToggle(Widget):
             self.current_mode = ProcessingMode.EXPERT
 
     def _sync_mode_buttons(self) -> None:
-        active_button_id = f"{self.button_id_prefix}{self.current_mode.value}-mode"
-        for button in self.query(Button):
+        mode_str = (
+            self.current_mode.value
+            if isinstance(self.current_mode, ProcessingMode)
+            else str(self.current_mode)
+        )
+        active_button_id = f"{self.button_id_prefix}{mode_str}-mode"
+        for button in self.query("#mode-selector Button"):
             button.set_class(button.id == active_button_id, "active")
 
         description = self.query_one("#mode-description", Static)
-        description.update(f"{self.current_mode.value.title()} processing mode")
+        description.update(f"{mode_str.title()} processing mode")
 
 
 class MediaSpecificOptions(Widget):

--- a/tldw_chatbook/Widgets/NewIngest/UnifiedProcessor.py
+++ b/tldw_chatbook/Widgets/NewIngest/UnifiedProcessor.py
@@ -125,6 +125,13 @@ class ModeToggle(Widget):
                 yield Button("Expert", id=f"{self.button_id_prefix}expert-mode")
             yield Static("Simple processing mode", id="mode-description")
 
+    def on_mount(self) -> None:
+        self._sync_mode_buttons()
+
+    def watch_current_mode(self, _mode: ProcessingMode) -> None:
+        if self.is_mounted:
+            self._sync_mode_buttons()
+
     @on(Button.Pressed)
     def _set_mode(self, event: Button.Pressed) -> None:
         button_id = event.button.id or ""
@@ -134,6 +141,14 @@ class ModeToggle(Widget):
             self.current_mode = ProcessingMode.ADVANCED
         elif button_id.endswith("expert-mode"):
             self.current_mode = ProcessingMode.EXPERT
+
+    def _sync_mode_buttons(self) -> None:
+        active_button_id = f"{self.button_id_prefix}{self.current_mode.value}-mode"
+        for button in self.query(Button):
+            button.set_class(button.id == active_button_id, "active")
+
+        description = self.query_one("#mode-description", Static)
+        description.update(f"{self.current_mode.value.title()} processing mode")
 
 
 class MediaSpecificOptions(Widget):

--- a/tldw_chatbook/css/features/_new_ingest.tcss
+++ b/tldw_chatbook/css/features/_new_ingest.tcss
@@ -635,32 +635,33 @@
     text-align: center;
 }
 
-.mode-selector {
+#mode-selector {
     layout: horizontal;
     height: auto;
     margin-bottom: 2;
     align: center middle;
 }
 
-.mode-selector RadioButton {
+#mode-selector Button {
     margin-right: 3;
     background: $surface;
-    border: solid $primary;
-    /* border-radius: 20px; - not supported in TCSS */
-    border: round $accent;
+    color: $text-muted;
+    border: round $border;
     padding: 1 2;
     transition: all 0.2s ease;
 }
 
-.mode-selector RadioButton:hover {
-    background: $primary 20%;
-    border: solid $accent;
+#mode-selector Button:hover {
+    background: $surface-lighten-1;
+    color: $text;
+    border: round $border;
 }
 
-.mode-selector RadioButton.-active {
-    background: $primary;
-    color: $surface;
-    border: solid $primary;
+#mode-selector Button.active {
+    background: $ds-focus-bg;
+    color: $ds-focus-fg;
+    border: round $ds-focus-accent;
+    text-style: bold underline;
 }
 
 .mode-description {

--- a/tldw_chatbook/css/features/_new_ingest.tcss
+++ b/tldw_chatbook/css/features/_new_ingest.tcss
@@ -664,7 +664,7 @@
     text-style: bold underline;
 }
 
-.mode-description {
+#mode-description {
     color: $text-muted;
     font-style: italic;
     text-align: center;


### PR DESCRIPTION
## Summary
- Updates New Ingest `ModeToggle` to mark the selected mode `Button` with an `active` class and keep the description synchronized.
- Replaces dead source-only `_new_ingest.tcss` `.mode-selector RadioButton` rules with `#mode-selector Button` rules matching the actual widget.
- Adds widget and CSS contract tests to prevent the dead selector mismatch from returning.

## Test Plan
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Widgets/test_unified_processor.py Tests/UI/test_non_obscuring_focus_contract.py Tests/UI/test_focus_accessibility.py -q`
- [x] `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m py_compile Tests/Widgets/test_unified_processor.py Tests/UI/test_non_obscuring_focus_contract.py tldw_chatbook/Widgets/NewIngest/UnifiedProcessor.py`
- [x] `git diff --check HEAD`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the New Ingest mode selector with actual `Button` usage: adds an `.active` class, syncs selection/description on mount and mode changes, and replaces dead RadioButton CSS with `#mode-selector Button` rules. Updates tests to lock the visual and interaction contract.

- **Bug Fixes**
  - Widget syncs `.active` on mount and when `current_mode` changes; updates `#mode-description` text.
  - CSS replaces `.mode-selector RadioButton*` and `.mode-description` with `#mode-selector Button` and `#mode-description`; sets base/hover/active with `$border`, `$surface-lighten-1`, `$ds-focus-*`, plus `text-style: bold underline`.
  - Tests assert only `Button`s are used, correct IDs/order, `.active` toggles with mode changes, description text updates, and no old RadioButton selectors; adds selected-state readability and no-dominant-geometry checks.

<sup>Written for commit df27710920b6d3fe41ef96c50242f6cee1c15985. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

