### PR TITLE
TASK-139 core app usability smoke gate

### DIFF
--- a/Docs/superpowers/plans/2026-06-26-core-app-usability-smoke-gate.md
+++ b/Docs/superpowers/plans/2026-06-26-core-app-usability-smoke-gate.md
@@ -1,0 +1,84 @@
+# Core App Usability Smoke Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prove latest `dev` still supports the core first-use app path without starting Sync or Persona work.
+
+**Architecture:** Keep this as a focused smoke/evidence slice over existing app behavior. Add automated coverage only where current smoke tests leave a gap, and treat any newly found product defect as either an in-scope fix with a failing test first or a separate backlog task if it belongs to another owner.
+
+**Tech Stack:** Python 3.11, pytest, Textual `run_test`, existing `TldwCli` test harness, Backlog.md.
+
+---
+
+### Task 1: Confirm TASK-88 Readiness Gate
+
+**Files:**
+- Read: `backlog/tasks/task-88 - Functionalize-Settings-MCP-defaults-after-Unified-MCP-upgrade.md`
+- Read: `tldw_chatbook/tldw_api/mcp_unified_client.py`
+- Read: `tldw_chatbook/tldw_api/mcp_unified_schemas.py`
+- Read: `tldw_chatbook/MCP/server_unified_service.py`
+- Read: `tldw_chatbook/MCP/unified_control_plane_service.py`
+- Modify: `backlog/tasks/task-139 - Latest-dev-core-app-usability-smoke-gate.md`
+
+- [x] **Step 1: Check for a server-first persisted MCP defaults contract**
+
+Run targeted `rg` and method-list scans for MCP defaults/settings APIs.
+
+Expected: No `MCPUnifiedClient`, schema, or service method exposes persisted MCP defaults separate from runtime/governance management.
+
+- [x] **Step 2: Decide ADR need**
+
+ADR required: no.
+Reason: TASK-139 does not add a new architecture boundary; it records that TASK-88 remains contract-gated and adds a QA smoke gate.
+
+### Task 2: Add Focused Core Smoke Coverage
+
+**Files:**
+- Create or modify: `Tests/UI/test_latest_dev_core_app_usability_smoke.py`
+- Reuse patterns from: `Tests/UI/test_product_maturity_phase1_navigation_smoke.py`
+- Reuse patterns from: `Tests/UI/test_product_maturity_phase1_core_loop.py`
+- Reuse patterns from: `Tests/UI/test_product_maturity_phase6_focus_visual_sweep.py`
+
+- [x] **Step 1: Write the smoke test first**
+
+Add a test that starts from a clean first-run environment, reaches Home, navigates only through core non-Sync/non-Persona destinations, and asserts no traceback, empty chrome, raw object repr, or local path leak is rendered.
+
+- [x] **Step 2: Run the smoke test**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/UI/test_latest_dev_core_app_usability_smoke.py --tb=short
+```
+
+Expected: If the behavior already works, the new gate passes. If it exposes a concrete defect, keep the failing test and fix only that defect.
+
+- [x] **Step 3: Add Console recovery and Library-to-Console checks**
+
+Cover the setup-required Console state and deterministic Library/Search-RAG handoff to Console staged context by reusing existing harness patterns instead of changing product behavior.
+
+### Task 3: Verify And Record Evidence
+
+**Files:**
+- Create: `Docs/superpowers/qa/core-app-usability-smoke/2026-06-26-latest-dev-core-app-smoke.md`
+- Modify: `backlog/tasks/task-139 - Latest-dev-core-app-usability-smoke-gate.md`
+
+- [x] **Step 1: Run focused verification**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest -q Tests/UI/test_latest_dev_core_app_usability_smoke.py Tests/UI/test_product_maturity_phase1_navigation_smoke.py Tests/UI/test_product_maturity_phase1_core_loop.py --tb=short
+```
+
+- [x] **Step 2: Run diff hygiene**
+
+Run:
+
+```bash
+git diff --check
+```
+
+- [x] **Step 3: Record evidence and close task**
+
+Record command outcomes, scope exclusions, and any follow-up tasks in the QA evidence file. Then check off TASK-139 acceptance criteria, add implementation notes, and set status to Done.

--- a/Docs/superpowers/qa/core-app-usability-smoke/2026-06-26-latest-dev-core-app-smoke.md
+++ b/Docs/superpowers/qa/core-app-usability-smoke/2026-06-26-latest-dev-core-app-smoke.md
@@ -1,0 +1,49 @@
+# Latest Dev Core App Usability Smoke Evidence
+
+Date: 2026-06-26
+Task: TASK-139
+Branch: codex/next-app-usability-scan
+Base HEAD: 2fef598b (Merge pull request #562 from rmusser01/codex/retire-legacy-entrypoints)
+
+## Scope
+
+- Covered clean first-run Home launch and non-Sync/non-Persona first-use routes: Home, Console, Library, Skills, MCP, Settings.
+- Covered Home model-setup recovery into Settings > Providers & Models.
+- Covered deterministic Library-to-Console staged context.
+- Explicitly excluded Sync and Persona implementation ownership.
+
+## Readiness Gate
+
+TASK-88 remains blocked. The current Unified MCP client/service/schema surfaces expose runtime, governance, tools, external server, credential, ACP, path, and workspace operations, but not a confirmed server-first persisted MCP defaults contract for Settings to own safely.
+
+## Red Findings
+
+- Settings Overview leaked the full local config path in first-run rendered content.
+- Home "Set up Console model" opened the legacy model route instead of taking the user to the Settings/provider configuration recovery path.
+
+## Fixes
+
+- Settings Overview now shows a non-sensitive config file label while leaving explicit Storage/Diagnostics detail surfaces unchanged.
+- Home model setup now routes to Settings and passes existing `providers-models` navigation context.
+- Added focused smoke coverage and tightened Home/Settings regression tests around these behaviors.
+
+## Verification
+
+- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_latest_dev_core_app_usability_smoke.py --tb=short`
+  - Result: 3 passed, 1 warning.
+- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Home/test_dashboard_state.py Tests/UI/test_home_screen.py::test_home_selected_action_uses_user_facing_route_labels Tests/UI/test_settings_configuration_hub.py::test_settings_overview_config_path_label_hides_local_directory Tests/UI/test_settings_configuration_hub.py::test_settings_first_slice_categories_have_real_content --tb=short`
+  - Result: 20 passed, 8 warnings.
+- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_home_screen.py Tests/UI/test_product_maturity_phase1_first_run.py --tb=short`
+  - Result: 43 passed, 1 warning.
+- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_product_maturity_phase1_empty_setup_states.py --tb=short`
+  - Result: 6 passed, 1 warning.
+- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_latest_dev_core_app_usability_smoke.py Tests/UI/test_product_maturity_phase1_navigation_smoke.py Tests/UI/test_product_maturity_phase1_core_loop.py --tb=short`
+  - Result: 7 passed, 1 warning.
+- `git diff --check`
+  - Result: passed.
+
+Warnings were existing dependency/import warnings and did not affect the smoke outcome.
+
+## Follow-Ups
+
+No new backlog defects were opened from this slice.

--- a/Tests/UI/test_home_screen.py
+++ b/Tests/UI/test_home_screen.py
@@ -14,6 +14,7 @@ from tldw_chatbook.Home.active_work_adapter import (
 from tldw_chatbook.Home.dashboard_state import HomeActiveWorkItem, HomeDashboardInput
 from tldw_chatbook.runtime_policy.types import RuntimeSourceState
 from tldw_chatbook.UI.Screens.home_screen import HomeScreen
+from tldw_chatbook.UI.Screens.settings_config_models import SettingsCategoryId
 from Tests.UI.test_screen_navigation import _build_test_app
 
 
@@ -31,12 +32,14 @@ class HomeHarness(App):
         super().__init__()
         self.app_instance = app_instance
         self.seen_routes = seen_routes if seen_routes is not None else []
+        self.seen_contexts = []
 
     async def on_mount(self) -> None:
         await self.push_screen(HomeScreen(self.app_instance))
 
     def on_navigate_to_screen(self, message) -> None:
         self.seen_routes.append(message.screen_name)
+        self.seen_contexts.append(dict(message.screen_context or {}))
 
 
 def _active_home_screen(host: HomeHarness):
@@ -288,7 +291,7 @@ async def test_home_selected_action_uses_user_facing_route_labels():
 
         selected_text = str(home.query_one("#home-selected-item-body").renderable)
         assert "Set up Console model" in selected_text
-        assert "Destination: Models" in selected_text
+        assert "Destination: Settings" in selected_text
         assert "Destination: Llm" not in selected_text
 
 
@@ -380,6 +383,7 @@ async def test_home_followup_row_stays_compact_below_dashboard_grid():
 @pytest.mark.asyncio
 async def test_home_primary_action_opens_target_route():
     app = _build_test_app()
+    app._home_dashboard_test_input = HomeDashboardInput(model_ready=False)
     seen = []
     host = HomeHarness(app, seen)
 
@@ -388,7 +392,10 @@ async def test_home_primary_action_opens_target_route():
         await pilot.click("#home-primary-action")
         await pilot.pause(HOME_MOUNT_PAUSE)
 
-    assert seen[-1] in {"chat", "llm", "library", "schedules", "subscriptions"}
+    assert seen[-1] == "settings"
+    assert host.seen_contexts[-1] == {
+        "category": SettingsCategoryId.PROVIDERS_MODELS.value,
+    }
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_latest_dev_core_app_usability_smoke.py
+++ b/Tests/UI/test_latest_dev_core_app_usability_smoke.py
@@ -1,0 +1,220 @@
+"""Latest-dev core app usability smoke gate."""
+
+from __future__ import annotations
+
+import re
+import time
+from collections.abc import Callable
+from unittest.mock import patch
+
+import pytest
+from textual.css.query import NoMatches
+from textual.widgets import Button, Static
+
+from Tests.UI.test_product_maturity_phase1_core_loop import _core_loop_payload
+from Tests.UI.test_product_maturity_phase1_first_run import (
+    _assert_no_local_path_prefixes,
+    _build_clean_first_run_app,
+    _test_cli_setting,
+)
+from Tests.UI.test_screen_navigation import _build_test_app
+from tldw_chatbook.Constants import (
+    TAB_CHAT,
+    TAB_HOME,
+    TAB_LIBRARY,
+    TAB_MCP,
+    TAB_SETTINGS,
+    TAB_SKILLS,
+)
+from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
+from tldw_chatbook.UI.Screens.settings_config_models import SettingsCategoryId
+from tldw_chatbook.Widgets.Console.console_composer_bar import ConsoleComposerBar
+
+
+RAW_OBJECT_REPR = re.compile(r"<[\w.]+ object at 0x[0-9a-fA-F]+>")
+BROKEN_TEXT_PATTERNS = (
+    "Traceback",
+    "Unhandled exception",
+    "No screens installed",
+    "Unable to mount",
+    "Internal Error",
+)
+CORE_FIRST_USE_ROUTES = (
+    (TAB_HOME, TAB_HOME, "HomeScreen", ("Home", "Set up Console model")),
+    (TAB_CHAT, TAB_CHAT, "ChatScreen", ("Console", "Live work sources")),
+    (TAB_LIBRARY, TAB_LIBRARY, "LibraryScreen", ("Library", "Search/RAG")),
+    (TAB_SKILLS, TAB_SKILLS, "SkillsScreen", ("Skills", "Agent Skills")),
+    (TAB_MCP, TAB_MCP, "MCPScreen", ("MCP", "Unified MCP")),
+    (TAB_SETTINGS, TAB_SETTINGS, "SettingsScreen", ("Settings", "Providers & Models")),
+)
+
+
+async def _wait_until(
+    pilot,
+    condition: Callable[[], bool],
+    *,
+    timeout_seconds: float = 10.0,
+    interval_seconds: float = 0.05,
+    context: str,
+) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if condition():
+            return
+        await pilot.pause(interval_seconds)
+    if condition():
+        return
+    raise AssertionError(f"condition was not met within {timeout_seconds:.1f}s for {context}")
+
+
+def _content_text(app) -> str:
+    try:
+        content = app.screen.query_one("#screen-content")
+    except NoMatches:
+        return ""
+    pieces: list[str] = []
+    for widget in content.query(Static):
+        pieces.append(str(widget.renderable))
+    for widget in content.query(Button):
+        pieces.append(str(widget.label).strip())
+    return "\n".join(piece for piece in pieces if piece.strip())
+
+
+def _assert_core_render_is_healthy(app, *, route: str) -> None:
+    text = _content_text(app)
+    assert text.strip(), f"{route} rendered empty content"
+    for broken_text in BROKEN_TEXT_PATTERNS:
+        assert broken_text not in text
+    assert RAW_OBJECT_REPR.search(text) is None
+    try:
+        _assert_no_local_path_prefixes(text)
+    except AssertionError as exc:
+        raise AssertionError(f"{route} leaked a local path in rendered content:\n{text}") from exc
+
+    svg = app.export_screenshot(title=f"Latest dev core smoke {route}", simplify=True)
+    assert "<svg" in svg
+    assert "</svg>" in svg
+    assert len(svg) > 1_000
+    for broken_text in BROKEN_TEXT_PATTERNS:
+        assert broken_text not in svg
+    assert RAW_OBJECT_REPR.search(svg) is None
+    try:
+        _assert_no_local_path_prefixes(svg)
+    except AssertionError as exc:
+        raise AssertionError(f"{route} leaked a local path in exported screenshot") from exc
+
+
+@pytest.mark.asyncio
+async def test_latest_dev_core_first_use_routes_exclude_sync_and_persona(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    app = _build_clean_first_run_app(monkeypatch, tmp_path)
+    visited_routes: list[str] = []
+
+    with patch("tldw_chatbook.app.get_cli_setting", side_effect=_test_cli_setting):
+        async with app.run_test(size=(180, 50)) as pilot:
+            await _wait_until(
+                pilot,
+                lambda: app.current_tab == TAB_HOME and app.screen.__class__.__name__ == "HomeScreen",
+                context="initial Home route",
+            )
+
+            for route, expected_tab, expected_screen_name, required_copy in CORE_FIRST_USE_ROUTES:
+                if route != TAB_HOME:
+                    await app.handle_screen_navigation(NavigateToScreen(route))
+                    await _wait_until(
+                        pilot,
+                        lambda expected_tab=expected_tab, expected_screen_name=expected_screen_name: (
+                            app.current_tab == expected_tab
+                            and app.screen.__class__.__name__ == expected_screen_name
+                        ),
+                        context=f"{route} navigation",
+                    )
+
+                await _wait_until(
+                    pilot,
+                    lambda required_copy=required_copy: all(
+                        copy in _content_text(app) for copy in required_copy
+                    ),
+                    context=f"{route} expected copy",
+                )
+                _assert_core_render_is_healthy(app, route=route)
+                visited_routes.append(route)
+
+            assert "personas" not in visited_routes
+            assert "sync" not in visited_routes
+
+
+@pytest.mark.asyncio
+async def test_home_console_model_setup_routes_to_settings_provider_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    app = _build_clean_first_run_app(monkeypatch, tmp_path)
+
+    with patch("tldw_chatbook.app.get_cli_setting", side_effect=_test_cli_setting):
+        async with app.run_test(size=(180, 50)) as pilot:
+            await _wait_until(
+                pilot,
+                lambda: app.current_tab == TAB_HOME and app.screen.__class__.__name__ == "HomeScreen",
+                context="initial Home route",
+            )
+
+            app.screen.query_one("#home-primary-action", Button).press()
+            await _wait_until(
+                pilot,
+                lambda: (
+                    app.current_tab == TAB_SETTINGS
+                    and app.screen.__class__.__name__ == "SettingsScreen"
+                ),
+                context="Home model setup Settings route",
+            )
+            await _wait_until(
+                pilot,
+                lambda: (
+                    getattr(app.screen, "active_category", None)
+                    == SettingsCategoryId.PROVIDERS_MODELS.value
+                    and "Provider readiness" in _content_text(app)
+                ),
+                context="Settings Providers & Models category",
+            )
+
+            _assert_core_render_is_healthy(app, route="home model setup")
+
+
+@pytest.mark.asyncio
+async def test_latest_dev_library_to_console_staged_context_smoke() -> None:
+    app = _build_test_app()
+    app.app_config["_first_run"] = False
+    app._initial_tab_value = TAB_HOME
+    payload = _core_loop_payload()
+
+    with patch("tldw_chatbook.app.get_cli_setting", side_effect=_test_cli_setting):
+        async with app.run_test(size=(140, 40)) as pilot:
+            await _wait_until(
+                pilot,
+                lambda: app.current_tab == TAB_HOME,
+                context="Home initial route",
+            )
+
+            app.open_chat_with_handoff(payload)
+            await _wait_until(
+                pilot,
+                lambda: app.current_tab == TAB_CHAT and app.screen.__class__.__name__ == "ChatScreen",
+                context="Console route after Library/RAG handoff",
+            )
+            await _wait_until(
+                pilot,
+                lambda: "Sources: 1 staged" in _content_text(app),
+                context="staged source count",
+            )
+
+            text = _content_text(app)
+            assert "RAG: on" in text
+            assert "Live work: Transcript chunk: Agentic terminal design" in text
+            assert "Evidence: 1/1 available" in text
+
+            composer = app.screen.query_one("#console-native-composer", ConsoleComposerBar)
+            assert payload.suggested_prompt in composer.draft_text()
+            _assert_core_render_is_healthy(app, route="library to console")

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -5170,6 +5170,18 @@ def test_settings_config_path_validates_env_override(monkeypatch):
         screen._config_path()
 
 
+def test_settings_overview_config_path_label_hides_local_directory(monkeypatch, tmp_path):
+    config_path = tmp_path / "config" / "config.toml"
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    screen = SettingsScreen(SimpleNamespace(app_config={}))
+
+    value = screen._config_path_overview_value()
+
+    assert "Override config: config.toml" in value
+    assert str(config_path) not in value
+    assert str(tmp_path) not in value
+
+
 def test_settings_advanced_config_save_reports_invalid_env_override(monkeypatch):
     app = SimpleNamespace(app_config={})
     screen = SettingsScreen(app)

--- a/backlog/tasks/task-139 - Latest-dev-core-app-usability-smoke-gate.md
+++ b/backlog/tasks/task-139 - Latest-dev-core-app-usability-smoke-gate.md
@@ -1,0 +1,60 @@
+---
+id: TASK-139
+title: Latest-dev core app usability smoke gate
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-06-26 17:16'
+updated_date: '2026-06-26 17:36'
+labels:
+  - qa
+  - app-usability
+  - console
+  - settings
+  - library
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a focused latest-dev smoke gate that proves the core app first-use path launches, navigates, and presents recoverable Console setup states without relying on Sync or Persona work. This gives the team a current app-usability signal before starting deferred or owner-blocked backlog items.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Clean first-run app launch reaches Home and the non-Sync/non-Persona core destinations needed for first use without traceback, empty chrome, raw object reprs, or local path leaks.
+- [x] #2 Console setup-required state remains recoverable from Home and Console with a visible Settings/provider configuration path.
+- [x] #3 Library-to-Console staged-context core loop remains usable with deterministic local fixtures.
+- [x] #4 The smoke explicitly avoids taking ownership of Sync and Persona implementation work.
+- [x] #5 Focused automated checks and actual QA evidence are recorded; any defects outside this slice become separate backlog tasks.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_PLAN:BEGIN -->
+ADR required: no
+ADR path: N/A
+Reason: This is a QA/test/evidence gate for existing app launch and recovery behavior. It does not change storage/schema, sync policy, security boundaries, provider/runtime ownership, service contracts, or long-lived UX architecture.
+
+Plan: [Docs/superpowers/plans/2026-06-26-core-app-usability-smoke-gate.md](../../Docs/superpowers/plans/2026-06-26-core-app-usability-smoke-gate.md)
+
+1. Record TASK-88 as not ready because no server-first persisted MCP defaults contract exists in the current client/service/schema surfaces.
+2. Add or reuse focused smoke coverage for clean first-run launch, non-Sync/non-Persona destination navigation, Console setup recovery, and Library-to-Console staged context.
+3. Run the smoke checks on latest `dev` and fix only defects exposed inside this task scope.
+4. Capture actual QA evidence under `Docs/superpowers/qa/core-app-usability-smoke/`.
+5. Check off acceptance criteria, add implementation notes, and mark the task Done only after verification passes.
+<!-- SECTION:IMPLEMENTATION_PLAN:END -->
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Added `Tests/UI/test_latest_dev_core_app_usability_smoke.py` as a latest-dev first-use smoke gate covering Home, Console, Library, Skills, MCP, Settings, Home-to-provider-settings recovery, and Library-to-Console staged context while excluding Sync and Persona ownership. The initial red run exposed two in-scope usability defects: Settings Overview rendered the full local config path, and Home model setup routed to the legacy model route instead of Settings/provider configuration. Settings Overview now renders a non-sensitive config filename/source label, and the Home model setup action routes to Settings with the existing Providers & Models navigation context.
+
+Recorded QA evidence in `Docs/superpowers/qa/core-app-usability-smoke/2026-06-26-latest-dev-core-app-smoke.md`. TASK-88 was left deferred because no confirmed server-first persisted MCP defaults contract exists in the current MCP client/service/schema surfaces.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Home/dashboard_state.py
+++ b/tldw_chatbook/Home/dashboard_state.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from tldw_chatbook.Constants import TAB_SETTINGS
+
 
 APPROVAL_RUN_STATUS = "approval"
 FAILED_RUN_STATUS = "failed"
@@ -123,7 +125,7 @@ def choose_next_best_action(state: HomeDashboardInput) -> HomeAction:
         return HomeAction(
             "fix_model_setup",
             "Set up Console model",
-            "llm",
+            TAB_SETTINGS,
             "Console needs a working model before live AI tasks.",
         )
     if _pending_approval_count(state):

--- a/tldw_chatbook/UI/Screens/home_screen.py
+++ b/tldw_chatbook/UI/Screens/home_screen.py
@@ -19,6 +19,7 @@ from tldw_chatbook.Home.dashboard_state import (
 from ..Navigation.base_app_screen import BaseAppScreen
 from ..Navigation.main_navigation import NavigateToScreen
 from ..Navigation.shell_destinations import get_shell_destination, resolve_shell_route
+from .settings_config_models import SettingsCategoryId
 
 
 HOME_CONTROL_METHODS = {
@@ -65,6 +66,12 @@ def _home_runtime_status_label(state: HomeDashboardInput) -> str:
         return "Local"
     server_label = str(state.server_label or "").strip()
     return f"Server: {server_label}" if server_label else "Server"
+
+
+def _home_primary_action_context(action: object) -> dict[str, object]:
+    if getattr(action, "action_id", None) == "fix_model_setup":
+        return {"category": SettingsCategoryId.PROVIDERS_MODELS.value}
+    return {}
 
 
 class HomeActionButton(Button):
@@ -274,7 +281,12 @@ class HomeScreen(BaseAppScreen):
         prepare = getattr(self.app_instance, "prepare_home_primary_action", None)
         if callable(prepare):
             prepare(dashboard.next_action)
-        self.post_message(NavigateToScreen(dashboard.next_action.target_route))
+        self.post_message(
+            NavigateToScreen(
+                dashboard.next_action.target_route,
+                screen_context=_home_primary_action_context(dashboard.next_action),
+            )
+        )
 
     def _activate_home_control(self, button_id: str) -> None:
         dashboard = self._current_dashboard

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -2664,6 +2664,15 @@ class SettingsScreen(BaseAppScreen):
         writable = os.access(target, os.W_OK) if target.exists() else os.access(target.parent, os.W_OK)
         return "writable" if writable else "not writable"
 
+    def _config_path_overview_value(self) -> str:
+        try:
+            config_path = self._config_path()
+        except (OSError, RuntimeError, ValueError) as exc:
+            return f"invalid path - {redact_secret_text(str(exc))}"
+        source = "Override config" if os.environ.get("TLDW_CONFIG_PATH") else "User config"
+        filename = config_path.name or "config.toml"
+        return f"{source}: {filename} ({self._config_writable_status()})"
+
     def _raw_config_text(self) -> str:
         try:
             config_path = self._config_path()
@@ -4883,7 +4892,7 @@ class SettingsScreen(BaseAppScreen):
             yield Static("Storage", classes="destination-section")
             yield self._detail_row(
                 "Config path",
-                f"{self._config_path()} ({self._config_writable_status()})",
+                self._config_path_overview_value(),
                 identifier="settings-overview-storage",
             )
             yield Static("Privacy", classes="destination-section")


### PR DESCRIPTION
## Summary
- Add TASK-139 latest-dev core app usability smoke coverage for Home, Console, Library, Skills, MCP, Settings, and Library-to-Console staged context.
- Route Home model setup recovery to Settings > Providers & Models.
- Hide the full local config path from the default Settings Overview surface while preserving explicit storage/diagnostics detail surfaces.

## Test Plan
- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_latest_dev_core_app_usability_smoke.py Tests/UI/test_product_maturity_phase1_navigation_smoke.py Tests/UI/test_product_maturity_phase1_core_loop.py --tb=short`
- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_home_screen.py Tests/UI/test_product_maturity_phase1_first_run.py --tb=short`
- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_product_maturity_phase1_empty_setup_states.py --tb=short`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a focused core app usability smoke gate for latest `dev`, covering first-use navigation (Home, Console, Library, Skills, MCP, Settings) and the Library→Console staged context. Routes the Home model-setup action to Settings > Providers & Models with context and hides the full local config path in Settings Overview, satisfying TASK-139.

- **New Features**
  - Added `Tests/UI/test_latest_dev_core_app_usability_smoke.py` to verify clean first-run routes, exclude Sync/Persona, assert no tracebacks/raw reprs/path leaks (including exported screenshots), and validate Library→Console staged context.
  - Added plan and QA evidence docs under `Docs/superpowers/...`.

- **Bug Fixes**
  - Home "Set up Console model" now opens `settings` with `screen_context` `{ category: Providers & Models }`; tests assert route, context, and "Destination: Settings" copy.
  - Settings Overview now shows only the config filename plus writable status via a new helper; added a unit test to prevent local path leaks.

<sup>Written for commit f2252dd58cf4b3f98885f92d79741b94bb770aa9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

