### PR TITLE
Fix Settings endpoint input autolinking

### DIFF
--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -2071,6 +2071,33 @@ async def test_settings_provider_openai_endpoint_placeholder_uses_provider_conte
         assert "127.0.0.1:9099" not in endpoint.placeholder
 
 
+def test_settings_endpoint_display_breaks_browser_autolinks_without_mutating_value():
+    endpoint = "http://localhost:8000/v1/chat/completions"
+
+    display_value = settings_screen_module._textual_web_safe_url_display(endpoint)
+
+    assert "http://" not in display_value
+    assert display_value.replace("\u200b", "") == endpoint
+
+
+@pytest.mark.asyncio
+async def test_settings_provider_endpoint_uses_url_safe_input_for_url_values():
+    app = _build_test_app()
+    app.app_config["chat_defaults"] = {"provider": "local_llm", "model": "local-model"}
+    app.app_config["api_settings"] = {
+        "local_llm": {"api_url": "http://localhost:8000/v1/chat/completions"}
+    }
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.click("#settings-category-providers-models")
+        screen = _active_destination_screen(host)
+        endpoint = screen.query_one("#settings-provider-endpoint-value", Input)
+
+        assert isinstance(endpoint, settings_screen_module.SettingsURLInput)
+        assert endpoint.value == "http://localhost:8000/v1/chat/completions"
+
+
 @pytest.mark.asyncio
 async def test_settings_provider_guided_save_revert_enable_only_when_dirty():
     app = _build_test_app()

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -2080,6 +2080,15 @@ def test_settings_endpoint_display_breaks_browser_autolinks_without_mutating_val
     assert display_value.replace("\u200b", "") == endpoint
 
 
+def test_settings_endpoint_display_index_maps_url_break_boundaries_to_visible_colon():
+    assert settings_screen_module._textual_web_safe_url_display_index(
+        "http://localhost:8000", len("http")
+    ) == len("http") + 1
+    assert settings_screen_module._textual_web_safe_url_display_index(
+        "https://api.example.com", len("https")
+    ) == len("https") + 1
+
+
 @pytest.mark.asyncio
 async def test_settings_provider_endpoint_uses_url_safe_input_for_url_values():
     app = _build_test_app()

--- a/backlog/tasks/task-77 - Settings-actual-use-corrective-QA-and-navigation-reliability.md
+++ b/backlog/tasks/task-77 - Settings-actual-use-corrective-QA-and-navigation-reliability.md
@@ -1,0 +1,52 @@
+---
+id: TASK-77
+title: Settings actual-use corrective QA and navigation reliability
+status: In Progress
+labels:
+- settings
+- ux
+- qa
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify the Settings configuration hub through actual rendered app use and correct any confirmed usability blockers in category navigation, field editing, dropdown selection, save/revert/test feedback, and keyboard operation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Actual rendered Settings walkthrough verifies category navigation works with mouse and keyboard.
+- [ ] #2 Provider, model, endpoint, credential, numeric, and toggle controls remain readable while focused and while text is entered.
+- [ ] #3 Dropdown selection works without clipping, hidden selection state, or invalid blank provider persistence.
+- [ ] #4 Save, revert, validation, and test actions show clear status/recovery feedback and do not block the UI for long work.
+- [ ] #5 Any confirmed blocker is covered by a failing regression before the production fix.
+- [ ] #6 Final CDP screenshot evidence is captured and explicitly approved before PR creation.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Run the Settings screen in textual-web from an isolated config/data home so actual behavior is observable without contaminating local user state.
+2. Use CDP/browser automation to verify rendered category navigation, provider dropdown selection, input focus visibility, save/revert/test feedback, and keyboard traversal.
+3. Record any confirmed blocker with exact reproduction steps and root-cause evidence before editing production code.
+4. Add a focused failing regression for the first confirmed blocker, then implement the smallest safe fix.
+5. Rerun focused Settings tests, run diff hygiene, capture actual final screenshots, and wait for user approval before PR creation.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Slice 1 addressed the confirmed endpoint-field blocker found during CDP QA: clicking a URL-valued provider endpoint in textual-web opened the browser URL instead of behaving like an editable Settings input. Added a URL-safe endpoint input renderer that breaks browser autolinking in display text while preserving the raw value for validation and saving. Added focused regressions for the display transform and endpoint widget composition, then verified with Settings tests and CDP screenshot evidence approved by the user.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -8,12 +8,15 @@ from pathlib import Path
 import re
 import tomllib
 
+from rich.cells import cell_len
+from rich.text import Text
 from textual import on, work
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.css.query import QueryError
 from textual.events import Key
 from textual.reactive import reactive
+from textual.strip import Strip
 from textual.widgets import Button, Input, Rule, Select, Static, TextArea
 
 from ...Chat.provider_readiness import get_provider_readiness, provider_config_key
@@ -105,6 +108,8 @@ CONSOLE_BACKGROUND_EFFECT_SAVE_ORDER = (
 CONSOLE_BACKGROUND_WORKBENCH_UNAVAILABLE_COPY = (
     "Workbench scope is not available in this build; using Transcript scope."
 )
+TEXTUAL_WEB_URL_AUTOLINK_BREAK = "\u200b"
+TEXTUAL_WEB_URL_SCHEME_RE = re.compile(r"\b(https?)://", re.IGNORECASE)
 CONSOLE_BEHAVIOR_CHAT_DEFAULT_KEYS = frozenset(
     {
         "streaming",
@@ -367,6 +372,119 @@ DOMAIN_CONTRACT_BY_CATEGORY = _build_domain_contract_by_category(
 )
 DOMAIN_SETTINGS_CATEGORY_IDS = frozenset(DOMAIN_CONTRACT_BY_CATEGORY)
 _WORKSPACE_RECORD_UNSET = object()
+
+
+def _textual_web_safe_url_display(value: str) -> str:
+    """Break URL schemes in rendered input text without changing the stored value."""
+    return TEXTUAL_WEB_URL_SCHEME_RE.sub(
+        lambda match: f"{match.group(1)}{TEXTUAL_WEB_URL_AUTOLINK_BREAK}://",
+        value,
+    )
+
+
+def _textual_web_safe_url_display_index(value: str, index: int) -> int:
+    display_index = index
+    for match in TEXTUAL_WEB_URL_SCHEME_RE.finditer(value):
+        insertion_index = match.start(1) + len(match.group(1))
+        if index > insertion_index:
+            display_index += len(TEXTUAL_WEB_URL_AUTOLINK_BREAK)
+    return display_index
+
+
+class SettingsURLInput(Input):
+    """Input that prevents textual-web from opening endpoint values as browser links."""
+
+    @property
+    def _value(self) -> Text:
+        if self.password:
+            return super()._value
+        text = Text(
+            _textual_web_safe_url_display(self.value),
+            no_wrap=True,
+            overflow="ignore",
+            end="",
+        )
+        if self.highlighter is not None:
+            text = self.highlighter(text)
+        return text
+
+    @property
+    def content_width(self) -> int:
+        if self.placeholder and not self.value:
+            return cell_len(self.placeholder)
+        return self._value.cell_len + 1
+
+    def _display_index(self, index: int) -> int:
+        if self.password:
+            return index
+        return _textual_web_safe_url_display_index(self.value, index)
+
+    def render_line(self, y: int) -> Strip:
+        if y != 0:
+            return Strip.blank(self.size.width, self.rich_style)
+
+        console = self.app.console
+        console_options = self.app.console_options
+        max_content_width = self.scrollable_content_region.width
+
+        if not self.value:
+            placeholder = Text(self.placeholder, justify="left", end="")
+            placeholder.stylize(self.get_component_rich_style("input--placeholder"))
+            if self.has_focus:
+                cursor_style = self.get_component_rich_style("input--cursor")
+                if self._cursor_visible:
+                    if len(placeholder) == 0:
+                        placeholder = Text(" ", end="")
+                    placeholder.stylize(cursor_style, 0, 1)
+
+            strip = Strip(
+                console.render(
+                    placeholder,
+                    console_options.update_width(max_content_width + 1),
+                )
+            )
+        else:
+            result = self._value
+
+            value = self.value
+            value_length = len(value)
+            suggestion = self._suggestion
+            show_suggestion = len(suggestion) > value_length and self.has_focus
+            if show_suggestion:
+                result += Text(
+                    suggestion[value_length:],
+                    self.get_component_rich_style("input--suggestion"),
+                    end="",
+                )
+
+            if self.has_focus:
+                if not self.selection.is_empty:
+                    start, end = self.selection
+                    start, end = sorted((start, end))
+                    selection_style = self.get_component_rich_style("input--selection")
+                    result.stylize_before(
+                        selection_style,
+                        self._display_index(start),
+                        self._display_index(end),
+                    )
+
+                if self._cursor_visible:
+                    cursor_style = self.get_component_rich_style("input--cursor")
+                    cursor = self._display_index(self.cursor_position)
+                    if not show_suggestion and self.cursor_at_end:
+                        result.pad_right(1)
+                    result.stylize(cursor_style, cursor, cursor + 1)
+
+            segments = list(
+                console.render(result, console_options.update_width(self.content_width))
+            )
+
+            strip = Strip(segments)
+            scroll_x, _ = self.scroll_offset
+            strip = strip.crop(scroll_x, scroll_x + max_content_width + 1)
+            strip = strip.extend_cell_length(max_content_width + 1)
+
+        return strip.apply_style(self.rich_style)
 
 
 class SettingsScreen(BaseAppScreen):
@@ -3145,7 +3263,7 @@ class SettingsScreen(BaseAppScreen):
                 )
             with Horizontal(classes="settings-input-row"):
                 yield Static("Endpoint", classes="settings-input-label")
-                yield Input(
+                yield SettingsURLInput(
                     value=str(values["endpoint"]),
                     id="settings-provider-endpoint-value",
                     classes="settings-compact-input",

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -386,13 +386,23 @@ def _textual_web_safe_url_display_index(value: str, index: int) -> int:
     display_index = index
     for match in TEXTUAL_WEB_URL_SCHEME_RE.finditer(value):
         insertion_index = match.start(1) + len(match.group(1))
-        if index > insertion_index:
+        if index >= insertion_index:
             display_index += len(TEXTUAL_WEB_URL_AUTOLINK_BREAK)
     return display_index
 
 
 class SettingsURLInput(Input):
-    """Input that prevents textual-web from opening endpoint values as browser links."""
+    """Render endpoint URLs without browser autolinking.
+
+    SettingsURLInput preserves the raw ``value`` used for validation, saving,
+    selection, and event handling. Only the rendered display text is adjusted by
+    inserting a zero-width break after URL schemes so textual-web/browser
+    terminals do not treat provider endpoint values as clickable links.
+
+    Args:
+        *args: Positional arguments forwarded to ``textual.widgets.Input``.
+        **kwargs: Keyword arguments forwarded to ``textual.widgets.Input``.
+    """
 
     @property
     def _value(self) -> Text:


### PR DESCRIPTION
## Summary
- add SettingsURLInput for provider endpoint fields so textual-web does not treat http/https endpoint values as browser links
- preserve raw endpoint values for validation/saving while only breaking URL schemes in rendered display text
- add regressions for URL-safe endpoint rendering and Settings endpoint widget composition
- add TASK-77 to track the broader actual-use Settings corrective QA work; this PR completes the first confirmed blocker slice

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_settings_configuration_hub.py --tb=short (157 passed, 1 warning)
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_settings_configuration_hub.py::test_settings_endpoint_display_breaks_browser_autolinks_without_mutating_value Tests/UI/test_settings_configuration_hub.py::test_settings_provider_endpoint_uses_url_safe_input_for_url_values --tb=short (2 passed, 1 warning)
- git diff --check
- CDP/textual-web: endpoint click and typing kept the browser page list at only http://127.0.0.1:8833/ before click, after click, and after typing; screenshot approved by user

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop browsers from auto-linking provider endpoint inputs in textual-web by inserting a zero‑width break after URL schemes in display only. Keeps the real value intact and now maps cursor/selection correctly, resolving the first blocker in TASK-77.

- **Bug Fixes**
  - Added `SettingsURLInput` that breaks `http/https` in display, preserves the raw value, and correctly maps cursor/selection and content width.
  - Replaced the provider endpoint field with `SettingsURLInput` in Settings.
  - Added tests for display transform, index mapping, and widget usage; added `TASK-77` QA tracking doc.

<sup>Written for commit b729bdbe07125f11f58ea3a1442cd77047b86f5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

