### PR TITLE
feat(library,media): cross-visit persistence batch (tasks 164,165,166)

### DIFF
--- a/Docs/superpowers/plans/2026-07-11-followups-persistence.md
+++ b/Docs/superpowers/plans/2026-07-11-followups-persistence.md
@@ -1,0 +1,51 @@
+# Follow-ups persistence batch — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Three cross-visit persistence follow-ups (backlog 164, 165, 166). Branch `claude/followups-persistence` off dev b37ce5b2. Anchors exact at branch point; grep symbols, lines drift.
+
+**Goal:** Restore Library per-pane filters across tab switches (164), re-populate the Media viewer + row highlight on restore (165), and make repeat Library visits render instantly from an app-scoped snapshot cache without staleness (166).
+
+**Context (binding):** Since the freeze fix (PR #595) navigation composes a FRESH screen instance per visit; continuity is via the app-owned `_screen_states` (`save_state`/`restore_state`, in-memory) called before mount. A per-SCREEN-INSTANCE cache does NOT survive a tab round-trip — 166 must be app-scoped.
+
+**Global Constraints:** explicit-path staging (NEVER `git add -A`); Fable 5 co-author line; RED-first; parameterized SQL only; `escape_markup` for user text in labels; venv pytest with isolated HOME. Test command: `HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest <files> -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread`.
+
+## Cluster A — persistence extensions (164 + 165)
+
+### T164 — persist Library per-pane filters/sort
+**Files:** Modify `tldw_chatbook/UI/Screens/library_screen.py` (`save_state` :761, `restore_state` :795). Test: `Tests/UI/test_library_shell.py`.
+- The existing save/restore (PR #595) persists selection/view + RAG state but NOT the per-pane filters. Add these four attrs:
+  - `_library_media_type_filter` (:548, default `"All"`) — the media type cycle.
+  - `_library_notes_sort` (:559, default `"newest"`) — notes sort mode.
+  - `_library_notes_filter` (:560, default `""`) — notes substring filter VALUE.
+  - `_library_conversation_query` (set in `handle_library_conversations_filter_submitted` :7331 via `_safe_text`) — conversations filter query.
+- save_state: `state["library_media_type_filter"] = self._library_media_type_filter`, `state["library_notes_sort"] = ...`, `state["library_notes_filter"] = ...`, `state["library_conversation_query"] = getattr(self, "_library_conversation_query", "")`. Do NOT persist `_library_notes_filter_records` (:561, a recomputed cache — leave it None so restore recomputes).
+- restore_state: read each back with a type-guard + default (mirror the existing `str(state.get(...) or default)` idiom); coerce `_library_media_type_filter` to a str defaulting `"All"`, `_library_notes_sort` to a str defaulting `"newest"`, the two filters to `""` default. Re-sanitize `library_conversation_query` through `self._safe_text` on restore (defense — it's user text, and a saved-state dict isn't statically typed).
+- These attrs are read by the canvas builders at mount (`active_type=self._library_media_type_filter` :2694; notes `sort_mode`/`filter_value` :2544-2550; conversations query in `_build_library_conversations_state`), so setting them pre-mount just works — no on_mount re-kick needed (unlike a fetched detail). Verify by reading each builder call.
+- RED pilot: cycle the media type filter off "All" (and set a notes sort/filter), save_state → restore_state on a fresh screen → assert the attrs are restored AND the media canvas renders the restored type (mirror the existing filter pilots' harness). One pilot per pane is fine; assert the round-trip via the real save/restore methods.
+
+### T165 — Media restore re-populates the viewer detail + row highlight
+**Files:** Modify `tldw_chatbook/UI/MediaWindow_v2.py` (`apply_restored_view_state` — currently returns after setting `active_media_type`/`selected_media_id` + re-running search, deliberately NOT fetching viewer detail). Test: media window tests (`ls Tests/UI | grep -i media_window`; else `Tests/UI/test_library_content_hub.py` neighbors — adjudicate).
+- Today `apply_restored_view_state` sets the scalars + re-runs the list search but leaves the viewer empty and the row un-highlighted (documented as "kept cheap"). T165 wires the missing half: when a `selected_media_id` is restored, trigger the SAME scoped media-detail fetch a live row click triggers (grep the row-click handler in MediaWindow_v2 for the detail-load method — likely `_load_media_details`/`_select_media_item`/a worker) so the viewer panel re-populates, and highlight the restored row in the list.
+- Stale-id safety: if the restored `selected_media_id` no longer resolves (deleted while away), the fetch must degrade the same way a live click on a since-deleted row does (grep that path — it likely notifies/clears the viewer). Do NOT crash; do NOT leave a permanent loading placeholder.
+- Keep it side-effect-safe before first paint: if the detail fetch is async/worker-based, kick it the same fire-and-forget way the row click does (don't await in the sync restore path). Update the method's docstring (it currently says detail restore is deliberately skipped — reword to describe the new behavior).
+- RED test: restore with a `selected_media_id` present in the seeded set → the viewer detail loads for that id (assert the detail-fetch was invoked / the viewer shows the item) and the row is highlighted; restore with a stale id → no crash, viewer degrades. Follow the existing media-window test harness.
+
+**Cluster A commit:** `feat(library,media): persist per-pane filters and restore the media viewer on return (164,165)`
+
+## Cluster B — app-scoped Library snapshot cache (166)
+
+### T166 — instant repeat-visit render via an app-level snapshot memo
+**Files:** Modify `tldw_chatbook/UI/Screens/library_screen.py` (`on_mount` :652, `_refresh_local_source_snapshot` :1043, `_apply_local_source_snapshot`); store the cache on the APP (`self.app_instance`), not the screen. Test: `Tests/UI/test_library_shell.py`.
+- Problem: `on_mount` calls `_refresh_local_source_snapshot()` on EVERY visit (screens are fresh per visit now), so repeat Library visits re-run the full DB snapshot fetch and show nothing until it returns. A memo on `self` is useless (new instance each visit).
+- Design — app-scoped cache + instant-then-reconcile (avoids staleness beyond one refresh cycle):
+  - App-level attr, e.g. `app_instance._library_source_snapshot_cache: tuple | None` and `app_instance._library_source_snapshot_cache_stamp: float | None` (init lazily via getattr; do NOT require app.py changes — use `getattr(self.app_instance, "_library_source_snapshot_cache", None)`).
+  - `_refresh_local_source_snapshot` (after computing the snapshot tuple) writes it + a `time.monotonic()` stamp to the app cache.
+  - `on_mount`: if a cached snapshot exists AND `monotonic() - stamp < LIBRARY_SNAPSHOT_CACHE_TTL_SECONDS` (define, e.g. `5.0`), apply the CACHED snapshot synchronously first (`_apply_local_source_snapshot(*cached)`) so the returning visit renders instantly, THEN still call `_refresh_local_source_snapshot()` to reconcile in the background (its completion re-applies fresh data + refreshes the cache). If no fresh cache, keep today's behavior (just `_refresh_local_source_snapshot()`). This bounds staleness to a single async refresh cycle — the AC's "no stale data beyond the memo window".
+  - Invalidation: every existing `_refresh_local_source_snapshot` call site already re-applies + re-caches, so Library-side mutations self-heal. Cross-screen mutations (e.g. ingest-tab note import — task 167) already trigger a Library refresh when Library is mounted; when it is NOT mounted the next visit's background reconcile corrects within one cycle. Document this bound.
+- CAUTION: the cache stores the raw snapshot tuple (records/counts/etc.) — the SAME data `_apply_local_source_snapshot` already holds transiently. It is not a NEW fetched-data retention surface (it mirrors what a live screen holds), and it's app-scoped so it's shared, not per-instance-leaked. Do not cache selection/view (that's `_screen_states`' job).
+- RED pilot: mount Library (populates cache), unmount, mount again within TTL → assert the second mount applied the cached snapshot BEFORE its own refresh completed (e.g. the canvas has content at first paint / `_apply_local_source_snapshot` was called with the cached tuple before the fresh fetch resolves — use a gated fake for the fetch to widen the window, bounded 30s). Second pilot: after TTL expiry, no stale apply (fresh fetch only). Verify RED: without the cache, the first-paint content assertion fails.
+
+**Cluster B commit:** `perf(library): app-scoped snapshot cache for instant repeat visits (166)`
+
+## Verification & gate
+
+Combined gate: `Tests/UI/test_library_shell.py Tests/UI/test_home_screen.py Tests/UI/test_library_content_hub.py Tests/Media/ Tests/Library/` + media-window tests + `python -c "import tldw_chatbook.app"`. Visual QA: 164 (a restored media type filter still applied after a tab round-trip) and 165 (media viewer populated on return) are visible — capture in the served TUI if the round-trip is scriptable; else rely on the pilots and note it. Mark backlog 164/165/166 Done (tick ACs). PR to dev; merge only on explicit user authorization.

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import re
 import threading
+import time
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock
@@ -3588,6 +3589,126 @@ async def test_library_shell_shows_lookup_error_in_canvas(monkeypatch):
         error_static = active_screen.query_one("#library-canvas-error")
         assert "unavailable" in str(error_static.renderable).lower()
         assert not active_screen.query("#library-canvas-loading")
+
+
+# --- 166: app-scoped snapshot cache for instant repeat visits --------------
+
+
+@pytest.mark.asyncio
+async def test_library_shell_repeat_visit_renders_cached_snapshot_before_refresh_resolves(
+    monkeypatch,
+):
+    """Navigation composes a FRESH ``LibraryScreen`` instance per visit (the
+    PR #595 freeze fix), so a per-instance memo cannot survive a tab
+    round-trip. Without an app-scoped cache, a returning visit re-shows the
+    loading placeholder until a brand-new DB snapshot fetch resolves.
+
+    Gates the SECOND mount's ``_list_local_source_snapshot`` call only (the
+    first is left unblocked so it can populate the cache), then asserts the
+    cached snapshot renders at the second mount's first paint -- strictly
+    before the gate is ever released, i.e. before that mount's own
+    background refresh could possibly have completed.
+    """
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+
+    calls = {"count": 0}
+    gate = threading.Event()
+    original_list_snapshot = LibraryScreen._list_local_source_snapshot
+
+    async def _gated_list_snapshot(self):
+        calls["count"] += 1
+        if calls["count"] > 1:
+            # Widen the window past the second mount's first paint without
+            # actually hanging the suite -- see the gated-fake convention
+            # note above (`_GATED_RELEASE_TIMEOUT_SECONDS`).
+            await asyncio.to_thread(gate.wait, _GATED_RELEASE_TIMEOUT_SECONDS)
+        return await original_list_snapshot(self)
+
+    monkeypatch.setattr(
+        LibraryScreen, "_list_local_source_snapshot", _gated_list_snapshot
+    )
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        first_screen = _active_library_screen(host)
+        await _wait_for_library_shell(first_screen, pilot)
+
+        assert getattr(app, "_library_source_snapshot_cache", None) is not None
+        assert getattr(app, "_library_source_snapshot_cache_stamp", None) is not None
+
+        await host.pop_screen()
+        await pilot.pause()
+
+        second_screen = LibraryScreen(app)
+        await host.push_screen(second_screen)
+
+        try:
+            # `_wait_for_library_shell` only waits on `_library_loaded` and
+            # the rail's presence -- both flip synchronously off the cached
+            # apply (including the recompose it forces), independent of
+            # the still-gated second fetch below. If the cache path
+            # regresses, this times out and raises (the RED failure)
+            # instead of silently passing.
+            await _wait_for_library_shell(second_screen, pilot)
+
+            visible = _visible_text(second_screen)
+            assert "Conversations (2)" in visible
+        finally:
+            # Release regardless of pass/fail so a failure here can't wedge
+            # the executor thread pool at interpreter shutdown.
+            gate.set()
+
+        # Let the gated reconcile fetch resolve before the harness tears
+        # down so its worker doesn't race teardown.
+        await pilot.pause()
+        await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_library_shell_expired_cache_does_not_apply_stale_snapshot(monkeypatch):
+    """The instant-apply is bounded to ``LIBRARY_SNAPSHOT_CACHE_TTL_SECONDS``:
+    once the cached snapshot is older than that, a repeat visit must NOT
+    render stale content -- it falls back to today's loading-then-refresh
+    behavior instead.
+    """
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        first_screen = _active_library_screen(host)
+        await _wait_for_library_shell(first_screen, pilot)
+
+        assert getattr(app, "_library_source_snapshot_cache", None) is not None
+        app._library_source_snapshot_cache_stamp = (
+            time.monotonic()
+            - library_screen_module.LIBRARY_SNAPSHOT_CACHE_TTL_SECONDS
+            - 1.0
+        )
+
+        await host.pop_screen()
+        await pilot.pause()
+
+        # `_never_loads` freezes the second mount's own refresh
+        # deterministically, mirroring the pre-load pilots above -- if the
+        # (expired) cache were wrongly applied, this would be the only
+        # source of content, making a false positive here impossible.
+        monkeypatch.setattr(
+            LibraryScreen, "_refresh_local_source_snapshot", _never_loads
+        )
+
+        second_screen = LibraryScreen(app)
+        second_screen.apply_navigation_context({"mode": "conversations"})
+        await host.push_screen(second_screen)
+        await pilot.pause()
+        await pilot.pause()
+
+        assert second_screen._library_loaded is False
+        assert second_screen.query_one("#library-canvas-loading")
+        assert not second_screen.query("#library-conversations-canvas")
+        visible = _visible_text(second_screen)
+        assert "Conversations (2)" not in visible
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -3711,6 +3711,86 @@ async def test_library_shell_expired_cache_does_not_apply_stale_snapshot(monkeyp
         assert "Conversations (2)" not in visible
 
 
+def _error_source_snapshot():
+    """A service-unavailable snapshot tuple, matching the shape
+    ``_list_local_source_snapshot`` returns when the local source services
+    are not callable (see its ``LIBRARY_SERVICE_UNAVAILABLE_COPY`` branch).
+    """
+    return (
+        {"notes": (), "media": (), "conversations": ()},
+        {"notes": 0, "media": 0, "conversations": 0},
+        {"notes": True, "media": True, "conversations": True},
+        library_screen_module.LIBRARY_SERVICE_UNAVAILABLE_COPY,
+        None,
+        {"study_decks": None, "flashcards_due": None, "quizzes": None},
+    )
+
+
+@pytest.mark.asyncio
+async def test_library_shell_error_snapshot_is_not_cached_for_instant_apply(monkeypatch):
+    """A failed/service-unavailable snapshot must NOT seed the app cache: it
+    still applies to the current view (the error banner shows now, unchanged),
+    but a return visit within TTL must do a normal fresh fetch instead of
+    instant-applying the stale error -- no "services unavailable" flash on
+    re-entry.
+    """
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+
+    calls = {"count": 0}
+    gate = threading.Event()
+
+    async def _gated_error_snapshot(self):
+        calls["count"] += 1
+        if calls["count"] > 1:
+            # Hold the second mount's fetch open so we can observe its
+            # pre-fetch first paint (bounded per the gated-fake convention).
+            await asyncio.to_thread(gate.wait, _GATED_RELEASE_TIMEOUT_SECONDS)
+        return _error_source_snapshot()
+
+    monkeypatch.setattr(
+        LibraryScreen, "_list_local_source_snapshot", _gated_error_snapshot
+    )
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        first_screen = _active_library_screen(host)
+        # Wait for the first (unblocked) error refresh to land.
+        for _ in range(120):
+            if first_screen._library_lookup_error:
+                break
+            await pilot.pause(0.02)
+        assert first_screen._library_lookup_error
+
+        # The crux: a failed snapshot must never become the instant-apply
+        # seed. Without the `lookup_error is None` guard this holds the error
+        # tuple instead of staying unset -> the RED failure.
+        assert getattr(app, "_library_source_snapshot_cache", None) is None
+        assert getattr(app, "_library_source_snapshot_cache_stamp", None) is None
+
+        await host.pop_screen()
+        await pilot.pause()
+
+        second_screen = LibraryScreen(app)
+        second_screen.apply_navigation_context({"mode": "conversations"})
+        await host.push_screen(second_screen)
+        await pilot.pause()
+        await pilot.pause()
+
+        try:
+            # No cached error to instant-apply -> the second mount shows the
+            # normal loading placeholder while its own (gated) fresh fetch is
+            # still in flight, NOT the "services unavailable" error banner.
+            assert second_screen._library_loaded is False
+            assert second_screen.query_one("#library-canvas-loading")
+            assert not second_screen.query("#library-canvas-error")
+        finally:
+            gate.set()
+
+        await pilot.pause()
+        await pilot.pause()
+
+
 @pytest.mark.asyncio
 async def test_library_shell_details_toggle_persists():
     app = _build_test_app()

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -3608,6 +3608,11 @@ async def test_library_shell_repeat_visit_renders_cached_snapshot_before_refresh
     cached snapshot renders at the second mount's first paint -- strictly
     before the gate is ever released, i.e. before that mount's own
     background refresh could possibly have completed.
+
+    Args:
+        monkeypatch: pytest fixture used to gate the SECOND mount's
+            ``_list_local_source_snapshot`` so the cached-apply window can be
+            observed before the fresh fetch resolves.
     """
     app = _build_test_app()
     _seed_conversations(app, _two_conversations())
@@ -3671,6 +3676,10 @@ async def test_library_shell_expired_cache_does_not_apply_stale_snapshot(monkeyp
     once the cached snapshot is older than that, a repeat visit must NOT
     render stale content -- it falls back to today's loading-then-refresh
     behavior instead.
+
+    Args:
+        monkeypatch: pytest fixture used to gate the second mount's snapshot
+            fetch so the (absence of an) instant-apply can be observed.
     """
     app = _build_test_app()
     _seed_conversations(app, _two_conversations())
@@ -3727,12 +3736,47 @@ def _error_source_snapshot():
 
 
 @pytest.mark.asyncio
+async def test_library_shell_snapshot_cache_is_isolated_from_live_record_mutation():
+    """The app-scoped snapshot cache must hold COPIES, not the live records
+    dict (Qodo review). ``_apply_local_source_snapshot`` aliases
+    ``self._local_source_records = records``, and later in-place key
+    reassignments (a media edit does ``self._local_source_records["media"]
+    = ...``) would otherwise mutate the cached dict too -- corrupting the
+    next visit's instant-apply. Mutating the live records after a snapshot is
+    cached must leave the cache untouched.
+    """
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+
+        cached = getattr(app, "_library_source_snapshot_cache", None)
+        assert cached is not None, "a successful snapshot should have been cached"
+        cached_records = cached[0]
+        # The cached dict must not be the same object the live view holds.
+        assert cached_records is not screen._local_source_records
+
+        sentinel = ({"id": "sentinel-mutation"},)
+        screen._local_source_records["media"] = sentinel
+
+        # The cache still holds the pre-mutation records.
+        assert app._library_source_snapshot_cache[0]["media"] is not sentinel
+
+
+@pytest.mark.asyncio
 async def test_library_shell_error_snapshot_is_not_cached_for_instant_apply(monkeypatch):
     """A failed/service-unavailable snapshot must NOT seed the app cache: it
     still applies to the current view (the error banner shows now, unchanged),
     but a return visit within TTL must do a normal fresh fetch instead of
     instant-applying the stale error -- no "services unavailable" flash on
     re-entry.
+
+    Args:
+        monkeypatch: pytest fixture used to swap ``_list_local_source_snapshot``
+            for a gated fake that returns an error snapshot on first mount.
     """
     app = _build_test_app()
     _seed_conversations(app, _two_conversations())

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -8725,6 +8725,196 @@ def test_library_shell_restore_state_tolerates_garbage_values():
     screen.restore_state(None)
 
 
+# --- T164: per-pane filter/sort persistence (PR #595 follow-up) ------------
+#
+# ``save_state``/``restore_state`` already carried selection/view + RAG
+# state; these four attrs -- media type cycle, notes sort, notes substring
+# filter, conversations query -- are VIEW state of the exact same kind (they
+# change what the canvas builders render, not what gets fetched) but were
+# left out of PR #595's contract. See ``LibraryScreen.save_state``.
+
+
+def test_library_shell_restore_state_sets_per_pane_filter_attrs_on_fresh_unmounted_instance():
+    """Mirrors ``test_library_shell_restore_state_sets_attrs_on_fresh_unmounted_instance``
+    for the four per-pane filter/sort attrs: round-trip through the real
+    ``save_state``/``restore_state`` methods on a freshly-constructed,
+    not-yet-mounted instance -- exactly how the app calls them.
+    """
+    app = _build_test_app()
+    original = LibraryScreen(app)
+    original._library_media_type_filter = "audio"
+    original._library_notes_sort = "oldest"
+    original._library_notes_filter = "retro"
+    original._library_notes_filter_records = ["must never be persisted"]
+    original._library_conversation_query = "quarterly"
+    state = original.save_state()
+
+    # The recomputed filter-records cache is a derived/bulk snapshot like
+    # ``_local_source_records`` -- it must never leak into the persisted
+    # dict (see ``save_state``'s docstring).
+    assert "library_notes_filter_records" not in state
+
+    restored = LibraryScreen(app)
+    restored.restore_state(state)
+
+    assert restored._library_media_type_filter == "audio"
+    assert restored._library_notes_sort == "oldest"
+    assert restored._library_notes_filter == "retro"
+    assert restored._library_conversation_query == "quarterly"
+    # Never restored -- the notes canvas recomputes it fresh from
+    # ``_library_notes_filter`` on mount.
+    assert restored._library_notes_filter_records is None
+
+
+def test_library_shell_restore_state_defaults_per_pane_filters_on_garbage_values():
+    """Same tolerate-garbage contract as
+    ``test_library_shell_restore_state_tolerates_garbage_values``, for the
+    four per-pane filter/sort attrs: a saved-state dict from a different
+    build/shape must never crash restore, and must fall back to each
+    attr's normal default.
+    """
+    app = _build_test_app()
+    screen = LibraryScreen(app)
+
+    screen.restore_state(
+        {
+            "library_media_type_filter": 42,
+            "library_notes_sort": ["oldest"],
+            "library_notes_filter": None,
+            "library_conversation_query": None,
+        }
+    )
+
+    assert screen._library_media_type_filter == "All"
+    assert screen._library_notes_sort == "newest"
+    assert screen._library_notes_filter == ""
+    assert screen._library_conversation_query == ""
+
+
+def test_library_shell_restore_state_resanitizes_conversation_query():
+    """The conversations query is user text -- restore must re-run it
+    through ``_safe_text`` (control-character stripping, tag removal,
+    length capping) rather than trusting the saved-state dict verbatim. A
+    saved-state dict is not statically typed, so this is defense, not a
+    real double-sanitization of trusted input (the live submit handler,
+    ``handle_library_conversations_filter_submitted``, already sanitizes
+    once on entry).
+    """
+    app = _build_test_app()
+    screen = LibraryScreen(app)
+
+    screen.restore_state({"library_conversation_query": "<b>hi</b> " + "x" * 300})
+
+    assert "<" not in screen._library_conversation_query
+    assert ">" not in screen._library_conversation_query
+    assert len(screen._library_conversation_query) <= 200
+
+
+@pytest.mark.asyncio
+async def test_library_shell_restored_media_type_filter_renders_on_first_paint():
+    """The media canvas builder reads ``_library_media_type_filter`` at
+    MOUNT time (``_build_library_media_state``'s ``active_type=``) -- a
+    restored non-default type must already narrow the canvas on first
+    paint, not just sit unused on the screen instance. Cycle the live
+    filter off "All" first to get a real, non-default saved value (not a
+    hand-typed one), mirroring ``test_library_shell_media_type_filter_narrows_list``.
+    """
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), media=_two_media_items())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-media").press()
+        await _wait_for_selector(screen, pilot, "#library-media-type-filter")
+        screen.query_one("#library-media-type-filter", Button).press()
+        await pilot.pause()
+        await pilot.pause()
+        active_type = screen._library_media_type_filter
+        assert active_type != "All"
+        state = screen.save_state()
+
+    assert state["library_media_type_filter"] == active_type
+
+    restored = LibraryScreen(app)
+    restored.restore_state(state)
+    host2 = LibraryHarness(app, screen=restored)
+
+    async with host2.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen2 = _active_library_screen(host2)
+        await _wait_for_selector(screen2, pilot, "#library-media-type-filter")
+
+        assert screen2._library_media_type_filter == active_type
+        filter_button = screen2.query_one("#library-media-type-filter", Button)
+        assert str(filter_button.label) == f"type: {active_type} ▸"
+        rows = list(screen2.query(".library-media-row"))
+        assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_library_shell_restored_notes_sort_and_filter_render_on_first_paint():
+    """The notes canvas builder reads ``_library_notes_sort``/
+    ``_library_notes_filter`` at MOUNT time (the notes branch of
+    ``compose_content``'s ``sort_mode=``/``filter_value=``) -- restored
+    values must already be reflected on first paint.
+    """
+    app = _build_test_app()
+    _seed_conversations(app, [], notes=_two_notes())
+
+    screen = LibraryScreen(app)
+    screen.restore_state(
+        {
+            "library_selected_row_id": LIBRARY_ROW_BROWSE_NOTES,
+            "library_notes_sort": "oldest",
+            "library_notes_filter": "retro",
+        }
+    )
+    host = LibraryHarness(app, screen=screen)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        active_screen = _active_library_screen(host)
+        await _wait_for_selector(active_screen, pilot, "#library-notes-sort")
+
+        sort_button = active_screen.query_one("#library-notes-sort")
+        assert "Oldest" in str(sort_button.label)
+        filter_box = active_screen.query_one("#library-notes-filter", Input)
+        assert filter_box.value == "retro"
+
+
+@pytest.mark.asyncio
+async def test_library_shell_restored_conversation_query_renders_on_first_paint():
+    """The conversations canvas builder reads ``_library_conversation_query``
+    at MOUNT time (``_build_library_conversations_state``'s ``query=``) --
+    a restored query must already narrow the canvas on first paint.
+    Restoring directly (rather than clicking the rail row) is deliberate:
+    the LIVE rail-row press for this pane always resets the query on entry
+    (``handle_library_rail_row``'s canvas-target branch) -- that is
+    existing, unrelated in-session behavior, not what a cross-visit
+    restore goes through.
+    """
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+
+    screen = LibraryScreen(app)
+    screen.restore_state(
+        {
+            "library_selected_row_id": LIBRARY_ROW_BROWSE_CONVERSATIONS,
+            "library_conversation_query": "quarterly",
+        }
+    )
+    host = LibraryHarness(app, screen=screen)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        active_screen = _active_library_screen(host)
+        await _wait_for_selector(active_screen, pilot, "#library-conversations-status")
+
+        status = str(active_screen.query_one("#library-conversations-status").renderable)
+        assert "quarterly" in status
+        filter_box = active_screen.query_one("#library-conversations-filter", Input)
+        assert filter_box.value == "quarterly"
+
+
 @pytest.mark.asyncio
 async def test_library_shell_restored_media_viewer_fetches_detail_on_mount():
     """Mirrors the notes-editor nav-context deep link ``on_mount`` already

--- a/Tests/UI/test_media_window_v2_parity.py
+++ b/Tests/UI/test_media_window_v2_parity.py
@@ -271,6 +271,145 @@ async def test_media_window_backend_change_clears_selected_record_and_viewer():
     window.viewer_panel.clear_display.assert_called_once()
 
 
+# --- T165: cross-visit restore re-populates the viewer + highlights the row -
+#
+# ``apply_restored_view_state`` used to set the scalars and re-run the list
+# search but deliberately left the viewer empty and the row unhighlighted.
+# These exercise the full restore -> re-run search -> resolve -> detail
+# fetch pipeline end-to-end, so they mount a real ``MediaWindow`` in a
+# running app (unlike the unit-style ``_build_media_window`` tests above) --
+# the resolution step defers through ``call_after_refresh``, which needs an
+# actual running message pump to deliver.
+
+
+@pytest.mark.asyncio
+async def test_media_window_restored_selection_fetches_detail_and_highlights_row():
+    """A cross-visit restore with a still-live ``selected_media_id`` must
+    re-populate the viewer panel and highlight the matching list row --
+    the same effect a live click on that row produces -- not just re-run
+    the list search and leave the viewer empty.
+    """
+    scope_service = Mock()
+    scope_service.search_media = AsyncMock(
+        return_value={
+            "items": [
+                {"id": "media-1", "title": "Kept Item", "type": "video", "backend": "local"},
+                {"id": "media-2", "title": "Other Item", "type": "video", "backend": "local"},
+            ],
+            "total": 2,
+        }
+    )
+    scope_service.get_media_detail = AsyncMock(
+        return_value={
+            "id": "media-1",
+            "backend": "local",
+            "source_id": "1",
+            "title": "Kept Item",
+            "content": "restored body",
+        }
+    )
+    app_instance = SimpleNamespace(
+        _media_types_for_ui=["All Media"],
+        media_runtime_state=MediaRuntimeState(runtime_backend="local"),
+        media_reading_scope_service=scope_service,
+        notify=Mock(),
+        media_db=None,
+    )
+
+    class MediaWindowApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield MediaWindow(app_instance)
+
+    app = MediaWindowApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        window = app.query_one(MediaWindow)
+
+        window.apply_restored_view_state(
+            {
+                "active_media_type": "all-media",
+                "search_term": "",
+                "keyword_filter": "",
+                "selected_media_id": "media-1",
+            }
+        )
+
+        for _ in range(100):
+            if window.viewer_panel.media_data is not None:
+                break
+            await pilot.pause(0.02)
+        else:
+            raise AssertionError("Restored selection never fetched the media detail.")
+
+        assert window.viewer_panel.media_data.get("id") == "media-1"
+        assert window.viewer_panel.media_data.get("content") == "restored body"
+        assert window.list_panel.selected_id == "media-1"
+        # The viewer is shown (not the empty state) once a restored
+        # selection's detail lands -- mirrors ``_show_viewer``.
+        assert "hidden" not in window.viewer_panel.classes
+
+
+@pytest.mark.asyncio
+async def test_media_window_restored_selection_with_stale_id_degrades_without_crash():
+    """A restored ``selected_media_id`` for a record deleted while the user
+    was away must degrade gracefully: the re-run search will not return
+    it, so nothing is highlighted and no detail fetch fires -- no crash,
+    no permanent loading placeholder, viewer stays in its untouched empty
+    state.
+    """
+    scope_service = Mock()
+    scope_service.search_media = AsyncMock(
+        return_value={
+            "items": [{"id": "media-2", "title": "Still Here", "type": "video", "backend": "local"}],
+            "total": 1,
+        }
+    )
+    scope_service.get_media_detail = AsyncMock(
+        side_effect=AssertionError("get_media_detail must not be called for a stale restored id")
+    )
+    app_instance = SimpleNamespace(
+        _media_types_for_ui=["All Media"],
+        media_runtime_state=MediaRuntimeState(runtime_backend="local"),
+        media_reading_scope_service=scope_service,
+        notify=Mock(),
+        media_db=None,
+    )
+
+    class MediaWindowApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield MediaWindow(app_instance)
+
+    app = MediaWindowApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        window = app.query_one(MediaWindow)
+
+        window.apply_restored_view_state(
+            {
+                "active_media_type": "all-media",
+                "search_term": "",
+                "keyword_filter": "",
+                "selected_media_id": "media-ghost",
+            }
+        )
+
+        for _ in range(80):
+            await pilot.pause(0.02)
+            if window.list_panel.items:
+                break
+        else:
+            raise AssertionError("Restored search for a stale id never completed.")
+
+        # Give a wrongly-fired fetch a further beat to show up before
+        # asserting it never did.
+        for _ in range(20):
+            await pilot.pause(0.02)
+
+        assert window.viewer_panel.media_data is None
+        assert window.list_panel.selected_id is None
+        scope_service.get_media_detail.assert_not_called()
+
+
 @pytest.mark.asyncio
 async def test_media_window_selection_uses_scope_service_detail_and_runtime_state():
     scope_service = Mock()

--- a/backlog/tasks/task-164 - Persist-Library-per-pane-filters-and-sort-across-tab-switches.md
+++ b/backlog/tasks/task-164 - Persist-Library-per-pane-filters-and-sort-across-tab-switches.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-164
 title: Persist Library per-pane filters and sort across tab switches
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-11 22:02'
+updated_date: '2026-07-12 02:36'
 labels:
   - follow-up
   - library
@@ -19,7 +20,13 @@ PR #595 added cross-visit state persistence for Library/Media/Search selection a
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Notes sort/filter survives a tab switch away and back
-- [ ] #2 Conversations query survives
-- [ ] #3 Media type filter survives
+- [x] #1 Notes sort/filter survives a tab switch away and back
+- [x] #2 Conversations query survives
+- [x] #3 Media type filter survives
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Fixed in the persistence batch (branch claude/followups-persistence). See Docs/superpowers/plans/2026-07-11-followups-persistence.md.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-165 - Richer-Media-screen-state-restore-row-highlight-and-viewer-detail.md
+++ b/backlog/tasks/task-165 - Richer-Media-screen-state-restore-row-highlight-and-viewer-detail.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-165
 title: Richer Media screen state restore (row highlight and viewer detail)
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-11 22:02'
+updated_date: '2026-07-12 02:36'
 labels:
   - follow-up
   - media
@@ -19,6 +20,12 @@ MediaScreen restore is scalar-only for the selected id: the list re-highlight an
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Restored Media screen re-highlights the previously selected row
-- [ ] #2 A previously open media viewer re-fetches its detail on restore
+- [x] #1 Restored Media screen re-highlights the previously selected row
+- [x] #2 A previously open media viewer re-fetches its detail on restore
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Fixed in the persistence batch (branch claude/followups-persistence). See Docs/superpowers/plans/2026-07-11-followups-persistence.md.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-166 - Library-repeat-visit-snapshot-fetch-cost.md
+++ b/backlog/tasks/task-166 - Library-repeat-visit-snapshot-fetch-cost.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-166
 title: Library repeat-visit snapshot-fetch cost
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-11 22:02'
+updated_date: '2026-07-12 02:36'
 labels:
   - follow-up
   - library
@@ -19,6 +20,12 @@ Since screen instance caching was removed (freeze fix, PR #595), LibraryScreen.o
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Repeat Library visits within a short window avoid a redundant full snapshot fetch
-- [ ] #2 No stale data shown beyond the memo window
+- [x] #1 Repeat Library visits within a short window avoid a redundant full snapshot fetch
+- [x] #2 No stale data shown beyond the memo window
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Fixed in the persistence batch (branch claude/followups-persistence). See Docs/superpowers/plans/2026-07-11-followups-persistence.md.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/MediaWindow_v2.py
+++ b/tldw_chatbook/UI/MediaWindow_v2.py
@@ -1771,7 +1771,9 @@ class MediaWindow(Container):
         record = next(
             (
                 item for item in results
-                if isinstance(item, dict) and str(item.get("id") or "") == pending_id
+                if isinstance(item, dict)
+                and item.get("id") is not None
+                and str(item.get("id")) == pending_id
             ),
             None,
         )

--- a/tldw_chatbook/UI/MediaWindow_v2.py
+++ b/tldw_chatbook/UI/MediaWindow_v2.py
@@ -151,6 +151,12 @@ class MediaWindow(Container):
         self.app_instance = app_instance
         self.runtime_state = getattr(app_instance, "media_runtime_state", None)
         self.media_types = self._get_media_types()
+        # Set by ``apply_restored_view_state`` when a cross-visit restore
+        # carries a ``selected_media_id`` -- consumed (and cleared) by the
+        # very next search completion in ``_apply_pending_restored_selection``
+        # regardless of outcome, so an ordinary in-session search can never
+        # misfire against a stale restore target.
+        self._pending_restored_selection_id: Optional[str] = None
         
     def _get_media_types(self) -> List[str]:
         """Get media types from the app instance."""
@@ -1679,15 +1685,22 @@ class MediaWindow(Container):
         type/search/keyword/selection gets re-applied instead of landing back
         on the untouched "pick a type" empty state every time.
 
-        Deliberately does not attempt to restore the viewer panel's detail
-        content or its active tab: unlike Library's separate list/viewer
-        canvas modes, this window always shows the list and viewer side by
-        side, and re-populating the viewer requires the same scoped
-        media-detail fetch a live row click triggers -- not wired here to
-        keep this restore path cheap and side-effect-free before the first
-        paint. A stale ``selected_media_id`` (the record was deleted while
-        the user was elsewhere) degrades gracefully: the re-run search below
-        simply will not return it, so nothing in the list matches it.
+        A restored ``selected_media_id`` also re-populates the viewer panel
+        and highlights the matching list row -- not just the list search.
+        The re-run search below is kicked as a worker exactly like any
+        other search (``_perform_search``); once its results land,
+        ``update_search_results`` resolves the restored id against them via
+        ``_apply_pending_restored_selection`` and, if it is still present,
+        fires the SAME scoped media-detail fetch a live row click triggers
+        (``handle_media_item_selected``) fire-and-forget, plus sets
+        ``list_panel.selected_id`` to highlight the row. Nothing here is
+        awaited synchronously, so this restore path stays as cheap and
+        side-effect-free before the first paint as it always was. A stale
+        ``selected_media_id`` (the record was deleted while the user was
+        elsewhere) degrades gracefully: the re-run search simply will not
+        return it, so nothing matches -- no highlight, no detail fetch, no
+        crash, and the viewer stays in its untouched empty state rather
+        than a permanent loading placeholder.
 
         Args:
             restore: The dict ``MediaScreen`` stashed from a previous visit's
@@ -1706,6 +1719,7 @@ class MediaWindow(Container):
 
         self.active_media_type = type_slug
         self.selected_media_id = selected_media_id
+        self._pending_restored_selection_id = selected_media_id
         if self.runtime_state is not None:
             self.runtime_state.active_media_type = type_slug
             self.runtime_state.search_term = search_term
@@ -1733,8 +1747,64 @@ class MediaWindow(Container):
             if self.runtime_state is not None:
                 self.runtime_state.browse_items = list(results)
             self.list_panel.load_items(results, page, total_pages)
+            self._apply_pending_restored_selection(results)
         except Exception as e:
             logger.opt(exception=True).error(f"Error updating search results: {e}")
+
+    def _apply_pending_restored_selection(self, results: List[Dict[str, Any]]) -> None:
+        """Resolve a cross-visit restored selection against freshly loaded results.
+
+        ``apply_restored_view_state`` stashes the restored
+        ``selected_media_id`` in ``_pending_restored_selection_id`` before
+        kicking the re-run search; every search completion (restore-driven
+        or an ordinary in-session search) funnels through
+        ``update_search_results``, which is the single natural point to
+        resolve it once real results are in hand. Consumed -- cleared --
+        here regardless of outcome, so a later unrelated search (pagination,
+        a type/filter change) can never misfire against a stale target.
+        """
+        pending_id = self._pending_restored_selection_id
+        if not pending_id:
+            return
+        self._pending_restored_selection_id = None
+
+        record = next(
+            (
+                item for item in results
+                if isinstance(item, dict) and str(item.get("id") or "") == pending_id
+            ),
+            None,
+        )
+        if record is None:
+            # Stale id: the record was deleted/moved while the user was
+            # away. The re-run search above simply does not return it, so
+            # there is nothing to highlight or fetch -- no crash, no
+            # permanent loading placeholder. A live click could never
+            # target a row that isn't actually in the list either, so this
+            # is the same degrade the list-only restore already relied on.
+            return
+
+        # Defer past the list panel's own async DOM refresh (scheduled by
+        # ``load_items`` above, via its ``watch_items`` -> ``call_later``)
+        # so the highlight lands on a row that actually exists in the tree
+        # yet -- ``call_after_refresh`` is used the same way elsewhere in
+        # this file (see ``on_mount``) to wait for a mount/refresh cascade
+        # to settle before touching the result.
+        self.call_after_refresh(self._select_restored_media_row, pending_id, dict(record))
+
+    def _select_restored_media_row(self, record_id: str, record: Dict[str, Any]) -> None:
+        """Highlight a restored row and kick its detail fetch, mirroring a live click.
+
+        Fire-and-forget, exactly like ``MediaListPanel.handle_item_selection``
+        (the row-click handler) never awaits its own
+        ``MediaItemSelectedEvent`` dispatch -- ``handle_media_item_selected``
+        already tolerates a failed/partial detail fetch on its own (see its
+        try/except around the scoped detail call), so nothing further is
+        needed here for that case.
+        """
+        if hasattr(self.list_panel, "selected_id"):
+            self.list_panel.selected_id = record_id
+        self.run_worker(self.handle_media_item_selected(MediaItemSelectedEvent(record_id, record)))
     
     def watch_media_active_view(self, old_view: Optional[str], new_view: Optional[str]) -> None:
         """React to media_active_view changes from app.py button handlers."""

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -1142,15 +1142,25 @@ class LibraryScreen(BaseAppScreen):
         # LibraryScreen instance mounted from here on -- including a
         # concurrent one, since screens are recomposed per visit -- reads
         # this fetch's result rather than stale/no data.
-        self.app_instance._library_source_snapshot_cache = (
-            records,
-            counts,
-            total_known,
-            lookup_error,
-            recovery_state,
-            study_counts,
-        )
-        self.app_instance._library_source_snapshot_cache_stamp = time.monotonic()
+        #
+        # Only a SUCCESSFUL snapshot (``lookup_error is None``) is cached: an
+        # error/service-unavailable result still applies to the current view
+        # as usual below (unchanged), but must not become the next visit's
+        # instant-apply seed -- otherwise a return visit within TTL would
+        # flash the "services unavailable" banner for one frame before the
+        # reconcile corrects it. Skipping the write leaves the previous good
+        # snapshot (or nothing) in place, so the next visit does a normal
+        # fresh fetch instead.
+        if lookup_error is None:
+            self.app_instance._library_source_snapshot_cache = (
+                records,
+                counts,
+                total_known,
+                lookup_error,
+                recovery_state,
+                study_counts,
+            )
+            self.app_instance._library_source_snapshot_cache_stamp = time.monotonic()
         self._apply_local_source_snapshot(
             records, counts, total_known, lookup_error, recovery_state, study_counts
         )

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import re
+import time
 from collections.abc import Mapping, Sequence
 from datetime import datetime
 from pathlib import Path
@@ -177,6 +178,15 @@ LIBRARY_INSPECTOR_EMPTY_NEXT_ACTION_COPY = (
     "Library remains a hub; Notes, Media, Search/RAG, and Study own deeper work."
 )
 LIBRARY_SOURCE_SNAPSHOT_TIMEOUT_SECONDS = 5.0
+# Navigation composes a FRESH LibraryScreen instance per visit (PR #595
+# freeze fix), so a per-instance memo is useless -- the previous visit's
+# snapshot is cached on the APP instance instead (see `on_mount` and
+# `_refresh_local_source_snapshot`) so a repeat visit within this window
+# renders instantly instead of showing the loading placeholder again. The
+# cached snapshot is always applied THEN immediately reconciled with a
+# fresh background fetch, so staleness is bounded to a single refresh
+# cycle regardless of this TTL's length.
+LIBRARY_SNAPSHOT_CACHE_TTL_SECONDS = 5.0
 LIBRARY_NOTES_AUTOSAVE_SECONDS = 2.0
 LIBRARY_NOTE_CONTENT_MAX_CHARS = 2_000_000
 LIBRARY_COLLECTION_SYNC_CONFLICT_LIMIT = 200
@@ -655,6 +665,39 @@ class LibraryScreen(BaseAppScreen):
             LIBRARY_SOURCE_SNAPSHOT_TIMEOUT_SECONDS,
             self._apply_source_snapshot_timeout,
         )
+        cached_snapshot = getattr(
+            self.app_instance, "_library_source_snapshot_cache", None
+        )
+        cached_stamp = getattr(
+            self.app_instance, "_library_source_snapshot_cache_stamp", None
+        )
+        if (
+            cached_snapshot is not None
+            and cached_stamp is not None
+            and time.monotonic() - cached_stamp < LIBRARY_SNAPSHOT_CACHE_TTL_SECONDS
+        ):
+            # Instant-then-reconcile: paint the previous visit's snapshot
+            # synchronously (this screen instance is brand new, so nothing
+            # else has populated `_local_source_records` yet) so a
+            # returning visit never shows the loading placeholder, then
+            # still kick the real refresh below -- its completion re-applies
+            # fresh data and refreshes the cache, so this can't drift more
+            # than one refresh cycle stale.
+            self._apply_local_source_snapshot(*cached_snapshot)
+            # `_apply_local_source_snapshot`'s own `self.is_mounted`-guarded
+            # `refresh(recompose=True)` is a no-op here: Textual only flips
+            # `_is_mounted` True in the `finally` clause AFTER the Mount
+            # event finishes dispatching (see
+            # `MessagePump._pre_process`) -- i.e. strictly after this very
+            # `on_mount` call returns -- so without an explicit recompose
+            # here the cached attrs above would be set correctly but the
+            # already-composed (stale, pre-cache) DOM would never actually
+            # repaint. `Widget.refresh(recompose=True)` itself has no such
+            # guard (it just schedules `_check_recompose` via
+            # `call_next`), so calling it directly is safe mid-mount and is
+            # what actually makes the cached snapshot visible at first
+            # paint.
+            self.refresh(recompose=True)
         self._refresh_local_source_snapshot()
         registry = self._library_ingest_registry()
         if registry is not None:
@@ -1094,6 +1137,20 @@ class LibraryScreen(BaseAppScreen):
             recovery_state,
             study_counts,
         ) = await self._list_local_source_snapshot()
+        # Refresh the app-scoped instant-repeat-visit cache (see `on_mount`)
+        # with this fresh snapshot before applying it, so any other
+        # LibraryScreen instance mounted from here on -- including a
+        # concurrent one, since screens are recomposed per visit -- reads
+        # this fetch's result rather than stale/no data.
+        self.app_instance._library_source_snapshot_cache = (
+            records,
+            counts,
+            total_known,
+            lookup_error,
+            recovery_state,
+            study_counts,
+        )
+        self.app_instance._library_source_snapshot_cache_stamp = time.monotonic()
         self._apply_local_source_snapshot(
             records, counts, total_known, lookup_error, recovery_state, study_counts
         )

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -775,6 +775,17 @@ class LibraryScreen(BaseAppScreen):
         ``_apply_library_rag_search_outcome``) are safe to carry verbatim
         because their rows are frozen dataclasses -- copies are taken below
         only to avoid aliasing a live mutable set with the stashed dict.
+
+        The four per-pane filter/sort values below (media type cycle, notes
+        sort mode, notes substring filter, conversations query) are VIEW
+        state exactly like the selection ids above -- they change what the
+        canvas builders render, not what data is fetched -- so they belong
+        here too (PR #595 shipped the selection/RAG half of this contract
+        but left these out). ``_library_notes_filter_records`` (the
+        substring filter's recomputed result cache) is deliberately NOT
+        persisted -- it is a derived/bulk snapshot like
+        ``_local_source_records``, and restore leaves it ``None`` so the
+        canvas recomputes it fresh from ``_library_notes_filter`` on mount.
         """
         state = super().save_state()
         state["library_selected_row_id"] = self._library_selected_row_id
@@ -790,6 +801,12 @@ class LibraryScreen(BaseAppScreen):
         state["library_rag_selected_result_id"] = self._library_rag_selected_result_id
         state["library_rag_retrieval_status"] = self._library_rag_retrieval_status
         state["library_rag_recovery_state"] = self._library_rag_recovery_state
+        state["library_media_type_filter"] = self._library_media_type_filter
+        state["library_notes_sort"] = self._library_notes_sort
+        state["library_notes_filter"] = self._library_notes_filter
+        state["library_conversation_query"] = getattr(
+            self, "_library_conversation_query", ""
+        )
         return state
 
     def restore_state(self, state: dict[str, Any]) -> None:
@@ -811,6 +828,20 @@ class LibraryScreen(BaseAppScreen):
         (should never happen, but a saved-state dict is not statically typed)
         degrades to the list view below rather than rendering a permanent
         loading placeholder.
+
+        The four per-pane filter/sort values restored below are read by the
+        canvas builders at mount time (``_build_library_media_state``,
+        the notes canvas branch of ``compose_content``,
+        ``_build_library_conversations_state``) -- setting them here, before
+        ``switch_screen`` mounts this instance, is all that is needed for
+        the first paint to already reflect them; no on_mount re-kick is
+        required (unlike a fetched detail). The conversations query is
+        user text re-sanitized through ``_safe_text`` here too -- it was
+        already sanitized once when the user submitted it
+        (``handle_library_conversations_filter_submitted``), but a saved-
+        state dict is not statically typed, so this is defense against a
+        corrupted/foreign dict rather than a real double-sanitization of
+        trusted input.
         """
         super().restore_state(state)
         if not isinstance(state, dict):
@@ -855,6 +886,20 @@ class LibraryScreen(BaseAppScreen):
         recovery_state = state.get("library_rag_recovery_state")
         self._library_rag_recovery_state = (
             recovery_state if isinstance(recovery_state, DestinationRecoveryState) else None
+        )
+
+        media_type_filter = state.get("library_media_type_filter")
+        self._library_media_type_filter = (
+            media_type_filter if isinstance(media_type_filter, str) and media_type_filter else "All"
+        )
+        notes_sort = state.get("library_notes_sort")
+        self._library_notes_sort = (
+            notes_sort if isinstance(notes_sort, str) and notes_sort else "newest"
+        )
+        notes_filter = state.get("library_notes_filter")
+        self._library_notes_filter = notes_filter if isinstance(notes_filter, str) else ""
+        self._library_conversation_query = self._safe_text(
+            state.get("library_conversation_query"), "", max_length=200
         )
 
     async def flush_pending_work(self) -> bool:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -660,6 +660,18 @@ class LibraryScreen(BaseAppScreen):
         self._library_export_run_id: int = 0
 
     def on_mount(self) -> None:
+        """Populate the Library on entry, rendering instantly from cache.
+
+        Arms the snapshot-timeout failsafe, then (166) if the app-scoped
+        snapshot cache holds a recent result (within
+        ``LIBRARY_SNAPSHOT_CACHE_TTL_SECONDS``) applies it synchronously so a
+        returning visit paints immediately instead of showing the loading
+        placeholder, and unconditionally kicks
+        ``_refresh_local_source_snapshot`` to reconcile against the DB. Also
+        seeds the ingest registry listener and runs any deferred deep-link
+        loads (collections / note editor / media viewer) that
+        ``apply_navigation_context`` could not run before mount.
+        """
         super().on_mount()
         self.set_timer(
             LIBRARY_SOURCE_SNAPSHOT_TIMEOUT_SECONDS,
@@ -941,8 +953,11 @@ class LibraryScreen(BaseAppScreen):
         )
         notes_filter = state.get("library_notes_filter")
         self._library_notes_filter = notes_filter if isinstance(notes_filter, str) else ""
+        conversation_query = state.get("library_conversation_query")
         self._library_conversation_query = self._safe_text(
-            state.get("library_conversation_query"), "", max_length=200
+            conversation_query if isinstance(conversation_query, str) else "",
+            "",
+            max_length=200,
         )
 
     async def flush_pending_work(self) -> bool:
@@ -1152,13 +1167,22 @@ class LibraryScreen(BaseAppScreen):
         # snapshot (or nothing) in place, so the next visit does a normal
         # fresh fetch instead.
         if lookup_error is None:
+            # Cache SHALLOW COPIES of the mutable containers, not the live
+            # objects (Qodo review): ``_apply_local_source_snapshot`` below
+            # aliases ``self._local_source_records = records``, and later
+            # in-place key reassignments (e.g. ``self._local_source_records
+            # ["media"] = ...`` after a media edit) would otherwise mutate
+            # the cached dict too, so a return visit's instant-apply would
+            # render a snapshot whose records no longer match its cached
+            # counts/totals. The record tuples themselves are immutable, so a
+            # one-level dict copy is enough to isolate the cache.
             self.app_instance._library_source_snapshot_cache = (
-                records,
-                counts,
-                total_known,
+                dict(records),
+                dict(counts) if isinstance(counts, dict) else counts,
+                dict(total_known) if isinstance(total_known, dict) else total_known,
                 lookup_error,
                 recovery_state,
-                study_counts,
+                dict(study_counts) if isinstance(study_counts, dict) else study_counts,
             )
             self.app_instance._library_source_snapshot_cache_stamp = time.monotonic()
         self._apply_local_source_snapshot(


### PR DESCRIPTION
## Summary

Three cross-visit persistence follow-ups, completing the state-continuity work started in PR #595 (which removed screen instance caching and added save/restore). Each RED-first and independently reviewed.

## Fixes

- **164 — Library per-pane filters now survive a tab switch.** `save_state`/`restore_state` persisted selection/view + RAG state but not the per-pane filters, so the media type filter, notes sort, notes substring filter, and conversations query all reset on a tab round-trip. Now persisted (the conversation query re-sanitized through the shared input-validation helper on restore). The restored attrs are read by the canvas builders at mount, so they take effect on first paint — reviewer traced each attr to its builder and confirmed no on-mount path resets it.
- **165 — the Media viewer re-populates on return.** `MediaWindow.apply_restored_view_state` restored the type/search/selection scalars but left the viewer panel empty and the row un-highlighted. It now triggers the *same* scoped detail fetch a live row click triggers (`handle_media_item_selected`, not a re-implementation) and highlights the restored row; a stale restored id (record deleted while away) degrades exactly like a live click on an absent row — no crash, no stuck loading state.
- **166 — instant repeat Library visits.** Since navigation composes a fresh screen per visit (the freeze fix), `on_mount` re-ran the full DB snapshot fetch every time, showing nothing until it returned. Added an **app-scoped** snapshot cache (the memo can't live on the fresh-per-visit screen): a return visit within a 5s TTL applies the cached snapshot instantly, then always reconciles in the background — so staleness is bounded to one refresh cycle. Only successful snapshots are cached (an error/unavailable snapshot won't flash on the next visit), and the failsafe timeout path never poisons the cache.

## Notable

- 166 surfaced a Textual subtlety: a snapshot applied *during* `on_mount` doesn't repaint on its own (the widget's `is_mounted` flag is still False mid-mount, so its guarded recompose no-ops), so the instant-apply adds an explicit `refresh(recompose=True)`. The opus review verified this against Textual 8.2.7 source — necessary, framework-safe (deferred + batched, no double-compose/flash), and RED-reproduced.

## Verification

- Combined gate: **940 passed** (library shell, home screen, content hub, media window parity, Media, Library); clean import.
- Both clusters reviewed (Cluster A RED-verified live by its reviewer; Cluster B at opus depth — staleness bound, mid-mount recompose safety, cache poisoning, and app-scope adjudication all confirmed). Cache scope is safe: Library snapshots are local-only, source-independent, single-user.
- Backlog tasks 164/165/166 marked Done (ACs ticked).
- Visual QA: 164/165 are user-visible (a restored filter still applied; the viewer populated on return); covered by the pilots — a served-TUI capture wasn't scripted this round (the same tab-round-trip/ingest fragility noted on prior batches), so this batch leans on the RED-verified pilots for those surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cross-visit state continuity: Library filters persist across tab switches, Media restores the selected item and viewer, and repeat Library visits render instantly via an app-scoped snapshot cache. Completes tasks 164, 165, and 166 and meets their ACs, with defensive fixes for cache isolation, error snapshots, and restore edge cases.

- **New Features**
  - Library: Persist per-pane filters on save/restore (media type, notes sort/filter, conversations query). Applied pre-mount so they show on first paint; conversations query is re-sanitized.
  - Media: `MediaWindow_v2.apply_restored_view_state` now re-highlights the restored row and fetches details via `handle_media_item_selected`; stale IDs degrade with no crash or stuck loading.
  - Library: App-scoped snapshot cache with a 5s TTL for instant repeat visits, then always reconciles in the background. Mid-mount forces `refresh(recompose=True)` so cached data paints immediately.

- **Bug Fixes**
  - Snapshot cache stores shallow copies and skips error snapshots (no “services unavailable” flash on return).
  - Restore paths harden edge cases: explicit None-safe ID match preserves `0`/`"0"` selections in Media, and `restore_state` type-guards the conversations query before sanitization.

<sup>Written for commit 5c5a7e356e402ea70320d1e078d8c8b9cf3436de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

