### PR TITLE
docs: fix PR #578 review nits (stale backlog task IDs, hardcoded paths)

### DIFF
--- a/Docs/superpowers/plans/2026-06-14-sync-v2-m1-p1-schema-transport.md
+++ b/Docs/superpowers/plans/2026-06-14-sync-v2-m1-p1-schema-transport.md
@@ -724,8 +724,8 @@ if __name__ == "__main__":
 
 Run:
 ```bash
-PYTHONPATH=/Users/macbook-dev/Documents/GitHub/tldw_chatbook \
-  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python /tmp/syncqa-v2/p1_check.py
+PYTHONPATH=. \
+  .venv/bin/python /tmp/syncqa-v2/p1_check.py
 ```
 Expected: prints capabilities + bootstrap details and `P1_EXIT_OK: True`.
 
@@ -741,7 +741,7 @@ Append the script output to the QA notes and update backlog task #24 with "P1 gr
 client parses M1 capabilities + bootstraps a profile live against :8076".
 
 ```bash
-cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook
+cd "$(git rev-parse --show-toplevel)"
 backlog task edit 24 --notes "P1 complete: client parses M1 capabilities and bootstraps a profile live vs :8076 (codex/sync-v2-m1-next @ 992e89a03)."
 ```
 

--- a/Docs/superpowers/plans/2026-06-25-console-conversation-rail-overflow.md
+++ b/Docs/superpowers/plans/2026-06-25-console-conversation-rail-overflow.md
@@ -83,7 +83,7 @@ Reason: this changes Console presentation and UI preference state only. It does 
 Run:
 
 ```bash
-backlog task edit 134 -s "In Progress" --plan "1. Add Console workspace conversation-section display state and pure tests.
+backlog task edit 138 -s "In Progress" --plan "1. Add Console workspace conversation-section display state and pure tests.
 2. Render bounded/collapsible/searchable Conversations UI in ConsoleWorkspaceContextTray.
 3. Add ChatScreen-owned query, collapse preference, search, stale-result, and row-selection wiring.
 4. Add TCSS rules for bounded list, summary, search, and collapse controls.
@@ -102,7 +102,7 @@ Expected: `TASK-138` status becomes `In Progress` and contains the ADR check in 
 Run:
 
 ```bash
-backlog task 134 --plain
+backlog task 138 --plain
 ```
 
 Expected: output includes `ADR required: no` and the six implementation steps.
@@ -1889,7 +1889,7 @@ Edit `backlog/tasks/task-138 - Fix-Console-conversation-rail-overflow.md`:
 Run:
 
 ```bash
-backlog task edit 134 -s Done
+backlog task edit 138 -s Done
 ```
 
 Expected: `TASK-138` status becomes `Done`.

--- a/Docs/superpowers/plans/2026-06-29-console-beginner-advanced-ux-remediation-plan.md
+++ b/Docs/superpowers/plans/2026-06-29-console-beginner-advanced-ux-remediation-plan.md
@@ -1122,7 +1122,7 @@ Update acceptance criteria to `[x]` and add implementation notes summarizing:
 Then run:
 
 ```bash
-backlog task edit 142 -s Done
+backlog task edit 144 -s Done
 ```
 
 - [ ] **Step 7: Commit closeout**


### PR DESCRIPTION
PR #578 was merged before its six Gemini review comments could be applied. All six were valid documentation nits (no code involved); this applies them on dev.

- **sync-v2 P1 plan** (`2026-06-14-...`): replaced hardcoded `/Users/macbook-dev/...` absolute paths in the run/record steps with portable forms (`PYTHONPATH=. .venv/bin/python …` and `cd "$(git rev-parse --show-toplevel)"`).
- **console-conversation-rail-overflow plan** (`2026-06-25-...`): three `backlog task … 134` command lines corrected to `138` (the plan's own prose and the real task file are `task-138`). The `task-134-*` QA evidence filenames are intentionally left unchanged — those files genuinely exist under that name.
- **console-beginner-advanced-ux-remediation plan** (`2026-06-29-...`): `backlog task edit 142` corrected to `144` (matches `task-144` throughout the plan).

Docs only — no code, no tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply six missed review nits from PR #578: make run commands portable and fix stale backlog task IDs in three docs plans. Docs-only; no code or tests.

- **Bug Fixes**
  - `2026-06-14-sync-v2-m1-p1-schema-transport.md`: replaced absolute `/Users/...` paths with `PYTHONPATH=.`, `.venv/bin/python`, and `cd "$(git rev-parse --show-toplevel)"`.
  - `2026-06-25-console-conversation-rail-overflow.md`: corrected `backlog task` IDs from 134 to 138; kept `task-134-*` evidence filenames unchanged.
  - `2026-06-29-console-beginner-advanced-ux-remediation-plan.md`: corrected `backlog task edit 142` to 144.

<sup>Written for commit 928a53d43820721b9a4625e53edf4ce6024ddae6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

