### PR TITLE
feat(export): Library chatbook export progress + cancel (task 157)

### DIFF
--- a/Docs/superpowers/plans/2026-07-11-library-export-progress-cancel.md
+++ b/Docs/superpowers/plans/2026-07-11-library-export-progress-cancel.md
@@ -1,0 +1,910 @@
+# Library chatbook export — progress + cancel — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax. Spec: `Docs/superpowers/specs/2026-07-11-library-export-progress-cancel-design.md`. Branch `claude/followups-export-progress` off origin/dev `bc8636b2`. Anchors are exact at the branch point; grep symbols, line numbers drift.
+
+**Goal:** Give the Library chatbook export a live per-phase item-count status line and a working Cancel control, by adding progress + cancel hooks to `ChatbookCreator` and wiring them into the Library export canvas.
+
+**Architecture:** `ChatbookCreator.create_chatbook` gains optional `progress_callback`/`cancel_check` (default `None` → byte-for-byte current behavior), carried as instance state so the `_collect_*`/`_discover_relationships`/`_create_zip_archive` helpers can emit progress and check cancel without new signatures. The zip is written to a sibling `.partial` and `os.replace`d onto the destination only on success (atomic finalize). `LocalChatbookService.export_chatbook` forwards the hooks and surfaces a `cancelled` flag. The Library screen's threaded export worker passes a throttled progress callback (marshalled to the UI thread, `run_id`-staleness-guarded) and a `threading.Event`-backed cancel check; a Cancel button sets the event.
+
+**Tech Stack:** Python ≥3.11, Textual, pytest. No new third-party deps. No new widget/progress-bar (text status line only).
+
+## Global Constraints
+
+- **No behavior change when hooks are absent:** `create_chatbook(...)` with `progress_callback=None, cancel_check=None` must behave exactly as today (existing tests still pass unchanged).
+- **Atomic finalize:** zip to `output_path.with_name(output_path.name + ".partial")` (same directory as the destination → `os.replace` is atomic across volumes); the destination file is never created/clobbered until success.
+- **Cleanup:** the temp `work_dir` AND the `.partial` file are removed on cancel, on failure, and on success.
+- **Cancel ≠ run_id bump:** the Cancel button sets the `threading.Event` but does NOT bump `_library_export_run_id`; navigate-away/reset sets the event AND bumps `run_id` (existing behavior).
+- **Every UI-thread apply handler** (`_apply_library_export_progress`, `_apply_library_export_cancelled`) checks `run_id != self._library_export_run_id` before mutating state/DOM — mirrors `_apply_library_export_failure`.
+- **Marshalling** off the worker thread wraps `self.app.call_from_thread(...)` in `try/except Exception` (Textual `NoApp` is not a `RuntimeError`) — mirrors `_marshal_library_export_failure`.
+- **Progress callback must never raise into export logic:** the creator's `_emit_progress` swallows callback exceptions (debug-log); the UI marshaller swallows too.
+- **Throttle:** emit when the phase changed, OR `current >= total`, OR `≥ 0.1s` since the last emit — always flush on phase-change and the final tick.
+- **Cancel granularity:** effective at the next item/file checkpoint; a single in-progress file copy / `zf.write` is not mid-interrupted (documented, acceptable).
+- **Only the Library export canvas** gets UI wiring; the server-mode export path is untouched.
+- **Staging:** explicit paths only (never `git add -A`). Every commit ends with the trailer `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- **Test command** (venv, isolated HOME):
+  ```
+  HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+    /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest <files> \
+    -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+  ```
+
+---
+
+### Task 1: Creator progress + cancel hooks + atomic finalize
+
+**Files:**
+- Modify: `tldw_chatbook/Chatbooks/chatbook_creator.py`
+- Test: `Tests/Chatbooks/test_chatbook_creator.py`
+
+**Interfaces:**
+- Produces:
+  - `ExportProgress` — `@dataclass(frozen=True)` with `phase: str`, `current: int`, `total: int`.
+  - `ChatbookExportCancelled(Exception)`.
+  - `ChatbookCreator.create_chatbook(..., progress_callback: Optional[Callable[[ExportProgress], None]] = None, cancel_check: Optional[Callable[[], bool]] = None)` — returns the same `(success, message, dependency_info)` tuple; on cancel returns `(False, "Export cancelled", {"cancelled": True, "missing_dependencies": [], "auto_included": []})`.
+
+**Phase names** (used verbatim by later tasks): `conversations`, `notes`, `characters`, `media`, `prompts`, `relationships`, `packaging`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `Tests/Chatbooks/test_chatbook_creator.py` (reuse the existing `chatbook_creator`, `temp_db_paths`, `tmp_path` fixtures and the `@patch` DB mocks that `test_create_chatbook_minimal` uses — copy its decorator stack and empty-selection shape):
+
+```python
+def test_create_chatbook_reports_packaging_progress(self, mock_prompts_db, mock_chacha_db, chatbook_creator, tmp_path):
+    """progress_callback fires ExportProgress events; packaging counts are monotonic to total."""
+    from tldw_chatbook.Chatbooks.chatbook_creator import ExportProgress
+    output_path = tmp_path / "cb.zip"
+    events = []
+    success, _msg, _dep = chatbook_creator.create_chatbook(
+        name="P", description="", content_selections={
+            ContentType.CONVERSATION: [], ContentType.NOTE: [], ContentType.CHARACTER: [],
+        }, output_path=output_path, progress_callback=events.append,
+    )
+    assert success is True
+    packaging = [e for e in events if e.phase == "packaging"]
+    assert packaging, "expected at least one packaging progress event"
+    assert all(isinstance(e, ExportProgress) for e in packaging)
+    currents = [e.current for e in packaging]
+    assert currents == sorted(currents) and packaging[-1].current == packaging[-1].total
+
+def test_create_chatbook_cancel_during_packaging_leaves_no_output(self, mock_prompts_db, mock_chacha_db, chatbook_creator, tmp_path):
+    """cancel_check True during packaging → cancelled result, no destination file, temp cleaned."""
+    output_path = tmp_path / "cb.zip"
+    calls = {"n": 0}
+    def cancel_after_first_package():
+        # allow collection to pass; trip on the first packaging checkpoint
+        calls["n"] += 1
+        return calls["n"] > 1
+    success, message, dep = chatbook_creator.create_chatbook(
+        name="C", description="", content_selections={
+            ContentType.CONVERSATION: [], ContentType.NOTE: [], ContentType.CHARACTER: [],
+        }, output_path=output_path, cancel_check=cancel_after_first_package,
+    )
+    assert success is False
+    assert dep.get("cancelled") is True
+    assert message == "Export cancelled"
+    assert not output_path.exists()
+    assert not output_path.with_name(output_path.name + ".partial").exists()
+
+def test_create_chatbook_success_leaves_no_partial(self, mock_prompts_db, mock_chacha_db, chatbook_creator, tmp_path):
+    """Atomic finalize: a successful export yields a valid zip and no .partial sibling."""
+    import zipfile
+    output_path = tmp_path / "cb.zip"
+    success, _msg, _dep = chatbook_creator.create_chatbook(
+        name="S", description="", content_selections={ContentType.CONVERSATION: []},
+        output_path=output_path,
+    )
+    assert success is True
+    assert output_path.exists() and zipfile.is_zipfile(output_path)
+    assert not output_path.with_name(output_path.name + ".partial").exists()
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run (RED):
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  "Tests/Chatbooks/test_chatbook_creator.py::TestChatbookCreator::test_create_chatbook_reports_packaging_progress" \
+  "Tests/Chatbooks/test_chatbook_creator.py::TestChatbookCreator::test_create_chatbook_cancel_during_packaging_leaves_no_output" \
+  "Tests/Chatbooks/test_chatbook_creator.py::TestChatbookCreator::test_create_chatbook_success_leaves_no_partial" \
+  -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: FAIL — `create_chatbook()` got an unexpected keyword argument `progress_callback` / cannot import `ExportProgress`. (Confirm the test class is `TestChatbookCreator`; if the surrounding class differs, use its actual name.)
+
+- [ ] **Step 3: Add the types + instance-state init**
+
+At the top of `chatbook_creator.py`, ensure `import os` and `from typing import Callable` are present (add if missing). After the imports / before `class ChatbookCreator`, add:
+
+```python
+@dataclass(frozen=True)
+class ExportProgress:
+    """A single progress tick emitted during chatbook creation."""
+    phase: str
+    current: int
+    total: int
+
+
+class ChatbookExportCancelled(Exception):
+    """Raised internally when cancel_check() returns True at a checkpoint."""
+```
+(`from dataclasses import dataclass` — add if not already imported.)
+
+In `ChatbookCreator.__init__` (around line 69), initialize the hook slots so the helpers are always safe:
+```python
+        self._progress_callback: Optional[Callable[[ExportProgress], None]] = None
+        self._cancel_check: Optional[Callable[[], bool]] = None
+```
+
+Add two private helpers to the class (place them just below `__init__`):
+```python
+    def _emit_progress(self, phase: str, current: int, total: int) -> None:
+        cb = self._progress_callback
+        if cb is None:
+            return
+        try:
+            cb(ExportProgress(phase=phase, current=current, total=total))
+        except Exception:
+            logger.opt(exception=True).debug("ChatbookCreator: progress_callback raised; ignored")
+
+    def _check_cancel(self) -> None:
+        if self._cancel_check is not None and self._cancel_check():
+            raise ChatbookExportCancelled()
+
+    def _cleanup_paths(self, *paths: Optional[Path]) -> None:
+        for p in paths:
+            if not p:
+                continue
+            try:
+                if p.is_dir():
+                    shutil.rmtree(p, ignore_errors=True)
+                elif p.exists():
+                    p.unlink()
+            except Exception:
+                logger.opt(exception=True).debug(f"ChatbookCreator: cleanup failed for {p}")
+```
+
+- [ ] **Step 4: Accept the params, store them, and rework the finalize/except/finally**
+
+Change the `create_chatbook` signature (around line 97) to add, after `auto_include_dependencies: bool = True`:
+```python
+        progress_callback: Optional[Callable[["ExportProgress"], None]] = None,
+        cancel_check: Optional[Callable[[], bool]] = None,
+```
+Immediately inside the method body (before the `try:` at line ~137) add:
+```python
+        self._progress_callback = progress_callback
+        self._cancel_check = cancel_check
+        work_dir: Optional[Path] = None
+        partial_path: Optional[Path] = None
+```
+Inside the `try`, where `work_dir` is currently assigned (line ~146) drop the `Path(...)` onto the pre-declared name (`work_dir = Path(tempfile.mkdtemp(...))`).
+
+Replace the packaging block (lines ~245-252, the `if output_path.suffix == '.zip': ... else: ...` duplication) with:
+```python
+            # Package into archive (atomic finalize: write .partial, then os.replace)
+            if output_path.suffix != '.zip':
+                output_path = output_path.with_suffix('.zip')
+            partial_path = output_path.with_name(output_path.name + ".partial")
+            logger.info(f"ChatbookCreator.create_chatbook: Creating ZIP archive at {output_path}")
+            self._create_zip_archive(work_dir, output_path, partial_path)
+```
+
+Replace the trailing `except Exception as e:` block (lines ~278-284) so cancel is handled first, both paths clean up, and a `finally` clears the hooks:
+```python
+        except ChatbookExportCancelled:
+            logger.info("ChatbookCreator.create_chatbook: cancelled by request")
+            self._cleanup_paths(work_dir, partial_path)
+            return False, "Export cancelled", {
+                "cancelled": True,
+                "missing_dependencies": list(self.missing_dependencies),
+                "auto_included": list(self.auto_included_characters),
+            }
+        except Exception as e:
+            logger.opt(exception=True).error("ChatbookCreator.create_chatbook: Error creating chatbook")
+            self._cleanup_paths(work_dir, partial_path)
+            dependency_info = {
+                "missing_dependencies": list(self.missing_dependencies),
+                "auto_included": list(self.auto_included_characters),
+            }
+            return False, f"Error creating chatbook: {str(e)}", dependency_info
+        finally:
+            self._progress_callback = None
+            self._cancel_check = None
+```
+(The success path already `shutil.rmtree(work_dir)`s before returning — leave it; after a successful `os.replace` there is no `.partial` to clean.)
+
+- [ ] **Step 5: Rework `_create_zip_archive` for the partial path + per-file progress/cancel**
+
+Replace `_create_zip_archive` (line ~1090) with:
+```python
+    def _create_zip_archive(self, work_dir: Path, output_path: Path, partial_path: Path) -> None:
+        """Zip work_dir into a sibling .partial, then atomically replace output_path."""
+        files = [p for p in work_dir.rglob('*') if p.is_file()]
+        total = len(files)
+        with zipfile.ZipFile(partial_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+            for idx, file_path in enumerate(files):
+                self._check_cancel()
+                arcname = file_path.relative_to(work_dir)
+                zf.write(file_path, arcname)
+                self._emit_progress("packaging", idx + 1, total)
+        os.replace(partial_path, output_path)
+```
+
+- [ ] **Step 6: Add check/emit to each collection phase and to `_discover_relationships`**
+
+For each `_collect_*` method, convert its top-level `for` over the id list to `enumerate`, and insert `self._check_cancel()` + `self._emit_progress(...)` as the FIRST statements of the loop body, BEFORE any per-item `try:` (so a cancel propagates rather than being swallowed by the item-level `except`). Use this exact shape (shown for conversations):
+
+```python
+        total = len(conversation_ids)
+        for idx, conv_id in enumerate(conversation_ids):
+            self._check_cancel()
+            self._emit_progress("conversations", idx + 1, total)
+            # ...existing loop body (logger.debug + try/except)...
+```
+
+Apply the same to every phase, using its id-list variable and phase name:
+
+| Method (approx line) | id-list variable | phase |
+|---|---|---|
+| `_collect_conversations` (286) | `conversation_ids` | `conversations` |
+| `_collect_notes` (641) | `note_ids` | `notes` |
+| `_collect_characters` (716) | `character_ids` | `characters` |
+| `_collect_media` (774) | `media_ids` | `media` |
+| `_collect_prompts` (878) | `prompt_ids` | `prompts` |
+
+Then in `_discover_relationships` (line ~1013), as the first statements of the method body add:
+```python
+        self._check_cancel()
+        self._emit_progress("relationships", 1, 1)
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run the three Step-1 tests (GREEN) plus the whole existing creator suite to prove no-behavior-change:
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Chatbooks/test_chatbook_creator.py \
+  -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: PASS (new tests green; all pre-existing creator tests still green).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tldw_chatbook/Chatbooks/chatbook_creator.py Tests/Chatbooks/test_chatbook_creator.py
+git commit -m "feat(export): ChatbookCreator progress + cancel hooks with atomic finalize (157)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Service passthrough of hooks + `cancelled` flag
+
+**Files:**
+- Modify: `tldw_chatbook/Chatbooks/local_chatbook_service.py:248-273` (`export_chatbook`)
+- Test: `Tests/Chatbooks/test_local_chatbook_service_export.py` (create)
+
+**Interfaces:**
+- Consumes: `ChatbookCreator.create_chatbook(..., progress_callback=, cancel_check=)` (Task 1).
+- Produces: `LocalChatbookService.export_chatbook(self, request_data, *, progress_callback=None, cancel_check=None)` → dict now includes `"cancelled": bool`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/Chatbooks/test_local_chatbook_service_export.py`:
+```python
+import asyncio
+from unittest.mock import patch, MagicMock
+
+from tldw_chatbook.Chatbooks.local_chatbook_service import LocalChatbookService
+
+
+def _service(tmp_path):
+    db_paths = {"ChaChaNotes": str(tmp_path / "c.db"), "Media": str(tmp_path / "m.db"),
+                "Prompts": str(tmp_path / "p.db")}
+    return LocalChatbookService(db_paths)
+
+
+def test_export_forwards_hooks_and_maps_cancelled(tmp_path):
+    svc = _service(tmp_path)
+    captured = {}
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return False, "Export cancelled", {"cancelled": True, "missing_dependencies": [], "auto_included": []}
+
+    cb = lambda evt: None
+    cc = lambda: True
+    with patch("tldw_chatbook.Chatbooks.local_chatbook_service.ChatbookCreator") as CC:
+        CC.return_value.create_chatbook.side_effect = fake_create
+        result = asyncio.run(svc.export_chatbook(
+            {"name": "N", "content_selections": {}, "output_path": str(tmp_path / "o.zip")},
+            progress_callback=cb, cancel_check=cc,
+        ))
+    assert captured["progress_callback"] is cb
+    assert captured["cancel_check"] is cc
+    assert result["cancelled"] is True
+    assert result["success"] is False
+
+
+def test_export_success_reports_not_cancelled(tmp_path):
+    svc = _service(tmp_path)
+    with patch("tldw_chatbook.Chatbooks.local_chatbook_service.ChatbookCreator") as CC:
+        CC.return_value.create_chatbook.return_value = (True, "ok", {"missing_dependencies": [], "auto_included": []})
+        result = asyncio.run(svc.export_chatbook(
+            {"name": "N", "content_selections": {}, "output_path": str(tmp_path / "o.zip")}))
+    assert result["cancelled"] is False
+    assert result["success"] is True
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run (RED):
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Chatbooks/test_local_chatbook_service_export.py \
+  -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: FAIL — `export_chatbook()` got an unexpected keyword argument `progress_callback`, and/or `KeyError: 'cancelled'`.
+
+- [ ] **Step 3: Implement the passthrough**
+
+In `local_chatbook_service.py`, change the `export_chatbook` signature to:
+```python
+    async def export_chatbook(self, request_data: Any, *, progress_callback=None, cancel_check=None) -> dict[str, Any]:
+```
+Add `progress_callback=progress_callback, cancel_check=cancel_check,` to the `creator.create_chatbook(...)` call. After the call, derive and return `cancelled`:
+```python
+        cancelled = bool(dependency_info.get("cancelled", False)) if isinstance(dependency_info, dict) else False
+        return {
+            "success": success,
+            "message": message,
+            "path": str(output_path),
+            "dependency_info": dependency_info,
+            "name": payload.get("name") or Path(output_path).stem,
+            "cancelled": cancelled,
+        }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run the Step-1 tests (GREEN). Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Chatbooks/local_chatbook_service.py Tests/Chatbooks/test_local_chatbook_service_export.py
+git commit -m "feat(export): local chatbook service forwards progress/cancel hooks + cancelled flag (157)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Progress throttle + status-line formatting helpers (pure)
+
+**Files:**
+- Create: `tldw_chatbook/Library/export_progress.py`
+- Test: `Tests/Library/test_export_progress.py` (create; `mkdir -p Tests/Library` if absent)
+
+**Interfaces:**
+- Produces:
+  - `ExportProgressThrottle(min_interval: float = 0.1)` with `should_emit(phase: str, current: int, total: int, now: float) -> bool`.
+  - `format_export_progress_line(phase: str, current: int, total: int) -> str`.
+  - `EXPORT_PHASE_LABELS: dict[str, str]`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/Library/test_export_progress.py`:
+```python
+from tldw_chatbook.Library.export_progress import (
+    ExportProgressThrottle, format_export_progress_line,
+)
+
+
+def test_throttle_emits_on_first_call_and_phase_change():
+    t = ExportProgressThrottle(min_interval=1.0)
+    assert t.should_emit("media", 1, 10, now=100.0) is True     # first ever
+    assert t.should_emit("media", 2, 10, now=100.1) is False    # within interval, same phase
+    assert t.should_emit("packaging", 1, 5, now=100.2) is True  # phase change flushes
+
+
+def test_throttle_emits_on_final_tick_and_interval():
+    t = ExportProgressThrottle(min_interval=1.0)
+    t.should_emit("media", 1, 10, now=0.0)
+    assert t.should_emit("media", 10, 10, now=0.05) is True     # current >= total flushes
+    t2 = ExportProgressThrottle(min_interval=0.1)
+    t2.should_emit("media", 1, 10, now=0.0)
+    assert t2.should_emit("media", 2, 10, now=0.2) is True      # interval elapsed
+
+
+def test_format_progress_line():
+    assert format_export_progress_line("media", 42, 318) == "Collecting media…  42/318"
+    assert format_export_progress_line("packaging", 210, 540) == "Packaging archive…  210/540 files"
+    assert format_export_progress_line("relationships", 1, 1) == "Resolving links…  1/1"
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run (RED):
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Library/test_export_progress.py \
+  -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: FAIL — `ModuleNotFoundError: tldw_chatbook.Library.export_progress`.
+
+- [ ] **Step 3: Implement the module**
+
+Create `tldw_chatbook/Library/export_progress.py`:
+```python
+"""Pure helpers for rendering chatbook-export progress in the Library canvas.
+
+Kept dependency-free (no Textual) so it is trivially unit-testable; the screen
+supplies ``time.monotonic()`` as ``now`` so the throttle has no hidden clock.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+EXPORT_PHASE_LABELS: dict[str, str] = {
+    "conversations": "Collecting conversations",
+    "notes": "Collecting notes",
+    "characters": "Collecting characters",
+    "media": "Collecting media",
+    "prompts": "Collecting prompts",
+    "relationships": "Resolving links",
+    "packaging": "Packaging archive",
+}
+
+
+def format_export_progress_line(phase: str, current: int, total: int) -> str:
+    label = EXPORT_PHASE_LABELS.get(phase, "Exporting")
+    unit = " files" if phase == "packaging" else ""
+    return f"{label}…  {current}/{total}{unit}"
+
+
+class ExportProgressThrottle:
+    """Decides whether a progress tick should be pushed to the UI thread.
+
+    Emits when the phase changes, when the phase's final item is reached
+    (``current >= total``), or when ``min_interval`` seconds have elapsed since
+    the last emit — so a fast inner loop never floods the UI, yet the line
+    never freezes mid-count.
+    """
+
+    def __init__(self, min_interval: float = 0.1) -> None:
+        self._min_interval = min_interval
+        self._last_phase: Optional[str] = None
+        self._last_emit: Optional[float] = None
+
+    def should_emit(self, phase: str, current: int, total: int, now: float) -> bool:
+        if (
+            phase != self._last_phase
+            or current >= total
+            or self._last_emit is None
+            or (now - self._last_emit) >= self._min_interval
+        ):
+            self._last_phase = phase
+            self._last_emit = now
+            return True
+        return False
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run the Step-1 tests (GREEN). Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Library/export_progress.py Tests/Library/test_export_progress.py
+git commit -m "feat(export): pure progress-throttle + status-line formatter for Library export (157)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Library UI — worker plumbing + live progress line
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py` (`__init__` state; `handle_library_export_submit`; `_start_library_export_worker`/`_run_library_export_worker`; `_run_library_export_via_service`; add `_apply_library_export_progress` + `_refresh_library_export_status_line`)
+- Test: `Tests/UI/test_library_export_progress_apply.py` (create; `mkdir -p Tests/UI` if absent)
+
+**Interfaces:**
+- Consumes: `LocalChatbookService.export_chatbook(..., progress_callback=, cancel_check=)` (Task 2); `ExportProgressThrottle`, `format_export_progress_line` (Task 3); `ExportProgress` (Task 1).
+- Produces: `self._library_export_cancel_event: threading.Event | None`; `_apply_library_export_progress(run_id, phase, current, total)`; `_refresh_library_export_status_line()`. `_run_library_export_via_service` now takes `*, progress_callback=None, cancel_check=None` and its worker builds them.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/UI/test_library_export_progress_apply.py` (uses a `SimpleNamespace` fake `self`, so no app/screen instantiation):
+```python
+from types import SimpleNamespace
+from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
+
+
+def _fake(run_id=7, running=True):
+    calls = []
+    fake = SimpleNamespace(
+        _library_export_run_id=run_id,
+        _library_export_running=running,
+        _library_export_status="",
+        _refresh_library_export_status_line=lambda: calls.append("refresh"),
+    )
+    return fake, calls
+
+
+def test_progress_apply_ignores_stale_run():
+    fake, calls = _fake(run_id=7)
+    LibraryScreen._apply_library_export_progress(fake, 3, "media", 5, 10)  # 3 != 7
+    assert fake._library_export_status == ""
+    assert calls == []
+
+
+def test_progress_apply_ignores_when_not_running():
+    fake, calls = _fake(run_id=7, running=False)
+    LibraryScreen._apply_library_export_progress(fake, 7, "media", 5, 10)
+    assert fake._library_export_status == ""
+    assert calls == []
+
+
+def test_progress_apply_updates_current_run():
+    fake, calls = _fake(run_id=7)
+    LibraryScreen._apply_library_export_progress(fake, 7, "media", 5, 10)
+    assert fake._library_export_status == "Collecting media…  5/10"
+    assert calls == ["refresh"]
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run (RED):
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/UI/test_library_export_progress_apply.py \
+  -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: FAIL — `AttributeError: type object 'LibraryScreen' has no attribute '_apply_library_export_progress'`.
+
+- [ ] **Step 3: Add imports + the cancel-event field**
+
+Near the top of `library_screen.py`, ensure `import threading` and `import time` are present (add if missing). Add the import:
+```python
+from tldw_chatbook.Library.export_progress import (
+    ExportProgressThrottle, format_export_progress_line,
+)
+```
+In `__init__` (alongside the other `_library_export_*` fields, ~line 636) add:
+```python
+        self._library_export_cancel_event: threading.Event | None = None
+```
+
+- [ ] **Step 4: Create the cancel event at submit**
+
+In `handle_library_export_submit` (line ~3418), right where it sets `_library_export_running = True`, add before the worker dispatch:
+```python
+        self._library_export_cancel_event = threading.Event()
+```
+(The event is created but nothing sets it yet; navigate-away and the Cancel button are wired in Task 5.)
+
+- [ ] **Step 5: Add the apply + refresh methods**
+
+Add to `LibraryScreen` (place next to `_apply_library_export_failure`):
+```python
+    def _apply_library_export_progress(self, run_id: int, phase: str, current: int, total: int) -> None:
+        """UI-thread progress tick: update the status line in place if this run is current."""
+        if run_id != self._library_export_run_id or not self._library_export_running:
+            return
+        self._library_export_status = format_export_progress_line(phase, current, total)
+        self._refresh_library_export_status_line()
+
+    def _refresh_library_export_status_line(self) -> None:
+        """Update only the #library-export-status-line widget (no recompose)."""
+        if not self.is_mounted or self._library_selected_row_id != LIBRARY_ROW_INGEST_EXPORT:
+            return
+        try:
+            widget = self.query_one("#library-export-status-line", Static)
+            widget.update(self._library_export_status)
+            widget.display = bool(self._library_export_status)
+        except (NoMatches, QueryError):
+            pass
+```
+(Confirm `Static`, `NoMatches`, `QueryError`, and `LIBRARY_ROW_INGEST_EXPORT` are already imported in this file — they are used by `_update_library_export_canvas_after_run`; reuse the same imports.)
+
+- [ ] **Step 6: Build the progress callback + cancel_check in the worker and thread them through**
+
+Change `_run_library_export_via_service` (line ~3524) signature to accept the hooks and forward them at the `export_chatbook` call:
+```python
+    @staticmethod
+    def _run_library_export_via_service(
+        service: Any,
+        payload: dict[str, Any],
+        *,
+        name: str,
+        description: str,
+        progress_callback=None,
+        cancel_check=None,
+    ) -> dict[str, Any]:
+```
+At the single `asyncio.run(service.export_chatbook(payload))` call (line ~3554) pass the hooks:
+```python
+        export_result = asyncio.run(service.export_chatbook(
+            payload, progress_callback=progress_callback, cancel_check=cancel_check,
+        ))
+```
+
+In `_run_library_export_worker` (line ~3600), before the `outcome = self._run_library_export_via_service(...)` call (line ~3642), build the throttled callback and the cancel check, capturing `run_id` and the event:
+```python
+        cancel_event = self._library_export_cancel_event
+        throttle = ExportProgressThrottle()
+
+        def _progress_cb(evt) -> None:
+            try:
+                if not throttle.should_emit(evt.phase, evt.current, evt.total, time.monotonic()):
+                    return
+                self.app.call_from_thread(
+                    self._apply_library_export_progress, run_id, evt.phase, evt.current, evt.total,
+                )
+            except Exception:
+                # NoApp/shutdown mid-marshal must not crash the worker.
+                pass
+
+        outcome = self._run_library_export_via_service(
+            service, payload, name=name, description=description,
+            progress_callback=_progress_cb,
+            cancel_check=(cancel_event.is_set if cancel_event is not None else None),
+        )
+```
+(Replace the existing `outcome = self._run_library_export_via_service(service, payload, name=name, description=description)` line.)
+
+- [ ] **Step 7: Run to verify it passes**
+
+Run the Step-1 apply tests (GREEN), plus a smoke import of the screen:
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/UI/test_library_export_progress_apply.py \
+  -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+HOME=/private/tmp/tldw-chatbook-test-home PYTHONPATH=$(pwd) \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -c "import tldw_chatbook.UI.Screens.library_screen; print('import ok')"
+```
+Expected: PASS + `import ok`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tldw_chatbook/UI/Screens/library_screen.py Tests/UI/test_library_export_progress_apply.py
+git commit -m "feat(export): live per-phase progress line in the Library export canvas (157)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Library UI — Cancel button + cancelled outcome
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/Library/library_export_canvas.py` (add the Cancel `Button`)
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py` (`handle_library_export_cancel`; propagate `cancelled` through `_run_library_export_via_service` + `_run_library_export_worker`; `_marshal_library_export_cancelled` + `_apply_library_export_cancelled`; set the event in `_reset_library_export_transient_state`; hide the Cancel button in `_update_library_export_canvas_after_run`)
+- Modify: `backlog/tasks/task-157 - Chatbook-export-progress-reporting-and-cancel.md` (mark Done, tick ACs)
+- Test: `Tests/UI/test_library_export_cancel.py` (create), plus a widget-level `app.run_test()` smoke.
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–4; the `cancelled` key added to the service outcome; `self._library_export_cancel_event` (Task 4).
+- Produces: `handle_library_export_cancel`; `_apply_library_export_cancelled(run_id)`; the canvas `#library-export-cancel` button.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/UI/test_library_export_cancel.py`:
+```python
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
+from tldw_chatbook.Widgets.Library.library_export_canvas import LibraryExportCanvas
+from tldw_chatbook.Library.library_export_state import build_library_export_form_state
+from tldw_chatbook.Library.library_export_scope import ExportScope
+
+
+def test_cancel_apply_ignores_stale_run():
+    calls = []
+    fake = SimpleNamespace(
+        _library_export_run_id=9, _library_export_running=True,
+        _library_export_status="Packaging archive…  1/5", _library_export_error="x",
+        _update_library_export_canvas_after_run=lambda: calls.append("update"),
+    )
+    LibraryScreen._apply_library_export_cancelled(fake, 4)  # 4 != 9
+    assert fake._library_export_running is True
+    assert calls == []
+
+
+def test_cancel_apply_current_run_sets_cancelled_status():
+    calls = []
+    fake = SimpleNamespace(
+        _library_export_run_id=9, _library_export_running=True,
+        _library_export_status="Packaging archive…  1/5", _library_export_error="x",
+        _update_library_export_canvas_after_run=lambda: calls.append("update"),
+    )
+    LibraryScreen._apply_library_export_cancelled(fake, 9)
+    assert fake._library_export_running is False
+    assert fake._library_export_status == "Export cancelled."
+    assert fake._library_export_error == ""
+    assert calls == ["update"]
+
+
+def test_cancel_handler_sets_event():
+    fake = SimpleNamespace(
+        _library_export_cancel_event=threading.Event(),
+        _library_export_running=True, _library_export_status="",
+        _refresh_library_export_status_line=lambda: None,
+    )
+    LibraryScreen.handle_library_export_cancel(fake, None)
+    assert fake._library_export_cancel_event.is_set()
+    assert fake._library_export_status == "Cancelling…"
+
+
+@pytest.mark.asyncio
+async def test_cancel_button_visible_only_while_running():
+    from textual.app import App
+
+    def _state(running):
+        return build_library_export_form_state(
+            scope=ExportScope(kind="everything"), counts={"total": 3}, name="n",
+            description="", media_quality="thumbnail", destination="/tmp/x.zip",
+            running=running, status_line="Exporting…" if running else "",
+        )
+
+    class Host(App):
+        def compose(self):
+            yield LibraryExportCanvas(_state(True), id="library-export-canvas")
+
+    app = Host()
+    async with app.run_test() as pilot:
+        cancel = pilot.app.query_one("#library-export-cancel")
+        assert cancel.display is True
+```
+(If the `counts=` shape differs from `{"total": 3}`, match whatever `build_library_export_form_state` expects — check `Tests/Library/` for an existing constructor call to copy.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run (RED):
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/UI/test_library_export_cancel.py \
+  -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: FAIL — `LibraryScreen` has no `_apply_library_export_cancelled`/`handle_library_export_cancel`; `#library-export-cancel` not found.
+
+- [ ] **Step 3: Add the Cancel button to the canvas widget**
+
+In `tldw_chatbook/Widgets/Library/library_export_canvas.py`, in `compose()` immediately after the `#library-export-submit` `Button` (the last yielded widget, ~line 137-143), add:
+```python
+        cancel_button = Button(
+            "Cancel",
+            id="library-export-cancel",
+            classes="library-canvas-action",
+            compact=True,
+        )
+        cancel_button.display = bool(state.running)
+        yield cancel_button
+```
+
+- [ ] **Step 4: Add the Cancel handler**
+
+In `library_screen.py`, next to `handle_library_export_submit`, add:
+```python
+    @on(Button.Pressed, "#library-export-cancel")
+    def handle_library_export_cancel(self, event: "Button.Pressed") -> None:
+        """Request cancellation of the in-flight export.
+
+        Sets the worker's cancel Event (idempotent) and flips the status line to
+        "Cancelling…". Deliberately does NOT bump _library_export_run_id: the run
+        is still the current, visible one until the worker reports back with the
+        cancelled outcome (see _apply_library_export_cancelled).
+        """
+        if not self._library_export_running:
+            return
+        event_obj = self._library_export_cancel_event
+        if event_obj is not None:
+            event_obj.set()
+        self._library_export_status = "Cancelling…"
+        self._refresh_library_export_status_line()
+```
+
+- [ ] **Step 5: Propagate `cancelled` through the worker outcome**
+
+In `_run_library_export_via_service` (library_screen.py), add `"cancelled": bool(export_result.get("cancelled", False)),` to the **not-success** return dict (the `if not export_result.get("success"):` branch, ~line 3540-3546) and `"cancelled": False,` to the success return dict (~line 3592-3598) and to the exception-return dict (~line 3529-3535). Then in `_run_library_export_worker` (line ~3645), branch on it:
+```python
+        if outcome.get("cancelled"):
+            self._marshal_library_export_cancelled(run_id)
+        elif outcome["success"]:
+            self._marshal_library_export_success(
+                run_id, outcome["path"], outcome["dependency_info"],
+                bool(outcome["registry_recorded"]), outcome["message"],
+            )
+        else:
+            self._marshal_library_export_failure(run_id, outcome["message"])
+```
+
+- [ ] **Step 6: Add the marshal + apply for cancelled**
+
+Add to `LibraryScreen` (next to `_marshal_library_export_failure` / `_apply_library_export_failure`):
+```python
+    def _marshal_library_export_cancelled(self, run_id: int) -> None:
+        """Marshal a cancelled run onto the UI thread (called from the worker)."""
+        try:
+            self.app.call_from_thread(self._apply_library_export_cancelled, run_id)
+        except Exception:
+            pass
+
+    def _apply_library_export_cancelled(self, run_id: int) -> None:
+        """UI-thread completion for a cancelled run: clear running, show cancelled, return to form."""
+        if run_id != self._library_export_run_id:
+            return
+        self._library_export_running = False
+        self._library_export_status = "Export cancelled."
+        self._library_export_error = ""
+        self._update_library_export_canvas_after_run()
+```
+
+- [ ] **Step 7: Signal cancel on navigate-away + hide the button on completion**
+
+In `_reset_library_export_transient_state` (line ~3139), before bumping `_library_export_run_id`, set the outgoing event so the worker stops:
+```python
+        if self._library_export_cancel_event is not None:
+            self._library_export_cancel_event.set()
+```
+In `_update_library_export_canvas_after_run` (line ~3827), inside the existing `try:` that updates the widgets, add a line hiding the cancel button when not running:
+```python
+            self.query_one("#library-export-cancel", Button).display = bool(state.running)
+```
+
+- [ ] **Step 8: Run to verify it passes**
+
+Run the Step-1 tests (GREEN):
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/UI/test_library_export_cancel.py Tests/UI/test_library_export_progress_apply.py \
+  -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: PASS.
+
+- [ ] **Step 9: Mark the backlog task Done**
+
+Tick the ACs and set status in `backlog/tasks/task-157 - Chatbook-export-progress-reporting-and-cancel.md`:
+```bash
+perl -0pi -e 's/- \[ \] (#\d)/- [x] $1/g' "backlog/tasks/task-157 - Chatbook-export-progress-reporting-and-cancel.md"
+perl -0pi -e 's/^status: .*/status: Done/m' "backlog/tasks/task-157 - Chatbook-export-progress-reporting-and-cancel.md"
+```
+Add a short `## Implementation Notes` section summarizing the approach (creator hooks + atomic finalize, service passthrough, throttle helper, Library canvas progress line + Cancel button).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add tldw_chatbook/Widgets/Library/library_export_canvas.py tldw_chatbook/UI/Screens/library_screen.py \
+  Tests/UI/test_library_export_cancel.py "backlog/tasks/task-157 - Chatbook-export-progress-reporting-and-cancel.md"
+git commit -m "feat(export): Cancel control + cancelled outcome for Library export (157)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Final gate (after Task 5)
+
+Run the full touched-surface suite:
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Chatbooks/ Tests/Library/test_export_progress.py Tests/UI/test_library_export_progress_apply.py Tests/UI/test_library_export_cancel.py \
+  -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Then the whole-branch review (opus), then finishing-a-development-branch. Served-TUI visual QA of the running progress line + Cancel press is worthwhile but optional (a live export with enough items to see counts move); the modal FileSave picker resists scripting, so a manual capture is acceptable.

--- a/Docs/superpowers/specs/2026-07-11-library-export-progress-cancel-design.md
+++ b/Docs/superpowers/specs/2026-07-11-library-export-progress-cancel-design.md
@@ -1,0 +1,232 @@
+# Library chatbook export — progress reporting + cancel (task 157)
+
+**Status:** Design approved (brainstorm), pending spec review.
+**Backlog:** task-157 — "Chatbook export progress reporting and cancel".
+**Builds on:** F4 bulk Library export (PR #597). v1 deliberately shipped with a
+static `Exporting…` line and no cancel.
+
+## Problem
+
+The Library export canvas dispatches a threaded worker that calls
+`local_chatbook_service.export_chatbook(...)` →
+`ChatbookCreator.create_chatbook(...)`, a single synchronous shot with no
+progress or cancel hook. A large export (many media items, a big zip) shows a
+frozen `Exporting… (N items)` line with no way to interrupt it. We want a live,
+per-phase item-count status line and a working Cancel control, reusing the
+existing chatbook export path.
+
+## Goal / Acceptance
+
+- **AC1** — the export canvas shows real, moving progress while a large export
+  runs (per-phase item/file counts, text, e.g. `Collecting media…  42/318`,
+  `Packaging archive…  210/540 files`).
+- **AC2** — the user can cancel an in-flight export; cancel is effective at the
+  next item/file checkpoint, leaves no partial artifact at the destination, and
+  returns the canvas to the export form with an `Export cancelled.` status.
+- **AC3** — `ChatbookCreator` exposes progress + cancel hooks (shared, reusable
+  by other chatbook UIs later; this task wires the UI only in the Library
+  export canvas).
+
+## Chosen approach
+
+**Callback + cancel-check carried by the creator**, chosen over (2) a polled
+shared-progress object (needs a UI timer, less precise, the creator must
+checkpoint anyway) and (3) rewriting `create_chatbook` as a progress-yielding
+generator (invasive rewrite of a ~1000-line method, breaks the return contract
+other callers depend on). Approach 1 is the smallest, most testable change and
+adds no new widget or layout.
+
+## Components
+
+### 1. Creator hooks (`tldw_chatbook/Chatbooks/chatbook_creator.py`)
+
+New public types (defined in this module):
+
+```python
+@dataclass(frozen=True)
+class ExportProgress:
+    phase: str      # "conversations" | "notes" | "characters" | "media"
+                    # | "prompts" | "relationships" | "packaging"
+    current: int    # 1-based items completed in this phase
+    total: int      # items in this phase (0 → indeterminate/skip)
+
+
+class ChatbookExportCancelled(Exception):
+    """Raised internally when cancel_check() returns True at a checkpoint."""
+```
+
+`create_chatbook(...)` gains two optional keyword params, both defaulting to
+`None` (→ today's behavior byte-for-byte):
+
+```python
+progress_callback: Optional[Callable[[ExportProgress], None]] = None
+cancel_check: Optional[Callable[[], bool]] = None
+```
+
+At the top of `create_chatbook`, store them on the instance
+(`self._progress_callback`, `self._cancel_check`) and clear them in a `finally`,
+so the `_collect_*` helpers and `_create_zip_archive` can call two private
+helpers without threading params through six signatures:
+
+- `self._emit_progress(phase, current, total)` — no-op if
+  `self._progress_callback is None`; else calls it with an `ExportProgress`.
+  Must **never** raise into the collection logic: wrap the callback in
+  `try/except Exception` and log at debug on failure (a flaky UI marshaller
+  must not abort a real export).
+- `self._check_cancel()` — if `self._cancel_check` and it returns `True`, raise
+  `ChatbookExportCancelled`.
+
+Instances are single-use (`creator = ChatbookCreator(...)` is constructed per
+export in `export_chatbook`), so instance state is safe.
+
+**Emit / check points:**
+- Each `_collect_*` phase (`_collect_conversations/notes/characters/media/prompts`):
+  call `self._check_cancel()` then `self._emit_progress(phase, i+1, total)` once
+  per item in its loop. `total` = `len(ids)` for that phase.
+- `_discover_relationships`: one `self._check_cancel()` + a single
+  `_emit_progress("relationships", 1, 1)` (fast phase, coarse is fine).
+- `_create_zip_archive`: materialize `files = [p for p in work_dir.rglob('*') if p.is_file()]`
+  once (so `total = len(files)` is known), then per file:
+  `self._check_cancel()` → `zf.write(...)` → `self._emit_progress("packaging", i+1, total)`.
+
+**Atomic finalize (cancel/crash safety):** `_create_zip_archive` writes to a
+sibling temp path in the **destination directory**
+(`output_path.parent / (output_path.name + ".partial")`) and, only after the
+zip completes, `os.replace(temp, output_path)` (atomic within one filesystem;
+same-dir keeps it atomic even when the destination is on a different volume than
+`self.temp_dir`). The destination file is never created or clobbered until
+success — so cancel/failure never leaves a truncated `.zip` there.
+
+**Cancel cleanup:** wrap the body of `create_chatbook` so that on
+`ChatbookExportCancelled` (and on any exception) it removes the temp `work_dir`
+and the `.partial` file if present, then:
+- for `ChatbookExportCancelled`: return `(False, "Export cancelled", {"cancelled": True, "missing_dependencies": [], "auto_included": []})`
+  (a distinct, recognizable cancelled outcome — not a generic failure).
+- for other exceptions: preserve today's failure return.
+
+### 2. Service passthrough (`tldw_chatbook/Chatbooks/local_chatbook_service.py`)
+
+`export_chatbook(self, request_data, *, progress_callback=None, cancel_check=None)`
+forwards both to `creator.create_chatbook(...)`. The returned dict gains a
+`"cancelled": bool` key (derived from `dependency_info.get("cancelled", False)`,
+or from `success is False and message == "Export cancelled"`). Callables are not
+serialized — this is the in-process local path only; the server service is
+untouched (export runs locally).
+
+### 3. Library UI wiring (`tldw_chatbook/UI/Screens/library_screen.py`)
+
+**Cancel signal.** Add `self._library_export_cancel_event: threading.Event | None`
+(created fresh in `handle_library_export_submit` at dispatch, captured by the
+worker closure). Two triggers, deliberately different:
+- **Cancel button** (new `#library-export-cancel` in the running-state canvas):
+  `event.set()` and set `_library_export_status = "Cancelling…"`, then refresh
+  the status label. It does **NOT** bump `_library_export_run_id` — the run is
+  still the current, visible one until the worker reports back.
+- **Navigate-away / `_reset_library_export_transient_state`:** set the outgoing
+  event (if any) **and** bump `_library_export_run_id` (existing behavior), so
+  the worker stops soon and its eventual cancelled result no-ops on the DOM.
+
+`cancel_check` handed to the service = `self._library_export_cancel_event.is_set`.
+
+**Progress.** The worker builds a `progress_callback` that marshals to the UI
+thread, mirroring the existing `_marshal_library_export_*` pattern:
+- **Throttle (worker-thread local state):** only marshal when the phase changed,
+  or `time.monotonic() - last_emit >= 0.1s`, or `current == total`. Always flush
+  on phase-change and the final tick so the line never freezes mid-count.
+- Each marshal = `self.app.call_from_thread(self._apply_library_export_progress, run_id, phase, current, total)`
+  wrapped in `try/except Exception` (Textual `NoApp` is not a `RuntimeError`),
+  exactly like `_marshal_library_export_success`.
+- `_apply_library_export_progress(run_id, phase, current, total)` runs on the UI
+  thread and **first** checks `if run_id != self._library_export_run_id: return`
+  (no stomping a superseded canvas), then sets
+  `self._library_export_status = f"{LABEL[phase]}…  {current}/{total}"` and
+  updates the single status `Static` **without a full recompose** (update the
+  label widget directly; fall back to a targeted refresh if the widget lookup
+  fails, guarded).
+  `LABEL` maps phase→friendly text: conversations→"Collecting conversations",
+  notes→"Collecting notes", characters→"Collecting characters",
+  media→"Collecting media", prompts→"Collecting prompts",
+  relationships→"Resolving links", packaging→"Packaging archive".
+
+**Completion.** `_run_library_export_via_service` propagates the service's
+`"cancelled"` flag into the `outcome` dict it returns (alongside
+`success`/`path`/`dependency_info`/`registry_recorded`/`message`). Because a
+cancelled export reports `success is False`, the existing "registry record only
+on success" guard already skips the `create_chatbook` registry step — no
+artifact is recorded for a cancelled run. `_run_library_export_worker` then
+inspects `outcome["cancelled"]`:
+- cancelled → `_marshal_library_export_cancelled(run_id)` →
+  `_apply_library_export_cancelled(run_id)`: same staleness guard as the other
+  apply handlers, then `_library_export_running = False`,
+  `_library_export_status = "Export cancelled."`,
+  `_update_library_export_canvas_after_run()` (returns to the form).
+- success/failure paths unchanged.
+
+The running-state canvas gains the Cancel button beside the status line; it is
+present only while `_library_export_running` and shows "Cancelling…" once
+pressed (button disabled after first press; `event.set()` is idempotent).
+
+## Data flow
+
+```
+Cancel button ── event.set() ─────────────────────────────┐
+                                                           ▼
+handle_submit → worker(thread) → service.export_chatbook(progress_cb, cancel_check)
+                                       └→ creator.create_chatbook
+                                            ├ _collect_* : check_cancel + emit(phase,i,total)
+                                            ├ _discover_relationships : check_cancel + emit
+                                            └ _create_zip_archive : per-file check_cancel + emit
+                                                 └ os.replace(.partial → output_path)  [success only]
+emit ─(throttled)→ call_from_thread → _apply_library_export_progress(run_id,…)
+                                          └ if run_id current: update status label
+outcome.cancelled → _marshal_library_export_cancelled → _apply_… → "Export cancelled." + form
+```
+
+## Error handling
+
+- Cancel is clean control flow (`ChatbookExportCancelled`), distinct from
+  failure (which keeps `_apply_library_export_failure`).
+- Temp `work_dir` **and** `.partial` removed on cancel, failure, and success.
+- Progress-callback exceptions are swallowed (debug-logged) in the creator and
+  in the marshaller — a UI hiccup never aborts a real export nor crashes the
+  worker on teardown.
+- `os.replace` failure (e.g. destination vanished) surfaces as a normal export
+  failure with the temp `.partial` cleaned up.
+
+## Testing
+
+Favor the seams (fast, deterministic) over a heavy full-threaded UI export
+(the project's UI harness lacks the app stylesheet and has a ~33-failure
+baseline; `AppTest` is unavailable → `app.run_test()`):
+
+- **Creator seam (`Tests/Chatbooks/`):**
+  - progress: a recording `progress_callback` over a small multi-type export →
+    assert every expected phase appears, `current` is monotonic 1..`total`
+    within each phase, and the final tick per phase is `current == total`.
+  - cancel: a `cancel_check` returning `True` after *k* calls → assert the
+    outcome is the cancelled tuple (`success is False`, `"cancelled": True`),
+    the temp `work_dir` is gone, **and no file exists at `output_path`**
+    (atomic finalize) — including the case where cancel fires during packaging.
+  - atomic finalize (success): a pre-existing file at `output_path` is only
+    replaced after a successful zip; a forced failure mid-zip leaves the
+    pre-existing file intact.
+  - default-None: `create_chatbook` with no hooks behaves exactly as before
+    (one existing happy-path assertion re-run).
+- **Throttle helper** — extract the "should I emit now?" decision into a small
+  pure function/class and unit-test phase-change / interval / final-tick.
+- **Cancelled-apply staleness** — unit-test `_apply_library_export_cancelled`
+  (and the progress apply) honor the `run_id` guard: a stale `run_id` leaves
+  `_library_export_running`/status untouched; a current one updates them.
+- **UI smoke (minimal, `app.run_test()`):** open the export canvas in a running
+  state, assert the Cancel button exists and pressing it sets the event /
+  flips the status to "Cancelling…". No full real export in-harness.
+
+## Scope / non-goals
+
+- Only the **Library export canvas** gets UI wiring. Other chatbook creation
+  UIs (ChatbookCreationWindow, wizard) may adopt the shared hooks later — out of
+  scope here (YAGNI).
+- No determinate percentage/progress-bar widget (chosen: text item counts).
+- A single in-progress giant file copy / `zf.write` is not mid-interrupted;
+  cancel takes effect at the next item/file boundary (acceptable v1).
+- The server-mode export path is unchanged (export runs locally).

--- a/Tests/Chatbooks/test_chatbook_creator.py
+++ b/Tests/Chatbooks/test_chatbook_creator.py
@@ -219,6 +219,51 @@ class TestChatbookCreator:
 
     @patch('tldw_chatbook.Chatbooks.chatbook_creator.CharactersRAGDB')
     @patch('tldw_chatbook.Chatbooks.chatbook_creator.PromptsDatabase')
+    def test_stat_failure_after_finalize_still_reports_success(self, mock_prompts_db, mock_chacha_db, chatbook_creator, tmp_path):
+        """A stat() failure AFTER the archive is os.replace'd into place must not
+        flip a genuinely-successful export into a reported failure."""
+        import zipfile
+        mock_chacha_db.return_value = MagicMock()
+        mock_prompts_db.return_value = MagicMock()
+        output_path = tmp_path / "cb.zip"
+        real_stat = Path.stat
+
+        def flaky_stat(self, *args, **kwargs):
+            if self == output_path:
+                raise OSError("simulated stat failure after finalize")
+            return real_stat(self, *args, **kwargs)
+
+        with patch.object(Path, "stat", flaky_stat):
+            success, _msg, _dep = chatbook_creator.create_chatbook(
+                name="S", description="", content_selections={ContentType.CONVERSATION: []},
+                output_path=output_path,
+            )
+        assert success is True
+        assert output_path.exists() and zipfile.is_zipfile(output_path)
+
+    @patch('tldw_chatbook.Chatbooks.chatbook_creator.CharactersRAGDB')
+    @patch('tldw_chatbook.Chatbooks.chatbook_creator.PromptsDatabase')
+    def test_cleanup_does_not_rmtree_directory_at_partial_path(self, mock_prompts_db, mock_chacha_db, chatbook_creator, tmp_path):
+        """If a directory unexpectedly sits at <dest>.partial, failure cleanup must
+        NOT recursively delete it — only the .partial FILE we create is removed."""
+        mock_chacha_db.return_value = MagicMock()
+        mock_prompts_db.return_value = MagicMock()
+        output_path = tmp_path / "cb.zip"
+        partial_dir = output_path.with_name(output_path.name + ".partial")
+        partial_dir.mkdir()
+        (partial_dir / "sentinel.txt").write_text("keep me", encoding="utf-8")
+        success, _msg, _dep = chatbook_creator.create_chatbook(
+            name="C", description="", content_selections={ContentType.CONVERSATION: []},
+            output_path=output_path,
+        )
+        # The zip write fails (partial path is a directory) → failure, but the
+        # pre-existing directory and its contents must survive untouched.
+        assert success is False
+        assert partial_dir.is_dir()
+        assert (partial_dir / "sentinel.txt").read_text(encoding="utf-8") == "keep me"
+
+    @patch('tldw_chatbook.Chatbooks.chatbook_creator.CharactersRAGDB')
+    @patch('tldw_chatbook.Chatbooks.chatbook_creator.PromptsDatabase')
     def test_create_chatbook_with_sample_data(self, mock_prompts_db, mock_chacha_db, chatbook_creator, temp_db_paths, tmp_path):
         """Test creating a chatbook with sample data."""
         # Setup mocks

--- a/Tests/Chatbooks/test_chatbook_creator.py
+++ b/Tests/Chatbooks/test_chatbook_creator.py
@@ -156,7 +156,67 @@ class TestChatbookCreator:
             assert manifest_data['name'] == "Test Chatbook"
             assert manifest_data['description'] == "A test chatbook"
             assert manifest_data['version'] == "1.0"
-    
+
+    @patch('tldw_chatbook.Chatbooks.chatbook_creator.CharactersRAGDB')
+    @patch('tldw_chatbook.Chatbooks.chatbook_creator.PromptsDatabase')
+    def test_create_chatbook_reports_packaging_progress(self, mock_prompts_db, mock_chacha_db, chatbook_creator, tmp_path):
+        """progress_callback fires ExportProgress events; packaging counts are monotonic to total."""
+        from tldw_chatbook.Chatbooks.chatbook_creator import ExportProgress
+        mock_chacha_db.return_value = MagicMock()
+        mock_prompts_db.return_value = MagicMock()
+        output_path = tmp_path / "cb.zip"
+        events = []
+        success, _msg, _dep = chatbook_creator.create_chatbook(
+            name="P", description="", content_selections={
+                ContentType.CONVERSATION: [], ContentType.NOTE: [], ContentType.CHARACTER: [],
+            }, output_path=output_path, progress_callback=events.append,
+        )
+        assert success is True
+        packaging = [e for e in events if e.phase == "packaging"]
+        assert packaging, "expected at least one packaging progress event"
+        assert all(isinstance(e, ExportProgress) for e in packaging)
+        currents = [e.current for e in packaging]
+        assert currents == sorted(currents) and packaging[-1].current == packaging[-1].total
+
+    @patch('tldw_chatbook.Chatbooks.chatbook_creator.CharactersRAGDB')
+    @patch('tldw_chatbook.Chatbooks.chatbook_creator.PromptsDatabase')
+    def test_create_chatbook_cancel_during_packaging_leaves_no_output(self, mock_prompts_db, mock_chacha_db, chatbook_creator, tmp_path):
+        """cancel_check True during packaging → cancelled result, no destination file, temp cleaned."""
+        mock_chacha_db.return_value = MagicMock()
+        mock_prompts_db.return_value = MagicMock()
+        output_path = tmp_path / "cb.zip"
+        calls = {"n": 0}
+        def cancel_after_first_package():
+            # allow collection to pass; trip on the first packaging checkpoint
+            calls["n"] += 1
+            return calls["n"] > 1
+        success, message, dep = chatbook_creator.create_chatbook(
+            name="C", description="", content_selections={
+                ContentType.CONVERSATION: [], ContentType.NOTE: [], ContentType.CHARACTER: [],
+            }, output_path=output_path, cancel_check=cancel_after_first_package,
+        )
+        assert success is False
+        assert dep.get("cancelled") is True
+        assert message == "Export cancelled"
+        assert not output_path.exists()
+        assert not output_path.with_name(output_path.name + ".partial").exists()
+
+    @patch('tldw_chatbook.Chatbooks.chatbook_creator.CharactersRAGDB')
+    @patch('tldw_chatbook.Chatbooks.chatbook_creator.PromptsDatabase')
+    def test_create_chatbook_success_leaves_no_partial(self, mock_prompts_db, mock_chacha_db, chatbook_creator, tmp_path):
+        """Atomic finalize: a successful export yields a valid zip and no .partial sibling."""
+        import zipfile
+        mock_chacha_db.return_value = MagicMock()
+        mock_prompts_db.return_value = MagicMock()
+        output_path = tmp_path / "cb.zip"
+        success, _msg, _dep = chatbook_creator.create_chatbook(
+            name="S", description="", content_selections={ContentType.CONVERSATION: []},
+            output_path=output_path,
+        )
+        assert success is True
+        assert output_path.exists() and zipfile.is_zipfile(output_path)
+        assert not output_path.with_name(output_path.name + ".partial").exists()
+
     @patch('tldw_chatbook.Chatbooks.chatbook_creator.CharactersRAGDB')
     @patch('tldw_chatbook.Chatbooks.chatbook_creator.PromptsDatabase')
     def test_create_chatbook_with_sample_data(self, mock_prompts_db, mock_chacha_db, chatbook_creator, temp_db_paths, tmp_path):

--- a/Tests/Chatbooks/test_local_chatbook_service_export.py
+++ b/Tests/Chatbooks/test_local_chatbook_service_export.py
@@ -1,0 +1,42 @@
+import asyncio
+from unittest.mock import patch, MagicMock
+
+from tldw_chatbook.Chatbooks.local_chatbook_service import LocalChatbookService
+
+
+def _service(tmp_path):
+    db_paths = {"ChaChaNotes": str(tmp_path / "c.db"), "Media": str(tmp_path / "m.db"),
+                "Prompts": str(tmp_path / "p.db")}
+    return LocalChatbookService(db_paths)
+
+
+def test_export_forwards_hooks_and_maps_cancelled(tmp_path):
+    svc = _service(tmp_path)
+    captured = {}
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return False, "Export cancelled", {"cancelled": True, "missing_dependencies": [], "auto_included": []}
+
+    cb = lambda evt: None
+    cc = lambda: True
+    with patch("tldw_chatbook.Chatbooks.local_chatbook_service.ChatbookCreator") as CC:
+        CC.return_value.create_chatbook.side_effect = fake_create
+        result = asyncio.run(svc.export_chatbook(
+            {"name": "N", "content_selections": {}, "output_path": str(tmp_path / "o.zip")},
+            progress_callback=cb, cancel_check=cc,
+        ))
+    assert captured["progress_callback"] is cb
+    assert captured["cancel_check"] is cc
+    assert result["cancelled"] is True
+    assert result["success"] is False
+
+
+def test_export_success_reports_not_cancelled(tmp_path):
+    svc = _service(tmp_path)
+    with patch("tldw_chatbook.Chatbooks.local_chatbook_service.ChatbookCreator") as CC:
+        CC.return_value.create_chatbook.return_value = (True, "ok", {"missing_dependencies": [], "auto_included": []})
+        result = asyncio.run(svc.export_chatbook(
+            {"name": "N", "content_selections": {}, "output_path": str(tmp_path / "o.zip")}))
+    assert result["cancelled"] is False
+    assert result["success"] is True

--- a/Tests/Chatbooks/test_local_chatbook_service_export.py
+++ b/Tests/Chatbooks/test_local_chatbook_service_export.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 from tldw_chatbook.Chatbooks.local_chatbook_service import LocalChatbookService
 

--- a/Tests/Library/test_export_progress.py
+++ b/Tests/Library/test_export_progress.py
@@ -1,0 +1,25 @@
+from tldw_chatbook.Library.export_progress import (
+    ExportProgressThrottle, format_export_progress_line,
+)
+
+
+def test_throttle_emits_on_first_call_and_phase_change():
+    t = ExportProgressThrottle(min_interval=1.0)
+    assert t.should_emit("media", 1, 10, now=100.0) is True     # first ever
+    assert t.should_emit("media", 2, 10, now=100.1) is False    # within interval, same phase
+    assert t.should_emit("packaging", 1, 5, now=100.2) is True  # phase change flushes
+
+
+def test_throttle_emits_on_final_tick_and_interval():
+    t = ExportProgressThrottle(min_interval=1.0)
+    t.should_emit("media", 1, 10, now=0.0)
+    assert t.should_emit("media", 10, 10, now=0.05) is True     # current >= total flushes
+    t2 = ExportProgressThrottle(min_interval=0.1)
+    t2.should_emit("media", 1, 10, now=0.0)
+    assert t2.should_emit("media", 2, 10, now=0.2) is True      # interval elapsed
+
+
+def test_format_progress_line():
+    assert format_export_progress_line("media", 42, 318) == "Collecting media…  42/318"
+    assert format_export_progress_line("packaging", 210, 540) == "Packaging archive…  210/540 files"
+    assert format_export_progress_line("relationships", 1, 1) == "Resolving links…  1/1"

--- a/Tests/Library/test_export_progress.py
+++ b/Tests/Library/test_export_progress.py
@@ -19,6 +19,16 @@ def test_throttle_emits_on_final_tick_and_interval():
     assert t2.should_emit("media", 2, 10, now=0.2) is True      # interval elapsed
 
 
+def test_throttle_total_zero_does_not_bypass_time_throttle():
+    # An indeterminate/skipped phase (total == 0) must NOT force an emit on
+    # every tick via `current >= total` (1 >= 0) — it should fall back to the
+    # time throttle, or it would flood the UI thread.
+    t = ExportProgressThrottle(min_interval=1.0)
+    assert t.should_emit("media", 0, 0, now=0.0) is True    # first ever emits
+    assert t.should_emit("media", 1, 0, now=0.1) is False   # within interval -> throttled
+    assert t.should_emit("media", 2, 0, now=1.2) is True    # interval elapsed -> emits
+
+
 def test_format_progress_line():
     assert format_export_progress_line("media", 42, 318) == "Collecting media…  42/318"
     assert format_export_progress_line("packaging", 210, 540) == "Packaging archive…  210/540 files"

--- a/Tests/Library/test_library_export_execution.py
+++ b/Tests/Library/test_library_export_execution.py
@@ -109,7 +109,7 @@ class _FakeExportService:
         }
         self._create_error = create_error
 
-    async def export_chatbook(self, request_data):
+    async def export_chatbook(self, request_data, *, progress_callback=None, cancel_check=None):
         self.calls.append("export_chatbook")
         self.export_payloads.append(dict(request_data))
         return dict(self._export_result)
@@ -198,7 +198,7 @@ def test_export_via_service_reports_success_even_when_registry_recording_raises(
 
 def test_export_via_service_wraps_export_chatbook_exception_as_failure():
     class _RaisingService:
-        async def export_chatbook(self, request_data):
+        async def export_chatbook(self, request_data, *, progress_callback=None, cancel_check=None):
             raise RuntimeError("boom")
 
     outcome = LibraryScreen._run_library_export_via_service(

--- a/Tests/Library/test_library_export_execution.py
+++ b/Tests/Library/test_library_export_execution.py
@@ -156,6 +156,7 @@ def test_export_via_service_calls_export_then_create_in_order_on_success():
         "path": "/tmp/out.zip",
         "dependency_info": {"auto_included": [1, 2]},
         "registry_recorded": True,
+        "cancelled": False,
     }
     assert service.create_kwargs[0]["file_path"] == "/tmp/out.zip"
     assert service.create_kwargs[0]["tags"] == ["library-export"]

--- a/Tests/UI/test_library_export_cancel.py
+++ b/Tests/UI/test_library_export_cancel.py
@@ -1,0 +1,67 @@
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
+from tldw_chatbook.Widgets.Library.library_export_canvas import LibraryExportCanvas
+from tldw_chatbook.Library.library_export_state import build_library_export_form_state
+from tldw_chatbook.Library.library_export_scope import ExportScope
+
+
+def test_cancel_apply_ignores_stale_run():
+    calls = []
+    fake = SimpleNamespace(
+        _library_export_run_id=9, _library_export_running=True,
+        _library_export_status="Packaging archive…  1/5", _library_export_error="x",
+        _update_library_export_canvas_after_run=lambda: calls.append("update"),
+    )
+    LibraryScreen._apply_library_export_cancelled(fake, 4)  # 4 != 9
+    assert fake._library_export_running is True
+    assert calls == []
+
+
+def test_cancel_apply_current_run_sets_cancelled_status():
+    calls = []
+    fake = SimpleNamespace(
+        _library_export_run_id=9, _library_export_running=True,
+        _library_export_status="Packaging archive…  1/5", _library_export_error="x",
+        _update_library_export_canvas_after_run=lambda: calls.append("update"),
+    )
+    LibraryScreen._apply_library_export_cancelled(fake, 9)
+    assert fake._library_export_running is False
+    assert fake._library_export_status == "Export cancelled."
+    assert fake._library_export_error == ""
+    assert calls == ["update"]
+
+
+def test_cancel_handler_sets_event():
+    fake = SimpleNamespace(
+        _library_export_cancel_event=threading.Event(),
+        _library_export_running=True, _library_export_status="",
+        _refresh_library_export_status_line=lambda: None,
+    )
+    LibraryScreen.handle_library_export_cancel(fake, None)
+    assert fake._library_export_cancel_event.is_set()
+    assert fake._library_export_status == "Cancelling…"
+
+
+@pytest.mark.asyncio
+async def test_cancel_button_visible_only_while_running():
+    from textual.app import App
+
+    def _state(running):
+        return build_library_export_form_state(
+            scope=ExportScope(kind="everything"), counts={"total": 3}, name="n",
+            description="", media_quality="thumbnail", destination="/tmp/x.zip",
+            running=running, status_line="Exporting…" if running else "",
+        )
+
+    class Host(App):
+        def compose(self):
+            yield LibraryExportCanvas(_state(True), id="library-export-canvas")
+
+    app = Host()
+    async with app.run_test() as pilot:
+        cancel = pilot.app.query_one("#library-export-cancel")
+        assert cancel.display is True

--- a/Tests/UI/test_library_export_progress_apply.py
+++ b/Tests/UI/test_library_export_progress_apply.py
@@ -1,0 +1,34 @@
+from types import SimpleNamespace
+from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
+
+
+def _fake(run_id=7, running=True):
+    calls = []
+    fake = SimpleNamespace(
+        _library_export_run_id=run_id,
+        _library_export_running=running,
+        _library_export_status="",
+        _refresh_library_export_status_line=lambda: calls.append("refresh"),
+    )
+    return fake, calls
+
+
+def test_progress_apply_ignores_stale_run():
+    fake, calls = _fake(run_id=7)
+    LibraryScreen._apply_library_export_progress(fake, 3, "media", 5, 10)  # 3 != 7
+    assert fake._library_export_status == ""
+    assert calls == []
+
+
+def test_progress_apply_ignores_when_not_running():
+    fake, calls = _fake(run_id=7, running=False)
+    LibraryScreen._apply_library_export_progress(fake, 7, "media", 5, 10)
+    assert fake._library_export_status == ""
+    assert calls == []
+
+
+def test_progress_apply_updates_current_run():
+    fake, calls = _fake(run_id=7)
+    LibraryScreen._apply_library_export_progress(fake, 7, "media", 5, 10)
+    assert fake._library_export_status == "Collecting media…  5/10"
+    assert calls == ["refresh"]

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -10070,7 +10070,7 @@ class _FakeLibraryExportService:
         self._gate = gate
         self._create_error = create_error
 
-    async def export_chatbook(self, request_data):
+    async def export_chatbook(self, request_data, *, progress_callback=None, cancel_check=None):
         if self._gate is not None:
             assert self._gate.wait(
                 timeout=_GATED_RELEASE_TIMEOUT_SECONDS

--- a/backlog/tasks/task-157 - Chatbook-export-progress-reporting-and-cancel.md
+++ b/backlog/tasks/task-157 - Chatbook-export-progress-reporting-and-cancel.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-157
 title: Chatbook export progress reporting and cancel
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-11 22:01'
 labels:
@@ -18,7 +18,50 @@ The Library export worker shows a static Exporting… line because ChatbookCreat
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Export form shows real progress while a large export runs
-- [ ] #2 User can cancel an in-flight export
-- [ ] #3 Creator exposes progress/cancel hooks
+- [x] #1 Export form shows real progress while a large export runs
+- [x] #2 User can cancel an in-flight export
+- [x] #3 Creator exposes progress/cancel hooks
 <!-- AC:END -->
+
+## Implementation Notes
+
+Implemented across five commits (T1-T5):
+
+- **T1**: `ChatbookCreator` (`tldw_chatbook/Chatbooks/chatbook_creator.py`)
+  grew `progress_callback`/`cancel_event` hooks, emitting phase/current/
+  total ticks during selection/media/conversation/notes collection and
+  checking the cancel event between phases; finalize (zip write + manifest)
+  is atomic so a cancel never leaves a partial archive.
+- **T2**: `export_chatbook` (`tldw_chatbook/Chatbooks/local_chatbook_service.py`)
+  forwards `progress_callback`/`cancel_check` to the creator and returns a
+  `cancelled: bool` alongside `success`/`message`/`path`/`dependency_info`.
+- **T3**: `tldw_chatbook/Library/export_progress.py` (new) — a pure
+  `ExportProgressThrottle` (rate-limits UI ticks) and
+  `format_export_progress_line` (phase/current/total -> display string),
+  unit-tested independent of Textual.
+- **T4**: The Library export worker (`tldw_chatbook/UI/Screens/library_screen.py`)
+  wires the throttle + formatter into a `_apply_library_export_progress`
+  targeted status-line update (no recompose), and a per-run
+  `threading.Event` is created at submit and threaded through as
+  `cancel_event` (not yet consumed by anything until T5).
+- **T5**: A `#library-export-cancel` Button in
+  `tldw_chatbook/Widgets/Library/library_export_canvas.py` (display-toggled
+  by `state.running`, same pattern as the canvas's other always-mounted/
+  toggled widgets) sets that Event via `handle_library_export_cancel`
+  without bumping `_library_export_run_id` (the run is still current until
+  the worker reports back). The worker's outcome dict now carries
+  `cancelled`; `_run_library_export_worker` branches cancelled ->
+  `_marshal_library_export_cancelled` before the success/failure branches.
+  `_apply_library_export_cancelled(run_id)` mirrors the failure path's
+  staleness guard (`run_id != self._library_export_run_id` bails before any
+  mutation), then sets `_library_export_status = "Export cancelled."` and
+  calls `_update_library_export_canvas_after_run()`, which now also hides
+  the Cancel button. `_reset_library_export_transient_state`
+  (navigate-away) sets the outgoing Event before bumping `run_id` so an
+  abandoned worker stops promptly.
+
+Tests: `Tests/Chatbooks/test_chatbook_creator.py`,
+`Tests/Chatbooks/test_local_chatbook_service_export.py`,
+`Tests/Library/test_export_progress.py`,
+`Tests/UI/test_library_export_progress_apply.py`,
+`Tests/UI/test_library_export_cancel.py` (new).

--- a/tldw_chatbook/Chatbooks/chatbook_creator.py
+++ b/tldw_chatbook/Chatbooks/chatbook_creator.py
@@ -12,6 +12,7 @@ import json
 import os
 import shutil
 import tempfile
+import threading
 import zipfile
 import hashlib
 import html
@@ -106,12 +107,15 @@ class ChatbookCreator:
         self.missing_dependencies: Set[int] = set()
         self.auto_included_characters: Set[int] = set()
         self._selected_characters: Set[str] = set()  # Track explicitly selected characters
-        self._progress_callback: Optional[Callable[[ExportProgress], None]] = None
-        self._cancel_check: Optional[Callable[[], bool]] = None
+        # Progress/cancel hooks are stored per-thread so a single ChatbookCreator
+        # instance reused across exports (e.g. ChatbookCreationWindow keeps one)
+        # can never have one export's callbacks overwrite another's if two ever
+        # run concurrently on different threads.
+        self._thread_local = threading.local()
         logger.info("ChatbookCreator.__init__: Initialization complete")
 
     def _emit_progress(self, phase: str, current: int, total: int) -> None:
-        cb = self._progress_callback
+        cb = getattr(self._thread_local, "progress_callback", None)
         if cb is None:
             return
         try:
@@ -120,7 +124,8 @@ class ChatbookCreator:
             logger.opt(exception=True).debug("ChatbookCreator: progress_callback raised; ignored")
 
     def _check_cancel(self) -> None:
-        if self._cancel_check is not None and self._cancel_check():
+        cancel_check = getattr(self._thread_local, "cancel_check", None)
+        if cancel_check is not None and cancel_check():
             raise ChatbookExportCancelled()
 
     def _cleanup_paths(self, *paths: Optional[Path]) -> None:
@@ -177,8 +182,8 @@ class ChatbookCreator:
         logger.info(f"ChatbookCreator.create_chatbook: Options - include_media={include_media}, media_quality={media_quality}, include_embeddings={include_embeddings}, auto_include_dependencies={auto_include_dependencies}")
         logger.info(f"ChatbookCreator.create_chatbook: Content selections - {[(t.value, len(ids)) for t, ids in content_selections.items()]}")
 
-        self._progress_callback = progress_callback
-        self._cancel_check = cancel_check
+        self._thread_local.progress_callback = progress_callback
+        self._thread_local.cancel_check = cancel_check
         work_dir: Optional[Path] = None
         partial_path: Optional[Path] = None
         try:
@@ -299,10 +304,9 @@ class ChatbookCreator:
             manifest.total_size_bytes = output_path.stat().st_size
             logger.info(f"ChatbookCreator.create_chatbook: Archive size: {manifest.total_size_bytes} bytes")
             
-            # Cleanup temp directory
-            logger.info(f"ChatbookCreator.create_chatbook: Cleaning up temporary directory {work_dir}")
-            shutil.rmtree(work_dir)
-            
+            # (temp work_dir + any leftover .partial are cleaned up in the
+            # `finally` below, on every exit path — success, cancel, error.)
+
             # Prepare dependency info
             dependency_info = {
                 "missing_dependencies": list(self.missing_dependencies),
@@ -321,7 +325,6 @@ class ChatbookCreator:
             
         except ChatbookExportCancelled:
             logger.info("ChatbookCreator.create_chatbook: cancelled by request")
-            self._cleanup_paths(work_dir, partial_path)
             return False, "Export cancelled", {
                 "cancelled": True,
                 "missing_dependencies": list(self.missing_dependencies),
@@ -329,15 +332,18 @@ class ChatbookCreator:
             }
         except Exception as e:
             logger.opt(exception=True).error("ChatbookCreator.create_chatbook: Error creating chatbook")
-            self._cleanup_paths(work_dir, partial_path)
             dependency_info = {
                 "missing_dependencies": list(self.missing_dependencies),
                 "auto_included": list(self.auto_included_characters)
             }
             return False, f"Error creating chatbook: {str(e)}", dependency_info
         finally:
-            self._progress_callback = None
-            self._cancel_check = None
+            # Single cleanup point for every exit path (success/cancel/error):
+            # remove the temp work_dir and any leftover .partial archive, and
+            # clear this thread's hooks so a reused instance never leaks them.
+            self._cleanup_paths(work_dir, partial_path)
+            self._thread_local.progress_callback = None
+            self._thread_local.cancel_check = None
 
     def _collect_conversations(
         self,

--- a/tldw_chatbook/Chatbooks/chatbook_creator.py
+++ b/tldw_chatbook/Chatbooks/chatbook_creator.py
@@ -128,17 +128,27 @@ class ChatbookCreator:
         if cancel_check is not None and cancel_check():
             raise ChatbookExportCancelled()
 
-    def _cleanup_paths(self, *paths: Optional[Path]) -> None:
-        for p in paths:
-            if not p:
-                continue
+    def _cleanup_run(self, work_dir: Optional[Path], partial_path: Optional[Path]) -> None:
+        """Remove this run's temp artifacts on any exit path.
+
+        ``work_dir`` is a temp directory we created (safe to rmtree).
+        ``partial_path`` is a sibling of the user-chosen destination and is only
+        ever a *file* we wrote, so it is unlinked as a file and NEVER rmtree'd —
+        a directory unexpectedly sitting at ``<dest>.partial`` must not be
+        recursively deleted.
+        """
+        if work_dir is not None:
             try:
-                if p.is_dir():
-                    shutil.rmtree(p, ignore_errors=True)
-                elif p.exists():
-                    p.unlink()
-            except Exception:
-                logger.opt(exception=True).debug(f"ChatbookCreator: cleanup failed for {p}")
+                if work_dir.is_dir():
+                    shutil.rmtree(work_dir, ignore_errors=True)
+            except OSError:
+                logger.opt(exception=True).debug(f"ChatbookCreator: could not remove work_dir {work_dir}")
+        if partial_path is not None:
+            try:
+                if partial_path.is_file():
+                    partial_path.unlink()
+            except OSError:
+                logger.opt(exception=True).debug(f"ChatbookCreator: could not remove partial {partial_path}")
 
     def create_chatbook(
         self,
@@ -300,9 +310,14 @@ class ChatbookCreator:
             logger.info(f"ChatbookCreator.create_chatbook: Creating ZIP archive at {output_path}")
             self._create_zip_archive(work_dir, output_path, partial_path)
             
-            # Calculate final size
-            manifest.total_size_bytes = output_path.stat().st_size
-            logger.info(f"ChatbookCreator.create_chatbook: Archive size: {manifest.total_size_bytes} bytes")
+            # Best-effort size calc: the archive is already finalized on disk
+            # (os.replace done inside _create_zip_archive), so a stat() failure
+            # here must NOT flip a successful export into a reported failure.
+            try:
+                manifest.total_size_bytes = output_path.stat().st_size
+                logger.info(f"ChatbookCreator.create_chatbook: Archive size: {manifest.total_size_bytes} bytes")
+            except OSError:
+                logger.opt(exception=True).debug("ChatbookCreator.create_chatbook: could not stat finalized archive")
             
             # (temp work_dir + any leftover .partial are cleaned up in the
             # `finally` below, on every exit path — success, cancel, error.)
@@ -341,7 +356,7 @@ class ChatbookCreator:
             # Single cleanup point for every exit path (success/cancel/error):
             # remove the temp work_dir and any leftover .partial archive, and
             # clear this thread's hooks so a reused instance never leaks them.
-            self._cleanup_paths(work_dir, partial_path)
+            self._cleanup_run(work_dir, partial_path)
             self._thread_local.progress_callback = None
             self._thread_local.cancel_check = None
 

--- a/tldw_chatbook/Chatbooks/chatbook_creator.py
+++ b/tldw_chatbook/Chatbooks/chatbook_creator.py
@@ -9,15 +9,17 @@ Handles the creation and packaging of chatbooks from database content.
 """
 
 import json
+import os
 import shutil
 import tempfile
 import zipfile
 import hashlib
 import html
 from collections.abc import Mapping
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import List, Dict, Any, Optional, Set, Tuple
+from typing import Callable, List, Dict, Any, Optional, Set, Tuple
 from loguru import logger
 
 from .chatbook_models import (
@@ -63,9 +65,21 @@ def _coerce_media_timestamp(value: Any) -> Optional[datetime]:
     return None
 
 
+@dataclass(frozen=True)
+class ExportProgress:
+    """A single progress tick emitted during chatbook creation."""
+    phase: str
+    current: int
+    total: int
+
+
+class ChatbookExportCancelled(Exception):
+    """Raised internally when cancel_check() returns True at a checkpoint."""
+
+
 class ChatbookCreator:
     """Service for creating chatbooks from database content."""
-    
+
     def __init__(self, db_paths: Dict[str, str]):
         """
         Initialize the chatbook creator.
@@ -92,8 +106,35 @@ class ChatbookCreator:
         self.missing_dependencies: Set[int] = set()
         self.auto_included_characters: Set[int] = set()
         self._selected_characters: Set[str] = set()  # Track explicitly selected characters
+        self._progress_callback: Optional[Callable[[ExportProgress], None]] = None
+        self._cancel_check: Optional[Callable[[], bool]] = None
         logger.info("ChatbookCreator.__init__: Initialization complete")
-        
+
+    def _emit_progress(self, phase: str, current: int, total: int) -> None:
+        cb = self._progress_callback
+        if cb is None:
+            return
+        try:
+            cb(ExportProgress(phase=phase, current=current, total=total))
+        except Exception:
+            logger.opt(exception=True).debug("ChatbookCreator: progress_callback raised; ignored")
+
+    def _check_cancel(self) -> None:
+        if self._cancel_check is not None and self._cancel_check():
+            raise ChatbookExportCancelled()
+
+    def _cleanup_paths(self, *paths: Optional[Path]) -> None:
+        for p in paths:
+            if not p:
+                continue
+            try:
+                if p.is_dir():
+                    shutil.rmtree(p, ignore_errors=True)
+                elif p.exists():
+                    p.unlink()
+            except Exception:
+                logger.opt(exception=True).debug(f"ChatbookCreator: cleanup failed for {p}")
+
     def create_chatbook(
         self,
         name: str,
@@ -106,7 +147,9 @@ class ChatbookCreator:
         include_embeddings: bool = False,
         tags: List[str] = None,
         categories: List[str] = None,
-        auto_include_dependencies: bool = True
+        auto_include_dependencies: bool = True,
+        progress_callback: Optional[Callable[["ExportProgress"], None]] = None,
+        cancel_check: Optional[Callable[[], bool]] = None,
     ) -> Tuple[bool, str, Dict[str, Any]]:
         """
         Create a chatbook from selected content.
@@ -133,7 +176,11 @@ class ChatbookCreator:
         logger.info(f"ChatbookCreator.create_chatbook: Starting creation of '{name}'")
         logger.info(f"ChatbookCreator.create_chatbook: Options - include_media={include_media}, media_quality={media_quality}, include_embeddings={include_embeddings}, auto_include_dependencies={auto_include_dependencies}")
         logger.info(f"ChatbookCreator.create_chatbook: Content selections - {[(t.value, len(ids)) for t, ids in content_selections.items()]}")
-        
+
+        self._progress_callback = progress_callback
+        self._cancel_check = cancel_check
+        work_dir: Optional[Path] = None
+        partial_path: Optional[Path] = None
         try:
             # Reset dependency tracking
             self.missing_dependencies.clear()
@@ -241,15 +288,12 @@ class ChatbookCreator:
             logger.info("ChatbookCreator.create_chatbook: Creating README")
             self._create_readme(work_dir, manifest)
             
-            # Package into archive
-            if output_path.suffix == '.zip':
-                logger.info(f"ChatbookCreator.create_chatbook: Creating ZIP archive at {output_path}")
-                self._create_zip_archive(work_dir, output_path)
-            else:
-                # Default to ZIP if no extension specified
+            # Package into archive (atomic finalize: write .partial, then os.replace)
+            if output_path.suffix != '.zip':
                 output_path = output_path.with_suffix('.zip')
-                logger.info(f"ChatbookCreator.create_chatbook: Creating ZIP archive at {output_path} (defaulted to .zip)")
-                self._create_zip_archive(work_dir, output_path)
+            partial_path = output_path.with_name(output_path.name + ".partial")
+            logger.info(f"ChatbookCreator.create_chatbook: Creating ZIP archive at {output_path}")
+            self._create_zip_archive(work_dir, output_path, partial_path)
             
             # Calculate final size
             manifest.total_size_bytes = output_path.stat().st_size
@@ -275,14 +319,26 @@ class ChatbookCreator:
             logger.info(f"ChatbookCreator.create_chatbook: Success - {message}")
             return True, message, dependency_info
             
+        except ChatbookExportCancelled:
+            logger.info("ChatbookCreator.create_chatbook: cancelled by request")
+            self._cleanup_paths(work_dir, partial_path)
+            return False, "Export cancelled", {
+                "cancelled": True,
+                "missing_dependencies": list(self.missing_dependencies),
+                "auto_included": list(self.auto_included_characters),
+            }
         except Exception as e:
             logger.opt(exception=True).error("ChatbookCreator.create_chatbook: Error creating chatbook")
+            self._cleanup_paths(work_dir, partial_path)
             dependency_info = {
                 "missing_dependencies": list(self.missing_dependencies),
                 "auto_included": list(self.auto_included_characters)
             }
             return False, f"Error creating chatbook: {str(e)}", dependency_info
-    
+        finally:
+            self._progress_callback = None
+            self._cancel_check = None
+
     def _collect_conversations(
         self,
         conversation_ids: List[str],
@@ -307,7 +363,10 @@ class ChatbookCreator:
         conv_dir.mkdir(parents=True, exist_ok=True)
         logger.info(f"ChatbookCreator._collect_conversations: Created conversations directory at {conv_dir}")
         
-        for conv_id in conversation_ids:
+        total = len(conversation_ids)
+        for idx, conv_id in enumerate(conversation_ids):
+            self._check_cancel()
+            self._emit_progress("conversations", idx + 1, total)
             logger.debug(f"ChatbookCreator._collect_conversations: Processing conversation {conv_id}")
             try:
                 # Get conversation details
@@ -654,7 +713,10 @@ class ChatbookCreator:
         notes_dir = work_dir / "content" / "notes"
         notes_dir.mkdir(parents=True, exist_ok=True)
         
-        for note_id in note_ids:
+        total = len(note_ids)
+        for idx, note_id in enumerate(note_ids):
+            self._check_cancel()
+            self._emit_progress("notes", idx + 1, total)
             try:
                 # Get note details
                 note = db.get_note_by_id(note_id)
@@ -729,7 +791,10 @@ class ChatbookCreator:
         chars_dir = work_dir / "content" / "characters"
         chars_dir.mkdir(parents=True, exist_ok=True)
         
-        for char_id in character_ids:
+        total = len(character_ids)
+        for idx, char_id in enumerate(character_ids):
+            self._check_cancel()
+            self._emit_progress("characters", idx + 1, total)
             try:
                 # Get character card (which includes all details)
                 char = db.get_character_card_by_id(int(char_id))
@@ -793,7 +858,10 @@ class ChatbookCreator:
         metadata_dir = media_dir / "metadata"
         metadata_dir.mkdir(exist_ok=True)
         
-        for media_id in media_ids:
+        total = len(media_ids)
+        for idx, media_id in enumerate(media_ids):
+            self._check_cancel()
+            self._emit_progress("media", idx + 1, total)
             try:
                 # Get media details from database
                 media_item = db.get_media_by_id(int(media_id))
@@ -891,7 +959,10 @@ class ChatbookCreator:
         prompts_dir = work_dir / "content" / "prompts"
         prompts_dir.mkdir(parents=True, exist_ok=True)
         
-        for prompt_id in prompt_ids:
+        total = len(prompt_ids)
+        for idx, prompt_id in enumerate(prompt_ids):
+            self._check_cancel()
+            self._emit_progress("prompts", idx + 1, total)
             try:
                 # Get prompt details
                 prompt = db.get_prompt_by_id(int(prompt_id))
@@ -1012,6 +1083,8 @@ class ChatbookCreator:
     
     def _discover_relationships(self, manifest: ChatbookManifest, content: ChatbookContent) -> None:
         """Discover relationships between content items."""
+        self._check_cancel()
+        self._emit_progress("relationships", 1, 1)
         # Find conversation-character relationships
         for conv in content.conversations:
             if conv.get('character_id'):
@@ -1087,10 +1160,14 @@ class ChatbookCreator:
             else:
                 f.write("See individual content files for licensing information.")
     
-    def _create_zip_archive(self, work_dir: Path, output_path: Path) -> None:
-        """Create a ZIP archive of the chatbook."""
-        with zipfile.ZipFile(output_path, 'w', zipfile.ZIP_DEFLATED) as zf:
-            for file_path in work_dir.rglob('*'):
-                if file_path.is_file():
-                    arcname = file_path.relative_to(work_dir)
-                    zf.write(file_path, arcname)
+    def _create_zip_archive(self, work_dir: Path, output_path: Path, partial_path: Path) -> None:
+        """Zip work_dir into a sibling .partial, then atomically replace output_path."""
+        files = [p for p in work_dir.rglob('*') if p.is_file()]
+        total = len(files)
+        with zipfile.ZipFile(partial_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+            for idx, file_path in enumerate(files):
+                self._check_cancel()
+                arcname = file_path.relative_to(work_dir)
+                zf.write(file_path, arcname)
+                self._emit_progress("packaging", idx + 1, total)
+        os.replace(partial_path, output_path)

--- a/tldw_chatbook/Chatbooks/local_chatbook_service.py
+++ b/tldw_chatbook/Chatbooks/local_chatbook_service.py
@@ -6,7 +6,7 @@ import json
 import threading
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable, Optional
 
 from tldw_chatbook.tldw_api.prompt_chatbook_schemas import ChatbookImportRequest
 from tldw_chatbook.Utils.atomic_file_ops import atomic_write_json
@@ -245,7 +245,13 @@ class LocalChatbookService:
             self._save_registry(registry)
         return True
 
-    async def export_chatbook(self, request_data: Any, *, progress_callback=None, cancel_check=None) -> dict[str, Any]:
+    async def export_chatbook(
+        self,
+        request_data: Any,
+        *,
+        progress_callback: Optional[Callable[[Any], None]] = None,
+        cancel_check: Optional[Callable[[], bool]] = None,
+    ) -> dict[str, Any]:
         payload = self._as_dict(request_data)
         output_path = payload.pop("output_path", None)
         if output_path is None:

--- a/tldw_chatbook/Chatbooks/local_chatbook_service.py
+++ b/tldw_chatbook/Chatbooks/local_chatbook_service.py
@@ -245,7 +245,7 @@ class LocalChatbookService:
             self._save_registry(registry)
         return True
 
-    async def export_chatbook(self, request_data: Any) -> dict[str, Any]:
+    async def export_chatbook(self, request_data: Any, *, progress_callback=None, cancel_check=None) -> dict[str, Any]:
         payload = self._as_dict(request_data)
         output_path = payload.pop("output_path", None)
         if output_path is None:
@@ -263,13 +263,17 @@ class LocalChatbookService:
             include_embeddings=bool(payload.get("include_embeddings", False)),
             tags=payload.get("tags") or [],
             categories=payload.get("categories") or [],
+            progress_callback=progress_callback,
+            cancel_check=cancel_check,
         )
+        cancelled = bool(dependency_info.get("cancelled", False)) if isinstance(dependency_info, dict) else False
         return {
             "success": success,
             "message": message,
             "path": str(output_path),
             "dependency_info": dependency_info,
             "name": payload.get("name") or Path(output_path).stem,
+            "cancelled": cancelled,
         }
 
     async def import_chatbook(self, chatbook_file_path: str | Path, request_data: Any) -> dict[str, Any]:

--- a/tldw_chatbook/Library/export_progress.py
+++ b/tldw_chatbook/Library/export_progress.py
@@ -41,7 +41,7 @@ class ExportProgressThrottle:
     def should_emit(self, phase: str, current: int, total: int, now: float) -> bool:
         if (
             phase != self._last_phase
-            or current >= total
+            or (total > 0 and current >= total)
             or self._last_emit is None
             or (now - self._last_emit) >= self._min_interval
         ):

--- a/tldw_chatbook/Library/export_progress.py
+++ b/tldw_chatbook/Library/export_progress.py
@@ -1,0 +1,51 @@
+"""Pure helpers for rendering chatbook-export progress in the Library canvas.
+
+Kept dependency-free (no Textual) so it is trivially unit-testable; the screen
+supplies ``time.monotonic()`` as ``now`` so the throttle has no hidden clock.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+EXPORT_PHASE_LABELS: dict[str, str] = {
+    "conversations": "Collecting conversations",
+    "notes": "Collecting notes",
+    "characters": "Collecting characters",
+    "media": "Collecting media",
+    "prompts": "Collecting prompts",
+    "relationships": "Resolving links",
+    "packaging": "Packaging archive",
+}
+
+
+def format_export_progress_line(phase: str, current: int, total: int) -> str:
+    label = EXPORT_PHASE_LABELS.get(phase, "Exporting")
+    unit = " files" if phase == "packaging" else ""
+    return f"{label}…  {current}/{total}{unit}"
+
+
+class ExportProgressThrottle:
+    """Decides whether a progress tick should be pushed to the UI thread.
+
+    Emits when the phase changes, when the phase's final item is reached
+    (``current >= total``), or when ``min_interval`` seconds have elapsed since
+    the last emit — so a fast inner loop never floods the UI, yet the line
+    never freezes mid-count.
+    """
+
+    def __init__(self, min_interval: float = 0.1) -> None:
+        self._min_interval = min_interval
+        self._last_phase: Optional[str] = None
+        self._last_emit: Optional[float] = None
+
+    def should_emit(self, phase: str, current: int, total: int, now: float) -> bool:
+        if (
+            phase != self._last_phase
+            or current >= total
+            or self._last_emit is None
+            or (now - self._last_emit) >= self._min_interval
+        ):
+            self._last_phase = phase
+            self._last_emit = now
+            return True
+        return False

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import re
+import threading
 import time
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
@@ -33,6 +34,10 @@ from ...Constants import (
     LIBRARY_NAV_CONTEXT_NOTES_CREATE,
 )
 from ...DB.ChaChaNotes_DB import ConflictError
+from ...Library.export_progress import (
+    ExportProgressThrottle,
+    format_export_progress_line,
+)
 from ...Library.library_collections_service import LibraryCollectionsServiceError
 from ...Library.library_collections_state import LibraryCollectionsPanelState
 from ...Library.library_conversations_state import build_library_conversations_state
@@ -659,6 +664,12 @@ class LibraryScreen(BaseAppScreen):
         # at, mirroring ``_apply_library_export_counts``'s scope-mismatch
         # staleness guard for the sibling counts worker.
         self._library_export_run_id: int = 0
+        # Task 4: the current run's cancellation signal. Created fresh at
+        # every submit (``handle_library_export_submit``); the worker reads
+        # ``event.is_set`` as the service's ``cancel_check``. Nothing sets
+        # it yet in this task -- the Cancel button and navigate-away wiring
+        # land in Task 5.
+        self._library_export_cancel_event: threading.Event | None = None
 
     def on_mount(self) -> None:
         """Populate the Library on entry, rendering instantly from cache.
@@ -3426,6 +3437,8 @@ class LibraryScreen(BaseAppScreen):
         self._library_export_status = f"Exporting… ({total} items)"
         self._library_export_run_id += 1
         run_id = self._library_export_run_id
+        self._library_export_cancel_event = threading.Event()
+        cancel_event = self._library_export_cancel_event
         self.refresh(recompose=True)
         self._start_library_export_worker(
             run_id=run_id,
@@ -3434,6 +3447,7 @@ class LibraryScreen(BaseAppScreen):
             description=description,
             media_quality=media_quality,
             destination=destination,
+            cancel_event=cancel_event,
         )
 
     def _start_library_export_worker(
@@ -3445,6 +3459,7 @@ class LibraryScreen(BaseAppScreen):
         description: str,
         media_quality: str,
         destination: str,
+        cancel_event: threading.Event,
     ) -> None:
         """Resolve selections (memory-DB-safe), then dispatch the real export worker.
 
@@ -3495,6 +3510,7 @@ class LibraryScreen(BaseAppScreen):
             media_db=media_db,
             chachanotes_db=chachanotes_db,
             preresolved_selections=preresolved_selections,
+            cancel_event=cancel_event,
         )
 
     @staticmethod
@@ -3534,6 +3550,8 @@ class LibraryScreen(BaseAppScreen):
         *,
         name: str,
         description: str,
+        progress_callback=None,
+        cancel_check=None,
     ) -> dict[str, Any]:
         """Execute one export through ``service``, synchronously: zip first, registry only on success.
 
@@ -3557,7 +3575,9 @@ class LibraryScreen(BaseAppScreen):
         ``dependency_info``, ``registry_recorded``.
         """
         try:
-            export_result = asyncio.run(service.export_chatbook(payload))
+            export_result = asyncio.run(service.export_chatbook(
+                payload, progress_callback=progress_callback, cancel_check=cancel_check,
+            ))
         except Exception as exc:
             logger.opt(exception=True).warning("Library export service call failed.")
             return {
@@ -3616,6 +3636,7 @@ class LibraryScreen(BaseAppScreen):
         media_db: Any,
         chachanotes_db: Any,
         preresolved_selections: dict[ContentType, list[str]] | None,
+        cancel_event: threading.Event | None,
     ) -> None:
         if preresolved_selections is not None:
             selections = preresolved_selections
@@ -3645,8 +3666,23 @@ class LibraryScreen(BaseAppScreen):
             destination=destination,
             media_quality=media_quality,
         )
+        throttle = ExportProgressThrottle()
+
+        def _progress_cb(evt) -> None:
+            try:
+                if not throttle.should_emit(evt.phase, evt.current, evt.total, time.monotonic()):
+                    return
+                self.app.call_from_thread(
+                    self._apply_library_export_progress, run_id, evt.phase, evt.current, evt.total,
+                )
+            except Exception:
+                # NoApp/shutdown mid-marshal must not crash the worker.
+                pass
+
         outcome = self._run_library_export_via_service(
-            service, payload, name=name, description=description
+            service, payload, name=name, description=description,
+            progress_callback=_progress_cb,
+            cancel_check=(cancel_event.is_set if cancel_event is not None else None),
         )
         if outcome["success"]:
             self._marshal_library_export_success(
@@ -3829,6 +3865,26 @@ class LibraryScreen(BaseAppScreen):
         self._library_export_status = ""
         self._library_export_error = escape_markup(str(message))
         self._update_library_export_canvas_after_run()
+
+    def _apply_library_export_progress(
+        self, run_id: int, phase: str, current: int, total: int
+    ) -> None:
+        """UI-thread progress tick: update the status line in place if this run is current."""
+        if run_id != self._library_export_run_id or not self._library_export_running:
+            return
+        self._library_export_status = format_export_progress_line(phase, current, total)
+        self._refresh_library_export_status_line()
+
+    def _refresh_library_export_status_line(self) -> None:
+        """Update only the #library-export-status-line widget (no recompose)."""
+        if not self.is_mounted or self._library_selected_row_id != LIBRARY_ROW_INGEST_EXPORT:
+            return
+        try:
+            widget = self.query_one("#library-export-status-line", Static)
+            widget.update(self._library_export_status)
+            widget.display = bool(self._library_export_status)
+        except (NoMatches, QueryError):
+            pass
 
     def _update_library_export_canvas_after_run(self) -> None:
         """Targeted DOM update once an export run finishes (success or failure).

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -3185,6 +3185,8 @@ class LibraryScreen(BaseAppScreen):
         self._library_export_running = False
         self._library_export_error = ""
         self._library_export_status = ""
+        if self._library_export_cancel_event is not None:
+            self._library_export_cancel_event.set()
         self._library_export_run_id += 1
 
     async def _open_library_export_canvas(self, scope: ExportScope) -> None:
@@ -3450,6 +3452,23 @@ class LibraryScreen(BaseAppScreen):
             cancel_event=cancel_event,
         )
 
+    @on(Button.Pressed, "#library-export-cancel")
+    def handle_library_export_cancel(self, event: "Button.Pressed") -> None:
+        """Request cancellation of the in-flight export.
+
+        Sets the worker's cancel Event (idempotent) and flips the status line to
+        "Cancelling…". Deliberately does NOT bump _library_export_run_id: the run
+        is still the current, visible one until the worker reports back with the
+        cancelled outcome (see _apply_library_export_cancelled).
+        """
+        if not self._library_export_running:
+            return
+        event_obj = self._library_export_cancel_event
+        if event_obj is not None:
+            event_obj.set()
+        self._library_export_status = "Cancelling…"
+        self._refresh_library_export_status_line()
+
     def _start_library_export_worker(
         self,
         *,
@@ -3586,6 +3605,7 @@ class LibraryScreen(BaseAppScreen):
                 "path": "",
                 "dependency_info": {},
                 "registry_recorded": False,
+                "cancelled": False,
             }
 
         if not export_result.get("success"):
@@ -3595,6 +3615,7 @@ class LibraryScreen(BaseAppScreen):
                 "path": export_result.get("path") or payload.get("output_path", ""),
                 "dependency_info": export_result.get("dependency_info") or {},
                 "registry_recorded": False,
+                "cancelled": bool(export_result.get("cancelled", False)),
             }
 
         output_path = export_result.get("path") or payload.get("output_path", "")
@@ -3621,6 +3642,7 @@ class LibraryScreen(BaseAppScreen):
             "path": output_path,
             "dependency_info": dependency_info,
             "registry_recorded": registry_recorded,
+            "cancelled": False,
         }
 
     @work(thread=True, exclusive=True, group="library_export")
@@ -3684,7 +3706,9 @@ class LibraryScreen(BaseAppScreen):
             progress_callback=_progress_cb,
             cancel_check=(cancel_event.is_set if cancel_event is not None else None),
         )
-        if outcome["success"]:
+        if outcome.get("cancelled"):
+            self._marshal_library_export_cancelled(run_id)
+        elif outcome["success"]:
             self._marshal_library_export_success(
                 run_id,
                 outcome["path"],
@@ -3730,6 +3754,25 @@ class LibraryScreen(BaseAppScreen):
             # Textual's NoApp (which subclasses Exception, not RuntimeError)
             # -- either way the worker thread must not crash on teardown.
             pass
+
+    def _marshal_library_export_cancelled(self, run_id: int) -> None:
+        """Marshal a cancelled run onto the UI thread (called from the worker)."""
+        try:
+            self.app.call_from_thread(self._apply_library_export_cancelled, run_id)
+        except Exception:
+            # A shutdown/detach mid-marshal can raise RuntimeError OR
+            # Textual's NoApp (which subclasses Exception, not RuntimeError)
+            # -- either way the worker thread must not crash on teardown.
+            pass
+
+    def _apply_library_export_cancelled(self, run_id: int) -> None:
+        """UI-thread completion for a cancelled run: clear running, show cancelled, return to form."""
+        if run_id != self._library_export_run_id:
+            return
+        self._library_export_running = False
+        self._library_export_status = "Export cancelled."
+        self._library_export_error = ""
+        self._update_library_export_canvas_after_run()
 
     @staticmethod
     def _build_library_export_success_message(
@@ -3923,6 +3966,7 @@ class LibraryScreen(BaseAppScreen):
             self.query_one("#library-export-submit", Button).disabled = (
                 not state.export_enabled
             )
+            self.query_one("#library-export-cancel", Button).display = bool(state.running)
         except (NoMatches, QueryError):
             pass
 

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -3463,6 +3463,8 @@ class LibraryScreen(BaseAppScreen):
         """
         if not self._library_export_running:
             return
+        if event is not None:
+            event.stop()
         event_obj = self._library_export_cancel_event
         if event_obj is not None:
             event_obj.set()

--- a/tldw_chatbook/Widgets/Library/library_export_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_export_canvas.py
@@ -141,3 +141,11 @@ class LibraryExportCanvas(VerticalScroll):
             compact=True,
             disabled=not state.export_enabled,
         )
+        cancel_button = Button(
+            "Cancel",
+            id="library-export-cancel",
+            classes="library-canvas-action",
+            compact=True,
+        )
+        cancel_button.display = bool(state.running)
+        yield cancel_button


### PR DESCRIPTION
## Summary

Backlog **task 157** (follow-up from the F-series tracking PR #598). The F4 bulk Library export shipped with a static `Exporting…` line and no way to interrupt a long run. This adds a **live per-phase item-count progress line** and a **working Cancel control**, reusing the existing chatbook export path.

Spec: `Docs/superpowers/specs/2026-07-11-library-export-progress-cancel-design.md`
Plan: `Docs/superpowers/plans/2026-07-11-library-export-progress-cancel.md`

## What changed (four layers)

- **`ChatbookCreator`** — optional `progress_callback` / `cancel_check` hooks (default `None` → byte-for-byte current behavior), carried as instance state so the `_collect_*` / `_discover_relationships` / `_create_zip_archive` helpers emit `ExportProgress(phase, current, total)` ticks and check for cancel at each item/file. **Atomic finalize:** the zip is written to a sibling `<dest>.partial` and `os.replace`d onto the destination only on success — so cancel or a crash never leaves a truncated zip and never clobbers a pre-existing file. Temp dir + `.partial` cleaned up on cancel, failure, and success.
- **`LocalChatbookService.export_chatbook`** — forwards the hooks and surfaces a `cancelled` bool.
- **`tldw_chatbook/Library/export_progress.py`** (new, pure/dependency-free) — `ExportProgressThrottle` (emit on phase-change / ≥100ms / final-tick) + `format_export_progress_line`.
- **Library screen + export canvas** — a per-run cancel `threading.Event` captured at dispatch and threaded through the worker (like `run_id`); a throttled, `run_id`-staleness-guarded progress callback marshalled to the UI thread (updates just the status line, no recompose); a **Cancel** button (visible only while running); and the cancelled-completion path (`_apply_library_export_cancelled` → "Export cancelled." → back to the form). The Cancel button sets the Event but does **not** bump `run_id`; navigate-away sets the Event **and** bumps `run_id`.

**No behavior change when the hooks are unused** — a genuine export produces the identical artifact; deps and errors surface exactly as before.

## How it looks

```
Collecting media…  42/318        [ Cancel ]
Packaging archive…  210/540 files [ Cancel ]
```

## Testing

Built subagent-driven (TDD, RED-first): creator seams (progress monotonicity, cancel + atomic-finalize cleanup, default-None parity), the throttle/formatter as pure units, and the UI apply-handlers via `SimpleNamespace` fakes + an `app.run_test()` Cancel-button visibility smoke — no heavy full-threaded UI export.

- Per-task reviews clean; two review-caught issues fixed: the cancel `Event` is captured at dispatch (prevents an orphan-run cancelling the wrong run once `.set()` is wired), and a stale exact-`outcome`-dict test updated for the new `cancelled` key.
- **Whole-branch review (opus): APPROVE** — traced the concurrency end-to-end (orphan-run cancel isolation, run_id staleness across all apply handlers, worker branch order, atomic finalize under cancel, non-swallowed cancel); three cosmetic minors only.
- **Final gate: 793 passed / 1 skipped** across `Tests/Chatbooks/`, `Tests/Library/`, and the Library UI suites.

Base was `bc8636b2`; dev has since advanced — will rebase before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds live per‑phase progress and a Cancel button to Library chatbook exports, with atomic zip finalize and safe cleanup. Wires progress/cancel through `ChatbookCreator` → `LocalChatbookService` → Library UI to meet task 157’s real-time progress and cancellation.

- **New Features**
  - `ChatbookCreator.create_chatbook` accepts `progress_callback` and `cancel_check`; emits `ExportProgress` across phases; clean cancel via `ChatbookExportCancelled`.
  - Atomic finalize: write `<dest>.partial` then `os.replace`; temp and `.partial` cleaned on success, failure, or cancel.
  - `LocalChatbookService.export_chatbook` forwards hooks and returns `cancelled: bool`.
  - New `tldw_chatbook/Library/export_progress.py` with `ExportProgressThrottle` and `format_export_progress_line`.
  - Library export canvas shows live per‑phase counts and a Cancel button; per‑run `threading.Event`; UI ignores stale `run_id`; Cancel hidden when not running.

- **Bug Fixes**
  - `ChatbookCreator` stores callbacks in `threading.local()` to avoid cross‑run clobbering when instances are reused.
  - Throttle guards against `total==0` so indeterminate phases don’t spam updates.
  - Post‑finalize reporting is best‑effort; cleanup only unlinks the created `.partial` file; consolidated safe cleanup in a single finally.

<sup>Written for commit f692121c72e8b8ae137ca5e69fd1ddacffd667ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

