### PR TITLE
Fix dev syntax error, dead server binding, and RuntimePolicy test rot

### DIFF
--- a/Tests/RuntimePolicy/test_runtime_policy_bootstrap.py
+++ b/Tests/RuntimePolicy/test_runtime_policy_bootstrap.py
@@ -17,6 +17,8 @@ def _make_app_like(*, base_url: str = "https://Example.COM:8443/api/") -> Simple
             }
         },
         app_state=AppState(),
+        # handle_runtime_backend_changed invalidates the screen cache.
+        invalidate_screen_cache=lambda: None,
     )
 
 
@@ -659,6 +661,7 @@ async def test_handle_runtime_backend_changed_forwards_resolved_authoritative_ba
         app_config={},
         app_state=AppState(),
         screen=SimpleNamespace(handle_runtime_backend_changed=screen_callback),
+        invalidate_screen_cache=lambda: None,
     )
     context = load_runtime_policy_for_app(app_like, store=store)
 

--- a/Tests/RuntimePolicy/test_runtime_policy_core.py
+++ b/Tests/RuntimePolicy/test_runtime_policy_core.py
@@ -173,6 +173,7 @@ EXPECTED_AUDITED_CAPABILITIES = {
     "kanban_boards_tasks": {
         "expected_domain_ids": {"kanban"},
         "expected_action_kinds_by_source": {
+            "local": _action_kinds("browse", "detail", "create", "update", "delete", "launch", "observe"),
             "server": _action_kinds("browse", "detail", "create", "update", "delete", "launch", "observe"),
         },
     },
@@ -235,6 +236,7 @@ EXPECTED_AUDITED_CAPABILITIES = {
     "server_skills": {
         "expected_domain_ids": {"skills"},
         "expected_action_kinds_by_source": {
+            "local": FULL_CRUD_AND_LAUNCH,
             "server": FULL_CRUD_AND_LAUNCH,
         },
     },
@@ -677,78 +679,146 @@ EXPECTED_ACTION_IDS_BY_CAPABILITY = {
         prompt_studio.test_cases.update.server
     """),
     "kanban_boards_tasks": _action_ids("""
+        kanban.activities.list.local
         kanban.activities.list.server
+        kanban.boards.archive.local
         kanban.boards.archive.server
+        kanban.boards.create.local
         kanban.boards.create.server
+        kanban.boards.delete.local
         kanban.boards.delete.server
+        kanban.boards.detail.local
         kanban.boards.detail.server
+        kanban.boards.export.local
         kanban.boards.export.server
+        kanban.boards.import.local
         kanban.boards.import.server
+        kanban.boards.list.local
         kanban.boards.list.server
+        kanban.boards.restore.local
         kanban.boards.restore.server
+        kanban.boards.update.local
         kanban.boards.update.server
+        kanban.card_labels.create.local
         kanban.card_labels.create.server
+        kanban.card_labels.delete.local
         kanban.card_labels.delete.server
+        kanban.card_labels.list.local
         kanban.card_labels.list.server
+        kanban.card_links.create.local
         kanban.card_links.create.server
+        kanban.card_links.delete.local
         kanban.card_links.delete.server
+        kanban.card_links.detail.local
         kanban.card_links.detail.server
+        kanban.card_links.list.local
         kanban.card_links.list.server
+        kanban.cards.archive.local
         kanban.cards.archive.server
+        kanban.cards.create.local
         kanban.cards.create.server
+        kanban.cards.delete.local
         kanban.cards.delete.server
+        kanban.cards.detail.local
         kanban.cards.detail.server
+        kanban.cards.launch.local
         kanban.cards.launch.server
+        kanban.cards.list.local
         kanban.cards.list.server
+        kanban.cards.reorder.local
         kanban.cards.reorder.server
+        kanban.cards.restore.local
         kanban.cards.restore.server
+        kanban.cards.update.local
         kanban.cards.update.server
+        kanban.checklist_items.create.local
         kanban.checklist_items.create.server
+        kanban.checklist_items.delete.local
         kanban.checklist_items.delete.server
+        kanban.checklist_items.detail.local
         kanban.checklist_items.detail.server
+        kanban.checklist_items.list.local
         kanban.checklist_items.list.server
+        kanban.checklist_items.reorder.local
         kanban.checklist_items.reorder.server
+        kanban.checklist_items.update.local
         kanban.checklist_items.update.server
+        kanban.checklists.create.local
         kanban.checklists.create.server
+        kanban.checklists.delete.local
         kanban.checklists.delete.server
+        kanban.checklists.detail.local
         kanban.checklists.detail.server
+        kanban.checklists.list.local
         kanban.checklists.list.server
+        kanban.checklists.reorder.local
         kanban.checklists.reorder.server
+        kanban.checklists.update.local
         kanban.checklists.update.server
+        kanban.comments.create.local
         kanban.comments.create.server
+        kanban.comments.delete.local
         kanban.comments.delete.server
+        kanban.comments.detail.local
         kanban.comments.detail.server
+        kanban.comments.list.local
         kanban.comments.list.server
+        kanban.comments.update.local
         kanban.comments.update.server
+        kanban.labels.create.local
         kanban.labels.create.server
+        kanban.labels.delete.local
         kanban.labels.delete.server
+        kanban.labels.detail.local
         kanban.labels.detail.server
+        kanban.labels.list.local
         kanban.labels.list.server
+        kanban.labels.update.local
         kanban.labels.update.server
+        kanban.lists.archive.local
         kanban.lists.archive.server
+        kanban.lists.create.local
         kanban.lists.create.server
+        kanban.lists.delete.local
         kanban.lists.delete.server
+        kanban.lists.detail.local
         kanban.lists.detail.server
+        kanban.lists.list.local
         kanban.lists.list.server
+        kanban.lists.reorder.local
         kanban.lists.reorder.server
+        kanban.lists.restore.local
         kanban.lists.restore.server
+        kanban.lists.update.local
         kanban.lists.update.server
+        kanban.search.detail.local
         kanban.search.detail.server
+        kanban.search.list.local
         kanban.search.list.server
     """),
     "translation_utility": _action_ids("""
         translation.text.launch.server
     """),
     "server_skills": _action_ids("""
+        skills.context.list.local
         skills.context.list.server
+        skills.create.local
         skills.create.server
+        skills.delete.local
         skills.delete.server
+        skills.detail.local
         skills.detail.server
+        skills.execute.launch.local
         skills.execute.launch.server
+        skills.export.launch.local
         skills.export.launch.server
+        skills.import.launch.local
         skills.import.launch.server
+        skills.list.local
         skills.list.server
+        skills.seed.launch.local
         skills.seed.launch.server
+        skills.update.local
         skills.update.server
     """),
     "server_tools": _action_ids("""

--- a/tldw_chatbook/MCP/unified_control_models.py
+++ b/tldw_chatbook/MCP/unified_control_models.py
@@ -272,9 +272,9 @@ class ConfiguredServerTarget:
         if not isinstance(app_config, Mapping):
             return None
 
-        api_config = app_config.get("tldw_api", {})
-        if not isinstance(api_config, Mapping):
-            api_config = {}
+        from tldw_chatbook.config import resolve_tldw_api_config
+
+        api_config = resolve_tldw_api_config(app_config)
 
         raw_url = str(api_config.get("base_url") or api_config.get("api_url") or api_config.get("url") or "").strip()
         if not raw_url:

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py
@@ -26,7 +26,7 @@ class EditCharacterRequested(Message):
     """
 
     def __init__(self, character_id: str) -> None:
-    def __init__(self, character_id: str) -> None:
+        super().__init__()
         self.character_id = character_id
 
 

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -590,6 +590,26 @@ _SETTINGS_CACHE: Optional[Dict[str, Any]] = None
 _SETTINGS_CACHE_SOURCE: Optional[Path] = None
 _SETTINGS_CACHE_LOCK = None  # Will be initialized when needed
 
+def resolve_tldw_api_config(app_config) -> Dict:
+    """Return the [tldw_api] section from either config shape.
+
+    Raw CLI config (load_cli_config_and_ensure_existence) carries [tldw_api]
+    at the top level; the app's normalized config (load_settings) keeps the
+    raw CLI config nested under COMPREHENSIVE_CONFIG_RAW. Every reader of the
+    server endpoint/token must accept both shapes.
+    """
+    if not isinstance(app_config, dict) and not hasattr(app_config, "get"):
+        return {}
+    api_config = app_config.get("tldw_api", {}) or {}
+    if not isinstance(api_config, dict) or not api_config:
+        raw_config = app_config.get("COMPREHENSIVE_CONFIG_RAW", {}) or {}
+        nested = raw_config.get("tldw_api", {}) if hasattr(raw_config, "get") else {}
+        api_config = nested if isinstance(nested, dict) else {}
+    if not isinstance(api_config, dict):
+        return {}
+    return dict(api_config)
+
+
 def load_settings(force_reload: bool = False) -> Dict:
     """
     Loads all settings from TOML config files, environment variables, or defaults into a dictionary.

--- a/tldw_chatbook/runtime_policy/bootstrap.py
+++ b/tldw_chatbook/runtime_policy/bootstrap.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any, Mapping
 from urllib.parse import urlsplit, urlunsplit
 
-from tldw_chatbook.config import DEFAULT_CONFIG_PATH
+from tldw_chatbook.config import DEFAULT_CONFIG_PATH, resolve_tldw_api_config
 from tldw_chatbook.tldw_api import TLDWAPIClient
 
 from .source_state import RuntimeSourceStateStore
@@ -38,9 +38,7 @@ def build_runtime_api_client(
     auth_token: str | None = None,
     auth_method: str | None = None,
 ) -> TLDWAPIClient:
-    api_config: dict[str, Any] = {}
-    if isinstance(app_config, Mapping):
-        api_config = dict(app_config.get("tldw_api", {}) or {})
+    api_config: dict[str, Any] = resolve_tldw_api_config(app_config)
 
     resolved_endpoint = str(
         endpoint_url
@@ -227,15 +225,7 @@ def derive_configured_server_binding(app_config: Mapping[str, Any] | None) -> Co
             last_known_server_label=None,
         )
 
-    api_config = app_config.get("tldw_api", {})
-    if not isinstance(api_config, Mapping) or not api_config:
-        # The app's app_config comes from load_settings(), which normalizes
-        # sections and keeps the raw CLI config nested under
-        # COMPREHENSIVE_CONFIG_RAW; [tldw_api] only exists there.
-        raw_config = app_config.get("COMPREHENSIVE_CONFIG_RAW", {})
-        api_config = raw_config.get("tldw_api", {}) if isinstance(raw_config, Mapping) else {}
-    if not isinstance(api_config, Mapping):
-        api_config = {}
+    api_config = resolve_tldw_api_config(app_config)
 
     raw_url = str(api_config.get("base_url") or api_config.get("api_url") or api_config.get("url") or "").strip()
     if not raw_url:

--- a/tldw_chatbook/runtime_policy/bootstrap.py
+++ b/tldw_chatbook/runtime_policy/bootstrap.py
@@ -228,6 +228,12 @@ def derive_configured_server_binding(app_config: Mapping[str, Any] | None) -> Co
         )
 
     api_config = app_config.get("tldw_api", {})
+    if not isinstance(api_config, Mapping) or not api_config:
+        # The app's app_config comes from load_settings(), which normalizes
+        # sections and keeps the raw CLI config nested under
+        # COMPREHENSIVE_CONFIG_RAW; [tldw_api] only exists there.
+        raw_config = app_config.get("COMPREHENSIVE_CONFIG_RAW", {})
+        api_config = raw_config.get("tldw_api", {}) if isinstance(raw_config, Mapping) else {}
     if not isinstance(api_config, Mapping):
         api_config = {}
 

--- a/tldw_chatbook/runtime_policy/server_context.py
+++ b/tldw_chatbook/runtime_policy/server_context.py
@@ -336,10 +336,9 @@ class RuntimeServerContextProvider:
         return normalized or None
 
     def _legacy_api_config(self) -> Mapping[str, Any]:
-        if not isinstance(self.app_config, Mapping):
-            return {}
-        api_config = self.app_config.get("tldw_api", {})
-        return api_config if isinstance(api_config, Mapping) else {}
+        from tldw_chatbook.config import resolve_tldw_api_config
+
+        return resolve_tldw_api_config(self.app_config)
 
     def _should_allow_legacy_config(
         self,


### PR DESCRIPTION
Three fixes surfaced while starting the TASK-70.6 Sync v2 actual-use QA:

1. **dev is currently broken**: web-edit commit `2d0d1c89` left an `IndentationError` in `personas_pane_messages.py` (duplicated `__init__` def line, dropped `super().__init__()`) — 26 test files fail collection and any Persona-widget import crashes. Restored the pre-edit body.

2. **Product bug: the server binding never activates from config.** `derive_configured_server_binding` reads `app_config['tldw_api']`, but the app's `app_config` comes from `load_settings()`, which normalizes sections and nests the raw CLI config under `COMPREHENSIVE_CONFIG_RAW` — so a configured `[tldw_api] base_url` never produced an active server profile, leaving **Manual Sync v2 permanently blocked** in the running app. The derivation now falls back to the nested raw config. (Found because the QA's first screenshot showed "Manual Sync requires an active server profile" with a fully configured server.)

3. **Tests/RuntimePolicy rot** (pre-existing on dev, outside the repaired baseline dirs): the kanban domain + skills local rows landed without updating the audited-registry test (blocks regenerated from the live registry, local+server kinds audited), and the runtime-backend fakes needed the `invalidate_screen_cache` stub. Suite now 248 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dev import errors, fully activates the configured server profile across the app, and restores green RuntimePolicy tests. Unblocks Manual Sync v2 by consistently reading `[tldw_api]` from raw CLI config or `COMPREHENSIVE_CONFIG_RAW` in `load_settings()` (TASK-70.6).

- **Bug Fixes**
  - Restored `EditCharacterRequested.__init__` to resolve an IndentationError in `personas_pane_messages.py`.
  - Unified all `tldw_api` readers behind `resolve_tldw_api_config`; server binding, runtime API client, MCP legacy target bootstrap, and server context now accept both config shapes so a configured `base_url` fully activates at runtime.
  - RuntimePolicy: expanded audited action sets to include local kanban/skills and added `invalidate_screen_cache` to fakes; suite now passes (248/0).

<sup>Written for commit 80fc71264f0a32290a73f07e7efba9abfbb2a8e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

