### PR TITLE
fix(navigation): rapid tab switching permanently froze the app — never re-mount cached screens

### DIFF
--- a/Tests/RuntimePolicy/test_runtime_policy_bootstrap.py
+++ b/Tests/RuntimePolicy/test_runtime_policy_bootstrap.py
@@ -18,7 +18,6 @@ def _make_app_like(*, base_url: str = "https://Example.COM:8443/api/") -> Simple
         },
         app_state=AppState(),
         # handle_runtime_backend_changed invalidates the screen cache.
-        invalidate_screen_cache=lambda: None,
     )
 
 
@@ -661,7 +660,6 @@ async def test_handle_runtime_backend_changed_forwards_resolved_authoritative_ba
         app_config={},
         app_state=AppState(),
         screen=SimpleNamespace(handle_runtime_backend_changed=screen_callback),
-        invalidate_screen_cache=lambda: None,
     )
     context = load_runtime_policy_for_app(app_like, store=store)
 

--- a/Tests/UI/test_home_screen.py
+++ b/Tests/UI/test_home_screen.py
@@ -1399,16 +1399,11 @@ def test_app_detail_hook_navigates_library_with_ingest_context_for_handled_inges
     assert posted.screen_context == {LIBRARY_NAV_CONTEXT_INGEST: True}
 
 
-def test_app_detail_hook_invalidates_cached_library_screen_for_ingest_detail():
-    """Home's ``Open details`` deep link must drop any cached Library screen
-    before navigating (mirrors ``open_notes_workspace``).
-
-    Library is a CACHEABLE route: without invalidation the deep link switches
-    to an already-mounted-then-unmounted cached instance that advances the
-    screen stack but never repaints (the live symptom -- the terminal keeps
-    rendering Home even though the app is "on" Library). The flashcards deep
-    link never hit this because Study is not a cacheable route and always
-    builds a fresh screen. This is the RED regression guard for that fix.
+def test_app_detail_hook_navigates_library_for_ingest_detail():
+    """Home's ``Open details`` deep link posts a Library navigation with the
+    ingest nav-context (screen instance caching was removed entirely after
+    the rapid-tab-switch freeze, so every navigation now composes a fresh,
+    cleanly repainted Library screen -- no invalidation step remains).
     """
     app = _build_test_app()
     adapter = RecordingHomeActiveWorkAdapter(

--- a/Tests/UI/test_home_screen.py
+++ b/Tests/UI/test_home_screen.py
@@ -1425,15 +1425,12 @@ def test_app_detail_hook_invalidates_cached_library_screen_for_ingest_detail():
     app.home_active_work_adapter = adapter
     app.notify = Mock()
     app.post_message = Mock()
-    library_sentinel = object()
-    app._screen_cache = {TAB_LIBRARY: library_sentinel}
 
     app.open_active_home_item_details(
         target_id="local:ingest:ingest-job-1",
         target_route="library",
     )
 
-    assert TAB_LIBRARY not in app._screen_cache
     posted = app.post_message.call_args.args[0]
     assert posted.screen_name == "library"
     assert posted.screen_context == {LIBRARY_NAV_CONTEXT_INGEST: True}
@@ -1454,13 +1451,10 @@ async def test_home_open_details_button_click_navigates_library_for_failed_inges
     app.library_ingest_jobs.mark_failed(job.job_id, error="Unsupported extension")
     app.notify = Mock()
     app.post_message = Mock()
-    # A Library screen the user already visited is cached under TAB_LIBRARY.
-    # The live bug: switching back to this cached-then-unmounted instance from
-    # the ingest deep link advanced the screen stack to Library but never
-    # repainted (the terminal stayed on Home). The fix drops the cached
-    # instance so a fresh Library screen composes + mounts + repaints.
-    library_sentinel = object()
-    app._screen_cache = {TAB_LIBRARY: library_sentinel}
+    # Navigation composes a FRESH Library screen on every visit (screen
+    # instance caching was removed after it caused the rapid-tab-switch
+    # freeze), so the deep link always lands on a cleanly mounted,
+    # repainted ingest canvas.
     host = HomeHarness(app)
 
     async with host.run_test(size=HOME_TEST_SIZE) as pilot:
@@ -1488,11 +1482,6 @@ async def test_home_open_details_button_click_navigates_library_for_failed_inges
         f"post_message calls: {app.post_message.call_args_list}"
     )
     assert navigations[-1].screen_context == {LIBRARY_NAV_CONTEXT_INGEST: True}
-    # The stale cached Library screen must be dropped so the deep link lands
-    # on a freshly composed, repainted ingest canvas (regression guard for the
-    # live "advances to Library but keeps rendering Home" symptom).
-    assert app._screen_cache.get(TAB_LIBRARY) is not library_sentinel
-    assert TAB_LIBRARY not in app._screen_cache
 
 
 def test_retry_active_home_item_requeues_ingest_job_via_real_seam():

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -4930,6 +4930,38 @@ async def test_library_shell_note_autosave_fires_after_debounce(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_library_flush_pending_work_saves_dirty_note_and_reports_conflicts():
+    """``flush_pending_work`` (the app's nav-away hook) must persist a dirty
+    note before the screen instance is discarded, and must return False when
+    the flush surfaces an unresolved save conflict so the app vetoes the
+    navigation instead of destroying the editor (and the user's edits) with
+    the outgoing screen.
+    """
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_note_editor(screen, pilot)
+
+        screen.query_one("#library-note-body", TextArea).text = "edited mid-tab-switch"
+        await pilot.pause()
+
+        allowed = await screen.flush_pending_work()
+
+        service = app.notes_scope_service
+        assert allowed is True
+        assert service.save_calls, "flush_pending_work never persisted the dirty note"
+        assert service.save_calls[-1]["content"] == "edited mid-tab-switch"
+
+        # An unresolved conflict must veto the navigation.
+        screen._library_note_autosave_state = "conflict"
+        assert await screen.flush_pending_work() is False
+
+
+@pytest.mark.asyncio
 async def test_library_shell_note_flush_on_back_saves_before_view_switches():
     """Editing the body then immediately pressing Back must flush (await)
     the pending save before the canvas leaves the editor -- proven by
@@ -5024,9 +5056,9 @@ async def test_library_shell_note_flush_on_notes_create_deeplink_saves_before_sw
     and rail-switch exits honour.
 
     ``apply_navigation_context`` is the retired Notes tab's re-pointed entry;
-    unlike its before-mount callers, ``_get_or_create_navigation_screen``
-    hands back the *cached* screen, so a palette "new note" fired mid-edit
-    runs it on a mounted, dirty editor. Without the flush the recompose to
+    navigation composes fresh screens, but this defense-in-depth branch
+    covers any direct caller that runs it on a mounted, dirty editor
+    mid-edit. Without the flush the recompose to
     the create view destroys the ``#library-note-body`` the debounced
     autosave would have read, silently dropping the last edits. Proven by
     the (deliberately slow) save being in flight while the selected row is

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -35,6 +35,7 @@ from tldw_chatbook.Library.library_shell_state import (
     LIBRARY_ROW_BROWSE_CONVERSATIONS,
     LIBRARY_ROW_BROWSE_MEDIA,
     LIBRARY_ROW_BROWSE_NOTES,
+    LIBRARY_ROW_BROWSE_SEARCH,
     LIBRARY_ROW_CREATE_NOTE,
     LIBRARY_ROW_INGEST_MEDIA,
 )
@@ -8466,3 +8467,228 @@ async def test_library_shell_ingest_canvas_different_canvas_isolation(tmp_path):
         assert screen._library_selected_row_id != LIBRARY_ROW_INGEST_MEDIA
         assert not screen.query("#library-ingest-path")
         assert not list(screen.query(".library-ingest-row"))
+
+
+# --- Cross-visit state persistence (save_state/restore_state) -------------
+#
+# Screens are never cached/reused across a navigation (a fresh instance is
+# constructed every visit); continuity is entirely the app's
+# ``_screen_states`` dict, keyed by screen name and populated/consumed by
+# ``save_state``/``restore_state`` (see app.py's ``handle_screen_navigation``).
+# These tests exercise ``LibraryScreen``'s real overrides directly (unit
+# style) plus the on_mount interaction the restored viewer/editor state
+# depends on (pilot style, via ``LibraryHarness``).
+
+
+@pytest.mark.asyncio
+async def test_library_shell_save_state_captures_selection_and_rag_state():
+    """``save_state`` is the ``_screen_states`` producer -- assert it
+    actually carries the selection/view attrs the restore contract
+    promises, and never leaks a bulk fetched snapshot.
+    """
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), media=_two_media_items())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+
+        screen.query_one("#library-row-browse-search").press()
+        await _wait_for_selector(screen, pilot, "#library-rag-query-input")
+        screen.query_one("#library-rag-query-input", Input).value = "roadmap"
+        await pilot.pause()
+        await pilot.pause()
+
+        state = screen.save_state()
+
+    assert state["library_selected_row_id"] == LIBRARY_ROW_BROWSE_SEARCH
+    assert state["library_rag_query"] == "roadmap"
+    assert state["library_rag_mode"] == "search"
+    assert state["library_rag_scope_deselected"] == set()
+    assert state["library_rag_results"] == ()
+    assert state["library_rag_selected_result_id"] == ""
+    # Bulk fetched snapshots must never leak into the persisted dict --
+    # screens re-fetch fresh on the next mount, and a restored id may be
+    # stale by then (see the stale-id tests below).
+    assert "local_source_records" not in state
+    assert "library_note_detail" not in state
+    assert "library_media_detail" not in state
+
+
+def test_library_shell_restore_state_sets_attrs_on_fresh_unmounted_instance():
+    """``restore_state`` runs on a freshly-constructed, not-yet-mounted
+    instance (see app.py's ``handle_screen_navigation``): construct one
+    exactly that way and assert every attr lands, mirroring the base
+    ``test_screen_state_preservation`` contract test but for Library's real
+    override.
+    """
+    app = _build_test_app()
+    original = LibraryScreen(app)
+    original._library_selected_row_id = LIBRARY_ROW_BROWSE_MEDIA
+    original._selected_media_id = "media-42"
+    original._library_media_view = "viewer"
+    original._library_rag_query = "alpha"
+    original._library_rag_mode = "rag"
+    original._library_rag_scope_deselected = {"notes"}
+    state = original.save_state()
+
+    restored = LibraryScreen(app)
+    restored.restore_state(state)
+
+    assert restored._library_selected_row_id == LIBRARY_ROW_BROWSE_MEDIA
+    assert restored._selected_media_id == "media-42"
+    assert restored._library_media_view == "viewer"
+    assert restored._library_rag_query == "alpha"
+    assert restored._library_rag_mode == "rag"
+    assert restored._library_rag_scope_deselected == {"notes"}
+
+    # The restore must not alias the saved dict's mutable set -- mutating
+    # the restored instance's copy must never bleed back into the saved
+    # state dict (a shallow-copied structure the app's runtime-policy
+    # reconciliation touches on every navigation).
+    restored._library_rag_scope_deselected.add("media")
+    assert state["library_rag_scope_deselected"] == {"notes"}
+
+
+def test_library_shell_restore_state_degrades_editor_view_without_matching_id():
+    """A corrupted/foreign saved-state dict (``library_notes_view`` says
+    "editor" but carries no note id) must not leave the screen pointed at a
+    permanent "Loading note..." placeholder -- fall back to the list view.
+    Same guard, mirrored for the media viewer.
+    """
+    app = _build_test_app()
+
+    notes_screen = LibraryScreen(app)
+    notes_screen.restore_state({"library_notes_view": "editor", "selected_note_id": ""})
+    assert notes_screen._library_notes_view == "list"
+    assert notes_screen._selected_note_id == ""
+
+    media_screen = LibraryScreen(app)
+    media_screen.restore_state({"library_media_view": "viewer", "selected_media_id": ""})
+    assert media_screen._library_media_view == "list"
+    assert media_screen._selected_media_id == ""
+
+
+def test_library_shell_restore_state_tolerates_garbage_values():
+    """``restore_state`` must never crash on a saved-state dict from a
+    different build/shape -- e.g. a non-dict ``library_rag_results``, or a
+    ``library_rag_mode`` outside the two known values.
+    """
+    app = _build_test_app()
+    screen = LibraryScreen(app)
+
+    screen.restore_state(
+        {
+            "library_rag_mode": "not-a-real-mode",
+            "library_rag_results": "not-a-tuple",
+            "library_rag_scope_deselected": "not-a-set",
+            "library_rag_recovery_state": "not-a-dataclass",
+        }
+    )
+
+    assert screen._library_rag_mode == "search"
+    assert screen._library_rag_results == ()
+    assert screen._library_rag_scope_deselected == set()
+    assert screen._library_rag_recovery_state is None
+
+    # A completely non-dict payload (e.g. a runtime-policy mismatch that
+    # ``reconcile_saved_screen_state`` failed to catch) must be a no-op,
+    # not a crash.
+    screen.restore_state(None)
+
+
+@pytest.mark.asyncio
+async def test_library_shell_restored_media_viewer_fetches_detail_on_mount():
+    """Mirrors the notes-editor nav-context deep link ``on_mount`` already
+    handled before this task: a restored ``_library_media_view == "viewer"``
+    with a ``_selected_media_id`` must kick the detail fetch itself, since
+    nothing else does for a restore (unlike a live row click, which calls
+    ``_refresh_library_media_detail`` directly from
+    ``handle_library_media_row``).
+    """
+    app = _build_test_app()
+    _seed_conversations(app, [], media=_two_media_items())
+
+    screen = LibraryScreen(app)
+    screen.restore_state(
+        {
+            "library_selected_row_id": LIBRARY_ROW_BROWSE_MEDIA,
+            "selected_media_id": "media-1",
+            "library_media_view": "viewer",
+        }
+    )
+    host = LibraryHarness(app, screen=screen)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_selector(screen, pilot, "#library-media-viewer")
+
+        assert screen._library_media_detail is not None
+        assert screen._library_media_detail.get("id") == "media-1"
+        assert screen._library_media_view == "viewer"
+
+
+@pytest.mark.asyncio
+async def test_library_shell_restored_media_viewer_with_deleted_item_falls_back_to_list():
+    """Stale-id safety: the media record backing a restored viewer selection
+    was deleted while the user was elsewhere. The existing
+    ``_refresh_library_media_detail`` unavailable-notify fallback must fire
+    the same way it does for a live click on a since-deleted row.
+    """
+    app = _build_test_app()
+    _seed_conversations(app, [], media=[])  # nothing resolves "media-ghost"
+    notified = []
+    app.notify = lambda message, **kwargs: notified.append(message)
+
+    screen = LibraryScreen(app)
+    screen.restore_state(
+        {
+            "library_selected_row_id": LIBRARY_ROW_BROWSE_MEDIA,
+            "selected_media_id": "media-ghost",
+            "library_media_view": "viewer",
+        }
+    )
+    host = LibraryHarness(app, screen=screen)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        for _ in range(120):
+            if screen._library_media_view == "list":
+                break
+            await pilot.pause(0.02)
+
+        assert screen._library_media_view == "list"
+        assert any("unavailable" in message.lower() for message in notified)
+
+
+@pytest.mark.asyncio
+async def test_library_shell_restored_notes_editor_with_deleted_note_falls_back_to_list():
+    """Same stale-id contract as the media viewer above, but for notes --
+    exercised through the pre-existing ``on_mount`` deep-link fetch (this
+    task's restore just feeds it the same inputs a ``note_id`` nav-context
+    deep link always could)."""
+    app = _build_test_app()
+    _seed_conversations(app, [], notes=_two_notes())
+    notified = []
+    app.notify = lambda message, **kwargs: notified.append(message)
+
+    screen = LibraryScreen(app)
+    screen.restore_state(
+        {
+            "library_selected_row_id": LIBRARY_ROW_BROWSE_NOTES,
+            "selected_note_id": "note-ghost",
+            "library_notes_view": "editor",
+        }
+    )
+    host = LibraryHarness(app, screen=screen)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        for _ in range(120):
+            if screen._library_notes_view == "list":
+                break
+            await pilot.pause(0.02)
+
+        assert screen._library_notes_view == "list"
+        assert notified  # _notify_library_note_missing_warning fired

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -4957,9 +4957,20 @@ async def test_library_flush_pending_work_saves_dirty_note_and_reports_conflicts
         assert service.save_calls, "flush_pending_work never persisted the dirty note"
         assert service.save_calls[-1]["content"] == "edited mid-tab-switch"
 
-        # An unresolved conflict must veto the navigation.
-        screen._library_note_autosave_state = "conflict"
+        # Unsaved edits surviving the flush must veto the navigation: a
+        # FAILED save leaves the edits only in this screen instance, so
+        # discarding it would lose them. Force a genuine save failure
+        # through the real seam and re-dirty the editor.
+        screen.query_one("#library-note-body", TextArea).text = "edit that must not be lost"
+        await pilot.pause()
+
+        async def _failing_save(**kwargs):
+            raise RuntimeError("simulated save failure")
+
+        service.save_note = _failing_save
         assert await screen.flush_pending_work() is False
+        assert screen._library_note_autosave_state == "error"
+        assert screen._library_note_dirty is True
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_media_ingest_window_rebuilt.py
+++ b/Tests/UI/test_media_ingest_window_rebuilt.py
@@ -161,7 +161,6 @@ async def test_app_level_runtime_backend_change_refreshes_media_ingest_screen_wi
         runtime_backend="server",
         media_runtime_state=MediaRuntimeState(runtime_backend="server"),
         screen=None,
-        invalidate_screen_cache=Mock(),
     )
     screen = MediaIngestScreen(app_instance=app_like)
     screen.media_ingest_window = SimpleNamespace(

--- a/Tests/UI/test_screen_navigation.py
+++ b/Tests/UI/test_screen_navigation.py
@@ -437,7 +437,18 @@ def test_legacy_tools_settings_route_uses_mcp_context():
 
 
 @pytest.mark.asyncio
-async def test_cacheable_screen_navigation_reuses_constructed_screen_instance(monkeypatch):
+async def test_screen_navigation_always_constructs_fresh_instances(monkeypatch):
+    """Regression lock for the rapid-tab-switch freeze (2026-07-11).
+
+    Navigation used to cache Screen INSTANCES for allowlisted routes and
+    re-mount them after ``switch_screen`` had already unmounted them. Under
+    rapid switching the re-mount interleaved with the still-in-flight
+    unmount, leaving zombie widgets (``mounted=True`` with stopped message
+    pumps), a compositor stuck on a stale frame, and an app that silently
+    swallowed every subsequent click -- a permanent, exception-free freeze.
+    Every navigation must therefore construct a FRESH screen instance; this
+    test fails if instance reuse ever returns.
+    """
     app = _build_test_app()
     constructed = {"chat": 0, "library": 0}
 
@@ -477,8 +488,57 @@ async def test_cacheable_screen_navigation_reuses_constructed_screen_instance(mo
         await app.handle_screen_navigation(NavigateToScreen("library"))
         await app.handle_screen_navigation(NavigateToScreen("chat"))
 
-    assert constructed == {"chat": 1, "library": 1}
-    assert switched_screens[0] is switched_screens[2]
+    assert constructed == {"chat": 2, "library": 1}
+    assert switched_screens[0] is not switched_screens[2]
+
+
+async def test_rapid_tab_switch_storm_leaves_no_zombie_widgets():
+    """Live-repro regression lock for the rapid-tab-switch freeze.
+
+    Storm real navigation across real screens with no settling pauses, then
+    assert the app is still responsive and the active screen's widget tree
+    contains no zombie widgets (attached but with a stopped message pump) --
+    the wedged state the instance cache used to produce, where the compositor
+    froze on a stale frame and dead pumps swallowed every click.
+    """
+    app = _build_test_app()
+
+    async with app.run_test(size=(160, 40)) as pilot:
+        # Wait for the app's own initial navigation screen before storming --
+        # in production the nav bar only exists once that screen is mounted,
+        # so a pre-boot NavigateToScreen is unreachable by real input.
+        for _ in range(150):
+            await pilot.pause(0.02)
+            if type(app.screen).__name__ != "Screen":
+                break
+        assert type(app.screen).__name__ != "Screen", "app never mounted its initial screen"
+        routes = ("home", "library", "workflows", "schedules")
+        for _round in range(3):
+            for route in routes:
+                app.post_message(NavigateToScreen(route))
+                await pilot.pause(0)
+        # Let the queued switches drain, then prove the app still navigates.
+        app.post_message(NavigateToScreen("library"))
+        for _ in range(150):
+            await pilot.pause(0.02)
+            if type(app.screen).__name__ == "LibraryScreen" and app.screen.is_running:
+                break
+        assert type(app.screen).__name__ == "LibraryScreen"
+        assert app.screen.is_running
+        zombies = [
+            widget
+            for widget in app.screen.walk_children()
+            if not widget.is_running
+        ]
+        assert not zombies, f"zombie widgets on active screen: {zombies[:5]}"
+        # One more hop for responsiveness.
+        app.post_message(NavigateToScreen("home"))
+        for _ in range(150):
+            await pilot.pause(0.02)
+            if type(app.screen).__name__ == "HomeScreen":
+                break
+        assert type(app.screen).__name__ == "HomeScreen"
+        assert app.screen.is_running
 
 
 def _build_test_app(configured_default: str | None = None) -> TldwCli:

--- a/Tests/UI/test_screen_navigation.py
+++ b/Tests/UI/test_screen_navigation.py
@@ -493,6 +493,61 @@ async def test_screen_navigation_always_constructs_fresh_instances(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_navigation_flushes_outgoing_screen_and_honors_veto(monkeypatch):
+    """Navigating away must flush the outgoing screen's pending work first.
+
+    Screens are no longer cached, so anything not persisted before the
+    switch is destroyed with the old instance (e.g. a Library note edit
+    whose debounced autosave has not fired yet). The app awaits the
+    outgoing screen's ``flush_pending_work()`` and aborts the switch when
+    it returns False (unresolved save conflict needs the user).
+    """
+    app = _build_test_app()
+
+    class FakeTargetScreen:
+        screen_name = "chat"
+
+        def __init__(self, app_instance):
+            self.app_instance = app_instance
+
+    def fake_resolve(target):
+        return "chat", "chat", FakeTargetScreen
+
+    switched_screens = []
+
+    async def fake_switch_screen(screen):
+        switched_screens.append(screen)
+
+    monkeypatch.setattr(app, "_resolve_screen_navigation_target", fake_resolve)
+    monkeypatch.setattr(app, "switch_screen", fake_switch_screen)
+
+    flush_results = {"value": False}
+    flush_calls = []
+
+    class FakeOutgoingScreen:
+        screen_name = "library"
+
+        async def flush_pending_work(self):
+            flush_calls.append(True)
+            return flush_results["value"]
+
+    outgoing = FakeOutgoingScreen()
+    # The handler only touches self.screen for the outgoing flush/save-state
+    # steps, so it is callable without a running app once switch_screen is
+    # stubbed -- patching the screen property this way would break the live
+    # compositor under run_test.
+    monkeypatch.setattr(type(app), "screen", property(lambda self: outgoing))
+
+    await app.handle_screen_navigation(NavigateToScreen("chat"))
+    assert flush_calls, "outgoing screen's flush_pending_work was never awaited"
+    assert switched_screens == [], "veto (False) must abort the switch"
+
+    flush_results["value"] = True
+    await app.handle_screen_navigation(NavigateToScreen("chat"))
+    assert len(switched_screens) == 1, "flush returning True must allow the switch"
+
+
+@pytest.mark.asyncio
 async def test_rapid_tab_switch_storm_leaves_no_zombie_widgets():
     """Live-repro regression lock for the rapid-tab-switch freeze.
 

--- a/Tests/UI/test_screen_navigation.py
+++ b/Tests/UI/test_screen_navigation.py
@@ -7,8 +7,8 @@ from types import SimpleNamespace
 import pytest
 from textual import on
 from textual.app import App
-from textual.widgets import Button
-from unittest.mock import MagicMock, patch
+from textual.widgets import Button, Input
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from tldw_chatbook.app import TldwCli
 from tldw_chatbook.Chat import (
@@ -122,6 +122,7 @@ from tldw_chatbook.UI.Navigation.main_navigation import MainNavigationBar
 from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
 from tldw_chatbook.UI.Screens.media_ingest_screen import MediaIngestScreen
 from tldw_chatbook.UI.Screens.media_screen import MediaScreen
+from tldw_chatbook.UI.Screens.search_screen import SearchScreen
 from tldw_chatbook.runtime_policy.types import RuntimeSourceState
 from tldw_chatbook.runtime_policy.server_capabilities import ActiveServerCapabilityService
 from tldw_chatbook.runtime_policy import KeyringServerCredentialStore, RuntimeServerContextProvider
@@ -1053,3 +1054,286 @@ def test_primary_routed_screens_use_base_app_screen():
             offenders.append((route_id, screen_class))
 
     assert offenders == []
+
+
+# --- Cross-visit state persistence (real save_state/restore_state) --------
+#
+# Screens are never cached/reused (see
+# ``test_screen_navigation_always_constructs_fresh_instances`` above), so
+# continuity across a visit depends entirely on ``_screen_states``
+# (``save_state``/``restore_state``). These are round-trip pilots through the
+# REAL navigation path -- ``NavigateToScreen`` posted, drained via bounded
+# polling (the storm pilot's idiom above), real widgets mutated the way a
+# user would -- not direct calls into ``save_state``/``restore_state``.
+
+
+@pytest.mark.asyncio
+async def test_library_screen_round_trip_restores_rag_query_and_rail_selection():
+    """Select the Search/RAG rail row, type a query into the real Input
+    widget, hop to Home and back, and assert both the internal state and
+    the visible Input value survived on the freshly-composed instance.
+    """
+    from tldw_chatbook.Library.library_shell_state import LIBRARY_ROW_BROWSE_SEARCH
+
+    app = _build_test_app()
+
+    async with app.run_test(size=(170, 48)) as pilot:
+        for _ in range(150):
+            await pilot.pause(0.02)
+            if type(app.screen).__name__ != "Screen":
+                break
+
+        app.post_message(NavigateToScreen("library"))
+        for _ in range(150):
+            await pilot.pause(0.02)
+            if (
+                type(app.screen).__name__ == "LibraryScreen"
+                and app.screen.query("#library-row-browse-search")
+            ):
+                break
+        assert type(app.screen).__name__ == "LibraryScreen"
+
+        app.screen.query_one("#library-row-browse-search").press()
+        for _ in range(150):
+            await pilot.pause(0.02)
+            if app.screen.query("#library-rag-query-input"):
+                break
+
+        app.screen.query_one("#library-rag-query-input", Input).value = "roadmap notes"
+        await pilot.pause()
+        await pilot.pause()
+
+        assert app.screen._library_rag_query == "roadmap notes"
+        assert app.screen._library_selected_row_id == LIBRARY_ROW_BROWSE_SEARCH
+
+        app.post_message(NavigateToScreen("home"))
+        for _ in range(150):
+            await pilot.pause(0.02)
+            if type(app.screen).__name__ == "HomeScreen":
+                break
+        assert type(app.screen).__name__ == "HomeScreen"
+
+        app.post_message(NavigateToScreen("library"))
+        for _ in range(150):
+            await pilot.pause(0.02)
+            if (
+                type(app.screen).__name__ == "LibraryScreen"
+                and app.screen.query("#library-rag-query-input")
+            ):
+                break
+
+        restored_screen = app.screen
+        assert type(restored_screen).__name__ == "LibraryScreen"
+        assert restored_screen._library_rag_query == "roadmap notes"
+        assert restored_screen._library_selected_row_id == LIBRARY_ROW_BROWSE_SEARCH
+        query_input = restored_screen.query_one("#library-rag-query-input", Input)
+        assert query_input.value == "roadmap notes"
+
+
+@pytest.mark.asyncio
+async def test_media_screen_round_trip_restores_type_filter_and_search_term():
+    """Regression lock for the bug this task fixes: nothing seeds
+    ``MediaWindow.active_media_type`` on a screen-navigated visit except a
+    live nav-panel click (the legacy ``watch_current_tab`` ->
+    ``activate_initial_view`` path is a no-op once ``_use_screen_navigation``
+    is set). Without restoring it first, a fresh ``MediaWindow`` instance
+    every visit meant the type/search/keyword filter silently reset on every
+    single navigation away and back.
+    """
+    app = _build_test_app()
+    # search_media hits the real MediaReadingScopeService -> media_db chain,
+    # and the test fixture's media_db is None -- stub just the DB-touching
+    # call (mirroring Tests/UI/test_media_window_v2_parity.py's pattern) so
+    # this exercises the real mount/restore path without a real database.
+    app.media_reading_scope_service.search_media = AsyncMock(
+        return_value={"items": [], "total": 0}
+    )
+
+    async with app.run_test(size=(170, 48)) as pilot:
+        for _ in range(150):
+            await pilot.pause(0.02)
+            if type(app.screen).__name__ != "Screen":
+                break
+
+        app.post_message(NavigateToScreen("media"))
+        for _ in range(150):
+            await pilot.pause(0.02)
+            if (
+                type(app.screen).__name__ == "MediaScreen"
+                and app.screen.query("#media-nav-all-media")
+            ):
+                break
+        assert type(app.screen).__name__ == "MediaScreen"
+
+        # Pick a type the way a real user does (there is exactly one media
+        # type in this fixture: "All Media" -> slug "all-media").
+        app.screen.query_one("#media-nav-all-media").press()
+        for _ in range(150):
+            await pilot.pause(0.02)
+            if app.screen.media_window.active_media_type:
+                break
+        assert app.screen.media_window.active_media_type == "all-media"
+
+        search_input = app.screen.query_one("#search-input", Input)
+        search_input.value = "quarterly report"
+        await pilot.pause()
+        await pilot.pause()
+
+        assert app.screen.media_window.search_panel.search_term == "quarterly report"
+
+        app.post_message(NavigateToScreen("home"))
+        for _ in range(150):
+            await pilot.pause(0.02)
+            if type(app.screen).__name__ == "HomeScreen":
+                break
+        assert type(app.screen).__name__ == "HomeScreen"
+
+        app.post_message(NavigateToScreen("media"))
+        for _ in range(150):
+            await pilot.pause(0.02)
+            if (
+                type(app.screen).__name__ == "MediaScreen"
+                and app.screen.query("#search-input")
+            ):
+                break
+
+        restored_screen = app.screen
+        assert type(restored_screen).__name__ == "MediaScreen"
+        assert restored_screen.media_window.active_media_type == "all-media"
+        for _ in range(150):
+            await pilot.pause(0.02)
+            if restored_screen.media_window.search_panel.search_term == "quarterly report":
+                break
+        assert restored_screen.media_window.search_panel.search_term == "quarterly report"
+        restored_input = restored_screen.query_one("#search-input", Input)
+        assert restored_input.value == "quarterly report"
+
+
+@pytest.mark.asyncio
+async def test_search_screen_round_trip_restores_query_input():
+    """SearchScreen wraps ``SearchRAGWindow`` directly with no app-owned
+    runtime-state seam of its own (unlike Media's shared
+    ``MediaRuntimeState``), so its query input is entirely at the mercy of
+    ``_screen_states``.
+    """
+    app = _build_test_app()
+
+    async with app.run_test(size=(170, 48)) as pilot:
+        for _ in range(150):
+            await pilot.pause(0.02)
+            if type(app.screen).__name__ != "Screen":
+                break
+
+        app.post_message(NavigateToScreen("search"))
+        for _ in range(150):
+            await pilot.pause(0.02)
+            if (
+                type(app.screen).__name__ == "SearchScreen"
+                and app.screen.query("#search-query-input")
+            ):
+                break
+        assert type(app.screen).__name__ == "SearchScreen"
+
+        query_input = app.screen.query_one("#search-query-input", Input)
+        query_input.value = "quantum encryption notes"
+        await pilot.pause()
+
+        app.post_message(NavigateToScreen("home"))
+        for _ in range(150):
+            await pilot.pause(0.02)
+            if type(app.screen).__name__ == "HomeScreen":
+                break
+        assert type(app.screen).__name__ == "HomeScreen"
+
+        app.post_message(NavigateToScreen("search"))
+        for _ in range(150):
+            await pilot.pause(0.02)
+            if (
+                type(app.screen).__name__ == "SearchScreen"
+                and app.screen.query("#search-query-input")
+            ):
+                break
+
+        restored_screen = app.screen
+        assert type(restored_screen).__name__ == "SearchScreen"
+        restored_input = restored_screen.query_one("#search-query-input", Input)
+        assert restored_input.value == "quantum encryption notes"
+
+
+# --- Media/Search unit-style save_state/restore_state contracts -----------
+
+
+def test_media_screen_save_state_returns_expected_keys():
+    app = _build_test_app()
+    screen = MediaScreen(app)
+    list(screen.compose_content())  # populate screen.media_window
+    screen.media_window.active_media_type = "all-media"
+    screen.media_window.selected_media_id = "media-7"
+    screen.media_window.search_panel = SimpleNamespace(
+        search_term="alpha", keyword_filter="beta"
+    )
+
+    state = screen.save_state()
+
+    assert state["media_active_type"] == "all-media"
+    assert state["media_selected_id"] == "media-7"
+    assert state["media_search_term"] == "alpha"
+    assert state["media_keyword_filter"] == "beta"
+
+
+def test_media_screen_save_state_never_raises_when_window_unset():
+    app = _build_test_app()
+    screen = MediaScreen(app)  # compose_content never ran -- media_window is None
+
+    state = screen.save_state()
+
+    assert "media_active_type" not in state
+
+
+def test_media_screen_restore_state_stashes_pending_dict_for_on_mount():
+    """``restore_state`` runs on a fresh, not-yet-mounted instance -- the
+    MediaWindow it will compose does not exist yet, so it can only stash the
+    values for ``on_mount`` to apply once ``compose_content`` has run.
+    """
+    app = _build_test_app()
+    screen = MediaScreen(app)
+
+    screen.restore_state(
+        {
+            "media_active_type": "video",
+            "media_selected_id": "media-9",
+            "media_search_term": "q",
+            "media_keyword_filter": "kw",
+        }
+    )
+
+    assert screen._pending_media_restore == {
+        "active_media_type": "video",
+        "selected_media_id": "media-9",
+        "search_term": "q",
+        "keyword_filter": "kw",
+    }
+
+
+def test_search_screen_save_state_never_raises_when_window_unset():
+    app = _build_test_app()
+    screen = SearchScreen(app)  # compose_content never ran -- search_window is None
+
+    state = screen.save_state()
+
+    assert "search_query" not in state
+
+
+def test_search_screen_restore_state_stashes_pending_dict_for_on_mount():
+    app = _build_test_app()
+    screen = SearchScreen(app)
+
+    screen.restore_state(
+        {"search_query": "hello", "search_mode": "hybrid", "search_active_tab": "history-tab"}
+    )
+
+    assert screen._pending_search_restore == {
+        "query": "hello",
+        "mode": "hybrid",
+        "active_tab": "history-tab",
+    }

--- a/Tests/UI/test_screen_navigation.py
+++ b/Tests/UI/test_screen_navigation.py
@@ -492,6 +492,7 @@ async def test_screen_navigation_always_constructs_fresh_instances(monkeypatch):
     assert switched_screens[0] is not switched_screens[2]
 
 
+@pytest.mark.asyncio
 async def test_rapid_tab_switch_storm_leaves_no_zombie_widgets():
     """Live-repro regression lock for the rapid-tab-switch freeze.
 

--- a/Tests/UI/test_study_screen.py
+++ b/Tests/UI/test_study_screen.py
@@ -479,7 +479,6 @@ async def test_app_level_runtime_backend_callback_updates_backend_and_forwards()
         current_runtime_backend="server",
         runtime_backend="server",
         screen=SimpleNamespace(handle_runtime_backend_changed=screen_callback),
-        invalidate_screen_cache=Mock(),
     )
 
     await TldwCli.handle_runtime_backend_changed(app_like, "local")

--- a/tldw_chatbook/UI/MediaWindow_v2.py
+++ b/tldw_chatbook/UI/MediaWindow_v2.py
@@ -1655,6 +1655,76 @@ class MediaWindow(Container):
                 from ..Utils.text import slugify
                 first_type = self.media_types[0]
                 self.activate_media_type(slugify(first_type), first_type)
+
+    def _display_name_for_type_slug(self, type_slug: str) -> str:
+        """Reverse a slug back to its display name for the search-panel summary."""
+        if type_slug == "all-media":
+            return "All Media"
+        from ..Utils.text import slugify
+        for media_type in self.media_types:
+            if slugify(media_type) == type_slug:
+                return media_type
+        return type_slug
+
+    def apply_restored_view_state(self, restore: Dict[str, Any]) -> None:
+        """Apply cross-visit view state restored by ``MediaScreen.restore_state``.
+
+        Called synchronously from ``MediaScreen.on_mount`` (this widget's
+        own ``on_mount`` has already run by then, since Textual mounts
+        children before their parent). Nothing else seeds
+        ``active_media_type`` for a screen-navigated Media visit -- the
+        legacy ``watch_current_tab`` -> ``activate_initial_view`` path is a
+        deliberate no-op once ``_use_screen_navigation`` is set (see its own
+        early return) -- so this is the only place a returning visit's
+        type/search/keyword/selection gets re-applied instead of landing back
+        on the untouched "pick a type" empty state every time.
+
+        Deliberately does not attempt to restore the viewer panel's detail
+        content or its active tab: unlike Library's separate list/viewer
+        canvas modes, this window always shows the list and viewer side by
+        side, and re-populating the viewer requires the same scoped
+        media-detail fetch a live row click triggers -- not wired here to
+        keep this restore path cheap and side-effect-free before the first
+        paint. A stale ``selected_media_id`` (the record was deleted while
+        the user was elsewhere) degrades gracefully: the re-run search below
+        simply will not return it, so nothing in the list matches it.
+
+        Args:
+            restore: The dict ``MediaScreen`` stashed from a previous visit's
+                ``save_state`` (see ``MediaScreen.restore_state``).
+        """
+        type_slug = str(restore.get("active_media_type") or "") or None
+        if type_slug is None:
+            # Nothing was active on the previous visit -- leave the window
+            # exactly as a genuinely first-ever visit would (no type
+            # selected; the nav panel is the entry point).
+            return
+
+        search_term = str(restore.get("search_term") or "")
+        keyword_filter = str(restore.get("keyword_filter") or "")
+        selected_media_id = str(restore.get("selected_media_id") or "") or None
+
+        self.active_media_type = type_slug
+        self.selected_media_id = selected_media_id
+        if self.runtime_state is not None:
+            self.runtime_state.active_media_type = type_slug
+            self.runtime_state.search_term = search_term
+            self.runtime_state.keyword_filter = keyword_filter
+            self.runtime_state.selected_record_id = selected_media_id
+
+        if hasattr(self, "nav_panel"):
+            self.nav_panel.selected_type = type_slug
+        if hasattr(self, "search_panel"):
+            self.search_panel.set_type_filter(
+                type_slug, self._display_name_for_type_slug(type_slug)
+            )
+            self.search_panel.search_term = search_term
+            self.search_panel.keyword_filter = keyword_filter
+        self._sync_saved_view_controls()
+
+        if hasattr(self, "list_panel"):
+            self.list_panel.current_page = 1
+        self._perform_search(type_slug, search_term, keyword_filter)
     
     def update_search_results(self, results: List[Dict[str, Any]], page: int, total_pages: int) -> None:
         """Update search results in the list panel."""

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -791,12 +791,14 @@ class LibraryScreen(BaseAppScreen):
         tabs mid-edit.
 
         Returns:
-            False when the flush surfaced an unresolved save conflict (the
-            navigation is vetoed so the user can resolve the banner),
-            True otherwise.
+            False whenever unsaved edits survive the flush -- an unresolved
+            save conflict (the user must resolve the banner) or a failed
+            save (state "error"; the edits are still only in the editor).
+            Both veto the navigation so the screen instance holding the
+            edits is not discarded. True once nothing dirty remains.
         """
         await self._flush_library_note_save()
-        return self._library_note_autosave_state != "conflict"
+        return not self._library_note_dirty
 
     def apply_navigation_context(self, context: Mapping[str, Any]) -> None:
         """Apply route context supplied by shell navigation.

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -608,8 +608,8 @@ class LibraryScreen(BaseAppScreen):
             counts_fn = getattr(registry, "counts", None)
             if callable(counts_fn):
                 # Seed from whatever the registry already knows so a
-                # re-mounted (cached) screen instance doesn't treat jobs
-                # that finished during a previous mount as a brand-new
+                # freshly composed screen doesn't treat jobs that finished
+                # during a previous Library visit as a brand-new
                 # done-transition and fire a redundant snapshot refresh.
                 self._library_ingest_last_done_count = counts_fn().get("done", 0)
             registry.add_listener(self._handle_library_ingest_registry_changed)
@@ -640,14 +640,11 @@ class LibraryScreen(BaseAppScreen):
         """Unregister the ingest registry listener registered in ``on_mount``.
 
         ``on_unmount`` (not ``on_screen_suspend``) is the correct pairing:
-        a Library screen fetched from ``switch_screen``'s replace can come
-        back later as the *same cached Python instance*
-        (``_get_or_create_navigation_screen``), which re-runs ``on_mount``
-        on every re-entry -- so listener add/remove must be symmetric with
-        that same mount/unmount cycle, not the temporary suspend/resume
-        pair a screen gets while merely covered by another screen on the
-        stack (suspend does not tear down and re-mount this screen, so
-        pairing removal with it would silently stop live updates while
+        listener add/remove must be symmetric with the mount/unmount
+        cycle, not the temporary suspend/resume pair a screen gets while
+        merely covered by another screen on the stack (suspend does not
+        tear down this screen, so pairing removal with it would silently
+        stop live updates while
         still fully composed and, per the plan brief, still able to
         resume). The registry itself is a plain in-memory object owned by
         the app, not this screen, and can keep firing mutations long after
@@ -663,6 +660,23 @@ class LibraryScreen(BaseAppScreen):
         registry = self._library_ingest_registry()
         if registry is not None:
             registry.remove_listener(self._handle_library_ingest_registry_changed)
+
+    async def flush_pending_work(self) -> bool:
+        """Persist pending note edits before the app navigates away.
+
+        The app awaits this from ``handle_screen_navigation`` before
+        discarding this screen instance -- without it, a note edit whose
+        debounced autosave has not fired yet (the timer re-arms on every
+        keystroke) would be destroyed with the screen when the user switches
+        tabs mid-edit.
+
+        Returns:
+            False when the flush surfaced an unresolved save conflict (the
+            navigation is vetoed so the user can resolve the banner),
+            True otherwise.
+        """
+        await self._flush_library_note_save()
+        return self._library_note_autosave_state != "conflict"
 
     def apply_navigation_context(self, context: Mapping[str, Any]) -> None:
         """Apply route context supplied by shell navigation.
@@ -685,10 +699,9 @@ class LibraryScreen(BaseAppScreen):
         if not isinstance(context, Mapping):
             return
         if self.is_mounted and self._library_note_dirty:
-            # A cached, already-mounted Library screen can still hold a dirty
-            # note editor: _get_or_create_navigation_screen hands back the same
-            # instance, so a palette "new note"/note_id deep link fired mid-edit
-            # runs this on a live editor. Applying it synchronously would
+            # Defense in depth for direct callers: navigation always
+            # composes a fresh (unmounted) screen, but a future palette
+            # shortcut could invoke this on a live, mounted editor mid-edit. Applying it synchronously would
             # recompose the canvas out from under the pending debounced
             # autosave, destroying the #library-note-body it reads and dropping
             # the last edits. Flush first (awaited, off this sync nav path),
@@ -761,8 +774,8 @@ class LibraryScreen(BaseAppScreen):
             # flush of a dirty editor is handled upstream by
             # apply_navigation_context's mounted dirty-editor branch; here we
             # only apply the selection the recompose reads. Reset the note
-            # editor state FIRST (a cached, already-mounted screen re-entered
-            # via this deep link can still hold a previously opened note's
+            # editor state FIRST (a mounted screen re-entered via this
+            # deep link can still hold a previously opened note's
             # id/detail/version) then re-assert the create-note target state
             # AFTER, since the reset flips _library_notes_view back to
             # "list" -- same reset-then-set ordering as

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -635,6 +635,27 @@ class LibraryScreen(BaseAppScreen):
                 exclusive=True,
                 group="library_note_detail",
             )
+        if (
+            self._library_media_view == "viewer"
+            and self._selected_media_id
+            and self._library_media_detail is None
+        ):
+            # Cross-visit state restore (``restore_state``) sets the media
+            # viewer's selection/view attrs before mount the same way a
+            # note_id nav-context deep-link does above, but -- unlike that
+            # case -- nothing else pre-mount kicks off the detail fetch:
+            # ``handle_library_media_row`` (the only other caller of
+            # ``_refresh_library_media_detail``) only runs from a live row
+            # click. Without this, a restored viewer would render its
+            # "Loading media…" placeholder forever. Deleted-record safety
+            # mirrors the note case: ``_refresh_library_media_detail``
+            # notifies and falls back to the list view when the id no
+            # longer resolves.
+            self.run_worker(
+                self._refresh_library_media_detail(self._selected_media_id),
+                exclusive=True,
+                group="library_media_detail",
+            )
 
     def on_unmount(self) -> None:
         """Unregister the ingest registry listener registered in ``on_mount``.
@@ -660,6 +681,105 @@ class LibraryScreen(BaseAppScreen):
         registry = self._library_ingest_registry()
         if registry is not None:
             registry.remove_listener(self._handle_library_ingest_registry_changed)
+
+    def save_state(self) -> dict[str, Any]:
+        """Persist Library selection/view state for the next visit.
+
+        Only SELECTION and VIEW state is captured -- never bulk fetched
+        snapshots (``_local_source_records`` and friends re-fetch fresh on
+        the next mount's ``_refresh_local_source_snapshot``, and a restored
+        id may be stale by then) or note editor text (``flush_pending_work``
+        has already persisted any dirty edit to the DB before the app calls
+        this). The ingest form/queue, rail collapse preferences, and search
+        history are deliberately excluded here: they are already persisted
+        elsewhere (the app-owned ingest job registry and the CLI config,
+        respectively) and re-seeding them from this in-memory dict would
+        fight those owners. The RAG results tuple (and its paired retrieval
+        status / recovery state, set together by
+        ``_apply_library_rag_search_outcome``) are safe to carry verbatim
+        because their rows are frozen dataclasses -- copies are taken below
+        only to avoid aliasing a live mutable set with the stashed dict.
+        """
+        state = super().save_state()
+        state["library_selected_row_id"] = self._library_selected_row_id
+        state["selected_conversation_id"] = self._selected_conversation_id
+        state["selected_note_id"] = self._selected_note_id
+        state["library_notes_view"] = self._library_notes_view
+        state["selected_media_id"] = self._selected_media_id
+        state["library_media_view"] = self._library_media_view
+        state["library_rag_query"] = self._library_rag_query
+        state["library_rag_mode"] = self._library_rag_mode
+        state["library_rag_scope_deselected"] = set(self._library_rag_scope_deselected)
+        state["library_rag_results"] = tuple(self._library_rag_results)
+        state["library_rag_selected_result_id"] = self._library_rag_selected_result_id
+        state["library_rag_retrieval_status"] = self._library_rag_retrieval_status
+        state["library_rag_recovery_state"] = self._library_rag_recovery_state
+        return state
+
+    def restore_state(self, state: dict[str, Any]) -> None:
+        """Restore Library selection/view state saved by ``save_state``.
+
+        The app calls this on a freshly-constructed, not-yet-mounted
+        instance BEFORE ``switch_screen`` mounts it, so these attrs are
+        exactly what ``on_mount`` and the first ``compose_content`` see.
+
+        Stale-id safety (the record was deleted or is otherwise gone by the
+        time the user comes back): the conversations and media LIST canvases
+        already fall back to the first displayed row when the restored id is
+        absent (``build_library_conversations_state`` /
+        ``build_library_media_state``); the notes-editor and media-viewer
+        deep-link fetches this triggers from ``on_mount`` notify the user and
+        fall back to the list view when the id no longer resolves
+        (``_refresh_library_note_detail`` / ``_refresh_library_media_detail``).
+        A restored ``editor``/``viewer`` view with no matching selected id
+        (should never happen, but a saved-state dict is not statically typed)
+        degrades to the list view below rather than rendering a permanent
+        loading placeholder.
+        """
+        super().restore_state(state)
+        if not isinstance(state, dict):
+            return
+
+        self._library_selected_row_id = str(state.get("library_selected_row_id") or "")
+        self._selected_conversation_id = str(state.get("selected_conversation_id") or "")
+
+        selected_note_id = str(state.get("selected_note_id") or "")
+        notes_view = str(state.get("library_notes_view") or "list")
+        if notes_view == "editor" and not selected_note_id:
+            notes_view = "list"
+        self._selected_note_id = selected_note_id
+        self._library_notes_view = notes_view
+
+        selected_media_id = str(state.get("selected_media_id") or "")
+        media_view = str(state.get("library_media_view") or "list")
+        if media_view == "viewer" and not selected_media_id:
+            media_view = "list"
+        self._selected_media_id = selected_media_id
+        self._library_media_view = media_view
+
+        self._library_rag_query = str(state.get("library_rag_query") or "")
+        rag_mode = state.get("library_rag_mode")
+        self._library_rag_mode = rag_mode if rag_mode in ("search", "rag") else "search"
+        scope_deselected = state.get("library_rag_scope_deselected")
+        self._library_rag_scope_deselected = (
+            set(scope_deselected)
+            if isinstance(scope_deselected, (set, frozenset, list, tuple))
+            else set()
+        )
+        rag_results = state.get("library_rag_results")
+        self._library_rag_results = (
+            tuple(rag_results) if isinstance(rag_results, (list, tuple)) else ()
+        )
+        self._library_rag_selected_result_id = str(
+            state.get("library_rag_selected_result_id") or ""
+        )
+        self._library_rag_retrieval_status = str(
+            state.get("library_rag_retrieval_status") or ""
+        )
+        recovery_state = state.get("library_rag_recovery_state")
+        self._library_rag_recovery_state = (
+            recovery_state if isinstance(recovery_state, DestinationRecoveryState) else None
+        )
 
     async def flush_pending_work(self) -> bool:
         """Persist pending note edits before the app navigates away.

--- a/tldw_chatbook/UI/Screens/media_screen.py
+++ b/tldw_chatbook/UI/Screens/media_screen.py
@@ -1,7 +1,8 @@
 """Media screen implementation."""
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
+from loguru import logger
 from textual.app import ComposeResult
 
 from ..Navigation.base_app_screen import BaseAppScreen
@@ -16,26 +17,88 @@ class MediaScreen(BaseAppScreen):
     """
     Media management screen wrapper.
     """
-    
+
     def __init__(self, app_instance: 'TldwCli', **kwargs):
         super().__init__(app_instance, "media", **kwargs)
         self.media_window = None
         self.media_runtime_state: MediaRuntimeState = app_instance.media_runtime_state
-    
+        # Stashed by restore_state on this (pre-mount) instance; applied to
+        # the freshly composed MediaWindow once it exists (see on_mount).
+        # MediaWindow itself is rebuilt fresh every visit -- there is no
+        # earlier seam to inject restored view state into before it mounts.
+        self._pending_media_restore: Optional[Dict[str, Any]] = None
+
     def compose_content(self) -> ComposeResult:
         """Compose the media window content."""
         self.media_window = MediaWindow(self.app_instance, classes="window")
         self.media_window.runtime_state = self.media_runtime_state
         # Yield the window widget directly
         yield self.media_window
-    
-    def save_state(self):
-        """Save media window state."""
+
+    def on_mount(self) -> None:
+        super().on_mount()
+        if self._pending_media_restore and self.media_window is not None:
+            # Nothing else seeds MediaWindow's active_media_type on a fresh
+            # visit under screen navigation (the legacy watch_current_tab ->
+            # activate_initial_view path is a deliberate no-op once
+            # ``_use_screen_navigation`` is set -- see its own early return),
+            # so this is the only place a returning visit's type/search/
+            # selection gets re-applied.
+            try:
+                self.media_window.apply_restored_view_state(self._pending_media_restore)
+            except Exception:
+                logger.opt(exception=True).error("Error applying restored Media view state")
+            self._pending_media_restore = None
+
+    def save_state(self) -> Dict[str, Any]:
+        """Save the Media window's user-facing view state.
+
+        Reads live values off the mounted window rather than duplicating
+        them in screen-level attrs, so this can never drift from what the
+        user is actually looking at. Every read is individually guarded --
+        this must never raise, since the app calls it unconditionally while
+        navigating away.
+        """
         state = super().save_state()
-        # Add any media-specific state here
+        window = self.media_window
+        if window is None:
+            return state
+
+        try:
+            state["media_active_type"] = window.active_media_type
+        except Exception:
+            logger.opt(exception=True).debug("Could not read Media active_media_type for save_state")
+        try:
+            state["media_selected_id"] = window.selected_media_id
+        except Exception:
+            logger.opt(exception=True).debug("Could not read Media selected_media_id for save_state")
+
+        search_panel = getattr(window, "search_panel", None)
+        if search_panel is not None:
+            try:
+                state["media_search_term"] = search_panel.search_term
+            except Exception:
+                logger.opt(exception=True).debug("Could not read Media search_term for save_state")
+            try:
+                state["media_keyword_filter"] = search_panel.keyword_filter
+            except Exception:
+                logger.opt(exception=True).debug("Could not read Media keyword_filter for save_state")
         return state
-    
-    def restore_state(self, state):
-        """Restore media window state."""
+
+    def restore_state(self, state: Dict[str, Any]) -> None:
+        """Stash restored Media view state for ``on_mount`` to apply.
+
+        Called on a freshly-constructed, not-yet-mounted screen -- the
+        MediaWindow it will compose does not exist yet, so the values are
+        held here and handed to ``MediaWindow.apply_restored_view_state``
+        once ``compose_content``/``on_mount`` have run.
+        """
         super().restore_state(state)
-        # Restore any media-specific state here
+        if not isinstance(state, dict):
+            return
+        self._pending_media_restore = {
+            "active_media_type": state.get("media_active_type"),
+            "selected_media_id": state.get("media_selected_id"),
+            "search_term": state.get("media_search_term"),
+            "keyword_filter": state.get("media_keyword_filter"),
+        }

--- a/tldw_chatbook/UI/Screens/search_screen.py
+++ b/tldw_chatbook/UI/Screens/search_screen.py
@@ -1,8 +1,10 @@
 """Search/RAG screen implementation."""
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
+from loguru import logger
 from textual.app import ComposeResult
+from textual.widgets import Input, Select, TabbedContent
 
 from ..Navigation.base_app_screen import BaseAppScreen
 from ..SearchRAGWindow import SearchRAGWindow
@@ -11,15 +13,28 @@ if TYPE_CHECKING:
     from tldw_chatbook.app import TldwCli
 
 
+# Static, compose-time-fixed option sets used to validate a restored value
+# before assigning it to a widget -- never trust a saved-state dict's shape,
+# and Select/TabbedContent raise on an out-of-range assignment rather than
+# tolerating one.
+_SEARCH_MODE_VALUES = {"plain", "contextual", "hybrid"}
+_SEARCH_TAB_IDS = {"search-tab", "saved-tab", "history-tab", "maintenance-tab"}
+
+
 class SearchScreen(BaseAppScreen):
     """
     Search/RAG screen wrapper.
     """
-    
+
     def __init__(self, app_instance: 'TldwCli', **kwargs):
         super().__init__(app_instance, "search", **kwargs)
         self.search_window = None
-    
+        # Stashed by restore_state on this (pre-mount) instance; applied to
+        # the freshly composed SearchRAGWindow once it exists (see
+        # on_mount). The window is rebuilt fresh every visit, so there is
+        # no earlier seam to inject restored state into before it mounts.
+        self._pending_search_restore: Optional[Dict[str, Any]] = None
+
     def compose_content(self) -> ComposeResult:
         """Compose the search window content."""
         self.search_window = SearchRAGWindow(self.app_instance)
@@ -27,14 +42,83 @@ class SearchScreen(BaseAppScreen):
         self.search_window.add_class("window")
         # Yield the window widget directly
         yield self.search_window
-    
-    def save_state(self):
-        """Save search window state."""
+
+    def on_mount(self) -> None:
+        super().on_mount()
+        if self._pending_search_restore and self.search_window is not None:
+            self._apply_pending_search_restore(self._pending_search_restore)
+            self._pending_search_restore = None
+
+    def _apply_pending_search_restore(self, restore: Dict[str, Any]) -> None:
+        """Apply a stashed restore dict to the now-mounted search window.
+
+        Mirrors ``SearchRAGWindow.handle_saved_search_load_requested``'s own
+        "apply a config to the live controls" pattern. Every assignment is
+        individually guarded so one bad/stale value (e.g. a saved-state dict
+        from a build that used different tab ids) can't abort the rest of
+        the restore or crash navigation.
+        """
+        window = self.search_window
+        query = restore.get("query")
+        if query:
+            try:
+                window.query_one("#search-query-input", Input).value = str(query)
+            except Exception:
+                logger.opt(exception=True).debug("Could not restore Search query input")
+
+        mode = restore.get("mode")
+        if mode in _SEARCH_MODE_VALUES:
+            try:
+                window.query_one("#search-mode-select", Select).value = mode
+            except Exception:
+                logger.opt(exception=True).debug("Could not restore Search mode select")
+
+        active_tab = restore.get("active_tab")
+        if active_tab in _SEARCH_TAB_IDS:
+            try:
+                window.query_one("#search-tabs", TabbedContent).active = active_tab
+            except Exception:
+                logger.opt(exception=True).debug("Could not restore Search active tab")
+
+    def save_state(self) -> Dict[str, Any]:
+        """Save the Search window's user-facing view state.
+
+        Reads live values off the mounted window; every read is
+        individually guarded so this can never raise -- the app calls it
+        unconditionally while navigating away.
+        """
         state = super().save_state()
-        # Add any search-specific state here
+        window = self.search_window
+        if window is None:
+            return state
+
+        try:
+            state["search_query"] = window.query_one("#search-query-input", Input).value
+        except Exception:
+            logger.opt(exception=True).debug("Could not read Search query input for save_state")
+        try:
+            state["search_mode"] = window.query_one("#search-mode-select", Select).value
+        except Exception:
+            logger.opt(exception=True).debug("Could not read Search mode select for save_state")
+        try:
+            state["search_active_tab"] = window.query_one("#search-tabs", TabbedContent).active
+        except Exception:
+            logger.opt(exception=True).debug("Could not read Search active tab for save_state")
         return state
-    
-    def restore_state(self, state):
-        """Restore search window state."""
+
+    def restore_state(self, state: Dict[str, Any]) -> None:
+        """Stash restored Search view state for ``on_mount`` to apply.
+
+        Called on a freshly-constructed, not-yet-mounted screen -- the
+        SearchRAGWindow it will compose does not exist yet, so the values
+        are held here and handed to ``on_mount`` once ``compose_content``
+        has run.
+        """
         super().restore_state(state)
-        # Restore any search-specific state here
+        if not isinstance(state, dict):
+            return
+        self._pending_search_restore = {
+            "query": state.get("search_query"),
+            "mode": state.get("search_mode"),
+            "active_tab": state.get("search_active_tab"),
+        }

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -4296,8 +4296,32 @@ class TldwCli(LibraryIngestQueueMixin, App[None]):  # Specify return type for ru
         screen_name, current_tab_value, screen_class = self._resolve_screen_navigation_target(requested_screen)
         logger.info(f"Navigating to screen: {requested_screen}")
 
-        # Save state of current screen before switching
         current_screen = self.screen
+
+        # Screens are never reused across navigations, so anything the
+        # outgoing screen has not persisted is destroyed with its instance.
+        # Give it one awaited chance to flush pending work (e.g. a Library
+        # note edit whose debounced autosave has not fired); False vetoes
+        # the switch, leaving the screen (and e.g. its save-conflict banner)
+        # in place for the user.
+        flush = getattr(current_screen, "flush_pending_work", None)
+        if callable(flush):
+            try:
+                flush_result = flush()
+                if inspect.isawaitable(flush_result):
+                    flush_result = await flush_result
+                if flush_result is False:
+                    logger.info(
+                        f"Navigation to {screen_name} vetoed by the outgoing "
+                        "screen's pending-work flush"
+                    )
+                    return
+            except Exception as e:
+                logger.opt(exception=True).error(
+                    f"Error flushing outgoing screen before navigation: {e}"
+                )
+
+        # Save state of current screen before switching
         if current_screen and hasattr(current_screen, 'save_state'):
             try:
                 state = current_screen.save_state()

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -367,14 +367,6 @@ SEARCH_NAV_WEB_SEARCH = "search-nav-web-search"
 SEARCH_NAV_EMBEDDINGS_CREATE = "search-nav-embeddings-create"
 SEARCH_NAV_EMBEDDINGS_MANAGE = "search-nav-embeddings-manage"
 
-CACHEABLE_SCREEN_ROUTES = {
-    TAB_CHAT,
-    TAB_LIBRARY,
-    TAB_MEDIA,
-    TAB_SEARCH,
-    TAB_SETTINGS,
-}
-
 DEFERRED_AUDIO_SERVICE_DELAY_SECONDS = 0.1
 DEFERRED_DB_SIZE_UPDATE_DELAY_SECONDS = 0.1
 DEFERRED_MEDIA_CLEANUP_DELAY_SECONDS = 5.0
@@ -2188,7 +2180,6 @@ class TldwCli(LibraryIngestQueueMixin, App[None]):  # Specify return type for ru
         
         # Tab switching optimization
         self._initialized_tabs = set()  # Track which tabs have been initialized
-        self._screen_cache: dict[str, Any] = {}
         
         # Reduce logging in production
         if not os.environ.get("TLDW_DEBUG"):
@@ -2506,7 +2497,6 @@ class TldwCli(LibraryIngestQueueMixin, App[None]):  # Specify return type for ru
             subview: The retired Notes tab's workspace subview. Accepted for
                 backward compatibility; no longer applied.
         """
-        self.invalidate_screen_cache()
         self.post_message(NavigateToScreen(TAB_LIBRARY, {LIBRARY_NAV_CONTEXT_MODE: "notes"}))
 
     def open_chat_with_handoff(
@@ -2731,20 +2721,9 @@ class TldwCli(LibraryIngestQueueMixin, App[None]):  # Specify return type for ru
                 # Home's ingest-jobs Running/Needs Attention rows one-hop
                 # back to the Library ingest canvas via the nav-context
                 # contract instead of a bare route (mirrors the
-                # subscriptions staging special-case above).
-                #
-                # Drop the cached Library screen first (mirrors
-                # ``open_notes_workspace``'s ``invalidate_screen_cache``):
-                # Library is a CACHEABLE route, so without this the deep
-                # link switches to the already-mounted-then-unmounted cached
-                # instance, which fails to repaint -- the app's screen stack
-                # advances to Library (logs confirm the switch) but the
-                # terminal keeps showing Home. Study (the flashcards deep
-                # link) never hit this because TAB_STUDY is not cacheable and
-                # always builds a fresh screen. Forcing a fresh Library
-                # screen restores the clean compose+mount+repaint that the
-                # ingest canvas landing depends on.
-                self.invalidate_screen_cache({TAB_LIBRARY})
+                # subscriptions staging special-case above). Navigation
+                # always composes a fresh Library screen, so the deep link
+                # lands on a cleanly mounted, repainted ingest canvas.
                 self.post_message(
                     NavigateToScreen("library", {LIBRARY_NAV_CONTEXT_INGEST: True})
                 )
@@ -3769,11 +3748,9 @@ class TldwCli(LibraryIngestQueueMixin, App[None]):  # Specify return type for ru
                 )
                 if callable(invalidate_for_server_switch):
                     invalidate_for_server_switch(previous_server_id, updated_state.active_server_id)
-                self.invalidate_screen_cache()
             else:
                 self.current_runtime_backend = normalized_backend
                 self.runtime_backend = normalized_backend
-                self.invalidate_screen_cache()
 
         resolved_backend = normalized_backend
         runtime_state = getattr(getattr(self, "runtime_policy", None), "state", None)
@@ -4262,40 +4239,21 @@ class TldwCli(LibraryIngestQueueMixin, App[None]):  # Specify return type for ru
         """Normalize navigation aliases to a routed screen id and canonical current_tab value."""
         return resolve_screen_target(target)
 
-    def invalidate_screen_cache(self, routes: set[str] | None = None) -> None:
-        """Clear cached destination screens after context changes."""
-        cache = getattr(self, "_screen_cache", None)
-        if not cache:
-            return
-        if routes is None:
-            cache.clear()
-            logger.debug("Cleared all cached destination screens")
-            return
-        for route in routes:
-            cache.pop(route, None)
-        logger.debug(f"Cleared cached destination screens: {sorted(routes)}")
+    def _create_navigation_screen(self, screen_name: str, screen_class: type):
+        """Build a FRESH screen instance for every navigation.
 
-    def _get_or_create_navigation_screen(self, screen_name: str, screen_class: type):
-        """Return a cached screen for allowlisted routes, otherwise build a fresh screen."""
-        if screen_name not in CACHEABLE_SCREEN_ROUTES:
-            return screen_class(self)
-
-        cache = getattr(self, "_screen_cache", None)
-        if cache is None:
-            cache = self._screen_cache = {}
-
-        cached_screen = cache.get(screen_name)
-        if cached_screen is not None:
-            try:
-                if cached_screen is self.screen:
-                    return screen_class(self)
-            except Exception:
-                pass
-            return cached_screen
-
-        new_screen = screen_class(self)
-        cache[screen_name] = new_screen
-        return new_screen
+        Screens must never be cached and re-mounted: ``switch_screen``
+        unmounts the outgoing screen, and re-mounting a previously-unmounted
+        instance races its still-in-flight teardown under rapid tab
+        switching -- child message pumps end up permanently stopped while
+        the widgets stay attached (``mounted=True``), the compositor keeps
+        presenting a stale frame, and every subsequent click is hit-tested
+        into the dead tree and silently swallowed: a total, exception-free
+        UI freeze (root-caused 2026-07-11). UX continuity across visits is
+        the job of ``_screen_states`` (``save_state``/``restore_state``),
+        not instance reuse.
+        """
+        return screen_class(self)
 
     def _valid_startup_route_ids(self) -> set[str]:
         """Return route ids allowed in startup config during the shell migration."""
@@ -4355,7 +4313,7 @@ class TldwCli(LibraryIngestQueueMixin, App[None]):  # Specify return type for ru
                 logger.error(f"Error saving screen state: {e}")
         
         if screen_class:
-            new_screen = self._get_or_create_navigation_screen(screen_name, screen_class)
+            new_screen = self._create_navigation_screen(screen_name, screen_class)
             
             # Restore state if available
             if hasattr(self, '_screen_states') and screen_name in self._screen_states:

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -4242,6 +4242,14 @@ class TldwCli(LibraryIngestQueueMixin, App[None]):  # Specify return type for ru
     def _create_navigation_screen(self, screen_name: str, screen_class: type):
         """Build a FRESH screen instance for every navigation.
 
+        Args:
+            screen_name: Routed screen id (used by callers for state keying;
+                unused here, kept for signature stability at the seam).
+            screen_class: The Screen subclass registered for the route.
+
+        Returns:
+            A newly constructed, never-mounted instance of ``screen_class``.
+
         Screens must never be cached and re-mounted: ``switch_screen``
         unmounts the outgoing screen, and re-mounting a previously-unmounted
         instance races its still-in-flight teardown under rapid tab
@@ -4317,9 +4325,21 @@ class TldwCli(LibraryIngestQueueMixin, App[None]):  # Specify return type for ru
                     )
                     return
             except Exception as e:
+                # Fail OPEN: a buggy flush must not permanently trap the
+                # user on this screen -- but the potential loss of pending
+                # work is surfaced, not silent.
                 logger.opt(exception=True).error(
-                    f"Error flushing outgoing screen before navigation: {e}"
+                    "Error flushing outgoing screen "
+                    f"{getattr(current_screen, 'screen_name', type(current_screen).__name__)!r} "
+                    f"before navigating to {screen_name!r}: {e}"
                 )
+                try:
+                    self.notify(
+                        "Couldn't save pending changes before switching screens.",
+                        severity="warning",
+                    )
+                except Exception:
+                    pass
 
         # Save state of current screen before switching
         if current_screen and hasattr(current_screen, 'save_state'):


### PR DESCRIPTION
## The bug

Rapidly switching tabs reliably and **permanently** froze the app: the display stuck on a stale frame, every click was silently swallowed, and it never recovered. No exception, no deadlock — live forensics on the frozen process (thread stacks, asyncio task stacks, and an app-object state dump via signal handlers) showed the event loop alive, all 125 tasks idle, queues empty… and **23 of 24 `MainNavigationBar` instances as zombies** (`mounted=True` with stopped message pumps), with the compositor presenting a screen that wasn't even active.

## Root cause (proven by intervention)

Navigation cached **Screen instances** for allowlisted routes (`CACHEABLE_SCREEN_ROUTES`: chat/library/media/search/settings) and re-mounted them — but `switch_screen` unmounts the outgoing screen, so the cache was re-mounting previously-unmounted widget trees, which Textual's lifecycle doesn't support. Under rapid switching, the re-mount raced the still-in-flight unmount (the app log's mount/unmount ordering visibly inverts at the exact wedge moment, always on a cached route), leaving dead pumps in an attached tree: clicks hit-tested into zombie widgets and vanished. Disabling the cache eliminated the freeze at an even harsher click rate; enabling it froze 2/2 runs. The L3b-era "cached screen never repaints" bug (patched then with `invalidate_screen_cache`) was the single-shot form of this same disease.

## The fix

- Every navigation composes a **fresh screen instance** (`_create_navigation_screen`); the instance cache, `CACHEABLE_SCREEN_ROUTES`, and `invalidate_screen_cache` + its four call sites (all symptom patches for this bug) are removed. Cross-visit continuity remains the job of the existing `_screen_states` save/restore.
- **Nav-away flush** (review finding): with instances no longer surviving, a Library note edit whose debounced autosave hadn't fired would be destroyed on tab switch. The app now awaits the outgoing screen's `flush_pending_work()` before switching and vetoes the switch on an unresolved save conflict — mirroring the in-canvas Back/rail flush contract.

## Verification

- **Regression tests, all RED-proven against the cached implementation:** fresh-instance semantics; a storm pilot whose zombie-widget census *deterministically reproduces* the old wedge in pytest; the app-level flush/veto protocol; a Library-side flush test persisting a mid-edit note.
- **Live:** 10 rounds × 8 tabs at 100ms over textual-serve — froze 2/2 runs before; navigates and repaints cleanly after.
- Suites: navigation/home/destination-shells/media-ingest/study/runtime-policy (448 passed) + library shell/home/library/content-hub/gate16 (664 passed) + touched suites re-run post-flush (251 passed); clean app import.

## Review

Opus review verdict "Ready for PR"; its unsaved-note-loss finding is fixed in this PR (flush seam). Follow-up implemented in this PR per user request: **real cross-visit state persistence for Library, Media, and Search** (fed3662f) — selection, view, and search state survive tab switches through the in-memory _screen_states save/restore (never bulk fetched data; stale restored ids degrade to the existing unavailable-item fallbacks; RED-verified round-trip pilots drive the real navigation path per screen; second opus review: zero defects). Settings keeps its stub by user decision. Remaining logged follow-ups: Library notes sort/filter + conversations query + media type filter persistence (never persisted before), richer Media restore (row highlight/viewer detail), and Library repeat-visit snapshot-fetch cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the permanent freeze from rapid tab switching by always creating fresh screens, and adds a safe nav-away flush so edits aren’t lost. Also restores cross-visit state for Library, Media, and Search.

- **Bug Fixes**
  - Never re-mount cached screens: removed `CACHEABLE_SCREEN_ROUTES`, `_screen_cache`, and `invalidate_screen_cache`; `_create_navigation_screen` now always returns a fresh instance. Added a storm test that catches zombie widgets and verifies responsiveness.
  - Nav-away flush: `handle_screen_navigation` awaits the outgoing screen’s `flush_pending_work()` and vetoes the switch whenever unsaved edits survive the flush (conflict or failed save). Flush exceptions fail open but trigger a warning notify.
  - `LibraryScreen.flush_pending_work()` persists dirty notes and reports conflicts/failures; tests cover save, veto, and mid-edit cases.

- **New Features**
  - Cross-visit state persistence (`save_state`/`restore_state`):
    - Library: rail selection; conversation/note/media selection + editor/viewer modes; Search/RAG state. `on_mount` fetches media detail for a restored viewer; stale ids fall back to list with a notify.
    - Media: restores type filter, search term, keyword filter, and selection on mount via `MediaWindow.apply_restored_view_state`.
    - Search: restores query input, mode, and active tab with validation against known options. Round-trip tests drive real navigation and validate restored UI state.

<sup>Written for commit 18dd180082700a4640085bc7b22a46213b3bd1f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

