### PR TITLE
feat(settings): inline API-key field under the Chat-Defaults provider picker

### DIFF
--- a/Docs/superpowers/plans/2026-07-05-chat-defaults-inline-api-key.md
+++ b/Docs/superpowers/plans/2026-07-05-chat-defaults-inline-api-key.md
@@ -87,7 +87,7 @@ def test_keyless_provider_is_disabled_and_not_persistable():
 
 def test_locked_config_is_disabled_with_unlock_hint():
     state = chat_api_key_field_state(
-        _readiness(ready=True, api_key="sk-secret", api_key_source="config:api_settings.openai.api_key"),
+        _readiness(ready=True, api_key="test-secret-key", api_key_source="config:api_settings.openai.api_key"),
         locked=True,
     )
     assert state.disabled is True
@@ -98,17 +98,17 @@ def test_locked_config_is_disabled_with_unlock_hint():
 
 def test_config_key_is_prefilled():
     state = chat_api_key_field_state(
-        _readiness(ready=True, api_key="sk-abc123", api_key_source="config:api_settings.openai.api_key"),
+        _readiness(ready=True, api_key="test-key-abc123", api_key_source="config:api_settings.openai.api_key"),
         locked=False,
     )
     assert state.disabled is False
-    assert state.value == "sk-abc123"
+    assert state.value == "test-key-abc123"
     assert state.can_persist is True
 
 
 def test_env_key_shows_hint_and_empty_value():
     state = chat_api_key_field_state(
-        _readiness(ready=True, api_key="sk-env", api_key_source="env:OPENAI_API_KEY", env_var="OPENAI_API_KEY"),
+        _readiness(ready=True, api_key="test-env-key", api_key_source="env:OPENAI_API_KEY", env_var="OPENAI_API_KEY"),
         locked=False,
     )
     assert state.value == ""
@@ -126,7 +126,7 @@ def test_missing_key_is_empty_and_persistable():
 
 def test_persist_skips_when_not_persistable():
     state = ChatApiKeyFieldState(value="", disabled=True, placeholder="", can_persist=False)
-    assert chat_api_key_value_to_persist("sk-new", state) is None
+    assert chat_api_key_value_to_persist("test-new-key", state) is None
 
 
 def test_persist_skips_blank_and_placeholder():
@@ -136,13 +136,13 @@ def test_persist_skips_blank_and_placeholder():
 
 
 def test_persist_skips_unchanged_config_value():
-    state = ChatApiKeyFieldState(value="sk-abc123", disabled=False, placeholder="", can_persist=True)
-    assert chat_api_key_value_to_persist("sk-abc123", state) is None
+    state = ChatApiKeyFieldState(value="test-key-abc123", disabled=False, placeholder="", can_persist=True)
+    assert chat_api_key_value_to_persist("test-key-abc123", state) is None
 
 
 def test_persist_returns_stripped_new_value():
-    state = ChatApiKeyFieldState(value="sk-old", disabled=False, placeholder="", can_persist=True)
-    assert chat_api_key_value_to_persist("  sk-new  ", state) == "sk-new"
+    state = ChatApiKeyFieldState(value="test-old-key", disabled=False, placeholder="", can_persist=True)
+    assert chat_api_key_value_to_persist("  test-new-key  ", state) == "test-new-key"
 ```
 
 - [ ] **Step 2: Run tests to verify they fail**
@@ -272,7 +272,7 @@ async def test_chat_api_key_field_prefilled_for_config_key(monkeypatch, temp_con
     create_dummy_config(temp_config_path, {
         "providers": {"OpenAI": ["gpt-4o"], "Ollama": ["llama3"]},
         "chat_defaults": {"provider": "OpenAI", "model": "gpt-4o"},
-        "api_settings": {"openai": {"api_key": "sk-configured"}},
+        "api_settings": {"openai": {"api_key": "test-configured-key"}},
     })
     monkeypatch.setattr(tldw_chatbook.config, "DEFAULT_CONFIG_PATH", temp_config_path)
     window = ToolsSettingsWindow(app_instance=mock_app_instance)
@@ -281,7 +281,7 @@ async def test_chat_api_key_field_prefilled_for_config_key(monkeypatch, temp_con
         await pilot.pause()
         field = window.query_one("#general-chat-api-key", Input)
         assert field.password is True
-        assert field.value == "sk-configured"
+        assert field.value == "test-configured-key"
         assert field.disabled is False
 
 
@@ -427,11 +427,11 @@ async def test_chat_api_key_field_reloads_on_provider_change(monkeypatch, temp_c
     config = {
         "providers": {"OpenAI": ["gpt-4o"], "Ollama": ["llama3"]},
         "chat_defaults": {"provider": "OpenAI", "model": "gpt-4o"},
-        "api_settings": {"openai": {"api_key": "sk-configured"}},
+        "api_settings": {"openai": {"api_key": "test-configured-key"}},
     }
     async with mount_settings_window(config, temp_config_path, monkeypatch) as (window, pilot):
         field = window.query_one("#general-chat-api-key", Input)
-        assert field.value == "sk-configured"
+        assert field.value == "test-configured-key"
 
         # Switch to a keyless provider -> field disables and clears
         window.query_one("#general-chat-provider", Select).value = "Ollama"
@@ -443,7 +443,7 @@ async def test_chat_api_key_field_reloads_on_provider_change(monkeypatch, temp_c
 - [ ] **Step 3: Run test to verify it fails**
 
 Run: `pytest Tests/UI/test_tools_settings_window.py -k reloads_on_provider_change -v`
-Expected: FAIL — field stays enabled with `sk-configured` (no handler yet).
+Expected: FAIL — field stays enabled with `test-configured-key` (no handler yet).
 
 - [ ] **Step 4: Add the handler**
 
@@ -522,17 +522,17 @@ async def test_chat_api_key_save_writes_config_and_updates_live_config(monkeypat
     }
     async with mount_settings_window(config, temp_config_path, monkeypatch) as (window, pilot):
         window.app_instance.app_config = {"api_settings": {}}
-        window.query_one("#general-chat-api-key", Input).value = "sk-brand-new"
+        window.query_one("#general-chat-api-key", Input).value = "test-brand-new-key"
 
         saved = window._save_chat_api_key()
         assert saved is True
 
         # Written to the on-disk config under the normalized provider key
         written = toml.load(temp_config_path)
-        assert written["api_settings"]["openai"]["api_key"] == "sk-brand-new"
+        assert written["api_settings"]["openai"]["api_key"] == "test-brand-new-key"
 
         # Live app config updated in place (no restart needed)
-        assert window.app_instance.app_config["api_settings"]["openai"]["api_key"] == "sk-brand-new"
+        assert window.app_instance.app_config["api_settings"]["openai"]["api_key"] == "test-brand-new-key"
 
 
 @pytest.mark.asyncio

--- a/Docs/superpowers/plans/2026-07-05-chat-defaults-inline-api-key.md
+++ b/Docs/superpowers/plans/2026-07-05-chat-defaults-inline-api-key.md
@@ -6,7 +6,7 @@
 
 **Architecture:** Two pure, UI-agnostic helper functions in `Chat/provider_readiness.py` map a `ProviderReadiness` (the app's single source of truth for how a provider's key is resolved) into the field's render/persist state. `Tools_Settings_Window.py` renders the field from that state, reloads it when the provider dropdown changes, saves the entered key to `api_settings.<provider>.api_key` (exactly where both live send paths read), and refreshes the live `app.app_config` in place so no restart is needed.
 
-**Tech Stack:** Python ≥3.11, Textual ≥3.3.0, TOML config, pytest / pytest-asyncio, Textual `AppTest`.
+**Tech Stack:** Python ≥3.11, Textual ≥3.3.0 (installed 8.2.7 — `textual.app.AppTest` is NOT available; use `app.run_test()` real-pilot harness), TOML config, pytest / pytest-asyncio.
 
 ## Global Constraints
 
@@ -401,23 +401,35 @@ Add a `Select.Changed` handler scoped to the provider dropdown that recomputes t
 - Consumes: `get_provider_readiness`, `chat_api_key_field_state`, `_config_is_locked` (Task 2). `on`, `Select`, `Input`, `QueryError` already imported.
 - Produces: `ToolsSettingsWindow._on_chat_provider_changed(self, event: Select.Changed) -> None`.
 
-- [ ] **Step 1: Write the failing test**
+> **Test harness note (IMPORTANT):** `textual.app.AppTest` does NOT exist in this repo's Textual (8.2.7). Task 2 established the real-pilot helper `mount_settings_window(config_dict, temp_config_path, monkeypatch)` (an `@asynccontextmanager`) plus `_ToolsSettingsHostApp(App)` at the top of `Tests/UI/test_tools_settings_window.py`. Use that helper for all UI tests here — do NOT use `AppTest` or `mock_app_instance` for these tests.
+
+- [ ] **Step 1: Evolve the mount helper to also yield the pilot**
+
+Task 3 must flush a `Select.Changed` message, which needs `pilot.pause()`. Update `mount_settings_window` to yield both the window and the pilot, and update Task 2's two existing call sites accordingly:
+
+```python
+# in mount_settings_window(...):  change the final yield
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        window = app.query_one(ToolsSettingsWindow)
+        yield window, pilot
+```
+
+Update the two existing Task 2 tests from `async with mount_settings_window(...) as window:` to `async with mount_settings_window(...) as (window, pilot):` (they ignore `pilot`). Re-run `pytest Tests/UI/test_tools_settings_window.py -k chat_api_key_field -v` and confirm the two still pass before proceeding.
+
+- [ ] **Step 2: Write the failing test**
 
 Add to `Tests/UI/test_tools_settings_window.py`:
 
 ```python
 @pytest.mark.asyncio
-async def test_chat_api_key_field_reloads_on_provider_change(monkeypatch, temp_config_path, mock_app_instance):
-    create_dummy_config(temp_config_path, {
+async def test_chat_api_key_field_reloads_on_provider_change(monkeypatch, temp_config_path):
+    config = {
         "providers": {"OpenAI": ["gpt-4o"], "Ollama": ["llama3"]},
         "chat_defaults": {"provider": "OpenAI", "model": "gpt-4o"},
         "api_settings": {"openai": {"api_key": "sk-configured"}},
-    })
-    monkeypatch.setattr(tldw_chatbook.config, "DEFAULT_CONFIG_PATH", temp_config_path)
-    window = ToolsSettingsWindow(app_instance=mock_app_instance)
-    async with AppTest(app=mock_app_instance, driver_class=None) as pilot:
-        mock_app_instance.mount(window)
-        await pilot.pause()
+    }
+    async with mount_settings_window(config, temp_config_path, monkeypatch) as (window, pilot):
         field = window.query_one("#general-chat-api-key", Input)
         assert field.value == "sk-configured"
 
@@ -428,12 +440,12 @@ async def test_chat_api_key_field_reloads_on_provider_change(monkeypatch, temp_c
         assert field.value == ""
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [ ] **Step 3: Run test to verify it fails**
 
 Run: `pytest Tests/UI/test_tools_settings_window.py -k reloads_on_provider_change -v`
 Expected: FAIL — field stays enabled with `sk-configured` (no handler yet).
 
-- [ ] **Step 3: Add the handler**
+- [ ] **Step 4: Add the handler**
 
 Add to `ToolsSettingsWindow` (place directly after `_compose_chat_defaults_settings`):
 
@@ -455,12 +467,12 @@ Add to `ToolsSettingsWindow` (place directly after `_compose_chat_defaults_setti
         api_key_input.placeholder = state.placeholder
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 5: Run test to verify it passes**
 
 Run: `pytest Tests/UI/test_tools_settings_window.py -k reloads_on_provider_change -v`
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
 git add tldw_chatbook/UI/Tools_Settings_Window.py Tests/UI/test_tools_settings_window.py
@@ -498,20 +510,18 @@ from ..Chat.provider_readiness import (
 
 Add to `Tests/UI/test_tools_settings_window.py`:
 
+Use the `mount_settings_window` helper (yields `(window, pilot)`). The window's `app_instance` is the real host app, so set/read `app_config` on `window.app_instance`:
+
 ```python
 @pytest.mark.asyncio
-async def test_chat_api_key_save_writes_config_and_updates_live_config(monkeypatch, temp_config_path, mock_app_instance):
-    create_dummy_config(temp_config_path, {
+async def test_chat_api_key_save_writes_config_and_updates_live_config(monkeypatch, temp_config_path):
+    config = {
         "providers": {"OpenAI": ["gpt-4o"]},
         "chat_defaults": {"provider": "OpenAI", "model": "gpt-4o"},
         "api_settings": {},
-    })
-    monkeypatch.setattr(tldw_chatbook.config, "DEFAULT_CONFIG_PATH", temp_config_path)
-    mock_app_instance.app_config = {"api_settings": {}}
-    window = ToolsSettingsWindow(app_instance=mock_app_instance)
-    async with AppTest(app=mock_app_instance, driver_class=None) as pilot:
-        mock_app_instance.mount(window)
-        await pilot.pause()
+    }
+    async with mount_settings_window(config, temp_config_path, monkeypatch) as (window, pilot):
+        window.app_instance.app_config = {"api_settings": {}}
         window.query_one("#general-chat-api-key", Input).value = "sk-brand-new"
 
         saved = window._save_chat_api_key()
@@ -522,22 +532,18 @@ async def test_chat_api_key_save_writes_config_and_updates_live_config(monkeypat
         assert written["api_settings"]["openai"]["api_key"] == "sk-brand-new"
 
         # Live app config updated in place (no restart needed)
-        assert mock_app_instance.app_config["api_settings"]["openai"]["api_key"] == "sk-brand-new"
+        assert window.app_instance.app_config["api_settings"]["openai"]["api_key"] == "sk-brand-new"
 
 
 @pytest.mark.asyncio
-async def test_chat_api_key_save_skips_blank(monkeypatch, temp_config_path, mock_app_instance):
-    create_dummy_config(temp_config_path, {
+async def test_chat_api_key_save_skips_blank(monkeypatch, temp_config_path):
+    config = {
         "providers": {"OpenAI": ["gpt-4o"]},
         "chat_defaults": {"provider": "OpenAI", "model": "gpt-4o"},
         "api_settings": {},
-    })
-    monkeypatch.setattr(tldw_chatbook.config, "DEFAULT_CONFIG_PATH", temp_config_path)
-    mock_app_instance.app_config = {"api_settings": {}}
-    window = ToolsSettingsWindow(app_instance=mock_app_instance)
-    async with AppTest(app=mock_app_instance, driver_class=None) as pilot:
-        mock_app_instance.mount(window)
-        await pilot.pause()
+    }
+    async with mount_settings_window(config, temp_config_path, monkeypatch) as (window, pilot):
+        window.app_instance.app_config = {"api_settings": {}}
         window.query_one("#general-chat-api-key", Input).value = "   "
         assert window._save_chat_api_key() is False
         written = toml.load(temp_config_path)

--- a/Docs/superpowers/plans/2026-07-05-chat-defaults-inline-api-key.md
+++ b/Docs/superpowers/plans/2026-07-05-chat-defaults-inline-api-key.md
@@ -1,0 +1,666 @@
+# Inline API-Key Field (Chat Defaults) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a provider-contextual API-Key input directly beneath the Provider dropdown in Settings → General Settings → 💬 Chat Defaults, so a new user can authenticate the provider they picked and start chatting without hunting through the config tab or restarting.
+
+**Architecture:** Two pure, UI-agnostic helper functions in `Chat/provider_readiness.py` map a `ProviderReadiness` (the app's single source of truth for how a provider's key is resolved) into the field's render/persist state. `Tools_Settings_Window.py` renders the field from that state, reloads it when the provider dropdown changes, saves the entered key to `api_settings.<provider>.api_key` (exactly where both live send paths read), and refreshes the live `app.app_config` in place so no restart is needed.
+
+**Tech Stack:** Python ≥3.11, Textual ≥3.3.0, TOML config, pytest / pytest-asyncio, Textual `AppTest`.
+
+## Global Constraints
+
+- Provider-name normalization MUST use `provider_config_key()` from `tldw_chatbook/Chat/provider_readiness.py` (lowercase, spaces/dashes → underscores). Do not hand-roll `.lower().replace(...)`.
+- Save target section is the nested `api_settings.<provider_key>` — use `save_setting_to_cli_config(f"api_settings.{provider_key}", "api_key", value)`.
+- Never pre-fill or persist the placeholder `<API_KEY_HERE>`, an env-provided key, or an encrypted/locked value. Gate with `is_valid_provider_api_key()` and the field-state helpers.
+- The new input's id is `general-chat-api-key`; the existing provider select id is `general-chat-provider`.
+- Tests run from the project venv: `source .venv/bin/activate` then `pytest`. The `timeout` command is unavailable.
+- Follow existing style: Google-style docstrings, early returns, `from textual import on` is already imported in the settings window.
+
+---
+
+### Task 1: Pure field-state helpers in `provider_readiness.py`
+
+Add two UI-agnostic functions that turn a `ProviderReadiness` into the inline field's state, and decide what (if anything) to persist. No Textual imports.
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/provider_readiness.py` (append after `get_provider_readiness`, currently ends line 255)
+- Test: `Tests/Chat/test_chat_api_key_field.py` (create)
+
+**Interfaces:**
+- Consumes: existing `ProviderReadiness` dataclass, `is_valid_provider_api_key(value) -> bool` (already in this module).
+- Produces:
+  - `ChatApiKeyFieldState` — frozen dataclass with fields `value: str`, `disabled: bool`, `placeholder: str`, `can_persist: bool`.
+  - `chat_api_key_field_state(readiness: ProviderReadiness, *, locked: bool) -> ChatApiKeyFieldState`
+  - `chat_api_key_value_to_persist(new_value: object, field_state: ChatApiKeyFieldState) -> Optional[str]`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/Chat/test_chat_api_key_field.py`:
+
+```python
+"""Unit tests for the inline Chat-Defaults API-key field state helpers."""
+
+import pytest
+
+from tldw_chatbook.Chat.provider_readiness import (
+    ProviderReadiness,
+    ChatApiKeyFieldState,
+    chat_api_key_field_state,
+    chat_api_key_value_to_persist,
+)
+
+
+def _readiness(
+    *,
+    requires_api_key=True,
+    ready=False,
+    api_key=None,
+    api_key_source=None,
+    env_var=None,
+    provider="OpenAI",
+    provider_key="openai",
+):
+    return ProviderReadiness(
+        provider=provider,
+        provider_key=provider_key,
+        requires_api_key=requires_api_key,
+        ready=ready,
+        api_key=api_key,
+        api_key_source=api_key_source,
+        env_var=env_var,
+        reason="test",
+        recovery=None,
+    )
+
+
+def test_keyless_provider_is_disabled_and_not_persistable():
+    state = chat_api_key_field_state(
+        _readiness(requires_api_key=False, ready=True, provider="Ollama", provider_key="ollama"),
+        locked=False,
+    )
+    assert state.disabled is True
+    assert state.can_persist is False
+    assert state.value == ""
+    assert "No API key needed" in state.placeholder
+
+
+def test_locked_config_is_disabled_with_unlock_hint():
+    state = chat_api_key_field_state(
+        _readiness(ready=True, api_key="sk-secret", api_key_source="config:api_settings.openai.api_key"),
+        locked=True,
+    )
+    assert state.disabled is True
+    assert state.can_persist is False
+    assert state.value == ""
+    assert "Unlock config" in state.placeholder
+
+
+def test_config_key_is_prefilled():
+    state = chat_api_key_field_state(
+        _readiness(ready=True, api_key="sk-abc123", api_key_source="config:api_settings.openai.api_key"),
+        locked=False,
+    )
+    assert state.disabled is False
+    assert state.value == "sk-abc123"
+    assert state.can_persist is True
+
+
+def test_env_key_shows_hint_and_empty_value():
+    state = chat_api_key_field_state(
+        _readiness(ready=True, api_key="sk-env", api_key_source="env:OPENAI_API_KEY", env_var="OPENAI_API_KEY"),
+        locked=False,
+    )
+    assert state.value == ""
+    assert state.disabled is False
+    assert state.can_persist is True
+    assert "OPENAI_API_KEY" in state.placeholder
+
+
+def test_missing_key_is_empty_and_persistable():
+    state = chat_api_key_field_state(_readiness(ready=False), locked=False)
+    assert state.value == ""
+    assert state.disabled is False
+    assert state.can_persist is True
+
+
+def test_persist_skips_when_not_persistable():
+    state = ChatApiKeyFieldState(value="", disabled=True, placeholder="", can_persist=False)
+    assert chat_api_key_value_to_persist("sk-new", state) is None
+
+
+def test_persist_skips_blank_and_placeholder():
+    state = ChatApiKeyFieldState(value="", disabled=False, placeholder="", can_persist=True)
+    assert chat_api_key_value_to_persist("   ", state) is None
+    assert chat_api_key_value_to_persist("<API_KEY_HERE>", state) is None
+
+
+def test_persist_skips_unchanged_config_value():
+    state = ChatApiKeyFieldState(value="sk-abc123", disabled=False, placeholder="", can_persist=True)
+    assert chat_api_key_value_to_persist("sk-abc123", state) is None
+
+
+def test_persist_returns_stripped_new_value():
+    state = ChatApiKeyFieldState(value="sk-old", disabled=False, placeholder="", can_persist=True)
+    assert chat_api_key_value_to_persist("  sk-new  ", state) == "sk-new"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest Tests/Chat/test_chat_api_key_field.py -v`
+Expected: FAIL — `ImportError: cannot import name 'ChatApiKeyFieldState'`.
+
+- [ ] **Step 3: Implement the helpers**
+
+Append to `tldw_chatbook/Chat/provider_readiness.py` (after line 255). Note `dataclass`, `Optional` are already imported at the top of the file.
+
+```python
+@dataclass(frozen=True)
+class ChatApiKeyFieldState:
+    """Render + persistence state for the inline Chat-Defaults API-key input."""
+
+    value: str          # masked prefill value; "" when nothing should be shown
+    disabled: bool      # True for keyless providers or a locked/encrypted config
+    placeholder: str    # hint shown when the box is empty
+    can_persist: bool   # whether a user-entered value should be written on save
+
+
+def chat_api_key_field_state(
+    readiness: ProviderReadiness,
+    *,
+    locked: bool,
+) -> ChatApiKeyFieldState:
+    """Map provider readiness to the inline API-key field's UI/persistence state.
+
+    Args:
+        readiness: Resolved readiness for the currently selected provider.
+        locked: True when config encryption is enabled but no session password is
+            available (stored values are ciphertext and must not be shown/saved).
+
+    Returns:
+        The field state to render and the flag for whether a typed value is savable.
+    """
+    if not readiness.requires_api_key:
+        return ChatApiKeyFieldState(
+            value="",
+            disabled=True,
+            placeholder="No API key needed for this provider.",
+            can_persist=False,
+        )
+    if locked:
+        return ChatApiKeyFieldState(
+            value="",
+            disabled=True,
+            placeholder="Unlock config to edit keys.",
+            can_persist=False,
+        )
+    source = readiness.api_key_source or ""
+    if source.startswith("config:") and readiness.api_key:
+        return ChatApiKeyFieldState(
+            value=readiness.api_key,
+            disabled=False,
+            placeholder="Enter API key",
+            can_persist=True,
+        )
+    if source.startswith("env:") and readiness.env_var:
+        return ChatApiKeyFieldState(
+            value="",
+            disabled=False,
+            placeholder=f"Detected from ${readiness.env_var} — leave blank to keep it",
+            can_persist=True,
+        )
+    return ChatApiKeyFieldState(
+        value="",
+        disabled=False,
+        placeholder="Enter your API key to start using this provider",
+        can_persist=True,
+    )
+
+
+def chat_api_key_value_to_persist(
+    new_value: object,
+    field_state: ChatApiKeyFieldState,
+) -> Optional[str]:
+    """Return the API-key value to persist, or None to skip the write.
+
+    Skips when the field is non-persistable, blank, a placeholder, or unchanged
+    from the currently displayed value.
+    """
+    if not field_state.can_persist:
+        return None
+    candidate = new_value.strip() if isinstance(new_value, str) else ""
+    if not is_valid_provider_api_key(candidate):
+        return None
+    if candidate == field_state.value:
+        return None
+    return candidate
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest Tests/Chat/test_chat_api_key_field.py -v`
+Expected: PASS (9 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Chat/provider_readiness.py Tests/Chat/test_chat_api_key_field.py
+git commit -m "feat(chat): add inline api-key field-state helpers to provider_readiness"
+```
+
+---
+
+### Task 2: Render the field + config-lock helper
+
+Insert the API-Key input between the Provider select and the Model input in the Chat-Defaults tab, driven by the Task 1 helpers. Add a `_config_is_locked()` helper.
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Tools_Settings_Window.py` — imports (line 25-30), `_compose_chat_defaults_settings` (line 692-727), add `_config_is_locked`
+- Test: `Tests/UI/test_tools_settings_window.py` (add two tests)
+
+**Interfaces:**
+- Consumes: `get_provider_readiness`, `provider_config_key`, `chat_api_key_field_state`, `ChatApiKeyFieldState` (Task 1) from `..Chat.provider_readiness`; `get_encryption_password` (already imported).
+- Produces: an `Input#general-chat-api-key` in the Chat-Defaults tab; `ToolsSettingsWindow._config_is_locked(self) -> bool`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `Tests/UI/test_tools_settings_window.py`. These build a tailored config, mount the window, and assert the field renders with the right state. Follow the file's existing `create_dummy_config` / `AppTest` / `MagicMock(spec=App)` patterns.
+
+```python
+@pytest.mark.asyncio
+async def test_chat_api_key_field_prefilled_for_config_key(monkeypatch, temp_config_path, mock_app_instance):
+    create_dummy_config(temp_config_path, {
+        "providers": {"OpenAI": ["gpt-4o"], "Ollama": ["llama3"]},
+        "chat_defaults": {"provider": "OpenAI", "model": "gpt-4o"},
+        "api_settings": {"openai": {"api_key": "sk-configured"}},
+    })
+    monkeypatch.setattr(tldw_chatbook.config, "DEFAULT_CONFIG_PATH", temp_config_path)
+    window = ToolsSettingsWindow(app_instance=mock_app_instance)
+    async with AppTest(app=mock_app_instance, driver_class=None) as pilot:
+        mock_app_instance.mount(window)
+        await pilot.pause()
+        field = window.query_one("#general-chat-api-key", Input)
+        assert field.password is True
+        assert field.value == "sk-configured"
+        assert field.disabled is False
+
+
+@pytest.mark.asyncio
+async def test_chat_api_key_field_disabled_for_keyless_provider(monkeypatch, temp_config_path, mock_app_instance):
+    create_dummy_config(temp_config_path, {
+        "providers": {"Ollama": ["llama3"], "OpenAI": ["gpt-4o"]},
+        "chat_defaults": {"provider": "Ollama", "model": "llama3"},
+        "api_settings": {},
+    })
+    monkeypatch.setattr(tldw_chatbook.config, "DEFAULT_CONFIG_PATH", temp_config_path)
+    window = ToolsSettingsWindow(app_instance=mock_app_instance)
+    async with AppTest(app=mock_app_instance, driver_class=None) as pilot:
+        mock_app_instance.mount(window)
+        await pilot.pause()
+        field = window.query_one("#general-chat-api-key", Input)
+        assert field.disabled is True
+        assert "No API key needed" in field.placeholder
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest Tests/UI/test_tools_settings_window.py -k chat_api_key_field -v`
+Expected: FAIL — `NoMatches`/`QueryError` for `#general-chat-api-key`.
+
+- [ ] **Step 3a: Add imports**
+
+In `tldw_chatbook/UI/Tools_Settings_Window.py`, extend the config import block (line 25-30) to include `load_settings`:
+
+```python
+from tldw_chatbook.config import (
+    load_cli_config_and_ensure_existence, DEFAULT_CONFIG_PATH, save_setting_to_cli_config, 
+    API_MODELS_BY_PROVIDER, check_encryption_needed, get_detected_api_providers,
+    enable_config_encryption, disable_config_encryption, change_encryption_password,
+    get_encryption_password, get_cli_setting, get_prompts_db_path, load_settings
+)
+```
+
+Add a new import line after the existing `from ..DB...`/`from .` imports block (near line 40):
+
+```python
+from ..Chat.provider_readiness import (
+    get_provider_readiness,
+    provider_config_key,
+    chat_api_key_field_state,
+)
+```
+
+- [ ] **Step 3b: Add the `_config_is_locked` helper**
+
+Add this method to `ToolsSettingsWindow` (place it just above `_compose_chat_defaults_settings`, line 692):
+
+```python
+    def _config_is_locked(self) -> bool:
+        """True when encryption is on but no session password is available."""
+        encryption_config = self.config_data.get("encryption", {})
+        if not encryption_config.get("enabled", False):
+            return False
+        return not get_encryption_password()
+```
+
+- [ ] **Step 3c: Insert the field in `_compose_chat_defaults_settings`**
+
+In `_compose_chat_defaults_settings` (line 692), inside the `settings-form-grid` container, insert the API-Key label + input immediately after the Provider `Select` (line 718) and before the `Label("Model:", ...)` (line 720):
+
+```python
+                    yield Select(
+                        options=provider_options,
+                        value=current_chat_provider,
+                        id="general-chat-provider",
+                        classes="settings-select",
+                        tooltip="Default AI provider for chat conversations"
+                    )
+
+                    # Inline API key for the selected provider (new-user quick start)
+                    _readiness = get_provider_readiness(current_chat_provider, self.config_data)
+                    _key_state = chat_api_key_field_state(_readiness, locked=self._config_is_locked())
+                    yield Label("API Key:", classes="settings-label")
+                    yield Input(
+                        value=_key_state.value,
+                        password=True,
+                        disabled=_key_state.disabled,
+                        id="general-chat-api-key",
+                        classes="settings-input",
+                        placeholder=_key_state.placeholder,
+                        tooltip="API key for the selected provider. Saved to [api_settings.<provider>]."
+                    )
+
+                    yield Label("Model:", classes="settings-label")
+```
+
+(Leave the existing Model/Temperature widgets untouched below.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest Tests/UI/test_tools_settings_window.py -k chat_api_key_field -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/UI/Tools_Settings_Window.py Tests/UI/test_tools_settings_window.py
+git commit -m "feat(settings): render inline api-key field under Chat-Defaults provider picker"
+```
+
+---
+
+### Task 3: Reload the field when the provider changes
+
+Add a `Select.Changed` handler scoped to the provider dropdown that recomputes the field state for the newly selected provider.
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Tools_Settings_Window.py` (add handler method)
+- Test: `Tests/UI/test_tools_settings_window.py` (add one test)
+
+**Interfaces:**
+- Consumes: `get_provider_readiness`, `chat_api_key_field_state`, `_config_is_locked` (Task 2). `on`, `Select`, `Input`, `QueryError` already imported.
+- Produces: `ToolsSettingsWindow._on_chat_provider_changed(self, event: Select.Changed) -> None`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `Tests/UI/test_tools_settings_window.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_chat_api_key_field_reloads_on_provider_change(monkeypatch, temp_config_path, mock_app_instance):
+    create_dummy_config(temp_config_path, {
+        "providers": {"OpenAI": ["gpt-4o"], "Ollama": ["llama3"]},
+        "chat_defaults": {"provider": "OpenAI", "model": "gpt-4o"},
+        "api_settings": {"openai": {"api_key": "sk-configured"}},
+    })
+    monkeypatch.setattr(tldw_chatbook.config, "DEFAULT_CONFIG_PATH", temp_config_path)
+    window = ToolsSettingsWindow(app_instance=mock_app_instance)
+    async with AppTest(app=mock_app_instance, driver_class=None) as pilot:
+        mock_app_instance.mount(window)
+        await pilot.pause()
+        field = window.query_one("#general-chat-api-key", Input)
+        assert field.value == "sk-configured"
+
+        # Switch to a keyless provider -> field disables and clears
+        window.query_one("#general-chat-provider", Select).value = "Ollama"
+        await pilot.pause()
+        assert field.disabled is True
+        assert field.value == ""
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest Tests/UI/test_tools_settings_window.py -k reloads_on_provider_change -v`
+Expected: FAIL — field stays enabled with `sk-configured` (no handler yet).
+
+- [ ] **Step 3: Add the handler**
+
+Add to `ToolsSettingsWindow` (place directly after `_compose_chat_defaults_settings`):
+
+```python
+    @on(Select.Changed, "#general-chat-provider")
+    def _on_chat_provider_changed(self, event: Select.Changed) -> None:
+        """Reload the inline API-key field for the newly selected chat provider."""
+        try:
+            api_key_input = self.query_one("#general-chat-api-key", Input)
+        except QueryError:
+            return
+        provider = event.value
+        if not provider or provider is Select.BLANK:
+            return
+        readiness = get_provider_readiness(str(provider), self.config_data)
+        state = chat_api_key_field_state(readiness, locked=self._config_is_locked())
+        api_key_input.value = state.value
+        api_key_input.disabled = state.disabled
+        api_key_input.placeholder = state.placeholder
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest Tests/UI/test_tools_settings_window.py -k reloads_on_provider_change -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/UI/Tools_Settings_Window.py Tests/UI/test_tools_settings_window.py
+git commit -m "feat(settings): reload inline api-key field when chat provider changes"
+```
+
+---
+
+### Task 4: Save the key + refresh live config (no restart)
+
+Persist the entered key to `api_settings.<provider>.api_key` and update the running `app.app_config` in place so the key is usable immediately. Wire it into the existing "Save Settings" flow.
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Tools_Settings_Window.py` — add `_save_chat_api_key` + `_refresh_live_api_settings`; call `_save_chat_api_key` from `_save_general_settings` (after the `chat_defaults.provider` save, line 3075)
+- Test: `Tests/UI/test_tools_settings_window.py` (add one test)
+
+**Interfaces:**
+- Consumes: `chat_api_key_field_state`, `chat_api_key_value_to_persist` (Task 1), `provider_config_key`, `get_provider_readiness`, `save_setting_to_cli_config`, `load_settings`, `load_cli_config_and_ensure_existence`, `_config_is_locked`.
+- Produces: `ToolsSettingsWindow._save_chat_api_key(self) -> bool`, `ToolsSettingsWindow._refresh_live_api_settings(self) -> None`.
+
+- [ ] **Step 1: Add the missing import for Task 1's persist helper**
+
+In the `from ..Chat.provider_readiness import (...)` block added in Task 2, add `chat_api_key_value_to_persist`:
+
+```python
+from ..Chat.provider_readiness import (
+    get_provider_readiness,
+    provider_config_key,
+    chat_api_key_field_state,
+    chat_api_key_value_to_persist,
+)
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Add to `Tests/UI/test_tools_settings_window.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_chat_api_key_save_writes_config_and_updates_live_config(monkeypatch, temp_config_path, mock_app_instance):
+    create_dummy_config(temp_config_path, {
+        "providers": {"OpenAI": ["gpt-4o"]},
+        "chat_defaults": {"provider": "OpenAI", "model": "gpt-4o"},
+        "api_settings": {},
+    })
+    monkeypatch.setattr(tldw_chatbook.config, "DEFAULT_CONFIG_PATH", temp_config_path)
+    mock_app_instance.app_config = {"api_settings": {}}
+    window = ToolsSettingsWindow(app_instance=mock_app_instance)
+    async with AppTest(app=mock_app_instance, driver_class=None) as pilot:
+        mock_app_instance.mount(window)
+        await pilot.pause()
+        window.query_one("#general-chat-api-key", Input).value = "sk-brand-new"
+
+        saved = window._save_chat_api_key()
+        assert saved is True
+
+        # Written to the on-disk config under the normalized provider key
+        written = toml.load(temp_config_path)
+        assert written["api_settings"]["openai"]["api_key"] == "sk-brand-new"
+
+        # Live app config updated in place (no restart needed)
+        assert mock_app_instance.app_config["api_settings"]["openai"]["api_key"] == "sk-brand-new"
+
+
+@pytest.mark.asyncio
+async def test_chat_api_key_save_skips_blank(monkeypatch, temp_config_path, mock_app_instance):
+    create_dummy_config(temp_config_path, {
+        "providers": {"OpenAI": ["gpt-4o"]},
+        "chat_defaults": {"provider": "OpenAI", "model": "gpt-4o"},
+        "api_settings": {},
+    })
+    monkeypatch.setattr(tldw_chatbook.config, "DEFAULT_CONFIG_PATH", temp_config_path)
+    mock_app_instance.app_config = {"api_settings": {}}
+    window = ToolsSettingsWindow(app_instance=mock_app_instance)
+    async with AppTest(app=mock_app_instance, driver_class=None) as pilot:
+        mock_app_instance.mount(window)
+        await pilot.pause()
+        window.query_one("#general-chat-api-key", Input).value = "   "
+        assert window._save_chat_api_key() is False
+        written = toml.load(temp_config_path)
+        assert written.get("api_settings", {}).get("openai", {}).get("api_key") is None
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `pytest Tests/UI/test_tools_settings_window.py -k "chat_api_key_save" -v`
+Expected: FAIL — `AttributeError: 'ToolsSettingsWindow' object has no attribute '_save_chat_api_key'`.
+
+- [ ] **Step 4: Implement the save + refresh methods**
+
+Add both methods to `ToolsSettingsWindow` (place after `_on_chat_provider_changed`):
+
+```python
+    def _refresh_live_api_settings(self) -> None:
+        """Push freshly-saved api_settings into the live app config (no restart).
+
+        Mutates the existing ``app_config`` dict in place so components that hold
+        a reference to it — including the Chat send path — observe the new key.
+        """
+        try:
+            reloaded = load_settings(force_reload=True)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning(f"Could not refresh live api_settings after save: {exc}")
+            return
+        app_config = getattr(self.app_instance, "app_config", None)
+        if isinstance(app_config, dict):
+            app_config["api_settings"] = reloaded.get("api_settings", {})
+        # Keep this window's own snapshot consistent.
+        self.config_data = load_cli_config_and_ensure_existence(force_reload=True)
+
+    def _save_chat_api_key(self) -> bool:
+        """Persist the inline Chat-Defaults API key for the selected provider.
+
+        Returns:
+            True if a key was written (and the live config refreshed), else False.
+        """
+        try:
+            provider_value = self.query_one("#general-chat-provider", Select).value
+            api_key_widget = self.query_one("#general-chat-api-key", Input)
+        except QueryError:
+            return False
+        if not provider_value or provider_value is Select.BLANK:
+            return False
+        readiness = get_provider_readiness(str(provider_value), self.config_data)
+        field_state = chat_api_key_field_state(readiness, locked=self._config_is_locked())
+        key_to_persist = chat_api_key_value_to_persist(api_key_widget.value, field_state)
+        if key_to_persist is None:
+            return False
+        provider_key = provider_config_key(str(provider_value))
+        if not save_setting_to_cli_config(f"api_settings.{provider_key}", "api_key", key_to_persist):
+            return False
+        self._refresh_live_api_settings()
+        return True
+```
+
+- [ ] **Step 5: Wire it into the Save Settings flow**
+
+In `_save_general_settings`, immediately after the `chat_defaults.provider` save (line 3075-3076):
+
+```python
+            # Chat Defaults
+            if save_setting_to_cli_config("chat_defaults", "provider", self.query_one("#general-chat-provider", Select).value):
+                saved_count += 1
+            # Inline API key for the selected provider (contextual quick-start field)
+            if self._save_chat_api_key():
+                saved_count += 1
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pytest Tests/UI/test_tools_settings_window.py -k "chat_api_key_save" -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tldw_chatbook/UI/Tools_Settings_Window.py Tests/UI/test_tools_settings_window.py
+git commit -m "feat(settings): save inline chat api-key and refresh live config without restart"
+```
+
+---
+
+### Task 5: Regression check + reset verification
+
+Confirm the full settings-window suite and provider-readiness suite pass, and that a settings reset does not wipe the key.
+
+**Files:**
+- Test only: `Tests/UI/test_tools_settings_window.py`, `Tests/Chat/test_provider_readiness.py`, `Tests/Chat/test_chat_api_key_field.py`
+
+- [ ] **Step 1: Run the affected suites**
+
+Run: `pytest Tests/UI/test_tools_settings_window.py Tests/Chat/test_provider_readiness.py Tests/Chat/test_chat_api_key_field.py -v`
+Expected: PASS (pre-existing failures unrelated to this change, if any, are noted in the dev-environment baseline — new tests must all pass).
+
+- [ ] **Step 2: Manually verify reset leaves the key intact**
+
+Read `_reset_general_settings` in `tldw_chatbook/UI/Tools_Settings_Window.py`. Confirm it does not query or clear `#general-chat-api-key`. If it recomposes the tab or sets specific fields, the key re-derives from config (unchanged) — no code change needed. If (and only if) it explicitly clears the field, remove that clearing so credentials are preserved. Record the finding in the task notes.
+
+- [ ] **Step 3: Commit (only if a change was needed in Step 2)**
+
+```bash
+git add tldw_chatbook/UI/Tools_Settings_Window.py
+git commit -m "fix(settings): preserve inline chat api-key on general-settings reset"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage**
+- Field location under provider picker → Task 2 (Step 3c). ✓
+- Reads `api_settings.<provider>.api_key` via `provider_config_key` → Global Constraints + Task 4. ✓
+- Masked, provider-aware, env-hint, keyless-disable, locked-disable → Task 1 helper + Task 2 render + Task 3 reload. ✓
+- Placeholder `<API_KEY_HERE>` / env / encrypted never pre-filled or saved → Task 1 (`is_valid_provider_api_key`, locked branch) + tests. ✓
+- Save via existing "Save Settings" button, skip blank/unchanged → Task 4. ✓
+- Live `app.app_config` refresh, no restart → Task 4 `_refresh_live_api_settings`. ✓
+- Reset preserves key → Task 5. ✓
+- Security (redaction, no plaintext render) → satisfied by existing `_setting_value_for_log` + `password=True` (no new code; noted). ✓
+- Tests (pure state + widget/integration + regression) → Tasks 1–5. ✓
+
+**Placeholder scan:** No TBD/TODO/"handle edge cases" — every code step shows full content. ✓
+
+**Type consistency:** `ChatApiKeyFieldState(value, disabled, placeholder, can_persist)`, `chat_api_key_field_state(readiness, *, locked)`, `chat_api_key_value_to_persist(new_value, field_state)`, `_config_is_locked()`, `_save_chat_api_key()`, `_refresh_live_api_settings()` — names/signatures match across all tasks and tests. Field id `general-chat-api-key` and provider select id `general-chat-provider` used consistently. ✓

--- a/Docs/superpowers/specs/2026-07-05-chat-defaults-inline-api-key-design.md
+++ b/Docs/superpowers/specs/2026-07-05-chat-defaults-inline-api-key-design.md
@@ -1,0 +1,133 @@
+# Inline API-Key field under the Chat-Defaults provider picker
+
+**Date:** 2026-07-05
+**Status:** Approved (design)
+**Area:** Settings → General Settings → 💬 Chat Defaults
+
+## Why
+
+A brand-new user who opens Settings (or is directed there by the Chat readiness
+message *"…add api_key under [api_settings.openai]"*) has no obvious place to
+enter an API key. The keys today are buried under **Configuration File Settings
+→ API Settings**, mixed per-provider with model/temperature/timeout fields. The
+Chat-Defaults tab already shows the provider they will use, but offers no way to
+authenticate it. The result is a dead end: pick a provider, then hunt through a
+second settings area to make it work.
+
+The goal is that the provider the user picks and the key that makes it work sit
+together, and saving the key lets them start chatting immediately.
+
+## What (scope)
+
+Add a single **API Key** input directly beneath the existing **Provider**
+dropdown (`#general-chat-provider`) in the "🤖 Default Provider & Model" group of
+`_compose_chat_defaults_settings` (`Tools_Settings_Window.py`). New field order:
+
+```
+Provider:     [ OpenAI            ▼ ]
+API Key:      [ ••••••••••••••••••••• ]   ← new
+Model:        [ gpt-4o               ]
+Temperature:  [ 0.6 ]
+```
+
+No new block, no new button, no new config keys, no new provider list. This is a
+promoted, provider-contextual shortcut onto the key the app already reads.
+
+Out of scope: the standalone API-Settings config tab (unchanged), the identical
+Character-Defaults picker (deferred follow-up), any multi-provider "quick start"
+wizard.
+
+## Where the key is read (why this works)
+
+Both live send paths resolve a provider's key from
+`api_settings.<normalized-provider>.api_key`, where the provider name is
+normalized to lowercase with spaces/dashes → underscores:
+
+- Main send: `chat_events.py:923` → `get_provider_readiness(provider, app.app_config)`
+  reads `api_settings.<key>.api_key` first, then the `PROVIDER_API_KEY` env var.
+- Continuation: `chat_events.py:4366` reads
+  `app.app_config["api_settings"][provider_key]["api_key"]` directly.
+
+Normalization is done by `provider_config_key()` in
+`Chat/provider_readiness.py`. `"OpenAI"` → `openai`, `"MistralAI"` → `mistralai`,
+matching the `[api_settings.*]` sub-tables. `save_setting_to_cli_config` supports
+nested sections (`"api_settings.openai"`).
+
+## Behavior
+
+The field's state is driven by a single call to
+`get_provider_readiness(selected_provider, self.config_data)`, so provider logic
+is never duplicated:
+
+1. **Masked password `Input`** (`password=True`), id `general-chat-api-key`,
+   placed between the Provider `Select` and the Model `Input` in the
+   `settings-form-grid`.
+2. **Valid config key present** → pre-fill the box (masked) with the stored
+   `api_settings.<key>.api_key`, gated by `is_valid_provider_api_key()` so the
+   literal placeholder `<API_KEY_HERE>` is shown as empty, not pre-filled.
+3. **Key satisfied by env var** (`api_key_source` starts with `env:`) → box empty,
+   placeholder hint `Detected from $OPENAI_API_KEY — leave blank to keep it`.
+4. **Keyless provider** (`requires_api_key == False`, e.g. Ollama, llama.cpp) →
+   box `disabled`, hint `No API key needed for this provider.`
+5. **Encryption enabled but locked** (stored value looks encrypted / no session
+   password) → box `disabled`, hint `Unlock config to edit keys.`
+
+### Reactivity
+
+`@on(Select.Changed, "#general-chat-provider")` reloads the API-Key box for the
+newly selected provider (re-running the state logic above). Scoped by id so it
+does not fire for the window's other `Select` widgets. An unsaved typed value is
+discarded on provider change (acceptable).
+
+### Save
+
+Within the existing `_save_general_settings` (near the Chat-Defaults block,
+`Tools_Settings_Window.py:3074`), after saving `chat_defaults.provider`:
+
+- Read `provider_key = provider_config_key(<selected provider>)`.
+- Read the box value. **Skip** the save when: the box is disabled (keyless /
+  locked), the value is blank, the value equals the currently stored value, or
+  the value fails `is_valid_provider_api_key()`. This prevents clobbering an
+  env-based or encrypted setup with an empty/placeholder string.
+- Otherwise `save_setting_to_cli_config(f"api_settings.{provider_key}", "api_key", value)`.
+- After a successful save, **surgically refresh the live config** so no restart
+  is needed: reload settings and replace `app_instance.app_config["api_settings"]`
+  in place (mutate the existing dict rather than reassigning `app_config`, since
+  other components hold the original reference; the send paths read
+  `app.app_config["api_settings"]` fresh each call).
+
+The existing "Save Settings" button (`save-general-settings`) triggers all of the
+above — no dedicated save button.
+
+### Reset
+
+`_reset_general_settings` does **not** clear or overwrite the API-Key field
+(credentials are preserved on a settings reset).
+
+## Security
+
+- API-key values are already redacted in save logs (`_setting_value_for_log` →
+  `<redacted>`).
+- The field never renders a secret in plaintext (masked input), and env/locked
+  keys are never copied into the config file.
+- Encryption-at-rest is unchanged: plaintext entered here is encrypted by the
+  existing on-exit mechanism, exactly as the current API-Settings tab behaves.
+
+## Testing
+
+- Unit: state resolution (valid config key → pre-fill; env-satisfied → empty +
+  hint; keyless → disabled; placeholder/encrypted → not saved). These can target
+  a small helper that maps `ProviderReadiness` → field state, kept pure and
+  testable independent of the widget.
+- Widget/integration: mount `ToolsSettingsWindow`, assert the API-Key `Input`
+  exists under the provider picker, changing the provider reloads it, and saving
+  writes to `api_settings.<provider>.api_key`.
+- Regression: run `Tests/UI/test_tools_settings_window.py` (no test currently
+  pins Chat-Defaults widget order).
+
+## Risks / limitations (accepted for v1)
+
+- Cannot blank out a stored key from this box (skip-on-blank); still removable in
+  the full API-Settings tab.
+- Provider change discards an unsaved typed key.
+- Character-Defaults picker gets no equivalent field yet.

--- a/Tests/Chat/test_chat_api_key_field.py
+++ b/Tests/Chat/test_chat_api_key_field.py
@@ -44,7 +44,7 @@ def test_keyless_provider_is_disabled_and_not_persistable():
 
 def test_locked_config_is_disabled_with_unlock_hint():
     state = chat_api_key_field_state(
-        _readiness(ready=True, api_key="sk-secret", api_key_source="config:api_settings.openai.api_key"),
+        _readiness(ready=True, api_key="test-secret-key", api_key_source="config:api_settings.openai.api_key"),
         locked=True,
     )
     assert state.disabled is True
@@ -55,17 +55,17 @@ def test_locked_config_is_disabled_with_unlock_hint():
 
 def test_config_key_is_prefilled():
     state = chat_api_key_field_state(
-        _readiness(ready=True, api_key="sk-abc123", api_key_source="config:api_settings.openai.api_key"),
+        _readiness(ready=True, api_key="test-key-abc123", api_key_source="config:api_settings.openai.api_key"),
         locked=False,
     )
     assert state.disabled is False
-    assert state.value == "sk-abc123"
+    assert state.value == "test-key-abc123"
     assert state.can_persist is True
 
 
 def test_env_key_shows_hint_and_empty_value():
     state = chat_api_key_field_state(
-        _readiness(ready=True, api_key="sk-env", api_key_source="env:OPENAI_API_KEY", env_var="OPENAI_API_KEY"),
+        _readiness(ready=True, api_key="test-env-key", api_key_source="env:OPENAI_API_KEY", env_var="OPENAI_API_KEY"),
         locked=False,
     )
     assert state.value == ""
@@ -83,7 +83,7 @@ def test_missing_key_is_empty_and_persistable():
 
 def test_persist_skips_when_not_persistable():
     state = ChatApiKeyFieldState(value="", disabled=True, placeholder="", can_persist=False)
-    assert chat_api_key_value_to_persist("sk-new", state) is None
+    assert chat_api_key_value_to_persist("test-new-key", state) is None
 
 
 def test_persist_skips_blank_and_placeholder():
@@ -93,10 +93,10 @@ def test_persist_skips_blank_and_placeholder():
 
 
 def test_persist_skips_unchanged_config_value():
-    state = ChatApiKeyFieldState(value="sk-abc123", disabled=False, placeholder="", can_persist=True)
-    assert chat_api_key_value_to_persist("sk-abc123", state) is None
+    state = ChatApiKeyFieldState(value="test-key-abc123", disabled=False, placeholder="", can_persist=True)
+    assert chat_api_key_value_to_persist("test-key-abc123", state) is None
 
 
 def test_persist_returns_stripped_new_value():
-    state = ChatApiKeyFieldState(value="sk-old", disabled=False, placeholder="", can_persist=True)
-    assert chat_api_key_value_to_persist("  sk-new  ", state) == "sk-new"
+    state = ChatApiKeyFieldState(value="test-old-key", disabled=False, placeholder="", can_persist=True)
+    assert chat_api_key_value_to_persist("  test-new-key  ", state) == "test-new-key"

--- a/Tests/Chat/test_chat_api_key_field.py
+++ b/Tests/Chat/test_chat_api_key_field.py
@@ -1,0 +1,104 @@
+"""Unit tests for the inline Chat-Defaults API-key field state helpers."""
+
+import pytest
+
+from tldw_chatbook.Chat.provider_readiness import (
+    ProviderReadiness,
+    ChatApiKeyFieldState,
+    chat_api_key_field_state,
+    chat_api_key_value_to_persist,
+)
+
+
+def _readiness(
+    *,
+    requires_api_key=True,
+    ready=False,
+    api_key=None,
+    api_key_source=None,
+    env_var=None,
+    provider="OpenAI",
+    provider_key="openai",
+):
+    return ProviderReadiness(
+        provider=provider,
+        provider_key=provider_key,
+        requires_api_key=requires_api_key,
+        ready=ready,
+        api_key=api_key,
+        api_key_source=api_key_source,
+        env_var=env_var,
+        reason="test",
+        recovery=None,
+    )
+
+
+def test_keyless_provider_is_disabled_and_not_persistable():
+    state = chat_api_key_field_state(
+        _readiness(requires_api_key=False, ready=True, provider="Ollama", provider_key="ollama"),
+        locked=False,
+    )
+    assert state.disabled is True
+    assert state.can_persist is False
+    assert state.value == ""
+    assert "No API key needed" in state.placeholder
+
+
+def test_locked_config_is_disabled_with_unlock_hint():
+    state = chat_api_key_field_state(
+        _readiness(ready=True, api_key="sk-secret", api_key_source="config:api_settings.openai.api_key"),
+        locked=True,
+    )
+    assert state.disabled is True
+    assert state.can_persist is False
+    assert state.value == ""
+    assert "Unlock config" in state.placeholder
+
+
+def test_config_key_is_prefilled():
+    state = chat_api_key_field_state(
+        _readiness(ready=True, api_key="sk-abc123", api_key_source="config:api_settings.openai.api_key"),
+        locked=False,
+    )
+    assert state.disabled is False
+    assert state.value == "sk-abc123"
+    assert state.can_persist is True
+
+
+def test_env_key_shows_hint_and_empty_value():
+    state = chat_api_key_field_state(
+        _readiness(ready=True, api_key="sk-env", api_key_source="env:OPENAI_API_KEY", env_var="OPENAI_API_KEY"),
+        locked=False,
+    )
+    assert state.value == ""
+    assert state.disabled is False
+    assert state.can_persist is True
+    assert "OPENAI_API_KEY" in state.placeholder
+
+
+def test_missing_key_is_empty_and_persistable():
+    state = chat_api_key_field_state(_readiness(ready=False), locked=False)
+    assert state.value == ""
+    assert state.disabled is False
+    assert state.can_persist is True
+
+
+def test_persist_skips_when_not_persistable():
+    state = ChatApiKeyFieldState(value="", disabled=True, placeholder="", can_persist=False)
+    assert chat_api_key_value_to_persist("sk-new", state) is None
+
+
+def test_persist_skips_blank_and_placeholder():
+    state = ChatApiKeyFieldState(value="", disabled=False, placeholder="", can_persist=True)
+    assert chat_api_key_value_to_persist("   ", state) is None
+    assert chat_api_key_value_to_persist("<API_KEY_HERE>", state) is None
+
+
+def test_persist_skips_unchanged_config_value():
+    state = ChatApiKeyFieldState(value="sk-abc123", disabled=False, placeholder="", can_persist=True)
+    assert chat_api_key_value_to_persist("sk-abc123", state) is None
+
+
+def test_persist_returns_stripped_new_value():
+    state = ChatApiKeyFieldState(value="sk-old", disabled=False, placeholder="", can_persist=True)
+    assert chat_api_key_value_to_persist("  sk-new  ", state) == "sk-new"

--- a/Tests/Chat/test_chat_api_key_field.py
+++ b/Tests/Chat/test_chat_api_key_field.py
@@ -1,7 +1,5 @@
 """Unit tests for the inline Chat-Defaults API-key field state helpers."""
 
-import pytest
-
 from tldw_chatbook.Chat.provider_readiness import (
     ProviderReadiness,
     ChatApiKeyFieldState,

--- a/Tests/UI/test_tools_settings_window.py
+++ b/Tests/UI/test_tools_settings_window.py
@@ -797,3 +797,46 @@ async def test_outputs_panel_routes_server_template_and_artifact_operations():
         )
         rendered_status = str(panel.query_one("#outputs-status", Static).render())
         assert "server:output:11" in rendered_status or "output_delete" in rendered_status
+
+
+@pytest.mark.asyncio
+async def test_chat_api_key_field_prefilled_for_config_key(monkeypatch, temp_config_path, mock_app_instance):
+    create_dummy_config(temp_config_path, {
+        "providers": {"OpenAI": ["gpt-4o"], "Ollama": ["llama3"]},
+        "chat_defaults": {"provider": "OpenAI", "model": "gpt-4o"},
+        "api_settings": {"openai": {"api_key": "sk-configured"}},
+    })
+    monkeypatch.setattr(tldw_chatbook.config, "DEFAULT_CONFIG_PATH", temp_config_path)
+    window = ToolsSettingsWindow(app_instance=mock_app_instance)
+
+    if AppTest is None:
+        pytest.skip("AppTest not available in this version of Textual")
+
+    async with AppTest(app=mock_app_instance, driver_class=None) as pilot:
+        mock_app_instance.mount(window)
+        await pilot.pause()
+        field = window.query_one("#general-chat-api-key", Input)
+        assert field.password is True
+        assert field.value == "sk-configured"
+        assert field.disabled is False
+
+
+@pytest.mark.asyncio
+async def test_chat_api_key_field_disabled_for_keyless_provider(monkeypatch, temp_config_path, mock_app_instance):
+    create_dummy_config(temp_config_path, {
+        "providers": {"Ollama": ["llama3"], "OpenAI": ["gpt-4o"]},
+        "chat_defaults": {"provider": "Ollama", "model": "llama3"},
+        "api_settings": {},
+    })
+    monkeypatch.setattr(tldw_chatbook.config, "DEFAULT_CONFIG_PATH", temp_config_path)
+    window = ToolsSettingsWindow(app_instance=mock_app_instance)
+
+    if AppTest is None:
+        pytest.skip("AppTest not available in this version of Textual")
+
+    async with AppTest(app=mock_app_instance, driver_class=None) as pilot:
+        mock_app_instance.mount(window)
+        await pilot.pause()
+        field = window.query_one("#general-chat-api-key", Input)
+        assert field.disabled is True
+        assert "No API key needed" in field.placeholder

--- a/Tests/UI/test_tools_settings_window.py
+++ b/Tests/UI/test_tools_settings_window.py
@@ -67,7 +67,7 @@ async def mount_settings_window(config_dict: dict, temp_config_path: Path, monke
     async with app.run_test() as pilot:
         await pilot.pause()
         window = app.query_one(ToolsSettingsWindow)
-        yield window
+        yield window, pilot
 
 
 @pytest.fixture
@@ -839,7 +839,7 @@ async def test_chat_api_key_field_prefilled_for_config_key(monkeypatch, temp_con
         "chat_defaults": {"provider": "OpenAI", "model": "gpt-4o"},
         "api_settings": {"openai": {"api_key": "sk-configured"}},
     }
-    async with mount_settings_window(config, temp_config_path, monkeypatch) as window:
+    async with mount_settings_window(config, temp_config_path, monkeypatch) as (window, pilot):
         field = window.query_one("#general-chat-api-key", Input)
         assert field.password is True
         assert field.value == "sk-configured"
@@ -853,7 +853,25 @@ async def test_chat_api_key_field_disabled_for_keyless_provider(monkeypatch, tem
         "chat_defaults": {"provider": "Ollama", "model": "llama3"},
         "api_settings": {},
     }
-    async with mount_settings_window(config, temp_config_path, monkeypatch) as window:
+    async with mount_settings_window(config, temp_config_path, monkeypatch) as (window, pilot):
         field = window.query_one("#general-chat-api-key", Input)
         assert field.disabled is True
         assert "No API key needed" in field.placeholder
+
+
+@pytest.mark.asyncio
+async def test_chat_api_key_field_reloads_on_provider_change(monkeypatch, temp_config_path):
+    config = {
+        "providers": {"OpenAI": ["gpt-4o"], "Ollama": ["llama3"]},
+        "chat_defaults": {"provider": "OpenAI", "model": "gpt-4o"},
+        "api_settings": {"openai": {"api_key": "sk-configured"}},
+    }
+    async with mount_settings_window(config, temp_config_path, monkeypatch) as (window, pilot):
+        field = window.query_one("#general-chat-api-key", Input)
+        assert field.value == "sk-configured"
+
+        # Switch to a keyless provider -> field disables and clears
+        window.query_one("#general-chat-provider", Select).value = "Ollama"
+        await pilot.pause()
+        assert field.disabled is True
+        assert field.value == ""

--- a/Tests/UI/test_tools_settings_window.py
+++ b/Tests/UI/test_tools_settings_window.py
@@ -1,6 +1,7 @@
 import pytest
 import pytest_asyncio
 import toml
+from contextlib import asynccontextmanager
 from pathlib import Path
 from unittest.mock import MagicMock, patch, AsyncMock, call
 import tempfile
@@ -35,6 +36,38 @@ def create_dummy_config(config_path: Path, content: dict):
     config_path.parent.mkdir(parents=True, exist_ok=True)
     with open(config_path, "w") as f:
         toml.dump(content, f)
+
+
+class _ToolsSettingsHostApp(App):
+    """Minimal real App that hosts a ToolsSettingsWindow as its own app_instance."""
+
+    def __init__(self):
+        super().__init__()
+        self.notify = MagicMock()
+        self.push_screen = MagicMock()
+        self.unified_mcp_service = None
+        self.current_runtime_backend = "local"
+        self.server_sharing_scope_service = None
+        self.server_outputs_scope_service = None
+
+    def get_authoritative_runtime_source(self):
+        return self.current_runtime_backend
+
+    def compose(self):
+        yield ToolsSettingsWindow(app_instance=self)
+
+
+@asynccontextmanager
+async def mount_settings_window(config_dict: dict, temp_config_path: Path, monkeypatch):
+    """Write config_dict to temp_config_path, patch DEFAULT_CONFIG_PATH, and yield a live-mounted ToolsSettingsWindow driven by a real pilot."""
+    create_dummy_config(temp_config_path, config_dict)
+    monkeypatch.setattr(tldw_chatbook.config, "DEFAULT_CONFIG_PATH", temp_config_path)
+
+    app = _ToolsSettingsHostApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        window = app.query_one(ToolsSettingsWindow)
+        yield window
 
 
 @pytest.fixture
@@ -800,21 +833,13 @@ async def test_outputs_panel_routes_server_template_and_artifact_operations():
 
 
 @pytest.mark.asyncio
-async def test_chat_api_key_field_prefilled_for_config_key(monkeypatch, temp_config_path, mock_app_instance):
-    create_dummy_config(temp_config_path, {
+async def test_chat_api_key_field_prefilled_for_config_key(monkeypatch, temp_config_path):
+    config = {
         "providers": {"OpenAI": ["gpt-4o"], "Ollama": ["llama3"]},
         "chat_defaults": {"provider": "OpenAI", "model": "gpt-4o"},
         "api_settings": {"openai": {"api_key": "sk-configured"}},
-    })
-    monkeypatch.setattr(tldw_chatbook.config, "DEFAULT_CONFIG_PATH", temp_config_path)
-    window = ToolsSettingsWindow(app_instance=mock_app_instance)
-
-    if AppTest is None:
-        pytest.skip("AppTest not available in this version of Textual")
-
-    async with AppTest(app=mock_app_instance, driver_class=None) as pilot:
-        mock_app_instance.mount(window)
-        await pilot.pause()
+    }
+    async with mount_settings_window(config, temp_config_path, monkeypatch) as window:
         field = window.query_one("#general-chat-api-key", Input)
         assert field.password is True
         assert field.value == "sk-configured"
@@ -822,21 +847,13 @@ async def test_chat_api_key_field_prefilled_for_config_key(monkeypatch, temp_con
 
 
 @pytest.mark.asyncio
-async def test_chat_api_key_field_disabled_for_keyless_provider(monkeypatch, temp_config_path, mock_app_instance):
-    create_dummy_config(temp_config_path, {
+async def test_chat_api_key_field_disabled_for_keyless_provider(monkeypatch, temp_config_path):
+    config = {
         "providers": {"Ollama": ["llama3"], "OpenAI": ["gpt-4o"]},
         "chat_defaults": {"provider": "Ollama", "model": "llama3"},
         "api_settings": {},
-    })
-    monkeypatch.setattr(tldw_chatbook.config, "DEFAULT_CONFIG_PATH", temp_config_path)
-    window = ToolsSettingsWindow(app_instance=mock_app_instance)
-
-    if AppTest is None:
-        pytest.skip("AppTest not available in this version of Textual")
-
-    async with AppTest(app=mock_app_instance, driver_class=None) as pilot:
-        mock_app_instance.mount(window)
-        await pilot.pause()
+    }
+    async with mount_settings_window(config, temp_config_path, monkeypatch) as window:
         field = window.query_one("#general-chat-api-key", Input)
         assert field.disabled is True
         assert "No API key needed" in field.placeholder

--- a/Tests/UI/test_tools_settings_window.py
+++ b/Tests/UI/test_tools_settings_window.py
@@ -875,3 +875,40 @@ async def test_chat_api_key_field_reloads_on_provider_change(monkeypatch, temp_c
         await pilot.pause()
         assert field.disabled is True
         assert field.value == ""
+
+
+@pytest.mark.asyncio
+async def test_chat_api_key_save_writes_config_and_updates_live_config(monkeypatch, temp_config_path):
+    config = {
+        "providers": {"OpenAI": ["gpt-4o"]},
+        "chat_defaults": {"provider": "OpenAI", "model": "gpt-4o"},
+        "api_settings": {},
+    }
+    async with mount_settings_window(config, temp_config_path, monkeypatch) as (window, pilot):
+        window.app_instance.app_config = {"api_settings": {}}
+        window.query_one("#general-chat-api-key", Input).value = "sk-brand-new"
+
+        saved = window._save_chat_api_key()
+        assert saved is True
+
+        # Written to the on-disk config under the normalized provider key
+        written = toml.load(temp_config_path)
+        assert written["api_settings"]["openai"]["api_key"] == "sk-brand-new"
+
+        # Live app config updated in place (no restart needed)
+        assert window.app_instance.app_config["api_settings"]["openai"]["api_key"] == "sk-brand-new"
+
+
+@pytest.mark.asyncio
+async def test_chat_api_key_save_skips_blank(monkeypatch, temp_config_path):
+    config = {
+        "providers": {"OpenAI": ["gpt-4o"]},
+        "chat_defaults": {"provider": "OpenAI", "model": "gpt-4o"},
+        "api_settings": {},
+    }
+    async with mount_settings_window(config, temp_config_path, monkeypatch) as (window, pilot):
+        window.app_instance.app_config = {"api_settings": {}}
+        window.query_one("#general-chat-api-key", Input).value = "   "
+        assert window._save_chat_api_key() is False
+        written = toml.load(temp_config_path)
+        assert written.get("api_settings", {}).get("openai", {}).get("api_key") is None

--- a/Tests/UI/test_tools_settings_window.py
+++ b/Tests/UI/test_tools_settings_window.py
@@ -1,13 +1,14 @@
+import shutil
+import sqlite3
+import tempfile
+from contextlib import asynccontextmanager
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch, AsyncMock, call
+
 import pytest
 import pytest_asyncio
 import toml
-from contextlib import asynccontextmanager
-from pathlib import Path
-from unittest.mock import MagicMock, patch, AsyncMock, call
-import tempfile
-import shutil
-import sqlite3
-from datetime import datetime
 
 from textual.widgets import Button, Checkbox, Input, Select, TextArea, Label, Static
 from textual.app import App
@@ -837,12 +838,12 @@ async def test_chat_api_key_field_prefilled_for_config_key(monkeypatch, temp_con
     config = {
         "providers": {"OpenAI": ["gpt-4o"], "Ollama": ["llama3"]},
         "chat_defaults": {"provider": "OpenAI", "model": "gpt-4o"},
-        "api_settings": {"openai": {"api_key": "sk-configured"}},
+        "api_settings": {"openai": {"api_key": "test-configured-key"}},
     }
     async with mount_settings_window(config, temp_config_path, monkeypatch) as (window, pilot):
         field = window.query_one("#general-chat-api-key", Input)
         assert field.password is True
-        assert field.value == "sk-configured"
+        assert field.value == "test-configured-key"
         assert field.disabled is False
 
 
@@ -864,11 +865,11 @@ async def test_chat_api_key_field_reloads_on_provider_change(monkeypatch, temp_c
     config = {
         "providers": {"OpenAI": ["gpt-4o"], "Ollama": ["llama3"]},
         "chat_defaults": {"provider": "OpenAI", "model": "gpt-4o"},
-        "api_settings": {"openai": {"api_key": "sk-configured"}},
+        "api_settings": {"openai": {"api_key": "test-configured-key"}},
     }
     async with mount_settings_window(config, temp_config_path, monkeypatch) as (window, pilot):
         field = window.query_one("#general-chat-api-key", Input)
-        assert field.value == "sk-configured"
+        assert field.value == "test-configured-key"
 
         # Switch to a keyless provider -> field disables and clears
         window.query_one("#general-chat-provider", Select).value = "Ollama"
@@ -886,17 +887,17 @@ async def test_chat_api_key_save_writes_config_and_updates_live_config(monkeypat
     }
     async with mount_settings_window(config, temp_config_path, monkeypatch) as (window, pilot):
         window.app_instance.app_config = {"api_settings": {}}
-        window.query_one("#general-chat-api-key", Input).value = "sk-brand-new"
+        window.query_one("#general-chat-api-key", Input).value = "test-brand-new-key"
 
         saved = window._save_chat_api_key()
         assert saved is True
 
         # Written to the on-disk config under the normalized provider key
         written = toml.load(temp_config_path)
-        assert written["api_settings"]["openai"]["api_key"] == "sk-brand-new"
+        assert written["api_settings"]["openai"]["api_key"] == "test-brand-new-key"
 
         # Live app config updated in place (no restart needed)
-        assert window.app_instance.app_config["api_settings"]["openai"]["api_key"] == "sk-brand-new"
+        assert window.app_instance.app_config["api_settings"]["openai"]["api_key"] == "test-brand-new-key"
 
 
 @pytest.mark.asyncio
@@ -912,3 +913,54 @@ async def test_chat_api_key_save_skips_blank(monkeypatch, temp_config_path):
         assert window._save_chat_api_key() is False
         written = toml.load(temp_config_path)
         assert written.get("api_settings", {}).get("openai", {}).get("api_key") is None
+
+
+@pytest.mark.asyncio
+async def test_chat_api_key_field_clears_when_provider_blanked(monkeypatch, temp_config_path):
+    """Blanking the provider must clear the field, not leave the prior key visible."""
+    config = {
+        "providers": {"OpenAI": ["gpt-4o"]},
+        "chat_defaults": {"provider": "OpenAI", "model": "gpt-4o"},
+        "api_settings": {"openai": {"api_key": "test-configured-key"}},
+    }
+    async with mount_settings_window(config, temp_config_path, monkeypatch) as (window, pilot):
+        field = window.query_one("#general-chat-api-key", Input)
+        assert field.value == "test-configured-key"
+
+        # The provider Select disallows a blank value in normal use, so drive the
+        # defensive handler branch directly with a synthetic BLANK change event.
+        select = window.query_one("#general-chat-provider", Select)
+        window._on_chat_provider_changed(Select.Changed(select, Select.BLANK))
+        assert field.value == ""
+        assert field.disabled is True
+        assert "Select a provider" in field.placeholder
+
+
+@pytest.mark.asyncio
+async def test_chat_api_key_save_pushes_decrypted_key_to_live_config_when_encrypted(monkeypatch, temp_config_path):
+    """With config encryption on, the live app_config must receive the DECRYPTED
+    key, never the on-disk ciphertext (which chat would send verbatim and fail)."""
+    # A session password unlocks the field and enables encrypt-on-write.
+    monkeypatch.setattr(tldw_chatbook.config, "_ENCRYPTION_PASSWORD", "test-master-pw")
+    config = {
+        "providers": {"OpenAI": ["gpt-4o"]},
+        "chat_defaults": {"provider": "OpenAI", "model": "gpt-4o"},
+        "api_settings": {},
+        "encryption": {"enabled": True},
+    }
+    async with mount_settings_window(config, temp_config_path, monkeypatch) as (window, pilot):
+        window.app_instance.app_config = {"api_settings": {}}
+        window.query_one("#general-chat-api-key", Input).value = "test-secret-live-key"
+
+        assert window._save_chat_api_key() is True
+
+        # On disk the key is encrypted...
+        enc_mod = tldw_chatbook.config.get_encryption_module()
+        written_key = toml.load(temp_config_path)["api_settings"]["openai"]["api_key"]
+        assert enc_mod.is_encrypted(written_key)
+        assert written_key != "test-secret-live-key"
+
+        # ...but the live config the send path reads holds decrypted plaintext.
+        live_key = window.app_instance.app_config["api_settings"]["openai"]["api_key"]
+        assert live_key == "test-secret-live-key"
+        assert not enc_mod.is_encrypted(live_key)

--- a/Tests/test_config_app_config_encryption.py
+++ b/Tests/test_config_app_config_encryption.py
@@ -1,0 +1,75 @@
+"""Regression tests for backlog task-151.
+
+With config encryption enabled, ``load_settings()`` (which populates
+``app.app_config``) must return DECRYPTED ``api_settings`` values, never ``enc:``
+ciphertext — otherwise the Chat send path passes the ciphertext to providers
+verbatim and auth fails. Also verifies that ``set_encryption_password`` drops the
+stale ciphertext cache primed before the startup unlock prompt.
+"""
+
+import toml
+import pytest
+
+import tldw_chatbook.config as cfg
+from tldw_chatbook.Utils.config_encryption import config_encryption
+
+PASSWORD = "test-master-pw"
+PLAINTEXT_KEY = "test-plaintext-openai-key"
+
+
+def _write_encrypted_config(path):
+    """Write a config whose api_settings.openai.api_key is encrypted on disk."""
+    plain = {
+        "encryption": {"enabled": True},
+        "api_settings": {"openai": {"api_key": PLAINTEXT_KEY}},
+    }
+    encrypted = cfg.encrypt_api_keys_in_config(plain, PASSWORD)
+    path.write_text(toml.dumps(encrypted))
+    on_disk = toml.load(path)["api_settings"]["openai"]["api_key"]
+    assert config_encryption.is_encrypted(on_disk), "precondition: on-disk key must be ciphertext"
+
+
+@pytest.fixture
+def reset_config_state():
+    """Ensure global encryption/cache state never leaks into other tests."""
+    yield
+    cfg.clear_encryption_password()
+    cfg._SETTINGS_CACHE = None
+    cfg._SETTINGS_CACHE_SOURCE = None
+    cfg._CONFIG_CACHE = None
+    cfg._CONFIG_CACHE_SOURCE = None
+
+
+def test_load_settings_decrypts_api_settings_when_encrypted(tmp_path, monkeypatch, reset_config_state):
+    cfg_path = tmp_path / "config.toml"
+    _write_encrypted_config(cfg_path)
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(cfg_path))
+    cfg.set_encryption_password(PASSWORD)
+
+    result = cfg.load_settings(force_reload=True)
+
+    key = result["api_settings"]["openai"]["api_key"]
+    assert key == PLAINTEXT_KEY
+    assert not config_encryption.is_encrypted(key)
+
+
+def test_set_encryption_password_invalidates_stale_ciphertext_cache(tmp_path, monkeypatch, reset_config_state):
+    """Mirrors app startup: config is cached (as ciphertext) before the unlock
+    prompt, then the password is entered — the next load must decrypt."""
+    cfg_path = tmp_path / "config.toml"
+    _write_encrypted_config(cfg_path)
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(cfg_path))
+
+    # 1) No password yet: load primes the cache with ciphertext.
+    cfg.clear_encryption_password()
+    cfg._SETTINGS_CACHE = None
+    cfg._SETTINGS_CACHE_SOURCE = None
+    primed = cfg.load_settings(force_reload=True)
+    assert config_encryption.is_encrypted(primed["api_settings"]["openai"]["api_key"])
+
+    # 2) Entering the password must invalidate the stale cache...
+    cfg.set_encryption_password(PASSWORD)
+    # 3) ...so the next NON-forced load re-reads and decrypts.
+    result = cfg.load_settings()
+
+    assert result["api_settings"]["openai"]["api_key"] == PLAINTEXT_KEY

--- a/backlog/tasks/task-151 - Decrypt-api_settings-when-building-app_config-in-load_settings.md
+++ b/backlog/tasks/task-151 - Decrypt-api_settings-when-building-app_config-in-load_settings.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-151
 title: Decrypt api_settings when building app_config in load_settings
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-06 15:43'
 labels:
@@ -19,8 +19,20 @@ When config encryption is enabled, load_settings() returns the raw [api_settings
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 With config encryption enabled and a session password set, app.app_config['api_settings'][provider]['api_key'] is decrypted plaintext at startup rather than enc: ciphertext
-- [ ] #2 The Chat send path authenticates successfully against a keyed provider whose api_key is stored encrypted (no restart-into-plaintext workaround needed)
-- [ ] #3 The non-encrypted path and startup performance are unchanged
-- [ ] #4 A regression test covers the encrypted-startup case
+- [x] #1 With config encryption enabled and a session password set, app.app_config['api_settings'][provider]['api_key'] is decrypted plaintext at startup rather than enc: ciphertext
+- [x] #2 The Chat send path authenticates successfully against a keyed provider whose api_key is stored encrypted (no restart-into-plaintext workaround needed)
+- [x] #3 The non-encrypted path and startup performance are unchanged
+- [x] #4 A regression test covers the encrypted-startup case
 <!-- AC:END -->
+
+## Implementation Notes
+
+Two changes in `tldw_chatbook/config.py`:
+
+1. **`load_settings()`** now calls `decrypt_config_section(toml_config_data)` right after merging the config layers (before section extraction). This mirrors the decrypt step already in `load_cli_config_and_ensure_existence`, so `app.app_config["api_settings"]` (and the legacy `[API]` keys) surface as plaintext. `decrypt_config_section` is a no-op when encryption is disabled or no session password is set, so the non-encrypted path (AC #3) is unaffected — decryption only runs its cost when encryption is actually on.
+
+2. **`set_encryption_password()`** now nulls `_SETTINGS_CACHE` and `_CONFIG_CACHE`. This closes a caching gap: `APP_CONFIG = load_settings()` runs at module import (app.py:409), *before* the startup unlock prompt, priming the settings cache with ciphertext; without cache invalidation, the later `self.app_config = load_settings()` (app.py:1382) would return that stale ciphertext even with change #1 in place. The startup ordering is: unlock prompt → `set_encryption_password` (app.py:7176, clears caches) → `TldwCli()` → `load_settings()` reloads and decrypts.
+
+**Tests:** `Tests/test_config_app_config_encryption.py` — (a) `load_settings(force_reload=True)` returns the decrypted key for an encrypted on-disk config; (b) after priming the cache with ciphertext (no password), `set_encryption_password` invalidates it so a subsequent non-forced load decrypts (the startup path). Broader sweep (config + settings + encryption + feature suites): 276 passed, 16 skipped, 0 failed.
+
+**Files:** `tldw_chatbook/config.py`, `Tests/test_config_app_config_encryption.py`.

--- a/backlog/tasks/task-151 - Decrypt-api_settings-when-building-app_config-in-load_settings.md
+++ b/backlog/tasks/task-151 - Decrypt-api_settings-when-building-app_config-in-load_settings.md
@@ -1,0 +1,26 @@
+---
+id: TASK-151
+title: Decrypt api_settings when building app_config in load_settings
+status: To Do
+assignee: []
+created_date: '2026-07-06 15:43'
+labels:
+  - bug
+  - security
+  - config
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+When config encryption is enabled, load_settings() returns the raw [api_settings] TOML table (it never calls decrypt_config_section), so at startup app.app_config['api_settings'][<provider>]['api_key'] holds enc: ciphertext. The Chat send path resolves keys from app.app_config via get_provider_readiness and passes that value verbatim, so provider auth fails for users who store keys with encryption enabled. load_cli_config_and_ensure_existence() already decrypts (config.py:2803); load_settings() (config.py:613) does not, and app.py:1382/7021 populate app_config from it. Discovered during PR #583 (inline Chat-Defaults API key), which fixed only the save-and-refresh path (_refresh_live_api_settings).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 With config encryption enabled and a session password set, app.app_config['api_settings'][provider]['api_key'] is decrypted plaintext at startup rather than enc: ciphertext
+- [ ] #2 The Chat send path authenticates successfully against a keyed provider whose api_key is stored encrypted (no restart-into-plaintext workaround needed)
+- [ ] #3 The non-encrypted path and startup performance are unchanged
+- [ ] #4 A regression test covers the encrypted-startup case
+<!-- AC:END -->

--- a/tldw_chatbook/Chat/provider_readiness.py
+++ b/tldw_chatbook/Chat/provider_readiness.py
@@ -324,6 +324,13 @@ def chat_api_key_value_to_persist(
 
     Skips when the field is non-persistable, blank, a placeholder, or unchanged
     from the currently displayed value.
+
+    Args:
+        new_value: The raw value typed in the field.
+        field_state: The ChatApiKeyFieldState for the selected provider.
+
+    Returns:
+        The stripped value to persist, or None to skip the write.
     """
     if not field_state.can_persist:
         return None

--- a/tldw_chatbook/Chat/provider_readiness.py
+++ b/tldw_chatbook/Chat/provider_readiness.py
@@ -252,3 +252,84 @@ def get_provider_readiness(
         reason="Missing API key",
         recovery=recovery,
     )
+
+
+@dataclass(frozen=True)
+class ChatApiKeyFieldState:
+    """Render + persistence state for the inline Chat-Defaults API-key input."""
+
+    value: str          # masked prefill value; "" when nothing should be shown
+    disabled: bool      # True for keyless providers or a locked/encrypted config
+    placeholder: str    # hint shown when the box is empty
+    can_persist: bool   # whether a user-entered value should be written on save
+
+
+def chat_api_key_field_state(
+    readiness: ProviderReadiness,
+    *,
+    locked: bool,
+) -> ChatApiKeyFieldState:
+    """Map provider readiness to the inline API-key field's UI/persistence state.
+
+    Args:
+        readiness: Resolved readiness for the currently selected provider.
+        locked: True when config encryption is enabled but no session password is
+            available (stored values are ciphertext and must not be shown/saved).
+
+    Returns:
+        The field state to render and the flag for whether a typed value is savable.
+    """
+    if not readiness.requires_api_key:
+        return ChatApiKeyFieldState(
+            value="",
+            disabled=True,
+            placeholder="No API key needed for this provider.",
+            can_persist=False,
+        )
+    if locked:
+        return ChatApiKeyFieldState(
+            value="",
+            disabled=True,
+            placeholder="Unlock config to edit keys.",
+            can_persist=False,
+        )
+    source = readiness.api_key_source or ""
+    if source.startswith("config:") and readiness.api_key:
+        return ChatApiKeyFieldState(
+            value=readiness.api_key,
+            disabled=False,
+            placeholder="Enter API key",
+            can_persist=True,
+        )
+    if source.startswith("env:") and readiness.env_var:
+        return ChatApiKeyFieldState(
+            value="",
+            disabled=False,
+            placeholder=f"Detected from ${readiness.env_var} — leave blank to keep it",
+            can_persist=True,
+        )
+    return ChatApiKeyFieldState(
+        value="",
+        disabled=False,
+        placeholder="Enter your API key to start using this provider",
+        can_persist=True,
+    )
+
+
+def chat_api_key_value_to_persist(
+    new_value: object,
+    field_state: ChatApiKeyFieldState,
+) -> Optional[str]:
+    """Return the API-key value to persist, or None to skip the write.
+
+    Skips when the field is non-persistable, blank, a placeholder, or unchanged
+    from the currently displayed value.
+    """
+    if not field_state.can_persist:
+        return None
+    candidate = new_value.strip() if isinstance(new_value, str) else ""
+    if not is_valid_provider_api_key(candidate):
+        return None
+    if candidate == field_state.value:
+        return None
+    return candidate

--- a/tldw_chatbook/UI/Tools_Settings_Window.py
+++ b/tldw_chatbook/UI/Tools_Settings_Window.py
@@ -42,6 +42,7 @@ from ..Chat.provider_readiness import (
     get_provider_readiness,
     provider_config_key,
     chat_api_key_field_state,
+    chat_api_key_value_to_persist,
 )
 #
 # Local Imports
@@ -845,6 +846,47 @@ class ToolsSettingsWindow(Container):
         api_key_input.value = state.value
         api_key_input.disabled = state.disabled
         api_key_input.placeholder = state.placeholder
+
+    def _refresh_live_api_settings(self) -> None:
+        """Push freshly-saved api_settings into the live app config (no restart).
+
+        Mutates the existing ``app_config`` dict in place so components that hold
+        a reference to it — including the Chat send path — observe the new key.
+        """
+        try:
+            reloaded = load_settings(force_reload=True)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning(f"Could not refresh live api_settings after save: {exc}")
+            return
+        app_config = getattr(self.app_instance, "app_config", None)
+        if isinstance(app_config, dict):
+            app_config["api_settings"] = reloaded.get("api_settings", {})
+        # Keep this window's own snapshot consistent.
+        self.config_data = load_cli_config_and_ensure_existence(force_reload=True)
+
+    def _save_chat_api_key(self) -> bool:
+        """Persist the inline Chat-Defaults API key for the selected provider.
+
+        Returns:
+            True if a key was written (and the live config refreshed), else False.
+        """
+        try:
+            provider_value = self.query_one("#general-chat-provider", Select).value
+            api_key_widget = self.query_one("#general-chat-api-key", Input)
+        except QueryError:
+            return False
+        if not provider_value or provider_value is Select.BLANK:
+            return False
+        readiness = get_provider_readiness(str(provider_value), self.config_data)
+        field_state = chat_api_key_field_state(readiness, locked=self._config_is_locked())
+        key_to_persist = chat_api_key_value_to_persist(api_key_widget.value, field_state)
+        if key_to_persist is None:
+            return False
+        provider_key = provider_config_key(str(provider_value))
+        if not save_setting_to_cli_config(f"api_settings.{provider_key}", "api_key", key_to_persist):
+            return False
+        self._refresh_live_api_settings()
+        return True
 
     def _compose_character_defaults_settings(self) -> ComposeResult:
         """Compose character default settings."""
@@ -3115,6 +3157,9 @@ Thank you for using tldw-chatbook! 🎉
             
             # Chat Defaults
             if save_setting_to_cli_config("chat_defaults", "provider", self.query_one("#general-chat-provider", Select).value):
+                saved_count += 1
+            # Inline API key for the selected provider (contextual quick-start field)
+            if self._save_chat_api_key():
                 saved_count += 1
             if save_setting_to_cli_config("chat_defaults", "model", self.query_one("#general-chat-model", Input).value):
                 saved_count += 1

--- a/tldw_chatbook/UI/Tools_Settings_Window.py
+++ b/tldw_chatbook/UI/Tools_Settings_Window.py
@@ -829,7 +829,23 @@ class ToolsSettingsWindow(Container):
                         variant="default",
                         tooltip="View available models for the selected provider"
                     )
-    
+
+    @on(Select.Changed, "#general-chat-provider")
+    def _on_chat_provider_changed(self, event: Select.Changed) -> None:
+        """Reload the inline API-key field for the newly selected chat provider."""
+        try:
+            api_key_input = self.query_one("#general-chat-api-key", Input)
+        except QueryError:
+            return
+        provider = event.value
+        if not provider or provider is Select.BLANK:
+            return
+        readiness = get_provider_readiness(str(provider), self.config_data)
+        state = chat_api_key_field_state(readiness, locked=self._config_is_locked())
+        api_key_input.value = state.value
+        api_key_input.disabled = state.disabled
+        api_key_input.placeholder = state.placeholder
+
     def _compose_character_defaults_settings(self) -> ComposeResult:
         """Compose character default settings."""
         with VerticalScroll(classes="settings-tab-content"):

--- a/tldw_chatbook/UI/Tools_Settings_Window.py
+++ b/tldw_chatbook/UI/Tools_Settings_Window.py
@@ -882,6 +882,7 @@ class ToolsSettingsWindow(Container):
         key_to_persist = chat_api_key_value_to_persist(api_key_widget.value, field_state)
         if key_to_persist is None:
             return False
+        # provider_config_key normalizes to the same key get_provider_readiness reads (lower + spaces/dashes -> _).
         provider_key = provider_config_key(str(provider_value))
         if not save_setting_to_cli_config(f"api_settings.{provider_key}", "api_key", key_to_persist):
             return False

--- a/tldw_chatbook/UI/Tools_Settings_Window.py
+++ b/tldw_chatbook/UI/Tools_Settings_Window.py
@@ -23,10 +23,10 @@ from textual.widgets import Markdown
 from textual import on
 # Local Imports
 from tldw_chatbook.config import (
-    load_cli_config_and_ensure_existence, DEFAULT_CONFIG_PATH, save_setting_to_cli_config, 
+    load_cli_config_and_ensure_existence, DEFAULT_CONFIG_PATH, save_setting_to_cli_config,
     API_MODELS_BY_PROVIDER, check_encryption_needed, get_detected_api_providers,
     enable_config_encryption, disable_config_encryption, change_encryption_password,
-    get_encryption_password, get_cli_setting, get_prompts_db_path
+    get_encryption_password, get_cli_setting, get_prompts_db_path, load_settings
 )
 from loguru import logger
 from ..DB.ChaChaNotes_DB import CharactersRAGDB
@@ -38,6 +38,11 @@ from .Sharing_Panel import SharingPanel
 from ..Utils.path_validation import validate_path
 from .Theme_Editor_Window import ThemeEditorView
 from .Widgets import ConfigSearchResult, UIElementSearchEngine
+from ..Chat.provider_readiness import (
+    get_provider_readiness,
+    provider_config_key,
+    chat_api_key_field_state,
+)
 #
 # Local Imports
 #
@@ -689,6 +694,13 @@ class ToolsSettingsWindow(Container):
                     tooltip="Reset all general settings to default values"
                 )
     
+    def _config_is_locked(self) -> bool:
+        """True when encryption is on but no session password is available."""
+        encryption_config = self.config_data.get("encryption", {})
+        if not encryption_config.get("enabled", False):
+            return False
+        return not get_encryption_password()
+
     def _compose_chat_defaults_settings(self) -> ComposeResult:
         """Compose chat default settings."""
         with VerticalScroll(classes="settings-tab-content"):
@@ -716,7 +728,21 @@ class ToolsSettingsWindow(Container):
                         classes="settings-select",
                         tooltip="Default AI provider for chat conversations"
                     )
-                    
+
+                    # Inline API key for the selected provider (new-user quick start)
+                    _readiness = get_provider_readiness(current_chat_provider, self.config_data)
+                    _key_state = chat_api_key_field_state(_readiness, locked=self._config_is_locked())
+                    yield Label("API Key:", classes="settings-label")
+                    yield Input(
+                        value=_key_state.value,
+                        password=True,
+                        disabled=_key_state.disabled,
+                        id="general-chat-api-key",
+                        classes="settings-input",
+                        placeholder=_key_state.placeholder,
+                        tooltip="API key for the selected provider. Saved to [api_settings.<provider>]."
+                    )
+
                     yield Label("Model:", classes="settings-label")
                     yield Input(
                         value=chat_config.get("model", "gpt-4o"),

--- a/tldw_chatbook/UI/Tools_Settings_Window.py
+++ b/tldw_chatbook/UI/Tools_Settings_Window.py
@@ -26,7 +26,7 @@ from tldw_chatbook.config import (
     load_cli_config_and_ensure_existence, DEFAULT_CONFIG_PATH, save_setting_to_cli_config,
     API_MODELS_BY_PROVIDER, check_encryption_needed, get_detected_api_providers,
     enable_config_encryption, disable_config_encryption, change_encryption_password,
-    get_encryption_password, get_cli_setting, get_prompts_db_path, load_settings
+    get_encryption_password, get_cli_setting, get_prompts_db_path
 )
 from loguru import logger
 from ..DB.ChaChaNotes_DB import CharactersRAGDB
@@ -840,6 +840,10 @@ class ToolsSettingsWindow(Container):
             return
         provider = event.value
         if not provider or provider is Select.BLANK:
+            # No provider selected: never leave the prior provider's key visible.
+            api_key_input.value = ""
+            api_key_input.disabled = True
+            api_key_input.placeholder = "Select a provider to enter an API key"
             return
         readiness = get_provider_readiness(str(provider), self.config_data)
         state = chat_api_key_field_state(readiness, locked=self._config_is_locked())
@@ -850,11 +854,16 @@ class ToolsSettingsWindow(Container):
     def _refresh_live_api_settings(self) -> None:
         """Push freshly-saved api_settings into the live app config (no restart).
 
-        Mutates the existing ``app_config`` dict in place so components that hold
-        a reference to it — including the Chat send path — observe the new key.
+        Reloads via ``load_cli_config_and_ensure_existence`` (which decrypts when
+        config encryption is enabled) so an encrypted ``api_key`` reaches the live
+        config as usable plaintext rather than ``enc:`` ciphertext — the Chat send
+        path expects a real key. ``save_setting_to_cli_config`` has already
+        force-reloaded that cache, so no ``force_reload`` is needed here. Mutates
+        the existing ``app_config`` dict in place so components holding a reference
+        to it — including the Chat send path — observe the new key.
         """
         try:
-            reloaded = load_settings(force_reload=True)
+            reloaded = load_cli_config_and_ensure_existence()
         except Exception as exc:  # pragma: no cover - defensive
             logger.warning(f"Could not refresh live api_settings after save: {exc}")
             return
@@ -862,7 +871,7 @@ class ToolsSettingsWindow(Container):
         if isinstance(app_config, dict):
             app_config["api_settings"] = reloaded.get("api_settings", {})
         # Keep this window's own snapshot consistent.
-        self.config_data = load_cli_config_and_ensure_existence(force_reload=True)
+        self.config_data = reloaded
 
     def _save_chat_api_key(self) -> bool:
         """Persist the inline Chat-Defaults API key for the selected provider.

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -398,9 +398,17 @@ def get_encryption_module():
 
 
 def set_encryption_password(password: str):
-    """Set the encryption password for the current session."""
-    global _ENCRYPTION_PASSWORD
+    """Set the encryption password for the current session.
+
+    Also invalidates the settings/CLI config caches: any config loaded before the
+    password was available (e.g. the module-level ``APP_CONFIG`` primed at import,
+    before the startup unlock prompt) holds ciphertext, so it must be dropped and
+    re-decrypted on the next load.
+    """
+    global _ENCRYPTION_PASSWORD, _SETTINGS_CACHE, _CONFIG_CACHE
     _ENCRYPTION_PASSWORD = password
+    _SETTINGS_CACHE = None
+    _CONFIG_CACHE = None
     logger.info("Encryption password set for current session")
 
 
@@ -690,6 +698,12 @@ def load_settings(force_reload: bool = False) -> Dict:
     toml_config_data = deep_merge_dicts(toml_config_data, base_config_data) # Merge primary config
     toml_config_data = deep_merge_dicts(toml_config_data, user_override_config_data) # Merge user CLI overrides
     logger.info("Merged all configurations: CLI Defaults < Primary Config < User CLI Config.")
+    # Decrypt sensitive values (e.g. [api_settings].*.api_key) when config encryption
+    # is enabled and a session password is available; a no-op otherwise. Without this,
+    # app.app_config (populated from load_settings) would carry `enc:` ciphertext keys
+    # that the Chat send path passes to providers verbatim, failing auth. Mirrors the
+    # decrypt step in load_cli_config_and_ensure_existence.
+    toml_config_data = decrypt_config_section(toml_config_data)
     logger.debug("load_settings: Configuration loaded from disk (cache miss or forced reload)")
     # logger.debug(f"Final toml_config_data after potential merge: {toml_config_data}") # Optional: for verbose debugging
 


### PR DESCRIPTION
## Why

A brand-new user who opens Settings has no obvious place to enter an API key — keys are buried under *Configuration File Settings → API Settings*, mixed per-provider with model/temperature/timeout fields. The Chat-Defaults tab already shows the provider they'll use but offers no way to authenticate it. This adds an inline **API Key** field right under the provider picker, so the provider you pick and the key that makes it work sit together, and saving it lets you start chatting immediately.

## What

Settings → **General Settings** → **💬 Chat Defaults** → "🤖 Default Provider & Model": a masked **API Key** input is inserted directly between the **Provider** dropdown and the **Model** field.

- **Saves to the location the app actually reads.** The key is written to `api_settings.<provider>.api_key` (normalized via `provider_config_key`) — exactly what the live chat send path resolves through `get_provider_readiness` (and the continuation path in `chat_events.py`). No new config keys.
- **Provider-aware.** Changing the provider dropdown reloads the field for that provider (pre-fills the stored key masked, or shows an env/keyless hint).
- **Safe states, driven by a single source of truth.** All render/save decisions funnel through two pure helpers in `Chat/provider_readiness.py`:
  - Keyless providers (Ollama, llama.cpp, …) → field disabled ("No API key needed").
  - Key already supplied via `$PROVIDER_API_KEY` → field left empty with a "Detected from $… — leave blank to keep it" hint; a blank save never clobbers it.
  - Encryption enabled but locked → field disabled ("Unlock config to edit keys"); ciphertext is never shown or persisted.
  - The placeholder `<API_KEY_HERE>`, blank, and unchanged values are never written.
- **Works without a restart.** On save, `app.app_config["api_settings"]` is refreshed in place, so the running send path picks up the new key immediately.

The standalone API-Settings tab, provider list, and config schema are unchanged — this is a promoted, provider-contextual shortcut to a key the app already reads.

## Testing

- New pure unit tests for the field-state helpers (keyless / locked / config-prefill / env / missing, plus every persist-skip case).
- New widget/integration tests under a real Textual pilot: field renders under the picker, reloads on provider change, saves to the on-disk TOML **and** updates live `app_config`, and skips blank saves.
- Affected suites: **39 passed, 16 skipped (pre-existing), 0 failed.** No regressions.

> Note: this repo's installed Textual (8.2.7) has no `textual.app.AppTest`, so the pre-existing `AppTest`-based tests in `test_tools_settings_window.py` skip. This PR adds a reusable real-pilot mount helper (`mount_settings_window`) so the new tests actually execute; the 16 skips are the untouched pre-existing siblings.

## Security

API key values are redacted in logs (existing `_setting_value_for_log`), encrypted at rest when config encryption is enabled, and never rendered in clear (masked input); env/locked keys are never copied into the config file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a masked API Key field under the provider picker in Settings → General → Chat Defaults so users can authenticate in place and start chatting. Also decrypts provider API keys into `app_config` on save and at startup so changes work immediately without a restart.

- **New Features**
  - Provider-aware: reloads on provider change; pre-fills stored keys; shows env-var hint (e.g., `$OPENAI_API_KEY`); disables for keyless providers; disables when encryption is locked; clears when the provider is blanked.
  - Single source of truth + save flow: field state and persistence use `get_provider_readiness` via `chat_api_key_field_state` + `chat_api_key_value_to_persist`; writes to `api_settings.<provider>.api_key` under the normalized `provider_config_key`; skips blanks, `<API_KEY_HERE>`, and unchanged values; never overwrites env/locked setups; refreshes live `app_config["api_settings"]` in place with decrypted plaintext (no restart).

- **Bug Fixes**
  - Startup decryption: `load_settings()` now decrypts `api_settings` when encryption is enabled and `set_encryption_password()` invalidates caches, so `app_config` holds plaintext keys at launch (fixes ciphertext being sent to providers).

<sup>Written for commit 659ba1139e9869ac994f6afc98f8c7170291edb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

