### PR TITLE
Fix Personas FTS search count copy

### DIFF
--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -1087,6 +1087,39 @@ class TestSearch:
             rows = screen.query(".personas-library-row")
             assert [_row_text(r) for r in rows] == ["Detective Sam"]
 
+    async def test_fts_search_count_uses_unbounded_full_library_copy(
+        self,
+        mock_app_instance: Any,
+        stub_characters: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """FTS search copy must not use the truncated loaded-page denominator.
+
+        Args:
+            mock_app_instance: Mounted test app fixture.
+            stub_characters: Character-list fixture for the Personas library.
+            monkeypatch: Pytest monkeypatch fixture used to force the FTS path.
+
+        Returns:
+            None.
+        """
+
+        def fake_fts(search_term: str, limit: int = 50) -> list[dict[str, Any]]:
+            return [{"id": 1, "name": "Detective Sam"}]
+
+        monkeypatch.setattr(character_handler_module, "search_characters_fts", fake_fts)
+
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            await pilot.pause()
+            screen.LIBRARY_FTS_THRESHOLD = 2
+            screen.query_one("#personas-library-search").value = "sam"
+            await self._wait_for_search_render(pilot)
+
+            count = str(screen.query_one("#personas-library-count", Static).renderable)
+            assert count == "Showing 1 character match from full library"
+
     async def test_fts_search_runs_off_the_event_loop(
         self, mock_app_instance, stub_characters, monkeypatch
     ):

--- a/backlog/tasks/task-113 - Personas-FTS-search-count-denominator-is-page-truncated.md
+++ b/backlog/tasks/task-113 - Personas-FTS-search-count-denominator-is-page-truncated.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-113
 title: Personas FTS search count denominator is page-truncated
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-06-11 03:23'
+updated_date: '2026-06-27 20:04'
 labels: []
 dependencies: []
 ---
@@ -16,5 +17,29 @@ When the FTS path is active the 'n of m' count uses the truncated loaded-page le
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Count line is accurate or explicitly unbounded when FTS is active
+- [x] #1 Count line is accurate or explicitly unbounded when FTS is active
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce the FTS-count bug with a mounted Personas search test that forces the FTS path and asserts the count line does not claim the loaded-page denominator.
+2. Implement the smallest count-copy extension in PersonasLibraryPane so filtered counts can be rendered with an unknown/full-library denominator.
+3. Pass the unknown-denominator mode from PersonasScreen only for character FTS search results; leave in-memory character filtering and persona profile filtering unchanged.
+4. Run the focused failing test, the Personas search group, the full Personas workbench test file, and git diff hygiene.
+
+ADR required: no
+ADR path: N/A
+Reason: bounded Personas UI copy/count correctness fix; no storage/schema, service boundary, sync policy, or long-lived architecture decision.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added explicit full-library count copy for filtered results with an unknown denominator: `Showing 1 character match from full library`.
+- Wired the unknown-denominator mode only for character FTS searches, where the loaded page may be truncated but the query searches the full local character corpus.
+- Left local in-memory character filtering and persona profile filtering on the existing `n of m` copy because those denominators are accurate.
+- Added a mounted regression that forced the FTS path and first failed against the old `1 of 2 characters` copy.
+- Verification: `.venv/bin/python -m pytest -q Tests/UI/test_personas_workbench.py::TestSearch::test_fts_search_count_uses_unbounded_full_library_copy --tb=short`, `.venv/bin/python -m pytest -q Tests/UI/test_personas_workbench.py::TestSearch --tb=short`, `.venv/bin/python -m pytest -q Tests/UI/test_personas_workbench.py --tb=short`, and `git diff --check` all passed.
+- ADR check completed: no ADR required for this bounded UI copy/count correctness fix.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -585,6 +585,7 @@ class PersonasScreen(BaseAppScreen):
 
         query = expected_query if expected_query is not None else self.state.search_query
         total = len(self._characters)
+        filtered_total_unbounded = False
         if query:
             if total >= self.LIBRARY_FTS_THRESHOLD:
                 # Large library: use FTS so the full DB corpus is searched
@@ -595,6 +596,7 @@ class PersonasScreen(BaseAppScreen):
                 matched = await asyncio.to_thread(
                     ccp_character_handler.search_characters_fts, query
                 )
+                filtered_total_unbounded = True
             else:
                 # Small library: filter in-memory, case-insensitively on name.
                 q_lower = query.lower()
@@ -616,7 +618,13 @@ class PersonasScreen(BaseAppScreen):
                 return
             rows = self._build_library_rows(matched, "character")
             library = self.query_one(PersonasLibraryPane)
-            await library.update_rows(rows, total=total, noun="characters", filtered=filtered)
+            await library.update_rows(
+                rows,
+                total=total,
+                noun="characters",
+                filtered=filtered,
+                filtered_total_unbounded=filtered_total_unbounded,
+            )
             if self.state.selected_entity_kind == "character" and self.state.selected_entity_id:
                 library.mark_active_row("character", self.state.selected_entity_id)
 

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_library_pane.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_library_pane.py
@@ -24,6 +24,16 @@ def _row_dom_id(kind: str, item_id: str) -> str:
     return f"personas-library-row-{kind}-{_ID_SAFE.sub('-', str(item_id))}"
 
 
+def _singular_noun(noun: str) -> str:
+    """Return a compact singular label for count copy."""
+
+    if noun.endswith("ies"):
+        return f"{noun[:-3]}y"
+    if noun.endswith("s"):
+        return noun[:-1]
+    return noun
+
+
 @dataclass(frozen=True)
 class LibraryRow:
     """One selectable row in the workbench library list."""
@@ -130,6 +140,7 @@ class PersonasLibraryPane(Vertical):
         total: int,
         noun: str,
         filtered: bool = False,
+        filtered_total_unbounded: bool = False,
         recovery_copy: str | None = None,
         recovery_id: str = "personas-library-recovery",
     ) -> None:
@@ -141,6 +152,8 @@ class PersonasLibraryPane(Vertical):
             total: Total number of rows known for the current mode.
             noun: User-facing noun used in empty and count copy.
             filtered: Whether ``rows`` is a filtered subset of ``total``.
+            filtered_total_unbounded: Whether filtered rows came from a
+                full-library search whose total match denominator is unknown.
             recovery_copy: Optional multi-line recovery copy. When present, the
                 pane renders a disabled recovery row instead of list or empty
                 rows.
@@ -193,6 +206,12 @@ class PersonasLibraryPane(Vertical):
         await list_view.extend(items)
         if recovery_copy:
             count = f"{noun.capitalize()} unavailable"
+        elif filtered and filtered_total_unbounded:
+            match_word = "match" if len(rows) == 1 else "matches"
+            count = (
+                f"Showing {len(rows)} {_singular_noun(noun)} "
+                f"{match_word} from full library"
+            )
         else:
             count = f"{len(rows)} of {total} {noun}" if filtered else f"{total} {noun}"
         self.query_one("#personas-library-count", Static).update(count)


### PR DESCRIPTION
## Summary
- Show explicit full-library count copy when Personas character search uses the FTS path and the total match denominator is unknown.
- Keep existing `n of m` copy for in-memory character filtering and persona-profile filtering where totals are accurate.
- Mark TASK-113 done with ADR check and verification notes.

## Test Plan
- [x] `.venv/bin/python -m pytest -q Tests/UI/test_personas_workbench.py::TestSearch::test_fts_search_count_uses_unbounded_full_library_copy --tb=short`
- [x] `.venv/bin/python -m pytest -q Tests/UI/test_personas_workbench.py::TestSearch --tb=short`
- [x] `.venv/bin/python -m pytest -q Tests/UI/test_personas_workbench.py --tb=short`
- [x] `git diff --check origin/dev...HEAD`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Personas search count when FTS is used by showing a full‑library match count instead of a misleading "n of m". Keeps accurate "n of m" for in‑memory and persona‑profile filters; addresses TASK-113.

- **Bug Fixes**
  - Add `filtered_total_unbounded` to `PersonasLibraryPane.update_rows` and wire it from the FTS path in `personas_screen`.
  - Render: "Showing n character match(es) from full library" when unbounded.
  - Add a mounted regression test for the FTS count copy.

<sup>Written for commit ff2e13ac1e01d17a8954756dc4b60f8fe42959c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

