### PR TITLE
Re-pin the two stale chat-tab widget tests

### DIFF
--- a/Tests/Widgets/test_chat_session.py
+++ b/Tests/Widgets/test_chat_session.py
@@ -462,13 +462,25 @@ class TestChatSessionStateManagement:
     
     def test_check_streaming_state(self, chat_session):
         """Test periodic streaming state check."""
+        from unittest.mock import PropertyMock
+
         chat_session._update_button_state = Mock()
-        
-        # Call the check method
-        chat_session._check_streaming_state()
-        
-        # Verify button state was updated
+        chat_session._stop_streaming_check_timer = Mock()
+
+        # Active, mounted sessions refresh the send/stop button.
+        chat_session._is_active = True
+        with patch.object(
+            type(chat_session), "is_mounted", new_callable=PropertyMock, return_value=True
+        ):
+            chat_session._check_streaming_state()
         chat_session._update_button_state.assert_called_once()
+
+        # Inactive sessions stop their timer instead of touching the button.
+        chat_session._update_button_state.reset_mock()
+        chat_session._is_active = False
+        chat_session._check_streaming_state()
+        chat_session._update_button_state.assert_not_called()
+        chat_session._stop_streaming_check_timer.assert_called_once()
     
     def test_worker_state_tracking(self, chat_session):
         """Test tracking of worker state in session data."""

--- a/Tests/Widgets/test_chat_tab_container.py
+++ b/Tests/Widgets/test_chat_tab_container.py
@@ -403,7 +403,9 @@ class TestChatTabContainer:
         assert tab_container.active_session_id == "def67890"
         
         # Verify tab bar was updated
-        tab_container.tab_bar.set_active_tab.assert_called_once_with("def67890")
+        # switch_to_tab_async sets the bar state without re-emitting the
+        # activation event (the container already handled it).
+        tab_container.tab_bar.set_active_tab.assert_called_once_with("def67890", emit=False)
     
     @pytest.mark.asyncio
     async def test_switch_to_nonexistent_tab(self, tab_container):


### PR DESCRIPTION
The last two failing tests anywhere in Tests/UI + Tests/Widgets, both pre-existing on clean dev (they surfaced during #513's verification):

- `test_switch_to_tab`: `switch_to_tab_async` now calls `set_active_tab(..., emit=False)` — the container already handled the activation event; the test pinned the old no-kwarg call.
- `test_check_streaming_state`: `_check_streaming_state` early-returns and stops its timer for inactive/unmounted sessions; the test sampled an unmounted fixture and expected the old unconditional refresh. It now covers both the active refresh path and the inactive stop path.

With this, `Tests/Widgets` is 351 passed / 0 failed, completing the green baseline across both UI test directories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update two chat widget tests to match current behavior and restore a green baseline in `Tests/Widgets` (351 passed, 0 failed). Covers `set_active_tab(..., emit=False)` in `switch_to_tab_async` and verifies `_check_streaming_state` refreshes when active and stops its timer when inactive.

<sup>Written for commit eb0db860973fdc3713053cf7f12b69782447c839. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

