### PR TITLE
fix: Personas workbench UAT findings (two P0 crashes + UX)

### DIFF
--- a/Tests/UI/test_personas_preview.py
+++ b/Tests/UI/test_personas_preview.py
@@ -123,6 +123,42 @@ async def test_seed_empty_greeting_clears_transcript():
         assert pane.transcript_text() == ""
 
 
+async def test_status_region_renders_below_transcript():
+    """The status line is its own region beneath the transcript, never above.
+
+    Regression guard: a provider/error status must not interleave above the
+    chronological greeting -> you -> character transcript. We assert DOM
+    ordering (transcript precedes status precedes input) and that, with both
+    a transcript and a status set, the greeting/user lines still read in
+    order while the status sits in its separate region.
+    """
+    app = PreviewApp()
+    async with app.run_test() as pilot:
+        pane = pilot.app.query_one(PersonasPreviewPane)
+        await pane.seed_greeting("Greetings, detective.")
+        pane.append_user("Who are you?")
+        pane.set_status("anthropic is not ready - configure in Settings")
+        await pilot.pause()
+
+        body = pilot.app.query_one("#personas-preview-body")
+        child_ids = [c.id for c in body.children]
+        transcript_pos = child_ids.index("personas-preview-transcript")
+        status_pos = child_ids.index("personas-preview-status")
+        input_pos = child_ids.index("personas-preview-input")
+        # Status must sit between the transcript and the input, not above it.
+        assert transcript_pos < status_pos < input_pos
+
+        # The transcript itself stays in chronological order.
+        assert _line_texts(pilot.app) == [
+            "character: Greetings, detective.",
+            "you: Who are you?",
+        ]
+        # The status lives in its own region, separate from the transcript.
+        assert "anthropic is not ready" in str(
+            pilot.app.query_one("#personas-preview-status", Static).renderable
+        )
+
+
 async def test_double_seed_same_tick_does_not_crash():
     app = PreviewApp()
     async with app.run_test() as pilot:

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -3236,3 +3236,78 @@ class TestConfirmationDialogEscape:
             await pilot.pause()
             assert results == [False]
             assert not isinstance(pilot.app.screen, ConfirmationDialog)
+
+
+class TestImportExportFilters:
+    """The file-picker filters must use callable testers, not glob strings.
+
+    Regression guard for the P0 crash: ``Filter.__call__`` does
+    ``self.tester(path)``; a glob STRING tester ("*.json") raises
+    ``TypeError: 'str' object is not callable`` and tears down the session
+    when Import / Export JSON / Export PNG is pressed. We drive the real
+    import/export workers, capture the picker actually built, and assert
+    every filter is callable and returns a bool without raising.
+    """
+
+    @staticmethod
+    def _assert_filters_callable(filters) -> None:
+        from pathlib import Path
+
+        # ``selections`` enumerates every registered filter; each must be a
+        # callable tester that survives being invoked on a Path.
+        assert bool(filters)
+        for _name, filter_id in filters.selections:
+            entry = filters[filter_id]
+            for sample in (Path("x.json"), Path("x.png"), Path("x.txt")):
+                result = entry(sample)
+                assert isinstance(result, bool)
+
+    async def _capture_picker(self, pilot, screen, launch):
+        from unittest.mock import AsyncMock
+
+        captured: dict = {}
+
+        async def _fake_push_screen_wait(picker):
+            captured["picker"] = picker
+            return None  # user cancels; the worker returns cleanly
+
+        pilot.app.push_screen_wait = AsyncMock(side_effect=_fake_push_screen_wait)
+        await launch()
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        assert "picker" in captured, "picker was never pushed"
+        return captured["picker"]
+
+    async def test_import_filters_are_callable(
+        self, mock_app_instance, stub_characters
+    ):
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            picker = await self._capture_picker(
+                pilot, screen, screen._import_dialog_worker
+            )
+            self._assert_filters_callable(picker.filters)
+
+    async def test_export_json_filters_are_callable(
+        self, mock_app_instance, stub_characters
+    ):
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            picker = await self._capture_picker(
+                pilot, screen, lambda: screen._export_dialog_worker("json")
+            )
+            self._assert_filters_callable(picker.filters)
+
+    async def test_export_png_filters_are_callable(
+        self, mock_app_instance, stub_characters
+    ):
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            picker = await self._capture_picker(
+                pilot, screen, lambda: screen._export_dialog_worker("png")
+            )
+            self._assert_filters_callable(picker.filters)

--- a/backlog/tasks/task-108 - Responsive-layout-pass-for-the-Personas-workbench-at-narrow-widths.md
+++ b/backlog/tasks/task-108 - Responsive-layout-pass-for-the-Personas-workbench-at-narrow-widths.md
@@ -1,0 +1,20 @@
+---
+id: TASK-108
+title: Responsive layout pass for the Personas workbench at narrow widths
+status: To Do
+assignee: []
+created_date: '2026-06-12 20:16'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+At ~900px the inspector readiness text wraps mid-phrase and the work-area middle column collapses; do a responsive review (min-widths, text wrapping, possibly collapsing a pane).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Work area stays usable at 80-col equivalent,Inspector text wraps cleanly
+<!-- AC:END -->

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -1274,10 +1274,10 @@ class PersonasScreen(BaseAppScreen):
             picker = EnhancedFileOpen(
                 title="Import Character Card",
                 filters=Filters(
-                    ("Character Cards", "*.json;*.png"),
-                    ("JSON Files", "*.json"),
-                    ("PNG Files (with embedded data)", "*.png"),
-                    ("All Files", "*.*"),
+                    ("Character Cards", lambda p: p.suffix.lower() in (".json", ".png")),
+                    ("JSON Files", lambda p: p.suffix.lower() == ".json"),
+                    ("PNG Files (with embedded data)", lambda p: p.suffix.lower() == ".png"),
+                    ("All Files", lambda p: True),
                 ),
                 context="character_import",
             )
@@ -1372,9 +1372,15 @@ class PersonasScreen(BaseAppScreen):
             safe_name = "".join(c for c in name if c.isalnum() or c in " -_").rstrip()
             default_filename = f"{safe_name or 'export'}.{fmt}"
             if fmt == "png":
-                filters = Filters(("PNG Files", "*.png"), ("All Files", "*.*"))
+                filters = Filters(
+                    ("PNG Files", lambda p: p.suffix.lower() == ".png"),
+                    ("All Files", lambda p: True),
+                )
             else:
-                filters = Filters(("JSON Files", "*.json"), ("All Files", "*.*"))
+                filters = Filters(
+                    ("JSON Files", lambda p: p.suffix.lower() == ".json"),
+                    ("All Files", lambda p: True),
+                )
             picker = EnhancedFileSave(
                 title=f"Export as {fmt.upper()}",
                 default_filename=default_filename,

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -2116,7 +2116,7 @@ class PersonasScreen(BaseAppScreen):
                 ShortcutAction(
                     "ctrl+enter", "attach", available=self._console_action_allowed()
                 ),
-                ShortcutAction("ctrl+1-5", "mode"),
+                ShortcutAction("[ ]", "mode"),
             ),
         )
 

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -186,6 +186,11 @@ class PersonasScreen(BaseAppScreen):
 
     #personas-work-area {
         width: 4fr;
+        /* The center card is the workbench's primary surface; keep it from
+           collapsing to an unusable sliver when the window narrows (~80 col).
+           A full responsive pass (collapsing a side pane, etc.) is tracked
+           separately. */
+        min-width: 40;
     }
 
     #personas-inspector-pane {

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py
@@ -26,7 +26,7 @@ class EditCharacterRequested(Message):
     """
 
     def __init__(self, character_id: str) -> None:
-    def __init__(self, character_id: str) -> None:
+        super().__init__()
         self.character_id = character_id
 
 

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_preview_pane.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_preview_pane.py
@@ -94,8 +94,11 @@ class PersonasPreviewPane(Vertical):
             classes="console-action-subdued",
         )
         with Vertical(id="personas-preview-body"):
-            yield Static("", id="personas-preview-status")
             yield VerticalScroll(id="personas-preview-transcript")
+            # The status line is a status region adjacent to the input, kept
+            # BELOW the transcript so provider/error messages never render
+            # above the chronological greeting -> you -> character history.
+            yield Static("", id="personas-preview-status")
             yield Input(placeholder="Test message...", id="personas-preview-input")
             with Horizontal(classes="ds-toolbar"):
                 yield Button(


### PR DESCRIPTION
Found by live UAT (running the real app via \`tldw-serve\` + Playwright, driving the actual rendered terminal) of the merged Personas workbench. Two of these are **P0 crashes currently live on \`dev\`** that the green test suite never caught because they live in the dialog/seam layer.

## Fixes (each its own commit)

1. **P0 — Personas screen was unopenable.** Commit \`2d0d1c89\` (a GitHub-web-applied review suggestion, the last commit before #509 merged) duplicated the \`def __init__\` line in \`EditCharacterRequested\` instead of keeping \`super().__init__()\`, producing an \`IndentationError\` that crashed the app the moment you click Personas. Restored the body.

2. **P0 — Import / Export JSON / Export PNG all hard-crashed the app.** The file picker \`Filters(...)\` was built with glob **strings** (\`\"*.json\"\`) where the API requires \`(name, Callable[[Path], bool])\` tuples; \`Filter.__call__\` then did \`\"*.json\"(path)\` → \`TypeError: 'str' object is not callable\`, tearing down the whole session. Converted to callables matching the house idiom (e.g. \`STTS_Window.py\`). Added a regression test that asserts every personas filter is callable (the existing tests bypass the dialog, which is why this shipped).

3. **Honest footer hint.** \`Ctrl+1\`–\`Ctrl+5\` mode chords aren't transmissible by standard terminals/xterm.js, so they're silently dead while \`[\`/\`]\` work. Footer now advertises \`[ ] mode\` instead of \`ctrl+1-5 mode\`.

4. **Preview transcript ordering.** The provider-error status line rendered *above* the greeting/user lines (out of chronological order). Moved the status region below the transcript, adjacent to the input.

5. **Narrow-width safety.** Added a \`min-width\` to the work area so the center column doesn't collapse at ~80 cols; full responsive pass filed as TASK-108.

## Verification (live, not just tests)
- Re-ran UAT on this branch: Personas **opens**, Export JSON and Import both render their file dialogs with **no session crash**, preview transcript is chronological. Screenshots captured.
- 216 personas/preview/widget/footer tests + 143 contract/handler tests green.

## Follow-up flagged (not in this PR)
The same glob-string \`Filters\` crash is latent in other screens (\`file_picker_dialog.get_eval_file_filters\`, \`ccp_*_handler.py\`, eval dialogs, transcription viewer). Worth a sweep — listed in the PR thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two P0 crashes in the Personas workbench and cleans up preview and layout behavior. Personas opens, import/export no longer crash, and the preview ordering and footer hint are corrected.

- **Bug Fixes**
  - Ensures proper initialization in EditCharacterRequested so Personas opens.
  - Replaced glob-string file filters with callables for Import/Export JSON/PNG; added regression tests to ensure filters are callable.
  - Moved preview status below the transcript; added a test asserting DOM order.

- **UI Improvements**
  - Footer now advertises “[ ] mode” instead of “ctrl+1-5 mode” for terminals that don’t send ctrl+digits.
  - Added a min-width to the work area to prevent collapse at narrow widths (partial step toward TASK-108).

<sup>Written for commit 38add3c0c0bf2b5ba5c8bfe08c3eadc9ec2d6169. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

