### PR TITLE
Add Sync v2 conflict review recovery

### DIFF
--- a/Tests/Sync_Interop/test_local_first_sync_service.py
+++ b/Tests/Sync_Interop/test_local_first_sync_service.py
@@ -338,6 +338,12 @@ async def test_local_first_sync_once_drains_persisted_outbox_and_records_push_fa
         dataset_id="dataset-1",
         status="dispatched",
     )
+    reviews = repo.list_sync_v2_conflict_reviews(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-1",
+        dataset_id="dataset-1",
+    )
 
     assert [envelope["client_envelope_id"] for envelope in server.calls[0][3]] == [
         accepted.client_envelope_id,
@@ -356,6 +362,9 @@ async def test_local_first_sync_once_drains_persisted_outbox_and_records_push_fa
     ]
     assert pending_after[0]["last_error"]["error_code"] == "stale_base"
     assert pending_after[1]["last_error"]["error_code"] == "conflict"
+    assert reviews[0]["source_conflict_key"] == conflicted.client_envelope_id
+    assert reviews[0]["item_label"] == "notes note-3"
+    assert reviews[0]["recovery_options"]["accept-remote"] == "available"
     assert repo.get_sync_v2_profile_state(
         server_profile_id="server-a",
         authenticated_principal_id="user-a",
@@ -822,9 +831,18 @@ async def test_local_first_sync_once_preserves_push_and_apply_attention_statuses
         authenticated_principal_id="user-a",
         workspace_scope="workspace-1",
     )
+    reviews = repo.list_sync_v2_conflict_reviews(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-1",
+        dataset_id="dataset-1",
+    )
 
     assert result["outbox_retained"] == 1
     assert result["conflicts"][0]["conflict_type"] == "encrypted_content_edit"
+    assert reviews[0]["conflict_kind"] == "encrypted_content_edit"
+    assert reviews[0]["item_label"] == "notes note-2"
+    assert reviews[0]["recovery_options"]["keep-local"] == "available"
     assert profile["last_error"] == (
         "push_partial_failure: stale_base; apply_conflict: encrypted_content_edit"
     )

--- a/Tests/Sync_Interop/test_local_first_sync_service.py
+++ b/Tests/Sync_Interop/test_local_first_sync_service.py
@@ -848,6 +848,48 @@ async def test_local_first_sync_once_preserves_push_and_apply_attention_statuses
     )
 
 
+async def test_local_first_sync_apply_conflict_review_uses_safe_fallback_key(tmp_path):
+    dataset_key = generate_dataset_key()
+    repo = _repo_with_profile(tmp_path)
+    profile = repo.get_sync_v2_profile_state(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-1",
+    )
+    service = LocalFirstSyncService(
+        server_service=FakeLocalFirstServer(),
+        state_repository=repo,
+        local_store=RecordingLocalStore(),
+        dataset_keys={"dataset-1": dataset_key},
+    )
+
+    service._record_conflict_reviews(
+        profile=profile,
+        dataset_id="dataset-1",
+        outbox_entries=[],
+        push_conflicts=[],
+        apply_conflicts=[
+            {
+                "domain": "notes",
+                "conflict_type": "encrypted_content_edit",
+                "message": "Malformed apply conflict.",
+            }
+        ],
+    )
+    reviews = repo.list_sync_v2_conflict_reviews(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-1",
+        dataset_id="dataset-1",
+    )
+
+    assert reviews[0]["source_conflict_key"] != "None"
+    assert reviews[0]["source_conflict_key"].startswith(
+        "apply-conflict:notes:encrypted_content_edit:"
+    )
+    assert reviews[0]["item_label"] != "notes None"
+
+
 async def test_local_first_sync_once_uses_stable_push_idempotency_key_for_retry(tmp_path):
     dataset_key = generate_dataset_key()
     builder = SyncEnvelopeBuilder(

--- a/Tests/Sync_Interop/test_manual_sync_control.py
+++ b/Tests/Sync_Interop/test_manual_sync_control.py
@@ -78,6 +78,33 @@ class MutatingLocalFirstSync(RecordingLocalFirstSync):
         return dict(self.result)
 
 
+class FailingMutatingLocalFirstSync(RecordingLocalFirstSync):
+    def __init__(self, repo: SyncStateRepository, *, failed_client_envelope_id: str) -> None:
+        super().__init__(exc=RuntimeError("temporary network split"))
+        self.repo = repo
+        self.failed_client_envelope_id = failed_client_envelope_id
+
+    async def sync_once(self, **kwargs):
+        self.calls.append(kwargs)
+        self.repo.mark_sync_v2_outbox_push_results(
+            server_profile_id=kwargs["server_profile_id"],
+            authenticated_principal_id=kwargs["authenticated_principal_id"],
+            workspace_scope=kwargs["workspace_scope"],
+            dataset_id="dataset-1",
+            accepted=[],
+            rejected=[
+                {
+                    "client_envelope_id": self.failed_client_envelope_id,
+                    "error_code": "push_failed",
+                    "message": "temporary network split",
+                    "retryable": True,
+                }
+            ],
+            conflicts=[],
+        )
+        raise self.exc
+
+
 def _repo_with_profile(tmp_path, *, dataset_id: str | None = "dataset-1") -> SyncStateRepository:
     repo = SyncStateRepository(tmp_path / "manual_sync_state.db")
     repo.set_sync_v2_profile_state(
@@ -317,3 +344,88 @@ async def test_manual_sync_run_returns_post_run_pending_counts(tmp_path):
 
     assert result.status == "success"
     assert result.preview.pending_total == 1
+
+
+async def test_manual_sync_run_surfaces_conflict_review_items(tmp_path):
+    dataset_key = generate_dataset_key()
+    repo = _repo_with_profile(tmp_path)
+    repo.record_sync_v2_conflict_review(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-a",
+        dataset_id="dataset-1",
+        domain="chat",
+        item_label="Chat message msg-1",
+        cause="Remote assistant variant conflicts with local variant.",
+        local_summary="Local chat message retained.",
+        remote_summary="Remote chat message changed.",
+        source_conflict_key="msg-1:remote",
+        conflict_kind="chat_variant_conflict",
+        recovery_options={
+            "retry": "available",
+            "keep-local": "available",
+            "accept-remote": "available",
+            "duplicate-fork": "available",
+            "defer-later": "available",
+        },
+    )
+    sync_runner = RecordingLocalFirstSync(
+        {
+            "pushed_envelopes": 0,
+            "pulled_envelopes": 0,
+            "applied_envelopes": 0,
+            "outbox_dispatched": 0,
+            "outbox_retained": 1,
+            "rejected_envelopes": [],
+            "push_conflicts": [{"client_envelope_id": "msg-1"}],
+            "conflicts": [],
+        }
+    )
+    service = ManualSyncControlService(
+        state_repository=repo,
+        local_first_sync_service=sync_runner,
+        dataset_keys={"dataset-1": dataset_key},
+    )
+
+    result = await service.run_once(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-a",
+    )
+
+    assert result.status == "conflict"
+    assert result.conflict_reviews[0].item_label == "Chat message msg-1"
+    assert result.conflict_reviews[0].recovery_options["duplicate-fork"] == "available"
+
+
+async def test_manual_sync_failed_run_surfaces_retained_outbox_failure(tmp_path):
+    dataset_key = generate_dataset_key()
+    repo = _repo_with_profile(tmp_path)
+    _enqueue_note_and_chat(repo, dataset_key)
+    pending_before = repo.list_pending_sync_v2_outbox_envelopes(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-a",
+        dataset_id="dataset-1",
+    )
+    failed_id = str(pending_before[0]["client_envelope_id"])
+    sync_runner = FailingMutatingLocalFirstSync(
+        repo,
+        failed_client_envelope_id=failed_id,
+    )
+    service = ManualSyncControlService(
+        state_repository=repo,
+        local_first_sync_service=sync_runner,
+        dataset_keys={"dataset-1": dataset_key},
+    )
+
+    result = await service.run_once(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-a",
+    )
+
+    assert result.status == "failed"
+    assert result.conflict_reviews
+    assert result.conflict_reviews[0].cause == "push_failed: temporary network split"
+    assert result.conflict_reviews[0].recovery_options["retry"] == "available"

--- a/Tests/Sync_Interop/test_sync_state_repository.py
+++ b/Tests/Sync_Interop/test_sync_state_repository.py
@@ -727,6 +727,127 @@ def test_sync_v2_profile_summary_aggregates_state_counts_and_status(tmp_path):
     assert summary["last_mirror_report"]["domain"] == "notes"
 
 
+def test_sync_v2_profile_summary_combines_legacy_and_v2_conflicts_before_limit(tmp_path):
+    repo = SyncStateRepository(tmp_path / "sync_state.db")
+    repo.set_sync_v2_profile_state(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-1",
+        profile_mode="local_first_sync",
+        device_id="device-1",
+        dataset_id="dataset-1",
+    )
+    for index in range(6):
+        repo.record_identity_mapping(
+            source_authority="server",
+            server_profile_id="server-a",
+            authenticated_principal_id="user-a",
+            workspace_scope="workspace-1",
+            domain="notes",
+            entity_type="note",
+            local_entity_id=f"legacy-note-{index}",
+            remote_entity_id=f"legacy-remote-{index}-a",
+            mapping_status="confirmed",
+        )
+        repo.record_identity_mapping(
+            source_authority="server",
+            server_profile_id="server-a",
+            authenticated_principal_id="user-a",
+            workspace_scope="workspace-1",
+            domain="notes",
+            entity_type="note",
+            local_entity_id=f"legacy-note-{index}",
+            remote_entity_id=f"legacy-remote-{index}-b",
+            mapping_status="confirmed",
+        )
+    repo.record_sync_v2_conflict_review(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-1",
+        dataset_id="dataset-1",
+        domain="notes",
+        item_label="Newest v2 conflict",
+        cause="Remote edit conflicts with local edit.",
+        local_summary="Local note changed.",
+        remote_summary="Remote note changed.",
+        source_conflict_key="v2-conflict-1",
+        conflict_kind="encrypted_content_edit",
+        recovery_options={"retry": "available"},
+    )
+
+    summary = repo.get_sync_v2_profile_summary(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-1",
+    )
+
+    assert summary["conflicts"]["count"] == 7
+    assert len(summary["conflicts"]["latest"]) == 5
+    assert summary["conflicts"]["latest"][0]["item_label"] == "Newest v2 conflict"
+
+
+def test_sync_v2_conflict_review_listing_is_bounded_by_default_and_newest_first(tmp_path):
+    repo = SyncStateRepository(tmp_path / "sync_state.db")
+    for index in range(101):
+        repo.record_sync_v2_conflict_review(
+            server_profile_id="server-a",
+            authenticated_principal_id="user-a",
+            workspace_scope="workspace-1",
+            dataset_id="dataset-1",
+            domain="notes",
+            item_label=f"Conflict {index}",
+            cause="Remote edit conflicts with local edit.",
+            local_summary="Local note changed.",
+            remote_summary="Remote note changed.",
+            source_conflict_key=f"review-{index}",
+            conflict_kind="encrypted_content_edit",
+            recovery_options={"retry": "available"},
+        )
+
+    reviews = repo.list_sync_v2_conflict_reviews(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-1",
+        dataset_id="dataset-1",
+    )
+
+    assert len(reviews) == 100
+    assert reviews[0]["source_conflict_key"] == "review-100"
+    assert reviews[-1]["source_conflict_key"] == "review-1"
+
+
+def test_sync_v2_conflict_review_listing_filters_domain_before_limit(tmp_path):
+    repo = SyncStateRepository(tmp_path / "sync_state.db")
+    for domain in ("chat", "notes"):
+        for index in range(3):
+            repo.record_sync_v2_conflict_review(
+                server_profile_id="server-a",
+                authenticated_principal_id="user-a",
+                workspace_scope="workspace-1",
+                dataset_id="dataset-1",
+                domain=domain,
+                item_label=f"{domain} conflict {index}",
+                cause="Remote edit conflicts with local edit.",
+                local_summary="Local item changed.",
+                remote_summary="Remote item changed.",
+                source_conflict_key=f"{domain}-{index}",
+                conflict_kind="encrypted_content_edit",
+                recovery_options={"retry": "available"},
+            )
+
+    reviews = repo.list_sync_v2_conflict_reviews(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-1",
+        dataset_id="dataset-1",
+        domains=["notes"],
+        limit=2,
+    )
+
+    assert [review["source_conflict_key"] for review in reviews] == ["notes-2", "notes-1"]
+    assert {review["domain"] for review in reviews} == {"notes"}
+
+
 def test_sync_v2_profile_summary_reports_missing_profile(tmp_path):
     repo = SyncStateRepository(tmp_path / "sync_state.db")
 

--- a/Tests/Sync_Interop/test_sync_state_repository.py
+++ b/Tests/Sync_Interop/test_sync_state_repository.py
@@ -429,6 +429,9 @@ def test_sync_v2_schema_migration_updates_legacy_schema_version(tmp_path):
         outbox = conn.execute(
             "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'sync_v2_local_outbox'"
         ).fetchone()
+        conflict_reviews = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'sync_v2_conflict_reviews'"
+        ).fetchone()
         schema_version = conn.execute("SELECT MAX(version) FROM schema_version").fetchone()[0]
         schema_versions = [
             row[0]
@@ -444,8 +447,9 @@ def test_sync_v2_schema_migration_updates_legacy_schema_version(tmp_path):
         "dry_run_metadata",
     }.issubset(columns)
     assert outbox is not None
-    assert schema_version == 2
-    assert schema_versions == [2]
+    assert conflict_reviews is not None
+    assert schema_version == 3
+    assert schema_versions == [3]
 
 
 def test_sync_v2_profile_column_migration_validates_column_identifiers(tmp_path, monkeypatch):

--- a/Tests/Sync_Interop/test_sync_v2_conflict_review.py
+++ b/Tests/Sync_Interop/test_sync_v2_conflict_review.py
@@ -115,3 +115,78 @@ def test_conflict_review_service_maps_retained_outbox_failures_without_plaintext
     assert reviews[0].recovery_options["defer-later"] == "available"
     assert "Private" not in str(reviews[0])
 
+
+def test_conflict_review_service_prefers_newest_durable_rows_and_dedupes_retained_failures(tmp_path):
+    dataset_key = generate_dataset_key()
+    builder = SyncEnvelopeBuilder(
+        dataset_id="dataset-1",
+        device_id="device-a",
+        dataset_key=dataset_key,
+    )
+    note = builder.build_note_upsert(
+        note_id="note-1",
+        title="Private title",
+        body="Private body",
+    )
+    repo = SyncStateRepository(tmp_path / "sync_state.db")
+    repo.record_sync_v2_conflict_review(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-a",
+        dataset_id="dataset-1",
+        domain="notes",
+        item_label="Old durable note",
+        cause="Earlier conflict.",
+        local_summary="Earlier local summary.",
+        remote_summary="Earlier remote summary.",
+        source_conflict_key="old-conflict",
+        conflict_kind="encrypted_content_edit",
+        recovery_options={"retry": "available"},
+    )
+    repo.enqueue_sync_v2_outbox_envelope(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-a",
+        dataset_id="dataset-1",
+        envelope=note,
+    )
+    repo.mark_sync_v2_outbox_push_results(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-a",
+        dataset_id="dataset-1",
+        accepted=[],
+        rejected=[],
+        conflicts=[
+            {
+                "client_envelope_id": note.client_envelope_id,
+                "conflict_id": "conflict-1",
+                "message": "Needs manual review.",
+            }
+        ],
+    )
+    repo.record_sync_v2_conflict_review(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-a",
+        dataset_id="dataset-1",
+        domain="notes",
+        item_label="New durable note",
+        cause="Needs manual review.",
+        local_summary="Local pending change retained after server conflict.",
+        remote_summary="Remote version requires review before overwrite.",
+        source_conflict_key=note.client_envelope_id,
+        conflict_kind="push_conflict",
+        recovery_options={"retry": "available"},
+    )
+    service = SyncV2ConflictReviewService(state_repository=repo)
+
+    reviews = service.build_review_items(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-a",
+        dataset_id="dataset-1",
+        domains=["notes"],
+    )
+
+    assert [review.item_label for review in reviews] == ["New durable note", "Old durable note"]

--- a/Tests/Sync_Interop/test_sync_v2_conflict_review.py
+++ b/Tests/Sync_Interop/test_sync_v2_conflict_review.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from tldw_chatbook.Sync_Interop.conflict_review import SyncV2ConflictReviewService
+from tldw_chatbook.Sync_Interop.crypto import generate_dataset_key
+from tldw_chatbook.Sync_Interop.envelope_builder import SyncEnvelopeBuilder
+from tldw_chatbook.Sync_Interop.sync_state_repository import SyncStateRepository
+
+
+def test_sync_v2_conflict_review_records_are_durable_and_user_facing(tmp_path):
+    db_path = tmp_path / "sync_state.db"
+    repo = SyncStateRepository(db_path)
+
+    repo.record_sync_v2_conflict_review(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-a",
+        dataset_id="dataset-1",
+        domain="notes",
+        item_label="Research note",
+        cause="Remote edit conflicts with local edit.",
+        local_summary="Local: title changed locally.",
+        remote_summary="Remote: body changed on server.",
+        source_conflict_key="note-1:remote-2",
+        conflict_kind="encrypted_content_edit",
+        recovery_options={
+            "retry": "available",
+            "keep-local": "available",
+            "accept-remote": "available",
+            "duplicate-fork": "available",
+            "defer-later": "available",
+        },
+        details={"client_envelope_id": "remote-envelope-1"},
+    )
+    repo.close()
+
+    reopened = SyncStateRepository(db_path)
+    reviews = reopened.list_sync_v2_conflict_reviews(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-a",
+        dataset_id="dataset-1",
+    )
+
+    assert len(reviews) == 1
+    assert reviews[0]["domain"] == "notes"
+    assert reviews[0]["item_label"] == "Research note"
+    assert reviews[0]["cause"] == "Remote edit conflicts with local edit."
+    assert reviews[0]["local_summary"] == "Local: title changed locally."
+    assert reviews[0]["remote_summary"] == "Remote: body changed on server."
+    assert reviews[0]["recovery_options"] == {
+        "retry": "available",
+        "keep-local": "available",
+        "accept-remote": "available",
+        "duplicate-fork": "available",
+        "defer-later": "available",
+    }
+    assert reviews[0]["resolution_status"] == "open"
+
+
+def test_conflict_review_service_maps_retained_outbox_failures_without_plaintext(tmp_path):
+    dataset_key = generate_dataset_key()
+    builder = SyncEnvelopeBuilder(
+        dataset_id="dataset-1",
+        device_id="device-a",
+        dataset_key=dataset_key,
+    )
+    note = builder.build_note_upsert(
+        note_id="note-1",
+        title="Private title",
+        body="Private body",
+    )
+    repo = SyncStateRepository(tmp_path / "sync_state.db")
+    repo.enqueue_sync_v2_outbox_envelope(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-a",
+        dataset_id="dataset-1",
+        envelope=note,
+    )
+    repo.mark_sync_v2_outbox_push_results(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-a",
+        dataset_id="dataset-1",
+        accepted=[],
+        rejected=[
+            {
+                "client_envelope_id": note.client_envelope_id,
+                "error_code": "stale_base",
+                "message": "Remote base changed.",
+            }
+        ],
+        conflicts=[],
+    )
+    service = SyncV2ConflictReviewService(state_repository=repo)
+
+    reviews = service.build_review_items(
+        server_profile_id="server-a",
+        authenticated_principal_id="user-a",
+        workspace_scope="workspace-a",
+        dataset_id="dataset-1",
+        domains=["notes"],
+    )
+
+    assert len(reviews) == 1
+    assert reviews[0].domain == "notes"
+    assert reviews[0].item_label == "notes note-1"
+    assert reviews[0].cause == "stale_base: Remote base changed."
+    assert reviews[0].local_summary == "Local pending notes change retained for retry."
+    assert reviews[0].remote_summary == "Remote state unavailable until retry or conflict review."
+    assert reviews[0].recovery_options["retry"] == "available"
+    assert reviews[0].recovery_options["keep-local"] == "unavailable"
+    assert reviews[0].recovery_options["accept-remote"] == "unavailable"
+    assert reviews[0].recovery_options["duplicate-fork"] == "unavailable"
+    assert reviews[0].recovery_options["defer-later"] == "available"
+    assert "Private" not in str(reviews[0])
+

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -36,6 +36,7 @@ from tldw_chatbook.Sync_Interop.manual_sync_control import (
     ManualSyncPreview,
     ManualSyncRunResult,
 )
+from tldw_chatbook.Sync_Interop.conflict_review import SyncV2ConflictReviewItem
 from tldw_chatbook.UI.Screens import library_screen as library_screen_module
 from tldw_chatbook.Workspaces.display_state import LIBRARY_WORKSPACE_VISIBILITY_COPY
 from tldw_chatbook.Workspaces.models import (
@@ -766,6 +767,51 @@ def test_settings_apply_manual_sync_result_updates_rows():
     rows = dict(screen.manual_sync_rows)
     assert rows["Manual sync status"] == "partial-failure"
     assert rows["Manual sync result"] == "Manual Sync partially completed."
+
+
+def test_settings_apply_manual_sync_result_includes_conflict_review_summary():
+    preview = ManualSyncPreview(
+        status="ready",
+        can_run=True,
+        pending_total=1,
+        pending_by_domain={"notes": 1},
+        user_message="Manual Sync preview: 1 pending outgoing change.",
+    )
+    result = ManualSyncRunResult(
+        status="conflict",
+        user_message="Manual Sync found 1 conflict.",
+        summary={"outbox_retained": 1},
+        preview=preview,
+        conflict_reviews=(
+            SyncV2ConflictReviewItem(
+                domain="notes",
+                item_label="Research note",
+                cause="Remote edit conflicts with local edit.",
+                local_summary="Local title changed.",
+                remote_summary="Remote body changed.",
+                recovery_options={
+                    "retry": "available",
+                    "keep-local": "available",
+                    "accept-remote": "available",
+                    "duplicate-fork": "available",
+                    "defer-later": "available",
+                },
+            ),
+        ),
+    )
+    screen = SettingsScreen(SimpleNamespace(app_config={}))
+
+    screen._apply_manual_sync_result(result)
+
+    rows = dict(screen.manual_sync_rows)
+    assert rows["Conflict review"] == (
+        "notes | Research note | Remote edit conflicts with local edit. | "
+        "local: Local title changed. | remote: Remote body changed."
+    )
+    assert rows["Recovery options"] == (
+        "retry: available; keep-local: available; accept-remote: available; "
+        "duplicate-fork: available; defer-later: available"
+    )
 
 
 def test_settings_manual_sync_run_worker_uses_main_event_loop_async_worker():

--- a/backlog/tasks/task-70.4 - Add-Sync-v2-conflict-review-and-recovery-plan.md
+++ b/backlog/tasks/task-70.4 - Add-Sync-v2-conflict-review-and-recovery-plan.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-70.4
 title: Add Sync v2 conflict review and recovery plan
-status: To Do
+status: Done
 labels:
 - sync
 - sync-v2
@@ -21,22 +21,36 @@ Make Sync v2 conflict and partial-failure states actionable enough for manual No
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Conflicts display domain, item label, cause, local summary, remote summary, and safe recovery options.
-- [ ] #2 Partial push failures remain durable and visible until resolved.
-- [ ] #3 Retry, keep-local, accept-remote, duplicate/fork, and defer-later states are modeled or explicitly marked unavailable.
-- [ ] #4 Tests cover conflict persistence, user-facing mapping, and no cursor advancement after failed apply.
+- [x] #1 Conflicts display domain, item label, cause, local summary, remote summary, and safe recovery options.
+- [x] #2 Partial push failures remain durable and visible until resolved.
+- [x] #3 Retry, keep-local, accept-remote, duplicate/fork, and defer-later states are modeled or explicitly marked unavailable.
+- [x] #4 Tests cover conflict persistence, user-facing mapping, and no cursor advancement after failed apply.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing Sync v2 regressions for durable conflict-review records, user-facing conflict mapping/actions, partial failure visibility, and cursor preservation on failed apply.
+2. Add a small conflict review/recovery model/service that converts raw push/apply conflicts and retained outbox failures into safe user-facing rows.
+3. Extend SyncStateRepository with durable Sync v2 conflict record helpers scoped to server profile/dataset/domain without exposing plaintext.
+4. Wire LocalFirstSyncService and ManualSyncControlService to persist and surface conflict/recovery records after manual sync results.
+5. Update TASK-70.4 completion notes and run focused Sync_Interop/UI verification plus git diff checks.
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+- Added `SyncV2ConflictReviewService` and `SyncV2ConflictReviewItem` to convert durable conflict rows and retained outbox failures into safe user-facing review rows.
+- Added `sync_v2_conflict_reviews` schema v3 storage plus repository helpers for scoped conflict persistence, listing, summary counts, and profile cleanup.
+- Wired local-first sync to persist push/apply conflict reviews, and wired manual sync results to include review rows even when a run fails after retaining outbox work.
+- Updated Settings manual sync result rows to show the first conflict summary and explicit recovery action availability.
+- Added regressions for durable conflict rows, retained push-failure visibility, manual sync conflict-review propagation, Settings display copy, and schema migration. Existing local-first failed-apply tests continue to verify cursors do not advance after failed apply.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Sync v2 conflict review and recovery state is now durable, user-facing, and surfaced through manual sync results without exposing encrypted payload plaintext.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/tldw_chatbook/Sync_Interop/conflict_review.py
+++ b/tldw_chatbook/Sync_Interop/conflict_review.py
@@ -1,0 +1,116 @@
+"""User-facing Sync v2 conflict review contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+
+RECOVERY_ACTIONS: tuple[str, ...] = (
+    "retry",
+    "keep-local",
+    "accept-remote",
+    "duplicate-fork",
+    "defer-later",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SyncV2ConflictReviewItem:
+    """Safe conflict row shown to users without exposing encrypted payload text."""
+
+    domain: str
+    item_label: str
+    cause: str
+    local_summary: str
+    remote_summary: str
+    recovery_options: dict[str, str]
+    conflict_review_id: int | None = None
+    resolution_status: str = "open"
+
+
+class SyncV2ConflictReviewService:
+    """Build actionable conflict and retained-failure rows for Sync v2 users."""
+
+    def __init__(self, *, state_repository: Any) -> None:
+        self.state_repository = state_repository
+
+    def build_review_items(
+        self,
+        *,
+        server_profile_id: str,
+        authenticated_principal_id: str | None,
+        workspace_scope: str | None,
+        dataset_id: str,
+        domains: Sequence[str] | None = None,
+    ) -> tuple[SyncV2ConflictReviewItem, ...]:
+        """Return durable conflict rows plus retained outbox failure rows."""
+
+        domain_filter = {str(domain) for domain in domains or () if str(domain)}
+        rows = self.state_repository.list_sync_v2_conflict_reviews(
+            server_profile_id=server_profile_id,
+            authenticated_principal_id=authenticated_principal_id,
+            workspace_scope=workspace_scope,
+            dataset_id=dataset_id,
+            domains=list(domain_filter) or None,
+            resolution_status="open",
+        )
+        review_items = [self._from_review_row(row) for row in rows]
+        retained = self.state_repository.list_pending_sync_v2_outbox_envelopes(
+            server_profile_id=server_profile_id,
+            authenticated_principal_id=authenticated_principal_id,
+            workspace_scope=workspace_scope,
+            dataset_id=dataset_id,
+            domains=list(domain_filter) or None,
+        )
+        review_items.extend(
+            self._from_retained_outbox_entry(entry)
+            for entry in retained
+            if entry.get("last_error")
+        )
+        return tuple(review_items)
+
+    @staticmethod
+    def _from_review_row(row: Mapping[str, Any]) -> SyncV2ConflictReviewItem:
+        return SyncV2ConflictReviewItem(
+            conflict_review_id=int(row["conflict_review_id"]),
+            domain=str(row["domain"]),
+            item_label=str(row["item_label"]),
+            cause=str(row["cause"]),
+            local_summary=str(row["local_summary"]),
+            remote_summary=str(row["remote_summary"]),
+            recovery_options=_normalize_recovery_options(row.get("recovery_options")),
+            resolution_status=str(row.get("resolution_status") or "open"),
+        )
+
+    @staticmethod
+    def _from_retained_outbox_entry(entry: Mapping[str, Any]) -> SyncV2ConflictReviewItem:
+        envelope = entry.get("envelope") if isinstance(entry.get("envelope"), Mapping) else {}
+        last_error = entry.get("last_error") if isinstance(entry.get("last_error"), Mapping) else {}
+        error_code = str(last_error.get("error_code") or "push_failed")
+        message = str(last_error.get("message") or "Outgoing change was retained.")
+        domain = str(entry.get("domain") or envelope.get("domain") or "sync")
+        entity_id = str(envelope.get("entity_id") or entry.get("client_envelope_id") or "pending")
+        return SyncV2ConflictReviewItem(
+            domain=domain,
+            item_label=f"{domain} {entity_id}",
+            cause=f"{error_code}: {message}",
+            local_summary=f"Local pending {domain} change retained for retry.",
+            remote_summary="Remote state unavailable until retry or conflict review.",
+            recovery_options={
+                "retry": "available",
+                "keep-local": "unavailable",
+                "accept-remote": "unavailable",
+                "duplicate-fork": "unavailable",
+                "defer-later": "available",
+            },
+        )
+
+
+def _normalize_recovery_options(value: Any) -> dict[str, str]:
+    if not isinstance(value, Mapping):
+        return {action: "unavailable" for action in RECOVERY_ACTIONS}
+    return {
+        action: str(value.get(action) or "unavailable")
+        for action in RECOVERY_ACTIONS
+    }

--- a/tldw_chatbook/Sync_Interop/conflict_review.py
+++ b/tldw_chatbook/Sync_Interop/conflict_review.py
@@ -55,6 +55,11 @@ class SyncV2ConflictReviewService:
             domains=list(domain_filter) or None,
             resolution_status="open",
         )
+        durable_source_keys = {
+            str(row.get("source_conflict_key"))
+            for row in rows
+            if row.get("source_conflict_key")
+        }
         review_items = [self._from_review_row(row) for row in rows]
         retained = self.state_repository.list_pending_sync_v2_outbox_envelopes(
             server_profile_id=server_profile_id,
@@ -65,8 +70,9 @@ class SyncV2ConflictReviewService:
         )
         review_items.extend(
             self._from_retained_outbox_entry(entry)
-            for entry in retained
+            for entry in sorted(retained, key=_retained_outbox_sort_key, reverse=True)
             if entry.get("last_error")
+            and str(entry.get("client_envelope_id") or "") not in durable_source_keys
         )
         return tuple(review_items)
 
@@ -114,3 +120,7 @@ def _normalize_recovery_options(value: Any) -> dict[str, str]:
         action: str(value.get(action) or "unavailable")
         for action in RECOVERY_ACTIONS
     }
+
+
+def _retained_outbox_sort_key(entry: Mapping[str, Any]) -> str:
+    return str(entry.get("updated_at") or entry.get("created_at") or "")

--- a/tldw_chatbook/Sync_Interop/local_first_sync_service.py
+++ b/tldw_chatbook/Sync_Interop/local_first_sync_service.py
@@ -488,10 +488,14 @@ class LocalFirstSyncService:
                 recovery_options=self._available_conflict_recovery_options(),
                 details=dict(conflict),
             )
-        for conflict in apply_conflicts:
+        for index, conflict in enumerate(apply_conflicts, start=1):
             client_envelope_id = str(conflict.get("client_envelope_id") or "").strip()
-            source_conflict_key = client_envelope_id or str(conflict.get("stable_key") or conflict.get("entity_id"))
             domain = str(conflict.get("domain") or "sync_v2")
+            conflict_kind = str(conflict.get("conflict_type") or "apply_conflict")
+            fallback_key = conflict.get("stable_key") or conflict.get("entity_id")
+            source_conflict_key = client_envelope_id or str(fallback_key or "").strip()
+            if not source_conflict_key:
+                source_conflict_key = f"apply-conflict:{domain}:{conflict_kind}:{index}"
             entity_id = str(conflict.get("entity_id") or source_conflict_key)
             self.state_repository.record_sync_v2_conflict_review(
                 server_profile_id=str(profile["server_profile_id"]),
@@ -510,7 +514,7 @@ class LocalFirstSyncService:
                     or "Remote envelope could not be applied safely."
                 ),
                 source_conflict_key=source_conflict_key,
-                conflict_kind=str(conflict.get("conflict_type") or "apply_conflict"),
+                conflict_kind=conflict_kind,
                 recovery_options=self._available_conflict_recovery_options(),
                 details=dict(conflict),
             )

--- a/tldw_chatbook/Sync_Interop/local_first_sync_service.py
+++ b/tldw_chatbook/Sync_Interop/local_first_sync_service.py
@@ -307,6 +307,13 @@ class LocalFirstSyncService:
             for result in results
             if result.get("status") == "conflict" and "conflict" in result
         ]
+        self._record_conflict_reviews(
+            profile=profile,
+            dataset_id=str(dataset_id),
+            outbox_entries=outbox_entries,
+            push_conflicts=push_record.get("conflicts", []),
+            apply_conflicts=conflicts,
+        )
         self._persist_profile_state(
             profile=profile,
             dataset_cursors=dataset_cursors,
@@ -438,6 +445,95 @@ class LocalFirstSyncService:
             ],
             conflicts=[],
         )
+
+    def _record_conflict_reviews(
+        self,
+        *,
+        profile: Mapping[str, Any],
+        dataset_id: str,
+        outbox_entries: list[Mapping[str, Any]],
+        push_conflicts: list[Mapping[str, Any]],
+        apply_conflicts: list[Mapping[str, Any]],
+    ) -> None:
+        if not hasattr(self.state_repository, "record_sync_v2_conflict_review"):
+            return
+        outbox_by_client_id = {
+            str(entry.get("client_envelope_id")): entry
+            for entry in outbox_entries
+            if entry.get("client_envelope_id")
+        }
+        for conflict in push_conflicts:
+            client_envelope_id = str(conflict.get("client_envelope_id") or "").strip()
+            if not client_envelope_id:
+                continue
+            outbox_entry = outbox_by_client_id.get(client_envelope_id, {})
+            envelope = outbox_entry.get("envelope") if isinstance(outbox_entry.get("envelope"), Mapping) else {}
+            domain = str(envelope.get("domain") or conflict.get("domain") or "sync_v2")
+            entity_id = str(envelope.get("entity_id") or client_envelope_id)
+            self.state_repository.record_sync_v2_conflict_review(
+                server_profile_id=str(profile["server_profile_id"]),
+                authenticated_principal_id=profile.get("authenticated_principal_id"),
+                workspace_scope=profile.get("workspace_scope"),
+                dataset_id=dataset_id,
+                domain=domain,
+                item_label=f"{domain} {entity_id}",
+                cause=self._conflict_cause(conflict),
+                local_summary=f"Local pending {domain} change retained after server conflict.",
+                remote_summary=str(
+                    conflict.get("remote_summary")
+                    or "Remote version requires review before overwrite."
+                ),
+                source_conflict_key=client_envelope_id,
+                conflict_kind=str(conflict.get("conflict_type") or conflict.get("error_code") or "push_conflict"),
+                recovery_options=self._available_conflict_recovery_options(),
+                details=dict(conflict),
+            )
+        for conflict in apply_conflicts:
+            client_envelope_id = str(conflict.get("client_envelope_id") or "").strip()
+            source_conflict_key = client_envelope_id or str(conflict.get("stable_key") or conflict.get("entity_id"))
+            domain = str(conflict.get("domain") or "sync_v2")
+            entity_id = str(conflict.get("entity_id") or source_conflict_key)
+            self.state_repository.record_sync_v2_conflict_review(
+                server_profile_id=str(profile["server_profile_id"]),
+                authenticated_principal_id=profile.get("authenticated_principal_id"),
+                workspace_scope=profile.get("workspace_scope"),
+                dataset_id=dataset_id,
+                domain=domain,
+                item_label=f"{domain} {entity_id}",
+                cause=self._conflict_cause(conflict),
+                local_summary=str(
+                    conflict.get("local_summary")
+                    or f"Local {domain} state blocked remote apply."
+                ),
+                remote_summary=str(
+                    conflict.get("remote_summary")
+                    or "Remote envelope could not be applied safely."
+                ),
+                source_conflict_key=source_conflict_key,
+                conflict_kind=str(conflict.get("conflict_type") or "apply_conflict"),
+                recovery_options=self._available_conflict_recovery_options(),
+                details=dict(conflict),
+            )
+
+    @staticmethod
+    def _available_conflict_recovery_options() -> dict[str, str]:
+        return {
+            "retry": "available",
+            "keep-local": "available",
+            "accept-remote": "available",
+            "duplicate-fork": "available",
+            "defer-later": "available",
+        }
+
+    @staticmethod
+    def _conflict_cause(conflict: Mapping[str, Any]) -> str:
+        cause = conflict.get("message") or conflict.get("cause")
+        if cause:
+            return str(cause)
+        conflict_type = conflict.get("conflict_type") or conflict.get("error_code")
+        if conflict_type:
+            return str(conflict_type)
+        return "Sync v2 conflict requires review."
 
     def _persist_profile_state(
         self,

--- a/tldw_chatbook/Sync_Interop/manual_sync_control.py
+++ b/tldw_chatbook/Sync_Interop/manual_sync_control.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Literal, Mapping, MutableMapping, Sequence
 
+from tldw_chatbook.Sync_Interop.conflict_review import (
+    SyncV2ConflictReviewItem,
+    SyncV2ConflictReviewService,
+)
 from tldw_chatbook.Sync_Interop.sync_state import is_local_first_sync_profile_mode
 
 ManualSyncStatus = Literal[
@@ -40,6 +44,7 @@ class ManualSyncRunResult:
     user_message: str
     summary: dict[str, Any]
     preview: ManualSyncPreview
+    conflict_reviews: tuple[SyncV2ConflictReviewItem, ...] = ()
 
 
 class ManualSyncControlService:
@@ -214,6 +219,10 @@ class ManualSyncControlService:
                 user_message=f"Manual Sync failed: {exc}",
                 summary={"error": str(exc), "error_type": type(exc).__name__},
                 preview=preview,
+                conflict_reviews=self._conflict_review_items(
+                    profile=preview.profile,
+                    domains=selected_domains,
+                ),
             )
         status, message = self._result_copy(summary)
         post_preview = self.preview(
@@ -227,6 +236,10 @@ class ManualSyncControlService:
             user_message=message,
             summary=dict(summary),
             preview=post_preview,
+            conflict_reviews=self._conflict_review_items(
+                profile=post_preview.profile or preview.profile,
+                domains=selected_domains,
+            ),
         )
 
     def _blocked(
@@ -246,6 +259,26 @@ class ManualSyncControlService:
     def _domains(self, domains: Sequence[str] | None) -> tuple[str, ...]:
         selected = tuple(str(domain).strip() for domain in (domains or self.default_domains))
         return tuple(domain for domain in selected if domain)
+
+    def _conflict_review_items(
+        self,
+        *,
+        profile: Mapping[str, Any] | None,
+        domains: Sequence[str],
+    ) -> tuple[SyncV2ConflictReviewItem, ...]:
+        if profile is None:
+            return ()
+        dataset_id = str(profile.get("dataset_id") or "").strip()
+        if not dataset_id:
+            return ()
+        service = SyncV2ConflictReviewService(state_repository=self.state_repository)
+        return service.build_review_items(
+            server_profile_id=str(profile["server_profile_id"]),
+            authenticated_principal_id=profile.get("authenticated_principal_id"),
+            workspace_scope=profile.get("workspace_scope"),
+            dataset_id=dataset_id,
+            domains=domains,
+        )
 
     @staticmethod
     def _result_copy(summary: Mapping[str, Any]) -> tuple[ManualSyncStatus, str]:

--- a/tldw_chatbook/Sync_Interop/sync_state_repository.py
+++ b/tldw_chatbook/Sync_Interop/sync_state_repository.py
@@ -37,6 +37,7 @@ _SYNC_V2_CONFLICT_RESOLUTION_STATUSES = {
     "duplicate-fork",
     "defer-later",
 }
+SYNC_V2_CONFLICT_REVIEW_DEFAULT_LIMIT = 100
 SYNC_STATE_SCHEMA_VERSION = 3
 _FILTER_UNSET = object()
 
@@ -1156,39 +1157,43 @@ class SyncStateRepository(BaseDB):
         if resolution_status is not None and resolution_status not in _SYNC_V2_CONFLICT_RESOLUTION_STATUSES:
             allowed = ", ".join(sorted(_SYNC_V2_CONFLICT_RESOLUTION_STATUSES))
             raise ValueError(f"resolution_status must be one of: {allowed}")
-        limit = _normalize_optional_limit(limit)
+        limit = _normalize_optional_limit(limit) or SYNC_V2_CONFLICT_REVIEW_DEFAULT_LIMIT
         source_scope_key = _sync_v2_outbox_scope_key(
             server_profile_id=server_profile_id,
             authenticated_principal_id=authenticated_principal_id,
             workspace_scope=workspace_scope,
         )
+        domain_values = tuple(dict.fromkeys(str(domain) for domain in domains or () if str(domain)))
+        domain_clause = ""
+        params: list[Any] = [
+            source_scope_key,
+            dataset_id,
+            source_conflict_key,
+            source_conflict_key,
+            resolution_status,
+            resolution_status,
+        ]
+        if domain_values:
+            placeholders = ", ".join("?" for _ in domain_values)
+            domain_clause = f" AND domain IN ({placeholders})"
+            params.extend(domain_values)
+        params.append(limit)
         with self._get_connection() as conn:
             rows = conn.execute(
-                """
+                f"""
                 SELECT *
                 FROM sync_v2_conflict_reviews
                 WHERE source_scope_key = ?
                   AND dataset_id = ?
                   AND (? IS NULL OR source_conflict_key = ?)
                   AND (? IS NULL OR resolution_status = ?)
-                ORDER BY conflict_review_id ASC
-                LIMIT COALESCE(?, -1)
+                  {domain_clause}
+                ORDER BY conflict_review_id DESC
+                LIMIT ?
                 """,
-                (
-                    source_scope_key,
-                    dataset_id,
-                    source_conflict_key,
-                    source_conflict_key,
-                    resolution_status,
-                    resolution_status,
-                    limit,
-                ),
+                params,
             ).fetchall()
-        reviews = [self._sync_v2_conflict_review_from_row(row) for row in rows]
-        if domains:
-            domain_set = set(domains)
-            reviews = [review for review in reviews if review["domain"] in domain_set]
-        return reviews
+        return [self._sync_v2_conflict_review_from_row(row) for row in rows]
 
     def set_sync_profile_state(
         self,
@@ -1652,12 +1657,17 @@ class SyncStateRepository(BaseDB):
                     ),
                 ),
             ).fetchone()
-        latest = [dict(row) for row in rows]
-        for report in latest:
+        legacy_latest = [dict(row) for row in rows]
+        for report in legacy_latest:
             report["details"] = json.loads(report["details"])
-        latest.extend(
+        v2_latest = [
             self._sync_v2_conflict_review_from_row(row)
             for row in review_rows
+        ]
+        latest = sorted(
+            legacy_latest + v2_latest,
+            key=_sync_v2_conflict_summary_sort_key,
+            reverse=True,
         )
         count = int(count_row["count"] if count_row else 0)
         count += int(review_count_row["count"] if review_count_row else 0)
@@ -2168,6 +2178,16 @@ def _normalize_optional_limit(limit: int | None) -> int | None:
     if normalized < 1:
         raise ValueError("limit must be a positive integer")
     return normalized
+
+
+def _sync_v2_conflict_summary_sort_key(item: Mapping[str, Any]) -> tuple[str, int]:
+    timestamp = str(item.get("updated_at") or item.get("created_at") or "")
+    identifier = item.get("conflict_review_id") or item.get("conflict_id") or 0
+    try:
+        numeric_identifier = int(identifier)
+    except (TypeError, ValueError):
+        numeric_identifier = 0
+    return timestamp, numeric_identifier
 
 
 def _json_dumps(value: Mapping[str, Any] | list[Any]) -> str:

--- a/tldw_chatbook/Sync_Interop/sync_state_repository.py
+++ b/tldw_chatbook/Sync_Interop/sync_state_repository.py
@@ -29,7 +29,15 @@ _LOCAL_NULL_ALLOWED = {"candidate", "orphaned_remote", "unsupported"}
 _REMOTE_NULL_ALLOWED = {"candidate", "orphaned_local", "unsupported"}
 _SYNC_V2_PROFILE_MODES = {"local_only", "local_first", "local_first_sync", "server_frontend"}
 _SYNC_V2_OUTBOX_STATUSES = {"pending", "dispatched"}
-SYNC_STATE_SCHEMA_VERSION = 2
+_SYNC_V2_CONFLICT_RESOLUTION_STATUSES = {
+    "open",
+    "retry",
+    "keep-local",
+    "accept-remote",
+    "duplicate-fork",
+    "defer-later",
+}
+SYNC_STATE_SCHEMA_VERSION = 3
 _FILTER_UNSET = object()
 
 
@@ -92,7 +100,7 @@ class SyncStateRepository(BaseDB):
                 CREATE TABLE IF NOT EXISTS schema_version (
                     version INTEGER PRIMARY KEY NOT NULL
                 );
-                INSERT OR IGNORE INTO schema_version (version) VALUES (2);
+                INSERT OR IGNORE INTO schema_version (version) VALUES (3);
 
                 CREATE TABLE IF NOT EXISTS sync_identity_mappings (
                     mapping_id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -218,6 +226,32 @@ class SyncStateRepository(BaseDB):
 
                 CREATE INDEX IF NOT EXISTS idx_sync_v2_outbox_scope_status
                     ON sync_v2_local_outbox(source_scope_key, dataset_id, status, outbox_id);
+
+                CREATE TABLE IF NOT EXISTS sync_v2_conflict_reviews (
+                    conflict_review_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    source_scope_key TEXT NOT NULL,
+                    server_profile_id TEXT NOT NULL,
+                    authenticated_principal_id TEXT NOT NULL,
+                    workspace_scope TEXT NOT NULL,
+                    dataset_id TEXT NOT NULL,
+                    domain TEXT NOT NULL,
+                    source_conflict_key TEXT NOT NULL,
+                    conflict_kind TEXT NOT NULL,
+                    item_label TEXT NOT NULL,
+                    cause TEXT NOT NULL,
+                    local_summary TEXT NOT NULL,
+                    remote_summary TEXT NOT NULL,
+                    recovery_options TEXT NOT NULL,
+                    resolution_status TEXT NOT NULL,
+                    details TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    resolved_at TEXT,
+                    UNIQUE(source_scope_key, dataset_id, source_conflict_key)
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_sync_v2_conflict_reviews_scope
+                    ON sync_v2_conflict_reviews(source_scope_key, dataset_id, resolution_status, conflict_review_id);
                 """
             )
             self._ensure_sync_v2_profile_columns(conn)
@@ -756,6 +790,18 @@ class SyncStateRepository(BaseDB):
                     _scope_value(authenticated_principal_id),
                 ),
             )
+            conn.execute(
+                """
+                DELETE FROM sync_v2_conflict_reviews
+                WHERE server_profile_id = ?
+                  AND (? IS NULL OR authenticated_principal_id = ?)
+                """,
+                (
+                    _scope_value(server_profile_id),
+                    authenticated_principal_id,
+                    _scope_value(authenticated_principal_id),
+                ),
+            )
             conn.commit()
 
     def enqueue_sync_v2_outbox_envelope(
@@ -977,6 +1023,172 @@ class SyncStateRepository(BaseDB):
                 retained += cursor.rowcount
             conn.commit()
         return {"dispatched": dispatched, "retained": retained}
+
+    def record_sync_v2_conflict_review(
+        self,
+        *,
+        server_profile_id: str,
+        authenticated_principal_id: str | None,
+        workspace_scope: str | None,
+        dataset_id: str,
+        domain: str,
+        item_label: str,
+        cause: str,
+        local_summary: str,
+        remote_summary: str,
+        source_conflict_key: str,
+        conflict_kind: str,
+        recovery_options: Mapping[str, str],
+        details: Mapping[str, Any] | None = None,
+        resolution_status: str = "open",
+    ) -> dict[str, Any]:
+        """Persist or update a user-facing Sync v2 conflict review row."""
+
+        if resolution_status not in _SYNC_V2_CONFLICT_RESOLUTION_STATUSES:
+            allowed = ", ".join(sorted(_SYNC_V2_CONFLICT_RESOLUTION_STATUSES))
+            raise ValueError(f"resolution_status must be one of: {allowed}")
+        if not dataset_id:
+            raise ValueError("dataset_id is required")
+        for field_name, value in (
+            ("domain", domain),
+            ("item_label", item_label),
+            ("cause", cause),
+            ("local_summary", local_summary),
+            ("remote_summary", remote_summary),
+            ("source_conflict_key", source_conflict_key),
+            ("conflict_kind", conflict_kind),
+        ):
+            if not str(value or "").strip():
+                raise ValueError(f"{field_name} is required")
+        source_scope_key = _sync_v2_outbox_scope_key(
+            server_profile_id=server_profile_id,
+            authenticated_principal_id=authenticated_principal_id,
+            workspace_scope=workspace_scope,
+        )
+        now = _utc_now()
+        with self._get_connection() as conn:
+            conn.execute(
+                """
+                INSERT INTO sync_v2_conflict_reviews (
+                    source_scope_key,
+                    server_profile_id,
+                    authenticated_principal_id,
+                    workspace_scope,
+                    dataset_id,
+                    domain,
+                    source_conflict_key,
+                    conflict_kind,
+                    item_label,
+                    cause,
+                    local_summary,
+                    remote_summary,
+                    recovery_options,
+                    resolution_status,
+                    details,
+                    created_at,
+                    updated_at,
+                    resolved_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+                ON CONFLICT(source_scope_key, dataset_id, source_conflict_key)
+                DO UPDATE SET
+                    domain = excluded.domain,
+                    conflict_kind = excluded.conflict_kind,
+                    item_label = excluded.item_label,
+                    cause = excluded.cause,
+                    local_summary = excluded.local_summary,
+                    remote_summary = excluded.remote_summary,
+                    recovery_options = excluded.recovery_options,
+                    resolution_status = excluded.resolution_status,
+                    details = excluded.details,
+                    updated_at = excluded.updated_at,
+                    resolved_at = CASE
+                        WHEN excluded.resolution_status = 'open' THEN NULL
+                        ELSE excluded.updated_at
+                    END
+                """,
+                (
+                    source_scope_key,
+                    _scope_value(server_profile_id),
+                    _scope_value(authenticated_principal_id),
+                    _scope_value(workspace_scope),
+                    dataset_id,
+                    domain,
+                    source_conflict_key,
+                    conflict_kind,
+                    item_label,
+                    cause,
+                    local_summary,
+                    remote_summary,
+                    _json_dumps(dict(recovery_options)),
+                    resolution_status,
+                    _json_dumps(dict(details or {})),
+                    now,
+                    now,
+                ),
+            )
+            conn.commit()
+        rows = self.list_sync_v2_conflict_reviews(
+            server_profile_id=server_profile_id,
+            authenticated_principal_id=authenticated_principal_id,
+            workspace_scope=workspace_scope,
+            dataset_id=dataset_id,
+            source_conflict_key=source_conflict_key,
+        )
+        if not rows:
+            raise RuntimeError("failed to persist Sync v2 conflict review")
+        return rows[0]
+
+    def list_sync_v2_conflict_reviews(
+        self,
+        *,
+        server_profile_id: str,
+        authenticated_principal_id: str | None,
+        workspace_scope: str | None,
+        dataset_id: str,
+        domains: list[str] | None = None,
+        source_conflict_key: str | None = None,
+        resolution_status: str | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return durable Sync v2 conflict review rows for one profile dataset."""
+
+        if resolution_status is not None and resolution_status not in _SYNC_V2_CONFLICT_RESOLUTION_STATUSES:
+            allowed = ", ".join(sorted(_SYNC_V2_CONFLICT_RESOLUTION_STATUSES))
+            raise ValueError(f"resolution_status must be one of: {allowed}")
+        limit = _normalize_optional_limit(limit)
+        source_scope_key = _sync_v2_outbox_scope_key(
+            server_profile_id=server_profile_id,
+            authenticated_principal_id=authenticated_principal_id,
+            workspace_scope=workspace_scope,
+        )
+        with self._get_connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT *
+                FROM sync_v2_conflict_reviews
+                WHERE source_scope_key = ?
+                  AND dataset_id = ?
+                  AND (? IS NULL OR source_conflict_key = ?)
+                  AND (? IS NULL OR resolution_status = ?)
+                ORDER BY conflict_review_id ASC
+                LIMIT COALESCE(?, -1)
+                """,
+                (
+                    source_scope_key,
+                    dataset_id,
+                    source_conflict_key,
+                    source_conflict_key,
+                    resolution_status,
+                    resolution_status,
+                    limit,
+                ),
+            ).fetchall()
+        reviews = [self._sync_v2_conflict_review_from_row(row) for row in rows]
+        if domains:
+            domain_set = set(domains)
+            reviews = [review for review in reviews if review["domain"] in domain_set]
+        return reviews
 
     def set_sync_profile_state(
         self,
@@ -1408,10 +1620,48 @@ class SyncStateRepository(BaseDB):
                 """,
                 (f"{scope_prefix}%",),
             ).fetchone()
+            review_rows = conn.execute(
+                """
+                SELECT *
+                FROM sync_v2_conflict_reviews
+                WHERE source_scope_key = ?
+                  AND resolution_status = 'open'
+                ORDER BY conflict_review_id DESC
+                LIMIT 5
+                """,
+                (
+                    _sync_v2_outbox_scope_key(
+                        server_profile_id=server_profile_id,
+                        authenticated_principal_id=authenticated_principal_id,
+                        workspace_scope=workspace_scope,
+                    ),
+                ),
+            ).fetchall()
+            review_count_row = conn.execute(
+                """
+                SELECT COUNT(*) AS count
+                FROM sync_v2_conflict_reviews
+                WHERE source_scope_key = ?
+                  AND resolution_status = 'open'
+                """,
+                (
+                    _sync_v2_outbox_scope_key(
+                        server_profile_id=server_profile_id,
+                        authenticated_principal_id=authenticated_principal_id,
+                        workspace_scope=workspace_scope,
+                    ),
+                ),
+            ).fetchone()
         latest = [dict(row) for row in rows]
         for report in latest:
             report["details"] = json.loads(report["details"])
-        return {"count": int(count_row["count"] if count_row else 0), "latest": latest}
+        latest.extend(
+            self._sync_v2_conflict_review_from_row(row)
+            for row in review_rows
+        )
+        count = int(count_row["count"] if count_row else 0)
+        count += int(review_count_row["count"] if review_count_row else 0)
+        return {"count": count, "latest": latest[:5]}
 
     def _get_mirror_report_by_id(self, report_id: int | None) -> dict[str, Any] | None:
         if report_id is None:
@@ -1543,6 +1793,30 @@ class SyncStateRepository(BaseDB):
             "created_at": row["created_at"],
             "updated_at": row["updated_at"],
             "dispatched_at": row["dispatched_at"],
+        }
+
+    @staticmethod
+    def _sync_v2_conflict_review_from_row(row: sqlite3.Row) -> dict[str, Any]:
+        return {
+            "conflict_review_id": int(row["conflict_review_id"]),
+            "source_scope_key": row["source_scope_key"],
+            "server_profile_id": _restore_scope_value(row["server_profile_id"]),
+            "authenticated_principal_id": _restore_scope_value(row["authenticated_principal_id"]),
+            "workspace_scope": _restore_scope_value(row["workspace_scope"]),
+            "dataset_id": row["dataset_id"],
+            "domain": row["domain"],
+            "source_conflict_key": row["source_conflict_key"],
+            "conflict_kind": row["conflict_kind"],
+            "item_label": row["item_label"],
+            "cause": row["cause"],
+            "local_summary": row["local_summary"],
+            "remote_summary": row["remote_summary"],
+            "recovery_options": json.loads(row["recovery_options"]),
+            "resolution_status": row["resolution_status"],
+            "details": json.loads(row["details"]),
+            "created_at": row["created_at"],
+            "updated_at": row["updated_at"],
+            "resolved_at": row["resolved_at"],
         }
 
     @staticmethod

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -1631,11 +1631,32 @@ class SettingsScreen(BaseAppScreen):
         self.manual_sync_rows = rows
 
     def _apply_manual_sync_result(self, result: ManualSyncRunResult) -> None:
-        self.manual_sync_rows = (
+        rows = [
             ("Manual sync status", result.status),
             ("Manual sync result", result.user_message),
             ("Pending outgoing", self._pending_copy(result.preview.pending_by_domain)),
-        )
+        ]
+        if result.conflict_reviews:
+            first_review = result.conflict_reviews[0]
+            rows.append(
+                (
+                    "Conflict review",
+                    (
+                        f"{first_review.domain} | {first_review.item_label} | {first_review.cause} | "
+                        f"local: {first_review.local_summary} | remote: {first_review.remote_summary}"
+                    ),
+                )
+            )
+            rows.append(
+                (
+                    "Recovery options",
+                    "; ".join(
+                        f"{action}: {state}"
+                        for action, state in first_review.recovery_options.items()
+                    ),
+                )
+            )
+        self.manual_sync_rows = tuple(rows)
 
     @staticmethod
     def _pending_copy(pending_by_domain: Mapping[str, int]) -> str:


### PR DESCRIPTION
## Summary
- add durable Sync v2 conflict-review rows and user-facing recovery models
- surface retained outbox failures and conflict reviews through manual sync results
- show conflict/recovery rows in Settings manual sync results and mark TASK-70.4 done

## Verification
- git diff --check
- python -m pytest -q Tests/Sync_Interop --tb=short
- python -m pytest -q Tests/UI/test_settings_configuration_hub.py --tb=short
- python -m pytest -q Tests/UI/test_product_maturity_phase1_harness.py::test_backlog_task_frontmatter_ids_are_unique --tb=short

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds durable Sync v2 conflict-review storage and a user-facing recovery model, including retained outbox failures, and surfaces these in manual sync results and Settings. Completes TASK-70.4; conflict summaries now include durable v2 reviews alongside legacy conflicts.

- New Features
  - Added `SyncV2ConflictReviewService` and `SyncV2ConflictReviewItem` to build safe, plaintext-free review rows from durable records and retained outbox failures; dedupes by `source_conflict_key`, filters by domain, newest-first with a 100-item default.
  - Local-first sync persists push/apply conflicts to durable review rows with safe fallback keys and standardized recovery options.
  - Manual sync returns `conflict_reviews` on success and failure; Settings shows the first conflict and its recovery options.
  - Profile summaries combine legacy conflicts and durable v2 reviews before the 5-item limit.

- Migration
  - Schema bumped to v3 adding `sync_v2_conflict_reviews` with scoped indexes and a uniqueness constraint on `(source_scope_key, dataset_id, source_conflict_key)`; `schema_version` updated to 3.
  - Auto-migrates on startup; clearing a server profile also removes its conflict reviews; no manual steps required.

<sup>Written for commit 1585e8018e7bac89273e5938530052a7333a3f09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

