### PR TITLE
Add Console transcript switch regressions

### DIFF
--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -1791,6 +1791,95 @@ async def test_console_native_tab_strip_creates_and_switches_sessions():
 
 
 @pytest.mark.asyncio
+async def test_console_native_tab_switch_restores_transcript_messages():
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+        store = console._ensure_console_chat_store()
+        first = store.ensure_session(title="Chat 1")
+        store.append_message(
+            first.id,
+            role=ConsoleMessageRole.USER,
+            content="first tab user prompt",
+        )
+        store.append_message(
+            first.id,
+            role=ConsoleMessageRole.ASSISTANT,
+            content="first tab assistant reply",
+        )
+        await console._sync_native_console_chat_ui()
+        await _wait_for_text(console, pilot, "first tab assistant reply")
+
+        await pilot.click("#console-new-chat-tab")
+        second = store.active_session_id
+        assert second != first.id
+        await _wait_for_selector(console, pilot, f"#console-session-tab-{second}")
+        await _wait_for_text(console, pilot, "No messages yet.")
+        assert "first tab assistant reply" not in _visible_text(console)
+
+        await pilot.click(f"#console-session-tab-{first.id}")
+
+        assert store.active_session_id == first.id
+        await _wait_for_text(console, pilot, "first tab user prompt")
+        await _wait_for_text(console, pilot, "first tab assistant reply")
+
+
+@pytest.mark.asyncio
+async def test_console_workspace_conversation_switch_restores_transcript_messages():
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+        store = console._ensure_console_chat_store()
+        first = store.ensure_session(title="Chat 1")
+        store.append_message(
+            first.id,
+            role=ConsoleMessageRole.USER,
+            content="workspace row user prompt",
+        )
+        store.append_message(
+            first.id,
+            role=ConsoleMessageRole.ASSISTANT,
+            content="workspace row assistant reply",
+        )
+        await console._sync_native_console_chat_ui()
+        await _wait_for_text(console, pilot, "workspace row assistant reply")
+
+        await _wait_for_selector(console, pilot, "#console-new-workspace-conversation")
+        console.query_one("#console-new-workspace-conversation", Button).press()
+        for _ in range(20):
+            if store.active_session_id != first.id:
+                break
+            await pilot.pause(0.05)
+        second = store.active_session_id
+        assert second != first.id
+        await _wait_for_workspace_conversation_text(
+            console,
+            pilot,
+            "Chat 2",
+            selected=True,
+        )
+        await _wait_for_text(console, pilot, "No messages yet.")
+        assert "workspace row assistant reply" not in _visible_text(console)
+
+        await _click_console_workspace_conversation_for_session(
+            console,
+            pilot,
+            store,
+            first.id,
+        )
+
+        assert store.active_session_id == first.id
+        await _wait_for_text(console, pilot, "workspace row user prompt")
+        await _wait_for_text(console, pilot, "workspace row assistant reply")
+
+
+@pytest.mark.asyncio
 async def test_console_new_chat_tab_appears_in_workspace_conversation_rail():
     app = _build_test_app()
     service = app.workspace_registry_service

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -171,6 +171,43 @@ async def _wait_for_focus(app, pilot, widget, *, attempts: int = 40) -> None:
     )
 
 
+async def _wait_for_active_session_change(
+    store: ConsoleChatStore,
+    pilot,
+    previous_session_id: str | None,
+    *,
+    attempts: int = 40,
+) -> str:
+    """Wait for the Console store to activate a different session."""
+    for _ in range(attempts):
+        active_session_id = store.active_session_id
+        if active_session_id is not None and active_session_id != previous_session_id:
+            return active_session_id
+        await pilot.pause(0.05)
+    raise AssertionError(
+        "Console active session did not change. "
+        f"previous={previous_session_id!r}; active={store.active_session_id!r}"
+    )
+
+
+async def _wait_for_active_session(
+    store: ConsoleChatStore,
+    pilot,
+    expected_session_id: str,
+    *,
+    attempts: int = 40,
+) -> None:
+    """Wait for the Console store to activate the expected session."""
+    for _ in range(attempts):
+        if store.active_session_id == expected_session_id:
+            return
+        await pilot.pause(0.05)
+    raise AssertionError(
+        "Console active session did not match expected session. "
+        f"expected={expected_session_id!r}; active={store.active_session_id!r}"
+    )
+
+
 def _static_plain_text(widget: Static) -> str:
     renderable = widget.renderable
     return getattr(renderable, "plain", str(renderable))
@@ -1792,6 +1829,7 @@ async def test_console_native_tab_strip_creates_and_switches_sessions():
 
 @pytest.mark.asyncio
 async def test_console_native_tab_switch_restores_transcript_messages():
+    """Verify native tab switching restores the prior session transcript."""
     app = _build_test_app()
     host = ConsoleHarness(app)
 
@@ -1813,22 +1851,23 @@ async def test_console_native_tab_switch_restores_transcript_messages():
         await console._sync_native_console_chat_ui()
         await _wait_for_text(console, pilot, "first tab assistant reply")
 
+        previous = store.active_session_id
         await pilot.click("#console-new-chat-tab")
-        second = store.active_session_id
-        assert second != first.id
+        second = await _wait_for_active_session_change(store, pilot, previous)
         await _wait_for_selector(console, pilot, f"#console-session-tab-{second}")
         await _wait_for_text(console, pilot, "No messages yet.")
         assert "first tab assistant reply" not in _visible_text(console)
 
         await pilot.click(f"#console-session-tab-{first.id}")
 
-        assert store.active_session_id == first.id
+        await _wait_for_active_session(store, pilot, first.id)
         await _wait_for_text(console, pilot, "first tab user prompt")
         await _wait_for_text(console, pilot, "first tab assistant reply")
 
 
 @pytest.mark.asyncio
 async def test_console_workspace_conversation_switch_restores_transcript_messages():
+    """Verify workspace conversation switching restores the prior transcript."""
     app = _build_test_app()
     host = ConsoleHarness(app)
 
@@ -1851,12 +1890,9 @@ async def test_console_workspace_conversation_switch_restores_transcript_message
         await _wait_for_text(console, pilot, "workspace row assistant reply")
 
         await _wait_for_selector(console, pilot, "#console-new-workspace-conversation")
-        console.query_one("#console-new-workspace-conversation", Button).press()
-        for _ in range(20):
-            if store.active_session_id != first.id:
-                break
-            await pilot.pause(0.05)
-        second = store.active_session_id
+        previous = store.active_session_id
+        await pilot.click("#console-new-workspace-conversation")
+        second = await _wait_for_active_session_change(store, pilot, previous)
         assert second != first.id
         await _wait_for_workspace_conversation_text(
             console,
@@ -1874,7 +1910,7 @@ async def test_console_workspace_conversation_switch_restores_transcript_message
             first.id,
         )
 
-        assert store.active_session_id == first.id
+        await _wait_for_active_session(store, pilot, first.id)
         await _wait_for_text(console, pilot, "workspace row user prompt")
         await _wait_for_text(console, pilot, "workspace row assistant reply")
 


### PR DESCRIPTION
## Summary
- Add mounted Console regression coverage for restoring transcript messages when switching native chat tabs.
- Add mounted Console regression coverage for restoring transcript messages when switching via the workspace conversation rail.

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_console_native_chat_flow.py::test_console_native_tab_switch_restores_transcript_messages Tests/UI/test_console_native_chat_flow.py::test_console_workspace_conversation_switch_restores_transcript_messages Tests/UI/test_console_native_chat_flow.py::test_console_native_tab_strip_creates_and_switches_sessions Tests/UI/test_console_native_chat_flow.py::test_console_native_tab_strip_isolates_composer_drafts Tests/UI/test_console_native_chat_flow.py::test_console_native_active_tab_title_opens_rename_modal Tests/UI/test_console_native_chat_flow.py::test_console_native_tab_rename_escape_restores_existing_title --tb=short
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added UI regression tests to ensure the Console restores transcript messages when switching sessions via native chat tabs and the workspace conversation rail.

Hardened tests with explicit waits for active session changes and activation; new sessions assert “No messages yet.” and switching back re-renders the prior user and assistant messages.

<sup>Written for commit df54624fb6867e0d273451034c1b2d4a0cbfb5ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

