### PR TITLE
Runtime source switch UI + server-switch modal (TASK-107)

### DIFF
--- a/tldw_chatbook/Sync_Interop/server_sync_service.py
+++ b/tldw_chatbook/Sync_Interop/server_sync_service.py
@@ -48,11 +48,13 @@ class ServerSyncService:
         app_config: Mapping[str, Any],
         *,
         policy_enforcer: Any | None = None,
+        state_repository: Any | None = None,
     ) -> "ServerSyncService":
         return cls(
             client=None,
             client_provider=build_runtime_api_client_provider_from_config(app_config),
             policy_enforcer=policy_enforcer,
+            state_repository=state_repository,
         )
 
     @classmethod

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -6541,10 +6541,18 @@ class SettingsScreen(BaseAppScreen):
         from tldw_chatbook.config import load_settings, save_setting_to_cli_config
         from tldw_chatbook.runtime_policy.bootstrap import load_runtime_policy_for_app
 
+        from tldw_chatbook.Utils.input_validation import validate_url
+
+        if not validate_url(base_url):
+            self.app.notify(
+                "Rejected server URL; nothing was changed.", severity="error"
+            )
+            return
         save_setting_to_cli_config("tldw_api", "base_url", base_url)
+        # Persist the token unconditionally so clearing it in the modal
+        # actually removes the stored credential.
         auth_token = str(result.get("auth_token") or "").strip()
-        if auth_token:
-            save_setting_to_cli_config("tldw_api", "auth_token", auth_token)
+        save_setting_to_cli_config("tldw_api", "auth_token", auth_token)
         app.app_config = load_settings(force_reload=True)
         load_runtime_policy_for_app(app)
         await app.handle_runtime_backend_changed("server")
@@ -6569,7 +6577,11 @@ class SettingsScreen(BaseAppScreen):
                     display_name=platform.node() or "tldw_chatbook",
                 )
             except Exception as exc:
-                logger.warning("Sync v2 profile preparation failed.", exc_info=True)
+                logger.warning(
+                    "Sync v2 profile preparation failed (server_profile_id={}, mode=local_first_sync).",
+                    server_id,
+                    exc_info=True,
+                )
                 self.app.notify(
                     f"Server activated, but Sync v2 setup failed: {exc}",
                     severity="warning",

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -4823,6 +4823,12 @@ class SettingsScreen(BaseAppScreen):
             yield Static("Server, sync, workspace, and handoff", classes="destination-section")
             for label, value in self.server_sync_workspace_handoff_rows:
                 yield self._detail_row(label, value)
+            with Horizontal(classes="settings-action-row"):
+                yield Button(
+                    "Switch Source / Server",
+                    id="settings-switch-runtime-source",
+                    tooltip="Choose local-only or bind a tldw server as the runtime source.",
+                )
             yield Static("Provider readiness", classes="destination-section")
             yield self._detail_row(
                 "Provider readiness",
@@ -6487,6 +6493,99 @@ class SettingsScreen(BaseAppScreen):
     def handle_preview_appearance(self, event: Button.Pressed) -> None:
         event.stop()
         self.action_settings_test_category()
+
+    @on(Button.Pressed, "#settings-switch-runtime-source")
+    def handle_switch_runtime_source(self, event: Button.Pressed) -> None:
+        """Open the runtime-source switch modal (callback-based, never wait)."""
+        event.stop()
+        from tldw_chatbook.Widgets.Settings_Widgets.server_switch_modal import ServerSwitchModal
+
+        state = self._runtime_source_state()
+        raw_config = (getattr(self.app_instance, "app_config", {}) or {}).get(
+            "COMPREHENSIVE_CONFIG_RAW", {}
+        )
+        api_config = raw_config.get("tldw_api", {}) if isinstance(raw_config, dict) else {}
+        modal = ServerSwitchModal(
+            current_source=str(getattr(state, "active_source", "local") or "local"),
+            current_server_label=str(
+                getattr(state, "last_known_server_label", "")
+                or getattr(state, "active_server_id", "")
+                or ""
+            ),
+            current_base_url=str(api_config.get("base_url") or ""),
+            current_auth_token=str(api_config.get("auth_token") or ""),
+        )
+        self.app.push_screen(modal, self._handle_runtime_source_switch_result)
+
+    def _handle_runtime_source_switch_result(self, result: dict | None) -> None:
+        if not result:
+            return
+        self.run_worker(
+            self._perform_runtime_source_switch(result),
+            exclusive=True,
+            group="settings-runtime-source-switch",
+        )
+
+    async def _perform_runtime_source_switch(self, result: dict) -> None:
+        """Apply the modal decision: persist, rebind, switch, enroll Sync v2."""
+        app = self.app_instance
+        if result.get("action") == "local":
+            await app.handle_runtime_backend_changed("local")
+            self.app.notify("Runtime source set to local.", severity="information")
+            self._refresh_manual_sync_rows()
+            return
+
+        base_url = str(result.get("base_url") or "").strip()
+        if not base_url:
+            return
+        from tldw_chatbook.config import load_settings, save_setting_to_cli_config
+        from tldw_chatbook.runtime_policy.bootstrap import load_runtime_policy_for_app
+
+        save_setting_to_cli_config("tldw_api", "base_url", base_url)
+        auth_token = str(result.get("auth_token") or "").strip()
+        if auth_token:
+            save_setting_to_cli_config("tldw_api", "auth_token", auth_token)
+        app.app_config = load_settings(force_reload=True)
+        load_runtime_policy_for_app(app)
+        await app.handle_runtime_backend_changed("server")
+
+        state = self._runtime_source_state()
+        server_id = str(getattr(state, "active_server_id", "") or "").strip()
+        if not server_id:
+            self.app.notify(
+                "Server could not be bound from the entered URL.", severity="error"
+            )
+            return
+
+        sync_scope_service = getattr(app, "sync_scope_service", None)
+        prepare = getattr(sync_scope_service, "prepare_sync_v2_profile_mode", None)
+        if callable(prepare):
+            import platform
+
+            try:
+                summary = await prepare(
+                    profile_mode="local_first_sync",
+                    server_profile_id=server_id,
+                    display_name=platform.node() or "tldw_chatbook",
+                )
+            except Exception as exc:
+                logger.warning("Sync v2 profile preparation failed.", exc_info=True)
+                self.app.notify(
+                    f"Server activated, but Sync v2 setup failed: {exc}",
+                    severity="warning",
+                )
+            else:
+                dataset = str(summary.get("dataset_id") or "unknown")
+                self.app.notify(
+                    f"Server activated; Sync v2 prepared (dataset {dataset}).",
+                    severity="information",
+                )
+        else:
+            self.app.notify(
+                "Server activated. Sync v2 service is unavailable in this runtime.",
+                severity="warning",
+            )
+        self._refresh_manual_sync_rows()
 
     @on(Button.Pressed, "#settings-manual-sync-preview")
     def handle_manual_sync_preview(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/Widgets/Settings_Widgets/__init__.py
+++ b/tldw_chatbook/Widgets/Settings_Widgets/__init__.py
@@ -1,0 +1,1 @@
+"""Settings-owned widgets and modals."""

--- a/tldw_chatbook/Widgets/Settings_Widgets/server_switch_modal.py
+++ b/tldw_chatbook/Widgets/Settings_Widgets/server_switch_modal.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 from typing import Any, Optional
 
 import httpx
+from urllib.parse import urlsplit
+
 from textual import on, work
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
@@ -158,6 +160,34 @@ class ServerSwitchModal(ModalScreen[Optional[dict]]):
         except QueryError:
             return ""
 
+    def _validated_root_url(self) -> str | None:
+        """Return the entered URL if it is a usable server ROOT, else None.
+
+        The runtime API client appends /api/v1/... itself, so the URL must be
+        scheme + host[:port] with no path/query/fragment; anything else is
+        rejected here instead of producing confusing joined endpoints later.
+        """
+        from tldw_chatbook.Utils.input_validation import validate_url
+
+        url = self._entered_url()
+        if not url:
+            self._set_status("Enter a server URL first.")
+            return None
+        parts = urlsplit(url)
+        if parts.scheme not in {"http", "https"} or not parts.netloc:
+            self._set_status("Use a full URL with scheme, e.g. http://127.0.0.1:8000")
+            return None
+        if parts.path.strip("/") or parts.query or parts.fragment:
+            self._set_status(
+                "Enter the server root only (no path) — e.g. http://host:8000; "
+                "the client adds /api/v1/... itself."
+            )
+            return None
+        if not validate_url(url):
+            self._set_status("That URL did not pass validation; check it and retry.")
+            return None
+        return url
+
     def _entered_token(self) -> str:
         try:
             return self.query_one("#server-switch-token", Input).value.strip()
@@ -167,9 +197,8 @@ class ServerSwitchModal(ModalScreen[Optional[dict]]):
     @on(Button.Pressed, "#server-switch-test")
     def handle_test_pressed(self, event: Button.Pressed) -> None:
         event.stop()
-        url = self._entered_url()
+        url = self._validated_root_url()
         if not url:
-            self._set_status("Enter a server URL to test.")
             return
         self._set_status(f"Testing {url} ...")
         self._run_connection_test(url, self._entered_token())
@@ -186,12 +215,20 @@ class ServerSwitchModal(ModalScreen[Optional[dict]]):
                         headers={"X-API-KEY": token},
                         json={},
                     )
-                    if probe.status_code == 401:
-                        auth_state = "token REJECTED (401)"
+                    if probe.status_code in {401, 403}:
+                        auth_state = f"token REJECTED (HTTP {probe.status_code})"
+                    elif probe.status_code == 404:
+                        auth_state = "could not verify (sync endpoint missing, HTTP 404)"
+                    elif probe.status_code >= 500:
+                        auth_state = f"could not verify (server error HTTP {probe.status_code})"
                     else:
+                        # 2xx, or 422 schema rejection — the token itself passed.
                         auth_state = f"token accepted (HTTP {probe.status_code})"
         except httpx.HTTPError as exc:
             self._set_status(f"Unreachable: {exc.__class__.__name__}: {exc}")
+            return
+        except Exception as exc:  # never leave the status stuck on "Testing..."
+            self._set_status(f"Test failed: {exc.__class__.__name__}: {exc}")
             return
         self._set_status(
             f"Reachable (HTTP {reach.status_code}). Auth: {auth_state}."
@@ -200,9 +237,8 @@ class ServerSwitchModal(ModalScreen[Optional[dict]]):
     @on(Button.Pressed, "#server-switch-activate")
     def handle_activate_pressed(self, event: Button.Pressed) -> None:
         event.stop()
-        url = self._entered_url()
+        url = self._validated_root_url()
         if not url:
-            self._set_status("Enter a server URL before activating.")
             return
         self.dismiss(
             {

--- a/tldw_chatbook/Widgets/Settings_Widgets/server_switch_modal.py
+++ b/tldw_chatbook/Widgets/Settings_Widgets/server_switch_modal.py
@@ -1,0 +1,223 @@
+"""Modal for switching the runtime source between local and a server.
+
+The modal only collects the decision (which server, or local) and reports
+reachability honestly; the Settings screen performs the actual activation
+(config persistence, runtime-policy rebind, Sync v2 enrollment) so this
+surface stays side-effect free until the user confirms.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import httpx
+from textual import on, work
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.css.query import QueryError
+from textual.screen import ModalScreen
+from textual.widgets import Button, Input, Static
+
+
+class ServerSwitchModal(ModalScreen[Optional[dict]]):
+    """Choose the runtime source: this device only, or a tldw server."""
+
+    BINDINGS = [("escape", "dismiss", "Cancel")]
+
+    DEFAULT_CSS = """
+    ServerSwitchModal {
+        align: center middle;
+    }
+    #server-switch-modal {
+        width: 84;
+        max-width: 95%;
+        height: auto;
+        max-height: 80%;
+        border: round $primary;
+        background: $surface;
+        padding: 1 2;
+    }
+    #server-switch-modal .server-switch-row {
+        height: 3;
+        margin-bottom: 1;
+    }
+    #server-switch-modal .server-switch-label {
+        width: 14;
+        min-width: 14;
+        padding-top: 1;
+        color: $text-muted;
+    }
+    #server-switch-modal Input {
+        width: 1fr;
+    }
+    #server-switch-current,
+    #server-switch-status {
+        height: auto;
+        min-height: 1;
+        margin-bottom: 1;
+        color: $text-muted;
+    }
+    #server-switch-actions {
+        height: 3;
+        align: right middle;
+    }
+    #server-switch-actions Button {
+        margin-left: 1;
+    }
+    """
+
+    def __init__(
+        self,
+        *,
+        current_source: str = "local",
+        current_server_label: str | None = None,
+        current_base_url: str = "",
+        current_auth_token: str = "",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._current_source = (current_source or "local").strip().lower()
+        self._current_server_label = (current_server_label or "").strip()
+        self._initial_base_url = current_base_url or ""
+        self._initial_auth_token = current_auth_token or ""
+
+    def compose(self) -> ComposeResult:
+        if self._current_source == "server" and self._current_server_label:
+            current_copy = f"Current source: server ({self._current_server_label})"
+        elif self._current_server_label:
+            current_copy = (
+                f"Current source: local. Server {self._current_server_label} is "
+                "configured but not active."
+            )
+        else:
+            current_copy = "Current source: local. No server is configured."
+
+        with Vertical(id="server-switch-modal"):
+            yield Static("Switch Runtime Source", classes="destination-section")
+            yield Static(current_copy, id="server-switch-current", markup=False)
+            with Horizontal(classes="server-switch-row"):
+                yield Static("Server URL", classes="server-switch-label")
+                yield Input(
+                    value=self._initial_base_url,
+                    placeholder="http://127.0.0.1:8000",
+                    id="server-switch-url",
+                )
+            with Horizontal(classes="server-switch-row"):
+                yield Static("API token", classes="server-switch-label")
+                yield Input(
+                    value=self._initial_auth_token,
+                    placeholder="X-API-KEY value",
+                    password=True,
+                    id="server-switch-token",
+                )
+            yield Static(
+                "Test the connection before activating; activation also "
+                "prepares the Sync v2 profile for this device.",
+                id="server-switch-status",
+                markup=False,
+            )
+            with Horizontal(id="server-switch-actions"):
+                yield Button(
+                    "Test Connection",
+                    id="server-switch-test",
+                    compact=True,
+                    classes="destination-action-button console-action-secondary",
+                    tooltip="Check reachability and whether the token is accepted.",
+                )
+                yield Button(
+                    "Use Local",
+                    id="server-switch-local",
+                    compact=True,
+                    classes="destination-action-button console-action-secondary",
+                    tooltip="Keep all data on this device only.",
+                )
+                yield Button(
+                    "Activate Server",
+                    id="server-switch-activate",
+                    compact=True,
+                    classes="destination-action-button console-action-primary",
+                    tooltip="Bind this server as the runtime source and prepare Sync v2.",
+                )
+                yield Button(
+                    "Cancel",
+                    id="server-switch-cancel",
+                    compact=True,
+                    classes="destination-action-button console-action-secondary",
+                    tooltip="Close without changing the runtime source.",
+                )
+
+    def _set_status(self, text: str) -> None:
+        try:
+            self.query_one("#server-switch-status", Static).update(text)
+        except QueryError:
+            pass
+
+    def _entered_url(self) -> str:
+        try:
+            return self.query_one("#server-switch-url", Input).value.strip().rstrip("/")
+        except QueryError:
+            return ""
+
+    def _entered_token(self) -> str:
+        try:
+            return self.query_one("#server-switch-token", Input).value.strip()
+        except QueryError:
+            return ""
+
+    @on(Button.Pressed, "#server-switch-test")
+    def handle_test_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        url = self._entered_url()
+        if not url:
+            self._set_status("Enter a server URL to test.")
+            return
+        self._set_status(f"Testing {url} ...")
+        self._run_connection_test(url, self._entered_token())
+
+    @work(exclusive=True, group="server-switch-test")
+    async def _run_connection_test(self, url: str, token: str) -> None:
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                reach = await client.get(f"{url}/docs")
+                auth_state = "not checked (no token entered)"
+                if token:
+                    probe = await client.post(
+                        f"{url}/api/v1/sync/send",
+                        headers={"X-API-KEY": token},
+                        json={},
+                    )
+                    if probe.status_code == 401:
+                        auth_state = "token REJECTED (401)"
+                    else:
+                        auth_state = f"token accepted (HTTP {probe.status_code})"
+        except httpx.HTTPError as exc:
+            self._set_status(f"Unreachable: {exc.__class__.__name__}: {exc}")
+            return
+        self._set_status(
+            f"Reachable (HTTP {reach.status_code}). Auth: {auth_state}."
+        )
+
+    @on(Button.Pressed, "#server-switch-activate")
+    def handle_activate_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        url = self._entered_url()
+        if not url:
+            self._set_status("Enter a server URL before activating.")
+            return
+        self.dismiss(
+            {
+                "action": "activate",
+                "base_url": url,
+                "auth_token": self._entered_token(),
+            }
+        )
+
+    @on(Button.Pressed, "#server-switch-local")
+    def handle_local_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.dismiss({"action": "local"})
+
+    @on(Button.Pressed, "#server-switch-cancel")
+    def handle_cancel_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.dismiss(None)

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -2494,11 +2494,13 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
             self.server_sync_service = ServerSyncService.from_config(
                 self.app_config,
                 policy_enforcer=self.service_policy_enforcer,
+                state_repository=self.sync_state_repository,
             )
         except ValueError:
             self.server_sync_service = ServerSyncService(
                 client=None,
                 policy_enforcer=self.service_policy_enforcer,
+                state_repository=self.sync_state_repository,
             )
         self.sync_scope_service = SyncScopeService(
             server_service=self.server_sync_service,

--- a/tldw_chatbook/runtime_policy/bootstrap.py
+++ b/tldw_chatbook/runtime_policy/bootstrap.py
@@ -41,6 +41,12 @@ def build_runtime_api_client(
     api_config: dict[str, Any] = {}
     if isinstance(app_config, Mapping):
         api_config = dict(app_config.get("tldw_api", {}) or {})
+        if not api_config:
+            # load_settings() keeps the raw CLI config (and its [tldw_api]
+            # section) nested under COMPREHENSIVE_CONFIG_RAW.
+            raw_config = app_config.get("COMPREHENSIVE_CONFIG_RAW", {})
+            if isinstance(raw_config, Mapping):
+                api_config = dict(raw_config.get("tldw_api", {}) or {})
 
     resolved_endpoint = str(
         endpoint_url


### PR DESCRIPTION
## What

(Stacks on #516 — includes its commits until that merges.)

Settings Overview gains **Switch Source / Server**, opening a Console-style modal: server URL + masked token, an honest **Test Connection** (reachability + token acceptance), **Activate Server**, **Use Local**, Cancel. The modal only collects the decision; the Settings screen performs activation — persist `[tldw_api]`, reload settings, rebind runtime policy, switch the authoritative source via `handle_runtime_backend_changed`, then enroll the Sync v2 local-first profile via `prepare_sync_v2_profile_mode` (the first production caller of either API — previously only tests invoked the source switch, which was gap TASK-107 from the Sync v2 QA).

Two more wiring gaps fixed en route (same class as #516's binding bug): `ServerSyncService` lacked its `state_repository` (every v2 dry-run raised), and `build_runtime_api_client` missed the `COMPREHENSIVE_CONFIG_RAW` nesting (the sync client could never resolve the configured base URL).

## Verification

- In-process pilot against a **live tldw_server2**: modal opens prefilled → "Reachable (HTTP 200). Auth: token accepted" → activation flips the authoritative source to server; Settings rows agree; 629 settings/policy/sync tests pass.
- Enrollment then reaches the real server and stops at `GET /api/v1/sync/capabilities` → 404: **the server implements only legacy `/sync/send|get`, not the v2 contract** — filed as the milestone-blocking follow-up for TASK-70.6.

Screenshots in the comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Switch Source / Server flow in Settings to toggle between local-only runtime and a bound server, with a modal to test and activate a server. Activation persists `tldw_api` config, reloads settings, switches the runtime backend, and enrolls the Sync v2 local-first profile (addresses TASK-107).

- New Features
  - Settings: new “Switch Source / Server” opens a modal with server URL and masked token.
  - Connection Test: checks reachability via /docs and token via an authenticated probe with clear verdicts (401/403 rejected, 404/5xx cannot verify, 2xx/422 accepted); handles errors so status never sticks.
  - Validation + Activation: enforces server ROOT URL (scheme + host[:port], no path; client appends /api/v1), re-validates before saving, persists `tldw_api` base_url and token (token saved even when cleared), reloads settings, rebinds runtime policy, switches to server, and prepares Sync v2; Use Local switches back.

- Bug Fixes
  - Respect `tldw_api` from `COMPREHENSIVE_CONFIG_RAW` when building the runtime API client and deriving server binding.
  - Pass `state_repository` when constructing `ServerSyncService` (both from_config and fallback) to fix missing repository errors.

<sup>Written for commit e8c094ce86da948db3bf5d8563872473ad1c2011. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

