### PR TITLE
Fix Chatbook delete confirmation labels

### DIFF
--- a/Tests/UI/test_chatbook_action_recovery_tooltips.py
+++ b/Tests/UI/test_chatbook_action_recovery_tooltips.py
@@ -8,6 +8,7 @@ from textual.widgets import Button
 
 from tldw_chatbook.UI.ChatbookExportManagementWindow import ChatbookExportManagementWindow
 from tldw_chatbook.UI.ChatbookTemplatesWindow import ChatbookTemplatesWindow
+from tldw_chatbook.Widgets.confirmation_dialog import ConfirmationDialog
 
 
 def _assert_button_tooltips(root, expected_tooltips: dict[str, str]) -> None:
@@ -98,6 +99,41 @@ async def test_chatbook_export_toolbar_actions_explain_selected_pack_requirement
                 "open-location": "Open the selected Chatbook location.",
             },
         )
+
+
+@pytest.mark.asyncio
+async def test_chatbook_delete_selected_opens_confirmation_with_delete_labels(tmp_path):
+    class ManagementApp:
+        def __init__(self):
+            self.config_data = {}
+            self.notify = Mock()
+            self.pushed_screen = None
+            self.wait_for_dismiss = None
+
+        async def push_screen(self, screen, wait_for_dismiss=False):
+            self.pushed_screen = screen
+            self.wait_for_dismiss = wait_for_dismiss
+            return False
+
+    app = ManagementApp()
+    window = ChatbookExportManagementWindow(app)
+    window.chatbook_files = [
+        {
+            "name": "Research Pack",
+            "path": tmp_path / "Research Pack.chatbook.zip",
+            "size": 1024,
+            "created": datetime(2026, 4, 20, 9, 0),
+            "modified": datetime(2026, 4, 20, 9, 0),
+        }
+    ]
+    window.selected_chatbook = 0
+
+    await window._delete_selected()
+
+    assert isinstance(app.pushed_screen, ConfirmationDialog)
+    assert app.wait_for_dismiss is True
+    assert app.pushed_screen.confirm_label == "Delete"
+    assert app.pushed_screen.cancel_label == "Cancel"
 
 
 @pytest.mark.asyncio

--- a/backlog/tasks/task-104 - ChatbookExportManagementWindow-passes-wrong-kwargs-to-ConfirmationDialog.md
+++ b/backlog/tasks/task-104 - ChatbookExportManagementWindow-passes-wrong-kwargs-to-ConfirmationDialog.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-104
 title: ChatbookExportManagementWindow passes wrong kwargs to ConfirmationDialog
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-06-11 21:31'
+updated_date: '2026-06-17 19:12'
 labels: []
 dependencies: []
 ---
@@ -16,5 +17,30 @@ ChatbookExportManagementWindow.py:970 passes confirm_text/cancel_text but Confir
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Delete confirmation opens without TypeError,Labels render as intended
+- [x] #1 Delete confirmation opens without TypeError,Labels render as intended
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+ADR path: N/A
+Reason: bounded dialog parameter bugfix; no storage, service, security, or long-lived architecture decision.
+
+1. Add a focused UI regression that drives ChatbookExportManagementWindow._delete_selected() with a selected chatbook and captures the pushed ConfirmationDialog.
+2. Verify the regression fails on current dev because ConfirmationDialog receives unsupported confirm_text/cancel_text kwargs.
+3. Replace the incorrect kwargs with confirm_label/cancel_label only.
+4. Rerun the focused regression and related Chatbook UI tests.
+5. Update TASK-104 acceptance criteria and implementation notes.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Fixed the Chatbook export delete confirmation to pass `confirm_label` and `cancel_label`, matching `ConfirmationDialog`'s constructor. Added a regression test that exercises `_delete_selected()` with a selected exported Chatbook and verifies the dialog opens with the intended Delete/Cancel labels instead of raising a `TypeError`.
+
+Verification:
+- `python -m pytest -q Tests/UI/test_chatbook_action_recovery_tooltips.py::test_chatbook_delete_selected_opens_confirmation_with_delete_labels --tb=short`
+- `python -m pytest -q Tests/UI/test_chatbook_action_recovery_tooltips.py Tests/UI/test_chatbook_management_server_jobs.py --tb=short`
+- `git diff --check`
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/ChatbookExportManagementWindow.py
+++ b/tldw_chatbook/UI/ChatbookExportManagementWindow.py
@@ -970,8 +970,8 @@ class ChatbookExportManagementWindow(ModalScreen):
         dialog = ConfirmationDialog(
             title="Delete Chatbook",
             message=f"Are you sure you want to delete '{chatbook['name']}'?\n\nThis action cannot be undone.",
-            confirm_text="Delete",
-            cancel_text="Cancel"
+            confirm_label="Delete",
+            cancel_label="Cancel"
         )
         
         result = await self.app_instance.push_screen(dialog, wait_for_dismiss=True)


### PR DESCRIPTION
## Summary
- Fix Chatbook export delete confirmation to use ConfirmationDialog's confirm_label/cancel_label parameters.
- Add a regression that exercises _delete_selected() and verifies the Delete/Cancel labels are passed without TypeError.
- Close TASK-104 with ADR check, acceptance criterion, and implementation notes.

## Verification
- python -m pytest -q Tests/UI/test_chatbook_action_recovery_tooltips.py::test_chatbook_delete_selected_opens_confirmation_with_delete_labels --tb=short
- python -m pytest -q Tests/UI/test_chatbook_action_recovery_tooltips.py Tests/UI/test_chatbook_management_server_jobs.py --tb=short
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Chatbook export delete confirmation by using the correct dialog label props so the dialog opens and shows Delete/Cancel. Addresses TASK-104.

- **Bug Fixes**
  - Use `confirm_label`/`cancel_label` in `_delete_selected()` instead of the wrong kwargs.
  - Add an async regression test that verifies a `ConfirmationDialog` is pushed with Delete/Cancel and `wait_for_dismiss=True`.

<sup>Written for commit c32142e07e508903b2d879851e6a4ac44ccf0fbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

