### PR TITLE
fix: callable file-picker filters across all remaining screens (latent P0)

### DIFF
--- a/Tests/UI/test_file_picker_filters_callable.py
+++ b/Tests/UI/test_file_picker_filters_callable.py
@@ -1,0 +1,83 @@
+"""Regression guard: every app-level Filters spec must use callable testers.
+
+A glob *string* (e.g. ``"*.json"``) passed where ``Filter`` expects a
+``Callable[[Path], bool]`` makes ``Filter.__call__`` do ``"*.json"(path)`` ->
+``TypeError: 'str' object is not callable``, which tears down the whole app
+session the moment the file dialog opens. Several screens shipped this bug;
+this test builds each Filters collection and asserts the testers are callable
+and return a bool without raising.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.Third_Party.textual_fspicker import Filters
+
+
+def _assert_filters_callable(filters: Filters) -> None:
+    # Filters stores Filter objects; calling one runs its tester(path).
+    for index, (_name, _id) in enumerate(filters.selections):
+        f = filters[index]
+        result = f(Path("sample.json"))
+        assert isinstance(result, bool), f"filter {index} returned {result!r}"
+        # A non-callable tester would raise TypeError above, not return a bool.
+
+
+def test_eval_default_filters_are_callable():
+    from tldw_chatbook.Widgets.file_picker_dialog import EvalFilePickerDialog
+
+    dialog = EvalFilePickerDialog()
+    _assert_filters_callable(dialog._get_default_filters())
+
+
+def test_create_filter_helper_is_callable_and_matches():
+    from tldw_chatbook.Widgets.file_picker_dialog import create_filter
+
+    f = create_filter("*.yaml;*.yml;*.json")
+    assert callable(f)
+    assert f(Path("x.json")) is True
+    assert f(Path("x.YAML")) is False  # case-sensitive fnmatch on name
+    assert f(Path("x.txt")) is False
+
+
+def test_eval_dialogs_dataset_filters_are_callable():
+    import tldw_chatbook.Widgets.Evals.eval_dialogs as ed
+
+    # The Filters live inline in a method/function; rebuild the exact spec.
+    filters = Filters(
+        ("Dataset Files", lambda p: p.suffix.lower() in (".json", ".jsonl", ".csv", ".parquet")),
+        ("JSON Files", lambda p: p.suffix.lower() in (".json", ".jsonl")),
+        ("CSV Files", lambda p: p.suffix.lower() == ".csv"),
+        ("Parquet Files", lambda p: p.suffix.lower() == ".parquet"),
+        ("All Files", lambda p: True),
+    )
+    _assert_filters_callable(filters)
+    # And guard the source no longer contains a list/glob tester.
+    src = Path(ed.__file__).read_text(encoding="utf-8")
+    assert '("Dataset Files", ["' not in src
+
+
+@pytest.mark.parametrize(
+    "module_path",
+    [
+        "tldw_chatbook/Widgets/file_picker_dialog.py",
+        "tldw_chatbook/Widgets/Evals/eval_dialogs.py",
+        "tldw_chatbook/Widgets/transcription_history_viewer.py",
+        "tldw_chatbook/UI/CCP_Modules/ccp_character_handler.py",
+        "tldw_chatbook/UI/CCP_Modules/ccp_dictionary_handler.py",
+        "tldw_chatbook/UI/CCP_Modules/ccp_prompt_handler.py",
+        "tldw_chatbook/UI/Screens/personas_screen.py",
+    ],
+)
+def test_no_glob_string_filter_tester_in_source(module_path):
+    """Static guard: no ``("Name", "*.ext")`` / ``("Name", ["*.ext"])`` in app Filters."""
+    import re
+
+    text = Path(module_path).read_text(encoding="utf-8")
+    # A filter tuple whose second element is a string/list literal beginning with
+    # a glob is the crash signature. create_filter("...") and lambdas are fine.
+    bad = re.findall(r'\(\s*"[^"]+"\s*,\s*(?:"\*|\[\s*"\*)', text)
+    assert not bad, f"glob-string Filters tester(s) in {module_path}: {bad}"

--- a/tldw_chatbook/UI/CCP_Modules/ccp_character_handler.py
+++ b/tldw_chatbook/UI/CCP_Modules/ccp_character_handler.py
@@ -780,12 +780,13 @@ class CCPCharacterHandler:
         
         try:
             # Create filters for character card files
+            # Filters need callable testers; glob strings crash the picker.
             filters = Filters(
-                ("Character Cards", "*.json;*.png;*.yaml;*.yml"),
-                ("JSON Files", "*.json"),
-                ("PNG Files (with embedded data)", "*.png"),
-                ("YAML Files", "*.yaml;*.yml"),
-                ("All Files", "*.*")
+                ("Character Cards", lambda p: p.suffix.lower() in (".json", ".png", ".yaml", ".yml")),
+                ("JSON Files", lambda p: p.suffix.lower() == ".json"),
+                ("PNG Files (with embedded data)", lambda p: p.suffix.lower() == ".png"),
+                ("YAML Files", lambda p: p.suffix.lower() in (".yaml", ".yml")),
+                ("All Files", lambda p: True),
             )
             
             # Create and show the file picker

--- a/tldw_chatbook/UI/CCP_Modules/ccp_dictionary_handler.py
+++ b/tldw_chatbook/UI/CCP_Modules/ccp_dictionary_handler.py
@@ -489,12 +489,13 @@ class CCPDictionaryHandler:
         
         try:
             # Create filters for dictionary/world book files
+            # Filters need callable testers; glob strings crash the picker.
             filters = Filters(
-                ("Dictionary Files", "*.json;*.csv;*.yaml;*.yml"),
-                ("JSON Files", "*.json"),
-                ("CSV Files", "*.csv"),
-                ("YAML Files", "*.yaml;*.yml"),
-                ("All Files", "*.*")
+                ("Dictionary Files", lambda p: p.suffix.lower() in (".json", ".csv", ".yaml", ".yml")),
+                ("JSON Files", lambda p: p.suffix.lower() == ".json"),
+                ("CSV Files", lambda p: p.suffix.lower() == ".csv"),
+                ("YAML Files", lambda p: p.suffix.lower() in (".yaml", ".yml")),
+                ("All Files", lambda p: True),
             )
             
             # Create and show the file picker

--- a/tldw_chatbook/UI/CCP_Modules/ccp_prompt_handler.py
+++ b/tldw_chatbook/UI/CCP_Modules/ccp_prompt_handler.py
@@ -705,12 +705,13 @@ class CCPPromptHandler:
         
         try:
             # Create filters for prompt files
+            # Filters need callable testers; glob strings crash the picker.
             filters = Filters(
-                ("Prompt Files", "*.json;*.yaml;*.yml;*.txt"),
-                ("JSON Files", "*.json"),
-                ("YAML Files", "*.yaml;*.yml"),
-                ("Text Files", "*.txt"),
-                ("All Files", "*.*")
+                ("Prompt Files", lambda p: p.suffix.lower() in (".json", ".yaml", ".yml", ".txt")),
+                ("JSON Files", lambda p: p.suffix.lower() == ".json"),
+                ("YAML Files", lambda p: p.suffix.lower() in (".yaml", ".yml")),
+                ("Text Files", lambda p: p.suffix.lower() == ".txt"),
+                ("All Files", lambda p: True),
             )
             
             # Create and show the file picker

--- a/tldw_chatbook/Widgets/Evals/eval_dialogs.py
+++ b/tldw_chatbook/Widgets/Evals/eval_dialogs.py
@@ -165,15 +165,14 @@ def open_dataset_file_picker(app, callback: Callable[[Path, Dict[str, Any]], Non
                 )
             )
     
-    # Define filters for dataset files
+    # Define filters for dataset files. Filters takes *filters of
+    # (name, Callable[[Path], bool]); glob-string/list testers crash the picker.
     filters = Filters(
-        [
-            ("Dataset Files", ["*.json", "*.jsonl", "*.csv", "*.parquet"]),
-            ("JSON Files", ["*.json", "*.jsonl"]),
-            ("CSV Files", ["*.csv"]),
-            ("Parquet Files", ["*.parquet"]),
-            ("All Files", ["*"])
-        ]
+        ("Dataset Files", lambda p: p.suffix.lower() in (".json", ".jsonl", ".csv", ".parquet")),
+        ("JSON Files", lambda p: p.suffix.lower() in (".json", ".jsonl")),
+        ("CSV Files", lambda p: p.suffix.lower() == ".csv"),
+        ("Parquet Files", lambda p: p.suffix.lower() == ".parquet"),
+        ("All Files", lambda p: True),
     )
     
     # Open enhanced file picker

--- a/tldw_chatbook/Widgets/file_picker_dialog.py
+++ b/tldw_chatbook/Widgets/file_picker_dialog.py
@@ -63,12 +63,14 @@ class EvalFilePickerDialog(ModalScreen):
     
     def _get_default_filters(self) -> Filters:
         """Get default file filters for evaluation files."""
+        # Filters require callable testers; glob strings here crash the picker
+        # (TypeError: 'str' object is not callable). Use the create_filter helper.
         return Filters(
-            ("All Evaluation Files", "*.yaml;*.yml;*.json;*.csv;*.tsv"),
-            ("YAML Files", "*.yaml;*.yml"),
-            ("JSON Files", "*.json"),
-            ("CSV Files", "*.csv;*.tsv"),
-            ("All Files", "*.*")
+            ("All Evaluation Files", create_filter("*.yaml;*.yml;*.json;*.csv;*.tsv")),
+            ("YAML Files", create_filter("*.yaml;*.yml")),
+            ("JSON Files", create_filter("*.json")),
+            ("CSV Files", create_filter("*.csv;*.tsv")),
+            ("All Files", lambda path: True),
         )
     
     def compose(self) -> ComposeResult:

--- a/tldw_chatbook/Widgets/transcription_history_viewer.py
+++ b/tldw_chatbook/Widgets/transcription_history_viewer.py
@@ -479,9 +479,13 @@ class TranscriptionHistoryViewer(Widget):
         # Show file save dialog
         self.app.push_screen(
             FileSave(
+                # Filters takes (name, Callable[[Path], bool]) tuples; the prior
+                # string/dict form crashed the picker on open.
                 filters=Filters(
-                    ("*.txt", "*.md", "*.json", "*.csv"),
-                    {"Text": ["*.txt"], "Markdown": ["*.md"], "JSON": ["*.json"], "CSV": ["*.csv"]}
+                    ("Text", lambda p: p.suffix.lower() == ".txt"),
+                    ("Markdown", lambda p: p.suffix.lower() == ".md"),
+                    ("JSON", lambda p: p.suffix.lower() == ".json"),
+                    ("CSV", lambda p: p.suffix.lower() == ".csv"),
                 ),
                 filename="transcription_history.txt"
             ),


### PR DESCRIPTION
Follow-up to #517. The UAT of the Personas workbench surfaced a glob-string \`Filters\` crash; that same bug was **latent in 6 other file dialogs** — each \`TypeError: 'str' object is not callable\` and tears down the whole app session the moment its dialog opens.

## Fixed (all converted to callable testers)
- \`Widgets/file_picker_dialog.py\` — \`_get_default_filters\` (eval picker default)
- \`Widgets/Evals/eval_dialogs.py\` — dataset picker (also had the wrong single-list arg shape)
- \`Widgets/transcription_history_viewer.py\` — export dialog (had a strings+dict shape, fully wrong)
- \`UI/CCP_Modules/ccp_character_handler.py\`, \`ccp_dictionary_handler.py\`, \`ccp_prompt_handler.py\` — import dialogs

(\`file_picker_dialog.py\`'s \`create_filter\`-based filters and \`chat_attachment_handler.py\` were already correct and are left as-is / pinned by tests.)

## Regression guard
New \`Tests/UI/test_file_picker_filters_callable.py\`:
- builds each Filters collection and asserts every tester is callable and returns a bool;
- a **static** parametrized guard over all 7 app modules that fails on any \`("Name", "*.ext")\` or \`("Name", ["*.ext"])\` literal — validated to catch both bad forms and pass all callable forms.

The only remaining glob-string \`Filters\` is in a vendored demo (\`Third_Party/.../example_enhanced.py\`), intentionally untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes crashes in all remaining file dialogs by converting glob-string `Filters` to callable testers. Prevents the app from tearing down when a dialog opens and adds a guard to block regressions.

- **Bug Fixes**
  - Converted `Filters` to callables across: eval picker defaults, eval dialogs (dataset picker), transcription export, and CCP character/dictionary/prompt import dialogs.
  - Corrected bad filter argument shapes and standardized on `create_filter` in `file_picker_dialog.py`.
  - Added `Tests/UI/test_file_picker_filters_callable.py` to assert callability and statically flag any glob-string/list testers; vendored demo left as-is.

<sup>Written for commit a590ffe8d8b4f2b046be60eeab20c29ade079c63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

