### PR TITLE
Label unsupported Console providers as WIP

### DIFF
--- a/Tests/Chat/test_console_session_settings.py
+++ b/Tests/Chat/test_console_session_settings.py
@@ -228,6 +228,14 @@ def test_provider_options_include_console_sendable_handlers_missing_from_model_r
     assert "mistralai" in option_values
 
 
+def test_provider_options_label_configured_unsupported_providers_as_wip() -> None:
+    options = build_console_provider_options({"local_onnx": ["manual-model"]})
+    options_by_value = {option.value: option for option in options}
+
+    assert options_by_value["local_onnx"].label == "local_onnx (WIP)"
+    assert options_by_value["local_ollama"].label == "local_ollama"
+
+
 def test_validation_rejects_out_of_range_temperature() -> None:
     settings = ConsoleSessionSettings(provider="llama_cpp", model="m", temperature=2.1)
 

--- a/tldw_chatbook/Chat/console_session_settings.py
+++ b/tldw_chatbook/Chat/console_session_settings.py
@@ -212,6 +212,9 @@ def build_console_provider_options(
 ) -> list[ConsoleSettingsOption]:
     """Return sorted Console-sendable provider options plus configured providers."""
     provider_keys = sorted({key for key in (provider_config_key(provider) for provider in providers_models) if key})
+    supported_provider_keys = supported_console_provider_readiness_keys(
+        CONSOLE_SETTINGS_EXECUTION_PROVIDER_KEYS
+    )
     provider_keys = sorted(
         {
             *provider_keys,
@@ -223,7 +226,15 @@ def build_console_provider_options(
             ),
         }
     )
-    return [ConsoleSettingsOption(label=provider_key, value=provider_key) for provider_key in provider_keys]
+    return [
+        ConsoleSettingsOption(
+            label=provider_key
+            if provider_key in supported_provider_keys
+            else f"{provider_key} (WIP)",
+            value=provider_key,
+        )
+        for provider_key in provider_keys
+    ]
 
 
 def build_console_model_options(


### PR DESCRIPTION
## Summary
- Label configured Console providers that are not sendable yet as "(WIP)" in the session settings provider dropdown.
- Preserve provider values so saved/configured unsupported providers remain recoverable and still show the existing blocked-state guidance when selected.
- Add regression coverage for unsupported vs supported provider labels.

## CDP evidence
- Verified in the in-app browser at http://127.0.0.1:8936/ that the Console provider dropdown now shows "local_onnx (WIP)" and "local_transformers (WIP)", while supported providers such as "local_ollama" remain unmarked.
- Screenshot: /private/tmp/console-provider-wip-labels.png

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chat/test_console_session_settings.py::test_provider_options_label_configured_unsupported_providers_as_wip --tb=short
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chat/test_console_session_settings.py Tests/UI/test_console_session_settings.py --tb=short
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chat/test_console_provider_support.py Tests/Chat/test_console_provider_gateway.py --tb=short
- git diff --check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mark unsupported Console providers as “(WIP)” in the session settings dropdown so users know what isn’t sendable yet. Configured unsupported providers stay selectable and preserved, and still show the existing blocked-state guidance when chosen.

<sup>Written for commit a5ef0c30fd64eb4306b056138fc604586ee08e6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

