### PR TITLE
Fix Console regenerate continuation requests

### DIFF
--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -816,3 +816,35 @@ async def test_regenerate_message_streams_new_selected_variant():
     assert result.accepted is True
     assert updated.variants.current.content == "hello"
     assert updated.variants.can_go_previous is True
+
+
+@pytest.mark.asyncio
+async def test_regenerate_continuation_message_ends_provider_payload_with_user_instruction():
+    store = ConsoleChatStore()
+    gateway = RecordingStreamingGateway()
+    controller = ConsoleChatController(store=store, provider_gateway=gateway)
+    session = store.ensure_session()
+    store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content="Prompt",
+    )
+    store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="Seed",
+    )
+    continuation = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="Continuation",
+    )
+
+    result = await controller.regenerate_message(continuation.id)
+
+    assert result.accepted is True
+    assert gateway.messages_seen == [
+        {"role": "user", "content": "Prompt"},
+        {"role": "assistant", "content": "Seed"},
+        {"role": "user", "content": "Continue and extend the selected message."},
+    ]

--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -668,6 +668,40 @@ async def test_retry_failed_message_records_retrying_then_streaming_transition()
 
 
 @pytest.mark.asyncio
+async def test_retry_failed_continuation_message_ends_provider_payload_with_user_instruction():
+    store = ConsoleChatStore()
+    gateway = RecordingStreamingGateway()
+    controller = ConsoleChatController(store=store, provider_gateway=gateway)
+    session = store.ensure_session()
+    store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content="Prompt",
+    )
+    store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="Seed",
+    )
+    failed = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="",
+    )
+    store.append_stream_chunk(failed.id, "Partial continuation")
+    store.mark_message_failed(failed.id)
+
+    result = await controller.retry_message(failed.id)
+
+    assert result.accepted is True
+    assert gateway.messages_seen == [
+        {"role": "user", "content": "Prompt"},
+        {"role": "assistant", "content": "Seed"},
+        {"role": "user", "content": "Continue and extend the selected message."},
+    ]
+
+
+@pytest.mark.asyncio
 async def test_retry_keeps_failed_content_if_replacement_fails_before_first_chunk():
     store = ConsoleChatStore()
     controller = ConsoleChatController(store=store, provider_gateway=FailingStreamingGateway())

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -328,6 +328,10 @@ class ConsoleChatController:
             session_id,
             before_message_id=message_id,
         )
+        if provider_messages and provider_messages[-1].get("role") == ConsoleMessageRole.ASSISTANT.value:
+            provider_messages.append(
+                {"role": ConsoleMessageRole.USER.value, "content": CONSOLE_CONTINUE_INSTRUCTION}
+            )
         self._set_run_state(ConsoleRunState(ConsoleRunStatus.STREAMING, "Regenerating response."))
         chunks: list[str] = []
         try:

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -256,6 +256,7 @@ class ConsoleChatController:
             session_id,
             before_message_id=message_id,
         )
+        self._ensure_user_continuation_instruction(provider_messages)
         return await self._stream_assistant_response(
             resolution=resolution,
             provider_messages=provider_messages,
@@ -285,10 +286,7 @@ class ConsoleChatController:
             return self._block(session_id, visible_copy)
 
         provider_messages = self._provider_messages_through_message(session_id, message_id)
-        if provider_messages and provider_messages[-1].get("role") == ConsoleMessageRole.ASSISTANT.value:
-            provider_messages.append(
-                {"role": ConsoleMessageRole.USER.value, "content": CONSOLE_CONTINUE_INSTRUCTION}
-            )
+        self._ensure_user_continuation_instruction(provider_messages)
         assistant = self.store.append_message(
             session_id,
             role=ConsoleMessageRole.ASSISTANT,
@@ -328,10 +326,7 @@ class ConsoleChatController:
             session_id,
             before_message_id=message_id,
         )
-        if provider_messages and provider_messages[-1].get("role") == ConsoleMessageRole.ASSISTANT.value:
-            provider_messages.append(
-                {"role": ConsoleMessageRole.USER.value, "content": CONSOLE_CONTINUE_INSTRUCTION}
-            )
+        self._ensure_user_continuation_instruction(provider_messages)
         self._set_run_state(ConsoleRunState(ConsoleRunStatus.STREAMING, "Regenerating response."))
         chunks: list[str] = []
         try:
@@ -375,6 +370,18 @@ class ConsoleChatController:
             streaming=self.streaming,
             workspace_context=self.store.workspace_context,
         )
+
+    @staticmethod
+    def _ensure_user_continuation_instruction(
+        provider_messages: list[dict[str, str]],
+    ) -> None:
+        if (
+            provider_messages
+            and provider_messages[-1].get("role") == ConsoleMessageRole.ASSISTANT.value
+        ):
+            provider_messages.append(
+                {"role": ConsoleMessageRole.USER.value, "content": CONSOLE_CONTINUE_INSTRUCTION}
+            )
 
     @staticmethod
     def _validated_draft(draft: str) -> tuple[str, str | None]:


### PR DESCRIPTION
## Summary
- Fix Console regenerate request shaping when regenerating an assistant continuation whose previous transcript item is also assistant.
- Add a regression ensuring the provider payload ends with the internal continue instruction instead of an assistant message.

## Verification
- CDP/textual-web UAT against local llama.cpp at http://127.0.0.1:9099: regenerate completed without the previous 400 and displayed variant controls.
- python -m pytest -q Tests/Chat/test_console_chat_controller.py --tb=short
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Console retry and regenerate for assistant continuations. Ensures the provider payload ends with the internal continue user instruction to prevent 400s and restore variant controls.

- **Bug Fixes**
  - Append the user continue instruction when the last provider message is assistant for both regenerate and retry paths.
  - Added regression tests covering retry and regenerate to validate payload order and ending with the user instruction.

<sup>Written for commit 2ce09cf0aae6f1dfd820494637e87d637f77c506. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

