### PR TITLE
fix: address PR #601 validation and docstring feedback

### DIFF
--- a/Tests/Library/test_library_local_rag_search_service.py
+++ b/Tests/Library/test_library_local_rag_search_service.py
@@ -183,6 +183,40 @@ async def test_notes_keyword_search_keeps_the_plain_query_unchanged():
     assert notes_service.calls[0]["query"] == 'operator "said'
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "query",
+    [
+        "<script>alert('unsafe')</script>",
+        "control\x00character",
+        "x" * 2_001,
+    ],
+)
+async def test_public_search_rejects_unsafe_query_before_source_calls(query):
+    notes_service = FakeNotesScopeService(rows=[])
+    service = LibraryLocalRagSearchService(
+        SimpleNamespace(notes_scope_service=notes_service)
+    )
+
+    with pytest.raises(ValueError, match="safe Library search query"):
+        await service.search(query, ("notes",), "search", top_k=5)
+
+    assert notes_service.calls == []
+
+
+@pytest.mark.asyncio
+async def test_public_search_rejects_unsafe_query_before_semantic_service_call():
+    rag_service = FakeRagService()
+    service = LibraryLocalRagSearchService(
+        SimpleNamespace(_rag_service=rag_service)
+    )
+
+    with pytest.raises(ValueError, match="safe Library search query"):
+        await service.search("<script>unsafe</script>", ("notes",), "rag", top_k=5)
+
+    assert rag_service.calls == []
+
+
 # (a) search mode returns note+media+conversation rows with correct source_id/provenance.
 @pytest.mark.asyncio
 async def test_search_mode_returns_rows_from_all_three_sources(conversations_db):

--- a/backlog/tasks/task-175 - Address-PR-601-review-feedback.md
+++ b/backlog/tasks/task-175 - Address-PR-601-review-feedback.md
@@ -1,0 +1,54 @@
+---
+id: TASK-175
+title: Address PR 601 review feedback
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-07-12 01:27'
+updated_date: '2026-07-12 01:32'
+labels:
+  - pr-review
+  - validation
+  - docs
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the actionable validation and documentation findings reported after rebasing PR 601 onto dev.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Library search validates queries through shared input validation before FTS or service calls.
+- [x] #2 New public Settings and CLI callables have complete Google-style docstrings.
+- [x] #3 Focused tests and static checks pass.
+- [x] #4 All PR 601 review feedback is answered and resolved.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+
+ADR path: N/A
+
+Reason: This is a boundary validation fix and documentation-only compliance update within existing interfaces.
+
+1. Add a failing service-boundary validation regression.
+2. Validate and reject unsafe Library queries with the shared helpers.
+3. Complete Google-style docstrings for Settings state and CLI entrypoints.
+4. Run focused verification, update task notes, and answer PR feedback.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added shared `sanitize_string` and `validate_text_input` enforcement at the public Library search boundary before keyword or semantic dispatch; unsafe, mutated, blank, and oversized queries fail closed.
+- Added regressions proving invalid queries never reach either the notes/FTS seams or the semantic RAG service.
+- Completed Google-style `Args`, `Returns`, and `Raises` sections for the reviewed Settings state, CLI entrypoint, and Library search callables.
+- Verified 23 Library search-service tests and 9 Settings/spawn tests; compileall and diff checks pass. Independent review reported no remaining findings.
+- Rebased PR #601 onto latest `dev`; the duplicate original fix commits were dropped because they already exist upstream.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Library/library_local_rag_search_service.py
+++ b/tldw_chatbook/Library/library_local_rag_search_service.py
@@ -9,8 +9,12 @@ from typing import Any
 from loguru import logger
 
 from tldw_chatbook.Library.library_rag_service import LibraryRagSearchOutcome
-from tldw_chatbook.Library.library_rag_state import LIBRARY_RAG_SERVICE_ERROR_SELECTOR
+from tldw_chatbook.Library.library_rag_state import (
+    LIBRARY_RAG_QUERY_MAX_LENGTH,
+    LIBRARY_RAG_SERVICE_ERROR_SELECTOR,
+)
 from tldw_chatbook.UI.destination_recovery import DestinationRecoveryState
+from tldw_chatbook.Utils.input_validation import sanitize_string, validate_text_input
 
 logger = logger.bind(module="LibraryLocalRagSearchService")
 
@@ -31,6 +35,35 @@ _SEMANTIC_SOURCE_TYPE_MAP = {
 def _plain_text_fts_query(query: str) -> str:
     """Quote whitespace-delimited terms for safe SQLite FTS MATCH input."""
     return " ".join('"' + term.replace('"', '""') + '"' for term in query.split())
+
+
+def _validated_query(query: str) -> str:
+    """Validate a user query before it reaches retrieval or FTS seams.
+
+    Args:
+        query: Raw Library search or RAG query.
+
+    Returns:
+        The unchanged query when it passes the shared input validators.
+
+    Raises:
+        ValueError: If the query is empty, oversized, contains stripped
+            control characters, or fails shared text-safety validation.
+    """
+    if not isinstance(query, str):
+        raise ValueError("Enter a safe Library search query.")
+    sanitized = sanitize_string(query, max_length=LIBRARY_RAG_QUERY_MAX_LENGTH)
+    if (
+        sanitized != query
+        or not sanitized.strip()
+        or not validate_text_input(
+            sanitized,
+            max_length=LIBRARY_RAG_QUERY_MAX_LENGTH,
+            allow_html=False,
+        )
+    ):
+        raise ValueError("Enter a safe Library search query.")
+    return sanitized
 
 
 class LibraryLocalRagSearchService:
@@ -63,7 +96,11 @@ class LibraryLocalRagSearchService:
             to normalize into evidence rows, or a `LibraryRagSearchOutcome`
             directly for blocked states (missing local seams, missing RAG
             runtime).
+
+        Raises:
+            ValueError: If `query` fails shared Library input validation.
         """
+        query = _validated_query(query)
         top_k = max(1, int(kwargs.get("top_k") or 5))
         if mode == "rag":
             return await self._search_semantic(query, scope, top_k, kwargs)

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -661,7 +661,11 @@ class SettingsScreen(BaseAppScreen):
         self.manual_sync_rows = self._manual_sync_loading_rows()
 
     def save_state(self) -> dict[str, object]:
-        """Save process-local Settings navigation and draft state."""
+        """Save process-local Settings navigation and draft state.
+
+        Returns:
+            A deep-copy-safe state mapping for a fresh Settings screen.
+        """
         state = super().save_state()
         if not isinstance(state, dict):
             state = {}
@@ -673,7 +677,11 @@ class SettingsScreen(BaseAppScreen):
         return state
 
     def restore_state(self, state: dict[str, object]) -> None:
-        """Restore validated process-local Settings state on a fresh screen."""
+        """Restore validated process-local Settings state on a fresh screen.
+
+        Args:
+            state: Previously saved Settings navigation and draft state.
+        """
         super().restore_state(state)
         if not isinstance(state, dict):
             return

--- a/tldw_chatbook/cli.py
+++ b/tldw_chatbook/cli.py
@@ -4,7 +4,11 @@ from typing import Any
 
 
 def main_cli_runner() -> Any:
-    """Load and run the full application only when the CLI is invoked."""
+    """Load and run the full application only when the CLI is invoked.
+
+    Returns:
+        The full application runner's return value.
+    """
 
     from tldw_chatbook.app import main_cli_runner as app_main_cli_runner
 


### PR DESCRIPTION
## Summary

- validate Library Search/RAG queries through the shared input-validation helpers before keyword, FTS, or semantic service dispatch
- reject unsafe, mutated, blank, and oversized queries, with regressions proving neither keyword nor semantic backends are called
- complete the required Google-style docstrings for Settings state persistence, the CLI entrypoint, and the public Library search method

## Context

PR #601 is rebased onto the latest `dev` commit (`4f1ba6a1`) and now targets `dev`. Git dropped the original eight follow-up commits because those fixes are already present upstream. This PR therefore contains only the additional changes requested by Qodo's review of #601.

## Verification

- 32 focused Library search, spawn-bootstrap, and Settings-state tests passed
- `python -m compileall -q tldw_chatbook` completed
- `git diff --check` passed
- independent review found no remaining correctness, compatibility, test-quality, or docstring issues

Backlog: TASK-175  
ADR required: no — the change enforces existing validation and documentation contracts.
