### PR TITLE
Console Save as modal avoids false destinations

### DIFF
--- a/Tests/Chat/test_console_message_actions.py
+++ b/Tests/Chat/test_console_message_actions.py
@@ -86,6 +86,17 @@ def test_unavailable_save_destinations_are_explicit_wip():
     assert "WIP" in note.reason
 
 
+def test_default_save_destinations_do_not_claim_chatbook_is_wired():
+    service = ConsoleMessageActionService()
+    message = ConsoleChatMessage(role=ConsoleMessageRole.ASSISTANT, content="answer")
+
+    destinations = service.save_as_destinations(message)
+
+    chatbook = next(destination for destination in destinations if destination.label == "Chatbook")
+    assert chatbook.available is False
+    assert "WIP" in chatbook.reason
+
+
 def test_action_labels_fit_compact_terminal_width_budget():
     service = ConsoleMessageActionService()
     message = ConsoleChatMessage(role=ConsoleMessageRole.ASSISTANT, content="answer")

--- a/Tests/UI/test_console_native_transcript.py
+++ b/Tests/UI/test_console_native_transcript.py
@@ -1,6 +1,6 @@
 import pytest
 from textual.app import App, ComposeResult
-from textual.widgets import Static
+from textual.widgets import Button, Static
 
 from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
 from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
@@ -46,10 +46,19 @@ class MutableTranscriptHarness(App):
 
 
 class SaveAsModalHarness(App):
+    def __init__(self, destinations: list[ConsoleSaveDestination] | None = None) -> None:
+        super().__init__()
+        self.destinations = destinations or save_as_modal_destinations()
+        self.selected_destination: str | None = None
+
     def on_mount(self) -> None:
         self.push_screen(
-            ConsoleSaveAsModal(destinations=save_as_modal_destinations())
+            ConsoleSaveAsModal(destinations=self.destinations),
+            self._capture_destination,
         )
+
+    def _capture_destination(self, destination: str | None) -> None:
+        self.selected_destination = destination
 
 
 def save_as_modal_destinations() -> list[ConsoleSaveDestination]:
@@ -468,6 +477,34 @@ async def test_save_as_modal_lists_available_and_wip_destinations():
     assert "Chatbook" in text
     assert "Note" in text
     assert "WIP: save as Note is not wired yet." in text
+
+
+@pytest.mark.asyncio
+async def test_save_as_modal_available_destination_is_clickable_control():
+    app = SaveAsModalHarness(
+        destinations=[
+            ConsoleSaveDestination(label="Chatbook", available=True, reason=""),
+            ConsoleSaveDestination(
+                label="Note",
+                available=False,
+                reason="WIP: save as Note is not wired yet.",
+            ),
+        ]
+    )
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _wait_for_selector(app.screen, pilot, "#console-save-as-destination-chatbook")
+        destination_button = app.screen.query_one("#console-save-as-destination-chatbook", Button)
+        text = _visible_text(app.screen)
+
+        assert destination_button.disabled is False
+        assert "Note [WIP]" in text
+        assert not app.screen.query("#console-save-as-destination-note")
+
+        await pilot.click("#console-save-as-destination-chatbook")
+        await pilot.pause(0.1)
+
+    assert app.selected_destination == "Chatbook"
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_native_transcript.py
+++ b/Tests/UI/test_console_native_transcript.py
@@ -48,7 +48,7 @@ class MutableTranscriptHarness(App):
 class SaveAsModalHarness(App):
     def __init__(self, destinations: list[ConsoleSaveDestination] | None = None) -> None:
         super().__init__()
-        self.destinations = destinations or save_as_modal_destinations()
+        self.destinations = save_as_modal_destinations() if destinations is None else destinations
         self.selected_destination: str | None = None
 
     def on_mount(self) -> None:
@@ -505,6 +505,19 @@ async def test_save_as_modal_available_destination_is_clickable_control():
         await pilot.pause(0.1)
 
     assert app.selected_destination == "Chatbook"
+
+
+@pytest.mark.asyncio
+async def test_save_as_modal_harness_preserves_empty_destination_list():
+    app = SaveAsModalHarness(destinations=[])
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _wait_for_selector(app.screen, pilot, "#console-save-as-modal")
+        text = _visible_text(app.screen)
+
+    assert "No Save as destinations are wired for selected messages yet." in text
+    assert "Chatbook" not in text
+    assert "Note" not in text
 
 
 @pytest.mark.asyncio

--- a/backlog/tasks/task-91 - Console-Save-as-modal-avoids-false-available-destinations.md
+++ b/backlog/tasks/task-91 - Console-Save-as-modal-avoids-false-available-destinations.md
@@ -1,0 +1,55 @@
+---
+id: TASK-91
+title: Console Save as modal avoids false available destinations
+status: Done
+assignee:
+- '@codex'
+labels:
+- console
+- ux
+- uat
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Ensure selected-message Save as... does not present unavailable destinations as actionable, and renders any explicitly wired destination as a real control instead of static text.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Save as modal marks unwired destinations as WIP with recovery copy.
+- [x] #2 Available Save as destinations render as focusable, clickable controls.
+- [x] #3 Default selected-message Save as destinations do not imply Chatbook export is wired when it is not.
+- [x] #4 Focused regression tests cover destination state and modal activation behavior.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Implemented the Console selected-message Save as honesty fix. `ConsoleMessageActionService` now treats Save as destination availability as opt-in, so default selected-message actions no longer claim Chatbook export is wired. `ConsoleSaveAsModal` now renders explicitly available destinations as real buttons and renders unavailable destinations as WIP rows with visible recovery copy. Added focused service and mounted modal regressions, then verified the Console message-action suites and captured an actual browser screenshot at `/private/tmp/console-save-as-fixed-modal.png`.
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Implementation Plan
+
+ADR required: no
+ADR path: N/A
+Reason: This is a focused UI honesty/actionability bug fix. It does not change storage, sync, runtime boundaries, service contracts, security policy, or long-lived application architecture.
+
+1. Add failing regressions proving default Save as destinations do not mark Chatbook as available when selected-message export is not wired.
+2. Add a modal regression proving explicitly available destinations render as focusable/clickable controls and WIP destinations remain non-actionable with recovery copy.
+3. Update the Console message action service to make Save as destination availability opt-in.
+4. Update the Save as modal to render available destinations as buttons and unavailable destinations as explicit WIP rows.
+5. Run focused Console message-action tests, diff checks, and a CDP screenshot pass against the running textual-web Console.
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Selected-message Save as no longer presents unavailable destinations as active. The modal is now explicit: no wired destinations by default, with Chatbook, Note, Media, and Prompt shown as WIP until their export paths are implemented.
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/tldw_chatbook/Chat/console_message_actions.py
+++ b/tldw_chatbook/Chat/console_message_actions.py
@@ -64,7 +64,7 @@ class ConsoleMessageActionService:
     )
 
     def __init__(self, *, available_save_destinations: set[str] | None = None) -> None:
-        self.available_save_destinations = available_save_destinations or {"Chatbook"}
+        self.available_save_destinations = set(available_save_destinations or ())
 
     def available_actions(self, message: ConsoleChatMessage) -> list[ConsoleMessageAction]:
         """Return canonical selected-message actions for a transcript message."""

--- a/tldw_chatbook/Widgets/Console/console_save_as_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_save_as_modal.py
@@ -10,7 +10,7 @@ from textual.widgets import Button, Static
 from tldw_chatbook.Chat.console_message_actions import ConsoleSaveDestination
 
 
-class ConsoleSaveAsModal(ModalScreen[None]):
+class ConsoleSaveAsModal(ModalScreen[str | None]):
     """List available and WIP Save as destinations for a selected message."""
 
     DEFAULT_CSS = """
@@ -26,9 +26,16 @@ class ConsoleSaveAsModal(ModalScreen[None]):
         padding: 1 2;
     }
 
-    .console-save-as-destination {
+    .console-save-as-destination,
+    .console-save-as-wip,
+    .console-save-as-empty-state {
         height: auto;
         margin: 0 0 1 0;
+    }
+
+    Button.console-save-as-destination {
+        width: 100%;
+        height: 3;
     }
     """
 
@@ -41,12 +48,25 @@ class ConsoleSaveAsModal(ModalScreen[None]):
     def compose(self) -> ComposeResult:
         with Vertical(id="console-save-as-modal"):
             yield Static("Save as...", classes="console-transcript-action-row")
+            if not any(destination.available for destination in self.destinations):
+                yield Static(
+                    "No Save as destinations are wired for selected messages yet.",
+                    classes="console-save-as-empty-state",
+                )
             for destination in self.destinations:
-                state = "available" if destination.available else "WIP"
+                destination_id = _destination_id(destination.label)
+                if destination.available:
+                    yield Button(
+                        destination.label,
+                        id=destination_id,
+                        classes="console-save-as-destination",
+                    )
+                    continue
                 reason = f"\n{destination.reason}" if destination.reason else ""
                 yield Static(
-                    f"{destination.label} [{state}]{reason}",
-                    classes="console-save-as-destination",
+                    f"{destination.label} [WIP]{reason}",
+                    id=destination_id.replace("destination", "wip", 1),
+                    classes="console-save-as-wip",
                 )
             yield Button("Close", id="console-save-as-close")
 
@@ -57,3 +77,15 @@ class ConsoleSaveAsModal(ModalScreen[None]):
         if event.button.id == "console-save-as-close":
             event.stop()
             self.dismiss(None)
+            return
+        for destination in self.destinations:
+            if destination.available and event.button.id == _destination_id(destination.label):
+                event.stop()
+                self.dismiss(destination.label)
+                return
+
+
+def _destination_id(label: str) -> str:
+    safe_label = "".join(character.lower() if character.isalnum() else "-" for character in label)
+    safe_label = "-".join(part for part in safe_label.split("-") if part)
+    return f"console-save-as-destination-{safe_label}"

--- a/tldw_chatbook/Widgets/Console/console_save_as_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_save_as_modal.py
@@ -65,7 +65,7 @@ class ConsoleSaveAsModal(ModalScreen[str | None]):
                 reason = f"\n{destination.reason}" if destination.reason else ""
                 yield Static(
                     f"{destination.label} [WIP]{reason}",
-                    id=destination_id.replace("destination", "wip", 1),
+                    id=_destination_id(destination.label, prefix="wip"),
                     classes="console-save-as-wip",
                 )
             yield Button("Close", id="console-save-as-close")
@@ -85,7 +85,7 @@ class ConsoleSaveAsModal(ModalScreen[str | None]):
                 return
 
 
-def _destination_id(label: str) -> str:
+def _destination_id(label: str, prefix: str = "destination") -> str:
     safe_label = "".join(character.lower() if character.isalnum() else "-" for character in label)
     safe_label = "-".join(part for part in safe_label.split("-") if part)
-    return f"console-save-as-destination-{safe_label}"
+    return f"console-save-as-{prefix}-{safe_label}"


### PR DESCRIPTION
## Summary
- Make selected-message Save as destination availability opt-in instead of falsely marking Chatbook as wired by default.
- Render explicitly available Save as destinations as real modal buttons while keeping unavailable destinations as WIP rows with recovery copy.
- Track the slice in Backlog task TASK-91.

## Test Plan
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chat/test_console_message_actions.py Tests/UI/test_console_native_transcript.py Tests/UI/test_console_native_chat_flow.py --tb=short
- git diff --check
- CDP/browser UAT against textual-web at 127.0.0.1:8942 with local llama.cpp stub response, screenshot captured at /private/tmp/console-save-as-fixed-modal.png

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Console “Save as…” modal honest by only enabling explicitly wired destinations and marking others as WIP, with a proper empty state. Removes the implicit `Chatbook` default and aligns with Linear TASK-91.

- **Bug Fixes**
  - ConsoleMessageActionService: availability is opt-in (no default `Chatbook`).
  - ConsoleSaveAsModal: available destinations render as buttons; WIP rows show reasons; preserves empty destination lists (no default injection) and shows an empty state; dismiss returns the selected destination label; adds stable, slugged IDs for destination and WIP rows.
  - Tests: cover default `Chatbook` as unavailable, empty-list behavior, ID-based targeting, button vs WIP rendering, and click-to-select via a harness.

<sup>Written for commit 806bf3ed19262f02efbf84532db558c2f6f9f42d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

