### PR TITLE
Restore provider UAT evidence traceability

### DIFF
--- a/Docs/superpowers/qa/provider-cdp-uat/2026-06-16-provider-uat-traceability.md
+++ b/Docs/superpowers/qa/provider-cdp-uat/2026-06-16-provider-uat-traceability.md
@@ -1,0 +1,46 @@
+# Provider UAT Traceability Repair - 2026-06-16
+
+## Purpose
+
+This document repairs provider UAT traceability after the current `dev` branch was found to contain `TASK-84` Done notes that reference provider sweep evidence files which are missing from current dev.
+
+The missing historical files are:
+
+- `Docs/superpowers/qa/provider-cdp-uat/2026-05-31-provider-cdp-uat.md`
+- `Docs/superpowers/qa/provider-cdp-uat/provider-sweep-results.json`
+
+Those historical results are not reconstructed here. The original full sweep table and JSON cannot be recovered from the merged branch without an external artifact source, so this report records the current verified evidence boundary and the residual gap.
+
+## Current Verified Evidence
+
+PR #527 merged provider/Console UAT fixes into `dev`.
+
+Verified before PR #527 was merged:
+
+- Anthropic Console send completed through the rendered Textual-web app using the provider settings flow.
+- The selected model was `claude-haiku-4-5-20251001`.
+- The assistant response rendered visibly in Console.
+- The focused provider regression suite passed with 125 tests.
+- Post-rebase critical checks passed.
+- `git diff --check` passed.
+
+Transient screenshot evidence from that run was captured outside the repo at:
+
+- `/private/tmp/console-uat-anthropic-ui-response-2.png`
+
+Because that screenshot is outside the repository, it is not counted as durable repo-tracked evidence.
+
+## Residual Gap
+
+`TASK-84` claimed a full provider CDP UAT sweep attempted 11 hosted providers, with 7 passing and 4 classified as external/provider failures or timeouts. The current branch does not contain the referenced report or JSON evidence, so that exact historical claim remains unverifiable from repo contents alone.
+
+Required follow-up if full sweep evidence is needed again:
+
+1. Re-run the provider CDP UAT sweep from the current runtime inventory.
+2. Save the durable report and redacted JSON under `Docs/superpowers/qa/provider-cdp-uat/`.
+3. Ensure raw API keys are not present in markdown, JSON, terminal logs, or screenshots.
+4. Verify each report path referenced by Backlog task notes exists in the repository.
+
+## Acceptance Decision
+
+This file does not re-approve or replace the missing `TASK-84` full sweep. It only records the traceability defect, the currently available provider evidence, and the boundary for future QA.

--- a/Tests/QA/test_provider_uat_traceability.py
+++ b/Tests/QA/test_provider_uat_traceability.py
@@ -29,6 +29,7 @@ def test_provider_uat_traceability_report_exists_and_discloses_gap() -> None:
 
 
 def test_provider_uat_traceability_task_points_to_existing_report() -> None:
+    assert (REPO_ROOT / TASK_123).exists()
     task = _text(TASK_123)
 
     assert TRACEABILITY_REPORT.as_posix() in task

--- a/Tests/QA/test_provider_uat_traceability.py
+++ b/Tests/QA/test_provider_uat_traceability.py
@@ -1,0 +1,35 @@
+"""Provider UAT evidence traceability regressions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TRACEABILITY_REPORT = Path(
+    "Docs/superpowers/qa/provider-cdp-uat/2026-06-16-provider-uat-traceability.md"
+)
+TASK_123 = Path("backlog/tasks/task-123 - Restore-provider-UAT-evidence-traceability.md")
+
+
+def _text(path: Path) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def test_provider_uat_traceability_report_exists_and_discloses_gap() -> None:
+    report = REPO_ROOT / TRACEABILITY_REPORT
+
+    assert report.exists()
+
+    text = _text(TRACEABILITY_REPORT)
+    assert "TASK-84" in text
+    assert "missing from current dev" in text
+    assert "not reconstructed" in text
+    assert "PR #527" in text
+
+
+def test_provider_uat_traceability_task_points_to_existing_report() -> None:
+    task = _text(TASK_123)
+
+    assert TRACEABILITY_REPORT.as_posix() in task
+    assert (REPO_ROOT / TRACEABILITY_REPORT).exists()

--- a/backlog/tasks/task-123 - Restore-provider-UAT-evidence-traceability.md
+++ b/backlog/tasks/task-123 - Restore-provider-UAT-evidence-traceability.md
@@ -1,0 +1,49 @@
+---
+id: TASK-123
+title: Restore provider UAT evidence traceability
+status: Done
+assignee: []
+created_date: '2026-06-16 14:15'
+updated_date: '2026-06-16 14:20'
+labels:
+  - qa
+  - providers
+  - console
+  - cdp
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Repair provider UAT traceability after current dev lost the QA evidence files referenced by TASK-84, without fabricating historical sweep results.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Provider UAT traceability report exists in repo.
+- [x] #2 Report explicitly identifies missing historical evidence and current available verification.
+- [x] #3 Backlog task reference points at an existing evidence file.
+- [x] #4 Regression test fails if the provider UAT evidence file is missing.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+ADR path: N/A
+Reason: Documentation and QA traceability repair only; no storage, provider contract, runtime boundary, or long-lived architecture decision changes.
+
+1. Add a regression that checks the provider UAT evidence path referenced by the corrective task exists.
+2. Add a provider UAT traceability report that records the missing historical TASK-84 artifact, current known verification from PR #527, and residual follow-up boundaries.
+3. Update the corrective Backlog task with implementation notes and checked acceptance criteria.
+4. Run focused verification and diff checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added durable provider UAT traceability evidence at `Docs/superpowers/qa/provider-cdp-uat/2026-06-16-provider-uat-traceability.md`. The report documents that `TASK-84` references historical provider sweep artifacts missing from current `dev`, records the currently verifiable PR #527 provider evidence boundary, and avoids reconstructing unavailable full-sweep results.
+
+Added `Tests/QA/test_provider_uat_traceability.py` to keep the corrective task linked to an existing report and to fail if the report no longer discloses the missing `TASK-84` evidence gap.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary
- add durable provider UAT traceability evidence for the missing TASK-84 report/json paths
- document the current verifiable PR #527 provider evidence boundary without reconstructing unavailable historical sweep data
- add a regression that fails if the corrective provider UAT report or task reference disappears

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/QA/test_provider_uat_traceability.py --tb=short
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore provider UAT evidence traceability by adding a durable report that documents the TASK-84 gap and a regression test that guards both the report and the backlog link. Connects TASK-123 to a repo-tracked evidence path without recreating missing historical sweep data.

- **Bug Fixes**
  - Added `Docs/superpowers/qa/provider-cdp-uat/2026-06-16-provider-uat-traceability.md` recording the current evidence boundary, referencing PR #527, and disclosing missing historical files.
  - Added `Tests/QA/test_provider_uat_traceability.py` to fail if the report is removed, stops mentioning the TASK-84 gap and PR #527, or if `TASK-123` stops pointing to the report.
  - Added `backlog/tasks/task-123 - Restore-provider-UAT-evidence-traceability.md` linking to the report and defining acceptance criteria.

<sup>Written for commit 4e277c1213529b5613ca6f101f0853311d24ddf6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

