### PR TITLE
Close backlog task-107 (shipped in #518)

### DIFF
--- a/backlog/tasks/task-107 - Add-a-user-facing-control-to-switch-the-runtime-source-to-server.md
+++ b/backlog/tasks/task-107 - Add-a-user-facing-control-to-switch-the-runtime-source-to-server.md
@@ -1,0 +1,27 @@
+---
+id: TASK-107
+title: Add a user-facing control to switch the runtime source to server
+status: Done
+assignee: []
+created_date: '2026-06-12 18:31'
+updated_date: '2026-06-12 22:24'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found during TASK-70.6 Sync v2 QA: runtime_policy active_source can only become 'server' via app.handle_runtime_backend_changed, which no production UI invokes (tests only). With no switch affordance, Manual Sync v2 stays 'blocked: requires an active server profile' even with a configured, reachable server (binding fix in PR #516). Settings (or Home) needs an explicit local/server source control wired to handle_runtime_backend_changed with reachability/auth feedback.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 User can switch active source local<->server from the UI,Manual Sync v2 unblocks when a configured server profile is active,Switch surfaces reachability/auth state honestly
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Shipped in PR #518 (merged to dev as 0138baca): Settings 'Switch Source / Server' + ServerSwitchModal with validated root URLs, honest per-class auth verdicts, unconditional token persistence; activation rebinds runtime policy, switches the authoritative source, and enrolls the Sync v2 profile. Verified live against tldw_server2.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-119 - tldw_server2-implement-the-Sync-v2-server-API-contract.md
+++ b/backlog/tasks/task-119 - tldw_server2-implement-the-Sync-v2-server-API-contract.md
@@ -1,0 +1,20 @@
+---
+id: TASK-119
+title: 'tldw_server2: implement the Sync v2 server API contract'
+status: To Do
+assignee: []
+created_date: '2026-06-12 20:29'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Milestone blocker found in TASK-70.6 QA: the chatbook Sync v2 client requires /api/v1/sync/capabilities, /sync/devices/register, /sync/datasets/enroll, /sync/push, /sync/pull, /sync/conflicts(+resolve), /sync/keys/recovery-bundle, /sync/attachments — tldw_server2 currently implements only legacy /sync/send and /sync/get, so Sync v2 enrollment dies at capabilities (404) and manual Notes/Chat sync cannot run end-to-end against the approved local target. Server-side work (tldw_server2 repo), or point QA at a server branch that has the v2 endpoints.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Sync v2 dry-run enrollment completes against the local server,Manual Notes+Chat sync push/pull round-trips end-to-end
+<!-- AC:END -->


### PR DESCRIPTION
Marks task-107 Done with implementation notes; the feature itself merged in #518.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks TASK-107 as Done and records the shipped runtime source switch (PR #518): UI switch local↔server with reachability/auth feedback; unblocks Manual Sync v2 when a valid server profile is active.
Adds TASK-119 (To Do) for `tldw_server2` to implement the Sync v2 API (capabilities, devices/register, datasets/enroll, push/pull, conflicts, keys recovery-bundle, attachments); current server only has legacy send/get, so v2 enrollment fails at capabilities and manual Notes/Chat sync can’t run end to end.

<sup>Written for commit c481d8a8f26f97c0ad95f01925c342de87766c56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

