### PR TITLE
Fix Console provider env smoke paths

### DIFF
--- a/Docs/superpowers/plans/2026-06-16-pr524-review-rebase-plan.md
+++ b/Docs/superpowers/plans/2026-06-16-pr524-review-rebase-plan.md
@@ -1,0 +1,61 @@
+# PR 524 Review Rebase Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rebase PR #524 onto the latest `dev` branch and resolve all actionable PR review comments.
+
+**Architecture:** Keep the PR scoped to provider smoke-test fixes. Preserve the existing HuggingFace request path and Console response-normalization shape, while hardening config-derived URL inputs through the existing validation helper and focused regression tests.
+
+**Tech Stack:** Python, pytest, Bandit, GitHub CLI, Backlog.md MCP.
+
+**ADR required:** no
+
+**ADR path:** N/A
+
+**Reason:** This is a bounded bugfix/review remediation for existing provider boundaries and tests, with no new long-lived architecture or dependency decision.
+
+---
+
+## Stage 1: Rebase Branch
+**Goal:** Put `codex/provider-env-smoke-fixes` on top of current `origin/dev`.
+**Success Criteria:** Branch rebases cleanly or conflicts are resolved without losing PR changes.
+**Tests:** `git status --short --branch`, `git diff --check`.
+**Status:** Complete
+
+- [x] Fetch `origin/dev` and PR branch.
+- [x] Rebase PR branch onto `origin/dev`.
+- [x] Resolve conflicts in `tldw_chatbook/LLM_Calls/LLM_API_Calls.py`.
+- [x] Verify clean conflict markers, syntax, and whitespace for the resolved file.
+
+## Stage 2: Review Comment Audit
+**Goal:** Confirm each PR comment is either already addressed or has a concrete code/test fix.
+**Success Criteria:** Qodo and Gemini comments are mapped to code or test evidence.
+**Tests:** Inspect `gh api graphql` review-thread output for PR #524.
+**Status:** Complete
+
+- [x] Re-read inline comments after rebasing.
+- [x] Confirm URL validation uses `input_validation.validate_url`.
+- [x] Confirm router host comparison handles case and explicit ports.
+- [x] Confirm null and non-string config values cannot crash URL normalization.
+- [x] Confirm the prior UI CI import error does not reproduce during `Tests/UI` collection.
+
+## Stage 3: Regression Coverage
+**Goal:** Add or adjust tests only for behavior still missing after the audit.
+**Success Criteria:** Focused tests cover the review-commented behaviors.
+**Tests:** `python -m pytest Tests/Chat/test_chat_functions.py -k "huggingface" -v`, `python -m pytest Tests/Chat/test_console_provider_gateway.py -v`.
+**Status:** Complete
+
+- [x] Run focused tests for current PR behavior.
+- [x] Add regression coverage for missing or non-string HuggingFace router base values.
+- [x] Re-run focused tests.
+
+## Stage 4: Verification And Finalization
+**Goal:** Verify the touched scope and update Backlog/GitHub branch state.
+**Success Criteria:** Tests pass and any pre-existing/security-scan blocker is documented.
+**Tests:** Focused pytest, UI collection, Bandit, `git diff --check`.
+**Status:** Complete
+
+- [x] Run focused Chat tests.
+- [x] Run Bandit on touched code paths.
+- [x] Update `TASK-120` acceptance criteria and implementation notes.
+- [x] Commit and push the rebased branch to PR #524.

--- a/Tests/Chat/test_chat_functions.py
+++ b/Tests/Chat/test_chat_functions.py
@@ -791,6 +791,81 @@ class TestProviderRequestPayloads:
         assert captured["json"]["max_tokens"] == 64
         assert response["choices"][0]["message"]["content"] == "OK"
 
+    def test_huggingface_router_base_with_case_and_port_normalizes(self, monkeypatch):
+        from tldw_chatbook.LLM_Calls import LLM_API_Calls
+
+        captured = {}
+        monkeypatch.setattr(
+            LLM_API_Calls,
+            "load_settings",
+            lambda: {
+                "huggingface_api": {
+                    "api_base_url": "https://ROUTER.HUGGINGFACE.CO:443/hf-inference/models",
+                    "streaming": False,
+                }
+            },
+        )
+        monkeypatch.setattr(
+            LLM_API_Calls.requests,
+            "Session",
+            lambda: _CapturedSession(
+                captured,
+                {
+                    "id": "hf-test",
+                    "model": "openai/gpt-oss-120b",
+                    "choices": [{"message": {"content": "OK"}, "finish_reason": "stop"}],
+                },
+            ),
+        )
+
+        LLM_API_Calls.chat_with_huggingface(
+            input_data=[{"role": "user", "content": "test"}],
+            api_key="hf_test",
+            model="openai/gpt-oss-120b",
+            streaming=False,
+            max_tokens=64,
+        )
+
+        assert captured["url"] == "https://ROUTER.HUGGINGFACE.CO:443/v1/chat/completions"
+
+    def test_huggingface_none_router_base_uses_safe_default(self, monkeypatch):
+        from tldw_chatbook.LLM_Calls import LLM_API_Calls
+
+        captured = {}
+        monkeypatch.setattr(
+            LLM_API_Calls,
+            "load_settings",
+            lambda: {
+                "huggingface_api": {
+                    "use_router_url_format": True,
+                    "router_base_url": None,
+                    "streaming": False,
+                }
+            },
+        )
+        monkeypatch.setattr(
+            LLM_API_Calls.requests,
+            "Session",
+            lambda: _CapturedSession(
+                captured,
+                {
+                    "id": "hf-test",
+                    "model": "openai/gpt-oss-120b",
+                    "choices": [{"message": {"content": "OK"}, "finish_reason": "stop"}],
+                },
+            ),
+        )
+
+        LLM_API_Calls.chat_with_huggingface(
+            input_data=[{"role": "user", "content": "test"}],
+            api_key="hf_test",
+            model="openai/gpt-oss-120b",
+            streaming=False,
+            max_tokens=64,
+        )
+
+        assert captured["url"] == "https://router.huggingface.co/v1/chat/completions"
+
 
 @pytest.mark.integration
 class TestChatHistorySaving:

--- a/Tests/Chat/test_chat_functions.py
+++ b/Tests/Chat/test_chat_functions.py
@@ -93,6 +93,11 @@ def test_huggingface_chat_api_call_passes_max_tokens_to_adapter(monkeypatch):
     assert "max_new_tokens" not in captured_kwargs
 
 
+def test_huggingface_router_chat_url_rejects_missing_or_non_string_base():
+    assert llm_api_calls_module._huggingface_router_chat_url(None) is None
+    assert llm_api_calls_module._huggingface_router_chat_url(443) is None
+
+
 def test_groq_chat_api_call_passes_max_tokens_to_adapter(monkeypatch):
     captured_kwargs = {}
 

--- a/Tests/Chat/test_chat_functions.py
+++ b/Tests/Chat/test_chat_functions.py
@@ -301,6 +301,23 @@ class TestChatApiCall:
         assert kwargs["thinking_effort"] == "high"
         assert kwargs["thinking_budget_tokens"] == 4096
 
+    def test_huggingface_max_tokens_maps_to_supported_handler_kwarg(self, mock_handlers, mocker):
+        mock_huggingface_handler = mocker.MagicMock(return_value="HuggingFace response")
+        mock_huggingface_handler.__name__ = "mock_huggingface_handler"
+        mock_handlers.get.return_value = mock_huggingface_handler
+
+        chat_api_call(
+            api_endpoint="huggingface",
+            messages_payload=[{"role": "user", "content": "test"}],
+            model="openai/gpt-oss-120b",
+            max_tokens=16,
+        )
+
+        kwargs = mock_huggingface_handler.call_args.kwargs
+        assert kwargs["model"] == "openai/gpt-oss-120b"
+        assert kwargs["max_tokens"] == 16
+        assert "max_new_tokens" not in kwargs
+
     def test_unsupported_endpoint_raises_error(self, mock_handlers):
         mock_handlers.get.return_value = None
         with pytest.raises(ValueError, match="Unsupported API endpoint: unsupported"):
@@ -734,6 +751,45 @@ class TestProviderRequestPayloads:
         )
 
         assert captured["json"]["thinking"] == {"type": "adaptive", "effort": "high"}
+
+    def test_huggingface_legacy_router_base_uses_openai_compatible_router_url(self, monkeypatch):
+        from tldw_chatbook.LLM_Calls import LLM_API_Calls
+
+        captured = {}
+        monkeypatch.setattr(
+            LLM_API_Calls,
+            "load_settings",
+            lambda: {
+                "huggingface_api": {
+                    "api_base_url": "https://router.huggingface.co/hf-inference/models",
+                    "streaming": False,
+                }
+            },
+        )
+        monkeypatch.setattr(
+            LLM_API_Calls.requests,
+            "Session",
+            lambda: _CapturedSession(
+                captured,
+                {
+                    "id": "hf-test",
+                    "model": "openai/gpt-oss-120b",
+                    "choices": [{"message": {"content": "OK"}, "finish_reason": "stop"}],
+                },
+            ),
+        )
+
+        response = LLM_API_Calls.chat_with_huggingface(
+            input_data=[{"role": "user", "content": "test"}],
+            api_key="hf_test",
+            model="/openai/gpt-oss-120b",
+            streaming=False,
+            max_tokens=64,
+        )
+
+        assert captured["url"] == "https://router.huggingface.co/v1/chat/completions"
+        assert captured["json"]["max_tokens"] == 64
+        assert response["choices"][0]["message"]["content"] == "OK"
 
 
 @pytest.mark.integration

--- a/Tests/Chat/test_console_provider_gateway.py
+++ b/Tests/Chat/test_console_provider_gateway.py
@@ -966,6 +966,27 @@ def test_normalize_generic_provider_response_dict_precedence() -> None:
     assert list(ConsoleProviderGateway.normalize_provider_response({"generated_text": "generated"})) == ["generated"]
 
 
+def test_normalize_google_gemini_candidates_response() -> None:
+    payload = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [{"text": "OK"}],
+                    "role": "model",
+                },
+                "finishReason": "STOP",
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 5,
+            "candidatesTokenCount": 1,
+            "totalTokenCount": 6,
+        },
+    }
+
+    assert list(ConsoleProviderGateway.normalize_provider_response(payload)) == ["OK"]
+
+
 def test_safe_provider_error_copy_redacts_secret_like_values() -> None:
     copy = safe_provider_error_copy(
         "openai",

--- a/backlog/tasks/task-120 - Address-PR-524-review-comments-and-rebase-on-dev.md
+++ b/backlog/tasks/task-120 - Address-PR-524-review-comments-and-rebase-on-dev.md
@@ -1,0 +1,69 @@
+---
+id: TASK-120
+title: Address PR 524 review comments and rebase on dev
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-16 12:53'
+labels:
+  - pr-review
+  - bugfix
+  - security
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Rebase PR #524 onto the latest dev branch and resolve the outstanding review comments around HuggingFace router URL handling, configuration robustness, docstring style, and CI feedback.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 PR branch is rebased onto current origin/dev without conflicts.
+- [x] #2 HuggingFace router URL handling validates and normalizes inputs consistently with centralized URL validation expectations.
+- [x] #3 Router configuration handles missing, null, and non-string values without runtime errors.
+- [x] #4 Focused regression tests cover the review-commented behaviors.
+- [x] #5 Touched-scope tests and security checks are run and documented.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Rebase `codex/provider-env-smoke-fixes` onto current `origin/dev` and resolve any conflicts without losing scoped PR behavior.
+2. Audit all PR #524 inline comments from Qodo and Gemini against the rebased code.
+3. Use TDD for any remaining untested behavior gaps around HuggingFace router URL validation/normalization and configuration robustness.
+4. Run focused Chat tests, `git diff --check`, and Bandit on touched code paths.
+5. Update Backlog implementation notes, commit, and push the rebased branch.
+
+ADR required: no
+ADR path: N/A
+Reason: bounded bugfix/review remediation for existing provider code and tests; no new architecture, storage, dependency, or service-contract decision.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Rebased codex/provider-env-smoke-fixes onto origin/dev fee3f79f and resolved LLM_API_Calls.py conflicts by preserving dev /v1 path handling while keeping PR router normalization.
+
+Addressed PR review comments by verifying _huggingface_router_chat_url uses validate_url, Google-style Args/Returns docstring, hostname-based router comparison preserving ports, safe optional config string handling, and regression coverage for None/non-string router base values.
+
+Verification run with project venv Python 3.12.11: Tests/Chat/test_chat_functions.py -v passed 41 tests; Tests/Chat/test_console_provider_gateway.py -v passed 49 tests; Tests/UI --collect-only -q collected 2221 tests. git diff --check passed. Bandit was run on tldw_chatbook/LLM_Calls and tldw_chatbook/Chat and reported pre-existing findings outside the changed lines: LLM_API_Calls.py:348 B113, LLM_API_Calls_Local.py:9 B404, Local_Summarization_Lib.py:106 B113, Summarization_General_Lib.py:795 B113.
+
+CI check state intentionally ignored per user direction because workflows are being actively canceled for a long-running CI job.
+
+ADR required: no; this is bounded PR review remediation of existing provider behavior.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Rebased PR #524 on latest dev and added a focused HuggingFace router URL regression for missing/non-string base values. Review-commented HuggingFace URL validation, docstring style, host normalization, port preservation, and null config handling are covered by code and tests. Local verification completed; CI state ignored per user instruction.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/tldw_chatbook/Chat/console_provider_gateway.py
+++ b/tldw_chatbook/Chat/console_provider_gateway.py
@@ -999,6 +999,25 @@ def _content_from_provider_mapping(item: Mapping[str, Any]) -> str | object:
             if isinstance(text, str):
                 return text
 
+    candidates = item.get("candidates")
+    if isinstance(candidates, list) and candidates:
+        first_candidate = candidates[0]
+        if isinstance(first_candidate, Mapping):
+            content = first_candidate.get("content")
+            if isinstance(content, Mapping):
+                parts = content.get("parts")
+                if isinstance(parts, list):
+                    text_parts = [
+                        part["text"]
+                        for part in parts
+                        if isinstance(part, Mapping) and isinstance(part.get("text"), str)
+                    ]
+                    if text_parts:
+                        return "".join(text_parts)
+            text = first_candidate.get("text")
+            if isinstance(text, str):
+                return text
+
     message = item.get("message")
     if isinstance(message, Mapping) and isinstance(message.get("content"), str):
         return message["content"]

--- a/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
+++ b/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
@@ -116,6 +116,7 @@ def _huggingface_router_chat_url(base_url: Any) -> Optional[str]:
         return None
     return f"{parsed.scheme}://{parsed.netloc}/v1/chat/completions"
 
+
 def extract_text_from_segments(segments):
     logger.debug(f"Segments received: {segments}")
     logger.debug(f"Type of segments: {type(segments)}")

--- a/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
+++ b/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
@@ -25,6 +25,7 @@
 import json
 import time
 from typing import List, Any, Optional, Tuple, Dict, Union
+from urllib.parse import urlparse
 #
 # Import 3rd-Party Libraries
 import requests
@@ -37,6 +38,7 @@ from tldw_chatbook.Chat.Chat_Deps import ChatAPIError, ChatAuthenticationError, 
     ChatBadRequestError, ChatProviderError, ChatConfigurationError
 from tldw_chatbook.config import load_settings, settings
 from tldw_chatbook.Metrics.metrics_logger import log_counter, log_histogram
+from tldw_chatbook.Utils.input_validation import validate_url
 #
 #######################################################################################################################
 # Provider Parameter Support Documentation
@@ -73,6 +75,46 @@ def _safe_cast(value: Any, cast_to: type, default: Any = None) -> Any:
     except (ValueError, TypeError):
         logger.warning(f"Could not cast '{value}' to {cast_to}. Using default: {default}")
         return default
+
+
+def _optional_config_string(value: Any, default: str = "") -> str:
+    """Return a stripped config string, or a safe default for empty values.
+
+    Args:
+        value: Raw configuration value.
+        default: Value to use when the raw value is missing or empty.
+
+    Returns:
+        A stripped string suitable for URL/path construction.
+    """
+    if value is None:
+        return default
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or default
+    return str(value).strip() or default
+
+
+def _huggingface_router_chat_url(base_url: Any) -> Optional[str]:
+    """Return the OpenAI-compatible HuggingFace router chat URL.
+
+    Args:
+        base_url: Raw HuggingFace router base URL from configuration.
+
+    Returns:
+        Normalized ``/v1/chat/completions`` URL for HuggingFace router bases,
+        or ``None`` when the URL is invalid or points to another host.
+    """
+    stripped_base_url = _optional_config_string(base_url)
+    if not stripped_base_url:
+        return None
+    candidate = stripped_base_url if "://" in stripped_base_url else f"https://{stripped_base_url}"
+    if not validate_url(candidate):
+        return None
+    parsed = urlparse(candidate)
+    if (parsed.hostname or "").lower() != "router.huggingface.co":
+        return None
+    return f"{parsed.scheme}://{parsed.netloc}/v1/chat/completions"
 
 def extract_text_from_segments(segments):
     logger.debug(f"Segments received: {segments}")
@@ -1978,6 +2020,7 @@ def chat_with_huggingface(
     if not final_model_for_payload:
         raise ChatConfigurationError(provider="huggingface",
                                      message="HuggingFace model ID is required (must be passed as 'model' or configured).")
+    final_model_for_payload = str(final_model_for_payload).strip().strip("/")
     logger.info(f"HuggingFace: Using model_id for payload: {final_model_for_payload}")
 
     # --- URL Construction ---
@@ -1988,33 +2031,48 @@ def chat_with_huggingface(
             hf_config.get('huggingface_use_router_url_format', "False"),
         )
     ).lower()
+    model_path_part = final_model_for_payload.strip('/')
 
     if use_router_url_format_str == "true":
         # This format explicitly puts the model in the URL path.
         # User must ensure router_base_url and model_id result in a valid endpoint.
-        router_base = hf_config.get(
-            'router_base_url',
-            hf_config.get('huggingface_router_base_url', 'https://router.huggingface.co/hf-inference'),
+        router_base = _optional_config_string(
+            hf_config.get(
+                'router_base_url',
+                hf_config.get('huggingface_router_base_url'),
+            ),
+            default='https://router.huggingface.co/hf-inference',
         ).rstrip('/')
-        model_path_part = final_model_for_payload.strip('/')
-        chat_path = hf_config.get('api_chat_path', 'v1/chat/completions').lstrip('/')
+        chat_path = _optional_config_string(hf_config.get('api_chat_path'), 'v1/chat/completions').lstrip('/')
         # Constructs URL like: {router_base}/models/{model_path_part}/{chat_path}
-        api_url = f"{router_base}/models/{model_path_part}/{chat_path}"
+        router_chat_url = _huggingface_router_chat_url(router_base)
+        if router_chat_url:
+            api_url = router_chat_url
+        elif router_base.endswith('/models'):
+            api_url = f"{router_base}/{model_path_part}/{chat_path}"
+        else:
+            api_url = f"{router_base}/models/{model_path_part}/{chat_path}"
         logger.info(f"HuggingFace: Using explicit 'use_router_url_format=true'. Target URL: {api_url}")
     else: # use_router_url_format is false, standard URL construction
-        configured_api_base_url = hf_config.get('api_base_url')
+        configured_api_base_url = _optional_config_string(hf_config.get('api_base_url'))
         # Default chat path can be just "chat/completions" if base_url includes /v1, or "v1/chat/completions" if not.
         # Let's make the default api_chat_path more flexible.
         # If using the public HF API, base is /v1 and path is chat/completions.
-        configured_api_base = (configured_api_base_url or '').rstrip('/')
+        configured_api_base = configured_api_base_url.rstrip('/')
         default_chat_path = 'chat/completions' if configured_api_base.endswith('/v1') else 'v1/chat/completions'
-        chat_completions_path = hf_config.get('api_chat_path', default_chat_path).lstrip('/')
+        chat_completions_path = _optional_config_string(hf_config.get('api_chat_path'), default_chat_path).lstrip('/')
 
         if configured_api_base_url:
             # If api_base_url is configured, use it directly and append the chat_completions_path.
             # The model is expected to be in the payload.
             # If the endpoint needs the model_id in the path, configured_api_base_url should include it fully.
-            api_url = f"{configured_api_base_url.rstrip('/')}/{chat_completions_path}"
+            router_chat_url = _huggingface_router_chat_url(configured_api_base)
+            if router_chat_url:
+                api_url = router_chat_url
+            elif configured_api_base.endswith('/models'):
+                api_url = f"{configured_api_base}/{model_path_part}/{chat_completions_path}"
+            else:
+                api_url = f"{configured_api_base}/{chat_completions_path}"
             logger.info(f"HuggingFace: Using configured 'api_base_url' ('{configured_api_base_url}') and 'api_chat_path' ('{chat_completions_path}'). Target URL: {api_url}. Model is in payload.")
         else:
             # Fallback if no api_base_url is configured.


### PR DESCRIPTION
## Summary
- Fix Console/Chatbook provider path issues found while testing with provider keys from the server .env.
- Map HuggingFace max_tokens to the adapter-supported argument and normalize legacy HuggingFace router config to the current OpenAI-compatible router endpoint.
- Teach Console provider response normalization to read Gemini candidate/parts responses.

## Test Plan
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chat/test_console_provider_gateway.py Tests/Chat/test_chat_functions.py --tb=short
- git diff --check
- Live smoke via ConsoleProviderGateway using /Users/macbook-dev/Documents/GitHub/tldw_server2/tldw_Server_API/Config_Files/.env for OpenAI, Anthropic, Cohere, Google, Groq, DeepSeek, MistralAI, HuggingFace, OpenRouter, and Moonshot

## Notes
- Secret values were not printed; only provider pass/fail output was used.
- Moonshot showed one transient 504 in a full run and passed on immediate single-provider retry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix provider path handling in Console/Chatbook when using server .env keys. Normalizes HuggingFace router URLs and config, maps `max_tokens` correctly, and parses Gemini candidates to stabilize provider smoke tests.

- **Bug Fixes**
  - HuggingFace router URLs: normalize `router.huggingface.co` to `/v1/chat/completions` (handles legacy `/hf-inference/models`, mixed-case hosts, ports, and missing/None/non-string bases); honor `api_base_url`/`router_base_url` and `use_router_url_format`; only embed the model when the base ends with `/models`; validate URLs.
  - HuggingFace args/model: pass `max_tokens` to handlers (not `max_new_tokens`); trim stray slashes from model IDs.
  - Console: parse Google Gemini `candidates[].content.parts[].text` (fallback to `candidates[].text`).
  - Tests: add coverage for router normalization and bad config types, HuggingFace arg mapping, and Gemini candidate parsing.

<sup>Written for commit d545f14464f0d08d08e2db66954318d8d2613734. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

