### PR TITLE
Improve Console workspace switcher current row

### DIFF
--- a/Tests/UI/test_console_workspace_context_rail.py
+++ b/Tests/UI/test_console_workspace_context_rail.py
@@ -299,6 +299,15 @@ async def test_console_change_workspace_switches_active_context_and_conversation
 
         console.query_one("#console-change-workspace", Button).press()
         modal_screen = await _wait_for_workspace_switcher_modal(host, pilot)
+        current_workspace = modal_screen.query_one(
+            "#console-workspace-switch-current-1",
+            Static,
+        )
+        assert str(current_workspace.renderable) == "Workspace A (current)"
+        assert all(
+            str(button.label) != "Workspace A (current)"
+            for button in modal_screen.query(Button)
+        )
         switch_button = next(
             button
             for button in modal_screen.query(Button)

--- a/Tests/UI/test_console_workspace_context_rail.py
+++ b/Tests/UI/test_console_workspace_context_rail.py
@@ -300,7 +300,7 @@ async def test_console_change_workspace_switches_active_context_and_conversation
         console.query_one("#console-change-workspace", Button).press()
         modal_screen = await _wait_for_workspace_switcher_modal(host, pilot)
         current_workspace = modal_screen.query_one(
-            "#console-workspace-switch-current-1",
+            ".console-workspace-switcher-current",
             Static,
         )
         assert str(current_workspace.renderable) == "Workspace A (current)"

--- a/tldw_chatbook/Widgets/Console/console_workspace_switcher_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_workspace_switcher_modal.py
@@ -47,6 +47,13 @@ class ConsoleWorkspaceSwitcherModal(ModalScreen[str | None]):
         margin: 0;
     }
 
+    .console-workspace-switcher-current {
+        content-align: center middle;
+        background: $surface;
+        color: $text;
+        text-style: bold;
+    }
+
     #console-workspace-switcher-actions {
         height: 3;
         min-height: 3;
@@ -85,16 +92,24 @@ class ConsoleWorkspaceSwitcherModal(ModalScreen[str | None]):
                 for index, workspace in enumerate(self._workspaces):
                     label = workspace.name
                     if workspace.workspace_id == self._active_workspace_id:
-                        label = f"{workspace.name} (current)"
-                    button = Button(
-                        label,
-                        id=f"console-workspace-switch-{index}",
-                        classes="console-workspace-switcher-option",
-                        disabled=workspace.workspace_id == self._active_workspace_id,
-                        compact=True,
-                    )
-                    button.tooltip = f"Use {workspace.name} as the active Console workspace"
-                    yield button
+                        yield Static(
+                            f"{workspace.name} (current)",
+                            id=f"console-workspace-switch-current-{index}",
+                            classes=(
+                                "console-workspace-switcher-option "
+                                "console-workspace-switcher-current"
+                            ),
+                            markup=False,
+                        )
+                    else:
+                        button = Button(
+                            label,
+                            id=f"console-workspace-switch-{index}",
+                            classes="console-workspace-switcher-option",
+                            compact=True,
+                        )
+                        button.tooltip = f"Use {workspace.name} as the active Console workspace"
+                        yield button
             with Horizontal(id="console-workspace-switcher-actions"):
                 yield Button("Cancel", id="console-workspace-switcher-cancel", compact=True)
 

--- a/tldw_chatbook/Widgets/Console/console_workspace_switcher_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_workspace_switcher_modal.py
@@ -17,7 +17,7 @@ class ConsoleWorkspaceSwitcherModal(ModalScreen[str | None]):
     Args:
         workspaces: Workspace records available for selection in the modal.
         active_workspace_id: Workspace id that should render as the current
-            disabled choice, or ``None`` when no workspace is active.
+            non-actionable row, or ``None`` when no workspace is active.
     """
 
     DEFAULT_CSS = """


### PR DESCRIPTION
## Summary
- Render the active Console workspace as readable non-actionable text instead of an almost-invisible disabled button.
- Keep other workspaces as selectable buttons in the switcher modal.
- Add a regression covering the current workspace row contract and preventing the current workspace from being rendered as a button.

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Workspaces/test_workspace_display_state.py Tests/UI/test_console_workspace_context_rail.py --tb=short
- git diff --check
- Actual CDP/browser screenshot approved: /private/tmp/tldw-console-workspace-uat/screens/console-workspace-switcher-fixed.png

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The Console workspace switcher now renders the active workspace as readable, non-actionable text using a dedicated `.console-workspace-switcher-current` `Static` row, while other workspaces remain selectable buttons. Tests now also assert the exact current-row label ("Workspace A (current)") and ensure that label never appears on any button.

<sup>Written for commit 53365fcfcea92b16dee748b469dc61a0922f28ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

