### PR TITLE
fix(console): bound unbounded console.rail_state config growth

### DIFF
--- a/Tests/Chat/test_console_rail_state_prune.py
+++ b/Tests/Chat/test_console_rail_state_prune.py
@@ -1,0 +1,77 @@
+"""Pure tests for collect_prunable_console_rail_keys (Console rail-state pruning)."""
+
+from tldw_chatbook.Chat.console_rail_state import collect_prunable_console_rail_keys
+
+
+def test_prunes_dead_scope_key():
+    stored_keys = ["console_rail_state:ws:dead-conv"]
+
+    prunable = collect_prunable_console_rail_keys(
+        stored_keys, live_scope_ids=["live-conv"]
+    )
+
+    assert prunable == ["console_rail_state:ws:dead-conv"]
+
+
+def test_keeps_live_scope_key():
+    stored_keys = ["console_rail_state:ws:live-conv"]
+
+    prunable = collect_prunable_console_rail_keys(
+        stored_keys, live_scope_ids=["live-conv"]
+    )
+
+    assert prunable == []
+
+
+def test_keeps_global_scope_key_even_with_no_live_scopes():
+    stored_keys = ["console_rail_state:ws:global"]
+
+    prunable = collect_prunable_console_rail_keys(stored_keys, live_scope_ids=[])
+
+    assert prunable == []
+
+
+def test_keeps_malformed_and_foreign_keys():
+    stored_keys = [
+        "other_prefix:ws:scope",  # wrong prefix
+        "console_rail_state:ws",  # too few parts
+        "console_rail_state:ws:scope:extra",  # too many parts
+        123,  # non-str
+        None,  # non-str
+    ]
+
+    prunable = collect_prunable_console_rail_keys(stored_keys, live_scope_ids=[])
+
+    assert prunable == []
+
+
+def test_live_ids_are_matched_after_sanitization():
+    # The module sanitizes raw scope ids (replacing characters outside
+    # [A-Za-z0-9_.-] with "_") before building persistence keys, so a raw id
+    # containing a colon is stored under its sanitized form.
+    stored_keys = ["console_rail_state:ws:conv_1"]
+
+    prunable = collect_prunable_console_rail_keys(
+        stored_keys, live_scope_ids=["conv:1"]
+    )
+
+    assert prunable == []
+
+
+def test_mixed_stored_keys_only_prunes_dead_scopes():
+    stored_keys = [
+        "console_rail_state:ws:global",
+        "console_rail_state:ws:live-conv",
+        "console_rail_state:ws:orphan-1",
+        "console_rail_state:ws:orphan-2",
+        "other_prefix:ws:scope",
+    ]
+
+    prunable = collect_prunable_console_rail_keys(
+        stored_keys, live_scope_ids=["live-conv"]
+    )
+
+    assert sorted(prunable) == [
+        "console_rail_state:ws:orphan-1",
+        "console_rail_state:ws:orphan-2",
+    ]

--- a/Tests/UI/test_console_persistent_rails.py
+++ b/Tests/UI/test_console_persistent_rails.py
@@ -1296,3 +1296,123 @@ def test_generated_console_stylesheet_includes_tab_strip_spacing_rule():
     for css in (component_css, generated_css):
         tab_strip_block = _css_block(css, "#console-native-tab-strip")
         assert "margin-bottom: 1;" in tab_strip_block
+
+
+async def _wait_for_recorded_calls(pilot, recorded, expected_count: int) -> None:
+    for _ in range(40):
+        if len(recorded) >= expected_count:
+            return
+        await pilot.pause(0.05)
+    raise AssertionError(
+        f"expected at least {expected_count} recorded calls, saw {len(recorded)}"
+    )
+
+
+class _StubConversationsDB:
+    """Minimal chachanotes_db exposing only list_all_active_conversations."""
+
+    def __init__(self, conversation_ids: list[str]) -> None:
+        self._rows = [{"id": cid} for cid in conversation_ids]
+
+    def list_all_active_conversations(self, limit: int = 1000, offset: int = 0):
+        return self._rows[offset : offset + limit]
+
+
+@pytest.mark.asyncio
+async def test_console_rail_preference_skips_persist_when_unchanged(monkeypatch):
+    app = _build_test_app()
+    app.app_config = {"console": {"rail_state": {}}}
+
+    monkeypatch.setattr(
+        chat_screen_module,
+        "save_setting_to_cli_config",
+        lambda section, key, value: True,
+        raising=False,
+    )
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(180, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_native_console_session(console, pilot)
+
+        persisted: list[str] = []
+        original_persist = console._persist_console_rail_preferences
+
+        def _spy_persist(key, preferences, **kwargs):
+            persisted.append(key)
+            return original_persist(key, preferences, **kwargs)
+
+        monkeypatch.setattr(
+            console, "_persist_console_rail_preferences", _spy_persist
+        )
+
+        # Details defaults to collapsed; opening it is a real change → one write.
+        console._set_console_rail_preference(section_updates={"details": True})
+        assert len(persisted) == 1
+
+        # Re-applying the identical value must not persist again (dirty-check).
+        console._set_console_rail_preference(section_updates={"details": True})
+        assert len(persisted) == 1
+
+        # A genuine change persists once more.
+        console._set_console_rail_preference(section_updates={"details": False})
+        assert len(persisted) == 2
+
+
+@pytest.mark.asyncio
+async def test_console_rail_prune_removes_orphans_and_is_one_shot(monkeypatch):
+    app = _build_test_app()
+    app.app_config = {"console": {"rail_state": {}}}
+
+    monkeypatch.setattr(
+        chat_screen_module,
+        "save_setting_to_cli_config",
+        lambda section, key, value: True,
+        raising=False,
+    )
+    deleted_calls: list[list[str]] = []
+    monkeypatch.setattr(
+        chat_screen_module,
+        "delete_settings_from_cli_config",
+        lambda section, keys: deleted_calls.append(list(keys)) or True,
+        raising=False,
+    )
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(180, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_native_console_session(console, pilot)
+
+        # Seed a mixed rail_state and stub conversation liveness. Reset the
+        # one-shot latch so the manual dispatch runs against this exact state
+        # rather than racing the natural mount-time dispatch.
+        live_key = f"console_rail_state:{DEFAULT_WORKSPACE_ID}:conv-live"
+        global_key = f"console_rail_state:{DEFAULT_WORKSPACE_ID}:global"
+        orphan_a = f"console_rail_state:{DEFAULT_WORKSPACE_ID}:conv-dead-a"
+        orphan_b = f"console_rail_state:{DEFAULT_WORKSPACE_ID}:conv-dead-b"
+        app.app_config["console"]["rail_state"] = {
+            live_key: _rail_prefs(left_open=True, right_open=False),
+            global_key: _rail_prefs(left_open=True, right_open=False),
+            orphan_a: _rail_prefs(left_open=False, right_open=True),
+            orphan_b: _rail_prefs(left_open=False, right_open=False),
+        }
+        console.app_instance.chachanotes_db = _StubConversationsDB(["conv-live"])
+        deleted_calls.clear()
+        console._console_rail_prune_dispatched = False
+
+        console._dispatch_console_rail_preference_prune()
+        await _wait_for_recorded_calls(pilot, deleted_calls, 1)
+
+        rail_state = app.app_config["console"]["rail_state"]
+        assert live_key in rail_state
+        assert global_key in rail_state
+        assert orphan_a not in rail_state
+        assert orphan_b not in rail_state
+        assert deleted_calls[-1] == [orphan_a, orphan_b]
+
+        # One-shot: a second dispatch does no further work.
+        assert console._console_rail_prune_dispatched is True
+        deleted_calls.clear()
+        console._dispatch_console_rail_preference_prune()
+        await pilot.pause(0.2)
+        assert deleted_calls == []

--- a/Tests/UI/test_console_persistent_rails.py
+++ b/Tests/UI/test_console_persistent_rails.py
@@ -1403,7 +1403,13 @@ async def test_console_rail_prune_removes_orphans_and_is_one_shot(monkeypatch):
         console._dispatch_console_rail_preference_prune()
         await _wait_for_recorded_calls(pilot, deleted_calls, 1)
 
+        # The disk delete is recorded on the worker; the in-memory removal is
+        # scheduled back onto the UI thread, so wait for it to land.
         rail_state = app.app_config["console"]["rail_state"]
+        for _ in range(40):
+            if orphan_a not in rail_state and orphan_b not in rail_state:
+                break
+            await pilot.pause(0.05)
         assert live_key in rail_state
         assert global_key in rail_state
         assert orphan_a not in rail_state

--- a/Tests/UI/test_console_persistent_rails.py
+++ b/Tests/UI/test_console_persistent_rails.py
@@ -682,6 +682,13 @@ async def test_console_session_preference_copies_to_durable_conversation_key(mon
         lambda section, key, value: True,
         raising=False,
     )
+    deleted_keys: list[str] = []
+    monkeypatch.setattr(
+        chat_screen_module,
+        "delete_settings_from_cli_config",
+        lambda section, keys: deleted_keys.extend(keys) or True,
+        raising=False,
+    )
     monkeypatch.setattr(
         console_chat_store_module,
         "uuid4",
@@ -698,12 +705,12 @@ async def test_console_session_preference_copies_to_durable_conversation_key(mon
         await _wait_for_selector(console, pilot, "#console-context-rail-handle")
 
     rail_state = app.app_config["console"]["rail_state"]
-    # The seeded session fallback entry is left untouched (raw two-key shape);
-    # the durable conversation copy is written through the full serialized shape.
-    assert rail_state[f"console_rail_state:{DEFAULT_WORKSPACE_ID}:session-1"] == {
-        "left_open": False,
-        "right_open": True,
-    }
+    # The durable conversation copy is written through the full serialized
+    # shape, and the superseded session fallback entry is deleted so it can
+    # no longer accumulate as a permanent orphan section.
+    session_key = f"console_rail_state:{DEFAULT_WORKSPACE_ID}:session-1"
+    assert session_key not in rail_state
+    assert session_key in deleted_keys
     assert rail_state[
         f"console_rail_state:{DEFAULT_WORKSPACE_ID}:conv-1"
     ] == _rail_prefs(left_open=False, right_open=True)

--- a/Tests/test_config_delete_settings.py
+++ b/Tests/test_config_delete_settings.py
@@ -1,0 +1,136 @@
+"""Tests for config_module.delete_settings_from_cli_config."""
+
+import os
+
+import toml
+import tomllib
+
+from tldw_chatbook import config as config_module
+
+
+def _write_config(config_path, data: dict) -> None:
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(toml.dumps(data), encoding="utf-8")
+
+
+def test_deletes_existing_keys_from_nested_section(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.toml"
+    _write_config(
+        config_path,
+        {
+            "console": {
+                "rail_state": {
+                    "console_rail_state:ws:orphan-1": {
+                        "left_open": True,
+                        "right_open": False,
+                    },
+                    "console_rail_state:ws:live-conv": {
+                        "left_open": False,
+                        "right_open": True,
+                    },
+                }
+            }
+        },
+    )
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+
+    assert config_module.delete_settings_from_cli_config(
+        "console.rail_state",
+        ["console_rail_state:ws:orphan-1"],
+    )
+
+    saved = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    rail_state = saved["console"]["rail_state"]
+    assert "console_rail_state:ws:orphan-1" not in rail_state
+    assert rail_state["console_rail_state:ws:live-conv"] == {
+        "left_open": False,
+        "right_open": True,
+    }
+
+
+def test_missing_section_is_a_noop_returning_true(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.toml"
+    _write_config(config_path, {"chat_defaults": {"streaming": True}})
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    original_content = config_path.read_text(encoding="utf-8")
+    original_mtime_ns = config_path.stat().st_mtime_ns
+
+    assert config_module.delete_settings_from_cli_config(
+        "console.rail_state",
+        ["whatever-key"],
+    )
+
+    assert config_path.read_text(encoding="utf-8") == original_content
+    assert config_path.stat().st_mtime_ns == original_mtime_ns
+
+
+def test_missing_file_returns_true(tmp_path, monkeypatch):
+    config_path = tmp_path / "does-not-exist" / "config.toml"
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+
+    assert config_module.delete_settings_from_cli_config(
+        "console.rail_state",
+        ["some-key"],
+    )
+
+    assert not config_path.exists()
+
+
+def test_non_matching_delete_leaves_file_byte_identical(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.toml"
+    _write_config(
+        config_path,
+        {
+            "console": {
+                "rail_state": {
+                    "console_rail_state:ws:live-conv": {
+                        "left_open": False,
+                        "right_open": True,
+                    },
+                }
+            }
+        },
+    )
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    original_bytes = config_path.read_bytes()
+    original_mtime_ns = config_path.stat().st_mtime_ns
+
+    assert config_module.delete_settings_from_cli_config(
+        "console.rail_state",
+        ["console_rail_state:ws:key-that-does-not-exist"],
+    )
+
+    # No key was actually removed, so the file must not be rewritten at all.
+    assert config_path.read_bytes() == original_bytes
+    assert config_path.stat().st_mtime_ns == original_mtime_ns
+
+
+def test_other_sections_and_keys_are_untouched(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.toml"
+    _write_config(
+        config_path,
+        {
+            "console": {
+                "rail_state": {
+                    "console_rail_state:ws:orphan-1": {"left_open": True},
+                    "console_rail_state:ws:live-conv": {"left_open": False},
+                },
+                "collapse_large_pastes": True,
+            },
+            "chat_defaults": {"streaming": True, "temperature": 0.33},
+        },
+    )
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+
+    assert config_module.delete_settings_from_cli_config(
+        "console.rail_state",
+        ["console_rail_state:ws:orphan-1"],
+    )
+
+    saved = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert "console_rail_state:ws:orphan-1" not in saved["console"]["rail_state"]
+    assert saved["console"]["rail_state"]["console_rail_state:ws:live-conv"] == {
+        "left_open": False,
+    }
+    assert saved["console"]["collapse_large_pastes"] is True
+    assert saved["chat_defaults"] == {"streaming": True, "temperature": 0.33}

--- a/Tests/test_config_delete_settings.py
+++ b/Tests/test_config_delete_settings.py
@@ -1,9 +1,9 @@
 """Tests for config_module.delete_settings_from_cli_config."""
 
 import os
+import tomllib
 
 import toml
-import tomllib
 
 from tldw_chatbook import config as config_module
 
@@ -134,3 +134,34 @@ def test_other_sections_and_keys_are_untouched(tmp_path, monkeypatch):
     }
     assert saved["console"]["collapse_large_pastes"] is True
     assert saved["chat_defaults"] == {"streaming": True, "temperature": 0.33}
+
+
+def test_delete_preserves_existing_file_permissions(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.toml"
+    _write_config(
+        config_path,
+        {"console": {"rail_state": {"console_rail_state:ws:orphan-1": {"left_open": True}}}},
+    )
+    os.chmod(config_path, 0o600)
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+
+    assert config_module.delete_settings_from_cli_config(
+        "console.rail_state",
+        ["console_rail_state:ws:orphan-1"],
+    )
+
+    # A hardened 0600 config must not be silently widened by the atomic write.
+    assert config_path.stat().st_mode & 0o777 == 0o600
+
+
+def test_save_preserves_existing_file_permissions(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.toml"
+    _write_config(config_path, {"chat_defaults": {"streaming": True}})
+    os.chmod(config_path, 0o600)
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+
+    assert config_module.save_settings_to_cli_config(
+        {"chat_defaults": {"temperature": 0.5}}
+    )
+
+    assert config_path.stat().st_mode & 0o777 == 0o600

--- a/tldw_chatbook/Chat/console_rail_state.py
+++ b/tldw_chatbook/Chat/console_rail_state.py
@@ -173,18 +173,27 @@ def collect_prunable_console_rail_keys(
 
     A key is prunable only when it matches the canonical
     ``console_rail_state:<workspace>:<scope>`` shape and its scope id is
-    neither the reserved ``global`` scope nor present in ``live_scope_ids``
-    (live conversation ids plus open session ids, raw or sanitized).
+    neither the reserved ``global`` scope nor present in ``live_scope_ids``.
     Unrecognized key shapes are always kept.
+
+    Args:
+        stored_keys: Iterable of stored config key strings (non-string
+            entries are ignored). ``None`` is treated as empty.
+        live_scope_ids: Iterable of live scope ids (conversation ids plus
+            open session ids), matched after the module's key sanitization.
+            ``None`` is treated as empty.
+
+    Returns:
+        The subset of ``stored_keys`` safe to delete, order-preserved.
     """
     live_sanitized = {
         sanitized
-        for raw in live_scope_ids
+        for raw in (live_scope_ids or ())
         for sanitized in (_sanitize_optional_key_part(raw),)
         if sanitized
     }
     prunable: list[str] = []
-    for key in stored_keys:
+    for key in (stored_keys or ()):
         if not isinstance(key, str):
             continue
         parts = key.split(":")

--- a/tldw_chatbook/Chat/console_rail_state.py
+++ b/tldw_chatbook/Chat/console_rail_state.py
@@ -164,6 +164,39 @@ def build_console_rail_preference_key(
     )
 
 
+def collect_prunable_console_rail_keys(
+    stored_keys: Any,
+    *,
+    live_scope_ids: Any,
+) -> list[str]:
+    """Return stored rail-preference keys whose scope is no longer live.
+
+    A key is prunable only when it matches the canonical
+    ``console_rail_state:<workspace>:<scope>`` shape and its scope id is
+    neither the reserved ``global`` scope nor present in ``live_scope_ids``
+    (live conversation ids plus open session ids, raw or sanitized).
+    Unrecognized key shapes are always kept.
+    """
+    live_sanitized = {
+        sanitized
+        for raw in live_scope_ids
+        for sanitized in (_sanitize_optional_key_part(raw),)
+        if sanitized
+    }
+    prunable: list[str] = []
+    for key in stored_keys:
+        if not isinstance(key, str):
+            continue
+        parts = key.split(":")
+        if len(parts) != 3 or parts[0] != _PERSISTENCE_PREFIX:
+            continue
+        scope_id = parts[2]
+        if scope_id == "global" or scope_id in live_sanitized:
+            continue
+        prunable.append(key)
+    return prunable
+
+
 def _coerce_bool(value: Any, fallback: bool) -> bool:
     if isinstance(value, bool):
         return value

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -100,6 +100,7 @@ from ...Chat.console_rail_state import (
     build_console_rail_preference_key,
     build_console_rail_state,
     coerce_console_rail_preferences,
+    collect_prunable_console_rail_keys,
     serialize_console_rail_preferences,
 )
 from ...config import (
@@ -108,6 +109,7 @@ from ...config import (
     MIN_CONSOLE_PASTE_COLLAPSE_THRESHOLD,
     coerce_bool_setting,
     coerce_int_setting,
+    delete_settings_from_cli_config,
     get_cli_providers_and_models,
     save_setting_to_cli_config,
 )
@@ -1037,6 +1039,7 @@ class ChatScreen(BaseAppScreen):
         self._console_control_model: Optional[Any] = None
         self._console_library_rag_query = ""
         self._console_chat_store: ConsoleChatStore | None = None
+        self._console_rail_prune_dispatched = False
         self._console_workspace_conversation_query = ""
         self._console_workspace_conversation_search_timer: Any | None = None
         self._console_workspace_conversation_search_token = 0
@@ -3415,6 +3418,81 @@ class ChatScreen(BaseAppScreen):
         if not saved and notify_on_failure:
             self.app.call_from_thread(self._notify_console_rail_preference_save_failure)
 
+    @work(thread=True)
+    def _delete_console_rail_preference_keys(self, keys: list[str]) -> None:
+        """Remove superseded/orphaned rail preference keys off the UI thread."""
+        try:
+            delete_settings_from_cli_config("console.rail_state", keys)
+        except Exception as exc:
+            logger.warning("Failed to prune Console rail preference keys: {}", exc)
+
+    def _dispatch_console_rail_preference_prune(self) -> None:
+        """Queue the one-shot orphaned rail-preference cleanup after mount."""
+        if self._console_rail_prune_dispatched:
+            return
+        store = self._console_chat_store
+        if store is None:
+            # Sessions not restored yet; retry on a later sync so open
+            # unsaved sessions are never mistaken for orphans.
+            return
+        self._console_rail_prune_dispatched = True
+        live_scope_ids: set[str] = set()
+        for session in store.sessions():
+            live_scope_ids.add(str(session.id))
+            persisted_id = getattr(session, "persisted_conversation_id", None)
+            if persisted_id:
+                live_scope_ids.add(str(persisted_id))
+        self._prune_console_rail_preferences(live_scope_ids)
+
+    @work(thread=True)
+    def _prune_console_rail_preferences(self, live_scope_ids: set[str]) -> None:
+        """Drop rail preference sections whose conversation/session is gone.
+
+        Rail preferences accumulate one config section per scope forever
+        (deleted conversations included); this best-effort pass bounds the
+        namespace to live scopes. It refuses to prune when conversation
+        liveness cannot be established.
+        """
+        try:
+            # Peek without _console_rail_state_config(): this is a read path
+            # and must not materialize an empty rail_state table.
+            app_config = getattr(self.app_instance, "app_config", None)
+            if not isinstance(app_config, dict):
+                return
+            console_config = app_config.get("console")
+            if not isinstance(console_config, dict):
+                return
+            rail_state_config = console_config.get("rail_state")
+            if not isinstance(rail_state_config, dict) or not rail_state_config:
+                return
+            stored_keys = list(rail_state_config.keys())
+            db = getattr(self.app_instance, "chachanotes_db", None)
+            if db is None:
+                return
+            live = set(live_scope_ids)
+            offset = 0
+            page_size = 1000
+            while True:
+                rows = db.list_all_active_conversations(limit=page_size, offset=offset)
+                live.update(str(row["id"]) for row in rows if row.get("id"))
+                if len(rows) < page_size:
+                    break
+                offset += page_size
+            prunable = collect_prunable_console_rail_keys(
+                stored_keys, live_scope_ids=live
+            )
+            if not prunable:
+                return
+            for key in prunable:
+                rail_state_config.pop(key, None)
+            if delete_settings_from_cli_config("console.rail_state", prunable):
+                logger.info(
+                    "Pruned {} orphaned Console rail preference section(s)",
+                    len(prunable),
+                )
+        except Exception as exc:
+            logger.warning("Console rail preference prune skipped: {}", exc)
+
     def _notify_console_rail_preference_save_failure(self) -> None:
         """Notify from the UI thread when background preference persistence fails."""
         self.app_instance.notify(
@@ -3496,6 +3574,10 @@ class ChatScreen(BaseAppScreen):
             preferences,
             notify_on_failure=False,
         )
+        # The session-scoped fallback is superseded by the durable key; drop
+        # it so migrations stop leaving permanent orphan sections behind.
+        rail_state_config.pop(fallback_key, None)
+        self._delete_console_rail_preference_keys([fallback_key])
 
     def _current_console_session_id(self) -> Optional[str]:
         """Return a durable external Console session scope when one is available."""
@@ -3753,14 +3835,15 @@ class ChatScreen(BaseAppScreen):
             if section_id in CONSOLE_RAIL_SECTION_IDS:
                 changes[f"{section_id}_open"] = bool(section_open)
         next_preferences = replace(current, **changes)
-        rail_state_config[preference_key.value] = serialize_console_rail_preferences(
-            next_preferences
-        )
-        self._persist_console_rail_preferences(
-            preference_key.value,
-            next_preferences,
-            notify_on_failure=notify_on_failure,
-        )
+        if next_preferences != current:
+            rail_state_config[preference_key.value] = serialize_console_rail_preferences(
+                next_preferences
+            )
+            self._persist_console_rail_preferences(
+                preference_key.value,
+                next_preferences,
+                notify_on_failure=notify_on_failure,
+            )
         if right_open is not None:
             self._pending_console_launch_auto_open_inspector = False
         rail_state = self._current_console_rail_state()
@@ -5966,6 +6049,7 @@ class ChatScreen(BaseAppScreen):
             self._sync_console_rail_visibility_if_changed(
                 self._current_console_rail_state()
             )
+            self._dispatch_console_rail_preference_prune()
         finally:
             self._record_ui_worker_finished("console-sync")
             self._console_sync_in_progress = False

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -3435,6 +3435,10 @@ class ChatScreen(BaseAppScreen):
             # Sessions not restored yet; retry on a later sync so open
             # unsaved sessions are never mistaken for orphans.
             return
+        if getattr(self.app_instance, "chachanotes_db", None) is None:
+            # Conversation liveness cannot be established yet; retry on a
+            # later sync rather than latching and never pruning this session.
+            return
         self._console_rail_prune_dispatched = True
         live_scope_ids: set[str] = set()
         for session in store.sessions():
@@ -3483,15 +3487,32 @@ class ChatScreen(BaseAppScreen):
             )
             if not prunable:
                 return
-            for key in prunable:
-                rail_state_config.pop(key, None)
             if delete_settings_from_cli_config("console.rail_state", prunable):
+                # The in-memory config dict is shared with UI-thread readers
+                # and writers; mutate it back on the UI thread, not here.
+                self.app.call_from_thread(
+                    self._drop_console_rail_preference_keys_in_memory, prunable
+                )
                 logger.info(
                     "Pruned {} orphaned Console rail preference section(s)",
                     len(prunable),
                 )
         except Exception as exc:
             logger.warning("Console rail preference prune skipped: {}", exc)
+
+    def _drop_console_rail_preference_keys_in_memory(self, keys: list[str]) -> None:
+        """Remove pruned keys from the live in-memory rail-state config (UI thread)."""
+        app_config = getattr(self.app_instance, "app_config", None)
+        if not isinstance(app_config, dict):
+            return
+        console_config = app_config.get("console")
+        if not isinstance(console_config, dict):
+            return
+        rail_state_config = console_config.get("rail_state")
+        if not isinstance(rail_state_config, dict):
+            return
+        for key in keys:
+            rail_state_config.pop(key, None)
 
     def _notify_console_rail_preference_save_failure(self) -> None:
         """Notify from the UI thread when background preference persistence fails."""

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -2874,20 +2874,46 @@ def _target_config_section(config_data: Dict[str, Any], section: str) -> Dict[st
     return current_level
 
 
-_CONFIG_FILE_LOCK: Any = None
+# Eagerly created at import (single-threaded), so every caller shares one
+# lock. Lazy init would let the first two concurrent workers each build a
+# separate lock and defeat serialization on the first write.
+import threading as _threading
+
+_CONFIG_FILE_LOCK = _threading.Lock()
+
+# Fallback permissions for a config file that does not exist yet. config.toml
+# may hold plaintext secrets (when encryption is disabled), so it is created
+# owner-only rather than world-readable.
+_CONFIG_FILE_DEFAULT_MODE = 0o600
 
 
 def _config_file_lock():
-    """Serialize config-file read-modify-write cycles across thread workers.
+    """Return the shared config-file read-modify-write lock.
 
-    Saves run on Textual thread workers; without this lock two concurrent
-    read-modify-write cycles can silently drop one writer's update.
+    Returns:
+        The process-wide lock serializing config file saves/deletes across
+        Textual thread workers so concurrent cycles cannot drop updates.
     """
-    global _CONFIG_FILE_LOCK
-    if _CONFIG_FILE_LOCK is None:
-        import threading
-        _CONFIG_FILE_LOCK = threading.Lock()
     return _CONFIG_FILE_LOCK
+
+
+def _config_write_mode(config_path: Path) -> int:
+    """Choose the file mode to write a config file with.
+
+    Args:
+        config_path: Target config file path.
+
+    Returns:
+        The existing file's permission bits when it already exists (so a
+        hardened ``0600`` config is never silently widened), otherwise the
+        owner-only default.
+    """
+    try:
+        if config_path.exists():
+            return config_path.stat().st_mode & 0o777
+    except OSError:
+        pass
+    return _CONFIG_FILE_DEFAULT_MODE
 
 
 def save_settings_to_cli_config(section_values: Mapping[str, Mapping[Any, Any]]) -> bool:
@@ -2935,7 +2961,11 @@ def save_settings_to_cli_config(section_values: Mapping[str, Mapping[Any, Any]])
             return False
 
         try:
-            atomic_write_text(config_path, toml.dumps(config_data))
+            atomic_write_text(
+                config_path,
+                toml.dumps(config_data),
+                mode=_config_write_mode(config_path),
+            )
             logger.success(f"Successfully saved settings batch to {config_path}")
 
             _CONFIG_CACHE = None
@@ -2953,8 +2983,14 @@ def save_settings_to_cli_config(section_values: Mapping[str, Mapping[Any, Any]])
 def delete_settings_from_cli_config(section: str, keys: List[str]) -> bool:
     """Remove keys from a config section and persist the file atomically.
 
-    Missing sections or keys are a no-op success. Returns False only when the
-    file exists but cannot be read or rewritten.
+    Args:
+        section: Dotted config section path (e.g. ``"console.rail_state"``).
+        keys: Keys to remove from that section.
+
+    Returns:
+        True on success, including the no-op cases where the file, section,
+        or every named key is already absent. False only when the file
+        exists but cannot be read or rewritten, or the path is not a table.
     """
     global _CONFIG_CACHE, _SETTINGS_CACHE, settings
     config_path = _get_effective_config_path()
@@ -2983,12 +3019,19 @@ def delete_settings_from_cli_config(section: str, keys: List[str]) -> bool:
             )
             return False
 
-        removed = [key for key in keys if current_level.pop(key, None) is not None]
+        # Sentinel, not None: a key whose stored value is legitimately None
+        # must still count as removed so the file is rewritten.
+        _MISSING = object()
+        removed = [key for key in keys if current_level.pop(key, _MISSING) is not _MISSING]
         if not removed:
             return True
 
         try:
-            atomic_write_text(config_path, toml.dumps(config_data))
+            atomic_write_text(
+                config_path,
+                toml.dumps(config_data),
+                mode=_config_write_mode(config_path),
+            )
             logger.info(f"Removed {len(removed)} key(s) from [{section}] in {config_path}")
 
             _CONFIG_CACHE = None

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -2874,6 +2874,22 @@ def _target_config_section(config_data: Dict[str, Any], section: str) -> Dict[st
     return current_level
 
 
+_CONFIG_FILE_LOCK: Any = None
+
+
+def _config_file_lock():
+    """Serialize config-file read-modify-write cycles across thread workers.
+
+    Saves run on Textual thread workers; without this lock two concurrent
+    read-modify-write cycles can silently drop one writer's update.
+    """
+    global _CONFIG_FILE_LOCK
+    if _CONFIG_FILE_LOCK is None:
+        import threading
+        _CONFIG_FILE_LOCK = threading.Lock()
+    return _CONFIG_FILE_LOCK
+
+
 def save_settings_to_cli_config(section_values: Mapping[str, Mapping[Any, Any]]) -> bool:
     """Persist multiple config values with one TOML read/write and one cache reload."""
     global _CONFIG_CACHE, _SETTINGS_CACHE, settings
@@ -2890,48 +2906,100 @@ def save_settings_to_cli_config(section_values: Mapping[str, Mapping[Any, Any]])
         logger.error(f"Could not create config directory {config_path.parent}: {e}")
         return False
 
-    config_data: Dict[str, Any] = {}
-    if config_path.exists():
+    with _config_file_lock():
+        config_data: Dict[str, Any] = {}
+        if config_path.exists():
+            try:
+                with open(config_path, "rb") as f:
+                    config_data = tomllib.load(f)
+            except tomllib.TOMLDecodeError as e:
+                logger.error(f"Corrupted config file at {config_path}. Cannot save. Please fix or delete it. Error: {e}")
+                # Consider creating a backup of the corrupt file for the user.
+                return False
+            except Exception as e:
+                logger.error(f"Unexpected error reading {config_path}: {e}", exc_info=True)
+                return False
+
+        try:
+            for section, values in section_values.items():
+                if not values:
+                    continue
+                current_level = _target_config_section(config_data, section)
+                for key, value in values.items():
+                    current_level[key] = _maybe_encrypt_setting_value(config_data, key, value)
+        except (TypeError, AttributeError):
+            logger.error(
+                "Configuration structure conflict. Could not save settings batch "
+                f"because a part of the path is not a table/dictionary. Please check your config file."
+            )
+            return False
+
+        try:
+            atomic_write_text(config_path, toml.dumps(config_data))
+            logger.success(f"Successfully saved settings batch to {config_path}")
+
+            _CONFIG_CACHE = None
+            _SETTINGS_CACHE = None
+            load_cli_config_and_ensure_existence(force_reload=True)
+            settings = load_settings(force_reload=True)
+            logger.info("Global configuration caches invalidated and reloaded.")
+
+            return True
+        except (IOError, OSError, toml.TomlDecodeError) as e:
+            logger.error(f"Failed to write updated config to {config_path}: {e}", exc_info=True)
+            return False
+
+
+def delete_settings_from_cli_config(section: str, keys: List[str]) -> bool:
+    """Remove keys from a config section and persist the file atomically.
+
+    Missing sections or keys are a no-op success. Returns False only when the
+    file exists but cannot be read or rewritten.
+    """
+    global _CONFIG_CACHE, _SETTINGS_CACHE, settings
+    config_path = _get_effective_config_path()
+    if not config_path.exists():
+        return True
+
+    with _config_file_lock():
         try:
             with open(config_path, "rb") as f:
-                config_data = tomllib.load(f)
+                config_data: Dict[str, Any] = tomllib.load(f)
         except tomllib.TOMLDecodeError as e:
-            logger.error(f"Corrupted config file at {config_path}. Cannot save. Please fix or delete it. Error: {e}")
-            # Consider creating a backup of the corrupt file for the user.
+            logger.error(f"Corrupted config file at {config_path}. Cannot delete from it. Error: {e}")
             return False
         except Exception as e:
             logger.error(f"Unexpected error reading {config_path}: {e}", exc_info=True)
             return False
 
-    try:
-        for section, values in section_values.items():
-            if not values:
-                continue
-            current_level = _target_config_section(config_data, section)
-            for key, value in values.items():
-                current_level[key] = _maybe_encrypt_setting_value(config_data, key, value)
-    except (TypeError, AttributeError):
-        logger.error(
-            "Configuration structure conflict. Could not save settings batch "
-            f"because a part of the path is not a table/dictionary. Please check your config file."
-        )
-        return False
+        current_level: Any = config_data
+        for part in section.split('.'):
+            if not isinstance(current_level, dict) or part not in current_level:
+                return True
+            current_level = current_level[part]
+        if not isinstance(current_level, dict):
+            logger.error(
+                f"Cannot delete keys from [{section}]: path is not a table in {config_path}."
+            )
+            return False
 
-    try:
-        with open(config_path, "w", encoding="utf-8") as f:
-            toml.dump(config_data, f)
-        logger.success(f"Successfully saved settings batch to {config_path}")
+        removed = [key for key in keys if current_level.pop(key, None) is not None]
+        if not removed:
+            return True
 
-        _CONFIG_CACHE = None
-        _SETTINGS_CACHE = None
-        load_cli_config_and_ensure_existence(force_reload=True)
-        settings = load_settings(force_reload=True)
-        logger.info("Global configuration caches invalidated and reloaded.")
+        try:
+            atomic_write_text(config_path, toml.dumps(config_data))
+            logger.info(f"Removed {len(removed)} key(s) from [{section}] in {config_path}")
 
-        return True
-    except (IOError, toml.TomlDecodeError) as e:
-        logger.error(f"Failed to write updated config to {config_path}: {e}", exc_info=True)
-        return False
+            _CONFIG_CACHE = None
+            _SETTINGS_CACHE = None
+            load_cli_config_and_ensure_existence(force_reload=True)
+            settings = load_settings(force_reload=True)
+
+            return True
+        except (IOError, OSError, toml.TomlDecodeError) as e:
+            logger.error(f"Failed to write updated config to {config_path}: {e}", exc_info=True)
+            return False
 
 
 def save_setting_to_cli_config(section: str, key: str, value: Any) -> bool:


### PR DESCRIPTION
## Problem

Console rail preferences persist into `config.toml` under `[console.rail_state."console_rail_state:<workspace>:<uuid>"]`, one section per conversation/session UUID, and the namespace only ever grew. A test HOME accumulated **1,605 sections / 367 KB in three days**. Root causes:

- **Migration orphaned data.** When an unsaved chat's session-scoped preference was copied forward to the durable conversation-scoped key, the session key was never deleted — every migrated conversation left two permanent sections.
- **No cleanup on delete.** Soft-deleting a conversation in the DB left its rail_state section behind forever.
- **Unconditional writes.** `_set_console_rail_preference` persisted on every call even when nothing changed.
- **Every save rewrote the whole file** (read-modify-write) with no lock and a non-atomic `open(w)`, so as the file grew each toggle got slower, and concurrent thread-worker saves could silently drop each other's updates.

## Fix

- **`config.py`**: new `delete_settings_from_cli_config(section, keys)`; both save and delete now write atomically (temp file + rename via `atomic_write_text`) and are serialized under a process-wide `_config_file_lock()`. No-op deletes don't rewrite the file.
- **Migration cleanup** (`chat_screen.py`): after copying the session fallback forward, the session key is dropped in-memory and deleted from disk.
- **Dirty-check**: `_set_console_rail_preference` skips persistence when the new preferences equal the current ones.
- **Orphan prune**: a one-shot, post-mount background pass (`_prune_console_rail_preferences`) drops rail_state sections whose scope is neither `global`, an open session, nor a live conversation (paged from `list_all_active_conversations`). It refuses to prune when conversation liveness can't be established (missing DB handle), and never materializes an empty `rail_state` table on the read path.
- New pure helper `collect_prunable_console_rail_keys` keeps `global`, foreign key shapes, and live (sanitized) scopes.

Scoping behavior is unchanged; only the storage lifecycle is bounded. Existing rail persistence/resume behavior is preserved.

## Tests

- `Tests/Chat/test_console_rail_state_prune.py` — pure prune-key selection (dead vs live vs `global` vs malformed; sanitized-id matching).
- `Tests/test_config_delete_settings.py` — delete API: removes keys, no-op on missing section/file, no rewrite when nothing matches, leaves other sections intact.
- `Tests/UI/test_console_persistent_rails.py` — migration now deletes the fallback key; dirty-check skips no-op writes; prune removes orphans, keeps live/`global`, and is one-shot. Realigned the existing migration test to the delete-after-copy contract.
- Full config-consumer suite (`-k config`): **576 passed, 4 skipped** — the atomic/locked save change is safe across every config writer.

Backlog: TASK-150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds unbounded growth of `console.rail_state` in `config.toml` and makes saves/deletes safe, atomic, and permission-preserving to prevent file bloat and dropped updates. Addresses TASK-150.

- **Bug Fixes**
  - Migration cleanup: after copying the session fallback to the durable conversation key, delete the session key on disk.
  - One-shot orphan prune after mount: removes `console_rail_state:<workspace>:<scope>` keys not tied to `global`, open sessions, or live conversations; retries until DB liveness is available and applies in-memory removals on the UI thread.
  - Skips persistence when rail preferences are unchanged (dirty-check).
  - Adds `delete_settings_from_cli_config(section, keys)` for targeted deletes.

- **Reliability**
  - Serializes config reads/writes under a process-wide lock created at import; saves/deletes are atomic (temp file + rename).
  - Preserves existing config file permissions and defaults new files to 0600 to avoid widening a hardened config.
  - No-op deletes do not rewrite the file; deletion uses a sentinel so actual removals always trigger a rewrite.
  - Read path never materializes an empty `rail_state` table.

<sup>Written for commit 8299ce61a787ef9f99c9d5bdd91a4de4a05e68bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

