### PR TITLE
Add collapsible Personas workbench rails

### DIFF
--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -148,6 +148,14 @@ class TestWorkbenchShell:
             assert screen.query_one("#personas-library-pane")
             assert screen.query_one("#personas-work-area")
             assert screen.query_one("#personas-inspector-pane")
+            assert (
+                screen.query_one("#personas-library-rail-open", Button).tooltip
+                == "Open Library rail"
+            )
+            assert (
+                screen.query_one("#personas-inspector-rail-open", Button).tooltip
+                == "Open Inspector rail"
+            )
 
     async def test_personas_screen_sets_up_reused_ccp_enhancements(
         self,
@@ -183,6 +191,72 @@ class TestWorkbenchShell:
             assert inspector.size.width >= 18
             assert _right_edge(inspector) <= _right_edge(workbench)
             assert str(readiness.renderable).startswith("Console blocked:")
+
+    async def test_library_rail_collapses_and_reopens_from_handle(
+        self,
+        mock_app_instance,
+        stub_characters,
+    ):
+        app = StyledPersonasTestApp(mock_app_instance)
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+
+            await pilot.click("#personas-library-rail-collapse")
+            await pilot.pause()
+
+            assert screen.query_one("#personas-library-pane").display is False
+            assert screen.query_one("#personas-library-rail-handle").display is True
+            assert screen.query_one("#personas-work-area").display is True
+
+            await pilot.click("#personas-library-rail-open")
+            await pilot.pause()
+
+            assert screen.query_one("#personas-library-pane").display is True
+            assert screen.query_one("#personas-library-rail-handle").display is False
+
+    async def test_inspector_rail_collapses_and_reopens_from_handle(
+        self,
+        mock_app_instance,
+        stub_characters,
+    ):
+        app = StyledPersonasTestApp(mock_app_instance)
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+
+            await pilot.click("#personas-inspector-rail-collapse")
+            await pilot.pause()
+
+            assert screen.query_one("#personas-inspector-pane").display is False
+            assert screen.query_one("#personas-inspector-rail-handle").display is True
+            assert screen.query_one("#personas-work-area").display is True
+
+            await pilot.click("#personas-inspector-rail-open")
+            await pilot.pause()
+
+            assert screen.query_one("#personas-inspector-pane").display is True
+            assert screen.query_one("#personas-inspector-rail-handle").display is False
+
+    async def test_collapsed_inspector_rail_handle_is_keyboard_reachable(
+        self,
+        mock_app_instance,
+        stub_characters,
+    ):
+        app = StyledPersonasTestApp(mock_app_instance)
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            await pilot.click("#personas-inspector-rail-collapse")
+            await pilot.pause()
+
+            open_button = screen.query_one("#personas-inspector-rail-open", Button)
+            await pilot.press("shift+f6")
+            await pilot.pause()
+            assert pilot.app.focused is open_button
+
+            await pilot.press("enter")
+            await pilot.pause()
+
+            assert screen.query_one("#personas-inspector-pane").display is True
+            assert screen.query_one("#personas-inspector-rail-handle").display is False
 
     async def test_resize_sync_skips_work_when_compact_state_is_unchanged(
         self, mock_app_instance, stub_characters, monkeypatch

--- a/backlog/tasks/task-101 - Collapsible-library-inspector-rails-for-Personas-workbench.md
+++ b/backlog/tasks/task-101 - Collapsible-library-inspector-rails-for-Personas-workbench.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-101
 title: Collapsible library/inspector rails for Personas workbench
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-06-11 18:26'
+updated_date: '2026-06-26 17:58'
 labels: []
 dependencies: []
 ---
@@ -16,5 +17,33 @@ Adopt ConsoleRailHandle (as Console and Notes do) for the Personas workbench lib
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Library and inspector collapse/expand via rail handles,Keyboard reachable,Tests cover collapsed state
+- [x] #1 Library and inspector collapse/expand via rail handles,Keyboard reachable,Tests cover collapsed state
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Verify latest origin/dev does not already include Personas rail collapse behavior.
+2. Reuse ConsoleRailHandle for collapsed Library and Inspector affordances.
+3. Add open-state collapse buttons to the Personas Library and Inspector pane headers using the existing Console/Notes rail header vocabulary.
+4. Keep rail collapsed state screen-local and sync pane/handle visibility without changing storage or shared Personas data contracts.
+5. Add mounted UI tests covering collapsed state, reopen behavior, and keyboard reachability.
+6. Run the focused Personas workbench suite and document results.
+
+ADR required: no
+ADR path: N/A
+Reason: This is a contained Textual UI composition parity change that reuses the existing ConsoleRailHandle pattern and does not alter storage, schema, sync policy, service boundaries, security, runtime contracts, or dependency choices.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added shared `ConsoleRailHandle` affordances for the Personas Library and Inspector panes, with screen-local collapsed state and explicit visibility sync for panes and handles. Added matching open-state collapse buttons to the Library and Inspector pane headers using the existing Console/Notes rail header classes. Covered the behavior with mounted UI tests for collapse/reopen, collapsed-state visibility, keyboard reachability through Shift+F6, and Personas-specific collapsed-handle tooltips.
+
+PR review follow-up rebased the branch onto the latest `origin/dev`, switched rail visibility updates to Textual's `Widget.display` property, added Google-style docstrings to modified public compose methods, moved collapse-button fixed width into TCSS, and replaced repeated rail handle width literals with named constants.
+
+Verification:
+- `.venv/bin/python -m pytest Tests/UI/test_personas_workbench.py` -> 138 passed
+- `git diff --check` -> passed
+- ADR required: no; no storage/schema/service/runtime/security/dependency boundary changed.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -27,6 +27,7 @@ from ...Chat.console_chat_models import ConsoleProviderSelection
 from ...Chat.console_provider_gateway import ConsoleProviderGateway
 from ...DB.ChaChaNotes_DB import ConflictError
 from ...tldw_api import PersonaProfileCreate, PersonaProfileUpdate
+from ...Widgets.Console.console_rail_handle import ConsoleRailHandle
 from ...Widgets.confirmation_dialog import ConfirmationDialog, UnsavedChangesDialog
 from ...Widgets.destination_workbench import DestinationModeStrip
 from ...Widgets.Persona_Widgets.persona_profile_card_widget import PersonaProfileCardWidget
@@ -90,6 +91,8 @@ PLACEHOLDER_COPY = "This mode is not available yet. Characters and Personas are 
 # 2:4:2 workbench minimums. Keep this screen-owned so a later rail-collapse
 # task can replace it without changing pane widgets.
 PERSONAS_COMPACT_WORKBENCH_MAX_WIDTH = 90
+PERSONAS_LIBRARY_RAIL_HANDLE_WIDTH = 13
+PERSONAS_INSPECTOR_RAIL_HANDLE_WIDTH = 11
 
 #: Center-area widgets toggled by ``_show_center``.
 _CENTER_VIEW_IDS: tuple[str, ...] = (
@@ -149,8 +152,16 @@ class PersonasScreen(BaseAppScreen):
     ]
     _WORKBENCH_FOCUS_TARGETS = (
         WorkbenchPaneTarget(
+            "personas-library-rail-handle",
+            ("personas-library-rail-open",),
+        ),
+        WorkbenchPaneTarget(
             "personas-library-pane",
-            ("personas-library-search", "personas-library-new"),
+            (
+                "personas-library-search",
+                "personas-library-rail-collapse",
+                "personas-library-new",
+            ),
         ),
         WorkbenchPaneTarget(
             "personas-work-area",
@@ -158,7 +169,15 @@ class PersonasScreen(BaseAppScreen):
         ),
         WorkbenchPaneTarget(
             "personas-inspector-pane",
-            ("personas-conversations-list", "personas-attach-to-console"),
+            (
+                "personas-conversations-list",
+                "personas-inspector-rail-collapse",
+                "personas-attach-to-console",
+            ),
+        ),
+        WorkbenchPaneTarget(
+            "personas-inspector-rail-handle",
+            ("personas-inspector-rail-open",),
         ),
     )
 
@@ -311,6 +330,8 @@ class PersonasScreen(BaseAppScreen):
         # (the selection key alone cannot catch a Reset of the SAME selection).
         self._preview_generation: int = 0
         self._workbench_compact: bool | None = None
+        self._library_rail_collapsed: bool = False
+        self._inspector_rail_collapsed: bool = False
         # Character id whose greeting last seeded the preview; the
         # CharacterMessage.Loaded handler uses it to avoid double-seeding.
         self._preview_seeded_for: str | None = None
@@ -323,6 +344,11 @@ class PersonasScreen(BaseAppScreen):
     # ===== Compose =====
 
     def compose_content(self) -> ComposeResult:
+        """Compose the Personas destination shell and workbench rails.
+
+        Returns:
+            Textual compose result for the Personas content tree.
+        """
         with Vertical(id="personas-shell"):
             yield Static(
                 self._title_text(),
@@ -353,10 +379,28 @@ class PersonasScreen(BaseAppScreen):
                         tooltip=f"Switch the workbench to {MODE_LABELS[mode]}.",
                     )
             with Horizontal(id="personas-workbench", classes="ds-panel destination-workbench"):
-                yield PersonasLibraryPane(
+                library_handle = ConsoleRailHandle(
+                    label="Library",
+                    button_id="personas-library-rail-open",
+                    badge_id="personas-library-rail-badge",
+                    side="left",
+                    id="personas-library-rail-handle",
+                )
+                library_handle.styles.width = PERSONAS_LIBRARY_RAIL_HANDLE_WIDTH
+                library_handle.styles.min_width = PERSONAS_LIBRARY_RAIL_HANDLE_WIDTH
+                library_handle.styles.max_width = PERSONAS_LIBRARY_RAIL_HANDLE_WIDTH
+                if not self._library_rail_collapsed:
+                    library_handle.display = False
+                yield library_handle
+
+                library_pane = PersonasLibraryPane(
                     id="personas-library-pane",
                     classes="destination-workbench-pane",
                 )
+                if self._library_rail_collapsed:
+                    library_pane.display = False
+                yield library_pane
+
                 with Vertical(id="personas-work-area", classes="destination-workbench-pane"):
                     with Container(id="personas-detail-stack"):
                         yield PersonasCharacterCardWidget()
@@ -376,10 +420,28 @@ class PersonasScreen(BaseAppScreen):
                         yield PersonasConversationTranscriptWidget()
                         yield Static(PLACEHOLDER_COPY, id="personas-mode-placeholder")
                     yield PersonasPreviewPane(id="personas-preview-pane")
-                yield PersonasInspectorPane(
+
+                inspector_pane = PersonasInspectorPane(
                     id="personas-inspector-pane",
                     classes="destination-workbench-pane ds-inspector",
                 )
+                if self._inspector_rail_collapsed:
+                    inspector_pane.display = False
+                yield inspector_pane
+
+                inspector_handle = ConsoleRailHandle(
+                    label="Inspector",
+                    button_id="personas-inspector-rail-open",
+                    badge_id="personas-inspector-rail-badge",
+                    side="right",
+                    id="personas-inspector-rail-handle",
+                )
+                inspector_handle.styles.width = PERSONAS_INSPECTOR_RAIL_HANDLE_WIDTH
+                inspector_handle.styles.min_width = PERSONAS_INSPECTOR_RAIL_HANDLE_WIDTH
+                inspector_handle.styles.max_width = PERSONAS_INSPECTOR_RAIL_HANDLE_WIDTH
+                if not self._inspector_rail_collapsed:
+                    inspector_handle.display = False
+                yield inspector_handle
 
     async def on_mount(self) -> None:
         super().on_mount()
@@ -388,6 +450,8 @@ class PersonasScreen(BaseAppScreen):
         if callable(setup_loading):
             await setup_loading()
         self._sync_responsive_workbench()
+        self._sync_personas_rails()
+        self._sync_personas_rail_tooltips()
         self.query_one(PersonasLibraryPane).set_mode(self.state.active_mode)
         self._show_center(None)
         await self.character_handler.refresh_character_list()
@@ -432,6 +496,32 @@ class PersonasScreen(BaseAppScreen):
                 self.query_one(pane_id).set_class(compact, "personas-workbench-compact-pane")
             except QueryError:
                 continue
+
+    def _sync_personas_rails(self) -> None:
+        """Mirror Console/Notes collapsible rails for Library and Inspector."""
+        if not self.is_mounted:
+            return
+        try:
+            library_open = not self._library_rail_collapsed
+            inspector_open = not self._inspector_rail_collapsed
+            self.query_one("#personas-library-pane").display = library_open
+            self.query_one("#personas-library-rail-handle").display = not library_open
+            self.query_one("#personas-inspector-pane").display = inspector_open
+            self.query_one("#personas-inspector-rail-handle").display = not inspector_open
+        except QueryError:
+            return
+
+    def _sync_personas_rail_tooltips(self) -> None:
+        """Set Personas-specific collapsed rail tooltips on shared handles."""
+        try:
+            self.query_one("#personas-library-rail-open", Button).tooltip = (
+                "Open Library rail"
+            )
+            self.query_one("#personas-inspector-rail-open", Button).tooltip = (
+                "Open Inspector rail"
+            )
+        except QueryError:
+            return
 
     # ===== Library rendering =====
 
@@ -638,6 +728,30 @@ class PersonasScreen(BaseAppScreen):
         if mode not in MODE_CHIP_ORDER or mode == self.state.active_mode:
             return
         await self._run_guarded(lambda: self._apply_mode(mode))
+
+    @on(Button.Pressed, "#personas-library-rail-collapse")
+    def _handle_library_rail_collapse(self, event: Button.Pressed) -> None:
+        event.stop()
+        self._library_rail_collapsed = True
+        self._sync_personas_rails()
+
+    @on(Button.Pressed, "#personas-library-rail-open")
+    def _handle_library_rail_open(self, event: Button.Pressed) -> None:
+        event.stop()
+        self._library_rail_collapsed = False
+        self._sync_personas_rails()
+
+    @on(Button.Pressed, "#personas-inspector-rail-collapse")
+    def _handle_inspector_rail_collapse(self, event: Button.Pressed) -> None:
+        event.stop()
+        self._inspector_rail_collapsed = True
+        self._sync_personas_rails()
+
+    @on(Button.Pressed, "#personas-inspector-rail-open")
+    def _handle_inspector_rail_open(self, event: Button.Pressed) -> None:
+        event.stop()
+        self._inspector_rail_collapsed = False
+        self._sync_personas_rails()
 
     async def _apply_mode(self, mode: str) -> None:
         self.state.switch_mode(mode)

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py
@@ -6,7 +6,7 @@ import re
 
 from textual import on
 from textual.app import ComposeResult
-from textual.containers import Vertical
+from textual.containers import Horizontal, Vertical
 from textual.widgets import Button, ListItem, ListView, Static
 
 from .personas_pane_messages import ConversationRowSelected
@@ -76,7 +76,26 @@ class PersonasInspectorPane(Vertical):
         self._conversation_lookup: dict[str, str] = {}
 
     def compose(self) -> ComposeResult:
-        yield Static("Inspector", classes="destination-section personas-column-title")
+        """Compose the Inspector pane summary, readiness, and actions.
+
+        Returns:
+            Textual compose result for the Inspector pane.
+        """
+        with Horizontal(classes="console-rail-header"):
+            title = Static(
+                "Inspector",
+                classes="destination-section personas-column-title console-rail-title",
+            )
+            title.styles.width = "1fr"
+            yield title
+            collapse_button = Button(
+                ">",
+                id="personas-inspector-rail-collapse",
+                classes="console-rail-collapse-button",
+                compact=True,
+            )
+            collapse_button.tooltip = "Collapse Inspector rail"
+            yield collapse_button
         yield Static("Selected: none", id="personas-selected-name")
         yield Static("Type: -", id="personas-selected-kind")
         yield Static("Authority: Local", id="personas-selected-authority")

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_library_pane.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_library_pane.py
@@ -81,7 +81,26 @@ class PersonasLibraryPane(Vertical):
         self._import_visible: bool = True
 
     def compose(self) -> ComposeResult:
-        yield Static("Library", classes="destination-section personas-column-title")
+        """Compose the Library pane header, search controls, and rows.
+
+        Returns:
+            Textual compose result for the Library pane.
+        """
+        with Horizontal(classes="console-rail-header"):
+            title = Static(
+                "Library",
+                classes="destination-section personas-column-title console-rail-title",
+            )
+            title.styles.width = "1fr"
+            yield title
+            collapse_button = Button(
+                "<",
+                id="personas-library-rail-collapse",
+                classes="console-rail-collapse-button",
+                compact=True,
+            )
+            collapse_button.tooltip = "Collapse Library rail"
+            yield collapse_button
         yield Input(placeholder="Search...", id="personas-library-search")
         with Horizontal(id="personas-library-toolbar", classes="ds-toolbar"):
             yield Button(

--- a/tldw_chatbook/css/components/_agentic_terminal.tcss
+++ b/tldw_chatbook/css/components/_agentic_terminal.tcss
@@ -831,6 +831,9 @@ Button#console-open-provider-settings.console-provider-api-key-action:hover:focu
 }
 
 .console-rail-collapse-button {
+    width: 3;
+    min-width: 3;
+    max-width: 3;
     height: 1;
     min-height: 1;
     text-align: left;

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -2359,6 +2359,9 @@ Button#console-open-provider-settings.console-provider-api-key-action:hover:focu
 }
 
 .console-rail-collapse-button {
+    width: 3;
+    min-width: 3;
+    max-width: 3;
     height: 1;
     min-height: 1;
     text-align: left;


### PR DESCRIPTION
## Summary
- add ConsoleRailHandle collapsed affordances for Personas Library and Inspector panes
- add open-state collapse buttons to the Personas pane headers using the existing Console/Notes rail vocabulary
- mark TASK-101 done with ADR check and implementation notes

## Tests
- .venv/bin/python -m pytest Tests/UI/test_personas_workbench.py
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds collapsible Library and Inspector rails to the Personas workbench using `ConsoleRailHandle`, with header collapse buttons, tooltips, keyboard access, and UI tests. Completes TASK-101 acceptance criteria.

- **New Features**
  - Collapsible Library (left) and Inspector (right) rails with header collapse buttons; shared `ConsoleRailHandle` to reopen; custom tooltips for open/close.
  - Local collapsed state with pane/handle visibility synced via `Widget.display`; fixed widths via constants/TCSS; no storage or schema changes.
  - Keyboard: Shift+F6 focuses the collapsed handle and Enter opens; mounted tests cover collapse/reopen, tooltips, and focus behavior.

<sup>Written for commit 4872748c2764a65d608ddaf2abb4da7021f72508. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

