### PR TITLE
Cover default workspace chat persistence

### DIFF
--- a/Tests/Chat/test_console_chat_store.py
+++ b/Tests/Chat/test_console_chat_store.py
@@ -579,6 +579,8 @@ def test_store_persists_default_workspace_chat_without_runtime_access(tmp_path):
         conversation = db.get_conversation_by_id(conversation_id)
         persisted_message = db.get_message_by_id(message.persisted_message_id)
         workspace_conversations = registry.list_workspace_conversations(DEFAULT_WORKSPACE_ID)
+        assert conversation is not None
+        assert persisted_message is not None
         assert conversation["scope_type"] == "workspace"
         assert conversation["workspace_id"] == DEFAULT_WORKSPACE_ID
         assert persisted_message["content"] == "default workspace chat remains usable"

--- a/Tests/Chat/test_console_chat_store.py
+++ b/Tests/Chat/test_console_chat_store.py
@@ -6,7 +6,7 @@ from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
 from tldw_chatbook.Chat.chat_persistence_service import ChatPersistenceService
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
 from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
-from tldw_chatbook.Workspaces import LocalWorkspaceRegistryService
+from tldw_chatbook.Workspaces import DEFAULT_WORKSPACE_ID, LocalWorkspaceRegistryService
 
 
 def test_store_creates_session_and_appends_messages():
@@ -552,6 +552,38 @@ def test_store_persists_workspace_session_with_real_chat_persistence_service(tmp
         assert persisted_message["content"] == "hello"
         workspace_conversations = registry.list_workspace_conversations("workspace-a")
         assert [item.item_id for item in workspace_conversations] == [conversation_id]
+    finally:
+        db.close()
+
+
+def test_store_persists_default_workspace_chat_without_runtime_access(tmp_path):
+    db = CharactersRAGDB(str(tmp_path / "chachanotes.sqlite"), "test_client")
+    try:
+        registry = LocalWorkspaceRegistryService(
+            WorkspaceDB(tmp_path / "workspaces.sqlite", client_id="test_client")
+        )
+        registry.ensure_default_workspace()
+        store = ConsoleChatStore(
+            persistence=ChatPersistenceService(db, workspace_registry=registry)
+        )
+        session = store.ensure_session(title="Chat 1", workspace_id=DEFAULT_WORKSPACE_ID)
+
+        conversation_id = store.persist_session_if_needed(session.id)
+        message = store.append_message(
+            session.id,
+            role=ConsoleMessageRole.USER,
+            content="default workspace chat remains usable",
+            persist=True,
+        )
+
+        conversation = db.get_conversation_by_id(conversation_id)
+        persisted_message = db.get_message_by_id(message.persisted_message_id)
+        workspace_conversations = registry.list_workspace_conversations(DEFAULT_WORKSPACE_ID)
+        assert conversation["scope_type"] == "workspace"
+        assert conversation["workspace_id"] == DEFAULT_WORKSPACE_ID
+        assert persisted_message["content"] == "default workspace chat remains usable"
+        assert [item.item_id for item in workspace_conversations] == [conversation_id]
+        assert registry.list_runtime_bindings(DEFAULT_WORKSPACE_ID) == ()
     finally:
         db.close()
 

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -9,7 +9,7 @@ from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
     ConsoleHarness,
     _visible_text,
 )
-from textual.widgets import Button, Input
+from textual.widgets import Button, Input, Static
 
 from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole, ConsoleRunStatus
 from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
@@ -17,6 +17,7 @@ from tldw_chatbook.Chat.console_provider_gateway import ConsoleProviderGateway
 from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
 from tldw_chatbook.Widgets.Console import ConsoleComposerBar, ConsoleTranscript
 from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+from tldw_chatbook.Workspaces import DEFAULT_WORKSPACE_ID
 
 
 class _ReadyResolutionGateway:
@@ -91,6 +92,34 @@ class CapturingGateway(_ReadyResolutionGateway):
         self.sent_messages.append(list(messages))
         for chunk in self.chunks:
             yield chunk
+
+
+class WorkspaceLinkingPersistence:
+    def __init__(self, registry_service) -> None:
+        self.registry_service = registry_service
+        self.conversation_count = 0
+        self.message_count = 0
+
+    def create_conversation(self, **kwargs):
+        self.conversation_count += 1
+        conversation_id = f"persisted-conversation-{self.conversation_count}"
+        workspace_id = kwargs.get("workspace_id")
+        if kwargs.get("scope_type") == "workspace" and workspace_id:
+            self.registry_service.link_membership(
+                workspace_id,
+                item_type="conversation",
+                item_id=conversation_id,
+                role="workspace-thread",
+                title=kwargs.get("conversation_title") or "Chat 1",
+            )
+        return conversation_id
+
+    def create_message(self, **kwargs):
+        self.message_count += 1
+        return f"persisted-message-{self.message_count}"
+
+    def update_message_content(self, **kwargs):
+        return True
 
 
 class FailThenRecoverGateway(_ReadyResolutionGateway):
@@ -316,7 +345,7 @@ def test_console_provider_selection_reads_local_llamacpp_configured_model():
     assert selection.base_url == "http://127.0.0.1:9099"
     assert selection.explicit_model == "runtime-model"
     assert selection.configured_model == "configured-model"
-    assert selection.workspace_context.active_workspace_id == "global"
+    assert selection.workspace_context.active_workspace_id == DEFAULT_WORKSPACE_ID
 
 
 def test_console_configured_llamacpp_override_wins_over_provider_api_url():
@@ -656,6 +685,36 @@ async def test_console_native_send_clears_composer_after_acceptance_and_updates_
         messages = store.messages_for_session(store.active_session_id)
         assert messages[-2].content == "hello"
         assert messages[-1].content == "hello"
+
+
+@pytest.mark.asyncio
+async def test_console_send_refreshes_workspace_conversation_rail_after_persistence():
+    app = _build_test_app()
+    app.chat_api_provider_value = "llama_cpp"
+    app.chat_api_model_value = "test-model"
+    app.console_provider_gateway_factory = lambda: CapturingGateway(chunks=("accepted",))
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        assert len(console.query("#console-workspace-empty-conversations")) == 1
+        store = console._ensure_console_chat_store()
+        store.persistence = WorkspaceLinkingPersistence(app.workspace_registry_service)
+        _select_llamacpp_console(console)
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.load_draft("hello")
+
+        console.query_one("#console-send-message", Button).press()
+        await _wait_for_text(console, pilot, "accepted")
+        await _wait_for_selector(console, pilot, "#console-workspace-conversation-0")
+
+        row = console.query_one("#console-workspace-conversation-0", Static)
+        row_text = getattr(row.renderable, "plain", str(row.renderable))
+        assert row_text.startswith("> ")
+        assert "Chat 1" in row_text
+        assert "workspace-thread" in row_text
+        assert len(console.query("#console-workspace-empty-conversations")) == 0
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -176,6 +176,18 @@ async def _wait_for_console_screen(host: ConsoleHarness, console, pilot) -> None
     raise AssertionError("Console modal did not dismiss")
 
 
+async def _wait_for_workspace_switcher_modal(host: ConsoleHarness, pilot):
+    for _ in range(40):
+        if (
+            host.screen_stack
+            and host.screen_stack[-1].query("#console-workspace-switcher-modal")
+        ):
+            await pilot.pause()
+            return host.screen_stack[-1]
+        await pilot.pause(0.05)
+    raise AssertionError("Console workspace switcher modal did not open")
+
+
 def _select_llamacpp_console(console: ChatScreen) -> None:
     """Select the native llama.cpp path after mounted controls initialize."""
     app_config = console.app_instance.app_config
@@ -715,6 +727,86 @@ async def test_console_send_refreshes_workspace_conversation_rail_after_persiste
         assert "Chat 1" in row_text
         assert "workspace-thread" in row_text
         assert len(console.query("#console-workspace-empty-conversations")) == 0
+
+
+@pytest.mark.asyncio
+async def test_console_send_after_workspace_switch_persists_to_selected_workspace():
+    app = _build_test_app()
+    app.chat_api_provider_value = "llama_cpp"
+    app.chat_api_model_value = "test-model"
+    app.console_provider_gateway_factory = lambda: CapturingGateway(chunks=("accepted",))
+    service = app.workspace_registry_service
+    service.create_workspace(workspace_id="ws-a", name="Workspace A")
+    service.create_workspace(workspace_id="ws-b", name="Workspace B")
+    service.set_active_workspace("ws-a")
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        await _wait_for_selector(console, pilot, "#console-change-workspace")
+        store = console._ensure_console_chat_store()
+        store.persistence = WorkspaceLinkingPersistence(service)
+        _select_llamacpp_console(console)
+        first_session = store.ensure_session()
+        store.replace_session_settings(
+            first_session.id,
+            ConsoleSessionSettings(provider="llama_cpp", model="test-model"),
+        )
+        assert first_session.workspace_id == "ws-a"
+
+        console.query_one("#console-change-workspace", Button).press()
+        modal_screen = await _wait_for_workspace_switcher_modal(host, pilot)
+        switch_button = next(
+            button
+            for button in modal_screen.query(Button)
+            if str(button.label) == "Workspace B"
+        )
+        switch_button.press()
+        await _wait_for_console_screen(host, console, pilot)
+        assert service.get_active_workspace().workspace_id == "ws-b"
+
+        active_session = store.switch_session(store.active_session_id)
+        assert active_session.workspace_id == "ws-b"
+        assert active_session.title == "Workspace B Chat"
+        assert active_session.settings.provider == "llama_cpp"
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.load_draft("hello from b")
+        console.query_one("#console-send-message", Button).press()
+        await _wait_for_text(console, pilot, "accepted")
+
+        workspace_a_conversations = service.list_workspace_conversations("ws-a")
+        workspace_b_conversations = service.list_workspace_conversations("ws-b")
+        assert workspace_a_conversations == ()
+        assert [row.title for row in workspace_b_conversations] == [active_session.title]
+
+
+@pytest.mark.asyncio
+async def test_console_tab_switch_aligns_active_workspace_context():
+    app = _build_test_app()
+    service = app.workspace_registry_service
+    service.create_workspace(workspace_id="ws-a", name="Workspace A")
+    service.create_workspace(workspace_id="ws-b", name="Workspace B")
+    service.set_active_workspace("ws-a")
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+        store = console._ensure_console_chat_store()
+        first = store.ensure_session(title="Workspace A Chat", workspace_id="ws-a")
+        second = store.create_session(title="Workspace B Chat", workspace_id="ws-b")
+        service.set_active_workspace("ws-b")
+        await console._sync_native_console_chat_ui()
+        await _wait_for_selector(console, pilot, f"#console-session-tab-{first.id}")
+        assert store.active_session_id == second.id
+        assert service.get_active_workspace().workspace_id == "ws-b"
+
+        await pilot.click(f"#console-session-tab-{first.id}")
+
+        assert store.active_session_id == first.id
+        assert service.get_active_workspace().workspace_id == "ws-a"
+        await _wait_for_text(console, pilot, "Workspace A")
 
 
 @pytest.mark.asyncio

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -2873,6 +2873,7 @@ class ChatScreen(BaseAppScreen):
             self._sync_console_settings_summary()
             self._sync_console_mode_bar()
             await self._sync_console_native_session_tabs()
+            self._sync_console_workspace_context()
             await self._sync_native_console_transcript_to_legacy_surface()
             self._sync_console_rail_visibility(self._current_console_rail_state())
         finally:

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -429,7 +429,9 @@ class ChatScreen(BaseAppScreen):
                     severity="error",
                 )
                 return
+            self._save_active_console_session_draft()
             self._sync_console_chat_core_state()
+            self._activate_console_session_for_workspace(workspace_id)
             self._sync_console_workspace_context()
 
         self.app.push_screen(
@@ -952,6 +954,79 @@ class ChatScreen(BaseAppScreen):
                 self._console_chat_controller.max_tokens = selection.max_tokens
                 self._console_chat_controller.streaming = selection.streaming
         return selection
+
+    def _activate_console_session_for_workspace(self, workspace_id: str) -> None:
+        """Activate or create the Console session for the selected workspace."""
+        target_workspace_id = str(workspace_id).strip()
+        if not target_workspace_id:
+            return
+        store = self._ensure_console_chat_store()
+        inherited_settings = None
+        if store.active_session_id is not None:
+            try:
+                inherited_settings = store.session_settings(store.active_session_id)
+            except KeyError:
+                inherited_settings = None
+        if store.active_session_id is not None:
+            for session in store.sessions():
+                if (
+                    session.id == store.active_session_id
+                    and session.workspace_id == target_workspace_id
+                ):
+                    return
+        for session in store.sessions():
+            if session.workspace_id == target_workspace_id:
+                store.switch_session(session.id)
+                return
+        store.create_session(
+            title=self._console_workspace_session_title(target_workspace_id),
+            workspace_id=target_workspace_id,
+            settings=inherited_settings or self._default_console_session_settings(),
+        )
+
+    def _console_workspace_session_title(self, workspace_id: str) -> str:
+        """Return a readable title for an auto-created workspace Console tab."""
+        registry_service = getattr(self.app_instance, "workspace_registry_service", None)
+        workspace_name = str(workspace_id).strip()
+        if registry_service is not None:
+            try:
+                workspace = registry_service.get_workspace(workspace_id)
+                if workspace is not None:
+                    workspace_name = workspace.name
+            except Exception:
+                logger.debug("Unable to read Console workspace title", exc_info=True)
+        if not workspace_name:
+            workspace_name = "Workspace"
+        return f"{workspace_name} Chat"
+
+    def _set_active_workspace_for_console_session(self, session_id: str) -> None:
+        """Keep workspace context aligned when switching Console tabs."""
+        store = self._ensure_console_chat_store()
+        target_session = next(
+            (session for session in store.sessions() if session.id == session_id),
+            None,
+        )
+        if target_session is None:
+            return
+        workspace_id = str(target_session.workspace_id or "").strip()
+        if not workspace_id or workspace_id == "global":
+            return
+        registry_service = getattr(self.app_instance, "workspace_registry_service", None)
+        if registry_service is None:
+            return
+        try:
+            active_workspace = registry_service.get_active_workspace()
+            if (
+                active_workspace is not None
+                and active_workspace.workspace_id == workspace_id
+            ):
+                return
+            registry_service.set_active_workspace(workspace_id)
+        except Exception:
+            logger.warning(
+                "Unable to align Console workspace with selected tab",
+                exc_info=True,
+            )
 
     def _console_composer_or_none(self) -> ConsoleComposerBar | None:
         """Return the native Console composer when it is mounted."""
@@ -4387,6 +4462,7 @@ class ChatScreen(BaseAppScreen):
                 self._open_console_session_rename_modal(session_id)
                 return
             self._save_active_console_session_draft()
+            self._set_active_workspace_for_console_session(session_id)
             controller.switch_session(session_id)
             await self._sync_native_console_chat_ui()
             return


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Add regression test for Default workspace chat persistence (no runtime bindings)
<code>🧪 Tests</code> <code>🐞 Bug fix</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## Summary
- Add a regression proving the built-in Default workspace can persist normal Console chat conversations.
- Lock in that Default remains runtime/file-tool safe by asserting no runtime bindings are exposed.

## Verification
- python -m pytest -q Tests/Chat/test_console_chat_store.py::test_store_persists_default_workspace_chat_without_runtime_access --tb=short
- python -m pytest -q Tests/Chat/test_console_chat_store.py Tests/Workspaces/test_workspace_registry_service.py Tests/Workspaces/test_workspace_display_state.py --tb=short
- git diff --check

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Add regression test ensuring Default workspace console chats persist to the DB.
• Assert persisted conversations are scoped to the Default workspace.
• Ensure Default workspace exposes no runtime/tool bindings during normal chat persistence.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["Test: console store"] --> B["ConsoleChatStore"] --> C["ChatPersistenceService"] --> D[("CharactersRAGDB")]
  A --> E["LocalWorkspaceRegistryService"] --> F[("WorkspaceDB")]
  B --> E
  E --> G["Default workspace (ID)"]
  C --> G

  subgraph Legend
    direction LR
    _test["Test"] ~~~ _svc["Service"] ~~~ _db[("Database")] ~~~ _id["Identifier"]
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The PR’s approach (an integration-style regression test spanning store + persistence + registry) is the right level to prevent recurrence: it verifies the Default workspace path end-to-end and locks in the security expectation of no runtime bindings.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Tests</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>test_console_chat_store.py</strong> <code>Add regression test for Default workspace chat persistence and binding safety</code> <code>+33/-1</code></summary>

<br/>

>Add regression test for Default workspace chat persistence and binding safety
>
><pre>
>• Introduces a new test that creates the Default workspace, persists a console chat session/message under DEFAULT_WORKSPACE_ID, and verifies the stored conversation is workspace-scoped and listed under that workspace. Adds an explicit assertion that the Default workspace has no runtime bindings exposed.
></pre>
>
><a href='https://github.com/rmusser01/tldw_chatbook/pull/491/files#diff-524952c8fe5ef1fa33ddbc78ff352998312d05ec4afc59c1379ee86bba131350'>Tests/Chat/test_console_chat_store.py</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>