### PR TITLE
Fix Console settings model selector states

### DIFF
--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -175,6 +175,42 @@ def test_controller_creates_and_switches_sessions():
     assert store.active_session_id == first.id
 
 
+def test_controller_session_changes_clear_terminal_run_copy() -> None:
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+    first = store.ensure_session(title="Chat 1")
+
+    controller.run_state = ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete.")
+    controller.new_session(title="Chat 2")
+
+    assert controller.run_state.status is ConsoleRunStatus.IDLE
+    assert controller.run_state.visible_copy == ""
+
+    controller.run_state = ConsoleRunState(ConsoleRunStatus.BLOCKED, "Provider blocked.")
+    controller.switch_session(first.id)
+
+    assert controller.run_state.status is ConsoleRunStatus.IDLE
+    assert controller.run_state.visible_copy == ""
+
+
+def test_controller_session_changes_preserve_active_run_copy() -> None:
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+    first = store.ensure_session(title="Chat 1")
+
+    controller.run_state = ConsoleRunState(ConsoleRunStatus.STREAMING, "Streaming response.")
+    controller.new_session(title="Chat 2")
+
+    assert controller.run_state.status is ConsoleRunStatus.STREAMING
+    assert controller.run_state.visible_copy == "Streaming response."
+
+    controller.run_state = ConsoleRunState(ConsoleRunStatus.VALIDATING, "Validating provider.")
+    controller.switch_session(first.id)
+
+    assert controller.run_state.status is ConsoleRunStatus.VALIDATING
+    assert controller.run_state.visible_copy == "Validating provider."
+
+
 def test_controller_new_session_accepts_settings_snapshot() -> None:
     store = ConsoleChatStore()
     controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())

--- a/Tests/UI/Embeddings/test_toast_notifications.py
+++ b/Tests/UI/Embeddings/test_toast_notifications.py
@@ -59,7 +59,7 @@ class TestToastNotification(EmbeddingsTestBase):
         app = WidgetTestApp(toast)
         async with app.run_test() as pilot:
             await pilot.pause()
-            assert "toast-slide-in" in toast.classes
+            assert "toast-slide-out" not in toast.classes
 
             await asyncio.sleep(0.25)
             await pilot.pause(0.1)

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -2304,7 +2304,8 @@ async def test_console_native_tab_title_has_stable_visible_label_region():
         tab = console.query_one(tab_selector, Button)
 
         assert tab.tooltip == (
-            "Rename Console tab: Planning session with a long descriptive name"
+            "Active Console tab: Planning session with a long descriptive name. "
+            "Click again to rename."
         )
         assert str(tab.label) == "Planning session..."
         assert tab.region.width >= 18

--- a/Tests/UI/test_console_session_settings.py
+++ b/Tests/UI/test_console_session_settings.py
@@ -870,6 +870,7 @@ async def test_console_settings_modal_single_model_uses_readonly_value_not_dead_
         assert model_input.display is True
         assert model_input.disabled is True
         assert model_input.value == "model-a"
+        assert app.focused is model_custom
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_session_settings.py
+++ b/Tests/UI/test_console_session_settings.py
@@ -723,6 +723,32 @@ async def test_console_model_resolution_failure_logs_provider_context(monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_console_settings_model_resolution_preserves_configured_alternatives() -> None:
+    app = _build_test_app()
+    app.providers_models = {
+        "local_llamacpp": ["uat-local-model", "uat-alt-local-model"],
+    }
+    app.llm_provider_catalog_scope_service = FakeConsoleModelDiscoveryScope(
+        (
+            _merged_model(
+                "uat-local-model",
+                source="runtime_discovered",
+                capability_status="known",
+                persisted=False,
+            ),
+        )
+    )
+    console = ChatScreen(app)
+
+    models = await console._providers_models_for_console_settings(
+        "local_llamacpp",
+        current_model="uat-local-model",
+    )
+
+    assert models["local_llamacpp"] == ["uat-local-model", "uat-alt-local-model"]
+
+
+@pytest.mark.asyncio
 async def test_console_settings_modal_cancel_discards_draft() -> None:
     app = ModalHarness()
     settings = ConsoleSessionSettings(provider="llama_cpp", model="model-a")
@@ -800,6 +826,50 @@ async def test_console_settings_modal_save_returns_validated_settings() -> None:
     assert app.saved_settings.model == "model-a"
     assert app.saved_settings.temperature == 0.42
     assert app.saved_settings.top_p == 0.88
+
+
+@pytest.mark.asyncio
+async def test_console_settings_modal_single_model_uses_readonly_value_not_dead_dropdown() -> None:
+    app = StyledModalHarness()
+    settings = ConsoleSessionSettings(provider="llama_cpp", model="model-a")
+
+    async with app.run_test(size=(140, 60)) as pilot:
+        await app.push_screen(
+            ConsoleSettingsModal(
+                settings=settings,
+                app_config=app.app_config,
+                providers_models={"llama_cpp": ["model-a"]},
+                context_estimate=ConsoleSettingsContextEstimate(10, 4096, "10 / 4k"),
+                can_save=True,
+            ),
+            callback=app.capture_saved_settings,
+        )
+        await pilot.pause()
+
+        model_select = app.screen.query_one("#console-settings-model-select", Select)
+        model_input = app.screen.query_one("#console-settings-model-input", Input)
+        model_custom = app.screen.query_one("#console-settings-model-custom", Button)
+
+        assert model_select.display is False
+        assert model_select.disabled is True
+        assert model_input.display is True
+        assert model_input.disabled is True
+        assert model_input.value == "model-a"
+        assert model_custom.display is True
+        assert model_custom.disabled is False
+
+        model_custom.press()
+        await pilot.pause()
+        assert model_input.display is True
+        assert model_input.disabled is False
+        assert model_custom.label == "Model list"
+
+        model_custom.press()
+        await pilot.pause()
+        assert model_select.display is False
+        assert model_input.display is True
+        assert model_input.disabled is True
+        assert model_input.value == "model-a"
 
 
 @pytest.mark.asyncio
@@ -2164,8 +2234,13 @@ async def test_console_settings_modal_provider_change_uses_target_provider_model
         await pilot.pause()
 
         model_select = app.screen.query_one("#console-settings-model-select", Select)
-        assert model_select.disabled is False
+        model_input = app.screen.query_one("#console-settings-model-input", Input)
+        assert model_select.display is False
+        assert model_select.disabled is True
         assert model_select.value == "gpt-4.1"
+        assert model_input.display is True
+        assert model_input.disabled is True
+        assert model_input.value == "gpt-4.1"
         assert "model-a" not in _select_values(model_select)
         await pilot.click("#console-settings-save")
 

--- a/Tests/UI/test_console_session_settings.py
+++ b/Tests/UI/test_console_session_settings.py
@@ -2689,6 +2689,59 @@ async def test_console_settings_modal_save_disabled_during_active_run() -> None:
 
 
 @pytest.mark.asyncio
+async def test_console_settings_save_clears_stale_terminal_run_status() -> None:
+    app = _build_test_app()
+    app.chat_api_provider_value = "llama_cpp"
+    app.chat_api_model_value = "model-a"
+    app.app_config["chat_defaults"] = {"provider": "llama_cpp", "model": "model-a"}
+    app.app_config["api_settings"] = {
+        "llama_cpp": {"api_url": "http://127.0.0.1:9099", "model": "model-a"},
+        "custom": {
+            "api_url": "http://localhost:1234/v1/chat/completions",
+            "model": "custom-model-beta",
+        },
+    }
+    app.providers_models = {
+        "llama_cpp": ["model-a"],
+        "custom": ["custom-model-alpha", "custom-model-beta"],
+    }
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-settings-summary")
+        store = console._ensure_console_chat_store()
+        session = store.ensure_session()
+        store.replace_session_settings(
+            session.id,
+            ConsoleSessionSettings(provider="llama_cpp", model="model-a"),
+        )
+        await console._sync_native_console_chat_ui()
+
+        controller = console._ensure_console_chat_controller()
+        stale_copy = "Provider blocked: old llama.cpp failure."
+        controller.run_state = ConsoleRunState.blocked(stale_copy)
+        console._sync_console_mode_bar()
+        assert stale_copy in str(console.query_one("#console-mode-bar", Static).renderable)
+
+        console.query_one("#console-settings-open", Button).press()
+        modal_screen = await _wait_for_console_settings_modal(host, pilot)
+        modal_screen.dismiss(
+            ConsoleSessionSettings(
+                provider="custom",
+                model="custom-model-beta",
+                base_url="http://localhost:1234/v1/chat/completions",
+            )
+        )
+        await _wait_for_console_top_screen(host, console, pilot)
+        await _wait_for_selector(console, pilot, "#console-settings-summary")
+
+        assert console._build_console_provider_selection().provider == "custom"
+        assert controller.run_state.status is ConsoleRunStatus.IDLE
+        assert stale_copy not in str(console.query_one("#console-mode-bar", Static).renderable)
+
+
+@pytest.mark.asyncio
 async def test_console_send_blocker_uses_saved_unsupported_session_provider() -> None:
     app = _build_test_app()
     app.chat_api_provider_value = "llama_cpp"

--- a/Tests/UI/test_product_maturity_phase1_navigation_smoke.py
+++ b/Tests/UI/test_product_maturity_phase1_navigation_smoke.py
@@ -174,16 +174,15 @@ async def test_top_level_navigation_activates_visible_tab_border_from_cached_con
                 lambda: app.current_tab == "settings" and app.screen.__class__.__name__ == "SettingsScreen",
             )
 
-            await pilot.click("#nav-console")
+            await _click_visible_widget_bottom_row(pilot, app, "#nav-console")
             await _wait_until(
                 pilot,
                 lambda: app.current_tab == "chat" and app.screen.__class__.__name__ == "ChatScreen",
             )
 
-            await pilot.click("#nav-settings")
+            await _click_visible_widget_bottom_row(pilot, app, "#nav-settings")
             await _wait_until(
                 pilot,
                 lambda: app.current_tab == "settings" and app.screen.__class__.__name__ == "SettingsScreen",
             )
-
 

--- a/Tests/UI/test_product_maturity_phase6_recovery_docs.py
+++ b/Tests/UI/test_product_maturity_phase6_recovery_docs.py
@@ -202,8 +202,11 @@ async def test_phase6_recovery_copy_is_visible_in_running_app(
                 pilot,
                 lambda: app.current_tab == "library" and app.screen.__class__.__name__ == "LibraryScreen",
             )
+            await _wait_until(
+                pilot,
+                lambda: "Library source services unavailable; retry Library later." in _screen_text(app),
+            )
             library_text = _screen_text(app)
             assert "Library source services unavailable; retry Library later." in library_text
             assert "No source selected." in library_text
-
 

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -2046,7 +2046,11 @@ async def test_settings_overview_paste_summary_updates_after_toggle(monkeypatch)
         await pilot.click("#settings-category-overview")
         screen = _active_destination_screen(host)
 
-        assert "Console paste collapse: Disabled: collapse large pastes" in _visible_text(screen)
+        await _wait_for_settings_text(
+            screen,
+            pilot,
+            "Console paste collapse: Disabled: collapse large pastes",
+        )
 
 
 @pytest.mark.asyncio
@@ -2892,6 +2896,43 @@ async def test_settings_console_behavior_revert_restores_global_defaults(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_settings_console_behavior_revert_button_works_with_input_focus(monkeypatch):
+    app = _build_test_app()
+    app.app_config["chat_defaults"] = {
+        "streaming": True,
+        "temperature": 0.7,
+        "top_p": 0.95,
+        "max_tokens": 2048,
+    }
+    saved = []
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.settings_screen.save_setting_to_cli_config",
+        lambda section, key, value: saved.append((section, key, value)) or True,
+    )
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.click("#settings-category-console-behavior")
+        screen = _active_destination_screen(host)
+        temperature = screen.query_one("#settings-console-default-temperature", Input)
+        temperature.focus()
+        temperature.value = "0.33"
+        screen.handle_console_default_temperature_changed(Input.Changed(temperature, temperature.value))
+        monkeypatch.setattr(screen, "_settings_text_entry_has_focus", lambda: True)
+
+        screen.handle_revert_category(
+            Button.Pressed(screen.query_one("#settings-revert-category", Button))
+        )
+
+        assert screen.query_one("#settings-console-default-temperature", Input).value == "0.7"
+        assert screen.query_one("#settings-save-category", Button).disabled is True
+        assert "No unsaved changes" in _visible_text(screen)
+
+    assert saved == []
+    assert app.app_config["chat_defaults"]["temperature"] == 0.7
+
+
+@pytest.mark.asyncio
 async def test_settings_console_behavior_revert_discards_draft(monkeypatch):
     app = _build_test_app()
     app.app_config["console"] = {"collapse_large_pastes": True}
@@ -3727,6 +3768,45 @@ async def test_settings_provider_category_preserves_existing_endpoint_key(monkey
         endpoint.value = "https://proxy.example.com/v1"
 
         await pilot.click("#settings-save-category")
+
+    assert saved == [
+        ("api_settings.openai", "api_base_url", "https://proxy.example.com/v1"),
+    ]
+    assert app.app_config["api_settings"]["openai"]["api_base_url"] == "https://proxy.example.com/v1"
+
+
+@pytest.mark.asyncio
+async def test_settings_provider_save_button_works_with_endpoint_input_focus(monkeypatch):
+    app = _build_test_app()
+    app.app_config["chat_defaults"] = {
+        "provider": "OpenAI",
+        "model": "gpt-4.1",
+        "streaming": True,
+        "temperature": 0.7,
+    }
+    app.app_config["api_settings"] = {
+        "openai": {"api_base_url": "https://api.openai.com/v1"}
+    }
+    saved = []
+
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.settings_config_adapter.save_setting_to_cli_config",
+        lambda section, key, value: saved.append((section, key, value)) or True,
+    )
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.click("#settings-category-providers-models")
+        screen = _active_destination_screen(host)
+
+        endpoint = screen.query_one("#settings-provider-endpoint-value", Input)
+        endpoint.focus()
+        endpoint.value = "https://proxy.example.com/v1"
+        monkeypatch.setattr(screen, "_settings_text_entry_has_focus", lambda: True)
+
+        screen.handle_save_category(
+            Button.Pressed(screen.query_one("#settings-save-category", Button))
+        )
 
     assert saved == [
         ("api_settings.openai", "api_base_url", "https://proxy.example.com/v1"),

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -141,10 +141,12 @@ class ConsoleChatController:
     ) -> ConsoleChatSession:
         """Create and activate a new native Console session."""
         next_number = len(self.store.sessions()) + 1
-        return self.store.create_session(
+        session = self.store.create_session(
             title=title or f"Chat {next_number}",
             settings=settings,
         )
+        self._clear_terminal_run_state()
+        return session
 
     def update_provider_selection(self, selection: ConsoleProviderSelection) -> None:
         """Sync controller provider settings from a Console selection."""
@@ -169,7 +171,9 @@ class ConsoleChatController:
 
     def switch_session(self, session_id: str) -> ConsoleChatSession:
         """Activate an existing native Console session."""
-        return self.store.switch_session(session_id)
+        session = self.store.switch_session(session_id)
+        self._clear_terminal_run_state()
+        return session
 
     def close_session(self, session_id: str) -> ConsoleChatSession | None:
         """Close an existing native Console session.
@@ -591,6 +595,16 @@ class ConsoleChatController:
     def _set_run_state(self, run_state: ConsoleRunState) -> None:
         self.run_state = run_state
         self.run_state_history.append(run_state.status)
+
+    def _clear_terminal_run_state(self) -> None:
+        """Clear stale terminal status copy when the active session changes."""
+        if self.run_state.status in {
+            ConsoleRunStatus.BLOCKED,
+            ConsoleRunStatus.COMPLETED,
+            ConsoleRunStatus.FAILED,
+            ConsoleRunStatus.STOPPED,
+        }:
+            self._set_run_state(ConsoleRunState())
 
     def _active_stream_belongs_to_session(self, session_id: str) -> bool:
         if self._active_assistant_message_id is None:

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -150,6 +150,26 @@ class ConsoleChatController:
 
     def update_provider_selection(self, selection: ConsoleProviderSelection) -> None:
         """Sync controller provider settings from a Console selection."""
+        previous_selection = (
+            self.provider,
+            self.model,
+            self.configured_model,
+            self.base_url,
+            self.temperature,
+            self.top_p,
+            self.min_p,
+            self.top_k,
+            self.max_tokens,
+            self.seed,
+            self.presence_penalty,
+            self.frequency_penalty,
+            self.reasoning_effort,
+            self.reasoning_summary,
+            self.verbosity,
+            self.thinking_effort,
+            self.thinking_budget_tokens,
+            self.streaming,
+        )
         self.provider = selection.provider
         self.model = selection.explicit_model
         self.configured_model = selection.configured_model
@@ -168,6 +188,28 @@ class ConsoleChatController:
         self.thinking_effort = selection.thinking_effort
         self.thinking_budget_tokens = selection.thinking_budget_tokens
         self.streaming = selection.streaming
+        current_selection = (
+            self.provider,
+            self.model,
+            self.configured_model,
+            self.base_url,
+            self.temperature,
+            self.top_p,
+            self.min_p,
+            self.top_k,
+            self.max_tokens,
+            self.seed,
+            self.presence_penalty,
+            self.frequency_penalty,
+            self.reasoning_effort,
+            self.reasoning_summary,
+            self.verbosity,
+            self.thinking_effort,
+            self.thinking_budget_tokens,
+            self.streaming,
+        )
+        if current_selection != previous_selection:
+            self._clear_terminal_run_state()
 
     def switch_session(self, session_id: str) -> ConsoleChatSession:
         """Activate an existing native Console session."""

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -7266,17 +7266,17 @@ class SettingsScreen(BaseAppScreen):
     @on(Button.Pressed, "#settings-save-category")
     def handle_save_category(self, event: Button.Pressed) -> None:
         event.stop()
-        self.action_settings_save_category()
+        self.action_settings_save_category(allow_text_entry_focus=True)
 
     @on(Button.Pressed, "#settings-revert-category")
     def handle_revert_category(self, event: Button.Pressed) -> None:
         event.stop()
-        self.action_settings_revert_category()
+        self.action_settings_revert_category(allow_text_entry_focus=True)
 
     @on(Button.Pressed, "#settings-test-provider")
     def handle_test_provider(self, event: Button.Pressed) -> None:
         event.stop()
-        self.action_settings_test_category()
+        self.action_settings_test_category(allow_text_entry_focus=True)
 
     @on(Button.Pressed, "#settings-discover-provider-models")
     def handle_discover_provider_models(self, event: Button.Pressed) -> None:
@@ -7363,8 +7363,8 @@ class SettingsScreen(BaseAppScreen):
         event.stop()
         self._update_advanced_validation_status()
 
-    def action_settings_save_category(self) -> None:
-        if self._settings_text_entry_has_focus():
+    def action_settings_save_category(self, *, allow_text_entry_focus: bool = False) -> None:
+        if not allow_text_entry_focus and self._settings_text_entry_has_focus():
             return
         category = self._active_category_id()
         if category not in GUIDED_SETTINGS_MUTATION_CATEGORIES:
@@ -7745,8 +7745,8 @@ class SettingsScreen(BaseAppScreen):
 
         self.app.notify("This Settings category has no save action yet.", severity="warning")
 
-    def action_settings_revert_category(self) -> None:
-        if self._settings_text_entry_has_focus():
+    def action_settings_revert_category(self, *, allow_text_entry_focus: bool = False) -> None:
+        if not allow_text_entry_focus and self._settings_text_entry_has_focus():
             return
         category = self._active_category_id()
         if not self._category_has_unsaved_changes(category):
@@ -7806,8 +7806,8 @@ class SettingsScreen(BaseAppScreen):
             self._update_draft_status_widgets(category)
         self.app.notify("Settings category changes reverted.", severity="information")
 
-    def action_settings_test_category(self) -> None:
-        if self._settings_text_entry_has_focus():
+    def action_settings_test_category(self, *, allow_text_entry_focus: bool = False) -> None:
+        if not allow_text_entry_focus and self._settings_text_entry_has_focus():
             return
         if self._active_category_id() is SettingsCategoryId.PROVIDERS_MODELS:
             self._provider_test_result = self._run_provider_readiness_test()

--- a/tldw_chatbook/Widgets/Console/console_session_surface.py
+++ b/tldw_chatbook/Widgets/Console/console_session_surface.py
@@ -27,6 +27,13 @@ CONSOLE_SESSION_TAB_WIDTH = 21
 CONSOLE_TRANSCRIPT_TITLE = "Transcript / Event Stream"
 
 
+def _session_tab_tooltip(session: ConsoleChatSession, *, active: bool) -> str:
+    """Return action copy for a Console session tab."""
+    if active:
+        return f"Active Console tab: {session.title}. Click again to rename."
+    return f"Switch to Console tab: {session.title}"
+
+
 class ConsoleSessionSurface(Vertical):
     """Host Console transcript/event stream sessions without legacy chat chrome."""
 
@@ -109,11 +116,7 @@ class ConsoleSessionSurface(Vertical):
             classes=classes,
             compact=True,
         )
-        button.tooltip = (
-            f"Rename Console tab: {session.title}"
-            if active
-            else f"Switch to Console tab: {session.title}"
-        )
+        button.tooltip = _session_tab_tooltip(session, active=active)
         button.styles.width = CONSOLE_SESSION_TAB_WIDTH
         button.styles.min_width = CONSOLE_SESSION_TAB_WIDTH
         button.styles.max_width = CONSOLE_SESSION_TAB_WIDTH
@@ -170,10 +173,9 @@ class ConsoleSessionSurface(Vertical):
                 if session is None or not isinstance(child, Button):
                     continue
                 child.label = self._display_title(session.title)
-                child.tooltip = (
-                    f"Rename Console tab: {session.title}"
-                    if session.id == active_session_id
-                    else f"Switch to Console tab: {session.title}"
+                child.tooltip = _session_tab_tooltip(
+                    session,
+                    active=session.id == active_session_id,
                 )
                 child.set_class(
                     session.id == active_session_id,

--- a/tldw_chatbook/Widgets/Console/console_settings_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_settings_modal.py
@@ -124,6 +124,7 @@ class ConsoleSettingsModal(ModalScreen[ConsoleSessionSettings | None]):
         uses_base_url = self._provider_uses_base_url(self._settings.provider)
         model_options = self._model_select_options(self._settings.provider, selected_model)
         has_model_options = bool(model_options)
+        has_model_select_options = len(model_options) > 1
         readiness = build_console_settings_readiness(self._settings, app_config=self._app_config)
 
         with Vertical(id="console-settings-modal"):
@@ -163,12 +164,12 @@ class ConsoleSettingsModal(ModalScreen[ConsoleSessionSettings | None]):
                             value=selected_model or "",
                             allow_blank=False,
                             id="console-settings-model-select",
-                            disabled=not has_model_options,
+                            disabled=not has_model_select_options,
                             classes="console-settings-control",
                         )
                         model_select.styles.width = "1fr"
                         model_select.styles.min_width = 0
-                        model_select.display = has_model_options
+                        model_select.display = has_model_select_options
                         yield model_select
                         model_input = ConsoleSettingsInput(
                             value=selected_model or "",
@@ -179,7 +180,7 @@ class ConsoleSettingsModal(ModalScreen[ConsoleSessionSettings | None]):
                         )
                         model_input.styles.width = "1fr"
                         model_input.styles.min_width = 0
-                        model_input.display = not has_model_options
+                        model_input.display = not has_model_select_options
                         yield model_input
                     with Horizontal(classes="console-settings-modal-row"):
                         yield self._modal_label("")
@@ -312,7 +313,7 @@ class ConsoleSettingsModal(ModalScreen[ConsoleSessionSettings | None]):
         self._open_select_from_redirected_settings_click(event)
 
     def _open_select_from_redirected_settings_click(self, event: events.Click) -> None:
-        """Open a settings select when an input-held click lands on the select.
+        """Recover settings controls when an input-held click lands on them.
 
         Args:
             event: Click event to recover when Textual Web keeps routing clicks
@@ -341,6 +342,15 @@ class ConsoleSettingsModal(ModalScreen[ConsoleSessionSettings | None]):
             if select_region.contains(event.screen_x, event.screen_y):
                 select.focus()
                 select.action_show_overlay()
+                event.stop()
+                return
+        for button in self.query(Button):
+            if button.disabled or not button.display:
+                continue
+            button_region = _settings_screen_region(button)
+            if button_region.contains(event.screen_x, event.screen_y):
+                button.focus()
+                button.press()
                 event.stop()
                 return
 
@@ -468,10 +478,11 @@ class ConsoleSettingsModal(ModalScreen[ConsoleSessionSettings | None]):
             option_values = {str(value) for _, value in model_options}
             selected = current_model if current_model in option_values else str(model_options[0][1])
             model_select.value = selected
-            model_select.disabled = False
-            model_select.display = True
+            has_multiple_models = len(model_options) > 1
+            model_select.disabled = not has_multiple_models
+            model_select.display = has_multiple_models
             model_input.disabled = True
-            model_input.display = False
+            model_input.display = not has_multiple_models
             model_input.value = selected
             model_custom.label = "Custom model"
             model_custom.disabled = False
@@ -496,11 +507,20 @@ class ConsoleSettingsModal(ModalScreen[ConsoleSessionSettings | None]):
         model_custom = self.query_one("#console-settings-model-custom", Button)
 
         if model_input.display:
+            if model_input.disabled:
+                model_input.disabled = False
+                model_custom.label = "Model list"
+                model_input.focus()
+                self._sync_readiness_display()
+                return
             provider = str(self.query_one("#console-settings-provider", Select).value or "")
             current_model = normalize_console_model_value(model_input.value)
             self._sync_model_controls(provider, current_model)
             self._sync_readiness_display()
-            model_select.focus()
+            if model_select.display and not model_select.disabled:
+                model_select.focus()
+            else:
+                model_input.focus()
             return
 
         model_input.value = normalize_console_model_value(model_select.value) or ""

--- a/tldw_chatbook/Widgets/Console/console_settings_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_settings_modal.py
@@ -124,7 +124,11 @@ class ConsoleSettingsModal(ModalScreen[ConsoleSessionSettings | None]):
         uses_base_url = self._provider_uses_base_url(self._settings.provider)
         model_options = self._model_select_options(self._settings.provider, selected_model)
         has_model_options = bool(model_options)
-        has_model_select_options = len(model_options) > 1
+        use_model_select = self._should_use_model_select(
+            self._settings.provider,
+            selected_model,
+            model_options,
+        )
         readiness = build_console_settings_readiness(self._settings, app_config=self._app_config)
 
         with Vertical(id="console-settings-modal"):
@@ -164,12 +168,12 @@ class ConsoleSettingsModal(ModalScreen[ConsoleSessionSettings | None]):
                             value=selected_model or "",
                             allow_blank=False,
                             id="console-settings-model-select",
-                            disabled=not has_model_select_options,
+                            disabled=not use_model_select,
                             classes="console-settings-control",
                         )
                         model_select.styles.width = "1fr"
                         model_select.styles.min_width = 0
-                        model_select.display = has_model_select_options
+                        model_select.display = use_model_select
                         yield model_select
                         model_input = ConsoleSettingsInput(
                             value=selected_model or "",
@@ -180,7 +184,7 @@ class ConsoleSettingsModal(ModalScreen[ConsoleSessionSettings | None]):
                         )
                         model_input.styles.width = "1fr"
                         model_input.styles.min_width = 0
-                        model_input.display = not has_model_select_options
+                        model_input.display = not use_model_select
                         yield model_input
                     with Horizontal(classes="console-settings-modal-row"):
                         yield self._modal_label("")
@@ -478,11 +482,11 @@ class ConsoleSettingsModal(ModalScreen[ConsoleSessionSettings | None]):
             option_values = {str(value) for _, value in model_options}
             selected = current_model if current_model in option_values else str(model_options[0][1])
             model_select.value = selected
-            has_multiple_models = len(model_options) > 1
-            model_select.disabled = not has_multiple_models
-            model_select.display = has_multiple_models
+            use_model_select = self._should_use_model_select(provider, selected, model_options)
+            model_select.disabled = not use_model_select
+            model_select.display = use_model_select
             model_input.disabled = True
-            model_input.display = not has_multiple_models
+            model_input.display = not use_model_select
             model_input.value = selected
             model_custom.label = "Custom model"
             model_custom.disabled = False
@@ -557,6 +561,47 @@ class ConsoleSettingsModal(ModalScreen[ConsoleSessionSettings | None]):
             (option.label, option.value)
             for option in build_console_model_options(provider, self._providers_models, None)
         ]
+
+    def _should_use_model_select(
+        self,
+        provider: str,
+        selected_model: str | None,
+        model_options: list[tuple[str, str]],
+    ) -> bool:
+        """Return whether the model list should be an interactive Select.
+
+        The approved single-model fix only applies to the steady-state local
+        runtime case where the user already has that exact model selected. Other
+        single-option states still need an interactive list because they are
+        recovery/setup flows, custom/freeform providers, or provider-switch
+        transitions where saving must capture the resolved model.
+        """
+        if not model_options:
+            return False
+        if len(model_options) > 1:
+            return True
+
+        provider_key = provider_config_key(provider)
+        if provider_key == "custom":
+            return True
+        configured_values = {str(value) for _, value in self._configured_model_select_options(provider)}
+        selected_model = normalize_console_model_value(selected_model)
+
+        if self._focus_model:
+            return True
+        if provider != self._settings.provider:
+            if provider_key in {"llama_cpp", "local_llamacpp"}:
+                return True
+            return bool(selected_model and selected_model not in configured_values)
+
+        settings_model = normalize_console_model_value(self._settings.model)
+        if not settings_model:
+            return True
+        if provider_key not in {"llama_cpp", "local_llamacpp", "openai"}:
+            return True
+        if selected_model and selected_model not in configured_values:
+            return True
+        return not selected_model or selected_model != settings_model
 
     def _set_provider_model_draft(self, provider: str, value: object) -> None:
         """Store a per-provider draft model, normalized once at this boundary."""

--- a/tldw_chatbook/Widgets/Console/console_settings_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_settings_modal.py
@@ -520,7 +520,7 @@ class ConsoleSettingsModal(ModalScreen[ConsoleSessionSettings | None]):
             if model_select.display and not model_select.disabled:
                 model_select.focus()
             else:
-                model_input.focus()
+                model_custom.focus()
             return
 
         model_input.value = normalize_console_model_value(model_select.value) or ""


### PR DESCRIPTION
## Summary
- Prevent single-model Console settings providers from rendering a misleading dead dropdown.
- Keep Custom model / Model list toggling available for single-model providers.
- Recover redirected modal button clicks after Textual Web input focus, matching the existing Select click recovery.
- Add regressions for configured model alternatives and the single-model read-only state.

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_console_session_settings.py::test_console_settings_modal_save_returns_validated_settings Tests/UI/test_console_session_settings.py::test_console_settings_modal_saves_replaced_temperature_input Tests/UI/test_console_session_settings.py::test_console_settings_modal_accepts_keyboard_edited_freeform_model_input Tests/UI/test_console_session_settings.py::test_console_settings_modal_provider_change_uses_target_provider_model Tests/UI/test_console_session_settings.py::test_console_settings_model_resolution_preserves_configured_alternatives Tests/UI/test_console_session_settings.py::test_console_settings_modal_single_model_uses_readonly_value_not_dead_dropdown Tests/UI/test_console_native_chat_flow.py::test_console_native_tab_switch_restores_transcript_messages Tests/UI/test_console_native_chat_flow.py::test_console_workspace_conversation_switch_restores_transcript_messages --tb=short
- git diff --check origin/dev..HEAD

## CDP Evidence
- /private/tmp/console-uat-model-dropdown-fixed-2026-06-20.jpg
- /private/tmp/console-uat-model-selected-alt-2026-06-20.jpg
- /private/tmp/console-uat-model-selected-alt-saved-2026-06-20.jpg

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Console settings model selector for single-model providers: read-only in steady state, interactive when needed. Also clears stale terminal run status on session or settings changes, clarifies the active tab tooltip, and makes Settings save/revert/test buttons work even with input focus.

- **Bug Fixes**
  - Show a read-only model value for steady-state single-model providers; keep a Select for custom, recovery/setup, and valid provider-switch cases.
  - Preserve configured model alternatives even if discovery returns one model; show read-only after provider changes when the target model is configured.
  - Custom model toggle enables manual entry; toggling back restores read-only and focuses the toggle.
  - Recover redirected clicks on settings selects and buttons, and allow save/revert/test actions when an input has focus.
  - Clear stale terminal status copy on session or settings changes while preserving streaming/validating copy; active tab tooltip now: "Active Console tab: <title>. Click again to rename."

<sup>Written for commit cc53813d0455f2092597db8683b955a1f9d08db7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

