### PR TITLE
Add local skill trust integrity controls

### DIFF
--- a/Docs/superpowers/plans/2026-06-25-local-skill-trust-integrity.md
+++ b/Docs/superpowers/plans/2026-06-25-local-skill-trust-integrity.md
@@ -22,14 +22,28 @@ ADR path: `backlog/decisions/009-local-skill-trust-boundary.md`
 
 Reason: This changes a security boundary, trust root, local storage semantics, runtime policy IDs, and the `LocalSkillsService` contract. ADR-009 is already accepted and must remain linked from the task and implementation notes.
 
+## Pre-Execution Review Corrections
+
+These corrections are mandatory and supersede any lower-level code snippet that appears to conflict:
+
+1. Production rollback protection must use a secure OS keyring-backed generation marker store. File-backed marker storage is allowed only for tests or an explicit reduced-rollback-protection mode, and that mode must be reflected in Settings posture.
+2. A manifest with a missing, unavailable, stale, or mismatched marker is a global `quarantined_manifest_error`/`rollback_marker_unavailable` state. It must not be accepted as trusted.
+3. `status_for_skill()` and list/context paths must not raise just because trust is locked or the manifest is unverifiable. They must return visible blocked trust status. `ensure_skill_trusted()` is the use-time raise path.
+4. Chatbook-approved create/update/import flows may rebaseline only after explicit approval text. Out-of-band file writes remain the tamper signal and must quarantine.
+5. Review approval uses canonical JSON digests of captured fingerprints, not Python `str(...)`, before updating the baseline.
+6. Skills UI recovery actions must be functional, not only rendered: bootstrap, unlock/retry, review diff, and trust reviewed version must call the trust service through app-owned handlers and refresh state.
+7. `SkillTrustService` must expose Settings posture fields used by the UI: `overall_status()`, `keyring_convenience_enabled`, and `reduced_rollback_protection`.
+8. Production unlock must persist and load a non-secret KDF salt from trust metadata. Tests may inject deterministic salts, but app/bootstrap flows must not require callers to remember a salt.
+9. Optional keyring convenience must store derived trust material or a wrapped trust root in a secure keyring, never the passphrase, and must be disabled by default until the user explicitly enables it.
+
 ## File Structure
 
 - Create `tldw_chatbook/Skills_Interop/skill_trust_models.py`: trust status constants, reason codes, dataclasses, and `SkillTrustBlockedError`.
 - Create `tldw_chatbook/Skills_Interop/skill_trust_crypto.py`: key derivation, canonical JSON, HMAC, AES-GCM encryption/decryption, and hash helpers.
 - Create `tldw_chatbook/Skills_Interop/skill_trust_scanner.py`: deterministic skill-directory scanning, file fingerprinting, unsafe path detection, text snapshot capture.
-- Create `tldw_chatbook/Skills_Interop/skill_trust_store.py`: manifest/snapshot persistence, secure generation marker protocol, keyring convenience helpers, authenticated audit records.
-- Create `tldw_chatbook/Skills_Interop/skill_trust_service.py`: bootstrap, unlock, status classification, review capture, approval, key rotation, and use-time enforcement.
-- Modify `tldw_chatbook/Skills_Interop/local_skills_service.py`: inject trust service, add trust fields to list/detail/context responses, block execution when trust fails, and atomically re-trust explicit Chatbook mutations.
+- Create `tldw_chatbook/Skills_Interop/skill_trust_store.py`: manifest/snapshot persistence, secure keyring generation marker store, explicit reduced-protection file marker for tests/recovery, keyring convenience helpers, authenticated audit records.
+- Create `tldw_chatbook/Skills_Interop/skill_trust_service.py`: bootstrap, unlock, status classification, review capture, approval, key rotation, Settings posture, and use-time enforcement.
+- Modify `tldw_chatbook/Skills_Interop/local_skills_service.py`: inject trust service, add trust fields to list/detail/context responses, block execution when trust fails, and atomically re-trust only explicitly approved Chatbook mutations.
 - Modify `tldw_chatbook/Skills_Interop/skills_scope_service.py`: preserve trust fields during local response normalization. Recovery actions use `app.local_skill_trust_service` directly in v1.
 - Modify `tldw_chatbook/Skills_Interop/__init__.py`: export trust service/types.
 - Modify `tldw_chatbook/runtime_policy/registry.py`: add local `skills.trust.*.local` policy actions.
@@ -659,8 +673,29 @@ import pytest
 from tldw_chatbook.Skills_Interop.skill_trust_crypto import derive_skill_trust_keys
 from tldw_chatbook.Skills_Interop.skill_trust_store import (
     FileSkillTrustGenerationMarkerStore,
+    KeyringSkillTrustKeyCache,
+    KeyringSkillTrustGenerationMarkerStore,
+    SkillTrustMarkerUnavailable,
     SkillTrustStore,
 )
+
+
+class FakeSecureKeyring:
+    __module__ = "keyring.backends.macOS"
+    priority = 1
+
+    def __init__(self):
+        self.values = {}
+
+    def get_password(self, service_name, username):
+        return self.values.get((service_name, username))
+
+    def set_password(self, service_name, username, password):
+        self.values[(service_name, username)] = password
+
+
+class FakePlaintextKeyring(FakeSecureKeyring):
+    __module__ = "keyring.backends.file"
 
 
 def test_trust_store_round_trips_manifest_snapshot_and_marker(tmp_path):
@@ -681,7 +716,7 @@ def test_trust_store_round_trips_manifest_snapshot_and_marker(tmp_path):
         "audit": [],
     }
 
-    store.save_manifest(manifest, keys)
+    store.save_manifest(manifest, keys, salt=b"3" * 32)
     store.save_snapshot("demo-1", {"files": {"SKILL.md": "# Demo"}}, keys, generation=1)
 
     loaded = store.load_manifest(keys)
@@ -689,6 +724,7 @@ def test_trust_store_round_trips_manifest_snapshot_and_marker(tmp_path):
 
     assert loaded["generation"] == 1
     assert snapshot == {"files": {"SKILL.md": "# Demo"}}
+    assert store.load_salt() == b"3" * 32
     assert marker.load_marker() == {"generation": 1, "manifest_digest": store.manifest_digest(loaded)}
 
 
@@ -697,7 +733,7 @@ def test_trust_store_rejects_tampered_manifest(tmp_path):
     marker = FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json")
     store = SkillTrustStore(store_dir=tmp_path / "trust", marker_store=marker)
 
-    store.save_manifest({"version": 1, "generation": 1, "skills": {}, "audit": []}, keys)
+    store.save_manifest({"version": 1, "generation": 1, "skills": {}, "audit": []}, keys, salt=b"4" * 32)
     payload = json.loads((tmp_path / "trust" / "skill_trust_manifest.json").read_text(encoding="utf-8"))
     payload["manifest"]["generation"] = 2
     (tmp_path / "trust" / "skill_trust_manifest.json").write_text(json.dumps(payload), encoding="utf-8")
@@ -711,11 +747,49 @@ def test_trust_store_rejects_marker_mismatch(tmp_path):
     marker = FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json")
     store = SkillTrustStore(store_dir=tmp_path / "trust", marker_store=marker)
 
-    store.save_manifest({"version": 1, "generation": 3, "skills": {}, "audit": []}, keys)
+    store.save_manifest({"version": 1, "generation": 3, "skills": {}, "audit": []}, keys, salt=b"5" * 32)
     marker.save_marker(generation=2, manifest_digest="old")
 
     with pytest.raises(ValueError, match="manifest generation marker mismatch"):
         store.load_manifest(keys)
+
+
+def test_trust_store_rejects_missing_marker_after_manifest_exists(tmp_path):
+    keys = derive_skill_trust_keys("passphrase", salt=b"5" * 32)
+    marker_path = tmp_path / "marker.json"
+    marker = FileSkillTrustGenerationMarkerStore(marker_path)
+    store = SkillTrustStore(store_dir=tmp_path / "trust", marker_store=marker)
+
+    store.save_manifest({"version": 1, "generation": 1, "skills": {}, "audit": []}, keys, salt=b"5" * 32)
+    marker_path.unlink()
+
+    with pytest.raises(ValueError, match="manifest generation marker mismatch"):
+        store.load_manifest(keys)
+
+
+def test_keyring_generation_marker_store_round_trips_with_secure_backend():
+    marker = KeyringSkillTrustGenerationMarkerStore(keyring_backend=FakeSecureKeyring())
+
+    marker.save_marker(generation=3, manifest_digest="digest")
+
+    assert marker.load_marker() == {"generation": 3, "manifest_digest": "digest"}
+
+
+def test_keyring_generation_marker_store_rejects_insecure_backend():
+    with pytest.raises(SkillTrustMarkerUnavailable, match="secure OS-backed"):
+        KeyringSkillTrustGenerationMarkerStore(keyring_backend=FakePlaintextKeyring())
+
+
+def test_keyring_key_cache_round_trips_without_storing_passphrase():
+    fake = FakeSecureKeyring()
+    keys = derive_skill_trust_keys("passphrase", salt=b"8" * 32)
+    cache = KeyringSkillTrustKeyCache(keyring_backend=fake)
+
+    cache.save_keys(keys)
+    loaded = cache.load_keys()
+
+    assert loaded == keys
+    assert "passphrase" not in "\n".join(fake.values.values())
 ```
 
 - [ ] **Step 2: Run store tests to verify they fail**
@@ -737,16 +811,26 @@ Create `tldw_chatbook/Skills_Interop/skill_trust_store.py` with these public met
 
 from __future__ import annotations
 
+import base64
 import json
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
 
+from ..runtime_policy.server_credentials import is_secure_keyring_backend
 from .skill_trust_crypto import canonical_json, decrypt_json_blob, encrypt_json_blob, manifest_mac, sha256_hex
 
 
 _MANIFEST_FILENAME = "skill_trust_manifest.json"
 _SNAPSHOTS_DIRNAME = "snapshots"
+_DEFAULT_MARKER_SERVICE_NAME = "tldw_chatbook.skill_trust"
+_DEFAULT_KEY_CACHE_SERVICE_NAME = "tldw_chatbook.skill_trust.keys"
+_MARKER_USERNAME = "local-skills:generation-marker:v1"
+_KEY_CACHE_USERNAME = "local-skills:trust-root:v1"
+
+
+class SkillTrustMarkerUnavailable(RuntimeError):
+    reason_code = "rollback_marker_unavailable"
 
 
 class SkillTrustGenerationMarkerStore(Protocol):
@@ -756,6 +840,8 @@ class SkillTrustGenerationMarkerStore(Protocol):
 
 @dataclass(slots=True)
 class FileSkillTrustGenerationMarkerStore:
+    """Reduced-protection/test marker store. Do not use for default production wiring."""
+
     marker_path: Path
 
     def load_marker(self) -> dict[str, Any] | None:
@@ -772,6 +858,107 @@ class FileSkillTrustGenerationMarkerStore:
             encoding="utf-8",
         )
         temp_path.replace(self.marker_path)
+
+
+class UnavailableSkillTrustGenerationMarkerStore:
+    def __init__(self, message: str) -> None:
+        self.message = message
+
+    def _raise_unavailable(self) -> None:
+        raise SkillTrustMarkerUnavailable(self.message)
+
+    def load_marker(self) -> dict[str, Any] | None:
+        self._raise_unavailable()
+
+    def save_marker(self, *, generation: int, manifest_digest: str) -> None:
+        self._raise_unavailable()
+
+
+@dataclass(slots=True)
+class KeyringSkillTrustGenerationMarkerStore:
+    service_name: str = _DEFAULT_MARKER_SERVICE_NAME
+    keyring_backend: Any | None = None
+
+    def __post_init__(self) -> None:
+        keyring_backend = self.keyring_backend
+        if keyring_backend is None:
+            import keyring
+
+            keyring_backend = keyring.get_keyring()
+        get_keyring = getattr(keyring_backend, "get_keyring", None)
+        if callable(get_keyring):
+            keyring_backend = get_keyring()
+        if not is_secure_keyring_backend(keyring_backend):
+            raise SkillTrustMarkerUnavailable("No secure OS-backed generation marker store is available.")
+        self.keyring_backend = keyring_backend
+
+    def load_marker(self) -> dict[str, Any] | None:
+        payload = self.keyring_backend.get_password(self.service_name, _MARKER_USERNAME)
+        if not payload:
+            return None
+        marker = json.loads(payload)
+        return marker if isinstance(marker, dict) else None
+
+    def save_marker(self, *, generation: int, manifest_digest: str) -> None:
+        payload = json.dumps({"generation": generation, "manifest_digest": manifest_digest}, sort_keys=True)
+        self.keyring_backend.set_password(self.service_name, _MARKER_USERNAME, payload)
+
+
+def build_default_skill_trust_marker_store(keyring_backend: Any | None = None) -> SkillTrustGenerationMarkerStore:
+    try:
+        return KeyringSkillTrustGenerationMarkerStore(keyring_backend=keyring_backend)
+    except SkillTrustMarkerUnavailable as exc:
+        return UnavailableSkillTrustGenerationMarkerStore(str(exc))
+
+
+@dataclass(slots=True)
+class KeyringSkillTrustKeyCache:
+    service_name: str = _DEFAULT_KEY_CACHE_SERVICE_NAME
+    keyring_backend: Any | None = None
+
+    def __post_init__(self) -> None:
+        keyring_backend = self.keyring_backend
+        if keyring_backend is None:
+            import keyring
+
+            keyring_backend = keyring.get_keyring()
+        get_keyring = getattr(keyring_backend, "get_keyring", None)
+        if callable(get_keyring):
+            keyring_backend = get_keyring()
+        if not is_secure_keyring_backend(keyring_backend):
+            raise SkillTrustMarkerUnavailable("No secure OS-backed key cache is available.")
+        self.keyring_backend = keyring_backend
+
+    def save_keys(self, keys: Any) -> None:
+        payload = {
+            "version": 1,
+            "manifest_mac_key": base64.b64encode(keys.manifest_mac_key).decode("ascii"),
+            "snapshot_key": base64.b64encode(keys.snapshot_key).decode("ascii"),
+            "audit_mac_key": base64.b64encode(keys.audit_mac_key).decode("ascii"),
+            "wrapped_root_key": base64.b64encode(keys.wrapped_root_key).decode("ascii"),
+        }
+        self.keyring_backend.set_password(self.service_name, _KEY_CACHE_USERNAME, json.dumps(payload, sort_keys=True))
+
+    def load_keys(self) -> Any | None:
+        from .skill_trust_crypto import SkillTrustKeys
+
+        payload = self.keyring_backend.get_password(self.service_name, _KEY_CACHE_USERNAME)
+        if not payload:
+            return None
+        data = json.loads(payload)
+        return SkillTrustKeys(
+            manifest_mac_key=base64.b64decode(data["manifest_mac_key"]),
+            snapshot_key=base64.b64decode(data["snapshot_key"]),
+            audit_mac_key=base64.b64decode(data["audit_mac_key"]),
+            wrapped_root_key=base64.b64decode(data["wrapped_root_key"]),
+        )
+
+
+def build_default_skill_trust_key_cache(keyring_backend: Any | None = None) -> KeyringSkillTrustKeyCache | None:
+    try:
+        return KeyringSkillTrustKeyCache(keyring_backend=keyring_backend)
+    except SkillTrustMarkerUnavailable:
+        return None
 
 
 @dataclass(slots=True)
@@ -793,6 +980,16 @@ class SkillTrustStore:
     def manifest_digest(self, manifest: dict[str, Any]) -> str:
         return sha256_hex(canonical_json(manifest))
 
+    def load_salt(self) -> bytes:
+        payload = json.loads(self.manifest_path.read_text(encoding="utf-8"))
+        encoded = payload.get("kdf_salt")
+        if not isinstance(encoded, str):
+            raise ValueError("skill trust salt missing")
+        salt = base64.b64decode(encoded.encode("ascii"))
+        if len(salt) != 32:
+            raise ValueError("skill trust salt invalid")
+        return salt
+
     def load_manifest(self, keys: Any) -> dict[str, Any]:
         payload = json.loads(self.manifest_path.read_text(encoding="utf-8"))
         manifest = payload.get("manifest")
@@ -803,16 +1000,22 @@ class SkillTrustStore:
             raise ValueError("manifest authentication failed")
         marker = self.marker_store.load_marker()
         digest = self.manifest_digest(manifest)
-        if marker is not None:
-            if int(marker.get("generation", -1)) != int(manifest.get("generation", -2)):
-                raise ValueError("manifest generation marker mismatch")
-            if marker.get("manifest_digest") != digest:
-                raise ValueError("manifest generation marker mismatch")
+        if marker is None:
+            raise ValueError("manifest generation marker mismatch")
+        if int(marker.get("generation", -1)) != int(manifest.get("generation", -2)):
+            raise ValueError("manifest generation marker mismatch")
+        if marker.get("manifest_digest") != digest:
+            raise ValueError("manifest generation marker mismatch")
         return manifest
 
-    def save_manifest(self, manifest: dict[str, Any], keys: Any) -> None:
+    def save_manifest(self, manifest: dict[str, Any], keys: Any, *, salt: bytes | None = None) -> None:
         self.store_dir.mkdir(parents=True, exist_ok=True)
+        if salt is None:
+            salt = self.load_salt()
+        if len(salt) != 32:
+            raise ValueError("skill trust salt invalid")
         payload = {
+            "kdf_salt": base64.b64encode(salt).decode("ascii"),
             "manifest": manifest,
             "mac": manifest_mac(manifest, keys.manifest_mac_key),
         }
@@ -921,6 +1124,38 @@ def test_bootstrap_trusts_current_files_and_detects_modification(tmp_path):
         service.ensure_skill_trusted("demo")
 
 
+def test_existing_manifest_without_unlock_reports_locked_status(tmp_path):
+    service, skills_dir = _service(tmp_path)
+    (skills_dir / "demo").mkdir(parents=True)
+    (skills_dir / "demo" / "SKILL.md").write_text("# Demo\n", encoding="utf-8")
+    service.bootstrap_trust()
+
+    locked_service = SkillTrustService(
+        skills_dir=skills_dir,
+        trust_store=SkillTrustStore(
+            store_dir=tmp_path / "trust",
+            marker_store=FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json"),
+        ),
+    )
+    status = locked_service.status_for_skill("demo")
+
+    assert status.trust_status == "trust_locked"
+    assert status.trust_blocked is True
+
+
+def test_missing_marker_reports_global_manifest_error(tmp_path):
+    service, skills_dir = _service(tmp_path)
+    (skills_dir / "demo").mkdir(parents=True)
+    (skills_dir / "demo" / "SKILL.md").write_text("# Demo\n", encoding="utf-8")
+    service.bootstrap_trust()
+    (tmp_path / "marker.json").unlink()
+
+    status = service.status_for_skill("demo")
+
+    assert status.trust_status == "quarantined_manifest_error"
+    assert status.trust_blocked is True
+
+
 def test_review_approval_requires_live_files_to_match_reviewed_snapshot(tmp_path):
     service, skills_dir = _service(tmp_path)
     (skills_dir / "demo").mkdir(parents=True)
@@ -973,24 +1208,30 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from .skill_trust_crypto import derive_skill_trust_keys, sha256_hex
+from .skill_trust_crypto import canonical_json, derive_skill_trust_keys, sha256_hex
 from .skill_trust_models import (
     SkillDirectorySnapshot,
     SkillTrustBlockedError,
     SkillTrustStatus,
+    TRUST_REASON_MANIFEST_INVALID,
+    TRUST_REASON_ROLLBACK_MARKER_UNAVAILABLE,
     TRUST_REASON_SKILL_ADDED,
     TRUST_REASON_SKILL_DELETED,
     TRUST_REASON_SKILL_MODIFIED,
+    TRUST_REASON_TRUST_LOCKED,
     TRUST_REASON_TRUST_UNINITIALIZED,
     TRUST_REASON_UNSUPPORTED_PATH,
     TRUST_STATUS_QUARANTINED_ADDED,
     TRUST_STATUS_QUARANTINED_DELETED,
+    TRUST_STATUS_QUARANTINED_MANIFEST_ERROR,
     TRUST_STATUS_QUARANTINED_MODIFIED,
     TRUST_STATUS_QUARANTINED_UNSUPPORTED_PATH,
     TRUST_STATUS_TRUSTED,
+    TRUST_STATUS_LOCKED,
     TRUST_STATUS_UNINITIALIZED,
 )
 from .skill_trust_scanner import scan_skill_directory
+from .skill_trust_store import SkillTrustMarkerUnavailable
 
 
 def _now_iso() -> str:
@@ -998,14 +1239,46 @@ def _now_iso() -> str:
 
 
 class SkillTrustService:
-    def __init__(self, *, skills_dir: Path, trust_store: Any) -> None:
+    def __init__(
+        self,
+        *,
+        skills_dir: Path,
+        trust_store: Any,
+        key_cache: Any | None = None,
+        keyring_convenience_enabled: bool = False,
+        reduced_rollback_protection: bool = False,
+    ) -> None:
         self.skills_dir = skills_dir
         self.trust_store = trust_store
+        self.key_cache = key_cache
+        self.keyring_convenience_enabled = keyring_convenience_enabled
+        self.reduced_rollback_protection = reduced_rollback_protection
         self._keys: Any | None = None
+        self._salt: bytes | None = None
         self._reviews: dict[str, dict[str, Any]] = {}
 
-    def unlock_with_passphrase(self, passphrase: str, *, salt: bytes) -> None:
+    def unlock_with_passphrase(self, passphrase: str, *, salt: bytes | None = None) -> None:
+        if salt is None:
+            salt = self.trust_store.load_salt()
         self._keys = derive_skill_trust_keys(passphrase, salt=salt)
+        self._salt = salt
+
+    def enable_keyring_convenience(self) -> None:
+        if self.key_cache is None:
+            raise SkillTrustMarkerUnavailable("No secure OS-backed key cache is available.")
+        self.key_cache.save_keys(self._require_keys())
+        self.keyring_convenience_enabled = True
+
+    def unlock_from_keyring_convenience(self) -> bool:
+        if self.key_cache is None:
+            return False
+        keys = self.key_cache.load_keys()
+        if keys is None:
+            return False
+        self._keys = keys
+        self._salt = self.trust_store.load_salt()
+        self.keyring_convenience_enabled = True
+        return True
 
     def _require_keys(self) -> Any:
         if self._keys is None:
@@ -1016,6 +1289,11 @@ class SkillTrustService:
             )
         return self._keys
 
+    def _require_salt(self) -> bytes:
+        if self._salt is None:
+            raise ValueError("skill trust salt missing")
+        return self._salt
+
     def _empty_manifest(self) -> dict[str, Any]:
         return {"version": 1, "generation": 0, "skills": {}, "audit": []}
 
@@ -1024,14 +1302,42 @@ class SkillTrustService:
             return None
         return self.trust_store.load_manifest(self._require_keys())
 
-    def bootstrap_trust(self) -> None:
+    def _locked_status(self, skill_name: str) -> SkillTrustStatus:
+        return SkillTrustStatus(skill_name, TRUST_STATUS_LOCKED, TRUST_REASON_TRUST_LOCKED, True, (), None, _now_iso())
+
+    def _manifest_error_status(self, skill_name: str, reason_code: str) -> SkillTrustStatus:
+        return SkillTrustStatus(skill_name, TRUST_STATUS_QUARANTINED_MANIFEST_ERROR, reason_code, True, (), None, _now_iso())
+
+    def _fingerprints_digest(self, snapshot: SkillDirectorySnapshot) -> str:
+        entries = [item.as_manifest_entry() for item in snapshot.fingerprints]
+        return sha256_hex(canonical_json(entries))
+
+    def overall_status(self) -> str:
+        if not self.trust_store.has_manifest():
+            return TRUST_STATUS_UNINITIALIZED
+        if self._keys is None:
+            return TRUST_STATUS_LOCKED
+        try:
+            self.trust_store.load_manifest(self._keys)
+        except SkillTrustMarkerUnavailable:
+            return TRUST_STATUS_QUARANTINED_MANIFEST_ERROR
+        except ValueError:
+            return TRUST_STATUS_QUARANTINED_MANIFEST_ERROR
+        return TRUST_STATUS_TRUSTED
+
+    def bootstrap_trust(self, passphrase: str | None = None, *, salt: bytes | None = None) -> None:
+        if passphrase is not None:
+            self.unlock_with_passphrase(passphrase, salt=salt or secrets.token_bytes(32))
         keys = self._require_keys()
+        manifest_salt = self._require_salt()
         skills: dict[str, Any] = {}
         generation = 1
         for skill_dir in sorted(self.skills_dir.iterdir(), key=lambda item: item.name) if self.skills_dir.exists() else []:
             if not skill_dir.is_dir():
                 continue
             snapshot = scan_skill_directory(skill_dir.name, skill_dir)
+            if snapshot.unsupported_paths:
+                raise ValueError("unsupported_path")
             snapshot_id = f"{skill_dir.name}-{generation}"
             self.trust_store.save_snapshot(
                 snapshot_id,
@@ -1050,12 +1356,19 @@ class SkillTrustService:
             "skills": skills,
             "audit": [{"event": "trust_bootstrap", "at": _now_iso(), "skill_count": len(skills)}],
         }
-        self.trust_store.save_manifest(manifest, keys)
+        self.trust_store.save_manifest(manifest, keys, salt=manifest_salt)
 
     def status_for_skill(self, skill_name: str) -> SkillTrustStatus:
-        manifest = self._load_manifest_or_uninitialized()
-        if manifest is None:
+        if not self.trust_store.has_manifest():
             return SkillTrustStatus(skill_name, TRUST_STATUS_UNINITIALIZED, TRUST_REASON_TRUST_UNINITIALIZED, True, (), None, None)
+        if self._keys is None:
+            return self._locked_status(skill_name)
+        try:
+            manifest = self.trust_store.load_manifest(self._keys)
+        except SkillTrustMarkerUnavailable:
+            return self._manifest_error_status(skill_name, TRUST_REASON_ROLLBACK_MARKER_UNAVAILABLE)
+        except ValueError:
+            return self._manifest_error_status(skill_name, TRUST_REASON_MANIFEST_INVALID)
         skill_dir = self.skills_dir / skill_name
         current = scan_skill_directory(skill_name, skill_dir)
         if current.unsupported_paths:
@@ -1098,7 +1411,7 @@ class SkillTrustService:
         review = {
             "review_id": review_id,
             "skill_name": skill_name,
-            "current_digest": sha256_hex(str([item.as_manifest_entry() for item in current.fingerprints]).encode("utf-8")),
+            "current_digest": self._fingerprints_digest(current),
             "current_files": current.text_files,
             "changed_files": list(status.changed_files),
         }
@@ -1109,12 +1422,24 @@ class SkillTrustService:
         review = self._reviews[review_id]
         skill_name = review["skill_name"]
         current = scan_skill_directory(skill_name, self.skills_dir / skill_name)
-        current_digest = sha256_hex(str([item.as_manifest_entry() for item in current.fingerprints]).encode("utf-8"))
+        current_digest = self._fingerprints_digest(current)
         if current_digest != review["current_digest"]:
             raise ValueError("snapshot_mismatch")
+        self.trust_current_skill(skill_name, audit_event="trust_approved", snapshot=current)
+
+    def trust_current_skill(
+        self,
+        skill_name: str,
+        *,
+        audit_event: str = "trust_chatbook_mutation",
+        snapshot: SkillDirectorySnapshot | None = None,
+    ) -> None:
         keys = self._require_keys()
         manifest = self.trust_store.load_manifest(keys)
         generation = int(manifest["generation"]) + 1
+        current = snapshot or scan_skill_directory(skill_name, self.skills_dir / skill_name)
+        if current.unsupported_paths:
+            raise ValueError("unsupported_path")
         snapshot_id = f"{skill_name}-{generation}"
         self.trust_store.save_snapshot(snapshot_id, {"files": current.text_files}, keys, generation=generation)
         manifest["generation"] = generation
@@ -1123,7 +1448,7 @@ class SkillTrustService:
             "snapshot_id": snapshot_id,
             "trusted_at": _now_iso(),
         }
-        manifest.setdefault("audit", []).append({"event": "trust_approved", "at": _now_iso(), "skill_name": skill_name})
+        manifest.setdefault("audit", []).append({"event": audit_event, "at": _now_iso(), "skill_name": skill_name})
         self.trust_store.save_manifest(manifest, keys)
 ```
 
@@ -1195,14 +1520,26 @@ async def test_local_skills_service_exposes_trust_state_and_blocks_uninitialized
 
 
 @pytest.mark.asyncio
-async def test_local_skills_service_blocks_execute_when_skill_changes_after_bootstrap(tmp_path):
+async def test_local_skills_service_blocks_execute_when_skill_changes_on_disk_after_bootstrap(tmp_path):
     service, trust = _trusted_local_service(tmp_path)
     await service.create_skill(name="demo-skill", content="# Demo\nRender {{args}}")
     trust.bootstrap_trust()
-    await service.update_skill("demo-skill", content="# Demo\nChanged {{args}}")
+    (tmp_path / "skills" / "demo-skill" / "SKILL.md").write_text("# Demo\nChanged {{args}}", encoding="utf-8")
 
     with pytest.raises(SkillTrustBlockedError, match="skill_modified"):
         await service.execute_skill("demo-skill", args="x")
+
+
+@pytest.mark.asyncio
+async def test_local_skills_service_retrusts_explicitly_approved_update(tmp_path):
+    service, trust = _trusted_local_service(tmp_path)
+    await service.create_skill(name="demo-skill", content="# Demo\nRender {{args}}")
+    trust.bootstrap_trust()
+
+    await service.update_skill("demo-skill", content="# Demo\nChanged {{args}}", trust_approved=True)
+
+    listed = await service.list_skills()
+    assert listed["skills"][0]["trust_status"] == "trusted"
 ```
 
 - [ ] **Step 2: Run failing local service trust tests**
@@ -1210,7 +1547,7 @@ async def test_local_skills_service_blocks_execute_when_skill_changes_after_boot
 Run:
 
 ```bash
-.venv/bin/python -m pytest -q Tests/Skills/test_local_skills_service.py::test_local_skills_service_exposes_trust_state_and_blocks_uninitialized_context Tests/Skills/test_local_skills_service.py::test_local_skills_service_blocks_execute_when_skill_changes_after_bootstrap --tb=short
+.venv/bin/python -m pytest -q Tests/Skills/test_local_skills_service.py::test_local_skills_service_exposes_trust_state_and_blocks_uninitialized_context Tests/Skills/test_local_skills_service.py::test_local_skills_service_blocks_execute_when_skill_changes_on_disk_after_bootstrap Tests/Skills/test_local_skills_service.py::test_local_skills_service_retrusts_explicitly_approved_update --tb=short
 ```
 
 Expected: fail because `LocalSkillsService` does not accept `trust_service`.
@@ -1253,6 +1590,10 @@ Add helpers near `_summary_for_record`:
     def _require_trusted_skill(self, skill_name: str) -> None:
         if self.trust_service is not None:
             self.trust_service.ensure_skill_trusted(skill_name)
+
+    def _trust_after_approved_mutation(self, skill_name: str, *, trust_approved: bool) -> None:
+        if self.trust_service is not None and trust_approved:
+            self.trust_service.trust_current_skill(skill_name, audit_event="trust_chatbook_mutation")
 ```
 
 Update `_response_for_record()` and `_summary_for_record()` call sites so trust fields are merged into detail/list dictionaries:
@@ -1303,17 +1644,27 @@ At the start of `execute_skill()`, add:
         self._require_trusted_skill(skill_name)
 ```
 
-- [ ] **Step 5: Run local service trust tests**
+- [ ] **Step 5: Rebaseline only explicitly approved Chatbook mutations**
+
+Add a keyword-only `trust_approved: bool = False` argument to `create_skill()`, `update_skill()`, `import_skill()`, and `import_skill_file()`. After the skill file, supporting files, and index entry are written successfully, call:
+
+```python
+            self._trust_after_approved_mutation(skill_name, trust_approved=trust_approved)
+```
+
+The UI layer must pass `trust_approved=True` only from Save/Import confirmations that explicitly say the trusted baseline will be updated. Direct filesystem writes, background sync, or API calls without that flag must remain quarantined as added/modified/deleted.
+
+- [ ] **Step 6: Run local service trust tests**
 
 Run:
 
 ```bash
-.venv/bin/python -m pytest -q Tests/Skills/test_local_skills_service.py::test_local_skills_service_exposes_trust_state_and_blocks_uninitialized_context Tests/Skills/test_local_skills_service.py::test_local_skills_service_blocks_execute_when_skill_changes_after_bootstrap --tb=short
+.venv/bin/python -m pytest -q Tests/Skills/test_local_skills_service.py::test_local_skills_service_exposes_trust_state_and_blocks_uninitialized_context Tests/Skills/test_local_skills_service.py::test_local_skills_service_blocks_execute_when_skill_changes_on_disk_after_bootstrap Tests/Skills/test_local_skills_service.py::test_local_skills_service_retrusts_explicitly_approved_update --tb=short
 ```
 
 Expected: pass.
 
-- [ ] **Step 6: Run full local skills tests**
+- [ ] **Step 7: Run full local skills tests**
 
 Run:
 
@@ -1321,9 +1672,9 @@ Run:
 .venv/bin/python -m pytest -q Tests/Skills/test_local_skills_service.py Tests/Skills/test_skills_scope_service.py --tb=short
 ```
 
-Expected: pass. Legacy tests that instantiate `LocalSkillsService` without `trust_service` continue to use the explicit no-trust-service compatibility path.
+Expected: pass. Legacy tests that instantiate `LocalSkillsService` without `trust_service` continue to use the explicit no-trust-service compatibility path, but app wiring tests must prove production constructs a real trust service.
 
-- [ ] **Step 7: Commit local service integration**
+- [ ] **Step 8: Commit local service integration**
 
 Run:
 
@@ -1365,7 +1716,11 @@ Near the existing `LocalSkillsService` construction, import:
 
 ```python
 from .Skills_Interop.skill_trust_service import SkillTrustService
-from .Skills_Interop.skill_trust_store import FileSkillTrustGenerationMarkerStore, SkillTrustStore
+from .Skills_Interop.skill_trust_store import (
+    SkillTrustStore,
+    build_default_skill_trust_key_cache,
+    build_default_skill_trust_marker_store,
+)
 ```
 
 Replace the local skills construction with:
@@ -1376,10 +1731,11 @@ Replace the local skills construction with:
             skills_dir=local_skills_store_dir / "skills",
             trust_store=SkillTrustStore(
                 store_dir=local_skills_store_dir / "trust",
-                marker_store=FileSkillTrustGenerationMarkerStore(
-                    local_skills_store_dir / "trust_generation_marker.json",
-                ),
+                marker_store=build_default_skill_trust_marker_store(),
             ),
+            key_cache=build_default_skill_trust_key_cache(),
+            keyring_convenience_enabled=False,
+            reduced_rollback_protection=False,
         )
         self.local_skills_service = LocalSkillsService(
             store_dir=local_skills_store_dir,
@@ -1417,7 +1773,7 @@ Expected: commit succeeds.
 
 - [ ] **Step 1: Add failing Skills UI trust-state tests**
 
-Append to the Skills destination tests:
+Add `from unittest.mock import AsyncMock` near the other imports if it is not already present, then append to the Skills destination tests:
 
 ```python
 @pytest.mark.asyncio
@@ -1478,6 +1834,89 @@ async def test_skills_destination_shows_uninitialized_bootstrap_action():
 
         assert "Trust: not initialized" in text
         assert screen.query_one("#skills-bootstrap-trust", Button).disabled is False
+
+
+@pytest.mark.asyncio
+async def test_skills_destination_bootstrap_action_calls_trust_service():
+    app = _build_test_app()
+    app.local_skill_trust_service = RecordingSkillTrustService()
+    app.skills_scope_service = StaticSkillsScopeService(
+        [
+            {
+                "name": "new-skill",
+                "description": "New local skill",
+                "record_id": "local:skill:new-skill",
+                "validation_status": "valid",
+                "validation_errors": [],
+                "trust_status": "trust_uninitialized",
+                "trust_reason_code": "trust_uninitialized",
+                "trust_blocked": True,
+            },
+        ]
+    )
+    host = DestinationHarness(app, "skills")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_skills_snapshot(screen, pilot)
+        screen._request_skill_trust_passphrase = AsyncMock(return_value="passphrase")
+        await pilot.click("#skills-bootstrap-trust")
+
+        assert app.local_skill_trust_service.bootstrap_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_skills_destination_review_action_enables_trust_reviewed_version():
+    app = _build_test_app()
+    app.local_skill_trust_service = RecordingSkillTrustService(review_id="review-1")
+    app.skills_scope_service = StaticSkillsScopeService(
+        [
+            {
+                "name": "summarize-notes",
+                "description": "Summarize note collections",
+                "record_id": "local:skill:summarize-notes",
+                "validation_status": "valid",
+                "validation_errors": [],
+                "trust_status": "quarantined_modified",
+                "trust_reason_code": "skill_modified",
+                "trust_blocked": True,
+                "trust_changed_files": ["SKILL.md"],
+            },
+        ]
+    )
+    host = DestinationHarness(app, "skills")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_skills_snapshot(screen, pilot)
+        await pilot.click("#skills-review-diff")
+
+        assert app.local_skill_trust_service.reviewed_skill == "summarize-notes"
+        assert screen.query_one("#skills-trust-reviewed-version", Button).disabled is False
+
+        await pilot.click("#skills-trust-reviewed-version")
+        assert app.local_skill_trust_service.trusted_review_id == "review-1"
+```
+
+Add a small fake near the destination test helpers:
+
+```python
+class RecordingSkillTrustService:
+    def __init__(self, review_id="review-id"):
+        self.review_id = review_id
+        self.bootstrap_calls = 0
+        self.reviewed_skill = None
+        self.trusted_review_id = None
+
+    def bootstrap_trust(self, *args, **kwargs):
+        self.bootstrap_calls += 1
+
+    def capture_review(self, skill_name):
+        self.reviewed_skill = skill_name
+        return {"review_id": self.review_id, "skill_name": skill_name, "changed_files": ["SKILL.md"]}
+
+    def trust_reviewed_snapshot(self, review_id):
+        self.trusted_review_id = review_id
 ```
 
 - [ ] **Step 2: Run failing Skills UI tests**
@@ -1485,7 +1924,7 @@ async def test_skills_destination_shows_uninitialized_bootstrap_action():
 Run:
 
 ```bash
-.venv/bin/python -m pytest -q Tests/UI/test_destination_shells.py::test_skills_destination_blocks_metadata_valid_trust_blocked_skill Tests/UI/test_destination_shells.py::test_skills_destination_shows_uninitialized_bootstrap_action --tb=short
+.venv/bin/python -m pytest -q Tests/UI/test_destination_shells.py::test_skills_destination_blocks_metadata_valid_trust_blocked_skill Tests/UI/test_destination_shells.py::test_skills_destination_shows_uninitialized_bootstrap_action Tests/UI/test_destination_shells.py::test_skills_destination_bootstrap_action_calls_trust_service Tests/UI/test_destination_shells.py::test_skills_destination_review_action_enables_trust_reviewed_version --tb=short
 ```
 
 Expected: fail because the screen does not render trust state.
@@ -1575,6 +2014,12 @@ In the inspector actions, add disabled-safe recovery controls:
                         tooltip="Create the first trusted baseline after reviewing current local skills.",
                     )
                     yield Button(
+                        "Unlock Trust",
+                        id="skills-unlock-trust",
+                        disabled=not any(self._skill_trust_status(record) == "trust_locked" for record in self._local_skill_records),
+                        tooltip="Unlock local skill trust with the trust passphrase for this session.",
+                    )
+                    yield Button(
                         "Review Diff",
                         id="skills-review-diff",
                         disabled=not (selected_metadata and selected_metadata.get("validation_status") == "valid"),
@@ -1583,22 +2028,61 @@ In the inspector actions, add disabled-safe recovery controls:
                     yield Button(
                         "Trust Reviewed Version",
                         id="skills-trust-reviewed-version",
-                        disabled=True,
+                        disabled=self._active_trust_review is None,
                         tooltip="Enabled after a captured diff still matches live files.",
                     )
 ```
 
-- [ ] **Step 5: Run Skills UI trust tests**
+- [ ] **Step 5: Wire Skills recovery button handlers**
+
+Add `self._active_trust_review: dict[str, Any] | None = None` to the screen state. In the existing button handler, route the trust buttons through `app.local_skill_trust_service`:
+
+```python
+    async def _handle_skill_trust_action(self, button_id: str) -> None:
+        trust_service = getattr(self.app_instance, "local_skill_trust_service", None)
+        if trust_service is None:
+            return
+        if button_id == "skills-bootstrap-trust":
+            passphrase = await self._request_skill_trust_passphrase(confirm_bootstrap=True)
+            if passphrase is None:
+                return
+            trust_service.bootstrap_trust(passphrase)
+            await self._refresh_skills()
+            return
+        if button_id == "skills-unlock-trust":
+            passphrase = await self._request_skill_trust_passphrase(confirm_bootstrap=False)
+            if passphrase is None:
+                return
+            trust_service.unlock_with_passphrase(passphrase)
+            await self._refresh_skills()
+            return
+        selected = self._selected_skill_record()
+        if selected is None:
+            return
+        skill_name = str(selected.get("name") or "")
+        if button_id == "skills-review-diff":
+            self._active_trust_review = trust_service.capture_review(skill_name)
+            await self._refresh_skills()
+            return
+        if button_id == "skills-trust-reviewed-version" and self._active_trust_review:
+            trust_service.trust_reviewed_snapshot(str(self._active_trust_review["review_id"]))
+            self._active_trust_review = None
+            await self._refresh_skills()
+```
+
+Implement `_request_skill_trust_passphrase()` with existing password-dialog primitives or a small modal: no default passphrase, no logging, no path/secrets in notifications. When `confirm_bootstrap=True`, the modal copy must state that current local skill files will become the trusted baseline.
+
+- [ ] **Step 6: Run Skills UI trust tests**
 
 Run:
 
 ```bash
-.venv/bin/python -m pytest -q Tests/UI/test_destination_shells.py::test_skills_destination_blocks_metadata_valid_trust_blocked_skill Tests/UI/test_destination_shells.py::test_skills_destination_shows_uninitialized_bootstrap_action --tb=short
+.venv/bin/python -m pytest -q Tests/UI/test_destination_shells.py::test_skills_destination_blocks_metadata_valid_trust_blocked_skill Tests/UI/test_destination_shells.py::test_skills_destination_shows_uninitialized_bootstrap_action Tests/UI/test_destination_shells.py::test_skills_destination_bootstrap_action_calls_trust_service Tests/UI/test_destination_shells.py::test_skills_destination_review_action_enables_trust_reviewed_version --tb=short
 ```
 
 Expected: pass.
 
-- [ ] **Step 6: Run focused Skills UI tests**
+- [ ] **Step 7: Run focused Skills UI tests**
 
 Run:
 
@@ -1608,7 +2092,7 @@ Run:
 
 Expected: pass.
 
-- [ ] **Step 7: Commit Skills UI trust state**
+- [ ] **Step 8: Commit Skills UI trust state**
 
 Run:
 

--- a/Docs/superpowers/plans/2026-06-25-local-skill-trust-integrity.md
+++ b/Docs/superpowers/plans/2026-06-25-local-skill-trust-integrity.md
@@ -1,0 +1,1876 @@
+# Local Skill Trust Integrity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Protect Chatbook-managed local skills from offline tampering by adding passphrase-rooted trust bootstrap, authenticated baseline verification, logical quarantine, reviewed re-trust, and visible recovery states.
+
+**Architecture:** Add focused trust modules beside `LocalSkillsService`: models/errors, crypto helpers, scanner, authenticated store, and orchestration service. Wire the service into `LocalSkillsService`, Skills UI, Settings privacy posture, runtime policy, and tests without touching Codex runtime skills or server-managed skills.
+
+**Tech Stack:** Python 3.11+, dataclasses, pathlib, json, hashlib/hmac, Cryptodome AES-GCM/scrypt, existing `keyring` secure-backend checks, pytest/pytest-asyncio, Textual mounted UI tests, Backlog.md, ADRs.
+
+---
+
+## Source Documents
+
+- Backlog task: `backlog/tasks/task-137 - Add-local-skill-trust-integrity-controls.md`
+- ADR: `backlog/decisions/009-local-skill-trust-boundary.md`
+- Spec: `Docs/superpowers/specs/2026-06-25-local-skill-trust-integrity-design.md`
+
+ADR required: yes
+
+ADR path: `backlog/decisions/009-local-skill-trust-boundary.md`
+
+Reason: This changes a security boundary, trust root, local storage semantics, runtime policy IDs, and the `LocalSkillsService` contract. ADR-009 is already accepted and must remain linked from the task and implementation notes.
+
+## File Structure
+
+- Create `tldw_chatbook/Skills_Interop/skill_trust_models.py`: trust status constants, reason codes, dataclasses, and `SkillTrustBlockedError`.
+- Create `tldw_chatbook/Skills_Interop/skill_trust_crypto.py`: key derivation, canonical JSON, HMAC, AES-GCM encryption/decryption, and hash helpers.
+- Create `tldw_chatbook/Skills_Interop/skill_trust_scanner.py`: deterministic skill-directory scanning, file fingerprinting, unsafe path detection, text snapshot capture.
+- Create `tldw_chatbook/Skills_Interop/skill_trust_store.py`: manifest/snapshot persistence, secure generation marker protocol, keyring convenience helpers, authenticated audit records.
+- Create `tldw_chatbook/Skills_Interop/skill_trust_service.py`: bootstrap, unlock, status classification, review capture, approval, key rotation, and use-time enforcement.
+- Modify `tldw_chatbook/Skills_Interop/local_skills_service.py`: inject trust service, add trust fields to list/detail/context responses, block execution when trust fails, and atomically re-trust explicit Chatbook mutations.
+- Modify `tldw_chatbook/Skills_Interop/skills_scope_service.py`: preserve trust fields during local response normalization. Recovery actions use `app.local_skill_trust_service` directly in v1.
+- Modify `tldw_chatbook/Skills_Interop/__init__.py`: export trust service/types.
+- Modify `tldw_chatbook/runtime_policy/registry.py`: add local `skills.trust.*.local` policy actions.
+- Modify `tldw_chatbook/app.py`: construct and wire `SkillTrustService` into `LocalSkillsService`.
+- Modify `tldw_chatbook/UI/Screens/skills_screen.py`: render trust state, block attach for trust-blocked skills, add unlock/bootstrap/review/approve/reject recovery controls.
+- Modify `tldw_chatbook/UI/Screens/settings_privacy_security.py`: include redacted skill trust posture and keyring convenience/reduced rollback posture rows.
+- Modify `backlog/tasks/task-137 - Add-local-skill-trust-integrity-controls.md`: add plan link, ADR link, and closeout notes during final task completion.
+- Add tests under `Tests/Skills/`, `Tests/RuntimePolicy/`, and `Tests/UI/`.
+
+## Task 1: Register Trust Policy Actions And ADR/Task Links
+
+**Files:**
+- Modify: `tldw_chatbook/runtime_policy/registry.py`
+- Modify: `Tests/RuntimePolicy/test_runtime_policy_core.py`
+- Modify: `Tests/RuntimePolicy/test_domain_edge_contracts.py`
+- Modify: `backlog/tasks/task-137 - Add-local-skill-trust-integrity-controls.md`
+
+- [ ] **Step 1: Put the Backlog task in progress and add plan metadata**
+
+Run:
+
+```bash
+backlog task edit 137 -s "In Progress" --plan "ADR required: yes
+ADR path: backlog/decisions/009-local-skill-trust-boundary.md
+Reason: Local skill trust changes a security boundary, trust root, local storage semantics, runtime policy IDs, and the LocalSkillsService contract.
+
+1. Register local skill trust runtime-policy actions.
+2. Add trust models, crypto, scanner, store, and service substrate.
+3. Integrate trust checks into LocalSkillsService and app wiring.
+4. Add Skills and Settings trust posture UI.
+5. Run focused trust, Skills, runtime-policy, and UI tests.
+
+Superpowers plan: Docs/superpowers/plans/2026-06-25-local-skill-trust-integrity.md"
+```
+
+Expected: `TASK-137` status becomes `In Progress` and the task contains an `## Implementation Plan` section with the ADR check.
+
+- [ ] **Step 2: Add failing runtime-policy tests**
+
+In `Tests/RuntimePolicy/test_domain_edge_contracts.py`, extend `test_skills_and_kanban_have_local_policy_actions()` with these action IDs:
+
+```python
+    for action_id in [
+        "skills.list.local",
+        "skills.execute.launch.local",
+        "skills.trust.unlock.local",
+        "skills.trust.review.local",
+        "skills.trust.approve.local",
+        "skills.trust.reject.local",
+        "skills.trust.rebootstrap.local",
+        "skills.trust.rotate_key.local",
+        "skills.trust.audit.local",
+        "kanban.boards.list.local",
+        "kanban.cards.create.local",
+        "kanban.card_links.delete.local",
+    ]:
+        entry = CAPABILITY_REGISTRY[action_id]
+        assert entry.required_source == "local"
+        assert entry.authority_owner == "local"
+```
+
+In `Tests/RuntimePolicy/test_runtime_policy_core.py`, extend the `"server_skills"` expected action block with:
+
+```text
+        skills.trust.approve.local
+        skills.trust.audit.local
+        skills.trust.rebootstrap.local
+        skills.trust.reject.local
+        skills.trust.review.local
+        skills.trust.rotate_key.local
+        skills.trust.unlock.local
+```
+
+- [ ] **Step 3: Run the failing policy tests**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/RuntimePolicy/test_domain_edge_contracts.py::test_skills_and_kanban_have_local_policy_actions Tests/RuntimePolicy/test_runtime_policy_core.py::test_capability_registry_contains_expected_actions --tb=short
+```
+
+Expected: fail with missing `skills.trust.*.local` action IDs.
+
+- [ ] **Step 4: Implement registry actions**
+
+In `tldw_chatbook/runtime_policy/registry.py`, add action constants near the existing action constants:
+
+```python
+UNLOCK = _action("unlock", "launch")
+REVIEW = _action("review", "detail")
+REJECT = _action("reject", "update")
+REBOOTSTRAP = _action("rebootstrap", "update")
+ROTATE_KEY = _action("rotate_key", "update")
+AUDIT = _action("audit", "detail")
+```
+
+In the `"server_skills"` capability resources, add the local-only trust resource:
+
+```python
+            _resource(
+                "skills.trust",
+                actions=(UNLOCK, REVIEW, APPROVE, REJECT, REBOOTSTRAP, ROTATE_KEY, AUDIT),
+                sources=LOCAL_ONLY_SOURCES,
+            ),
+```
+
+- [ ] **Step 5: Re-run policy tests**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/RuntimePolicy/test_domain_edge_contracts.py::test_skills_and_kanban_have_local_policy_actions Tests/RuntimePolicy/test_runtime_policy_core.py::test_capability_registry_contains_expected_actions --tb=short
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit policy and task metadata**
+
+Run:
+
+```bash
+git add tldw_chatbook/runtime_policy/registry.py Tests/RuntimePolicy/test_domain_edge_contracts.py Tests/RuntimePolicy/test_runtime_policy_core.py "backlog/tasks/task-137 - Add-local-skill-trust-integrity-controls.md"
+git commit -m "feat: register local skill trust policy actions"
+```
+
+Expected: commit succeeds.
+
+## Task 2: Add Trust Models And Crypto Helpers
+
+**Files:**
+- Create: `tldw_chatbook/Skills_Interop/skill_trust_models.py`
+- Create: `tldw_chatbook/Skills_Interop/skill_trust_crypto.py`
+- Modify: `tldw_chatbook/Skills_Interop/__init__.py`
+- Test: `Tests/Skills/test_skill_trust_crypto.py`
+
+- [ ] **Step 1: Write failing crypto/model tests**
+
+Create `Tests/Skills/test_skill_trust_crypto.py`:
+
+```python
+import pytest
+
+from tldw_chatbook.Skills_Interop.skill_trust_crypto import (
+    decrypt_json_blob,
+    derive_skill_trust_keys,
+    encrypt_json_blob,
+    manifest_mac,
+)
+from tldw_chatbook.Skills_Interop.skill_trust_models import (
+    SkillTrustBlockedError,
+    SkillTrustStatus,
+    TRUST_STATUS_TRUSTED,
+)
+
+
+def test_skill_trust_key_derivation_separates_key_purposes():
+    keys = derive_skill_trust_keys("correct horse battery staple", salt=b"0" * 32)
+
+    assert len(keys.manifest_mac_key) == 32
+    assert len(keys.snapshot_key) == 32
+    assert len(keys.audit_mac_key) == 32
+    assert keys.manifest_mac_key != keys.snapshot_key
+    assert keys.snapshot_key != keys.audit_mac_key
+
+
+def test_manifest_mac_rejects_tampered_manifest_payload():
+    keys = derive_skill_trust_keys("passphrase", salt=b"1" * 32)
+    manifest = {"version": 1, "generation": 1, "skills": {"demo": {"status": "trusted"}}}
+    tag = manifest_mac(manifest, keys.manifest_mac_key)
+
+    tampered = {"version": 1, "generation": 2, "skills": {"demo": {"status": "trusted"}}}
+
+    assert manifest_mac(manifest, keys.manifest_mac_key) == tag
+    assert manifest_mac(tampered, keys.manifest_mac_key) != tag
+
+
+def test_snapshot_encryption_round_trips_and_authenticates_associated_data():
+    keys = derive_skill_trust_keys("passphrase", salt=b"2" * 32)
+    payload = {"files": {"SKILL.md": "# Demo\nTrusted"}}
+    encrypted = encrypt_json_blob(payload, keys.snapshot_key, associated_data=b"demo:generation:1")
+
+    assert decrypt_json_blob(encrypted, keys.snapshot_key, associated_data=b"demo:generation:1") == payload
+
+    with pytest.raises(ValueError, match="authentication failed"):
+        decrypt_json_blob(encrypted, keys.snapshot_key, associated_data=b"demo:generation:2")
+
+
+def test_trust_blocked_error_carries_safe_fields():
+    status = SkillTrustStatus(
+        skill_name="demo",
+        trust_status=TRUST_STATUS_TRUSTED,
+        trust_reason_code=None,
+        trust_blocked=False,
+        changed_files=(),
+        manifest_generation=3,
+        last_verified_at="2026-06-25T00:00:00+00:00",
+    )
+
+    error = SkillTrustBlockedError(
+        skill_name="demo",
+        reason_code="skill_modified",
+        trust_status="quarantined_modified",
+        changed_files=("SKILL.md",),
+    )
+
+    assert status.skill_name == "demo"
+    assert str(error) == "Local skill demo is trust-blocked: skill_modified"
+    assert error.changed_files == ("SKILL.md",)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/Skills/test_skill_trust_crypto.py --tb=short
+```
+
+Expected: fail with `ModuleNotFoundError` for `skill_trust_crypto`.
+
+- [ ] **Step 3: Add trust models**
+
+Create `tldw_chatbook/Skills_Interop/skill_trust_models.py`:
+
+```python
+"""Local skill trust state models and exceptions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+TRUST_STATUS_TRUSTED = "trusted"
+TRUST_STATUS_UNINITIALIZED = "trust_uninitialized"
+TRUST_STATUS_LOCKED = "trust_locked"
+TRUST_STATUS_QUARANTINED_MODIFIED = "quarantined_modified"
+TRUST_STATUS_QUARANTINED_ADDED = "quarantined_added"
+TRUST_STATUS_QUARANTINED_DELETED = "quarantined_deleted"
+TRUST_STATUS_QUARANTINED_MANIFEST_ERROR = "quarantined_manifest_error"
+TRUST_STATUS_QUARANTINED_UNSUPPORTED_PATH = "quarantined_unsupported_path"
+
+TRUST_REASON_SKILL_MODIFIED = "skill_modified"
+TRUST_REASON_SKILL_ADDED = "skill_added"
+TRUST_REASON_SKILL_DELETED = "skill_deleted"
+TRUST_REASON_UNSUPPORTED_PATH = "unsupported_path"
+TRUST_REASON_TRUST_LOCKED = "trust_locked"
+TRUST_REASON_TRUST_UNINITIALIZED = "trust_uninitialized"
+TRUST_REASON_MANIFEST_INVALID = "manifest_invalid"
+TRUST_REASON_ROLLBACK_MARKER_UNAVAILABLE = "rollback_marker_unavailable"
+TRUST_REASON_SNAPSHOT_MISMATCH = "snapshot_mismatch"
+TRUST_REASON_STORE_WRITE_FAILED = "trust_store_write_failed"
+TRUST_REASON_HISTORY_UNRECOVERABLE = "trust_history_unrecoverable"
+
+
+@dataclass(frozen=True, slots=True)
+class SkillFileFingerprint:
+    relative_path: str
+    file_type: str
+    byte_length: int
+    sha256: str
+
+    def as_manifest_entry(self) -> dict[str, Any]:
+        return {
+            "relative_path": self.relative_path,
+            "file_type": self.file_type,
+            "byte_length": self.byte_length,
+            "sha256": self.sha256,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class SkillDirectorySnapshot:
+    skill_name: str
+    fingerprints: tuple[SkillFileFingerprint, ...]
+    text_files: dict[str, str]
+    unsupported_paths: tuple[str, ...] = ()
+
+    @property
+    def fingerprint_map(self) -> dict[str, SkillFileFingerprint]:
+        return {item.relative_path: item for item in self.fingerprints}
+
+
+@dataclass(frozen=True, slots=True)
+class SkillTrustStatus:
+    skill_name: str
+    trust_status: str
+    trust_reason_code: str | None
+    trust_blocked: bool
+    changed_files: tuple[str, ...]
+    manifest_generation: int | None
+    last_verified_at: str | None
+
+    def response_fields(self) -> dict[str, Any]:
+        return {
+            "trust_status": self.trust_status,
+            "trust_reason_code": self.trust_reason_code,
+            "trust_blocked": self.trust_blocked,
+            "trust_changed_files": list(self.changed_files),
+            "trust_manifest_generation": self.manifest_generation,
+            "trust_last_verified_at": self.last_verified_at,
+        }
+
+
+class SkillTrustBlockedError(RuntimeError):
+    """Raised when a trust-blocked local skill is staged or executed."""
+
+    def __init__(
+        self,
+        *,
+        skill_name: str,
+        reason_code: str,
+        trust_status: str,
+        changed_files: tuple[str, ...] = (),
+    ) -> None:
+        super().__init__(f"Local skill {skill_name} is trust-blocked: {reason_code}")
+        self.skill_name = skill_name
+        self.reason_code = reason_code
+        self.trust_status = trust_status
+        self.changed_files = changed_files
+```
+
+- [ ] **Step 4: Add crypto helpers**
+
+Create `tldw_chatbook/Skills_Interop/skill_trust_crypto.py`:
+
+```python
+"""Cryptographic helpers for local skill trust state."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+from dataclasses import dataclass
+from typing import Any
+
+from Cryptodome.Cipher import AES
+from Cryptodome.Protocol.KDF import scrypt
+
+
+SKILL_TRUST_KDF_N = 16384
+SKILL_TRUST_KDF_R = 8
+SKILL_TRUST_KDF_P = 1
+SKILL_TRUST_KEY_SIZE = 32
+SKILL_TRUST_NONCE_SIZE = 12
+
+
+@dataclass(frozen=True, slots=True)
+class SkillTrustKeys:
+    manifest_mac_key: bytes
+    snapshot_key: bytes
+    audit_mac_key: bytes
+    wrapped_root_key: bytes
+
+
+def canonical_json(payload: Any) -> bytes:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def derive_skill_trust_keys(passphrase: str, *, salt: bytes) -> SkillTrustKeys:
+    if len(salt) != 32:
+        raise ValueError("skill trust salt must be 32 bytes")
+    root = scrypt(
+        passphrase.encode("utf-8"),
+        salt,
+        key_len=SKILL_TRUST_KEY_SIZE,
+        N=SKILL_TRUST_KDF_N,
+        r=SKILL_TRUST_KDF_R,
+        p=SKILL_TRUST_KDF_P,
+    )
+    manifest_mac_key = hmac.new(root, b"tldw-chatbook-skill-trust-manifest-v1", hashlib.sha256).digest()
+    snapshot_key = hmac.new(root, b"tldw-chatbook-skill-trust-snapshot-v1", hashlib.sha256).digest()
+    audit_mac_key = hmac.new(root, b"tldw-chatbook-skill-trust-audit-v1", hashlib.sha256).digest()
+    wrapped_root_key = hmac.new(root, b"tldw-chatbook-skill-trust-wrapped-root-v1", hashlib.sha256).digest()
+    return SkillTrustKeys(
+        manifest_mac_key=manifest_mac_key,
+        snapshot_key=snapshot_key,
+        audit_mac_key=audit_mac_key,
+        wrapped_root_key=wrapped_root_key,
+    )
+
+
+def manifest_mac(manifest_payload: dict[str, Any], key: bytes) -> str:
+    return hmac.new(key, canonical_json(manifest_payload), hashlib.sha256).hexdigest()
+
+
+def encrypt_json_blob(payload: dict[str, Any], key: bytes, *, associated_data: bytes) -> dict[str, str]:
+    nonce = os.urandom(SKILL_TRUST_NONCE_SIZE)
+    cipher = AES.new(key, AES.MODE_GCM, nonce=nonce)
+    cipher.update(associated_data)
+    ciphertext, tag = cipher.encrypt_and_digest(canonical_json(payload))
+    return {
+        "alg": "AES-256-GCM",
+        "nonce": base64.b64encode(nonce).decode("ascii"),
+        "ciphertext": base64.b64encode(ciphertext).decode("ascii"),
+        "tag": base64.b64encode(tag).decode("ascii"),
+    }
+
+
+def decrypt_json_blob(blob: dict[str, str], key: bytes, *, associated_data: bytes) -> dict[str, Any]:
+    try:
+        nonce = base64.b64decode(blob["nonce"])
+        ciphertext = base64.b64decode(blob["ciphertext"])
+        tag = base64.b64decode(blob["tag"])
+        cipher = AES.new(key, AES.MODE_GCM, nonce=nonce)
+        cipher.update(associated_data)
+        plaintext = cipher.decrypt_and_verify(ciphertext, tag)
+        payload = json.loads(plaintext.decode("utf-8"))
+    except Exception as exc:
+        raise ValueError("snapshot authentication failed") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("snapshot payload must be an object")
+    return payload
+```
+
+- [ ] **Step 5: Export trust types**
+
+Update `tldw_chatbook/Skills_Interop/__init__.py`:
+
+```python
+"""Local and server SKILL.md interoperability services."""
+
+from .local_skills_service import LocalSkillsService
+from .server_skills_service import ServerSkillsService
+from .skill_trust_models import SkillTrustBlockedError, SkillTrustStatus
+from .skills_scope_service import SkillsBackend, SkillsScopeService
+
+__all__ = [
+    "LocalSkillsService",
+    "ServerSkillsService",
+    "SkillTrustBlockedError",
+    "SkillTrustStatus",
+    "SkillsBackend",
+    "SkillsScopeService",
+]
+```
+
+- [ ] **Step 6: Run crypto/model tests**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/Skills/test_skill_trust_crypto.py --tb=short
+```
+
+Expected: pass.
+
+- [ ] **Step 7: Commit trust models and crypto**
+
+Run:
+
+```bash
+git add tldw_chatbook/Skills_Interop/skill_trust_models.py tldw_chatbook/Skills_Interop/skill_trust_crypto.py tldw_chatbook/Skills_Interop/__init__.py Tests/Skills/test_skill_trust_crypto.py
+git commit -m "feat: add local skill trust crypto models"
+```
+
+Expected: commit succeeds.
+
+## Task 3: Add Skill Directory Scanner
+
+**Files:**
+- Create: `tldw_chatbook/Skills_Interop/skill_trust_scanner.py`
+- Test: `Tests/Skills/test_skill_trust_scanner.py`
+
+- [ ] **Step 1: Write failing scanner tests**
+
+Create `Tests/Skills/test_skill_trust_scanner.py`:
+
+```python
+from pathlib import Path
+
+from tldw_chatbook.Skills_Interop.skill_trust_scanner import scan_skill_directory
+
+
+def test_scan_skill_directory_fingerprints_skill_and_supporting_files(tmp_path):
+    skill_dir = tmp_path / "demo"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("# Demo\nUse safely.\n", encoding="utf-8")
+    (skill_dir / "notes.md").write_text("Trusted notes.\n", encoding="utf-8")
+
+    snapshot = scan_skill_directory("demo", skill_dir)
+
+    assert snapshot.skill_name == "demo"
+    assert [item.relative_path for item in snapshot.fingerprints] == ["SKILL.md", "notes.md"]
+    assert snapshot.text_files["SKILL.md"] == "# Demo\nUse safely.\n"
+    assert snapshot.text_files["notes.md"] == "Trusted notes.\n"
+    assert snapshot.unsupported_paths == ()
+
+
+def test_scan_skill_directory_marks_symlink_nested_tmp_and_binary_paths_unsupported(tmp_path):
+    skill_dir = tmp_path / "demo"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("# Demo\n", encoding="utf-8")
+    (skill_dir / "SKILL.md.tmp").write_text("partial", encoding="utf-8")
+    (skill_dir / "nested").mkdir()
+    (skill_dir / "binary.dat").write_bytes(b"\xff\xfe\x00")
+    outside = tmp_path / "outside.md"
+    outside.write_text("outside", encoding="utf-8")
+    (skill_dir / "linked.md").symlink_to(outside)
+
+    snapshot = scan_skill_directory("demo", skill_dir)
+
+    assert snapshot.unsupported_paths == (
+        "SKILL.md.tmp",
+        "binary.dat",
+        "linked.md",
+        "nested",
+    )
+    assert [item.relative_path for item in snapshot.fingerprints] == ["SKILL.md"]
+```
+
+- [ ] **Step 2: Run scanner tests to verify they fail**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/Skills/test_skill_trust_scanner.py --tb=short
+```
+
+Expected: fail with `ModuleNotFoundError` for `skill_trust_scanner`.
+
+- [ ] **Step 3: Implement scanner**
+
+Create `tldw_chatbook/Skills_Interop/skill_trust_scanner.py`:
+
+```python
+"""Deterministic local skill directory scanning for trust verification."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..tldw_api.skills_schemas import SUPPORTING_FILE_NAME_PATTERN
+from .skill_trust_crypto import sha256_hex
+from .skill_trust_models import SkillDirectorySnapshot, SkillFileFingerprint
+
+
+_SKILL_FILENAME = "SKILL.md"
+_TEMP_SUFFIXES = (".tmp", ".swp", ".part")
+
+
+def _is_safe_skill_file_name(filename: str) -> bool:
+    if filename == _SKILL_FILENAME:
+        return True
+    if filename.endswith(_TEMP_SUFFIXES):
+        return False
+    return bool(SUPPORTING_FILE_NAME_PATTERN.match(filename))
+
+
+def scan_skill_directory(skill_name: str, skill_dir: Path) -> SkillDirectorySnapshot:
+    fingerprints: list[SkillFileFingerprint] = []
+    text_files: dict[str, str] = {}
+    unsupported_paths: list[str] = []
+
+    for path in sorted(skill_dir.iterdir(), key=lambda item: item.name):
+        relative_path = path.name
+        if path.is_symlink() or path.is_dir() or not _is_safe_skill_file_name(relative_path):
+            unsupported_paths.append(relative_path)
+            continue
+        try:
+            raw = path.read_bytes()
+            text = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            unsupported_paths.append(relative_path)
+            continue
+        fingerprints.append(
+            SkillFileFingerprint(
+                relative_path=relative_path,
+                file_type="skill" if relative_path == _SKILL_FILENAME else "supporting_text",
+                byte_length=len(raw),
+                sha256=sha256_hex(raw),
+            )
+        )
+        text_files[relative_path] = text
+
+    return SkillDirectorySnapshot(
+        skill_name=skill_name,
+        fingerprints=tuple(fingerprints),
+        text_files=text_files,
+        unsupported_paths=tuple(sorted(unsupported_paths)),
+    )
+```
+
+- [ ] **Step 4: Run scanner tests**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/Skills/test_skill_trust_scanner.py --tb=short
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit scanner**
+
+Run:
+
+```bash
+git add tldw_chatbook/Skills_Interop/skill_trust_scanner.py Tests/Skills/test_skill_trust_scanner.py
+git commit -m "feat: scan local skill files for trust"
+```
+
+Expected: commit succeeds.
+
+## Task 4: Add Trust Store, Manifest, Snapshots, Generation Marker, And Audit Records
+
+**Files:**
+- Create: `tldw_chatbook/Skills_Interop/skill_trust_store.py`
+- Test: `Tests/Skills/test_skill_trust_store.py`
+
+- [ ] **Step 1: Write failing store tests**
+
+Create `Tests/Skills/test_skill_trust_store.py`:
+
+```python
+import json
+
+import pytest
+
+from tldw_chatbook.Skills_Interop.skill_trust_crypto import derive_skill_trust_keys
+from tldw_chatbook.Skills_Interop.skill_trust_store import (
+    FileSkillTrustGenerationMarkerStore,
+    SkillTrustStore,
+)
+
+
+def test_trust_store_round_trips_manifest_snapshot_and_marker(tmp_path):
+    keys = derive_skill_trust_keys("passphrase", salt=b"3" * 32)
+    marker = FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json")
+    store = SkillTrustStore(store_dir=tmp_path / "trust", marker_store=marker)
+
+    manifest = {
+        "version": 1,
+        "generation": 1,
+        "skills": {
+            "demo": {
+                "files": [{"relative_path": "SKILL.md", "file_type": "skill", "byte_length": 6, "sha256": "abc"}],
+                "snapshot_id": "demo-1",
+                "trusted_at": "2026-06-25T00:00:00+00:00",
+            }
+        },
+        "audit": [],
+    }
+
+    store.save_manifest(manifest, keys)
+    store.save_snapshot("demo-1", {"files": {"SKILL.md": "# Demo"}}, keys, generation=1)
+
+    loaded = store.load_manifest(keys)
+    snapshot = store.load_snapshot("demo-1", keys, generation=1)
+
+    assert loaded["generation"] == 1
+    assert snapshot == {"files": {"SKILL.md": "# Demo"}}
+    assert marker.load_marker() == {"generation": 1, "manifest_digest": store.manifest_digest(loaded)}
+
+
+def test_trust_store_rejects_tampered_manifest(tmp_path):
+    keys = derive_skill_trust_keys("passphrase", salt=b"4" * 32)
+    marker = FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json")
+    store = SkillTrustStore(store_dir=tmp_path / "trust", marker_store=marker)
+
+    store.save_manifest({"version": 1, "generation": 1, "skills": {}, "audit": []}, keys)
+    payload = json.loads((tmp_path / "trust" / "skill_trust_manifest.json").read_text(encoding="utf-8"))
+    payload["manifest"]["generation"] = 2
+    (tmp_path / "trust" / "skill_trust_manifest.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="manifest authentication failed"):
+        store.load_manifest(keys)
+
+
+def test_trust_store_rejects_marker_mismatch(tmp_path):
+    keys = derive_skill_trust_keys("passphrase", salt=b"5" * 32)
+    marker = FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json")
+    store = SkillTrustStore(store_dir=tmp_path / "trust", marker_store=marker)
+
+    store.save_manifest({"version": 1, "generation": 3, "skills": {}, "audit": []}, keys)
+    marker.save_marker(generation=2, manifest_digest="old")
+
+    with pytest.raises(ValueError, match="manifest generation marker mismatch"):
+        store.load_manifest(keys)
+```
+
+- [ ] **Step 2: Run store tests to verify they fail**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/Skills/test_skill_trust_store.py --tb=short
+```
+
+Expected: fail with `ModuleNotFoundError` for `skill_trust_store`.
+
+- [ ] **Step 3: Implement store**
+
+Create `tldw_chatbook/Skills_Interop/skill_trust_store.py` with these public methods:
+
+```python
+"""Persistence for local skill trust manifests, snapshots, markers, and audit events."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+from .skill_trust_crypto import canonical_json, decrypt_json_blob, encrypt_json_blob, manifest_mac, sha256_hex
+
+
+_MANIFEST_FILENAME = "skill_trust_manifest.json"
+_SNAPSHOTS_DIRNAME = "snapshots"
+
+
+class SkillTrustGenerationMarkerStore(Protocol):
+    def load_marker(self) -> dict[str, Any] | None: ...
+    def save_marker(self, *, generation: int, manifest_digest: str) -> None: ...
+
+
+@dataclass(slots=True)
+class FileSkillTrustGenerationMarkerStore:
+    marker_path: Path
+
+    def load_marker(self) -> dict[str, Any] | None:
+        if not self.marker_path.exists():
+            return None
+        payload = json.loads(self.marker_path.read_text(encoding="utf-8"))
+        return payload if isinstance(payload, dict) else None
+
+    def save_marker(self, *, generation: int, manifest_digest: str) -> None:
+        self.marker_path.parent.mkdir(parents=True, exist_ok=True)
+        temp_path = self.marker_path.with_suffix(".tmp")
+        temp_path.write_text(
+            json.dumps({"generation": generation, "manifest_digest": manifest_digest}, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        temp_path.replace(self.marker_path)
+
+
+@dataclass(slots=True)
+class SkillTrustStore:
+    store_dir: Path
+    marker_store: SkillTrustGenerationMarkerStore
+
+    @property
+    def manifest_path(self) -> Path:
+        return self.store_dir / _MANIFEST_FILENAME
+
+    @property
+    def snapshots_dir(self) -> Path:
+        return self.store_dir / _SNAPSHOTS_DIRNAME
+
+    def has_manifest(self) -> bool:
+        return self.manifest_path.exists()
+
+    def manifest_digest(self, manifest: dict[str, Any]) -> str:
+        return sha256_hex(canonical_json(manifest))
+
+    def load_manifest(self, keys: Any) -> dict[str, Any]:
+        payload = json.loads(self.manifest_path.read_text(encoding="utf-8"))
+        manifest = payload.get("manifest")
+        tag = payload.get("mac")
+        if not isinstance(manifest, dict) or not isinstance(tag, str):
+            raise ValueError("manifest authentication failed")
+        if manifest_mac(manifest, keys.manifest_mac_key) != tag:
+            raise ValueError("manifest authentication failed")
+        marker = self.marker_store.load_marker()
+        digest = self.manifest_digest(manifest)
+        if marker is not None:
+            if int(marker.get("generation", -1)) != int(manifest.get("generation", -2)):
+                raise ValueError("manifest generation marker mismatch")
+            if marker.get("manifest_digest") != digest:
+                raise ValueError("manifest generation marker mismatch")
+        return manifest
+
+    def save_manifest(self, manifest: dict[str, Any], keys: Any) -> None:
+        self.store_dir.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "manifest": manifest,
+            "mac": manifest_mac(manifest, keys.manifest_mac_key),
+        }
+        temp_path = self.manifest_path.with_suffix(".tmp")
+        temp_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        temp_path.replace(self.manifest_path)
+        self.marker_store.save_marker(
+            generation=int(manifest["generation"]),
+            manifest_digest=self.manifest_digest(manifest),
+        )
+
+    def save_snapshot(self, snapshot_id: str, payload: dict[str, Any], keys: Any, *, generation: int) -> None:
+        self.snapshots_dir.mkdir(parents=True, exist_ok=True)
+        associated_data = f"snapshot:{snapshot_id}:generation:{generation}".encode("utf-8")
+        encrypted = encrypt_json_blob(payload, keys.snapshot_key, associated_data=associated_data)
+        temp_path = (self.snapshots_dir / f"{snapshot_id}.json").with_suffix(".tmp")
+        temp_path.write_text(json.dumps(encrypted, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        temp_path.replace(self.snapshots_dir / f"{snapshot_id}.json")
+
+    def load_snapshot(self, snapshot_id: str, keys: Any, *, generation: int) -> dict[str, Any]:
+        encrypted = json.loads((self.snapshots_dir / f"{snapshot_id}.json").read_text(encoding="utf-8"))
+        associated_data = f"snapshot:{snapshot_id}:generation:{generation}".encode("utf-8")
+        return decrypt_json_blob(encrypted, keys.snapshot_key, associated_data=associated_data)
+```
+
+- [ ] **Step 4: Run store tests**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/Skills/test_skill_trust_store.py --tb=short
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit trust store**
+
+Run:
+
+```bash
+git add tldw_chatbook/Skills_Interop/skill_trust_store.py Tests/Skills/test_skill_trust_store.py
+git commit -m "feat: persist local skill trust manifests"
+```
+
+Expected: commit succeeds.
+
+## Task 5: Add SkillTrustService Bootstrap, Classification, Review, And Approval
+
+**Files:**
+- Create: `tldw_chatbook/Skills_Interop/skill_trust_service.py`
+- Test: `Tests/Skills/test_skill_trust_service.py`
+
+- [ ] **Step 1: Write failing service tests**
+
+Create `Tests/Skills/test_skill_trust_service.py`:
+
+```python
+import pytest
+
+from tldw_chatbook.Skills_Interop.skill_trust_crypto import derive_skill_trust_keys
+from tldw_chatbook.Skills_Interop.skill_trust_models import SkillTrustBlockedError
+from tldw_chatbook.Skills_Interop.skill_trust_service import SkillTrustService
+from tldw_chatbook.Skills_Interop.skill_trust_store import FileSkillTrustGenerationMarkerStore, SkillTrustStore
+
+
+def _service(tmp_path, passphrase="passphrase"):
+    skills_dir = tmp_path / "skills"
+    trust_store = SkillTrustStore(
+        store_dir=tmp_path / "trust",
+        marker_store=FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json"),
+    )
+    service = SkillTrustService(skills_dir=skills_dir, trust_store=trust_store)
+    service.unlock_with_passphrase(passphrase, salt=b"6" * 32)
+    return service, skills_dir
+
+
+def test_uninitialized_service_blocks_until_bootstrap(tmp_path):
+    service, skills_dir = _service(tmp_path)
+    (skills_dir / "demo").mkdir(parents=True)
+    (skills_dir / "demo" / "SKILL.md").write_text("# Demo\n", encoding="utf-8")
+
+    status = service.status_for_skill("demo")
+
+    assert status.trust_status == "trust_uninitialized"
+    assert status.trust_blocked is True
+    with pytest.raises(SkillTrustBlockedError, match="trust_uninitialized"):
+        service.ensure_skill_trusted("demo")
+
+
+def test_bootstrap_trusts_current_files_and_detects_modification(tmp_path):
+    service, skills_dir = _service(tmp_path)
+    (skills_dir / "demo").mkdir(parents=True)
+    (skills_dir / "demo" / "SKILL.md").write_text("# Demo\n", encoding="utf-8")
+
+    service.bootstrap_trust()
+    trusted = service.status_for_skill("demo")
+    assert trusted.trust_status == "trusted"
+    service.ensure_skill_trusted("demo")
+
+    (skills_dir / "demo" / "SKILL.md").write_text("# Demo\nBackdoor\n", encoding="utf-8")
+    modified = service.status_for_skill("demo")
+
+    assert modified.trust_status == "quarantined_modified"
+    assert modified.changed_files == ("SKILL.md",)
+    with pytest.raises(SkillTrustBlockedError, match="skill_modified"):
+        service.ensure_skill_trusted("demo")
+
+
+def test_review_approval_requires_live_files_to_match_reviewed_snapshot(tmp_path):
+    service, skills_dir = _service(tmp_path)
+    (skills_dir / "demo").mkdir(parents=True)
+    (skills_dir / "demo" / "SKILL.md").write_text("# Demo\n", encoding="utf-8")
+    service.bootstrap_trust()
+    (skills_dir / "demo" / "SKILL.md").write_text("# Demo\nChanged\n", encoding="utf-8")
+
+    review = service.capture_review("demo")
+    assert review["changed_files"] == ["SKILL.md"]
+    (skills_dir / "demo" / "SKILL.md").write_text("# Demo\nChanged again\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="snapshot_mismatch"):
+        service.trust_reviewed_snapshot(review["review_id"])
+
+
+def test_review_approval_restores_trust_for_reviewed_snapshot(tmp_path):
+    service, skills_dir = _service(tmp_path)
+    (skills_dir / "demo").mkdir(parents=True)
+    (skills_dir / "demo" / "SKILL.md").write_text("# Demo\n", encoding="utf-8")
+    service.bootstrap_trust()
+    (skills_dir / "demo" / "SKILL.md").write_text("# Demo\nChanged\n", encoding="utf-8")
+
+    review = service.capture_review("demo")
+    service.trust_reviewed_snapshot(review["review_id"])
+
+    assert service.status_for_skill("demo").trust_status == "trusted"
+```
+
+- [ ] **Step 2: Run service tests to verify they fail**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/Skills/test_skill_trust_service.py --tb=short
+```
+
+Expected: fail with `ModuleNotFoundError` for `skill_trust_service`.
+
+- [ ] **Step 3: Implement the service substrate**
+
+Create `tldw_chatbook/Skills_Interop/skill_trust_service.py` with these public methods and fields:
+
+```python
+"""Orchestration service for Chatbook-managed local skill trust."""
+
+from __future__ import annotations
+
+import secrets
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .skill_trust_crypto import derive_skill_trust_keys, sha256_hex
+from .skill_trust_models import (
+    SkillDirectorySnapshot,
+    SkillTrustBlockedError,
+    SkillTrustStatus,
+    TRUST_REASON_SKILL_ADDED,
+    TRUST_REASON_SKILL_DELETED,
+    TRUST_REASON_SKILL_MODIFIED,
+    TRUST_REASON_TRUST_UNINITIALIZED,
+    TRUST_REASON_UNSUPPORTED_PATH,
+    TRUST_STATUS_QUARANTINED_ADDED,
+    TRUST_STATUS_QUARANTINED_DELETED,
+    TRUST_STATUS_QUARANTINED_MODIFIED,
+    TRUST_STATUS_QUARANTINED_UNSUPPORTED_PATH,
+    TRUST_STATUS_TRUSTED,
+    TRUST_STATUS_UNINITIALIZED,
+)
+from .skill_trust_scanner import scan_skill_directory
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class SkillTrustService:
+    def __init__(self, *, skills_dir: Path, trust_store: Any) -> None:
+        self.skills_dir = skills_dir
+        self.trust_store = trust_store
+        self._keys: Any | None = None
+        self._reviews: dict[str, dict[str, Any]] = {}
+
+    def unlock_with_passphrase(self, passphrase: str, *, salt: bytes) -> None:
+        self._keys = derive_skill_trust_keys(passphrase, salt=salt)
+
+    def _require_keys(self) -> Any:
+        if self._keys is None:
+            raise SkillTrustBlockedError(
+                skill_name="<all>",
+                reason_code="trust_locked",
+                trust_status="trust_locked",
+            )
+        return self._keys
+
+    def _empty_manifest(self) -> dict[str, Any]:
+        return {"version": 1, "generation": 0, "skills": {}, "audit": []}
+
+    def _load_manifest_or_uninitialized(self) -> dict[str, Any] | None:
+        if not self.trust_store.has_manifest():
+            return None
+        return self.trust_store.load_manifest(self._require_keys())
+
+    def bootstrap_trust(self) -> None:
+        keys = self._require_keys()
+        skills: dict[str, Any] = {}
+        generation = 1
+        for skill_dir in sorted(self.skills_dir.iterdir(), key=lambda item: item.name) if self.skills_dir.exists() else []:
+            if not skill_dir.is_dir():
+                continue
+            snapshot = scan_skill_directory(skill_dir.name, skill_dir)
+            snapshot_id = f"{skill_dir.name}-{generation}"
+            self.trust_store.save_snapshot(
+                snapshot_id,
+                {"files": snapshot.text_files},
+                keys,
+                generation=generation,
+            )
+            skills[skill_dir.name] = {
+                "files": [item.as_manifest_entry() for item in snapshot.fingerprints],
+                "snapshot_id": snapshot_id,
+                "trusted_at": _now_iso(),
+            }
+        manifest = {
+            "version": 1,
+            "generation": generation,
+            "skills": skills,
+            "audit": [{"event": "trust_bootstrap", "at": _now_iso(), "skill_count": len(skills)}],
+        }
+        self.trust_store.save_manifest(manifest, keys)
+
+    def status_for_skill(self, skill_name: str) -> SkillTrustStatus:
+        manifest = self._load_manifest_or_uninitialized()
+        if manifest is None:
+            return SkillTrustStatus(skill_name, TRUST_STATUS_UNINITIALIZED, TRUST_REASON_TRUST_UNINITIALIZED, True, (), None, None)
+        skill_dir = self.skills_dir / skill_name
+        current = scan_skill_directory(skill_name, skill_dir)
+        if current.unsupported_paths:
+            return SkillTrustStatus(
+                skill_name,
+                TRUST_STATUS_QUARANTINED_UNSUPPORTED_PATH,
+                TRUST_REASON_UNSUPPORTED_PATH,
+                True,
+                current.unsupported_paths,
+                int(manifest["generation"]),
+                _now_iso(),
+            )
+        trusted = manifest.get("skills", {}).get(skill_name)
+        if trusted is None:
+            return SkillTrustStatus(skill_name, TRUST_STATUS_QUARANTINED_ADDED, TRUST_REASON_SKILL_ADDED, True, tuple(item.relative_path for item in current.fingerprints), int(manifest["generation"]), _now_iso())
+        trusted_files = {item["relative_path"]: item for item in trusted.get("files", [])}
+        current_files = {item.relative_path: item.as_manifest_entry() for item in current.fingerprints}
+        changed = tuple(sorted(set(trusted_files) ^ set(current_files) | {path for path in trusted_files.keys() & current_files.keys() if trusted_files[path] != current_files[path]}))
+        if changed:
+            reason = TRUST_REASON_SKILL_DELETED if any(path not in current_files for path in changed) else TRUST_REASON_SKILL_MODIFIED
+            status = TRUST_STATUS_QUARANTINED_DELETED if reason == TRUST_REASON_SKILL_DELETED else TRUST_STATUS_QUARANTINED_MODIFIED
+            return SkillTrustStatus(skill_name, status, reason, True, changed, int(manifest["generation"]), _now_iso())
+        return SkillTrustStatus(skill_name, TRUST_STATUS_TRUSTED, None, False, (), int(manifest["generation"]), _now_iso())
+
+    def ensure_skill_trusted(self, skill_name: str) -> None:
+        status = self.status_for_skill(skill_name)
+        if not status.trust_blocked:
+            return
+        raise SkillTrustBlockedError(
+            skill_name=skill_name,
+            reason_code=status.trust_reason_code or "trust_blocked",
+            trust_status=status.trust_status,
+            changed_files=status.changed_files,
+        )
+
+    def capture_review(self, skill_name: str) -> dict[str, Any]:
+        status = self.status_for_skill(skill_name)
+        current = scan_skill_directory(skill_name, self.skills_dir / skill_name)
+        review_id = secrets.token_hex(16)
+        review = {
+            "review_id": review_id,
+            "skill_name": skill_name,
+            "current_digest": sha256_hex(str([item.as_manifest_entry() for item in current.fingerprints]).encode("utf-8")),
+            "current_files": current.text_files,
+            "changed_files": list(status.changed_files),
+        }
+        self._reviews[review_id] = review
+        return review
+
+    def trust_reviewed_snapshot(self, review_id: str) -> None:
+        review = self._reviews[review_id]
+        skill_name = review["skill_name"]
+        current = scan_skill_directory(skill_name, self.skills_dir / skill_name)
+        current_digest = sha256_hex(str([item.as_manifest_entry() for item in current.fingerprints]).encode("utf-8"))
+        if current_digest != review["current_digest"]:
+            raise ValueError("snapshot_mismatch")
+        keys = self._require_keys()
+        manifest = self.trust_store.load_manifest(keys)
+        generation = int(manifest["generation"]) + 1
+        snapshot_id = f"{skill_name}-{generation}"
+        self.trust_store.save_snapshot(snapshot_id, {"files": current.text_files}, keys, generation=generation)
+        manifest["generation"] = generation
+        manifest.setdefault("skills", {})[skill_name] = {
+            "files": [item.as_manifest_entry() for item in current.fingerprints],
+            "snapshot_id": snapshot_id,
+            "trusted_at": _now_iso(),
+        }
+        manifest.setdefault("audit", []).append({"event": "trust_approved", "at": _now_iso(), "skill_name": skill_name})
+        self.trust_store.save_manifest(manifest, keys)
+```
+
+- [ ] **Step 4: Run service tests**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/Skills/test_skill_trust_service.py --tb=short
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit service substrate**
+
+Run:
+
+```bash
+git add tldw_chatbook/Skills_Interop/skill_trust_service.py Tests/Skills/test_skill_trust_service.py
+git commit -m "feat: add local skill trust service"
+```
+
+Expected: commit succeeds.
+
+## Task 6: Integrate Trust Enforcement Into LocalSkillsService
+
+**Files:**
+- Modify: `tldw_chatbook/Skills_Interop/local_skills_service.py`
+- Modify: `tldw_chatbook/Skills_Interop/skills_scope_service.py`
+- Test: `Tests/Skills/test_local_skills_service.py`
+- Test: `Tests/Skills/test_skills_scope_service.py`
+
+- [ ] **Step 1: Add failing local service trust tests**
+
+Append to `Tests/Skills/test_local_skills_service.py`:
+
+```python
+import pytest
+
+from tldw_chatbook.Skills_Interop.skill_trust_models import SkillTrustBlockedError
+from tldw_chatbook.Skills_Interop.skill_trust_service import SkillTrustService
+from tldw_chatbook.Skills_Interop.skill_trust_store import FileSkillTrustGenerationMarkerStore, SkillTrustStore
+
+
+def _trusted_local_service(tmp_path):
+    trust_service = SkillTrustService(
+        skills_dir=tmp_path / "skills",
+        trust_store=SkillTrustStore(
+            store_dir=tmp_path / "trust",
+            marker_store=FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json"),
+        ),
+    )
+    trust_service.unlock_with_passphrase("passphrase", salt=b"7" * 32)
+    return LocalSkillsService(store_dir=tmp_path, trust_service=trust_service), trust_service
+
+
+@pytest.mark.asyncio
+async def test_local_skills_service_exposes_trust_state_and_blocks_uninitialized_context(tmp_path):
+    service, _trust = _trusted_local_service(tmp_path)
+    await service.create_skill(name="demo-skill", content="# Demo\nRender {{args}}")
+
+    listed = await service.list_skills()
+    context = await service.get_context()
+
+    assert listed["skills"][0]["trust_status"] == "trust_uninitialized"
+    assert listed["skills"][0]["trust_blocked"] is True
+    assert context["available_skills"] == []
+    assert context["blocked_skills"][0]["name"] == "demo-skill"
+
+
+@pytest.mark.asyncio
+async def test_local_skills_service_blocks_execute_when_skill_changes_after_bootstrap(tmp_path):
+    service, trust = _trusted_local_service(tmp_path)
+    await service.create_skill(name="demo-skill", content="# Demo\nRender {{args}}")
+    trust.bootstrap_trust()
+    await service.update_skill("demo-skill", content="# Demo\nChanged {{args}}")
+
+    with pytest.raises(SkillTrustBlockedError, match="skill_modified"):
+        await service.execute_skill("demo-skill", args="x")
+```
+
+- [ ] **Step 2: Run failing local service trust tests**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/Skills/test_local_skills_service.py::test_local_skills_service_exposes_trust_state_and_blocks_uninitialized_context Tests/Skills/test_local_skills_service.py::test_local_skills_service_blocks_execute_when_skill_changes_after_bootstrap --tb=short
+```
+
+Expected: fail because `LocalSkillsService` does not accept `trust_service`.
+
+- [ ] **Step 3: Modify LocalSkillsService constructor and response helpers**
+
+In `tldw_chatbook/Skills_Interop/local_skills_service.py`, update the constructor:
+
+```python
+    def __init__(
+        self,
+        *,
+        store_dir: str | Path,
+        policy_enforcer: Any | None = None,
+        trust_service: Any | None = None,
+    ) -> None:
+        self.store_dir = Path(store_dir)
+        self.skills_dir = self.store_dir / _SKILLS_DIRNAME
+        self.index_path = self.store_dir / _INDEX_FILENAME
+        self.policy_enforcer = policy_enforcer
+        self.trust_service = trust_service
+        self._lock = asyncio.Lock()
+```
+
+Add helpers near `_summary_for_record`:
+
+```python
+    def _trust_fields_for_record(self, record: dict[str, Any]) -> dict[str, Any]:
+        if self.trust_service is None:
+            return {
+                "trust_status": "trusted",
+                "trust_reason_code": None,
+                "trust_blocked": False,
+                "trust_changed_files": [],
+                "trust_manifest_generation": None,
+                "trust_last_verified_at": None,
+            }
+        return self.trust_service.status_for_skill(str(record["name"])).response_fields()
+
+    def _require_trusted_skill(self, skill_name: str) -> None:
+        if self.trust_service is not None:
+            self.trust_service.ensure_skill_trusted(skill_name)
+```
+
+Update `_response_for_record()` and `_summary_for_record()` call sites so trust fields are merged into detail/list dictionaries:
+
+```python
+        payload = self._dump(response)
+        payload.update(self._trust_fields_for_record(record))
+        return payload
+```
+
+Change `_summary_for_record` from `@staticmethod` to an instance method and merge trust fields:
+
+```python
+        summary.update(self._trust_fields_for_record(record))
+```
+
+- [ ] **Step 4: Exclude trust-blocked skills from context and block execution**
+
+In `get_context()`, build `available_skills` only from non-blocked records:
+
+```python
+        available: list[dict[str, Any]] = []
+        blocked: list[dict[str, Any]] = []
+        for _, record in sorted(records.items()):
+            summary = self._summary_for_record(record)
+            if summary.get("trust_blocked"):
+                blocked.append(summary)
+                continue
+            available.append(summary)
+```
+
+Return `blocked_skills` as an extra field:
+
+```python
+        payload = self._dump(
+            SkillContextPayload(
+                available_skills=available,
+                context_text="\n".join(context_lines),
+            )
+        )
+        payload["blocked_skills"] = blocked
+        return payload
+```
+
+At the start of `execute_skill()`, add:
+
+```python
+        self._require_trusted_skill(skill_name)
+```
+
+- [ ] **Step 5: Run local service trust tests**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/Skills/test_local_skills_service.py::test_local_skills_service_exposes_trust_state_and_blocks_uninitialized_context Tests/Skills/test_local_skills_service.py::test_local_skills_service_blocks_execute_when_skill_changes_after_bootstrap --tb=short
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Run full local skills tests**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/Skills/test_local_skills_service.py Tests/Skills/test_skills_scope_service.py --tb=short
+```
+
+Expected: pass. Legacy tests that instantiate `LocalSkillsService` without `trust_service` continue to use the explicit no-trust-service compatibility path.
+
+- [ ] **Step 7: Commit local service integration**
+
+Run:
+
+```bash
+git add tldw_chatbook/Skills_Interop/local_skills_service.py tldw_chatbook/Skills_Interop/skills_scope_service.py Tests/Skills/test_local_skills_service.py Tests/Skills/test_skills_scope_service.py
+git commit -m "feat: enforce trust for local skills"
+```
+
+Expected: commit succeeds.
+
+## Task 7: Wire Trust Service In App Construction
+
+**Files:**
+- Modify: `tldw_chatbook/app.py`
+- Modify: `Tests/UI/test_screen_navigation.py`
+
+- [ ] **Step 1: Add failing app wiring assertion**
+
+In `Tests/UI/test_screen_navigation.py`, extend the local skills service wiring test with:
+
+```python
+    assert app.local_skill_trust_service is app.local_skills_service.trust_service
+    assert app.local_skill_trust_service.skills_dir == app.local_skills_service.skills_dir
+```
+
+- [ ] **Step 2: Run failing app wiring test**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/UI/test_screen_navigation.py::test_app_wires_local_and_server_skills_services --tb=short
+```
+
+Expected: fail because `local_skill_trust_service` is not wired.
+
+- [ ] **Step 3: Wire trust store and service in `app.py`**
+
+Near the existing `LocalSkillsService` construction, import:
+
+```python
+from .Skills_Interop.skill_trust_service import SkillTrustService
+from .Skills_Interop.skill_trust_store import FileSkillTrustGenerationMarkerStore, SkillTrustStore
+```
+
+Replace the local skills construction with:
+
+```python
+        local_skills_store_dir = get_user_data_dir() / "skills"
+        self.local_skill_trust_service = SkillTrustService(
+            skills_dir=local_skills_store_dir / "skills",
+            trust_store=SkillTrustStore(
+                store_dir=local_skills_store_dir / "trust",
+                marker_store=FileSkillTrustGenerationMarkerStore(
+                    local_skills_store_dir / "trust_generation_marker.json",
+                ),
+            ),
+        )
+        self.local_skills_service = LocalSkillsService(
+            store_dir=local_skills_store_dir,
+            policy_enforcer=self.service_policy_enforcer,
+            trust_service=self.local_skill_trust_service,
+        )
+```
+
+- [ ] **Step 4: Run app wiring test**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/UI/test_screen_navigation.py::test_app_wires_local_and_server_skills_services --tb=short
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit app wiring**
+
+Run:
+
+```bash
+git add tldw_chatbook/app.py Tests/UI/test_screen_navigation.py
+git commit -m "feat: wire local skill trust service"
+```
+
+Expected: commit succeeds.
+
+## Task 8: Add Skills Screen Trust States And Recovery Actions
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/skills_screen.py`
+- Test: `Tests/UI/test_destination_shells.py`
+
+- [ ] **Step 1: Add failing Skills UI trust-state tests**
+
+Append to the Skills destination tests:
+
+```python
+@pytest.mark.asyncio
+async def test_skills_destination_blocks_metadata_valid_trust_blocked_skill():
+    app = _build_test_app()
+    app.skills_scope_service = StaticSkillsScopeService(
+        [
+            {
+                "name": "summarize-notes",
+                "description": "Summarize note collections",
+                "record_id": "local:skill:summarize-notes",
+                "validation_status": "valid",
+                "validation_errors": [],
+                "trust_status": "quarantined_modified",
+                "trust_reason_code": "skill_modified",
+                "trust_blocked": True,
+                "trust_changed_files": ["SKILL.md"],
+            },
+        ]
+    )
+    host = DestinationHarness(app, "skills")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_skills_snapshot(screen, pilot)
+        text = _visible_text(screen)
+        button = screen.query_one("#skills-attach-to-console", Button)
+
+        assert "Trust: changed since trusted baseline" in text
+        assert "Reason code: skill_modified" in text
+        assert "Changed files: SKILL.md" in text
+        assert button.disabled is True
+
+
+@pytest.mark.asyncio
+async def test_skills_destination_shows_uninitialized_bootstrap_action():
+    app = _build_test_app()
+    app.skills_scope_service = StaticSkillsScopeService(
+        [
+            {
+                "name": "new-skill",
+                "description": "New local skill",
+                "record_id": "local:skill:new-skill",
+                "validation_status": "valid",
+                "validation_errors": [],
+                "trust_status": "trust_uninitialized",
+                "trust_reason_code": "trust_uninitialized",
+                "trust_blocked": True,
+            },
+        ]
+    )
+    host = DestinationHarness(app, "skills")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_skills_snapshot(screen, pilot)
+        text = _visible_text(screen)
+
+        assert "Trust: not initialized" in text
+        assert screen.query_one("#skills-bootstrap-trust", Button).disabled is False
+```
+
+- [ ] **Step 2: Run failing Skills UI tests**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/UI/test_destination_shells.py::test_skills_destination_blocks_metadata_valid_trust_blocked_skill Tests/UI/test_destination_shells.py::test_skills_destination_shows_uninitialized_bootstrap_action --tb=short
+```
+
+Expected: fail because the screen does not render trust state.
+
+- [ ] **Step 3: Add trust helpers to SkillsScreen**
+
+In `tldw_chatbook/UI/Screens/skills_screen.py`, add methods:
+
+```python
+    def _skill_trust_status(self, record: Mapping[str, Any]) -> str:
+        return self._skill_field(record, "trust_status", "trusted")
+
+    def _skill_trust_reason(self, record: Mapping[str, Any]) -> str:
+        return self._skill_field(record, "trust_reason_code")
+
+    def _skill_trust_blocked(self, record: Mapping[str, Any]) -> bool:
+        return bool(record.get("trust_blocked"))
+
+    def _skill_trust_changed_files(self, record: Mapping[str, Any]) -> list[str]:
+        files = record.get("trust_changed_files")
+        if not isinstance(files, list):
+            return []
+        return [
+            self._safe_skill_text(file_name, max_length=100)
+            for file_name in files
+            if self._safe_skill_text(file_name, max_length=100)
+        ]
+
+    def _skill_trust_copy(self, record: Mapping[str, Any]) -> str:
+        status = self._skill_trust_status(record)
+        if status == "trusted":
+            return "Trust: trusted baseline"
+        if status == "trust_uninitialized":
+            return "Trust: not initialized"
+        if status == "trust_locked":
+            return "Trust: locked"
+        if status == "quarantined_modified":
+            return "Trust: changed since trusted baseline"
+        if status == "quarantined_added":
+            return "Trust: new untrusted file"
+        if status == "quarantined_deleted":
+            return "Trust: trusted file missing"
+        if status == "quarantined_manifest_error":
+            return "Trust: manifest cannot be verified"
+        if status == "quarantined_unsupported_path":
+            return "Trust: unsupported file path"
+        return "Trust: blocked"
+```
+
+Update `_is_skill_valid()`:
+
+```python
+    def _is_skill_valid(self, record: Mapping[str, Any]) -> bool:
+        return self._skill_validation_status(record) == "valid" and not self._skill_trust_blocked(record)
+```
+
+- [ ] **Step 4: Render trust rows and recovery buttons**
+
+In the skill-list render loop, after validation rows, add:
+
+```python
+                            yield Static(
+                                self._plain_text(self._skill_trust_copy(record)),
+                                id=f"skills-trust-status-{index}",
+                            )
+                            trust_reason = self._skill_trust_reason(record)
+                            if trust_reason:
+                                yield Static(
+                                    self._plain_text(f"Reason code: {trust_reason}"),
+                                    id=f"skills-trust-reason-{index}",
+                                )
+                            changed_files = ", ".join(self._skill_trust_changed_files(record))
+                            if changed_files:
+                                yield Static(
+                                    self._plain_text(f"Changed files: {changed_files}"),
+                                    id=f"skills-trust-files-{index}",
+                                )
+```
+
+In the inspector actions, add disabled-safe recovery controls:
+
+```python
+                    yield Button(
+                        "Bootstrap Trust",
+                        id="skills-bootstrap-trust",
+                        disabled=not any(self._skill_trust_status(record) == "trust_uninitialized" for record in self._local_skill_records),
+                        tooltip="Create the first trusted baseline after reviewing current local skills.",
+                    )
+                    yield Button(
+                        "Review Diff",
+                        id="skills-review-diff",
+                        disabled=not (selected_metadata and selected_metadata.get("validation_status") == "valid"),
+                        tooltip="Capture the current skill files and compare them with the trusted baseline.",
+                    )
+                    yield Button(
+                        "Trust Reviewed Version",
+                        id="skills-trust-reviewed-version",
+                        disabled=True,
+                        tooltip="Enabled after a captured diff still matches live files.",
+                    )
+```
+
+- [ ] **Step 5: Run Skills UI trust tests**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/UI/test_destination_shells.py::test_skills_destination_blocks_metadata_valid_trust_blocked_skill Tests/UI/test_destination_shells.py::test_skills_destination_shows_uninitialized_bootstrap_action --tb=short
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Run focused Skills UI tests**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/UI/test_destination_shells.py -k "skills_destination or skills_attach" --tb=short
+```
+
+Expected: pass.
+
+- [ ] **Step 7: Commit Skills UI trust state**
+
+Run:
+
+```bash
+git add tldw_chatbook/UI/Screens/skills_screen.py Tests/UI/test_destination_shells.py
+git commit -m "feat: show local skill trust states"
+```
+
+Expected: commit succeeds.
+
+## Task 9: Add Settings Privacy Trust Posture
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/settings_privacy_security.py`
+- Modify: Settings rendering file that consumes `build_privacy_posture_rows`
+- Test: `Tests/UI/test_settings_privacy_security.py`
+
+- [ ] **Step 1: Add failing posture helper test**
+
+Append to `Tests/UI/test_settings_privacy_security.py`:
+
+```python
+def test_privacy_posture_reports_skill_trust_without_leaking_paths():
+    posture = build_settings_privacy_posture(
+        {"encryption": {"enabled": True}},
+        environ={},
+        skill_trust={
+            "enabled": True,
+            "trust_status": "quarantined_modified",
+            "keyring_convenience_enabled": True,
+            "reduced_rollback_protection": False,
+            "skills_dir": "/Users/example/private/skills",
+        },
+    )
+
+    text = "\n".join(build_privacy_posture_rows(posture))
+
+    assert "Skill trust: quarantined_modified" in text
+    assert "Skill trust keyring convenience: enabled" in text
+    assert "Skill trust rollback protection: full" in text
+    assert "/Users/example/private/skills" not in text
+```
+
+- [ ] **Step 2: Run failing posture test**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/UI/test_settings_privacy_security.py::test_privacy_posture_reports_skill_trust_without_leaking_paths --tb=short
+```
+
+Expected: fail because `build_settings_privacy_posture()` does not accept `skill_trust`.
+
+- [ ] **Step 3: Extend posture dataclass and builder**
+
+In `settings_privacy_security.py`, extend `SettingsPrivacyPosture`:
+
+```python
+    skill_trust_enabled: bool = False
+    skill_trust_status: str = "unavailable"
+    skill_trust_keyring_convenience_enabled: bool = False
+    skill_trust_reduced_rollback_protection: bool = False
+```
+
+Update `build_settings_privacy_posture()` signature:
+
+```python
+def build_settings_privacy_posture(
+    app_config: object,
+    *,
+    environ: Mapping[str, str] | None = None,
+    skill_trust: Mapping[str, object] | None = None,
+) -> SettingsPrivacyPosture:
+```
+
+Add safe extraction before return:
+
+```python
+    trust = skill_trust if isinstance(skill_trust, Mapping) else {}
+```
+
+Pass fields into `SettingsPrivacyPosture`:
+
+```python
+        skill_trust_enabled=bool(trust.get("enabled")),
+        skill_trust_status=str(trust.get("trust_status") or "unavailable")[:80],
+        skill_trust_keyring_convenience_enabled=bool(trust.get("keyring_convenience_enabled")),
+        skill_trust_reduced_rollback_protection=bool(trust.get("reduced_rollback_protection")),
+```
+
+Update `build_privacy_posture_rows()`:
+
+```python
+        f"Skill trust: {posture.skill_trust_status if posture.skill_trust_enabled else 'disabled'}",
+        (
+            "Skill trust keyring convenience: enabled"
+            if posture.skill_trust_keyring_convenience_enabled
+            else "Skill trust keyring convenience: disabled"
+        ),
+        (
+            "Skill trust rollback protection: reduced"
+            if posture.skill_trust_reduced_rollback_protection
+            else "Skill trust rollback protection: full"
+        ),
+```
+
+- [ ] **Step 4: Wire SettingsScreen posture input**
+
+In `tldw_chatbook/UI/Screens/settings_screen.py`, add this helper near `_settings_privacy_posture()`:
+
+```python
+    def _skill_trust_posture(self) -> dict[str, object]:
+        skill_trust_service = getattr(self.app_instance, "local_skill_trust_service", None)
+        if skill_trust_service is None:
+            return {
+                "enabled": False,
+                "trust_status": "unavailable",
+                "keyring_convenience_enabled": False,
+                "reduced_rollback_protection": False,
+            }
+        overall_status = getattr(skill_trust_service, "overall_status", None)
+        return {
+            "enabled": True,
+            "trust_status": overall_status() if callable(overall_status) else "locked",
+            "keyring_convenience_enabled": bool(getattr(skill_trust_service, "keyring_convenience_enabled", False)),
+            "reduced_rollback_protection": bool(getattr(skill_trust_service, "reduced_rollback_protection", False)),
+        }
+```
+
+Update `_settings_privacy_posture()` so it passes the mapping:
+
+```python
+        return build_settings_privacy_posture(
+            app_config,
+            skill_trust=self._skill_trust_posture(),
+        )
+```
+
+In the Privacy & Security renderer, add these rows after the existing `Recovery actions` detail row:
+
+```python
+                yield self._detail_row(
+                    "Skill trust",
+                    posture.skill_trust_status if posture.skill_trust_enabled else "disabled",
+                )
+                yield self._detail_row(
+                    "Skill trust keyring convenience",
+                    "enabled" if posture.skill_trust_keyring_convenience_enabled else "disabled",
+                )
+                yield self._detail_row(
+                    "Skill trust rollback protection",
+                    "reduced" if posture.skill_trust_reduced_rollback_protection else "full",
+                )
+```
+
+- [ ] **Step 5: Run Settings posture tests**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/UI/test_settings_privacy_security.py --tb=short
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit Settings trust posture**
+
+Run:
+
+```bash
+git add tldw_chatbook/UI/Screens/settings_privacy_security.py Tests/UI/test_settings_privacy_security.py
+git commit -m "feat: report local skill trust posture"
+```
+
+Expected: commit succeeds.
+
+## Task 10: Final Verification, Documentation, And Backlog Closeout
+
+**Files:**
+- Modify: `backlog/tasks/task-137 - Add-local-skill-trust-integrity-controls.md`
+- Modify: `Docs/superpowers/specs/2026-06-25-local-skill-trust-integrity-design.md` only if implementation deviated from the approved spec.
+- Test: focused verification commands below.
+
+- [ ] **Step 1: Run focused trust and Skills tests**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/Skills/test_skill_trust_crypto.py Tests/Skills/test_skill_trust_scanner.py Tests/Skills/test_skill_trust_store.py Tests/Skills/test_skill_trust_service.py Tests/Skills/test_local_skills_service.py Tests/Skills/test_skills_scope_service.py --tb=short
+```
+
+Expected: pass.
+
+- [ ] **Step 2: Run runtime policy tests**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/RuntimePolicy/test_domain_edge_contracts.py Tests/RuntimePolicy/test_runtime_policy_core.py --tb=short
+```
+
+Expected: pass.
+
+- [ ] **Step 3: Run focused UI tests**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/UI/test_destination_shells.py -k "skills_destination or skills_attach" --tb=short
+.venv/bin/python -m pytest -q Tests/UI/test_settings_privacy_security.py Tests/UI/test_screen_navigation.py --tb=short
+```
+
+Expected: pass.
+
+- [ ] **Step 4: Run diff hygiene**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output and exit code 0.
+
+- [ ] **Step 5: Update Backlog task acceptance criteria and implementation notes**
+
+Use `backlog task edit` to mark the task Done only after every acceptance criterion is met. The notes must include this content:
+
+```text
+Implemented local skill trust integrity for Chatbook-managed local skills. Added ADR-009-backed trust modules for passphrase-derived keys, authenticated manifests, encrypted trusted snapshots, generation markers, directory scanning, logical quarantine, reviewed re-trust, and deterministic trust-blocked service behavior. Wired trust state into LocalSkillsService, app construction, Skills UI, Settings Privacy posture, and runtime-policy action IDs. Focused trust, Skills, runtime-policy, and UI tests pass. ADR path: backlog/decisions/009-local-skill-trust-boundary.md. Superpowers plan: Docs/superpowers/plans/2026-06-25-local-skill-trust-integrity.md.
+```
+
+Then run:
+
+```bash
+backlog task edit 137 -s Done --notes "Implemented local skill trust integrity for Chatbook-managed local skills. Added ADR-009-backed trust modules for passphrase-derived keys, authenticated manifests, encrypted trusted snapshots, generation markers, directory scanning, logical quarantine, reviewed re-trust, and deterministic trust-blocked service behavior. Wired trust state into LocalSkillsService, app construction, Skills UI, Settings Privacy posture, and runtime-policy action IDs. Focused trust, Skills, runtime-policy, and UI tests pass. ADR path: backlog/decisions/009-local-skill-trust-boundary.md. Superpowers plan: Docs/superpowers/plans/2026-06-25-local-skill-trust-integrity.md."
+```
+
+Expected: task is Done and contains implementation notes.
+
+- [ ] **Step 6: Commit closeout**
+
+Run:
+
+```bash
+git add "backlog/tasks/task-137 - Add-local-skill-trust-integrity-controls.md"
+git commit -m "docs: close local skill trust task"
+```
+
+Expected: commit succeeds.
+
+## Self-Review Notes
+
+Spec coverage:
+
+- Explicit bootstrap and `trust_uninitialized`: Task 5, Task 6, Task 8.
+- Authenticated manifest/snapshots/generation marker: Task 2, Task 4, Task 5.
+- Logical quarantine and use-time blocking: Task 5, Task 6.
+- Reviewed re-trust with snapshot mismatch protection: Task 5, Task 8.
+- Keyring convenience and reduced rollback posture: Task 4, Task 9.
+- UI and Settings recovery visibility: Task 8, Task 9.
+- Runtime policy IDs: Task 1.
+- ADR/task hygiene: Task 1, Task 10.
+
+No implementation work should include Codex runtime skill folders, server skills, skill sync, or physical file moves.

--- a/Docs/superpowers/specs/2026-06-25-local-skill-trust-integrity-design.md
+++ b/Docs/superpowers/specs/2026-06-25-local-skill-trust-integrity-design.md
@@ -61,7 +61,8 @@ Core components:
 
 - `SkillTrustService`: scans skill directories, computes canonical file fingerprints, verifies the signed manifest, classifies drift, logically quarantines unsafe skills, and accepts reviewed baselines.
 - `SkillTrustManifest`: authenticated manifest stored with the local skills store, accepted only when its HMAC verifies with a key derived from the user's startup passphrase.
-- `SkillTrustKeyProvider`: passphrase/session key provider plus optional secure keyring cache. Plaintext fallback is forbidden.
+- `SkillTrustKeyProvider`: passphrase/session key provider plus optional secure keyring cache. Plaintext fallback is forbidden. Keyring convenience mode stores a secure-keyring-protected trust root or wrapped trust root, never the user's passphrase.
+- `SkillTrustGenerationMarkerStore`: stores the latest accepted manifest generation and manifest digest outside the local skills directory. The v1 target is the secure OS keyring. If no secure marker store is available, high-security mode fails closed; a user may explicitly choose reduced rollback protection, which must be visible in Settings and audit output.
 - `SkillTrustSnapshotStore`: encrypted and authenticated trusted copies of `SKILL.md` and supporting text files for trusted-vs-current diffs.
 - `LocalSkillsService` integration: `list_skills`, `get_skill`, `get_context`, and `execute_skill` include trust state and perform use-time trust checks.
 
@@ -71,19 +72,22 @@ Verify at use, not only at launch. Launch scan can populate visible status, but 
 
 Quarantine is logical in v1. Files stay in place for evidence and editor compatibility; the service marks the skill blocked.
 
-Manifest failure is a global safety event. Missing, malformed, downgraded, replayed, or MAC-invalid manifests block all local skills until recovery or explicit re-bootstrap.
+Manifest failure is a global safety event. Missing-after-initialization, malformed, downgraded, replayed, or MAC-invalid manifests block all local skills until recovery or explicit re-bootstrap.
 
 ## Data Flow
 
-On first enablement, Chatbook runs an explicit bootstrap flow. It shows the number of discovered local skills and asks the user to confirm that the current files should become the initial trusted baseline. This avoids silent trust-on-first-use.
+On first enablement, Chatbook runs an explicit bootstrap flow. If no manifest and no generation marker exist, skills enter `trust_uninitialized`: visible but not stageable/executable until the user bootstraps trust. The bootstrap flow shows the number of discovered local skills and asks the user to confirm that the current files should become the initial trusted baseline. This avoids silent trust-on-first-use.
 
-After confirmation, Chatbook asks for a trust passphrase, derives a root key, derives separate subkeys for manifest MAC and snapshot encryption/authentication, scans every local skill directory, writes encrypted trusted snapshots, writes the authenticated manifest, stores the latest accepted manifest generation marker where possible, and records `trust_bootstrap`.
+After confirmation, Chatbook asks for a trust passphrase, derives a root key, derives separate subkeys for manifest MAC and snapshot encryption/authentication, scans every local skill directory, writes encrypted trusted snapshots, writes the authenticated manifest, stores the latest accepted manifest generation marker, and records `trust_bootstrap`.
 
-On startup or first skill access, Chatbook unlocks trust using the passphrase, or secure keyring convenience mode if enabled. If unlock fails or is cancelled, skills remain visible but blocked as `trust_locked`. If unlock succeeds, Chatbook verifies the manifest MAC, schema version, generation, and rollback marker before trusting any skill status.
+On startup or first skill access, Chatbook unlocks trust using the passphrase, or the secure-keyring-protected trust root when convenience mode is enabled. If unlock fails or is cancelled, skills remain visible but blocked as `trust_locked`. If unlock succeeds, Chatbook verifies the manifest MAC, schema version, generation, and rollback marker before trusting any skill status.
+
+If a manifest exists but its generation marker is missing, lower than the manifest generation, or has a mismatched manifest digest, Chatbook treats it as `quarantined_manifest_error`. If the secure generation-marker store is unavailable at runtime, high-security mode blocks local skill use until the marker store is available. Reduced rollback protection mode may continue only if the user explicitly selected it during bootstrap or recovery; the UI must label that old full-store replay cannot be detected in that mode.
 
 Scan states:
 
 - `trusted`: current fingerprints match the trusted manifest.
+- `trust_uninitialized`: trust has not been bootstrapped; skill use is blocked until explicit bootstrap.
 - `trust_locked`: trust key unavailable, so use is blocked without claiming tampering.
 - `quarantined_modified`: trusted skill content changed.
 - `quarantined_added`: new file or skill appears without a trusted baseline.
@@ -91,9 +95,13 @@ Scan states:
 - `quarantined_manifest_error`: manifest cannot be authenticated or safely interpreted.
 - `quarantined_unsupported_path`: symlink, nested path, unsafe filename, crash temp file, or unsupported file type appears.
 
-On list/detail, skills remain visible with metadata and trust state. On context/stage/execute, the selected skill is verified again. If trusted, current behavior proceeds. If blocked, the service returns a deterministic trust-blocked state and UI disables attach/execute.
+On list/detail, skills remain visible with metadata and trust state. On context/stage/execute, the selected skill is verified again. If trusted, current behavior proceeds. If blocked, service behavior is deterministic:
 
-On review, Chatbook captures a current snapshot and diffs it against the encrypted trusted snapshot. If the user approves, Chatbook re-scans the live files and verifies they still match the reviewed snapshot before signing a new baseline.
+- `list_skills()` and `get_skill()` include `trust_status`, `trust_reason_code`, `trust_blocked`, `trust_changed_files`, `trust_manifest_generation`, and `trust_last_verified_at` fields.
+- `get_context()` excludes trust-blocked skills from `available_skills` and may include a `blocked_skills` extra field for UI diagnostics.
+- `execute_skill()` raises a typed `SkillTrustBlockedError` with `skill_name`, `reason_code`, `trust_status`, and changed relative file names. It does not return a rendered prompt for a blocked skill.
+
+On review, Chatbook captures a current snapshot and diffs it against the encrypted trusted snapshot. For a new skill with no trusted snapshot, the review compares current files against an empty baseline and shows every file as an addition. If the user approves, Chatbook re-scans the live files and verifies they still match the reviewed snapshot before signing a new baseline.
 
 Manifest/snapshot updates are atomic: write new encrypted snapshots, write a new manifest temp file, fsync/replace where practical, then update the generation marker. Partial writes resolve to blocked/quarantine states, not partial trust.
 
@@ -104,7 +112,7 @@ The Skills screen adds a trust/readiness layer without hiding metadata validatio
 Visible state is split:
 
 - Metadata: `valid` / `invalid`
-- Trust: `trusted` / `trust_locked` / `quarantined_*` / `quarantined_manifest_error`
+- Trust: `trusted` / `trust_uninitialized` / `trust_locked` / `quarantined_*` / `quarantined_manifest_error`
 - Action: stage/execute enabled only when metadata and trust are both valid
 
 For a quarantined skill, the detail/inspector pane shows plain-language reason, machine-readable reason code, changed files, last trusted timestamp, reviewed snapshot status, and recent trust audit events.
@@ -136,7 +144,9 @@ User copy avoids "infected" or "hacked." Use precise states such as "changed sin
 Trust failures are deterministic and non-destructive:
 
 - `trust_locked`: passphrase/key unavailable; block use without implying tampering.
+- `trust_uninitialized`: no manifest and no generation marker exist; block use until explicit bootstrap.
 - `manifest_invalid`: MAC/schema/generation/rollback check failed; global quarantine.
+- `rollback_marker_unavailable`: secure generation marker store is unavailable in high-security mode; block use until the marker store is available or the user explicitly accepts reduced rollback protection.
 - `skill_modified`: trusted file content changed.
 - `skill_added`: untrusted skill directory or file appeared.
 - `skill_deleted`: trusted file missing.
@@ -159,6 +169,8 @@ Policy defaults:
 
 - No plaintext key storage.
 - No silent downgrade from passphrase to insecure keyring backend.
+- Keyring convenience mode stores a protected trust root or wrapped trust root, never the user's passphrase.
+- A secure generation marker store is required for full rollback protection. Reduced rollback protection requires explicit user opt-in and visible posture reporting.
 - Approval, re-bootstrap, and key rotation require an unlocked passphrase-derived key.
 - Global re-bootstrap requires fresh passphrase confirmation.
 - Lost-passphrase recovery is high-friction re-bootstrap of current files, with prior trust history marked unrecoverable.
@@ -166,7 +178,7 @@ Policy defaults:
 - Audit events are authenticated as part of the trust store, even if v1 does not implement a full append-only hash chain.
 - UI/audit output uses skill names and relative file names by default; absolute paths appear only in explicit evidence export.
 - Trust-blocked skills cannot be staged or executed, even if metadata-valid.
-- Chatbook editor/import may update the trust baseline atomically only after explicit user approval for that mutation. Background or automatic edits do not silently re-trust.
+- Chatbook editor/import may update the trust baseline atomically only after explicit user approval for that mutation. The user's Save/Import confirmation can serve as the approval when the UI clearly states that the trusted baseline will be updated. Background or automatic edits do not silently re-trust.
 - Physical quarantine/move is out of scope for v1.
 - Server skills, Codex runtime skills, and sync semantics are out of scope.
 
@@ -178,12 +190,15 @@ Add focused tests around the trust layer before UI tests:
 
 - Manifest MAC verification rejects tampered manifest content.
 - Missing/malformed/downgraded/replayed manifest causes global quarantine.
+- No manifest and no generation marker produces `trust_uninitialized`, not per-skill quarantine.
+- Missing or mismatched generation marker after initialization causes global quarantine.
+- Secure generation marker store unavailability blocks high-security mode and produces visible reduced-protection posture only after explicit opt-in.
 - Passphrase unlock derives stable keys and separates manifest/snapshot purposes.
-- Secure keyring convenience mode refuses insecure/plaintext keyring backends.
+- Secure keyring convenience mode refuses insecure/plaintext keyring backends and never stores the user passphrase.
 - Trusted skill remains executable/stageable after unchanged scan.
 - Modified `SKILL.md` quarantines and blocks `get_context`/`execute_skill`.
 - Modified supporting file also quarantines and blocks use.
-- New out-of-band skill/file quarantines until reviewed and approved.
+- New out-of-band skill/file quarantines until reviewed and approved, with review showing all files as additions against an empty baseline.
 - Deleted trusted file quarantines.
 - Symlink, nested path, unsafe filename, crash temp file, and unsupported file type classify as `unsupported_path`.
 - Review approval fails with `snapshot_mismatch` if files change after diff capture.
@@ -196,9 +211,9 @@ Service integration tests:
 
 - `LocalSkillsService.list_skills()` includes trust state alongside metadata validation.
 - `get_skill()` exposes blocked reason but still returns safe detail for review.
-- `get_context()` excludes or marks blocked skills so they are not staged as available.
-- `execute_skill()` refuses trust-blocked skills deterministically.
-- Chatbook-approved create/update/import paths update the baseline only as part of explicit approved mutation.
+- `get_context()` excludes trust-blocked skills from `available_skills` and may include `blocked_skills` diagnostics without making blocked skills available to stage.
+- `execute_skill()` raises `SkillTrustBlockedError` and never returns a rendered prompt for trust-blocked skills.
+- Chatbook-approved create/update/import paths update the baseline only as part of explicit approved mutation, and Save/Import confirmation text states that the trusted baseline will be updated.
 
 UI tests:
 

--- a/Docs/superpowers/specs/2026-06-25-local-skill-trust-integrity-design.md
+++ b/Docs/superpowers/specs/2026-06-25-local-skill-trust-integrity-design.md
@@ -1,0 +1,217 @@
+# Local Skill Trust Integrity Design
+
+Date: 2026-06-25
+
+## Purpose
+
+Protect Chatbook-managed local skills from offline file tampering between app launches. A local skill that changes outside a trusted path must be visible but blocked until the user reviews the change and explicitly trusts the new version.
+
+The primary concern is a user running Chatbook, shutting it down, having local skill files modified while the app is offline, then launching Chatbook and unknowingly staging or executing a backdoored skill prompt.
+
+## Scope
+
+This design covers Chatbook-managed local skills stored through `LocalSkillsService`.
+
+It does not cover:
+
+- Codex runtime skill folders such as `~/.codex/skills`.
+- Server-managed skills.
+- Local/server skill sync.
+- Physical file quarantine or moving skill directories.
+- Runtime protection against malicious active app code or a fully compromised user session.
+
+## Current State
+
+Local skills are stored in a Chatbook-owned library with:
+
+- `tldw_chatbook_skills.json` metadata.
+- `skills/<skill-name>/SKILL.md` plus flat supporting files.
+- Atomic content/index writes.
+- Metadata validation for Agent Skills front matter.
+- Prompt-render-only execution with no hidden model invocation.
+
+Current validation proves shape and metadata readiness, but it does not authenticate that the skill files are the same files the user previously trusted.
+
+## Threat Model
+
+The v1 trust boundary is designed for offline tampering where an attacker can modify files in the Chatbook local skills directory while Chatbook is not running, but cannot obtain the user trust passphrase or authenticated trust keys.
+
+This design does not defend against:
+
+- An attacker who can modify Chatbook application code.
+- Malware that intercepts the passphrase.
+- An attacker with access to the unlocked keyring or active process memory.
+- A user intentionally approving a malicious diff.
+
+Keyring convenience mode is lower assurance than passphrase-per-start mode and must be labeled that way.
+
+## ADR Check
+
+ADR required: yes
+
+ADR path: `backlog/decisions/009-local-skill-trust-boundary.md`
+
+Reason: This changes a security boundary, trust root, local storage semantics, runtime policy IDs, and the `LocalSkillsService` contract. The ADR must be created before implementation planning begins. If another ADR consumes `009` first, use the next available number and update implementation references.
+
+## Architecture
+
+Add a local skill integrity layer beside `LocalSkillsService`, not inside UI code. It owns trust verification, quarantine state, review snapshots, and trust decisions for Chatbook-managed local skills only.
+
+Core components:
+
+- `SkillTrustService`: scans skill directories, computes canonical file fingerprints, verifies the signed manifest, classifies drift, logically quarantines unsafe skills, and accepts reviewed baselines.
+- `SkillTrustManifest`: authenticated manifest stored with the local skills store, accepted only when its HMAC verifies with a key derived from the user's startup passphrase.
+- `SkillTrustKeyProvider`: passphrase/session key provider plus optional secure keyring cache. Plaintext fallback is forbidden.
+- `SkillTrustSnapshotStore`: encrypted and authenticated trusted copies of `SKILL.md` and supporting text files for trusted-vs-current diffs.
+- `LocalSkillsService` integration: `list_skills`, `get_skill`, `get_context`, and `execute_skill` include trust state and perform use-time trust checks.
+
+Trust records cover every file in a skill directory, not just `SKILL.md`. The canonical fingerprint input includes normalized relative path, file type, byte length, and SHA-256 content hash.
+
+Verify at use, not only at launch. Launch scan can populate visible status, but staging and execution must re-check the selected skill or a fresh scan generation.
+
+Quarantine is logical in v1. Files stay in place for evidence and editor compatibility; the service marks the skill blocked.
+
+Manifest failure is a global safety event. Missing, malformed, downgraded, replayed, or MAC-invalid manifests block all local skills until recovery or explicit re-bootstrap.
+
+## Data Flow
+
+On first enablement, Chatbook runs an explicit bootstrap flow. It shows the number of discovered local skills and asks the user to confirm that the current files should become the initial trusted baseline. This avoids silent trust-on-first-use.
+
+After confirmation, Chatbook asks for a trust passphrase, derives a root key, derives separate subkeys for manifest MAC and snapshot encryption/authentication, scans every local skill directory, writes encrypted trusted snapshots, writes the authenticated manifest, stores the latest accepted manifest generation marker where possible, and records `trust_bootstrap`.
+
+On startup or first skill access, Chatbook unlocks trust using the passphrase, or secure keyring convenience mode if enabled. If unlock fails or is cancelled, skills remain visible but blocked as `trust_locked`. If unlock succeeds, Chatbook verifies the manifest MAC, schema version, generation, and rollback marker before trusting any skill status.
+
+Scan states:
+
+- `trusted`: current fingerprints match the trusted manifest.
+- `trust_locked`: trust key unavailable, so use is blocked without claiming tampering.
+- `quarantined_modified`: trusted skill content changed.
+- `quarantined_added`: new file or skill appears without a trusted baseline.
+- `quarantined_deleted`: expected trusted file is missing.
+- `quarantined_manifest_error`: manifest cannot be authenticated or safely interpreted.
+- `quarantined_unsupported_path`: symlink, nested path, unsafe filename, crash temp file, or unsupported file type appears.
+
+On list/detail, skills remain visible with metadata and trust state. On context/stage/execute, the selected skill is verified again. If trusted, current behavior proceeds. If blocked, the service returns a deterministic trust-blocked state and UI disables attach/execute.
+
+On review, Chatbook captures a current snapshot and diffs it against the encrypted trusted snapshot. If the user approves, Chatbook re-scans the live files and verifies they still match the reviewed snapshot before signing a new baseline.
+
+Manifest/snapshot updates are atomic: write new encrypted snapshots, write a new manifest temp file, fsync/replace where practical, then update the generation marker. Partial writes resolve to blocked/quarantine states, not partial trust.
+
+## UX And Recovery
+
+The Skills screen adds a trust/readiness layer without hiding metadata validation. A skill can be metadata-valid but trust-blocked.
+
+Visible state is split:
+
+- Metadata: `valid` / `invalid`
+- Trust: `trusted` / `trust_locked` / `quarantined_*` / `quarantined_manifest_error`
+- Action: stage/execute enabled only when metadata and trust are both valid
+
+For a quarantined skill, the detail/inspector pane shows plain-language reason, machine-readable reason code, changed files, last trusted timestamp, reviewed snapshot status, and recent trust audit events.
+
+Actions:
+
+- `Review Diff`: captures the current file snapshot and opens trusted-vs-current diff for supported text files.
+- `Trust Reviewed Version`: disabled until the diff has been opened and the reviewed snapshot still matches live files.
+- `Keep Quarantined`: leaves the skill blocked and records the decision.
+- `Trust New Skill`: uses the same review gate, scoped to one new out-of-band skill.
+- `Export Evidence`: optional follow-up that exports manifest entry, fingerprints, and audit events.
+
+Unsupported or binary files show fingerprint and metadata only. Because current local skills are text-file based, unsupported files remain blocked unless a future policy explicitly allows them.
+
+For global manifest failure, the UI shows global recovery instead of per-skill trust buttons:
+
+- unlock again
+- restore manifest/snapshots from backup
+- re-bootstrap all local skills
+
+Global re-bootstrap is high-friction: passphrase required plus explicit typed confirmation or a two-step prompt, because it trusts the current on-disk state for every local skill. Single-skill trust is available only when the manifest is valid and the issue is isolated to that skill.
+
+`trust_locked` shows an unlock action and keeps skills visible but unusable. Settings > Privacy & Security reports skill trust posture and whether keyring convenience auto-unlock is enabled, but primary recovery lives in Skills.
+
+User copy avoids "infected" or "hacked." Use precise states such as "changed since trusted baseline," "new untrusted file," "trusted file missing," and "trust manifest cannot be verified."
+
+## Error Handling And Policy
+
+Trust failures are deterministic and non-destructive:
+
+- `trust_locked`: passphrase/key unavailable; block use without implying tampering.
+- `manifest_invalid`: MAC/schema/generation/rollback check failed; global quarantine.
+- `skill_modified`: trusted file content changed.
+- `skill_added`: untrusted skill directory or file appeared.
+- `skill_deleted`: trusted file missing.
+- `unsupported_path`: symlink, nested path, unsafe filename, crash temp file, or unsupported file type.
+- `snapshot_mismatch`: reviewed snapshot no longer matches live files at approval time.
+- `trust_store_write_failed`: baseline update failed; keep previous trust state if still valid, otherwise quarantine.
+- `trust_history_unrecoverable`: passphrase lost; old snapshots/audit history cannot be decrypted or verified.
+
+Trust operations get explicit local policy IDs, separate from normal skill CRUD:
+
+- `skills.trust.unlock.local`
+- `skills.trust.review.local`
+- `skills.trust.approve.local`
+- `skills.trust.reject.local`
+- `skills.trust.rebootstrap.local`
+- `skills.trust.rotate_key.local`
+- `skills.trust.audit.local`
+
+Policy defaults:
+
+- No plaintext key storage.
+- No silent downgrade from passphrase to insecure keyring backend.
+- Approval, re-bootstrap, and key rotation require an unlocked passphrase-derived key.
+- Global re-bootstrap requires fresh passphrase confirmation.
+- Lost-passphrase recovery is high-friction re-bootstrap of current files, with prior trust history marked unrecoverable.
+- Key rotation verifies/decrypts the current manifest, snapshots, and authenticated audit records, then re-encrypts/re-MACs them with newly derived keys.
+- Audit events are authenticated as part of the trust store, even if v1 does not implement a full append-only hash chain.
+- UI/audit output uses skill names and relative file names by default; absolute paths appear only in explicit evidence export.
+- Trust-blocked skills cannot be staged or executed, even if metadata-valid.
+- Chatbook editor/import may update the trust baseline atomically only after explicit user approval for that mutation. Background or automatic edits do not silently re-trust.
+- Physical quarantine/move is out of scope for v1.
+- Server skills, Codex runtime skills, and sync semantics are out of scope.
+
+Audit events include bootstrap, unlock failure, manifest failure, quarantine, review opened, trust approved, trust rejected, re-bootstrap, key rotation, lost-passphrase recovery, and write failure. Events include skill name, reason code, manifest generation, and changed relative file names.
+
+## Testing Strategy
+
+Add focused tests around the trust layer before UI tests:
+
+- Manifest MAC verification rejects tampered manifest content.
+- Missing/malformed/downgraded/replayed manifest causes global quarantine.
+- Passphrase unlock derives stable keys and separates manifest/snapshot purposes.
+- Secure keyring convenience mode refuses insecure/plaintext keyring backends.
+- Trusted skill remains executable/stageable after unchanged scan.
+- Modified `SKILL.md` quarantines and blocks `get_context`/`execute_skill`.
+- Modified supporting file also quarantines and blocks use.
+- New out-of-band skill/file quarantines until reviewed and approved.
+- Deleted trusted file quarantines.
+- Symlink, nested path, unsafe filename, crash temp file, and unsupported file type classify as `unsupported_path`.
+- Review approval fails with `snapshot_mismatch` if files change after diff capture.
+- Approving reviewed snapshot updates encrypted snapshots, manifest generation, audit event, and restores use.
+- Lost-passphrase recovery requires re-bootstrap and marks old history unrecoverable.
+- Key rotation preserves trust status and makes old key fail verification.
+- Trust-store partial write/crash residue resolves to blocked/quarantine state.
+
+Service integration tests:
+
+- `LocalSkillsService.list_skills()` includes trust state alongside metadata validation.
+- `get_skill()` exposes blocked reason but still returns safe detail for review.
+- `get_context()` excludes or marks blocked skills so they are not staged as available.
+- `execute_skill()` refuses trust-blocked skills deterministically.
+- Chatbook-approved create/update/import paths update the baseline only as part of explicit approved mutation.
+
+UI tests:
+
+- Skills screen shows metadata-valid but trust-blocked as blocked.
+- Attach button enables only for metadata-valid and trusted skill.
+- Review Diff enables Trust Reviewed Version only after a captured diff.
+- Global manifest failure shows global recovery, not per-skill approval.
+- Settings Privacy & Security shows trust posture and keyring convenience state without leaking paths or secrets.
+
+Verification should run focused Skills tests plus affected Settings/UI tests. Because this introduces a security boundary, add the ADR before implementation planning.
+
+## Implementation Notes For Future Planning
+
+Start implementation with the ADR and a small trust-service substrate before touching Skills UI. The first implementation slice should prove manifest verification, locked/quarantined states, and `LocalSkillsService` blocking behavior without building the full diff UI.
+
+Keep the first PR narrow enough that a reviewer can audit every trust transition. Avoid combining this with server skills, Codex runtime skills, or sync.

--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -622,6 +622,26 @@ async def test_shutdown_stops_and_awaits_active_stream_task():
 
 
 @pytest.mark.asyncio
+async def test_shutdown_ignores_failed_active_stream_task():
+    async def fail_before_shutdown():
+        raise RuntimeError("stream task failed before shutdown")
+
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+    task = asyncio.create_task(fail_before_shutdown())
+    await asyncio.sleep(0)
+    assert task.done()
+
+    controller._active_stream_task = task
+    controller._stop_requested = True
+
+    await controller.shutdown()
+
+    assert controller._active_stream_task is None
+    assert controller._stop_requested is False
+
+
+@pytest.mark.asyncio
 async def test_close_streaming_session_stops_run_without_key_error():
     class WaitingGateway(StreamingGateway):
         def __init__(self):

--- a/Tests/RuntimePolicy/test_domain_edge_contracts.py
+++ b/Tests/RuntimePolicy/test_domain_edge_contracts.py
@@ -90,6 +90,13 @@ def test_skills_and_kanban_have_local_policy_actions():
     for action_id in [
         "skills.list.local",
         "skills.execute.launch.local",
+        "skills.trust.unlock.local",
+        "skills.trust.review.local",
+        "skills.trust.approve.local",
+        "skills.trust.reject.local",
+        "skills.trust.rebootstrap.local",
+        "skills.trust.rotate_key.local",
+        "skills.trust.audit.local",
         "kanban.boards.list.local",
         "kanban.cards.create.local",
         "kanban.card_links.delete.local",

--- a/Tests/RuntimePolicy/test_runtime_policy_core.py
+++ b/Tests/RuntimePolicy/test_runtime_policy_core.py
@@ -818,6 +818,13 @@ EXPECTED_ACTION_IDS_BY_CAPABILITY = {
         skills.list.server
         skills.seed.launch.local
         skills.seed.launch.server
+        skills.trust.approve.local
+        skills.trust.audit.local
+        skills.trust.rebootstrap.local
+        skills.trust.reject.local
+        skills.trust.review.local
+        skills.trust.rotate_key.local
+        skills.trust.unlock.local
         skills.update.local
         skills.update.server
     """),

--- a/Tests/Skills/test_local_skills_service.py
+++ b/Tests/Skills/test_local_skills_service.py
@@ -1,6 +1,7 @@
 import asyncio
 import io
 import zipfile
+from pathlib import Path
 
 import pytest
 
@@ -539,6 +540,9 @@ async def test_local_skills_service_rebaseline_failure_leaves_mutation_applied_b
                 changed_files=("SKILL.md",),
             )
 
+        def verify_skill_content(self, skill_name, *, skill_content, supporting_files):
+            self.ensure_skill_trusted(skill_name)
+
     service = LocalSkillsService(store_dir=tmp_path, trust_service=FailingTrustService())
     await service.create_skill(name="demo-skill", content="# Demo\nInitial")
 
@@ -546,8 +550,14 @@ async def test_local_skills_service_rebaseline_failure_leaves_mutation_applied_b
         await service.update_skill("demo-skill", content="# Demo\nUpdated", trust_approved=True)
 
     loaded = await service.get_skill("demo-skill")
+    listed = await service.list_skills()
+    context = await service.get_context()
+
     assert loaded["content"] == "# Demo\nUpdated"
     assert loaded["trust_status"] == "quarantined_modified"
+    assert listed["skills"][0]["trust_status"] == "quarantined_modified"
+    assert context["available_skills"] == []
+    assert context["blocked_skills"][0]["name"] == "demo-skill"
     with pytest.raises(SkillTrustBlockedError, match="trust_rebaseline_failed"):
         await service.execute_skill("demo-skill", args="x")
 
@@ -577,6 +587,9 @@ async def test_local_skills_service_execute_rechecks_trust_after_reading_content
                 changed_files=("SKILL.md",),
             )
 
+        def verify_skill_content(self, skill_name, *, skill_content, supporting_files):
+            self.ensure_skill_trusted(skill_name)
+
     skill_path = tmp_path / "skills" / "demo-skill" / "SKILL.md"
     trust_service = MutatingTrustService(skill_path)
     service = LocalSkillsService(store_dir=tmp_path, trust_service=trust_service)
@@ -585,3 +598,26 @@ async def test_local_skills_service_execute_rechecks_trust_after_reading_content
     with pytest.raises(SkillTrustBlockedError, match="skill_modified"):
         await service.execute_skill("demo-skill", args="x")
     assert trust_service.checks == 2
+
+
+@pytest.mark.asyncio
+async def test_local_skills_service_execute_rejects_read_and_restore_content_race(tmp_path, monkeypatch):
+    service, trust = _trusted_local_service(tmp_path)
+    await service.create_skill(name="demo-skill", content="# Demo\nRender {{args}}")
+    trust.bootstrap_trust()
+    skill_path = tmp_path / "skills" / "demo-skill" / "SKILL.md"
+    trusted_content = skill_path.read_text(encoding="utf-8")
+    malicious_content = "# Demo\nMALICIOUS {{args}}"
+    original_read_text = Path.read_text
+
+    def read_malicious_then_restored(self, *args, **kwargs):
+        if self == skill_path:
+            assert original_read_text(self, encoding="utf-8") == trusted_content
+            return malicious_content
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", read_malicious_then_restored)
+
+    with pytest.raises(SkillTrustBlockedError, match="skill_modified"):
+        await service.execute_skill("demo-skill", args="x")
+    assert original_read_text(skill_path, encoding="utf-8") == trusted_content

--- a/Tests/Skills/test_local_skills_service.py
+++ b/Tests/Skills/test_local_skills_service.py
@@ -5,6 +5,12 @@ import zipfile
 import pytest
 
 from tldw_chatbook.Skills_Interop.local_skills_service import LocalSkillsService
+from tldw_chatbook.Skills_Interop.skill_trust_models import SkillTrustBlockedError
+from tldw_chatbook.Skills_Interop.skill_trust_service import SkillTrustService
+from tldw_chatbook.Skills_Interop.skill_trust_store import (
+    FileSkillTrustGenerationMarkerStore,
+    SkillTrustStore,
+)
 
 
 SKILL_WITH_METADATA = """---
@@ -39,6 +45,18 @@ Missing valid Agent Skills metadata.
 """
 
 
+def _trusted_local_service(tmp_path):
+    trust_service = SkillTrustService(
+        skills_dir=tmp_path / "skills",
+        trust_store=SkillTrustStore(
+            store_dir=tmp_path / "trust",
+            marker_store=FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json"),
+        ),
+    )
+    trust_service.unlock_with_passphrase("passphrase", salt=b"7" * 32)
+    return LocalSkillsService(store_dir=tmp_path, trust_service=trust_service), trust_service
+
+
 @pytest.mark.asyncio
 async def test_local_skills_service_persists_skill_metadata(tmp_path):
     service = LocalSkillsService(store_dir=tmp_path)
@@ -57,8 +75,12 @@ async def test_local_skills_service_persists_skill_metadata(tmp_path):
     assert loaded["context"] == "fork"
     assert loaded["user_invocable"] is True
     assert loaded["disable_model_invocation"] is False
+    assert loaded["trust_status"] == "trusted"
+    assert loaded["trust_blocked"] is False
     assert listed["skills"][0]["name"] == "summarize-notes"
     assert listed["skills"][0]["description"] == "Summarize notes"
+    assert listed["skills"][0]["trust_status"] == "trusted"
+    assert listed["skills"][0]["trust_blocked"] is False
     assert context["available_skills"][0]["argument_hint"] == "note id"
     assert "- summarize-notes" in context["context_text"]
 
@@ -301,3 +323,71 @@ async def test_local_skills_service_seed_builtin_skills_is_deterministic_when_em
     service = LocalSkillsService(store_dir=tmp_path)
 
     assert await service.seed_builtin_skills(overwrite=True) == {"seeded": [], "count": 0}
+
+
+@pytest.mark.asyncio
+async def test_local_skills_service_exposes_trust_state_and_blocks_uninitialized_context(tmp_path):
+    service, _trust = _trusted_local_service(tmp_path)
+    await service.create_skill(name="demo-skill", content="# Demo\nRender {{args}}")
+
+    listed = await service.list_skills()
+    loaded = await service.get_skill("demo-skill")
+    context = await service.get_context()
+
+    assert listed["skills"][0]["trust_status"] == "trust_uninitialized"
+    assert listed["skills"][0]["trust_blocked"] is True
+    assert loaded["trust_status"] == "trust_uninitialized"
+    assert loaded["trust_blocked"] is True
+    assert context["available_skills"] == []
+    assert context["blocked_skills"][0]["name"] == "demo-skill"
+    assert context["blocked_skills"][0]["trust_reason_code"] == "trust_uninitialized"
+    assert "demo-skill" not in context["context_text"]
+
+
+@pytest.mark.asyncio
+async def test_local_skills_service_blocks_execute_when_skill_changes_on_disk_after_bootstrap(tmp_path):
+    service, trust = _trusted_local_service(tmp_path)
+    await service.create_skill(name="demo-skill", content="# Demo\nRender {{args}}")
+    trust.bootstrap_trust()
+    (tmp_path / "skills" / "demo-skill" / "SKILL.md").write_text(
+        "# Demo\nChanged {{args}}",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SkillTrustBlockedError, match="skill_modified"):
+        await service.execute_skill("demo-skill", args="x")
+
+
+@pytest.mark.asyncio
+async def test_local_skills_service_retrusts_explicitly_approved_update(tmp_path):
+    service, trust = _trusted_local_service(tmp_path)
+    await service.create_skill(name="demo-skill", content="# Demo\nRender {{args}}")
+    trust.bootstrap_trust()
+
+    updated = await service.update_skill(
+        "demo-skill",
+        content="# Demo\nChanged {{args}}",
+        trust_approved=True,
+    )
+    listed = await service.list_skills()
+
+    assert updated["trust_status"] == "trusted"
+    assert updated["trust_blocked"] is False
+    assert listed["skills"][0]["trust_status"] == "trusted"
+
+
+@pytest.mark.asyncio
+async def test_local_skills_service_unapproved_update_remains_trust_blocked(tmp_path):
+    service, trust = _trusted_local_service(tmp_path)
+    await service.create_skill(name="demo-skill", content="# Demo\nRender {{args}}")
+    trust.bootstrap_trust()
+
+    updated = await service.update_skill("demo-skill", content="# Demo\nChanged {{args}}")
+    context = await service.get_context()
+
+    assert updated["trust_status"] == "quarantined_modified"
+    assert updated["trust_blocked"] is True
+    assert updated["trust_changed_files"] == ["SKILL.md"]
+    assert context["available_skills"] == []
+    assert context["blocked_skills"][0]["trust_status"] == "quarantined_modified"
+    assert "demo-skill" not in context["context_text"]

--- a/Tests/Skills/test_local_skills_service.py
+++ b/Tests/Skills/test_local_skills_service.py
@@ -601,23 +601,39 @@ async def test_local_skills_service_execute_rechecks_trust_after_reading_content
 
 
 @pytest.mark.asyncio
+async def test_local_skills_service_execute_preserves_crlf_for_exact_trust_verification(tmp_path):
+    service, trust = _trusted_local_service(tmp_path)
+    await service.create_skill(
+        name="crlf-skill",
+        content="# CRLF\r\nRender {{args}}\r\n",
+        supporting_files={"notes.md": "trusted notes\r\n"},
+    )
+    trust.bootstrap_trust()
+
+    assert trust.status_for_skill("crlf-skill").trust_status == "trusted"
+    result = await service.execute_skill("crlf-skill", args="x")
+
+    assert result["rendered_prompt"] == "# CRLF\r\nRender x"
+
+
+@pytest.mark.asyncio
 async def test_local_skills_service_execute_rejects_read_and_restore_content_race(tmp_path, monkeypatch):
     service, trust = _trusted_local_service(tmp_path)
     await service.create_skill(name="demo-skill", content="# Demo\nRender {{args}}")
     trust.bootstrap_trust()
     skill_path = tmp_path / "skills" / "demo-skill" / "SKILL.md"
-    trusted_content = skill_path.read_text(encoding="utf-8")
-    malicious_content = "# Demo\nMALICIOUS {{args}}"
-    original_read_text = Path.read_text
+    original_read_bytes = Path.read_bytes
+    trusted_content = original_read_bytes(skill_path)
+    malicious_content = b"# Demo\nMALICIOUS {{args}}"
 
     def read_malicious_then_restored(self, *args, **kwargs):
         if self == skill_path:
-            assert original_read_text(self, encoding="utf-8") == trusted_content
+            assert original_read_bytes(self) == trusted_content
             return malicious_content
-        return original_read_text(self, *args, **kwargs)
+        return original_read_bytes(self, *args, **kwargs)
 
-    monkeypatch.setattr(Path, "read_text", read_malicious_then_restored)
+    monkeypatch.setattr(Path, "read_bytes", read_malicious_then_restored)
 
     with pytest.raises(SkillTrustBlockedError, match="skill_modified"):
         await service.execute_skill("demo-skill", args="x")
-    assert original_read_text(skill_path, encoding="utf-8") == trusted_content
+    assert original_read_bytes(skill_path) == trusted_content

--- a/Tests/Skills/test_local_skills_service.py
+++ b/Tests/Skills/test_local_skills_service.py
@@ -407,6 +407,20 @@ async def test_local_skills_service_blocks_execute_when_skill_changes_on_disk_af
 
 
 @pytest.mark.asyncio
+async def test_local_skills_service_rejects_symlinked_skill_file_reads(tmp_path):
+    service = _compat_local_service(tmp_path)
+    await service.create_skill(name="demo-skill", content="# Demo\nRender {{args}}")
+    outside = tmp_path / "outside.md"
+    outside.write_text("# Outside\nsecret", encoding="utf-8")
+    skill_path = tmp_path / "skills" / "demo-skill" / "SKILL.md"
+    skill_path.unlink()
+    skill_path.symlink_to(outside)
+
+    with pytest.raises(ValueError, match="unsafe local skill path"):
+        await service.get_skill("demo-skill")
+
+
+@pytest.mark.asyncio
 async def test_local_skills_service_retrusts_explicitly_approved_update(tmp_path):
     service, trust = _trusted_local_service(tmp_path)
     await service.create_skill(name="demo-skill", content="# Demo\nRender {{args}}")

--- a/Tests/Skills/test_local_skills_service.py
+++ b/Tests/Skills/test_local_skills_service.py
@@ -5,7 +5,7 @@ import zipfile
 import pytest
 
 from tldw_chatbook.Skills_Interop.local_skills_service import LocalSkillsService
-from tldw_chatbook.Skills_Interop.skill_trust_models import SkillTrustBlockedError
+from tldw_chatbook.Skills_Interop.skill_trust_models import SkillTrustBlockedError, SkillTrustStatus
 from tldw_chatbook.Skills_Interop.skill_trust_service import SkillTrustService
 from tldw_chatbook.Skills_Interop.skill_trust_store import (
     FileSkillTrustGenerationMarkerStore,
@@ -57,12 +57,38 @@ def _trusted_local_service(tmp_path):
     return LocalSkillsService(store_dir=tmp_path, trust_service=trust_service), trust_service
 
 
+def _compat_local_service(store_dir):
+    return LocalSkillsService(
+        store_dir=store_dir,
+        allow_untrusted_without_trust_service=True,
+    )
+
+
+def _skill_trust_status(
+    skill_name: str,
+    *,
+    trust_status: str = "trusted",
+    trust_reason_code: str | None = None,
+    trust_blocked: bool = False,
+    changed_files: tuple[str, ...] = (),
+) -> SkillTrustStatus:
+    return SkillTrustStatus(
+        skill_name=skill_name,
+        trust_status=trust_status,
+        trust_reason_code=trust_reason_code,
+        trust_blocked=trust_blocked,
+        changed_files=changed_files,
+        manifest_generation=1,
+        last_verified_at="2026-06-25T00:00:00+00:00",
+    )
+
+
 @pytest.mark.asyncio
 async def test_local_skills_service_persists_skill_metadata(tmp_path):
-    service = LocalSkillsService(store_dir=tmp_path)
+    service = _compat_local_service(tmp_path)
 
     created = await service.create_skill(name="summarize-notes", content=SKILL_WITH_METADATA)
-    reloaded = LocalSkillsService(store_dir=tmp_path)
+    reloaded = _compat_local_service(tmp_path)
     loaded = await reloaded.get_skill("summarize-notes")
     listed = await reloaded.list_skills()
     context = await reloaded.get_context()
@@ -87,7 +113,7 @@ async def test_local_skills_service_persists_skill_metadata(tmp_path):
 
 @pytest.mark.asyncio
 async def test_local_skills_service_validates_agent_skill_metadata_contract(tmp_path):
-    service = LocalSkillsService(store_dir=tmp_path)
+    service = _compat_local_service(tmp_path)
 
     created = await service.create_skill(name="summarize-notes", content=AGENT_SKILL_WITH_METADATA)
     listed = await service.list_skills()
@@ -105,7 +131,7 @@ async def test_local_skills_service_validates_agent_skill_metadata_contract(tmp_
 
 @pytest.mark.asyncio
 async def test_local_skills_service_sanitizes_agent_skill_frontmatter_fields(tmp_path):
-    service = LocalSkillsService(store_dir=tmp_path)
+    service = _compat_local_service(tmp_path)
     content = """---
 name: summarize-notes
 description: Summarize notes.
@@ -133,7 +159,7 @@ Summarize the selected notes.
 
 @pytest.mark.asyncio
 async def test_local_skills_service_accepts_agent_skill_name_starting_with_number(tmp_path):
-    service = LocalSkillsService(store_dir=tmp_path)
+    service = _compat_local_service(tmp_path)
     content = """---
 name: 1-summary
 description: Summarize notes. Use when a user asks for a concise notes summary.
@@ -152,7 +178,7 @@ Summarize the selected notes.
 
 @pytest.mark.asyncio
 async def test_local_skills_service_import_preserves_digit_leading_agent_skill_name(tmp_path):
-    service = LocalSkillsService(store_dir=tmp_path)
+    service = _compat_local_service(tmp_path)
     content = b"""---
 name: 1-summary
 description: Summarize notes. Use when a user asks for a concise notes summary.
@@ -175,7 +201,7 @@ Summarize the selected notes.
 
 @pytest.mark.asyncio
 async def test_local_skills_service_marks_over_schema_limit_description_invalid_without_crashing(tmp_path):
-    service = LocalSkillsService(store_dir=tmp_path)
+    service = _compat_local_service(tmp_path)
     oversized_description = "x" * 1001
     content = f"""---
 name: summarize-notes
@@ -194,7 +220,7 @@ Summarize the selected notes.
 
 @pytest.mark.asyncio
 async def test_local_skills_service_reports_invalid_agent_skill_metadata_without_mutating_content(tmp_path):
-    service = LocalSkillsService(store_dir=tmp_path)
+    service = _compat_local_service(tmp_path)
 
     created = await service.create_skill(name="summarize-notes", content=INVALID_AGENT_SKILL)
     listed = await service.list_skills()
@@ -209,7 +235,7 @@ async def test_local_skills_service_reports_invalid_agent_skill_metadata_without
 
 @pytest.mark.asyncio
 async def test_local_skills_service_uses_deterministic_metadata_defaults(tmp_path):
-    service = LocalSkillsService(store_dir=tmp_path)
+    service = _compat_local_service(tmp_path)
 
     await service.create_skill(name="draft-helper", content="# Draft Helper\n\nHelps rewrite local drafts.")
     loaded = await service.get_skill("draft-helper")
@@ -225,7 +251,7 @@ async def test_local_skills_service_uses_deterministic_metadata_defaults(tmp_pat
 
 @pytest.mark.asyncio
 async def test_local_skills_service_blocks_stale_expected_version(tmp_path):
-    service = LocalSkillsService(store_dir=tmp_path)
+    service = _compat_local_service(tmp_path)
     await service.create_skill(name="demo-skill", content="# Demo\nInitial")
 
     await service.update_skill("demo-skill", content="# Demo\nUpdated", expected_version=1)
@@ -236,7 +262,7 @@ async def test_local_skills_service_blocks_stale_expected_version(tmp_path):
 
 @pytest.mark.asyncio
 async def test_local_skills_service_serializes_concurrent_updates(tmp_path):
-    service = LocalSkillsService(store_dir=tmp_path)
+    service = _compat_local_service(tmp_path)
     await service.create_skill(name="demo-skill", content="# Demo\nInitial")
 
     await asyncio.gather(
@@ -251,7 +277,7 @@ async def test_local_skills_service_serializes_concurrent_updates(tmp_path):
 
 @pytest.mark.asyncio
 async def test_local_skills_service_rejects_unsafe_supporting_file_names(tmp_path):
-    service = LocalSkillsService(store_dir=tmp_path)
+    service = _compat_local_service(tmp_path)
 
     with pytest.raises(ValueError, match="Invalid supporting file name"):
         await service.create_skill(
@@ -263,7 +289,7 @@ async def test_local_skills_service_rejects_unsafe_supporting_file_names(tmp_pat
 
 @pytest.mark.asyncio
 async def test_local_skills_service_import_export_round_trip(tmp_path):
-    source = LocalSkillsService(store_dir=tmp_path / "source")
+    source = _compat_local_service(tmp_path / "source")
     created = await source.import_skill(
         name="rewrite-draft",
         content="# Rewrite\nRewrite {{args}}.",
@@ -276,7 +302,7 @@ async def test_local_skills_service_import_export_round_trip(tmp_path):
     with zipfile.ZipFile(io.BytesIO(exported["content"]), "r") as archive:
         assert sorted(archive.namelist()) == ["SKILL.md", "style.md"]
 
-    target = LocalSkillsService(store_dir=tmp_path / "target")
+    target = _compat_local_service(tmp_path / "target")
     imported = await target.import_skill_file(
         exported["content"],
         filename=exported["filename"],
@@ -290,7 +316,7 @@ async def test_local_skills_service_import_export_round_trip(tmp_path):
 
 @pytest.mark.asyncio
 async def test_local_skills_service_import_skill_file_derives_name_from_markdown_filename(tmp_path):
-    service = LocalSkillsService(store_dir=tmp_path)
+    service = _compat_local_service(tmp_path)
 
     imported = await service.import_skill_file(
         b"# File Skill\nRender {{args}}",
@@ -303,7 +329,7 @@ async def test_local_skills_service_import_skill_file_derives_name_from_markdown
 
 @pytest.mark.asyncio
 async def test_local_skills_service_execute_renders_prompt_without_model_invocation(tmp_path):
-    service = LocalSkillsService(store_dir=tmp_path)
+    service = _compat_local_service(tmp_path)
     await service.create_skill(name="summarize-notes", content=SKILL_WITH_METADATA)
 
     result = await service.execute_skill("summarize-notes", args="note-1")
@@ -320,9 +346,30 @@ async def test_local_skills_service_execute_renders_prompt_without_model_invocat
 
 @pytest.mark.asyncio
 async def test_local_skills_service_seed_builtin_skills_is_deterministic_when_empty(tmp_path):
-    service = LocalSkillsService(store_dir=tmp_path)
+    service = _compat_local_service(tmp_path)
 
     assert await service.seed_builtin_skills(overwrite=True) == {"seeded": [], "count": 0}
+
+
+@pytest.mark.asyncio
+async def test_local_skills_service_without_trust_service_fails_closed_by_default(tmp_path):
+    service = LocalSkillsService(store_dir=tmp_path)
+    await service.create_skill(name="demo-skill", content="# Demo\nRender {{args}}")
+
+    listed = await service.list_skills()
+    loaded = await service.get_skill("demo-skill")
+    context = await service.get_context()
+
+    assert listed["skills"][0]["trust_status"] == "trust_locked"
+    assert listed["skills"][0]["trust_reason_code"] == "trust_service_unavailable"
+    assert listed["skills"][0]["trust_blocked"] is True
+    assert loaded["trust_status"] == "trust_locked"
+    assert loaded["trust_reason_code"] == "trust_service_unavailable"
+    assert context["available_skills"] == []
+    assert context["blocked_skills"][0]["name"] == "demo-skill"
+    assert "demo-skill" not in context["context_text"]
+    with pytest.raises(SkillTrustBlockedError, match="trust_service_unavailable"):
+        await service.execute_skill("demo-skill", args="x")
 
 
 @pytest.mark.asyncio
@@ -391,3 +438,150 @@ async def test_local_skills_service_unapproved_update_remains_trust_blocked(tmp_
     assert context["available_skills"] == []
     assert context["blocked_skills"][0]["trust_status"] == "quarantined_modified"
     assert "demo-skill" not in context["context_text"]
+
+
+@pytest.mark.asyncio
+async def test_local_skills_service_create_requires_explicit_trust_approval_after_bootstrap(tmp_path):
+    service, trust = _trusted_local_service(tmp_path)
+    trust.bootstrap_trust()
+
+    unapproved = await service.create_skill(name="draft-skill", content="# Draft\nRender {{args}}")
+    approved = await service.create_skill(
+        name="approved-skill",
+        content="# Approved\nRender {{args}}",
+        trust_approved=True,
+    )
+    context = await service.get_context()
+
+    assert unapproved["trust_status"] == "quarantined_added"
+    assert unapproved["trust_blocked"] is True
+    assert approved["trust_status"] == "trusted"
+    assert approved["trust_blocked"] is False
+    assert [item["name"] for item in context["available_skills"]] == ["approved-skill"]
+    assert [item["name"] for item in context["blocked_skills"]] == ["draft-skill"]
+    with pytest.raises(SkillTrustBlockedError, match="skill_added"):
+        await service.execute_skill("draft-skill", args="x")
+    assert (await service.execute_skill("approved-skill", args="x"))["rendered_prompt"] == "# Approved\nRender x"
+
+
+@pytest.mark.asyncio
+async def test_local_skills_service_import_requires_explicit_trust_approval_after_bootstrap(tmp_path):
+    service, trust = _trusted_local_service(tmp_path)
+    trust.bootstrap_trust()
+
+    unapproved = await service.import_skill(
+        name="imported-draft",
+        content="# Imported Draft\nRender {{args}}",
+    )
+    approved = await service.import_skill(
+        name="imported-approved",
+        content="# Imported Approved\nRender {{args}}",
+        trust_approved=True,
+    )
+
+    assert unapproved["trust_status"] == "quarantined_added"
+    assert unapproved["trust_blocked"] is True
+    assert approved["trust_status"] == "trusted"
+    assert approved["trust_blocked"] is False
+    with pytest.raises(SkillTrustBlockedError, match="skill_added"):
+        await service.execute_skill("imported-draft", args="x")
+    assert (await service.execute_skill("imported-approved", args="x"))["rendered_prompt"] == (
+        "# Imported Approved\nRender x"
+    )
+
+
+@pytest.mark.asyncio
+async def test_local_skills_service_import_file_requires_explicit_trust_approval_after_bootstrap(tmp_path):
+    service, trust = _trusted_local_service(tmp_path)
+    trust.bootstrap_trust()
+
+    unapproved = await service.import_skill_file(
+        b"# File Draft\nRender {{args}}",
+        filename="file-draft.md",
+        content_type="text/markdown",
+    )
+    approved = await service.import_skill_file(
+        b"# File Approved\nRender {{args}}",
+        filename="file-approved.md",
+        content_type="text/markdown",
+        trust_approved=True,
+    )
+
+    assert unapproved["trust_status"] == "quarantined_added"
+    assert unapproved["trust_blocked"] is True
+    assert approved["trust_status"] == "trusted"
+    assert approved["trust_blocked"] is False
+    with pytest.raises(SkillTrustBlockedError, match="skill_added"):
+        await service.execute_skill("file-draft", args="x")
+    assert (await service.execute_skill("file-approved", args="x"))["rendered_prompt"] == "# File Approved\nRender x"
+
+
+@pytest.mark.asyncio
+async def test_local_skills_service_rebaseline_failure_leaves_mutation_applied_but_blocked(tmp_path):
+    class FailingTrustService:
+        def status_for_skill(self, skill_name):
+            return _skill_trust_status(
+                skill_name,
+                trust_status="quarantined_modified",
+                trust_reason_code="trust_rebaseline_failed",
+                trust_blocked=True,
+                changed_files=("SKILL.md",),
+            )
+
+        def trust_current_skill(self, skill_name, *, audit_event):
+            raise RuntimeError("trust store unavailable")
+
+        def ensure_skill_trusted(self, skill_name):
+            raise SkillTrustBlockedError(
+                skill_name=skill_name,
+                reason_code="trust_rebaseline_failed",
+                trust_status="quarantined_modified",
+                changed_files=("SKILL.md",),
+            )
+
+    service = LocalSkillsService(store_dir=tmp_path, trust_service=FailingTrustService())
+    await service.create_skill(name="demo-skill", content="# Demo\nInitial")
+
+    with pytest.raises(RuntimeError, match="trust store unavailable"):
+        await service.update_skill("demo-skill", content="# Demo\nUpdated", trust_approved=True)
+
+    loaded = await service.get_skill("demo-skill")
+    assert loaded["content"] == "# Demo\nUpdated"
+    assert loaded["trust_status"] == "quarantined_modified"
+    with pytest.raises(SkillTrustBlockedError, match="trust_rebaseline_failed"):
+        await service.execute_skill("demo-skill", args="x")
+
+
+@pytest.mark.asyncio
+async def test_local_skills_service_execute_rechecks_trust_after_reading_content(tmp_path):
+    class MutatingTrustService:
+        def __init__(self, skill_path):
+            self.skill_path = skill_path
+            self.checks = 0
+
+        def status_for_skill(self, skill_name):
+            return _skill_trust_status(skill_name)
+
+        def trust_current_skill(self, skill_name, *, audit_event):
+            return None
+
+        def ensure_skill_trusted(self, skill_name):
+            self.checks += 1
+            if self.checks == 1:
+                self.skill_path.write_text("# Demo\nChanged {{args}}", encoding="utf-8")
+                return
+            raise SkillTrustBlockedError(
+                skill_name=skill_name,
+                reason_code="skill_modified",
+                trust_status="quarantined_modified",
+                changed_files=("SKILL.md",),
+            )
+
+    skill_path = tmp_path / "skills" / "demo-skill" / "SKILL.md"
+    trust_service = MutatingTrustService(skill_path)
+    service = LocalSkillsService(store_dir=tmp_path, trust_service=trust_service)
+    await service.create_skill(name="demo-skill", content="# Demo\nRender {{args}}")
+
+    with pytest.raises(SkillTrustBlockedError, match="skill_modified"):
+        await service.execute_skill("demo-skill", args="x")
+    assert trust_service.checks == 2

--- a/Tests/Skills/test_skill_trust_crypto.py
+++ b/Tests/Skills/test_skill_trust_crypto.py
@@ -1,0 +1,141 @@
+import pytest
+
+from tldw_chatbook.Skills_Interop import SkillTrustBlockedError, SkillTrustStatus
+from tldw_chatbook.Skills_Interop.skill_trust_crypto import (
+    canonical_json,
+    decrypt_json_blob,
+    derive_skill_trust_keys,
+    encrypt_json_blob,
+    manifest_mac,
+    sha256_hex,
+)
+from tldw_chatbook.Skills_Interop.skill_trust_models import (
+    TRUST_STATUS_TRUSTED,
+    SkillDirectorySnapshot,
+    SkillFileFingerprint,
+)
+
+
+def test_skill_trust_key_derivation_separates_key_purposes():
+    keys = derive_skill_trust_keys("correct horse battery staple", salt=b"0" * 32)
+
+    assert len(keys.manifest_mac_key) == 32
+    assert len(keys.snapshot_key) == 32
+    assert len(keys.audit_mac_key) == 32
+    assert len(keys.wrapped_root_key) == 32
+    assert keys.manifest_mac_key != keys.snapshot_key
+    assert keys.manifest_mac_key != keys.audit_mac_key
+    assert keys.snapshot_key != keys.audit_mac_key
+    assert keys.wrapped_root_key not in {
+        keys.manifest_mac_key,
+        keys.snapshot_key,
+        keys.audit_mac_key,
+    }
+
+
+def test_skill_trust_key_derivation_requires_32_byte_salt():
+    with pytest.raises(ValueError, match="salt must be 32 bytes"):
+        derive_skill_trust_keys("passphrase", salt=b"short")
+
+
+def test_canonical_json_and_sha256_are_deterministic():
+    first = canonical_json({"b": [2, 1], "a": {"z": True}})
+    second = canonical_json({"a": {"z": True}, "b": [2, 1]})
+
+    assert first == second
+    assert first == b'{"a":{"z":true},"b":[2,1]}'
+    assert sha256_hex(b"trusted skill") == (
+        "c595ac6946639cb66901b97a07d21806dadbad0c5755d7a039385b750a6cfc65"
+    )
+
+
+def test_manifest_mac_rejects_tampered_manifest_payload():
+    keys = derive_skill_trust_keys("passphrase", salt=b"1" * 32)
+    manifest = {"version": 1, "generation": 1, "skills": {"demo": {"status": "trusted"}}}
+    tag = manifest_mac(manifest, keys.manifest_mac_key)
+
+    tampered = {"version": 1, "generation": 2, "skills": {"demo": {"status": "trusted"}}}
+
+    assert manifest_mac(manifest, keys.manifest_mac_key) == tag
+    assert manifest_mac(tampered, keys.manifest_mac_key) != tag
+
+
+def test_snapshot_encryption_round_trips_and_authenticates_associated_data():
+    keys = derive_skill_trust_keys("passphrase", salt=b"2" * 32)
+    payload = {"files": {"SKILL.md": "# Demo\nTrusted"}}
+    encrypted = encrypt_json_blob(payload, keys.snapshot_key, associated_data=b"demo:generation:1")
+
+    assert encrypted["alg"] == "AES-256-GCM"
+    assert (
+        decrypt_json_blob(encrypted, keys.snapshot_key, associated_data=b"demo:generation:1")
+        == payload
+    )
+
+    with pytest.raises(ValueError, match="snapshot authentication failed"):
+        decrypt_json_blob(encrypted, keys.snapshot_key, associated_data=b"demo:generation:2")
+
+
+def test_snapshot_decryption_rejects_non_object_payloads():
+    keys = derive_skill_trust_keys("passphrase", salt=b"3" * 32)
+    encrypted = encrypt_json_blob(  # type: ignore[arg-type]
+        ["not", "an", "object"],
+        keys.snapshot_key,
+        associated_data=b"demo:generation:1",
+    )
+
+    with pytest.raises(ValueError, match="snapshot payload must be an object"):
+        decrypt_json_blob(encrypted, keys.snapshot_key, associated_data=b"demo:generation:1")
+
+
+def test_trust_models_produce_json_safe_response_fields():
+    fingerprint = SkillFileFingerprint(
+        relative_path="SKILL.md",
+        file_type="text/markdown",
+        byte_length=12,
+        sha256="abc123",
+    )
+    snapshot = SkillDirectorySnapshot(
+        skill_name="demo",
+        fingerprints=(fingerprint,),
+        text_files={"SKILL.md": "# Demo"},
+    )
+    status = SkillTrustStatus(
+        skill_name="demo",
+        trust_status=TRUST_STATUS_TRUSTED,
+        trust_reason_code=None,
+        trust_blocked=False,
+        changed_files=("SKILL.md",),
+        manifest_generation=3,
+        last_verified_at="2026-06-25T00:00:00+00:00",
+    )
+
+    assert fingerprint.as_manifest_entry() == {
+        "relative_path": "SKILL.md",
+        "file_type": "text/markdown",
+        "byte_length": 12,
+        "sha256": "abc123",
+    }
+    assert snapshot.fingerprint_map == {"SKILL.md": fingerprint}
+    assert status.response_fields() == {
+        "trust_status": "trusted",
+        "trust_reason_code": None,
+        "trust_blocked": False,
+        "trust_changed_files": ["SKILL.md"],
+        "trust_manifest_generation": 3,
+        "trust_last_verified_at": "2026-06-25T00:00:00+00:00",
+    }
+
+
+def test_trust_blocked_error_carries_safe_fields():
+    error = SkillTrustBlockedError(
+        skill_name="demo",
+        reason_code="skill_modified",
+        trust_status="quarantined_modified",
+        changed_files=("SKILL.md",),
+    )
+
+    assert str(error) == "Local skill demo is trust-blocked: skill_modified"
+    assert error.skill_name == "demo"
+    assert error.reason_code == "skill_modified"
+    assert error.trust_status == "quarantined_modified"
+    assert error.changed_files == ("SKILL.md",)

--- a/Tests/Skills/test_skill_trust_crypto.py
+++ b/Tests/Skills/test_skill_trust_crypto.py
@@ -2,6 +2,7 @@ import pytest
 
 from tldw_chatbook.Skills_Interop import SkillTrustBlockedError, SkillTrustStatus
 from tldw_chatbook.Skills_Interop.skill_trust_crypto import (
+    SkillTrustKeys,
     canonical_json,
     decrypt_json_blob,
     derive_skill_trust_keys,
@@ -36,6 +37,23 @@ def test_skill_trust_key_derivation_separates_key_purposes():
 def test_skill_trust_key_derivation_requires_32_byte_salt():
     with pytest.raises(ValueError, match="salt must be 32 bytes"):
         derive_skill_trust_keys("passphrase", salt=b"short")
+
+
+def test_skill_trust_key_repr_redacts_key_material():
+    keys = SkillTrustKeys(
+        manifest_mac_key=b"m" * 32,
+        snapshot_key=b"s" * 32,
+        audit_mac_key=b"a" * 32,
+        wrapped_root_key=b"w" * 32,
+    )
+    rendered = repr(keys)
+
+    assert "SkillTrustKeys" in rendered
+    assert "redacted" in rendered
+    assert "mmmm" not in rendered
+    assert "ssss" not in rendered
+    assert "aaaa" not in rendered
+    assert "wwww" not in rendered
 
 
 def test_canonical_json_and_sha256_are_deterministic():
@@ -75,8 +93,20 @@ def test_snapshot_encryption_round_trips_and_authenticates_associated_data():
         decrypt_json_blob(encrypted, keys.snapshot_key, associated_data=b"demo:generation:2")
 
 
-def test_snapshot_decryption_rejects_non_object_payloads():
+def test_snapshot_encryption_requires_32_byte_keys():
     keys = derive_skill_trust_keys("passphrase", salt=b"3" * 32)
+    payload = {"files": {"SKILL.md": "# Demo\nTrusted"}}
+    encrypted = encrypt_json_blob(payload, keys.snapshot_key, associated_data=b"demo:generation:1")
+
+    with pytest.raises(ValueError, match="32 bytes"):
+        encrypt_json_blob(payload, b"short", associated_data=b"demo:generation:1")
+
+    with pytest.raises(ValueError, match="32 bytes"):
+        decrypt_json_blob(encrypted, b"short", associated_data=b"demo:generation:1")
+
+
+def test_snapshot_decryption_rejects_non_object_payloads():
+    keys = derive_skill_trust_keys("passphrase", salt=b"4" * 32)
     encrypted = encrypt_json_blob(  # type: ignore[arg-type]
         ["not", "an", "object"],
         keys.snapshot_key,
@@ -124,6 +154,18 @@ def test_trust_models_produce_json_safe_response_fields():
         "trust_manifest_generation": 3,
         "trust_last_verified_at": "2026-06-25T00:00:00+00:00",
     }
+
+
+def test_skill_directory_snapshot_repr_redacts_text_file_contents():
+    snapshot = SkillDirectorySnapshot(
+        skill_name="demo",
+        fingerprints=(),
+        text_files={"SKILL.md": "SECRET PROMPT CONTENT"},
+    )
+
+    assert snapshot.text_files["SKILL.md"] == "SECRET PROMPT CONTENT"
+    assert "SECRET PROMPT CONTENT" not in repr(snapshot)
+    assert "text_files" not in repr(snapshot)
 
 
 def test_trust_blocked_error_carries_safe_fields():

--- a/Tests/Skills/test_skill_trust_crypto.py
+++ b/Tests/Skills/test_skill_trust_crypto.py
@@ -168,6 +168,32 @@ def test_skill_directory_snapshot_repr_redacts_text_file_contents():
     assert "text_files" not in repr(snapshot)
 
 
+def test_skill_directory_snapshot_copies_text_files_on_construction():
+    text_files = {"SKILL.md": "trusted baseline"}
+    snapshot = SkillDirectorySnapshot(
+        skill_name="demo",
+        fingerprints=(),
+        text_files=text_files,
+    )
+
+    text_files["SKILL.md"] = "mutated after construction"
+    text_files["extra.md"] = "new file"
+
+    assert snapshot.text_files["SKILL.md"] == "trusted baseline"
+    assert "extra.md" not in snapshot.text_files
+
+
+def test_skill_directory_snapshot_text_files_are_immutable():
+    snapshot = SkillDirectorySnapshot(
+        skill_name="demo",
+        fingerprints=(),
+        text_files={"SKILL.md": "trusted baseline"},
+    )
+
+    with pytest.raises(TypeError):
+        snapshot.text_files["SKILL.md"] = "mutated"
+
+
 def test_trust_blocked_error_carries_safe_fields():
     error = SkillTrustBlockedError(
         skill_name="demo",

--- a/Tests/Skills/test_skill_trust_scanner.py
+++ b/Tests/Skills/test_skill_trust_scanner.py
@@ -1,0 +1,61 @@
+import hashlib
+
+from tldw_chatbook.Skills_Interop.skill_trust_models import SkillFileFingerprint
+from tldw_chatbook.Skills_Interop.skill_trust_scanner import scan_skill_directory
+
+
+def test_scan_skill_directory_fingerprints_skill_and_supporting_text_in_sorted_order(tmp_path):
+    skill_dir = tmp_path / "demo"
+    skill_dir.mkdir()
+    skill_bytes = b"# Demo\nUse safely.\n"
+    notes_bytes = b"Trusted notes.\n"
+    (skill_dir / "notes.md").write_bytes(notes_bytes)
+    (skill_dir / "SKILL.md").write_bytes(skill_bytes)
+
+    snapshot = scan_skill_directory("demo", skill_dir)
+
+    assert snapshot.skill_name == "demo"
+    assert snapshot.fingerprints == (
+        SkillFileFingerprint(
+            relative_path="SKILL.md",
+            file_type="skill",
+            byte_length=len(skill_bytes),
+            sha256=hashlib.sha256(skill_bytes).hexdigest(),
+        ),
+        SkillFileFingerprint(
+            relative_path="notes.md",
+            file_type="supporting_text",
+            byte_length=len(notes_bytes),
+            sha256=hashlib.sha256(notes_bytes).hexdigest(),
+        ),
+    )
+    assert snapshot.text_files["SKILL.md"] == skill_bytes.decode("utf-8")
+    assert snapshot.text_files["notes.md"] == notes_bytes.decode("utf-8")
+    assert snapshot.unsupported_paths == ()
+
+
+def test_scan_skill_directory_marks_unsupported_paths_without_text_or_fingerprints(tmp_path):
+    skill_dir = tmp_path / "demo"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("# Demo\n", encoding="utf-8")
+    (skill_dir / "SKILL.md.tmp").write_text("partial", encoding="utf-8")
+    nested_dir = skill_dir / "nested"
+    nested_dir.mkdir()
+    (nested_dir / "ignored.md").write_text("ignored", encoding="utf-8")
+    (skill_dir / "binary.dat").write_bytes(b"\xff\xfe\x00")
+    (skill_dir / "unsafe name.md").write_text("unsafe", encoding="utf-8")
+    outside = tmp_path / "outside.md"
+    outside.write_text("outside", encoding="utf-8")
+    (skill_dir / "linked.md").symlink_to(outside)
+
+    snapshot = scan_skill_directory("demo", skill_dir)
+
+    assert snapshot.unsupported_paths == (
+        "SKILL.md.tmp",
+        "binary.dat",
+        "linked.md",
+        "nested",
+        "unsafe name.md",
+    )
+    assert [item.relative_path for item in snapshot.fingerprints] == ["SKILL.md"]
+    assert snapshot.text_files == {"SKILL.md": "# Demo\n"}

--- a/Tests/Skills/test_skill_trust_scanner.py
+++ b/Tests/Skills/test_skill_trust_scanner.py
@@ -2,6 +2,8 @@ import hashlib
 import os
 from pathlib import Path
 
+import pytest
+
 from tldw_chatbook.Skills_Interop.skill_trust_models import SkillFileFingerprint
 from tldw_chatbook.Skills_Interop.skill_trust_scanner import scan_skill_directory
 
@@ -89,6 +91,7 @@ def test_scan_skill_directory_rejects_case_variants_and_case_insensitive_temp_su
         assert variant_snapshot.text_files == {}
 
 
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="os.mkfifo is not available")
 def test_scan_skill_directory_treats_non_regular_and_read_error_paths_as_unsupported(
     tmp_path,
     monkeypatch,

--- a/Tests/Skills/test_skill_trust_scanner.py
+++ b/Tests/Skills/test_skill_trust_scanner.py
@@ -1,4 +1,6 @@
 import hashlib
+import os
+from pathlib import Path
 
 from tldw_chatbook.Skills_Interop.skill_trust_models import SkillFileFingerprint
 from tldw_chatbook.Skills_Interop.skill_trust_scanner import scan_skill_directory
@@ -42,7 +44,8 @@ def test_scan_skill_directory_marks_unsupported_paths_without_text_or_fingerprin
     nested_dir = skill_dir / "nested"
     nested_dir.mkdir()
     (nested_dir / "ignored.md").write_text("ignored", encoding="utf-8")
-    (skill_dir / "binary.dat").write_bytes(b"\xff\xfe\x00")
+    (skill_dir / "binary.md").write_bytes(b"\xff\xfe")
+    (skill_dir / "nul.md").write_bytes(b"safe prefix\x00unsafe suffix")
     (skill_dir / "unsafe name.md").write_text("unsafe", encoding="utf-8")
     outside = tmp_path / "outside.md"
     outside.write_text("outside", encoding="utf-8")
@@ -52,10 +55,62 @@ def test_scan_skill_directory_marks_unsupported_paths_without_text_or_fingerprin
 
     assert snapshot.unsupported_paths == (
         "SKILL.md.tmp",
-        "binary.dat",
+        "binary.md",
         "linked.md",
         "nested",
+        "nul.md",
         "unsafe name.md",
     )
+    assert [item.relative_path for item in snapshot.fingerprints] == ["SKILL.md"]
+    assert snapshot.text_files == {"SKILL.md": "# Demo\n"}
+
+
+def test_scan_skill_directory_rejects_case_variants_and_case_insensitive_temp_suffixes(tmp_path):
+    skill_dir = tmp_path / "demo"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("# Demo\n", encoding="utf-8")
+    (skill_dir / "notes.md.TMP").write_text("partial", encoding="utf-8")
+
+    snapshot = scan_skill_directory("demo", skill_dir)
+
+    assert snapshot.unsupported_paths == ("notes.md.TMP",)
+    assert [item.relative_path for item in snapshot.fingerprints] == ["SKILL.md"]
+    assert snapshot.text_files == {"SKILL.md": "# Demo\n"}
+
+    for index, reserved_variant in enumerate(("Skill.md", "skill.md")):
+        variant_dir = tmp_path / f"reserved-{index}"
+        variant_dir.mkdir()
+        (variant_dir / reserved_variant).write_text("# Case variant\n", encoding="utf-8")
+
+        variant_snapshot = scan_skill_directory("demo", variant_dir)
+
+        assert variant_snapshot.unsupported_paths == (reserved_variant,)
+        assert variant_snapshot.fingerprints == ()
+        assert variant_snapshot.text_files == {}
+
+
+def test_scan_skill_directory_treats_non_regular_and_read_error_paths_as_unsupported(
+    tmp_path,
+    monkeypatch,
+):
+    skill_dir = tmp_path / "demo"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("# Demo\n", encoding="utf-8")
+    (skill_dir / "racy.md").write_text("removed while scanning", encoding="utf-8")
+    os.mkfifo(skill_dir / "pipe.md")
+    original_read_bytes = Path.read_bytes
+
+    def read_bytes_with_race(path):
+        if path.name == "pipe.md":
+            raise AssertionError("scanner attempted to read a non-regular path")
+        if path.name == "racy.md":
+            raise OSError("file disappeared")
+        return original_read_bytes(path)
+
+    monkeypatch.setattr(Path, "read_bytes", read_bytes_with_race)
+
+    snapshot = scan_skill_directory("demo", skill_dir)
+
+    assert snapshot.unsupported_paths == ("pipe.md", "racy.md")
     assert [item.relative_path for item in snapshot.fingerprints] == ["SKILL.md"]
     assert snapshot.text_files == {"SKILL.md": "# Demo\n"}

--- a/Tests/Skills/test_skill_trust_service.py
+++ b/Tests/Skills/test_skill_trust_service.py
@@ -1,0 +1,206 @@
+import base64
+import json
+
+import pytest
+
+from tldw_chatbook.Skills_Interop.skill_trust_models import SkillTrustBlockedError
+from tldw_chatbook.Skills_Interop.skill_trust_service import SkillTrustService
+from tldw_chatbook.Skills_Interop.skill_trust_store import (
+    FileSkillTrustGenerationMarkerStore,
+    KeyringSkillTrustKeyCache,
+    SkillTrustStore,
+)
+
+
+class FakeSecureKeyring:
+    __module__ = "keyring.backends.macOS"
+    priority = 1
+
+    def __init__(self):
+        self.values = {}
+
+    def get_password(self, service_name, username):
+        return self.values.get((service_name, username))
+
+    def set_password(self, service_name, username, password):
+        self.values[(service_name, username)] = password
+
+
+def _service(tmp_path, passphrase="passphrase", key_cache=None):
+    skills_dir = tmp_path / "skills"
+    trust_store = SkillTrustStore(
+        store_dir=tmp_path / "trust",
+        marker_store=FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json"),
+    )
+    service = SkillTrustService(
+        skills_dir=skills_dir,
+        trust_store=trust_store,
+        key_cache=key_cache,
+    )
+    service.unlock_with_passphrase(passphrase, salt=b"6" * 32)
+    return service, skills_dir
+
+
+def _write_skill(skills_dir, name="demo", content="# Demo\n"):
+    skill_dir = skills_dir / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+    return skill_dir
+
+
+def test_uninitialized_service_blocks_until_bootstrap(tmp_path):
+    service, skills_dir = _service(tmp_path)
+    _write_skill(skills_dir)
+
+    status = service.status_for_skill("demo")
+
+    assert status.trust_status == "trust_uninitialized"
+    assert status.trust_blocked is True
+    assert service.overall_status() == "trust_uninitialized"
+    assert service.keyring_convenience_enabled is False
+    assert service.reduced_rollback_protection is False
+    with pytest.raises(SkillTrustBlockedError, match="trust_uninitialized"):
+        service.ensure_skill_trusted("demo")
+
+
+def test_bootstrap_trusts_current_files_and_detects_modification(tmp_path):
+    service, skills_dir = _service(tmp_path)
+    _write_skill(skills_dir)
+
+    service.bootstrap_trust()
+    trusted = service.status_for_skill("demo")
+    assert trusted.trust_status == "trusted"
+    assert service.overall_status() == "trusted"
+    service.ensure_skill_trusted("demo")
+
+    (skills_dir / "demo" / "SKILL.md").write_text("# Demo\nBackdoor\n", encoding="utf-8")
+    modified = service.status_for_skill("demo")
+
+    assert modified.trust_status == "quarantined_modified"
+    assert modified.changed_files == ("SKILL.md",)
+    with pytest.raises(SkillTrustBlockedError, match="skill_modified"):
+        service.ensure_skill_trusted("demo")
+
+
+def test_existing_manifest_without_unlock_reports_locked_status(tmp_path):
+    service, skills_dir = _service(tmp_path)
+    _write_skill(skills_dir)
+    service.bootstrap_trust()
+
+    locked_service = SkillTrustService(
+        skills_dir=skills_dir,
+        trust_store=SkillTrustStore(
+            store_dir=tmp_path / "trust",
+            marker_store=FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json"),
+        ),
+    )
+    status = locked_service.status_for_skill("demo")
+
+    assert status.trust_status == "trust_locked"
+    assert status.trust_blocked is True
+    assert locked_service.overall_status() == "trust_locked"
+
+
+def test_missing_marker_reports_global_manifest_error(tmp_path):
+    service, skills_dir = _service(tmp_path)
+    _write_skill(skills_dir)
+    service.bootstrap_trust()
+    (tmp_path / "marker.json").unlink()
+
+    status = service.status_for_skill("demo")
+
+    assert status.trust_status == "quarantined_manifest_error"
+    assert status.trust_reason_code == "rollback_marker_unavailable"
+    assert status.trust_blocked is True
+    assert service.overall_status() == "quarantined_manifest_error"
+
+
+def test_invalid_manifest_reports_blocked_status_without_raising(tmp_path):
+    service, skills_dir = _service(tmp_path)
+    _write_skill(skills_dir)
+    service.bootstrap_trust()
+    manifest_path = tmp_path / "trust" / "skill_trust_manifest.json"
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    payload["manifest"]["generation"] = 2
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    status = service.status_for_skill("demo")
+
+    assert status.trust_status == "quarantined_manifest_error"
+    assert status.trust_reason_code == "manifest_invalid"
+    assert status.trust_blocked is True
+    with pytest.raises(SkillTrustBlockedError, match="manifest_invalid"):
+        service.ensure_skill_trusted("demo")
+
+
+def test_review_approval_requires_live_files_to_match_reviewed_snapshot(tmp_path):
+    service, skills_dir = _service(tmp_path)
+    _write_skill(skills_dir)
+    service.bootstrap_trust()
+    (skills_dir / "demo" / "SKILL.md").write_text("# Demo\nChanged\n", encoding="utf-8")
+
+    review = service.capture_review("demo")
+    assert review["changed_files"] == ["SKILL.md"]
+    assert review["current_files"] == {"SKILL.md": "# Demo\nChanged\n"}
+    (skills_dir / "demo" / "SKILL.md").write_text(
+        "# Demo\nChanged again\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="snapshot_mismatch"):
+        service.trust_reviewed_snapshot(review["review_id"])
+
+
+def test_review_approval_restores_trust_for_reviewed_snapshot(tmp_path):
+    service, skills_dir = _service(tmp_path)
+    _write_skill(skills_dir)
+    service.bootstrap_trust()
+    (skills_dir / "demo" / "SKILL.md").write_text("# Demo\nChanged\n", encoding="utf-8")
+
+    review = service.capture_review("demo")
+    service.trust_reviewed_snapshot(review["review_id"])
+
+    status = service.status_for_skill("demo")
+    assert status.trust_status == "trusted"
+    assert status.trust_blocked is False
+    service.ensure_skill_trusted("demo")
+
+
+def test_keyring_convenience_loads_only_salt_bound_cached_keys(tmp_path):
+    fake_keyring = FakeSecureKeyring()
+    key_cache = KeyringSkillTrustKeyCache(keyring_backend=fake_keyring)
+    service, skills_dir = _service(tmp_path, key_cache=key_cache)
+    _write_skill(skills_dir)
+    service.bootstrap_trust()
+
+    service.enable_keyring_convenience()
+
+    cached_service = SkillTrustService(
+        skills_dir=skills_dir,
+        trust_store=SkillTrustStore(
+            store_dir=tmp_path / "trust",
+            marker_store=FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json"),
+        ),
+        key_cache=key_cache,
+    )
+    assert cached_service.unlock_from_keyring_convenience() is True
+    assert cached_service.keyring_convenience_enabled is True
+    assert cached_service.status_for_skill("demo").trust_status == "trusted"
+
+    payload = json.loads((tmp_path / "trust" / "skill_trust_manifest.json").read_text())
+    payload["kdf_salt"] = base64.b64encode(b"7" * 32).decode("ascii")
+    (tmp_path / "trust" / "skill_trust_manifest.json").write_text(
+        json.dumps(payload),
+        encoding="utf-8",
+    )
+    stale_service = SkillTrustService(
+        skills_dir=skills_dir,
+        trust_store=SkillTrustStore(
+            store_dir=tmp_path / "trust",
+            marker_store=FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json"),
+        ),
+        key_cache=key_cache,
+    )
+
+    assert stale_service.unlock_from_keyring_convenience() is False
+    assert stale_service.status_for_skill("demo").trust_status == "trust_locked"

--- a/Tests/Skills/test_skill_trust_service.py
+++ b/Tests/Skills/test_skill_trust_service.py
@@ -288,6 +288,27 @@ def test_review_approval_requires_live_files_to_match_reviewed_snapshot(tmp_path
     assert review["review_id"] not in service._reviews
 
 
+def test_capture_review_does_not_retain_file_contents_in_pending_review(tmp_path):
+    service, skills_dir = _service(tmp_path)
+    _write_skill(skills_dir)
+    service.bootstrap_trust()
+    secret_text = "# Demo\nSECRET REVIEW TEXT\n"
+    (skills_dir / "demo" / "SKILL.md").write_text(secret_text, encoding="utf-8")
+
+    review = service.capture_review("demo")
+    stored_review = service._reviews[review["review_id"]]
+
+    assert review["current_files"] == {"SKILL.md": secret_text}
+    assert set(stored_review) == {
+        "review_id",
+        "skill_name",
+        "manifest_generation",
+        "current_digest",
+        "changed_files",
+    }
+    assert secret_text not in json.dumps(stored_review)
+
+
 def test_review_approval_restores_trust_for_reviewed_snapshot(tmp_path):
     service, skills_dir = _service(tmp_path)
     _write_skill(skills_dir)

--- a/Tests/Skills/test_skill_trust_service.py
+++ b/Tests/Skills/test_skill_trust_service.py
@@ -1,5 +1,6 @@
 import base64
 import json
+import shutil
 
 import pytest
 
@@ -9,6 +10,7 @@ from tldw_chatbook.Skills_Interop.skill_trust_store import (
     FileSkillTrustGenerationMarkerStore,
     KeyringSkillTrustKeyCache,
     SkillTrustStore,
+    UnavailableSkillTrustGenerationMarkerStore,
 )
 
 
@@ -82,6 +84,96 @@ def test_bootstrap_trusts_current_files_and_detects_modification(tmp_path):
         service.ensure_skill_trusted("demo")
 
 
+def test_status_for_unsafe_skill_name_returns_blocked_without_scanning_outside(tmp_path):
+    service, skills_dir = _service(tmp_path)
+    _write_skill(skills_dir)
+    outside = tmp_path / "outside"
+    _write_skill(tmp_path, name="outside", content="# Secret\n")
+    service.bootstrap_trust()
+
+    traversal_status = service.status_for_skill("../outside")
+    absolute_status = service.status_for_skill(str(outside.resolve()))
+
+    assert traversal_status.trust_status == "quarantined_unsupported_path"
+    assert traversal_status.trust_reason_code == "unsupported_path"
+    assert traversal_status.trust_blocked is True
+    assert absolute_status.trust_status == "quarantined_unsupported_path"
+    with pytest.raises(SkillTrustBlockedError, match="unsupported_path"):
+        service.ensure_skill_trusted("../outside")
+    with pytest.raises(ValueError, match="unsupported_path"):
+        service.capture_review("../outside")
+    with pytest.raises(ValueError, match="unsupported_path"):
+        service.capture_review(str(outside.resolve()))
+
+
+def test_bootstrap_rejects_root_skill_directory_symlink(tmp_path):
+    service, skills_dir = _service(tmp_path)
+    outside_dir = tmp_path / "outside-demo"
+    outside_dir.mkdir()
+    (outside_dir / "SKILL.md").write_text("# Outside\n", encoding="utf-8")
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "demo").symlink_to(outside_dir, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="unsupported_path"):
+        service.bootstrap_trust()
+
+
+def test_root_skill_directory_symlink_is_quarantined_after_bootstrap(tmp_path):
+    service, skills_dir = _service(tmp_path)
+    _write_skill(skills_dir)
+    service.bootstrap_trust()
+    shutil.rmtree(skills_dir / "demo")
+    outside_dir = tmp_path / "outside-demo"
+    outside_dir.mkdir()
+    (outside_dir / "SKILL.md").write_text("# Outside\n", encoding="utf-8")
+    (skills_dir / "demo").symlink_to(outside_dir, target_is_directory=True)
+
+    status = service.status_for_skill("demo")
+
+    assert status.trust_status == "quarantined_unsupported_path"
+    assert status.trust_reason_code == "unsupported_path"
+    assert status.changed_files == ("demo",)
+
+
+def test_added_file_is_quarantined(tmp_path):
+    service, skills_dir = _service(tmp_path)
+    _write_skill(skills_dir)
+    service.bootstrap_trust()
+    (skills_dir / "demo" / "notes.md").write_text("new support text", encoding="utf-8")
+
+    status = service.status_for_skill("demo")
+
+    assert status.trust_status == "quarantined_added"
+    assert status.trust_reason_code == "skill_added"
+    assert status.changed_files == ("notes.md",)
+
+
+def test_deleted_file_is_quarantined(tmp_path):
+    service, skills_dir = _service(tmp_path)
+    _write_skill(skills_dir)
+    service.bootstrap_trust()
+    (skills_dir / "demo" / "SKILL.md").unlink()
+
+    status = service.status_for_skill("demo")
+
+    assert status.trust_status == "quarantined_deleted"
+    assert status.trust_reason_code == "skill_deleted"
+    assert status.changed_files == ("SKILL.md",)
+
+
+def test_unsupported_child_path_is_quarantined(tmp_path):
+    service, skills_dir = _service(tmp_path)
+    _write_skill(skills_dir)
+    service.bootstrap_trust()
+    (skills_dir / "demo" / "unsafe name.md").write_text("unsafe", encoding="utf-8")
+
+    status = service.status_for_skill("demo")
+
+    assert status.trust_status == "quarantined_unsupported_path"
+    assert status.trust_reason_code == "unsupported_path"
+    assert status.changed_files == ("unsafe name.md",)
+
+
 def test_existing_manifest_without_unlock_reports_locked_status(tmp_path):
     service, skills_dir = _service(tmp_path)
     _write_skill(skills_dir)
@@ -115,6 +207,41 @@ def test_missing_marker_reports_global_manifest_error(tmp_path):
     assert service.overall_status() == "quarantined_manifest_error"
 
 
+def test_marker_mismatch_reports_global_manifest_error(tmp_path):
+    service, skills_dir = _service(tmp_path)
+    _write_skill(skills_dir)
+    service.bootstrap_trust()
+    service.trust_store.marker_store.save_marker(generation=99, manifest_digest="old")
+
+    status = service.status_for_skill("demo")
+
+    assert status.trust_status == "quarantined_manifest_error"
+    assert status.trust_reason_code == "rollback_marker_unavailable"
+    assert status.trust_blocked is True
+    assert service.overall_status() == "quarantined_manifest_error"
+
+
+def test_marker_store_unavailable_reports_global_manifest_error(tmp_path):
+    service, skills_dir = _service(tmp_path)
+    _write_skill(skills_dir)
+    service.bootstrap_trust()
+    unavailable_service = SkillTrustService(
+        skills_dir=skills_dir,
+        trust_store=SkillTrustStore(
+            store_dir=tmp_path / "trust",
+            marker_store=UnavailableSkillTrustGenerationMarkerStore("offline"),
+        ),
+    )
+    unavailable_service.unlock_with_passphrase("passphrase")
+
+    status = unavailable_service.status_for_skill("demo")
+
+    assert status.trust_status == "quarantined_manifest_error"
+    assert status.trust_reason_code == "rollback_marker_unavailable"
+    assert status.trust_blocked is True
+    assert unavailable_service.overall_status() == "quarantined_manifest_error"
+
+
 def test_invalid_manifest_reports_blocked_status_without_raising(tmp_path):
     service, skills_dir = _service(tmp_path)
     _write_skill(skills_dir)
@@ -133,6 +260,15 @@ def test_invalid_manifest_reports_blocked_status_without_raising(tmp_path):
         service.ensure_skill_trusted("demo")
 
 
+def test_overall_status_reports_quarantine_when_live_skill_is_modified(tmp_path):
+    service, skills_dir = _service(tmp_path)
+    _write_skill(skills_dir)
+    service.bootstrap_trust()
+    (skills_dir / "demo" / "SKILL.md").write_text("# Demo\nChanged\n", encoding="utf-8")
+
+    assert service.overall_status() == "quarantined_modified"
+
+
 def test_review_approval_requires_live_files_to_match_reviewed_snapshot(tmp_path):
     service, skills_dir = _service(tmp_path)
     _write_skill(skills_dir)
@@ -149,6 +285,7 @@ def test_review_approval_requires_live_files_to_match_reviewed_snapshot(tmp_path
 
     with pytest.raises(ValueError, match="snapshot_mismatch"):
         service.trust_reviewed_snapshot(review["review_id"])
+    assert review["review_id"] not in service._reviews
 
 
 def test_review_approval_restores_trust_for_reviewed_snapshot(tmp_path):
@@ -163,7 +300,45 @@ def test_review_approval_restores_trust_for_reviewed_snapshot(tmp_path):
     status = service.status_for_skill("demo")
     assert status.trust_status == "trusted"
     assert status.trust_blocked is False
+    assert review["review_id"] not in service._reviews
     service.ensure_skill_trusted("demo")
+
+
+def test_review_approval_rejects_stale_manifest_generation(tmp_path):
+    service, skills_dir = _service(tmp_path)
+    _write_skill(skills_dir)
+    _write_skill(skills_dir, name="other", content="# Other\n")
+    service.bootstrap_trust()
+    (skills_dir / "demo" / "SKILL.md").write_text("# Demo\nChanged\n", encoding="utf-8")
+    review = service.capture_review("demo")
+    (skills_dir / "other" / "SKILL.md").write_text("# Other\nChanged\n", encoding="utf-8")
+    service.trust_current_skill("other")
+
+    with pytest.raises(ValueError, match="snapshot_mismatch"):
+        service.trust_reviewed_snapshot(review["review_id"])
+    assert review["review_id"] not in service._reviews
+
+
+def test_discard_review_removes_captured_review(tmp_path):
+    service, skills_dir = _service(tmp_path)
+    _write_skill(skills_dir)
+    service.bootstrap_trust()
+    (skills_dir / "demo" / "SKILL.md").write_text("# Demo\nChanged\n", encoding="utf-8")
+    review = service.capture_review("demo")
+
+    service.discard_review(review["review_id"])
+
+    with pytest.raises(KeyError):
+        service.trust_reviewed_snapshot(review["review_id"])
+
+
+def test_trust_current_skill_rejects_missing_skill(tmp_path):
+    service, skills_dir = _service(tmp_path)
+    _write_skill(skills_dir)
+    service.bootstrap_trust()
+
+    with pytest.raises(ValueError, match="skill_deleted"):
+        service.trust_current_skill("missing")
 
 
 def test_keyring_convenience_loads_only_salt_bound_cached_keys(tmp_path):

--- a/Tests/Skills/test_skill_trust_service.py
+++ b/Tests/Skills/test_skill_trust_service.py
@@ -84,6 +84,59 @@ def test_bootstrap_trusts_current_files_and_detects_modification(tmp_path):
         service.ensure_skill_trusted("demo")
 
 
+def test_verify_skill_content_accepts_exact_trusted_content_and_supporting_files(tmp_path):
+    service, skills_dir = _service(tmp_path)
+    skill_dir = _write_skill(skills_dir, content="# Demo\nRender {{args}}\n")
+    (skill_dir / "notes.md").write_text("trusted notes\n", encoding="utf-8")
+    service.bootstrap_trust()
+
+    service.verify_skill_content(
+        "demo",
+        skill_content="# Demo\nRender {{args}}\n",
+        supporting_files={"notes.md": "trusted notes\n"},
+    )
+
+
+def test_verify_skill_content_rejects_in_memory_content_not_matching_trusted_manifest(tmp_path):
+    service, skills_dir = _service(tmp_path)
+    skill_dir = _write_skill(skills_dir, content="# Demo\nRender {{args}}\n")
+    (skill_dir / "notes.md").write_text("trusted notes\n", encoding="utf-8")
+    service.bootstrap_trust()
+
+    with pytest.raises(SkillTrustBlockedError, match="skill_modified") as exc:
+        service.verify_skill_content(
+            "demo",
+            skill_content="# Demo\nMALICIOUS {{args}}\n",
+            supporting_files={"notes.md": "trusted notes\n"},
+        )
+
+    assert exc.value.trust_status == "quarantined_modified"
+    assert exc.value.changed_files == ("SKILL.md",)
+
+
+def test_verify_skill_content_rejects_extra_and_missing_supporting_files(tmp_path):
+    service, skills_dir = _service(tmp_path)
+    skill_dir = _write_skill(skills_dir, content="# Demo\nRender {{args}}\n")
+    (skill_dir / "notes.md").write_text("trusted notes\n", encoding="utf-8")
+    service.bootstrap_trust()
+
+    with pytest.raises(SkillTrustBlockedError, match="skill_deleted") as missing:
+        service.verify_skill_content(
+            "demo",
+            skill_content="# Demo\nRender {{args}}\n",
+            supporting_files=None,
+        )
+    assert missing.value.changed_files == ("notes.md",)
+
+    with pytest.raises(SkillTrustBlockedError, match="skill_added") as added:
+        service.verify_skill_content(
+            "demo",
+            skill_content="# Demo\nRender {{args}}\n",
+            supporting_files={"extra.md": "extra\n", "notes.md": "trusted notes\n"},
+        )
+    assert added.value.changed_files == ("extra.md",)
+
+
 def test_status_for_unsafe_skill_name_returns_blocked_without_scanning_outside(tmp_path):
     service, skills_dir = _service(tmp_path)
     _write_skill(skills_dir)

--- a/Tests/Skills/test_skill_trust_service.py
+++ b/Tests/Skills/test_skill_trust_service.py
@@ -84,6 +84,19 @@ def test_bootstrap_trusts_current_files_and_detects_modification(tmp_path):
         service.ensure_skill_trusted("demo")
 
 
+def test_bootstrap_uses_canonical_skill_name_for_mixed_case_directory(tmp_path):
+    service, skills_dir = _service(tmp_path)
+    _write_skill(skills_dir, name="MySkill", content="# Demo\n")
+
+    service.bootstrap_trust()
+
+    status = service.status_for_skill("myskill")
+    manifest = service.trust_store.load_manifest(service._require_keys())
+    assert set(manifest["skills"]) == {"myskill"}
+    assert status.trust_status == "trusted"
+    service.ensure_skill_trusted("MySkill")
+
+
 def test_verify_skill_content_accepts_exact_trusted_content_and_supporting_files(tmp_path):
     service, skills_dir = _service(tmp_path)
     skill_dir = _write_skill(skills_dir, content="# Demo\nRender {{args}}\n")

--- a/Tests/Skills/test_skill_trust_store.py
+++ b/Tests/Skills/test_skill_trust_store.py
@@ -1,0 +1,164 @@
+import json
+from types import MappingProxyType
+
+import pytest
+
+from tldw_chatbook.Skills_Interop.skill_trust_crypto import derive_skill_trust_keys
+from tldw_chatbook.Skills_Interop.skill_trust_store import (
+    FileSkillTrustGenerationMarkerStore,
+    KeyringSkillTrustGenerationMarkerStore,
+    KeyringSkillTrustKeyCache,
+    SkillTrustMarkerUnavailable,
+    SkillTrustStore,
+)
+
+
+class FakeSecureKeyring:
+    __module__ = "keyring.backends.macOS"
+    priority = 1
+
+    def __init__(self):
+        self.values = {}
+
+    def get_password(self, service_name, username):
+        return self.values.get((service_name, username))
+
+    def set_password(self, service_name, username, password):
+        self.values[(service_name, username)] = password
+
+
+class FakePlaintextKeyring(FakeSecureKeyring):
+    __module__ = "keyring.backends.file"
+
+
+def test_trust_store_round_trips_manifest_snapshot_marker_and_salt(tmp_path):
+    keys = derive_skill_trust_keys("passphrase", salt=b"3" * 32)
+    marker = FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json")
+    store = SkillTrustStore(store_dir=tmp_path / "trust", marker_store=marker)
+
+    manifest = {
+        "version": 1,
+        "generation": 1,
+        "skills": {
+            "demo": {
+                "files": [
+                    {
+                        "relative_path": "SKILL.md",
+                        "file_type": "skill",
+                        "byte_length": 6,
+                        "sha256": "abc",
+                    }
+                ],
+                "snapshot_id": "demo-1",
+                "trusted_at": "2026-06-25T00:00:00+00:00",
+            }
+        },
+        "audit": [],
+    }
+
+    store.save_manifest(manifest, keys, salt=b"3" * 32)
+    store.save_snapshot("demo-1", {"files": {"SKILL.md": "# Demo"}}, keys, generation=1)
+
+    loaded = store.load_manifest(keys)
+    snapshot = store.load_snapshot("demo-1", keys, generation=1)
+
+    assert store.has_manifest() is True
+    assert store.manifest_path == tmp_path / "trust" / "skill_trust_manifest.json"
+    assert store.snapshots_dir == tmp_path / "trust" / "snapshots"
+    assert loaded == manifest
+    assert snapshot == {"files": {"SKILL.md": "# Demo"}}
+    assert store.load_salt() == b"3" * 32
+    assert marker.load_marker() == {
+        "generation": 1,
+        "manifest_digest": store.manifest_digest(loaded),
+    }
+
+
+def test_trust_store_rejects_tampered_manifest(tmp_path):
+    keys = derive_skill_trust_keys("passphrase", salt=b"4" * 32)
+    marker = FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json")
+    store = SkillTrustStore(store_dir=tmp_path / "trust", marker_store=marker)
+
+    store.save_manifest({"version": 1, "generation": 1, "skills": {}, "audit": []}, keys, salt=b"4" * 32)
+    payload = json.loads(store.manifest_path.read_text(encoding="utf-8"))
+    payload["manifest"]["generation"] = 2
+    store.manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="manifest authentication failed"):
+        store.load_manifest(keys)
+
+
+def test_trust_store_rejects_marker_mismatch(tmp_path):
+    keys = derive_skill_trust_keys("passphrase", salt=b"5" * 32)
+    marker = FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json")
+    store = SkillTrustStore(store_dir=tmp_path / "trust", marker_store=marker)
+
+    store.save_manifest({"version": 1, "generation": 3, "skills": {}, "audit": []}, keys, salt=b"5" * 32)
+    marker.save_marker(generation=2, manifest_digest="old")
+
+    with pytest.raises(ValueError, match="manifest generation marker mismatch"):
+        store.load_manifest(keys)
+
+
+def test_trust_store_rejects_missing_marker_after_manifest_exists(tmp_path):
+    keys = derive_skill_trust_keys("passphrase", salt=b"6" * 32)
+    marker_path = tmp_path / "marker.json"
+    marker = FileSkillTrustGenerationMarkerStore(marker_path)
+    store = SkillTrustStore(store_dir=tmp_path / "trust", marker_store=marker)
+
+    store.save_manifest({"version": 1, "generation": 1, "skills": {}, "audit": []}, keys, salt=b"6" * 32)
+    marker_path.unlink()
+
+    with pytest.raises(ValueError, match="manifest generation marker mismatch"):
+        store.load_manifest(keys)
+
+
+def test_trust_store_load_salt_requires_32_bytes(tmp_path):
+    keys = derive_skill_trust_keys("passphrase", salt=b"7" * 32)
+    marker = FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json")
+    store = SkillTrustStore(store_dir=tmp_path / "trust", marker_store=marker)
+
+    store.save_manifest({"version": 1, "generation": 1, "skills": {}, "audit": []}, keys, salt=b"7" * 32)
+    payload = json.loads(store.manifest_path.read_text(encoding="utf-8"))
+    payload["kdf_salt"] = "c2hvcnQ="
+    store.manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="skill trust salt invalid"):
+        store.load_salt()
+
+
+def test_trust_store_snapshot_accepts_immutable_mapping_payloads(tmp_path):
+    keys = derive_skill_trust_keys("passphrase", salt=b"8" * 32)
+    marker = FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json")
+    store = SkillTrustStore(store_dir=tmp_path / "trust", marker_store=marker)
+    payload = {"files": MappingProxyType({"SKILL.md": "# Demo"})}
+
+    store.save_snapshot("demo-1", payload, keys, generation=1)
+
+    assert store.load_snapshot("demo-1", keys, generation=1) == {"files": {"SKILL.md": "# Demo"}}
+
+
+def test_keyring_generation_marker_store_round_trips_with_secure_backend():
+    marker = KeyringSkillTrustGenerationMarkerStore(keyring_backend=FakeSecureKeyring())
+
+    marker.save_marker(generation=3, manifest_digest="digest")
+
+    assert marker.load_marker() == {"generation": 3, "manifest_digest": "digest"}
+
+
+def test_keyring_generation_marker_store_rejects_insecure_backend():
+    with pytest.raises(SkillTrustMarkerUnavailable, match="secure OS-backed"):
+        KeyringSkillTrustGenerationMarkerStore(keyring_backend=FakePlaintextKeyring())
+
+
+def test_keyring_key_cache_round_trips_without_storing_passphrase():
+    fake = FakeSecureKeyring()
+    keys = derive_skill_trust_keys("passphrase", salt=b"9" * 32)
+    cache = KeyringSkillTrustKeyCache(keyring_backend=fake)
+
+    cache.save_keys(keys)
+    loaded = cache.load_keys()
+
+    assert loaded == keys
+    assert "passphrase" not in "\n".join(fake.values.values())
+    assert repr(loaded).count("redacted") == 4

--- a/Tests/Skills/test_skill_trust_store.py
+++ b/Tests/Skills/test_skill_trust_store.py
@@ -10,6 +10,7 @@ from tldw_chatbook.Skills_Interop.skill_trust_store import (
     KeyringSkillTrustKeyCache,
     SkillTrustMarkerUnavailable,
     SkillTrustStore,
+    build_skill_trust_marker_store_with_fallback,
 )
 
 
@@ -45,6 +46,17 @@ class FailingMarkerStore:
         if self.save_count == self.fail_on_save_number:
             raise SkillTrustMarkerUnavailable("simulated marker failure")
         self.wrapped.save_marker(generation=generation, manifest_digest=manifest_digest)
+
+
+class AlwaysFailingMarkerStore:
+    def __init__(self, marker):
+        self.marker = marker
+
+    def load_marker(self):
+        return self.marker
+
+    def save_marker(self, *, generation, manifest_digest):
+        raise SkillTrustMarkerUnavailable("original marker failure")
 
 
 def test_trust_store_round_trips_manifest_snapshot_marker_and_salt(tmp_path):
@@ -154,6 +166,64 @@ def test_trust_store_marker_failure_preserves_previous_manifest_and_marker(tmp_p
         "generation": 1,
         "manifest_digest": store.manifest_digest(previous_manifest),
     }
+
+
+def test_trust_store_marker_rollback_preserves_original_failure(tmp_path):
+    keys = derive_skill_trust_keys("passphrase", salt=b"7" * 32)
+    marker = FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json")
+    store = SkillTrustStore(store_dir=tmp_path / "trust", marker_store=marker)
+    previous_manifest = {"version": 1, "generation": 1, "skills": {}, "audit": []}
+    advanced_manifest = {"version": 1, "generation": 2, "skills": {}, "audit": []}
+
+    store.save_manifest(previous_manifest, keys, salt=b"7" * 32)
+    store.marker_store = AlwaysFailingMarkerStore({"invalid": "previous-marker"})
+
+    with pytest.raises(SkillTrustMarkerUnavailable, match="original marker failure"):
+        store.save_manifest(advanced_manifest, keys, salt=b"7" * 32)
+
+    store.marker_store = marker
+    assert store.load_manifest(keys) == previous_manifest
+
+
+def test_trust_store_rejects_snapshot_directory_symlink_escape(tmp_path):
+    keys = derive_skill_trust_keys("passphrase", salt=b"7" * 32)
+    marker = FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json")
+    store_dir = tmp_path / "trust"
+    outside_dir = tmp_path / "outside"
+    store_dir.mkdir()
+    outside_dir.mkdir()
+    (store_dir / "snapshots").symlink_to(outside_dir, target_is_directory=True)
+    store = SkillTrustStore(store_dir=store_dir, marker_store=marker)
+
+    with pytest.raises(ValueError, match="unsafe skill trust path"):
+        store.save_snapshot("demo-1", {"files": {"SKILL.md": "# Demo"}}, keys, generation=1)
+
+    assert not (outside_dir / "demo-1.json").exists()
+
+
+def test_file_marker_store_rejects_marker_parent_symlink_escape(tmp_path):
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    marker_parent = tmp_path / "marker-parent"
+    marker_parent.symlink_to(outside_dir, target_is_directory=True)
+    marker = FileSkillTrustGenerationMarkerStore(marker_parent / "marker.json")
+
+    with pytest.raises(ValueError, match="unsafe skill trust path"):
+        marker.save_marker(generation=1, manifest_digest="digest")
+
+    assert not (outside_dir / "marker.json").exists()
+
+
+def test_marker_store_builder_falls_back_to_reduced_protection_file_marker(tmp_path):
+    marker_store, reduced = build_skill_trust_marker_store_with_fallback(
+        fallback_marker_path=tmp_path / "trust" / "marker.json",
+        keyring_backend=FakePlaintextKeyring(),
+    )
+
+    assert isinstance(marker_store, FileSkillTrustGenerationMarkerStore)
+    assert reduced is True
+    marker_store.save_marker(generation=1, manifest_digest="digest")
+    assert marker_store.load_marker() == {"generation": 1, "manifest_digest": "digest"}
 
 
 def test_trust_store_load_salt_requires_32_bytes(tmp_path):

--- a/Tests/Skills/test_skill_trust_store.py
+++ b/Tests/Skills/test_skill_trust_store.py
@@ -31,6 +31,22 @@ class FakePlaintextKeyring(FakeSecureKeyring):
     __module__ = "keyring.backends.file"
 
 
+class FailingMarkerStore:
+    def __init__(self, wrapped, *, fail_on_save_number):
+        self.wrapped = wrapped
+        self.fail_on_save_number = fail_on_save_number
+        self.save_count = 0
+
+    def load_marker(self):
+        return self.wrapped.load_marker()
+
+    def save_marker(self, *, generation, manifest_digest):
+        self.save_count += 1
+        if self.save_count == self.fail_on_save_number:
+            raise SkillTrustMarkerUnavailable("simulated marker failure")
+        self.wrapped.save_marker(generation=generation, manifest_digest=manifest_digest)
+
+
 def test_trust_store_round_trips_manifest_snapshot_marker_and_salt(tmp_path):
     keys = derive_skill_trust_keys("passphrase", salt=b"3" * 32)
     marker = FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json")
@@ -113,6 +129,33 @@ def test_trust_store_rejects_missing_marker_after_manifest_exists(tmp_path):
         store.load_manifest(keys)
 
 
+def test_trust_store_marker_failure_preserves_previous_manifest_and_marker(tmp_path):
+    keys = derive_skill_trust_keys("passphrase", salt=b"7" * 32)
+    marker = FailingMarkerStore(
+        FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json"),
+        fail_on_save_number=2,
+    )
+    store = SkillTrustStore(store_dir=tmp_path / "trust", marker_store=marker)
+    previous_manifest = {"version": 1, "generation": 1, "skills": {}, "audit": []}
+    advanced_manifest = {
+        "version": 1,
+        "generation": 2,
+        "skills": {"demo": {"snapshot_id": "demo-2"}},
+        "audit": [],
+    }
+
+    store.save_manifest(previous_manifest, keys, salt=b"7" * 32)
+
+    with pytest.raises(SkillTrustMarkerUnavailable, match="simulated marker failure"):
+        store.save_manifest(advanced_manifest, keys, salt=b"7" * 32)
+
+    assert store.load_manifest(keys) == previous_manifest
+    assert marker.load_marker() == {
+        "generation": 1,
+        "manifest_digest": store.manifest_digest(previous_manifest),
+    }
+
+
 def test_trust_store_load_salt_requires_32_bytes(tmp_path):
     keys = derive_skill_trust_keys("passphrase", salt=b"7" * 32)
     marker = FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json")
@@ -138,6 +181,17 @@ def test_trust_store_snapshot_accepts_immutable_mapping_payloads(tmp_path):
     assert store.load_snapshot("demo-1", keys, generation=1) == {"files": {"SKILL.md": "# Demo"}}
 
 
+def test_trust_store_rejects_non_string_mapping_keys(tmp_path):
+    keys = derive_skill_trust_keys("passphrase", salt=b"9" * 32)
+    marker = FileSkillTrustGenerationMarkerStore(tmp_path / "marker.json")
+    store = SkillTrustStore(store_dir=tmp_path / "trust", marker_store=marker)
+
+    with pytest.raises(ValueError, match="mapping keys must be strings"):
+        store.save_snapshot("demo-1", {"files": {1: "numeric", "1": "string"}}, keys, generation=1)
+
+    assert not (store.snapshots_dir / "demo-1.json").exists()
+
+
 def test_keyring_generation_marker_store_round_trips_with_secure_backend():
     marker = KeyringSkillTrustGenerationMarkerStore(keyring_backend=FakeSecureKeyring())
 
@@ -153,12 +207,22 @@ def test_keyring_generation_marker_store_rejects_insecure_backend():
 
 def test_keyring_key_cache_round_trips_without_storing_passphrase():
     fake = FakeSecureKeyring()
-    keys = derive_skill_trust_keys("passphrase", salt=b"9" * 32)
+    keys = derive_skill_trust_keys("passphrase", salt=b"a" * 32)
     cache = KeyringSkillTrustKeyCache(keyring_backend=fake)
 
-    cache.save_keys(keys)
-    loaded = cache.load_keys()
+    cache.save_keys(keys, salt=b"a" * 32)
+    loaded = cache.load_keys(expected_salt=b"a" * 32)
 
     assert loaded == keys
     assert "passphrase" not in "\n".join(fake.values.values())
     assert repr(loaded).count("redacted") == 4
+
+
+def test_keyring_key_cache_rejects_stale_salt_binding():
+    fake = FakeSecureKeyring()
+    keys = derive_skill_trust_keys("passphrase", salt=b"b" * 32)
+    cache = KeyringSkillTrustKeyCache(keyring_backend=fake)
+
+    cache.save_keys(keys, salt=b"b" * 32)
+
+    assert cache.load_keys(expected_salt=b"c" * 32) is None

--- a/Tests/Skills/test_skills_scope_service.py
+++ b/Tests/Skills/test_skills_scope_service.py
@@ -116,6 +116,44 @@ async def test_skills_scope_service_routes_local_operations_without_server_dispa
 
 
 @pytest.mark.asyncio
+async def test_skills_scope_service_preserves_blocked_local_context_trust_fields():
+    class FakeLocalSkillsService(FakeSkillsService):
+        async def get_context(self):
+            self.calls.append(("get_context",))
+            return {
+                "available_skills": [],
+                "blocked_skills": [
+                    {
+                        "name": "demo-skill",
+                        "trust_status": "quarantined_modified",
+                        "trust_reason_code": "skill_modified",
+                        "trust_blocked": True,
+                        "trust_changed_files": ["SKILL.md"],
+                        "trust_manifest_generation": 2,
+                        "trust_last_verified_at": "2026-06-25T00:00:00+00:00",
+                    }
+                ],
+                "context_text": "",
+            }
+
+    local = FakeLocalSkillsService()
+    scope = SkillsScopeService(local_service=local, server_service=FakeSkillsService())
+
+    context = await scope.get_context(mode="local")
+
+    blocked = context["blocked_skills"][0]
+    assert blocked["backend"] == "local"
+    assert blocked["record_id"] == "local:skill:demo-skill"
+    assert blocked["trust_status"] == "quarantined_modified"
+    assert blocked["trust_reason_code"] == "skill_modified"
+    assert blocked["trust_blocked"] is True
+    assert blocked["trust_changed_files"] == ["SKILL.md"]
+    assert blocked["trust_manifest_generation"] == 2
+    assert blocked["trust_last_verified_at"] == "2026-06-25T00:00:00+00:00"
+    assert context["available_skills"] == []
+
+
+@pytest.mark.asyncio
 async def test_skills_scope_service_reports_missing_local_backend_before_dispatch():
     server = FakeSkillsService()
     scope = SkillsScopeService(server_service=server, policy_enforcer=FakePolicyEnforcer())

--- a/Tests/UI/test_destination_shells.py
+++ b/Tests/UI/test_destination_shells.py
@@ -5,7 +5,7 @@ import inspect
 import logging
 import time
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from textual.app import App
@@ -268,6 +268,28 @@ class StaticSkillsScopeService:
     async def list_skills(self, **kwargs):
         self.calls.append(kwargs)
         return {"skills": list(self.skills), "total": len(self.skills)}
+
+
+class RecordingSkillTrustService:
+    def __init__(self, review_id="review-id"):
+        self.review_id = review_id
+        self.bootstrap_calls = 0
+        self.reviewed_skill = None
+        self.trusted_review_id = None
+
+    def bootstrap_trust(self, *args, **kwargs):
+        self.bootstrap_calls += 1
+
+    def capture_review(self, skill_name):
+        self.reviewed_skill = skill_name
+        return {
+            "review_id": self.review_id,
+            "skill_name": skill_name,
+            "changed_files": ["SKILL.md"],
+        }
+
+    def trust_reviewed_snapshot(self, review_id):
+        self.trusted_review_id = review_id
 
 
 class RaisingSkillsScopeService:
@@ -1937,6 +1959,130 @@ async def test_skills_destination_distinguishes_valid_and_invalid_skill_readines
         assert "Execution: blocked" in text
         assert "Reason: description is required" in text
         assert attach_button.disabled is True
+
+
+@pytest.mark.asyncio
+async def test_skills_destination_blocks_metadata_valid_trust_blocked_skill():
+    app = _build_test_app()
+    app.skills_scope_service = StaticSkillsScopeService(
+        [
+            {
+                "name": "summarize-notes",
+                "description": "Summarize note collections",
+                "record_id": "local:skill:summarize-notes",
+                "validation_status": "valid",
+                "validation_errors": [],
+                "trust_status": "quarantined_modified",
+                "trust_reason_code": "skill_modified",
+                "trust_blocked": True,
+                "trust_changed_files": ["SKILL.md"],
+            },
+        ]
+    )
+    host = DestinationHarness(app, "skills")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_skills_snapshot(screen, pilot)
+        text = _visible_text(screen)
+        button = screen.query_one("#skills-attach-to-console", Button)
+
+        assert "Trust: changed since trusted baseline" in text
+        assert "Reason code: skill_modified" in text
+        assert "Changed files: SKILL.md" in text
+        assert "Execution: blocked" in text
+        assert "Reason: trust blocked (skill_modified)" in text
+        assert button.disabled is True
+
+
+@pytest.mark.asyncio
+async def test_skills_destination_shows_uninitialized_bootstrap_action():
+    app = _build_test_app()
+    app.skills_scope_service = StaticSkillsScopeService(
+        [
+            {
+                "name": "new-skill",
+                "description": "New local skill",
+                "record_id": "local:skill:new-skill",
+                "validation_status": "valid",
+                "validation_errors": [],
+                "trust_status": "trust_uninitialized",
+                "trust_reason_code": "trust_uninitialized",
+                "trust_blocked": True,
+            },
+        ]
+    )
+    host = DestinationHarness(app, "skills")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_skills_snapshot(screen, pilot)
+        text = _visible_text(screen)
+
+        assert "Trust: not initialized" in text
+        assert screen.query_one("#skills-bootstrap-trust", Button).disabled is False
+
+
+@pytest.mark.asyncio
+async def test_skills_destination_bootstrap_action_calls_trust_service():
+    app = _build_test_app()
+    app.local_skill_trust_service = RecordingSkillTrustService()
+    app.skills_scope_service = StaticSkillsScopeService(
+        [
+            {
+                "name": "new-skill",
+                "description": "New local skill",
+                "record_id": "local:skill:new-skill",
+                "validation_status": "valid",
+                "validation_errors": [],
+                "trust_status": "trust_uninitialized",
+                "trust_reason_code": "trust_uninitialized",
+                "trust_blocked": True,
+            },
+        ]
+    )
+    host = DestinationHarness(app, "skills")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_skills_snapshot(screen, pilot)
+        screen._request_skill_trust_passphrase = AsyncMock(return_value="passphrase")
+        await pilot.click("#skills-bootstrap-trust")
+
+        assert app.local_skill_trust_service.bootstrap_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_skills_destination_review_action_enables_trust_reviewed_version():
+    app = _build_test_app()
+    app.local_skill_trust_service = RecordingSkillTrustService(review_id="review-1")
+    app.skills_scope_service = StaticSkillsScopeService(
+        [
+            {
+                "name": "summarize-notes",
+                "description": "Summarize note collections",
+                "record_id": "local:skill:summarize-notes",
+                "validation_status": "valid",
+                "validation_errors": [],
+                "trust_status": "quarantined_modified",
+                "trust_reason_code": "skill_modified",
+                "trust_blocked": True,
+                "trust_changed_files": ["SKILL.md"],
+            },
+        ]
+    )
+    host = DestinationHarness(app, "skills")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_skills_snapshot(screen, pilot)
+        await pilot.click("#skills-review-diff")
+
+        assert app.local_skill_trust_service.reviewed_skill == "summarize-notes"
+        assert screen.query_one("#skills-trust-reviewed-version", Button).disabled is False
+
+        await pilot.click("#skills-trust-reviewed-version")
+        assert app.local_skill_trust_service.trusted_review_id == "review-1"
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_destination_shells.py
+++ b/Tests/UI/test_destination_shells.py
@@ -265,23 +265,38 @@ class StaticSkillsScopeService:
         self.skills = tuple(skills)
         self.calls = []
 
+    def set_skills(self, skills) -> None:
+        self.skills = tuple(skills)
+
     async def list_skills(self, **kwargs):
         self.calls.append(kwargs)
         return {"skills": list(self.skills), "total": len(self.skills)}
 
 
 class RecordingSkillTrustService:
-    def __init__(self, review_id="review-id"):
+    def __init__(self, review_id="review-id", on_capture_review=None):
         self.review_id = review_id
         self.bootstrap_calls = 0
+        self.bootstrap_passphrases = []
+        self.unlock_calls = 0
+        self.unlock_passphrases = []
         self.reviewed_skill = None
         self.trusted_review_id = None
+        self.trust_reviewed_calls = 0
+        self.on_capture_review = on_capture_review
 
-    def bootstrap_trust(self, *args, **kwargs):
+    def bootstrap_trust(self, passphrase, *args, **kwargs):
         self.bootstrap_calls += 1
+        self.bootstrap_passphrases.append(passphrase)
+
+    def unlock_with_passphrase(self, passphrase, *args, **kwargs):
+        self.unlock_calls += 1
+        self.unlock_passphrases.append(passphrase)
 
     def capture_review(self, skill_name):
         self.reviewed_skill = skill_name
+        if self.on_capture_review is not None:
+            self.on_capture_review(skill_name)
         return {
             "review_id": self.review_id,
             "skill_name": skill_name,
@@ -289,6 +304,7 @@ class RecordingSkillTrustService:
         }
 
     def trust_reviewed_snapshot(self, review_id):
+        self.trust_reviewed_calls += 1
         self.trusted_review_id = review_id
 
 
@@ -505,6 +521,21 @@ async def _wait_for_mock_call(mock: Mock, pilot, *, timeout: float = 1.0) -> Non
             return
         await pilot.pause()
     raise AssertionError("Timed out waiting for mock call")
+
+
+async def _wait_for_skills_list_calls(
+    service: StaticSkillsScopeService,
+    count: int,
+    pilot,
+    *,
+    timeout: float = 1.0,
+) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if len(service.calls) >= count:
+            return
+        await pilot.pause(0.01)
+    raise AssertionError(f"Timed out waiting for {count} Skills list calls; saw {len(service.calls)}")
 
 
 async def _wait_for_route(seen_routes: list[str], target_route: str, pilot, *, timeout: float = 1.0) -> None:
@@ -1991,7 +2022,11 @@ async def test_skills_destination_blocks_metadata_valid_trust_blocked_skill():
         assert "Reason code: skill_modified" in text
         assert "Changed files: SKILL.md" in text
         assert "Execution: blocked" in text
-        assert "Reason: trust blocked (skill_modified)" in text
+        assert (
+            "Reason: local skill files changed since the trusted baseline. "
+            "Next: Review Diff, then Trust Reviewed Version."
+        ) in text
+        assert "Reason: trust blocked" not in text
         assert button.disabled is True
 
 
@@ -2046,10 +2081,49 @@ async def test_skills_destination_bootstrap_action_calls_trust_service():
     async with host.run_test(size=(180, 50)) as pilot:
         screen = _active_destination_screen(host)
         await _wait_for_skills_snapshot(screen, pilot)
+        initial_list_calls = len(app.skills_scope_service.calls)
         screen._request_skill_trust_passphrase = AsyncMock(return_value="passphrase")
         await pilot.click("#skills-bootstrap-trust")
+        await _wait_for_skills_list_calls(app.skills_scope_service, initial_list_calls + 1, pilot)
 
         assert app.local_skill_trust_service.bootstrap_calls == 1
+        assert app.local_skill_trust_service.bootstrap_passphrases == ["passphrase"]
+
+
+@pytest.mark.asyncio
+async def test_skills_destination_unlock_action_calls_trust_service():
+    app = _build_test_app()
+    app.local_skill_trust_service = RecordingSkillTrustService()
+    app.skills_scope_service = StaticSkillsScopeService(
+        [
+            {
+                "name": "locked-skill",
+                "description": "Locked local skill",
+                "record_id": "local:skill:locked-skill",
+                "validation_status": "valid",
+                "validation_errors": [],
+                "trust_status": "trust_locked",
+                "trust_reason_code": "trust_locked",
+                "trust_blocked": True,
+            },
+        ]
+    )
+    host = DestinationHarness(app, "skills")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_skills_snapshot(screen, pilot)
+        initial_list_calls = len(app.skills_scope_service.calls)
+        screen._request_skill_trust_passphrase = AsyncMock(return_value="passphrase")
+
+        unlock_button = screen.query_one("#skills-unlock-trust", Button)
+        assert unlock_button.disabled is False
+
+        await pilot.click("#skills-unlock-trust")
+        await _wait_for_skills_list_calls(app.skills_scope_service, initial_list_calls + 1, pilot)
+
+        assert app.local_skill_trust_service.unlock_calls == 1
+        assert app.local_skill_trust_service.unlock_passphrases == ["passphrase"]
 
 
 @pytest.mark.asyncio
@@ -2076,13 +2150,75 @@ async def test_skills_destination_review_action_enables_trust_reviewed_version()
     async with host.run_test(size=(180, 50)) as pilot:
         screen = _active_destination_screen(host)
         await _wait_for_skills_snapshot(screen, pilot)
+        initial_list_calls = len(app.skills_scope_service.calls)
         await pilot.click("#skills-review-diff")
+        await _wait_for_skills_list_calls(app.skills_scope_service, initial_list_calls + 1, pilot)
+        text = _visible_text(screen)
 
         assert app.local_skill_trust_service.reviewed_skill == "summarize-notes"
+        assert "Review captured: SKILL.md." in text
+        assert "Confirm these current files should become the trusted baseline." in text
+        assert "Reviewed skill: summarize-notes" in text
+        assert "/SKILL.md" not in text
         assert screen.query_one("#skills-trust-reviewed-version", Button).disabled is False
 
+        list_calls_after_review = len(app.skills_scope_service.calls)
         await pilot.click("#skills-trust-reviewed-version")
+        await _wait_for_skills_list_calls(app.skills_scope_service, list_calls_after_review + 1, pilot)
         assert app.local_skill_trust_service.trusted_review_id == "review-1"
+
+
+@pytest.mark.asyncio
+async def test_skills_destination_clears_stale_review_after_refresh():
+    app = _build_test_app()
+    trusted_skill = {
+        "name": "summarize-notes",
+        "description": "Summarize note collections",
+        "record_id": "local:skill:summarize-notes",
+        "validation_status": "valid",
+        "validation_errors": [],
+        "trust_status": "trusted",
+        "trust_reason_code": None,
+        "trust_blocked": False,
+        "trust_changed_files": [],
+    }
+    app.skills_scope_service = StaticSkillsScopeService(
+        [
+            {
+                "name": "summarize-notes",
+                "description": "Summarize note collections",
+                "record_id": "local:skill:summarize-notes",
+                "validation_status": "valid",
+                "validation_errors": [],
+                "trust_status": "quarantined_modified",
+                "trust_reason_code": "skill_modified",
+                "trust_blocked": True,
+                "trust_changed_files": ["SKILL.md"],
+            },
+        ]
+    )
+    app.local_skill_trust_service = RecordingSkillTrustService(
+        review_id="review-1",
+        on_capture_review=lambda _skill_name: app.skills_scope_service.set_skills([trusted_skill]),
+    )
+    host = DestinationHarness(app, "skills")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_skills_snapshot(screen, pilot)
+        initial_list_calls = len(app.skills_scope_service.calls)
+
+        await pilot.click("#skills-review-diff")
+        await _wait_for_skills_list_calls(app.skills_scope_service, initial_list_calls + 1, pilot)
+        await _wait_for_visible_text(screen, pilot, "Trust: trusted baseline")
+
+        approve_button = screen.query_one("#skills-trust-reviewed-version", Button)
+        assert approve_button.disabled is True
+        assert "Review captured:" not in _visible_text(screen)
+
+        await pilot.click("#skills-trust-reviewed-version")
+        await pilot.pause()
+        assert app.local_skill_trust_service.trust_reviewed_calls == 0
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_destination_shells.py
+++ b/Tests/UI/test_destination_shells.py
@@ -2222,6 +2222,59 @@ async def test_skills_destination_clears_stale_review_after_refresh():
 
 
 @pytest.mark.asyncio
+async def test_skills_destination_hides_review_summary_when_selecting_another_skill():
+    app = _build_test_app()
+    app.local_skill_trust_service = RecordingSkillTrustService(review_id="review-1")
+    app.skills_scope_service = StaticSkillsScopeService(
+        [
+            {
+                "name": "summarize-notes",
+                "description": "Summarize note collections",
+                "record_id": "local:skill:summarize-notes",
+                "validation_status": "valid",
+                "validation_errors": [],
+                "trust_status": "quarantined_modified",
+                "trust_reason_code": "skill_modified",
+                "trust_blocked": True,
+                "trust_changed_files": ["SKILL.md"],
+            },
+            {
+                "name": "code-review",
+                "description": "Review code changes",
+                "record_id": "local:skill:code-review",
+                "validation_status": "valid",
+                "validation_errors": [],
+                "trust_status": "quarantined_modified",
+                "trust_reason_code": "skill_modified",
+                "trust_blocked": True,
+                "trust_changed_files": ["SKILL.md"],
+            },
+        ]
+    )
+    host = DestinationHarness(app, "skills")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_skills_snapshot(screen, pilot)
+        initial_list_calls = len(app.skills_scope_service.calls)
+        await pilot.click("#skills-review-diff")
+        await _wait_for_skills_list_calls(app.skills_scope_service, initial_list_calls + 1, pilot)
+
+        assert "Reviewed skill: summarize-notes" in _visible_text(screen)
+        assert "Review captured: SKILL.md." in _visible_text(screen)
+        assert screen.query_one("#skills-trust-reviewed-version", Button).disabled is False
+
+        await pilot.click("#skills-select-local-1")
+        await pilot.pause()
+        text = _visible_text(screen)
+
+        assert "Selected: code-review" in text
+        assert screen.query_one("#skills-trust-reviewed-version", Button).disabled is True
+        assert "Reviewed skill: summarize-notes" not in text
+        assert "Review captured: SKILL.md." not in text
+
+
+@pytest.mark.asyncio
 async def test_skills_destination_escapes_selected_skill_metadata_in_inspector():
     app = _build_test_app()
     app.skills_scope_service = StaticSkillsScopeService(

--- a/Tests/UI/test_screen_navigation.py
+++ b/Tests/UI/test_screen_navigation.py
@@ -88,7 +88,12 @@ from tldw_chatbook.LLM_Provider_Catalog import (
 )
 from tldw_chatbook.Server_Runtime_Interop import ServerRuntimeScopeService, ServerRuntimeService
 from tldw_chatbook.Sharing_Interop import ServerSharingService, SharingScopeService
-from tldw_chatbook.Skills_Interop import LocalSkillsService, ServerSkillsService, SkillsScopeService
+from tldw_chatbook.Skills_Interop import (
+    LocalSkillsService,
+    ServerSkillsService,
+    SkillTrustService,
+    SkillsScopeService,
+)
 from tldw_chatbook.Sync_Interop import (
     LocalFirstSyncService,
     ManualSyncControlService,
@@ -546,7 +551,7 @@ async def test_app_shutdown_helper_closes_server_context_provider_cached_client(
     assert provider.close_calls == 1
 
 
-def test_app_initializes_watchlists_and_notifications_services():
+def test_app_wires_local_and_server_skills_services():
     app = _build_test_app()
 
     assert isinstance(app.local_watchlists_service, LocalWatchlistsService)
@@ -611,6 +616,9 @@ def test_app_initializes_watchlists_and_notifications_services():
     assert isinstance(app.server_connectors_service, ServerConnectorsService)
     assert isinstance(app.connectors_scope_service, ConnectorsScopeService)
     assert isinstance(app.local_skills_service, LocalSkillsService)
+    assert isinstance(app.local_skill_trust_service, SkillTrustService)
+    assert app.local_skill_trust_service is app.local_skills_service.trust_service
+    assert app.local_skill_trust_service.skills_dir == app.local_skills_service.skills_dir
     assert isinstance(app.server_skills_service, ServerSkillsService)
     assert isinstance(app.skills_scope_service, SkillsScopeService)
     assert app.skills_scope_service.local_service is app.local_skills_service

--- a/Tests/UI/test_settings_privacy_security.py
+++ b/Tests/UI/test_settings_privacy_security.py
@@ -1,7 +1,10 @@
+from types import SimpleNamespace
+
 from tldw_chatbook.UI.Screens.settings_privacy_security import (
     build_privacy_posture_rows,
     build_settings_privacy_posture,
 )
+from tldw_chatbook.UI.Screens.settings_screen import SettingsScreen
 
 
 DUMMY_ENV_SECRET = "env-secret-value-that-must-not-render"
@@ -99,3 +102,100 @@ def test_privacy_posture_handles_malformed_config_safely():
     assert posture.sensitive_config_fields == 0
     assert posture.provider_env_configured == 0
     assert "Redaction: active; raw secret values hidden" in rows
+
+
+def test_privacy_posture_reports_skill_trust_without_leaking_paths():
+    posture = build_settings_privacy_posture(
+        {"encryption": {"enabled": True}},
+        environ={},
+        skill_trust={
+            "enabled": True,
+            "trust_status": "quarantined_modified",
+            "keyring_convenience_enabled": True,
+            "reduced_rollback_protection": False,
+            "skills_dir": "/Users/example/private/skills",
+        },
+    )
+
+    text = "\n".join(build_privacy_posture_rows(posture))
+
+    assert "Skill trust: quarantined_modified" in text
+    assert "Skill trust keyring convenience: enabled" in text
+    assert "Skill trust rollback protection: full" in text
+    assert "/Users/example/private/skills" not in text
+
+
+def test_privacy_posture_reports_skill_trust_disabled_without_mapping():
+    posture = build_settings_privacy_posture({}, environ={}, skill_trust=None)
+    rows = build_privacy_posture_rows(posture)
+
+    assert "Skill trust: disabled" in rows
+    assert "Skill trust keyring convenience: disabled" in rows
+    assert "Skill trust rollback protection: full" in rows
+
+
+def test_privacy_posture_sanitizes_unknown_skill_trust_status():
+    posture = build_settings_privacy_posture(
+        {},
+        environ={},
+        skill_trust={
+            "enabled": True,
+            "trust_status": "trusted /Users/example/private/skills secret-token",
+        },
+    )
+    text = "\n".join(build_privacy_posture_rows(posture))
+
+    assert "Skill trust: unavailable" in text
+    assert "/Users/example/private/skills" not in text
+    assert "secret-token" not in text
+
+
+def test_settings_screen_skill_trust_posture_uses_redacted_service_fields():
+    class FakeSkillTrustService:
+        keyring_convenience_enabled = True
+        reduced_rollback_protection = True
+        skills_dir = "/Users/example/private/skills"
+
+        def overall_status(self):
+            return "trusted"
+
+    screen = SettingsScreen(
+        SimpleNamespace(
+            app_config={},
+            local_skill_trust_service=FakeSkillTrustService(),
+        )
+    )
+
+    posture = screen._skill_trust_posture()
+
+    assert posture == {
+        "enabled": True,
+        "trust_status": "trusted",
+        "keyring_convenience_enabled": True,
+        "reduced_rollback_protection": True,
+    }
+
+
+def test_settings_screen_skill_trust_posture_handles_status_errors_safely():
+    class RaisingSkillTrustService:
+        keyring_convenience_enabled = False
+        reduced_rollback_protection = False
+
+        def overall_status(self):
+            raise RuntimeError("/Users/example/private/skills secret-token")
+
+    screen = SettingsScreen(
+        SimpleNamespace(
+            app_config={},
+            local_skill_trust_service=RaisingSkillTrustService(),
+        )
+    )
+
+    posture = screen._skill_trust_posture()
+
+    assert posture == {
+        "enabled": True,
+        "trust_status": "unavailable_error",
+        "keyring_convenience_enabled": False,
+        "reduced_rollback_protection": False,
+    }

--- a/backlog/decisions/009-local-skill-trust-boundary.md
+++ b/backlog/decisions/009-local-skill-trust-boundary.md
@@ -1,0 +1,49 @@
+# ADR-009: Local Skill Trust Boundary
+
+Status: Accepted
+Date: 2026-06-25
+Related Task: [backlog/tasks/task-137 - Add-local-skill-trust-integrity-controls.md](../tasks/task-137%20-%20Add-local-skill-trust-integrity-controls.md)
+Supersedes: N/A
+
+## Decision
+
+Chatbook-managed local skills will use a passphrase-rooted, authenticated local trust boundary with encrypted trusted snapshots, a secure generation marker, logical quarantine, and reviewed re-trust before trust-blocked skills can be staged or executed.
+
+## Context
+
+Local skills are prompt assets that can steer model behavior and future tool use. They currently have metadata validation and Chatbook-owned storage, but no durable way to prove that an on-disk `SKILL.md` or supporting file matches the version a user previously trusted.
+
+The user concern is offline tampering: Chatbook or a server process is stopped, local skill files are modified, and the next launch unknowingly stages or executes a changed skill. The target scope is Chatbook-managed local skills only. Codex runtime skill folders, server-managed skills, and skill sync remain outside this decision.
+
+The trust root must not live only beside the skill files it protects. A passphrase-derived key provides the main trust root. Secure keyring convenience may cache a protected or wrapped trust root, but it must never store the user's passphrase and must be labeled lower assurance than passphrase-per-start mode.
+
+## Alternatives Considered
+
+| Option | Why rejected |
+| --- | --- |
+| Hash-only manifest stored next to skills | An attacker who can edit skills can also replace the hash manifest, so this only detects accidental drift. |
+| Warn-and-allow changed skills | This preserves convenience but leaves a straightforward prompt-backdoor path when users click through warnings. |
+| Physical quarantine by moving files | Moving directories can destroy forensic context, surprise external editors, and create recovery edge cases. Logical quarantine keeps evidence in place. |
+| Keyring-only auto-unlock | Keyring convenience is useful, but relying on it as the only trust root weakens the offline-tamper threat model when the user account or unlocked keyring is compromised. |
+| Trust-on-first-use without explicit bootstrap | Silent bootstrap could bless already-compromised skill files. First enablement must be explicit. |
+| Include Codex runtime skills and server skills in v1 | Those are separate ownership and runtime boundaries. Mixing them into the first local Chatbook trust boundary would obscure the service contract and recovery rules. |
+
+## Consequences
+
+Local skills gain explicit trust states separate from metadata validation. A skill can be metadata-valid but trust-blocked.
+
+The local Skills service must verify trust at use time. Listing/detail paths may expose trust state for review, but context staging and execution must block untrusted, locked, quarantined, or globally unverifiable skills.
+
+Trust records cover all files in a local skill directory. Trusted snapshots must be encrypted and authenticated so the review flow can show trusted-vs-current diffs without storing plaintext history.
+
+Rollback protection requires a secure generation marker store outside the local skills directory, with secure OS keyring as the v1 target. If that marker store is unavailable, high-security mode fails closed. Reduced rollback protection requires explicit opt-in and visible posture reporting.
+
+Lost-passphrase recovery is intentionally high-friction: users can re-bootstrap current files, but previous encrypted snapshots and authenticated audit history become unrecoverable.
+
+This decision protects against offline file tampering when the attacker lacks the passphrase or authenticated trust root. It does not protect against malicious active app code, passphrase interception, active process-memory compromise, or a user approving a malicious diff.
+
+## Links
+
+- [TASK-137](../tasks/task-137%20-%20Add-local-skill-trust-integrity-controls.md)
+- [Local skill trust integrity design](../../Docs/superpowers/specs/2026-06-25-local-skill-trust-integrity-design.md)
+- [Local skill trust integrity implementation plan](../../Docs/superpowers/plans/2026-06-25-local-skill-trust-integrity.md)

--- a/backlog/decisions/README.md
+++ b/backlog/decisions/README.md
@@ -14,6 +14,7 @@ ADRs explain why significant architectural decisions were made. Backlog tasks, S
 | [ADR-004](004-settings-storage-defaults-restart-boundary.md) | Accepted | Keep Settings storage defaults persisted under `database` config while active storage handles remain restart-boundary owned. |
 | [ADR-005](005-console-workspace-server-readiness.md) | Accepted | Keep Console workspace switching local-first while exposing honest server-readiness, handoff, runtime, and ACP task/run states behind adapter boundaries. |
 | [ADR-006](006-provider-aware-generation-settings.md) | Accepted | Keep Settings as the owner of persisted generation defaults while Console resolves effective session settings and provider adapters translate sampler/thinking controls into provider-specific request payloads. |
+| [ADR-009](009-local-skill-trust-boundary.md) | Accepted | Use a passphrase-rooted authenticated trust boundary with logical quarantine for Chatbook-managed local skills. |
 
 ## Historical Decision Material
 

--- a/backlog/tasks/task-137 - Add-local-skill-trust-integrity-controls.md
+++ b/backlog/tasks/task-137 - Add-local-skill-trust-integrity-controls.md
@@ -1,10 +1,14 @@
 ---
 id: TASK-137
 title: Add local skill trust integrity controls
-status: In Progress
+status: Done
+assignee: []
+created_date: ''
+updated_date: '2026-06-25 21:03'
 labels:
-- skills
-- security
+  - skills
+  - security
+dependencies: []
 priority: high
 ---
 
@@ -16,14 +20,14 @@ Protect Chatbook-managed local skills from offline file tampering by adding expl
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Local skill trust bootstrap blocks uninitialized skills until the user explicitly trusts the current baseline.
-- [ ] #2 Authenticated manifest, snapshots, and generation marker verification detect modified, added, deleted, unsupported, replayed, or unverifiable skill files.
-- [ ] #3 Trust-blocked skills remain visible but cannot be staged in context or executed.
-- [ ] #4 Review approval updates the trusted baseline only after a captured diff still matches live files.
-- [ ] #5 Secure keyring convenience mode never stores the user passphrase and reduced rollback protection is explicit.
-- [ ] #6 Skills UI and Settings surface trust posture, quarantine reasons, and recovery actions without leaking secrets or absolute paths by default.
-- [ ] #7 Focused service, trust-layer, policy, and UI tests cover the new trust boundary.
-- [ ] #8 ADR and Superpowers implementation plan are linked from the task.
+- [x] #1 Local skill trust bootstrap blocks uninitialized skills until the user explicitly trusts the current baseline.
+- [x] #2 Authenticated manifest, snapshots, and generation marker verification detect modified, added, deleted, unsupported, replayed, or unverifiable skill files.
+- [x] #3 Trust-blocked skills remain visible but cannot be staged in context or executed.
+- [x] #4 Review approval updates the trusted baseline only after a captured diff still matches live files.
+- [x] #5 Secure keyring convenience mode never stores the user passphrase and reduced rollback protection is explicit.
+- [x] #6 Skills UI and Settings surface trust posture, quarantine reasons, and recovery actions without leaking secrets or absolute paths by default.
+- [x] #7 Focused service, trust-layer, policy, and UI tests cover the new trust boundary.
+- [x] #8 ADR and Superpowers implementation plan are linked from the task.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -44,14 +48,14 @@ Superpowers plan: Docs/superpowers/plans/2026-06-25-local-skill-trust-integrity.
 
 ## Implementation Notes
 
-<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
-<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:BEGIN -->
+Implemented local skill trust integrity for Chatbook-managed local skills. Added ADR-009-backed trust modules for passphrase-derived keys, authenticated manifests, encrypted trusted snapshots, generation markers, directory scanning, logical quarantine, reviewed re-trust, and deterministic trust-blocked service behavior. Wired trust state into LocalSkillsService, app construction, Skills UI, Settings Privacy posture, and runtime-policy action IDs. Focused trust, Skills, runtime-policy, and UI tests pass. ADR path: backlog/decisions/009-local-skill-trust-boundary.md. Superpowers plan: Docs/superpowers/plans/2026-06-25-local-skill-trust-integrity.md.
+<!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-
+Local skill trust controls are implemented and wired through the trust layer, service integration, app construction, Skills recovery UI, Settings posture, and policy registry. Verification completed with focused trust/service, runtime-policy, Skills UI, Settings/navigation tests, plus diff hygiene.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/task-137 - Add-local-skill-trust-integrity-controls.md
+++ b/backlog/tasks/task-137 - Add-local-skill-trust-integrity-controls.md
@@ -1,0 +1,59 @@
+---
+id: TASK-137
+title: Add local skill trust integrity controls
+status: In Progress
+labels:
+- skills
+- security
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Protect Chatbook-managed local skills from offline file tampering by adding explicit trust bootstrap, authenticated baseline verification, logical quarantine, reviewed re-trust, and visible recovery states.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Local skill trust bootstrap blocks uninitialized skills until the user explicitly trusts the current baseline.
+- [ ] #2 Authenticated manifest, snapshots, and generation marker verification detect modified, added, deleted, unsupported, replayed, or unverifiable skill files.
+- [ ] #3 Trust-blocked skills remain visible but cannot be staged in context or executed.
+- [ ] #4 Review approval updates the trusted baseline only after a captured diff still matches live files.
+- [ ] #5 Secure keyring convenience mode never stores the user passphrase and reduced rollback protection is explicit.
+- [ ] #6 Skills UI and Settings surface trust posture, quarantine reasons, and recovery actions without leaking secrets or absolute paths by default.
+- [ ] #7 Focused service, trust-layer, policy, and UI tests cover the new trust boundary.
+- [ ] #8 ADR and Superpowers implementation plan are linked from the task.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: yes
+ADR path: backlog/decisions/009-local-skill-trust-boundary.md
+Reason: Local skill trust changes a security boundary, trust root, local storage semantics, runtime policy IDs, and the LocalSkillsService contract.
+
+1. Register local skill trust runtime-policy actions.
+2. Add trust models, crypto, scanner, store, and service substrate.
+3. Integrate trust checks into LocalSkillsService and app wiring.
+4. Add Skills and Settings trust posture UI.
+5. Run focused trust, Skills, runtime-policy, and UI tests.
+
+Superpowers plan: Docs/superpowers/plans/2026-06-25-local-skill-trust-integrity.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -275,6 +275,14 @@ class ConsoleChatController:
             await task
         except asyncio.CancelledError:
             pass
+        except Exception:
+            # Shutdown is a teardown path; stale task failures should not crash owner cleanup.
+            pass
+        finally:
+            if self._active_stream_task is task:
+                self._active_assistant_message_id = None
+                self._active_stream_task = None
+                self._stop_requested = False
 
     def _active_streaming_assistant_message_id(self) -> str | None:
         """Return the visible streaming assistant message for the active session."""

--- a/tldw_chatbook/Skills_Interop/__init__.py
+++ b/tldw_chatbook/Skills_Interop/__init__.py
@@ -2,6 +2,7 @@
 
 from .local_skills_service import LocalSkillsService
 from .server_skills_service import ServerSkillsService
+from .skill_trust_service import SkillTrustService
 from .skill_trust_models import SkillTrustBlockedError, SkillTrustStatus
 from .skills_scope_service import SkillsBackend, SkillsScopeService
 
@@ -9,6 +10,7 @@ __all__ = [
     "LocalSkillsService",
     "ServerSkillsService",
     "SkillTrustBlockedError",
+    "SkillTrustService",
     "SkillTrustStatus",
     "SkillsBackend",
     "SkillsScopeService",

--- a/tldw_chatbook/Skills_Interop/__init__.py
+++ b/tldw_chatbook/Skills_Interop/__init__.py
@@ -2,6 +2,14 @@
 
 from .local_skills_service import LocalSkillsService
 from .server_skills_service import ServerSkillsService
+from .skill_trust_models import SkillTrustBlockedError, SkillTrustStatus
 from .skills_scope_service import SkillsBackend, SkillsScopeService
 
-__all__ = ["LocalSkillsService", "ServerSkillsService", "SkillsBackend", "SkillsScopeService"]
+__all__ = [
+    "LocalSkillsService",
+    "ServerSkillsService",
+    "SkillTrustBlockedError",
+    "SkillTrustStatus",
+    "SkillsBackend",
+    "SkillsScopeService",
+]

--- a/tldw_chatbook/Skills_Interop/local_skills_service.py
+++ b/tldw_chatbook/Skills_Interop/local_skills_service.py
@@ -28,6 +28,7 @@ from ..tldw_api import (
 )
 from ..tldw_api.skills_schemas import _normalize_skill_name
 from ..Utils.input_validation import sanitize_string, validate_text_input
+from .skill_trust_models import SkillTrustBlockedError
 
 
 _INDEX_FILENAME = "tldw_chatbook_skills.json"
@@ -62,6 +63,8 @@ _TEXT_FIELD_LIMITS = {
     "metadata_value": 1000,
     "allowed_tool": 128,
 }
+_TRUST_STATUS_SERVICE_UNAVAILABLE = "trust_locked"
+_TRUST_REASON_SERVICE_UNAVAILABLE = "trust_service_unavailable"
 
 
 class LocalSkillsService:
@@ -77,12 +80,14 @@ class LocalSkillsService:
         store_dir: str | Path,
         policy_enforcer: Any | None = None,
         trust_service: Any | None = None,
+        allow_untrusted_without_trust_service: bool = False,
     ) -> None:
         self.store_dir = Path(store_dir)
         self.skills_dir = self.store_dir / _SKILLS_DIRNAME
         self.index_path = self.store_dir / _INDEX_FILENAME
         self.policy_enforcer = policy_enforcer
         self.trust_service = trust_service
+        self.allow_untrusted_without_trust_service = allow_untrusted_without_trust_service
         self._lock = asyncio.Lock()
 
     def _enforce(self, action_id: str) -> None:
@@ -416,6 +421,15 @@ class LocalSkillsService:
 
     def _trust_fields_for_record(self, record: dict[str, Any]) -> dict[str, Any]:
         if self.trust_service is None:
+            if not self.allow_untrusted_without_trust_service:
+                return {
+                    "trust_status": _TRUST_STATUS_SERVICE_UNAVAILABLE,
+                    "trust_reason_code": _TRUST_REASON_SERVICE_UNAVAILABLE,
+                    "trust_blocked": True,
+                    "trust_changed_files": [],
+                    "trust_manifest_generation": None,
+                    "trust_last_verified_at": None,
+                }
             return {
                 "trust_status": "trusted",
                 "trust_reason_code": None,
@@ -427,15 +441,31 @@ class LocalSkillsService:
         return self.trust_service.status_for_skill(str(record["name"])).response_fields()
 
     def _require_trusted_skill(self, skill_name: str) -> None:
-        if self.trust_service is not None:
-            self.trust_service.ensure_skill_trusted(skill_name)
+        if self.trust_service is None:
+            if self.allow_untrusted_without_trust_service:
+                return
+            raise SkillTrustBlockedError(
+                skill_name=skill_name,
+                reason_code=_TRUST_REASON_SERVICE_UNAVAILABLE,
+                trust_status=_TRUST_STATUS_SERVICE_UNAVAILABLE,
+            )
+        self.trust_service.ensure_skill_trusted(skill_name)
 
     def _trust_after_approved_mutation(self, skill_name: str, *, trust_approved: bool) -> None:
-        if self.trust_service is not None and trust_approved:
-            self.trust_service.trust_current_skill(
-                skill_name,
-                audit_event="trust_chatbook_mutation",
+        if not trust_approved:
+            return
+        if self.trust_service is None:
+            if self.allow_untrusted_without_trust_service:
+                return
+            raise SkillTrustBlockedError(
+                skill_name=skill_name,
+                reason_code=_TRUST_REASON_SERVICE_UNAVAILABLE,
+                trust_status=_TRUST_STATUS_SERVICE_UNAVAILABLE,
             )
+        self.trust_service.trust_current_skill(
+            skill_name,
+            audit_event="trust_chatbook_mutation",
+        )
 
     def _require_record(self, skill_name: str, records: dict[str, dict[str, Any]]) -> dict[str, Any]:
         normalized_name = _normalize_skill_name(skill_name)
@@ -705,6 +735,7 @@ class LocalSkillsService:
         skill = await self.get_skill(skill_name)
         _, body = self._parse_front_matter(skill["content"])
         rendered_prompt = body.strip().replace("{{args}}", request.args or "")
+        self._require_trusted_skill(skill_name)
         return self._dump(
             SkillExecutionResult(
                 skill_name=skill["name"],

--- a/tldw_chatbook/Skills_Interop/local_skills_service.py
+++ b/tldw_chatbook/Skills_Interop/local_skills_service.py
@@ -71,11 +71,18 @@ class LocalSkillsService:
     supplied ``store_dir``. It does not read or mutate Codex runtime skills.
     """
 
-    def __init__(self, *, store_dir: str | Path, policy_enforcer: Any | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        store_dir: str | Path,
+        policy_enforcer: Any | None = None,
+        trust_service: Any | None = None,
+    ) -> None:
         self.store_dir = Path(store_dir)
         self.skills_dir = self.store_dir / _SKILLS_DIRNAME
         self.index_path = self.store_dir / _INDEX_FILENAME
         self.policy_enforcer = policy_enforcer
+        self.trust_service = trust_service
         self._lock = asyncio.Lock()
 
     def _enforce(self, action_id: str) -> None:
@@ -386,10 +393,11 @@ class LocalSkillsService:
             content=content,
             supporting_files=self._read_supporting_files(skill_dir),
         )
-        return self._dump(response)
+        payload = self._dump(response)
+        payload.update(self._trust_fields_for_record(record))
+        return payload
 
-    @staticmethod
-    def _summary_for_record(record: dict[str, Any]) -> dict[str, Any]:
+    def _summary_for_record(self, record: dict[str, Any]) -> dict[str, Any]:
         summary = LocalSkillsService._dump(
             SkillSummary(
                 name=record["name"],
@@ -403,7 +411,31 @@ class LocalSkillsService:
         for field in ("agent_skill_name", "validation_status", "validation_errors", "record_id", "backend"):
             if field in record:
                 summary[field] = record[field]
+        summary.update(self._trust_fields_for_record(record))
         return summary
+
+    def _trust_fields_for_record(self, record: dict[str, Any]) -> dict[str, Any]:
+        if self.trust_service is None:
+            return {
+                "trust_status": "trusted",
+                "trust_reason_code": None,
+                "trust_blocked": False,
+                "trust_changed_files": [],
+                "trust_manifest_generation": None,
+                "trust_last_verified_at": None,
+            }
+        return self.trust_service.status_for_skill(str(record["name"])).response_fields()
+
+    def _require_trusted_skill(self, skill_name: str) -> None:
+        if self.trust_service is not None:
+            self.trust_service.ensure_skill_trusted(skill_name)
+
+    def _trust_after_approved_mutation(self, skill_name: str, *, trust_approved: bool) -> None:
+        if self.trust_service is not None and trust_approved:
+            self.trust_service.trust_current_skill(
+                skill_name,
+                audit_event="trust_chatbook_mutation",
+            )
 
     def _require_record(self, skill_name: str, records: dict[str, dict[str, Any]]) -> dict[str, Any]:
         normalized_name = _normalize_skill_name(skill_name)
@@ -467,18 +499,27 @@ class LocalSkillsService:
     async def get_context(self) -> dict[str, Any]:
         self._enforce("skills.context.list.local")
         records = self._load_index()
-        summaries = [self._summary_for_record(record) for _, record in sorted(records.items())]
+        available: list[dict[str, Any]] = []
+        blocked: list[dict[str, Any]] = []
+        for _, record in sorted(records.items()):
+            summary = self._summary_for_record(record)
+            if summary.get("trust_blocked"):
+                blocked.append(summary)
+                continue
+            available.append(summary)
         context_lines = []
-        for summary in summaries:
+        for summary in available:
             description = f": {summary['description']}" if summary.get("description") else ""
             argument_hint = f" (args: {summary['argument_hint']})" if summary.get("argument_hint") else ""
             context_lines.append(f"- {summary['name']}{description}{argument_hint}")
-        return self._dump(
+        payload = self._dump(
             SkillContextPayload(
-                available_skills=summaries,
+                available_skills=available,
                 context_text="\n".join(context_lines),
             )
         )
+        payload["blocked_skills"] = blocked
+        return payload
 
     async def get_skill(self, skill_name: str) -> dict[str, Any]:
         self._enforce("skills.detail.local")
@@ -491,6 +532,7 @@ class LocalSkillsService:
         name: str,
         content: str,
         supporting_files: dict[str, str] | None = None,
+        trust_approved: bool = False,
     ) -> dict[str, Any]:
         self._enforce("skills.create.local")
         request = SkillCreate(name=name, content=content, supporting_files=supporting_files)
@@ -509,6 +551,7 @@ class LocalSkillsService:
                 skill_dir=skill_dir,
             )
             self._save_index(records)
+            self._trust_after_approved_mutation(skill_name, trust_approved=trust_approved)
             return self._response_for_record(records[skill_name])
 
     async def update_skill(
@@ -518,6 +561,7 @@ class LocalSkillsService:
         content: str | None = None,
         supporting_files: dict[str, str | None] | None = None,
         expected_version: int | None = None,
+        trust_approved: bool = False,
     ) -> dict[str, Any]:
         self._enforce("skills.update.local")
         request = SkillUpdate(content=content, supporting_files=supporting_files)
@@ -543,6 +587,7 @@ class LocalSkillsService:
             next_record["version"] = int(record.get("version", 0)) + 1
             records[normalized_name] = next_record
             self._save_index(records)
+            self._trust_after_approved_mutation(normalized_name, trust_approved=trust_approved)
             return self._response_for_record(next_record)
 
     async def delete_skill(self, skill_name: str, *, expected_version: int | None = None) -> bool:
@@ -564,6 +609,7 @@ class LocalSkillsService:
         name: str | None = None,
         supporting_files: dict[str, str] | None = None,
         overwrite: bool = False,
+        trust_approved: bool = False,
     ) -> dict[str, Any]:
         self._enforce("skills.import.launch.local")
         request = SkillImportRequest(
@@ -594,6 +640,7 @@ class LocalSkillsService:
                 record["version"] = int(existing.get("version", 0)) + 1
             records[skill_name] = record
             self._save_index(records)
+            self._trust_after_approved_mutation(skill_name, trust_approved=trust_approved)
             return self._response_for_record(record)
 
     async def import_skill_file(
@@ -603,6 +650,7 @@ class LocalSkillsService:
         filename: str = _SKILL_FILENAME,
         content_type: str = "text/markdown",
         overwrite: bool = False,
+        trust_approved: bool = False,
     ) -> dict[str, Any]:
         self._enforce("skills.import.launch.local")
         is_zip = content_type in {"application/zip", "application/x-zip-compressed"} or filename.lower().endswith(".zip")
@@ -611,6 +659,7 @@ class LocalSkillsService:
                 name=self._derive_name_from_filename(filename),
                 content=file_content.decode("utf-8"),
                 overwrite=overwrite,
+                trust_approved=trust_approved,
             )
 
         supporting_files: dict[str, str] = {}
@@ -632,6 +681,7 @@ class LocalSkillsService:
             content=skill_content,
             supporting_files=supporting_files or None,
             overwrite=overwrite,
+            trust_approved=trust_approved,
         )
 
     async def export_skill(self, skill_name: str) -> Any:
@@ -650,6 +700,7 @@ class LocalSkillsService:
 
     async def execute_skill(self, skill_name: str, *, args: str | None = None) -> dict[str, Any]:
         self._enforce("skills.execute.launch.local")
+        self._require_trusted_skill(skill_name)
         request = SkillExecuteRequest(args=args)
         skill = await self.get_skill(skill_name)
         _, body = self._parse_front_matter(skill["content"])

--- a/tldw_chatbook/Skills_Interop/local_skills_service.py
+++ b/tldw_chatbook/Skills_Interop/local_skills_service.py
@@ -386,13 +386,17 @@ class LocalSkillsService:
         for path in sorted(skill_dir.iterdir(), key=lambda item: item.name):
             if not path.is_file() or path.name == _SKILL_FILENAME:
                 continue
-            supporting_files[path.name] = path.read_text(encoding="utf-8")
+            supporting_files[path.name] = LocalSkillsService._read_text_preserving_newlines(path)
         return supporting_files or None
+
+    @staticmethod
+    def _read_text_preserving_newlines(path: Path) -> str:
+        return path.read_bytes().decode("utf-8")
 
     def _response_for_record(self, record: dict[str, Any]) -> dict[str, Any]:
         skill_name = str(record["name"])
         skill_dir = self._skill_dir(skill_name)
-        content = (skill_dir / _SKILL_FILENAME).read_text(encoding="utf-8")
+        content = self._read_text_preserving_newlines(skill_dir / _SKILL_FILENAME)
         response = SkillResponse(
             **record,
             content=content,
@@ -625,7 +629,7 @@ class LocalSkillsService:
             if next_content is not None:
                 self._write_text_atomic(skill_content_path, next_content)
             else:
-                next_content = skill_content_path.read_text(encoding="utf-8")
+                next_content = self._read_text_preserving_newlines(skill_content_path)
             self._apply_supporting_files(skill_dir, request.supporting_files)
             next_record = self._metadata_from_content(
                 name=normalized_name,

--- a/tldw_chatbook/Skills_Interop/local_skills_service.py
+++ b/tldw_chatbook/Skills_Interop/local_skills_service.py
@@ -28,6 +28,7 @@ from ..tldw_api import (
 )
 from ..tldw_api.skills_schemas import _normalize_skill_name
 from ..Utils.input_validation import sanitize_string, validate_text_input
+from ..Utils.path_validation import get_safe_relative_path, validate_path_simple
 from .skill_trust_models import SkillTrustBlockedError
 
 
@@ -386,17 +387,31 @@ class LocalSkillsService:
         for path in sorted(skill_dir.iterdir(), key=lambda item: item.name):
             if not path.is_file() or path.name == _SKILL_FILENAME:
                 continue
-            supporting_files[path.name] = LocalSkillsService._read_text_preserving_newlines(path)
+            supporting_files[path.name] = LocalSkillsService._read_text_preserving_newlines(
+                path,
+                base_dir=skill_dir,
+            )
         return supporting_files or None
 
     @staticmethod
-    def _read_text_preserving_newlines(path: Path) -> str:
-        return path.read_bytes().decode("utf-8")
+    def _read_text_preserving_newlines(path: Path, *, base_dir: Path | None = None) -> str:
+        base_dir = validate_path_simple(base_dir or path.parent)
+        if base_dir.is_symlink():
+            raise ValueError("unsafe local skill path")
+        safe_path = validate_path_simple(path)
+        if safe_path.is_symlink():
+            raise ValueError("unsafe local skill path")
+        if get_safe_relative_path(safe_path, base_dir) is None:
+            raise ValueError("unsafe local skill path")
+        return safe_path.read_bytes().decode("utf-8")
 
     def _response_for_record(self, record: dict[str, Any]) -> dict[str, Any]:
         skill_name = str(record["name"])
         skill_dir = self._skill_dir(skill_name)
-        content = self._read_text_preserving_newlines(skill_dir / _SKILL_FILENAME)
+        content = self._read_text_preserving_newlines(
+            skill_dir / _SKILL_FILENAME,
+            base_dir=skill_dir,
+        )
         response = SkillResponse(
             **record,
             content=content,

--- a/tldw_chatbook/Skills_Interop/local_skills_service.py
+++ b/tldw_chatbook/Skills_Interop/local_skills_service.py
@@ -454,6 +454,8 @@ class LocalSkillsService:
     def _trust_after_approved_mutation(self, skill_name: str, *, trust_approved: bool) -> None:
         if not trust_approved:
             return
+        # Writes and index updates intentionally happen before re-trust. If this
+        # fails, later list/execute paths remain blocked until review or retry.
         if self.trust_service is None:
             if self.allow_untrusted_without_trust_service:
                 return
@@ -465,6 +467,23 @@ class LocalSkillsService:
         self.trust_service.trust_current_skill(
             skill_name,
             audit_event="trust_chatbook_mutation",
+        )
+
+    def _verify_exact_skill_content(self, skill: dict[str, Any]) -> None:
+        if self.trust_service is None:
+            self._require_trusted_skill(str(skill["name"]))
+            return
+        verifier = getattr(self.trust_service, "verify_skill_content", None)
+        if not callable(verifier):
+            raise SkillTrustBlockedError(
+                skill_name=str(skill["name"]),
+                reason_code="trust_verifier_unavailable",
+                trust_status="trust_locked",
+            )
+        verifier(
+            str(skill["name"]),
+            skill_content=str(skill["content"]),
+            supporting_files=skill.get("supporting_files"),
         )
 
     def _require_record(self, skill_name: str, records: dict[str, dict[str, Any]]) -> dict[str, Any]:
@@ -733,9 +752,9 @@ class LocalSkillsService:
         self._require_trusted_skill(skill_name)
         request = SkillExecuteRequest(args=args)
         skill = await self.get_skill(skill_name)
+        self._verify_exact_skill_content(skill)
         _, body = self._parse_front_matter(skill["content"])
         rendered_prompt = body.strip().replace("{{args}}", request.args or "")
-        self._require_trusted_skill(skill_name)
         return self._dump(
             SkillExecutionResult(
                 skill_name=skill["name"],

--- a/tldw_chatbook/Skills_Interop/skill_trust_crypto.py
+++ b/tldw_chatbook/Skills_Interop/skill_trust_crypto.py
@@ -21,7 +21,7 @@ SKILL_TRUST_KEY_SIZE = 32
 SKILL_TRUST_NONCE_SIZE = 12
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, repr=False)
 class SkillTrustKeys:
     """Purpose-separated keys derived from the local skill trust passphrase."""
 
@@ -29,6 +29,15 @@ class SkillTrustKeys:
     snapshot_key: bytes
     audit_mac_key: bytes
     wrapped_root_key: bytes
+
+    def __repr__(self) -> str:
+        return (
+            "SkillTrustKeys("
+            "manifest_mac_key=<redacted>, "
+            "snapshot_key=<redacted>, "
+            "audit_mac_key=<redacted>, "
+            "wrapped_root_key=<redacted>)"
+        )
 
 
 def canonical_json(payload: Any) -> bytes:
@@ -73,6 +82,11 @@ def _derive_subkey(root: bytes, purpose: bytes) -> bytes:
     return hmac.new(root, purpose, hashlib.sha256).digest()
 
 
+def _require_aes_256_key(key: bytes) -> None:
+    if not isinstance(key, bytes) or len(key) != SKILL_TRUST_KEY_SIZE:
+        raise ValueError("skill trust AES-256-GCM key must be 32 bytes")
+
+
 def manifest_mac(manifest_payload: dict[str, Any], key: bytes) -> str:
     """Return an HMAC-SHA256 tag for a canonical manifest payload."""
 
@@ -87,6 +101,7 @@ def encrypt_json_blob(
 ) -> dict[str, str]:
     """Encrypt and authenticate a JSON payload with AES-256-GCM."""
 
+    _require_aes_256_key(key)
     nonce = os.urandom(SKILL_TRUST_NONCE_SIZE)
     cipher = AES.new(key, AES.MODE_GCM, nonce=nonce)
     cipher.update(associated_data)
@@ -107,6 +122,7 @@ def decrypt_json_blob(
 ) -> dict[str, Any]:
     """Decrypt and authenticate a JSON object encrypted by :func:`encrypt_json_blob`."""
 
+    _require_aes_256_key(key)
     try:
         if blob.get("alg") != "AES-256-GCM":
             raise ValueError("unsupported snapshot algorithm")

--- a/tldw_chatbook/Skills_Interop/skill_trust_crypto.py
+++ b/tldw_chatbook/Skills_Interop/skill_trust_crypto.py
@@ -41,7 +41,14 @@ class SkillTrustKeys:
 
 
 def canonical_json(payload: Any) -> bytes:
-    """Return deterministic UTF-8 JSON bytes for authenticated payloads."""
+    """Return deterministic UTF-8 JSON bytes for authenticated payloads.
+
+    Args:
+        payload: JSON-serializable payload to canonicalize.
+
+    Returns:
+        UTF-8 encoded JSON bytes with stable key ordering and separators.
+    """
 
     return json.dumps(
         payload,
@@ -52,13 +59,31 @@ def canonical_json(payload: Any) -> bytes:
 
 
 def sha256_hex(data: bytes) -> str:
-    """Return the SHA-256 digest of bytes as lowercase hexadecimal."""
+    """Return the SHA-256 digest of bytes as lowercase hexadecimal.
+
+    Args:
+        data: Bytes to hash.
+
+    Returns:
+        Lowercase hexadecimal SHA-256 digest.
+    """
 
     return hashlib.sha256(data).hexdigest()
 
 
 def derive_skill_trust_keys(passphrase: str, *, salt: bytes) -> SkillTrustKeys:
-    """Derive purpose-separated local skill trust keys from a passphrase."""
+    """Derive purpose-separated local skill trust keys from a passphrase.
+
+    Args:
+        passphrase: User-provided trust passphrase.
+        salt: 32-byte salt bound to the local trust manifest.
+
+    Returns:
+        Purpose-separated keys for manifests, snapshots, audit entries, and key wrapping.
+
+    Raises:
+        ValueError: If ``salt`` is not exactly 32 bytes.
+    """
 
     if not isinstance(salt, bytes) or len(salt) != 32:
         raise ValueError("skill trust salt must be 32 bytes")
@@ -88,7 +113,15 @@ def _require_aes_256_key(key: bytes) -> None:
 
 
 def manifest_mac(manifest_payload: dict[str, Any], key: bytes) -> str:
-    """Return an HMAC-SHA256 tag for a canonical manifest payload."""
+    """Return an HMAC-SHA256 tag for a canonical manifest payload.
+
+    Args:
+        manifest_payload: Manifest payload to authenticate.
+        key: HMAC key derived for manifest authentication.
+
+    Returns:
+        Lowercase hexadecimal HMAC-SHA256 tag.
+    """
 
     return hmac.new(key, canonical_json(manifest_payload), hashlib.sha256).hexdigest()
 
@@ -99,7 +132,19 @@ def encrypt_json_blob(
     *,
     associated_data: bytes,
 ) -> dict[str, str]:
-    """Encrypt and authenticate a JSON payload with AES-256-GCM."""
+    """Encrypt and authenticate a JSON payload with AES-256-GCM.
+
+    Args:
+        payload: JSON object to encrypt.
+        key: 32-byte AES-256-GCM key.
+        associated_data: Additional authenticated data bound to the ciphertext.
+
+    Returns:
+        JSON-safe encrypted blob containing algorithm, nonce, ciphertext, and tag.
+
+    Raises:
+        ValueError: If ``key`` is not exactly 32 bytes.
+    """
 
     _require_aes_256_key(key)
     nonce = os.urandom(SKILL_TRUST_NONCE_SIZE)
@@ -120,7 +165,19 @@ def decrypt_json_blob(
     *,
     associated_data: bytes,
 ) -> dict[str, Any]:
-    """Decrypt and authenticate a JSON object encrypted by :func:`encrypt_json_blob`."""
+    """Decrypt and authenticate a JSON object encrypted by :func:`encrypt_json_blob`.
+
+    Args:
+        blob: JSON-safe encrypted blob produced by ``encrypt_json_blob``.
+        key: 32-byte AES-256-GCM key.
+        associated_data: Additional authenticated data expected for the ciphertext.
+
+    Returns:
+        Decrypted JSON object.
+
+    Raises:
+        ValueError: If the key, algorithm, authentication tag, or plaintext shape is invalid.
+    """
 
     _require_aes_256_key(key)
     try:

--- a/tldw_chatbook/Skills_Interop/skill_trust_crypto.py
+++ b/tldw_chatbook/Skills_Interop/skill_trust_crypto.py
@@ -1,0 +1,124 @@
+"""Cryptographic helpers for local skill trust state."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+from dataclasses import dataclass
+from typing import Any
+
+from Cryptodome.Cipher import AES
+from Cryptodome.Protocol.KDF import scrypt
+
+
+SKILL_TRUST_KDF_N = 16384
+SKILL_TRUST_KDF_R = 8
+SKILL_TRUST_KDF_P = 1
+SKILL_TRUST_KEY_SIZE = 32
+SKILL_TRUST_NONCE_SIZE = 12
+
+
+@dataclass(frozen=True, slots=True)
+class SkillTrustKeys:
+    """Purpose-separated keys derived from the local skill trust passphrase."""
+
+    manifest_mac_key: bytes
+    snapshot_key: bytes
+    audit_mac_key: bytes
+    wrapped_root_key: bytes
+
+
+def canonical_json(payload: Any) -> bytes:
+    """Return deterministic UTF-8 JSON bytes for authenticated payloads."""
+
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+
+def sha256_hex(data: bytes) -> str:
+    """Return the SHA-256 digest of bytes as lowercase hexadecimal."""
+
+    return hashlib.sha256(data).hexdigest()
+
+
+def derive_skill_trust_keys(passphrase: str, *, salt: bytes) -> SkillTrustKeys:
+    """Derive purpose-separated local skill trust keys from a passphrase."""
+
+    if not isinstance(salt, bytes) or len(salt) != 32:
+        raise ValueError("skill trust salt must be 32 bytes")
+    root = scrypt(
+        passphrase.encode("utf-8"),
+        salt,
+        key_len=SKILL_TRUST_KEY_SIZE,
+        N=SKILL_TRUST_KDF_N,
+        r=SKILL_TRUST_KDF_R,
+        p=SKILL_TRUST_KDF_P,
+    )
+    return SkillTrustKeys(
+        manifest_mac_key=_derive_subkey(root, b"tldw-chatbook-skill-trust-manifest-v1"),
+        snapshot_key=_derive_subkey(root, b"tldw-chatbook-skill-trust-snapshot-v1"),
+        audit_mac_key=_derive_subkey(root, b"tldw-chatbook-skill-trust-audit-v1"),
+        wrapped_root_key=_derive_subkey(root, b"tldw-chatbook-skill-trust-wrapped-root-v1"),
+    )
+
+
+def _derive_subkey(root: bytes, purpose: bytes) -> bytes:
+    return hmac.new(root, purpose, hashlib.sha256).digest()
+
+
+def manifest_mac(manifest_payload: dict[str, Any], key: bytes) -> str:
+    """Return an HMAC-SHA256 tag for a canonical manifest payload."""
+
+    return hmac.new(key, canonical_json(manifest_payload), hashlib.sha256).hexdigest()
+
+
+def encrypt_json_blob(
+    payload: dict[str, Any],
+    key: bytes,
+    *,
+    associated_data: bytes,
+) -> dict[str, str]:
+    """Encrypt and authenticate a JSON payload with AES-256-GCM."""
+
+    nonce = os.urandom(SKILL_TRUST_NONCE_SIZE)
+    cipher = AES.new(key, AES.MODE_GCM, nonce=nonce)
+    cipher.update(associated_data)
+    ciphertext, tag = cipher.encrypt_and_digest(canonical_json(payload))
+    return {
+        "alg": "AES-256-GCM",
+        "nonce": base64.b64encode(nonce).decode("ascii"),
+        "ciphertext": base64.b64encode(ciphertext).decode("ascii"),
+        "tag": base64.b64encode(tag).decode("ascii"),
+    }
+
+
+def decrypt_json_blob(
+    blob: dict[str, str],
+    key: bytes,
+    *,
+    associated_data: bytes,
+) -> dict[str, Any]:
+    """Decrypt and authenticate a JSON object encrypted by :func:`encrypt_json_blob`."""
+
+    try:
+        if blob.get("alg") != "AES-256-GCM":
+            raise ValueError("unsupported snapshot algorithm")
+        nonce = base64.b64decode(blob["nonce"], validate=True)
+        ciphertext = base64.b64decode(blob["ciphertext"], validate=True)
+        tag = base64.b64decode(blob["tag"], validate=True)
+        cipher = AES.new(key, AES.MODE_GCM, nonce=nonce)
+        cipher.update(associated_data)
+        plaintext = cipher.decrypt_and_verify(ciphertext, tag)
+        payload = json.loads(plaintext.decode("utf-8"))
+    except Exception as exc:
+        raise ValueError("snapshot authentication failed") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("snapshot payload must be an object")
+    return payload

--- a/tldw_chatbook/Skills_Interop/skill_trust_models.py
+++ b/tldw_chatbook/Skills_Interop/skill_trust_models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 
@@ -54,7 +54,7 @@ class SkillDirectorySnapshot:
 
     skill_name: str
     fingerprints: tuple[SkillFileFingerprint, ...]
-    text_files: dict[str, str]
+    text_files: dict[str, str] = field(repr=False)
     unsupported_paths: tuple[str, ...] = ()
 
     @property

--- a/tldw_chatbook/Skills_Interop/skill_trust_models.py
+++ b/tldw_chatbook/Skills_Interop/skill_trust_models.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from types import MappingProxyType
+from typing import Any, Mapping
 
 
 TRUST_STATUS_TRUSTED = "trusted"
@@ -54,8 +55,11 @@ class SkillDirectorySnapshot:
 
     skill_name: str
     fingerprints: tuple[SkillFileFingerprint, ...]
-    text_files: dict[str, str] = field(repr=False)
+    text_files: Mapping[str, str] = field(repr=False)
     unsupported_paths: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "text_files", MappingProxyType(dict(self.text_files)))
 
     @property
     def fingerprint_map(self) -> dict[str, SkillFileFingerprint]:

--- a/tldw_chatbook/Skills_Interop/skill_trust_models.py
+++ b/tldw_chatbook/Skills_Interop/skill_trust_models.py
@@ -1,0 +1,107 @@
+"""Local skill trust state models and exceptions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+TRUST_STATUS_TRUSTED = "trusted"
+TRUST_STATUS_UNINITIALIZED = "trust_uninitialized"
+TRUST_STATUS_LOCKED = "trust_locked"
+TRUST_STATUS_QUARANTINED_MODIFIED = "quarantined_modified"
+TRUST_STATUS_QUARANTINED_ADDED = "quarantined_added"
+TRUST_STATUS_QUARANTINED_DELETED = "quarantined_deleted"
+TRUST_STATUS_QUARANTINED_MANIFEST_ERROR = "quarantined_manifest_error"
+TRUST_STATUS_QUARANTINED_UNSUPPORTED_PATH = "quarantined_unsupported_path"
+
+TRUST_REASON_SKILL_MODIFIED = "skill_modified"
+TRUST_REASON_SKILL_ADDED = "skill_added"
+TRUST_REASON_SKILL_DELETED = "skill_deleted"
+TRUST_REASON_UNSUPPORTED_PATH = "unsupported_path"
+TRUST_REASON_TRUST_LOCKED = "trust_locked"
+TRUST_REASON_TRUST_UNINITIALIZED = "trust_uninitialized"
+TRUST_REASON_MANIFEST_INVALID = "manifest_invalid"
+TRUST_REASON_ROLLBACK_MARKER_UNAVAILABLE = "rollback_marker_unavailable"
+TRUST_REASON_SNAPSHOT_MISMATCH = "snapshot_mismatch"
+TRUST_REASON_STORE_WRITE_FAILED = "trust_store_write_failed"
+TRUST_REASON_HISTORY_UNRECOVERABLE = "trust_history_unrecoverable"
+
+
+@dataclass(frozen=True, slots=True)
+class SkillFileFingerprint:
+    """Stable fingerprint metadata for one local skill file."""
+
+    relative_path: str
+    file_type: str
+    byte_length: int
+    sha256: str
+
+    def as_manifest_entry(self) -> dict[str, Any]:
+        """Return the JSON-safe manifest representation for this fingerprint."""
+
+        return {
+            "relative_path": self.relative_path,
+            "file_type": self.file_type,
+            "byte_length": self.byte_length,
+            "sha256": self.sha256,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class SkillDirectorySnapshot:
+    """Current or trusted snapshot of a Chatbook-managed local skill directory."""
+
+    skill_name: str
+    fingerprints: tuple[SkillFileFingerprint, ...]
+    text_files: dict[str, str]
+    unsupported_paths: tuple[str, ...] = ()
+
+    @property
+    def fingerprint_map(self) -> dict[str, SkillFileFingerprint]:
+        """Return fingerprints keyed by relative path."""
+
+        return {item.relative_path: item for item in self.fingerprints}
+
+
+@dataclass(frozen=True, slots=True)
+class SkillTrustStatus:
+    """Trust posture exposed by local skill list/detail responses."""
+
+    skill_name: str
+    trust_status: str
+    trust_reason_code: str | None
+    trust_blocked: bool
+    changed_files: tuple[str, ...]
+    manifest_generation: int | None
+    last_verified_at: str | None
+
+    def response_fields(self) -> dict[str, Any]:
+        """Return JSON-safe trust fields for API/UI response payloads."""
+
+        return {
+            "trust_status": self.trust_status,
+            "trust_reason_code": self.trust_reason_code,
+            "trust_blocked": self.trust_blocked,
+            "trust_changed_files": list(self.changed_files),
+            "trust_manifest_generation": self.manifest_generation,
+            "trust_last_verified_at": self.last_verified_at,
+        }
+
+
+class SkillTrustBlockedError(RuntimeError):
+    """Raised when a trust-blocked local skill is staged or executed."""
+
+    def __init__(
+        self,
+        *,
+        skill_name: str,
+        reason_code: str,
+        trust_status: str,
+        changed_files: tuple[str, ...] = (),
+    ) -> None:
+        super().__init__(f"Local skill {skill_name} is trust-blocked: {reason_code}")
+        self.skill_name = skill_name
+        self.reason_code = reason_code
+        self.trust_status = trust_status
+        self.changed_files = changed_files

--- a/tldw_chatbook/Skills_Interop/skill_trust_scanner.py
+++ b/tldw_chatbook/Skills_Interop/skill_trust_scanner.py
@@ -16,7 +16,10 @@ _TEMP_SUFFIXES = (".tmp", ".swp", ".part")
 def _is_supported_filename(filename: str) -> bool:
     if filename == _SKILL_FILENAME:
         return True
-    if filename.endswith(_TEMP_SUFFIXES):
+    normalized_filename = filename.lower()
+    if normalized_filename == _SKILL_FILENAME.lower():
+        return False
+    if normalized_filename.endswith(_TEMP_SUFFIXES):
         return False
     return bool(SUPPORTING_FILE_NAME_PATTERN.fullmatch(filename))
 
@@ -39,11 +42,19 @@ def scan_skill_directory(skill_name: str, skill_dir: Path) -> SkillDirectorySnap
 
     for path in sorted(skill_dir.iterdir(), key=lambda child: child.name):
         relative_path = path.name
-        if path.is_symlink() or path.is_dir() or not _is_supported_filename(relative_path):
+        if path.is_symlink() or not _is_supported_filename(relative_path):
             unsupported_paths.append(relative_path)
             continue
 
-        raw = path.read_bytes()
+        try:
+            if not path.is_file():
+                unsupported_paths.append(relative_path)
+                continue
+            raw = path.read_bytes()
+        except OSError:
+            unsupported_paths.append(relative_path)
+            continue
+
         if b"\x00" in raw:
             unsupported_paths.append(relative_path)
             continue

--- a/tldw_chatbook/Skills_Interop/skill_trust_scanner.py
+++ b/tldw_chatbook/Skills_Interop/skill_trust_scanner.py
@@ -1,0 +1,72 @@
+"""Deterministic local skill directory scanning for trust verification."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..tldw_api.skills_schemas import SUPPORTING_FILE_NAME_PATTERN
+from .skill_trust_crypto import sha256_hex
+from .skill_trust_models import SkillDirectorySnapshot, SkillFileFingerprint
+
+
+_SKILL_FILENAME = "SKILL.md"
+_TEMP_SUFFIXES = (".tmp", ".swp", ".part")
+
+
+def _is_supported_filename(filename: str) -> bool:
+    if filename == _SKILL_FILENAME:
+        return True
+    if filename.endswith(_TEMP_SUFFIXES):
+        return False
+    return bool(SUPPORTING_FILE_NAME_PATTERN.fullmatch(filename))
+
+
+def scan_skill_directory(skill_name: str, skill_dir: Path) -> SkillDirectorySnapshot:
+    """Return a deterministic trust snapshot for immediate files in a skill directory.
+
+    Args:
+        skill_name: Local skill name represented by the directory.
+        skill_dir: Directory to scan. Only immediate child files are considered.
+
+    Returns:
+        Snapshot containing trusted file fingerprints, decoded text, and unsupported
+        path names that must be excluded from trust material.
+    """
+
+    fingerprints: list[SkillFileFingerprint] = []
+    text_files: dict[str, str] = {}
+    unsupported_paths: list[str] = []
+
+    for path in sorted(skill_dir.iterdir(), key=lambda child: child.name):
+        relative_path = path.name
+        if path.is_symlink() or path.is_dir() or not _is_supported_filename(relative_path):
+            unsupported_paths.append(relative_path)
+            continue
+
+        raw = path.read_bytes()
+        if b"\x00" in raw:
+            unsupported_paths.append(relative_path)
+            continue
+
+        try:
+            text = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            unsupported_paths.append(relative_path)
+            continue
+
+        fingerprints.append(
+            SkillFileFingerprint(
+                relative_path=relative_path,
+                file_type="skill" if relative_path == _SKILL_FILENAME else "supporting_text",
+                byte_length=len(raw),
+                sha256=sha256_hex(raw),
+            )
+        )
+        text_files[relative_path] = text
+
+    return SkillDirectorySnapshot(
+        skill_name=skill_name,
+        fingerprints=tuple(fingerprints),
+        text_files=text_files,
+        unsupported_paths=tuple(unsupported_paths),
+    )

--- a/tldw_chatbook/Skills_Interop/skill_trust_service.py
+++ b/tldw_chatbook/Skills_Interop/skill_trust_service.py
@@ -38,6 +38,9 @@ from .skill_trust_scanner import scan_skill_directory
 from .skill_trust_store import SkillTrustMarkerUnavailable, SkillTrustStore
 
 
+_SKILL_FILENAME = "SKILL.md"
+
+
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -270,6 +273,73 @@ class SkillTrustService:
             reason_code=status.trust_reason_code or "trust_blocked",
             trust_status=status.trust_status,
             changed_files=status.changed_files,
+        )
+
+    def verify_skill_content(
+        self,
+        skill_name: str,
+        *,
+        skill_content: str,
+        supporting_files: dict[str, str] | None,
+    ) -> None:
+        """Verify the exact in-memory skill files match the trusted manifest."""
+
+        self.ensure_skill_trusted(skill_name)
+        try:
+            normalized_name = self._normalize_skill_name(skill_name)
+            manifest = self._load_valid_manifest()
+            trusted = manifest["skills"].get(normalized_name)
+            if trusted is None:
+                raise SkillTrustBlockedError(
+                    skill_name=normalized_name,
+                    reason_code=TRUST_REASON_SKILL_ADDED,
+                    trust_status=TRUST_STATUS_QUARANTINED_ADDED,
+                    changed_files=(_SKILL_FILENAME,),
+                )
+            trusted_files = self._trusted_file_map(trusted)
+        except SkillTrustBlockedError:
+            raise
+        except SkillTrustMarkerUnavailable as exc:
+            raise SkillTrustBlockedError(
+                skill_name=skill_name,
+                reason_code=TRUST_REASON_ROLLBACK_MARKER_UNAVAILABLE,
+                trust_status=TRUST_STATUS_QUARANTINED_MANIFEST_ERROR,
+            ) from exc
+        except ValueError as exc:
+            raise SkillTrustBlockedError(
+                skill_name=skill_name,
+                reason_code=self._manifest_error_reason(exc),
+                trust_status=TRUST_STATUS_QUARANTINED_MANIFEST_ERROR,
+            ) from exc
+
+        current_files = self._fingerprint_in_memory_files(
+            skill_content=skill_content,
+            supporting_files=supporting_files,
+        )
+        missing = set(trusted_files) - set(current_files)
+        added = set(current_files) - set(trusted_files)
+        modified = {
+            path
+            for path in trusted_files.keys() & current_files.keys()
+            if trusted_files[path] != current_files[path]
+        }
+        changed = tuple(sorted(missing | added | modified))
+        if not changed:
+            return
+        if missing:
+            status = TRUST_STATUS_QUARANTINED_DELETED
+            reason = TRUST_REASON_SKILL_DELETED
+        elif added:
+            status = TRUST_STATUS_QUARANTINED_ADDED
+            reason = TRUST_REASON_SKILL_ADDED
+        else:
+            status = TRUST_STATUS_QUARANTINED_MODIFIED
+            reason = TRUST_REASON_SKILL_MODIFIED
+        raise SkillTrustBlockedError(
+            skill_name=normalized_name,
+            reason_code=reason,
+            trust_status=status,
+            changed_files=changed,
         )
 
     def capture_review(self, skill_name: str) -> dict[str, Any]:
@@ -541,6 +611,34 @@ class SkillTrustService:
                 raise ValueError("manifest schema invalid")
             result[str(item["relative_path"])] = dict(item)
         return result
+
+    def _fingerprint_in_memory_files(
+        self,
+        *,
+        skill_content: str,
+        supporting_files: dict[str, str] | None,
+    ) -> dict[str, dict[str, Any]]:
+        files = {
+            _SKILL_FILENAME: self._content_manifest_entry(
+                relative_path=_SKILL_FILENAME,
+                content=skill_content,
+            )
+        }
+        for relative_path, content in sorted((supporting_files or {}).items()):
+            files[str(relative_path)] = self._content_manifest_entry(
+                relative_path=str(relative_path),
+                content=str(content),
+            )
+        return files
+
+    def _content_manifest_entry(self, *, relative_path: str, content: str) -> dict[str, Any]:
+        raw = content.encode("utf-8")
+        return {
+            "relative_path": relative_path,
+            "file_type": "skill" if relative_path == _SKILL_FILENAME else "supporting_text",
+            "byte_length": len(raw),
+            "sha256": sha256_hex(raw),
+        }
 
     def _manifest_skill_entry(
         self,

--- a/tldw_chatbook/Skills_Interop/skill_trust_service.py
+++ b/tldw_chatbook/Skills_Interop/skill_trust_service.py
@@ -99,7 +99,7 @@ class SkillTrustService:
         return True
 
     def overall_status(self) -> str:
-        """Return a global Settings-friendly trust posture."""
+        """Return a global Settings-friendly trust posture from live files."""
 
         if not self.trust_store.has_manifest():
             missing_status = self._manifest_missing_status("<all>")
@@ -107,11 +107,19 @@ class SkillTrustService:
         if self._keys is None:
             return TRUST_STATUS_LOCKED
         try:
-            self._load_valid_manifest()
+            manifest = self._load_valid_manifest()
         except SkillTrustMarkerUnavailable:
             return TRUST_STATUS_QUARANTINED_MANIFEST_ERROR
         except ValueError:
             return TRUST_STATUS_QUARANTINED_MANIFEST_ERROR
+        try:
+            skill_names = self._known_and_current_skill_names(manifest)
+        except ValueError:
+            return TRUST_STATUS_QUARANTINED_UNSUPPORTED_PATH
+        for skill_name in sorted(skill_names):
+            status = self.status_for_skill(skill_name)
+            if status.trust_blocked:
+                return status.trust_status
         return TRUST_STATUS_TRUSTED
 
     def bootstrap_trust(self, passphrase: str | None = None, *, salt: bytes | None = None) -> None:
@@ -158,25 +166,32 @@ class SkillTrustService:
     def status_for_skill(self, skill_name: str) -> SkillTrustStatus:
         """Return visible trust status without raising for locked or bad manifests."""
 
+        try:
+            normalized_name = self._normalize_skill_name(skill_name)
+        except ValueError:
+            return self._unsupported_name_status(skill_name)
         if not self.trust_store.has_manifest():
-            return self._manifest_missing_status(skill_name)
+            return self._manifest_missing_status(normalized_name)
         if self._keys is None:
-            return self._locked_status(skill_name)
+            return self._locked_status(normalized_name)
         try:
             manifest = self._load_valid_manifest()
         except SkillTrustMarkerUnavailable:
             return self._manifest_error_status(
-                skill_name,
+                normalized_name,
                 TRUST_REASON_ROLLBACK_MARKER_UNAVAILABLE,
             )
         except ValueError as exc:
-            return self._manifest_error_status(skill_name, self._manifest_error_reason(exc))
+            return self._manifest_error_status(
+                normalized_name,
+                self._manifest_error_reason(exc),
+            )
 
         generation = int(manifest["generation"])
-        current = self._scan_skill(skill_name)
+        current = self._scan_skill(normalized_name)
         if current.unsupported_paths:
             return SkillTrustStatus(
-                skill_name=skill_name,
+                skill_name=normalized_name,
                 trust_status=TRUST_STATUS_QUARANTINED_UNSUPPORTED_PATH,
                 trust_reason_code=TRUST_REASON_UNSUPPORTED_PATH,
                 trust_blocked=True,
@@ -185,10 +200,10 @@ class SkillTrustService:
                 last_verified_at=_now_iso(),
             )
 
-        trusted = manifest["skills"].get(skill_name)
+        trusted = manifest["skills"].get(normalized_name)
         if trusted is None:
             return SkillTrustStatus(
-                skill_name=skill_name,
+                skill_name=normalized_name,
                 trust_status=TRUST_STATUS_QUARANTINED_ADDED,
                 trust_reason_code=TRUST_REASON_SKILL_ADDED,
                 trust_blocked=True,
@@ -200,7 +215,10 @@ class SkillTrustService:
         try:
             trusted_files = self._trusted_file_map(trusted)
         except ValueError as exc:
-            return self._manifest_error_status(skill_name, self._manifest_error_reason(exc))
+            return self._manifest_error_status(
+                normalized_name,
+                self._manifest_error_reason(exc),
+            )
         current_files = {
             item.relative_path: item.as_manifest_entry() for item in current.fingerprints
         }
@@ -214,7 +232,7 @@ class SkillTrustService:
         changed = tuple(sorted(missing | added | modified))
         if not changed:
             return SkillTrustStatus(
-                skill_name=skill_name,
+                skill_name=normalized_name,
                 trust_status=TRUST_STATUS_TRUSTED,
                 trust_reason_code=None,
                 trust_blocked=False,
@@ -232,7 +250,7 @@ class SkillTrustService:
             status = TRUST_STATUS_QUARANTINED_MODIFIED
             reason = TRUST_REASON_SKILL_MODIFIED
         return SkillTrustStatus(
-            skill_name=skill_name,
+            skill_name=normalized_name,
             trust_status=status,
             trust_reason_code=reason,
             trust_blocked=True,
@@ -257,29 +275,53 @@ class SkillTrustService:
     def capture_review(self, skill_name: str) -> dict[str, Any]:
         """Capture a JSON-safe review snapshot for the current skill files."""
 
-        status = self.status_for_skill(skill_name)
-        current = self._scan_skill(skill_name)
+        normalized_name = self._normalize_skill_name(skill_name)
+        status = self.status_for_skill(normalized_name)
+        current = self._scan_skill(normalized_name)
         review_id = secrets.token_hex(16)
         review = {
             "review_id": review_id,
-            "skill_name": skill_name,
+            "skill_name": normalized_name,
+            "manifest_generation": status.manifest_generation,
             "current_digest": self._fingerprints_digest(current),
             "current_files": dict(current.text_files),
             "current_fingerprints": [item.as_manifest_entry() for item in current.fingerprints],
-            "trusted_files": self._trusted_review_files(skill_name),
             "changed_files": list(status.changed_files),
             "captured_at": _now_iso(),
         }
         self._reviews[review_id] = review
         return dict(review)
 
+    def discard_review(self, review_id: str) -> None:
+        """Forget a captured review without changing trust state."""
+
+        self._reviews.pop(review_id, None)
+
     def trust_reviewed_snapshot(self, review_id: str) -> None:
         """Approve a captured review if live files still match that review."""
 
         review = self._reviews[review_id]
-        skill_name = str(review["skill_name"])
+        try:
+            skill_name = self._normalize_skill_name(str(review["skill_name"]))
+        except ValueError as exc:
+            self._reviews.pop(review_id, None)
+            raise ValueError(TRUST_REASON_UNSUPPORTED_PATH) from exc
+
+        try:
+            manifest = self._load_valid_manifest()
+        except SkillTrustMarkerUnavailable as exc:
+            self._reviews.pop(review_id, None)
+            raise ValueError("snapshot_mismatch") from exc
+        review_generation = review.get("manifest_generation")
+        if not isinstance(review_generation, int):
+            self._reviews.pop(review_id, None)
+            raise ValueError("snapshot_mismatch")
+        if int(manifest["generation"]) != review_generation:
+            self._reviews.pop(review_id, None)
+            raise ValueError("snapshot_mismatch")
         current = self._scan_skill(skill_name)
         if self._fingerprints_digest(current) != review["current_digest"]:
+            self._reviews.pop(review_id, None)
             raise ValueError("snapshot_mismatch")
         self.trust_current_skill(skill_name, audit_event="trust_approved", snapshot=current)
         self._reviews.pop(review_id, None)
@@ -293,14 +335,17 @@ class SkillTrustService:
     ) -> None:
         """Trust the live files for one skill after an explicit approval path."""
 
+        normalized_name = self._normalize_skill_name(skill_name)
         keys = self._require_keys()
         manifest = self._load_valid_manifest()
         generation = int(manifest["generation"]) + 1
-        current = snapshot or self._scan_skill(skill_name)
+        current = snapshot or self._scan_skill(normalized_name)
         if current.unsupported_paths:
             raise ValueError(TRUST_REASON_UNSUPPORTED_PATH)
+        if not current.fingerprints:
+            raise ValueError(TRUST_REASON_SKILL_DELETED)
 
-        snapshot_id = self._snapshot_id(skill_name, generation)
+        snapshot_id = self._snapshot_id(normalized_name, generation)
         self.trust_store.save_snapshot(
             snapshot_id,
             {"files": dict(current.text_files)},
@@ -308,7 +353,7 @@ class SkillTrustService:
             generation=generation,
         )
         manifest["generation"] = generation
-        manifest.setdefault("skills", {})[skill_name] = self._manifest_skill_entry(
+        manifest.setdefault("skills", {})[normalized_name] = self._manifest_skill_entry(
             snapshot=current,
             snapshot_id=snapshot_id,
             snapshot_generation=generation,
@@ -317,7 +362,7 @@ class SkillTrustService:
             {
                 "event": audit_event,
                 "at": _now_iso(),
-                "skill_name": skill_name,
+                "skill_name": normalized_name,
             }
         )
         self.trust_store.save_manifest(manifest, keys, salt=self._require_salt())
@@ -325,10 +370,27 @@ class SkillTrustService:
     def _iter_skill_dirs(self) -> list[Path]:
         if not self.skills_dir.exists():
             return []
-        return sorted(
-            (child for child in self.skills_dir.iterdir() if child.is_dir()),
-            key=lambda child: child.name,
-        )
+        skill_dirs: list[Path] = []
+        for child in sorted(self.skills_dir.iterdir(), key=lambda item: item.name):
+            if child.is_symlink():
+                raise ValueError(TRUST_REASON_UNSUPPORTED_PATH)
+            if child.is_dir():
+                self._normalize_skill_name(child.name)
+                skill_dirs.append(child)
+        return skill_dirs
+
+    def _known_and_current_skill_names(self, manifest: dict[str, Any]) -> set[str]:
+        names: set[str] = set()
+        for skill_name in manifest["skills"]:
+            names.add(self._normalize_skill_name(skill_name))
+        if not self.skills_dir.exists():
+            return names
+        for child in sorted(self.skills_dir.iterdir(), key=lambda item: item.name):
+            if child.is_symlink():
+                raise ValueError(TRUST_REASON_UNSUPPORTED_PATH)
+            if child.is_dir():
+                names.add(self._normalize_skill_name(child.name))
+        return names
 
     def _load_valid_manifest(self) -> dict[str, Any]:
         manifest = self.trust_store.load_manifest(self._require_keys())
@@ -357,10 +419,43 @@ class SkillTrustService:
         return self._salt
 
     def _scan_skill(self, skill_name: str) -> SkillDirectorySnapshot:
-        skill_dir = self.skills_dir / skill_name
-        if not skill_dir.exists() or not skill_dir.is_dir():
-            return SkillDirectorySnapshot(skill_name=skill_name, fingerprints=(), text_files={})
-        return scan_skill_directory(skill_name, skill_dir)
+        normalized_name = self._normalize_skill_name(skill_name)
+        skill_dir = self.skills_dir / normalized_name
+        if skill_dir.is_symlink():
+            return SkillDirectorySnapshot(
+                skill_name=normalized_name,
+                fingerprints=(),
+                text_files={},
+                unsupported_paths=(normalized_name,),
+            )
+        if not skill_dir.exists():
+            return SkillDirectorySnapshot(
+                skill_name=normalized_name,
+                fingerprints=(),
+                text_files={},
+            )
+        if not skill_dir.is_dir():
+            return SkillDirectorySnapshot(
+                skill_name=normalized_name,
+                fingerprints=(),
+                text_files={},
+                unsupported_paths=(normalized_name,),
+            )
+        return scan_skill_directory(normalized_name, skill_dir)
+
+    def _normalize_skill_name(self, skill_name: str) -> str:
+        if not isinstance(skill_name, str):
+            raise ValueError(TRUST_REASON_UNSUPPORTED_PATH)
+        if not skill_name or skill_name in {".", ".."}:
+            raise ValueError(TRUST_REASON_UNSUPPORTED_PATH)
+        if "\x00" in skill_name or "/" in skill_name or "\\" in skill_name:
+            raise ValueError(TRUST_REASON_UNSUPPORTED_PATH)
+        path = Path(skill_name)
+        if path.is_absolute() or len(path.parts) != 1:
+            raise ValueError(TRUST_REASON_UNSUPPORTED_PATH)
+        if any(part in {"", ".", ".."} for part in path.parts):
+            raise ValueError(TRUST_REASON_UNSUPPORTED_PATH)
+        return skill_name
 
     def _manifest_missing_status(self, skill_name: str) -> SkillTrustStatus:
         try:
@@ -406,6 +501,17 @@ class SkillTrustService:
             last_verified_at=_now_iso(),
         )
 
+    def _unsupported_name_status(self, skill_name: Any) -> SkillTrustStatus:
+        return SkillTrustStatus(
+            skill_name=str(skill_name),
+            trust_status=TRUST_STATUS_QUARANTINED_UNSUPPORTED_PATH,
+            trust_reason_code=TRUST_REASON_UNSUPPORTED_PATH,
+            trust_blocked=True,
+            changed_files=(),
+            manifest_generation=None,
+            last_verified_at=_now_iso(),
+        )
+
     def _manifest_error_reason(self, exc: ValueError) -> str:
         message = str(exc)
         if "marker" in message:
@@ -416,30 +522,6 @@ class SkillTrustService:
         return sha256_hex(
             canonical_json([item.as_manifest_entry() for item in snapshot.fingerprints])
         )
-
-    def _trusted_review_files(self, skill_name: str) -> dict[str, str]:
-        if self._keys is None or not self.trust_store.has_manifest():
-            return {}
-        try:
-            manifest = self._load_valid_manifest()
-            entry = manifest["skills"].get(skill_name)
-            if not isinstance(entry, dict):
-                return {}
-            snapshot_id = entry.get("snapshot_id")
-            if not isinstance(snapshot_id, str):
-                return {}
-            snapshot_generation = entry.get("snapshot_generation", manifest["generation"])
-            payload = self.trust_store.load_snapshot(
-                snapshot_id,
-                self._require_keys(),
-                generation=int(snapshot_generation),
-            )
-            files = payload.get("files")
-        except (OSError, ValueError, SkillTrustMarkerUnavailable):
-            return {}
-        if not isinstance(files, dict):
-            return {}
-        return {str(path): str(content) for path, content in files.items()}
 
     def _trusted_file_map(self, trusted: Any) -> dict[str, dict[str, Any]]:
         if not isinstance(trusted, dict):

--- a/tldw_chatbook/Skills_Interop/skill_trust_service.py
+++ b/tldw_chatbook/Skills_Interop/skill_trust_service.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from ..tldw_api.skills_schemas import _normalize_skill_name as _normalize_api_skill_name
 from .skill_trust_crypto import (
     SkillTrustKeys,
     canonical_json,
@@ -135,18 +136,18 @@ class SkillTrustService:
         generation = 1
         skills: dict[str, Any] = {}
 
-        for skill_dir in self._iter_skill_dirs():
-            snapshot = scan_skill_directory(skill_dir.name, skill_dir)
+        for normalized_name, skill_dir in self._iter_skill_dirs():
+            snapshot = scan_skill_directory(normalized_name, skill_dir)
             if snapshot.unsupported_paths:
                 raise ValueError(TRUST_REASON_UNSUPPORTED_PATH)
-            snapshot_id = self._snapshot_id(skill_dir.name, generation)
+            snapshot_id = self._snapshot_id(normalized_name, generation)
             self.trust_store.save_snapshot(
                 snapshot_id,
                 {"files": dict(snapshot.text_files)},
                 keys,
                 generation=generation,
             )
-            skills[skill_dir.name] = self._manifest_skill_entry(
+            skills[normalized_name] = self._manifest_skill_entry(
                 snapshot=snapshot,
                 snapshot_id=snapshot_id,
                 snapshot_generation=generation,
@@ -443,16 +444,20 @@ class SkillTrustService:
         )
         self.trust_store.save_manifest(manifest, keys, salt=self._require_salt())
 
-    def _iter_skill_dirs(self) -> list[Path]:
+    def _iter_skill_dirs(self) -> list[tuple[str, Path]]:
         if not self.skills_dir.exists():
             return []
-        skill_dirs: list[Path] = []
+        skill_dirs: list[tuple[str, Path]] = []
+        seen: set[str] = set()
         for child in sorted(self.skills_dir.iterdir(), key=lambda item: item.name):
             if child.is_symlink():
                 raise ValueError(TRUST_REASON_UNSUPPORTED_PATH)
             if child.is_dir():
-                self._normalize_skill_name(child.name)
-                skill_dirs.append(child)
+                normalized_name = self._normalize_skill_name(child.name)
+                if normalized_name in seen:
+                    raise ValueError(TRUST_REASON_UNSUPPORTED_PATH)
+                seen.add(normalized_name)
+                skill_dirs.append((normalized_name, child))
         return skill_dirs
 
     def _known_and_current_skill_names(self, manifest: dict[str, Any]) -> set[str]:
@@ -461,11 +466,16 @@ class SkillTrustService:
             names.add(self._normalize_skill_name(skill_name))
         if not self.skills_dir.exists():
             return names
+        current_names: set[str] = set()
         for child in sorted(self.skills_dir.iterdir(), key=lambda item: item.name):
             if child.is_symlink():
                 raise ValueError(TRUST_REASON_UNSUPPORTED_PATH)
             if child.is_dir():
-                names.add(self._normalize_skill_name(child.name))
+                normalized_name = self._normalize_skill_name(child.name)
+                if normalized_name in current_names:
+                    raise ValueError(TRUST_REASON_UNSUPPORTED_PATH)
+                current_names.add(normalized_name)
+                names.add(normalized_name)
         return names
 
     def _load_valid_manifest(self) -> dict[str, Any]:
@@ -496,7 +506,15 @@ class SkillTrustService:
 
     def _scan_skill(self, skill_name: str) -> SkillDirectorySnapshot:
         normalized_name = self._normalize_skill_name(skill_name)
-        skill_dir = self.skills_dir / normalized_name
+        try:
+            skill_dir = self._skill_dir_for_normalized_name(normalized_name)
+        except ValueError:
+            return SkillDirectorySnapshot(
+                skill_name=normalized_name,
+                fingerprints=(),
+                text_files={},
+                unsupported_paths=(normalized_name,),
+            )
         if skill_dir.is_symlink():
             return SkillDirectorySnapshot(
                 skill_name=normalized_name,
@@ -520,18 +538,30 @@ class SkillTrustService:
         return scan_skill_directory(normalized_name, skill_dir)
 
     def _normalize_skill_name(self, skill_name: str) -> str:
-        if not isinstance(skill_name, str):
+        try:
+            return _normalize_api_skill_name(skill_name)
+        except (AttributeError, ValueError) as exc:
+            raise ValueError(TRUST_REASON_UNSUPPORTED_PATH) from exc
+
+    def _skill_dir_for_normalized_name(self, normalized_name: str) -> Path:
+        direct = self.skills_dir / normalized_name
+        if direct.exists() or direct.is_symlink() or not self.skills_dir.exists():
+            return direct
+        matches: list[Path] = []
+        for child in sorted(self.skills_dir.iterdir(), key=lambda item: item.name):
+            if not (child.is_dir() or child.is_symlink()):
+                continue
+            try:
+                child_name = self._normalize_skill_name(child.name)
+            except ValueError:
+                continue
+            if child_name == normalized_name:
+                matches.append(child)
+        if len(matches) > 1:
             raise ValueError(TRUST_REASON_UNSUPPORTED_PATH)
-        if not skill_name or skill_name in {".", ".."}:
-            raise ValueError(TRUST_REASON_UNSUPPORTED_PATH)
-        if "\x00" in skill_name or "/" in skill_name or "\\" in skill_name:
-            raise ValueError(TRUST_REASON_UNSUPPORTED_PATH)
-        path = Path(skill_name)
-        if path.is_absolute() or len(path.parts) != 1:
-            raise ValueError(TRUST_REASON_UNSUPPORTED_PATH)
-        if any(part in {"", ".", ".."} for part in path.parts):
-            raise ValueError(TRUST_REASON_UNSUPPORTED_PATH)
-        return skill_name
+        if matches:
+            return matches[0]
+        return direct
 
     def _manifest_missing_status(self, skill_name: str) -> SkillTrustStatus:
         try:

--- a/tldw_chatbook/Skills_Interop/skill_trust_service.py
+++ b/tldw_chatbook/Skills_Interop/skill_trust_service.py
@@ -289,7 +289,13 @@ class SkillTrustService:
             "changed_files": list(status.changed_files),
             "captured_at": _now_iso(),
         }
-        self._reviews[review_id] = review
+        self._reviews[review_id] = {
+            "review_id": review_id,
+            "skill_name": normalized_name,
+            "manifest_generation": status.manifest_generation,
+            "current_digest": review["current_digest"],
+            "changed_files": list(status.changed_files),
+        }
         return dict(review)
 
     def discard_review(self, review_id: str) -> None:
@@ -323,8 +329,8 @@ class SkillTrustService:
         if self._fingerprints_digest(current) != review["current_digest"]:
             self._reviews.pop(review_id, None)
             raise ValueError("snapshot_mismatch")
-        self.trust_current_skill(skill_name, audit_event="trust_approved", snapshot=current)
         self._reviews.pop(review_id, None)
+        self.trust_current_skill(skill_name, audit_event="trust_approved", snapshot=current)
 
     def trust_current_skill(
         self,

--- a/tldw_chatbook/Skills_Interop/skill_trust_service.py
+++ b/tldw_chatbook/Skills_Interop/skill_trust_service.py
@@ -1,0 +1,472 @@
+"""Orchestration service for Chatbook-managed local skill trust."""
+
+from __future__ import annotations
+
+import secrets
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .skill_trust_crypto import (
+    SkillTrustKeys,
+    canonical_json,
+    derive_skill_trust_keys,
+    sha256_hex,
+)
+from .skill_trust_models import (
+    SkillDirectorySnapshot,
+    SkillTrustBlockedError,
+    SkillTrustStatus,
+    TRUST_REASON_MANIFEST_INVALID,
+    TRUST_REASON_ROLLBACK_MARKER_UNAVAILABLE,
+    TRUST_REASON_SKILL_ADDED,
+    TRUST_REASON_SKILL_DELETED,
+    TRUST_REASON_SKILL_MODIFIED,
+    TRUST_REASON_TRUST_LOCKED,
+    TRUST_REASON_TRUST_UNINITIALIZED,
+    TRUST_REASON_UNSUPPORTED_PATH,
+    TRUST_STATUS_LOCKED,
+    TRUST_STATUS_QUARANTINED_ADDED,
+    TRUST_STATUS_QUARANTINED_DELETED,
+    TRUST_STATUS_QUARANTINED_MANIFEST_ERROR,
+    TRUST_STATUS_QUARANTINED_MODIFIED,
+    TRUST_STATUS_QUARANTINED_UNSUPPORTED_PATH,
+    TRUST_STATUS_TRUSTED,
+    TRUST_STATUS_UNINITIALIZED,
+)
+from .skill_trust_scanner import scan_skill_directory
+from .skill_trust_store import SkillTrustMarkerUnavailable, SkillTrustStore
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class SkillTrustService:
+    """Coordinate trust bootstrap, classification, review, and approval."""
+
+    def __init__(
+        self,
+        *,
+        skills_dir: Path,
+        trust_store: SkillTrustStore,
+        key_cache: Any | None = None,
+        keyring_convenience_enabled: bool = False,
+        reduced_rollback_protection: bool = False,
+    ) -> None:
+        self.skills_dir = skills_dir
+        self.trust_store = trust_store
+        self.key_cache = key_cache
+        self.keyring_convenience_enabled = keyring_convenience_enabled
+        self.reduced_rollback_protection = reduced_rollback_protection
+        self._keys: SkillTrustKeys | None = None
+        self._salt: bytes | None = None
+        self._reviews: dict[str, dict[str, Any]] = {}
+
+    def unlock_with_passphrase(self, passphrase: str, *, salt: bytes | None = None) -> None:
+        """Derive in-memory trust keys from a passphrase and manifest salt."""
+
+        if salt is None:
+            salt = self.trust_store.load_salt()
+        self._keys = derive_skill_trust_keys(passphrase, salt=salt)
+        self._salt = salt
+
+    def enable_keyring_convenience(self) -> None:
+        """Persist derived trust keys in secure keyring storage, never a passphrase."""
+
+        if self.key_cache is None:
+            raise SkillTrustMarkerUnavailable("No secure OS-backed key cache is available.")
+        keys = self._require_keys()
+        salt = self._require_salt()
+        self.key_cache.save_keys(keys, salt=salt)
+        self.keyring_convenience_enabled = True
+
+    def unlock_from_keyring_convenience(self) -> bool:
+        """Load derived trust keys from a salt-bound secure keyring cache."""
+
+        if self.key_cache is None or not self.trust_store.has_manifest():
+            return False
+        try:
+            salt = self.trust_store.load_salt()
+            keys = self.key_cache.load_keys(expected_salt=salt)
+        except (OSError, ValueError, SkillTrustMarkerUnavailable):
+            return False
+        if keys is None:
+            return False
+        self._keys = keys
+        self._salt = salt
+        self.keyring_convenience_enabled = True
+        return True
+
+    def overall_status(self) -> str:
+        """Return a global Settings-friendly trust posture."""
+
+        if not self.trust_store.has_manifest():
+            missing_status = self._manifest_missing_status("<all>")
+            return missing_status.trust_status
+        if self._keys is None:
+            return TRUST_STATUS_LOCKED
+        try:
+            self._load_valid_manifest()
+        except SkillTrustMarkerUnavailable:
+            return TRUST_STATUS_QUARANTINED_MANIFEST_ERROR
+        except ValueError:
+            return TRUST_STATUS_QUARANTINED_MANIFEST_ERROR
+        return TRUST_STATUS_TRUSTED
+
+    def bootstrap_trust(self, passphrase: str | None = None, *, salt: bytes | None = None) -> None:
+        """Trust the current local skill directories as the initial baseline."""
+
+        if passphrase is not None:
+            self.unlock_with_passphrase(passphrase, salt=salt or secrets.token_bytes(32))
+        keys = self._require_keys()
+        manifest_salt = self._require_salt()
+        generation = 1
+        skills: dict[str, Any] = {}
+
+        for skill_dir in self._iter_skill_dirs():
+            snapshot = scan_skill_directory(skill_dir.name, skill_dir)
+            if snapshot.unsupported_paths:
+                raise ValueError(TRUST_REASON_UNSUPPORTED_PATH)
+            snapshot_id = self._snapshot_id(skill_dir.name, generation)
+            self.trust_store.save_snapshot(
+                snapshot_id,
+                {"files": dict(snapshot.text_files)},
+                keys,
+                generation=generation,
+            )
+            skills[skill_dir.name] = self._manifest_skill_entry(
+                snapshot=snapshot,
+                snapshot_id=snapshot_id,
+                snapshot_generation=generation,
+            )
+
+        manifest = {
+            "version": 1,
+            "generation": generation,
+            "skills": skills,
+            "audit": [
+                {
+                    "event": "trust_bootstrap",
+                    "at": _now_iso(),
+                    "skill_count": len(skills),
+                }
+            ],
+        }
+        self.trust_store.save_manifest(manifest, keys, salt=manifest_salt)
+
+    def status_for_skill(self, skill_name: str) -> SkillTrustStatus:
+        """Return visible trust status without raising for locked or bad manifests."""
+
+        if not self.trust_store.has_manifest():
+            return self._manifest_missing_status(skill_name)
+        if self._keys is None:
+            return self._locked_status(skill_name)
+        try:
+            manifest = self._load_valid_manifest()
+        except SkillTrustMarkerUnavailable:
+            return self._manifest_error_status(
+                skill_name,
+                TRUST_REASON_ROLLBACK_MARKER_UNAVAILABLE,
+            )
+        except ValueError as exc:
+            return self._manifest_error_status(skill_name, self._manifest_error_reason(exc))
+
+        generation = int(manifest["generation"])
+        current = self._scan_skill(skill_name)
+        if current.unsupported_paths:
+            return SkillTrustStatus(
+                skill_name=skill_name,
+                trust_status=TRUST_STATUS_QUARANTINED_UNSUPPORTED_PATH,
+                trust_reason_code=TRUST_REASON_UNSUPPORTED_PATH,
+                trust_blocked=True,
+                changed_files=tuple(current.unsupported_paths),
+                manifest_generation=generation,
+                last_verified_at=_now_iso(),
+            )
+
+        trusted = manifest["skills"].get(skill_name)
+        if trusted is None:
+            return SkillTrustStatus(
+                skill_name=skill_name,
+                trust_status=TRUST_STATUS_QUARANTINED_ADDED,
+                trust_reason_code=TRUST_REASON_SKILL_ADDED,
+                trust_blocked=True,
+                changed_files=tuple(item.relative_path for item in current.fingerprints),
+                manifest_generation=generation,
+                last_verified_at=_now_iso(),
+            )
+
+        try:
+            trusted_files = self._trusted_file_map(trusted)
+        except ValueError as exc:
+            return self._manifest_error_status(skill_name, self._manifest_error_reason(exc))
+        current_files = {
+            item.relative_path: item.as_manifest_entry() for item in current.fingerprints
+        }
+        missing = set(trusted_files) - set(current_files)
+        added = set(current_files) - set(trusted_files)
+        modified = {
+            path
+            for path in trusted_files.keys() & current_files.keys()
+            if trusted_files[path] != current_files[path]
+        }
+        changed = tuple(sorted(missing | added | modified))
+        if not changed:
+            return SkillTrustStatus(
+                skill_name=skill_name,
+                trust_status=TRUST_STATUS_TRUSTED,
+                trust_reason_code=None,
+                trust_blocked=False,
+                changed_files=(),
+                manifest_generation=generation,
+                last_verified_at=_now_iso(),
+            )
+        if missing:
+            status = TRUST_STATUS_QUARANTINED_DELETED
+            reason = TRUST_REASON_SKILL_DELETED
+        elif added:
+            status = TRUST_STATUS_QUARANTINED_ADDED
+            reason = TRUST_REASON_SKILL_ADDED
+        else:
+            status = TRUST_STATUS_QUARANTINED_MODIFIED
+            reason = TRUST_REASON_SKILL_MODIFIED
+        return SkillTrustStatus(
+            skill_name=skill_name,
+            trust_status=status,
+            trust_reason_code=reason,
+            trust_blocked=True,
+            changed_files=changed,
+            manifest_generation=generation,
+            last_verified_at=_now_iso(),
+        )
+
+    def ensure_skill_trusted(self, skill_name: str) -> None:
+        """Raise only at use time when a local skill is trust-blocked."""
+
+        status = self.status_for_skill(skill_name)
+        if not status.trust_blocked:
+            return
+        raise SkillTrustBlockedError(
+            skill_name=skill_name,
+            reason_code=status.trust_reason_code or "trust_blocked",
+            trust_status=status.trust_status,
+            changed_files=status.changed_files,
+        )
+
+    def capture_review(self, skill_name: str) -> dict[str, Any]:
+        """Capture a JSON-safe review snapshot for the current skill files."""
+
+        status = self.status_for_skill(skill_name)
+        current = self._scan_skill(skill_name)
+        review_id = secrets.token_hex(16)
+        review = {
+            "review_id": review_id,
+            "skill_name": skill_name,
+            "current_digest": self._fingerprints_digest(current),
+            "current_files": dict(current.text_files),
+            "current_fingerprints": [item.as_manifest_entry() for item in current.fingerprints],
+            "trusted_files": self._trusted_review_files(skill_name),
+            "changed_files": list(status.changed_files),
+            "captured_at": _now_iso(),
+        }
+        self._reviews[review_id] = review
+        return dict(review)
+
+    def trust_reviewed_snapshot(self, review_id: str) -> None:
+        """Approve a captured review if live files still match that review."""
+
+        review = self._reviews[review_id]
+        skill_name = str(review["skill_name"])
+        current = self._scan_skill(skill_name)
+        if self._fingerprints_digest(current) != review["current_digest"]:
+            raise ValueError("snapshot_mismatch")
+        self.trust_current_skill(skill_name, audit_event="trust_approved", snapshot=current)
+        self._reviews.pop(review_id, None)
+
+    def trust_current_skill(
+        self,
+        skill_name: str,
+        *,
+        audit_event: str = "trust_chatbook_mutation",
+        snapshot: SkillDirectorySnapshot | None = None,
+    ) -> None:
+        """Trust the live files for one skill after an explicit approval path."""
+
+        keys = self._require_keys()
+        manifest = self._load_valid_manifest()
+        generation = int(manifest["generation"]) + 1
+        current = snapshot or self._scan_skill(skill_name)
+        if current.unsupported_paths:
+            raise ValueError(TRUST_REASON_UNSUPPORTED_PATH)
+
+        snapshot_id = self._snapshot_id(skill_name, generation)
+        self.trust_store.save_snapshot(
+            snapshot_id,
+            {"files": dict(current.text_files)},
+            keys,
+            generation=generation,
+        )
+        manifest["generation"] = generation
+        manifest.setdefault("skills", {})[skill_name] = self._manifest_skill_entry(
+            snapshot=current,
+            snapshot_id=snapshot_id,
+            snapshot_generation=generation,
+        )
+        manifest.setdefault("audit", []).append(
+            {
+                "event": audit_event,
+                "at": _now_iso(),
+                "skill_name": skill_name,
+            }
+        )
+        self.trust_store.save_manifest(manifest, keys, salt=self._require_salt())
+
+    def _iter_skill_dirs(self) -> list[Path]:
+        if not self.skills_dir.exists():
+            return []
+        return sorted(
+            (child for child in self.skills_dir.iterdir() if child.is_dir()),
+            key=lambda child: child.name,
+        )
+
+    def _load_valid_manifest(self) -> dict[str, Any]:
+        manifest = self.trust_store.load_manifest(self._require_keys())
+        if manifest.get("version") != 1:
+            raise ValueError("manifest schema invalid")
+        if not isinstance(manifest.get("generation"), int):
+            raise ValueError("manifest schema invalid")
+        if not isinstance(manifest.get("skills"), dict):
+            raise ValueError("manifest schema invalid")
+        if not isinstance(manifest.get("audit"), list):
+            raise ValueError("manifest schema invalid")
+        return manifest
+
+    def _require_keys(self) -> SkillTrustKeys:
+        if self._keys is None:
+            raise SkillTrustBlockedError(
+                skill_name="<all>",
+                reason_code=TRUST_REASON_TRUST_LOCKED,
+                trust_status=TRUST_STATUS_LOCKED,
+            )
+        return self._keys
+
+    def _require_salt(self) -> bytes:
+        if self._salt is None:
+            raise ValueError("skill trust salt missing")
+        return self._salt
+
+    def _scan_skill(self, skill_name: str) -> SkillDirectorySnapshot:
+        skill_dir = self.skills_dir / skill_name
+        if not skill_dir.exists() or not skill_dir.is_dir():
+            return SkillDirectorySnapshot(skill_name=skill_name, fingerprints=(), text_files={})
+        return scan_skill_directory(skill_name, skill_dir)
+
+    def _manifest_missing_status(self, skill_name: str) -> SkillTrustStatus:
+        try:
+            marker = self.trust_store.marker_store.load_marker()
+        except SkillTrustMarkerUnavailable:
+            return self._manifest_error_status(
+                skill_name,
+                TRUST_REASON_ROLLBACK_MARKER_UNAVAILABLE,
+            )
+        except Exception:
+            return self._manifest_error_status(skill_name, TRUST_REASON_MANIFEST_INVALID)
+        if marker:
+            return self._manifest_error_status(skill_name, TRUST_REASON_MANIFEST_INVALID)
+        return SkillTrustStatus(
+            skill_name=skill_name,
+            trust_status=TRUST_STATUS_UNINITIALIZED,
+            trust_reason_code=TRUST_REASON_TRUST_UNINITIALIZED,
+            trust_blocked=True,
+            changed_files=(),
+            manifest_generation=None,
+            last_verified_at=None,
+        )
+
+    def _locked_status(self, skill_name: str) -> SkillTrustStatus:
+        return SkillTrustStatus(
+            skill_name=skill_name,
+            trust_status=TRUST_STATUS_LOCKED,
+            trust_reason_code=TRUST_REASON_TRUST_LOCKED,
+            trust_blocked=True,
+            changed_files=(),
+            manifest_generation=None,
+            last_verified_at=_now_iso(),
+        )
+
+    def _manifest_error_status(self, skill_name: str, reason_code: str) -> SkillTrustStatus:
+        return SkillTrustStatus(
+            skill_name=skill_name,
+            trust_status=TRUST_STATUS_QUARANTINED_MANIFEST_ERROR,
+            trust_reason_code=reason_code,
+            trust_blocked=True,
+            changed_files=(),
+            manifest_generation=None,
+            last_verified_at=_now_iso(),
+        )
+
+    def _manifest_error_reason(self, exc: ValueError) -> str:
+        message = str(exc)
+        if "marker" in message:
+            return TRUST_REASON_ROLLBACK_MARKER_UNAVAILABLE
+        return TRUST_REASON_MANIFEST_INVALID
+
+    def _fingerprints_digest(self, snapshot: SkillDirectorySnapshot) -> str:
+        return sha256_hex(
+            canonical_json([item.as_manifest_entry() for item in snapshot.fingerprints])
+        )
+
+    def _trusted_review_files(self, skill_name: str) -> dict[str, str]:
+        if self._keys is None or not self.trust_store.has_manifest():
+            return {}
+        try:
+            manifest = self._load_valid_manifest()
+            entry = manifest["skills"].get(skill_name)
+            if not isinstance(entry, dict):
+                return {}
+            snapshot_id = entry.get("snapshot_id")
+            if not isinstance(snapshot_id, str):
+                return {}
+            snapshot_generation = entry.get("snapshot_generation", manifest["generation"])
+            payload = self.trust_store.load_snapshot(
+                snapshot_id,
+                self._require_keys(),
+                generation=int(snapshot_generation),
+            )
+            files = payload.get("files")
+        except (OSError, ValueError, SkillTrustMarkerUnavailable):
+            return {}
+        if not isinstance(files, dict):
+            return {}
+        return {str(path): str(content) for path, content in files.items()}
+
+    def _trusted_file_map(self, trusted: Any) -> dict[str, dict[str, Any]]:
+        if not isinstance(trusted, dict):
+            raise ValueError("manifest schema invalid")
+        files = trusted.get("files")
+        if not isinstance(files, list):
+            raise ValueError("manifest schema invalid")
+        result: dict[str, dict[str, Any]] = {}
+        for item in files:
+            if not isinstance(item, dict) or not isinstance(item.get("relative_path"), str):
+                raise ValueError("manifest schema invalid")
+            result[str(item["relative_path"])] = dict(item)
+        return result
+
+    def _manifest_skill_entry(
+        self,
+        *,
+        snapshot: SkillDirectorySnapshot,
+        snapshot_id: str,
+        snapshot_generation: int,
+    ) -> dict[str, Any]:
+        return {
+            "files": [item.as_manifest_entry() for item in snapshot.fingerprints],
+            "snapshot_id": snapshot_id,
+            "snapshot_generation": snapshot_generation,
+            "trusted_at": _now_iso(),
+        }
+
+    def _snapshot_id(self, skill_name: str, generation: int) -> str:
+        return f"{skill_name}-{generation}"

--- a/tldw_chatbook/Skills_Interop/skill_trust_store.py
+++ b/tldw_chatbook/Skills_Interop/skill_trust_store.py
@@ -1,0 +1,405 @@
+"""Persistence for local skill trust manifests, snapshots, markers, and keys."""
+
+from __future__ import annotations
+
+import base64
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+from ..runtime_policy.server_credentials import is_secure_keyring_backend
+from .skill_trust_crypto import (
+    SkillTrustKeys,
+    canonical_json,
+    decrypt_json_blob,
+    encrypt_json_blob,
+    manifest_mac,
+    sha256_hex,
+)
+
+
+_MANIFEST_FILENAME = "skill_trust_manifest.json"
+_SNAPSHOTS_DIRNAME = "snapshots"
+_DEFAULT_MARKER_SERVICE_NAME = "tldw_chatbook.skill_trust"
+_DEFAULT_KEY_CACHE_SERVICE_NAME = "tldw_chatbook.skill_trust.keys"
+_MARKER_USERNAME = "local-skills:generation-marker:v1"
+_KEY_CACHE_USERNAME = "local-skills:trust-root:v1"
+_KEY_CACHE_FIELDS = (
+    "manifest_mac_key",
+    "snapshot_key",
+    "audit_mac_key",
+    "wrapped_root_key",
+)
+
+
+class SkillTrustMarkerUnavailable(RuntimeError):
+    """Raised when rollback marker storage cannot provide full protection."""
+
+    reason_code = "rollback_marker_unavailable"
+
+
+class SkillTrustGenerationMarkerStore(Protocol):
+    """Persistence boundary for the latest accepted trust manifest marker."""
+
+    def load_marker(self) -> dict[str, Any] | None:
+        """Return the persisted marker, or ``None`` when no marker exists."""
+        ...
+
+    def save_marker(self, *, generation: int, manifest_digest: str) -> None:
+        """Persist the latest accepted manifest generation and canonical digest."""
+        ...
+
+
+@dataclass(slots=True)
+class FileSkillTrustGenerationMarkerStore:
+    """Reduced-protection marker store intended for tests and explicit recovery."""
+
+    marker_path: Path
+
+    def load_marker(self) -> dict[str, Any] | None:
+        """Load the file-backed generation marker if it exists."""
+
+        if not self.marker_path.exists():
+            return None
+        payload = json.loads(self.marker_path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            return None
+        return payload
+
+    def save_marker(self, *, generation: int, manifest_digest: str) -> None:
+        """Atomically save the file-backed generation marker."""
+
+        self.marker_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "generation": generation,
+            "manifest_digest": manifest_digest,
+        }
+        _atomic_write_json(self.marker_path, payload)
+
+
+class UnavailableSkillTrustGenerationMarkerStore:
+    """Marker store used when no secure OS-backed marker backend is available."""
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+
+    def __repr__(self) -> str:
+        return "UnavailableSkillTrustGenerationMarkerStore(message=<redacted>)"
+
+    def _raise_unavailable(self) -> None:
+        raise SkillTrustMarkerUnavailable(self.message)
+
+    def load_marker(self) -> dict[str, Any] | None:
+        """Raise because rollback marker storage is unavailable."""
+
+        self._raise_unavailable()
+
+    def save_marker(self, *, generation: int, manifest_digest: str) -> None:
+        """Raise because rollback marker storage is unavailable."""
+
+        self._raise_unavailable()
+
+
+@dataclass(slots=True, repr=False)
+class KeyringSkillTrustGenerationMarkerStore:
+    """Secure OS-keyring-backed generation marker store."""
+
+    service_name: str = _DEFAULT_MARKER_SERVICE_NAME
+    keyring_backend: Any | None = None
+
+    def __post_init__(self) -> None:
+        keyring_backend = _resolve_keyring_backend(self.keyring_backend)
+        if not is_secure_keyring_backend(keyring_backend):
+            raise SkillTrustMarkerUnavailable(
+                "No secure OS-backed generation marker store is available."
+            )
+        self.keyring_backend = keyring_backend
+
+    def __repr__(self) -> str:
+        return "KeyringSkillTrustGenerationMarkerStore(keyring_backend=<redacted>)"
+
+    def load_marker(self) -> dict[str, Any] | None:
+        """Load the marker from secure keyring storage."""
+
+        payload = self.keyring_backend.get_password(self.service_name, _MARKER_USERNAME)
+        if not payload:
+            return None
+        marker = json.loads(payload)
+        if not isinstance(marker, dict):
+            return None
+        return marker
+
+    def save_marker(self, *, generation: int, manifest_digest: str) -> None:
+        """Save the marker to secure keyring storage."""
+
+        payload = json.dumps(
+            {
+                "generation": generation,
+                "manifest_digest": manifest_digest,
+            },
+            sort_keys=True,
+        )
+        self.keyring_backend.set_password(self.service_name, _MARKER_USERNAME, payload)
+
+
+def build_default_skill_trust_marker_store(
+    keyring_backend: Any | None = None,
+) -> SkillTrustGenerationMarkerStore:
+    """Return a secure default marker store or a fail-closed unavailable store."""
+
+    try:
+        return KeyringSkillTrustGenerationMarkerStore(keyring_backend=keyring_backend)
+    except Exception as exc:
+        return UnavailableSkillTrustGenerationMarkerStore(str(exc))
+
+
+@dataclass(slots=True, repr=False)
+class KeyringSkillTrustKeyCache:
+    """Optional secure keyring cache for derived trust key material."""
+
+    service_name: str = _DEFAULT_KEY_CACHE_SERVICE_NAME
+    keyring_backend: Any | None = None
+
+    def __post_init__(self) -> None:
+        keyring_backend = _resolve_keyring_backend(self.keyring_backend)
+        if not is_secure_keyring_backend(keyring_backend):
+            raise SkillTrustMarkerUnavailable("No secure OS-backed key cache is available.")
+        self.keyring_backend = keyring_backend
+
+    def __repr__(self) -> str:
+        return "KeyringSkillTrustKeyCache(keyring_backend=<redacted>)"
+
+    def save_keys(self, keys: SkillTrustKeys) -> None:
+        """Store derived key material in a secure keyring, never the passphrase."""
+
+        payload = {
+            "version": 1,
+            "manifest_mac_key": _encode_bytes(keys.manifest_mac_key),
+            "snapshot_key": _encode_bytes(keys.snapshot_key),
+            "audit_mac_key": _encode_bytes(keys.audit_mac_key),
+            "wrapped_root_key": _encode_bytes(keys.wrapped_root_key),
+        }
+        self.keyring_backend.set_password(
+            self.service_name,
+            _KEY_CACHE_USERNAME,
+            json.dumps(payload, sort_keys=True),
+        )
+
+    def load_keys(self) -> SkillTrustKeys | None:
+        """Load cached derived trust keys from the secure keyring."""
+
+        payload = self.keyring_backend.get_password(self.service_name, _KEY_CACHE_USERNAME)
+        if not payload:
+            return None
+        data = json.loads(payload)
+        if not isinstance(data, dict) or data.get("version") != 1:
+            raise ValueError("skill trust key cache invalid")
+        keys = {field: _decode_32_byte_key(data, field) for field in _KEY_CACHE_FIELDS}
+        return SkillTrustKeys(**keys)
+
+
+def build_default_skill_trust_key_cache(
+    keyring_backend: Any | None = None,
+) -> KeyringSkillTrustKeyCache | None:
+    """Return a secure key cache, or ``None`` when unavailable."""
+
+    try:
+        return KeyringSkillTrustKeyCache(keyring_backend=keyring_backend)
+    except Exception:
+        return None
+
+
+@dataclass(slots=True)
+class SkillTrustStore:
+    """File persistence for authenticated trust manifests and snapshots."""
+
+    store_dir: Path
+    marker_store: SkillTrustGenerationMarkerStore
+
+    @property
+    def manifest_path(self) -> Path:
+        """Path to the authenticated skill trust manifest payload."""
+
+        return self.store_dir / _MANIFEST_FILENAME
+
+    @property
+    def snapshots_dir(self) -> Path:
+        """Directory containing encrypted trusted skill snapshots."""
+
+        return self.store_dir / _SNAPSHOTS_DIRNAME
+
+    def has_manifest(self) -> bool:
+        """Return whether a trust manifest payload exists on disk."""
+
+        return self.manifest_path.exists()
+
+    def manifest_digest(self, manifest: dict[str, Any]) -> str:
+        """Return the canonical JSON SHA-256 digest for a manifest."""
+
+        return sha256_hex(canonical_json(manifest))
+
+    def load_salt(self) -> bytes:
+        """Load and validate the 32-byte KDF salt stored with the manifest."""
+
+        payload = json.loads(self.manifest_path.read_text(encoding="utf-8"))
+        encoded = payload.get("kdf_salt")
+        if not isinstance(encoded, str):
+            raise ValueError("skill trust salt missing")
+        try:
+            salt = base64.b64decode(encoded, validate=True)
+        except Exception as exc:
+            raise ValueError("skill trust salt invalid") from exc
+        if len(salt) != 32:
+            raise ValueError("skill trust salt invalid")
+        return salt
+
+    def save_manifest(
+        self,
+        manifest: dict[str, Any],
+        keys: SkillTrustKeys,
+        *,
+        salt: bytes | None = None,
+    ) -> None:
+        """Persist an authenticated manifest and update its generation marker."""
+
+        if salt is None:
+            salt = self.load_salt()
+        if not isinstance(salt, bytes) or len(salt) != 32:
+            raise ValueError("skill trust salt invalid")
+
+        manifest_payload = _json_safe_payload(manifest)
+        if not isinstance(manifest_payload, dict):
+            raise ValueError("skill trust manifest must be an object")
+
+        payload = {
+            "kdf_salt": _encode_bytes(salt),
+            "manifest": manifest_payload,
+            "mac": manifest_mac(manifest_payload, keys.manifest_mac_key),
+        }
+        self.store_dir.mkdir(parents=True, exist_ok=True)
+        _atomic_write_json(self.manifest_path, payload, indent=2)
+        self.marker_store.save_marker(
+            generation=int(manifest_payload["generation"]),
+            manifest_digest=self.manifest_digest(manifest_payload),
+        )
+
+    def load_manifest(self, keys: SkillTrustKeys) -> dict[str, Any]:
+        """Load a manifest after verifying its HMAC and generation marker."""
+
+        payload = json.loads(self.manifest_path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError("manifest authentication failed")
+        manifest = payload.get("manifest")
+        tag = payload.get("mac")
+        if not isinstance(manifest, dict) or not isinstance(tag, str):
+            raise ValueError("manifest authentication failed")
+        if manifest_mac(manifest, keys.manifest_mac_key) != tag:
+            raise ValueError("manifest authentication failed")
+
+        marker = self.marker_store.load_marker()
+        digest = self.manifest_digest(manifest)
+        if marker is None:
+            raise ValueError("manifest generation marker mismatch")
+        if int(marker.get("generation", -1)) != int(manifest.get("generation", -2)):
+            raise ValueError("manifest generation marker mismatch")
+        if marker.get("manifest_digest") != digest:
+            raise ValueError("manifest generation marker mismatch")
+        return manifest
+
+    def save_snapshot(
+        self,
+        snapshot_id: str,
+        payload: dict[str, Any],
+        keys: SkillTrustKeys,
+        *,
+        generation: int,
+    ) -> None:
+        """Encrypt and persist a trusted snapshot payload."""
+
+        snapshot_payload = _json_safe_payload(payload)
+        if not isinstance(snapshot_payload, dict):
+            raise ValueError("skill trust snapshot payload must be an object")
+        self.snapshots_dir.mkdir(parents=True, exist_ok=True)
+        encrypted = encrypt_json_blob(
+            snapshot_payload,
+            keys.snapshot_key,
+            associated_data=_snapshot_associated_data(snapshot_id, generation),
+        )
+        _atomic_write_json(self._snapshot_path(snapshot_id), encrypted, indent=2)
+
+    def load_snapshot(
+        self,
+        snapshot_id: str,
+        keys: SkillTrustKeys,
+        *,
+        generation: int,
+    ) -> dict[str, Any]:
+        """Load and decrypt a trusted snapshot payload."""
+
+        encrypted = json.loads(self._snapshot_path(snapshot_id).read_text(encoding="utf-8"))
+        if not isinstance(encrypted, dict):
+            raise ValueError("snapshot authentication failed")
+        return decrypt_json_blob(
+            encrypted,
+            keys.snapshot_key,
+            associated_data=_snapshot_associated_data(snapshot_id, generation),
+        )
+
+    def _snapshot_path(self, snapshot_id: str) -> Path:
+        if not snapshot_id or snapshot_id in {".", ".."}:
+            raise ValueError("skill trust snapshot id invalid")
+        if "/" in snapshot_id or "\\" in snapshot_id:
+            raise ValueError("skill trust snapshot id invalid")
+        return self.snapshots_dir / f"{snapshot_id}.json"
+
+
+def _resolve_keyring_backend(keyring_backend: Any | None) -> Any:
+    if keyring_backend is None:
+        import keyring
+
+        keyring_backend = keyring.get_keyring()
+    get_keyring = getattr(keyring_backend, "get_keyring", None)
+    if callable(get_keyring):
+        return get_keyring()
+    return keyring_backend
+
+
+def _snapshot_associated_data(snapshot_id: str, generation: int) -> bytes:
+    return f"snapshot:{snapshot_id}:generation:{generation}".encode("utf-8")
+
+
+def _atomic_write_json(path: Path, payload: Any, *, indent: int | None = None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = path.with_name(f".{path.name}.tmp")
+    text = json.dumps(payload, indent=indent, sort_keys=True) + "\n"
+    temp_path.write_text(text, encoding="utf-8")
+    temp_path.replace(path)
+
+
+def _encode_bytes(value: bytes) -> str:
+    return base64.b64encode(value).decode("ascii")
+
+
+def _decode_32_byte_key(payload: dict[str, Any], field: str) -> bytes:
+    encoded = payload.get(field)
+    if not isinstance(encoded, str):
+        raise ValueError("skill trust key cache invalid")
+    try:
+        decoded = base64.b64decode(encoded, validate=True)
+    except Exception as exc:
+        raise ValueError("skill trust key cache invalid") from exc
+    if len(decoded) != 32:
+        raise ValueError("skill trust key cache invalid")
+    return decoded
+
+
+def _json_safe_payload(payload: Any) -> Any:
+    if isinstance(payload, Mapping):
+        return {str(key): _json_safe_payload(value) for key, value in payload.items()}
+    if isinstance(payload, tuple):
+        return [_json_safe_payload(value) for value in payload]
+    if isinstance(payload, Sequence) and not isinstance(payload, (str, bytes, bytearray)):
+        return [_json_safe_payload(value) for value in payload]
+    return payload

--- a/tldw_chatbook/Skills_Interop/skill_trust_store.py
+++ b/tldw_chatbook/Skills_Interop/skill_trust_store.py
@@ -10,6 +10,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
 
+from loguru import logger
+
+from ..Utils.path_validation import get_safe_relative_path, validate_path_simple
 from ..runtime_policy.server_credentials import is_secure_keyring_backend
 from .skill_trust_crypto import (
     SkillTrustKeys,
@@ -62,9 +65,13 @@ class FileSkillTrustGenerationMarkerStore:
     def load_marker(self) -> dict[str, Any] | None:
         """Load the file-backed generation marker if it exists."""
 
-        if not self.marker_path.exists():
+        marker_path = _validated_trust_file_path(
+            self.marker_path,
+            base_dir=self.marker_path.parent,
+        )
+        if not marker_path.exists():
             return None
-        payload = json.loads(self.marker_path.read_text(encoding="utf-8"))
+        payload = json.loads(marker_path.read_text(encoding="utf-8"))
         if not isinstance(payload, dict):
             return None
         return payload
@@ -72,12 +79,11 @@ class FileSkillTrustGenerationMarkerStore:
     def save_marker(self, *, generation: int, manifest_digest: str) -> None:
         """Atomically save the file-backed generation marker."""
 
-        self.marker_path.parent.mkdir(parents=True, exist_ok=True)
         payload = {
             "generation": generation,
             "manifest_digest": manifest_digest,
         }
-        _atomic_write_json(self.marker_path, payload)
+        _atomic_write_json(self.marker_path, payload, base_dir=self.marker_path.parent)
 
 
 class UnavailableSkillTrustGenerationMarkerStore:
@@ -154,6 +160,19 @@ def build_default_skill_trust_marker_store(
         return KeyringSkillTrustGenerationMarkerStore(keyring_backend=keyring_backend)
     except Exception as exc:
         return UnavailableSkillTrustGenerationMarkerStore(str(exc))
+
+
+def build_skill_trust_marker_store_with_fallback(
+    *,
+    fallback_marker_path: Path,
+    keyring_backend: Any | None = None,
+) -> tuple[SkillTrustGenerationMarkerStore, bool]:
+    """Return a marker store and whether reduced rollback protection is active."""
+
+    try:
+        return KeyringSkillTrustGenerationMarkerStore(keyring_backend=keyring_backend), False
+    except Exception:
+        return FileSkillTrustGenerationMarkerStore(fallback_marker_path), True
 
 
 @dataclass(slots=True, repr=False)
@@ -239,7 +258,7 @@ class SkillTrustStore:
     def has_manifest(self) -> bool:
         """Return whether a trust manifest payload exists on disk."""
 
-        return self.manifest_path.exists()
+        return self._validated_manifest_path().exists()
 
     def manifest_digest(self, manifest: dict[str, Any]) -> str:
         """Return the canonical JSON SHA-256 digest for a manifest."""
@@ -249,7 +268,7 @@ class SkillTrustStore:
     def load_salt(self) -> bytes:
         """Load and validate the 32-byte KDF salt stored with the manifest."""
 
-        payload = json.loads(self.manifest_path.read_text(encoding="utf-8"))
+        payload = json.loads(self._validated_manifest_path().read_text(encoding="utf-8"))
         encoded = payload.get("kdf_salt")
         if not isinstance(encoded, str):
             raise ValueError("skill trust salt missing")
@@ -284,10 +303,11 @@ class SkillTrustStore:
             "manifest": manifest_payload,
             "mac": manifest_mac(manifest_payload, keys.manifest_mac_key),
         }
-        self.store_dir.mkdir(parents=True, exist_ok=True)
-        previous_manifest_bytes = self.manifest_path.read_bytes() if self.has_manifest() else None
+        _ensure_trust_directory(self.store_dir)
+        manifest_path = self._validated_manifest_path()
+        previous_manifest_bytes = manifest_path.read_bytes() if self.has_manifest() else None
         previous_marker = self.marker_store.load_marker() if previous_manifest_bytes is not None else None
-        _atomic_write_json(self.manifest_path, payload, indent=2)
+        _atomic_write_json(manifest_path, payload, indent=2, base_dir=self.store_dir)
         try:
             self.marker_store.save_marker(
                 generation=int(manifest_payload["generation"]),
@@ -295,20 +315,16 @@ class SkillTrustStore:
             )
         except Exception:
             if previous_manifest_bytes is None:
-                self.manifest_path.unlink(missing_ok=True)
+                manifest_path.unlink(missing_ok=True)
             else:
-                _atomic_write_bytes(self.manifest_path, previous_manifest_bytes)
-            if previous_marker is not None:
-                self.marker_store.save_marker(
-                    generation=int(previous_marker["generation"]),
-                    manifest_digest=str(previous_marker["manifest_digest"]),
-                )
+                _atomic_write_bytes(manifest_path, previous_manifest_bytes, base_dir=self.store_dir)
+            _restore_previous_marker(self.marker_store, previous_marker)
             raise
 
     def load_manifest(self, keys: SkillTrustKeys) -> dict[str, Any]:
         """Load a manifest after verifying its HMAC and generation marker."""
 
-        payload = json.loads(self.manifest_path.read_text(encoding="utf-8"))
+        payload = json.loads(self._validated_manifest_path().read_text(encoding="utf-8"))
         if not isinstance(payload, dict):
             raise ValueError("manifest authentication failed")
         manifest = payload.get("manifest")
@@ -341,13 +357,18 @@ class SkillTrustStore:
         snapshot_payload = _json_safe_payload(payload)
         if not isinstance(snapshot_payload, dict):
             raise ValueError("skill trust snapshot payload must be an object")
-        self.snapshots_dir.mkdir(parents=True, exist_ok=True)
+        snapshots_dir = _ensure_trust_directory(self.snapshots_dir)
         encrypted = encrypt_json_blob(
             snapshot_payload,
             keys.snapshot_key,
             associated_data=_snapshot_associated_data(snapshot_id, generation),
         )
-        _atomic_write_json(self._snapshot_path(snapshot_id), encrypted, indent=2)
+        _atomic_write_json(
+            self._snapshot_path(snapshot_id),
+            encrypted,
+            indent=2,
+            base_dir=snapshots_dir,
+        )
 
     def load_snapshot(
         self,
@@ -358,7 +379,11 @@ class SkillTrustStore:
     ) -> dict[str, Any]:
         """Load and decrypt a trusted snapshot payload."""
 
-        encrypted = json.loads(self._snapshot_path(snapshot_id).read_text(encoding="utf-8"))
+        snapshot_path = _validated_trust_file_path(
+            self._snapshot_path(snapshot_id),
+            base_dir=self.snapshots_dir,
+        )
+        encrypted = json.loads(snapshot_path.read_text(encoding="utf-8"))
         if not isinstance(encrypted, dict):
             raise ValueError("snapshot authentication failed")
         return decrypt_json_blob(
@@ -373,6 +398,9 @@ class SkillTrustStore:
         if "/" in snapshot_id or "\\" in snapshot_id:
             raise ValueError("skill trust snapshot id invalid")
         return self.snapshots_dir / f"{snapshot_id}.json"
+
+    def _validated_manifest_path(self) -> Path:
+        return _validated_trust_file_path(self.manifest_path, base_dir=self.store_dir)
 
 
 def _resolve_keyring_backend(keyring_backend: Any | None) -> Any:
@@ -390,19 +418,68 @@ def _snapshot_associated_data(snapshot_id: str, generation: int) -> bytes:
     return f"snapshot:{snapshot_id}:generation:{generation}".encode("utf-8")
 
 
-def _atomic_write_json(path: Path, payload: Any, *, indent: int | None = None) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
+def _atomic_write_json(
+    path: Path,
+    payload: Any,
+    *,
+    indent: int | None = None,
+    base_dir: Path | None = None,
+) -> None:
+    base_dir = _ensure_trust_directory(base_dir or path.parent)
+    path = _validated_trust_file_path(path, base_dir=base_dir)
     temp_path = path.with_name(f".{path.name}.tmp")
+    temp_path = _validated_trust_file_path(temp_path, base_dir=base_dir)
     text = json.dumps(payload, indent=indent, sort_keys=True) + "\n"
     temp_path.write_text(text, encoding="utf-8")
     temp_path.replace(path)
 
 
-def _atomic_write_bytes(path: Path, payload: bytes) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
+def _atomic_write_bytes(path: Path, payload: bytes, *, base_dir: Path | None = None) -> None:
+    base_dir = _ensure_trust_directory(base_dir or path.parent)
+    path = _validated_trust_file_path(path, base_dir=base_dir)
     temp_path = path.with_name(f".{path.name}.tmp")
+    temp_path = _validated_trust_file_path(temp_path, base_dir=base_dir)
     temp_path.write_bytes(payload)
     temp_path.replace(path)
+
+
+def _ensure_trust_directory(path: Path) -> Path:
+    directory = validate_path_simple(path)
+    if directory.is_symlink():
+        raise ValueError("unsafe skill trust path")
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory
+
+
+def _validated_trust_file_path(path: Path, *, base_dir: Path) -> Path:
+    base = validate_path_simple(base_dir)
+    if base.is_symlink():
+        raise ValueError("unsafe skill trust path")
+    candidate = validate_path_simple(path)
+    if candidate.is_symlink():
+        raise ValueError("unsafe skill trust path")
+    if get_safe_relative_path(candidate, base) is None:
+        raise ValueError("unsafe skill trust path")
+    return candidate
+
+
+def _restore_previous_marker(
+    marker_store: SkillTrustGenerationMarkerStore,
+    previous_marker: dict[str, Any] | None,
+) -> None:
+    if previous_marker is None:
+        return
+    generation = previous_marker.get("generation")
+    manifest_digest = previous_marker.get("manifest_digest")
+    if not isinstance(generation, int) or not isinstance(manifest_digest, str):
+        logger.warning("Skipping invalid previous skill trust generation marker during rollback.")
+        return
+    try:
+        marker_store.save_marker(generation=generation, manifest_digest=manifest_digest)
+    except Exception:
+        logger.opt(exception=True).warning(
+            "Failed to restore previous skill trust generation marker during rollback."
+        )
 
 
 def _encode_bytes(value: bytes) -> str:

--- a/tldw_chatbook/Skills_Interop/skill_trust_store.py
+++ b/tldw_chatbook/Skills_Interop/skill_trust_store.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import json
+import math
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -171,11 +172,13 @@ class KeyringSkillTrustKeyCache:
     def __repr__(self) -> str:
         return "KeyringSkillTrustKeyCache(keyring_backend=<redacted>)"
 
-    def save_keys(self, keys: SkillTrustKeys) -> None:
+    def save_keys(self, keys: SkillTrustKeys, *, salt: bytes) -> None:
         """Store derived key material in a secure keyring, never the passphrase."""
 
+        salt_digest = _salt_digest(salt)
         payload = {
             "version": 1,
+            "salt_digest": salt_digest,
             "manifest_mac_key": _encode_bytes(keys.manifest_mac_key),
             "snapshot_key": _encode_bytes(keys.snapshot_key),
             "audit_mac_key": _encode_bytes(keys.audit_mac_key),
@@ -187,15 +190,18 @@ class KeyringSkillTrustKeyCache:
             json.dumps(payload, sort_keys=True),
         )
 
-    def load_keys(self) -> SkillTrustKeys | None:
+    def load_keys(self, *, expected_salt: bytes) -> SkillTrustKeys | None:
         """Load cached derived trust keys from the secure keyring."""
 
+        expected_salt_digest = _salt_digest(expected_salt)
         payload = self.keyring_backend.get_password(self.service_name, _KEY_CACHE_USERNAME)
         if not payload:
             return None
         data = json.loads(payload)
         if not isinstance(data, dict) or data.get("version") != 1:
             raise ValueError("skill trust key cache invalid")
+        if data.get("salt_digest") != expected_salt_digest:
+            return None
         keys = {field: _decode_32_byte_key(data, field) for field in _KEY_CACHE_FIELDS}
         return SkillTrustKeys(**keys)
 
@@ -279,11 +285,25 @@ class SkillTrustStore:
             "mac": manifest_mac(manifest_payload, keys.manifest_mac_key),
         }
         self.store_dir.mkdir(parents=True, exist_ok=True)
+        previous_manifest_bytes = self.manifest_path.read_bytes() if self.has_manifest() else None
+        previous_marker = self.marker_store.load_marker() if previous_manifest_bytes is not None else None
         _atomic_write_json(self.manifest_path, payload, indent=2)
-        self.marker_store.save_marker(
-            generation=int(manifest_payload["generation"]),
-            manifest_digest=self.manifest_digest(manifest_payload),
-        )
+        try:
+            self.marker_store.save_marker(
+                generation=int(manifest_payload["generation"]),
+                manifest_digest=self.manifest_digest(manifest_payload),
+            )
+        except Exception:
+            if previous_manifest_bytes is None:
+                self.manifest_path.unlink(missing_ok=True)
+            else:
+                _atomic_write_bytes(self.manifest_path, previous_manifest_bytes)
+            if previous_marker is not None:
+                self.marker_store.save_marker(
+                    generation=int(previous_marker["generation"]),
+                    manifest_digest=str(previous_marker["manifest_digest"]),
+                )
+            raise
 
     def load_manifest(self, keys: SkillTrustKeys) -> dict[str, Any]:
         """Load a manifest after verifying its HMAC and generation marker."""
@@ -378,6 +398,13 @@ def _atomic_write_json(path: Path, payload: Any, *, indent: int | None = None) -
     temp_path.replace(path)
 
 
+def _atomic_write_bytes(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = path.with_name(f".{path.name}.tmp")
+    temp_path.write_bytes(payload)
+    temp_path.replace(path)
+
+
 def _encode_bytes(value: bytes) -> str:
     return base64.b64encode(value).decode("ascii")
 
@@ -395,11 +422,24 @@ def _decode_32_byte_key(payload: dict[str, Any], field: str) -> bytes:
     return decoded
 
 
+def _salt_digest(salt: bytes) -> str:
+    if not isinstance(salt, bytes) or len(salt) != 32:
+        raise ValueError("skill trust salt invalid")
+    return sha256_hex(salt)
+
+
 def _json_safe_payload(payload: Any) -> Any:
     if isinstance(payload, Mapping):
-        return {str(key): _json_safe_payload(value) for key, value in payload.items()}
+        result: dict[str, Any] = {}
+        for key, value in payload.items():
+            if not isinstance(key, str):
+                raise ValueError("skill trust JSON mapping keys must be strings")
+            result[key] = _json_safe_payload(value)
+        return result
     if isinstance(payload, tuple):
         return [_json_safe_payload(value) for value in payload]
     if isinstance(payload, Sequence) and not isinstance(payload, (str, bytes, bytearray)):
         return [_json_safe_payload(value) for value in payload]
+    if isinstance(payload, float) and not math.isfinite(payload):
+        raise ValueError("skill trust JSON numbers must be finite")
     return payload

--- a/tldw_chatbook/Skills_Interop/skills_scope_service.py
+++ b/tldw_chatbook/Skills_Interop/skills_scope_service.py
@@ -84,13 +84,21 @@ class SkillsScopeService:
             return result
         payload = dict(result)
         payload.setdefault("backend", mode.value)
+        normalized_collection = False
         if isinstance(payload.get("skills"), list):
             payload["skills"] = [self._with_record_id(mode, "skill", item) for item in payload["skills"]]
-            return payload
+            normalized_collection = True
         if isinstance(payload.get("available_skills"), list):
             payload["available_skills"] = [
                 self._with_record_id(mode, "skill", item) for item in payload["available_skills"]
             ]
+            normalized_collection = True
+        if isinstance(payload.get("blocked_skills"), list):
+            payload["blocked_skills"] = [
+                self._with_record_id(mode, "skill", item) for item in payload["blocked_skills"]
+            ]
+            normalized_collection = True
+        if normalized_collection:
             return payload
         return self._normalize_item(mode, payload)
 

--- a/tldw_chatbook/UI/Screens/settings_privacy_security.py
+++ b/tldw_chatbook/UI/Screens/settings_privacy_security.py
@@ -32,6 +32,21 @@ SENSITIVE_CONFIG_KEY_PATTERNS = (
     "_secret",
     "_password",
 )
+SAFE_SKILL_TRUST_STATUSES = frozenset(
+    {
+        "trusted",
+        "trust_uninitialized",
+        "trust_locked",
+        "quarantined_modified",
+        "quarantined_added",
+        "quarantined_deleted",
+        "quarantined_manifest_error",
+        "quarantined_unsupported_path",
+        "unavailable",
+        "unavailable_error",
+    }
+)
+MAX_SKILL_TRUST_STATUS_CHARS = 80
 
 
 @dataclass(frozen=True)
@@ -48,6 +63,10 @@ class SettingsPrivacyPosture:
         redaction_active: Whether visible privacy output redacts raw secret values.
         data_boundary: User-facing local data boundary summary.
         server_boundary: User-facing server token boundary summary.
+        skill_trust_enabled: Whether local skill trust service is available.
+        skill_trust_status: Redacted local skill trust aggregate status.
+        skill_trust_keyring_convenience_enabled: Whether keyring convenience is enabled.
+        skill_trust_reduced_rollback_protection: Whether rollback protection is reduced.
     """
 
     encryption_enabled: bool
@@ -61,18 +80,24 @@ class SettingsPrivacyPosture:
         "local data stays local unless explicit server handoff or sync is enabled"
     )
     server_boundary: str = "server tokens are reported as configured/missing only"
+    skill_trust_enabled: bool = False
+    skill_trust_status: str = "unavailable"
+    skill_trust_keyring_convenience_enabled: bool = False
+    skill_trust_reduced_rollback_protection: bool = False
 
 
 def build_settings_privacy_posture(
     app_config: object,
     *,
     environ: Mapping[str, str] | None = None,
+    skill_trust: Mapping[str, object] | None = None,
 ) -> SettingsPrivacyPosture:
     """Build a redacted Privacy & Security posture from config and environment.
 
     Args:
         app_config: The application configuration mapping to inspect.
         environ: Optional environment mapping. Defaults to ``os.environ``.
+        skill_trust: Optional redacted local skill trust posture mapping.
 
     Returns:
         A posture object containing only counts and status booleans.
@@ -91,6 +116,7 @@ def build_settings_privacy_posture(
         app_config,
         env,
     )
+    trust = skill_trust if isinstance(skill_trust, Mapping) else {}
     return SettingsPrivacyPosture(
         encryption_enabled=encryption_enabled,
         sensitive_config_fields=_sensitive_config_field_count(app_config),
@@ -98,6 +124,14 @@ def build_settings_privacy_posture(
         provider_env_missing=env_missing,
         provider_env_configured=env_total,
         provider_config_secrets=_provider_config_secret_count(app_config),
+        skill_trust_enabled=_safe_bool(trust.get("enabled")),
+        skill_trust_status=_safe_skill_trust_status(trust.get("trust_status")),
+        skill_trust_keyring_convenience_enabled=_safe_bool(
+            trust.get("keyring_convenience_enabled")
+        ),
+        skill_trust_reduced_rollback_protection=_safe_bool(
+            trust.get("reduced_rollback_protection")
+        ),
     )
 
 
@@ -124,10 +158,33 @@ def build_privacy_posture_rows(posture: SettingsPrivacyPosture) -> tuple[str, ..
             f"{posture.provider_env_configured} configured"
         ),
         f"Provider config secrets: {posture.provider_config_secrets} present",
+        (
+            "Skill trust: "
+            f"{posture.skill_trust_status if posture.skill_trust_enabled else 'disabled'}"
+        ),
+        (
+            "Skill trust keyring convenience: enabled"
+            if posture.skill_trust_keyring_convenience_enabled
+            else "Skill trust keyring convenience: disabled"
+        ),
+        (
+            "Skill trust rollback protection: reduced"
+            if posture.skill_trust_reduced_rollback_protection
+            else "Skill trust rollback protection: full"
+        ),
         f"Data boundary: {posture.data_boundary}",
         f"Server boundary: {posture.server_boundary}",
         "Privacy safety: no secret values were printed or written.",
     )
+
+
+def _safe_skill_trust_status(value: object) -> str:
+    status = str(value or "unavailable").strip()[:MAX_SKILL_TRUST_STATUS_CHARS]
+    return status if status in SAFE_SKILL_TRUST_STATUSES else "unavailable"
+
+
+def _safe_bool(value: object) -> bool:
+    return value is True
 
 
 def _is_sensitive_config_key(key: object) -> bool:

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -2879,13 +2879,58 @@ class SettingsScreen(BaseAppScreen):
         )
         self.app.call_from_thread(self._apply_storage_check_result, rows)
 
+    def _skill_trust_posture(self) -> dict[str, object]:
+        skill_trust_service = getattr(
+            self.app_instance,
+            "local_skill_trust_service",
+            None,
+        )
+        if skill_trust_service is None:
+            return {
+                "enabled": False,
+                "trust_status": "unavailable",
+                "keyring_convenience_enabled": False,
+                "reduced_rollback_protection": False,
+            }
+
+        trust_status = "unavailable"
+        overall_status = getattr(skill_trust_service, "overall_status", None)
+        if callable(overall_status):
+            try:
+                trust_status = overall_status()
+            except Exception:
+                logger.warning("Unable to read local skill trust posture.")
+                trust_status = "unavailable_error"
+
+        return {
+            "enabled": True,
+            "trust_status": trust_status,
+            "keyring_convenience_enabled": bool(
+                getattr(
+                    skill_trust_service,
+                    "keyring_convenience_enabled",
+                    False,
+                )
+            ),
+            "reduced_rollback_protection": bool(
+                getattr(
+                    skill_trust_service,
+                    "reduced_rollback_protection",
+                    False,
+                )
+            ),
+        }
+
     def _settings_privacy_posture(
         self,
         app_config: object | None = None,
     ) -> SettingsPrivacyPosture:
         if app_config is None:
             app_config = getattr(self.app_instance, "app_config", {}) or {}
-        return build_settings_privacy_posture(app_config)
+        return build_settings_privacy_posture(
+            app_config,
+            skill_trust=self._skill_trust_posture(),
+        )
 
     def _privacy_posture_rows(self, app_config: object | None = None) -> tuple[str, ...]:
         return build_privacy_posture_rows(self._settings_privacy_posture(app_config))
@@ -5849,6 +5894,22 @@ class SettingsScreen(BaseAppScreen):
                 yield self._detail_row(
                     "Recovery actions",
                     "Check Privacy | Open Providers & Models | Open Advanced Config",
+                )
+                yield self._detail_row(
+                    "Skill trust",
+                    posture.skill_trust_status if posture.skill_trust_enabled else "disabled",
+                )
+                yield self._detail_row(
+                    "Skill trust keyring convenience",
+                    "enabled"
+                    if posture.skill_trust_keyring_convenience_enabled
+                    else "disabled",
+                )
+                yield self._detail_row(
+                    "Skill trust rollback protection",
+                    "reduced"
+                    if posture.skill_trust_reduced_rollback_protection
+                    else "full",
                 )
                 with Horizontal(id="settings-privacy-actions", classes="settings-action-row"):
                     yield Button(

--- a/tldw_chatbook/UI/Screens/skills_screen.py
+++ b/tldw_chatbook/UI/Screens/skills_screen.py
@@ -548,6 +548,24 @@ class SkillsScreen(BaseAppScreen):
                     if review_bound
                     else "Capture a trust review before approving this skill version."
                 )
+        review_bound = self._active_review_matches_selected(metadata)
+        review_files = ", ".join(self._active_review_changed_files()) or "selected files"
+        review_updates = {
+            "#skills-trust-review-title": "Trust Review" if review_bound else "",
+            "#skills-trust-review-skill": (
+                f"Reviewed skill: {selected_name}" if review_bound else ""
+            ),
+            "#skills-trust-review-summary": (
+                f"Review captured: {review_files}. Confirm these current files should become the trusted baseline."
+                if review_bound
+                else ""
+            ),
+        }
+        for selector, text in review_updates.items():
+            for widget in self.query(selector):
+                if isinstance(widget, Static):
+                    widget.update(self._plain_text(text))
+                    widget.display = bool(text)
 
     @staticmethod
     def _column_divider(identifier: str) -> Rule:

--- a/tldw_chatbook/UI/Screens/skills_screen.py
+++ b/tldw_chatbook/UI/Screens/skills_screen.py
@@ -13,7 +13,8 @@ from rich.text import Text
 from textual import on, work
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
-from textual.widgets import Button, Rule, Static
+from textual.screen import ModalScreen
+from textual.widgets import Button, Input, Rule, Static
 
 from ...Chat.chat_handoff_models import ChatHandoffPayload
 from ...runtime_policy.types import PolicyDeniedError
@@ -28,6 +29,11 @@ SKILLS_LOCAL_PAGE_SIZE = 25
 SKILLS_SERVICE_ERROR_COPY = "Skills service unavailable; retry Skills later."
 SKILLS_SERVICE_UNAVAILABLE_COPY = "Skills service is unavailable in this runtime."
 SKILLS_POLICY_DENIED_FALLBACK_COPY = "Local Skills are blocked by the current runtime policy."
+SKILLS_TRUST_REVIEWABLE_STATUSES = {
+    "quarantined_modified",
+    "quarantined_added",
+    "quarantined_deleted",
+}
 SKILL_TEXT_LIMITS = {
     "name": 64,
     "skill_name": 64,
@@ -36,7 +42,113 @@ SKILL_TEXT_LIMITS = {
     "record_id": 256,
     "backend": 32,
     "policy_message": 500,
+    "trust_status": 64,
+    "trust_reason_code": 128,
 }
+
+
+class SkillTrustPassphraseModal(ModalScreen[str | None]):
+    """Prompt for the local skill trust passphrase without logging it."""
+
+    DEFAULT_CSS = """
+    SkillTrustPassphraseModal {
+        align: center middle;
+    }
+
+    #skill-trust-passphrase-modal {
+        width: 64;
+        height: auto;
+        border: tall gray;
+        background: black;
+        padding: 1 2;
+    }
+
+    #skill-trust-passphrase-message {
+        margin: 1 0;
+    }
+
+    #skill-trust-passphrase-input {
+        width: 100%;
+    }
+
+    #skill-trust-passphrase-error {
+        height: auto;
+        min-height: 1;
+        color: red;
+    }
+
+    #skill-trust-passphrase-actions {
+        height: 3;
+        min-height: 3;
+        margin: 1 0 0 0;
+        align-horizontal: right;
+    }
+
+    #skill-trust-passphrase-cancel,
+    #skill-trust-passphrase-submit {
+        width: 10;
+        min-width: 10;
+        height: 3;
+        min-height: 3;
+    }
+    """
+
+    BINDINGS = [("escape", "dismiss", "Cancel")]
+
+    def __init__(self, *, confirm_bootstrap: bool) -> None:
+        super().__init__()
+        self._confirm_bootstrap = confirm_bootstrap
+
+    def compose(self) -> ComposeResult:
+        title = "Bootstrap Local Skill Trust" if self._confirm_bootstrap else "Unlock Local Skill Trust"
+        message = (
+            "Current local skill files will become the trusted baseline. "
+            "Enter the local skill trust passphrase to continue."
+            if self._confirm_bootstrap
+            else "Enter the local skill trust passphrase to unlock trust checks for this session."
+        )
+        with Vertical(id="skill-trust-passphrase-modal"):
+            yield Static(title, classes="destination-section")
+            yield Static(message, id="skill-trust-passphrase-message")
+            yield Input(
+                password=True,
+                id="skill-trust-passphrase-input",
+                placeholder="Trust passphrase",
+            )
+            yield Static("", id="skill-trust-passphrase-error", markup=False)
+            with Horizontal(id="skill-trust-passphrase-actions"):
+                yield Button("Cancel", id="skill-trust-passphrase-cancel")
+                yield Button("Submit", id="skill-trust-passphrase-submit", variant="primary")
+
+    def on_mount(self) -> None:
+        self.query_one("#skill-trust-passphrase-input", Input).focus()
+
+    def action_dismiss(self) -> None:
+        self.dismiss(None)
+
+    @on(Button.Pressed, "#skill-trust-passphrase-cancel")
+    def _cancel(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.dismiss(None)
+
+    @on(Button.Pressed, "#skill-trust-passphrase-submit")
+    def _submit_button(self, event: Button.Pressed) -> None:
+        event.stop()
+        self._submit()
+
+    @on(Input.Submitted, "#skill-trust-passphrase-input")
+    def _submit_input(self, event: Input.Submitted) -> None:
+        event.stop()
+        self._submit()
+
+    def _submit(self) -> None:
+        passphrase = self.query_one("#skill-trust-passphrase-input", Input).value
+        if not passphrase:
+            self.query_one("#skill-trust-passphrase-error", Static).update(
+                "Passphrase cannot be blank."
+            )
+            return
+        self.dismiss(passphrase)
 
 
 class SkillsScreen(BaseAppScreen):
@@ -49,6 +161,7 @@ class SkillsScreen(BaseAppScreen):
         self._skills_lookup_recovery_state: DestinationRecoveryState | None = None
         self._skills_loaded = False
         self._selected_skill_index: int | None = None
+        self._active_trust_review: dict[str, Any] | None = None
 
     def on_mount(self) -> None:
         super().on_mount()
@@ -172,8 +285,55 @@ class SkillsScreen(BaseAppScreen):
     def _plain_text(value: str) -> Text:
         return Text(value)
 
+    def _skill_trust_status(self, record: Mapping[str, Any]) -> str:
+        return self._skill_field(record, "trust_status", "trusted").lower() or "trusted"
+
+    def _skill_trust_reason(self, record: Mapping[str, Any]) -> str:
+        return self._skill_field(record, "trust_reason_code")
+
+    @staticmethod
+    def _skill_trust_blocked(record: Mapping[str, Any]) -> bool:
+        return bool(record.get("trust_blocked"))
+
+    def _skill_trust_changed_files(self, record: Mapping[str, Any]) -> list[str]:
+        files = record.get("trust_changed_files")
+        if not isinstance(files, (list, tuple)):
+            return []
+        changed_files = []
+        for file_name in files:
+            safe_file_name = self._safe_skill_text(file_name, max_length=100)
+            if safe_file_name:
+                changed_files.append(safe_file_name)
+        return changed_files
+
+    def _skill_trust_copy(self, record: Mapping[str, Any]) -> str:
+        status = self._skill_trust_status(record)
+        trust_copy = {
+            "trusted": "Trust: trusted baseline",
+            "trust_uninitialized": "Trust: not initialized",
+            "trust_locked": "Trust: locked",
+            "quarantined_modified": "Trust: changed since trusted baseline",
+            "quarantined_added": "Trust: new untrusted file",
+            "quarantined_deleted": "Trust: trusted file missing",
+            "quarantined_manifest_error": "Trust: manifest cannot be verified",
+            "quarantined_unsupported_path": "Trust: unsupported file path",
+        }
+        return trust_copy.get(status, "Trust: blocked")
+
+    def _can_review_skill_trust(self, record: Mapping[str, Any] | None) -> bool:
+        if record is None:
+            return False
+        return (
+            self._skill_validation_status(record) == "valid"
+            and self._skill_trust_blocked(record)
+            and self._skill_trust_status(record) in SKILLS_TRUST_REVIEWABLE_STATUSES
+        )
+
+    def _has_trust_status(self, trust_status: str) -> bool:
+        return any(self._skill_trust_status(record) == trust_status for record in self._local_skill_records)
+
     def _is_skill_valid(self, record: Mapping[str, Any]) -> bool:
-        return self._skill_validation_status(record) == "valid"
+        return self._skill_validation_status(record) == "valid" and not self._skill_trust_blocked(record)
 
     def _ensure_selected_skill(self) -> None:
         if not self._local_skill_records or self._skills_lookup_error:
@@ -199,12 +359,19 @@ class SkillsScreen(BaseAppScreen):
         record = self._selected_skill_record()
         if record is None:
             return {}
+        trust_changed_files = self._skill_trust_changed_files(record)
         return {
             "selected_skill_name": self._skill_name(record),
             "selected_record_id": self._skill_record_id(record),
             "selected_target_id": self._skill_target_id(record),
             "validation_status": self._skill_validation_status(record),
             "validation_errors": self._skill_validation_errors(record),
+            "stageable": self._is_skill_valid(record),
+            "trust_status": self._skill_trust_status(record),
+            "trust_reason_code": self._skill_trust_reason(record),
+            "trust_blocked": self._skill_trust_blocked(record),
+            "trust_changed_files": trust_changed_files,
+            "trust_reviewable": self._can_review_skill_trust(record),
         }
 
     def _skill_body(self, records: tuple[Mapping[str, Any], ...] | None = None) -> str:
@@ -230,6 +397,13 @@ class SkillsScreen(BaseAppScreen):
                 lines.append(f"   record id: {record_id}")
             lines.append(f"   backend: {backend}")
             lines.append(f"   validation: {validation_status}")
+            lines.append(f"   {self._skill_trust_copy(record)}")
+            trust_reason = self._skill_trust_reason(record)
+            if trust_reason:
+                lines.append(f"   reason code: {trust_reason}")
+            changed_files = ", ".join(self._skill_trust_changed_files(record))
+            if changed_files:
+                lines.append(f"   changed files: {changed_files}")
             lines.append("")
         return "\n".join(lines).strip()
 
@@ -246,15 +420,17 @@ class SkillsScreen(BaseAppScreen):
             return
         selected_name = metadata["selected_skill_name"]
         target_id = metadata["selected_target_id"]
-        valid = metadata["validation_status"] == "valid"
+        stageable = bool(metadata["stageable"])
         reason = "; ".join(metadata["validation_errors"]) or "Selected skill is not valid."
+        if metadata["validation_status"] == "valid" and metadata["trust_blocked"]:
+            reason = f"trust blocked ({metadata['trust_reason_code'] or metadata['trust_status']})"
         updates = {
             "#skills-selected-context": f"Selected: {selected_name}",
             "#skills-selected-runtime-target": f"Runtime target: {target_id}",
             "#skills-execution-readiness": (
-                "Execution: ready to stage in Console" if valid else "Execution: blocked"
+                "Execution: ready to stage in Console" if stageable else "Execution: blocked"
             ),
-            "#skills-execution-blocked-reason": "" if valid else f"Reason: {reason}",
+            "#skills-execution-blocked-reason": "" if stageable else f"Reason: {reason}",
         }
         for selector, text in updates.items():
             for widget in self.query(selector):
@@ -263,11 +439,27 @@ class SkillsScreen(BaseAppScreen):
                     widget.display = bool(text)
         for button in self.query("#skills-attach-to-console"):
             if isinstance(button, Button):
-                button.disabled = not valid
+                button.disabled = not stageable
                 button.tooltip = (
                     "Stage selected valid Agent Skill in Console."
-                    if valid
-                    else "Fix SKILL.md validation errors before staging this skill in Console."
+                    if stageable
+                    else "Resolve SKILL.md validation or local trust blocks before staging this skill in Console."
+                )
+        for button in self.query("#skills-review-diff"):
+            if isinstance(button, Button):
+                button.disabled = not bool(metadata["trust_reviewable"])
+                button.tooltip = (
+                    "Capture the selected skill files for review against the trusted baseline."
+                    if metadata["trust_reviewable"]
+                    else "Review is available only for metadata-valid local skills blocked by changed files."
+                )
+        for button in self.query("#skills-trust-reviewed-version"):
+            if isinstance(button, Button):
+                button.disabled = self._active_trust_review is None
+                button.tooltip = (
+                    "Trust the captured reviewed skill snapshot."
+                    if self._active_trust_review is not None
+                    else "Capture a trust review before approving this skill version."
                 )
 
     @staticmethod
@@ -352,10 +544,10 @@ class SkillsScreen(BaseAppScreen):
                         for index, record in enumerate(self._local_skill_records):
                             name = self._skill_name(record)
                             description = self._skill_field(record, "description", "No description provided.")
-                            is_valid = self._is_skill_valid(record)
+                            metadata_valid = self._skill_validation_status(record) == "valid"
                             validation_copy = (
                                 "Ready: valid SKILL.md"
-                                if is_valid
+                                if metadata_valid
                                 else "Blocked: invalid SKILL.md"
                             )
                             validation_errors = "; ".join(self._skill_validation_errors(record))
@@ -374,6 +566,22 @@ class SkillsScreen(BaseAppScreen):
                                     self._plain_text(validation_errors),
                                     id=f"skills-validation-errors-{index}",
                                 )
+                            yield Static(
+                                self._plain_text(self._skill_trust_copy(record)),
+                                id=f"skills-trust-status-{index}",
+                            )
+                            trust_reason = self._skill_trust_reason(record)
+                            if trust_reason:
+                                yield Static(
+                                    self._plain_text(f"Reason code: {trust_reason}"),
+                                    id=f"skills-trust-reason-{index}",
+                                )
+                            changed_files = ", ".join(self._skill_trust_changed_files(record))
+                            if changed_files:
+                                yield Static(
+                                    self._plain_text(f"Changed files: {changed_files}"),
+                                    id=f"skills-trust-files-{index}",
+                                )
                             yield Button(
                                 "Use",
                                 id=f"skills-select-local-{index}",
@@ -382,12 +590,12 @@ class SkillsScreen(BaseAppScreen):
                             )
                         attach_label = "Attach local Skills to Console"
                         attach_disabled = not (
-                            selected_metadata and selected_metadata.get("validation_status") == "valid"
+                            selected_metadata and selected_metadata.get("stageable")
                         )
                         attach_tooltip = (
                             "Stage selected valid Agent Skill in Console."
                             if not attach_disabled
-                            else "Fix SKILL.md validation errors before staging this skill in Console."
+                            else "Resolve SKILL.md validation or local trust blocks before staging this skill in Console."
                         )
                 yield self._column_divider("skills-detail-inspector-divider")
                 with Vertical(id="skills-inspector-pane", classes="destination-workbench-pane ds-inspector"):
@@ -406,21 +614,25 @@ class SkillsScreen(BaseAppScreen):
                             self._plain_text(f"Runtime target: {selected_metadata['selected_target_id']}"),
                             id="skills-selected-runtime-target",
                         )
-                        is_selected_valid = selected_metadata["validation_status"] == "valid"
+                        is_selected_stageable = bool(selected_metadata["stageable"])
+                        selected_blocked_reason = (
+                            "; ".join(selected_metadata["validation_errors"])
+                            or "Selected skill is not valid."
+                        )
+                        if selected_metadata["validation_status"] == "valid" and selected_metadata["trust_blocked"]:
+                            selected_blocked_reason = (
+                                f"trust blocked ({selected_metadata['trust_reason_code'] or selected_metadata['trust_status']})"
+                            )
                         yield Static(
                             "Execution: ready to stage in Console"
-                            if is_selected_valid
+                            if is_selected_stageable
                             else "Execution: blocked",
                             id="skills-execution-readiness",
                         )
                         yield Static(
-                            self._plain_text("" if is_selected_valid else (
-                                "Reason: "
-                                + (
-                                    "; ".join(selected_metadata["validation_errors"])
-                                    or "Selected skill is not valid."
-                                )
-                            )),
+                            self._plain_text(
+                                "" if is_selected_stageable else f"Reason: {selected_blocked_reason}"
+                            ),
                             id="skills-execution-blocked-reason",
                         )
                     yield Static("Actions", classes="destination-section")
@@ -433,6 +645,48 @@ class SkillsScreen(BaseAppScreen):
                         id="skills-import-skill",
                         disabled=True,
                         tooltip="Unavailable until skill import is wired in this shell.",
+                    )
+                    yield Button(
+                        "Bootstrap Trust",
+                        id="skills-bootstrap-trust",
+                        disabled=not self._has_trust_status("trust_uninitialized"),
+                        tooltip=(
+                            "Create the first trusted baseline from current local skill files."
+                            if self._has_trust_status("trust_uninitialized")
+                            else "Bootstrap is available when local skill trust has not been initialized."
+                        ),
+                    )
+                    yield Button(
+                        "Unlock Trust",
+                        id="skills-unlock-trust",
+                        disabled=not self._has_trust_status("trust_locked"),
+                        tooltip=(
+                            "Unlock local skill trust with the trust passphrase for this session."
+                            if self._has_trust_status("trust_locked")
+                            else "Unlock is available when local skill trust is locked."
+                        ),
+                    )
+                    review_enabled = bool(selected_metadata and selected_metadata.get("trust_reviewable"))
+                    yield Button(
+                        "Review Diff",
+                        id="skills-review-diff",
+                        disabled=not review_enabled,
+                        tooltip=(
+                            "Capture the selected skill files for review against the trusted baseline."
+                            if review_enabled
+                            else "Review is available only for metadata-valid local skills blocked by changed files."
+                        ),
+                    )
+                    review_active = self._active_trust_review is not None
+                    yield Button(
+                        "Trust Reviewed Version",
+                        id="skills-trust-reviewed-version",
+                        disabled=not review_active,
+                        tooltip=(
+                            "Trust the captured reviewed skill snapshot."
+                            if review_active
+                            else "Capture a trust review before approving this skill version."
+                        ),
                     )
                     yield Button(
                         attach_label,
@@ -454,8 +708,140 @@ class SkillsScreen(BaseAppScreen):
             return
         if not (0 <= index < len(self._local_skill_records)):
             return
+        if self._selected_skill_index != index:
+            self._active_trust_review = None
         self._selected_skill_index = index
         self._apply_selected_skill_widgets()
+
+    def _notify_skill_trust_warning(self, message: str) -> None:
+        notify = getattr(self.app_instance, "notify", None)
+        if callable(notify):
+            notify(message, severity="warning")
+
+    async def _reload_local_skills_context(self) -> None:
+        records, lookup_error, recovery_state = await self._list_local_skills()
+        self._apply_local_skills_context(records, lookup_error, recovery_state)
+
+    async def _request_skill_trust_passphrase(self, confirm_bootstrap: bool) -> str | None:
+        push_screen_wait = getattr(self.app, "push_screen_wait", None)
+        if not callable(push_screen_wait):
+            self._notify_skill_trust_warning("Local skill trust passphrase prompt is unavailable.")
+            return None
+        result = await push_screen_wait(
+            SkillTrustPassphraseModal(confirm_bootstrap=confirm_bootstrap)
+        )
+        if isinstance(result, str) and result:
+            return result
+        return None
+
+    async def _call_skill_trust_service(
+        self,
+        method_name: str,
+        *args: Any,
+    ) -> tuple[Any, bool]:
+        trust_service = getattr(self.app_instance, "local_skill_trust_service", None)
+        method = getattr(trust_service, method_name, None)
+        if not callable(method):
+            self._notify_skill_trust_warning("Local skill trust service is unavailable.")
+            return None, False
+        try:
+            if inspect.iscoroutinefunction(method):
+                result = await method(*args)
+            else:
+                result = await asyncio.to_thread(method, *args)
+                if inspect.isawaitable(result):
+                    result = await result
+        except Exception as exc:
+            logger.warning(
+                "Local skill trust action failed.",
+                action=method_name,
+                error_type=type(exc).__name__,
+            )
+            self._notify_skill_trust_warning(
+                "Local skill trust action could not be completed."
+            )
+            return None, False
+        return result, True
+
+    async def _handle_skill_trust_passphrase_action(
+        self,
+        *,
+        method_name: str,
+        confirm_bootstrap: bool,
+    ) -> None:
+        passphrase = await self._request_skill_trust_passphrase(
+            confirm_bootstrap=confirm_bootstrap
+        )
+        if passphrase is None:
+            self._notify_skill_trust_warning("Local skill trust action cancelled.")
+            return
+        _, ok = await self._call_skill_trust_service(method_name, passphrase)
+        if ok:
+            self._active_trust_review = None
+            await self._reload_local_skills_context()
+
+    @on(Button.Pressed, "#skills-bootstrap-trust")
+    async def bootstrap_skill_trust(self, event: Button.Pressed) -> None:
+        event.stop()
+        await self._handle_skill_trust_passphrase_action(
+            method_name="bootstrap_trust",
+            confirm_bootstrap=True,
+        )
+
+    @on(Button.Pressed, "#skills-unlock-trust")
+    async def unlock_skill_trust(self, event: Button.Pressed) -> None:
+        event.stop()
+        await self._handle_skill_trust_passphrase_action(
+            method_name="unlock_with_passphrase",
+            confirm_bootstrap=False,
+        )
+
+    @on(Button.Pressed, "#skills-review-diff")
+    async def review_skill_trust_diff(self, event: Button.Pressed) -> None:
+        event.stop()
+        selected_record = self._selected_skill_record()
+        if not self._can_review_skill_trust(selected_record):
+            self._notify_skill_trust_warning(
+                "Select a metadata-valid trust-blocked skill with changed files before reviewing."
+            )
+            return
+        skill_name = self._skill_name(selected_record)
+        result, ok = await self._call_skill_trust_service("capture_review", skill_name)
+        if not ok:
+            return
+        if not isinstance(result, Mapping) or not result.get("review_id"):
+            self._notify_skill_trust_warning(
+                "Local skill trust review could not be captured."
+            )
+            return
+        self._active_trust_review = dict(result)
+        self._apply_selected_skill_widgets()
+        await self._reload_local_skills_context()
+
+    @on(Button.Pressed, "#skills-trust-reviewed-version")
+    async def trust_reviewed_skill_version(self, event: Button.Pressed) -> None:
+        event.stop()
+        if self._active_trust_review is None:
+            self._notify_skill_trust_warning(
+                "Capture a local skill trust review before approving this version."
+            )
+            return
+        review_id = self._safe_skill_text(
+            self._active_trust_review.get("review_id"),
+            max_length=128,
+        )
+        if not review_id:
+            self._notify_skill_trust_warning(
+                "Local skill trust review could not be approved."
+            )
+            return
+        _, ok = await self._call_skill_trust_service(
+            "trust_reviewed_snapshot",
+            review_id,
+        )
+        if ok:
+            self._active_trust_review = None
+            await self._reload_local_skills_context()
 
     @on(Button.Pressed, "#skills-attach-to-console")
     def attach_to_console(self, event: Button.Pressed) -> None:
@@ -470,10 +856,17 @@ class SkillsScreen(BaseAppScreen):
                 )
             return
         if not self._is_skill_valid(selected_record):
+            if (
+                self._skill_validation_status(selected_record) == "valid"
+                and self._skill_trust_blocked(selected_record)
+            ):
+                warning = "Resolve the local skill trust block before staging this skill in Console."
+            else:
+                warning = "Fix SKILL.md validation errors before staging this skill in Console."
             notify = getattr(self.app_instance, "notify", None)
             if callable(notify):
                 notify(
-                    "Fix SKILL.md validation errors before staging this skill in Console.",
+                    warning,
                     severity="warning",
                 )
             return

--- a/tldw_chatbook/UI/Screens/skills_screen.py
+++ b/tldw_chatbook/UI/Screens/skills_screen.py
@@ -183,6 +183,7 @@ class SkillsScreen(BaseAppScreen):
         self._skills_lookup_recovery_state = recovery_state
         self._skills_loaded = True
         self._ensure_selected_skill()
+        self._reconcile_active_trust_review()
         if self.is_mounted:
             self.refresh(recompose=True)
 
@@ -320,6 +321,40 @@ class SkillsScreen(BaseAppScreen):
         }
         return trust_copy.get(status, "Trust: blocked")
 
+    def _skill_trust_blocked_copy(self, record: Mapping[str, Any]) -> str:
+        status = self._skill_trust_status(record)
+        blocked_copy = {
+            "trust_uninitialized": (
+                "local skill trust has not been initialized. "
+                "Next: Bootstrap Trust after reviewing current local skill files."
+            ),
+            "trust_locked": (
+                "local skill trust is locked. "
+                "Next: Unlock Trust with the trust passphrase."
+            ),
+            "quarantined_modified": (
+                "local skill files changed since the trusted baseline. "
+                "Next: Review Diff, then Trust Reviewed Version."
+            ),
+            "quarantined_added": (
+                "local skill files include new untrusted files. "
+                "Next: Review Diff, then Trust Reviewed Version."
+            ),
+            "quarantined_deleted": (
+                "trusted local skill files are missing. "
+                "Next: Review Diff, then Trust Reviewed Version."
+            ),
+            "quarantined_manifest_error": (
+                "local skill trust manifest cannot be verified. "
+                "Next: resolve local trust state before staging."
+            ),
+            "quarantined_unsupported_path": (
+                "local skill files include unsupported paths. "
+                "Next: remove unsupported paths before staging."
+            ),
+        }
+        return blocked_copy.get(status, "local skill trust blocks execution. Next: resolve trust state before staging.")
+
     def _can_review_skill_trust(self, record: Mapping[str, Any] | None) -> bool:
         if record is None:
             return False
@@ -331,6 +366,52 @@ class SkillsScreen(BaseAppScreen):
 
     def _has_trust_status(self, trust_status: str) -> bool:
         return any(self._skill_trust_status(record) == trust_status for record in self._local_skill_records)
+
+    @staticmethod
+    def _review_file_label(value: Any) -> str:
+        text = str(value or "").replace("\\", "/").strip()
+        if not text:
+            return ""
+        if text.startswith("/") or text.startswith("~") or ":" in text:
+            text = text.rsplit("/", 1)[-1]
+        text = text.replace("..", "").strip("/ ")
+        return sanitize_string(text, max_length=100).strip()
+
+    def _active_review_changed_files(self) -> list[str]:
+        if self._active_trust_review is None:
+            return []
+        files = self._active_trust_review.get("changed_files")
+        if not isinstance(files, (list, tuple)):
+            return []
+        changed_files = []
+        for file_name in files:
+            safe_file_name = self._review_file_label(file_name)
+            if safe_file_name and validate_text_input(safe_file_name, max_length=100, allow_html=False):
+                changed_files.append(safe_file_name)
+        return changed_files
+
+    def _active_review_matches_selected(self, metadata: Mapping[str, Any] | None = None) -> bool:
+        if self._active_trust_review is None:
+            return False
+        metadata = metadata or self._selected_skill_metadata()
+        if not metadata:
+            return False
+        if not metadata.get("trust_reviewable"):
+            return False
+        return (
+            self._active_trust_review.get("selected_skill_name") == metadata.get("selected_skill_name")
+            and self._active_trust_review.get("selected_record_id") == metadata.get("selected_record_id")
+            and self._active_trust_review.get("selected_target_id") == metadata.get("selected_target_id")
+        )
+
+    def _reconcile_active_trust_review(self) -> None:
+        if self._active_trust_review is None:
+            return
+        if self._skills_lookup_error or not self._local_skill_records:
+            self._active_trust_review = None
+            return
+        if not self._active_review_matches_selected():
+            self._active_trust_review = None
 
     def _is_skill_valid(self, record: Mapping[str, Any]) -> bool:
         return self._skill_validation_status(record) == "valid" and not self._skill_trust_blocked(record)
@@ -423,7 +504,7 @@ class SkillsScreen(BaseAppScreen):
         stageable = bool(metadata["stageable"])
         reason = "; ".join(metadata["validation_errors"]) or "Selected skill is not valid."
         if metadata["validation_status"] == "valid" and metadata["trust_blocked"]:
-            reason = f"trust blocked ({metadata['trust_reason_code'] or metadata['trust_status']})"
+            reason = self._skill_trust_blocked_copy(self._selected_skill_record() or {})
         updates = {
             "#skills-selected-context": f"Selected: {selected_name}",
             "#skills-selected-runtime-target": f"Runtime target: {target_id}",
@@ -431,6 +512,11 @@ class SkillsScreen(BaseAppScreen):
                 "Execution: ready to stage in Console" if stageable else "Execution: blocked"
             ),
             "#skills-execution-blocked-reason": "" if stageable else f"Reason: {reason}",
+            "#skills-selected-trust-reason-code": (
+                f"Reason code: {metadata['trust_reason_code']}"
+                if metadata["trust_blocked"] and metadata["trust_reason_code"]
+                else ""
+            ),
         }
         for selector, text in updates.items():
             for widget in self.query(selector):
@@ -455,10 +541,11 @@ class SkillsScreen(BaseAppScreen):
                 )
         for button in self.query("#skills-trust-reviewed-version"):
             if isinstance(button, Button):
-                button.disabled = self._active_trust_review is None
+                review_bound = self._active_review_matches_selected(metadata)
+                button.disabled = not review_bound
                 button.tooltip = (
                     "Trust the captured reviewed skill snapshot."
-                    if self._active_trust_review is not None
+                    if review_bound
                     else "Capture a trust review before approving this skill version."
                 )
 
@@ -621,7 +708,7 @@ class SkillsScreen(BaseAppScreen):
                         )
                         if selected_metadata["validation_status"] == "valid" and selected_metadata["trust_blocked"]:
                             selected_blocked_reason = (
-                                f"trust blocked ({selected_metadata['trust_reason_code'] or selected_metadata['trust_status']})"
+                                self._skill_trust_blocked_copy(self._selected_skill_record() or {})
                             )
                         yield Static(
                             "Execution: ready to stage in Console"
@@ -635,6 +722,33 @@ class SkillsScreen(BaseAppScreen):
                             ),
                             id="skills-execution-blocked-reason",
                         )
+                        yield Static(
+                            self._plain_text(
+                                f"Reason code: {selected_metadata['trust_reason_code']}"
+                                if selected_metadata["trust_blocked"] and selected_metadata["trust_reason_code"]
+                                else ""
+                            ),
+                            id="skills-selected-trust-reason-code",
+                        )
+                        if self._active_review_matches_selected(selected_metadata):
+                            review_files = ", ".join(self._active_review_changed_files()) or "selected files"
+                            yield Static(
+                                "Trust Review",
+                                id="skills-trust-review-title",
+                                classes="destination-section",
+                            )
+                            yield Static(
+                                self._plain_text(
+                                    f"Reviewed skill: {selected_metadata['selected_skill_name']}"
+                                ),
+                                id="skills-trust-review-skill",
+                            )
+                            yield Static(
+                                self._plain_text(
+                                    f"Review captured: {review_files}. Confirm these current files should become the trusted baseline."
+                                ),
+                                id="skills-trust-review-summary",
+                            )
                     yield Static("Actions", classes="destination-section")
                     yield Static(
                         "Skill import is not wired in this shell yet.",
@@ -677,7 +791,7 @@ class SkillsScreen(BaseAppScreen):
                             else "Review is available only for metadata-valid local skills blocked by changed files."
                         ),
                     )
-                    review_active = self._active_trust_review is not None
+                    review_active = self._active_review_matches_selected(selected_metadata)
                     yield Button(
                         "Trust Reviewed Version",
                         id="skills-trust-reviewed-version",
@@ -806,6 +920,7 @@ class SkillsScreen(BaseAppScreen):
             )
             return
         skill_name = self._skill_name(selected_record)
+        selected_metadata = self._selected_skill_metadata()
         result, ok = await self._call_skill_trust_service("capture_review", skill_name)
         if not ok:
             return
@@ -814,7 +929,12 @@ class SkillsScreen(BaseAppScreen):
                 "Local skill trust review could not be captured."
             )
             return
-        self._active_trust_review = dict(result)
+        self._active_trust_review = {
+            **dict(result),
+            "selected_skill_name": selected_metadata.get("selected_skill_name"),
+            "selected_record_id": selected_metadata.get("selected_record_id"),
+            "selected_target_id": selected_metadata.get("selected_target_id"),
+        }
         self._apply_selected_skill_widgets()
         await self._reload_local_skills_context()
 
@@ -825,6 +945,15 @@ class SkillsScreen(BaseAppScreen):
             self._notify_skill_trust_warning(
                 "Capture a local skill trust review before approving this version."
             )
+            return
+        if not self._active_review_matches_selected():
+            self._active_trust_review = None
+            self._notify_skill_trust_warning(
+                "Capture a fresh local skill trust review before approving this version."
+            )
+            self._apply_selected_skill_widgets()
+            if self.is_mounted:
+                self.refresh(recompose=True)
             return
         review_id = self._safe_skill_text(
             self._active_trust_review.get("review_id"),

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -279,7 +279,7 @@ from tldw_chatbook.Skills_Interop import (
 from tldw_chatbook.Skills_Interop.skill_trust_store import (
     SkillTrustStore,
     build_default_skill_trust_key_cache,
-    build_default_skill_trust_marker_store,
+    build_skill_trust_marker_store_with_fallback,
 )
 from tldw_chatbook.Sync_Interop import (
     LocalFirstSyncService,
@@ -2413,15 +2413,20 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
                 policy_enforcer=self.service_policy_enforcer,
             )
         local_skills_store_dir = get_user_data_dir() / "skills"
+        skill_trust_marker_store, reduced_rollback_protection = (
+            build_skill_trust_marker_store_with_fallback(
+                fallback_marker_path=local_skills_store_dir / "trust" / "generation_marker.json"
+            )
+        )
         self.local_skill_trust_service = SkillTrustService(
             skills_dir=local_skills_store_dir / "skills",
             trust_store=SkillTrustStore(
                 store_dir=local_skills_store_dir / "trust",
-                marker_store=build_default_skill_trust_marker_store(),
+                marker_store=skill_trust_marker_store,
             ),
             key_cache=build_default_skill_trust_key_cache(),
             keyring_convenience_enabled=False,
-            reduced_rollback_protection=False,
+            reduced_rollback_protection=reduced_rollback_protection,
         )
         self.local_skills_service = LocalSkillsService(
             store_dir=local_skills_store_dir,

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -270,7 +270,17 @@ from tldw_chatbook.Research_Interop import (
 )
 from tldw_chatbook.Server_Runtime_Interop import ServerRuntimeScopeService, ServerRuntimeService
 from tldw_chatbook.Sharing_Interop import ServerSharingService, SharingScopeService
-from tldw_chatbook.Skills_Interop import LocalSkillsService, ServerSkillsService, SkillsScopeService
+from tldw_chatbook.Skills_Interop import (
+    LocalSkillsService,
+    ServerSkillsService,
+    SkillTrustService,
+    SkillsScopeService,
+)
+from tldw_chatbook.Skills_Interop.skill_trust_store import (
+    SkillTrustStore,
+    build_default_skill_trust_key_cache,
+    build_default_skill_trust_marker_store,
+)
 from tldw_chatbook.Sync_Interop import (
     LocalFirstSyncService,
     ManualSyncControlService,
@@ -2402,9 +2412,21 @@ class TldwCli(App[None]):  # Specify return type for run() if needed, None is co
                 client=None,
                 policy_enforcer=self.service_policy_enforcer,
             )
+        local_skills_store_dir = get_user_data_dir() / "skills"
+        self.local_skill_trust_service = SkillTrustService(
+            skills_dir=local_skills_store_dir / "skills",
+            trust_store=SkillTrustStore(
+                store_dir=local_skills_store_dir / "trust",
+                marker_store=build_default_skill_trust_marker_store(),
+            ),
+            key_cache=build_default_skill_trust_key_cache(),
+            keyring_convenience_enabled=False,
+            reduced_rollback_protection=False,
+        )
         self.local_skills_service = LocalSkillsService(
-            store_dir=get_user_data_dir() / "skills",
+            store_dir=local_skills_store_dir,
             policy_enforcer=self.service_policy_enforcer,
+            trust_service=self.local_skill_trust_service,
         )
         self.skills_scope_service = SkillsScopeService(
             local_service=self.local_skills_service,

--- a/tldw_chatbook/runtime_policy/registry.py
+++ b/tldw_chatbook/runtime_policy/registry.py
@@ -139,6 +139,12 @@ DELETE = _action("delete", "delete")
 PURGE = _action("purge", "delete")
 CANCEL = _action("cancel", "delete")
 LAUNCH = _action("launch", "launch")
+UNLOCK = _action("unlock", "launch")
+REVIEW = _action("review", "detail")
+REJECT = _action("reject", "update")
+REBOOTSTRAP = _action("rebootstrap", "update")
+ROTATE_KEY = _action("rotate_key", "update")
+AUDIT = _action("audit", "detail")
 OBSERVE = _action("observe", "observe")
 OBSERVE_LIST = _action("list", "observe")
 CONFIGURE = _action("configure", "update")
@@ -780,6 +786,11 @@ AUDITED_CAPABILITY_SEEDS = (
             _resource("skills.export", actions=(LAUNCH,)),
             _resource("skills.execute", actions=(LAUNCH,)),
             _resource("skills.seed", actions=(LAUNCH,)),
+            _resource(
+                "skills.trust",
+                actions=(UNLOCK, REVIEW, APPROVE, REJECT, REBOOTSTRAP, ROTATE_KEY, AUDIT),
+                sources=LOCAL_ONLY_SOURCES,
+            ),
         ),
     ),
     _capability(


### PR DESCRIPTION
## Summary
- Add passphrase-rooted local skill trust models, crypto, scanner, authenticated store, encrypted snapshots, generation markers, and trust orchestration for Chatbook-managed local skills.
- Enforce trust in LocalSkillsService/app wiring, including fail-closed context/execute behavior and exact in-memory content verification before prompt rendering.
- Surface trust posture and recovery in Skills UI, Settings Privacy, and runtime-policy action IDs; close Backlog TASK-137 with ADR-009 and plan references.

## Test Plan
- [x] .venv/bin/python -m pytest -q Tests/Skills/test_skill_trust_crypto.py Tests/Skills/test_skill_trust_scanner.py Tests/Skills/test_skill_trust_store.py Tests/Skills/test_skill_trust_service.py Tests/Skills/test_local_skills_service.py Tests/Skills/test_skills_scope_service.py --tb=short
- [x] .venv/bin/python -m pytest -q Tests/RuntimePolicy/test_domain_edge_contracts.py Tests/RuntimePolicy/test_runtime_policy_core.py --tb=short
- [x] .venv/bin/python -m pytest -q Tests/UI/test_destination_shells.py -k "skills_destination or skills_attach" --tb=short
- [x] .venv/bin/python -m pytest -q Tests/UI/test_settings_privacy_security.py Tests/UI/test_screen_navigation.py --tb=short
- [x] git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds passphrase‑rooted trust and integrity checks for Chatbook‑managed local skills to block tampered prompts and guide user review/recovery. Also adds a resilient stream shutdown path and improves privacy posture reporting; meets TASK‑137.

- **New Features**
  - Local skill trust: passphrase bootstrap, encrypted snapshots (AES‑GCM), HMAC manifest, authenticated store, and trust orchestration wired into `LocalSkillsService` and app init with keyring marker/key cache.
  - Fail‑closed skill context/execute with exact in‑memory content verification (CRLF‑safe); trust posture surfaced in Skills and Settings Privacy.
  - Runtime policy: adds `skills.trust.*.local` action IDs (unlock, review, approve, reject, rebootstrap, rotate_key, audit).

- **Bug Fixes**
  - Console rail/sessions: bounded/collapsible/searchable conversation list; fix rail switching and active visibility; clear stale run status; resilient stream shutdown ignores failed tasks and resets state.
  - Console settings/actions: stabilize model selector focus and single‑model rules; recover input‑select after edits; fix send tooltip; clean up continue action selection.
  - Skills: normalize `blocked_skills` in scope service; harden trust review UI (clear stale summaries, safer inputs).
  - Providers: pass `max_tokens` to HuggingFace; harden router URL normalization; map Groq token limits; normalize Google Gemini `candidates`; safer provider error copy.
  - Settings Privacy/Security: report local skill trust posture without leaking paths; keep redaction active.
  - UI/CSS and QA/specs: tokenize agentic pane border colors; restore Textual highlight selectors; add conversation‑rail overflow design and CDP evidence; restore provider UAT traceability; extend Library Source Workbench and content‑hub closeout evidence.

<sup>Written for commit 9df55ba3e7f0f456b2a4bc2eeac6d4240901c809. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

