### PR TITLE
Settings modification/UI fixup - API and Model settings in Settings Screen

### DIFF
--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -1034,6 +1034,23 @@ async def test_settings_provider_category_lists_console_supported_catalog():
 
 
 @pytest.mark.asyncio
+async def test_settings_provider_model_defaults_appear_before_reference_copy():
+    app = _build_test_app()
+    app.app_config["chat_defaults"] = {"provider": "OpenAI", "model": "gpt-4.1"}
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.click("#settings-category-providers-models")
+        screen = _active_destination_screen(host)
+        text = _visible_text(screen)
+
+        assert "Selected model defaults" in text
+        assert "Provider catalog" in text
+        assert text.index("Selected model defaults") < text.index("Provider catalog")
+        assert text.index("Temperature") < text.index("Provider catalog")
+
+
+@pytest.mark.asyncio
 async def test_settings_provider_text_inputs_do_not_trigger_footer_shortcuts(monkeypatch):
     app = _build_test_app()
     app.app_config["chat_defaults"] = {"provider": "OpenAI", "model": "gpt-4.1"}

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -1042,12 +1042,15 @@ async def test_settings_provider_model_defaults_appear_before_reference_copy():
     async with host.run_test(size=(180, 50)) as pilot:
         await pilot.click("#settings-category-providers-models")
         screen = _active_destination_screen(host)
-        text = _visible_text(screen)
+        card = screen.query_one("#settings-providers-models-card")
+        title = card.query_one("#settings-selected-model-defaults-title", Static)
+        temperature = card.query_one("#settings-model-profile-temperature", Input)
+        catalog = card.query_one("#settings-provider-catalog", Static)
+        widgets = list(card.query("*"))
 
-        assert "Selected model defaults" in text
-        assert "Provider catalog" in text
-        assert text.index("Selected model defaults") < text.index("Provider catalog")
-        assert text.index("Temperature") < text.index("Provider catalog")
+        assert str(title.renderable) == "Selected model defaults"
+        assert widgets.index(title) < widgets.index(catalog)
+        assert widgets.index(temperature) < widgets.index(catalog)
 
 
 @pytest.mark.asyncio
@@ -2594,6 +2597,28 @@ async def test_settings_provider_model_switch_loads_selected_model_profile():
         assert screen.query_one("#settings-model-profile-temperature", Input).value == "0.45"
         assert screen.query_one("#settings-model-profile-top-p", Input).value == "0.9"
         assert screen.query_one("#settings-model-profile-streaming", Input).value == "false"
+
+
+@pytest.mark.asyncio
+async def test_settings_provider_model_profile_none_values_render_as_blank_inputs():
+    app = _build_test_app()
+    app.app_config["chat_defaults"] = {"provider": "OpenAI", "model": "gpt-4.1"}
+    app.app_config["api_settings"] = {
+        "openai": {
+            "model_defaults": {
+                "gpt-4.1": {"temperature": None, "top_p": None, "streaming": None},
+            },
+        },
+    }
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.click("#settings-category-providers-models")
+        screen = _active_destination_screen(host)
+
+        assert screen.query_one("#settings-model-profile-temperature", Input).value == ""
+        assert screen.query_one("#settings-model-profile-top-p", Input).value == ""
+        assert screen.query_one("#settings-model-profile-streaming", Input).value == ""
 
 
 @pytest.mark.asyncio

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -3775,7 +3775,11 @@ class SettingsScreen(BaseAppScreen):
                     classes="settings-compact-input",
                     placeholder="Model name",
                 )
-            yield Static("Selected model defaults", classes="destination-section")
+            yield Static(
+                "Selected model defaults",
+                id="settings-selected-model-defaults-title",
+                classes="destination-section",
+            )
             yield Static(
                 "Global fallbacks live under Console Defaults; these values apply only "
                 "to the provider+model above.",
@@ -3784,7 +3788,7 @@ class SettingsScreen(BaseAppScreen):
             with Horizontal(classes="settings-input-row"):
                 yield Static("Temperature", classes="settings-input-label")
                 yield Input(
-                    value=str(values["model_profile_temperature"]),
+                    value=self._profile_input_value(values["model_profile_temperature"]),
                     id="settings-model-profile-temperature",
                     classes="settings-compact-input",
                     placeholder="0.0 - 2.0",
@@ -3792,7 +3796,7 @@ class SettingsScreen(BaseAppScreen):
             with Horizontal(classes="settings-input-row"):
                 yield Static("Top P", classes="settings-input-label")
                 yield Input(
-                    value=str(values["model_profile_top_p"]),
+                    value=self._profile_input_value(values["model_profile_top_p"]),
                     id="settings-model-profile-top-p",
                     classes="settings-compact-input",
                     placeholder="0.0 - 1.0",
@@ -3800,9 +3804,7 @@ class SettingsScreen(BaseAppScreen):
             with Horizontal(classes="settings-input-row"):
                 yield Static("Streaming", classes="settings-input-label")
                 yield Input(
-                    value=str(values["model_profile_streaming"]).lower()
-                    if isinstance(values["model_profile_streaming"], bool)
-                    else str(values["model_profile_streaming"]),
+                    value=self._profile_input_value(values["model_profile_streaming"]),
                     id="settings-model-profile-streaming",
                     classes="settings-compact-input",
                     placeholder="true or false",

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -3775,6 +3775,38 @@ class SettingsScreen(BaseAppScreen):
                     classes="settings-compact-input",
                     placeholder="Model name",
                 )
+            yield Static("Selected model defaults", classes="destination-section")
+            yield Static(
+                "Global fallbacks live under Console Defaults; these values apply only "
+                "to the provider+model above.",
+                classes="settings-detail-row",
+            )
+            with Horizontal(classes="settings-input-row"):
+                yield Static("Temperature", classes="settings-input-label")
+                yield Input(
+                    value=str(values["model_profile_temperature"]),
+                    id="settings-model-profile-temperature",
+                    classes="settings-compact-input",
+                    placeholder="0.0 - 2.0",
+                )
+            with Horizontal(classes="settings-input-row"):
+                yield Static("Top P", classes="settings-input-label")
+                yield Input(
+                    value=str(values["model_profile_top_p"]),
+                    id="settings-model-profile-top-p",
+                    classes="settings-compact-input",
+                    placeholder="0.0 - 1.0",
+                )
+            with Horizontal(classes="settings-input-row"):
+                yield Static("Streaming", classes="settings-input-label")
+                yield Input(
+                    value=str(values["model_profile_streaming"]).lower()
+                    if isinstance(values["model_profile_streaming"], bool)
+                    else str(values["model_profile_streaming"]),
+                    id="settings-model-profile-streaming",
+                    classes="settings-compact-input",
+                    placeholder="true or false",
+                )
             with Horizontal(classes="settings-input-row"):
                 yield Static("Endpoint", classes="settings-input-label")
                 yield SettingsURLInput(
@@ -3816,38 +3848,6 @@ class SettingsScreen(BaseAppScreen):
                 self._provider_endpoint_row(str(values["provider"])).removeprefix("Endpoint key: "),
                 identifier="settings-provider-endpoint-key",
             )
-            yield Static("Selected model defaults", classes="destination-section")
-            yield Static(
-                "Global fallbacks live under Console Defaults; this panel saves only "
-                "the selected provider+model profile.",
-                classes="settings-detail-row",
-            )
-            with Horizontal(classes="settings-input-row"):
-                yield Static("Temperature", classes="settings-input-label")
-                yield Input(
-                    value=str(values["model_profile_temperature"]),
-                    id="settings-model-profile-temperature",
-                    classes="settings-compact-input",
-                    placeholder="0.0 - 2.0",
-                )
-            with Horizontal(classes="settings-input-row"):
-                yield Static("Top P", classes="settings-input-label")
-                yield Input(
-                    value=str(values["model_profile_top_p"]),
-                    id="settings-model-profile-top-p",
-                    classes="settings-compact-input",
-                    placeholder="0.0 - 1.0",
-                )
-            with Horizontal(classes="settings-input-row"):
-                yield Static("Streaming", classes="settings-input-label")
-                yield Input(
-                    value=str(values["model_profile_streaming"]).lower()
-                    if isinstance(values["model_profile_streaming"], bool)
-                    else str(values["model_profile_streaming"]),
-                    id="settings-model-profile-streaming",
-                    classes="settings-compact-input",
-                    placeholder="true or false",
-                )
             yield Static("Provider readiness", classes="destination-section")
             yield self._detail_row(
                 "Readiness",


### PR DESCRIPTION
## Summary
- Moves selected per-model defaults directly under the Model field in Settings > Providers & Models.
- Keeps endpoint, credential, and provider catalog reference copy below the primary editable model controls.
- Adds regression coverage so model defaults remain before provider reference copy.

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_settings_configuration_hub.py --tb=short
- git diff --check
- Rendered Settings screenshot reviewed and approved by user.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reordered the Providers & Models settings so per-model defaults (Temperature, Top P, Streaming) appear directly under the selected Model, with endpoints/credentials and provider catalog copy below. Also fixed model default inputs so unset values render as blank.

- **Bug Fixes**
  - Treat `None` values for Temperature, Top P, and Streaming as blank inputs instead of “None”.
  - Added regression tests to lock the layout (defaults before provider catalog) and verify blank rendering.

<sup>Written for commit 867a858032413bfe949474c7554d7583e7112f03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

