### PR TITLE
Fix Personas service failure recovery state

### DIFF
--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -597,6 +597,30 @@ class TestPersonasMode:
             stub_scope_service.create_persona_profile.assert_awaited_once()
             assert screen._edit_mode == "view"
 
+    async def test_profile_save_refresh_failure_updates_status_row_and_recovery(
+        self, mock_app_instance, stub_characters, stub_scope_service
+    ):
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test() as pilot:
+            screen = await self._enter_personas_mode(pilot)
+            assert "Personas: 1" in str(
+                screen.query_one("#personas-status-row", Static).renderable
+            )
+
+            stub_scope_service.list_persona_profiles.side_effect = RuntimeError("scope offline")
+            await pilot.click("#personas-library-new")
+            await pilot.pause()
+            screen.post_message(PersonaProfileSaveRequested({"name": "Mentor"}))
+            await pilot.pause()
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+
+            assert screen.query_one("#personas-service-error", Static)
+            assert not list(screen.query(".personas-library-row"))
+            assert "Personas: 0" in str(
+                screen.query_one("#personas-status-row", Static).renderable
+            )
+
     async def test_profile_edit_save_calls_update(
         self, mock_app_instance, stub_characters, stub_scope_service
     ):

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -520,6 +520,53 @@ class TestPersonasMode:
             rows = screen.query(".personas-library-row")
             assert [_row_text(r) for r in rows] == ["Archivist"]
 
+    async def test_personas_mode_service_failure_shows_recovery_state(
+        self, mock_app_instance, stub_characters, stub_scope_service
+    ):
+        stub_scope_service.list_persona_profiles.side_effect = RuntimeError("scope offline")
+
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test() as pilot:
+            screen = await self._enter_personas_mode(pilot)
+
+            recovery = screen.query_one("#personas-service-error", Static)
+            copy = str(recovery.renderable)
+            assert "Persona profiles unavailable" in copy
+            assert "Unavailable:" in copy
+            assert "Recovery:" in copy
+            assert "scope offline" in copy
+            assert not list(screen.query("#personas-library-empty"))
+
+    async def test_personas_mode_service_failure_replaces_stale_rows(
+        self, mock_app_instance, stub_characters, stub_scope_service
+    ):
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test() as pilot:
+            screen = await self._enter_personas_mode(pilot)
+            assert [_row_text(r) for r in screen.query(".personas-library-row")] == ["Archivist"]
+
+            stub_scope_service.list_persona_profiles.side_effect = RuntimeError("scope offline")
+            screen._refresh_profile_rows_worker()
+            await pilot.pause()
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+
+            assert screen.query_one("#personas-service-error", Static)
+            assert not list(screen.query(".personas-library-row"))
+
+    async def test_personas_mode_empty_state_copy_unchanged(
+        self, mock_app_instance, stub_characters, stub_scope_service
+    ):
+        stub_scope_service.list_persona_profiles.return_value = {"items": [], "total": 0}
+
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test() as pilot:
+            screen = await self._enter_personas_mode(pilot)
+
+            empty = screen.query_one("#personas-library-empty", Static)
+            assert str(empty.renderable) == "No persona profiles yet - use New to add one."
+            assert not list(screen.query("#personas-service-error"))
+
     async def test_profile_selection_shows_card(
         self, mock_app_instance, stub_characters, stub_scope_service
     ):

--- a/backlog/tasks/task-111 - Personas-library-shows-misleading-empty-state-on-service-failure.md
+++ b/backlog/tasks/task-111 - Personas-library-shows-misleading-empty-state-on-service-failure.md
@@ -38,6 +38,7 @@ Reason: bounded UI recovery-state bugfix; no storage/schema, sync policy, servic
 
 - Added strict persona profile list refresh handling for Personas workbench callers so missing or failing persona scope services produce a `DestinationRecoveryState` instead of being collapsed into an empty list.
 - Updated the Personas library pane to render a dedicated recovery row with a stable `#personas-service-error` selector; recovery replaces stale rows and the true empty copy remains unchanged for successful empty lists.
-- Added mounted regressions for service failure recovery, stale-row replacement, and true-empty state copy.
-- Verification: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_personas_workbench.py Tests/UI/test_ccp_handlers.py::TestCCPPersonaHandler::test_refresh_persona_list_routes_through_scope_service --tb=short` passed with 130 tests; `git diff --check` passed.
+- Added mounted regressions for service failure recovery, stale-row replacement, true-empty state copy, and post-save refresh failure status-row consistency.
+- Addressed PR review follow-up by clearing stale profile cache and refreshing `#personas-status-row` when a post-save list refresh enters recovery, and by documenting modified public methods with Google-style docstrings.
+- Verification: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_personas_workbench.py Tests/UI/test_ccp_handlers.py::TestCCPPersonaHandler::test_refresh_persona_list_routes_through_scope_service --tb=short` passed with 131 tests; `git diff --check` passed.
 - ADR check completed: no ADR required for this bounded UI recovery-state bugfix.

--- a/backlog/tasks/task-111 - Personas-library-shows-misleading-empty-state-on-service-failure.md
+++ b/backlog/tasks/task-111 - Personas-library-shows-misleading-empty-state-on-service-failure.md
@@ -1,10 +1,13 @@
 ---
 id: TASK-111
 title: Personas library shows misleading empty state on service failure
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-06-11 03:01'
-labels: []
+labels:
+  - personas
+  - recovery
+  - ux
 dependencies: []
 ---
 
@@ -16,5 +19,25 @@ When refresh_persona_list fails or the backend lacks persona support, the workbe
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Service failure renders recovery copy distinct from the true empty state,True empty state copy unchanged
+- [x] #1 Service failure renders recovery copy distinct from the true empty state,True empty state copy unchanged
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Trace the Personas profile list refresh path and identify where failures are collapsed into the true-empty state.
+2. Add a mounted regression that forces `refresh_persona_list()` to fail in Personas mode and asserts the library pane renders recovery copy instead of the true-empty copy.
+3. Add a companion assertion that a successful empty result keeps the existing true-empty state unchanged.
+4. Implement the smallest recovery-state path using the existing destination recovery vocabulary and stable selector.
+5. Run focused Personas workbench tests plus diff hygiene, then update acceptance criteria and notes.
+
+ADR required: no
+ADR path: N/A
+Reason: bounded UI recovery-state bugfix; no storage/schema, sync policy, service contract, or data ownership boundary changes.
+
+## Implementation Notes
+
+- Added strict persona profile list refresh handling for Personas workbench callers so missing or failing persona scope services produce a `DestinationRecoveryState` instead of being collapsed into an empty list.
+- Updated the Personas library pane to render a dedicated recovery row with a stable `#personas-service-error` selector; recovery replaces stale rows and the true empty copy remains unchanged for successful empty lists.
+- Added mounted regressions for service failure recovery, stale-row replacement, and true-empty state copy.
+- Verification: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_personas_workbench.py Tests/UI/test_ccp_handlers.py::TestCCPPersonaHandler::test_refresh_persona_list_routes_through_scope_service --tb=short` passed with 130 tests; `git diff --check` passed.
+- ADR check completed: no ADR required for this bounded UI recovery-state bugfix.

--- a/tldw_chatbook/UI/CCP_Modules/ccp_persona_handler.py
+++ b/tldw_chatbook/UI/CCP_Modules/ccp_persona_handler.py
@@ -93,11 +93,15 @@ class CCPPersonaHandler:
         except Exception:
             logger.debug("Persona editor widget unavailable during load", exc_info=True)
 
-    async def refresh_persona_list(self) -> List[Dict[str, Any]]:
+    async def refresh_persona_list(
+        self, *, raise_on_unavailable: bool = False
+    ) -> List[Dict[str, Any]]:
         """Refresh the available persona profile list from the shared scope service."""
         service = getattr(self.app_instance, "character_persona_scope_service", None)
         if service is None or not hasattr(service, "list_persona_profiles"):
             logger.debug("Persona scope service unavailable; returning empty persona list")
+            if raise_on_unavailable:
+                raise RuntimeError("Persona profile service is unavailable.")
             self.persona_list = []
             return self.persona_list
 
@@ -105,6 +109,8 @@ class CCPPersonaHandler:
             personas = await service.list_persona_profiles(mode=self._current_mode())
         except ValueError:
             logger.debug("Persona list unavailable in current mode", exc_info=True)
+            if raise_on_unavailable:
+                raise
             self.persona_list = []
             return self.persona_list
 

--- a/tldw_chatbook/UI/CCP_Modules/ccp_persona_handler.py
+++ b/tldw_chatbook/UI/CCP_Modules/ccp_persona_handler.py
@@ -96,7 +96,23 @@ class CCPPersonaHandler:
     async def refresh_persona_list(
         self, *, raise_on_unavailable: bool = False
     ) -> List[Dict[str, Any]]:
-        """Refresh the available persona profile list from the shared scope service."""
+        """Refresh the available persona profile list from the shared scope service.
+
+        Args:
+            raise_on_unavailable: When ``True``, raise instead of collapsing
+                missing persona-profile support or mode unavailability into an
+                empty list. Tolerant legacy callers keep the default ``False``.
+
+        Returns:
+            Normalized persona profile records available in the current runtime
+            mode.
+
+        Raises:
+            RuntimeError: If persona profile listing is unavailable and
+                ``raise_on_unavailable`` is ``True``.
+            ValueError: If the current mode cannot list persona profiles and
+                ``raise_on_unavailable`` is ``True``.
+        """
         service = getattr(self.app_instance, "character_persona_scope_service", None)
         if service is None or not hasattr(service, "list_persona_profiles"):
             logger.debug("Persona scope service unavailable; returning empty persona list")

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -1876,17 +1876,18 @@ class PersonasScreen(BaseAppScreen):
 
     async def _after_profile_save(self, saved: dict) -> None:
         # Refresh the cached profile list tolerantly even when the user has
-        # already left the screen or switched modes during the save.
         try:
             profiles = await self.persona_handler.refresh_persona_list(
                 raise_on_unavailable=True
             )
-            self._profiles = [dict(record) for record in (profiles or [])]
-            self._profile_lookup_recovery_state = None
         except Exception as exc:
             logger.warning("Could not refresh persona profiles after a save.", exc_info=True)
-            self._profiles = []
             self._profile_lookup_recovery_state = self._profile_list_recovery_state(exc)
+            profiles = []
+        else:
+            self._profile_lookup_recovery_state = None
+        self._profiles = [dict(record) for record in (profiles or [])]
+        self._update_status_row()
         self._update_status_row()
         if not self.is_mounted or self.state.active_mode != "personas":
             # Leave the selection, inspector, and center pane alone.

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -67,6 +67,7 @@ from ..CCP_Modules import ccp_character_handler
 from ..CCP_Modules.ccp_character_handler import CCPCharacterHandler
 from ..CCP_Modules.ccp_messages import CharacterMessage
 from ..CCP_Modules.ccp_persona_handler import CCPPersonaHandler
+from .destination_recovery import DestinationRecoveryState
 from ..Navigation.base_app_screen import BaseAppScreen
 from ..Navigation.shortcut_context import ShortcutAction, ShortcutContext
 from ..Persona_Modules.personas_conversations_controller import (
@@ -271,6 +272,7 @@ class PersonasScreen(BaseAppScreen):
         self._profile_save_inflight: bool = False
         self._characters: list[dict] = []
         self._profiles: list[dict] = []
+        self._profile_lookup_recovery_state: DestinationRecoveryState | None = None
         # Serializes library renders: the pane's update_rows has two
         # suspension points, so interleaved renders could double-mount rows.
         self._render_lock = asyncio.Lock()
@@ -431,14 +433,39 @@ class PersonasScreen(BaseAppScreen):
                 return record
         return None
 
+    def _profile_list_recovery_state(self, exc: Exception) -> DestinationRecoveryState:
+        """Build recovery copy when persona profile listing is unavailable."""
+
+        reason = str(exc).strip() or "The current backend did not return persona profiles."
+        disabled_tooltip = (
+            f"{reason} Retry Personas or use Characters until persona profiles are available."
+        )
+        return DestinationRecoveryState(
+            status_label="Persona profiles unavailable",
+            unavailable_what="Browse persona profiles in Personas",
+            why=reason,
+            next_action=(
+                "Check the current runtime backend or retry after persona profile support is available"
+            ),
+            recovery_action="Retry Personas or use Characters",
+            authority_owner="persona scope service",
+            stable_selector="personas-service-error",
+            disabled_tooltip=disabled_tooltip,
+        )
+
     @work(exclusive=True, group="personas-list-refresh")
     async def _refresh_profile_rows_worker(self) -> None:
         """Fetch persona profile rows and render them while still in Personas mode."""
         try:
-            profiles = await self.persona_handler.refresh_persona_list()
-        except Exception:
+            profiles = await self.persona_handler.refresh_persona_list(
+                raise_on_unavailable=True
+            )
+        except Exception as exc:
             logger.warning("Could not refresh the persona profile list.", exc_info=True)
+            self._profile_lookup_recovery_state = self._profile_list_recovery_state(exc)
             profiles = []
+        else:
+            self._profile_lookup_recovery_state = None
         self._profiles = [dict(record) for record in (profiles or [])]
         self._update_status_row()
         if not self.is_mounted or self.state.active_mode != "personas":
@@ -463,7 +490,21 @@ class PersonasScreen(BaseAppScreen):
         async with self._render_lock:
             rows = self._build_library_rows(matched, "persona_profile")
             library = self.query_one(PersonasLibraryPane)
-            await library.update_rows(rows, total=total, noun="persona profiles", filtered=filtered)
+            recovery_state = self._profile_lookup_recovery_state
+            await library.update_rows(
+                rows,
+                total=total,
+                noun="persona profiles",
+                filtered=filtered,
+                recovery_copy=(
+                    recovery_state.visible_copy if recovery_state is not None else None
+                ),
+                recovery_id=(
+                    recovery_state.stable_selector
+                    if recovery_state is not None
+                    else "personas-library-recovery"
+                ),
+            )
             if self.state.selected_entity_kind == "persona_profile" and self.state.selected_entity_id:
                 library.mark_active_row("persona_profile", self.state.selected_entity_id)
 
@@ -560,6 +601,7 @@ class PersonasScreen(BaseAppScreen):
             await self._render_library_rows()
             self._show_center(None)
         elif mode == "personas":
+            self._profile_lookup_recovery_state = None
             await library.update_rows((), total=0, noun="persona profiles")
             self._show_center(None)
             self._refresh_profile_rows_worker()
@@ -1836,10 +1878,14 @@ class PersonasScreen(BaseAppScreen):
         # Refresh the cached profile list tolerantly even when the user has
         # already left the screen or switched modes during the save.
         try:
-            profiles = await self.persona_handler.refresh_persona_list()
+            profiles = await self.persona_handler.refresh_persona_list(
+                raise_on_unavailable=True
+            )
             self._profiles = [dict(record) for record in (profiles or [])]
-        except Exception:
+            self._profile_lookup_recovery_state = None
+        except Exception as exc:
             logger.warning("Could not refresh persona profiles after a save.", exc_info=True)
+            self._profile_lookup_recovery_state = self._profile_list_recovery_state(exc)
         if not self.is_mounted or self.state.active_mode != "personas":
             # Leave the selection, inspector, and center pane alone.
             return

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -1885,7 +1885,9 @@ class PersonasScreen(BaseAppScreen):
             self._profile_lookup_recovery_state = None
         except Exception as exc:
             logger.warning("Could not refresh persona profiles after a save.", exc_info=True)
+            self._profiles = []
             self._profile_lookup_recovery_state = self._profile_list_recovery_state(exc)
+        self._update_status_row()
         if not self.is_mounted or self.state.active_mode != "personas":
             # Leave the selection, inspector, and center pane alone.
             return

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_library_pane.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_library_pane.py
@@ -61,6 +61,18 @@ class PersonasLibraryPane(Vertical):
         text-wrap: nowrap;
         text-overflow: ellipsis;
     }
+
+    PersonasLibraryPane #personas-library-rows ListItem.personas-library-recovery-row {
+        height: auto;
+        min-height: 6;
+    }
+
+    PersonasLibraryPane #personas-library-rows ListItem.personas-library-recovery-row Static {
+        height: auto;
+        min-height: 6;
+        text-wrap: wrap;
+        text-overflow: clip;
+    }
     """
 
     def __init__(self, **kwargs) -> None:
@@ -99,13 +111,24 @@ class PersonasLibraryPane(Vertical):
         total: int,
         noun: str,
         filtered: bool = False,
+        recovery_copy: str | None = None,
+        recovery_id: str = "personas-library-recovery",
     ) -> None:
         """Replace the visible rows and count line."""
         list_view = self.query_one("#personas-library-rows", ListView)
         await list_view.clear()
         self._row_lookup = {}
         items: list[ListItem] = []
-        if not rows:
+        visible_rows = () if recovery_copy else rows
+        if recovery_copy:
+            items.append(
+                ListItem(
+                    Static(recovery_copy, id=recovery_id, markup=False),
+                    classes="personas-library-recovery-row",
+                    disabled=True,
+                )
+            )
+        elif not visible_rows:
             hint = "use New or Import" if self._import_visible else "use New"
             items.append(
                 ListItem(
@@ -118,7 +141,7 @@ class PersonasLibraryPane(Vertical):
                 )
             )
         seen: set[str] = set()
-        for row in rows:
+        for row in visible_rows:
             dom_id = _row_dom_id(row.kind, row.item_id)
             if dom_id in seen:
                 suffix = 2
@@ -134,7 +157,10 @@ class PersonasLibraryPane(Vertical):
                 ListItem(Static(row.name, markup=False), id=dom_id, classes=classes)
             )
         await list_view.extend(items)
-        count = f"{len(rows)} of {total} {noun}" if filtered else f"{total} {noun}"
+        if recovery_copy:
+            count = f"{noun.capitalize()} unavailable"
+        else:
+            count = f"{len(rows)} of {total} {noun}" if filtered else f"{total} {noun}"
         self.query_one("#personas-library-count", Static).update(count)
 
     def mark_active_row(self, kind: str, item_id: str) -> None:

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_library_pane.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_library_pane.py
@@ -114,7 +114,22 @@ class PersonasLibraryPane(Vertical):
         recovery_copy: str | None = None,
         recovery_id: str = "personas-library-recovery",
     ) -> None:
-        """Replace the visible rows and count line."""
+        """Replace the visible rows and count line.
+
+        Args:
+            rows: Selectable library rows to render when no recovery state is
+                active.
+            total: Total number of rows known for the current mode.
+            noun: User-facing noun used in empty and count copy.
+            filtered: Whether ``rows`` is a filtered subset of ``total``.
+            recovery_copy: Optional multi-line recovery copy. When present, the
+                pane renders a disabled recovery row instead of list or empty
+                rows.
+            recovery_id: Stable DOM id for the recovery copy widget.
+
+        Returns:
+            None.
+        """
         list_view = self.query_one("#personas-library-rows", ListView)
         await list_view.clear()
         self._row_lookup = {}


### PR DESCRIPTION
## Summary
- Render a distinct Personas profile recovery state when the persona scope service is unavailable or fails.
- Preserve the true empty Personas copy for successful empty results.
- Replace stale profile rows with the recovery row after later list refresh failures.

## Test Plan
- [x] python -m pytest -q Tests/UI/test_personas_workbench.py Tests/UI/test_ccp_handlers.py::TestCCPPersonaHandler::test_refresh_persona_list_routes_through_scope_service --tb=short
- [x] git diff --check HEAD~1..HEAD

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a dedicated recovery state in Personas when the persona scope service is unavailable or fails, while keeping the true empty state for real empty results. Recovery replaces stale rows, shows the failure reason, updates count/status after saves, and clears on mode switch. Addresses TASK-111.

- **Bug Fixes**
  - Personas screen builds `DestinationRecoveryState` on list failures and passes `recovery_copy`/`recovery_id` (`#personas-service-error`) to the library; recovery is cleared when entering Personas; count shows “Persona profiles unavailable.”
  - Added `refresh_persona_list(raise_on_unavailable=True)` so callers can surface outages or mode limits instead of collapsing to empty; documented with docstrings.
  - Library pane renders a disabled, multi-line recovery row with a stable id and wrapped text; preserves the true empty-state copy for successful empty results; replaces stale rows.
  - Tests added for recovery rendering, stale-row replacement, true-empty copy, and status-row updates on post-save refresh failures.

<sup>Written for commit 1defde3f28fc5b7635b24f45e307b2593aca9dd5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

