### PR TITLE
fix(home,chatbooks): correctness follow-up batch (tasks 152,153,156)

### DIFF
--- a/Docs/superpowers/plans/2026-07-11-followups-correctness.md
+++ b/Docs/superpowers/plans/2026-07-11-followups-correctness.md
@@ -1,0 +1,40 @@
+# Follow-ups correctness batch — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Three correctness follow-ups (backlog 152, 153, 156). Branch `claude/followups-correctness` off dev cedd2223. Anchors exact at branch point; grep symbols, lines drift.
+
+**Goal:** Fix three correctness defects: Home Retry requeues the wrong item, recent-only Home items can't be opened, and the chatbook registry write is a lost-update race.
+
+**Global Constraints:** explicit-path staging (NEVER `git add -A`); Fable 5 co-author line; RED-first; parameterized SQL only; venv pytest with isolated HOME. Test command: `HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest <files> -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread`.
+
+## Cluster A — Home dashboard controls (152 + 153)
+
+**Root cause (152), already traced:** the rendered Home canvas buttons come from the SELECTION-SCOPED controls (`build_home_triage_state(..., selected_row_id=...)` → `triage.canvas.actions`, built via `build_home_controls(state, selected_item=<selected>)`), which already set `home-retry.target_id` to the SELECTED failed item (dashboard_state.py:353-360, the `selected_item_is_failed` override). But `home_screen.py::_activate_home_control` (~:363) dispatches by looking the pressed control up in `self._current_dashboard.controls` — the UNSCOPED `summarize_home_dashboard(...)` result, whose `home-retry.target_id` is `_first_item_for_status(...)` (the FIRST failed item). So Retry always requeues the first failed item, not the selected one.
+
+### T152 — dispatch from the scoped canvas controls
+**Files:** Modify `tldw_chatbook/UI/Screens/home_screen.py` (store the scoped controls at the two `build_home_triage_state` sites ~:153/:299; `_activate_home_control` ~:363). Test: `Tests/UI/test_home_screen.py`.
+- Store the scoped canvas controls on the screen whenever the triage is (re)built — e.g. `self._current_canvas_controls: tuple[HomeControl, ...] = triage.canvas.actions` alongside the existing `self._current_dashboard` assignment (both refresh sites). Init it `()` in `__init__`.
+- In `_activate_home_control`, resolve the pressed control from `self._current_canvas_controls` FIRST (the scoped set the user actually sees/pressed), falling back to `self._current_dashboard.controls` only when not found there (defensive; count-only fallback canvases have no selected item and their controls live in both). Everything downstream (`method(**kwargs)` with `target_id`) is unchanged — the scoped control simply carries the correct `target_id`.
+- RED pilot: build a Home with 2+ retryable failed items, select the SECOND, press its rendered `#home-retry`, assert `app.retry_active_home_item` was called with the SECOND item's `target_id` (not the first). Verify it fails against the current unscoped dispatch. Mirror the existing home_screen pilots' harness (real HomeHarness / RecordingHomeActiveWorkAdapter, bounded pauses).
+
+### T153 — recent-only selected item gets an open control
+**Files:** Modify `tldw_chatbook/Home/dashboard_state.py` (`build_home_controls` ~:376-460, the `home-open-details` emission block). Test: `Tests/Home/test_dashboard_state.py`.
+- Today `home-open-details` is emitted only inside the `if _pending_approval_count(state) or _active/_running/_paused/_failed count` block, so a selected RECENT-ONLY item (a done import, a chatbook artifact — present only in `recent_work_items`, bumping no active count) gets NO open control on its canvas.
+- Fix: when `selected_item is not None` AND no `home-open-details` control was emitted by the count-driven block AND the selected item is not already covered, append a `home-open-details` HomeControl targeting the selected item (`target_route=selected_item.detail_route`, `target_id=selected_item.item_id`, `applies_to="work_details"` — match the existing open-details control's shape; read it in the count-driven block). Keep the count-driven open-details path unchanged for active items. Guard against a double `home-open-details` (only add when absent).
+- The dispatch method `open_active_home_item_details` already accepts a `local:ingest:*`/recent id (verified in F1b review — recent path routes through the same handler), so AC#2 (no crash) holds; add a light assertion in the pilot that invoking it for a recent item doesn't raise.
+- RED unit: a Home input whose ONLY selectable item is a recent-only item (empty active/failed counts, one `recent_work_items` entry) selected → its canvas controls include `home-open-details` targeting that item. Verify it fails today (no open control).
+
+**Cluster A commit:** `fix(home): Retry requeues the selected failed item; recent-only items get an open control (152,153)`
+
+## Cluster B — chatbook registry write race (156)
+
+### T156 — serialize the registry read-modify-write
+**Files:** Modify `tldw_chatbook/Chatbooks/local_chatbook_service.py` (`__init__` :22; every load→mutate→`_save_registry` region: `create_chatbook` :173, and the update/delete methods around :160-223). Test: `Tests/Chatbooks/` (add a concurrency test).
+- Concurrency is across OS threads (the export worker calls these via `asyncio.run` on a `@work(thread=True)` worker; a second overlapping export runs on another thread — the disclosed by-design path). `_load_registry`→mutate→`_save_registry` with no lock can lose-update a record or collide on `next_id`.
+- Add `self._registry_lock = threading.Lock()` in `__init__` (import `threading`). Wrap EACH read-modify-write region (create/update/delete — every method that calls `_save_registry`) in `with self._registry_lock:` covering the `_load_registry()` through `_save_registry()` span so the whole RMW is atomic. Pure reads (`list_chatbooks`, `_find_record`-only) need no lock. `_save_registry` already uses `atomic_write_json` (keeps the file valid) — the lock closes the lost-update window.
+- RED test: spawn N threads (e.g. 20) each calling `create_chatbook` concurrently against one service instance (real temp registry path); after `join`, assert the registry has exactly N records and N distinct `chatbook_id`s (no lost updates, no id collision). Verify it fails without the lock (flaky-fails; run it a few times or with enough threads to force the race — document the pre-fix failure).
+
+**Cluster B commit:** `fix(chatbooks): serialize the registry read-modify-write against concurrent exports (156)`
+
+## Verification & gate
+
+Combined gate: `Tests/Home/ Tests/UI/test_home_screen.py Tests/Chatbooks/ Tests/Library/` + `python -c "import tldw_chatbook.app"`. Visual QA: only 153 adds a visible control — capture the Home canvas with a recent-only item selected showing its open control (cheap, served TUI). Present with the PR. Mark backlog 152/153/156 Done. PR to dev; merge only on explicit user authorization.

--- a/Tests/Chatbooks/test_local_chatbook_service_concurrency.py
+++ b/Tests/Chatbooks/test_local_chatbook_service_concurrency.py
@@ -1,0 +1,66 @@
+"""Concurrency regression coverage for the local chatbook registry read-modify-write.
+
+The registry file is a JSON document guarded (post-fix) by a single in-process
+lock on ``LocalChatbookService``. Without the lock, two overlapping exports
+running on separate OS threads (the real-world path: the F4 export worker
+calls ``asyncio.run(service.export_chatbook(...))`` inside
+``@work(thread=True)``) can interleave their
+``_load_registry()`` -> mutate -> ``_save_registry()`` sequence and lose a
+record or collide on ``next_id``.
+
+This test drives the service the way production code does: one shared
+``LocalChatbookService`` instance, many OS threads, each thread running
+``asyncio.run(service.create_chatbook(...))`` against its own fresh event
+loop (mirroring ``library_screen.py``'s worker-thread ``asyncio.run`` calls).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+from tldw_chatbook.Chatbooks import LocalChatbookService
+
+THREAD_COUNT = 20
+
+
+def test_concurrent_create_chatbook_preserves_all_records_and_unique_ids(tmp_path):
+    registry_path = tmp_path / "chatbooks.json"
+    service = LocalChatbookService(db_paths={}, registry_path=registry_path)
+
+    errors: list[BaseException] = []
+    barrier = threading.Barrier(THREAD_COUNT)
+
+    def worker(index: int) -> None:
+        try:
+            barrier.wait()  # maximize overlap so the race actually fires
+            asyncio.run(
+                service.create_chatbook(
+                    name=f"Concurrent Pack {index}",
+                    description="created from a worker thread",
+                )
+            )
+        except BaseException as exc:  # noqa: BLE001 - surface every failure to the main thread
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(THREAD_COUNT)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+
+    assert not errors, f"worker thread(s) raised: {errors}"
+
+    registry = service._load_registry()
+    records = registry["records"]
+
+    assert len(records) == THREAD_COUNT, (
+        f"expected {THREAD_COUNT} records, found {len(records)} "
+        "(a lost update dropped a record written by an overlapping thread)"
+    )
+
+    chatbook_ids = [record["chatbook_id"] for record in records]
+    assert len(set(chatbook_ids)) == THREAD_COUNT, (
+        f"expected {THREAD_COUNT} distinct chatbook_id values, found "
+        f"{len(set(chatbook_ids))} (next_id collided across overlapping writers)"
+    )

--- a/Tests/Chatbooks/test_local_chatbook_service_concurrency.py
+++ b/Tests/Chatbooks/test_local_chatbook_service_concurrency.py
@@ -25,6 +25,13 @@ THREAD_COUNT = 20
 
 
 def test_concurrent_create_chatbook_preserves_all_records_and_unique_ids(tmp_path):
+    """Concurrent create_chatbook calls must not lose records or collide on next_id.
+
+    Spawns ``THREAD_COUNT`` OS threads that each call ``create_chatbook`` on
+    one shared service, synchronized on a barrier to force interleaving, and
+    asserts the registry ends with exactly ``THREAD_COUNT`` records and that
+    many distinct ``chatbook_id``s. Fails without the read-modify-write lock.
+    """
     registry_path = tmp_path / "chatbooks.json"
     service = LocalChatbookService(db_paths={}, registry_path=registry_path)
 
@@ -48,6 +55,11 @@ def test_concurrent_create_chatbook_preserves_all_records_and_unique_ids(tmp_pat
         thread.start()
     for thread in threads:
         thread.join(timeout=30)
+
+    # A thread still alive after join() means it hung (e.g. a deadlock on the
+    # registry lock) -- fail loudly rather than reading a half-written registry.
+    stuck = [t.name for t in threads if t.is_alive()]
+    assert not stuck, f"worker thread(s) did not terminate within 30s: {stuck}"
 
     assert not errors, f"worker thread(s) raised: {errors}"
 

--- a/Tests/Home/test_dashboard_state.py
+++ b/Tests/Home/test_dashboard_state.py
@@ -726,6 +726,36 @@ def test_build_home_controls_selected_recent_only_item_gets_open_details():
     assert controls_by_id["home-open-details"].applies_to == "work_details"
 
 
+def test_build_home_controls_open_details_targets_selected_failed_item_not_first():
+    """PR #600 review (Gemini): the count-driven ``home-open-details`` must
+    target the SELECTED item, not whichever ``choose_home_selected_item``
+    ranks first. With 2+ failed items, selecting the second and opening its
+    details must open the second's details -- the same selected-item scoping
+    Retry/Pause already have.
+    """
+    first = HomeActiveWorkItem(
+        item_id="fail-1", title="first", source="Runs", status="failed",
+        detail_route="chat",
+    )
+    second = HomeActiveWorkItem(
+        item_id="fail-2", title="second", source="Runs", status="failed",
+        detail_route="chat",
+    )
+    state = HomeDashboardInput(
+        model_ready=True,
+        failed_run_count=2,
+        active_work_items=(first, second),
+    )
+
+    controls = build_home_controls(
+        state, selected_row_id=second.item_id, selected_item=second
+    )
+
+    controls_by_id = {c.control_id: c for c in controls}
+    assert "home-open-details" in controls_by_id
+    assert controls_by_id["home-open-details"].target_id == second.item_id
+
+
 def test_triage_selecting_recent_only_row_builds_canvas_with_open_details():
     """Same defect as above, exercised through the full triage builder (the
     real production path: ``build_home_triage_state`` resolves the selected

--- a/Tests/Home/test_dashboard_state.py
+++ b/Tests/Home/test_dashboard_state.py
@@ -695,6 +695,95 @@ def test_build_home_controls_without_selected_item_keeps_default_retry_behavior(
     assert any(c.control_id == "home-retry" for c in controls)
 
 
+def test_build_home_controls_selected_recent_only_item_gets_open_details():
+    """T153: a selected item that lives ONLY in ``recent_work_items`` (a
+    finished import, a chatbook artifact) bumps no active/failed/running/
+    paused count, so the count-driven block that emits ``home-open-details``
+    is skipped entirely -- before the fix, this leaves the selected item
+    with no control to open it at all.
+    """
+    recent_item = HomeActiveWorkItem(
+        item_id="local:ingest:done-1",
+        title="report.pdf",
+        source="Library",
+        status="done",
+        detail_route="library",
+    )
+    state = HomeDashboardInput(
+        model_ready=True,
+        has_library_content=True,
+        recent_work_items=(recent_item,),
+    )
+
+    controls = build_home_controls(
+        state, selected_row_id=recent_item.item_id, selected_item=recent_item
+    )
+
+    controls_by_id = {c.control_id: c for c in controls}
+    assert "home-open-details" in controls_by_id
+    assert controls_by_id["home-open-details"].target_id == recent_item.item_id
+    assert controls_by_id["home-open-details"].target_route == recent_item.detail_route
+    assert controls_by_id["home-open-details"].applies_to == "work_details"
+
+
+def test_triage_selecting_recent_only_row_builds_canvas_with_open_details():
+    """Same defect as above, exercised through the full triage builder (the
+    real production path: ``build_home_triage_state`` resolves the selected
+    row's backing item from ``active_work_items + recent_work_items`` and
+    threads it into ``build_home_controls`` as ``selected_item``).
+    """
+    state = HomeDashboardInput(
+        model_ready=True,
+        has_library_content=True,
+        recent_work_items=(
+            HomeActiveWorkItem(
+                item_id="local:ingest:done-1",
+                title="report.pdf",
+                source="Library",
+                status="done",
+                detail_route="library",
+            ),
+        ),
+    )
+
+    triage = build_home_triage_state(
+        state, selected_row_id="local:ingest:done-1", now=_NOW
+    )
+
+    controls_by_id = {c.control_id: c for c in triage.canvas.actions}
+    assert "home-open-details" in controls_by_id
+    assert controls_by_id["home-open-details"].target_id == "local:ingest:done-1"
+    assert controls_by_id["home-open-details"].target_route == "library"
+
+
+def test_build_home_controls_does_not_duplicate_open_details_for_active_selection():
+    """Guard against a double ``home-open-details``: when the selected item
+    is already covered by the count-driven block (a real active/failed
+    item), the recent-only fallback must not append a second control."""
+    state = HomeDashboardInput(
+        model_ready=True,
+        has_library_content=True,
+        active_work_items=(
+            HomeActiveWorkItem(
+                item_id="local:watchlist_run:5",
+                title="Daily security feed",
+                source="W+C",
+                status="failed",
+                detail_route="subscriptions",
+            ),
+        ),
+    )
+    selected = state.active_work_items[0]
+
+    controls = build_home_controls(
+        state, selected_row_id=selected.item_id, selected_item=selected
+    )
+
+    open_details_controls = [c for c in controls if c.control_id == "home-open-details"]
+    assert len(open_details_controls) == 1
+    assert open_details_controls[0].target_id == selected.item_id
+
+
 def test_canvas_primary_control_flips_between_failed_item_and_flashcards_row():
     """Selecting a different row moves primary emphasis with it (no button
     stays permanently accented) -- mirrors the live pilot: failed ingest

--- a/Tests/UI/test_home_screen.py
+++ b/Tests/UI/test_home_screen.py
@@ -1591,3 +1591,108 @@ async def test_home_retry_button_click_requeues_failed_ingest_job():
     # (L3b AB wave, B1) Retry supersedes the original failed job -- net job
     # count is unchanged (one hidden, one added).
     assert len(app.library_ingest_jobs.jobs()) == jobs_before
+
+
+@pytest.mark.asyncio
+async def test_home_retry_requeues_selected_failed_item_not_first():
+    """T152: with 2+ retryable failed items, Retry must requeue the
+    SELECTED failed item, not just the first failed item in the list.
+
+    ``build_home_controls`` already scopes ``home-retry.target_id`` to the
+    selected item (the ``selected_item_is_failed`` override), but
+    ``_activate_home_control`` was dispatching from the UNSCOPED
+    ``self._current_dashboard.controls`` (``summarize_home_dashboard(...)``
+    output, whose ``home-retry.target_id`` is always
+    ``_first_item_for_status`` -- the FIRST failed item) instead of the
+    selection-scoped ``triage.canvas.actions`` the user actually sees and
+    presses. Fixed by dispatching from the scoped canvas controls first.
+    """
+    app = _build_test_app()
+    app._home_dashboard_test_input = HomeDashboardInput(
+        model_ready=True,
+        has_library_content=True,
+        active_work_items=(
+            HomeActiveWorkItem(
+                item_id="local:watchlist_run:1",
+                title="First failed run",
+                source="W+C",
+                status="failed",
+                detail_route="subscriptions",
+            ),
+            HomeActiveWorkItem(
+                item_id="local:watchlist_run:2",
+                title="Second failed run",
+                source="W+C",
+                status="failed",
+                detail_route="subscriptions",
+            ),
+        ),
+    )
+    app.retry_active_home_item = Mock()
+    host = HomeHarness(app)
+
+    async with host.run_test(size=HOME_TEST_SIZE) as pilot:
+        await pilot.pause(HOME_MOUNT_PAUSE)
+        home = _active_home_screen(host)
+
+        # Select the SECOND failed item's rail row via a real press.
+        row_button = next(
+            btn for btn in home.query("Button")
+            if str(getattr(btn, "row_id", "")) == "local:watchlist_run:2"
+        )
+        await pilot.click(row_button)
+        await pilot.pause(HOME_MOUNT_PAUSE)
+
+        await pilot.click("#home-retry")
+        await pilot.pause(HOME_MOUNT_PAUSE)
+
+    app.retry_active_home_item.assert_called_once_with(
+        target_id="local:watchlist_run:2"
+    )
+
+
+@pytest.mark.asyncio
+async def test_home_recent_only_item_selection_gets_open_details_control():
+    """T153: a selected item that lives ONLY in ``recent_work_items`` (a
+    finished import, a chatbook artifact) bumps no active/failed/running/
+    paused count, so the canvas's count-driven ``home-open-details`` block
+    was skipped entirely -- selecting it left the item with no control to
+    open it at all. Also covers AC#2: pressing the real button for a
+    recent-only item must not raise (``open_active_home_item_details``
+    already accepts recent/ingest ids per the F1b review).
+    """
+    app = _build_test_app()
+    app._home_dashboard_test_input = HomeDashboardInput(
+        model_ready=True,
+        has_library_content=True,
+        recent_work_items=(
+            HomeActiveWorkItem(
+                item_id="local:ingest:done-1",
+                title="report.pdf",
+                source="Library",
+                status="done",
+                detail_route="library",
+            ),
+        ),
+    )
+    host = HomeHarness(app)
+
+    async with host.run_test(size=HOME_TEST_SIZE) as pilot:
+        await pilot.pause(HOME_MOUNT_PAUSE)
+        home = _active_home_screen(host)
+
+        row_button = next(
+            btn for btn in home.query("Button")
+            if str(getattr(btn, "row_id", "")) == "local:ingest:done-1"
+        )
+        await pilot.click(row_button)
+        await pilot.pause(HOME_MOUNT_PAUSE)
+
+        assert home.query_one("#home-open-details"), (
+            "recent-only selected item has no home-open-details control"
+        )
+
+        # AC#2: pressing it must not raise even though the item only ever
+        # lived in recent_work_items (never active/failed/running/paused).
+        await pilot.click("#home-open-details")
+        await pilot.pause(HOME_MOUNT_PAUSE)

--- a/backlog/tasks/task-152 - Home-Retry-targets-the-first-failed-item-not-the-selected-one.md
+++ b/backlog/tasks/task-152 - Home-Retry-targets-the-first-failed-item-not-the-selected-one.md
@@ -19,8 +19,8 @@ Home's Retry control dispatches through the unscoped summarize_home_dashboard co
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Pressing Retry on a selected failed Home item requeues THAT item
-- [ ] #2 Regression test with 2+ retryable failed items asserts the selected item is the one requeued
+- [x] #1 Pressing Retry on a selected failed Home item requeues THAT item
+- [x] #2 Regression test with 2+ retryable failed items asserts the selected item is the one requeued
 <!-- AC:END -->
 
 ## Implementation Notes

--- a/backlog/tasks/task-152 - Home-Retry-targets-the-first-failed-item-not-the-selected-one.md
+++ b/backlog/tasks/task-152 - Home-Retry-targets-the-first-failed-item-not-the-selected-one.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-152
 title: 'Home Retry targets the first failed item, not the selected one'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-11 22:01'
+updated_date: '2026-07-12 01:08'
 labels:
   - follow-up
   - home
@@ -21,3 +22,9 @@ Home's Retry control dispatches through the unscoped summarize_home_dashboard co
 - [ ] #1 Pressing Retry on a selected failed Home item requeues THAT item
 - [ ] #2 Regression test with 2+ retryable failed items asserts the selected item is the one requeued
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Fixed in the correctness batch (branch claude/followups-correctness). See Docs/superpowers/plans/2026-07-11-followups-correctness.md.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-153 - Recent-only-Home-items-have-no-per-item-open-control.md
+++ b/backlog/tasks/task-153 - Recent-only-Home-items-have-no-per-item-open-control.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-153
 title: Recent-only Home items have no per-item open control
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-11 22:01'
+updated_date: '2026-07-12 01:08'
 labels:
   - follow-up
   - home
@@ -21,3 +22,9 @@ A Home item that appears only in the Recent feed (e.g. a done Library import, a 
 - [ ] #1 A selected recent-only Home item exposes an open/details control on its canvas
 - [ ] #2 No crash when the control is invoked for a recent item
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Fixed in the correctness batch (branch claude/followups-correctness). See Docs/superpowers/plans/2026-07-11-followups-correctness.md.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-153 - Recent-only-Home-items-have-no-per-item-open-control.md
+++ b/backlog/tasks/task-153 - Recent-only-Home-items-have-no-per-item-open-control.md
@@ -19,8 +19,8 @@ A Home item that appears only in the Recent feed (e.g. a done Library import, a 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A selected recent-only Home item exposes an open/details control on its canvas
-- [ ] #2 No crash when the control is invoked for a recent item
+- [x] #1 A selected recent-only Home item exposes an open/details control on its canvas
+- [x] #2 No crash when the control is invoked for a recent item
 <!-- AC:END -->
 
 ## Implementation Notes

--- a/backlog/tasks/task-156 - LocalChatbookService.create_chatbook-registry-write-is-non-atomic.md
+++ b/backlog/tasks/task-156 - LocalChatbookService.create_chatbook-registry-write-is-non-atomic.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-156
 title: LocalChatbookService.create_chatbook registry write is non-atomic
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-11 22:01'
+updated_date: '2026-07-12 01:08'
 labels:
   - follow-up
   - chatbooks
@@ -21,3 +22,9 @@ create_chatbook does a read-modify-write of the chatbook registry with no lock. 
 - [ ] #1 Concurrent create_chatbook calls do not lose records or collide on next_id
 - [ ] #2 Serialization/locking added around the registry read-modify-write
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Fixed in the correctness batch (branch claude/followups-correctness). See Docs/superpowers/plans/2026-07-11-followups-correctness.md.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-156 - LocalChatbookService.create_chatbook-registry-write-is-non-atomic.md
+++ b/backlog/tasks/task-156 - LocalChatbookService.create_chatbook-registry-write-is-non-atomic.md
@@ -19,8 +19,8 @@ create_chatbook does a read-modify-write of the chatbook registry with no lock. 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Concurrent create_chatbook calls do not lose records or collide on next_id
-- [ ] #2 Serialization/locking added around the registry read-modify-write
+- [x] #1 Concurrent create_chatbook calls do not lose records or collide on next_id
+- [x] #2 Serialization/locking added around the registry read-modify-write
 <!-- AC:END -->
 
 ## Implementation Notes

--- a/tldw_chatbook/Chatbooks/local_chatbook_service.py
+++ b/tldw_chatbook/Chatbooks/local_chatbook_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import threading
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -22,6 +23,10 @@ class LocalChatbookService:
     def __init__(self, db_paths: dict[str, str] | None = None, *, registry_path: str | Path | None = None):
         self.db_paths = db_paths or {}
         self.registry_path = Path(registry_path).expanduser() if registry_path is not None else self._default_registry_path()
+        # Guards every load -> mutate -> save span against overlapping registry
+        # read-modify-writes from concurrent OS threads (e.g. two overlapping
+        # `asyncio.run(...)` exports on separate `@work(thread=True)` workers).
+        self._registry_lock = threading.Lock()
 
     def _default_registry_path(self) -> Path:
         for key in ("Prompts", "ChaChaNotes", "Media"):
@@ -181,60 +186,63 @@ class LocalChatbookService:
         metadata: dict[str, Any] | None = None,
         **extra: Any,
     ) -> dict[str, Any]:
-        registry = self._load_registry()
-        chatbook_id = int(registry["next_id"])
-        now = self._utc_now()
-        record = {
-            "id": str(chatbook_id),
-            "chatbook_id": chatbook_id,
-            "name": str(name),
-            "description": str(description or ""),
-            "file_path": str(file_path) if file_path is not None else None,
-            "tags": self._coerce_string_list(tags),
-            "categories": self._coerce_string_list(categories),
-            "metadata": self._coerce_metadata(metadata),
-            "created_at": now,
-            "updated_at": now,
-        }
-        if extra:
-            record["metadata"].update({key: value for key, value in extra.items() if value is not None})
-        registry["records"].append(record)
-        registry["next_id"] = chatbook_id + 1
-        self._save_registry(registry)
+        with self._registry_lock:
+            registry = self._load_registry()
+            chatbook_id = int(registry["next_id"])
+            now = self._utc_now()
+            record = {
+                "id": str(chatbook_id),
+                "chatbook_id": chatbook_id,
+                "name": str(name),
+                "description": str(description or ""),
+                "file_path": str(file_path) if file_path is not None else None,
+                "tags": self._coerce_string_list(tags),
+                "categories": self._coerce_string_list(categories),
+                "metadata": self._coerce_metadata(metadata),
+                "created_at": now,
+                "updated_at": now,
+            }
+            if extra:
+                record["metadata"].update({key: value for key, value in extra.items() if value is not None})
+            registry["records"].append(record)
+            registry["next_id"] = chatbook_id + 1
+            self._save_registry(registry)
         return self._record_copy(record)
 
     async def update_chatbook(self, chatbook_id: int | str, **fields: Any) -> dict[str, Any]:
-        registry = self._load_registry()
-        record = self._find_record(registry, chatbook_id)
-        if "name" in fields:
-            record["name"] = str(fields["name"])
-        if "description" in fields:
-            record["description"] = str(fields["description"] or "")
-        if "file_path" in fields:
-            file_path = fields["file_path"]
-            record["file_path"] = str(file_path) if file_path is not None else None
-        if "tags" in fields:
-            record["tags"] = self._coerce_string_list(fields["tags"])
-        if "categories" in fields:
-            record["categories"] = self._coerce_string_list(fields["categories"])
-        if "metadata" in fields:
-            record["metadata"] = self._coerce_metadata(fields["metadata"])
-        record["updated_at"] = self._utc_now()
-        self._save_registry(registry)
+        with self._registry_lock:
+            registry = self._load_registry()
+            record = self._find_record(registry, chatbook_id)
+            if "name" in fields:
+                record["name"] = str(fields["name"])
+            if "description" in fields:
+                record["description"] = str(fields["description"] or "")
+            if "file_path" in fields:
+                file_path = fields["file_path"]
+                record["file_path"] = str(file_path) if file_path is not None else None
+            if "tags" in fields:
+                record["tags"] = self._coerce_string_list(fields["tags"])
+            if "categories" in fields:
+                record["categories"] = self._coerce_string_list(fields["categories"])
+            if "metadata" in fields:
+                record["metadata"] = self._coerce_metadata(fields["metadata"])
+            record["updated_at"] = self._utc_now()
+            self._save_registry(registry)
         return self._record_copy(record)
 
     async def delete_chatbook(self, chatbook_id: int | str) -> bool:
-        registry = self._load_registry()
-        wanted = str(chatbook_id)
-        remaining = [
-            record
-            for record in registry["records"]
-            if str(record.get("chatbook_id")) != wanted and str(record.get("id")) != wanted
-        ]
-        if len(remaining) == len(registry["records"]):
-            raise KeyError(f"Local chatbook not found: {chatbook_id}")
-        registry["records"] = remaining
-        self._save_registry(registry)
+        with self._registry_lock:
+            registry = self._load_registry()
+            wanted = str(chatbook_id)
+            remaining = [
+                record
+                for record in registry["records"]
+                if str(record.get("chatbook_id")) != wanted and str(record.get("id")) != wanted
+            ]
+            if len(remaining) == len(registry["records"]):
+                raise KeyError(f"Local chatbook not found: {chatbook_id}")
+            registry["records"] = remaining
+            self._save_registry(registry)
         return True
 
     async def export_chatbook(self, request_data: Any) -> dict[str, Any]:

--- a/tldw_chatbook/Home/dashboard_state.py
+++ b/tldw_chatbook/Home/dashboard_state.py
@@ -374,7 +374,16 @@ def build_home_controls(
     # fallback) Pause keeps its unconditional-when-running behavior.
     selected_item_is_ingest_job = selected_item_is_running and _is_local_ingest_item(selected_item)
     chatbook_item = _first_chatbook_artifact_item(state)
-    detail_item = choose_home_selected_item(state)
+    # When a real item is selected, its details/console controls target THAT
+    # item -- mirroring the selected_item overrides for Retry/Pause above (PR
+    # #600 review). Without this, "Open details" (and "Open in Console")
+    # pointed at whichever item ``choose_home_selected_item`` ranks first
+    # (approval > failed > running > ...), so selecting a non-first failed
+    # item and pressing Open details opened the first item's details while the
+    # canvas showed the second. The no-selection callers (summarize_home_
+    # dashboard, the triage builder's count-only fallback) pass
+    # ``selected_item=None`` and keep today's first-in-priority behavior.
+    detail_item = selected_item if selected_item is not None else choose_home_selected_item(state)
 
     if _pending_approval_count(state):
         controls.extend(

--- a/tldw_chatbook/Home/dashboard_state.py
+++ b/tldw_chatbook/Home/dashboard_state.py
@@ -485,6 +485,26 @@ def build_home_controls(
                     chatbook_item.item_id,
                 )
             )
+    # T153: the block above only fires when some active/failed/running/
+    # paused/approval count is nonzero, so a selected RECENT-ONLY item (a
+    # done import, a chatbook artifact -- present only in
+    # ``state.recent_work_items``, bumping no active count) got no
+    # ``home-open-details`` control at all, even though it is the item the
+    # user actually selected. Append one, targeting the selected item,
+    # unless the count-driven block already covered it above (guards
+    # against a double ``home-open-details``).
+    if selected_item is not None and not any(
+        control.control_id == "home-open-details" for control in controls
+    ):
+        controls.append(
+            HomeControl(
+                "home-open-details",
+                "Open details",
+                selected_item.detail_route,
+                "work_details",
+                selected_item.item_id,
+            )
+        )
     if state.flashcards_due_count > 0 and (
         not selected_row_id or selected_row_id == HOME_FLASHCARDS_DUE_ROW_ID
     ):

--- a/tldw_chatbook/UI/Screens/home_screen.py
+++ b/tldw_chatbook/UI/Screens/home_screen.py
@@ -10,6 +10,7 @@ from textual.widgets import Button, Static
 
 from tldw_chatbook.config import get_cli_setting, save_setting_to_cli_config
 from tldw_chatbook.Home.dashboard_state import (
+    HomeControl,
     HomeDashboard,
     HomeDashboardInput,
     HomeTriageState,
@@ -92,6 +93,14 @@ class HomeScreen(BaseAppScreen):
         self._current_dashboard: HomeDashboard | None = None
         self._current_dashboard_input: HomeDashboardInput | None = None
         self._home_selected_row_id: str = ""
+        # T152: the scoped canvas controls the user actually sees/presses
+        # (``triage.canvas.actions``) -- kept alongside ``_current_dashboard``
+        # (the UNSCOPED ``summarize_home_dashboard`` controls) because only
+        # the scoped set carries a selection-aware ``target_id`` (e.g.
+        # ``home-retry`` pointed at the SELECTED failed item rather than
+        # just the first failed item in the list). See
+        # ``_activate_home_control``.
+        self._current_canvas_controls: tuple[HomeControl, ...] = ()
 
     def on_mount(self) -> None:
         super().on_mount()
@@ -154,9 +163,14 @@ class HomeScreen(BaseAppScreen):
             dashboard_input,
             selected_row_id=self._home_selected_row_id,
         )
-        # Keep the legacy dashboard object for the unchanged control dispatch.
+        # Keep the legacy dashboard object as the defensive fallback for
+        # control dispatch (count-only canvases with no selection have
+        # their controls in both); the scoped canvas controls
+        # (``_current_canvas_controls``) are what the user actually sees
+        # and presses, and are tried first in ``_activate_home_control``.
         self._current_dashboard = summarize_home_dashboard(dashboard_input)
         self._current_dashboard_input = dashboard_input
+        self._current_canvas_controls = triage.canvas.actions
         self._home_selected_row_id = triage.selected_row_id
 
         yield Static(
@@ -302,6 +316,7 @@ class HomeScreen(BaseAppScreen):
         )
         self._current_dashboard = summarize_home_dashboard(dashboard_input)
         self._current_dashboard_input = dashboard_input
+        self._current_canvas_controls = triage.canvas.actions
         self._home_selected_row_id = triage.selected_row_id
         try:
             self.query_one("#home-rail", HomeRail).sync_state(
@@ -364,7 +379,19 @@ class HomeScreen(BaseAppScreen):
         dashboard = self._current_dashboard
         if dashboard is None:
             return
-        control = next((item for item in dashboard.controls if item.control_id == button_id), None)
+        # T152: resolve from the SELECTION-SCOPED canvas controls first --
+        # the set the user actually sees and presses, whose target_id
+        # reflects the SELECTED item (e.g. home-retry pointed at the
+        # selected failed item, not just the first failed item in the
+        # list). Fall back to the unscoped dashboard controls only when
+        # the pressed control isn't there (defensive: count-only fallback
+        # canvases with no selection have their controls in both sets).
+        control = next(
+            (item for item in self._current_canvas_controls if item.control_id == button_id),
+            None,
+        )
+        if control is None:
+            control = next((item for item in dashboard.controls if item.control_id == button_id), None)
         if control is None:
             return
 


### PR DESCRIPTION
## Summary

Three correctness follow-ups from the backlog, each RED-first and independently reviewed.

## Fixes

- **152 — Home Retry requeued the wrong item.** The rendered Home canvas buttons come from the selection-scoped controls (which already set `home-retry`'s target to the selected failed item), but `_activate_home_control` dispatched from the *unscoped* `summarize_home_dashboard` controls, whose retry target is the *first* failed item. So with 2+ retryable failures, Retry always requeued the first one. Fixed: dispatch resolves the pressed control from the scoped canvas controls (fallback to unscoped). Pause inherits the same selected-item targeting as a bonus. RED pilot: select the second failed item, press Retry, assert the second's id is requeued.
- **153 — recent-only Home items had no open control.** `home-open-details` was only emitted from the count-driven block, so an item present only in the Recent feed (a done import, a chatbook artifact) got no open control on its canvas. Fixed: when a real item is selected and no open-details control was emitted, append one targeting it (guarded against duplicating the active-item path). The handler already accepts a recent/`local:ingest:*` id, so no crash. RED units + a UI pilot that presses the real button.
- **156 — chatbook registry write was a lost-update race.** `LocalChatbookService.create_chatbook`/`update`/`delete` did `_load_registry` → mutate → `_save_registry` with no lock; two overlapping exports (each on its own `asyncio.run` worker thread) could drop a record or collide on `next_id`. Fixed with a non-reentrant `threading.Lock` around each read-modify-write span (pure reads unlocked; `atomic_write_json` unchanged). RED concurrency test: 20 threads → exactly 20 records + 20 distinct ids; reviewer independently reproduced the pre-fix drop (1–2 of 20 survived) and confirmed no await-inside-lock / re-entrancy risk.

## Verification

- Combined gate: **678 passed, 1 skipped** (Home, home screen, Chatbooks, Library); clean import.
- Both clusters task-reviewed with zero findings; all RED claims reproduced by the reviewers (retry mis-target, missing open control, registry record loss).
- Backlog tasks 152/153/156 marked Done.
- Visual QA: 153 adds one button (Open details on a recent-only item's canvas) — covered by a UI pilot that presses it; a served-TUI capture wasn't landed (the scripted ingest-into-Recent flow hit the known modal/coordinate fragility), so this batch relies on the pilot for that surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix three correctness issues across Home and Chatbooks. Retry/Pause and Open Details/Console now act on the selected item; recent-only items get Open Details; and chatbook registry writes are serialized to prevent lost updates. Resolves tasks 152, 153, and 156.

- **Bug Fixes**
  - Home: Dispatch resolves pressed controls from the selection-scoped canvas first so Retry, Pause, Open details, and Open in Console target the selected item; recent-only selections also get “Open details” (no duplicates; supports recent/ingest IDs).
  - Chatbooks: Guard registry read-modify-write with a `threading.Lock` in `LocalChatbookService` for create/update/delete; adds a concurrency test that verifies unique IDs and asserts worker threads terminate to catch hangs.

<sup>Written for commit 69ad81ebf25c26a2a87b2315e22ebc385451d2d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

