### PR TITLE
Fix Settings diagnostics config source handling

### DIFF
--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -1335,6 +1335,8 @@ class SettingsScreen(BaseAppScreen):
 
     def _diagnostics_validation_and_reload_results(self) -> tuple[str, str, dict | None]:
         adapter = SettingsConfigAdapter()
+        try:
+            config_path = self._config_path()
         except Exception as exc:
             message = redact_secret_text(str(exc))
             source = "Config source: invalid"


### PR DESCRIPTION
Fixes a merged dev regression in Settings diagnostics by restoring the missing config path try block while preserving the non-duplicating invalid config source copy expected by existing tests. Verification: python -m py_compile tldw_chatbook/UI/Screens/settings_screen.py; python -m pytest -q Tests/UI/test_settings_configuration_hub.py --tb=short; git diff --check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the missing try/except when resolving the config path in Settings diagnostics. This fixes the dev regression, correctly marks invalid config sources without duplicate text, and keeps existing tests passing.

<sup>Written for commit b1f341e03940e0354ae1a279402ac470993fa2b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

