### PR TITLE
Extract Personas preview controller

### DIFF
--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -2993,6 +2993,65 @@ class TestPreviewIntegration:
             )
             assert "Provider error" in status
 
+    async def test_provider_failure_logs_native_exception_with_preview_context(
+        self, mock_app_instance, stub_characters, stub_conversations
+    ):
+        """Provider failures include Loguru-native exceptions and safe context."""
+        from loguru import logger as loguru_logger
+
+        from tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages import (
+            PreviewReplyRequested,
+        )
+
+        records: list[dict[str, Any]] = []
+        sink_id = loguru_logger.add(
+            lambda message: records.append(message.record), level="ERROR"
+        )
+        mock_app_instance.app_config = {
+            "character_defaults": {
+                "provider": "openai",
+                "model": "gpt-4o-mini",
+            }
+        }
+        fake = _FakePreviewGateway(error=RuntimeError("provider exploded"))
+        app = PersonasTestApp(mock_app_instance)
+        try:
+            async with app.run_test(size=(160, 50)) as pilot:
+                screen = await self._select_first_character(pilot)
+                screen.preview.ensure_gateway = lambda: fake
+                screen.post_message(PreviewReplyRequested("Hi"))
+                await pilot.pause()
+                await app.workers.wait_for_complete()
+                await pilot.pause()
+        finally:
+            loguru_logger.remove(sink_id)
+
+        stream_failure = next(
+            record
+            for record in records
+            if record["message"]
+            == "Preview provider call failed; retrying without streaming."
+        )
+        retry_failure = next(
+            record
+            for record in records
+            if record["message"] == "Preview non-streaming retry failed."
+        )
+        assert stream_failure["exception"] is not None
+        assert retry_failure["exception"] is not None
+        extra = stream_failure["extra"]
+        assert extra["attempt"] == "streaming"
+        assert extra["streaming"] is True
+        assert retry_failure["extra"]["attempt"] == "non_streaming"
+        assert retry_failure["extra"]["streaming"] is False
+        assert extra["provider"] == "openai"
+        assert extra["model"] == "gpt-4o-mini"
+        assert extra["selection_kind"] == "character"
+        assert extra["selection_id"] == "1"
+        assert extra["resolved_provider"] == "openai"
+        assert extra["resolved_model"] == "test-model"
+        assert isinstance(extra["generation"], int)
+
     async def test_draft_aware_system_prompt_uses_editor_data(
         self, mock_app_instance, stub_characters, stub_conversations
     ):

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -2652,6 +2652,19 @@ class TestPreviewIntegration:
         await pilot.pause()
         return screen
 
+    async def test_preview_logic_is_owned_by_controller(
+        self, mock_app_instance, stub_characters
+    ):
+        from tldw_chatbook.UI.Persona_Modules.personas_preview_controller import (
+            PersonasPreviewController,
+        )
+
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await _mounted(pilot)
+            assert isinstance(screen.preview, PersonasPreviewController)
+            assert screen.preview.screen is screen
+
     async def test_preview_pane_is_mounted_in_work_area(
         self, mock_app_instance, stub_characters
     ):
@@ -2801,14 +2814,14 @@ class TestPreviewIntegration:
         app = PersonasTestApp(mock_app_instance)
         async with app.run_test(size=(160, 50)) as pilot:
             screen = await self._select_first_character(pilot)
-            screen._ensure_preview_gateway = lambda: fake
+            screen.preview.ensure_gateway = lambda: fake
             screen.post_message(PreviewReplyRequested("Hi there"))
             await pilot.pause()
             await app.workers.wait_for_complete()
             await pilot.pause()
             pane = screen.query_one(PersonasPreviewPane)
             assert "character: Hello, world." in pane.transcript_text()
-            assert screen._preview_history == [
+            assert screen.preview.history == [
                 {"role": "user", "content": "Hi there"},
                 {"role": "assistant", "content": "Hello, world."},
             ]
@@ -2840,7 +2853,7 @@ class TestPreviewIntegration:
         app = PersonasTestApp(mock_app_instance)
         async with app.run_test(size=(160, 50)) as pilot:
             screen = await self._select_first_character(pilot)
-            screen._ensure_preview_gateway = lambda: fake
+            screen.preview.ensure_gateway = lambda: fake
             pane = screen.query_one(PersonasPreviewPane)
             screen.post_message(PreviewReplyRequested("Hi"))
             await pilot.pause()
@@ -2852,7 +2865,7 @@ class TestPreviewIntegration:
             assert "character: Hello, " in pane.transcript_text()
             # History gets the consolidated entry only at the end.
             assert not any(
-                entry["role"] == "assistant" for entry in screen._preview_history
+                entry["role"] == "assistant" for entry in screen.preview.history
             )
             mid_gate.set()
             await app.workers.wait_for_complete()
@@ -2862,7 +2875,7 @@ class TestPreviewIntegration:
             assert "character: Hello, " not in [
                 line for line in lines if line != "character: Hello, world."
             ]
-            assert screen._preview_history[-1] == {
+            assert screen.preview.history[-1] == {
                 "role": "assistant",
                 "content": "Hello, world.",
             }
@@ -2887,7 +2900,7 @@ class TestPreviewIntegration:
         app = PersonasTestApp(mock_app_instance)
         async with app.run_test(size=(160, 50)) as pilot:
             screen = await self._select_first_character(pilot)
-            screen._ensure_preview_gateway = lambda: fake
+            screen.preview.ensure_gateway = lambda: fake
             pane = screen.query_one(PersonasPreviewPane)
             screen.post_message(PreviewReplyRequested("Hi"))
             await pilot.pause()
@@ -2906,7 +2919,7 @@ class TestPreviewIntegration:
                 "character: The name's Detective Sam. Who's asking?"
             )
             assert not any(
-                entry["role"] == "assistant" for entry in screen._preview_history
+                entry["role"] == "assistant" for entry in screen.preview.history
             )
 
     async def test_selection_change_mid_stream_removes_partial_line(
@@ -2927,7 +2940,7 @@ class TestPreviewIntegration:
         app = PersonasTestApp(mock_app_instance)
         async with app.run_test(size=(160, 50)) as pilot:
             screen = await self._select_first_character(pilot)
-            screen._ensure_preview_gateway = lambda: fake
+            screen.preview.ensure_gateway = lambda: fake
             pane = screen.query_one(PersonasPreviewPane)
             screen.post_message(PreviewReplyRequested("Hi"))
             await pilot.pause()
@@ -2943,7 +2956,7 @@ class TestPreviewIntegration:
             await pilot.pause()
             assert "Hello" not in pane.transcript_text()
             assert not any(
-                entry["role"] == "assistant" for entry in screen._preview_history
+                entry["role"] == "assistant" for entry in screen.preview.history
             )
 
     async def test_error_mid_stream_removes_partial_line(
@@ -2967,14 +2980,14 @@ class TestPreviewIntegration:
         app = PersonasTestApp(mock_app_instance)
         async with app.run_test(size=(160, 50)) as pilot:
             screen = await self._select_first_character(pilot)
-            screen._ensure_preview_gateway = lambda: fake
+            screen.preview.ensure_gateway = lambda: fake
             screen.post_message(PreviewReplyRequested("Hi"))
             await pilot.pause()
             await app.workers.wait_for_complete()
             await pilot.pause()
             pane = screen.query_one(PersonasPreviewPane)
             assert "Hello" not in pane.transcript_text()
-            assert screen._preview_history == []
+            assert screen.preview.history == []
             status = str(
                 screen.query_one("#personas-preview-status", _Static).renderable
             )
@@ -3000,7 +3013,7 @@ class TestPreviewIntegration:
                 "#personas-char-editor-description", _TextArea
             ).text = "Draft noir vibes, unsaved."
             await pilot.pause()
-            prompt = screen._preview_system_prompt()
+            prompt = screen.preview.system_prompt()
             assert "Draft noir vibes, unsaved." in prompt
 
     async def test_open_in_console_stages_preview_transcript(
@@ -3048,7 +3061,7 @@ class TestPreviewIntegration:
         app = PersonasTestApp(mock_app_instance)
         async with app.run_test(size=(160, 50)) as pilot:
             screen = await self._select_first_character(pilot)
-            screen._ensure_preview_gateway = lambda: fake
+            screen.preview.ensure_gateway = lambda: fake
             screen.post_message(PreviewReplyRequested("Hi"))
             await pilot.pause()
             # Let the worker reach the gated stream deterministically.
@@ -3068,7 +3081,7 @@ class TestPreviewIntegration:
             pane = screen.query_one(PersonasPreviewPane)
             assert "character: Hello, world." not in pane.transcript_text()
             assert not any(
-                entry["role"] == "assistant" for entry in screen._preview_history
+                entry["role"] == "assistant" for entry in screen.preview.history
             )
             from textual.widgets import Static as _Static
 
@@ -3087,14 +3100,14 @@ class TestPreviewIntegration:
         app = PersonasTestApp(mock_app_instance)
         async with app.run_test(size=(160, 50)) as pilot:
             screen = await self._select_first_character(pilot)
-            screen._preview_history.append({"role": "user", "content": "Hi"})
+            screen.preview.history.append({"role": "user", "content": "Hi"})
             screen.post_message(PreviewResetRequested())
             await pilot.pause()
-            assert screen._preview_history == []
-            screen._preview_history.append({"role": "user", "content": "Hi again"})
+            assert screen.preview.history == []
+            screen.preview.history.append({"role": "user", "content": "Hi again"})
             await screen._apply_mode("prompts")
             await pilot.pause()
-            assert screen._preview_history == []
+            assert screen.preview.history == []
 
     async def test_reset_mid_stream_drops_late_reply(
         self, mock_app_instance, stub_characters, stub_conversations
@@ -3121,7 +3134,7 @@ class TestPreviewIntegration:
         app = PersonasTestApp(mock_app_instance)
         async with app.run_test(size=(160, 50)) as pilot:
             screen = await self._select_first_character(pilot)
-            screen._ensure_preview_gateway = lambda: fake
+            screen.preview.ensure_gateway = lambda: fake
             screen.post_message(PreviewReplyRequested("Hi"))
             await pilot.pause()
             # Let the worker reach the gated stream deterministically.
@@ -3139,7 +3152,7 @@ class TestPreviewIntegration:
             pane = screen.query_one(PersonasPreviewPane)
             assert "character: Hello, world." not in pane.transcript_text()
             assert not any(
-                entry["role"] == "assistant" for entry in screen._preview_history
+                entry["role"] == "assistant" for entry in screen.preview.history
             )
 
     async def test_error_pops_orphaned_user_history_entry(
@@ -3160,7 +3173,7 @@ class TestPreviewIntegration:
         app = PersonasTestApp(mock_app_instance)
         async with app.run_test(size=(160, 50)) as pilot:
             screen = await self._select_first_character(pilot)
-            screen._ensure_preview_gateway = lambda: fake
+            screen.preview.ensure_gateway = lambda: fake
             pane = screen.query_one(PersonasPreviewPane)
             pane.expand()
             await pilot.pause()
@@ -3171,7 +3184,7 @@ class TestPreviewIntegration:
             await pilot.pause()
             # History: no trailing unanswered user entry.
             assert not any(
-                entry["role"] == "user" for entry in screen._preview_history
+                entry["role"] == "user" for entry in screen.preview.history
             )
             # Transcript: the user line stays visible.
             assert "you: Hi" in pane.transcript_text()
@@ -3198,7 +3211,7 @@ class TestPreviewIntegration:
         app = PersonasTestApp(mock_app_instance)
         async with app.run_test(size=(160, 50)) as pilot:
             screen = await self._select_first_character(pilot)
-            screen._ensure_preview_gateway = lambda: fake
+            screen.preview.ensure_gateway = lambda: fake
             screen.post_message(PreviewReplyRequested("Hi"))
             await pilot.pause()
             await app.workers.wait_for_complete()
@@ -3208,7 +3221,7 @@ class TestPreviewIntegration:
             assert len(fake.requests) == 2
             pane = screen.query_one(PersonasPreviewPane)
             assert "character: Hello, world." in pane.transcript_text()
-            assert screen._preview_history[-1] == {
+            assert screen.preview.history[-1] == {
                 "role": "assistant",
                 "content": "Hello, world.",
             }
@@ -3235,7 +3248,7 @@ class TestPreviewIntegration:
         app = PersonasTestApp(mock_app_instance)
         async with app.run_test(size=(160, 50)) as pilot:
             screen = await self._select_first_character(pilot)
-            screen._ensure_preview_gateway = lambda: fake
+            screen.preview.ensure_gateway = lambda: fake
             screen.post_message(PreviewReplyRequested("Hi"))
             await pilot.pause()
             await app.workers.wait_for_complete()
@@ -3243,7 +3256,7 @@ class TestPreviewIntegration:
             # Streaming attempt + one non-streaming retry, no more.
             assert [s.streaming for s in fake.selections] == [True, False]
             assert len(fake.requests) == 2
-            assert screen._preview_history == []
+            assert screen.preview.history == []
             pane = screen.query_one(PersonasPreviewPane)
             assert "Hello" not in pane.transcript_text()
             status = str(
@@ -3268,7 +3281,7 @@ class TestPreviewIntegration:
         app = PersonasTestApp(mock_app_instance)
         async with app.run_test(size=(160, 50)) as pilot:
             screen = await self._select_first_character(pilot)
-            screen._ensure_preview_gateway = lambda: fake
+            screen.preview.ensure_gateway = lambda: fake
             screen.post_message(PreviewReplyRequested("Hi"))
             await pilot.pause()
             await app.workers.wait_for_complete()
@@ -3279,7 +3292,7 @@ class TestPreviewIntegration:
                 for line in pane.transcript_text().splitlines()
             )
             assert not any(
-                entry["role"] == "assistant" for entry in screen._preview_history
+                entry["role"] == "assistant" for entry in screen.preview.history
             )
             assert (
                 str(screen.query_one("#personas-preview-status", _Static).renderable)
@@ -3294,7 +3307,7 @@ class TestPreviewIntegration:
         app = PersonasTestApp(mock_app_instance)
         async with app.run_test(size=(160, 50)) as pilot:
             screen = await self._select_first_character(pilot)
-            screen._preview_gateway = fake
+            screen.preview.gateway = fake
         assert fake.closed is True
 
     async def test_double_fire_coalesces_user_turns(
@@ -3314,7 +3327,7 @@ class TestPreviewIntegration:
         app = PersonasTestApp(mock_app_instance)
         async with app.run_test(size=(160, 50)) as pilot:
             screen = await self._select_first_character(pilot)
-            screen._ensure_preview_gateway = lambda: fake
+            screen.preview.ensure_gateway = lambda: fake
             screen.post_message(PreviewReplyRequested("Hi"))
             await pilot.pause()
             for _ in range(50):

--- a/backlog/tasks/task-118 - Extract-PersonasPreviewController-from-personas_screen.md
+++ b/backlog/tasks/task-118 - Extract-PersonasPreviewController-from-personas_screen.md
@@ -4,7 +4,7 @@ title: Extract PersonasPreviewController from personas_screen
 status: Done
 assignee: []
 created_date: '2026-06-11 13:25'
-updated_date: '2026-06-29 05:27'
+updated_date: '2026-07-03 09:46'
 labels: []
 dependencies: []
 ---
@@ -41,9 +41,14 @@ Extracted the ephemeral Personas preview conversation state, gateway lifecycle, 
 
 Updated preview integration tests to assert through the controller seam (`screen.preview.history`, `screen.preview.ensure_gateway`, and `screen.preview.system_prompt`) and added a structural regression that verifies `PersonasScreen.preview` is a `PersonasPreviewController`.
 
+Review follow-up replaced Loguru `exc_info=True` calls in `PersonasPreviewController` with native `logger.opt(exception=True)` exception capture and bound safe provider/model/selection/generation context on preview provider failures. Added a regression that captures real Loguru records for streaming and non-streaming provider errors.
+
+ADR check: no new ADR required; this remains a bounded UI/controller extraction under existing Personas ADR-004 and ADR-007, with no storage, schema, sync, service-contract, provider-boundary, or security-boundary change.
+
 Verification:
-- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_personas_workbench.py::TestPreviewIntegration --tb=short` -> 22 passed.
-- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_personas_workbench.py --tb=short` -> 160 passed.
-- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m py_compile tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py tldw_chatbook/UI/Screens/personas_screen.py` -> passed.
+- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_personas_workbench.py::TestPreviewIntegration --tb=short` -> 23 passed.
+- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_personas_workbench.py --tb=short` -> 161 passed.
+- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_console_native_chat_flow.py::test_console_conversation_browser_search_ignores_stale_results 'Tests/UI/test_destination_visual_parity_correction.py::test_runtime_and_settings_destinations_use_pane_layouts[settings-#settings-category-strip-#settings-workbench-panes1-actions1]' Tests/UI/test_settings_configuration_hub.py::test_settings_console_background_effects_save_nested_config Tests/UI/test_settings_configuration_hub.py::test_settings_console_background_workbench_loaded_scope_unrelated_save_falls_back Tests/UI/test_settings_configuration_hub.py::test_settings_console_behavior_revert_restores_global_defaults --tb=short` -> 5 passed.
+- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m py_compile tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py Tests/UI/test_personas_workbench.py` -> passed.
 - `git diff --check` -> passed.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-118 - Extract-PersonasPreviewController-from-personas_screen.md
+++ b/backlog/tasks/task-118 - Extract-PersonasPreviewController-from-personas_screen.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-118
 title: Extract PersonasPreviewController from personas_screen
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-06-11 13:25'
+updated_date: '2026-06-29 05:27'
 labels: []
 dependencies: []
 ---
@@ -16,5 +17,33 @@ The preview block (~180-210 lines: seeding rule, system-prompt builder, worker, 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Screen delegates preview logic to a controller,Tests repointed,Behavior preserved
+- [x] #1 Screen delegates preview logic to a controller,Tests repointed,Behavior preserved
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+ADR path: N/A
+Reason: bounded UI/controller extraction that preserves existing Personas preview behavior and does not change storage, schema, sync policy, service contracts, or security boundaries.
+
+1. Run the existing Personas preview integration baseline from current dev.
+2. Add a failing structural regression requiring PersonasScreen to own a PersonasPreviewController and delegate preview reply/reset/open-console handling to it.
+3. Extract the preview state, gateway lifecycle, system-prompt builder, seeding, worker, and open-console logic into UI/Persona_Modules/personas_preview_controller.py.
+4. Keep PersonasScreen event handlers and selection paths thin, delegating preview operations to the controller.
+5. Re-run focused preview tests, the full Personas workbench file, and diff checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Extracted the ephemeral Personas preview conversation state, gateway lifecycle, system prompt construction, reply worker, reset handling, and Console handoff into `PersonasPreviewController`. `PersonasScreen` now owns a `preview` controller and keeps only selection/lifecycle/event delegation, matching the existing conversations-controller pattern.
+
+Updated preview integration tests to assert through the controller seam (`screen.preview.history`, `screen.preview.ensure_gateway`, and `screen.preview.system_prompt`) and added a structural regression that verifies `PersonasScreen.preview` is a `PersonasPreviewController`.
+
+Verification:
+- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_personas_workbench.py::TestPreviewIntegration --tb=short` -> 22 passed.
+- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_personas_workbench.py --tb=short` -> 160 passed.
+- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m py_compile tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py tldw_chatbook/UI/Screens/personas_screen.py` -> passed.
+- `git diff --check` -> passed.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py
+++ b/tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py
@@ -1,0 +1,328 @@
+"""Ephemeral preview-chat controller for the Personas workbench screen.
+
+The preview conversation is intentionally in-memory: history lives here,
+transcript rendering lives in ``PersonasPreviewPane``, and provider calls go
+through the same Console gateway boundary without writing to local storage.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+from textual.css.query import QueryError
+
+from ...Character_Chat.Character_Chat_Lib import replace_placeholders
+from ...Chat.console_chat_models import ConsoleProviderSelection
+from ...Chat.console_provider_gateway import ConsoleProviderGateway
+from ...Widgets.Persona_Widgets.personas_character_editor_widget import (
+    PersonasCharacterEditorWidget,
+)
+from ...Widgets.Persona_Widgets.personas_preview_pane import PersonasPreviewPane
+
+if TYPE_CHECKING:
+    from ..Screens.personas_screen import PersonasScreen
+
+
+logger = logger.bind(module="PersonasPreviewController")
+
+# Cap on the preview transcript text staged into a Console handoff body.
+PREVIEW_HANDOFF_TRANSCRIPT_CHAR_LIMIT = 6000
+
+
+class PersonasPreviewController:
+    """Owns preview chat state, provider calls, and Console handoff."""
+
+    def __init__(self, screen: "PersonasScreen") -> None:
+        self.screen = screen
+        self.history: list[dict[str, str]] = []
+        # Monotonic generation invalidates in-flight replies when Reset clears
+        # the same selection without changing the selected entity key.
+        self.generation: int = 0
+        # Character id whose greeting last seeded the preview.
+        self.seeded_for: str | None = None
+        self.gateway: ConsoleProviderGateway | None = None
+
+    def invalidate(self) -> None:
+        """Clear history and cancel in-flight preview workers."""
+        self.generation += 1
+        self.screen.workers.cancel_group(self.screen, "personas-preview")
+        self.history.clear()
+
+    async def reset(self, greeting: str, *, seeded_for: str | None = None) -> None:
+        """Clear preview state and reseed the preview transcript.
+
+        Args:
+            greeting: Character greeting to render as the transcript seed.
+            seeded_for: Optional selected character id represented by the seed.
+        """
+        self.invalidate()
+        self.seeded_for = None
+        try:
+            await self.screen.query_one(PersonasPreviewPane).seed_greeting(greeting)
+        except QueryError:
+            # Tolerate calls that race screen teardown.
+            pass
+        self.seeded_for = seeded_for
+
+    async def reset_for_character(
+        self,
+        *,
+        character_id: str,
+        character_name: str,
+        record: dict[str, Any] | None,
+    ) -> None:
+        """Seed the preview from a selected character when its full card is cached.
+
+        Args:
+            character_id: Selected character identifier.
+            character_name: Display name used for greeting placeholders.
+            record: Full character record, or ``None`` while the worker loads it.
+        """
+        if record is None:
+            await self.reset("")
+            return
+        greeting = replace_placeholders(
+            str(record.get("first_message") or ""), character_name, "User"
+        )
+        await self.reset(greeting, seeded_for=character_id)
+
+    async def close_gateway(self) -> None:
+        """Release the preview gateway's HTTP client if it was created."""
+        gateway = self.gateway
+        self.gateway = None
+        if gateway is None:
+            return
+        try:
+            await gateway.aclose()
+        except Exception:
+            logger.warning("Could not close the preview provider gateway.", exc_info=True)
+
+    async def handle_character_loaded(
+        self, *, character_id: str, card_data: dict[str, Any] | None
+    ) -> None:
+        """Seed the preview greeting once the character load worker delivers.
+
+        Args:
+            character_id: Loaded character id.
+            card_data: Full character card data from the load worker.
+        """
+        screen = self.screen
+        character_id = str(character_id)
+        if (
+            screen.state.active_mode != "characters"
+            or screen.state.selected_entity_kind != "character"
+            or str(screen.state.selected_entity_id or "") != character_id
+        ):
+            return
+        try:
+            pane = screen.query_one(PersonasPreviewPane)
+        except QueryError:
+            return
+        record = dict(card_data or {})
+        name = str(record.get("name") or screen.state.selected_entity_name or "")
+        greeting = replace_placeholders(
+            str(record.get("first_message") or ""), name, "User"
+        )
+        # Same-character reloads after an edit should update the reset seed,
+        # not erase an in-progress preview conversation.
+        if self.seeded_for == character_id and pane.transcript_text():
+            pane.refresh_greeting_seed(greeting)
+            return
+        self.invalidate()
+        await pane.seed_greeting(greeting)
+        self.seeded_for = character_id
+
+    def ensure_gateway(self) -> ConsoleProviderGateway:
+        """Return the lazily-created Console provider gateway.
+
+        Returns:
+            Gateway configured from the app's current config snapshot.
+        """
+        if self.gateway is None:
+            self.gateway = ConsoleProviderGateway(
+                config_provider=lambda: getattr(
+                    self.screen.app_instance, "app_config", {}
+                )
+                or {},
+            )
+        return self.gateway
+
+    def system_prompt(self) -> str:
+        """Build a draft-aware system prompt for the selected persona source.
+
+        Returns:
+            Prompt text assembled from editor or selected-record fields.
+        """
+        screen = self.screen
+        record: dict[str, Any] = {}
+        if screen.state.active_mode == "characters":
+            if screen._edit_mode in ("edit", "create"):
+                try:
+                    record = (
+                        screen.query_one(PersonasCharacterEditorWidget).get_character_data()
+                        or {}
+                    )
+                except Exception:
+                    logger.warning(
+                        "Could not collect editor data for the preview.",
+                        exc_info=True,
+                    )
+                    record = {}
+            else:
+                record = screen._full_character_record(
+                    str(screen.state.selected_entity_id or "")
+                ) or {}
+        elif screen.state.active_mode == "personas":
+            record = screen._profile_record(screen.state.selected_entity_id) or {}
+        parts = [
+            str(record.get(key) or "").strip()
+            for key in ("system_prompt", "personality", "description", "scenario")
+        ]
+        prompt = "\n".join(part for part in parts if part)
+        return prompt or "Stay in character."
+
+    def handle_reply_requested(self, user_message: str) -> None:
+        """Append the user turn and schedule one provider reply.
+
+        Args:
+            user_message: Message entered in the preview composer.
+        """
+        self.history.append({"role": "user", "content": user_message})
+        self.screen.run_worker(
+            self._run_reply(),
+            exclusive=True,
+            group="personas-preview",
+        )
+
+    def handle_reset(self) -> None:
+        """Clear provider-facing preview state after the pane resets itself."""
+        self.invalidate()
+
+    def open_in_console(self) -> None:
+        """Stage the current preview transcript as a Console handoff."""
+        screen = self.screen
+        transcript = screen.query_one(PersonasPreviewPane).transcript_text()
+        truncated = len(transcript) > PREVIEW_HANDOFF_TRANSCRIPT_CHAR_LIMIT
+        staged = screen._stage_handoff(
+            item_type="preview-conversation",
+            title="Personas preview conversation",
+            body=transcript[:PREVIEW_HANDOFF_TRANSCRIPT_CHAR_LIMIT],
+            body_truncated=truncated,
+            suggested_prompt="Continue this conversation in character.",
+        )
+        if staged:
+            screen._notify("Preview conversation staged in Console.", "information")
+
+    def _pop_orphaned_user_turn(self) -> None:
+        """Drop a trailing unanswered user entry from provider history only."""
+        if self.history and self.history[-1].get("role") == "user":
+            self.history.pop()
+
+    async def _run_reply(self) -> None:
+        """Resolve the configured provider and stream one preview reply."""
+        screen = self.screen
+        pane = screen.query_one(PersonasPreviewPane)
+        config = getattr(screen.app_instance, "app_config", {}) or {}
+        defaults = config.get("character_defaults", {}) or {}
+        provider = str(defaults.get("provider") or "")
+        model = str(defaults.get("model") or "")
+        selection = ConsoleProviderSelection(provider=provider, explicit_model=model or None)
+        gateway = self.ensure_gateway()
+        selection_key = (screen.state.selected_entity_kind, screen.state.selected_entity_id)
+        generation = self.generation
+
+        def _stale() -> bool:
+            return (
+                not screen.is_mounted
+                or generation != self.generation
+                or (screen.state.selected_entity_kind, screen.state.selected_entity_id)
+                != selection_key
+            )
+
+        try:
+            resolution = await gateway.resolve_for_send(selection)
+        except Exception:
+            logger.error("Preview provider resolution failed.", exc_info=True)
+            if not _stale():
+                self._pop_orphaned_user_turn()
+                pane.set_status("Provider error - try again or configure in Settings")
+            return
+        if not resolution.ready:
+            if not _stale():
+                self._pop_orphaned_user_turn()
+                pane.set_status(
+                    resolution.visible_copy or "Provider unavailable - configure in Settings"
+                )
+            return
+        pane.set_status("Running")
+        await pane.discard_partial_reply()
+        history: list[dict[str, str]] = []
+        for entry in self.history:
+            if history and entry["role"] == "user" and history[-1]["role"] == "user":
+                history[-1] = {
+                    "role": "user",
+                    "content": f"{history[-1]['content']}\n{entry['content']}",
+                }
+            else:
+                history.append(dict(entry))
+        messages = [{"role": "system", "content": self.system_prompt()}] + history
+
+        async def _consume(res: Any) -> str | None:
+            """Render one provider stream into the pane; ``None`` means stale."""
+            consumed = ""
+            opened = False
+            async for chunk in gateway.stream_chat(res, messages):
+                if _stale():
+                    await pane.discard_partial_reply()
+                    return None
+                consumed += chunk
+                if chunk:
+                    if not opened:
+                        pane.begin_reply()
+                        opened = True
+                    pane.append_reply_chunk(chunk)
+            return consumed
+
+        try:
+            reply = await _consume(resolution)
+        except Exception:
+            logger.error(
+                "Preview provider call failed; retrying without streaming.",
+                exc_info=True,
+            )
+            if _stale():
+                await pane.discard_partial_reply()
+                return
+            await pane.discard_partial_reply()
+            pane.set_status("Retrying without streaming...")
+            try:
+                retry_resolution = await gateway.resolve_for_send(
+                    dataclasses.replace(selection, streaming=False)
+                )
+                if not retry_resolution.ready:
+                    raise RuntimeError(
+                        retry_resolution.visible_copy or "provider unavailable"
+                    )
+                reply = await _consume(retry_resolution)
+            except Exception:
+                logger.error("Preview non-streaming retry failed.", exc_info=True)
+                if not _stale():
+                    self._pop_orphaned_user_turn()
+                    await pane.discard_partial_reply()
+                    pane.set_status(
+                        "Provider error - try again or configure in Settings"
+                    )
+                return
+        if reply is None:
+            return
+        if _stale():
+            await pane.discard_partial_reply()
+            return
+        if reply:
+            self.history.append({"role": "assistant", "content": reply})
+            pane.finalize_reply()
+            pane.set_status("Ready")
+        else:
+            pane.set_status("No reply received")

--- a/tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py
+++ b/tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py
@@ -97,7 +97,9 @@ class PersonasPreviewController:
         try:
             await gateway.aclose()
         except Exception:
-            logger.warning("Could not close the preview provider gateway.", exc_info=True)
+            logger.bind(gateway_type=type(gateway).__name__).opt(
+                exception=True
+            ).warning("Could not close the preview provider gateway.")
 
     async def handle_character_loaded(
         self, *, character_id: str, card_data: dict[str, Any] | None
@@ -165,9 +167,13 @@ class PersonasPreviewController:
                         or {}
                     )
                 except Exception:
-                    logger.warning(
-                        "Could not collect editor data for the preview.",
-                        exc_info=True,
+                    logger.bind(
+                        active_mode=screen.state.active_mode,
+                        edit_mode=screen._edit_mode,
+                        selection_kind=screen.state.selected_entity_kind,
+                        selection_id=str(screen.state.selected_entity_id or ""),
+                    ).opt(exception=True).warning(
+                        "Could not collect editor data for the preview."
                     )
                     record = {}
             else:
@@ -220,6 +226,39 @@ class PersonasPreviewController:
         if self.history and self.history[-1].get("role") == "user":
             self.history.pop()
 
+    @staticmethod
+    def _selection_model(selection: ConsoleProviderSelection) -> str:
+        """Return the effective model label from a provider selection."""
+        return selection.explicit_model or selection.configured_model or ""
+
+    def _reply_log_context(
+        self,
+        *,
+        selection: ConsoleProviderSelection,
+        selection_key: tuple[str | None, Any],
+        generation: int,
+        attempt: str,
+        resolution: Any | None = None,
+    ) -> dict[str, Any]:
+        """Build safe context fields for preview provider exception logs."""
+        selected_kind, selected_id = selection_key
+        context: dict[str, Any] = {
+            "operation": "personas_preview_reply",
+            "provider": selection.provider,
+            "model": self._selection_model(selection),
+            "selection_kind": selected_kind or "",
+            "selection_id": str(selected_id or ""),
+            "generation": generation,
+            "attempt": attempt,
+            "streaming": selection.streaming,
+        }
+        if resolution is not None:
+            context.update(
+                resolved_provider=str(getattr(resolution, "provider", "") or ""),
+                resolved_model=str(getattr(resolution, "model", "") or ""),
+            )
+        return context
+
     async def _run_reply(self) -> None:
         """Resolve the configured provider and stream one preview reply."""
         screen = self.screen
@@ -244,7 +283,14 @@ class PersonasPreviewController:
         try:
             resolution = await gateway.resolve_for_send(selection)
         except Exception:
-            logger.error("Preview provider resolution failed.", exc_info=True)
+            logger.bind(
+                **self._reply_log_context(
+                    selection=selection,
+                    selection_key=selection_key,
+                    generation=generation,
+                    attempt="resolve",
+                )
+            ).opt(exception=True).error("Preview provider resolution failed.")
             if not _stale():
                 self._pop_orphaned_user_turn()
                 pane.set_status("Provider error - try again or configure in Settings")
@@ -288,26 +334,41 @@ class PersonasPreviewController:
         try:
             reply = await _consume(resolution)
         except Exception:
-            logger.error(
-                "Preview provider call failed; retrying without streaming.",
-                exc_info=True,
+            logger.bind(
+                **self._reply_log_context(
+                    selection=selection,
+                    selection_key=selection_key,
+                    generation=generation,
+                    attempt="streaming",
+                    resolution=resolution,
+                )
+            ).opt(exception=True).error(
+                "Preview provider call failed; retrying without streaming."
             )
             if _stale():
                 await pane.discard_partial_reply()
                 return
             await pane.discard_partial_reply()
             pane.set_status("Retrying without streaming...")
+            retry_selection = dataclasses.replace(selection, streaming=False)
+            retry_resolution = None
             try:
-                retry_resolution = await gateway.resolve_for_send(
-                    dataclasses.replace(selection, streaming=False)
-                )
+                retry_resolution = await gateway.resolve_for_send(retry_selection)
                 if not retry_resolution.ready:
                     raise RuntimeError(
                         retry_resolution.visible_copy or "provider unavailable"
                     )
                 reply = await _consume(retry_resolution)
             except Exception:
-                logger.error("Preview non-streaming retry failed.", exc_info=True)
+                logger.bind(
+                    **self._reply_log_context(
+                        selection=retry_selection,
+                        selection_key=selection_key,
+                        generation=generation,
+                        attempt="non_streaming",
+                        resolution=retry_resolution,
+                    )
+                ).opt(exception=True).error("Preview non-streaming retry failed.")
                 if not _stale():
                     self._pop_orphaned_user_turn()
                     await pane.discard_partial_reply()

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import dataclasses
 import json
 from pathlib import Path
 from typing import Any, Awaitable, Callable
@@ -20,12 +19,9 @@ from textual.widgets import Button, Input, ListView, Static, TextArea
 from ...Character_Chat.Character_Chat_Lib import (
     export_character_card_to_json,
     export_character_card_to_png,
-    replace_placeholders,
     validate_character_book,
 )
 from ...Chat.chat_handoff_models import ChatHandoffPayload
-from ...Chat.console_chat_models import ConsoleProviderSelection
-from ...Chat.console_provider_gateway import ConsoleProviderGateway
 from ...DB.ChaChaNotes_DB import ConflictError
 from ...tldw_api import PersonaProfileCreate, PersonaProfileUpdate
 from ...Utils.path_validation import validate_path_simple
@@ -77,9 +73,9 @@ from ..Navigation.base_app_screen import BaseAppScreen
 from ..Navigation.shortcut_context import ShortcutAction, ShortcutContext
 from ..Persona_Modules.personas_conversations_controller import (
     _CONVERSATION_VIEW_ID,
-    _HANDOFF_TRANSCRIPT_CHAR_LIMIT,
     PersonasConversationsController,
 )
+from ..Persona_Modules.personas_preview_controller import PersonasPreviewController
 
 
 logger = logger.bind(module="PersonasScreen")
@@ -333,22 +329,13 @@ class PersonasScreen(BaseAppScreen):
         # Serializes library renders: the pane's update_rows has two
         # suspension points, so interleaved renders could double-mount rows.
         self._render_lock = asyncio.Lock()
-        # Ephemeral preview conversation: in-memory only, never persisted.
-        self._preview_history: list[dict[str, str]] = []
-        # Monotonic generation for the preview: every reset/reseed bumps it,
-        # invalidating in-flight preview workers whose snapshot is older
-        # (the selection key alone cannot catch a Reset of the SAME selection).
-        self._preview_generation: int = 0
         self._workbench_compact: bool | None = None
         self._library_rail_collapsed: bool = False
         self._inspector_rail_collapsed: bool = False
-        # Character id whose greeting last seeded the preview; the
-        # CharacterMessage.Loaded handler uses it to avoid double-seeding.
-        self._preview_seeded_for: str | None = None
-        self._preview_gateway: ConsoleProviderGateway | None = None
         self.character_handler = CCPCharacterHandler(self)
         self.persona_handler = CCPPersonaHandler(self)
         self.conversations = PersonasConversationsController(self)
+        self.preview = PersonasPreviewController(self)
         setup_ccp_enhancements(self)
 
     # ===== Compose =====
@@ -471,14 +458,7 @@ class PersonasScreen(BaseAppScreen):
         super().on_unmount()
         self._cancel_search_debounce()
         self._clear_footer_shortcuts()
-        # Release the preview gateway's HTTP client; unmount must not crash.
-        gateway = self._preview_gateway
-        self._preview_gateway = None
-        if gateway is not None:
-            try:
-                await gateway.aclose()
-            except Exception:
-                logger.warning("Could not close the preview provider gateway.", exc_info=True)
+        await self.preview.close_gateway()
 
     def on_resize(self, event: Any) -> None:
         """Refresh compact workbench classes after terminal size changes.
@@ -885,7 +865,7 @@ class PersonasScreen(BaseAppScreen):
         library.set_mode(mode)
         # clear_selection empties the conversations panel; drop the caches too.
         self.conversations.reset()
-        await self._reset_preview("")
+        await self.preview.reset("")
         await self.query_one(PersonasInspectorPane).clear_selection()
         if mode == "characters":
             await self._render_library_rows()
@@ -980,14 +960,11 @@ class PersonasScreen(BaseAppScreen):
         # this character's full card (re-selection), seed now; otherwise clear
         # the preview and let the CharacterMessage.Loaded handler seed it.
         record = self._full_character_record(entity_id)
-        if record is not None:
-            greeting = replace_placeholders(
-                str(record.get("first_message") or ""), entity_name, "User"
-            )
-            await self._reset_preview(greeting)
-            self._preview_seeded_for = entity_id
-        else:
-            await self._reset_preview("")
+        await self.preview.reset_for_character(
+            character_id=entity_id,
+            character_name=entity_name,
+            record=record,
+        )
 
     async def _select_profile(self, entity_id: str, entity_name: str) -> None:
         self.state.select_entity(
@@ -1009,7 +986,7 @@ class PersonasScreen(BaseAppScreen):
         self.conversations.reset()
         await inspector.show_conversations(())
         # Profiles have no first_message concept; start the preview empty.
-        await self._reset_preview("")
+        await self.preview.reset("")
 
     # ===== Saved conversations =====
 
@@ -1216,289 +1193,28 @@ class PersonasScreen(BaseAppScreen):
         event.stop()
         await self._attach_selection_to_console(intent="start_chat")
 
-    # ===== Ephemeral preview conversation =====
-    #
-    # The preview is in-memory only: history lives on the screen, the
-    # transcript lives in the pane, and the provider call goes straight
-    # through the Console gateway. Nothing is ever written to a database.
-
-    def _invalidate_preview(self) -> None:
-        """Drop the preview history and invalidate in-flight preview replies.
-
-        Every path that clears the history (Reset, mode switch, selection
-        change, greeting reseed) must come through here so a late-landing
-        reply can never be appended to the cleared state: the generation bump
-        makes any running worker's snapshot stale, and the group cancel stops
-        the stream outright instead of letting it finish for nothing.
-        """
-        self._preview_generation += 1
-        self.workers.cancel_group(self, "personas-preview")
-        self._preview_history.clear()
-
-    async def _reset_preview(self, greeting: str) -> None:
-        """Clear the preview history and reseed the pane's transcript."""
-        self._invalidate_preview()
-        self._preview_seeded_for = None
-        try:
-            await self.query_one(PersonasPreviewPane).seed_greeting(greeting)
-        except QueryError:
-            # Tolerate calls that race screen teardown.
-            pass
-
     @on(CharacterMessage.Loaded)
     async def _handle_character_loaded(self, message: CharacterMessage.Loaded) -> None:
-        """Seed the preview greeting once the load worker delivers the card.
-
-        ``load_character`` only schedules a thread worker, so
-        ``_select_character`` usually cannot read ``first_message``
-        synchronously; the handler posts ``CharacterMessage.Loaded`` (with the
-        full card) to this screen when the load completes.
-        """
         message.stop()
-        character_id = str(message.character_id)
-        # Staleness check: only the current character selection, in
-        # Characters mode, may seed the preview.
-        if (
-            self.state.active_mode != "characters"
-            or self.state.selected_entity_kind != "character"
-            or str(self.state.selected_entity_id or "") != character_id
-        ):
-            return
-        try:
-            pane = self.query_one(PersonasPreviewPane)
-        except QueryError:
-            return
-        record = dict(message.card_data or {})
-        name = str(record.get("name") or self.state.selected_entity_name or "")
-        greeting = replace_placeholders(
-            str(record.get("first_message") or ""), name, "User"
+        await self.preview.handle_character_loaded(
+            character_id=str(message.character_id),
+            card_data=message.card_data,
         )
-        # Seeding rule: seed only when the pane transcript is empty OR the
-        # loaded id differs from the last-seeded id. A re-load of the same
-        # already-previewed character (e.g. after a save) mid-conversation
-        # must not wipe the in-progress preview. It still refreshes the
-        # stored reset seed so Reset reflects saved greeting edits.
-        if self._preview_seeded_for == character_id and pane.transcript_text():
-            pane.refresh_greeting_seed(greeting)
-            return
-        # Greeting reseed implies fresh preview state (history + workers).
-        self._invalidate_preview()
-        await pane.seed_greeting(greeting)
-        self._preview_seeded_for = character_id
-
-    def _ensure_preview_gateway(self) -> ConsoleProviderGateway:
-        """Lazy singleton gateway, config-injected like the Console screen's."""
-        if self._preview_gateway is None:
-            self._preview_gateway = ConsoleProviderGateway(
-                config_provider=lambda: getattr(self.app_instance, "app_config", {}) or {},
-            )
-        return self._preview_gateway
-
-    def _preview_system_prompt(self) -> str:
-        """System prompt for the preview call; draft-aware while editing.
-
-        An open character edit session previews the editor's CURRENT form
-        data (the point of the pane); otherwise the selected full character
-        record or persona profile record is used.
-        """
-        record: dict = {}
-        if self.state.active_mode == "characters":
-            if self._edit_mode in ("edit", "create"):
-                try:
-                    record = self.query_one(PersonasCharacterEditorWidget).get_character_data() or {}
-                except Exception:
-                    logger.warning("Could not collect editor data for the preview.", exc_info=True)
-                    record = {}
-            else:
-                record = self._full_character_record(str(self.state.selected_entity_id or "")) or {}
-        elif self.state.active_mode == "personas":
-            record = self._profile_record(self.state.selected_entity_id) or {}
-        parts = [
-            str(record.get(key) or "").strip()
-            for key in ("system_prompt", "personality", "description", "scenario")
-        ]
-        prompt = "\n".join(part for part in parts if part)
-        return prompt or "Stay in character."
 
     @on(PreviewReplyRequested)
     def _handle_preview_reply(self, message: PreviewReplyRequested) -> None:
         message.stop()
-        self._preview_history.append({"role": "user", "content": message.user_message})
-        self._run_preview_reply()
-
-    def _pop_orphaned_preview_user_turn(self) -> None:
-        """Drop a trailing unanswered user entry from the preview history.
-
-        Called on failure paths: _handle_preview_reply appends the user turn
-        before the worker runs, so a failed reply would otherwise leave an
-        orphan that makes a retry send the message twice. The transcript line
-        is deliberately LEFT visible - the user really did say it; only the
-        provider-facing history is corrected.
-        """
-        if self._preview_history and self._preview_history[-1].get("role") == "user":
-            self._preview_history.pop()
-
-    @work(exclusive=True, group="personas-preview")
-    async def _run_preview_reply(self) -> None:
-        """Resolve the configured provider and stream one preview reply."""
-        pane = self.query_one(PersonasPreviewPane)
-        config = getattr(self.app_instance, "app_config", {}) or {}
-        defaults = config.get("character_defaults", {}) or {}
-        provider = str(defaults.get("provider") or "")
-        model = str(defaults.get("model") or "")
-        selection = ConsoleProviderSelection(provider=provider, explicit_model=model or None)
-        gateway = self._ensure_preview_gateway()
-        # Staleness snapshot: the selection key catches selection moves; the
-        # generation catches a Reset/reseed of the SAME selection, which
-        # clears the history without changing the key. _invalidate_preview
-        # also cancels this worker group, but the snapshot guards any window
-        # where the cancellation has not landed yet.
-        selection_key = (self.state.selected_entity_kind, self.state.selected_entity_id)
-        generation = self._preview_generation
-
-        def _stale() -> bool:
-            return (
-                not self.is_mounted
-                or generation != self._preview_generation
-                or (self.state.selected_entity_kind, self.state.selected_entity_id)
-                != selection_key
-            )
-
-        try:
-            resolution = await gateway.resolve_for_send(selection)
-        except Exception:
-            logger.error("Preview provider resolution failed.", exc_info=True)
-            if not _stale():
-                self._pop_orphaned_preview_user_turn()
-                pane.set_status("Provider error - try again or configure in Settings")
-            return
-        if not resolution.ready:
-            if not _stale():
-                self._pop_orphaned_preview_user_turn()
-                pane.set_status(
-                    resolution.visible_copy or "Provider unavailable - configure in Settings"
-                )
-            return
-        pane.set_status("Running")
-        # An exclusive-cancelled predecessor may have left a half-streamed
-        # reply line behind; this run owns the transcript now, so drop it.
-        await pane.discard_partial_reply()
-        # Coalesce consecutive user turns: an exclusive-cancelled predecessor
-        # worker (double-fired Test Reply) leaves [user, user] in the history,
-        # which strict providers reject; join them into one message instead.
-        history: list[dict[str, str]] = []
-        for entry in self._preview_history:
-            if history and entry["role"] == "user" and history[-1]["role"] == "user":
-                history[-1] = {
-                    "role": "user",
-                    "content": f"{history[-1]['content']}\n{entry['content']}",
-                }
-            else:
-                history.append(dict(entry))
-        messages = [
-            {"role": "system", "content": self._preview_system_prompt()}
-        ] + history
-        async def _consume(res: Any) -> str | None:
-            """Render one provider stream into the pane; None means stale-abort."""
-            consumed = ""
-            opened = False
-            async for chunk in gateway.stream_chat(res, messages):
-                if _stale():
-                    # The selection changed or the preview was reset while the
-                    # provider was streaming. The invalidation paths reseed the
-                    # pane (removing the partial line); the discard here only
-                    # covers the window before that reseed lands, and is a
-                    # no-op afterwards.
-                    await pane.discard_partial_reply()
-                    return None
-                consumed += chunk
-                if chunk:
-                    # Progressive rendering: the first chunk opens the reply
-                    # line, later chunks grow it in place.
-                    if not opened:
-                        pane.begin_reply()
-                        opened = True
-                    pane.append_reply_chunk(chunk)
-            return consumed
-
-        try:
-            reply = await _consume(resolution)
-        except Exception:
-            logger.error(
-                "Preview provider call failed; retrying without streaming.",
-                exc_info=True,
-            )
-            if _stale():
-                await pane.discard_partial_reply()
-                return
-            # Non-streaming fallback: retry ONCE with streaming disabled.
-            # Any half-streamed fragment belongs to the failed attempt and
-            # must not prefix the retry's rendering.
-            await pane.discard_partial_reply()
-            pane.set_status("Retrying without streaming...")
-            try:
-                retry_resolution = await gateway.resolve_for_send(
-                    dataclasses.replace(selection, streaming=False)
-                )
-                if not retry_resolution.ready:
-                    raise RuntimeError(
-                        retry_resolution.visible_copy or "provider unavailable"
-                    )
-                reply = await _consume(retry_resolution)
-            except Exception:
-                logger.error("Preview non-streaming retry failed.", exc_info=True)
-                if not _stale():
-                    # Keep the user's transcript line, but pop the unanswered
-                    # history entry so a retry does not duplicate the turn, and
-                    # remove any half-streamed reply line - the reply never
-                    # completed, so the transcript must not keep a fragment.
-                    # The orphan pop happens only HERE, after both attempts.
-                    self._pop_orphaned_preview_user_turn()
-                    await pane.discard_partial_reply()
-                    pane.set_status(
-                        "Provider error - try again or configure in Settings"
-                    )
-                return
-        if reply is None:
-            # A stale-abort inside _consume already discarded the partial line.
-            return
-        if _stale():
-            # Same staleness rule for a stream that ended after invalidation.
-            await pane.discard_partial_reply()
-            return
-        if reply:
-            # The transcript already shows the full streamed line; commit it
-            # and give the history ONE consolidated assistant entry.
-            self._preview_history.append({"role": "assistant", "content": reply})
-            pane.finalize_reply()
-            pane.set_status("Ready")
-        else:
-            # An empty stream must not add a bare "character:" line or an
-            # empty assistant history entry (no line was begun: chunks were
-            # empty or absent).
-            pane.set_status("No reply received")
+        self.preview.handle_reply_requested(message.user_message)
 
     @on(PreviewResetRequested)
     def _handle_preview_reset(self, message: PreviewResetRequested) -> None:
         message.stop()
-        # The pane already restored its transcript to the greeting; clear the
-        # history AND invalidate any in-flight reply so it cannot land late.
-        self._invalidate_preview()
+        self.preview.handle_reset()
 
     @on(PreviewOpenInConsoleRequested)
     def _handle_preview_open_console(self, message: PreviewOpenInConsoleRequested) -> None:
         message.stop()
-        transcript = self.query_one(PersonasPreviewPane).transcript_text()
-        truncated = len(transcript) > _HANDOFF_TRANSCRIPT_CHAR_LIMIT
-        staged = self._stage_handoff(
-            item_type="preview-conversation",
-            title="Personas preview conversation",
-            body=transcript[:_HANDOFF_TRANSCRIPT_CHAR_LIMIT],
-            body_truncated=truncated,
-            suggested_prompt="Continue this conversation in character.",
-        )
-        if staged:
-            self._notify("Preview conversation staged in Console.", "information")
+        self.preview.open_in_console()
 
     # ===== Create / edit =====
 
@@ -2128,7 +1844,7 @@ class PersonasScreen(BaseAppScreen):
             # clear_selection on the inspector also empties the conversations
             # panel; drop the controller caches and the ephemeral preview too.
             self.conversations.reset()
-            await self._reset_preview("")
+            await self.preview.reset("")
             await self.query_one(PersonasInspectorPane).clear_selection()
             self._show_center(None)
             self._register_footer_shortcuts()


### PR DESCRIPTION
## Summary
- Extracted Personas preview chat state, provider gateway lifecycle, system prompt construction, reply worker, reset handling, and Console handoff into PersonasPreviewController.
- Kept PersonasScreen as the UI/event owner with thin delegation to the preview controller.
- Repointed preview integration tests to the controller seam and added a structural ownership regression.

## Test Plan
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_personas_workbench.py::TestPreviewIntegration --tb=short
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_personas_workbench.py --tb=short
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m py_compile tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py tldw_chatbook/UI/Screens/personas_screen.py
- git diff --check
- git diff --cached --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted Personas preview chat logic into `PersonasPreviewController` to isolate state and provider calls while keeping `PersonasScreen` thin. Meets TASK-118, preserves behavior, and adds clearer provider error logging with safe context.

- **Refactors**
  - Added `tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py` to own preview history, generation invalidation, draft-aware system prompt, provider gateway lifecycle (including unmount close), and Console handoff (with a 6k transcript cap).
  - `PersonasScreen` now exposes `screen.preview` and delegates reply/reset/open-in-console handling, character-load seeding, and unmount cleanup to it.
  - Provider failures now use `loguru` native exception capture with bound context (provider/model, selection, generation, attempt, streaming) and retain the non-streaming retry path.
  - Repointed preview integration tests to `screen.preview` (`history`, `ensure_gateway`, `system_prompt`), added a structural ownership check, and added a regression for provider error logging. No storage, schema, or API changes.

<sup>Written for commit b8a1420d3b64f1a966e9383da8f08e6569fee61b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

