### PR TITLE
Fix Console api_base_url endpoint precedence

### DIFF
--- a/Tests/Chat/test_console_session_settings.py
+++ b/Tests/Chat/test_console_session_settings.py
@@ -111,17 +111,29 @@ def test_default_settings_uses_api_base_url_for_llamacpp_base_url() -> None:
     settings = build_default_console_session_settings(
         {
             "chat_defaults": {"provider": "llama_cpp"},
+            "api_settings": {"llama_cpp": {"api_base_url": "127.0.0.1:9292/v1"}},
+        },
+        provider="llama_cpp",
+    )
+
+    assert settings.base_url == "http://127.0.0.1:9292"
+
+
+def test_default_settings_prefers_api_base_url_over_merged_llamacpp_api_url() -> None:
+    settings = build_default_console_session_settings(
+        {
+            "chat_defaults": {"provider": "llama_cpp"},
             "api_settings": {
                 "llama_cpp": {
                     "api_url": "http://localhost:8080/completion",
-                    "api_base_url": "127.0.0.1:9191/v1",
+                    "api_base_url": "127.0.0.1:9292/v1",
                 }
             },
         },
         provider="llama_cpp",
     )
 
-    assert settings.base_url == "http://127.0.0.1:9191"
+    assert settings.base_url == "http://127.0.0.1:9292"
 
 
 def test_public_helpers_accept_planned_positional_call_forms() -> None:
@@ -305,6 +317,35 @@ def test_readiness_allows_llamacpp_configured_v1_endpoint_normalized_to_root() -
     readiness = build_console_settings_readiness(
         ConsoleSessionSettings(provider="llama_cpp", model="llama3", base_url="http://127.0.0.1:9099"),
         app_config={"api_settings": {"llama_cpp": {"api_url": "http://127.0.0.1:9099/v1"}}},
+        environ={},
+    )
+
+    assert readiness.label == "Ready"
+    assert readiness.native_send_supported is True
+
+
+def test_readiness_allows_llamacpp_api_base_url_endpoint_normalized_to_root() -> None:
+    readiness = build_console_settings_readiness(
+        ConsoleSessionSettings(provider="llama_cpp", model="llama3", base_url="http://127.0.0.1:9292"),
+        app_config={"api_settings": {"llama_cpp": {"api_base_url": "http://127.0.0.1:9292/v1"}}},
+        environ={},
+    )
+
+    assert readiness.label == "Ready"
+    assert readiness.native_send_supported is True
+
+
+def test_readiness_prefers_api_base_url_over_merged_llamacpp_api_url() -> None:
+    readiness = build_console_settings_readiness(
+        ConsoleSessionSettings(provider="llama_cpp", model="llama3", base_url="http://127.0.0.1:9292"),
+        app_config={
+            "api_settings": {
+                "llama_cpp": {
+                    "api_url": "http://localhost:8080/completion",
+                    "api_base_url": "http://127.0.0.1:9292/v1",
+                }
+            }
+        },
         environ={},
     )
 

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -399,14 +399,15 @@ def test_console_configured_llamacpp_override_wins_over_provider_api_url():
     assert selection.base_url == "http://127.0.0.1:9099"
 
 
-def test_console_provider_selection_reads_llamacpp_api_base_url_alias():
+def test_console_llamacpp_api_base_url_wins_over_merged_provider_api_url(monkeypatch):
+    monkeypatch.delenv("TLDW_CONSOLE_LLAMA_CPP_BASE_URL", raising=False)
     app = _build_test_app()
     app.chat_api_provider_value = "llama_cpp"
     app.chat_api_model_value = "configured-model"
     app.app_config["api_settings"] = {
         "llama_cpp": {
-            "api_url": "http://localhost:8080/completion",
-            "api_base_url": "http://127.0.0.1:9191/v1",
+            "api_url": "http://localhost:8080/v1",
+            "api_base_url": "http://127.0.0.1:9099/v1",
             "model": "fallback-model",
         }
     }
@@ -414,7 +415,7 @@ def test_console_provider_selection_reads_llamacpp_api_base_url_alias():
 
     selection = screen._build_console_provider_selection()
 
-    assert selection.base_url == "http://127.0.0.1:9191"
+    assert selection.base_url == "http://127.0.0.1:9099"
 
 
 def test_console_llamacpp_env_url_wins_over_provider_api_url(monkeypatch):

--- a/backlog/tasks/task-88 - Console-honors-api-base-url-endpoint-overrides.md
+++ b/backlog/tasks/task-88 - Console-honors-api-base-url-endpoint-overrides.md
@@ -1,0 +1,65 @@
+---
+id: TASK-88
+title: Console honors api_base_url endpoint overrides
+status: Done
+labels:
+- console
+- settings
+- provider-config
+- regression
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix Console provider endpoint resolution so llama.cpp and compatible local providers use the same endpoint precedence as Settings and readiness checks. This prevents merged default api_url values from overriding a user-configured api_base_url endpoint during actual Console send flows.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Console session defaults honor api_base_url for llama_cpp/local_llamacpp endpoints.
+- [x] #2 Console readiness honors api_base_url when merged provider defaults also contain api_url.
+- [x] #3 Console active provider selection uses the same endpoint precedence as readiness and Settings.
+- [x] #4 Regression tests cover endpoint precedence for defaults, readiness, and active Console selection.
+- [x] #5 CDP verification captures Console using the configured localhost llama.cpp endpoint and rendering a sent message response.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+ADR path: N/A
+Reason: This is a bugfix aligning existing endpoint alias precedence across Console, readiness, and Settings; it does not introduce a new storage, provider boundary, service contract, or long-lived architectural decision.
+
+1. Reproduce the mismatch with a config that contains both merged default api_url and user api_base_url for llama_cpp.
+2. Add failing regression coverage for default session settings, readiness, and active Console provider selection.
+3. Align endpoint alias precedence so api_base_url wins over default api_url consistently.
+4. Verify the focused provider/session tests and run diff whitespace checks.
+5. Use CDP against textual-web to verify Console displays the configured localhost endpoint and renders a sent response.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Aligned Console endpoint resolution so llama.cpp-compatible providers prefer explicit `api_base_url` over merged default `api_url` across session defaults, readiness checks, and active send selection. The fix centralizes the active Console selection path on the shared endpoint helper and adds regressions for default settings, readiness, and `ChatScreen` provider selection.
+
+Verification:
+- `python -m pytest -q Tests/Chat/test_console_session_settings.py Tests/UI/test_console_native_chat_flow.py --tb=short` -> 89 passed.
+- `python -m pytest -q Tests/Chat/test_console_provider_gateway.py Tests/Chat/test_console_session_settings.py Tests/UI/test_console_native_chat_flow.py --tb=short` -> 137 passed.
+- `git diff --check` -> passed.
+- CDP screenshot evidence: `/private/tmp/console-current-uat-start.jpg`, `/private/tmp/console-current-uat-typed-viewport.jpg`, `/private/tmp/console-current-uat-response.jpg`.
+
+Direct endpoint probe confirmed the localhost service at `127.0.0.1:9099` returns the same UAT stub payload shown in Console, so the UI is reaching the configured endpoint and rendering the service response.
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Console now honors `api_base_url` endpoint overrides consistently when merged provider defaults also include `api_url`, preventing the active Console send path from falling back to the built-in llama.cpp default endpoint.
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/tldw_chatbook/Chat/console_provider_endpoints.py
+++ b/tldw_chatbook/Chat/console_provider_endpoints.py
@@ -25,8 +25,15 @@ URL_BASED_PROVIDER_KEYS = frozenset(
         "vllm",
     }
 )
-_ENDPOINT_SETTING_KEYS = ("api_base_url", "api_url", "base_url", "api_base", "api_endpoint", "endpoint")
-_URL_PROVIDER_SETTING_KEYS = ("api_base_url", "api_url", "base_url", "api_base")
+_ENDPOINT_SETTING_KEYS = (
+    "api_base_url",
+    "api_base",
+    "base_url",
+    "api_url",
+    "api_endpoint",
+    "endpoint",
+)
+_URL_PROVIDER_SETTING_KEYS = ("api_base_url", "api_base", "base_url", "api_url")
 _INVALID_ENDPOINT_DISPLAY = "invalid endpoint"
 
 

--- a/tldw_chatbook/Chat/console_session_settings.py
+++ b/tldw_chatbook/Chat/console_session_settings.py
@@ -637,9 +637,9 @@ def _has_provider_settings_key(app_config: Mapping[str, object], provider_key: s
 def _default_base_url(provider_key: str, provider_settings: Mapping[str, object]) -> str | None:
     base_url = _first_string(
         provider_settings.get("api_base_url"),
-        provider_settings.get("api_url"),
-        provider_settings.get("base_url"),
         provider_settings.get("api_base"),
+        provider_settings.get("base_url"),
+        provider_settings.get("api_url"),
     )
     if provider_key in {"llama_cpp", "local_llamacpp"}:
         return normalize_llamacpp_base_url(base_url or DEFAULT_LLAMACPP_BASE_URL)

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -55,6 +55,7 @@ from ...Chat.console_provider_gateway import (
     ConsoleProviderGateway,
     normalize_llamacpp_base_url,
 )
+from ...Chat.console_provider_endpoints import first_configured_endpoint
 from ...Chat.console_display_state import (
     CONSOLE_INSPECTOR_NO_APPROVAL_REASON,
     CONSOLE_INSPECTOR_NO_TOOL_CALLS_REASON,
@@ -802,10 +803,7 @@ class ChatScreen(BaseAppScreen):
             fallback_url = (
                 os.environ.get("TLDW_CONSOLE_LLAMA_CPP_BASE_URL")
                 or console_config.get("llama_cpp_base_url_override")
-                or provider_config.get("api_base_url")
-                or provider_config.get("api_url")
-                or provider_config.get("base_url")
-                or provider_config.get("api_base")
+                or first_configured_endpoint(provider_config)
             )
             override_url = (
                 selection_settings.base_url


### PR DESCRIPTION
## Summary
- Align Console llama.cpp endpoint resolution so api_base_url wins over merged default api_url.
- Reuse the shared endpoint helper in active Console provider selection.
- Add TASK-88 and regressions for defaults, readiness, and active Console selection.

## Verification
- python -m pytest -q Tests/Chat/test_console_provider_gateway.py Tests/Chat/test_console_session_settings.py Tests/UI/test_console_native_chat_flow.py --tb=short
- git diff --check

## CDP evidence
- /private/tmp/console-current-uat-start.jpg
- /private/tmp/console-current-uat-typed-viewport.jpg
- /private/tmp/console-current-uat-response.jpg

Note: direct localhost probe confirmed 127.0.0.1:9099 returned the same UAT stub payload rendered by Console, so Console is reaching the configured endpoint.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Console endpoint resolution so `api_base_url` takes precedence over merged `api_url` for `llama_cpp`/`local_llamacpp`, aligning defaults, readiness, and the active send path. Satisfies TASK-88 by ensuring Console uses the user-configured endpoint instead of a merged default.

- **Bug Fixes**
  - `api_base_url` now wins across session defaults, readiness checks, and provider selection; `/v1` paths are normalized to the base URL for llama.cpp.
  - Added regressions covering defaults, readiness, and active selection to prevent fallback to merged `api_url`.

- **Refactors**
  - Centralized Console selection on the shared `first_configured_endpoint` helper.
  - Standardized endpoint key order to prefer `api_base_url` → `api_base` → `base_url` → `api_url`.

<sup>Written for commit 569d7481d3ca9a05ac0273ff94cd3ece5ba7c010. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

