### PR TITLE
Fix Console settings provider model fallback

### DIFF
--- a/Tests/UI/test_console_session_settings.py
+++ b/Tests/UI/test_console_session_settings.py
@@ -1429,6 +1429,68 @@ async def test_console_settings_modal_provider_change_uses_configured_provider_m
     assert app.saved_settings.base_url == "http://127.0.0.1:9099"
 
 
+@pytest.mark.parametrize(
+    ("provider_settings", "expected_model"),
+    (
+        (
+            {
+                "api_url": "http://127.0.0.1:9099",
+                "api_model": "gemma-api-model",
+            },
+            "gemma-api-model",
+        ),
+        (
+            {
+                "api_url": "http://127.0.0.1:9099",
+                "model": "None",
+                "api_model": "null",
+                "default_model": "gemma-default-model",
+            },
+            "gemma-default-model",
+        ),
+    ),
+)
+@pytest.mark.asyncio
+async def test_console_settings_modal_provider_change_uses_model_alias_fallbacks(
+    provider_settings: dict[str, str],
+    expected_model: str,
+) -> None:
+    app = ModalHarness()
+    app.app_config["api_settings"]["llama_cpp"] = provider_settings
+    settings = ConsoleSessionSettings(
+        provider="custom",
+        model="custom-model-beta",
+        base_url="http://localhost:1234/v1/chat/completions",
+    )
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        await app.push_screen(
+            ConsoleSettingsModal(
+                settings=settings,
+                app_config=app.app_config,
+                providers_models={
+                    "Custom": ["custom-model-alpha", "custom-model-beta"],
+                    "Llama_cpp": ["None"],
+                },
+                context_estimate=ConsoleSettingsContextEstimate(10, 4096, "10 / 4k"),
+                can_save=True,
+            ),
+            callback=app.capture_saved_settings,
+        )
+        await pilot.pause()
+        app.screen.query_one("#console-settings-provider", Select).value = "llama_cpp"
+        await pilot.pause()
+
+        model_select = app.screen.query_one("#console-settings-model-select", Select)
+        assert model_select.display is True
+        assert model_select.value == expected_model
+        await pilot.click("#console-settings-save")
+
+    assert app.saved_settings is not None
+    assert app.saved_settings.provider == "llama_cpp"
+    assert app.saved_settings.model == expected_model
+
+
 @pytest.mark.asyncio
 async def test_console_settings_modal_can_select_runtime_discovered_model_with_warning() -> None:
     app = _build_test_app()

--- a/Tests/UI/test_console_session_settings.py
+++ b/Tests/UI/test_console_session_settings.py
@@ -1380,6 +1380,56 @@ async def test_console_settings_modal_preserves_missing_registry_model_for_curre
 
 
 @pytest.mark.asyncio
+async def test_console_settings_modal_provider_change_uses_configured_provider_model() -> None:
+    app = ModalHarness()
+    app.app_config["api_settings"]["llama_cpp"] = {
+        "api_url": "http://127.0.0.1:9099",
+        "model": "gemma-local-config-model",
+    }
+    settings = ConsoleSessionSettings(
+        provider="custom",
+        model="custom-model-beta",
+        base_url="http://localhost:1234/v1/chat/completions",
+    )
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        await app.push_screen(
+            ConsoleSettingsModal(
+                settings=settings,
+                app_config=app.app_config,
+                providers_models={
+                    "Custom": ["custom-model-alpha", "custom-model-beta"],
+                    "Llama_cpp": ["None"],
+                },
+                context_estimate=ConsoleSettingsContextEstimate(10, 4096, "10 / 4k"),
+                can_save=True,
+            ),
+            callback=app.capture_saved_settings,
+        )
+        await pilot.pause()
+        app.screen.query_one("#console-settings-provider", Select).value = "llama_cpp"
+        await pilot.pause()
+
+        model_select = app.screen.query_one("#console-settings-model-select", Select)
+        model_input = app.screen.query_one("#console-settings-model-input", Input)
+        base_url_input = app.screen.query_one("#console-settings-base-url", Input)
+        assert model_select.display is True
+        assert model_select.disabled is False
+        assert model_select.value == "gemma-local-config-model"
+        assert model_input.display is False
+        assert model_input.disabled is True
+        assert model_input.value == "gemma-local-config-model"
+        assert base_url_input.value == "http://127.0.0.1:9099"
+
+        await pilot.click("#console-settings-save")
+
+    assert app.saved_settings is not None
+    assert app.saved_settings.provider == "llama_cpp"
+    assert app.saved_settings.model == "gemma-local-config-model"
+    assert app.saved_settings.base_url == "http://127.0.0.1:9099"
+
+
+@pytest.mark.asyncio
 async def test_console_settings_modal_can_select_runtime_discovered_model_with_warning() -> None:
     app = _build_test_app()
     app.providers_models = {"openai": ["gpt-4.1"]}

--- a/backlog/tasks/task-90 - Console-Settings-keeps-provider-model-when-switching-to-configured-provider.md
+++ b/backlog/tasks/task-90 - Console-Settings-keeps-provider-model-when-switching-to-configured-provider.md
@@ -1,0 +1,48 @@
+---
+id: TASK-90
+title: Console Settings keeps provider model when switching to configured provider
+status: Done
+assignee: []
+created_date: '2026-06-10 01:15'
+updated_date: '2026-06-10 01:52'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Ensure Console Settings provider switching preserves or discovers the configured model for the selected provider so users can return to a local/provider-backed runtime without manually retyping the model.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Switching from a custom provider to llama_cpp pre-fills the configured llama_cpp model.
+- [x] #2 Switching providers preserves the configured base URL.
+- [x] #3 Users can save the switched provider without an empty model when config defines one.
+- [x] #4 Regression coverage proves the provider-switch path.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+ADR path: N/A
+Reason: UI/settings bugfix aligning provider-switch behavior with existing config ownership; no new storage, sync, or service boundary decision.
+
+1. Add a mounted regression for switching Console Settings from custom to llama_cpp when app_config defines api_settings.llama_cpp.model and endpoint settings.
+2. Verify the regression fails because the switched model is blank.
+3. Update ConsoleSettingsModal model resolution to fallback to provider config model when no catalog/runtime options exist.
+4. Run the focused Console Settings tests and diff checks.
+5. Relaunch the textual-web UAT app from this branch, capture CDP screenshots for the switched model and local llama send path.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added a mounted regression covering custom-to-llama_cpp provider switching with a configured model and local endpoint.
+- Updated ConsoleSettingsModal model resolution so provider-specific draft values still win, then provider config model is used before falling back to current settings or catalog options.
+- Verified the regression failed before the fix, then passed after the fix.
+- Verified broader Console Settings behavior with focused UI and pure helper tests.
+- Verified in CDP/textual-web that switching to llama_cpp prefilled `uat-model` and `http://127.0.0.1:9099`, saving updated the Console rail, and sending `say ok` rendered the local response.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-90 - Console-Settings-keeps-provider-model-when-switching-to-configured-provider.md
+++ b/backlog/tasks/task-90 - Console-Settings-keeps-provider-model-when-switching-to-configured-provider.md
@@ -45,4 +45,5 @@ Reason: UI/settings bugfix aligning provider-switch behavior with existing confi
 - Verified the regression failed before the fix, then passed after the fix.
 - Verified broader Console Settings behavior with focused UI and pure helper tests.
 - Verified in CDP/textual-web that switching to llama_cpp prefilled `uat-model` and `http://127.0.0.1:9099`, saving updated the Console rail, and sending `say ok` rendered the local response.
+- Addressed review follow-up by aligning modal provider model fallback with session defaults: `model`, `api_model`, and `default_model` are checked in order, with placeholder values skipped before falling through.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Widgets/Console/console_settings_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_settings_modal.py
@@ -422,7 +422,11 @@ class ConsoleSettingsModal(ModalScreen[ConsoleSessionSettings | None]):
     def _default_model_for_provider(self, provider: str) -> str | None:
         provider_key = provider_config_key(provider)
         provider_settings = self._provider_settings(provider_key)
-        return normalize_console_model_value(provider_settings.get("model"))
+        for key in ("model", "api_model", "default_model"):
+            configured_model = normalize_console_model_value(provider_settings.get(key))
+            if configured_model:
+                return configured_model
+        return None
 
     def _sync_base_url_control(self, provider: str, base_url: str | None) -> None:
         base_url_input = self.query_one("#console-settings-base-url", Input)

--- a/tldw_chatbook/Widgets/Console/console_settings_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_settings_modal.py
@@ -403,18 +403,26 @@ class ConsoleSettingsModal(ModalScreen[ConsoleSessionSettings | None]):
             )
 
     def _model_for_provider(self, provider: str) -> str | None:
-        configured_model_options = self._configured_model_select_options(provider)
-        if configured_model_options:
-            stored_model = normalize_console_model_value(self._provider_model_drafts.get(provider, ""))
+        if provider in self._provider_model_drafts:
+            stored_model = normalize_console_model_value(self._provider_model_drafts[provider])
             if stored_model:
                 return stored_model
-            return configured_model_options[0][1]
-
-        if provider in self._provider_model_drafts:
-            return normalize_console_model_value(self._provider_model_drafts[provider])
+        configured_model = self._default_model_for_provider(provider)
+        if configured_model:
+            return configured_model
         if provider == self._settings.provider:
-            return normalize_console_model_value(self._settings.model)
+            settings_model = normalize_console_model_value(self._settings.model)
+            if settings_model:
+                return settings_model
+        configured_model_options = self._configured_model_select_options(provider)
+        if configured_model_options:
+            return configured_model_options[0][1]
         return None
+
+    def _default_model_for_provider(self, provider: str) -> str | None:
+        provider_key = provider_config_key(provider)
+        provider_settings = self._provider_settings(provider_key)
+        return normalize_console_model_value(provider_settings.get("model"))
 
     def _sync_base_url_control(self, provider: str, base_url: str | None) -> None:
         base_url_input = self.query_one("#console-settings-base-url", Input)


### PR DESCRIPTION
## Summary\n- Keep Console Settings provider switches usable by falling back to the selected provider's configured model when no per-provider draft exists.\n- Preserve configured endpoint behavior while still allowing catalog/runtime model options to populate the model select.\n- Add TASK-90 regression coverage for switching from custom to llama_cpp with a configured model and endpoint.\n\n## Verification\n- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_console_session_settings.py Tests/Chat/test_console_session_settings.py --tb=short\n- git diff --check\n- CDP screenshot: /private/tmp/console-model-switch-8940-llamacpp-prefilled.jpg\n- CDP screenshot: /private/tmp/console-model-switch-8940-llamacpp-response.jpg

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Console Settings provider switching so the model and base URL fall back to the selected provider’s configured values, with support for `model`, `api_model`, and `default_model` aliases. Prevents blank models after switching and keeps endpoint behavior intact (TASK-90).

- **Bug Fixes**
  - Updated fallback order: provider draft → provider config model (checks `model`, `api_model`, `default_model`, skipping placeholders) → current settings (if same provider) → first catalog option; added `_default_model_for_provider`.
  - UI now pre-fills `llama_cpp` model and base URL when configured, and allows saving without an empty model.
  - Added regression tests for switching to `llama_cpp` and for alias fallback resolution.

<sup>Written for commit 3cea119cc7f16d75ee9e28af62a6718b78fdf0f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

