### PR TITLE
Fix Textual Web viewport density

### DIFF
--- a/Tests/Web_Server/test_textual_web_viewport.py
+++ b/Tests/Web_Server/test_textual_web_viewport.py
@@ -1,6 +1,60 @@
 import asyncio
 
+import pytest
+
 from tldw_chatbook.Web_Server import serve
+
+
+pytestmark = pytest.mark.skipif(
+    not serve.check_web_server_available(),
+    reason="web server optional dependencies are unavailable",
+)
+
+
+class FakeTextualServeServer:
+    """Server base that exercises Chatbook overrides without spawning a server."""
+
+    def __init__(
+        self,
+        command: str,
+        host: str,
+        port: int,
+        title: str,
+        *,
+        public_url: str | None = None,
+        statics_path: str = "/tmp/static",
+        templates_path: str = "/tmp/templates",
+    ):
+        self.command = command
+        self.host = host
+        self.port = port
+        self.title = title
+        self.public_url = public_url or f"http://{host}:{port}"
+        self.statics_path = statics_path
+        self.templates_path = templates_path
+
+    async def handle_websocket(self, request):
+        raise NotImplementedError
+
+    async def handle_download(self, request):
+        raise NotImplementedError
+
+    async def on_startup(self, app):
+        return None
+
+    async def on_shutdown(self, app):
+        return None
+
+
+def _make_test_server(**kwargs):
+    server_class = serve.build_chatbook_web_server_class(FakeTextualServeServer)
+    return server_class(
+        command="python -m tldw_chatbook.app",
+        host="127.0.0.1",
+        port=0,
+        title="test",
+        **kwargs,
+    )
 
 
 def test_web_font_size_defaults_to_dense_terminal_cells(monkeypatch):
@@ -20,6 +74,8 @@ def test_web_font_size_config_fills_missing_or_invalid_query(monkeypatch):
 
     assert serve.resolve_web_font_size(None) == 14
     assert serve.resolve_web_font_size("not-a-size") == 14
+    assert serve.resolve_web_font_size("64") == 14
+    assert serve.resolve_web_font_size("12.5") == 14
 
 
 def test_textual_serve_resize_patch_forces_full_terminal_repaint():
@@ -32,6 +88,7 @@ def test_textual_serve_resize_patch_forces_full_terminal_repaint():
     patched = serve.patch_textual_serve_viewport_js(upstream)
 
     assert "window.addEventListener(\"resize\",this._chatbookViewportResize)" in patched
+    assert "window.onresize=this._chatbookViewportResize" not in patched
     assert "ResizeObserver" in patched
     assert "this.terminal.refresh(0,this.terminal.rows-1)" in patched
     assert "this.terminal.clearTextureAtlas" in patched
@@ -48,19 +105,50 @@ def test_textual_serve_resize_patch_fails_closed_when_upstream_changes():
     assert patched == upstream
 
 
-def test_chatbook_web_server_overrides_textual_js_before_static_assets():
-    server = serve.ChatbookWebServer(
-        command="python -m tldw_chatbook.app",
-        host="127.0.0.1",
-        port=0,
-        title="test",
-    )
+def test_chatbook_web_server_overrides_textual_js_before_static_assets(tmp_path):
+    server = _make_test_server(statics_path=str(tmp_path))
 
     app = asyncio.run(server._make_app())
+    resources = list(app.router.resources())
     route_keys = [
         resource.get_info().get("path") or resource.get_info().get("prefix")
-        for resource in app.router.resources()
+        for resource in resources
     ]
+    static_resource = resources[route_keys.index("/static")]
 
     assert "/static/js/textual.js" in route_keys
     assert route_keys.index("/static/js/textual.js") < route_keys.index("/static")
+    assert getattr(static_resource, "_show_index", None) is False
+
+
+def test_chatbook_web_server_uses_urlparse_for_ipv6_websocket_url():
+    server = _make_test_server(public_url="https://[::1]:8443")
+
+    assert server._app_websocket_url == "wss://[::1]:8443/ws"
+
+
+def test_patched_textual_js_is_cached_until_source_changes(tmp_path, monkeypatch):
+    js_dir = tmp_path / "js"
+    js_dir.mkdir()
+    source = (
+        "before this.webglAddon=new p.WebglAddon,this.terminal.loadAddon(this.webglAddon),"
+        "this.canvasAddon=new m.CanvasAddon,this.terminal.loadAddon(this.canvasAddon),"
+        "window.onresize=()=>{this.fit()} after"
+    )
+    (js_dir / "textual.js").write_text(source, encoding="utf-8")
+    server = _make_test_server(statics_path=str(tmp_path))
+    patch_calls = 0
+    original_patch = serve.patch_textual_serve_viewport_js
+
+    def counted_patch(js_source: str) -> str:
+        nonlocal patch_calls
+        patch_calls += 1
+        return original_patch(js_source)
+
+    monkeypatch.setattr(serve, "patch_textual_serve_viewport_js", counted_patch)
+
+    first = server._patched_textual_js()
+    second = server._patched_textual_js()
+
+    assert first == second
+    assert patch_calls == 1

--- a/Tests/Web_Server/test_textual_web_viewport.py
+++ b/Tests/Web_Server/test_textual_web_viewport.py
@@ -1,0 +1,66 @@
+import asyncio
+
+from tldw_chatbook.Web_Server import serve
+
+
+def test_web_font_size_defaults_to_dense_terminal_cells(monkeypatch):
+    monkeypatch.setattr(serve, "get_cli_setting", lambda *_, default=None: default)
+
+    assert serve.resolve_web_font_size(None) == 12
+
+
+def test_web_font_size_query_overrides_default(monkeypatch):
+    monkeypatch.setattr(serve, "get_cli_setting", lambda *_, default=None: default)
+
+    assert serve.resolve_web_font_size("16") == 16
+
+
+def test_web_font_size_config_fills_missing_or_invalid_query(monkeypatch):
+    monkeypatch.setattr(serve, "get_cli_setting", lambda *_, default=None: "14")
+
+    assert serve.resolve_web_font_size(None) == 14
+    assert serve.resolve_web_font_size("not-a-size") == 14
+
+
+def test_textual_serve_resize_patch_forces_full_terminal_repaint():
+    upstream = (
+        "before this.webglAddon=new p.WebglAddon,this.terminal.loadAddon(this.webglAddon),"
+        "this.canvasAddon=new m.CanvasAddon,this.terminal.loadAddon(this.canvasAddon),"
+        "window.onresize=()=>{this.fit()} after"
+    )
+
+    patched = serve.patch_textual_serve_viewport_js(upstream)
+
+    assert "window.addEventListener(\"resize\",this._chatbookViewportResize)" in patched
+    assert "ResizeObserver" in patched
+    assert "this.terminal.refresh(0,this.terminal.rows-1)" in patched
+    assert "this.terminal.clearTextureAtlas" in patched
+    assert "new p.WebglAddon" not in patched
+    assert "new m.CanvasAddon" not in patched
+    assert patched != upstream
+
+
+def test_textual_serve_resize_patch_fails_closed_when_upstream_changes():
+    upstream = "before window.onresize=()=>{this.fit()} after"
+
+    patched = serve.patch_textual_serve_viewport_js(upstream)
+
+    assert patched == upstream
+
+
+def test_chatbook_web_server_overrides_textual_js_before_static_assets():
+    server = serve.ChatbookWebServer(
+        command="python -m tldw_chatbook.app",
+        host="127.0.0.1",
+        port=0,
+        title="test",
+    )
+
+    app = asyncio.run(server._make_app())
+    route_keys = [
+        resource.get_info().get("path") or resource.get_info().get("prefix")
+        for resource in app.router.resources()
+    ]
+
+    assert "/static/js/textual.js" in route_keys
+    assert route_keys.index("/static/js/textual.js") < route_keys.index("/static")

--- a/tldw_chatbook/Web_Server/README.md
+++ b/tldw_chatbook/Web_Server/README.md
@@ -52,8 +52,13 @@ enabled = true
 host = "localhost"
 port = 8000
 title = "tldw chatbook"
+font_size = 12
 debug = false
 ```
+
+`font_size` controls the browser terminal cell density. The default `12` keeps
+the web UI close to native terminal screenshots; use `?fontsize=16` in the URL
+or set `font_size = 16` if you prefer larger text.
 
 ## Security Considerations
 

--- a/tldw_chatbook/Web_Server/serve.py
+++ b/tldw_chatbook/Web_Server/serve.py
@@ -14,6 +14,139 @@ from loguru import logger
 from ..Utils.optional_deps import DEPENDENCIES_AVAILABLE, require_dependency
 from ..config import get_cli_setting
 
+try:
+    from textual_serve.server import Server as TextualServeServer
+except ImportError:  # pragma: no cover - create_server reports the missing optional dep.
+    TextualServeServer = object
+
+
+_TEXTUAL_SERVE_RESIZE_HOOK = "window.onresize=()=>{this.fit()}"
+_TEXTUAL_SERVE_CANVAS_RENDERERS = (
+    "this.webglAddon=new p.WebglAddon,this.terminal.loadAddon(this.webglAddon),"
+    "this.canvasAddon=new m.CanvasAddon,this.terminal.loadAddon(this.canvasAddon),"
+)
+_CHATBOOK_VIEWPORT_PATCH_MARKER = "this._chatbookViewportResize"
+_CHATBOOK_DEFAULT_WEB_FONT_SIZE = 12
+
+
+def _to_int(value: object, default: int) -> int:
+    """Convert a value to int or return the supplied default."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def resolve_web_font_size(query_value: str | None) -> int:
+    """Resolve the Textual Web font size using query, config, then app default."""
+    configured_value = get_cli_setting(
+        "web_server",
+        "font_size",
+        default=_CHATBOOK_DEFAULT_WEB_FONT_SIZE,
+    )
+    configured_font_size = _to_int(configured_value, _CHATBOOK_DEFAULT_WEB_FONT_SIZE)
+    if query_value is None:
+        return configured_font_size
+    return _to_int(query_value, configured_font_size)
+
+
+def patch_textual_serve_viewport_js(source: str) -> str:
+    """Patch textual-serve's browser resize hook to repaint after viewport changes."""
+    if _CHATBOOK_VIEWPORT_PATCH_MARKER in source:
+        return source
+    if (
+        _TEXTUAL_SERVE_RESIZE_HOOK not in source
+        or _TEXTUAL_SERVE_CANVAS_RENDERERS not in source
+    ):
+        return source
+
+    patched = source.replace(
+        _TEXTUAL_SERVE_CANVAS_RENDERERS,
+        "this.webglAddon=null,this.canvasAddon=null,",
+        1,
+    )
+
+    resize_replacement = (
+        "this._chatbookViewportRepaint=()=>{"
+        "this.fit();"
+        "try{this.terminal.clearTextureAtlas&&this.terminal.clearTextureAtlas()}catch(e){}"
+        "try{this.terminal.refresh(0,this.terminal.rows-1)}catch(e){}"
+        "};"
+        "this._chatbookViewportResize=()=>{"
+        "this._chatbookViewportRepaint();"
+        "clearTimeout(this._chatbookViewportResizeTimer);"
+        "this._chatbookViewportResizeTimer=setTimeout(this._chatbookViewportRepaint,75);"
+        "requestAnimationFrame(this._chatbookViewportRepaint)"
+        "};"
+        "window.addEventListener(\"resize\",this._chatbookViewportResize);"
+        "window.onresize=this._chatbookViewportResize;"
+        "try{new ResizeObserver(this._chatbookViewportResize).observe(this.element)}catch(e){}"
+    )
+    return patched.replace(_TEXTUAL_SERVE_RESIZE_HOOK, resize_replacement, 1)
+
+
+class ChatbookWebServer(TextualServeServer):
+    """Textual web server with Chatbook-specific viewport resize hardening."""
+
+    async def _make_app(self):
+        """Make the aiohttp app and override only the resize-sensitive JS asset."""
+        import aiohttp_jinja2
+        import jinja2
+        from aiohttp import web
+
+        app = web.Application()
+        aiohttp_jinja2.setup(app, loader=jinja2.FileSystemLoader(self.templates_path))
+
+        routes = [
+            web.get("/", self.handle_index, name="index"),
+            web.get("/ws", self.handle_websocket, name="websocket"),
+            web.get("/download/{key}", self.handle_download, name="download"),
+            web.get("/static/js/textual.js", self.handle_textual_js, name="textual_js"),
+            web.static("/static", self.statics_path, show_index=True, name="static"),
+        ]
+        app.add_routes(routes)
+
+        app.on_startup.append(self.on_startup)
+        app.on_shutdown.append(self.on_shutdown)
+        return app
+
+    @property
+    def _static_url(self) -> str:
+        """Return the public static asset URL with a trailing slash."""
+        return f"{self.public_url}/static/"
+
+    @property
+    def _app_websocket_url(self) -> str:
+        """Return the public websocket URL used by textual-serve's browser client."""
+        websocket_url = f"{self.public_url}/ws"
+        if websocket_url.startswith("https"):
+            return "wss:" + websocket_url.split(":", 1)[1]
+        return "ws:" + websocket_url.split(":", 1)[1]
+
+    async def handle_index(self, request):
+        """Serve the HTML shell with Chatbook's denser terminal default."""
+        import aiohttp_jinja2
+
+        font_size = resolve_web_font_size(request.query.get("fontsize"))
+        context = {
+            "font_size": font_size,
+            "app_websocket_url": self._app_websocket_url,
+            "config": {"static": {"url": self._static_url}},
+            "application": {"name": self.title},
+        }
+        return aiohttp_jinja2.render_template("app_index.html", request, context)
+
+    async def handle_textual_js(self, request):
+        """Serve textual-serve JS with a full repaint after browser viewport resize."""
+        from aiohttp import web
+
+        source_path = Path(self.statics_path) / "js" / "textual.js"
+        source = source_path.read_text(encoding="utf-8")
+        return web.Response(
+            text=patch_textual_serve_viewport_js(source),
+            content_type="application/javascript",
+        )
+
 
 def check_web_server_available() -> bool:
     """Check if web server dependencies are available."""
@@ -44,9 +177,6 @@ def create_server(
     # Require the dependency
     textual_serve = require_dependency('textual_serve', 'web')
     
-    # Import the Server class
-    from textual_serve.server import Server
-    
     # Create the command to run the app
     # textual-serve expects a command string, not a list
     command = f"{sys.executable} -m tldw_chatbook.app"
@@ -57,7 +187,7 @@ def create_server(
     
     # Create the server
     logger.info(f"Creating web server on {host}:{port}")
-    server = Server(
+    server = ChatbookWebServer(
         command=command,
         host=host,
         port=port,

--- a/tldw_chatbook/Web_Server/serve.py
+++ b/tldw_chatbook/Web_Server/serve.py
@@ -7,17 +7,15 @@ allowing users to access the TUI through their web browser.
 """
 
 import sys
-from typing import Optional
 from pathlib import Path
+from typing import Optional
+from urllib.parse import urlparse, urlunparse
+
 from loguru import logger
 
+from ..Utils.input_validation import validate_number_range
 from ..Utils.optional_deps import DEPENDENCIES_AVAILABLE, require_dependency
 from ..config import get_cli_setting
-
-try:
-    from textual_serve.server import Server as TextualServeServer
-except ImportError:  # pragma: no cover - create_server reports the missing optional dep.
-    TextualServeServer = object
 
 
 _TEXTUAL_SERVE_RESIZE_HOOK = "window.onresize=()=>{this.fit()}"
@@ -27,14 +25,27 @@ _TEXTUAL_SERVE_CANVAS_RENDERERS = (
 )
 _CHATBOOK_VIEWPORT_PATCH_MARKER = "this._chatbookViewportResize"
 _CHATBOOK_DEFAULT_WEB_FONT_SIZE = 12
+_CHATBOOK_MIN_WEB_FONT_SIZE = 6
+_CHATBOOK_MAX_WEB_FONT_SIZE = 32
 
 
-def _to_int(value: object, default: int) -> int:
-    """Convert a value to int or return the supplied default."""
+def _coerce_web_font_size(value: object, default: int) -> int:
+    """Validate and coerce a configured or requested web terminal font size."""
+    if not validate_number_range(
+        value,
+        min_val=_CHATBOOK_MIN_WEB_FONT_SIZE,
+        max_val=_CHATBOOK_MAX_WEB_FONT_SIZE,
+    ):
+        return default
+
     try:
-        return int(value)
+        numeric_value = float(value)
     except (TypeError, ValueError):
         return default
+
+    if not numeric_value.is_integer():
+        return default
+    return int(numeric_value)
 
 
 def resolve_web_font_size(query_value: str | None) -> int:
@@ -44,10 +55,13 @@ def resolve_web_font_size(query_value: str | None) -> int:
         "font_size",
         default=_CHATBOOK_DEFAULT_WEB_FONT_SIZE,
     )
-    configured_font_size = _to_int(configured_value, _CHATBOOK_DEFAULT_WEB_FONT_SIZE)
+    configured_font_size = _coerce_web_font_size(
+        configured_value,
+        _CHATBOOK_DEFAULT_WEB_FONT_SIZE,
+    )
     if query_value is None:
         return configured_font_size
-    return _to_int(query_value, configured_font_size)
+    return _coerce_web_font_size(query_value, configured_font_size)
 
 
 def patch_textual_serve_viewport_js(source: str) -> str:
@@ -79,13 +93,12 @@ def patch_textual_serve_viewport_js(source: str) -> str:
         "requestAnimationFrame(this._chatbookViewportRepaint)"
         "};"
         "window.addEventListener(\"resize\",this._chatbookViewportResize);"
-        "window.onresize=this._chatbookViewportResize;"
         "try{new ResizeObserver(this._chatbookViewportResize).observe(this.element)}catch(e){}"
     )
     return patched.replace(_TEXTUAL_SERVE_RESIZE_HOOK, resize_replacement, 1)
 
 
-class ChatbookWebServer(TextualServeServer):
+class ChatbookWebServerMixin:
     """Textual web server with Chatbook-specific viewport resize hardening."""
 
     async def _make_app(self):
@@ -102,7 +115,7 @@ class ChatbookWebServer(TextualServeServer):
             web.get("/ws", self.handle_websocket, name="websocket"),
             web.get("/download/{key}", self.handle_download, name="download"),
             web.get("/static/js/textual.js", self.handle_textual_js, name="textual_js"),
-            web.static("/static", self.statics_path, show_index=True, name="static"),
+            web.static("/static", self.statics_path, show_index=False, name="static"),
         ]
         app.add_routes(routes)
 
@@ -113,15 +126,14 @@ class ChatbookWebServer(TextualServeServer):
     @property
     def _static_url(self) -> str:
         """Return the public static asset URL with a trailing slash."""
-        return f"{self.public_url}/static/"
+        return f"{self.public_url.rstrip('/')}/static/"
 
     @property
     def _app_websocket_url(self) -> str:
         """Return the public websocket URL used by textual-serve's browser client."""
-        websocket_url = f"{self.public_url}/ws"
-        if websocket_url.startswith("https"):
-            return "wss:" + websocket_url.split(":", 1)[1]
-        return "ws:" + websocket_url.split(":", 1)[1]
+        parsed_url = urlparse(f"{self.public_url.rstrip('/')}/ws")
+        websocket_scheme = "wss" if parsed_url.scheme == "https" else "ws"
+        return urlunparse(parsed_url._replace(scheme=websocket_scheme))
 
     async def handle_index(self, request):
         """Serve the HTML shell with Chatbook's denser terminal default."""
@@ -136,16 +148,47 @@ class ChatbookWebServer(TextualServeServer):
         }
         return aiohttp_jinja2.render_template("app_index.html", request, context)
 
+    def _patched_textual_js(self) -> str:
+        """Return cached patched textual-serve JS, refreshing when the file changes."""
+        source_path = Path(self.statics_path) / "js" / "textual.js"
+        source_stat = source_path.stat()
+        cached_mtime = getattr(self, "_cached_textual_js_mtime_ns", None)
+        cached_text = getattr(self, "_cached_textual_js", None)
+
+        if cached_text is not None and cached_mtime == source_stat.st_mtime_ns:
+            return cached_text
+
+        source = source_path.read_text(encoding="utf-8")
+        patched = patch_textual_serve_viewport_js(source)
+        self._cached_textual_js = patched
+        self._cached_textual_js_mtime_ns = source_stat.st_mtime_ns
+        return patched
+
     async def handle_textual_js(self, request):
         """Serve textual-serve JS with a full repaint after browser viewport resize."""
         from aiohttp import web
 
-        source_path = Path(self.statics_path) / "js" / "textual.js"
-        source = source_path.read_text(encoding="utf-8")
         return web.Response(
-            text=patch_textual_serve_viewport_js(source),
+            text=self._patched_textual_js(),
             content_type="application/javascript",
         )
+
+
+def _load_textual_serve_server_class() -> type:
+    """Load textual-serve's Server class after the optional dependency gate."""
+    require_dependency('textual_serve', 'web')
+    from textual_serve.server import Server as TextualServeServer
+
+    return TextualServeServer
+
+
+def build_chatbook_web_server_class(textual_serve_server_class: type) -> type:
+    """Build the Chatbook server subclass from a provided textual-serve base."""
+    class ChatbookWebServer(ChatbookWebServerMixin, textual_serve_server_class):
+        pass
+
+    ChatbookWebServer.__name__ = "ChatbookWebServer"
+    return ChatbookWebServer
 
 
 def check_web_server_available() -> bool:
@@ -174,8 +217,10 @@ def create_server(
     Raises:
         ImportError: If textual-serve is not installed
     """
-    # Require the dependency
-    textual_serve = require_dependency('textual_serve', 'web')
+    textual_serve_server_class = _load_textual_serve_server_class()
+    chatbook_web_server_class = build_chatbook_web_server_class(
+        textual_serve_server_class,
+    )
     
     # Create the command to run the app
     # textual-serve expects a command string, not a list
@@ -187,7 +232,7 @@ def create_server(
     
     # Create the server
     logger.info(f"Creating web server on {host}:{port}")
-    server = ChatbookWebServer(
+    server = chatbook_web_server_class(
         command=command,
         host=host,
         port=port,

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -2671,6 +2671,7 @@ enabled = true  # Enable web server functionality
 host = "localhost"  # Host address to bind to
 port = 8000  # Port to bind to
 title = "tldw chatbook"  # Title for the web page
+font_size = 12  # Browser terminal font size; 12 keeps Textual Web close to native terminal density
 debug = false  # Enable debug mode for development
 """
 


### PR DESCRIPTION
## Summary
- Override the served Textual Web JS asset with a guarded viewport repaint patch so the browser surface fills the available viewport.
- Default web terminal font size to 12 cells for native-like density while preserving config and `?fontsize=` overrides.
- Document `web_server.font_size` and add focused regression tests for the viewport patch and font-size precedence.

## Test Plan
- `python -m pytest -q Tests/Web_Server/test_textual_web_viewport.py --tb=short`
- `python - <<'PY'\nfrom tldw_chatbook.config import DEFAULT_CONFIG_FROM_TOML\nassert DEFAULT_CONFIG_FROM_TOML['web_server']['font_size'] == 12\nprint('web_server.font_size=12')\nPY`
- `git diff --check origin/dev..HEAD`

## Visual QA
- Captured actual Textual Web screenshot at 1600x900 and user approved the density/fill correction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Textual Web viewport density by patching `textual_serve` client JS to repaint on resize so the terminal fills the browser viewport. Sets the web terminal default font size to 12 for native-like density, with URL and config overrides.

- **Bug Fixes**
  - Replace the resize hook with a guarded full repaint (uses `ResizeObserver` and `requestAnimationFrame`), disable WebGL/Canvas renderers, and force a full terminal refresh to avoid texture atlas artifacts and ensure viewport fill.
  - Generate correct websocket URLs (handles `wss` and IPv6 via `urlparse`) and serve the patched `textual.js` via a dedicated route ahead of `/static`, with mtime-based caching and no directory index.

- **New Features**
  - Add `web_server.font_size` (default 12) with precedence: `?fontsize=` query > config > default; documented and covered by tests.

<sup>Written for commit 3075ae5900a846b0c17ce6d744b8e2f41aae400a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

