### PR TITLE
Fix Personas preview reset greeting refresh

### DIFF
--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -2718,9 +2718,14 @@ class TestPreviewIntegration:
     async def test_reset_after_character_reload_uses_updated_greeting(
         self, mock_app_instance, stub_characters, stub_conversations
     ):
-        """A same-character reload refreshes Reset's stored greeting seed."""
-        from textual.widgets import Button as _Button
+        """A same-character reload refreshes Reset's stored greeting seed.
 
+        Args:
+            mock_app_instance: Fixture providing the app object used by the
+                mounted Personas test app.
+            stub_characters: Fixture stubbing local character list/load data.
+            stub_conversations: Fixture stubbing character conversation data.
+        """
         from tldw_chatbook.UI.CCP_Modules.ccp_messages import CharacterMessage
         from tldw_chatbook.Widgets.Persona_Widgets.personas_preview_pane import (
             PersonasPreviewPane,
@@ -2750,7 +2755,7 @@ class TestPreviewIntegration:
             assert pane.transcript_text() == (
                 "character: The name's Detective Sam. Who's asking?"
             )
-            screen.query_one("#personas-preview-reset", _Button).press()
+            screen.query_one("#personas-preview-reset", Button).press()
             await pilot.pause()
 
             assert pane.transcript_text() == (

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -2715,6 +2715,48 @@ class TestPreviewIntegration:
             lines = [line for line in pane.transcript_text().splitlines() if line]
             assert lines == [greeting_line]
 
+    async def test_reset_after_character_reload_uses_updated_greeting(
+        self, mock_app_instance, stub_characters, stub_conversations
+    ):
+        """A same-character reload refreshes Reset's stored greeting seed."""
+        from textual.widgets import Button as _Button
+
+        from tldw_chatbook.UI.CCP_Modules.ccp_messages import CharacterMessage
+        from tldw_chatbook.Widgets.Persona_Widgets.personas_preview_pane import (
+            PersonasPreviewPane,
+        )
+
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await self._select_first_character(pilot)
+            pane = screen.query_one(PersonasPreviewPane)
+            assert (
+                "character: The name's Detective Sam. Who's asking?"
+                in pane.transcript_text()
+            )
+
+            screen.post_message(
+                CharacterMessage.Loaded(
+                    "1",
+                    {
+                        "id": 1,
+                        "name": "Detective Sam",
+                        "first_message": "Edited opener from {{char}} to {{user}}.",
+                        "version": 2,
+                    },
+                )
+            )
+            await pilot.pause()
+            assert pane.transcript_text() == (
+                "character: The name's Detective Sam. Who's asking?"
+            )
+            screen.query_one("#personas-preview-reset", _Button).press()
+            await pilot.pause()
+
+            assert pane.transcript_text() == (
+                "character: Edited opener from Detective Sam to User."
+            )
+
     async def test_blocked_provider_shows_readable_status(
         self, mock_app_instance, stub_characters, stub_conversations
     ):

--- a/backlog/tasks/task-117 - Refresh-stored-preview-greeting-after-character-edits.md
+++ b/backlog/tasks/task-117 - Refresh-stored-preview-greeting-after-character-edits.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-117
 title: Refresh stored preview greeting after character edits
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-06-11 13:25'
+updated_date: '2026-06-28 03:29'
 labels: []
 dependencies: []
 ---
@@ -16,5 +17,25 @@ PersonasPreviewPane keeps the original greeting for Reset; after editing first_m
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Reset after an edit uses the updated greeting
+- [x] #1 Reset after an edit uses the updated greeting
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+ADR path: N/A
+Reason: bounded Personas preview UI state bugfix; no storage/schema/sync/service boundary changes.
+
+1. Reproduce the stale reset greeting behavior with a focused mounted regression.
+2. Verify the regression fails for the expected reason before changing production code.
+3. Add the smallest preview-pane seam to refresh the stored reset greeting without reseeding the visible transcript.
+4. Wire the character-loaded/save path to update the stored greeting for the active selected character.
+5. Run focused Personas preview tests and git diff checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added a mounted Personas preview regression proving that a same-character reload keeps the visible transcript stable but updates the greeting used by Reset. Implemented `PersonasPreviewPane.refresh_greeting_seed()` and wired `PersonasScreen._handle_character_loaded()` to call it when the currently seeded character is reloaded after a save/edit, avoiding an unnecessary transcript reseed while ensuring Reset restores the updated first message. Verification: targeted regression passed, full `TestPreviewIntegration` passed, full `Tests/UI/test_personas_workbench.py` passed, and `git diff --check` passed. ADR required: no; this is a bounded UI state bugfix with no storage, schema, sync, or service-boundary changes.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -1268,18 +1268,19 @@ class PersonasScreen(BaseAppScreen):
             pane = self.query_one(PersonasPreviewPane)
         except QueryError:
             return
-        # Seeding rule: seed only when the pane transcript is empty OR the
-        # loaded id differs from the last-seeded id. A re-load of the same
-        # already-previewed character (e.g. after a save) mid-conversation
-        # must not wipe the in-progress preview, and the instant path in
-        # _select_character must not be double-seeded.
-        if self._preview_seeded_for == character_id and pane.transcript_text():
-            return
         record = dict(message.card_data or {})
         name = str(record.get("name") or self.state.selected_entity_name or "")
         greeting = replace_placeholders(
             str(record.get("first_message") or ""), name, "User"
         )
+        # Seeding rule: seed only when the pane transcript is empty OR the
+        # loaded id differs from the last-seeded id. A re-load of the same
+        # already-previewed character (e.g. after a save) mid-conversation
+        # must not wipe the in-progress preview. It still refreshes the
+        # stored reset seed so Reset reflects saved greeting edits.
+        if self._preview_seeded_for == character_id and pane.transcript_text():
+            pane.refresh_greeting_seed(greeting)
+            return
         # Greeting reseed implies fresh preview state (history + workers).
         self._invalidate_preview()
         await pane.seed_greeting(greeting)

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_preview_pane.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_preview_pane.py
@@ -137,7 +137,12 @@ class PersonasPreviewPane(Vertical):
         await self._render_seed_lines()
 
     def refresh_greeting_seed(self, text: str) -> None:
-        """Update the greeting Reset restores without changing the transcript."""
+        """Update the greeting Reset restores without changing the transcript.
+
+        Args:
+            text: Greeting text that future Reset actions should restore. Empty
+                values clear the stored greeting seed.
+        """
         self._greeting = str(text or "")
 
     def append_user(self, text: str) -> None:

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_preview_pane.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_preview_pane.py
@@ -136,6 +136,10 @@ class PersonasPreviewPane(Vertical):
         self.set_status("")
         await self._render_seed_lines()
 
+    def refresh_greeting_seed(self, text: str) -> None:
+        """Update the greeting Reset restores without changing the transcript."""
+        self._greeting = str(text or "")
+
     def append_user(self, text: str) -> None:
         """Append a "you: ..." transcript line."""
         self._append_line(f"you: {text}", "personas-preview-line-you")


### PR DESCRIPTION
## Summary
- Add a mounted regression for same-character preview reloads after greeting edits.
- Refresh the preview pane reset seed without visibly reseeding the active transcript.
- Close TASK-117 with ADR check and implementation notes.

## Test Plan
- python -m pytest -q Tests/UI/test_personas_workbench.py::TestPreviewIntegration::test_reset_after_character_reload_uses_updated_greeting --tb=short
- python -m pytest -q Tests/UI/test_personas_workbench.py::TestPreviewIntegration --tb=short
- python -m pytest -q Tests/UI/test_personas_workbench.py --tb=short
- git diff --check
- git diff --check HEAD

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Personas preview so Reset uses the updated greeting after editing and reloading the same character, without clearing the current transcript. Completes TASK-117.

- **Bug Fixes**
  - On same-character reloads, refresh the preview pane’s stored greeting seed while keeping the transcript intact (updates in PersonasScreen._handle_character_loaded; new PersonasPreviewPane.refresh_greeting_seed()).
  - Added a mounted regression to verify Reset uses the edited greeting and marked TASK-117 as Done with notes.

<sup>Written for commit 2d1fb62ece9e7085a3b4cd2ef9455ee71007a433. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

