### PR TITLE
Fix Backlog task ID hygiene

### DIFF
--- a/Docs/superpowers/qa/provider-cdp-uat/2026-05-31-provider-cdp-uat.md
+++ b/Docs/superpowers/qa/provider-cdp-uat/2026-05-31-provider-cdp-uat.md
@@ -3,7 +3,7 @@
 Date: 2026-06-01
 Branch: codex/provider-cdp-uat-execution
 Spec: Docs/superpowers/specs/2026-05-31-provider-cdp-uat-design.md
-Backlog task: TASK-75 - Provider CDP UAT sweep
+Backlog task: TASK-84 - Provider CDP UAT sweep
 Textual-web URL: http://127.0.0.1:8897
 Isolated QA root: `${TMPDIR:-system temp}/tldw-chatbook-provider-cdp-uat` via `run_textual_web_with_env.py`
 Isolated HOME: `<qa-root>/home`

--- a/backlog/decisions/005-console-workspace-server-readiness.md
+++ b/backlog/decisions/005-console-workspace-server-readiness.md
@@ -2,7 +2,7 @@
 
 Status: Accepted
 Date: 2026-06-08
-Related Task: [backlog/tasks/task-81 - Console-workspace-switching-server-readiness-contracts.md](../tasks/task-81%20-%20Console-workspace-switching-server-readiness-contracts.md)
+Related Task: [backlog/tasks/task-86 - Console-workspace-switching-server-readiness-contracts.md](../tasks/task-86%20-%20Console-workspace-switching-server-readiness-contracts.md)
 Supersedes: N/A
 
 ## Decision
@@ -43,7 +43,7 @@ The built-in `Default` workspace is local-only and not-configured for sync. It c
 
 ## Links
 
-- [Backlog task TASK-81](../tasks/task-81%20-%20Console-workspace-switching-server-readiness-contracts.md)
+- [Backlog task TASK-86](../tasks/task-86%20-%20Console-workspace-switching-server-readiness-contracts.md)
 - [Workspace operating context PRD](../../Docs/superpowers/specs/2026-05-20-workspace-operating-context-handoff-prd-design.md)
 - [Workspace operating context implementation plan](../../Docs/superpowers/plans/2026-05-20-workspace-operating-context-implementation.md)
 - [Server parity roadmap](../../Docs/superpowers/specs/2026-04-28-remaining-server-parity-roadmap-design.md)

--- a/backlog/tasks/task-84 - Provider-CDP-UAT-sweep.md
+++ b/backlog/tasks/task-84 - Provider-CDP-UAT-sweep.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-75
+id: TASK-84
 title: Provider CDP UAT sweep
 status: Done
 assignee: []

--- a/backlog/tasks/task-85 - Console-UAT-basic-chat-frontend-acceptance.md
+++ b/backlog/tasks/task-85 - Console-UAT-basic-chat-frontend-acceptance.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-80
+id: TASK-85
 title: Console UAT basic chat frontend acceptance
 status: Done
 labels:

--- a/backlog/tasks/task-86 - Console-workspace-switching-server-readiness-contracts.md
+++ b/backlog/tasks/task-86 - Console-workspace-switching-server-readiness-contracts.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-81
+id: TASK-86
 title: Console workspace switching server-readiness contracts
 status: Done
 labels:
@@ -33,7 +33,7 @@ Prepare Console workspace switching for future tldw_server and ACP handoff suppo
 <!-- SECTION:PLAN:BEGIN -->
 ADR required: yes
 ADR path: backlog/decisions/005-console-workspace-server-readiness.md
-Reason: TASK-81 defines long-lived workspace authority, sync/handoff policy, server adapter boundaries, and ACP task/run package readiness contracts.
+Reason: TASK-86 defines long-lived workspace authority, sync/handoff policy, server adapter boundaries, and ACP task/run package readiness contracts.
 
 1. Create ADR 005 to lock the local-first/server-readiness boundary: no sync engine, local registry fallback, explicit adapter states, and ACP handoff as visible future target.
 2. Write failing pure regressions for Console workspace server-readiness display state covering server-unavailable, remote-only, conflict, runtime-missing, source/conversation transfer policy labels, and ACP handoff blocked/ready/failure/audit states.

--- a/backlog/tasks/task-87 - Settings-remaining-category-functional-QA-sweep.md
+++ b/backlog/tasks/task-87 - Settings-remaining-category-functional-QA-sweep.md
@@ -1,0 +1,37 @@
+---
+id: TASK-87
+title: Settings remaining category functional QA sweep
+status: To Do
+assignee: []
+created_date: '2026-06-09 01:03'
+updated_date: '2026-06-09 01:06'
+labels:
+  - settings
+  - ux
+  - qa
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Audit and verify the Settings screen categories not covered by recent focused Settings slices through actual rendered app use. The goal is to identify remaining broken controls, placeholder states, and category ownership gaps before claiming Settings is a real configuration hub.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Actual CDP/Textual-web walkthrough covers the remaining Settings categories that still rely on read-only contracts or incomplete mutation paths: Overview, Storage, Privacy & Security, Diagnostics, Advanced Config, Server/Sync/Workspace/Handoff, and Domain Defaults for Library/RAG, Artifacts, Personas, Skills, Schedules, Watchlists, Workflows, MCP, and ACP.
+- [ ] #2 Every category records whether it is guided-editable, read-only status/recovery, owned by another destination, or an explicit WIP placeholder.
+- [ ] #3 Confirmed usability blockers receive a failing regression before fixes, or become child Backlog tasks with evidence when they are outside this sweep.
+- [ ] #4 Dropdown/input focus, save/revert/test feedback, and keyboard operation are verified for each editable category.
+- [ ] #5 Actual screenshots and QA notes are recorded, and user approval is captured before a functional Settings PR is created.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 ADR check is documented before implementation starts; create or link an ADR only if the sweep changes storage, runtime, provider, sync, or ownership boundaries.
+- [ ] #2 Focused automated regressions cover every in-scope code change made from confirmed Settings blockers.
+- [ ] #3 Actual CDP/Textual-web screenshots and QA notes are attached for each approved Settings fix or category sweep result.
+- [ ] #4 Verification commands and residual risks are recorded in Implementation Notes before the task can move to Done.
+<!-- DOD:END -->


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Renumber Backlog task IDs to eliminate duplicates and update references
<code>🐞 Bug fix</code> <code>📝 Documentation</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## Summary
- Renumber duplicate Backlog task IDs so completed Provider/Console records no longer collide with Settings tasks
- Update direct Provider UAT and Console workspace ADR references to the new task IDs
- Add TASK-87 for the remaining Settings category functional QA sweep with explicit CDP, regression, and approval gates

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_product_maturity_phase1_harness.py::test_backlog_task_frontmatter_ids_are_unique --tb=short
- git diff --check

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Renumber completed Backlog tasks to restore unique TASK IDs across categories.
• Update UAT/ADR documents to reference the new task IDs.
• Add TASK-87 to capture remaining Settings functional QA sweep gates.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["Backlog task files"] --> B["Pytest ID uniqueness check"] --> C["Passes in CI/local"]
  D["Provider CDP UAT doc"] --> A
  E["Console workspace ADR"] --> A
  A --> F["Cross-doc links stay valid"]

  subgraph Legend
    direction LR
    _docs["Docs/ADR"] ~~~ _tasks["Backlog tasks"] ~~~ _test["Test guard"]
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Enforce unique TASK IDs via a pre-commit/CI guard</b></summary>

- ➕ Prevents future collisions before they land in main
- ➕ Makes hygiene automatic instead of manual renumbering
- ➖ Requires adding repo tooling and CI wiring
- ➖ May add friction for contributors when editing backlog files

</details>

<details>
<summary><b>2. Switch to globally unique IDs (UUID/date-based) and keep TASK-xx as a display alias</b></summary>

- ➕ Eliminates collision class entirely
- ➕ Allows stable internal identity even if numbering changes
- ➖ Bigger migration across existing links and conventions
- ➖ Less human-friendly identifiers in frontmatter unless aliased

</details>

**Recommendation:** The PR’s approach (renumber + update references + add the missing Settings QA task) is the fastest safe fix and aligns with the existing TASK-xx convention. Consider adding a lightweight CI/pre-commit check next to make ID collisions impossible to reintroduce.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>task-87 - Settings-remaining-category-functional-QA-sweep.md</strong> <code>Add TASK-87 for remaining Settings category functional QA sweep</code> <code>+37/-0</code></summary>

<br/>

>Add TASK-87 for remaining Settings category functional QA sweep
>
><pre>
>• Introduces a new Settings QA sweep task with explicit acceptance criteria and definition-of-done gates covering CDP/Textual-web walkthrough, regressions, evidence capture, and approval requirements.
></pre>
>
><a href='https://github.com/rmusser01/tldw_chatbook/pull/493/files#diff-33c20adcbbb48ea46ca967447d78a6cbad40ee29cc7f433772cbb19e7ca6d2a5'>backlog/tasks/task-87 - Settings-remaining-category-functional-QA-sweep.md</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Bug fix</strong> (3)</summary>

<blockquote>
<details>
<summary><strong>task-84 - Provider-CDP-UAT-sweep.md</strong> <code>Renumber Provider CDP UAT sweep from TASK-75 to TASK-84</code> <code>+1/-1</code></summary>

<br/>

>Renumber Provider CDP UAT sweep from TASK-75 to TASK-84
>
><pre>
>• Changes the task frontmatter ID to TASK-84 to remove a duplicate/collision in the backlog ID space while keeping the task content/status intact.
></pre>
>
><a href='https://github.com/rmusser01/tldw_chatbook/pull/493/files#diff-bb7ecb60b1151000867dc57b339f94888d27d1f7a56550c4f203b0aed4f5b9b3'>backlog/tasks/task-84 - Provider-CDP-UAT-sweep.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>task-85 - Console-UAT-basic-chat-frontend-acceptance.md</strong> <code>Renumber Console UAT acceptance from TASK-80 to TASK-85</code> <code>+1/-1</code></summary>

<br/>

>Renumber Console UAT acceptance from TASK-80 to TASK-85
>
><pre>
>• Changes the task frontmatter ID to TASK-85 to avoid collisions with other TASK-80 usage while leaving the task definition unchanged.
></pre>
>
><a href='https://github.com/rmusser01/tldw_chatbook/pull/493/files#diff-dd6c0a9f96e895d9f0634f23c2ec20c9af69285bc3ddc3bc0c053ff0c02e715d'>backlog/tasks/task-85 - Console-UAT-basic-chat-frontend-acceptance.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>task-86 - Console-workspace-switching-server-readiness-contracts.md</strong> <code>Renumber Console workspace readiness from TASK-81 to TASK-86 and update internal references</code> <code>+2/-2</code></summary>

<br/>

>Renumber Console workspace readiness from TASK-81 to TASK-86 and update internal references
>
><pre>
>• Updates the task frontmatter ID to TASK-86 and adjusts the embedded plan &#x27;Reason&#x27; line to match the new task ID, keeping the ADR path stable.
></pre>
>
><a href='https://github.com/rmusser01/tldw_chatbook/pull/493/files#diff-3808671daaf01da83301e6304ae9813e6235a57d52ca4343183e38c419f29e20'>backlog/tasks/task-86 - Console-workspace-switching-server-readiness-contracts.md</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Documentation</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>2026-05-31-provider-cdp-uat.md</strong> <code>Update Provider CDP UAT doc to reference TASK-84</code> <code>+1/-1</code></summary>

<br/>

>Update Provider CDP UAT doc to reference TASK-84
>
><pre>
>• Renames the referenced backlog task in the UAT execution frontmatter from TASK-75 to TASK-84 to match the renumbered task ID.
></pre>
>
><a href='https://github.com/rmusser01/tldw_chatbook/pull/493/files#diff-1a04050d76e0b30d8df316a1b26391151d5fe57b8fb0ab52ebda43e15a8a65ab'>Docs/superpowers/qa/provider-cdp-uat/2026-05-31-provider-cdp-uat.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>005-console-workspace-server-readiness.md</strong> <code>Retarget ADR links from TASK-81 to TASK-86</code> <code>+2/-2</code></summary>

<br/>

>Retarget ADR links from TASK-81 to TASK-86
>
><pre>
>• Updates the ADR&#x27;s &#x27;Related Task&#x27; link and link list entry to point at the renumbered Console workspace readiness task (TASK-86) instead of TASK-81.
></pre>
>
><a href='https://github.com/rmusser01/tldw_chatbook/pull/493/files#diff-434b436673dbfaed61bb4249ccc1059104fcfee66397c2ef5c08793f7d29088c'>backlog/decisions/005-console-workspace-server-readiness.md</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>