### PR TITLE
Add Personas workbench foundation contracts

### DIFF
--- a/Tests/UI/test_personas_workbench_foundation.py
+++ b/Tests/UI/test_personas_workbench_foundation.py
@@ -1,0 +1,117 @@
+"""Foundation coverage for the destination-native Personas workbench."""
+
+from tldw_chatbook.Widgets.Persona_Widgets.personas_messages import (
+    PersonaActionRequested,
+    PersonaEntitySelected,
+    PersonaModeChanged,
+    PersonaSearchChanged,
+)
+from tldw_chatbook.Widgets.Persona_Widgets.personas_state import (
+    PersonasWorkbenchState,
+)
+
+
+def test_personas_workbench_state_defaults_to_local_character_mode():
+    state = PersonasWorkbenchState()
+
+    assert state.active_mode == "characters"
+    assert state.runtime_source == "local"
+    assert state.search_query == ""
+    assert state.filter_text == ""
+    assert state.selected_entity_kind is None
+    assert state.selected_entity_id is None
+    assert state.selected_runtime_target is None
+    assert state.is_loading is False
+    assert state.has_unsaved_changes is False
+
+
+def test_personas_workbench_mode_switch_clears_selection_and_dirty_state():
+    state = PersonasWorkbenchState(
+        active_mode="characters",
+        selected_entity_kind="character",
+        selected_entity_id="42",
+        selected_entity_name="Ada",
+        selected_runtime_target="local:character:42",
+        has_unsaved_changes=True,
+        status_message="Editing Ada",
+    )
+
+    state.switch_mode("personas")
+
+    assert state.active_mode == "personas"
+    assert state.selected_entity_kind is None
+    assert state.selected_entity_id is None
+    assert state.selected_runtime_target is None
+    assert state.has_unsaved_changes is False
+    assert state.status_message == "Mode: Personas"
+
+
+def test_personas_workbench_selection_builds_console_target_metadata():
+    state = PersonasWorkbenchState()
+
+    state.select_entity(
+        entity_kind="persona_profile",
+        entity_id="persona.local.researcher",
+        entity_name="Researcher",
+    )
+
+    assert state.selected_entity_kind == "persona_profile"
+    assert state.selected_entity_id == "persona.local.researcher"
+    assert state.selected_runtime_target == "local:persona_profile:persona.local.researcher"
+    assert state.selected_metadata() == {
+        "selected_kind": "persona_profile",
+        "selected_record_id": "persona.local.researcher",
+        "selected_name": "Researcher",
+        "selected_target_id": "local:persona_profile:persona.local.researcher",
+    }
+
+
+def test_personas_workbench_state_reset_preserves_runtime_source():
+    state = PersonasWorkbenchState(
+        active_mode="prompts",
+        runtime_source="server",
+        search_query="qa",
+        filter_text="draft",
+        selected_entity_kind="prompt",
+        selected_entity_id="p1",
+        selected_entity_name="QA prompt",
+        selected_runtime_target="server:prompt:p1",
+        has_unsaved_changes=True,
+        is_loading=True,
+    )
+
+    state.reset_for_runtime_source_change("local")
+
+    assert state.runtime_source == "local"
+    assert state.active_mode == "prompts"
+    assert state.search_query == ""
+    assert state.filter_text == ""
+    assert state.selected_entity_id is None
+    assert state.is_loading is False
+    assert state.has_unsaved_changes is False
+
+
+def test_personas_workbench_messages_are_screen_independent_payloads():
+    mode_changed = PersonaModeChanged("dictionaries")
+    selected = PersonaEntitySelected(
+        entity_kind="character",
+        entity_id="7",
+        entity_name="Bean",
+        runtime_target="local:character:7",
+    )
+    search_changed = PersonaSearchChanged(query="bean", filter_text="local")
+    action = PersonaActionRequested(
+        action="attach_to_console",
+        entity_kind="character",
+        entity_id="7",
+    )
+
+    assert mode_changed.mode == "dictionaries"
+    assert selected.entity_kind == "character"
+    assert selected.entity_id == "7"
+    assert selected.runtime_target == "local:character:7"
+    assert search_changed.query == "bean"
+    assert search_changed.filter_text == "local"
+    assert action.action == "attach_to_console"
+    assert action.entity_kind == "character"
+    assert action.entity_id == "7"

--- a/backlog/decisions/007-personas-workbench-route-consolidation.md
+++ b/backlog/decisions/007-personas-workbench-route-consolidation.md
@@ -1,0 +1,36 @@
+# ADR-007: Personas Workbench Route Consolidation
+
+Status: Accepted
+Date: 2026-06-10
+Related Task: [backlog/tasks/task-90 - Personas-workbench-foundation-and-route-consolidation-ADR.md](../tasks/task-90%20-%20Personas-workbench-foundation-and-route-consolidation-ADR.md)
+Supersedes: N/A
+
+## Decision
+
+The top-level `personas` route is the durable product destination for characters, persona profiles, prompts, dictionaries, lore, import/export, and Console handoff; `ccp` remains a compatibility route only while its reusable handlers and widgets are incrementally adapted behind destination-native Personas state and messages.
+
+## Context
+
+Personas currently has two user-facing surfaces. The `personas` route is the shell that appears in the unified top navigation, but it only exposes a behavior-context snapshot and can send users to `ccp` for deeper work. The `ccp` route already contains much of the functional character/persona editor behavior, but it carries legacy naming and route ownership that does not match the approved top-level product model.
+
+The product direction is to make Personas a first-class destination that users can understand without knowing CCP. Characters, persona profiles, prompts, dictionaries, lore, card import/export, conversation preview, and Console attach/start-chat actions should live under that destination. This foundation must not force a broad rewrite or break existing working CCP handlers, so the transition needs a shared state/message layer that lets later UI slices move features without coupling new widgets directly to `CCPScreen`.
+
+## Alternatives Considered
+
+| Option | Why rejected |
+| --- | --- |
+| Keep `ccp` as the real destination and make `personas` a permanent wrapper | This preserves legacy terminology and makes the top-level Personas tab misleading because meaningful work still happens in another route. |
+| Rewrite all CCP handlers and widgets in one PR | Too risky for character/persona CRUD, import/export, prompt, dictionary, and conversation flows; it would make review and rollback difficult. |
+| Split Personas and Characters into separate top-level destinations | This conflicts with the current shell IA and separates closely related behavior-shaping concepts that users need to compare and attach to Console together. |
+| Move prompts, dictionaries, and lore into Settings | These are reusable behavior assets, not global app preferences; Settings should configure defaults and safety boundaries, not own authoring workflows. |
+
+## Consequences
+
+New Personas work should target reusable `Persona_Widgets` state/messages and the top-level `personas` destination. Existing CCP handlers/widgets may be reused as implementation detail, but new code should avoid adding fresh dependencies from destination-native Personas widgets back into `CCPScreen`.
+
+Visible UI migration should happen in small screenshot-approved slices. Until those slices land, `ccp` can continue serving compatibility paths so existing tests and user workflows do not regress. Later work can map `ccp`, `characters`, `prompts`, and related aliases to the destination-native Personas workbench once feature parity and QA are complete.
+
+## Links
+
+- [CCP destination-native route replacement plan](../../Docs/superpowers/plans/2026-05-20-ccp-destination-native-route-replacement.md)
+- [Personas loading recovery task](../tasks/task-60.5%20-%20Fix-Personas-destination-indefinite-behavior-context-loading-state.md)

--- a/backlog/tasks/task-90 - Personas-workbench-foundation-and-route-consolidation-ADR.md
+++ b/backlog/tasks/task-90 - Personas-workbench-foundation-and-route-consolidation-ADR.md
@@ -1,0 +1,57 @@
+---
+id: TASK-90
+title: Personas workbench foundation and route consolidation ADR
+status: Done
+assignee: []
+created_date: '2026-06-10 06:12'
+updated_date: '2026-06-10 06:21'
+labels:
+  - personas
+  - ux
+  - foundation
+dependencies: []
+documentation:
+  - >-
+    Docs/superpowers/plans/2026-05-20-ccp-destination-native-route-replacement.md
+  - backlog/decisions/007-personas-workbench-route-consolidation.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Establish the durable Personas workbench foundation before moving more visible UI out of the legacy CCP surface. The goal is to make the top-level Personas route the product-owned destination for characters, persona profiles, prompts, dictionaries, lore, import/export, and Console handoff while keeping the current CCP route as compatibility plumbing until later UI slices retire it safely.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 ADR records the top-level Personas destination, CCP compatibility boundary, and non-goals before code changes.
+- [x] #2 A reusable Personas workbench state model covers mode, selected entity, search/filter text, runtime source, loading state, dirty state, and reset behavior.
+- [x] #3 A reusable Personas message vocabulary covers mode changes, entity selection, search/filter changes, create/import/export, attach/start-chat, save, cancel, and refresh events without depending on CCPScreen.
+- [x] #4 Focused unit tests verify state defaults, mode switching, selection metadata, reset behavior, and message payloads.
+- [x] #5 This foundation slice makes no user-visible Personas layout changes and requires no screenshot approval until a later UI slice.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: yes
+ADR path: backlog/decisions/007-personas-workbench-route-consolidation.md
+Reason: This task defines long-lived destination ownership, route compatibility, and UI module boundaries.
+
+1. Create the ADR and link it from this task.
+2. Add failing unit tests for reusable Personas workbench state and messages.
+3. Implement the smallest state/message modules under `tldw_chatbook/Widgets/Persona_Widgets`.
+4. Run focused tests and `git diff --check`.
+5. Add implementation notes before marking ready for review.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added ADR-007 to record Personas as the durable top-level destination and CCP as a compatibility route while reusable handlers/widgets are adapted.
+- Added `tldw_chatbook/Widgets/Persona_Widgets` with screen-independent state and Textual message contracts for later destination-native panes.
+- Added focused regression coverage for state defaults, mode switching, selection metadata, runtime-source reset, and message payloads.
+- No visible UI layout changed in this slice, so no screenshot approval was required.
+- Verification: `python -m pytest -q Tests/UI/test_personas_workbench_foundation.py --tb=short` passed; `python -m pytest -q Tests/UI/test_ccp_screen.py --tb=short` passed; `git diff --check` passed.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Widgets/Persona_Widgets/__init__.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/__init__.py
@@ -1,0 +1,17 @@
+"""Reusable widgets and contracts for the destination-native Personas workbench."""
+
+from .personas_messages import (
+    PersonaActionRequested,
+    PersonaEntitySelected,
+    PersonaModeChanged,
+    PersonaSearchChanged,
+)
+from .personas_state import PersonasWorkbenchState
+
+__all__ = [
+    "PersonaActionRequested",
+    "PersonaEntitySelected",
+    "PersonaModeChanged",
+    "PersonaSearchChanged",
+    "PersonasWorkbenchState",
+]

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_messages.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_messages.py
@@ -1,0 +1,96 @@
+"""Screen-independent message contracts for Personas workbench widgets."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from textual.message import Message
+
+
+PersonaWorkbenchMode = Literal[
+    "characters",
+    "personas",
+    "prompts",
+    "dictionaries",
+    "lore",
+    "import_export",
+]
+PersonaEntityKind = Literal[
+    "character",
+    "persona_profile",
+    "prompt",
+    "dictionary",
+    "lore",
+]
+PersonaAction = Literal[
+    "create",
+    "import",
+    "export",
+    "attach_to_console",
+    "start_chat",
+    "save",
+    "cancel",
+    "refresh",
+]
+
+
+class PersonaModeChanged(Message):
+    """Request a Personas workbench mode change."""
+
+    def __init__(self, mode: PersonaWorkbenchMode) -> None:
+        super().__init__()
+        self.mode = mode
+
+
+class PersonaEntitySelected(Message):
+    """Notify the workbench that a character, persona, or related asset was selected."""
+
+    def __init__(
+        self,
+        *,
+        entity_kind: PersonaEntityKind,
+        entity_id: str,
+        entity_name: str,
+        runtime_target: str | None = None,
+    ) -> None:
+        super().__init__()
+        self.entity_kind = entity_kind
+        self.entity_id = entity_id
+        self.entity_name = entity_name
+        self.runtime_target = runtime_target
+
+
+class PersonaSearchChanged(Message):
+    """Notify the workbench that list search or filter input changed."""
+
+    def __init__(self, *, query: str = "", filter_text: str = "") -> None:
+        super().__init__()
+        self.query = query
+        self.filter_text = filter_text
+
+
+class PersonaActionRequested(Message):
+    """Request a Personas action without coupling child widgets to a screen class."""
+
+    def __init__(
+        self,
+        *,
+        action: PersonaAction,
+        entity_kind: PersonaEntityKind | None = None,
+        entity_id: str | None = None,
+    ) -> None:
+        super().__init__()
+        self.action = action
+        self.entity_kind = entity_kind
+        self.entity_id = entity_id
+
+
+__all__ = [
+    "PersonaAction",
+    "PersonaActionRequested",
+    "PersonaEntityKind",
+    "PersonaEntitySelected",
+    "PersonaModeChanged",
+    "PersonaSearchChanged",
+    "PersonaWorkbenchMode",
+]

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_state.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_state.py
@@ -1,0 +1,122 @@
+"""Shared state model for the destination-native Personas workbench."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .personas_messages import PersonaEntityKind, PersonaWorkbenchMode
+
+
+VALID_PERSONA_MODES: tuple[PersonaWorkbenchMode, ...] = (
+    "characters",
+    "personas",
+    "prompts",
+    "dictionaries",
+    "lore",
+    "import_export",
+)
+VALID_PERSONA_ENTITY_KINDS: tuple[PersonaEntityKind, ...] = (
+    "character",
+    "persona_profile",
+    "prompt",
+    "dictionary",
+    "lore",
+)
+MODE_LABELS: dict[PersonaWorkbenchMode, str] = {
+    "characters": "Characters",
+    "personas": "Personas",
+    "prompts": "Prompts",
+    "dictionaries": "Dictionaries",
+    "lore": "Lore",
+    "import_export": "Import / Export",
+}
+
+
+@dataclass(slots=True)
+class PersonasWorkbenchState:
+    """Serializable state shared by future Personas workbench panes."""
+
+    active_mode: PersonaWorkbenchMode = "characters"
+    runtime_source: str = "local"
+    search_query: str = ""
+    filter_text: str = ""
+    selected_entity_kind: PersonaEntityKind | None = None
+    selected_entity_id: str | None = None
+    selected_entity_name: str = ""
+    selected_runtime_target: str | None = None
+    is_loading: bool = False
+    has_unsaved_changes: bool = False
+    status_message: str = "Mode: Characters"
+
+    def switch_mode(self, mode: PersonaWorkbenchMode) -> None:
+        """Switch the active workbench mode and clear mode-scoped edit state."""
+        if mode not in VALID_PERSONA_MODES:
+            raise ValueError(f"Unsupported Personas mode: {mode}")
+        self.active_mode = mode
+        self.clear_selection()
+        self.has_unsaved_changes = False
+        self.is_loading = False
+        self.status_message = f"Mode: {MODE_LABELS[mode]}"
+
+    def select_entity(
+        self,
+        *,
+        entity_kind: PersonaEntityKind,
+        entity_id: str,
+        entity_name: str,
+        runtime_target: str | None = None,
+    ) -> None:
+        """Select an entity and derive its Console runtime target when omitted."""
+        if entity_kind not in VALID_PERSONA_ENTITY_KINDS:
+            raise ValueError(f"Unsupported Personas entity kind: {entity_kind}")
+        self.selected_entity_kind = entity_kind
+        self.selected_entity_id = str(entity_id)
+        self.selected_entity_name = str(entity_name)
+        self.selected_runtime_target = runtime_target or self._default_runtime_target(
+            entity_kind,
+            self.selected_entity_id,
+        )
+        self.status_message = f"Selected: {self.selected_entity_name}"
+
+    def clear_selection(self) -> None:
+        """Clear the selected entity without changing the active mode."""
+        self.selected_entity_kind = None
+        self.selected_entity_id = None
+        self.selected_entity_name = ""
+        self.selected_runtime_target = None
+
+    def reset_for_runtime_source_change(self, runtime_source: str) -> None:
+        """Reset source-scoped state after switching local/server runtime authority."""
+        self.runtime_source = str(runtime_source or "local")
+        self.search_query = ""
+        self.filter_text = ""
+        self.clear_selection()
+        self.is_loading = False
+        self.has_unsaved_changes = False
+        self.status_message = f"Mode: {MODE_LABELS[self.active_mode]}"
+
+    def selected_metadata(self) -> dict[str, str]:
+        """Return stable Console handoff metadata for the selected entity."""
+        if (
+            self.selected_entity_kind is None
+            or self.selected_entity_id is None
+            or self.selected_runtime_target is None
+        ):
+            return {}
+        return {
+            "selected_kind": self.selected_entity_kind,
+            "selected_record_id": self.selected_entity_id,
+            "selected_name": self.selected_entity_name,
+            "selected_target_id": self.selected_runtime_target,
+        }
+
+    def _default_runtime_target(self, entity_kind: PersonaEntityKind, entity_id: str) -> str:
+        return f"{self.runtime_source}:{entity_kind}:{entity_id}"
+
+
+__all__ = [
+    "MODE_LABELS",
+    "VALID_PERSONA_ENTITY_KINDS",
+    "VALID_PERSONA_MODES",
+    "PersonasWorkbenchState",
+]


### PR DESCRIPTION
## Summary
- Add ADR-007 documenting Personas as the durable top-level destination and CCP as a compatibility route during migration.
- Add reusable Personas workbench state and Textual message contracts under Persona_Widgets.
- Add focused tests for state defaults, mode switching, selection metadata, runtime-source reset, and message payloads.

## UI / Screenshot
- No visible UI layout changed in this foundation slice, so screenshot approval is not required.

## Verification
- python -m pytest -q Tests/UI/test_personas_workbench_foundation.py Tests/UI/test_ccp_screen.py --tb=short
- git diff --check HEAD~1..HEAD

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lays the foundation for a destination-native Personas workbench and sets `personas` as the long-term route while keeping `ccp` as a compatibility path. Enables later UI slices to reuse state and messages without coupling to `CCPScreen`.

- **New Features**
  - ADR-007 documents route consolidation: `personas` as durable destination, `ccp` as temporary compatibility.
  - Added shared state `PersonasWorkbenchState` and message contracts under `tldw_chatbook/Widgets/Persona_Widgets`.
  - Added focused tests for state defaults, mode switching, selection metadata, runtime-source reset, and message payloads.

<sup>Written for commit 828da127f5112c520dd781f76907384666777305. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

