### PR TITLE
Harden Console workspace and settings UAT

### DIFF
--- a/Tests/Chat/test_console_session_settings.py
+++ b/Tests/Chat/test_console_session_settings.py
@@ -368,7 +368,30 @@ def test_readiness_allows_llamacpp_default_endpoint_without_saved_config() -> No
     assert readiness.native_send_supported is True
 
 
-def test_readiness_blocks_llamacpp_custom_endpoint_without_saved_config() -> None:
+def test_readiness_allows_llamacpp_session_endpoint_override() -> None:
+    readiness = build_console_settings_readiness(
+        ConsoleSessionSettings(
+            provider="llama_cpp",
+            model="llama3",
+            base_url="http://127.0.0.1:9099",
+        ),
+        app_config={
+            "api_settings": {
+                "llama_cpp": {
+                    "api_url": "http://localhost:8080/completion",
+                    "model": "llama3",
+                },
+            },
+            "chat_defaults": {"provider": "llama_cpp", "model": "llama3"},
+        },
+        environ={},
+    )
+
+    assert readiness.label == "Ready"
+    assert readiness.native_send_supported is True
+
+
+def test_readiness_allows_llamacpp_custom_endpoint_without_saved_config() -> None:
     readiness = build_console_settings_readiness(
         ConsoleSessionSettings(
             provider="llama_cpp",
@@ -379,10 +402,8 @@ def test_readiness_blocks_llamacpp_custom_endpoint_without_saved_config() -> Non
         environ={},
     )
 
-    assert readiness.label == "Endpoint not saved"
-    assert readiness.native_send_supported is False
-    assert "Selected endpoint: http://127.0.0.1:9191" in readiness.detail
-    assert "Saved endpoint: not saved" in readiness.detail
+    assert readiness.label == "Ready"
+    assert readiness.native_send_supported is True
 
 
 def test_readiness_blocks_unsaved_generic_endpoint_with_safe_details() -> None:

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -820,6 +820,54 @@ async def test_console_send_after_workspace_switch_persists_to_selected_workspac
 
 
 @pytest.mark.asyncio
+async def test_console_workspace_switch_refreshes_visible_session_tabs():
+    app = _build_test_app()
+    service = app.workspace_registry_service
+    service.create_workspace(workspace_id="ws-a", name="Workspace A")
+    service.create_workspace(workspace_id="ws-b", name="Workspace B")
+    service.set_active_workspace("ws-a")
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        await _wait_for_selector(console, pilot, "#console-change-workspace")
+        store = console._ensure_console_chat_store()
+        first_session = store.ensure_session()
+        assert first_session.workspace_id == "ws-a"
+
+        console.query_one("#console-change-workspace", Button).press()
+        modal_screen = await _wait_for_workspace_switcher_modal(host, pilot)
+        switch_button = next(
+            button
+            for button in modal_screen.query(Button)
+            if str(button.label) == "Workspace B"
+        )
+        switch_button.press()
+        await _wait_for_console_screen(host, console, pilot)
+
+        active_session = store.switch_session(store.active_session_id)
+        assert active_session.workspace_id == "ws-b"
+        await _wait_for_selector(console, pilot, f"#console-session-tab-{active_session.id}")
+        assert "Workspace B Chat" in _visible_text(console)
+
+
+@pytest.mark.asyncio
+async def test_console_mount_uses_active_workspace_title_for_initial_session():
+    app = _build_test_app()
+    service = app.workspace_registry_service
+    service.create_workspace(workspace_id="ws-a", name="Workspace A")
+    service.set_active_workspace("ws-a")
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        await _wait_for_text(console, pilot, "Workspace A Chat")
+        assert "Workspace A" in _visible_text(console)
+
+
+@pytest.mark.asyncio
 async def test_console_tab_switch_aligns_active_workspace_context():
     app = _build_test_app()
     service = app.workspace_registry_service

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -1476,6 +1476,58 @@ async def test_console_native_tab_strip_creates_and_switches_sessions():
 
 
 @pytest.mark.asyncio
+async def test_console_new_chat_focuses_composer_for_immediate_typing():
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+        store = console._ensure_console_chat_store()
+        first = store.ensure_session(title="Chat 1")
+        await console._sync_native_console_chat_ui()
+
+        await pilot.click("#console-new-chat-tab")
+        second = store.active_session_id
+        assert second != first.id
+        await _wait_for_selector(console, pilot, f"#console-session-tab-{second}")
+
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        await pilot.press("n")
+        await pilot.pause(0.1)
+
+        assert console.app.focused is composer
+        assert composer.draft_text() == "n"
+
+
+@pytest.mark.asyncio
+async def test_console_tab_switch_focuses_composer_for_immediate_typing():
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+        store = console._ensure_console_chat_store()
+        first = store.ensure_session(title="Chat 1")
+        await console._sync_native_console_chat_ui()
+        await pilot.click("#console-new-chat-tab")
+        second = store.active_session_id
+        assert second != first.id
+        await _wait_for_selector(console, pilot, f"#console-session-tab-{second}")
+
+        await pilot.click(f"#console-session-tab-{first.id}")
+        assert store.active_session_id == first.id
+
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        await pilot.press("s")
+        await pilot.pause(0.1)
+
+        assert console.app.focused is composer
+        assert composer.draft_text() == "s"
+
+
+@pytest.mark.asyncio
 async def test_console_native_tab_strip_isolates_composer_drafts():
     app = _build_test_app()
     host = ConsoleHarness(app)

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -853,6 +853,60 @@ async def test_console_workspace_switch_refreshes_visible_session_tabs():
 
 
 @pytest.mark.asyncio
+async def test_console_workspace_switch_refresh_is_not_dropped_during_inflight_sync():
+    app = _build_test_app()
+    service = app.workspace_registry_service
+    service.create_workspace(workspace_id="ws-a", name="Workspace A")
+    service.create_workspace(workspace_id="ws-b", name="Workspace B")
+    service.set_active_workspace("ws-a")
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        await _wait_for_selector(console, pilot, "#console-change-workspace")
+        store = console._ensure_console_chat_store()
+        first_session = store.ensure_session()
+        assert first_session.workspace_id == "ws-a"
+
+        first_sync_blocked = asyncio.Event()
+        release_first_sync = asyncio.Event()
+        original_sync_tabs = console._sync_console_native_session_tabs
+        blocked_once = False
+
+        async def blocking_sync_tabs():
+            nonlocal blocked_once
+            await original_sync_tabs()
+            if blocked_once:
+                return
+            blocked_once = True
+            first_sync_blocked.set()
+            await release_first_sync.wait()
+
+        console._sync_console_native_session_tabs = blocking_sync_tabs
+        first_sync_task = asyncio.create_task(console._sync_native_console_chat_ui())
+        await first_sync_blocked.wait()
+
+        console.query_one("#console-change-workspace", Button).press()
+        modal_screen = await _wait_for_workspace_switcher_modal(host, pilot)
+        switch_button = next(
+            button
+            for button in modal_screen.query(Button)
+            if str(button.label) == "Workspace B"
+        )
+        switch_button.press()
+        await _wait_for_console_screen(host, console, pilot)
+
+        active_session = store.switch_session(store.active_session_id)
+        assert active_session.workspace_id == "ws-b"
+        release_first_sync.set()
+        await first_sync_task
+
+        await _wait_for_selector(console, pilot, f"#console-session-tab-{active_session.id}")
+        assert "Workspace B Chat" in _visible_text(console)
+
+
+@pytest.mark.asyncio
 async def test_console_mount_uses_active_workspace_title_for_initial_session():
     app = _build_test_app()
     service = app.workspace_registry_service

--- a/Tests/UI/test_console_session_settings.py
+++ b/Tests/UI/test_console_session_settings.py
@@ -749,6 +749,45 @@ async def test_console_settings_modal_save_returns_validated_settings() -> None:
     assert app.saved_settings.top_p == 0.88
 
 
+@pytest.mark.asyncio
+async def test_console_settings_modal_saves_replaced_temperature_input() -> None:
+    app = StyledModalHarness()
+    settings = ConsoleSessionSettings(
+        provider="llama_cpp",
+        model="model-a",
+        temperature=0.60,
+    )
+
+    async with app.run_test(size=(140, 60)) as pilot:
+        await app.push_screen(
+            ConsoleSettingsModal(
+                settings=settings,
+                app_config=app.app_config,
+                providers_models={"llama_cpp": ["model-a"]},
+                context_estimate=ConsoleSettingsContextEstimate(10, 4096, "10 / 4k"),
+                can_save=True,
+            ),
+            callback=app.capture_saved_settings,
+        )
+        await pilot.pause()
+        temperature = app.screen.query_one("#console-settings-temperature", Input)
+        body = app.screen.query_one("#console-settings-body")
+        body.scroll_to_widget(temperature)
+        await pilot.pause()
+
+        await pilot.click(temperature)
+        await pilot.press("ctrl+a")
+        await pilot.press("0")
+        await pilot.press(".")
+        await pilot.press("7")
+        assert temperature.value == "0.7"
+
+        await pilot.click("#console-settings-save")
+
+    assert app.saved_settings is not None
+    assert app.saved_settings.temperature == 0.7
+
+
 @pytest.mark.parametrize(
     ("field_id", "attribute", "backspace_count", "typed_suffix", "expected"),
     [

--- a/Tests/UI/test_console_session_settings.py
+++ b/Tests/UI/test_console_session_settings.py
@@ -788,6 +788,41 @@ async def test_console_settings_modal_saves_replaced_temperature_input() -> None
     assert app.saved_settings.temperature == 0.7
 
 
+@pytest.mark.asyncio
+async def test_console_settings_modal_replaces_focused_sampling_input() -> None:
+    app = StyledModalHarness()
+    settings = ConsoleSessionSettings(
+        provider="llama_cpp",
+        model="model-a",
+        temperature=0.60,
+    )
+
+    async with app.run_test(size=(140, 60)) as pilot:
+        await app.push_screen(
+            ConsoleSettingsModal(
+                settings=settings,
+                app_config=app.app_config,
+                providers_models={"llama_cpp": ["model-a"]},
+                context_estimate=ConsoleSettingsContextEstimate(10, 4096, "10 / 4k"),
+                can_save=True,
+            ),
+            callback=app.capture_saved_settings,
+        )
+        await pilot.pause()
+        temperature = app.screen.query_one("#console-settings-temperature", Input)
+        body = app.screen.query_one("#console-settings-body")
+        body.scroll_to_widget(temperature)
+        await pilot.pause()
+
+        await pilot.click(temperature)
+        await pilot.press("0")
+        await pilot.press(".")
+        await pilot.press("7")
+        await pilot.press("2")
+
+        assert temperature.value == "0.72"
+
+
 @pytest.mark.parametrize(
     ("field_id", "attribute", "backspace_count", "typed_suffix", "expected"),
     [

--- a/tldw_chatbook/Chat/console_chat_models.py
+++ b/tldw_chatbook/Chat/console_chat_models.py
@@ -32,6 +32,8 @@ class ConsoleRunStatus(str, Enum):
 
 ConsoleMessageStatus = Literal["complete", "pending", "streaming", "stopped", "failed"]
 ConsoleMessageFeedback = Literal["up", "down"]
+CONSOLE_GLOBAL_WORKSPACE_ID = "global"
+DEFAULT_CONSOLE_SESSION_TITLE = "Chat 1"
 
 
 @dataclass(frozen=True)
@@ -48,7 +50,7 @@ class ConsoleStagedSource:
 class ConsoleWorkspaceContext:
     """Workspace and source policy state used before sending to a provider."""
 
-    active_workspace_id: str = "global"
+    active_workspace_id: str = CONSOLE_GLOBAL_WORKSPACE_ID
     staged_sources: tuple[ConsoleStagedSource, ...] = ()
     active_run_id: str | None = None
     handoff_id: str | None = None

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -9,6 +9,8 @@ from uuid import uuid4
 from loguru import logger
 
 from tldw_chatbook.Chat.console_chat_models import (
+    CONSOLE_GLOBAL_WORKSPACE_ID,
+    DEFAULT_CONSOLE_SESSION_TITLE,
     ConsoleChatMessage,
     ConsoleMessageFeedback,
     ConsoleMessageRole,
@@ -66,8 +68,8 @@ class ConsoleChatSyncProducer(Protocol):
 class ConsoleChatSession:
     """A native Console chat session."""
 
-    title: str = "Chat 1"
-    workspace_id: str = "global"
+    title: str = DEFAULT_CONSOLE_SESSION_TITLE
+    workspace_id: str = CONSOLE_GLOBAL_WORKSPACE_ID
     id: str = field(default_factory=lambda: str(uuid4()))
     persisted_conversation_id: str | None = None
     settings: ConsoleSessionSettings | None = None
@@ -118,7 +120,7 @@ class ConsoleChatStore:
     def ensure_session(
         self,
         *,
-        title: str = "Chat 1",
+        title: str = DEFAULT_CONSOLE_SESSION_TITLE,
         workspace_id: str | None = None,
         settings: ConsoleSessionSettings | None = None,
     ) -> ConsoleChatSession:
@@ -130,7 +132,7 @@ class ConsoleChatStore:
     def create_session(
         self,
         *,
-        title: str = "Chat 1",
+        title: str = DEFAULT_CONSOLE_SESSION_TITLE,
         workspace_id: str | None = None,
         settings: ConsoleSessionSettings | None = None,
     ) -> ConsoleChatSession:
@@ -618,9 +620,9 @@ class ConsoleChatStore:
 
     @staticmethod
     def _persistence_scope(session: ConsoleChatSession) -> tuple[str, str | None]:
-        if session.workspace_id and session.workspace_id != "global":
+        if session.workspace_id and session.workspace_id != CONSOLE_GLOBAL_WORKSPACE_ID:
             return "workspace", session.workspace_id
-        return "global", None
+        return CONSOLE_GLOBAL_WORKSPACE_ID, None
 
     @staticmethod
     def _validate_can_stream(message: ConsoleChatMessage) -> None:

--- a/tldw_chatbook/Chat/console_session_settings.py
+++ b/tldw_chatbook/Chat/console_session_settings.py
@@ -372,6 +372,7 @@ def build_console_settings_readiness(
         )
     if (
         base_url
+        and not identity.uses_direct_llama_path
         and _is_url_based_provider(provider_key, provider_settings)
         and _endpoint_differs_for_provider(provider_key, base_url, provider_settings)
     ):

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -33,6 +33,8 @@ from ...Chat.chat_conversation_service import derive_conversation_title
 from ...Chat.chat_persistence_service import ChatPersistenceService
 from ...Chat.console_chat_controller import ConsoleChatController
 from ...Chat.console_chat_models import (
+    CONSOLE_GLOBAL_WORKSPACE_ID,
+    DEFAULT_CONSOLE_SESSION_TITLE,
     ConsoleMessageRole,
     ConsoleProviderSelection,
     ConsoleRunStatus,
@@ -472,6 +474,7 @@ class ChatScreen(BaseAppScreen):
         self._last_console_action: ConsoleActionResult | None = None
         self._console_transcript_sync_timer: Any | None = None
         self._console_sync_in_progress = False
+        self._console_sync_requested = False
         self._last_native_transcript_refresh_key: tuple[int, tuple[Any, ...]] | None = None
         self._console_guidance_dismissed = False
         self.ui_state = UIState()
@@ -741,7 +744,7 @@ class ChatScreen(BaseAppScreen):
 
     def _current_console_workspace_context(self) -> ConsoleWorkspaceContext:
         """Return explicit workspace policy context for native Console sends."""
-        workspace_id = "global"
+        workspace_id = CONSOLE_GLOBAL_WORKSPACE_ID
         registry_service = getattr(self.app_instance, "workspace_registry_service", None)
         if registry_service is not None:
             try:
@@ -1033,8 +1036,11 @@ class ChatScreen(BaseAppScreen):
     def _console_initial_session_title_for_workspace(self, workspace_id: str | None) -> str:
         """Return the first Console tab title for the active workspace."""
         target_workspace_id = str(workspace_id or "").strip()
-        if not target_workspace_id or target_workspace_id in {"global", DEFAULT_WORKSPACE_ID}:
-            return "Chat 1"
+        if not target_workspace_id or target_workspace_id in {
+            CONSOLE_GLOBAL_WORKSPACE_ID,
+            DEFAULT_WORKSPACE_ID,
+        }:
+            return DEFAULT_CONSOLE_SESSION_TITLE
         return self._console_workspace_session_title(target_workspace_id)
 
     def _set_active_workspace_for_console_session(self, session_id: str) -> None:
@@ -1047,7 +1053,7 @@ class ChatScreen(BaseAppScreen):
         if target_session is None:
             return
         workspace_id = str(target_session.workspace_id or "").strip()
-        if not workspace_id or workspace_id == "global":
+        if not workspace_id or workspace_id == CONSOLE_GLOBAL_WORKSPACE_ID:
             return
         registry_service = getattr(self.app_instance, "workspace_registry_service", None)
         if registry_service is None:
@@ -3056,6 +3062,7 @@ class ChatScreen(BaseAppScreen):
     async def _sync_native_console_chat_ui(self) -> None:
         """Refresh visible Console-native state after send/stop transitions."""
         if self._console_sync_in_progress:
+            self._console_sync_requested = True
             return
         self._console_sync_in_progress = True
         try:
@@ -3070,6 +3077,9 @@ class ChatScreen(BaseAppScreen):
             self._sync_console_rail_visibility(self._current_console_rail_state())
         finally:
             self._console_sync_in_progress = False
+            if self._console_sync_requested:
+                self._console_sync_requested = False
+                self.run_worker(self._sync_native_console_chat_ui(), exclusive=True)
 
     async def _sync_console_native_session_tabs(self) -> None:
         """Refresh native Console session tabs from store state."""

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -4618,6 +4618,7 @@ class ChatScreen(BaseAppScreen):
                 settings=self._default_console_session_settings(),
             )
             await self._sync_native_console_chat_ui()
+            self._focus_console_composer_if_needed(force=True)
             return
         if button_id and button_id.startswith("console-close-session-tab-"):
             event.stop()
@@ -4656,6 +4657,7 @@ class ChatScreen(BaseAppScreen):
             self._set_active_workspace_for_console_session(session_id)
             controller.switch_session(session_id)
             await self._sync_native_console_chat_ui()
+            self._focus_console_composer_if_needed(force=True)
             return
         if button_id and button_id.startswith("console-message-action-"):
             handled = await self.handle_console_message_action(event)

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -128,6 +128,7 @@ from ...Workspaces.display_state import (
     ConsoleWorkspaceContextState,
     build_console_workspace_state,
 )
+from ...Workspaces import DEFAULT_WORKSPACE_ID
 from ...Widgets.compact_model_bar import CompactModelBar
 from ..Views.RAGSearch.search_handoff import build_library_rag_console_live_work_payload
 
@@ -435,6 +436,7 @@ class ChatScreen(BaseAppScreen):
             self._sync_console_chat_core_state()
             self._activate_console_session_for_workspace(workspace_id)
             self._sync_console_workspace_context()
+            self.run_worker(self._sync_native_console_chat_ui(), exclusive=True)
 
         self.app.push_screen(
             ConsoleWorkspaceSwitcherModal(
@@ -663,8 +665,10 @@ class ChatScreen(BaseAppScreen):
     def _ensure_active_console_session_settings(self) -> ConsoleSessionSettings:
         """Ensure the active native Console session owns a settings snapshot."""
         store = self._ensure_console_chat_store()
+        workspace_id = store.workspace_context.active_workspace_id
         session = store.ensure_session(
-            workspace_id=store.workspace_context.active_workspace_id,
+            title=self._console_initial_session_title_for_workspace(workspace_id),
+            workspace_id=workspace_id,
             settings=self._default_console_session_settings(),
         )
         if session.settings is None:
@@ -679,8 +683,10 @@ class ChatScreen(BaseAppScreen):
     ) -> None:
         """Replace settings for only the active native Console session."""
         store = self._ensure_console_chat_store()
+        workspace_id = store.workspace_context.active_workspace_id
         session = store.ensure_session(
-            workspace_id=store.workspace_context.active_workspace_id,
+            title=self._console_initial_session_title_for_workspace(workspace_id),
+            workspace_id=workspace_id,
             settings=self._default_console_session_settings(),
         )
         store.replace_session_settings(session.id, settings)
@@ -1024,6 +1030,13 @@ class ChatScreen(BaseAppScreen):
             workspace_name = "Workspace"
         return f"{workspace_name} Chat"
 
+    def _console_initial_session_title_for_workspace(self, workspace_id: str | None) -> str:
+        """Return the first Console tab title for the active workspace."""
+        target_workspace_id = str(workspace_id or "").strip()
+        if not target_workspace_id or target_workspace_id in {"global", DEFAULT_WORKSPACE_ID}:
+            return "Chat 1"
+        return self._console_workspace_session_title(target_workspace_id)
+
     def _set_active_workspace_for_console_session(self, session_id: str) -> None:
         """Keep workspace context aligned when switching Console tabs."""
         store = self._ensure_console_chat_store()
@@ -1069,6 +1082,9 @@ class ChatScreen(BaseAppScreen):
         """
         store = self._ensure_console_chat_store()
         session = store.ensure_session(
+            title=self._console_initial_session_title_for_workspace(
+                store.workspace_context.active_workspace_id
+            ),
             workspace_id=store.workspace_context.active_workspace_id,
             settings=self._default_console_session_settings(),
         )
@@ -3063,6 +3079,9 @@ class ChatScreen(BaseAppScreen):
             return
         store = self._ensure_console_chat_store()
         store.ensure_session(
+            title=self._console_initial_session_title_for_workspace(
+                store.workspace_context.active_workspace_id
+            ),
             workspace_id=store.workspace_context.active_workspace_id,
             settings=self._default_console_session_settings(),
         )
@@ -3076,6 +3095,9 @@ class ChatScreen(BaseAppScreen):
         """Append a system message to native Console state and refresh the bridge."""
         store = self._ensure_console_chat_store()
         session = store.ensure_session(
+            title=self._console_initial_session_title_for_workspace(
+                store.workspace_context.active_workspace_id
+            ),
             workspace_id=store.workspace_context.active_workspace_id,
         )
         store.append_message(

--- a/tldw_chatbook/Widgets/Console/console_settings_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_settings_modal.py
@@ -6,6 +6,7 @@ from typing import Mapping
 
 from textual import on
 from textual.app import ComposeResult
+from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
 from textual.css.query import NoMatches, QueryError
 from textual.screen import ModalScreen
@@ -31,6 +32,21 @@ from tldw_chatbook.Chat.console_session_settings import (
 
 
 MODEL_INPUT_PLACEHOLDER = "Enter model id"
+
+
+class ConsoleSettingsInput(Input):
+    """Input field with browser-friendly select-all behavior."""
+
+    BINDINGS = [
+        (
+            Binding("home", "home", binding.description, show=binding.show)
+            if binding.key == "home,ctrl+a"
+            else binding
+        )
+        for binding in Input.BINDINGS
+    ] + [
+        Binding("ctrl+a,super+a", "select_all", "Select all", show=False),
+    ]
 
 
 class ConsoleSettingsModal(ModalScreen[ConsoleSessionSettings | None]):
@@ -117,7 +133,7 @@ class ConsoleSettingsModal(ModalScreen[ConsoleSessionSettings | None]):
                         )
                         model_select.display = has_model_options
                         yield model_select
-                        model_input = Input(
+                        model_input = ConsoleSettingsInput(
                             value=selected_model or "",
                             placeholder=MODEL_INPUT_PLACEHOLDER,
                             id="console-settings-model-input",
@@ -128,7 +144,7 @@ class ConsoleSettingsModal(ModalScreen[ConsoleSessionSettings | None]):
                         yield model_input
                     with Horizontal(classes="console-settings-modal-row"):
                         yield Static("Base URL", classes="console-settings-modal-label")
-                        base_url_input = Input(
+                        base_url_input = ConsoleSettingsInput(
                             value=base_url or "",
                             id="console-settings-base-url",
                             disabled=not uses_base_url,
@@ -141,35 +157,35 @@ class ConsoleSettingsModal(ModalScreen[ConsoleSessionSettings | None]):
                     yield Static("Sampling", classes="destination-section")
                     with Horizontal(classes="console-settings-modal-row"):
                         yield Static("Temperature", classes="console-settings-modal-label")
-                        yield Input(
+                        yield ConsoleSettingsInput(
                             value=self._format_value(self._settings.temperature),
                             id="console-settings-temperature",
                             classes="console-settings-control",
                         )
                     with Horizontal(classes="console-settings-modal-row"):
                         yield Static("Top P", classes="console-settings-modal-label")
-                        yield Input(
+                        yield ConsoleSettingsInput(
                             value=self._format_value(self._settings.top_p),
                             id="console-settings-top-p",
                             classes="console-settings-control",
                         )
                     with Horizontal(classes="console-settings-modal-row"):
                         yield Static("Min P", classes="console-settings-modal-label")
-                        yield Input(
+                        yield ConsoleSettingsInput(
                             value=self._format_value(self._settings.min_p),
                             id="console-settings-min-p",
                             classes="console-settings-control",
                         )
                     with Horizontal(classes="console-settings-modal-row"):
                         yield Static("Top K", classes="console-settings-modal-label")
-                        yield Input(
+                        yield ConsoleSettingsInput(
                             value=self._format_value(self._settings.top_k),
                             id="console-settings-top-k",
                             classes="console-settings-control",
                         )
                     with Horizontal(classes="console-settings-modal-row"):
                         yield Static("Max tokens", classes="console-settings-modal-label")
-                        yield Input(
+                        yield ConsoleSettingsInput(
                             value=self._format_value(self._settings.max_tokens),
                             id="console-settings-max-tokens",
                             classes="console-settings-control",

--- a/tldw_chatbook/Widgets/Console/console_settings_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_settings_modal.py
@@ -48,6 +48,14 @@ class ConsoleSettingsInput(Input):
         Binding("ctrl+a,super+a", "select_all", "Select all", show=False),
     ]
 
+    def on_focus(self) -> None:
+        """Select the current value after click focus settles."""
+        self.call_after_refresh(self.select_all)
+
+    def on_click(self) -> None:
+        """Keep click-to-replace reliable in textual-web."""
+        self.select_all()
+
 
 class ConsoleSettingsModal(ModalScreen[ConsoleSessionSettings | None]):
     """Edit a draft of the current Console session settings."""

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py
@@ -26,8 +26,8 @@ class EditCharacterRequested(Message):
     """
 
     def __init__(self, character_id: str) -> None:
-    def __init__(self, character_id: str) -> None:
         self.character_id = character_id
+        super().__init__()
 
 
 class CharacterSaveRequested(Message):


### PR DESCRIPTION
## Summary
- Refresh native Console chat UI after workspace switches so the visible tab strip matches the active workspace.
- Use workspace-specific first-tab titles for non-default workspaces on mount and session recovery.
- Make Console Settings inputs support reliable select-all replacement in textual-web/browser UAT.

## Test Plan
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_console_native_chat_flow.py Tests/UI/test_console_session_settings.py --tb=short
- git diff --check
- Actual textual-web/CDP screenshot: /private/tmp/tldw-console-uat-fresh/final-current-console-workspace-state.png

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves Console workspace switching and settings UX. Tabs refresh reliably on workspace change, first-tab titles follow the active workspace, composer focuses after tab changes and new chats, settings inputs support select-all replacement, and per-session `llama_cpp` endpoints are allowed.

- **Bug Fixes**
  - Refresh and queue native Console tab updates on workspace switch so no refresh is lost during in‑flight sync.
  - Use workspace‑specific initial session titles on mount and recovery; default/global stays "Chat 1".
  - Focus the composer after creating a new chat or switching tabs for immediate typing.
  - Replace settings inputs with `ConsoleSettingsInput` that selects all on focus and click, supports ctrl+a/super+a, and reliably saves replaced values across model, base URL, and sampling fields in textual‑web/CDP.
  - Allow session‑scoped custom endpoints for `llama_cpp` without requiring a saved config; readiness is "Ready".
  - Fix Personas pane message construction by calling super().__init__ in EditCharacterRequested.

<sup>Written for commit 68c7728415360743fa98453e3e03e0459675bf00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

