### PR TITLE
Wire Personas avatar upload

### DIFF
--- a/Docs/superpowers/plans/2026-06-27-personas-avatar-upload.md
+++ b/Docs/superpowers/plans/2026-06-27-personas-avatar-upload.md
@@ -1,0 +1,745 @@
+# Personas Avatar Upload Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore avatar upload in the ds-native Personas character editor with staged-until-Save persistence.
+
+**Architecture:** Keep the editor responsible for UI state and pending form data, while `PersonasScreen` owns file picker orchestration, path validation, notifications, and Save integration. Store staged avatar data as raw bytes in `_character_data["image"]`, then let the existing character create/update flow persist it on Save.
+
+**Tech Stack:** Python 3.11+, Textual, existing `EnhancedFileOpen`, `path_validation.validate_path_simple`, existing CCP character persistence helpers, pytest mounted UI tests.
+
+---
+
+## Source Material
+
+- Backlog task: `backlog/tasks/task-100 - Wire-avatar-upload-in-the-ds-native-character-editor.md`
+- Approved design: `Docs/superpowers/specs/2026-06-27-personas-avatar-upload-design.md`
+- Editor widget: `tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py`
+- Pane messages: `tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py`
+- Personas screen: `tldw_chatbook/UI/Screens/personas_screen.py`
+- Widget tests: `Tests/UI/test_personas_character_widgets.py`
+- Workbench tests: `Tests/UI/test_personas_workbench.py`
+
+## Scope Check
+
+This is one bounded UI workflow restoration.
+
+- In scope: upload button, upload-request message, image-only file picker flow, path-based staging helper, raw-byte staging, avatar status update, dirty-state signaling, Save-path persistence, focused tests, Backlog task hygiene.
+- Out of scope: avatar preview rendering, image resizing/compression, remove-avatar control, avatar URL editing, schema changes, sync changes, legacy editor resurrection, character-card import semantics.
+
+ADR required: no
+ADR path: N/A
+Reason: this restores a scoped UI workflow using existing editor, file picker, dirty-state, and character persistence boundaries. No schema, storage policy, sync policy, provider/runtime boundary, or long-lived application architecture changes.
+
+## File Structure
+
+- Modify `backlog/tasks/task-100 - Wire-avatar-upload-in-the-ds-native-character-editor.md`
+  - Track status, implementation plan, acceptance criteria, and implementation notes.
+
+- Create/modify `Docs/superpowers/plans/2026-06-27-personas-avatar-upload.md`
+  - Keep this implementation plan as the executable source of truth.
+
+- Modify `tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py`
+  - Add `CharacterImageUploadRequested`.
+
+- Modify `tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py`
+  - Render the upload button in the avatar row.
+  - Add a public `set_avatar_image(image_data: bytes)` editor API.
+  - Refactor dirty-state announcement into a helper used by text fields and avatar staging.
+  - Keep avatar status derived from pending editor state.
+
+- Modify `tldw_chatbook/UI/Screens/personas_screen.py`
+  - Handle `CharacterImageUploadRequested`.
+  - Open `EnhancedFileOpen` with image-only filters and `character_avatar_upload` context.
+  - Add a path-based helper that validates, reads bytes off the UI thread, stages into the editor, and notifies on failure.
+
+- Modify `Tests/UI/test_personas_character_widgets.py`
+  - Replace the old "no upload button" regression.
+  - Add widget-level tests for message emission, byte staging, status update, and dirty notification.
+
+- Modify `Tests/UI/test_personas_workbench.py`
+  - Add screen-level tests for path validation, editor mutation, dirty state, and Save persistence.
+
+---
+
+### Task 0: Backlog Task Hygiene
+
+**Files:**
+- Modify: `backlog/tasks/task-100 - Wire-avatar-upload-in-the-ds-native-character-editor.md`
+- Modify: `Docs/superpowers/plans/2026-06-27-personas-avatar-upload.md`
+
+- [ ] **Step 1: Confirm the task is In Progress**
+
+Run:
+
+```bash
+backlog task 100 --plain
+```
+
+Expected: status is `In Progress`.
+
+- [ ] **Step 2: Add the implementation plan summary to Backlog**
+
+Run:
+
+```bash
+backlog task edit 100 --plan "1. Add the CharacterImageUploadRequested message, upload button, and editor-side staged image API.
+2. Add widget tests proving the upload button emits the message and staged bytes update avatar status/dirty state.
+3. Add the PersonasScreen file-picker handler and path-based avatar staging helper using validate_path_simple.
+4. Add screen tests for valid staging, invalid paths/extensions, stale edit mode, and Save-path persistence.
+5. Run focused Personas tests and git diff --check.
+6. Update acceptance criteria and implementation notes before marking Done.
+
+ADR required: no
+ADR path: N/A
+Reason: scoped UI workflow restoration using existing editor, file picker, dirty-state, and character persistence boundaries; no schema, sync, storage, provider/runtime, or application-architecture change."
+```
+
+Expected: `TASK-100` contains the plan summary and ADR check.
+
+- [ ] **Step 3: Commit the planning artifacts**
+
+Run:
+
+```bash
+git add "backlog/tasks/task-100 - Wire-avatar-upload-in-the-ds-native-character-editor.md" Docs/superpowers/plans/2026-06-27-personas-avatar-upload.md
+git commit -m "docs: plan personas avatar upload"
+```
+
+Expected: commit succeeds with only the task file and plan staged.
+
+---
+
+### Task 1: Add Editor Upload Contract
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py`
+- Modify: `tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py`
+- Test: `Tests/UI/test_personas_character_widgets.py`
+
+- [ ] **Step 1: Write failing widget tests**
+
+In `Tests/UI/test_personas_character_widgets.py`, update the imports:
+
+```python
+from tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages import (
+    CharacterEditorCancelled,
+    CharacterImageUploadRequested,
+    CharacterSaveRequested,
+    EditCharacterRequested,
+    EditorContentChanged,
+)
+```
+
+Replace `test_no_upload_button_and_avatar_status_is_read_only` with tests shaped like:
+
+```python
+async def test_upload_button_posts_image_upload_request(self):
+    received = []
+
+    class CaptureApp(WidgetApp):
+        def on_character_image_upload_requested(
+            self, message: CharacterImageUploadRequested
+        ) -> None:
+            received.append(message)
+
+    app = CaptureApp()
+    async with app.run_test() as pilot:
+        button = pilot.app.query_one("#personas-char-editor-avatar-upload", Button)
+        button.press()
+        await pilot.pause()
+        assert len(received) == 1
+
+
+async def test_set_avatar_image_stages_bytes_updates_status_and_marks_dirty(self):
+    dirty_events = []
+
+    class CaptureApp(WidgetApp):
+        def on_editor_content_changed(self, message: EditorContentChanged) -> None:
+            dirty_events.append(message)
+
+    app = CaptureApp()
+    async with app.run_test() as pilot:
+        editor = pilot.app.query_one(PersonasCharacterEditorWidget)
+        record = dict(CHARACTER)
+        record.pop("image", None)
+        editor.load_character(record)
+        await pilot.pause()
+
+        editor.set_avatar_image(b"\x89PNG staged")
+        await pilot.pause()
+
+        assert editor.get_character_data()["image"] == b"\x89PNG staged"
+        assert (
+            str(
+                pilot.app.query_one(
+                    "#personas-char-editor-avatar-status", Static
+                ).renderable
+            )
+            == "Avatar: embedded"
+        )
+        assert len(dirty_events) == 1
+```
+
+Expected: tests fail because the message, button, and `set_avatar_image` API do not exist.
+
+- [ ] **Step 2: Run the widget tests and confirm failure**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_personas_character_widgets.py -q
+```
+
+Expected: failure references missing `CharacterImageUploadRequested`, missing `#personas-char-editor-avatar-upload`, or missing `set_avatar_image`.
+
+- [ ] **Step 3: Add the message class**
+
+In `tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py`, add:
+
+```python
+class CharacterImageUploadRequested(Message):
+    """User requested to choose an image for the active character editor."""
+```
+
+- [ ] **Step 4: Add the editor button and styles**
+
+In `PersonasCharacterEditorWidget.DEFAULT_CSS`, extend the avatar row styles:
+
+```python
+    PersonasCharacterEditorWidget #personas-char-editor-avatar-upload {
+        width: auto;
+        min-width: 0;
+        height: 1;
+        min-height: 1;
+        padding: 0 1;
+        border: none;
+    }
+```
+
+In `compose()`, change the avatar row to:
+
+```python
+with Horizontal(id="personas-char-editor-avatar-row"):
+    yield Static("Avatar: none", id="personas-char-editor-avatar-status")
+    yield Button(
+        "Upload",
+        id="personas-char-editor-avatar-upload",
+        classes="console-action-subdued",
+    )
+```
+
+- [ ] **Step 5: Add editor staging helpers**
+
+In `PersonasCharacterEditorWidget`, add helpers equivalent to:
+
+```python
+def _set_avatar_status_from_record(self) -> None:
+    avatar = "embedded" if (
+        self._character_data.get("image") or self._character_data.get("avatar")
+    ) else "none"
+    self.query_one("#personas-char-editor-avatar-status", Static).update(
+        f"Avatar: {avatar}"
+    )
+
+
+def _mark_dirty(self) -> None:
+    if self._loading or self._dirty_posted or self._loaded_snapshot is None:
+        return
+    self._dirty_posted = True
+    self.post_message(EditorContentChanged())
+
+
+def set_avatar_image(self, image_data: bytes) -> None:
+    """Stage avatar image bytes for persistence on the next Save."""
+    if not isinstance(image_data, bytes) or not image_data:
+        raise ValueError("Avatar image data must be non-empty bytes.")
+    self._character_data["image"] = image_data
+    self._set_avatar_status_from_record()
+    self._mark_dirty()
+```
+
+Then replace the repeated avatar-status update in `_populate_form()` with `self._set_avatar_status_from_record()`.
+
+- [ ] **Step 6: Reuse `_mark_dirty()` for text/input changes**
+
+Update `_field_changed()` so it still suppresses programmatic population, but delegates the one-time announcement:
+
+```python
+if self._loading or self._dirty_posted or self._loaded_snapshot is None:
+    return
+if self._form_snapshot() == self._loaded_snapshot:
+    return
+self._mark_dirty()
+```
+
+- [ ] **Step 7: Emit upload requests from the button**
+
+Import `CharacterImageUploadRequested`, then add:
+
+```python
+@on(Button.Pressed, "#personas-char-editor-avatar-upload")
+def _upload_avatar_pressed(self, event: Button.Pressed) -> None:
+    event.stop()
+    self.post_message(CharacterImageUploadRequested())
+```
+
+- [ ] **Step 8: Run widget tests until green**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_personas_character_widgets.py -q
+```
+
+Expected: all widget tests pass.
+
+- [ ] **Step 9: Commit Task 1**
+
+Run:
+
+```bash
+git add Tests/UI/test_personas_character_widgets.py tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
+git commit -m "feat: stage character avatar uploads in editor"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 2: Add Personas Screen Upload Flow
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/personas_screen.py`
+- Test: `Tests/UI/test_personas_workbench.py`
+
+- [ ] **Step 1: Write failing screen tests for path staging**
+
+In `Tests/UI/test_personas_workbench.py`, extend imports:
+
+```python
+from textual.widgets import Button, Static, Input
+
+from tldw_chatbook.Widgets.Persona_Widgets.personas_character_editor_widget import (
+    PersonasCharacterEditorWidget,
+)
+```
+
+Add tests near the import/export/path-based flow tests:
+
+```python
+async def test_stage_character_avatar_from_path_updates_editor_and_dirty_state(
+    self, mock_app_instance, stub_characters, tmp_path
+):
+    avatar = tmp_path / "avatar.png"
+    avatar.write_bytes(b"\x89PNG staged avatar")
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _mounted(pilot)
+        await pilot.pause()
+        await pilot.click("#personas-library-new")
+        await pilot.pause()
+
+        await screen._stage_character_avatar_from_path(str(avatar))
+        await pilot.pause()
+
+        editor = screen.query_one(PersonasCharacterEditorWidget)
+        assert editor.get_character_data()["image"] == b"\x89PNG staged avatar"
+        assert (
+            str(screen.query_one("#personas-char-editor-avatar-status", Static).renderable)
+            == "Avatar: embedded"
+        )
+        assert screen.state.has_unsaved_changes is True
+```
+
+Add an invalid-extension regression:
+
+```python
+async def test_stage_character_avatar_rejects_unsupported_extension_without_mutation(
+    self, mock_app_instance, stub_characters, tmp_path
+):
+    bad = tmp_path / "avatar.txt"
+    bad.write_text("not an image")
+    app = PersonasTestApp(mock_app_instance)
+    notifications = TestImportExport._capture_notifications(app)
+
+    async with app.run_test() as pilot:
+        screen = await _mounted(pilot)
+        await pilot.pause()
+        await pilot.click("#personas-library-new")
+        await pilot.pause()
+
+        await screen._stage_character_avatar_from_path(str(bad))
+        await pilot.pause()
+
+        editor = screen.query_one(PersonasCharacterEditorWidget)
+        assert "image" not in editor.get_character_data()
+        assert screen.state.has_unsaved_changes is False
+        assert any("Unsupported avatar image type" in msg for msg, _ in notifications)
+```
+
+Add a stale-mode regression:
+
+```python
+async def test_stage_character_avatar_requires_open_editor(
+    self, mock_app_instance, stub_characters, tmp_path
+):
+    avatar = tmp_path / "avatar.png"
+    avatar.write_bytes(b"\x89PNG staged avatar")
+    app = PersonasTestApp(mock_app_instance)
+    notifications = TestImportExport._capture_notifications(app)
+
+    async with app.run_test() as pilot:
+        screen = await _mounted(pilot)
+        await pilot.pause()
+
+        await screen._stage_character_avatar_from_path(str(avatar))
+        await pilot.pause()
+
+        assert screen.state.has_unsaved_changes is False
+        assert any("Open a character editor" in msg for msg, _ in notifications)
+```
+
+Expected: tests fail because `_stage_character_avatar_from_path` does not exist.
+
+- [ ] **Step 2: Run the targeted failing tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_personas_workbench.py -q -k "avatar"
+```
+
+Expected: failure references missing avatar staging helper.
+
+- [ ] **Step 3: Import the new message and path validation**
+
+In `tldw_chatbook/UI/Screens/personas_screen.py`, import:
+
+```python
+from ...Utils.path_validation import validate_path_simple
+```
+
+and add `CharacterImageUploadRequested` to the existing pane-message imports.
+
+- [ ] **Step 4: Add supported suffix constants**
+
+Near other screen-level constants, add:
+
+```python
+PERSONAS_AVATAR_IMAGE_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".webp", ".gif"})
+PERSONAS_AVATAR_IMAGE_SUFFIX_COPY = "PNG, JPG, JPEG, WEBP, or GIF"
+```
+
+- [ ] **Step 5: Add the read/validate helper**
+
+Add a synchronous helper so tests and the async wrapper have one validation source:
+
+```python
+def _read_avatar_image_bytes(self, path: str) -> bytes:
+    candidate = validate_path_simple(path, require_exists=True)
+    if not candidate.is_file():
+        raise ValueError("Choose an existing avatar image file.")
+    if candidate.suffix.lower() not in PERSONAS_AVATAR_IMAGE_SUFFIXES:
+        raise ValueError(
+            f"Unsupported avatar image type. Use {PERSONAS_AVATAR_IMAGE_SUFFIX_COPY}."
+        )
+    data = candidate.read_bytes()
+    if not data:
+        raise ValueError("Avatar image file is empty.")
+    return data
+```
+
+- [ ] **Step 6: Add the async path-based staging helper**
+
+Add:
+
+```python
+async def _stage_character_avatar_from_path(self, path: str) -> None:
+    if self._edit_mode not in ("create", "edit"):
+        self._notify("Open a character editor before uploading an avatar.", "warning")
+        return
+    try:
+        image_data = await asyncio.to_thread(self._read_avatar_image_bytes, path)
+    except ValueError as exc:
+        self._notify(str(exc), "error")
+        return
+    except OSError as exc:
+        logger.error(f"Error reading avatar image from {path}: {exc}", exc_info=True)
+        self._notify(f"Avatar upload failed: {exc}", "error")
+        return
+    try:
+        self.query_one(PersonasCharacterEditorWidget).set_avatar_image(image_data)
+    except Exception as exc:
+        logger.error("Could not stage avatar image in editor.", exc_info=True)
+        self._notify(f"Avatar upload failed: {exc}", "error")
+        return
+    self._notify("Avatar staged. Save the character to persist it.", "information")
+```
+
+- [ ] **Step 7: Run the path-staging tests until green**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_personas_workbench.py -q -k "avatar"
+```
+
+Expected: the new path helper tests pass.
+
+- [ ] **Step 8: Add the dialog worker and message handler**
+
+Add:
+
+```python
+@on(CharacterImageUploadRequested)
+def _handle_character_image_upload_requested(
+    self, message: CharacterImageUploadRequested
+) -> None:
+    message.stop()
+    if self._edit_mode not in ("create", "edit"):
+        self._notify("Open a character editor before uploading an avatar.", "warning")
+        return
+    if self._io_dialog_active:
+        logger.debug("Import/export dialog already active; ignoring avatar upload request.")
+        return
+    self._io_dialog_active = True
+    self.run_worker(self._avatar_upload_dialog_worker(), group="personas-io")
+```
+
+Add:
+
+```python
+async def _avatar_upload_dialog_worker(self) -> None:
+    from ...Widgets.enhanced_file_picker import EnhancedFileOpen, Filters
+
+    try:
+        picker = EnhancedFileOpen(
+            title="Upload Character Avatar",
+            filters=Filters(
+                (
+                    "Image Files",
+                    lambda p: p.suffix.lower() in PERSONAS_AVATAR_IMAGE_SUFFIXES,
+                ),
+                ("PNG Files", lambda p: p.suffix.lower() == ".png"),
+                ("JPEG Files", lambda p: p.suffix.lower() in (".jpg", ".jpeg")),
+                ("WEBP Files", lambda p: p.suffix.lower() == ".webp"),
+                ("GIF Files", lambda p: p.suffix.lower() == ".gif"),
+            ),
+            context="character_avatar_upload",
+        )
+        try:
+            file_path = await self.app.push_screen_wait(picker)
+        except Exception:
+            logger.warning("Could not show the avatar upload file dialog.", exc_info=True)
+            return
+        if file_path:
+            await self._stage_character_avatar_from_path(str(file_path))
+    finally:
+        self._io_dialog_active = False
+```
+
+- [ ] **Step 9: Add a message-handler test**
+
+Add a test that posts `CharacterImageUploadRequested` while in create mode, monkeypatches `_avatar_upload_dialog_worker`, and asserts exactly one worker is launched unless `_io_dialog_active` is already true.
+
+Minimal shape:
+
+```python
+async def test_avatar_upload_request_launches_dialog_worker(
+    self, mock_app_instance, stub_characters
+):
+    calls: list[int] = []
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _mounted(pilot)
+        await pilot.pause()
+        await pilot.click("#personas-library-new")
+        await pilot.pause()
+
+        def worker():
+            calls.append(1)
+
+            async def _noop():
+                pass
+
+            return _noop()
+
+        screen._avatar_upload_dialog_worker = worker
+        screen.post_message(CharacterImageUploadRequested())
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        assert calls == [1]
+```
+
+- [ ] **Step 10: Run workbench avatar tests until green**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_personas_workbench.py -q -k "avatar"
+```
+
+Expected: all avatar-related workbench tests pass.
+
+- [ ] **Step 11: Commit Task 2**
+
+Run:
+
+```bash
+git add Tests/UI/test_personas_workbench.py tldw_chatbook/UI/Screens/personas_screen.py
+git commit -m "feat: wire personas avatar upload flow"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 3: Prove Save Persists Staged Avatar Bytes
+
+**Files:**
+- Modify: `Tests/UI/test_personas_workbench.py`
+
+- [ ] **Step 1: Add a Save-path regression**
+
+Add a mounted create-flow test:
+
+```python
+async def test_save_persists_staged_avatar_bytes(
+    self, mock_app_instance, stub_characters, monkeypatch, tmp_path
+):
+    avatar = tmp_path / "avatar.png"
+    avatar.write_bytes(b"\x89PNG staged avatar")
+    created: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        character_handler_module,
+        "create_character",
+        lambda data: created.append(dict(data)) or 99,
+    )
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _mounted(pilot)
+        await pilot.pause()
+        await pilot.click("#personas-library-new")
+        await pilot.pause()
+        screen.query_one("#personas-char-editor-name", Input).value = "Avatar Hero"
+        await screen._stage_character_avatar_from_path(str(avatar))
+        await pilot.pause()
+        await pilot.press("ctrl+s")
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+    assert created
+    assert created[0]["name"] == "Avatar Hero"
+    assert created[0]["image"] == b"\x89PNG staged avatar"
+```
+
+Expected: if Task 2 is incomplete, this fails because no image is staged or persisted.
+
+- [ ] **Step 2: Run the Save-path regression**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_personas_workbench.py -q -k "avatar or ctrl_s_saves_from_editor"
+```
+
+Expected: avatar tests and the nearby Save keyboard regression pass.
+
+- [ ] **Step 3: Commit Task 3**
+
+Run:
+
+```bash
+git add Tests/UI/test_personas_workbench.py
+git commit -m "test: cover staged avatar save"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 4: Final Verification and Backlog Completion
+
+**Files:**
+- Modify: `backlog/tasks/task-100 - Wire-avatar-upload-in-the-ds-native-character-editor.md`
+
+- [ ] **Step 1: Run focused UI suites**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_personas_character_widgets.py Tests/UI/test_personas_workbench.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Run diff whitespace check**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output and exit code 0.
+
+- [ ] **Step 3: Inspect the implementation diff**
+
+Run:
+
+```bash
+git diff origin/dev...HEAD --stat
+git diff origin/dev...HEAD -- tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py tldw_chatbook/UI/Screens/personas_screen.py
+```
+
+Expected: diff is scoped to the planned files, no unrelated refactors, and avatar image data is stored as bytes.
+
+- [ ] **Step 4: Update Backlog acceptance criteria and implementation notes**
+
+Edit `backlog/tasks/task-100 - Wire-avatar-upload-in-the-ds-native-character-editor.md` so both ACs are checked and add:
+
+```markdown
+## Implementation Notes
+
+Restored character avatar upload in the ds-native Personas editor using the existing staged edit workflow. The editor now emits `CharacterImageUploadRequested`, stages raw image bytes in pending character data, updates avatar status, and marks the session dirty. `PersonasScreen` opens an image-filtered picker, validates selected paths with `validate_path_simple`, reads bytes off the UI thread, and persists the staged image through the existing Save flow.
+
+ADR required: no
+ADR path: N/A
+Reason: scoped UI workflow restoration using existing editor, file picker, dirty-state, and character persistence boundaries; no schema, sync, storage, provider/runtime, or application-architecture change.
+```
+
+- [ ] **Step 5: Mark the task Done via Backlog CLI**
+
+Run:
+
+```bash
+backlog task edit 100 -s Done
+```
+
+Expected: `TASK-100` status is `Done`.
+
+- [ ] **Step 6: Commit task completion**
+
+Run:
+
+```bash
+git add "backlog/tasks/task-100 - Wire-avatar-upload-in-the-ds-native-character-editor.md"
+git commit -m "docs: complete avatar upload task"
+```
+
+Expected: commit succeeds.
+
+- [ ] **Step 7: Final branch check**
+
+Run:
+
+```bash
+git status --short --branch
+```
+
+Expected: clean branch, ahead of `origin/dev` by the planning and implementation commits.

--- a/Docs/superpowers/plans/2026-06-27-personas-markdown-character-import.md
+++ b/Docs/superpowers/plans/2026-06-27-personas-markdown-character-import.md
@@ -1,0 +1,155 @@
+# Personas Markdown Character Import Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow Personas character import to accept Markdown files that embed existing supported character-card data.
+
+**Architecture:** Reuse the existing character-card import helper and parser. Expand only the ds-native Personas picker affordance and add regression coverage for Markdown YAML frontmatter, Markdown fenced JSON, invalid Markdown failure, and existing JSON/PNG import behavior.
+
+**Tech Stack:** Python 3.11+, Textual, existing `EnhancedFileOpen`, existing `Character_Chat_Lib.load_character_card_from_string_content`, pytest mounted UI/unit tests.
+
+---
+
+## Source Material
+
+- Backlog task: `backlog/tasks/task-140 - Support-Markdown-character-card-imports.md`
+- Approved design: `Docs/superpowers/specs/2026-06-27-personas-markdown-character-import-design.md`
+- Personas screen import picker: `tldw_chatbook/UI/Screens/personas_screen.py`
+- Parser: `tldw_chatbook/Character_Chat/Character_Chat_Lib.py`
+- Import-flow tests: `Tests/UI/test_personas_workbench.py`
+- Parser tests: `Tests/Character_Chat/test_character_chat.py` or a new focused character-import parser test file if local imports make that cleaner.
+
+## Scope Check
+
+This is one small import affordance and coverage change.
+
+- In scope: `.md` / `.markdown` picker filters, parser regression tests for the existing Markdown wrappers, Personas import-flow tests.
+- Out of scope: a new heading/prose Markdown schema, bulk import, DB/schema changes, sync changes, avatar upload changes.
+
+ADR required: no
+ADR path: N/A
+Reason: import picker/parser affordance and regression coverage using existing import and storage boundaries; no new long-lived Markdown schema or storage contract.
+
+## File Structure
+
+- Modify `backlog/tasks/task-140 - Support-Markdown-character-card-imports.md`
+  - Track implementation plan, checked ACs, and implementation notes.
+
+- Create/modify `Docs/superpowers/plans/2026-06-27-personas-markdown-character-import.md`
+  - This implementation plan.
+
+- Modify `tldw_chatbook/UI/Screens/personas_screen.py`
+  - Add `.md` / `.markdown` to the import picker filters.
+
+- Modify `Tests/UI/test_personas_workbench.py`
+  - Add filter coverage and import-flow regressions for Markdown success/failure.
+
+- Modify/create `Tests/Character_Chat/test_character_import_markdown.py`
+  - Add parser regressions for YAML frontmatter and fenced JSON Markdown.
+
+---
+
+### Task 1: Add Parser Regression Coverage
+
+**Files:**
+- Test: `Tests/Character_Chat/test_character_import_markdown.py`
+
+- [ ] **Step 1: Add failing parser tests**
+
+Create tests that call `load_character_card_from_string_content()` with:
+
+- Markdown fenced JSON containing a valid V2 card.
+- Markdown YAML frontmatter containing a valid V2-like card object.
+- Invalid Markdown with no card data.
+
+Expected:
+
+- Valid Markdown returns parsed card data with `name`, `first_message`, and `message_example`.
+- Invalid Markdown returns `None`.
+
+- [ ] **Step 2: Run parser tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Character_Chat/test_character_import_markdown.py -q
+```
+
+Expected: pass if the existing parser already supports the approved forms. If a test fails because of a parser bug in an approved form, fix the parser minimally.
+
+---
+
+### Task 2: Add Personas Picker and Import Flow Coverage
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/personas_screen.py`
+- Modify: `Tests/UI/test_personas_workbench.py`
+
+- [ ] **Step 1: Add failing UI/import tests**
+
+Add tests proving:
+
+- The import picker filters include `.md` / `.markdown` in the "Character Cards" filter and expose a Markdown-specific filter option.
+- `_import_character_from_path()` passes `.md` paths to `ccp_character_handler.import_character_card()`.
+- Invalid Markdown import failure leaves the existing selection unchanged and shows the existing failure notification.
+
+- [ ] **Step 2: Update import picker filters**
+
+In `_import_dialog_worker()`, expand filters to include Markdown:
+
+```python
+("Character Cards", lambda p: p.suffix.lower() in (".json", ".md", ".markdown", ".png")),
+("JSON Files", lambda p: p.suffix.lower() == ".json"),
+("Markdown Files", lambda p: p.suffix.lower() in (".md", ".markdown")),
+("PNG Files (with embedded data)", lambda p: p.suffix.lower() == ".png"),
+("All Files", lambda p: True),
+```
+
+- [ ] **Step 3: Run focused UI tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_personas_workbench.py -q -k "import"
+```
+
+Expected: import-flow tests pass and existing JSON/PNG/import behavior remains unchanged.
+
+---
+
+### Task 3: Final Verification and Task Completion
+
+**Files:**
+- Modify: `backlog/tasks/task-140 - Support-Markdown-character-card-imports.md`
+
+- [ ] **Step 1: Run focused verification**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Character_Chat/test_character_import_markdown.py Tests/UI/test_personas_workbench.py -q -k "markdown or import"
+git diff --check
+```
+
+Expected: tests and diff check pass.
+
+- [ ] **Step 2: Complete Backlog task**
+
+Check all ACs, add implementation notes, and run:
+
+```bash
+backlog task edit 140 -s Done
+```
+
+- [ ] **Step 3: Commit**
+
+Run:
+
+```bash
+git add Docs/superpowers/plans/2026-06-27-personas-markdown-character-import.md \
+  "backlog/tasks/task-140 - Support-Markdown-character-card-imports.md" \
+  Tests/Character_Chat/test_character_import_markdown.py \
+  Tests/UI/test_personas_workbench.py \
+  tldw_chatbook/UI/Screens/personas_screen.py
+git commit -m "feat: support markdown character imports"
+```

--- a/Docs/superpowers/specs/2026-06-27-personas-avatar-upload-design.md
+++ b/Docs/superpowers/specs/2026-06-27-personas-avatar-upload-design.md
@@ -1,0 +1,74 @@
+# Personas Avatar Upload Design
+
+## Task
+
+TASK-100 - Wire avatar upload in the ds-native character editor.
+
+## Goal
+
+Restore avatar upload in the Personas character editor so users can select an image file, see the editor reflect that an avatar is staged, and persist the avatar through the normal Save flow.
+
+## Current Context
+
+The ds-native `PersonasCharacterEditorWidget` replaced the legacy editor with a flat form and a read-only avatar status line. The screen already owns character Save, validation, dirty state, import/export dialogs, and worker-backed file picker flows. Character card storage uses the `image` field as a BLOB/bytes value; character card export handles base64 conversion later when producing JSON or PNG card output.
+
+## UX Decision
+
+Avatar upload is staged until Save.
+
+Selecting a file updates only the active editor session. It does not immediately write to the database. Save persists the staged image through the existing create/update path. Cancel, mode changes guarded by unsaved state, or leaving without saving discard the staged upload exactly like other unsaved editor changes.
+
+## Proposed Flow
+
+1. The character editor avatar row shows the current status and an `Upload` button.
+2. Pressing `Upload` posts a `CharacterImageUploadRequested` message.
+3. `PersonasScreen` handles the message only while `_edit_mode` is `create` or `edit`.
+4. The screen opens `EnhancedFileOpen` in a worker, using image-only filters and a distinct `character_avatar_upload` picker context.
+5. A path-based helper validates the selected path, reads image bytes, and passes those bytes to the editor.
+6. The editor stages the bytes in `_character_data["image"]`, updates the status line to `Avatar: embedded`, and posts `EditorContentChanged` if the session is not already dirty.
+7. The existing Save handler persists `get_character_data()` through `ccp_character_handler.create_character` or `update_character`.
+
+## Data Handling
+
+Store staged avatar data as raw `bytes` in the editor's pending character data. Do not base64-encode at upload time. Existing DB and export code already treat `character_cards.image` as bytes and perform export-time base64 conversion when needed.
+
+If the loaded record contains an existing `image`, untouched saves continue to preserve it because `get_character_data()` starts from `_character_data`. Upload replaces only the pending `image` value for the active editor session.
+
+## Validation
+
+The picker filters should accept common local image formats: `.png`, `.jpg`, `.jpeg`, `.webp`, and `.gif`. The path-based helper must also validate:
+
+- the path exists and is a file
+- the suffix is one of the supported image extensions
+- the file can be read
+- empty files are rejected
+
+Validation errors should notify the user and leave the editor state unchanged.
+
+## Tests
+
+Update the existing regression that asserts the upload button is absent. It should now assert that the button exists and posts `CharacterImageUploadRequested`.
+
+Add focused coverage for:
+
+- selected image bytes update the editor status to `Avatar: embedded`
+- `get_character_data()` includes the staged bytes before Save
+- staged image upload posts dirty-state notification
+- the screen path helper rejects invalid paths/extensions without mutating editor state
+- Save receives/persists the staged `image` bytes through the existing character save path
+
+## ADR Check
+
+ADR required: no
+
+ADR path: N/A
+
+Reason: this restores a scoped UI workflow using existing editor, file picker, dirty-state, and character persistence boundaries. It does not change schema, storage policy, sync policy, provider/runtime boundaries, or long-lived application architecture.
+
+## Reviewed Refinements
+
+The design review tightened the initial proposal in three places:
+
+- stage raw bytes, not base64 text
+- validate selected paths in the helper instead of relying only on picker filters
+- use a dedicated avatar-upload picker context rather than reusing character import semantics

--- a/Docs/superpowers/specs/2026-06-27-personas-markdown-character-import-design.md
+++ b/Docs/superpowers/specs/2026-06-27-personas-markdown-character-import-design.md
@@ -1,0 +1,87 @@
+# Personas Markdown Character Import Design
+
+## Task
+
+TASK-140 - Support Markdown character card imports.
+
+## Goal
+
+Let users import Markdown files from the ds-native Personas character import flow when the Markdown embeds the same character-card data formats already supported by the lower-level importer.
+
+## Current Context
+
+The ds-native Personas import picker currently advertises character card imports as `.json` and `.png`. The lower-level character import path already reads text files and parses character-card data from direct JSON, YAML frontmatter, or fenced JSON blocks before saving through the existing character-card import helper.
+
+The gap is mostly the Personas picker affordance and regression coverage. A user with a valid `.md` character card can bypass the picker only indirectly; the normal import flow does not make Markdown visible as a supported card source.
+
+## Scope
+
+In scope:
+
+- Add `.md` / `.markdown` to the ds-native Personas character import picker filters.
+- Keep JSON and PNG import behavior unchanged.
+- Add tests for Markdown import paths that already match the importer contract.
+- Add tests for invalid Markdown failing through the existing import failure path.
+
+Out of scope:
+
+- A new heading-based or prose-based Markdown character schema.
+- Markdown-to-character inference.
+- Bulk imports.
+- Schema or DB changes.
+- Changes to avatar upload behavior.
+
+## Supported Markdown Forms
+
+Markdown import is valid only when the file contains existing character-card data in one of these forms:
+
+1. YAML frontmatter containing the character card object.
+2. A fenced JSON block containing the character card object.
+
+The object inside either wrapper must still satisfy the existing V1/V2 character card parser. Invalid Markdown should not create or select a character.
+
+## Proposed Flow
+
+1. User chooses Import from the Personas character mode.
+2. `EnhancedFileOpen` offers `.json`, `.md` / `.markdown`, and `.png`.
+3. The selected path continues through `_import_character_from_path()`.
+4. `_import_character_from_path()` continues delegating to `ccp_character_handler.import_character_card()`.
+5. The lower-level importer reads text content and extracts/parses the embedded character-card object.
+6. Success refreshes, selects, and reveals the imported character exactly like JSON/PNG import.
+7. Failure uses the existing import failure notification.
+
+## Alternatives Considered
+
+### Recommended: Picker + Regression Coverage
+
+Expose Markdown in the ds-native picker and add parser/import tests around the existing text-card contract.
+
+Pros: smallest change, reuses existing parser, does not create a second format, low risk to the open PR.
+
+Cons: Markdown must embed structured card data; prose-only Markdown remains unsupported.
+
+### New Human-Readable Markdown Schema
+
+Parse headings like `# Name`, `## Personality`, and `## Scenario`.
+
+Pros: easier for humans to write from scratch.
+
+Cons: ambiguous, larger parser surface, likely to diverge from V1/V2 card semantics, and out of scope for this follow-up.
+
+## Tests
+
+Add focused coverage for:
+
+- Personas import picker filters include Markdown alongside JSON and PNG.
+- `_import_character_from_path()` accepts `.md` paths and routes them through the existing import helper.
+- `load_character_card_from_string_content()` parses Markdown fenced JSON with valid V2 card data.
+- `load_character_card_from_string_content()` parses Markdown YAML frontmatter with valid card data.
+- Invalid Markdown returns no parsed card and the screen import flow shows the existing failure notification without changing the current selection.
+
+## ADR Check
+
+ADR required: no
+
+ADR path: N/A
+
+Reason: this is an import picker/parser affordance and regression coverage using existing import and storage boundaries. It introduces no new storage schema, persistence policy, sync policy, provider/runtime boundary, or long-lived Markdown schema.

--- a/Tests/Character_Chat/test_character_import_markdown.py
+++ b/Tests/Character_Chat/test_character_import_markdown.py
@@ -1,0 +1,91 @@
+"""Regression tests for Markdown-wrapped character card imports."""
+
+from __future__ import annotations
+
+import json
+
+from tldw_chatbook.Character_Chat.Character_Chat_Lib import (
+    load_character_card_from_string_content,
+)
+
+
+def _v2_card(name: str = "Markdown Hero") -> dict:
+    return {
+        "spec": "chara_card_v2",
+        "spec_version": "2.0",
+        "data": {
+            "name": name,
+            "description": "Imported from Markdown.",
+            "personality": "Careful and direct.",
+            "scenario": "A Markdown import test.",
+            "first_mes": "Hello from Markdown.",
+            "mes_example": "User: hi\nCharacter: hello",
+            "creator_notes": "Keep the wrapper format structured.",
+            "system_prompt": "Stay in character.",
+            "post_history_instructions": "Keep replies brief.",
+            "alternate_greetings": ["Second hello."],
+            "tags": ["markdown", "test"],
+            "creator": "Test Suite",
+            "character_version": "1.0",
+        },
+    }
+
+
+def test_load_character_card_from_markdown_json_code_block() -> None:
+    card = _v2_card("Fenced JSON Hero")
+    markdown = f"""# Character Card
+
+```json
+{json.dumps(card)}
+```
+"""
+
+    parsed = load_character_card_from_string_content(markdown)
+
+    assert parsed is not None
+    assert parsed["name"] == "Fenced JSON Hero"
+    assert parsed["first_message"] == "Hello from Markdown."
+    assert parsed["message_example"] == "User: hi\nCharacter: hello"
+
+
+def test_load_character_card_from_markdown_yaml_frontmatter() -> None:
+    markdown = """---
+spec: chara_card_v2
+spec_version: '2.0'
+data:
+  name: YAML Hero
+  description: Imported from Markdown frontmatter.
+  personality: Careful and direct.
+  scenario: A Markdown import test.
+  first_mes: Hello from YAML frontmatter.
+  mes_example: "User: hi\\nCharacter: hello"
+  creator_notes: Keep the wrapper format structured.
+  system_prompt: Stay in character.
+  post_history_instructions: Keep replies brief.
+  alternate_greetings:
+    - Second hello.
+  tags:
+    - markdown
+    - yaml
+  creator: Test Suite
+  character_version: '1.0'
+---
+
+# YAML Hero
+"""
+
+    parsed = load_character_card_from_string_content(markdown)
+
+    assert parsed is not None
+    assert parsed["name"] == "YAML Hero"
+    assert parsed["first_message"] == "Hello from YAML frontmatter."
+    assert parsed["message_example"] == "User: hi\nCharacter: hello"
+
+
+def test_load_character_card_from_invalid_markdown_returns_none() -> None:
+    markdown = """# Not a Character Card
+
+This prose does not contain YAML frontmatter or a fenced JSON character card.
+"""
+
+    assert load_character_card_from_string_content(markdown) is None

--- a/Tests/UI/test_personas_character_widgets.py
+++ b/Tests/UI/test_personas_character_widgets.py
@@ -6,8 +6,10 @@ from textual.widgets import Button, Input, Static, TextArea
 
 from tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages import (
     CharacterEditorCancelled,
+    CharacterImageUploadRequested,
     CharacterSaveRequested,
     EditCharacterRequested,
+    EditorContentChanged,
 )
 from tldw_chatbook.Widgets.Persona_Widgets.personas_character_card_widget import (
     PersonasCharacterCardWidget,
@@ -404,14 +406,41 @@ class TestCharacterEditor:
             assert advanced.display is False
             assert str(toggle.label) == "Advanced ▸"
 
-    async def test_no_upload_button_and_avatar_status_is_read_only(self):
-        """No handler exists for avatar upload, so the editor must not offer it."""
-        app = WidgetApp()
+    async def test_upload_button_posts_image_upload_request(self):
+        received = []
+
+        class CaptureApp(WidgetApp):
+            def on_character_image_upload_requested(
+                self, message: CharacterImageUploadRequested
+            ) -> None:
+                received.append(message)
+
+        app = CaptureApp()
         async with app.run_test() as pilot:
-            assert not list(pilot.app.query("#personas-char-editor-avatar-upload"))
-            editor = pilot.app.query_one(PersonasCharacterEditorWidget)
-            editor.load_character(dict(CHARACTER))
+            button = pilot.app.query_one("#personas-char-editor-avatar-upload", Button)
+            button.press()
             await pilot.pause()
+            assert len(received) == 1
+
+    async def test_set_avatar_image_stages_bytes_updates_status_and_marks_dirty(self):
+        dirty_events = []
+
+        class CaptureApp(WidgetApp):
+            def on_editor_content_changed(self, message: EditorContentChanged) -> None:
+                dirty_events.append(message)
+
+        app = CaptureApp()
+        async with app.run_test() as pilot:
+            editor = pilot.app.query_one(PersonasCharacterEditorWidget)
+            record = dict(CHARACTER)
+            record.pop("image", None)
+            editor.load_character(record)
+            await pilot.pause()
+
+            editor.set_avatar_image(b"\x89PNG staged")
+            await pilot.pause()
+
+            assert editor.get_character_data()["image"] == b"\x89PNG staged"
             assert (
                 str(
                     pilot.app.query_one(
@@ -420,6 +449,7 @@ class TestCharacterEditor:
                 )
                 == "Avatar: embedded"
             )
+            assert len(dirty_events) == 1
 
     async def test_default_id_matches_screen_query(self):
         app = WidgetApp()

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -1436,6 +1436,58 @@ class TestImportExport:
             assert screen.state.has_unsaved_changes is False
             assert any("Unsupported avatar image type" in msg for msg, _ in notifications)
 
+    async def test_stage_character_avatar_rejects_oversize_without_mutation(
+        self, mock_app_instance, stub_characters, tmp_path
+    ):
+        avatar = tmp_path / "avatar.png"
+        with avatar.open("wb") as avatar_file:
+            avatar_file.truncate(personas_screen_module.PERSONAS_AVATAR_MAX_BYTES + 1)
+        app = PersonasTestApp(mock_app_instance)
+        notifications = TestImportExport._capture_notifications(app)
+
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            await pilot.pause()
+            await pilot.click("#personas-library-new")
+            await pilot.pause()
+
+            await screen._stage_character_avatar_from_path(str(avatar))
+            await pilot.pause()
+
+            editor = screen.query_one(PersonasCharacterEditorWidget)
+            assert "image" not in editor.get_character_data()
+            assert screen.state.has_unsaved_changes is False
+            assert any("5 MB or smaller" in msg for msg, _ in notifications)
+
+    async def test_stage_character_avatar_drops_stale_read_after_editor_restarts(
+        self, mock_app_instance, stub_characters, monkeypatch, tmp_path
+    ):
+        avatar = tmp_path / "avatar.png"
+        avatar.write_bytes(b"\x89PNG original avatar")
+        app = PersonasTestApp(mock_app_instance)
+        notifications = TestImportExport._capture_notifications(app)
+
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            await pilot.pause()
+            await pilot.click("#personas-library-new")
+            await pilot.pause()
+
+            async def fake_to_thread(function: Any, path: str) -> bytes:
+                screen._finish_cancel_edit()
+                await screen._begin_create_character()
+                return b"\x89PNG stale avatar"
+
+            monkeypatch.setattr(personas_screen_module.asyncio, "to_thread", fake_to_thread)
+
+            await screen._stage_character_avatar_from_path(str(avatar))
+            await pilot.pause()
+
+            editor = screen.query_one(PersonasCharacterEditorWidget)
+            assert "image" not in editor.get_character_data()
+            assert screen.state.has_unsaved_changes is False
+            assert not any("Avatar staged" in msg for msg, _ in notifications)
+
     async def test_stage_character_avatar_requires_open_editor(
         self, mock_app_instance, stub_characters, tmp_path
     ):

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -1242,6 +1242,76 @@ class TestImportExport:
             rows = screen.query(".personas-library-row")
             assert "Imported Hero" in [_row_text(r) for r in rows]
 
+    async def test_import_markdown_routes_through_character_import_helper(
+        self, mock_app_instance, stub_characters, monkeypatch, tmp_path
+    ):
+        imported_paths: list[str] = []
+        card_path = tmp_path / "card.md"
+        card_path.write_text("# Character Card\n", encoding="utf-8")
+
+        def fake_import(file_path):
+            imported_paths.append(file_path)
+            return 3
+
+        monkeypatch.setattr(
+            character_handler_module, "import_character_card", fake_import
+        )
+
+        def fetch_all_with_imported():
+            characters = [dict(c) for c in CHARACTERS]
+            if imported_paths:
+                characters.append({"id": 3, "name": "Markdown Hero", "version": 1})
+            return characters
+
+        monkeypatch.setattr(
+            character_handler_module, "fetch_all_characters", fetch_all_with_imported
+        )
+        monkeypatch.setattr(
+            character_handler_module,
+            "fetch_character_by_id",
+            lambda character_id: next(
+                (
+                    dict(c)
+                    for c in fetch_all_with_imported()
+                    if str(c["id"]) == str(character_id)
+                ),
+                None,
+            ),
+        )
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            await pilot.pause()
+            await screen._import_character_from_path(str(card_path))
+            await pilot.pause()
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+            assert imported_paths == [str(card_path)]
+            assert screen.state.selected_entity_id == "3"
+
+    async def test_import_invalid_markdown_uses_failure_path_without_selection_change(
+        self, mock_app_instance, stub_characters, monkeypatch, tmp_path
+    ):
+        bad_path = tmp_path / "bad.md"
+        bad_path.write_text("# Not a character card\n", encoding="utf-8")
+        monkeypatch.setattr(
+            character_handler_module, "import_character_card", lambda file_path: None
+        )
+        app = PersonasTestApp(mock_app_instance)
+        notifications = self._capture_notifications(app)
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            await pilot.pause()
+            await pilot.click("#personas-library-row-character-1")
+            await pilot.pause()
+            await screen._import_character_from_path(str(bad_path))
+            await pilot.pause()
+            assert screen.state.selected_entity_id == "1"
+            assert any(
+                "valid character card" in message and severity == "error"
+                for message, severity in notifications
+            )
+
     async def test_second_import_request_ignored_while_dialog_active(
         self, mock_app_instance, stub_characters
     ):
@@ -3956,6 +4026,29 @@ class TestImportExportFilters:
                 pilot, screen, screen._import_dialog_worker
             )
             self._assert_filters_callable(picker.filters)
+
+    async def test_import_filters_include_markdown(
+        self, mock_app_instance, stub_characters
+    ):
+        from pathlib import Path
+
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            picker = await self._capture_picker(
+                pilot, screen, screen._import_dialog_worker
+            )
+            filter_by_name = {
+                name: picker.filters[filter_id]
+                for name, filter_id in picker.filters.selections
+            }
+
+            assert "Markdown Files" in filter_by_name
+            assert filter_by_name["Character Cards"](Path("character.md")) is True
+            assert filter_by_name["Character Cards"](Path("character.markdown")) is True
+            assert filter_by_name["Markdown Files"](Path("character.md")) is True
+            assert filter_by_name["Markdown Files"](Path("character.markdown")) is True
+            assert filter_by_name["Markdown Files"](Path("character.json")) is False
 
     async def test_export_json_filters_are_callable(
         self, mock_app_instance, stub_characters

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -3520,6 +3520,36 @@ class TestKeyboardInteraction:
             assert screen._edit_mode == "view"
         assert created and created[0]["name"] == "New Hero"
 
+    async def test_save_persists_staged_avatar_bytes(
+        self, mock_app_instance, stub_characters, monkeypatch, tmp_path
+    ):
+        avatar = tmp_path / "avatar.png"
+        avatar.write_bytes(b"\x89PNG staged avatar")
+        created: list[dict[str, Any]] = []
+        monkeypatch.setattr(
+            character_handler_module,
+            "create_character",
+            lambda data: created.append(dict(data)) or 99,
+        )
+        app = PersonasTestApp(mock_app_instance)
+
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            await pilot.pause()
+            await pilot.click("#personas-library-new")
+            await pilot.pause()
+            screen.query_one("#personas-char-editor-name", Input).value = "Avatar Hero"
+            await screen._stage_character_avatar_from_path(str(avatar))
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+        assert created
+        assert created[0]["name"] == "Avatar Hero"
+        assert created[0]["image"] == b"\x89PNG staged avatar"
+
     async def test_ctrl_s_noop_in_view_mode(
         self, mock_app_instance, stub_characters, monkeypatch
     ):

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 from textual.app import App
-from textual.widgets import Button, Static
+from textual.widgets import Button, Input, Static
 
 import tldw_chatbook.UI.CCP_Modules.ccp_character_handler as character_handler_module
 import tldw_chatbook.UI.Persona_Modules.personas_conversations_controller as conversations_controller_module
@@ -27,7 +27,11 @@ from tldw_chatbook.Widgets.Persona_Widgets.personas_messages import PersonaActio
 from tldw_chatbook.Widgets.Persona_Widgets.personas_inspector_pane import (
     PersonasInspectorPane,
 )
+from tldw_chatbook.Widgets.Persona_Widgets.personas_character_editor_widget import (
+    PersonasCharacterEditorWidget,
+)
 from tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages import (
+    CharacterImageUploadRequested,
     EditPersonaRequested,
     PersonaProfileSaveRequested,
 )
@@ -1315,6 +1319,101 @@ class TestImportExport:
                 for message, severity in notifications
             )
             assert screen.state.selected_entity_id == "1"
+
+    async def test_stage_character_avatar_from_path_updates_editor_and_dirty_state(
+        self, mock_app_instance, stub_characters, tmp_path
+    ):
+        avatar = tmp_path / "avatar.png"
+        avatar.write_bytes(b"\x89PNG staged avatar")
+        app = PersonasTestApp(mock_app_instance)
+
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            await pilot.pause()
+            await pilot.click("#personas-library-new")
+            await pilot.pause()
+
+            await screen._stage_character_avatar_from_path(str(avatar))
+            await pilot.pause()
+
+            editor = screen.query_one(PersonasCharacterEditorWidget)
+            assert editor.get_character_data()["image"] == b"\x89PNG staged avatar"
+            assert (
+                str(screen.query_one("#personas-char-editor-avatar-status", Static).renderable)
+                == "Avatar: embedded"
+            )
+            assert screen.state.has_unsaved_changes is True
+
+    async def test_stage_character_avatar_rejects_unsupported_extension_without_mutation(
+        self, mock_app_instance, stub_characters, tmp_path
+    ):
+        bad = tmp_path / "avatar.txt"
+        bad.write_text("not an image")
+        app = PersonasTestApp(mock_app_instance)
+        notifications = TestImportExport._capture_notifications(app)
+
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            await pilot.pause()
+            await pilot.click("#personas-library-new")
+            await pilot.pause()
+
+            await screen._stage_character_avatar_from_path(str(bad))
+            await pilot.pause()
+
+            editor = screen.query_one(PersonasCharacterEditorWidget)
+            assert "image" not in editor.get_character_data()
+            assert screen.state.has_unsaved_changes is False
+            assert any("Unsupported avatar image type" in msg for msg, _ in notifications)
+
+    async def test_stage_character_avatar_requires_open_editor(
+        self, mock_app_instance, stub_characters, tmp_path
+    ):
+        avatar = tmp_path / "avatar.png"
+        avatar.write_bytes(b"\x89PNG staged avatar")
+        app = PersonasTestApp(mock_app_instance)
+        notifications = TestImportExport._capture_notifications(app)
+
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            await pilot.pause()
+
+            await screen._stage_character_avatar_from_path(str(avatar))
+            await pilot.pause()
+
+            assert screen.state.has_unsaved_changes is False
+            assert any("Open a character editor" in msg for msg, _ in notifications)
+
+    async def test_avatar_upload_request_launches_dialog_worker(
+        self, mock_app_instance, stub_characters
+    ):
+        calls: list[int] = []
+        app = PersonasTestApp(mock_app_instance)
+
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            await pilot.pause()
+            await pilot.click("#personas-library-new")
+            await pilot.pause()
+
+            def worker():
+                calls.append(1)
+
+                async def _noop():
+                    pass
+
+                return _noop()
+
+            screen._avatar_upload_dialog_worker = worker
+            screen.post_message(CharacterImageUploadRequested())
+            await pilot.pause()
+            await app.workers.wait_for_complete()
+            assert calls == [1]
+
+            screen.post_message(CharacterImageUploadRequested())
+            await pilot.pause()
+            await app.workers.wait_for_complete()
+            assert calls == [1]
 
     async def test_export_json_writes_file(
         self, mock_app_instance, stub_characters, stub_db, monkeypatch, tmp_path
@@ -2651,9 +2750,6 @@ class TestPreviewIntegration:
         from tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages import (
             EditCharacterRequested,
         )
-        from tldw_chatbook.Widgets.Persona_Widgets.personas_character_editor_widget import (
-            PersonasCharacterEditorWidget,
-        )
 
         app = PersonasTestApp(mock_app_instance)
         async with app.run_test(size=(160, 50)) as pilot:
@@ -2817,7 +2913,6 @@ class TestPreviewIntegration:
         history entry is popped so a retry does not send [user, user].
         """
         from textual.widgets import Button as _Button, Static as _Static
-        from textual.widgets import Input as _Input
 
         from tldw_chatbook.Widgets.Persona_Widgets.personas_preview_pane import (
             PersonasPreviewPane,
@@ -2831,7 +2926,7 @@ class TestPreviewIntegration:
             pane = screen.query_one(PersonasPreviewPane)
             pane.expand()
             await pilot.pause()
-            screen.query_one("#personas-preview-input", _Input).value = "Hi"
+            screen.query_one("#personas-preview-input", Input).value = "Hi"
             screen.query_one("#personas-preview-test-reply", _Button).press()
             await pilot.pause()
             await app.workers.wait_for_complete()
@@ -3340,8 +3435,6 @@ class TestKeyboardInteraction:
     async def test_ctrl_s_saves_from_editor(
         self, mock_app_instance, stub_characters, monkeypatch
     ):
-        from textual.widgets import Input
-
         created = []
         monkeypatch.setattr(
             character_handler_module, "create_character",

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -1384,6 +1384,75 @@ class TestImportExport:
             assert screen.state.has_unsaved_changes is False
             assert any("Open a character editor" in msg for msg, _ in notifications)
 
+    @staticmethod
+    async def _open_persona_editor(pilot, mode: str):
+        screen = await _mounted(pilot)
+        await pilot.pause()
+        await pilot.click("#personas-mode-personas")
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        if mode == "create":
+            await pilot.click("#personas-library-new")
+            await pilot.pause()
+        else:
+            await pilot.click("#personas-library-row-persona_profile-p-1")
+            await pilot.pause()
+            screen.post_message(EditPersonaRequested("p-1"))
+            await pilot.pause()
+        assert screen._edit_mode == mode
+        assert screen.state.has_unsaved_changes is False
+        return screen
+
+    @pytest.mark.parametrize("mode", ["create", "edit"])
+    async def test_stage_character_avatar_ignores_persona_editor_session(
+        self, mock_app_instance, stub_characters, stub_scope_service, tmp_path, mode
+    ):
+        avatar = tmp_path / f"persona-{mode}.png"
+        avatar.write_bytes(b"\x89PNG persona editor avatar")
+        app = PersonasTestApp(mock_app_instance)
+        notifications = TestImportExport._capture_notifications(app)
+
+        async with app.run_test() as pilot:
+            screen = await self._open_persona_editor(pilot, mode)
+
+            await screen._stage_character_avatar_from_path(str(avatar))
+            await pilot.pause()
+
+            editor = screen.query_one(PersonasCharacterEditorWidget)
+            assert "image" not in editor.get_character_data()
+            assert screen.state.has_unsaved_changes is False
+            assert any("Open a character editor" in msg for msg, _ in notifications)
+
+    @pytest.mark.parametrize("mode", ["create", "edit"])
+    async def test_avatar_upload_request_ignores_persona_editor_session(
+        self, mock_app_instance, stub_characters, stub_scope_service, mode
+    ):
+        calls: list[int] = []
+        app = PersonasTestApp(mock_app_instance)
+        notifications = TestImportExport._capture_notifications(app)
+
+        async with app.run_test() as pilot:
+            screen = await self._open_persona_editor(pilot, mode)
+
+            def worker():
+                calls.append(1)
+
+                async def _noop():
+                    pass
+
+                return _noop()
+
+            screen._avatar_upload_dialog_worker = worker
+            screen.post_message(CharacterImageUploadRequested())
+            await pilot.pause()
+            await app.workers.wait_for_complete()
+
+            assert calls == []
+            assert screen._io_dialog_active is False
+            assert screen.state.has_unsaved_changes is False
+            assert any("Open a character editor" in msg for msg, _ in notifications)
+
     async def test_avatar_upload_request_launches_dialog_worker(
         self, mock_app_instance, stub_characters
     ):
@@ -3879,3 +3948,42 @@ class TestImportExportFilters:
                 pilot, screen, lambda: screen._export_dialog_worker("png")
             )
             self._assert_filters_callable(picker.filters)
+
+    @pytest.mark.parametrize("outcome", ["cancel", "error", "selection"])
+    async def test_avatar_upload_worker_resets_flag_and_uses_avatar_context(
+        self, mock_app_instance, stub_characters, tmp_path, outcome
+    ):
+        avatar = tmp_path / "avatar.png"
+        avatar.write_bytes(b"\x89PNG selected avatar")
+        app = PersonasTestApp(mock_app_instance)
+
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            await pilot.pause()
+            await pilot.click("#personas-library-new")
+            await pilot.pause()
+            captured: dict = {}
+
+            async def _fake_push_screen_wait(picker):
+                captured["picker"] = picker
+                if outcome == "error":
+                    raise RuntimeError("dialog failed")
+                if outcome == "selection":
+                    return avatar
+                return None
+
+            pilot.app.push_screen_wait = AsyncMock(side_effect=_fake_push_screen_wait)
+            screen._io_dialog_active = True
+
+            await screen._avatar_upload_dialog_worker()
+            await pilot.pause()
+
+            assert screen._io_dialog_active is False
+            picker = captured["picker"]
+            assert picker.context == "character_avatar_upload"
+            self._assert_filters_callable(picker.filters)
+            editor = screen.query_one(PersonasCharacterEditorWidget)
+            if outcome == "selection":
+                assert editor.get_character_data()["image"] == b"\x89PNG selected avatar"
+            else:
+                assert "image" not in editor.get_character_data()

--- a/backlog/tasks/task-100 - Wire-avatar-upload-in-the-ds-native-character-editor.md
+++ b/backlog/tasks/task-100 - Wire-avatar-upload-in-the-ds-native-character-editor.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-100
 title: Wire avatar upload in the ds-native character editor
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-06-11 18:12'
-updated_date: '2026-06-27 20:38'
+updated_date: '2026-06-28 01:12'
 labels: []
 dependencies: []
 ---
@@ -17,12 +17,13 @@ The legacy editor posted CharacterImageUploadRequested but no handler exists any
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Upload button opens a file picker and persists the avatar
-- [ ] #2 Avatar status reflects the change
+- [x] #1 Upload button opens a file picker and persists the avatar
+- [x] #2 Avatar status reflects the change
 <!-- AC:END -->
 
 ## Implementation Plan
 
+<!-- SECTION:PLAN:BEGIN -->
 1. Add the `CharacterImageUploadRequested` message, upload button, and editor-side staged image API.
 2. Add widget tests proving the upload button emits the message and staged bytes update avatar status/dirty state.
 3. Add the `PersonasScreen` file-picker handler and path-based avatar staging helper using `validate_path_simple`.
@@ -35,3 +36,14 @@ Plan: `Docs/superpowers/plans/2026-06-27-personas-avatar-upload.md`
 ADR required: no
 ADR path: N/A
 Reason: scoped UI workflow restoration using existing editor, file picker, dirty-state, and character persistence boundaries; no schema, sync, storage, provider/runtime, or application-architecture change.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Restored character avatar upload in the ds-native Personas editor using the existing staged edit workflow. The editor now emits `CharacterImageUploadRequested`, stages raw image bytes in pending character data, updates avatar status, and marks the session dirty. `PersonasScreen` opens an image-filtered picker, validates selected paths with `validate_path_simple`, reads bytes off the UI thread, constrains upload to the active character editor, and persists the staged image through the existing Save flow.
+
+ADR required: no
+ADR path: N/A
+Reason: scoped UI workflow restoration using existing editor, file picker, dirty-state, and character persistence boundaries; no schema, sync, storage, provider/runtime, or application-architecture change.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-100 - Wire-avatar-upload-in-the-ds-native-character-editor.md
+++ b/backlog/tasks/task-100 - Wire-avatar-upload-in-the-ds-native-character-editor.md
@@ -43,6 +43,8 @@ Reason: scoped UI workflow restoration using existing editor, file picker, dirty
 <!-- SECTION:NOTES:BEGIN -->
 Restored character avatar upload in the ds-native Personas editor using the existing staged edit workflow. The editor now emits `CharacterImageUploadRequested`, stages raw image bytes in pending character data, updates avatar status, and marks the session dirty. `PersonasScreen` opens an image-filtered picker, validates selected paths with `validate_path_simple`, reads bytes off the UI thread, constrains upload to the active character editor, and persists the staged image through the existing Save flow.
 
+Post-review hardening added a 5 MB avatar size cap before reads, a character-editor session token that drops stale async upload results, contextual staging error logs, and regression coverage for oversize and stale-session cases.
+
 ADR required: no
 ADR path: N/A
 Reason: scoped UI workflow restoration using existing editor, file picker, dirty-state, and character persistence boundaries; no schema, sync, storage, provider/runtime, or application-architecture change.

--- a/backlog/tasks/task-100 - Wire-avatar-upload-in-the-ds-native-character-editor.md
+++ b/backlog/tasks/task-100 - Wire-avatar-upload-in-the-ds-native-character-editor.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-100
 title: Wire avatar upload in the ds-native character editor
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-06-11 18:12'
+updated_date: '2026-06-27 20:38'
 labels: []
 dependencies: []
 ---
@@ -19,3 +20,18 @@ The legacy editor posted CharacterImageUploadRequested but no handler exists any
 - [ ] #1 Upload button opens a file picker and persists the avatar
 - [ ] #2 Avatar status reflects the change
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Add the `CharacterImageUploadRequested` message, upload button, and editor-side staged image API.
+2. Add widget tests proving the upload button emits the message and staged bytes update avatar status/dirty state.
+3. Add the `PersonasScreen` file-picker handler and path-based avatar staging helper using `validate_path_simple`.
+4. Add screen tests for valid staging, invalid paths/extensions, stale edit mode, and Save-path persistence.
+5. Run focused Personas tests and `git diff --check`.
+6. Update acceptance criteria and implementation notes before marking Done.
+
+Plan: `Docs/superpowers/plans/2026-06-27-personas-avatar-upload.md`
+
+ADR required: no
+ADR path: N/A
+Reason: scoped UI workflow restoration using existing editor, file picker, dirty-state, and character persistence boundaries; no schema, sync, storage, provider/runtime, or application-architecture change.

--- a/backlog/tasks/task-140 - Support-Markdown-character-card-imports.md
+++ b/backlog/tasks/task-140 - Support-Markdown-character-card-imports.md
@@ -1,0 +1,24 @@
+---
+id: TASK-140
+title: Support Markdown character card imports
+status: To Do
+assignee: []
+created_date: '2026-06-28 02:43'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Allow the ds-native Personas character import flow to import Markdown files that embed existing supported character-card data, without introducing a new free-form Markdown schema.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Personas import picker offers Markdown files alongside existing JSON and PNG character-card imports
+- [ ] #2 Markdown files with YAML frontmatter import through the existing character-card parser
+- [ ] #3 Markdown files with fenced JSON card data import through the existing character-card parser
+- [ ] #4 Invalid Markdown fails without creating or selecting a character and shows the existing import failure path
+- [ ] #5 Existing JSON and PNG import behavior remains unchanged
+<!-- AC:END -->

--- a/backlog/tasks/task-140 - Support-Markdown-character-card-imports.md
+++ b/backlog/tasks/task-140 - Support-Markdown-character-card-imports.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-140
 title: Support Markdown character card imports
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-06-28 02:43'
+updated_date: '2026-06-28 02:45'
 labels: []
 dependencies: []
 ---
@@ -22,3 +23,17 @@ Allow the ds-native Personas character import flow to import Markdown files that
 - [ ] #4 Invalid Markdown fails without creating or selecting a character and shows the existing import failure path
 - [ ] #5 Existing JSON and PNG import behavior remains unchanged
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Add parser regressions for Markdown YAML frontmatter, Markdown fenced JSON, and invalid Markdown.
+2. Add Personas import-flow regressions for Markdown picker filters, `.md` path routing, and invalid Markdown failure.
+3. Update the ds-native Personas import picker filters to include `.md` and `.markdown`.
+4. Run focused parser/import tests plus `git diff --check`.
+5. Check acceptance criteria, add implementation notes, and mark the task Done.
+
+Plan: `Docs/superpowers/plans/2026-06-27-personas-markdown-character-import.md`
+
+ADR required: no
+ADR path: N/A
+Reason: import picker/parser affordance and regression coverage using existing import and storage boundaries; no new long-lived Markdown schema or storage contract.

--- a/backlog/tasks/task-140 - Support-Markdown-character-card-imports.md
+++ b/backlog/tasks/task-140 - Support-Markdown-character-card-imports.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-140
 title: Support Markdown character card imports
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-06-28 02:43'
-updated_date: '2026-06-28 02:45'
+updated_date: '2026-06-28 02:50'
 labels: []
 dependencies: []
 ---
@@ -17,15 +17,16 @@ Allow the ds-native Personas character import flow to import Markdown files that
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Personas import picker offers Markdown files alongside existing JSON and PNG character-card imports
-- [ ] #2 Markdown files with YAML frontmatter import through the existing character-card parser
-- [ ] #3 Markdown files with fenced JSON card data import through the existing character-card parser
-- [ ] #4 Invalid Markdown fails without creating or selecting a character and shows the existing import failure path
-- [ ] #5 Existing JSON and PNG import behavior remains unchanged
+- [x] #1 Personas import picker offers Markdown files alongside existing JSON and PNG character-card imports
+- [x] #2 Markdown files with YAML frontmatter import through the existing character-card parser
+- [x] #3 Markdown files with fenced JSON card data import through the existing character-card parser
+- [x] #4 Invalid Markdown fails without creating or selecting a character and shows the existing import failure path
+- [x] #5 Existing JSON and PNG import behavior remains unchanged
 <!-- AC:END -->
 
 ## Implementation Plan
 
+<!-- SECTION:PLAN:BEGIN -->
 1. Add parser regressions for Markdown YAML frontmatter, Markdown fenced JSON, and invalid Markdown.
 2. Add Personas import-flow regressions for Markdown picker filters, `.md` path routing, and invalid Markdown failure.
 3. Update the ds-native Personas import picker filters to include `.md` and `.markdown`.
@@ -37,3 +38,14 @@ Plan: `Docs/superpowers/plans/2026-06-27-personas-markdown-character-import.md`
 ADR required: no
 ADR path: N/A
 Reason: import picker/parser affordance and regression coverage using existing import and storage boundaries; no new long-lived Markdown schema or storage contract.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added Markdown character-card import support to the ds-native Personas import picker by including `.md` and `.markdown` in the Character Cards filter and adding a Markdown-specific filter. Reused the existing character-card import helper and parser; no new Markdown schema was introduced. Added parser coverage for Markdown YAML frontmatter, Markdown fenced JSON, and invalid Markdown, plus Personas import-flow coverage for Markdown path routing, invalid Markdown failure behavior, and existing callable import filters.
+
+ADR required: no
+ADR path: N/A
+Reason: import picker/parser affordance and regression coverage using existing import and storage boundaries; no new long-lived Markdown schema or storage contract.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -92,6 +92,8 @@ PLACEHOLDER_COPY = "This mode is not available yet. Characters and Personas are 
 PERSONAS_SEARCH_DEBOUNCE_SECONDS = 0.2
 PERSONAS_AVATAR_IMAGE_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".webp", ".gif"})
 PERSONAS_AVATAR_IMAGE_SUFFIX_COPY = "PNG, JPG, JPEG, WEBP, or GIF"
+PERSONAS_AVATAR_MAX_BYTES = 5 * 1024 * 1024
+PERSONAS_AVATAR_MAX_SIZE_COPY = "5 MB"
 
 # 80-column terminals need a tighter three-pane split than the default
 # 2:4:2 workbench minimums. Keep this screen-owned so a later rail-collapse
@@ -322,6 +324,7 @@ class PersonasScreen(BaseAppScreen):
         self._io_dialog_active: bool = False
         # Same refuse-reentry idiom for the delete confirmation dialog.
         self._delete_dialog_active: bool = False
+        self._character_editor_generation: int = 0
         self._profile_save_inflight: bool = False
         self._characters: list[dict] = []
         self._profiles: list[dict] = []
@@ -1516,6 +1519,7 @@ class PersonasScreen(BaseAppScreen):
         # Delete and the rest are wired in follow-up tasks.
 
     async def _begin_create_character(self) -> None:
+        self._character_editor_generation += 1
         self._edit_mode = "create"
         self.state.clear_selection()
         # Change-based dirty tracking: the session starts clean; the editor
@@ -1573,6 +1577,7 @@ class PersonasScreen(BaseAppScreen):
         if record is None:
             self._notify("Character data is not loaded yet.", severity="warning")
             return
+        self._character_editor_generation += 1
         self._edit_mode = "edit"
         # Change-based dirty tracking: the session starts clean; the editor
         # posts EditorContentChanged on the first real modification.
@@ -1644,6 +1649,20 @@ class PersonasScreen(BaseAppScreen):
             return False
         return editor.display is True
 
+    def _character_editor_session_token(
+        self,
+    ) -> tuple[int, str, str, str | None, str | None] | None:
+        """Return the current character edit session identity, if visible."""
+        if not self._character_editor_is_active():
+            return None
+        return (
+            self._character_editor_generation,
+            self._edit_mode,
+            self.state.active_mode,
+            self.state.selected_entity_kind,
+            self.state.selected_entity_id,
+        )
+
     def _read_avatar_image_bytes(self, path: str) -> bytes:
         candidate = validate_path_simple(path, require_exists=True)
         if not candidate.is_file():
@@ -1652,13 +1671,18 @@ class PersonasScreen(BaseAppScreen):
             raise ValueError(
                 f"Unsupported avatar image type. Use {PERSONAS_AVATAR_IMAGE_SUFFIX_COPY}."
             )
+        if candidate.stat().st_size > PERSONAS_AVATAR_MAX_BYTES:
+            raise ValueError(
+                f"Avatar image must be {PERSONAS_AVATAR_MAX_SIZE_COPY} or smaller."
+            )
         data = candidate.read_bytes()
         if not data:
             raise ValueError("Avatar image file is empty.")
         return data
 
     async def _stage_character_avatar_from_path(self, path: str) -> None:
-        if not self._character_editor_is_active():
+        session_token = self._character_editor_session_token()
+        if session_token is None:
             self._notify("Open a character editor before uploading an avatar.", "warning")
             return
         try:
@@ -1670,10 +1694,25 @@ class PersonasScreen(BaseAppScreen):
             logger.error(f"Error reading avatar image from {path}: {exc}", exc_info=True)
             self._notify(f"Avatar upload failed: {exc}", "error")
             return
+        if self._character_editor_session_token() != session_token:
+            logger.debug(
+                "Avatar upload result ignored because the character editor session "
+                f"changed. path={path!r}, original_session={session_token!r}, "
+                f"current_session={self._character_editor_session_token()!r}"
+            )
+            return
         try:
             self.query_one(PersonasCharacterEditorWidget).set_avatar_image(image_data)
         except Exception as exc:
-            logger.error("Could not stage avatar image in editor.", exc_info=True)
+            logger.error(
+                "Could not stage avatar image in editor. "
+                f"path={path!r}, edit_mode={self._edit_mode!r}, "
+                f"active_mode={self.state.active_mode!r}, "
+                f"selected_kind={self.state.selected_entity_kind!r}, "
+                f"selected_id={self.state.selected_entity_id!r}, "
+                f"image_size_bytes={len(image_data)}: {exc}",
+                exc_info=True,
+            )
             self._notify(f"Avatar upload failed: {exc}", "error")
             return
         self._notify("Avatar staged. Save the character to persist it.", "information")
@@ -2167,6 +2206,7 @@ class PersonasScreen(BaseAppScreen):
             except Exception:
                 logger.warning("Could not refresh characters after a late save.", exc_info=True)
             return
+        self._character_editor_generation += 1
         self._edit_mode = "view"
         self._set_active_row_unsaved(False)
         await self.character_handler.refresh_character_list()
@@ -2305,6 +2345,7 @@ class PersonasScreen(BaseAppScreen):
         await self._run_guarded(_finish)
 
     def _finish_cancel_edit(self) -> None:
+        self._character_editor_generation += 1
         self._edit_mode = "view"
         self.state.has_unsaved_changes = False
         inspector = self.query_one(PersonasInspectorPane)

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -1634,6 +1634,16 @@ class PersonasScreen(BaseAppScreen):
             return dict(loaded)
         return None
 
+    def _character_editor_is_active(self) -> bool:
+        """Return whether the visible edit session is the character editor."""
+        if self._edit_mode not in ("create", "edit"):
+            return False
+        try:
+            editor = self.query_one(PersonasCharacterEditorWidget)
+        except QueryError:
+            return False
+        return editor.display is True
+
     def _read_avatar_image_bytes(self, path: str) -> bytes:
         candidate = validate_path_simple(path, require_exists=True)
         if not candidate.is_file():
@@ -1648,7 +1658,7 @@ class PersonasScreen(BaseAppScreen):
         return data
 
     async def _stage_character_avatar_from_path(self, path: str) -> None:
-        if self._edit_mode not in ("create", "edit"):
+        if not self._character_editor_is_active():
             self._notify("Open a character editor before uploading an avatar.", "warning")
             return
         try:
@@ -1681,7 +1691,7 @@ class PersonasScreen(BaseAppScreen):
         self, message: CharacterImageUploadRequested
     ) -> None:
         message.stop()
-        if self._edit_mode not in ("create", "edit"):
+        if not self._character_editor_is_active():
             self._notify("Open a character editor before uploading an avatar.", "warning")
             return
         if self._io_dialog_active:

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -28,6 +28,7 @@ from ...Chat.console_chat_models import ConsoleProviderSelection
 from ...Chat.console_provider_gateway import ConsoleProviderGateway
 from ...DB.ChaChaNotes_DB import ConflictError
 from ...tldw_api import PersonaProfileCreate, PersonaProfileUpdate
+from ...Utils.path_validation import validate_path_simple
 from ...Widgets.Console.console_rail_handle import ConsoleRailHandle
 from ...Widgets.confirmation_dialog import ConfirmationDialog, UnsavedChangesDialog
 from ...Widgets.destination_workbench import DestinationModeStrip
@@ -51,6 +52,7 @@ from ...Widgets.Persona_Widgets.personas_messages import (
 )
 from ...Widgets.Persona_Widgets.personas_pane_messages import (
     CharacterEditorCancelled,
+    CharacterImageUploadRequested,
     CharacterSaveRequested,
     ConversationRowSelected,
     EditCharacterRequested,
@@ -88,6 +90,8 @@ MODE_CHIP_ORDER: tuple[str, ...] = ("characters", "personas", "prompts", "dictio
 
 PLACEHOLDER_COPY = "This mode is not available yet. Characters and Personas are the supported modes."
 PERSONAS_SEARCH_DEBOUNCE_SECONDS = 0.2
+PERSONAS_AVATAR_IMAGE_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".webp", ".gif"})
+PERSONAS_AVATAR_IMAGE_SUFFIX_COPY = "PNG, JPG, JPEG, WEBP, or GIF"
 
 # 80-column terminals need a tighter three-pane split than the default
 # 2:4:2 workbench minimums. Keep this screen-owned so a later rail-collapse
@@ -1630,6 +1634,40 @@ class PersonasScreen(BaseAppScreen):
             return dict(loaded)
         return None
 
+    def _read_avatar_image_bytes(self, path: str) -> bytes:
+        candidate = validate_path_simple(path, require_exists=True)
+        if not candidate.is_file():
+            raise ValueError("Choose an existing avatar image file.")
+        if candidate.suffix.lower() not in PERSONAS_AVATAR_IMAGE_SUFFIXES:
+            raise ValueError(
+                f"Unsupported avatar image type. Use {PERSONAS_AVATAR_IMAGE_SUFFIX_COPY}."
+            )
+        data = candidate.read_bytes()
+        if not data:
+            raise ValueError("Avatar image file is empty.")
+        return data
+
+    async def _stage_character_avatar_from_path(self, path: str) -> None:
+        if self._edit_mode not in ("create", "edit"):
+            self._notify("Open a character editor before uploading an avatar.", "warning")
+            return
+        try:
+            image_data = await asyncio.to_thread(self._read_avatar_image_bytes, path)
+        except ValueError as exc:
+            self._notify(str(exc), "error")
+            return
+        except OSError as exc:
+            logger.error(f"Error reading avatar image from {path}: {exc}", exc_info=True)
+            self._notify(f"Avatar upload failed: {exc}", "error")
+            return
+        try:
+            self.query_one(PersonasCharacterEditorWidget).set_avatar_image(image_data)
+        except Exception as exc:
+            logger.error("Could not stage avatar image in editor.", exc_info=True)
+            self._notify(f"Avatar upload failed: {exc}", "error")
+            return
+        self._notify("Avatar staged. Save the character to persist it.", "information")
+
     # ===== Import / export =====
     #
     # Dialog flows run in workers (push_screen_wait requires one); the
@@ -1637,6 +1675,48 @@ class PersonasScreen(BaseAppScreen):
     # directly. Sync DB/file work runs via asyncio.to_thread instead of a
     # threaded Textual worker because import and export need their result
     # awaited inline for the follow-up selection/notification steps.
+
+    @on(CharacterImageUploadRequested)
+    def _handle_character_image_upload_requested(
+        self, message: CharacterImageUploadRequested
+    ) -> None:
+        message.stop()
+        if self._edit_mode not in ("create", "edit"):
+            self._notify("Open a character editor before uploading an avatar.", "warning")
+            return
+        if self._io_dialog_active:
+            logger.debug("Import/export dialog already active; ignoring avatar upload request.")
+            return
+        self._io_dialog_active = True
+        self.run_worker(self._avatar_upload_dialog_worker(), group="personas-io")
+
+    async def _avatar_upload_dialog_worker(self) -> None:
+        from ...Widgets.enhanced_file_picker import EnhancedFileOpen, Filters
+
+        try:
+            picker = EnhancedFileOpen(
+                title="Upload Character Avatar",
+                filters=Filters(
+                    (
+                        "Image Files",
+                        lambda p: p.suffix.lower() in PERSONAS_AVATAR_IMAGE_SUFFIXES,
+                    ),
+                    ("PNG Files", lambda p: p.suffix.lower() == ".png"),
+                    ("JPEG Files", lambda p: p.suffix.lower() in (".jpg", ".jpeg")),
+                    ("WEBP Files", lambda p: p.suffix.lower() == ".webp"),
+                    ("GIF Files", lambda p: p.suffix.lower() == ".gif"),
+                ),
+                context="character_avatar_upload",
+            )
+            try:
+                file_path = await self.app.push_screen_wait(picker)
+            except Exception:
+                logger.warning("Could not show the avatar upload file dialog.", exc_info=True)
+                return
+            if file_path:
+                await self._stage_character_avatar_from_path(str(file_path))
+        finally:
+            self._io_dialog_active = False
 
     async def _open_import_dialog(self) -> None:
         """Continuation for the guarded import action: launch the dialog worker."""

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -1745,8 +1745,16 @@ class PersonasScreen(BaseAppScreen):
             picker = EnhancedFileOpen(
                 title="Import Character Card",
                 filters=Filters(
-                    ("Character Cards", lambda p: p.suffix.lower() in (".json", ".png")),
+                    (
+                        "Character Cards",
+                        lambda p: p.suffix.lower()
+                        in (".json", ".md", ".markdown", ".png"),
+                    ),
                     ("JSON Files", lambda p: p.suffix.lower() == ".json"),
+                    (
+                        "Markdown Files",
+                        lambda p: p.suffix.lower() in (".md", ".markdown"),
+                    ),
                     ("PNG Files (with embedded data)", lambda p: p.suffix.lower() == ".png"),
                     ("All Files", lambda p: True),
                 ),

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
@@ -268,7 +268,14 @@ class PersonasCharacterEditorWidget(Container):
         self.load_character({})
 
     def set_avatar_image(self, image_data: bytes) -> None:
-        """Stage avatar image bytes for persistence on the next Save."""
+        """Stage avatar image bytes for persistence on the next Save.
+
+        Args:
+            image_data: Non-empty avatar image bytes selected by the upload flow.
+
+        Raises:
+            ValueError: If ``image_data`` is not non-empty bytes.
+        """
         if not isinstance(image_data, bytes) or not image_data:
             raise ValueError("Avatar image data must be non-empty bytes.")
         self._character_data["image"] = image_data

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
@@ -5,8 +5,8 @@ the legacy widget's external contract — the ``ccp-character-editor-view``
 default id, the ``load_character``/``new_character``/``get_character_data``
 API, and the legacy ``CharacterSaveRequested``/``CharacterEditorCancelled``
 messages — while rendering with the workbench's flat ds vocabulary (primary
-fields up top, an Advanced section for the long tail, a read-only avatar
-status line, no image box).
+fields up top, an Advanced section for the long tail, an avatar upload/status
+line, no image box).
 """
 
 from __future__ import annotations
@@ -20,6 +20,7 @@ from textual.widgets import Button, Input, Label, Static, TextArea
 
 from .personas_pane_messages import (
     CharacterEditorCancelled,
+    CharacterImageUploadRequested,
     CharacterSaveRequested,
     EditorContentChanged,
 )
@@ -93,6 +94,15 @@ class PersonasCharacterEditorWidget(Container):
     PersonasCharacterEditorWidget #personas-char-editor-avatar-status {
         width: auto;
         margin-right: 2;
+    }
+
+    PersonasCharacterEditorWidget #personas-char-editor-avatar-upload {
+        width: auto;
+        min-width: 0;
+        height: 1;
+        min-height: 1;
+        padding: 0 1;
+        border: none;
     }
 
     PersonasCharacterEditorWidget .ds-toolbar {
@@ -182,6 +192,11 @@ class PersonasCharacterEditorWidget(Container):
                     yield TextArea(id="personas-char-editor-alt-greetings")
             with Horizontal(id="personas-char-editor-avatar-row"):
                 yield Static("Avatar: none", id="personas-char-editor-avatar-status")
+                yield Button(
+                    "Upload",
+                    id="personas-char-editor-avatar-upload",
+                    classes="console-action-subdued",
+                )
         yield Static("", id="personas-char-editor-validation")
         with Horizontal(classes="ds-toolbar"):
             yield Button(
@@ -244,16 +259,21 @@ class PersonasCharacterEditorWidget(Container):
         ]
         self._loaded_greetings_text = "\n".join(self._loaded_greetings)
         self._area("alt-greetings").text = self._loaded_greetings_text
-        avatar = "embedded" if (record.get("image") or record.get("avatar")) else "none"
-        self.query_one("#personas-char-editor-avatar-status", Static).update(
-            f"Avatar: {avatar}"
-        )
+        self._set_avatar_status_from_record()
         self.query_one("#personas-char-editor-validation", Static).update("")
         self._set_advanced_open(False)
 
     def new_character(self) -> None:
         """Clear the form for a new (unsaved) character; version defaults 1.0."""
         self.load_character({})
+
+    def set_avatar_image(self, image_data: bytes) -> None:
+        """Stage avatar image bytes for persistence on the next Save."""
+        if not isinstance(image_data, bytes) or not image_data:
+            raise ValueError("Avatar image data must be non-empty bytes.")
+        self._character_data["image"] = image_data
+        self._set_avatar_status_from_record()
+        self._mark_dirty()
 
     def show_validation(self, errors: tuple[str, ...]) -> None:
         """Render screen-side validation errors in the editor footer.
@@ -337,6 +357,20 @@ class PersonasCharacterEditorWidget(Container):
             "Advanced ▾" if open_ else "Advanced ▸"
         )
 
+    def _set_avatar_status_from_record(self) -> None:
+        avatar = "embedded" if (
+            self._character_data.get("image") or self._character_data.get("avatar")
+        ) else "none"
+        self.query_one("#personas-char-editor-avatar-status", Static).update(
+            f"Avatar: {avatar}"
+        )
+
+    def _mark_dirty(self) -> None:
+        if self._loading or self._dirty_posted or self._loaded_snapshot is None:
+            return
+        self._dirty_posted = True
+        self.post_message(EditorContentChanged())
+
     # ===== Events =====
 
     @on(Input.Changed)
@@ -356,8 +390,7 @@ class PersonasCharacterEditorWidget(Container):
             return
         if self._form_snapshot() == self._loaded_snapshot:
             return
-        self._dirty_posted = True
-        self.post_message(EditorContentChanged())
+        self._mark_dirty()
 
     @on(Button.Pressed, "#personas-char-editor-advanced-toggle")
     def _toggle_advanced(self, event: Button.Pressed) -> None:
@@ -365,6 +398,11 @@ class PersonasCharacterEditorWidget(Container):
         self._set_advanced_open(
             not self.query_one("#personas-char-editor-advanced").display
         )
+
+    @on(Button.Pressed, "#personas-char-editor-avatar-upload")
+    def _upload_avatar_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.post_message(CharacterImageUploadRequested())
 
     @on(Button.Pressed, "#personas-char-editor-save")
     def _save_pressed(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py
@@ -48,6 +48,10 @@ class CharacterEditorCancelled(Message):
     """
 
 
+class CharacterImageUploadRequested(Message):
+    """User requested to choose an image for the active character editor."""
+
+
 class EditPersonaRequested(Message):
     """Edit was requested for the displayed persona profile."""
 


### PR DESCRIPTION
## Summary
- Restore the ds-native Personas character editor avatar Upload action and staged image state.
- Add PersonasScreen image picker/path validation flow that stages raw image bytes only for the active character editor.
- Add Markdown character-card imports for .md/.markdown files that embed existing supported card data via YAML frontmatter or fenced JSON.
- Cover upload event, path validation, persona-editor guard, worker reset/context, Save persistence, Markdown parser wrappers, Markdown picker filters, and invalid Markdown failure behavior with tests.

## Test Plan
- [x] /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_personas_character_widgets.py Tests/UI/test_personas_workbench.py -q
- [x] /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Character_Chat/test_character_import_markdown.py Tests/UI/test_personas_workbench.py -q -k "markdown or import"
- [x] git diff --check