### PR TITLE
Fix Console readiness after Settings merge

### DIFF
--- a/Tests/Chat/test_console_session_settings.py
+++ b/Tests/Chat/test_console_session_settings.py
@@ -262,6 +262,38 @@ def test_readiness_allows_llamacpp_configured_v1_endpoint_normalized_to_root() -
     assert readiness.native_send_supported is True
 
 
+def test_readiness_allows_llamacpp_default_endpoint_without_saved_config() -> None:
+    readiness = build_console_settings_readiness(
+        ConsoleSessionSettings(
+            provider="llama_cpp",
+            model="llama3",
+            base_url=session_settings.DEFAULT_LLAMACPP_BASE_URL,
+        ),
+        app_config={"chat_defaults": {"provider": "llama_cpp", "model": "llama3"}},
+        environ={},
+    )
+
+    assert readiness.label == "Ready"
+    assert readiness.native_send_supported is True
+
+
+def test_readiness_blocks_llamacpp_custom_endpoint_without_saved_config() -> None:
+    readiness = build_console_settings_readiness(
+        ConsoleSessionSettings(
+            provider="llama_cpp",
+            model="llama3",
+            base_url="http://127.0.0.1:9191",
+        ),
+        app_config={"chat_defaults": {"provider": "llama_cpp", "model": "llama3"}},
+        environ={},
+    )
+
+    assert readiness.label == "Endpoint not saved"
+    assert readiness.native_send_supported is False
+    assert "Selected endpoint: http://127.0.0.1:9191" in readiness.detail
+    assert "Saved endpoint: not saved" in readiness.detail
+
+
 def test_readiness_blocks_unsaved_generic_endpoint_with_safe_details() -> None:
     readiness = build_console_settings_readiness(
         ConsoleSessionSettings(

--- a/tldw_chatbook/Chat/console_session_settings.py
+++ b/tldw_chatbook/Chat/console_session_settings.py
@@ -603,7 +603,11 @@ def _endpoint_differs_for_provider(
     if provider_key in {"llama_cpp", "local_llamacpp"}:
         configured_endpoint = first_configured_endpoint(provider_settings)
         if not configured_endpoint:
-            return bool(normalize_generic_endpoint_for_compare(base_url))
+            selected = normalize_generic_endpoint_for_compare(
+                normalize_llamacpp_base_url(base_url)
+            )
+            default = normalize_generic_endpoint_for_compare(DEFAULT_LLAMACPP_BASE_URL)
+            return bool(selected) and selected != default
         selected = normalize_generic_endpoint_for_compare(normalize_llamacpp_base_url(base_url))
         configured = normalize_generic_endpoint_for_compare(normalize_llamacpp_base_url(configured_endpoint))
         return selected != configured

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -1335,6 +1335,8 @@ class SettingsScreen(BaseAppScreen):
 
     def _diagnostics_validation_and_reload_results(self) -> tuple[str, str, dict | None]:
         adapter = SettingsConfigAdapter()
+        try:
+            config_path = self._config_path()
         except Exception as exc:
             message = redact_secret_text(str(exc))
             source = "Config source: invalid"


### PR DESCRIPTION
## Summary
- Repair the Settings diagnostics helper syntax regression from latest dev.
- Treat the built-in llama.cpp default endpoint as a real default instead of an unsaved Console override.
- Keep custom unsaved llama.cpp endpoints blocked and covered by regression tests.

## Tests
- python -m py_compile tldw_chatbook/UI/Screens/settings_screen.py tldw_chatbook/Chat/console_session_settings.py
- python -m pytest -q Tests/Chat/test_console_session_settings.py --tb=short
- python -m pytest -q Tests/Chat/test_console_session_settings.py Tests/UI/test_settings_configuration_hub.py::test_settings_diagnostics_combined_helper_validates_once Tests/UI/test_settings_configuration_hub.py::test_settings_diagnostics_combined_helper_skips_reload_when_invalid Tests/UI/test_settings_configuration_hub.py::test_settings_diagnostics_results_include_config_source_and_redact_errors Tests/UI/test_settings_configuration_hub.py::test_settings_diagnostics_invalid_config_source_does_not_duplicate_error --tb=short
- env HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share python -m pytest -q Tests/UI/test_console_internals_decomposition.py Tests/UI/test_console_persistent_rails.py Tests/UI/test_console_native_chat_flow.py --tb=short
- git diff --check

## Visual QA
- Captured Console empty and typed post-merge screenshots during the QA pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Console readiness after the Settings merge. Treats the built‑in `llama.cpp` default endpoint as a true default and repairs the diagnostics helper to prevent false "unsaved endpoint" warnings and crashes.

- **Bug Fixes**
  - Readiness: when provider is `llama_cpp` and no endpoint is saved, allow the default base URL; block unsaved custom endpoints with clear details.
  - Diagnostics: wrap config path lookup in try/except to validate once, mark invalid sources correctly, and redact error messages.

<sup>Written for commit f52229627b4bf250ef97f43f996a75f93c4dc70f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

