### PR TITLE
Add Console workspace creation click regression

### DIFF
--- a/Tests/UI/test_post_release_workspaces_library_depth.py
+++ b/Tests/UI/test_post_release_workspaces_library_depth.py
@@ -213,7 +213,7 @@ async def test_library_workspaces_create_local_workspace_mouse_clicks() -> None:
         screen = _active_destination_screen(host)
         await _wait_for_library_snapshot(screen, pilot)
 
-        screen.query_one("#library-mode-workspaces", Button).press()
+        await pilot.click("#library-mode-workspaces")
         await _wait_for_selector(screen, pilot, "#library-create-local-workspace")
 
         await pilot.click("#library-create-local-workspace")

--- a/Tests/UI/test_post_release_workspaces_library_depth.py
+++ b/Tests/UI/test_post_release_workspaces_library_depth.py
@@ -206,6 +206,7 @@ async def test_library_workspaces_can_create_and_select_local_workspace() -> Non
 
 @pytest.mark.asyncio
 async def test_library_workspaces_create_local_workspace_mouse_clicks() -> None:
+    """Verify mouse clicks can create and activate a local workspace."""
     app = _build_test_app()
     host = DestinationHarness(app, "library")
 

--- a/Tests/UI/test_post_release_workspaces_library_depth.py
+++ b/Tests/UI/test_post_release_workspaces_library_depth.py
@@ -205,6 +205,31 @@ async def test_library_workspaces_can_create_and_select_local_workspace() -> Non
 
 
 @pytest.mark.asyncio
+async def test_library_workspaces_create_local_workspace_mouse_clicks() -> None:
+    app = _build_test_app()
+    host = DestinationHarness(app, "library")
+
+    async with host.run_test(size=(140, 40)) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_library_snapshot(screen, pilot)
+
+        screen.query_one("#library-mode-workspaces", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-create-local-workspace")
+
+        await pilot.click("#library-create-local-workspace")
+        await _wait_for_selector(screen, pilot, "#library-workspaces-active-workspace")
+
+        active_workspace = app.workspace_registry_service.get_active_workspace()
+        assert active_workspace is not None
+        assert active_workspace.workspace_id == "workspace-local-1"
+        assert active_workspace.name == "Workspace 1"
+
+        visible = _visible_text(screen)
+        assert "Active workspace: Workspace 1" in visible
+        assert "Active workspace: Local Default" not in visible
+
+
+@pytest.mark.asyncio
 async def test_library_workspaces_create_skips_archived_local_workspace_identity() -> None:
     app = _build_test_app()
     service = app.workspace_registry_service


### PR DESCRIPTION
## Summary
- Adds a mounted regression covering mouse activation of Library > Workspaces > Create local workspace.
- Locks in the workspace creation path used during Console workspace switching UAT.
- Keeps runtime sync semantics unchanged: local registry remains authoritative and server sync remains WIP/unavailable.

## CDP evidence
- /private/tmp/console-uat-change-workspace-modal-2026-06-19.png
- /private/tmp/console-uat-workspace-switched-default-2026-06-19.png
- /private/tmp/console-uat-workspace-switched-workspace1-2026-06-19.png
- /private/tmp/console-uat-workspace1-new-conversation-2026-06-19.png
- /private/tmp/console-uat-workspace1-response-2026-06-19.png

## Test Plan
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_post_release_workspaces_library_depth.py Tests/UI/test_console_workspace_context_rail.py Tests/UI/test_console_native_chat_flow.py::test_console_workspace_rail_new_conversation_creates_default_workspace_session Tests/UI/test_console_native_chat_flow.py::test_console_send_after_workspace_switch_persists_to_selected_workspace Tests/UI/test_console_native_chat_flow.py::test_console_workspace_switch_refreshes_visible_session_tabs --tb=short
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a UI regression using mouse clicks to open Library > Workspaces and create a local workspace, verifying it becomes active. Clarifies the test intent and keeps the UAT flow unchanged: the local registry is authoritative and server sync remains WIP/unavailable.

<sup>Written for commit 9979368758c91eda44626089d9f6d0facd351034. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/539?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

