### PR TITLE
Fix Anthropic Console provider UAT

### DIFF
--- a/Docs/superpowers/plans/2026-06-16-pr527-console-anthropic-review-rebase-plan.md
+++ b/Docs/superpowers/plans/2026-06-16-pr527-console-anthropic-review-rebase-plan.md
@@ -1,0 +1,27 @@
+## Stage 1: Rebase And Conflict Resolution
+**Goal**: Put PR #527 on top of latest `origin/dev` without dropping existing regression coverage.
+**Success Criteria**: Rebase completes cleanly; conflicting chat tests retain both dev and PR assertions.
+**Tests**: `git status --short --branch`; focused chat test collection.
+**Status**: Complete
+
+ADR required: no
+ADR path: `backlog/decisions/006-provider-aware-generation-settings.md`
+Reason: This is bounded review remediation implementing the existing provider-aware generation settings boundary; no new storage, sync, provider ownership, or cross-module contract decision is introduced.
+
+## Stage 2: Review Regression Tests
+**Goal**: Capture each unresolved review finding with focused failing tests before implementation where practical.
+**Success Criteria**: Tests cover Anthropic `temperature`/`top_p` exclusivity, safe chat exception logging without `status_code`, and Console custom-model toggle/readiness state.
+**Tests**: `./.venv/bin/python -m pytest Tests/Chat/test_chat_functions.py Tests/UI/test_console_session_settings.py -q`
+**Status**: Complete
+
+## Stage 3: Minimal Fixes
+**Goal**: Apply narrow fixes to the Anthropic adapter, chat error logging, and Console settings modal.
+**Success Criteria**: Explicit `top_p` is honored when temperature is not explicitly set, conflicting explicit samplers prefer temperature with a warning, chat logging cannot raise `AttributeError`, custom model width is named, and toggling back refreshes readiness.
+**Tests**: Focused regressions from Stage 2.
+**Status**: Complete
+
+## Stage 4: Verification And PR Closeout
+**Goal**: Verify, document, push, and resolve addressed review threads.
+**Success Criteria**: Focused tests pass, Bandit reports no new findings in touched production files, `TASK-122` is complete, branch is pushed to PR #527, and review threads are resolved.
+**Tests**: Focused pytest suite, `git diff --check`, Bandit on touched production files.
+**Status**: Complete

--- a/Tests/Chat/test_chat_functions.py
+++ b/Tests/Chat/test_chat_functions.py
@@ -323,6 +323,25 @@ class TestChatApiCall:
         assert kwargs["max_tokens"] == 16
         assert "max_new_tokens" not in kwargs
 
+    def test_provider_json_error_body_is_not_masked_by_dispatcher_logging(self, mock_handlers, mocker):
+        provider_error = ChatBadRequestError(
+            provider="anthropic",
+            message='Bad request (404). Detail: {"type":"error","error":{"type":"not_found_error"}}',
+        )
+        mock_handler = mocker.MagicMock(side_effect=provider_error)
+        mock_handler.__name__ = "mock_handler"
+        mock_handlers.get.return_value = mock_handler
+
+        with pytest.raises(ChatBadRequestError) as exc_info:
+            chat_api_call(
+                "anthropic",
+                messages_payload=[{"role": "user", "content": "test"}],
+                api_key=DUMMY_ANTHROPIC_API_KEY,
+            )
+
+        assert exc_info.value is provider_error
+        assert '{"type":"error"' in exc_info.value.message
+
     def test_unsupported_endpoint_raises_error(self, mock_handlers):
         mock_handlers.get.return_value = None
         with pytest.raises(ValueError, match="Unsupported API endpoint: unsupported"):
@@ -647,6 +666,45 @@ class TestProviderRequestPayloads:
         assert "temperature" not in captured["json"]
         assert "top_p" not in captured["json"]
         assert "top_k" not in captured["json"]
+
+    def test_anthropic_modern_models_do_not_send_temperature_and_top_p_together(self, monkeypatch):
+        from tldw_chatbook.LLM_Calls import LLM_API_Calls
+
+        captured = {}
+        monkeypatch.setattr(
+            LLM_API_Calls,
+            "load_settings",
+            lambda: {"anthropic_api": {"api_base_url": "https://api.anthropic.test/v1"}},
+        )
+        monkeypatch.setattr(
+            LLM_API_Calls.requests,
+            "Session",
+            lambda: _CapturedSession(
+                captured,
+                {
+                    "id": "msg_test",
+                    "model": "claude-haiku-4-5-20251001",
+                    "content": [{"type": "text", "text": "modern answer"}],
+                    "stop_reason": "end_turn",
+                    "usage": {"input_tokens": 4, "output_tokens": 5},
+                },
+            ),
+        )
+
+        LLM_API_Calls.chat_with_anthropic(
+            input_data=[{"role": "user", "content": "test"}],
+            api_key=DUMMY_ANTHROPIC_API_KEY,
+            model="claude-haiku-4-5-20251001",
+            streaming=False,
+            temp=0.6,
+            topp=0.95,
+            topk=50,
+            max_tokens=64,
+        )
+
+        assert captured["json"]["temperature"] == 0.6
+        assert "top_p" not in captured["json"]
+        assert captured["json"]["top_k"] == 50
 
     def test_anthropic_thinking_effort_maps_to_budget_tokens(self, monkeypatch):
         from tldw_chatbook.LLM_Calls import LLM_API_Calls

--- a/Tests/Chat/test_chat_functions.py
+++ b/Tests/Chat/test_chat_functions.py
@@ -324,15 +324,21 @@ class TestChatApiCall:
         assert "max_new_tokens" not in kwargs
 
     def test_provider_json_error_body_is_not_masked_by_dispatcher_logging(self, mock_handlers, mocker):
-        provider_error = ChatBadRequestError(
-            provider="anthropic",
-            message='Bad request (404). Detail: {"type":"error","error":{"type":"not_found_error"}}',
-        )
+        class LegacyProviderError(ChatAPIError):
+            def __init__(self):
+                Exception.__init__(
+                    self,
+                    'Bad request (404). Detail: {"type":"error","error":{"type":"not_found_error"}}',
+                )
+                self.provider = "anthropic"
+                self.message = str(self)
+
+        provider_error = LegacyProviderError()
         mock_handler = mocker.MagicMock(side_effect=provider_error)
         mock_handler.__name__ = "mock_handler"
         mock_handlers.get.return_value = mock_handler
 
-        with pytest.raises(ChatBadRequestError) as exc_info:
+        with pytest.raises(LegacyProviderError) as exc_info:
             chat_api_call(
                 "anthropic",
                 messages_payload=[{"role": "user", "content": "test"}],
@@ -671,6 +677,7 @@ class TestProviderRequestPayloads:
         from tldw_chatbook.LLM_Calls import LLM_API_Calls
 
         captured = {}
+        warnings = []
         monkeypatch.setattr(
             LLM_API_Calls,
             "load_settings",
@@ -690,6 +697,7 @@ class TestProviderRequestPayloads:
                 },
             ),
         )
+        monkeypatch.setattr(LLM_API_Calls.logger, "warning", lambda message, *args, **kwargs: warnings.append(str(message)))
 
         LLM_API_Calls.chat_with_anthropic(
             input_data=[{"role": "user", "content": "test"}],
@@ -705,6 +713,48 @@ class TestProviderRequestPayloads:
         assert captured["json"]["temperature"] == 0.6
         assert "top_p" not in captured["json"]
         assert captured["json"]["top_k"] == 50
+        assert any("top_p" in warning and "temperature" in warning for warning in warnings)
+
+    def test_anthropic_explicit_top_p_omits_default_temperature(self, monkeypatch):
+        from tldw_chatbook.LLM_Calls import LLM_API_Calls
+
+        captured = {}
+        monkeypatch.setattr(
+            LLM_API_Calls,
+            "load_settings",
+            lambda: {
+                "anthropic_api": {
+                    "api_base_url": "https://api.anthropic.test/v1",
+                    "temperature": 0.7,
+                }
+            },
+        )
+        monkeypatch.setattr(
+            LLM_API_Calls.requests,
+            "Session",
+            lambda: _CapturedSession(
+                captured,
+                {
+                    "id": "msg_test",
+                    "model": "claude-haiku-4-5-20251001",
+                    "content": [{"type": "text", "text": "top-p answer"}],
+                    "stop_reason": "end_turn",
+                    "usage": {"input_tokens": 4, "output_tokens": 5},
+                },
+            ),
+        )
+
+        LLM_API_Calls.chat_with_anthropic(
+            input_data=[{"role": "user", "content": "test"}],
+            api_key=DUMMY_ANTHROPIC_API_KEY,
+            model="claude-haiku-4-5-20251001",
+            streaming=False,
+            topp=0.91,
+            max_tokens=64,
+        )
+
+        assert captured["json"]["top_p"] == 0.91
+        assert "temperature" not in captured["json"]
 
     def test_anthropic_thinking_effort_maps_to_budget_tokens(self, monkeypatch):
         from tldw_chatbook.LLM_Calls import LLM_API_Calls

--- a/Tests/UI/test_console_session_settings.py
+++ b/Tests/UI/test_console_session_settings.py
@@ -1517,6 +1517,48 @@ async def test_console_settings_modal_allows_manual_model_when_registry_has_stal
 
 
 @pytest.mark.asyncio
+async def test_console_settings_modal_refreshes_readiness_after_returning_to_model_list() -> None:
+    app = ModalHarness()
+    settings = ConsoleSessionSettings(provider="llama_cpp", model="model-a")
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        await app.push_screen(
+            ConsoleSettingsModal(
+                settings=settings,
+                app_config=app.app_config,
+                providers_models={"llama_cpp": ["model-a"]},
+                context_estimate=ConsoleSettingsContextEstimate(10, 4096, "10 / 4k"),
+                can_save=True,
+                focus_model=True,
+            ),
+            callback=app.capture_saved_settings,
+        )
+        await pilot.pause()
+
+        await pilot.click("#console-settings-model-custom")
+        await pilot.pause()
+
+        model_input = app.screen.query_one("#console-settings-model-input", Input)
+        readiness = app.screen.query_one("#console-settings-readiness", Static)
+        provider_model_section = app.screen.query_one("#console-settings-provider-model-section")
+        model_input.value = ""
+        app.screen._sync_readiness_display()
+        await pilot.pause()
+
+        assert "Choose a model to enable sending." in str(readiness.renderable)
+        assert provider_model_section.has_class("console-settings-primary-section") is True
+
+        app.screen._toggle_manual_model_input()
+        await pilot.pause()
+
+        model_select = app.screen.query_one("#console-settings-model-select", Select)
+        assert model_select.display is True
+        assert model_select.value == "model-a"
+        assert str(readiness.renderable) == "llama_cpp is ready. No API key is required."
+        assert provider_model_section.has_class("console-settings-primary-section") is False
+
+
+@pytest.mark.asyncio
 async def test_console_settings_modal_provider_change_uses_configured_provider_model() -> None:
     app = ModalHarness()
     app.app_config["api_settings"]["llama_cpp"] = {

--- a/Tests/UI/test_console_session_settings.py
+++ b/Tests/UI/test_console_session_settings.py
@@ -1478,6 +1478,45 @@ async def test_console_settings_modal_preserves_missing_registry_model_for_curre
 
 
 @pytest.mark.asyncio
+async def test_console_settings_modal_allows_manual_model_when_registry_has_stale_options() -> None:
+    app = ModalHarness()
+    settings = ConsoleSessionSettings(provider="anthropic", model="claude-3-haiku-20240307")
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        await app.push_screen(
+            ConsoleSettingsModal(
+                settings=settings,
+                app_config=app.app_config,
+                providers_models={"anthropic": ["claude-3-haiku-20240307"]},
+                context_estimate=ConsoleSettingsContextEstimate(10, 4096, "10 / 4k"),
+                can_save=True,
+            ),
+            callback=app.capture_saved_settings,
+        )
+        await pilot.pause()
+
+        model_select = app.screen.query_one("#console-settings-model-select", Select)
+        model_input = app.screen.query_one("#console-settings-model-input", Input)
+        custom_button = app.screen.query_one("#console-settings-model-custom", Button)
+        assert model_select.display is True
+        assert model_input.display is False
+        assert custom_button.display is True
+
+        await pilot.click("#console-settings-model-custom")
+        await pilot.pause()
+
+        assert model_select.display is False
+        assert model_input.display is True
+        assert model_input.disabled is False
+        model_input.value = "claude-haiku-4-5-20251001"
+        await pilot.click("#console-settings-save")
+
+    assert app.saved_settings is not None
+    assert app.saved_settings.provider == "anthropic"
+    assert app.saved_settings.model == "claude-haiku-4-5-20251001"
+
+
+@pytest.mark.asyncio
 async def test_console_settings_modal_provider_change_uses_configured_provider_model() -> None:
     app = ModalHarness()
     app.app_config["api_settings"]["llama_cpp"] = {

--- a/backlog/tasks/task-122 - Address-PR-527-review-comments-and-rebase-on-dev.md
+++ b/backlog/tasks/task-122 - Address-PR-527-review-comments-and-rebase-on-dev.md
@@ -1,0 +1,66 @@
+---
+id: TASK-122
+title: Address PR 527 review comments and rebase on dev
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-16 14:04'
+labels:
+  - pr-review
+  - console
+  - anthropic
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_chatbook/pull/527'
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Rebase PR #527 on the latest dev branch and address the outstanding review comments around Anthropic sampling parameters, chat exception logging, and Console settings modal state.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 PR branch is rebased on the latest origin/dev without unresolved conflicts.
+- [x] #2 Anthropic request payload construction keeps temperature/top_p mutually exclusive while honoring explicit top_p requests.
+- [x] #3 Chat direct-call exception logging cannot mask original errors when status_code is absent.
+- [x] #4 Console settings modal custom model controls avoid unexplained repeated sizing literals and refresh readiness after toggling back to the model list.
+- [x] #5 Focused regression tests cover the reviewed behaviors and pass locally.
+- [x] #6 Bandit is run on touched production paths and no new findings are introduced.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+ADR path: backlog/decisions/006-provider-aware-generation-settings.md
+Reason: This is a bounded PR review remediation that implements the existing provider-aware generation settings boundary; it does not introduce a new storage, sync, provider ownership, or cross-module contract decision.
+
+1. Complete the rebase onto origin/dev and resolve the test conflict without dropping either branch's regression coverage.
+2. Add/adjust failing focused tests for Anthropic temperature/top_p mutual exclusion, safe chat exception logging, and Console settings modal custom-model toggle/readiness behavior.
+3. Implement the minimal reviewed fixes in the Anthropic adapter, chat direct-call logging path, and Console settings modal.
+4. Run the focused regression suite, diff checks, and Bandit on touched production files.
+5. Update TASK-122 with verification notes, stage, commit, push the rebased PR branch, and resolve the addressed review threads.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the PR #527 review remediation as a bounded follow-up to ADR-006. The branch was rebased onto origin/dev and the single test conflict was resolved by retaining both existing regression cases.
+
+Code changes keep Anthropic temperature/top_p mutually exclusive based on explicit caller intent: explicit top_p is sent when temperature was not explicitly provided, and explicit temperature wins with a warning when both are supplied. Chat direct-call error logging now guards status_code access so custom ChatAPIError subclasses are re-raised instead of masked. Console settings now names the custom model button width and refreshes readiness/emphasis after toggling from manual model entry back to the model list.
+
+Verification run: targeted review regressions passed; /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Chat/test_chat_functions.py Tests/UI/test_console_session_settings.py -q passed with 130 tests. git diff --check and conflict-marker scan passed. Bandit on touched production files wrote /tmp/bandit_pr527.json and reported only pre-existing B113 at tldw_chatbook/LLM_Calls/LLM_API_Calls.py:348, outside changed lines.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Rebased PR #527 onto origin/dev, resolving the single chat test conflict by retaining both regression cases. Addressed all unresolved review comments by honoring explicit Anthropic top_p when temperature was not explicitly provided, warning and preferring temperature when both samplers are explicit, safely logging direct ChatAPIError subclasses without status_code, naming the Console custom-model button width, and refreshing Console readiness after returning to the model list. Verification: targeted review regressions passed; `Tests/Chat/test_chat_functions.py` and `Tests/UI/test_console_session_settings.py` passed together with 130 tests. `git diff --check` and conflict-marker scans passed. Bandit was run on touched production files and reported only pre-existing B113 at LLM_API_Calls.py:348, outside the changed lines.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/tldw_chatbook/Chat/Chat_Functions.py
+++ b/tldw_chatbook/Chat/Chat_Functions.py
@@ -848,7 +848,7 @@ def chat_api_call(
 
         # Log safely first
         try:
-            logger.error("%s. Details: %s", log_message_base, error_text[:500], exc_info=False)
+            logger.opt(exception=False).error("{}. Details: {}", log_message_base, error_text[:500])
         except Exception as log_e:
             logger.error(f"Error during logging HTTPError details: {log_e}")
 
@@ -878,9 +878,12 @@ def chat_api_call(
         # This catches cases where the handler itself has already processed an error
         # (e.g. non-HTTP error, or it decided to raise a specific Chat*Error type)
         # and raises one of our custom exceptions.
-        logger.error(
-            f"Handler for {endpoint_lower} directly raised: {type(e_chat_direct).__name__} - {e_chat_direct.message}",
-            exc_info=True if e_chat_direct.status_code >= 500 else False)
+        logger.opt(exception=e_chat_direct.status_code >= 500).error(
+            "Handler for {} directly raised: {} - {}",
+            endpoint_lower,
+            type(e_chat_direct).__name__,
+            e_chat_direct.message,
+        )
         raise e_chat_direct  # Re-raise the specific error
     except (ValueError, TypeError, KeyError) as e:
         logger.error(f"Value/Type/Key error during chat API call setup for {endpoint_lower}: {e}", exc_info=True)

--- a/tldw_chatbook/Chat/Chat_Functions.py
+++ b/tldw_chatbook/Chat/Chat_Functions.py
@@ -878,7 +878,8 @@ def chat_api_call(
         # This catches cases where the handler itself has already processed an error
         # (e.g. non-HTTP error, or it decided to raise a specific Chat*Error type)
         # and raises one of our custom exceptions.
-        logger.opt(exception=e_chat_direct.status_code >= 500).error(
+        status_code = getattr(e_chat_direct, "status_code", 0)
+        logger.opt(exception=isinstance(status_code, int) and status_code >= 500).error(
             "Handler for {} directly raised: {} - {}",
             endpoint_lower,
             type(e_chat_direct).__name__,

--- a/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
+++ b/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
@@ -771,7 +771,7 @@ def chat_with_anthropic(
     if system_prompt is not None: data["system"] = system_prompt # Anthropic uses 'system' at the top level
     if thinking_config is None:
         if current_temp is not None: data["temperature"] = current_temp
-        if current_top_p is not None: data["top_p"] = current_top_p
+        elif current_top_p is not None: data["top_p"] = current_top_p
         if current_top_k is not None: data["top_k"] = current_top_k
     elif any(value is not None for value in (current_temp, current_top_p, current_top_k)):
         logger.warning(

--- a/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
+++ b/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
@@ -707,7 +707,8 @@ def chat_with_anthropic(
     logger.debug("Anthropic: API key provided.")
 
     current_model = model or anthropic_config.get('model', 'claude-3-haiku-20240307')
-    current_temp = temp if temp is not None else float(anthropic_config.get('temperature', 0.7))
+    default_temperature = float(anthropic_config.get('temperature', 0.7))
+    current_temp = temp if temp is not None else default_temperature
     current_top_p = topp
     current_top_k = topk
     current_streaming_cfg = anthropic_config.get('streaming', False)
@@ -770,10 +771,18 @@ def chat_with_anthropic(
     }
     if system_prompt is not None: data["system"] = system_prompt # Anthropic uses 'system' at the top level
     if thinking_config is None:
-        if current_temp is not None: data["temperature"] = current_temp
-        elif current_top_p is not None: data["top_p"] = current_top_p
+        if temp is not None:
+            data["temperature"] = current_temp
+            if current_top_p is not None:
+                logger.warning(
+                    "Anthropic: both temperature and top_p were provided; sending temperature and dropping top_p."
+                )
+        elif current_top_p is not None:
+            data["top_p"] = current_top_p
+        else:
+            data["temperature"] = current_temp
         if current_top_k is not None: data["top_k"] = current_top_k
-    elif any(value is not None for value in (current_temp, current_top_p, current_top_k)):
+    elif any(value is not None for value in (temp, current_top_p, current_top_k)):
         logger.warning(
             "Anthropic: omitting temperature/top_p/top_k because thinking is enabled."
         )

--- a/tldw_chatbook/Widgets/Console/console_settings_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_settings_modal.py
@@ -32,6 +32,7 @@ from tldw_chatbook.Chat.console_session_settings import (
 
 
 MODEL_INPUT_PLACEHOLDER = "Enter model id"
+MODAL_LABEL_WIDTH = 16
 
 
 class ConsoleSettingsInput(Input):
@@ -121,7 +122,7 @@ class ConsoleSettingsModal(ModalScreen[ConsoleSessionSettings | None]):
                 ):
                     yield Static("Provider and model", classes="destination-section")
                     with Horizontal(classes="console-settings-modal-row"):
-                        yield Static("Provider", classes="console-settings-modal-label")
+                        yield self._modal_label("Provider")
                         yield Select(
                             provider_options,
                             value=self._settings.provider,
@@ -130,7 +131,7 @@ class ConsoleSettingsModal(ModalScreen[ConsoleSessionSettings | None]):
                             classes="console-settings-control",
                         )
                     with Horizontal(classes="console-settings-modal-row"):
-                        yield Static("Model", classes="console-settings-modal-label")
+                        yield self._modal_label("Model")
                         model_select = Select(
                             model_options or [("No configured models", "")],
                             value=selected_model or "",
@@ -139,6 +140,8 @@ class ConsoleSettingsModal(ModalScreen[ConsoleSessionSettings | None]):
                             disabled=not has_model_options,
                             classes="console-settings-control",
                         )
+                        model_select.styles.width = "1fr"
+                        model_select.styles.min_width = 0
                         model_select.display = has_model_options
                         yield model_select
                         model_input = ConsoleSettingsInput(
@@ -148,10 +151,24 @@ class ConsoleSettingsModal(ModalScreen[ConsoleSessionSettings | None]):
                             disabled=has_model_options,
                             classes="console-settings-control",
                         )
+                        model_input.styles.width = "1fr"
+                        model_input.styles.min_width = 0
                         model_input.display = not has_model_options
                         yield model_input
                     with Horizontal(classes="console-settings-modal-row"):
-                        yield Static("Base URL", classes="console-settings-modal-label")
+                        yield self._modal_label("")
+                        model_custom = Button(
+                            "Custom model",
+                            id="console-settings-model-custom",
+                            disabled=not has_model_options,
+                        )
+                        model_custom.styles.width = 18
+                        model_custom.styles.min_width = 18
+                        model_custom.styles.max_width = 18
+                        model_custom.display = has_model_options
+                        yield model_custom
+                    with Horizontal(classes="console-settings-modal-row"):
+                        yield self._modal_label("Base URL")
                         base_url_input = ConsoleSettingsInput(
                             value=base_url or "",
                             id="console-settings-base-url",
@@ -164,42 +181,42 @@ class ConsoleSettingsModal(ModalScreen[ConsoleSessionSettings | None]):
                 with Vertical(classes="console-settings-modal-section"):
                     yield Static("Sampling", classes="destination-section")
                     with Horizontal(classes="console-settings-modal-row"):
-                        yield Static("Temperature", classes="console-settings-modal-label")
+                        yield self._modal_label("Temperature")
                         yield ConsoleSettingsInput(
                             value=self._format_value(self._settings.temperature),
                             id="console-settings-temperature",
                             classes="console-settings-control",
                         )
                     with Horizontal(classes="console-settings-modal-row"):
-                        yield Static("Top P", classes="console-settings-modal-label")
+                        yield self._modal_label("Top P")
                         yield ConsoleSettingsInput(
                             value=self._format_value(self._settings.top_p),
                             id="console-settings-top-p",
                             classes="console-settings-control",
                         )
                     with Horizontal(classes="console-settings-modal-row"):
-                        yield Static("Min P", classes="console-settings-modal-label")
+                        yield self._modal_label("Min P")
                         yield ConsoleSettingsInput(
                             value=self._format_value(self._settings.min_p),
                             id="console-settings-min-p",
                             classes="console-settings-control",
                         )
                     with Horizontal(classes="console-settings-modal-row"):
-                        yield Static("Top K", classes="console-settings-modal-label")
+                        yield self._modal_label("Top K")
                         yield ConsoleSettingsInput(
                             value=self._format_value(self._settings.top_k),
                             id="console-settings-top-k",
                             classes="console-settings-control",
                         )
                     with Horizontal(classes="console-settings-modal-row"):
-                        yield Static("Max tokens", classes="console-settings-modal-label")
+                        yield self._modal_label("Max tokens")
                         yield ConsoleSettingsInput(
                             value=self._format_value(self._settings.max_tokens),
                             id="console-settings-max-tokens",
                             classes="console-settings-control",
                         )
                     with Horizontal(classes="console-settings-modal-row"):
-                        yield Static("Streaming", classes="console-settings-modal-label")
+                        yield self._modal_label("Streaming")
                         yield Checkbox(
                             value=self._settings.streaming,
                             id="console-settings-streaming",
@@ -288,6 +305,13 @@ class ConsoleSettingsModal(ModalScreen[ConsoleSessionSettings | None]):
             classes += " console-settings-primary-section"
         return classes
 
+    def _modal_label(self, text: str) -> Static:
+        label = Static(text, classes="console-settings-modal-label")
+        label.styles.width = MODAL_LABEL_WIDTH
+        label.styles.min_width = MODAL_LABEL_WIDTH
+        label.styles.max_width = MODAL_LABEL_WIDTH
+        return label
+
     def action_dismiss(self) -> None:
         self.dismiss(None)
 
@@ -329,6 +353,11 @@ class ConsoleSettingsModal(ModalScreen[ConsoleSessionSettings | None]):
     def _model_input_changed(self, event: Input.Changed) -> None:
         self._sync_readiness_display()
 
+    @on(Button.Pressed, "#console-settings-model-custom")
+    def _model_custom_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        self._toggle_manual_model_input()
+
     def _sync_readiness_display(self) -> None:
         draft = self._build_draft()
         readiness = build_console_settings_readiness(draft, app_config=self._app_config)
@@ -363,6 +392,7 @@ class ConsoleSettingsModal(ModalScreen[ConsoleSessionSettings | None]):
     def _sync_model_controls(self, provider: str, current_model: str | None) -> None:
         model_select = self.query_one("#console-settings-model-select", Select)
         model_input = self.query_one("#console-settings-model-input", Input)
+        model_custom = self.query_one("#console-settings-model-custom", Button)
         current_model = normalize_console_model_value(current_model)
         model_options = self._model_select_options(provider, current_model)
         if model_options:
@@ -375,6 +405,9 @@ class ConsoleSettingsModal(ModalScreen[ConsoleSessionSettings | None]):
             model_input.disabled = True
             model_input.display = False
             model_input.value = selected
+            model_custom.label = "Custom model"
+            model_custom.disabled = False
+            model_custom.display = True
             return
 
         fallback = current_model or ""
@@ -385,6 +418,30 @@ class ConsoleSettingsModal(ModalScreen[ConsoleSessionSettings | None]):
         model_input.value = fallback
         model_input.disabled = False
         model_input.display = True
+        model_custom.label = "Custom model"
+        model_custom.disabled = True
+        model_custom.display = False
+
+    def _toggle_manual_model_input(self) -> None:
+        model_select = self.query_one("#console-settings-model-select", Select)
+        model_input = self.query_one("#console-settings-model-input", Input)
+        model_custom = self.query_one("#console-settings-model-custom", Button)
+
+        if model_input.display:
+            provider = str(self.query_one("#console-settings-provider", Select).value or "")
+            current_model = normalize_console_model_value(model_input.value)
+            self._sync_model_controls(provider, current_model)
+            model_select.focus()
+            return
+
+        model_input.value = normalize_console_model_value(model_select.value) or ""
+        model_select.display = False
+        model_select.disabled = True
+        model_input.display = True
+        model_input.disabled = False
+        model_custom.label = "Model list"
+        model_input.focus()
+        self._sync_readiness_display()
 
     def _focus_model_control(self) -> None:
         model_select = self.query_one("#console-settings-model-select", Select)

--- a/tldw_chatbook/Widgets/Console/console_settings_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_settings_modal.py
@@ -33,6 +33,7 @@ from tldw_chatbook.Chat.console_session_settings import (
 
 MODEL_INPUT_PLACEHOLDER = "Enter model id"
 MODAL_LABEL_WIDTH = 16
+MODEL_CUSTOM_BUTTON_WIDTH = 18
 
 
 class ConsoleSettingsInput(Input):
@@ -162,9 +163,9 @@ class ConsoleSettingsModal(ModalScreen[ConsoleSessionSettings | None]):
                             id="console-settings-model-custom",
                             disabled=not has_model_options,
                         )
-                        model_custom.styles.width = 18
-                        model_custom.styles.min_width = 18
-                        model_custom.styles.max_width = 18
+                        model_custom.styles.width = MODEL_CUSTOM_BUTTON_WIDTH
+                        model_custom.styles.min_width = MODEL_CUSTOM_BUTTON_WIDTH
+                        model_custom.styles.max_width = MODEL_CUSTOM_BUTTON_WIDTH
                         model_custom.display = has_model_options
                         yield model_custom
                     with Horizontal(classes="console-settings-modal-row"):
@@ -431,6 +432,7 @@ class ConsoleSettingsModal(ModalScreen[ConsoleSessionSettings | None]):
             provider = str(self.query_one("#console-settings-provider", Select).value or "")
             current_model = normalize_console_model_value(model_input.value)
             self._sync_model_controls(provider, current_model)
+            self._sync_readiness_display()
             model_select.focus()
             return
 


### PR DESCRIPTION
## Summary
- prevent Anthropic request payloads from sending both temperature and top_p
- preserve provider JSON error bodies when dispatcher logging handles braces
- add a Console Settings custom model fallback for stale provider model lists

## Verification
- python -m pytest -q Tests/UI/test_console_session_settings.py::test_console_settings_modal_allows_manual_model_when_registry_has_stale_options Tests/Chat/test_chat_functions.py::TestProviderRequestPayloads::test_anthropic_modern_models_do_not_send_temperature_and_top_p_together --tb=short
- Focused local run before rebase: 125 passed
- CDP/Textual-web UAT: Anthropic selected with claude-haiku-4-5-20251001 and rendered ANTHROPIC-UAT-OK response

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Anthropic Console provider UAT by making sampling parameters mutually exclusive, hardening error logging, and enabling a manual model flow when the provider model list is stale.

- **Bug Fixes**
  - Anthropic requests never send both `temperature` and `top_p`; if both are set explicitly, `temperature` wins with a warning; if only `top_p` is set, the default temperature is omitted; thinking mode omits all samplers.
  - Provider JSON error details are preserved in logs; direct-raised chat errors are logged without requiring `status_code`, so the original message is not masked.

- **New Features**
  - Console Settings adds a “Custom model” toggle for manual entry and a “Model list” return; toggling back refreshes readiness and keeps layout stable with named widths.

<sup>Written for commit 531d3cc2474fe15397186ff4b140567ca0bda8fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

