### PR TITLE
Debounce Personas library search

### DIFF
--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -3,6 +3,7 @@
 
 import inspect
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -880,6 +881,93 @@ PROFILES_FOR_SEARCH = [
 
 
 class TestSearch:
+    async def _wait_for_search_render(self, pilot: Any) -> None:
+        await pilot.pause(personas_screen_module.PERSONAS_SEARCH_DEBOUNCE_SECONDS + 0.05)
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+    async def test_search_input_debounces_rapid_changes(
+        self,
+        mock_app_instance: Any,
+        stub_characters: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Rapid search edits render only the final query after the debounce window."""
+
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            await pilot.pause()
+
+            rendered_queries: list[str] = []
+            original_render = screen._render_library_rows
+
+            async def observe_render(
+                *,
+                expected_query: str | None = None,
+                expected_mode: str | None = None,
+            ) -> None:
+                rendered_queries.append(screen.state.search_query)
+                await original_render(
+                    expected_query=expected_query,
+                    expected_mode=expected_mode,
+                )
+
+            monkeypatch.setattr(screen, "_render_library_rows", observe_render)
+
+            search_input = screen.query_one("#personas-library-search")
+            search_input.value = "s"
+            search_input.value = "sa"
+            search_input.value = "sam"
+
+            await pilot.pause(0.05)
+            assert rendered_queries == []
+
+            await self._wait_for_search_render(pilot)
+            assert rendered_queries == ["sam"]
+            rows = screen.query(".personas-library-row")
+            assert [_row_text(r) for r in rows] == ["Detective Sam"]
+
+    async def test_stale_fts_search_result_does_not_update_library_rows(
+        self,
+        mock_app_instance: Any,
+        stub_characters: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A slower search result is dropped if the query changes while it awaits."""
+
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            await pilot.pause()
+
+            screen.LIBRARY_FTS_THRESHOLD = 2
+            library = screen.query_one("#personas-library-pane")
+            original_update_rows = library.update_rows
+            rendered_rows: list[tuple[str, ...]] = []
+
+            async def observe_update_rows(rows: tuple[Any, ...], **kwargs: Any) -> None:
+                rendered_rows.append(tuple(row.name for row in rows))
+                await original_update_rows(rows, **kwargs)
+
+            async def fake_to_thread(
+                function: Any,
+                query: str,
+                *args: Any,
+                **kwargs: Any,
+            ) -> list[dict[str, Any]]:
+                screen.state.search_query = "lab"
+                return [{"id": 1, "name": "Detective Sam"}]
+
+            monkeypatch.setattr(library, "update_rows", observe_update_rows)
+            monkeypatch.setattr(personas_screen_module.asyncio, "to_thread", fake_to_thread)
+
+            screen.state.search_query = "sam"
+            await screen._render_search_query(query="sam", mode="characters")
+            await pilot.pause()
+
+            assert rendered_rows == []
+
     async def test_search_filters_loaded_characters_locally(self, mock_app_instance, stub_characters):
         app = PersonasTestApp(mock_app_instance)
         async with app.run_test() as pilot:
@@ -888,7 +976,7 @@ class TestSearch:
             # Type into the search input
             search_input = screen.query_one("#personas-library-search")
             search_input.value = "sam"
-            await pilot.pause()
+            await self._wait_for_search_render(pilot)
             rows = screen.query(".personas-library-row")
             assert [_row_text(r) for r in rows] == ["Detective Sam"]
             count = str(screen.query_one("#personas-library-count", Static).renderable)
@@ -902,10 +990,10 @@ class TestSearch:
             search_input = screen.query_one("#personas-library-search")
             # Filter first
             search_input.value = "sam"
-            await pilot.pause()
+            await self._wait_for_search_render(pilot)
             # Then clear
             search_input.value = ""
-            await pilot.pause()
+            await self._wait_for_search_render(pilot)
             rows = screen.query(".personas-library-row")
             assert [_row_text(r) for r in rows] == ["Detective Sam", "Lab Assistant"]
             count = str(screen.query_one("#personas-library-count", Static).renderable)
@@ -919,7 +1007,7 @@ class TestSearch:
             await pilot.pause()
             search_input = screen.query_one("#personas-library-search")
             search_input.value = "LAB"
-            await pilot.pause()
+            await self._wait_for_search_render(pilot)
             rows = screen.query(".personas-library-row")
             assert [_row_text(r) for r in rows] == ["Lab Assistant"]
 
@@ -942,7 +1030,7 @@ class TestSearch:
             # Two profiles loaded; now search for "nav"
             search_input = screen.query_one("#personas-library-search")
             search_input.value = "nav"
-            await pilot.pause()
+            await self._wait_for_search_render(pilot)
             rows = screen.query(".personas-library-row")
             assert [_row_text(r) for r in rows] == ["Navigator"]
             count = str(screen.query_one("#personas-library-count", Static).renderable)
@@ -958,7 +1046,7 @@ class TestSearch:
             # Search in characters mode
             search_input = screen.query_one("#personas-library-search")
             search_input.value = "sam"
-            await pilot.pause()
+            await self._wait_for_search_render(pilot)
             assert len(screen.query(".personas-library-row")) == 1
             # Switch to personas mode and back
             await pilot.click("#personas-mode-personas")
@@ -994,7 +1082,7 @@ class TestSearch:
             screen.LIBRARY_FTS_THRESHOLD = 2
             search_input = screen.query_one("#personas-library-search")
             search_input.value = "sam"
-            await pilot.pause()
+            await self._wait_for_search_render(pilot)
             assert fts_calls == ["sam"]
             rows = screen.query(".personas-library-row")
             assert [_row_text(r) for r in rows] == ["Detective Sam"]
@@ -1023,9 +1111,7 @@ class TestSearch:
             await pilot.pause()
             screen.LIBRARY_FTS_THRESHOLD = 2
             screen.query_one("#personas-library-search").value = "sam"
-            await pilot.pause()
-            await app.workers.wait_for_complete()
-            await pilot.pause()
+            await self._wait_for_search_render(pilot)
             assert loop_seen == [False]
             rows = screen.query(".personas-library-row")
             assert [_row_text(r) for r in rows] == ["Detective Sam"]

--- a/backlog/tasks/task-112 - Debounce-Personas-library-search-input.md
+++ b/backlog/tasks/task-112 - Debounce-Personas-library-search-input.md
@@ -1,10 +1,13 @@
 ---
 id: TASK-112
 title: Debounce Personas library search input
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-06-11 03:23'
-labels: []
+labels:
+  - personas
+  - search
+  - performance
 dependencies: []
 ---
 
@@ -16,5 +19,29 @@ Search re-renders per keystroke; add ~200ms debounce in the search pipeline to c
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Typing quickly triggers at most one render per debounce window,Final query always renders
+- [x] #1 Typing quickly triggers at most one render per debounce window,Final query always renders
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Trace the current Personas library search pipeline from `Input.Changed` through screen-level row rendering.
+2. Add a mounted regression that changes the search input rapidly and asserts intermediate changes do not trigger multiple renders before the debounce window completes.
+3. Add a companion assertion that the final query always renders after the debounce window.
+4. Implement a small debounced search worker/timer path that preserves mode-specific rendering and cancels stale work on mode changes.
+5. Run focused Personas search tests plus diff hygiene, then update acceptance criteria and implementation notes.
+
+ADR required: no
+ADR path: N/A
+Reason: bounded UI debounce/performance fix; no storage/schema, sync policy, service boundary, or long-lived architecture decision.
+
+## Implementation Notes
+
+- Added a 200ms screen-owned debounce timer for Personas library search changes.
+- Search renders now run through a single exclusive `personas-library-search` worker and ignore stale mode/query snapshots.
+- Pending search timers are cancelled on mode changes and unmount to prevent late renders into the wrong mode.
+- Added a mounted regression proving rapid search changes do not render before the debounce window and the final query renders once.
+- Updated existing Personas search tests to wait through the debounce window deterministically.
+- Review follow-up: row render helpers now re-check the captured query/mode after awaited FTS work and before updating the library pane, so stale search results cannot render into a newer query or mode.
+- Added a mounted regression for stale FTS results and typed/documented the debounce regression called out in review.
+- Verification: `.venv/bin/python -m pytest -q Tests/UI/test_personas_workbench.py --tb=short` passed with 140 tests; the four UI tests that failed on the old PR head passed locally after the rebase; `git diff --check` passed.
+- ADR check completed: no ADR required for this bounded UI interaction/performance fix.

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -14,6 +14,7 @@ from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Container, Horizontal, Vertical
 from textual.css.query import QueryError
+from textual.timer import Timer
 from textual.widgets import Button, Input, ListView, Static, TextArea
 
 from ...Character_Chat.Character_Chat_Lib import (
@@ -86,6 +87,7 @@ logger = logger.bind(module="PersonasScreen")
 MODE_CHIP_ORDER: tuple[str, ...] = ("characters", "personas", "prompts", "dictionaries", "lore")
 
 PLACEHOLDER_COPY = "This mode is not available yet. Characters and Personas are the supported modes."
+PERSONAS_SEARCH_DEBOUNCE_SECONDS = 0.2
 
 # 80-column terminals need a tighter three-pane split than the default
 # 2:4:2 workbench minimums. Keep this screen-owned so a later rail-collapse
@@ -320,6 +322,7 @@ class PersonasScreen(BaseAppScreen):
         self._characters: list[dict] = []
         self._profiles: list[dict] = []
         self._profile_lookup_recovery_state: DestinationRecoveryState | None = None
+        self._search_debounce_timer: Timer | None = None
         # Serializes library renders: the pane's update_rows has two
         # suspension points, so interleaved renders could double-mount rows.
         self._render_lock = asyncio.Lock()
@@ -459,6 +462,7 @@ class PersonasScreen(BaseAppScreen):
 
     async def on_unmount(self) -> None:
         super().on_unmount()
+        self._cancel_search_debounce()
         self._clear_footer_shortcuts()
         # Release the preview gateway's HTTP client; unmount must not crash.
         gateway = self._preview_gateway
@@ -550,8 +554,36 @@ class PersonasScreen(BaseAppScreen):
             if record.get("id") is not None
         )
 
-    async def _render_library_rows(self) -> None:
-        query = self.state.search_query
+    def _library_render_snapshot_is_current(
+        self,
+        *,
+        expected_query: str | None = None,
+        expected_mode: str | None = None,
+    ) -> bool:
+        """Return whether a delayed library render still matches live state."""
+
+        has_snapshot = expected_query is not None or expected_mode is not None
+        if has_snapshot and not self.is_mounted:
+            return False
+        if expected_mode is not None and expected_mode != self.state.active_mode:
+            return False
+        if expected_query is not None and expected_query != self.state.search_query:
+            return False
+        return True
+
+    async def _render_library_rows(
+        self,
+        *,
+        expected_query: str | None = None,
+        expected_mode: str | None = None,
+    ) -> None:
+        if not self._library_render_snapshot_is_current(
+            expected_query=expected_query,
+            expected_mode=expected_mode,
+        ):
+            return
+
+        query = expected_query if expected_query is not None else self.state.search_query
         total = len(self._characters)
         if query:
             if total >= self.LIBRARY_FTS_THRESHOLD:
@@ -571,7 +603,17 @@ class PersonasScreen(BaseAppScreen):
         else:
             matched = self._characters
             filtered = False
+        if not self._library_render_snapshot_is_current(
+            expected_query=expected_query,
+            expected_mode=expected_mode,
+        ):
+            return
         async with self._render_lock:
+            if not self._library_render_snapshot_is_current(
+                expected_query=expected_query,
+                expected_mode=expected_mode,
+            ):
+                return
             rows = self._build_library_rows(matched, "character")
             library = self.query_one(PersonasLibraryPane)
             await library.update_rows(rows, total=total, noun="characters", filtered=filtered)
@@ -630,8 +672,19 @@ class PersonasScreen(BaseAppScreen):
             # Tolerate refreshes that race screen teardown.
             logger.warning("Could not render the persona profile rows.", exc_info=True)
 
-    async def _render_profile_rows(self) -> None:
-        query = self.state.search_query
+    async def _render_profile_rows(
+        self,
+        *,
+        expected_query: str | None = None,
+        expected_mode: str | None = None,
+    ) -> None:
+        if not self._library_render_snapshot_is_current(
+            expected_query=expected_query,
+            expected_mode=expected_mode,
+        ):
+            return
+
+        query = expected_query if expected_query is not None else self.state.search_query
         total = len(self._profiles)
         if query:
             q_lower = query.lower()
@@ -641,6 +694,11 @@ class PersonasScreen(BaseAppScreen):
             matched = self._profiles
             filtered = False
         async with self._render_lock:
+            if not self._library_render_snapshot_is_current(
+                expected_query=expected_query,
+                expected_mode=expected_mode,
+            ):
+                return
             rows = self._build_library_rows(matched, "persona_profile")
             library = self.query_one(PersonasLibraryPane)
             recovery_state = self._profile_lookup_recovery_state
@@ -662,18 +720,57 @@ class PersonasScreen(BaseAppScreen):
                 library.mark_active_row("persona_profile", self.state.selected_entity_id)
 
     @on(PersonaSearchChanged)
-    async def _handle_search_changed(self, message: PersonaSearchChanged) -> None:
+    def _handle_search_changed(self, message: PersonaSearchChanged) -> None:
         message.stop()
         # Search does not change selection or center pane — no unsaved guard needed.
         self.state.search_query = message.query.strip()
-        if self.state.active_mode == "characters":
+        self._cancel_search_debounce()
+        query = self.state.search_query
+        mode = self.state.active_mode
+        self._search_debounce_timer = self.set_timer(
+            PERSONAS_SEARCH_DEBOUNCE_SECONDS,
+            lambda: self._start_debounced_search_render(query=query, mode=mode),
+        )
+
+    def _cancel_search_debounce(self) -> None:
+        """Cancel a pending search render when newer state supersedes it."""
+
+        if self._search_debounce_timer is not None:
+            self._search_debounce_timer.stop()
+            self._search_debounce_timer = None
+
+    def _start_debounced_search_render(self, *, query: str, mode: str) -> None:
+        """Start the debounced render after the active timer has fired."""
+
+        self._search_debounce_timer = None
+        self.run_worker(
+            self._render_search_query(query=query, mode=mode),
+            exclusive=True,
+            group="personas-library-search",
+        )
+
+    async def _render_search_query(self, *, query: str, mode: str) -> None:
+        """Render the latest debounced library search for the active mode."""
+
+        if not self._library_render_snapshot_is_current(
+            expected_query=query,
+            expected_mode=mode,
+        ):
+            return
+        if mode == "characters":
             try:
-                await self._render_library_rows()
+                await self._render_library_rows(
+                    expected_query=query,
+                    expected_mode=mode,
+                )
             except Exception:
                 logger.warning("Could not re-render character rows after search.", exc_info=True)
-        elif self.state.active_mode == "personas":
+        elif mode == "personas":
             try:
-                await self._render_profile_rows()
+                await self._render_profile_rows(
+                    expected_query=query,
+                    expected_mode=mode,
+                )
             except Exception:
                 logger.warning("Could not re-render profile rows after search.", exc_info=True)
 
@@ -754,6 +851,7 @@ class PersonasScreen(BaseAppScreen):
         self._sync_personas_rails()
 
     async def _apply_mode(self, mode: str) -> None:
+        self._cancel_search_debounce()
         self.state.switch_mode(mode)
         # switch_mode does not reset search_query; clear it explicitly and
         # reset the Input widget so the library starts unfiltered in the new mode.


### PR DESCRIPTION
## Summary
- Add a 200ms debounce for Personas library search changes.
- Route final search renders through one exclusive worker and ignore stale mode/query snapshots.
- Cancel pending search renders on mode changes and unmount.

## Test Plan
- [x] python -m pytest -q Tests/UI/test_personas_workbench.py --tb=short
- [x] git diff --check HEAD~1..HEAD

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Debounced the Personas library search by 200ms so only the final input renders, reducing redundant updates and flicker. Renders now validate query/mode snapshots and drop stale work, and run via one exclusive `personas-library-search` worker; addresses TASK-112.

- **New Features**
  - Added a 200ms, screen-owned debounce for search input; cancel timers on mode changes and unmount.
  - Snapshot-safe rendering for characters and personas: ignore stale query/mode before/after FTS and inside the render lock; route through the exclusive `personas-library-search` worker.

<sup>Written for commit c70d67413b1a17844bf7824901690e7feaf6817a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

