### PR TITLE
Release: re-cut as v0.1.8.0 (supersedes v0.1.7.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to Some kind of Versioning
 - Initial features pending documentation
 
 
-## [0.1.7.4] - 2026-07-08
+## [0.1.8.0] - 2026-07-08
 ### Changed
 - Master-shell UI/navigation overhaul: the app is organized around primary destinations
   (Home, Console, Library, Artifacts, Personas, Watchlists, Schedules, Workflows, MCP, ACP,

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A sophisticated Terminal User Interface (TUI) application built with the Textual
 
 ## Project Status & Recent UI Overhaul
 
-tldw_chatbook is in active development (currently `v0.1.7.4`, pre-1.0). The `dev` branch has landed a major UI/navigation overhaul that reorganizes the app around a **master shell** with a small set of primary destinations instead of a flat tab bar. Older tabs (Chat, Notes, Media, Ingest, Search, Coding, Characters/Prompts, Subscriptions, Chatbooks) remain reachable as routes/aliases during migration, but are no longer separate primary destinations.
+tldw_chatbook is in active development (currently `v0.1.8.0`, pre-1.0). The `dev` branch has landed a major UI/navigation overhaul that reorganizes the app around a **master shell** with a small set of primary destinations instead of a flat tab bar. Older tabs (Chat, Notes, Media, Ingest, Search, Coding, Characters/Prompts, Subscriptions, Chatbooks) remain reachable as routes/aliases during migration, but are no longer separate primary destinations.
 
 **Highlights:**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tldw_chatbook"
-version = "0.1.7.4"
+version = "0.1.8.0"
 authors = [
   { name="Robert Musser", email="contact@rmusser.net" },
 ]

--- a/tldw_chatbook/__init__.py
+++ b/tldw_chatbook/__init__.py
@@ -34,13 +34,13 @@ def _install_textual_compatibility_shims() -> None:
 
 _install_textual_compatibility_shims()
 
-__version__ = "0.1.7.4"
+__version__ = "0.1.8.0"
 __author__ = "Robert Musser"
 __email__ = "contact@rmusser.net"
 __license__ = "AGPLv3+"
 
 # Version tuple for programmatic comparison
-VERSION_TUPLE = (0, 1, 7, 3)
+VERSION_TUPLE = (0, 1, 8, 0)
 
 # Export key components when package is imported
 __all__ = [


### PR DESCRIPTION
Follow-up to #588. Bumps the version `0.1.7.4 → 0.1.8.0` — a minor bump better reflects the scale of the master-shell UI overhaul (552 commits) than the initial patch tag.

- `pyproject.toml` + `tldw_chatbook/__init__.py` → `0.1.8.0` (also fixes the previously-stale `VERSION_TUPLE`, now `(0, 1, 8, 0)`).
- CHANGELOG entry retitled `[0.1.8.0]`; README status line updated.

The `v0.1.7.4` tag and GitHub release are being deleted and replaced by `v0.1.8.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-cut the release as v0.1.8.0 to better match the scope of the master-shell UI overhaul and replace v0.1.7.4. This updates version metadata and docs, and removes the prior tag/release.

Updates version in pyproject and `tldw_chatbook/__init__.py` (fixes VERSION_TUPLE), retitles the CHANGELOG entry, and refreshes the README status line. Deletes the v0.1.7.4 tag and GitHub release.

<sup>Written for commit 10abdedeab9ad0186eb1d91720bbb268cfe0b3f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

