### PR TITLE
Fix Console Enter blocked-send feedback

### DIFF
--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -286,6 +286,39 @@ async def test_console_native_missing_key_blocks_before_clearing_generic_draft()
 
 
 @pytest.mark.asyncio
+async def test_console_native_enter_on_setup_blocked_send_shows_recovery_feedback():
+    app = _build_test_app()
+    app.app_config["chat_defaults"] = {"provider": "openai", "model": "gpt-4.1"}
+    app.app_config["api_settings"] = {
+        "openai": {"api_key_env_var": "MISSING_OPENAI_KEY"}
+    }
+    app.console_provider_gateway_factory = lambda: ConsoleProviderGateway(
+        config_provider=lambda: app.app_config,
+        environ={},
+    )
+    notifications: list[tuple[str, dict]] = []
+    app.notify = lambda message, **kwargs: notifications.append((message, kwargs))
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.load_draft("preserve this from keyboard")
+
+        await pilot.press("enter")
+        await pilot.pause(0.05)
+
+        assert composer.draft_text() == "preserve this from keyboard"
+        assert notifications == [
+            (
+                "Add API Key in Settings before sending.",
+                {"severity": "warning"},
+            )
+        ]
+
+
+@pytest.mark.asyncio
 async def test_console_native_blocked_send_preserves_composer_text_and_shows_recovery():
     app = _build_test_app()
     app.chat_api_provider_value = "llama_cpp"

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -3182,9 +3182,14 @@ class ChatScreen(BaseAppScreen):
             return
         self._dismiss_console_guidance()
         if blocked_reason := self._console_send_blocked_reason():
-            if self._console_setup_blocked_reason() and not blocked_reason.startswith(
+            setup_blocked_reason = self._console_setup_blocked_reason()
+            if setup_blocked_reason and not blocked_reason.startswith(
                 "Console send blocked: Library Search/RAG"
             ):
+                self.app_instance.notify(
+                    setup_blocked_reason,
+                    severity="warning",
+                )
                 self._focus_console_composer_if_needed(force=True)
                 return
             await self._append_native_console_system_message(blocked_reason)


### PR DESCRIPTION
## Summary
- Adds visible warning feedback when Enter submits a Console draft while provider setup blocks send.
- Preserves the existing composer draft and focus behavior.
- Adds a regression for keyboard-submit parity in the setup-blocked path.

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_console_native_chat_flow.py::test_console_native_enter_on_setup_blocked_send_shows_recovery_feedback --tb=short
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_console_native_chat_flow.py Tests/UI/test_console_session_settings.py --tb=short
- git diff --check
- CDP screenshot evidence: /private/tmp/console-uat-current-enter-feedback.png

## CDP evidence
Pressing Enter in the blocked-provider composer now preserves the draft and shows: "Add API Key in Settings before sending."

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Enter key behavior in the Console when provider setup blocks send. The composer now preserves the draft and shows a clear warning to add an API key.

- **Bug Fixes**
  - Show warning: "Add API Key in Settings before sending." when setup blocks send (including Enter key submits).
  - Preserve composer text and keep focus.
  - Add regression test for keyboard submit on setup-blocked sends.

<sup>Written for commit 773cf91add2ad1cffb367a0aecff47a36b068701. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

