### PR TITLE
Fix lazy web server dependency gate

### DIFF
--- a/Tests/Web_Server/test_web_server_dependency_gate.py
+++ b/Tests/Web_Server/test_web_server_dependency_gate.py
@@ -1,0 +1,111 @@
+from tldw_chatbook.Web_Server import serve
+
+
+def test_check_web_server_available_refreshes_lazy_dependency_state(monkeypatch):
+    """The web server gate must not trust the lazy default False cache.
+
+    Args:
+        monkeypatch: Pytest fixture for replacing dependency-gate state.
+    """
+    calls = []
+
+    def fake_check_web_server_deps() -> bool:
+        calls.append("checked")
+        serve.DEPENDENCIES_AVAILABLE["web"] = True
+        return True
+
+    monkeypatch.setitem(serve.DEPENDENCIES_AVAILABLE, "web", False)
+    monkeypatch.setattr(
+        serve,
+        "check_web_server_deps",
+        fake_check_web_server_deps,
+        raising=False,
+    )
+
+    assert serve.check_web_server_available() is True
+    assert calls == ["checked"]
+
+
+def test_check_web_server_available_handles_probe_exceptions(monkeypatch):
+    """The availability gate must fail closed when dependency probing crashes.
+
+    Args:
+        monkeypatch: Pytest fixture for replacing dependency-gate state.
+    """
+
+    def broken_check_web_server_deps() -> bool:
+        raise RuntimeError("broken optional dependency import")
+
+    monkeypatch.setitem(serve.DEPENDENCIES_AVAILABLE, "web", False)
+    monkeypatch.setitem(serve.DEPENDENCIES_AVAILABLE, "textual_serve", True)
+    monkeypatch.setattr(
+        serve,
+        "check_web_server_deps",
+        broken_check_web_server_deps,
+        raising=False,
+    )
+
+    assert serve.check_web_server_available() is False
+    assert serve.DEPENDENCIES_AVAILABLE["web"] is False
+    assert serve.DEPENDENCIES_AVAILABLE["textual_serve"] is False
+
+
+def test_main_cli_runner_serve_uses_web_dependency_gate(monkeypatch, tmp_path):
+    """The installed CLI serve flag must use the refreshed web dependency gate.
+
+    Args:
+        monkeypatch: Pytest fixture for replacing app startup dependencies.
+        tmp_path: Pytest fixture for creating isolated package/config files.
+    """
+    import atexit
+    import signal
+    import sys
+
+    from tldw_chatbook import app as app_module
+
+    package_root = tmp_path / "package"
+    css_dir = package_root / "css"
+    css_dir.mkdir(parents=True)
+    (css_dir / "tldw_cli_modular.tcss").write_text("", encoding="utf-8")
+    (css_dir / "build_css.py").write_text("", encoding="utf-8")
+
+    run_calls = []
+
+    def fake_run_web_server(**kwargs):
+        run_calls.append(kwargs)
+
+    monkeypatch.setattr(app_module, "__file__", str(package_root / "app.py"))
+    monkeypatch.setattr(app_module, "DEFAULT_CONFIG_PATH", tmp_path / "config.toml")
+    monkeypatch.setattr(app_module, "initialize_early_logging", lambda: object())
+    monkeypatch.setattr(app_module, "supports_emoji", lambda: False)
+    monkeypatch.setattr(app_module, "get_char", lambda _emoji, fallback: fallback)
+    monkeypatch.setattr(atexit, "register", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(signal, "signal", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(serve, "check_web_server_available", lambda: True)
+    monkeypatch.setattr(serve, "run_web_server", fake_run_web_server)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "tldw-cli",
+            "--serve",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "8941",
+            "--web-title",
+            "Test Title",
+            "--debug",
+        ],
+    )
+
+    app_module.main_cli_runner()
+
+    assert run_calls == [
+        {
+            "host": "127.0.0.1",
+            "port": 8941,
+            "title": "Test Title",
+            "debug": True,
+        }
+    ]

--- a/tldw_chatbook/Web_Server/serve.py
+++ b/tldw_chatbook/Web_Server/serve.py
@@ -14,7 +14,11 @@ from urllib.parse import urlparse, urlunparse
 from loguru import logger
 
 from ..Utils.input_validation import validate_number_range
-from ..Utils.optional_deps import DEPENDENCIES_AVAILABLE, require_dependency
+from ..Utils.optional_deps import (
+    DEPENDENCIES_AVAILABLE,
+    check_web_server_deps,
+    require_dependency,
+)
 from ..config import get_cli_setting
 
 
@@ -235,8 +239,22 @@ def build_chatbook_web_server_class(textual_serve_server_class: type) -> type:
 
 
 def check_web_server_available() -> bool:
-    """Check if web server dependencies are available."""
-    return DEPENDENCIES_AVAILABLE.get('web', False)
+    """Check if web server dependencies are available.
+
+    Returns:
+        True when textual-web dependencies are available, otherwise False.
+    """
+    if DEPENDENCIES_AVAILABLE.get('web', False):
+        return True
+    try:
+        return check_web_server_deps()
+    except Exception as exc:
+        logger.warning(
+            f"Web server dependency probe failed. Web mode is unavailable. Reason: {exc}"
+        )
+        DEPENDENCIES_AVAILABLE['web'] = False
+        DEPENDENCIES_AVAILABLE['textual_serve'] = False
+        return False
 
 
 def create_server(

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -7254,8 +7254,8 @@ def main_cli_runner():
     # If --serve flag is provided, run as web server
     if args.serve:
         # Check if web server dependencies are available
-        from .Utils.optional_deps import DEPENDENCIES_AVAILABLE
-        if not DEPENDENCIES_AVAILABLE.get('web', False):
+        from .Web_Server.serve import check_web_server_available, run_web_server
+        if not check_web_server_available():
             loguru_logger.error("\n" + "="*60)
             loguru_logger.error("Web server feature is not available!")
             loguru_logger.error("="*60)
@@ -7266,9 +7266,7 @@ def main_cli_runner():
             loguru_logger.error("  pip install -e \".[web]\"")
             loguru_logger.error("\n" + "="*60 + "\n")
             return
-        
-        from .Web_Server.serve import run_web_server
-        
+
         loguru_logger.info("Starting tldw_chatbook in web server mode")
         run_web_server(
             host=args.host,


### PR DESCRIPTION
## Summary
- refresh the lazy web dependency state before deciding web server availability
- route tldw-cli --serve through the same web-server availability helper
- add regressions for the lazy dependency gate and CLI serve delegation

## Verification
- python -m pytest -q Tests/Web_Server/test_web_server_dependency_gate.py Tests/Web_Server/test_textual_web_viewport.py --tb=short
- git diff --check
- manual: tldw-cli --serve --host 127.0.0.1 --port 8941 returned HTTP 200 without TLDW_EAGER_DEPENDENCY_CHECK

Stacked on PR #532 because origin/dev does not yet contain codex/bind-personas-start-chat-session.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the web server availability gate to refresh dependency state before deciding. Routes `tldw-cli --serve` through the same helper and fails closed on probe errors.

- **Bug Fixes**
  - `check_web_server_available` now re-checks via `check_web_server_deps` when the lazy cache is False and short-circuits if already True.
  - On probe exceptions, logs a warning and marks `DEPENDENCIES_AVAILABLE['web']` and `['textual_serve']` False to disable web mode safely.
  - CLI `--serve` now uses `tldw_chatbook.Web_Server.serve.check_web_server_available` and `run_web_server`; tests cover gate refresh, exception handling, and serve delegation.

<sup>Written for commit 66f5681596f360810cc9ebe7e69e64be4319735f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

