### PR TITLE
Surface Settings Storage checks before path editor

### DIFF
--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -994,6 +994,31 @@ async def test_settings_storage_renders_guided_defaults_and_validates(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_settings_storage_surfaces_check_action_before_long_path_editor(tmp_path):
+    app = _build_test_app()
+    db_dir = tmp_path / "db"
+    db_dir.mkdir()
+    app.app_config["database"] = {
+        "USER_DB_BASE_DIR": str(tmp_path),
+        "chachanotes_db_path": str(db_dir / "chatbook.db"),
+        "prompts_db_path": str(db_dir / "prompts.db"),
+        "media_db_path": str(db_dir / "media.db"),
+        "research_db_path": str(db_dir / "research.db"),
+        "writing_db_path": str(db_dir / "writing.db"),
+        "library_collections_db_path": str(db_dir / "collections.db"),
+        "workspaces_db_path": str(db_dir / "workspaces.db"),
+    }
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.click("#settings-category-storage")
+        screen = _active_destination_screen(host)
+        text = _visible_text(screen)
+
+        assert text.index("Draft path check") < text.index("Database paths")
+
+
+@pytest.mark.asyncio
 async def test_settings_storage_save_and_revert_defaults(monkeypatch, tmp_path):
     app = _build_test_app()
     db_dir = tmp_path / "db"

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -5713,19 +5713,6 @@ class SettingsScreen(BaseAppScreen):
                     "Save writes config only; no files are moved or reconnected",
                 )
                 yield self._detail_row("Config path", config_path)
-                yield Static("Database paths", classes="destination-section")
-                for key, label in STORAGE_FIELD_LABELS.items():
-                    selector = self._storage_field_selector(key)
-                    if selector is None:
-                        continue
-                    with Horizontal(classes="settings-input-row"):
-                        yield Static(label, classes="settings-input-label")
-                        yield Input(
-                            value=str(values[key]),
-                            id=selector.removeprefix("#"),
-                            classes="settings-compact-input",
-                            placeholder="~/path/to/database.db",
-                        )
                 yield Static("Draft path check", classes="destination-section")
                 yield self._detail_row(
                     "Check mode",
@@ -5747,6 +5734,19 @@ class SettingsScreen(BaseAppScreen):
                     id="settings-storage-save-result",
                     classes="settings-status-row",
                 )
+                yield Static("Database paths", classes="destination-section")
+                for key, label in STORAGE_FIELD_LABELS.items():
+                    selector = self._storage_field_selector(key)
+                    if selector is None:
+                        continue
+                    with Horizontal(classes="settings-input-row"):
+                        yield Static(label, classes="settings-input-label")
+                        yield Input(
+                            value=str(values[key]),
+                            id=selector.removeprefix("#"),
+                            classes="settings-compact-input",
+                            placeholder="~/path/to/database.db",
+                        )
                 yield Static("Runtime local paths", classes="destination-section")
                 for path_summary in self._known_storage_paths():
                     yield self._split_detail_row(path_summary)


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Move Storage draft-path checks above database path editor in Settings
<code>✨ Enhancement</code> <code>🧪 Tests</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## Summary
- Moves the Storage draft path check controls above the long database path editor so the action is visible in the normal Settings viewport.
- Keeps the existing non-mutating Storage check behavior intact.
- Adds a regression test that protects the visible IA order.

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_settings_configuration_hub.py Tests/UI/test_settings_library_rag_defaults.py Tests/UI/test_settings_appearance_defaults.py Tests/UI/test_settings_privacy_security.py Tests/UI/test_console_session_settings.py --tb=short
- git diff --check

## Visual QA
- CDP screenshot approved by user: settings-task87-storage-check-above-paths.png

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Reorders Storage settings so “Draft path check” appears before the long “Database paths” editor.
• Preserves existing non-mutating storage check behavior while improving visibility in the default
  viewport.
• Adds a UI regression test to lock in the intended information architecture order.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["Settings: Storage pane"] --> B["Draft path check"] --> C["Database paths editor"] --> D["Runtime local paths"]
  E["UI regression test"] --> A

  subgraph Legend
    direction LR
    _ui["UI section"] ~~~ _test["Test"]
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Make sections collapsible (accordion) in Storage settings</b></summary>

- ➕ Keeps all controls accessible without requiring reordering
- ➕ Reduces vertical scrolling regardless of content length
- ➖ More UI complexity and interaction states to test
- ➖ May hide important actions behind collapsed sections

</details>

<details>
<summary><b>2. Add an in-pane quick action bar (sticky header) for checks</b></summary>

- ➕ Ensures check actions are always visible while scrolling
- ➕ Scales well as the Storage pane grows
- ➖ Requires layout/styling work and careful focus/scroll handling
- ➖ Adds more moving parts than a simple reorder

</details>

**Recommendation:** The current approach (reordering sections) is the best fit: it achieves the stated visibility goal with minimal behavioral risk and is now protected by a regression test. Consider an accordion or sticky action bar only if the Storage pane continues to expand and reordering no longer keeps key actions in view.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>settings_screen.py</strong> <code>Reorder Storage detail sections to show draft-path check before DB paths</code> <code>+13/-13</code></summary>

<br/>

>Reorder Storage detail sections to show draft-path check before DB paths
>
><pre>
>• Moves the “Database paths” input section below the “Draft path check” section within the Storage settings detail pane. This improves discoverability of the check controls without altering the underlying storage-check behavior.
></pre>
>
><a href='https://github.com/rmusser01/tldw_chatbook/pull/495/files#diff-3552caf8451aab25fba035e66d76dcae159d2f01bdb0ce0bcd364d654a4150e7'>tldw_chatbook/UI/Screens/settings_screen.py</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Tests</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>test_settings_configuration_hub.py</strong> <code>Add regression test enforcing Storage section ordering</code> <code>+25/-0</code></summary>

<br/>

>Add regression test enforcing Storage section ordering
>
><pre>
>• Introduces an async UI test that navigates to Storage settings and asserts that “Draft path check” appears before “Database paths” in the visible text. Uses a temporary database directory/config to ensure the long path editor is present during the check.
></pre>
>
><a href='https://github.com/rmusser01/tldw_chatbook/pull/495/files#diff-dab638f5a8c5a561ed6844d6b94e6dd76111e49274d1706bf74fb3c3418394f1'>Tests/UI/test_settings_configuration_hub.py</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>