### PR TITLE
feat(export): Library multi-select row export (task 159)

### DIFF
--- a/Docs/superpowers/plans/2026-07-12-library-multiselect-export.md
+++ b/Docs/superpowers/plans/2026-07-12-library-multiselect-export.md
@@ -607,10 +607,15 @@ In `library_media_canvas.py compose()`, replace the existing `Export…` button 
                             classes="library-canvas-action", compact=True)
         export_btn.display = not select_mode
         yield export_btn
+        rendered_count = len(self.canvas.rows)   # NOT self.canvas.count (that is the
+                                                 # pre-filter total; only rendered rows
+                                                 # are selectable). Conversations state
+                                                 # has no `.count` field, so len(rows) is
+                                                 # also the portable idiom for the siblings.
         select_btn = Button("Done" if select_mode else "Select",
                             id="library-media-select-toggle",
                             classes="library-canvas-action", compact=True)
-        select_btn.disabled = self.canvas.count == 0
+        select_btn.disabled = rendered_count == 0
         yield select_btn
         if select_mode:
             action_row = Horizontal(classes="ds-toolbar")
@@ -618,7 +623,7 @@ In `library_media_canvas.py compose()`, replace the existing `Export…` button 
             with action_row:
                 yield Static(f"{self.canvas.selected_count} selected",
                              id="library-media-selected-count", markup=False)
-                yield Button(f"Select all {self.canvas.count} shown",
+                yield Button(f"Select all {rendered_count} shown",
                              id="library-media-select-all",
                              classes="library-canvas-action", compact=True)
                 yield Button("Clear", id="library-media-select-clear",

--- a/Docs/superpowers/plans/2026-07-12-library-multiselect-export.md
+++ b/Docs/superpowers/plans/2026-07-12-library-multiselect-export.md
@@ -1,0 +1,871 @@
+# Library multi-select row export — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax. Spec: `Docs/superpowers/specs/2026-07-11-library-multiselect-export-design.md`. Branch `claude/followups-multiselect-export` off dev `b15880fd`. Anchors are exact at branch point; grep symbols, line numbers drift.
+
+**Goal:** Let a user enter a per-source "select mode" in a Library browse canvas (Media / Conversations / Notes), check individual rows, and export exactly those rows as a chatbook.
+
+**Architecture:** Reuse `ExportScope.kind` + a new hashable `ids` override so an `ExportScope(kind="media", ids=(...))` means "export exactly these ids" (empty `ids` = today's whole-source behavior, unchanged). A pure `RowSelection` helper holds the per-source checked-id set. The three canvas state builders gain `checked`/`select_mode`/`selected_count`; the three canvases render a ☑/☐ glyph + a selection action row in select mode; the screen wires a Select toggle + row-press interception, all driven through the same full-screen `self.refresh(recompose=True)` every Library interaction already uses.
+
+**Tech Stack:** Python ≥3.11, Textual, pytest. No new third-party deps.
+
+## Global Constraints
+
+- **No behavior change when `ids` is empty:** every existing export path (`ExportScope(kind=...)` with no ids) behaves byte-for-byte as today.
+- **`ids` is a `tuple[str, ...]`** so `ExportScope` stays frozen/hashable/`==`-comparable (the counts worker's `scope != self._library_export_scope` stale-guard requires it).
+- **`ids` only for a single-source kind:** `ExportScope(kind="everything", ids=(...))` raises.
+- **Reuse `kind`, do NOT add a `"selected"` kind:** `library_export_state.py:167` (`show_media_fields = scope.kind in _MEDIA_BEARING_SCOPE_KINDS`) must keep working for selected-media — reusing `kind="media"` does; a new kind would silently hide the media-quality field.
+- **`ids` branch runs BEFORE `_effective_media_type`** in every resolver.
+- **Per-source only** (no cross-source tray); **visible/rendered rows only**.
+- **Selection lifecycle (plan deviation from spec — see note below):** the set is cleared on the source's filter/sort change and whenever select mode is toggled off. It **persists across canvas switches** (the spec said "clear on leaving the canvas", but the codebase has no single clean canvas-leave hook, and reconcile-on-render already keeps a persisted set honest — a returning user resumes the mode they left, and a stale id is dropped on the next render). This is a deliberate, safe simplification; if the user wants strict clear-on-leave, add a clear call to the rail browse-row switch.
+- **Reconcile on render:** in select mode the selection set is intersected with the currently-rendered ids each build (drops vanished ids), so the count and export stay WYSIWYG.
+- **Notes select-mode entry** first `await self._flush_library_note_save()`.
+- **Recompose model:** row toggle and all select-mode actions recompose via the screen's `self.refresh(recompose=True)` (the only working canvas-update path in this codebase — `sync_state` is dead). No new targeted-update infrastructure.
+- **Staging:** explicit paths only. Every commit ends with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- **Test command** (venv, isolated HOME):
+  ```
+  HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+    /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest <files> \
+    -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+  ```
+
+---
+
+### Task 1: `ExportScope.ids` + resolver/count/label branches (pure)
+
+**Files:**
+- Modify: `tldw_chatbook/Library/library_export_scope.py`
+- Test: `Tests/Library/test_library_export_scope_ids.py` (create)
+
+**Interfaces:**
+- Produces: `ExportScope(kind, media_type=None, ids: tuple[str, ...] = ())`; `resolve_export_selections`/`count_export_scope`/`export_scope_label` honor `ids`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/Library/test_library_export_scope_ids.py`:
+```python
+import pytest
+
+from tldw_chatbook.Chatbooks.chatbook_models import ContentType
+from tldw_chatbook.Library.library_export_scope import (
+    ExportScope, resolve_export_selections, count_export_scope, export_scope_label,
+)
+
+
+class _RecordingMediaDB:
+    def __init__(self): self.calls = 0
+    def get_all_active_media_ids(self, media_type=None):
+        self.calls += 1
+        return [1, 2, 3]
+
+
+class _RecordingChaChaDB:
+    def __init__(self): self.calls = 0
+    def get_all_conversation_ids(self):
+        self.calls += 1
+        return ["c1", "c2"]
+    def get_all_note_ids(self):
+        self.calls += 1
+        return ["n1"]
+
+
+def test_ids_only_valid_for_single_source():
+    ExportScope(kind="media", ids=("1", "2"))          # ok
+    with pytest.raises(ValueError):
+        ExportScope(kind="everything", ids=("1",))
+
+
+def test_scope_with_ids_is_hashable_and_equal():
+    a = ExportScope(kind="media", ids=("1", "2"))
+    b = ExportScope(kind="media", ids=("1", "2"))
+    assert a == b and hash(a) == hash(b)
+    assert a in {b}
+
+
+def test_resolve_with_ids_returns_them_without_querying():
+    media, chacha = _RecordingMediaDB(), _RecordingChaChaDB()
+    sel = resolve_export_selections(ExportScope(kind="media", ids=("7", "8")), media, chacha)
+    assert sel == {ContentType.MEDIA: ["7", "8"]}
+    assert media.calls == 0 and chacha.calls == 0   # no whole-source query
+
+
+def test_resolve_without_ids_unchanged():
+    media, chacha = _RecordingMediaDB(), _RecordingChaChaDB()
+    sel = resolve_export_selections(ExportScope(kind="media"), media, chacha)
+    assert sel == {ContentType.MEDIA: ["1", "2", "3"]}
+    assert media.calls == 1
+
+
+def test_count_with_ids():
+    media, chacha = _RecordingMediaDB(), _RecordingChaChaDB()
+    counts = count_export_scope(ExportScope(kind="notes", ids=("a", "b", "c")), media, chacha)
+    assert counts == {"media": 0, "conversations": 0, "notes": 3}
+    assert chacha.calls == 0
+
+
+def test_label_with_ids():
+    counts = count_export_scope(
+        ExportScope(kind="conversations", ids=("x", "y")), _RecordingMediaDB(), _RecordingChaChaDB()
+    )
+    assert export_scope_label(ExportScope(kind="conversations", ids=("x", "y")), counts) \
+        == "Selected conversations · 2 items"
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run:
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Library/test_library_export_scope_ids.py -q -p no:cacheprovider -o addopts="" --timeout=120
+```
+Expected: FAIL — `ExportScope.__init__() got an unexpected keyword argument 'ids'`.
+
+- [ ] **Step 3: Add the `ids` field + validation**
+
+In `library_export_scope.py`, add to the `ExportScope` dataclass (after `media_type`):
+```python
+    ids: tuple[str, ...] = ()
+```
+Extend `__post_init__`:
+```python
+    def __post_init__(self) -> None:
+        if self.kind not in _VALID_KINDS:
+            raise ValueError(
+                f"Unknown export scope kind: {self.kind!r}. Expected one of {_VALID_KINDS}."
+            )
+        if self.ids and self.kind == "everything":
+            raise ValueError("ExportScope.ids may only scope a single source, not 'everything'.")
+```
+Add near `_VALID_KINDS`:
+```python
+_KIND_TO_CONTENT_TYPE = {
+    "media": ContentType.MEDIA,
+    "conversations": ContentType.CONVERSATION,
+    "notes": ContentType.NOTE,
+}
+```
+
+- [ ] **Step 4: Branch the three functions on `scope.ids` (before any media_type logic)**
+
+`resolve_export_selections` — add at the very top of the body (before the existing `selections = {}`):
+```python
+    if scope.ids:
+        return {_KIND_TO_CONTENT_TYPE[scope.kind]: list(scope.ids)}
+```
+`count_export_scope` — add right after `counts = {"media": 0, "conversations": 0, "notes": 0}`:
+```python
+    if scope.ids:
+        counts[scope.kind] = len(scope.ids)
+        return counts
+```
+`export_scope_label` — add as the first branch:
+```python
+    if scope.ids:
+        return f"Selected {scope.kind} · {counts.get(scope.kind, len(scope.ids))} items"
+```
+
+- [ ] **Step 5: Run to verify it passes + full existing scope suite**
+
+Run:
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Library/test_library_export_scope_ids.py Tests/Library/ -k "export_scope or export" \
+  -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: PASS (new tests green; pre-existing scope tests unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/Library/library_export_scope.py Tests/Library/test_library_export_scope_ids.py
+git commit -m "feat(export): ExportScope.ids override for explicit-subset export (159)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `RowSelection` pure helper
+
+**Files:**
+- Create: `tldw_chatbook/Library/row_selection.py`
+- Test: `Tests/Library/test_row_selection.py` (create)
+
+**Interfaces:**
+- Consumes: `ExportScope` (Task 1).
+- Produces: `RowSelection(kind)` with `.ids -> frozenset[str]`, `.count -> int`, `.is_selected(id)`, `.toggle(id)`, `.select_all(iterable)`, `.clear()`, `.reconcile(iterable)`, `.export_scope() -> ExportScope`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/Library/test_row_selection.py`:
+```python
+from tldw_chatbook.Library.row_selection import RowSelection
+from tldw_chatbook.Library.library_export_scope import ExportScope
+
+
+def test_toggle_add_remove():
+    s = RowSelection("media")
+    s.toggle("1"); s.toggle("2")
+    assert s.is_selected("1") and s.count == 2
+    s.toggle("1")
+    assert not s.is_selected("1") and s.count == 1
+    s.toggle("")  # empty id ignored
+    assert s.count == 1
+
+
+def test_select_all_and_clear():
+    s = RowSelection("notes")
+    s.select_all(["a", "b", "", "c"])   # empties skipped
+    assert s.ids == frozenset({"a", "b", "c"})
+    s.clear()
+    assert s.count == 0
+
+
+def test_reconcile_drops_absent_ids():
+    s = RowSelection("conversations")
+    s.select_all(["a", "b", "c"])
+    s.reconcile(["b", "c", "d"])        # 'a' no longer rendered
+    assert s.ids == frozenset({"b", "c"})
+
+
+def test_export_scope_sorts_ids():
+    s = RowSelection("media")
+    s.select_all(["10", "2", "1"])
+    assert s.export_scope() == ExportScope(kind="media", ids=("1", "10", "2"))
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run:
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Library/test_row_selection.py -q -p no:cacheprovider -o addopts="" --timeout=120
+```
+Expected: FAIL — `ModuleNotFoundError: tldw_chatbook.Library.row_selection`.
+
+- [ ] **Step 3: Implement the module**
+
+Create `tldw_chatbook/Library/row_selection.py`:
+```python
+"""Per-source checked-row accumulator for the Library multi-select export.
+
+Pure and Textual-free: the screen owns one instance per browsable source
+(media/conversations/notes) and drives it from the row-press handlers, then
+turns the checked ids into an ``ExportScope`` for the export canvas.
+"""
+from __future__ import annotations
+
+from typing import Iterable
+
+from tldw_chatbook.Library.library_export_scope import ExportScope
+
+
+class RowSelection:
+    def __init__(self, kind: str) -> None:
+        # kind is one of "media" | "conversations" | "notes" — the ExportScope
+        # single-source kind these ids belong to.
+        self._kind = kind
+        self._ids: set[str] = set()
+
+    @property
+    def ids(self) -> frozenset[str]:
+        return frozenset(self._ids)
+
+    @property
+    def count(self) -> int:
+        return len(self._ids)
+
+    def is_selected(self, row_id: str) -> bool:
+        return row_id in self._ids
+
+    def toggle(self, row_id: str) -> None:
+        if not row_id:
+            return
+        self._ids.discard(row_id) if row_id in self._ids else self._ids.add(row_id)
+
+    def select_all(self, rendered_ids: Iterable[str]) -> None:
+        self._ids.update(rid for rid in rendered_ids if rid)
+
+    def clear(self) -> None:
+        self._ids.clear()
+
+    def reconcile(self, rendered_ids: Iterable[str]) -> None:
+        """Drop any selected id no longer present in the rendered rows."""
+        self._ids &= set(rendered_ids)
+
+    def export_scope(self) -> ExportScope:
+        return ExportScope(kind=self._kind, ids=tuple(sorted(self._ids)))
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run the Step-1 tests. Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Library/row_selection.py Tests/Library/test_row_selection.py
+git commit -m "feat(export): pure RowSelection accumulator for per-source multi-select (159)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `checked` / `select_mode` / `selected_count` in the three state builders (pure)
+
+**Files:**
+- Modify: `tldw_chatbook/Library/library_media_state.py`, `library_conversations_state.py`, `library_notes_state.py`
+- Test: `Tests/Library/test_library_multiselect_state.py` (create)
+
+**Interfaces:**
+- Produces:
+  - `LibraryMediaRow`/`LibraryConversationRow`/`LibraryNotesListRow` gain `checked: bool = False`.
+  - `build_library_media_state(..., select_mode: bool = False, selected_ids: frozenset[str] = frozenset())`; same two new kw params on `build_library_conversations_state` and `build_library_notes_list_state`.
+  - Each `*CanvasState`/`LibraryNotesListState` gains `select_mode: bool` and `selected_count: int` (= number of rendered rows whose `checked` is True).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/Library/test_library_multiselect_state.py`:
+```python
+from tldw_chatbook.Library.library_media_state import build_library_media_state
+from tldw_chatbook.Library.library_conversations_state import build_library_conversations_state
+from tldw_chatbook.Library.library_notes_state import build_library_notes_list_state
+
+
+def test_media_checked_and_count():
+    records = [
+        {"id": "1", "title": "A", "type": "video", "updated_at": None},
+        {"id": "2", "title": "B", "type": "audio", "updated_at": None},
+    ]
+    state = build_library_media_state(records, select_mode=True, selected_ids=frozenset({"1"}))
+    by_id = {r.media_id: r for r in state.rows}
+    assert by_id["1"].checked is True and by_id["2"].checked is False
+    assert state.select_mode is True and state.selected_count == 1
+
+
+def test_media_default_no_select_mode():
+    records = [{"id": "1", "title": "A", "type": "video", "updated_at": None}]
+    state = build_library_media_state(records)
+    assert state.select_mode is False and state.selected_count == 0
+    assert state.rows[0].checked is False
+
+
+def test_conversations_checked_and_count():
+    records = [
+        {"id": "c1", "title": "One", "message_count": 1, "updated_at": None},
+        {"id": "c2", "title": "Two", "message_count": 2, "updated_at": None},
+    ]
+    state = build_library_conversations_state(records, select_mode=True, selected_ids=frozenset({"c2"}))
+    by_id = {r.conversation_id: r for r in state.rows}
+    assert by_id["c2"].checked is True and by_id["c1"].checked is False
+    assert state.selected_count == 1
+
+
+def test_notes_checked_and_count():
+    records = [{"id": "n1", "title": "N1"}, {"id": "n2", "title": "N2"}]
+    state = build_library_notes_list_state(records, select_mode=True, selected_ids=frozenset({"n1"}))
+    by_id = {r.note_id: r for r in state.rows}
+    assert by_id["n1"].checked is True and by_id["n2"].checked is False
+    assert state.select_mode is True and state.selected_count == 1
+```
+(If a builder's minimal record shape differs — e.g. required keys — copy the shape an existing `Tests/Library/test_library_*_state.py` uses; the `checked`/`select_mode`/`selected_count` assertions are the point.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run:
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Library/test_library_multiselect_state.py -q -p no:cacheprovider -o addopts="" --timeout=120
+```
+Expected: FAIL — `build_library_media_state() got an unexpected keyword argument 'select_mode'`.
+
+- [ ] **Step 3: Media state**
+
+In `library_media_state.py`: add `checked: bool = False` to `LibraryMediaRow`; add `select_mode: bool = False` and `selected_count: int = 0` to the `LibraryMediaCanvasState` dataclass. Add params to `build_library_media_state`:
+```python
+def build_library_media_state(
+    records: Sequence[Mapping[str, Any]],
+    *,
+    active_type: str = "All",
+    selected_id: str = "",
+    now: datetime | None = None,
+    limit: int = 75,
+    select_mode: bool = False,
+    selected_ids: frozenset[str] = frozenset(),
+) -> LibraryMediaCanvasState:
+```
+In the row comprehension add `checked=entry.media_id in selected_ids,` to each `LibraryMediaRow(...)`. After building `rows`, compute `selected_count = sum(1 for r in rows if r.checked)` and pass `select_mode=select_mode, selected_count=selected_count` into the returned `LibraryMediaCanvasState(...)`.
+
+- [ ] **Step 4: Conversations state**
+
+Same shape in `library_conversations_state.py`: `checked: bool = False` on `LibraryConversationRow`; `select_mode`/`selected_count` on `LibraryConversationsCanvasState`; the two new kw params on `build_library_conversations_state`; `checked=entry.conversation_id in selected_ids,` in the row comprehension; `selected_count = sum(1 for r in rows if r.checked)`.
+
+- [ ] **Step 5: Notes state**
+
+In `library_notes_state.py`: add `checked: bool = False` to `LibraryNotesListRow`; add `select_mode: bool` and `selected_count: int` to `LibraryNotesListState`. Change `_row` and its caller to thread `selected_ids`:
+```python
+def _row(record: Mapping[str, Any], *, now: datetime, selected_ids: frozenset[str]) -> LibraryNotesListRow:
+    raw = _updated_raw(record)
+    note_id = _text(record.get("id"))
+    return LibraryNotesListRow(
+        note_id=note_id,
+        title=_text(record.get("title")) or "Untitled",
+        age_label=format_console_relative_age(raw, now=now) if raw else "",
+        checked=note_id in selected_ids,
+    )
+```
+Add `select_mode: bool = False, selected_ids: frozenset[str] = frozenset()` to `build_library_notes_list_state`; pass `selected_ids=selected_ids` into each `_row(...)`; `selected_count = sum(1 for r in rows if r.checked)`; set both new fields on the returned `LibraryNotesListState`.
+
+- [ ] **Step 6: Run to verify it passes + existing state suites**
+
+Run:
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Library/test_library_multiselect_state.py Tests/Library/ -k "media_state or conversations_state or notes_state or notes_list" \
+  -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: PASS (defaults keep every existing state test green).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tldw_chatbook/Library/library_media_state.py tldw_chatbook/Library/library_conversations_state.py tldw_chatbook/Library/library_notes_state.py Tests/Library/test_library_multiselect_state.py
+git commit -m "feat(export): checked/select_mode/selected_count in Library row state builders (159)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Media canvas + screen wiring (reference slice)
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/Library/library_media_canvas.py`
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py`
+- Test: `Tests/UI/test_library_multiselect_media.py` (create)
+
+**Interfaces:**
+- Consumes: `RowSelection` (Task 2); the media state's `checked`/`select_mode`/`selected_count` (Task 3); `ExportScope`, `_open_library_export_canvas` (existing).
+- Produces: screen fields `self._library_media_row_selection: RowSelection`, `self._library_media_select_mode: bool`; handlers for `#library-media-select-toggle`, `#library-media-select-all`, `#library-media-select-clear`, `#library-media-export-selected`; select-aware `handle_library_media_row`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/UI/test_library_multiselect_media.py` (uses `SimpleNamespace` fakes; the row-press and export handlers are plain methods that only touch the fields listed):
+```python
+from types import SimpleNamespace
+import pytest
+
+from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
+from tldw_chatbook.Library.row_selection import RowSelection
+from tldw_chatbook.Library.library_export_scope import ExportScope
+
+
+def _media_fake(select_mode):
+    return SimpleNamespace(
+        _library_media_select_mode=select_mode,
+        _library_media_row_selection=RowSelection("media"),
+        _opened=[],
+        _refreshed=0,
+        _viewer_opened=[],
+    )
+
+
+def test_row_press_in_select_mode_toggles_not_opens():
+    fake = _media_fake(select_mode=True)
+    fake.refresh = lambda **k: setattr(fake, "_refreshed", fake._refreshed + 1)
+    fake._open_library_media_viewer = lambda mid: fake._viewer_opened.append(mid)
+    event = SimpleNamespace(button=SimpleNamespace(media_id="7"), stop=lambda: None)
+    LibraryScreen.handle_library_media_row(fake, event)
+    assert fake._library_media_row_selection.is_selected("7")
+    assert fake._viewer_opened == []          # viewer NOT opened
+    assert fake._refreshed == 1
+
+
+def test_row_press_normal_mode_opens_viewer():
+    fake = _media_fake(select_mode=False)
+    fake._open_library_media_viewer = lambda mid: fake._viewer_opened.append(mid)
+    event = SimpleNamespace(button=SimpleNamespace(media_id="7"), stop=lambda: None)
+    LibraryScreen.handle_library_media_row(fake, event)
+    assert fake._viewer_opened == ["7"]
+    assert not fake._library_media_row_selection.is_selected("7")
+
+
+@pytest.mark.asyncio
+async def test_export_selected_builds_ids_scope():
+    fake = _media_fake(select_mode=True)
+    fake._library_media_row_selection.select_all(["3", "1", "2"])
+    async def _open(scope): fake._opened.append(scope)
+    fake._open_library_export_canvas = _open
+    event = SimpleNamespace(stop=lambda: None)
+    await LibraryScreen.handle_library_media_export_selected(fake, event)
+    assert fake._opened == [ExportScope(kind="media", ids=("1", "2", "3"))]
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run:
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/UI/test_library_multiselect_media.py -q -p no:cacheprovider -o addopts="" --timeout=120
+```
+Expected: FAIL — `handle_library_media_export_selected` doesn't exist / `_library_media_row_selection` AttributeError.
+
+- [ ] **Step 3: Screen state fields**
+
+In `library_screen.py.__init__` (alongside `self._selected_media_id`, ~:561-579) add:
+```python
+        self._library_media_select_mode: bool = False
+        self._library_media_row_selection = RowSelection("media")
+```
+Add the import near the other Library imports:
+```python
+from tldw_chatbook.Library.row_selection import RowSelection
+```
+
+- [ ] **Step 4: Feed select state into the media build + reconcile**
+
+Change `_build_library_media_state` (~:2843) to pass select state and reconcile the set to the rendered rows:
+```python
+    def _build_library_media_state(self) -> LibraryMediaCanvasState:
+        """Build the media canvas display state from local records."""
+        state = build_library_media_state(
+            self._local_source_records.get("media", ()),
+            active_type=self._library_media_type_filter,
+            selected_id=self._selected_media_id,
+            select_mode=self._library_media_select_mode,
+            selected_ids=self._library_media_row_selection.ids,
+        )
+        if self._library_media_select_mode:
+            self._library_media_row_selection.reconcile(r.media_id for r in state.rows)
+        return state
+```
+
+- [ ] **Step 5: Select-aware row press + the four action handlers**
+
+Replace `handle_library_media_row` (~:5311) so a press toggles in select mode:
+```python
+    @on(Button.Pressed, ".library-media-row")
+    def handle_library_media_row(self, event: Button.Pressed) -> None:
+        """Select mode: toggle the row's checkbox. Normal mode: open the viewer."""
+        event.stop()
+        media_id = str(getattr(event.button, "media_id", "") or "")
+        if self._library_media_select_mode:
+            self._library_media_row_selection.toggle(media_id)
+            self.refresh(recompose=True)
+            return
+        self._open_library_media_viewer(media_id)
+```
+Add (next to the other media handlers):
+```python
+    @on(Button.Pressed, "#library-media-select-toggle")
+    def handle_library_media_select_toggle(self, event: Button.Pressed) -> None:
+        """Enter/exit media select mode; entering starts from an empty set."""
+        event.stop()
+        self._library_media_select_mode = not self._library_media_select_mode
+        self._library_media_row_selection.clear()
+        self.refresh(recompose=True)
+
+    @on(Button.Pressed, "#library-media-select-all")
+    def handle_library_media_select_all(self, event: Button.Pressed) -> None:
+        event.stop()
+        rows = self._build_library_media_state().rows
+        self._library_media_row_selection.select_all(r.media_id for r in rows)
+        self.refresh(recompose=True)
+
+    @on(Button.Pressed, "#library-media-select-clear")
+    def handle_library_media_select_clear(self, event: Button.Pressed) -> None:
+        event.stop()
+        self._library_media_row_selection.clear()
+        self.refresh(recompose=True)
+
+    @on(Button.Pressed, "#library-media-export-selected")
+    async def handle_library_media_export_selected(self, event: Button.Pressed) -> None:
+        event.stop()
+        await self._open_library_export_canvas(self._library_media_row_selection.export_scope())
+```
+
+- [ ] **Step 6: Clear selection + exit select mode on filter change**
+
+In `handle_library_media_type_filter_pressed` (~:5285), after setting `self._library_media_type_filter = ...` and before `self.refresh(recompose=True)`, add:
+```python
+        self._library_media_select_mode = False
+        self._library_media_row_selection.clear()
+```
+
+- [ ] **Step 7: Canvas — Select toggle, glyph, action row, hide Export in select mode**
+
+In `library_media_canvas.py compose()`, replace the existing `Export…` button block (~:60-66) with this — build the Export button as a variable so its `.display` can be toggled off in select mode, add the Select toggle, and add an action row shown only in select mode:
+```python
+        select_mode = getattr(self.canvas, "select_mode", False)
+        export_btn = Button("Export…", id="library-media-export",
+                            classes="library-canvas-action", compact=True)
+        export_btn.display = not select_mode
+        yield export_btn
+        select_btn = Button("Done" if select_mode else "Select",
+                            id="library-media-select-toggle",
+                            classes="library-canvas-action", compact=True)
+        select_btn.disabled = self.canvas.count == 0
+        yield select_btn
+        if select_mode:
+            action_row = Horizontal(classes="ds-toolbar")
+            action_row.styles.height = "auto"
+            with action_row:
+                yield Static(f"{self.canvas.selected_count} selected",
+                             id="library-media-selected-count", markup=False)
+                yield Button(f"Select all {self.canvas.count} shown",
+                             id="library-media-select-all",
+                             classes="library-canvas-action", compact=True)
+                yield Button("Clear", id="library-media-select-clear",
+                             classes="library-canvas-action", compact=True)
+                export_selected = Button("Export selected",
+                                         id="library-media-export-selected",
+                                         classes="library-canvas-action", compact=True)
+                export_selected.disabled = self.canvas.selected_count == 0
+                yield export_selected
+```
+(Add `from textual.containers import Horizontal` and `from textual.widgets import Static` to the imports if not already present.) In the row loop (~:80), pick the glyph from checked in select mode:
+```python
+                if select_mode:
+                    marker = "☑" if row.checked else "☐"
+                else:
+                    marker = "▸" if row.selected else " "
+```
+
+- [ ] **Step 8: Run to verify it passes + a canvas smoke**
+
+Run the Step-1 tests:
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/UI/test_library_multiselect_media.py -q -p no:cacheprovider -o addopts="" --timeout=120
+```
+Add a canvas smoke to the same file (mount `LibraryMediaCanvas` with a select-mode state via `app.run_test()`, assert `#library-media-select-all` exists and `#library-media-export-selected` is disabled at 0 selected). Run again. Then the import smoke:
+```
+HOME=/private/tmp/tldw-chatbook-test-home PYTHONPATH=$(pwd) \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -c "import tldw_chatbook.UI.Screens.library_screen; print('import ok')"
+```
+Expected: PASS + `import ok`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add tldw_chatbook/Widgets/Library/library_media_canvas.py tldw_chatbook/UI/Screens/library_screen.py Tests/UI/test_library_multiselect_media.py
+git commit -m "feat(export): media multi-select mode + export selected (159)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Conversations canvas + screen wiring
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/Library/library_conversations_canvas.py`
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py`
+- Test: `Tests/UI/test_library_multiselect_conversations.py` (create)
+
+Mirror Task 4 for conversations. **Interfaces produced:** `self._library_conversations_select_mode`, `self._library_conversations_row_selection = RowSelection("conversations")`; handlers for `#library-conversations-select-toggle`/`-select-all`/`-select-clear`/`-export-selected`; select-aware `handle_library_conversation_row`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/UI/test_library_multiselect_conversations.py` — same shape as the media tests, using `conversation_id`, `RowSelection("conversations")`, `handle_library_conversation_row`, `handle_library_conversations_export_selected`, and asserting the normal-mode path sets `_selected_conversation_id` + `_library_selected_row_id` (rather than opening a viewer). Concretely:
+```python
+from types import SimpleNamespace
+import pytest
+from tldw_chatbook.UI.Screens.library_screen import LibraryScreen, LIBRARY_ROW_BROWSE_CONVERSATIONS
+from tldw_chatbook.Library.row_selection import RowSelection
+from tldw_chatbook.Library.library_export_scope import ExportScope
+
+
+def _fake(select_mode):
+    return SimpleNamespace(
+        _library_conversations_select_mode=select_mode,
+        _library_conversations_row_selection=RowSelection("conversations"),
+        _selected_conversation_id="", _library_selected_row_id="", _refreshed=0, _opened=[],
+    )
+
+
+def test_convo_row_select_mode_toggles():
+    fake = _fake(True); fake.refresh = lambda **k: setattr(fake, "_refreshed", fake._refreshed + 1)
+    ev = SimpleNamespace(button=SimpleNamespace(conversation_id="c5"), stop=lambda: None)
+    LibraryScreen.handle_library_conversation_row(fake, ev)
+    assert fake._library_conversations_row_selection.is_selected("c5")
+    assert fake._selected_conversation_id == ""     # did NOT open/select the detail
+    assert fake._refreshed == 1
+
+
+def test_convo_row_normal_mode_selects():
+    fake = _fake(False); fake.refresh = lambda **k: None
+    ev = SimpleNamespace(button=SimpleNamespace(conversation_id="c5"), stop=lambda: None)
+    LibraryScreen.handle_library_conversation_row(fake, ev)
+    assert fake._selected_conversation_id == "c5"
+    assert fake._library_selected_row_id == LIBRARY_ROW_BROWSE_CONVERSATIONS
+
+
+@pytest.mark.asyncio
+async def test_convo_export_selected_scope():
+    fake = _fake(True); fake._library_conversations_row_selection.select_all(["c2", "c1"])
+    async def _open(s): fake._opened.append(s)
+    fake._open_library_export_canvas = _open
+    await LibraryScreen.handle_library_conversations_export_selected(fake, SimpleNamespace(stop=lambda: None))
+    assert fake._opened == [ExportScope(kind="conversations", ids=("c1", "c2"))]
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run the new file; Expected: FAIL (missing handler/field).
+
+- [ ] **Step 3: Screen fields + build + handlers**
+
+In `__init__`: `self._library_conversations_select_mode: bool = False` and `self._library_conversations_row_selection = RowSelection("conversations")`. In `_build_library_conversations_state` (~:2835) pass `select_mode=self._library_conversations_select_mode, selected_ids=self._library_conversations_row_selection.ids` and, when in select mode, `self._library_conversations_row_selection.reconcile(r.conversation_id for r in state.rows)`. Replace `handle_library_conversation_row` (~:5271):
+```python
+    @on(Button.Pressed, ".library-conversation-row")
+    def handle_library_conversation_row(self, event: Button.Pressed) -> None:
+        event.stop()
+        conversation_id = str(getattr(event.button, "conversation_id", "") or "")
+        if self._library_conversations_select_mode:
+            self._library_conversations_row_selection.toggle(conversation_id)
+            self.refresh(recompose=True)
+            return
+        if conversation_id:
+            self._selected_conversation_id = conversation_id
+        self._library_selected_row_id = LIBRARY_ROW_BROWSE_CONVERSATIONS
+        self.refresh(recompose=True)
+```
+Add `handle_library_conversations_select_toggle` / `_select_all` / `_select_clear` / `_export_selected` mirroring Task 4 Step 5 (ids `#library-conversations-select-*`, using `_library_conversations_row_selection`; select-all builds `self._build_library_conversations_state().rows`). Clear select mode + selection on filter change in `handle_library_conversations_filter_submitted` (~:7634) before its `self.refresh(recompose=True)`.
+
+- [ ] **Step 4: Canvas**
+
+In `library_conversations_canvas.py compose()`, apply the same Export-hide + Select toggle + action-row + glyph changes as Task 4 Step 7, with `#library-conversations-*` ids and `row.conversation_id`.
+
+- [ ] **Step 5: Run to verify it passes + import smoke**
+
+Run the new test file + the `import tldw_chatbook.UI.Screens.library_screen` smoke. Expected: PASS + `import ok`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/Widgets/Library/library_conversations_canvas.py tldw_chatbook/UI/Screens/library_screen.py Tests/UI/test_library_multiselect_conversations.py
+git commit -m "feat(export): conversations multi-select mode + export selected (159)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Notes canvas + screen wiring + backlog Done
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/Library/library_notes_canvas.py`
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py`
+- Modify: `backlog/tasks/task-159 - Multi-select-row-export-for-the-Library.md`
+- Test: `Tests/UI/test_library_multiselect_notes.py` (create)
+
+Mirror Task 4/5 for notes, with two notes-specific differences: **(a)** notes list rows had no marker before, so add the ☑/☐ glyph in `_compose_list` (normal mode shows no marker — keep today's markerless label); **(b)** the notes row handler is `async` and flushes; entering notes select mode must `await self._flush_library_note_save()` first.
+
+**Interfaces produced:** `self._library_notes_select_mode`, `self._library_notes_row_selection = RowSelection("notes")`; `#library-notes-select-toggle`/`-select-all`/`-select-clear`/`-export-selected`; select-aware `handle_library_notes_row`. The notes canvas needs `select_mode`/`selected_count` — pass them from the list_state (Task 3 already added them to `LibraryNotesListState`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/UI/test_library_multiselect_notes.py`:
+```python
+from types import SimpleNamespace
+import pytest
+from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
+from tldw_chatbook.Library.row_selection import RowSelection
+from tldw_chatbook.Library.library_export_scope import ExportScope
+
+
+def _fake(select_mode):
+    return SimpleNamespace(
+        _library_notes_select_mode=select_mode,
+        _library_notes_row_selection=RowSelection("notes"),
+        _selected_note_id="", _library_note_dirty=False, _refreshed=0, _opened=[], _flushed=0,
+        _library_notes_view="list",
+    )
+
+
+@pytest.mark.asyncio
+async def test_notes_row_select_mode_toggles_and_does_not_open_editor():
+    fake = _fake(True)
+    fake.refresh = lambda **k: setattr(fake, "_refreshed", fake._refreshed + 1)
+    async def _flush(): fake._flushed += 1
+    fake._flush_library_note_save = _flush
+    ev = SimpleNamespace(button=SimpleNamespace(note_id="n9"), stop=lambda: None)
+    await LibraryScreen.handle_library_notes_row(fake, ev)
+    assert fake._library_notes_row_selection.is_selected("n9")
+    assert fake._library_notes_view == "list"      # editor NOT opened
+    assert fake._refreshed == 1
+
+
+@pytest.mark.asyncio
+async def test_notes_export_selected_scope():
+    fake = _fake(True); fake._library_notes_row_selection.select_all(["n2", "n1"])
+    async def _open(s): fake._opened.append(s)
+    fake._open_library_export_canvas = _open
+    await LibraryScreen.handle_library_notes_export_selected(fake, SimpleNamespace(stop=lambda: None))
+    assert fake._opened == [ExportScope(kind="notes", ids=("n1", "n2"))]
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run the new file; Expected: FAIL (missing handler/field).
+
+- [ ] **Step 3: Screen fields + select-aware handler + actions**
+
+`__init__`: `self._library_notes_select_mode: bool = False`, `self._library_notes_row_selection = RowSelection("notes")`. In the notes compose branch (~:2690), pass `select_mode`/`selected_ids` into `build_library_notes_list_state(...)` and reconcile in select mode. Replace `handle_library_notes_row` (~:6359) so select mode toggles (still `async`, still flushes so a dirty edit isn't stranded):
+```python
+    @on(Button.Pressed, ".library-notes-row")
+    async def handle_library_notes_row(self, event: Button.Pressed) -> None:
+        event.stop()
+        await self._flush_library_note_save()
+        if self._library_note_dirty:
+            return
+        note_id = str(getattr(event.button, "note_id", "") or "")
+        if self._library_notes_select_mode:
+            self._library_notes_row_selection.toggle(note_id)
+            self.refresh(recompose=True)
+            return
+        # ... existing "open editor" body unchanged ...
+```
+Add `handle_library_notes_select_toggle` (async — `await self._flush_library_note_save()` before flipping the flag, then clear + recompose), `_select_all`, `_select_clear`, `_export_selected` (mirror Task 4, ids `#library-notes-select-*`, using `_library_notes_row_selection` and the notes list_state's rows). Clear select mode + selection on sort/filter change in `handle_library_notes_sort` (~:5377) and `handle_library_notes_filter` (~:5388) (and the empty-submit branch), before their recompose.
+
+- [ ] **Step 4: Canvas (`_compose_list`)**
+
+In `library_notes_canvas.py._compose_list`, add the Select toggle to the existing `ds-toolbar` (and hide `#library-notes-export` in select mode), add the action row (shown in select mode) with `#library-notes-select-all/-clear/-export-selected` + the `N selected` Static, and in the row loop prefix the label with `("☑ " if row.checked else "☐ ")` **only when** `list_state.select_mode` (normal mode keeps today's markerless label). Read `select_mode`/`selected_count` from `list_state`.
+
+- [ ] **Step 5: Run to verify it passes + import smoke + mark backlog Done**
+
+Run the notes test file + `import tldw_chatbook.UI.Screens.library_screen` smoke. Then tick ACs + status in the backlog file:
+```bash
+perl -0pi -e 's/- \[ \] (#\d)/- [x] $1/g' "backlog/tasks/task-159 - Multi-select-row-export-for-the-Library.md"
+perl -0pi -e 's/^status: .*/status: Done/m' "backlog/tasks/task-159 - Multi-select-row-export-for-the-Library.md"
+```
+Add a short `## Implementation Notes` section (ExportScope.ids override; RowSelection helper; per-source select mode across the three canvases; reconcile/WYSIWYG; recompose-based like every other Library interaction).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/Widgets/Library/library_notes_canvas.py tldw_chatbook/UI/Screens/library_screen.py Tests/UI/test_library_multiselect_notes.py "backlog/tasks/task-159 - Multi-select-row-export-for-the-Library.md"
+git commit -m "feat(export): notes multi-select mode + export selected; task 159 done (159)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Final gate (after Task 6)
+
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Library/ Tests/UI/test_library_multiselect_media.py Tests/UI/test_library_multiselect_conversations.py Tests/UI/test_library_multiselect_notes.py Tests/UI/test_library_shell.py \
+  -q -p no:cacheprovider -o addopts="" --timeout=600 --timeout-method=thread
+```
+Then the whole-branch review (opus) and finishing-a-development-branch. Served-TUI visual QA of select mode (glyph, action row, Export selected → export canvas showing "Selected media · N items") is worthwhile but optional.

--- a/Docs/superpowers/specs/2026-07-11-library-multiselect-export-design.md
+++ b/Docs/superpowers/specs/2026-07-11-library-multiselect-export-design.md
@@ -67,6 +67,18 @@ class ExportScope:
   the existing per-kind label. `media_type` is ignored when `ids` is set (the
   ids already encode the exact subset).
 
+In every resolver the `scope.ids` check must run **before** any `media_type`
+logic (`_effective_media_type`, `:76`) so an ids export never touches the
+media-type path.
+
+**Deliberately unchanged consumer:** `library_export_state.py:167`
+(`show_media_fields = scope.kind in _MEDIA_BEARING_SCOPE_KINDS`) gates the
+media-only form fields (media quality). Because we reuse `kind="media"` for a
+selected-media scope, those fields correctly still render — a new `"selected"`
+kind would have silently hidden them. This is why the design reuses `kind` +
+`ids` rather than adding a kind; keep `kind` intact when building a selected
+scope.
+
 ### 3. Row `checked` state (`Library/library_{media,conversations,notes}_state.py`)
 
 Each row dataclass gains `checked: bool = False`. The pure state builder accepts
@@ -81,11 +93,18 @@ the current selection set and a `select_mode` flag and sets `checked` =
   only the leading glyph changes.)
 - Toolbar: a **Select** toggle button (`#library-{source}-select-toggle`).
 - A selection action row, shown only in select mode, with `N selected` text and
-  buttons: **Select all** (`#library-{source}-select-all`), **Clear**
+  buttons: **Select all N shown** (`#library-{source}-select-all`) — labelled
+  with the rendered-row count so the cap is explicit — **Clear**
   (`#library-{source}-select-clear`), **Export selected**
   (`#library-{source}-export-selected`, disabled when the set is empty).
   Rendered via the same always-yield-then-`.display`-toggle pattern the canvas
   already uses, so it can be shown/hidden without a full recompose.
+
+**Row-toggle update:** toggling a row's checkbox updates that row's `Button.label`
+in place (and the `N selected` text) rather than recomposing the whole
+canvas — a full recompose of 50–100 rows per keystroke is janky. This reuses the
+targeted-update discipline established in task-157
+(`_update_library_export_canvas_after_run`).
 
 ### 5. Screen wiring (`UI/Screens/library_screen.py`)
 
@@ -109,6 +128,18 @@ the current selection set and a `select_mode` flag and sets `checked` =
 - **Lifecycle:** leaving the canvas / changing the source filter clears the set
   and turns select mode off (fresh WYSIWYG). Selection covers only the rendered
   (capped) rows — `LIBRARY_SOURCE_PAGE_SIZES` (notes 100, media/conv 50).
+- **Reconcile on re-render:** the Library re-renders on background ingest
+  snapshot refreshes. On each select-mode render the selection set is reconciled
+  to the currently-rendered ids (ids no longer present are dropped), so
+  `N selected` and the eventual export never drift from what the user sees.
+- **Notes flush:** entering select mode on the Notes canvas first calls the
+  existing `_flush_library_note_save` (as `_open_library_export_canvas` does at
+  `:3197`), so a pending in-canvas note edit is never stranded by the mode switch.
+- **Shared helper:** factor the per-source selection set + toggle + reconcile +
+  `Export selected` scope-building into one small shared helper (keyed by source
+  → ContentType/kind) so Media/Conversations/Notes do not carry three divergent
+  copies of the logic; only the row-widget glyph and toolbar wiring stay
+  per-canvas.
 
 ## Data flow
 
@@ -141,6 +172,10 @@ Export selected → ExportScope(kind="media", ids=(…)) → _open_library_expor
   - `export_scope_label` with `ids` returns `"Selected {source} · N items"`.
   - State builder: `checked` is set for ids in the selection and false otherwise;
     select-all/clear semantics.
+  - Shared selection helper: toggle add/remove; select-all-shown adds only
+    rendered ids; **reconcile drops ids no longer in the rendered set** (keeps
+    `N selected` honest); `Export selected` builds `ExportScope(kind=<source>,
+    ids=tuple(sorted(sel)))`.
 - **Screen handlers:** a row press in select mode toggles the id and does NOT
   open the viewer; "Export selected" builds the expected `ExportScope`
   (`SimpleNamespace`-fake `self` where feasible, mirroring the task-157 tests).

--- a/Docs/superpowers/specs/2026-07-11-library-multiselect-export-design.md
+++ b/Docs/superpowers/specs/2026-07-11-library-multiselect-export-design.md
@@ -91,7 +91,14 @@ the current selection set and a `select_mode` flag and sets `checked` =
 - Row `Button` label prefix: in select mode show `☑`/`☐` from `row.checked`;
   in normal mode the existing `▸`/space marker. (Keep it a single `Button`;
   only the leading glyph changes.)
-- Toolbar: a **Select** toggle button (`#library-{source}-select-toggle`).
+- Toolbar: a **Select** toggle button (`#library-{source}-select-toggle`) that
+  reflects its active state (its label/pressed style shows select mode is on —
+  it is also the control to exit, by pressing it again). It is **disabled when
+  the source has 0 rows** (nothing to select).
+- Entering select mode **hides the whole-source "Export…" toolbar button**
+  (`#library-{source}-export`); it returns on exit. So normal mode offers
+  whole-source "Export…" and select mode offers "Export selected" — never both
+  at once.
 - A selection action row, shown only in select mode, with `N selected` text and
   buttons: **Select all N shown** (`#library-{source}-select-all`) — labelled
   with the rendered-row count so the cap is explicit — **Clear**
@@ -132,6 +139,10 @@ targeted-update discipline established in task-157
   snapshot refreshes. On each select-mode render the selection set is reconciled
   to the currently-rendered ids (ids no longer present are dropped), so
   `N selected` and the eventual export never drift from what the user sees.
+  *Accepted tradeoff:* a background refresh could push a still-existing selected
+  item past the row cap and thus drop it from the selection. This is consistent
+  with the visible-rows-only / WYSIWYG rule; the alternative (freezing the list
+  during selection) fights the live-snapshot design and is out of scope.
 - **Notes flush:** entering select mode on the Notes canvas first calls the
   existing `_flush_library_note_save` (as `_open_library_export_canvas` does at
   `:3197`), so a pending in-canvas note edit is never stranded by the mode switch.

--- a/Docs/superpowers/specs/2026-07-11-library-multiselect-export-design.md
+++ b/Docs/superpowers/specs/2026-07-11-library-multiselect-export-design.md
@@ -1,0 +1,158 @@
+# Library multi-select row export (task 159)
+
+**Status:** Design approved (brainstorm), pending spec review.
+**Backlog:** task-159 — "Multi-select row export for the Library".
+**Builds on:** F4 whole-scope export (PR #597) + task-157 export progress/cancel (PR #607).
+
+## Problem
+
+F4 shipped current-scope export: the whole library, or one source (optionally
+media-type-filtered). There is no way to export an *arbitrary subset* of rows.
+The Library browses Media, Conversations, and Notes as three separate canvases,
+each a `Vertical` of one compact `Button` per row (the record id stashed as
+`button.media_id`/`.conversation_id`/`.note_id`); selection today is a single
+highlighted id per source, and pressing a row opens its viewer/editor. We want
+per-row multi-select so a user can check specific rows and export exactly those.
+
+## Goal / Acceptance
+
+- **AC1** — In a browse canvas the user can enter a selection mode, check
+  individual rows, and export exactly the checked rows as a chatbook.
+- **AC2** — The export form accepts an explicit id set as its scope (counts,
+  scope label, and the actual export all reflect the chosen ids).
+
+## Chosen approach
+
+**Per-source selection** (decided in brainstorm): multi-select operates within
+the active canvas; selection is a set of ids for that source and is cleared when
+the source's filter changes or the user leaves the canvas ("what you see is what
+you export"). Cross-source accumulation was rejected for v1 (needs persistent
+cross-canvas state + a review surface).
+
+**Reuse `ExportScope.kind`, add an `ids` override** rather than a new kind: an
+`ExportScope(kind="media", ids=(...))` means "export exactly these media ids";
+an empty `ids` keeps today's whole-source behavior byte-for-byte.
+
+## Components
+
+### 1. `ExportScope` — new `ids` field (`tldw_chatbook/Library/library_export_scope.py:24-50`)
+
+```python
+@dataclass(frozen=True)
+class ExportScope:
+    kind: str
+    media_type: str | None = None
+    ids: tuple[str, ...] = ()   # explicit id subset; empty ⇒ whole source
+
+    def __post_init__(self) -> None:
+        if self.kind not in _VALID_KINDS:
+            raise ValueError(...)
+        if self.ids and self.kind == "everything":
+            raise ValueError("ids may only scope a single source, not 'everything'.")
+```
+`ids` is a `tuple` (hashable) so `ExportScope` stays `==`-comparable and hashable
+— required by the counts worker's stale-scope guard (`scope != self._library_export_scope`).
+
+### 2. Resolvers branch on `scope.ids` (same file)
+
+- `resolve_export_selections` (`:104-143`): for each single-source `kind`, if
+  `scope.ids` is non-empty return `{ContentType.X: list(scope.ids)}` directly
+  (no `get_all_*` DB query); else the existing whole-source query. The
+  ContentType is the one already mapped to that kind (media→MEDIA,
+  conversations→CONVERSATION, notes→NOTE).
+- `count_export_scope` (`:83-101`): symmetric — `{source: len(scope.ids)}` when
+  `scope.ids`, else the existing `len(query)`.
+- `export_scope_label` (`:146-169`): when `scope.ids`, render
+  `"Selected {source} · {n} items"` (e.g. `"Selected media · 3 items"`); else
+  the existing per-kind label. `media_type` is ignored when `ids` is set (the
+  ids already encode the exact subset).
+
+### 3. Row `checked` state (`Library/library_{media,conversations,notes}_state.py`)
+
+Each row dataclass gains `checked: bool = False`. The pure state builder accepts
+the current selection set and a `select_mode` flag and sets `checked` =
+`row_id in selection` (only meaningful in select mode). The existing single-id
+`selected` field and its `▸` marker are unchanged and used only in normal mode.
+
+### 4. Canvas widgets (`Widgets/Library/library_{media,conversations,notes}_canvas.py`)
+
+- Row `Button` label prefix: in select mode show `☑`/`☐` from `row.checked`;
+  in normal mode the existing `▸`/space marker. (Keep it a single `Button`;
+  only the leading glyph changes.)
+- Toolbar: a **Select** toggle button (`#library-{source}-select-toggle`).
+- A selection action row, shown only in select mode, with `N selected` text and
+  buttons: **Select all** (`#library-{source}-select-all`), **Clear**
+  (`#library-{source}-select-clear`), **Export selected**
+  (`#library-{source}-export-selected`, disabled when the set is empty).
+  Rendered via the same always-yield-then-`.display`-toggle pattern the canvas
+  already uses, so it can be shown/hidden without a full recompose.
+
+### 5. Screen wiring (`UI/Screens/library_screen.py`)
+
+- New per-source state: `self._library_{media,conversations,notes}_selection: set[str]`
+  and `self._library_{source}_select_mode: bool` (mirrors the existing
+  `_selected_*_id` fields at `:561-579`).
+- **Select toggle handler** flips `_library_{source}_select_mode` and recomposes
+  the canvas; entering fresh clears any stale set.
+- **Row press dispatch:** the existing per-row handlers
+  (`handle_library_conversation_row` `:5271`, the media `:5311` and notes
+  `:6359` equivalents) check the source's `select_mode`: if ON, toggle the row's
+  id in the selection set and update just the row + the `N selected` text
+  (targeted update, no viewer/editor open); if OFF, today's open-viewer path.
+- **Select all** adds every currently-rendered row id to the set; **Clear**
+  empties it.
+- **Export selected** builds `ExportScope(kind=<source>, ids=tuple(sorted(sel)))`
+  and calls the existing `_open_library_export_canvas(scope)` (`:3192`). The
+  export canvas, counts worker, scope label, progress, and cancel all already
+  flow from `ExportScope` — no export-side changes beyond the resolver branches
+  in §2.
+- **Lifecycle:** leaving the canvas / changing the source filter clears the set
+  and turns select mode off (fresh WYSIWYG). Selection covers only the rendered
+  (capped) rows — `LIBRARY_SOURCE_PAGE_SIZES` (notes 100, media/conv 50).
+
+## Data flow
+
+```
+Select toggle → select_mode = True → canvas recomposes with ☐ rows
+row press (mode ON) → toggle id in _library_media_selection → update row + "N selected"
+Export selected → ExportScope(kind="media", ids=(…)) → _open_library_export_canvas
+   → counts worker: count_export_scope sees ids → "Selected media · 3 items"
+   → run export: resolve_export_selections returns {MEDIA: [ids]} → creator exports those
+```
+
+## Error handling
+
+- **Export selected** disabled while the set is empty.
+- An id deleted between select and export is harmless: `ChatbookCreator`'s
+  `_collect_*` already logs "not found" and continues for missing ids.
+- Server-mode export stays disabled exactly as today (the existing
+  `_library_export_is_server_mode` guard in `_open_library_export_canvas`).
+
+## Testing
+
+- **Pure/unit (`Tests/Library/`):**
+  - `ExportScope(kind="media", ids=("1","2"))` constructs; `ids` with
+    `kind="everything"` raises; equality/hash hold (two equal scopes compare
+    equal, usable as a dict key).
+  - `resolve_export_selections` with `ids` returns exactly `{ContentType.X:
+    [ids]}` and issues NO `get_all_*` call (assert via a stub id-source that
+    records calls); without `ids` behaves as before.
+  - `count_export_scope` with `ids` returns `len(ids)`.
+  - `export_scope_label` with `ids` returns `"Selected {source} · N items"`.
+  - State builder: `checked` is set for ids in the selection and false otherwise;
+    select-all/clear semantics.
+- **Screen handlers:** a row press in select mode toggles the id and does NOT
+  open the viewer; "Export selected" builds the expected `ExportScope`
+  (`SimpleNamespace`-fake `self` where feasible, mirroring the task-157 tests).
+- **Canvas smoke (`app.run_test()`):** in select mode the Select-all/Clear/Export
+  buttons render and "Export selected" is disabled at 0 selected.
+
+## Scope / non-goals
+
+- **Per-source only** — no cross-source selection tray.
+- **Visible rows only** — selection is over rendered (capped) rows; changing the
+  filter or leaving the canvas clears it. "Export all matching a filter" is
+  already served by the existing whole-source/filtered export.
+- No new keyboard multi-select shortcuts beyond the Select toggle.
+- No change to the export execution/progress/cancel path beyond the two
+  resolver branches — that machinery already consumes `ExportScope`.

--- a/Tests/Library/test_library_export_scope_ids.py
+++ b/Tests/Library/test_library_export_scope_ids.py
@@ -1,0 +1,65 @@
+import pytest
+
+from tldw_chatbook.Chatbooks.chatbook_models import ContentType
+from tldw_chatbook.Library.library_export_scope import (
+    ExportScope, resolve_export_selections, count_export_scope, export_scope_label,
+)
+
+
+class _RecordingMediaDB:
+    def __init__(self): self.calls = 0
+    def get_all_active_media_ids(self, media_type=None):
+        self.calls += 1
+        return [1, 2, 3]
+
+
+class _RecordingChaChaDB:
+    def __init__(self): self.calls = 0
+    def get_all_conversation_ids(self):
+        self.calls += 1
+        return ["c1", "c2"]
+    def get_all_note_ids(self):
+        self.calls += 1
+        return ["n1"]
+
+
+def test_ids_only_valid_for_single_source():
+    ExportScope(kind="media", ids=("1", "2"))          # ok
+    with pytest.raises(ValueError):
+        ExportScope(kind="everything", ids=("1",))
+
+
+def test_scope_with_ids_is_hashable_and_equal():
+    a = ExportScope(kind="media", ids=("1", "2"))
+    b = ExportScope(kind="media", ids=("1", "2"))
+    assert a == b and hash(a) == hash(b)
+    assert a in {b}
+
+
+def test_resolve_with_ids_returns_them_without_querying():
+    media, chacha = _RecordingMediaDB(), _RecordingChaChaDB()
+    sel = resolve_export_selections(ExportScope(kind="media", ids=("7", "8")), media, chacha)
+    assert sel == {ContentType.MEDIA: ["7", "8"]}
+    assert media.calls == 0 and chacha.calls == 0   # no whole-source query
+
+
+def test_resolve_without_ids_unchanged():
+    media, chacha = _RecordingMediaDB(), _RecordingChaChaDB()
+    sel = resolve_export_selections(ExportScope(kind="media"), media, chacha)
+    assert sel == {ContentType.MEDIA: ["1", "2", "3"]}
+    assert media.calls == 1
+
+
+def test_count_with_ids():
+    media, chacha = _RecordingMediaDB(), _RecordingChaChaDB()
+    counts = count_export_scope(ExportScope(kind="notes", ids=("a", "b", "c")), media, chacha)
+    assert counts == {"media": 0, "conversations": 0, "notes": 3}
+    assert chacha.calls == 0
+
+
+def test_label_with_ids():
+    counts = count_export_scope(
+        ExportScope(kind="conversations", ids=("x", "y")), _RecordingMediaDB(), _RecordingChaChaDB()
+    )
+    assert export_scope_label(ExportScope(kind="conversations", ids=("x", "y")), counts) \
+        == "Selected conversations · 2 items"

--- a/Tests/Library/test_library_multiselect_state.py
+++ b/Tests/Library/test_library_multiselect_state.py
@@ -1,0 +1,40 @@
+from tldw_chatbook.Library.library_media_state import build_library_media_state
+from tldw_chatbook.Library.library_conversations_state import build_library_conversations_state
+from tldw_chatbook.Library.library_notes_state import build_library_notes_list_state
+
+
+def test_media_checked_and_count():
+    records = [
+        {"id": "1", "title": "A", "type": "video", "updated_at": None},
+        {"id": "2", "title": "B", "type": "audio", "updated_at": None},
+    ]
+    state = build_library_media_state(records, select_mode=True, selected_ids=frozenset({"1"}))
+    by_id = {r.media_id: r for r in state.rows}
+    assert by_id["1"].checked is True and by_id["2"].checked is False
+    assert state.select_mode is True and state.selected_count == 1
+
+
+def test_media_default_no_select_mode():
+    records = [{"id": "1", "title": "A", "type": "video", "updated_at": None}]
+    state = build_library_media_state(records)
+    assert state.select_mode is False and state.selected_count == 0
+    assert state.rows[0].checked is False
+
+
+def test_conversations_checked_and_count():
+    records = [
+        {"id": "c1", "title": "One", "message_count": 1, "updated_at": None},
+        {"id": "c2", "title": "Two", "message_count": 2, "updated_at": None},
+    ]
+    state = build_library_conversations_state(records, select_mode=True, selected_ids=frozenset({"c2"}))
+    by_id = {r.conversation_id: r for r in state.rows}
+    assert by_id["c2"].checked is True and by_id["c1"].checked is False
+    assert state.selected_count == 1
+
+
+def test_notes_checked_and_count():
+    records = [{"id": "n1", "title": "N1"}, {"id": "n2", "title": "N2"}]
+    state = build_library_notes_list_state(records, select_mode=True, selected_ids=frozenset({"n1"}))
+    by_id = {r.note_id: r for r in state.rows}
+    assert by_id["n1"].checked is True and by_id["n2"].checked is False
+    assert state.select_mode is True and state.selected_count == 1

--- a/Tests/Library/test_row_selection.py
+++ b/Tests/Library/test_row_selection.py
@@ -1,0 +1,33 @@
+from tldw_chatbook.Library.row_selection import RowSelection
+from tldw_chatbook.Library.library_export_scope import ExportScope
+
+
+def test_toggle_add_remove():
+    s = RowSelection("media")
+    s.toggle("1"); s.toggle("2")
+    assert s.is_selected("1") and s.count == 2
+    s.toggle("1")
+    assert not s.is_selected("1") and s.count == 1
+    s.toggle("")  # empty id ignored
+    assert s.count == 1
+
+
+def test_select_all_and_clear():
+    s = RowSelection("notes")
+    s.select_all(["a", "b", "", "c"])   # empties skipped
+    assert s.ids == frozenset({"a", "b", "c"})
+    s.clear()
+    assert s.count == 0
+
+
+def test_reconcile_drops_absent_ids():
+    s = RowSelection("conversations")
+    s.select_all(["a", "b", "c"])
+    s.reconcile(["b", "c", "d"])        # 'a' no longer rendered
+    assert s.ids == frozenset({"b", "c"})
+
+
+def test_export_scope_sorts_ids():
+    s = RowSelection("media")
+    s.select_all(["10", "2", "1"])
+    assert s.export_scope() == ExportScope(kind="media", ids=("1", "10", "2"))

--- a/Tests/UI/test_library_multiselect_conversations.py
+++ b/Tests/UI/test_library_multiselect_conversations.py
@@ -1,0 +1,96 @@
+from types import SimpleNamespace
+import pytest
+from textual.app import App
+from textual.widgets import Button
+
+from tldw_chatbook.UI.Screens.library_screen import LibraryScreen, LIBRARY_ROW_BROWSE_CONVERSATIONS
+from tldw_chatbook.Library.row_selection import RowSelection
+from tldw_chatbook.Library.library_export_scope import ExportScope
+from tldw_chatbook.Library.library_conversations_state import (
+    LibraryConversationsCanvasState,
+    LibraryConversationRow,
+)
+from tldw_chatbook.Widgets.Library.library_conversations_canvas import (
+    LibraryConversationsCanvas,
+)
+
+
+def _fake(select_mode):
+    return SimpleNamespace(
+        _library_conversations_select_mode=select_mode,
+        _library_conversations_row_selection=RowSelection("conversations"),
+        _selected_conversation_id="", _library_selected_row_id="", _refreshed=0, _opened=[],
+    )
+
+
+def test_convo_row_select_mode_toggles():
+    fake = _fake(True); fake.refresh = lambda **k: setattr(fake, "_refreshed", fake._refreshed + 1)
+    ev = SimpleNamespace(button=SimpleNamespace(conversation_id="c5"), stop=lambda: None)
+    LibraryScreen.handle_library_conversation_row(fake, ev)
+    assert fake._library_conversations_row_selection.is_selected("c5")
+    assert fake._selected_conversation_id == ""     # did NOT open/select the detail
+    assert fake._refreshed == 1
+
+
+def test_convo_row_normal_mode_selects():
+    fake = _fake(False); fake.refresh = lambda **k: None
+    ev = SimpleNamespace(button=SimpleNamespace(conversation_id="c5"), stop=lambda: None)
+    LibraryScreen.handle_library_conversation_row(fake, ev)
+    assert fake._selected_conversation_id == "c5"
+    assert fake._library_selected_row_id == LIBRARY_ROW_BROWSE_CONVERSATIONS
+
+
+@pytest.mark.asyncio
+async def test_convo_export_selected_scope():
+    fake = _fake(True); fake._library_conversations_row_selection.select_all(["c2", "c1"])
+    async def _open(s): fake._opened.append(s)
+    fake._open_library_export_canvas = _open
+    await LibraryScreen.handle_library_conversations_export_selected(fake, SimpleNamespace(stop=lambda: None))
+    assert fake._opened == [ExportScope(kind="conversations", ids=("c1", "c2"))]
+
+
+def _select_mode_canvas_state() -> LibraryConversationsCanvasState:
+    rows = (
+        LibraryConversationRow(
+            conversation_id="c1",
+            title="First conversation",
+            secondary="today",
+            checked=False,
+        ),
+        LibraryConversationRow(
+            conversation_id="c2",
+            title="Second conversation",
+            secondary="today",
+            checked=False,
+        ),
+    )
+    return LibraryConversationsCanvasState(
+        rows=rows,
+        query="",
+        status_copy="",
+        empty_copy="No conversations in your Library yet.",
+        selected_id="",
+        preview_lines=(),
+        select_mode=True,
+        selected_count=0,
+    )
+
+
+class _ConversationsCanvasApp(App):
+    def compose(self):
+        yield LibraryConversationsCanvas(
+            canvas=_select_mode_canvas_state(), id="library-conversations-canvas"
+        )
+
+
+@pytest.mark.asyncio
+async def test_canvas_select_mode_renders_action_row_and_disables_export():
+    app = _ConversationsCanvasApp()
+    async with app.run_test() as pilot:
+        select_all_btn = pilot.app.query_one("#library-conversations-select-all", Button)
+        assert select_all_btn is not None
+        assert "2 shown" in str(select_all_btn.label)
+        export_selected_btn = pilot.app.query_one(
+            "#library-conversations-export-selected", Button
+        )
+        assert export_selected_btn.disabled is True

--- a/Tests/UI/test_library_multiselect_media.py
+++ b/Tests/UI/test_library_multiselect_media.py
@@ -6,7 +6,11 @@ from textual.widgets import Button
 from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
 from tldw_chatbook.Library.row_selection import RowSelection
 from tldw_chatbook.Library.library_export_scope import ExportScope
-from tldw_chatbook.Library.library_media_state import LibraryMediaCanvasState, LibraryMediaRow
+from tldw_chatbook.Library.library_media_state import (
+    LibraryMediaCanvasState,
+    LibraryMediaRow,
+    build_library_media_state,
+)
 from tldw_chatbook.Widgets.Library.library_media_canvas import LibraryMediaCanvas
 
 
@@ -95,3 +99,40 @@ async def test_canvas_select_mode_renders_action_row_and_disables_export():
         assert select_all_btn is not None
         export_selected_btn = pilot.app.query_one("#library-media-export-selected", Button)
         assert export_selected_btn.disabled is True
+
+
+def _filtered_select_mode_state() -> LibraryMediaCanvasState:
+    # Two media types; filtering to "video" renders ONE row while
+    # ``count`` (the pre-filter total across all types) stays at 3.
+    records = [
+        {"media_id": "1", "title": "A video", "type": "video", "last_modified": "2026-07-10T00:00:00Z"},
+        {"media_id": "2", "title": "An audio", "type": "audio", "last_modified": "2026-07-10T00:00:00Z"},
+        {"media_id": "3", "title": "More audio", "type": "audio", "last_modified": "2026-07-10T00:00:00Z"},
+    ]
+    return build_library_media_state(
+        records,
+        active_type="video",
+        select_mode=True,
+    )
+
+
+class _FilteredMediaCanvasApp(App):
+    def compose(self):
+        yield LibraryMediaCanvas(canvas=_filtered_select_mode_state(), id="library-media-canvas")
+
+
+@pytest.mark.asyncio
+async def test_select_all_label_uses_rendered_count_not_total_count():
+    """The "Select all N shown" label must count the rendered rows, not
+    ``canvas.count`` (the pre-filter total across all media types). With a
+    media-type filter active, ``count`` (3) overstates the one rendered row.
+    """
+    state = _filtered_select_mode_state()
+    assert len(state.rows) == 1
+    assert state.count == 3  # guards the fixture: total > rendered
+    app = _FilteredMediaCanvasApp()
+    async with app.run_test() as pilot:
+        select_all_btn = pilot.app.query_one("#library-media-select-all", Button)
+        label = str(select_all_btn.label)
+        assert f"Select all {len(state.rows)} shown" == label
+        assert str(state.count) not in label

--- a/Tests/UI/test_library_multiselect_media.py
+++ b/Tests/UI/test_library_multiselect_media.py
@@ -1,0 +1,97 @@
+from types import SimpleNamespace
+import pytest
+from textual.app import App
+from textual.widgets import Button
+
+from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
+from tldw_chatbook.Library.row_selection import RowSelection
+from tldw_chatbook.Library.library_export_scope import ExportScope
+from tldw_chatbook.Library.library_media_state import LibraryMediaCanvasState, LibraryMediaRow
+from tldw_chatbook.Widgets.Library.library_media_canvas import LibraryMediaCanvas
+
+
+def _media_fake(select_mode):
+    return SimpleNamespace(
+        _library_media_select_mode=select_mode,
+        _library_media_row_selection=RowSelection("media"),
+        _opened=[],
+        _refreshed=0,
+        _viewer_opened=[],
+    )
+
+
+def test_row_press_in_select_mode_toggles_not_opens():
+    fake = _media_fake(select_mode=True)
+    fake.refresh = lambda **k: setattr(fake, "_refreshed", fake._refreshed + 1)
+    fake._open_library_media_viewer = lambda mid: fake._viewer_opened.append(mid)
+    event = SimpleNamespace(button=SimpleNamespace(media_id="7"), stop=lambda: None)
+    LibraryScreen.handle_library_media_row(fake, event)
+    assert fake._library_media_row_selection.is_selected("7")
+    assert fake._viewer_opened == []          # viewer NOT opened
+    assert fake._refreshed == 1
+
+
+def test_row_press_normal_mode_opens_viewer():
+    fake = _media_fake(select_mode=False)
+    fake._open_library_media_viewer = lambda mid: fake._viewer_opened.append(mid)
+    event = SimpleNamespace(button=SimpleNamespace(media_id="7"), stop=lambda: None)
+    LibraryScreen.handle_library_media_row(fake, event)
+    assert fake._viewer_opened == ["7"]
+    assert not fake._library_media_row_selection.is_selected("7")
+
+
+@pytest.mark.asyncio
+async def test_export_selected_builds_ids_scope():
+    fake = _media_fake(select_mode=True)
+    fake._library_media_row_selection.select_all(["3", "1", "2"])
+    async def _open(scope): fake._opened.append(scope)
+    fake._open_library_export_canvas = _open
+    event = SimpleNamespace(stop=lambda: None)
+    await LibraryScreen.handle_library_media_export_selected(fake, event)
+    assert fake._opened == [ExportScope(kind="media", ids=("1", "2", "3"))]
+
+
+def _select_mode_canvas_state() -> LibraryMediaCanvasState:
+    rows = (
+        LibraryMediaRow(
+            media_id="1",
+            title="First item",
+            media_type="video",
+            secondary="video · today",
+            checked=False,
+        ),
+        LibraryMediaRow(
+            media_id="2",
+            title="Second item",
+            media_type="audio",
+            secondary="audio · today",
+            checked=False,
+        ),
+    )
+    return LibraryMediaCanvasState(
+        rows=rows,
+        type_options=("All", "audio", "video"),
+        active_type="All",
+        status_copy="",
+        empty_copy="No media in your Library yet. Ingest something to see it here.",
+        selected_id="",
+        preview_lines=(),
+        count=len(rows),
+        select_mode=True,
+        selected_count=0,
+    )
+
+
+class _MediaCanvasApp(App):
+    def compose(self):
+        yield LibraryMediaCanvas(canvas=_select_mode_canvas_state(), id="library-media-canvas")
+
+
+@pytest.mark.asyncio
+async def test_canvas_select_mode_renders_action_row_and_disables_export():
+    app = _MediaCanvasApp()
+    async with app.run_test() as pilot:
+        select_all_btn = pilot.app.query_one("#library-media-select-all", Button)
+        assert select_all_btn is not None
+        export_selected_btn = pilot.app.query_one("#library-media-export-selected", Button)
+        assert export_selected_btn.disabled is True

--- a/Tests/UI/test_library_multiselect_media.py
+++ b/Tests/UI/test_library_multiselect_media.py
@@ -55,6 +55,18 @@ async def test_export_selected_builds_ids_scope():
     assert fake._opened == [ExportScope(kind="media", ids=("1", "2", "3"))]
 
 
+@pytest.mark.asyncio
+async def test_export_selected_empty_is_noop_not_whole_source():
+    # An empty selection must NOT fall through to a whole-source export
+    # (empty ids == whole source in resolve_export_selections).
+    fake = _media_fake(select_mode=True)
+    async def _open(scope): fake._opened.append(scope)
+    fake._open_library_export_canvas = _open
+    event = SimpleNamespace(stop=lambda: None)
+    await LibraryScreen.handle_library_media_export_selected(fake, event)
+    assert fake._opened == []
+
+
 def _select_mode_canvas_state() -> LibraryMediaCanvasState:
     rows = (
         LibraryMediaRow(

--- a/Tests/UI/test_library_multiselect_notes.py
+++ b/Tests/UI/test_library_multiselect_notes.py
@@ -1,0 +1,36 @@
+from types import SimpleNamespace
+import pytest
+from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
+from tldw_chatbook.Library.row_selection import RowSelection
+from tldw_chatbook.Library.library_export_scope import ExportScope
+
+
+def _fake(select_mode):
+    return SimpleNamespace(
+        _library_notes_select_mode=select_mode,
+        _library_notes_row_selection=RowSelection("notes"),
+        _selected_note_id="", _library_note_dirty=False, _refreshed=0, _opened=[], _flushed=0,
+        _library_notes_view="list",
+    )
+
+
+@pytest.mark.asyncio
+async def test_notes_row_select_mode_toggles_and_does_not_open_editor():
+    fake = _fake(True)
+    fake.refresh = lambda **k: setattr(fake, "_refreshed", fake._refreshed + 1)
+    async def _flush(): fake._flushed += 1
+    fake._flush_library_note_save = _flush
+    ev = SimpleNamespace(button=SimpleNamespace(note_id="n9"), stop=lambda: None)
+    await LibraryScreen.handle_library_notes_row(fake, ev)
+    assert fake._library_notes_row_selection.is_selected("n9")
+    assert fake._library_notes_view == "list"      # editor NOT opened
+    assert fake._refreshed == 1
+
+
+@pytest.mark.asyncio
+async def test_notes_export_selected_scope():
+    fake = _fake(True); fake._library_notes_row_selection.select_all(["n2", "n1"])
+    async def _open(s): fake._opened.append(s)
+    fake._open_library_export_canvas = _open
+    await LibraryScreen.handle_library_notes_export_selected(fake, SimpleNamespace(stop=lambda: None))
+    assert fake._opened == [ExportScope(kind="notes", ids=("n1", "n2"))]

--- a/backlog/tasks/task-159 - Multi-select-row-export-for-the-Library.md
+++ b/backlog/tasks/task-159 - Multi-select-row-export-for-the-Library.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-159
 title: Multi-select row export for the Library
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-11 22:01'
 labels:
@@ -18,6 +18,50 @@ F4 shipped current-scope export (everything, or a section's current filter). Add
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 User can check individual Library rows and export exactly those
-- [ ] #2 Export form accepts an explicit id set as its scope
+- [x] #1 User can check individual Library rows and export exactly those
+- [x] #2 Export form accepts an explicit id set as its scope
 <!-- AC:END -->
+
+## Implementation Notes
+
+- `ExportScope` gained an `ids: tuple[str, ...]` field: when non-empty it
+  overrides the normal current-scope-filter resolve/count/label branches
+  with an explicit-subset export ("Selected media/conversations/notes ·
+  N items").
+- `RowSelection` (pure, Textual-free) is a per-source checked-id
+  accumulator: `toggle`/`select_all`/`clear`/`reconcile` on the id set,
+  plus `export_scope()` to turn it into an `ExportScope`. The screen owns
+  one instance per browsable source (media/conversations/notes).
+- Each of the three Library row-state builders (`build_library_media_state`,
+  `build_library_conversations_state`, `build_library_notes_list_state`)
+  gained `checked`/`select_mode`/`selected_count` so the canvases can
+  render the ☑/☐ glyph and selection count without any screen-side
+  bookkeeping duplicated in the widgets.
+- Select mode is per-source: entering it on one canvas doesn't affect the
+  others, and switching a source's sort/filter/type-filter clears that
+  source's selection and exits select mode (reconciled against the
+  currently rendered rows so a stale selection can never silently export
+  more/less than what's on screen -- WYSIWYG).
+- All select-mode transitions recompose via the screen's
+  `self.refresh(recompose=True)` (the only reliable update path already
+  used everywhere else in this canvas family) rather than a targeted
+  per-widget update.
+- Notes is the one source where entering/toggling select mode is `async`:
+  it awaits `_flush_library_note_save()` first (mirroring the existing
+  note-row-press flush) so entering select mode, or toggling a row while
+  select mode is active, never strands a dirty note edit mid-save. Notes
+  rows also had no marker at all before this task, so the ☑/☐ glyph only
+  ever appears once select mode is active; normal mode keeps its
+  markerless label.
+- Modified/added files: `tldw_chatbook/Library/library_export_scope.py`,
+  `tldw_chatbook/Library/row_selection.py`,
+  `tldw_chatbook/Library/library_media_state.py`,
+  `tldw_chatbook/Library/library_conversations_state.py`,
+  `tldw_chatbook/Library/library_notes_state.py`,
+  `tldw_chatbook/Widgets/Library/library_media_canvas.py`,
+  `tldw_chatbook/Widgets/Library/library_conversations_canvas.py`,
+  `tldw_chatbook/Widgets/Library/library_notes_canvas.py`,
+  `tldw_chatbook/UI/Screens/library_screen.py`,
+  `Tests/Library/*`, `Tests/UI/test_library_multiselect_media.py`,
+  `Tests/UI/test_library_multiselect_conversations.py`,
+  `Tests/UI/test_library_multiselect_notes.py`.

--- a/backlog/tasks/task-192 - De-flake-library-note-conflict-shell-test-under-CPU-contention.md
+++ b/backlog/tasks/task-192 - De-flake-library-note-conflict-shell-test-under-CPU-contention.md
@@ -1,0 +1,17 @@
+---
+id: TASK-192
+title: De-flake library note-conflict shell test under CPU contention
+status: To Do
+assignee: []
+created_date: '2026-07-12 14:05'
+labels:
+  - follow-up
+  - test-flake
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+test_library_shell_note_conflict_shows_overwrite_reload_and_keeps_user_text intermittently fails under concurrent CPU load (passes in isolation). Widen its polling/timeout budget or replace the timing loop with condition-based waiting. Discovered during task 159; unrelated to that diff.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tldw_chatbook/Library/library_conversations_state.py
+++ b/tldw_chatbook/Library/library_conversations_state.py
@@ -31,6 +31,7 @@ class LibraryConversationRow:
     title: str
     secondary: str
     selected: bool = False
+    checked: bool = False
 
 
 @dataclass(frozen=True)
@@ -43,6 +44,8 @@ class LibraryConversationsCanvasState:
     selected_id: str
     preview_lines: tuple[str, ...]
     query: str
+    select_mode: bool = False
+    selected_count: int = 0
 
 
 @dataclass(frozen=True)
@@ -120,6 +123,8 @@ def build_library_conversations_state(
     selected_id: str = "",
     now: datetime | None = None,
     limit: int = 75,
+    select_mode: bool = False,
+    selected_ids: frozenset[str] = frozenset(),
 ) -> LibraryConversationsCanvasState:
     """Build the Library Browse ▸ Conversations canvas display state.
 
@@ -179,9 +184,11 @@ def build_library_conversations_state(
                 format_console_relative_age(entry.updated_raw, now=reference_now),
             ),
             selected=entry.conversation_id == resolved_selected_id,
+            checked=entry.conversation_id in selected_ids,
         )
         for entry in limited_entries
     )
+    selected_count = sum(1 for r in rows if r.checked)
 
     if normalized_query:
         # match_count is from the filtered-but-unlimited entries list, not the limited rows
@@ -224,4 +231,6 @@ def build_library_conversations_state(
         selected_id=resolved_selected_id,
         preview_lines=preview_lines,
         query=normalized_query,
+        select_mode=select_mode,
+        selected_count=selected_count,
     )

--- a/tldw_chatbook/Library/library_export_scope.py
+++ b/tldw_chatbook/Library/library_export_scope.py
@@ -26,6 +26,12 @@ _VALID_KINDS = ("everything", "media", "conversations", "notes")
 # Sentinel used by the Library media canvas's "no filter" select option.
 _UNFILTERED_MEDIA_TYPE_SENTINEL = "All"
 
+_KIND_TO_CONTENT_TYPE = {
+    "media": ContentType.MEDIA,
+    "conversations": ContentType.CONVERSATION,
+    "notes": ContentType.NOTE,
+}
+
 
 @dataclass(frozen=True)
 class ExportScope:
@@ -38,16 +44,24 @@ class ExportScope:
             other ``kind``. ``None`` and the Library media canvas's "no
             filter" sentinel ``"All"`` both mean unfiltered -- every active
             media item is in scope.
+        ids: An explicit subset of ids to export, overriding a whole-source
+            query. Only meaningful for a single-source ``kind`` ("media",
+            "conversations", "notes") -- raises if set with
+            ``kind="everything"``. When non-empty, every resolver returns
+            these ids directly without querying the database.
     """
 
     kind: str
     media_type: str | None = None
+    ids: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         if self.kind not in _VALID_KINDS:
             raise ValueError(
                 f"Unknown export scope kind: {self.kind!r}. Expected one of {_VALID_KINDS}."
             )
+        if self.ids and self.kind == "everything":
+            raise ValueError("ExportScope.ids may only scope a single source, not 'everything'.")
 
 
 class MediaIdSource(Protocol):
@@ -92,6 +106,9 @@ def count_export_scope(
     outside ``scope`` reports 0 rather than being omitted from the dict.
     """
     counts = {"media": 0, "conversations": 0, "notes": 0}
+    if scope.ids:
+        counts[scope.kind] = len(scope.ids)
+        return counts
     if scope.kind in ("everything", "media"):
         counts["media"] = len(media_db.get_all_active_media_ids(_effective_media_type(scope)))
     if scope.kind in ("everything", "conversations"):
@@ -124,6 +141,8 @@ def resolve_export_selections(
     ``ContentType.MEDIA in selections`` -> ``include_media`` decision --
     correct without extra empty-list special-casing downstream.
     """
+    if scope.ids:
+        return {_KIND_TO_CONTENT_TYPE[scope.kind]: list(scope.ids)}
     selections: dict[ContentType, list[str]] = {}
     if scope.kind in ("everything", "media"):
         media_ids = [
@@ -153,6 +172,8 @@ def export_scope_label(scope: ExportScope, counts: Mapping[str, int]) -> str:
         "Conversations · 542 items"
         "Notes · 87 items"
     """
+    if scope.ids:
+        return f"Selected {scope.kind} · {counts.get(scope.kind, len(scope.ids))} items"
     if scope.kind == "everything":
         return (
             f"Everything: {counts.get('media', 0)} media · "

--- a/tldw_chatbook/Library/library_media_state.py
+++ b/tldw_chatbook/Library/library_media_state.py
@@ -24,6 +24,7 @@ class LibraryMediaRow:
     media_type: str
     secondary: str
     selected: bool = False
+    checked: bool = False
 
 
 @dataclass(frozen=True)
@@ -38,6 +39,8 @@ class LibraryMediaCanvasState:
     selected_id: str
     preview_lines: tuple[str, ...]
     count: int
+    select_mode: bool = False
+    selected_count: int = 0
 
 
 @dataclass(frozen=True)
@@ -116,6 +119,8 @@ def build_library_media_state(
     selected_id: str = "",
     now: datetime | None = None,
     limit: int = 75,
+    select_mode: bool = False,
+    selected_ids: frozenset[str] = frozenset(),
 ) -> LibraryMediaCanvasState:
     """Build the Library Browse ▸ Media canvas display state.
 
@@ -185,9 +190,11 @@ def build_library_media_state(
                 format_console_relative_age(entry.updated_raw, now=reference_now),
             ),
             selected=entry.media_id == resolved_selected_id,
+            checked=entry.media_id in selected_ids,
         )
         for entry in limited_entries
     )
+    selected_count = sum(1 for r in rows if r.checked)
 
     # Build type_options: ("All",) + sorted distinct non-empty types
     distinct_types = {entry.media_type for entry in entries if entry.media_type}
@@ -237,4 +244,6 @@ def build_library_media_state(
         selected_id=resolved_selected_id,
         preview_lines=preview_lines,
         count=total_count,
+        select_mode=select_mode,
+        selected_count=selected_count,
     )

--- a/tldw_chatbook/Library/library_notes_state.py
+++ b/tldw_chatbook/Library/library_notes_state.py
@@ -29,11 +29,13 @@ class LibraryNotesListRow:
         age_label: Relative-age label (e.g. ``"3m"``, ``"1d"``) derived
             from the note's most recent modified/created timestamp, or
             ``""`` when no timestamp is available.
+        checked: Whether this row is checked in multi-select mode.
     """
 
     note_id: str
     title: str
     age_label: str
+    checked: bool = False
 
 
 @dataclass(frozen=True)
@@ -47,12 +49,16 @@ class LibraryNotesListState:
             results"``), or ``""`` when no filter is active.
         empty_copy: Empty-state copy shown when ``rows`` is empty, or
             ``""`` when there are rows to render.
+        select_mode: Whether multi-select mode is active.
+        selected_count: Number of rendered rows currently checked.
     """
 
     rows: tuple[LibraryNotesListRow, ...]
     header_copy: str
     status_copy: str
     empty_copy: str
+    select_mode: bool = False
+    selected_count: int = 0
 
 
 @dataclass(frozen=True)
@@ -94,12 +100,16 @@ def _updated_raw(record: Mapping[str, Any]) -> str:
     return ""
 
 
-def _row(record: Mapping[str, Any], *, now: datetime) -> LibraryNotesListRow:
+def _row(
+    record: Mapping[str, Any], *, now: datetime, selected_ids: frozenset[str]
+) -> LibraryNotesListRow:
     raw = _updated_raw(record)
+    note_id = _text(record.get("id"))
     return LibraryNotesListRow(
-        note_id=_text(record.get("id")),
+        note_id=note_id,
         title=_text(record.get("title")) or "Untitled",
         age_label=format_console_relative_age(raw, now=now) if raw else "",
+        checked=note_id in selected_ids,
     )
 
 
@@ -108,6 +118,8 @@ def build_library_notes_list_state(
     *,
     filter_note: str = "",
     now: datetime | None = None,
+    select_mode: bool = False,
+    selected_ids: frozenset[str] = frozenset(),
 ) -> LibraryNotesListState:
     """Build the Library notes canvas's list-view display state.
 
@@ -122,13 +134,15 @@ def build_library_notes_list_state(
             result-count status copy; ``""`` when no filter is active.
         now: Reference time for relative-age labels; defaults to the
             current UTC time.
+        select_mode: Whether multi-select mode is active.
+        selected_ids: The currently checked note ids.
 
     Returns:
         The list view's display state.
     """
     reference_now = now if now is not None else datetime.now(timezone.utc)
     rows = tuple(
-        _row(record, now=reference_now)
+        _row(record, now=reference_now, selected_ids=selected_ids)
         for record in (records or ())
         if isinstance(record, Mapping) and _text(record.get("id"))
     )
@@ -136,11 +150,14 @@ def build_library_notes_list_state(
     if filter_note:
         noun = "result" if len(rows) == 1 else "results"
         status_copy = f"filter: {filter_note} · {len(rows)} {noun}"
+    selected_count = sum(1 for r in rows if r.checked)
     return LibraryNotesListState(
         rows=rows,
         header_copy=f"Notes ({len(rows)})",
         status_copy=status_copy,
         empty_copy="" if rows else _EMPTY_NOTES_COPY,
+        select_mode=select_mode,
+        selected_count=selected_count,
     )
 
 

--- a/tldw_chatbook/Library/row_selection.py
+++ b/tldw_chatbook/Library/row_selection.py
@@ -1,0 +1,48 @@
+"""Per-source checked-row accumulator for the Library multi-select export.
+
+Pure and Textual-free: the screen owns one instance per browsable source
+(media/conversations/notes) and drives it from the row-press handlers, then
+turns the checked ids into an ``ExportScope`` for the export canvas.
+"""
+from __future__ import annotations
+
+from typing import Iterable
+
+from tldw_chatbook.Library.library_export_scope import ExportScope
+
+
+class RowSelection:
+    def __init__(self, kind: str) -> None:
+        # kind is one of "media" | "conversations" | "notes" — the ExportScope
+        # single-source kind these ids belong to.
+        self._kind = kind
+        self._ids: set[str] = set()
+
+    @property
+    def ids(self) -> frozenset[str]:
+        return frozenset(self._ids)
+
+    @property
+    def count(self) -> int:
+        return len(self._ids)
+
+    def is_selected(self, row_id: str) -> bool:
+        return row_id in self._ids
+
+    def toggle(self, row_id: str) -> None:
+        if not row_id:
+            return
+        self._ids.discard(row_id) if row_id in self._ids else self._ids.add(row_id)
+
+    def select_all(self, rendered_ids: Iterable[str]) -> None:
+        self._ids.update(rid for rid in rendered_ids if rid)
+
+    def clear(self) -> None:
+        self._ids.clear()
+
+    def reconcile(self, rendered_ids: Iterable[str]) -> None:
+        """Drop any selected id no longer present in the rendered rows."""
+        self._ids &= set(rendered_ids)
+
+    def export_scope(self) -> ExportScope:
+        return ExportScope(kind=self._kind, ids=tuple(sorted(self._ids)))

--- a/tldw_chatbook/Library/row_selection.py
+++ b/tldw_chatbook/Library/row_selection.py
@@ -32,7 +32,10 @@ class RowSelection:
     def toggle(self, row_id: str) -> None:
         if not row_id:
             return
-        self._ids.discard(row_id) if row_id in self._ids else self._ids.add(row_id)
+        if row_id in self._ids:
+            self._ids.discard(row_id)
+        else:
+            self._ids.add(row_id)
 
     def select_all(self, rendered_ids: Iterable[str]) -> None:
         self._ids.update(rid for rid in rendered_ids if rid)

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -128,6 +128,7 @@ from ...Library.library_shell_state import (
     LibraryShellInput,
     build_library_shell_state,
 )
+from ...Library.row_selection import RowSelection
 from ...runtime_policy.server_event_scope import event_principal_id_from_active_context
 from ...runtime_policy.types import PolicyDeniedError, RuntimeSourceState
 from ...Sync_Interop.sync_promotion_state import build_sync_promotion_state
@@ -563,6 +564,8 @@ class LibraryScreen(BaseAppScreen):
         self._library_conversation_query: str = ""
         self._library_media_type_filter: str = "All"
         self._selected_media_id: str = ""
+        self._library_media_select_mode: bool = False
+        self._library_media_row_selection = RowSelection("media")
         self._library_media_view: str = "list"
         self._library_media_detail: Mapping[str, Any] | None = None
         self._library_media_editing: bool = False
@@ -2842,11 +2845,16 @@ class LibraryScreen(BaseAppScreen):
 
     def _build_library_media_state(self) -> LibraryMediaCanvasState:
         """Build the media canvas display state from local records."""
-        return build_library_media_state(
+        state = build_library_media_state(
             self._local_source_records.get("media", ()),
             active_type=self._library_media_type_filter,
             selected_id=self._selected_media_id,
+            select_mode=self._library_media_select_mode,
+            selected_ids=self._library_media_row_selection.ids,
         )
+        if self._library_media_select_mode:
+            self._library_media_row_selection.reconcile(r.media_id for r in state.rows)
+        return state
 
     async def _refresh_library_media_detail(self, media_id: str) -> None:
         """Fetch and store the full detail for a selected Library media item.
@@ -5306,14 +5314,20 @@ class LibraryScreen(BaseAppScreen):
             current_index = 0
         next_index = (current_index + 1) % len(type_options)
         self._library_media_type_filter = type_options[next_index]
+        self._library_media_select_mode = False
+        self._library_media_row_selection.clear()
         self.refresh(recompose=True)
 
     @on(Button.Pressed, ".library-media-row")
     def handle_library_media_row(self, event: Button.Pressed) -> None:
-        """Select a media row and open the full Library media viewer.
+        """Select mode: toggle the row's checkbox. Normal mode: open the viewer.
 
-        Switches the media canvas from its list view to the in-canvas
-        viewer, clears any stale detail, and kicks the async detail fetch
+        In select mode, a row press toggles that row's id in
+        ``_library_media_row_selection`` and recomposes the screen -- it
+        never opens the full Library media viewer while in select mode.
+        Outside select mode, behavior is unchanged: switches the media
+        canvas from its list view to the in-canvas viewer, clears any
+        stale detail, and kicks the async detail fetch
         (``_refresh_library_media_detail``); the viewer renders a loading
         line until that worker stores the fetched detail and recomposes.
 
@@ -5322,7 +5336,40 @@ class LibraryScreen(BaseAppScreen):
         """
         event.stop()
         media_id = str(getattr(event.button, "media_id", "") or "")
+        if self._library_media_select_mode:
+            self._library_media_row_selection.toggle(media_id)
+            self.refresh(recompose=True)
+            return
         self._open_library_media_viewer(media_id)
+
+    @on(Button.Pressed, "#library-media-select-toggle")
+    def handle_library_media_select_toggle(self, event: Button.Pressed) -> None:
+        """Enter/exit media select mode; entering starts from an empty set."""
+        event.stop()
+        self._library_media_select_mode = not self._library_media_select_mode
+        self._library_media_row_selection.clear()
+        self.refresh(recompose=True)
+
+    @on(Button.Pressed, "#library-media-select-all")
+    def handle_library_media_select_all(self, event: Button.Pressed) -> None:
+        """Select every media row currently rendered by the canvas."""
+        event.stop()
+        rows = self._build_library_media_state().rows
+        self._library_media_row_selection.select_all(r.media_id for r in rows)
+        self.refresh(recompose=True)
+
+    @on(Button.Pressed, "#library-media-select-clear")
+    def handle_library_media_select_clear(self, event: Button.Pressed) -> None:
+        """Clear the current media selection without leaving select mode."""
+        event.stop()
+        self._library_media_row_selection.clear()
+        self.refresh(recompose=True)
+
+    @on(Button.Pressed, "#library-media-export-selected")
+    async def handle_library_media_export_selected(self, event: Button.Pressed) -> None:
+        """Open the export canvas scoped to the currently selected media ids."""
+        event.stop()
+        await self._open_library_export_canvas(self._library_media_row_selection.export_scope())
 
     @on(Button.Pressed, "#library-media-open-viewer")
     def handle_library_media_open_viewer(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -74,6 +74,7 @@ from ...Library.library_media_viewer_state import (
 )
 from ...Library.library_notes_state import (
     LibraryNoteEditorState,
+    LibraryNotesListState,
     build_library_note_editor_state,
     build_library_notes_list_state,
     build_note_export_content,
@@ -577,6 +578,8 @@ class LibraryScreen(BaseAppScreen):
         self._library_media_content_query: str = ""
         self._library_media_content_match_index: int = 0
         self._library_notes_view: str = "list"
+        self._library_notes_select_mode: bool = False
+        self._library_notes_row_selection = RowSelection("notes")
         self._library_notes_sort: str = "newest"
         self._library_notes_filter: str = ""
         self._library_notes_filter_records: list | None = None
@@ -2693,17 +2696,8 @@ class LibraryScreen(BaseAppScreen):
                         id="library-notes-canvas",
                     )
                 elif shell.canvas_kind == "notes":
-                    source_records = (
-                        self._library_notes_filter_records
-                        if self._library_notes_filter_records is not None
-                        else self._local_source_records.get("notes", ())
-                    )
-                    notes_list_state = build_library_notes_list_state(
-                        sort_notes_records(source_records, self._library_notes_sort),
-                        filter_note=self._library_notes_filter,
-                    )
                     yield LibraryNotesCanvas(
-                        notes_list_state,
+                        self._build_library_notes_state(),
                         sort_mode=self._library_notes_sort,
                         filter_value=self._library_notes_filter,
                         id="library-notes-canvas",
@@ -2863,6 +2857,23 @@ class LibraryScreen(BaseAppScreen):
         )
         if self._library_media_select_mode:
             self._library_media_row_selection.reconcile(r.media_id for r in state.rows)
+        return state
+
+    def _build_library_notes_state(self) -> LibraryNotesListState:
+        """Build the notes canvas's list-view display state from local records."""
+        source_records = (
+            self._library_notes_filter_records
+            if self._library_notes_filter_records is not None
+            else self._local_source_records.get("notes", ())
+        )
+        state = build_library_notes_list_state(
+            sort_notes_records(source_records, self._library_notes_sort),
+            filter_note=self._library_notes_filter,
+            select_mode=self._library_notes_select_mode,
+            selected_ids=self._library_notes_row_selection.ids,
+        )
+        if self._library_notes_select_mode:
+            self._library_notes_row_selection.reconcile(r.note_id for r in state.rows)
         return state
 
     async def _refresh_library_media_detail(self, media_id: str) -> None:
@@ -5482,6 +5493,8 @@ class LibraryScreen(BaseAppScreen):
         """
         event.stop()
         self._library_notes_sort = next_notes_sort_mode(self._library_notes_sort)
+        self._library_notes_select_mode = False
+        self._library_notes_row_selection.clear()
         self.refresh(recompose=True)
 
     @on(Input.Submitted, "#library-notes-filter")
@@ -5496,6 +5509,8 @@ class LibraryScreen(BaseAppScreen):
         if submitted == self._library_notes_filter:
             return
         self._library_notes_filter = submitted
+        self._library_notes_select_mode = False
+        self._library_notes_row_selection.clear()
         if not submitted:
             self._library_notes_filter_records = None
             self.refresh(recompose=True)
@@ -6457,17 +6472,21 @@ class LibraryScreen(BaseAppScreen):
 
     @on(Button.Pressed, ".library-notes-row")
     async def handle_library_notes_row(self, event: Button.Pressed) -> None:
-        """Select a note row and open the in-canvas Library note editor.
+        """Select mode: toggle the row's checkbox. Normal mode: open the editor.
 
-        Switches the notes canvas from its list view to the editor, clears
-        any stale detail, and kicks the async detail fetch
-        (``_refresh_library_note_detail``); ``compose_content`` renders a
-        loading line until that worker stores the fetched detail and
-        recomposes. Mirrors ``handle_library_media_row``.
+        Flushes any dirty edit from a previously-open note first (awaited,
+        regardless of select mode) so switching notes -- or entering select
+        mode -- never silently discards unsaved text; an unsaved edit
+        surviving the flush aborts either path.
 
-        Flushes any dirty edit from a previously-open note first (awaited)
-        so switching notes never silently discards unsaved text; an
-        unsaved edit surviving the flush aborts the switch.
+        In select mode, a row press toggles that row's id in
+        ``_library_notes_row_selection`` and recomposes the screen -- it
+        never opens the in-canvas Library note editor while in select mode.
+        Outside select mode, behavior is unchanged: switches the notes
+        canvas from its list view to the editor, clears any stale detail,
+        and kicks the async detail fetch (``_refresh_library_note_detail``);
+        ``compose_content`` renders a loading line until that worker stores
+        the fetched detail and recomposes. Mirrors ``handle_library_media_row``.
 
         Args:
             event: Button press event emitted by a note row button.
@@ -6477,6 +6496,10 @@ class LibraryScreen(BaseAppScreen):
         if self._library_note_dirty:
             return
         note_id = str(getattr(event.button, "note_id", "") or "")
+        if self._library_notes_select_mode:
+            self._library_notes_row_selection.toggle(note_id)
+            self.refresh(recompose=True)
+            return
         if note_id:
             self._selected_note_id = note_id
         self._library_selected_row_id = LIBRARY_ROW_BROWSE_NOTES
@@ -6500,6 +6523,47 @@ class LibraryScreen(BaseAppScreen):
                 group="library_note_detail",
             )
         self.refresh(recompose=True)
+
+    @on(Button.Pressed, "#library-notes-select-toggle")
+    async def handle_library_notes_select_toggle(self, event: Button.Pressed) -> None:
+        """Enter/exit notes select mode; clears the selection set (both on enter and exit).
+
+        Flushes any dirty edit first (awaited) so entering select mode
+        never strands a dirty note edit mid-save -- select mode is only
+        reachable from the notes list view, but the flush stays
+        unconditional here to mirror ``handle_library_notes_row``'s
+        always-flush-first behavior.
+
+        Args:
+            event: Button press event emitted by the notes canvas's
+                Select/Done toggle.
+        """
+        event.stop()
+        await self._flush_library_note_save()
+        self._library_notes_select_mode = not self._library_notes_select_mode
+        self._library_notes_row_selection.clear()
+        self.refresh(recompose=True)
+
+    @on(Button.Pressed, "#library-notes-select-all")
+    def handle_library_notes_select_all(self, event: Button.Pressed) -> None:
+        """Select every note row currently rendered by the canvas."""
+        event.stop()
+        rows = self._build_library_notes_state().rows
+        self._library_notes_row_selection.select_all(r.note_id for r in rows)
+        self.refresh(recompose=True)
+
+    @on(Button.Pressed, "#library-notes-select-clear")
+    def handle_library_notes_select_clear(self, event: Button.Pressed) -> None:
+        """Clear the current notes selection without leaving select mode."""
+        event.stop()
+        self._library_notes_row_selection.clear()
+        self.refresh(recompose=True)
+
+    @on(Button.Pressed, "#library-notes-export-selected")
+    async def handle_library_notes_export_selected(self, event: Button.Pressed) -> None:
+        """Open the export canvas scoped to the currently selected note ids."""
+        event.stop()
+        await self._open_library_export_canvas(self._library_notes_row_selection.export_scope())
 
     @on(Button.Pressed, "#library-note-back")
     async def handle_library_note_back(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -5349,6 +5349,12 @@ class LibraryScreen(BaseAppScreen):
     async def handle_library_conversations_export_selected(self, event: Button.Pressed) -> None:
         """Open the export canvas scoped to the currently selected conversation ids."""
         event.stop()
+        # Defensive: an empty selection would resolve to a whole-source export
+        # (empty ids == whole source). The button is disabled at 0 selected, so
+        # this is normally unreachable -- guard anyway so a future activation
+        # path can't silently export everything.
+        if not self._library_conversations_row_selection.count:
+            return
         await self._open_library_export_canvas(
             self._library_conversations_row_selection.export_scope()
         )
@@ -5432,6 +5438,10 @@ class LibraryScreen(BaseAppScreen):
     async def handle_library_media_export_selected(self, event: Button.Pressed) -> None:
         """Open the export canvas scoped to the currently selected media ids."""
         event.stop()
+        # Defensive: an empty selection would resolve to a whole-source export
+        # (empty ids == whole source); the button is disabled at 0 selected.
+        if not self._library_media_row_selection.count:
+            return
         await self._open_library_export_canvas(self._library_media_row_selection.export_scope())
 
     @on(Button.Pressed, "#library-media-open-viewer")
@@ -6563,6 +6573,10 @@ class LibraryScreen(BaseAppScreen):
     async def handle_library_notes_export_selected(self, event: Button.Pressed) -> None:
         """Open the export canvas scoped to the currently selected note ids."""
         event.stop()
+        # Defensive: an empty selection would resolve to a whole-source export
+        # (empty ids == whole source); the button is disabled at 0 selected.
+        if not self._library_notes_row_selection.count:
+            return
         await self._open_library_export_canvas(self._library_notes_row_selection.export_scope())
 
     @on(Button.Pressed, "#library-note-back")

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -5344,7 +5344,7 @@ class LibraryScreen(BaseAppScreen):
 
     @on(Button.Pressed, "#library-media-select-toggle")
     def handle_library_media_select_toggle(self, event: Button.Pressed) -> None:
-        """Enter/exit media select mode; entering starts from an empty set."""
+        """Enter/exit media select mode; clears the selection set (both on enter and exit)."""
         event.stop()
         self._library_media_select_mode = not self._library_media_select_mode
         self._library_media_row_selection.clear()

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -562,6 +562,8 @@ class LibraryScreen(BaseAppScreen):
         self._selected_conversation_id = ""
         self._library_selected_row_id: str = ""
         self._library_conversation_query: str = ""
+        self._library_conversations_select_mode: bool = False
+        self._library_conversations_row_selection = RowSelection("conversations")
         self._library_media_type_filter: str = "All"
         self._selected_media_id: str = ""
         self._library_media_select_mode: bool = False
@@ -2837,11 +2839,18 @@ class LibraryScreen(BaseAppScreen):
 
     def _build_library_conversations_state(self):
         """Build the conversations canvas display state from local records."""
-        return build_library_conversations_state(
+        state = build_library_conversations_state(
             self._conversation_records(),
             query=self._library_conversation_query,
             selected_id=self._selected_conversation_id,
+            select_mode=self._library_conversations_select_mode,
+            selected_ids=self._library_conversations_row_selection.ids,
         )
+        if self._library_conversations_select_mode:
+            self._library_conversations_row_selection.reconcile(
+                r.conversation_id for r in state.rows
+            )
+        return state
 
     def _build_library_media_state(self) -> LibraryMediaCanvasState:
         """Build the media canvas display state from local records."""
@@ -5278,17 +5287,60 @@ class LibraryScreen(BaseAppScreen):
 
     @on(Button.Pressed, ".library-conversation-row")
     def handle_library_conversation_row(self, event: Button.Pressed) -> None:
-        """Select a conversation row in the Library conversations canvas.
+        """Select mode: toggle the row's checkbox. Normal mode: select the row.
+
+        In select mode, a row press toggles that row's id in
+        ``_library_conversations_row_selection`` and recomposes the screen --
+        it never sets the normal-mode selection/detail while in select mode.
+        Outside select mode, behavior is unchanged: selects the conversation
+        and switches the Library rail to the conversations browse row.
 
         Args:
             event: Button press event emitted by a conversation row button.
         """
         event.stop()
         conversation_id = str(getattr(event.button, "conversation_id", "") or "")
+        if self._library_conversations_select_mode:
+            self._library_conversations_row_selection.toggle(conversation_id)
+            self.refresh(recompose=True)
+            return
         if conversation_id:
             self._selected_conversation_id = conversation_id
         self._library_selected_row_id = LIBRARY_ROW_BROWSE_CONVERSATIONS
         self.refresh(recompose=True)
+
+    @on(Button.Pressed, "#library-conversations-select-toggle")
+    def handle_library_conversations_select_toggle(self, event: Button.Pressed) -> None:
+        """Enter/exit conversations select mode; clears the selection set (both on enter and exit)."""
+        event.stop()
+        self._library_conversations_select_mode = not self._library_conversations_select_mode
+        self._library_conversations_row_selection.clear()
+        self.refresh(recompose=True)
+
+    @on(Button.Pressed, "#library-conversations-select-all")
+    def handle_library_conversations_select_all(self, event: Button.Pressed) -> None:
+        """Select every conversation row currently rendered by the canvas."""
+        event.stop()
+        rows = self._build_library_conversations_state().rows
+        self._library_conversations_row_selection.select_all(
+            r.conversation_id for r in rows
+        )
+        self.refresh(recompose=True)
+
+    @on(Button.Pressed, "#library-conversations-select-clear")
+    def handle_library_conversations_select_clear(self, event: Button.Pressed) -> None:
+        """Clear the current conversations selection without leaving select mode."""
+        event.stop()
+        self._library_conversations_row_selection.clear()
+        self.refresh(recompose=True)
+
+    @on(Button.Pressed, "#library-conversations-export-selected")
+    async def handle_library_conversations_export_selected(self, event: Button.Pressed) -> None:
+        """Open the export canvas scoped to the currently selected conversation ids."""
+        event.stop()
+        await self._open_library_export_canvas(
+            self._library_conversations_row_selection.export_scope()
+        )
 
     @on(Button.Pressed, "#library-media-type-filter")
     def handle_library_media_type_filter_pressed(self, event: Button.Pressed) -> None:
@@ -7695,6 +7747,8 @@ class LibraryScreen(BaseAppScreen):
         """
         event.stop()
         self._library_conversation_query = self._safe_text(event.value, max_length=200)
+        self._library_conversations_select_mode = False
+        self._library_conversations_row_selection.clear()
         self.refresh(recompose=True)
         self.call_after_refresh(self._focus_library_conversations_filter)
 

--- a/tldw_chatbook/Widgets/Library/library_conversations_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_conversations_canvas.py
@@ -50,12 +50,41 @@ class LibraryConversationsCanvas(Vertical):
         Returns:
             ComposeResult for the conversations canvas.
         """
-        yield Button(
+        select_mode = getattr(self.canvas, "select_mode", False)
+        # Gate/label off the RENDERED rows, not a pre-filter total -- the
+        # conversations canvas state has no ``.count`` field at all (unlike
+        # media), so ``len(self.canvas.rows)`` is the only correct source for
+        # "how many rows are shown right now".
+        rendered_count = len(self.canvas.rows)
+        export_btn = Button(
             "Export…",
             id="library-conversations-export",
             classes="library-canvas-action",
             compact=True,
         )
+        export_btn.display = not select_mode
+        yield export_btn
+        select_btn = Button("Done" if select_mode else "Select",
+                            id="library-conversations-select-toggle",
+                            classes="library-canvas-action", compact=True)
+        select_btn.disabled = rendered_count == 0
+        yield select_btn
+        if select_mode:
+            action_row = Horizontal(classes="ds-toolbar")
+            action_row.styles.height = "auto"
+            with action_row:
+                yield Static(f"{self.canvas.selected_count} selected",
+                             id="library-conversations-selected-count", markup=False)
+                yield Button(f"Select all {rendered_count} shown",
+                             id="library-conversations-select-all",
+                             classes="library-canvas-action", compact=True)
+                yield Button("Clear", id="library-conversations-select-clear",
+                             classes="library-canvas-action", compact=True)
+                export_selected = Button("Export selected",
+                                         id="library-conversations-export-selected",
+                                         classes="library-canvas-action", compact=True)
+                export_selected.disabled = self.canvas.selected_count == 0
+                yield export_selected
 
         status_text = self.canvas.status_copy or self.canvas.empty_copy
         status = Static(
@@ -76,7 +105,10 @@ class LibraryConversationsCanvas(Vertical):
         conversation_list.styles.height = "auto"
         with conversation_list:
             for index, row in enumerate(self.canvas.rows):
-                marker = "▸" if row.selected else " "
+                if select_mode:
+                    marker = "☑" if row.checked else "☐"
+                else:
+                    marker = "▸" if row.selected else " "
                 button = Button(
                     f"{marker} {_visible_row_title(row.title)}"
                     f"\n    {row.secondary}",

--- a/tldw_chatbook/Widgets/Library/library_media_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_media_canvas.py
@@ -59,6 +59,14 @@ class LibraryMediaCanvas(Vertical):
             compact=True,
         )
         select_mode = getattr(self.canvas, "select_mode", False)
+        # Gate/label off the RENDERED rows, not ``canvas.count`` -- the latter
+        # is the pre-filter total across ALL media types, so with a media-type
+        # filter active it overstates what's shown (and stays > 0 when the
+        # filter renders nothing). ``handle_library_media_select_all`` already
+        # selects only the rendered rows, so this keeps the copy/gate honest.
+        # Also portable to the conversations canvas state, which has no
+        # ``.count`` field.
+        rendered_count = len(self.canvas.rows)
         export_btn = Button("Export…", id="library-media-export",
                             classes="library-canvas-action", compact=True)
         export_btn.display = not select_mode
@@ -66,7 +74,7 @@ class LibraryMediaCanvas(Vertical):
         select_btn = Button("Done" if select_mode else "Select",
                             id="library-media-select-toggle",
                             classes="library-canvas-action", compact=True)
-        select_btn.disabled = self.canvas.count == 0
+        select_btn.disabled = rendered_count == 0
         yield select_btn
         if select_mode:
             action_row = Horizontal(classes="ds-toolbar")
@@ -74,7 +82,7 @@ class LibraryMediaCanvas(Vertical):
             with action_row:
                 yield Static(f"{self.canvas.selected_count} selected",
                              id="library-media-selected-count", markup=False)
-                yield Button(f"Select all {self.canvas.count} shown",
+                yield Button(f"Select all {rendered_count} shown",
                              id="library-media-select-all",
                              classes="library-canvas-action", compact=True)
                 yield Button("Clear", id="library-media-select-clear",

--- a/tldw_chatbook/Widgets/Library/library_media_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_media_canvas.py
@@ -58,12 +58,32 @@ class LibraryMediaCanvas(Vertical):
             classes="library-canvas-action",
             compact=True,
         )
-        yield Button(
-            "Export…",
-            id="library-media-export",
-            classes="library-canvas-action",
-            compact=True,
-        )
+        select_mode = getattr(self.canvas, "select_mode", False)
+        export_btn = Button("Export…", id="library-media-export",
+                            classes="library-canvas-action", compact=True)
+        export_btn.display = not select_mode
+        yield export_btn
+        select_btn = Button("Done" if select_mode else "Select",
+                            id="library-media-select-toggle",
+                            classes="library-canvas-action", compact=True)
+        select_btn.disabled = self.canvas.count == 0
+        yield select_btn
+        if select_mode:
+            action_row = Horizontal(classes="ds-toolbar")
+            action_row.styles.height = "auto"
+            with action_row:
+                yield Static(f"{self.canvas.selected_count} selected",
+                             id="library-media-selected-count", markup=False)
+                yield Button(f"Select all {self.canvas.count} shown",
+                             id="library-media-select-all",
+                             classes="library-canvas-action", compact=True)
+                yield Button("Clear", id="library-media-select-clear",
+                             classes="library-canvas-action", compact=True)
+                export_selected = Button("Export selected",
+                                         id="library-media-export-selected",
+                                         classes="library-canvas-action", compact=True)
+                export_selected.disabled = self.canvas.selected_count == 0
+                yield export_selected
 
         status_text = self.canvas.status_copy or self.canvas.empty_copy
         status = Static(
@@ -78,7 +98,10 @@ class LibraryMediaCanvas(Vertical):
         media_list.styles.height = "auto"
         with media_list:
             for index, row in enumerate(self.canvas.rows):
-                marker = "▸" if row.selected else " "
+                if select_mode:
+                    marker = "☑" if row.checked else "☐"
+                else:
+                    marker = "▸" if row.selected else " "
                 button = Button(
                     f"{marker} {_visible_row_title(row.title)}"
                     f"\n    {row.secondary}",

--- a/tldw_chatbook/Widgets/Library/library_notes_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_notes_canvas.py
@@ -182,12 +182,16 @@ class LibraryNotesCanvas(Vertical):
                 # (or crashing on an unmatched closing tag) -- the same
                 # fix class as the escaped search-history Button labels.
                 title = escape_markup(row.title)
-                label = f"{title}\n{row.age_label}" if row.age_label else title
                 if select_mode:
                     # Notes rows had no marker at all before select mode
                     # existed -- normal mode keeps that markerless label
-                    # (no ``▸``, unlike the media/conversations rows).
-                    label = ("☑ " if row.checked else "☐ ") + label
+                    # (no ``▸``, unlike the media/conversations rows). The 2-col
+                    # glyph shifts line 1, so indent the age line by 2 to keep it
+                    # aligned under the title rather than under the checkbox.
+                    glyph = "☑ " if row.checked else "☐ "
+                    label = f"{glyph}{title}\n  {row.age_label}" if row.age_label else f"{glyph}{title}"
+                else:
+                    label = f"{title}\n{row.age_label}" if row.age_label else title
                 button = Button(
                     label,
                     id=f"library-notes-row-{index}",

--- a/tldw_chatbook/Widgets/Library/library_notes_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_notes_canvas.py
@@ -113,9 +113,14 @@ class LibraryNotesCanvas(Vertical):
             id="library-notes-filter",
             value=self.filter_value,
         )
-        # One horizontal ds-toolbar row for sort/Sync/Import note/Export…
-        # (2026-07 UAT: the previous bare stacked Buttons rendered as an
-        # overlapped vertical pile eating into the first list row). Safe
+        select_mode = list_state.select_mode
+        # Gate/label off the RENDERED rows, not any total-count field -- only
+        # rendered rows are selectable, matching the media/conversations
+        # canvases' ``len(rows)`` convention.
+        rendered_count = len(list_state.rows)
+        # One horizontal ds-toolbar row for sort/Sync/Import note/Export…/
+        # Select (2026-07 UAT: the previous bare stacked Buttons rendered as
+        # an overlapped vertical pile eating into the first list row). Safe
         # here because every child is a fixed-width compact Button -- the
         # known non-rendering failure mode for this canvas family is only
         # a Horizontal mixing a 1fr sibling with fixed-width children,
@@ -135,10 +140,35 @@ class LibraryNotesCanvas(Vertical):
                 "Import note", id="library-notes-import",
                 classes="library-canvas-action", compact=True,
             )
-            yield Button(
+            export_btn = Button(
                 "Export…", id="library-notes-export",
                 classes="library-canvas-action", compact=True,
             )
+            export_btn.display = not select_mode
+            yield export_btn
+            select_btn = Button(
+                "Done" if select_mode else "Select",
+                id="library-notes-select-toggle",
+                classes="library-canvas-action", compact=True,
+            )
+            select_btn.disabled = rendered_count == 0
+            yield select_btn
+        if select_mode:
+            action_row = Horizontal(classes="ds-toolbar")
+            action_row.styles.height = "auto"
+            with action_row:
+                yield Static(f"{list_state.selected_count} selected",
+                             id="library-notes-selected-count", markup=False)
+                yield Button(f"Select all {rendered_count} shown",
+                             id="library-notes-select-all",
+                             classes="library-canvas-action", compact=True)
+                yield Button("Clear", id="library-notes-select-clear",
+                             classes="library-canvas-action", compact=True)
+                export_selected = Button("Export selected",
+                                         id="library-notes-export-selected",
+                                         classes="library-canvas-action", compact=True)
+                export_selected.disabled = list_state.selected_count == 0
+                yield export_selected
         if list_state.status_copy:
             yield Static(list_state.status_copy, id="library-notes-status", markup=False)
         if not list_state.rows:
@@ -152,8 +182,14 @@ class LibraryNotesCanvas(Vertical):
                 # (or crashing on an unmatched closing tag) -- the same
                 # fix class as the escaped search-history Button labels.
                 title = escape_markup(row.title)
+                label = f"{title}\n{row.age_label}" if row.age_label else title
+                if select_mode:
+                    # Notes rows had no marker at all before select mode
+                    # existed -- normal mode keeps that markerless label
+                    # (no ``▸``, unlike the media/conversations rows).
+                    label = ("☑ " if row.checked else "☐ ") + label
                 button = Button(
-                    f"{title}\n{row.age_label}" if row.age_label else title,
+                    label,
                     id=f"library-notes-row-{index}",
                     classes="library-notes-row", compact=True,
                 )


### PR DESCRIPTION
## Summary

Backlog **task 159** (follow-up from PR #598). F4 shipped whole-scope Library export (everything, or a section's current filter); this adds **per-source multi-select** so a user can check individual rows and export exactly those as a chatbook.

Spec: `Docs/superpowers/specs/2026-07-11-library-multiselect-export-design.md`
Plan: `Docs/superpowers/plans/2026-07-12-library-multiselect-export.md`

## How it works

Each browse canvas (Media / Conversations / Notes) gets a **Select** toggle. In select mode:

```
Media — Select mode                     [ Done ]
─────────────────────────────────────────────────
 ☑ Interview transcript
 ☐ Budget spreadsheet
 ☑ Design doc.pdf
─────────────────────────────────────────────────
 2 selected  [ Select all 3 shown ] [ Clear ] [ Export selected ]
```

**Export selected** opens the existing export canvas scoped to exactly the checked ids (`Selected media · 2 items`) — reusing the whole counts/progress/cancel machinery from #597/#607.

## Design

- **`ExportScope.ids`** — a new hashable `tuple[str, ...]` override on the frozen `ExportScope`. `ExportScope(kind="media", ids=(...))` means "export exactly these ids"; empty `ids` = today's whole-source behavior, byte-for-byte. `resolve_export_selections` / `count_export_scope` / `export_scope_label` each branch on `ids`. Reusing `kind` (not a new `"selected"` kind) keeps `show_media_fields` working for selected-media. `ids` with `kind="everything"` raises.
- **`RowSelection`** — a pure, Textual-free per-source accumulator (toggle / select-all / clear / reconcile / export_scope).
- **State builders** gain `checked` / `select_mode` / `selected_count`; `selected_count` is derived from the rendered rows, so it auto-reconciles to what's shown.
- **Per-source, WYSIWYG:** selection is over the rendered (capped) rows; reconciled to the visible ids on each render; cleared on filter/sort change.

## Testing

Built subagent-driven (TDD, RED-first): pure-core units (`ExportScope.ids`, `RowSelection`, state builders), per-canvas UI handlers via `SimpleNamespace` fakes + `app.run_test()` smokes.

- Per-task reviews clean; two review-caught issues fixed: the "Select all N shown" label/gate now uses the **rendered-row count** (not the pre-filter total), and the export-selected handlers **guard an empty selection** (an empty `ids` scope would otherwise resolve to a whole-source export — RED-verified).
- **Whole-branch review (opus): APPROVE** — traced `ids`/`kind` reuse end-to-end, confirmed the three slices consistent and the default path inert.
- **Final gate: 698 passed / 1 pre-existing flake** (`test_library_shell_note_conflict_...`, passes in isolation, untouched by this diff — logged as task 192 to de-flake).

## Deliberate deviations from the spec (documented in the plan)

- **Recompose, not in-place update** — the codebase has no working targeted per-widget update (`sync_state` is dead); every Library interaction, including today's single-select, full-recomposes. Row toggle does the same.
- **Selection persists across canvas switches** (cleared on filter/sort change and Select-toggle-off) — there's no clean single canvas-leave hook, and reconcile-on-render keeps a persisted set honest.

Base was `b15880fd`; rebased onto latest dev before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-source multi-select to Library browse canvases (Media, Conversations, Notes) so users can check rows and export exactly those as a chatbook. Implements task 159 and keeps whole-scope export behavior unchanged.

- **New Features**
  - Select mode toggle per canvas; check rows and see a selected count.
  - Export selected opens the existing export UI scoped to checked IDs.
  - Selection is WYSIWYG over rendered rows; reconciles on render; cleared on filter/sort or when leaving select mode.
  - Added ExportScope.ids for explicit-subset exports, a pure RowSelection helper, and `checked`/`select_mode`/`selected_count` in state builders.

- **Bug Fixes**
  - “Select all N shown” and gating use the rendered-row count, not pre-filter totals.
  - Guard empty selection to avoid falling through to a whole-source export.
  - Align notes list age label under the title in select mode to avoid layout shift.

<sup>Written for commit b71a177d9d7a3ad8ed6039ab3fd992be6208a3e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

