### PR TITLE
docs(rag): RAG module audit + remediation backlog (tasks 196-206)

### DIFF
--- a/backlog/docs/rag-module-audit-2026-07-12.md
+++ b/backlog/docs/rag-module-audit-2026-07-12.md
@@ -10,7 +10,7 @@
 
 The chatbook RAG module **copies the shape** of tldw_server's design — semantic/hybrid modes, an embeddings wrapper, vector-store classes, citations, reranking — but at runtime **every retrieval a user can trigger resolves to SQLite FTS5 keyword search**. The semantic machinery is fully coded and almost entirely dead, because:
 
-1. **Nothing ever populates the vector store.** The only indexing entry point (`index_documents_modular` → `rag_service.embed_documents`, `Event_Handlers/Chat_Events/chat_rag_integration.py:300-325`) has **zero callers**. No app code calls `index_document` / `index_batch` on any RAG service. (task-197)
+1. **Nothing ever populates the vector store.** The only indexing entry point (`index_documents_modular` → `rag_service.embed_documents`, `Event_Handlers/Chat_Events/chat_rag_integration.py:300-325`) has **zero callers** (and would crash with an `AttributeError` if called, as `embed_documents` is not defined on `RAGService`). No app code calls `index_document` / `index_batch` on any RAG service. (task-197)
 2. **The default vector store is in-memory** (`RAG_Search/simplified/config.py:48`, `type: str = "memory"`), and the `hybrid_basic` runtime profile doesn't override it — so even if something indexed, it would start empty every launch. (task-196)
 3. **The RAG runtime itself is only initialized by one lazy path** — the chat sidebar (`chat_rag_events.py:339` is the sole caller of `get_or_initialize_rag_service`). Every other surface that offers a "semantic" mode either never initializes it or silently returns nothing when it's absent.
 

--- a/backlog/docs/rag-module-audit-2026-07-12.md
+++ b/backlog/docs/rag-module-audit-2026-07-12.md
@@ -1,0 +1,70 @@
+# RAG Module Audit — 2026-07-12
+
+**Scope:** Does the chatbook Search/RAG surface actually perform semantic (embeddings + vector) retrieval as designed in tldw_server's RAG module, or is it plain-text FTS5 search in practice?
+**Verified against:** `dev` @ `6a9c624a`. Reference design: `tldw_server2` @ local checkout of the same date.
+**Follow-up work:** backlog tasks **196–206** (each task carries its own evidence pointers).
+
+---
+
+## Verdict
+
+The chatbook RAG module **copies the shape** of tldw_server's design — semantic/hybrid modes, an embeddings wrapper, vector-store classes, citations, reranking — but at runtime **every retrieval a user can trigger resolves to SQLite FTS5 keyword search**. The semantic machinery is fully coded and almost entirely dead, because:
+
+1. **Nothing ever populates the vector store.** The only indexing entry point (`index_documents_modular` → `rag_service.embed_documents`, `Event_Handlers/Chat_Events/chat_rag_integration.py:300-325`) has **zero callers**. No app code calls `index_document` / `index_batch` on any RAG service. (task-197)
+2. **The default vector store is in-memory** (`RAG_Search/simplified/config.py:48`, `type: str = "memory"`), and the `hybrid_basic` runtime profile doesn't override it — so even if something indexed, it would start empty every launch. (task-196)
+3. **The RAG runtime itself is only initialized by one lazy path** — the chat sidebar (`chat_rag_events.py:339` is the sole caller of `get_or_initialize_rag_service`). Every other surface that offers a "semantic" mode either never initializes it or silently returns nothing when it's absent.
+
+So "semantic search" today means: embed the query (if the `embeddings_rag` extra is even installed), query an empty in-memory store, return zero rows.
+
+## Per-surface findings
+
+### Library Search canvas (the current flagship surface)
+Wired to `LibraryLocalRagSearchService` (`app.py:3128`, service in `Library/library_local_rag_search_service.py`).
+
+- **`search` mode — real and working, but keyword-only.** Fans out FTS5 over the notes / media / conversations seams (with the task-185 plural/singular MATCH widening via `library_fts_query.py`). Runtime backend label: `local-fts`. This is honest FTS, not RAG.
+- **`rag` mode ("RAG Answer") — never functional.** Delegates to `app._rag_service` (`library_local_rag_search_service.py:239`); the Library screen never initializes it, so users always get the "RAG unavailable" recovery state. Even after a chat semantic search creates the service, the index is empty (point 1 above), so it would return zero rows. (task-199)
+
+### Chat sidebar RAG
+`get_rag_context_for_chat` → pipelines in `RAG_Search/pipeline_builder_simple.py`:
+
+- `plain` = pure FTS5 (`pipeline_functions_simple.py:19-173`).
+- `semantic` = returns `[]` with only a log warning if `_rag_service` is unset (`pipeline_functions_simple.py:184-186`); with it set, queries the empty store.
+- `hybrid` = FTS5 legs + a vector leg that contributes nothing.
+- On a default install (no `embeddings_rag` extra), semantic falls back to plain (`chat_rag_events.py:341-342`).
+
+### Standalone Search window (`TAB_SEARCH`, `UI/Views/RAGSearch/search_rag_window.py`)
+Default mode is `plain` (`:171`). It never initializes `_rag_service`, so "contextual" silently returns nothing and "hybrid" degrades to FTS-only with no indication (task-200). Its **"Start Indexing" button (`:474`) has no event handler anywhere** — a dead control (task-201).
+
+## Divergence from the tldw_server reference design
+
+| tldw_server (reference) | chatbook (actual) |
+|---|---|
+| Single `unified_rag_pipeline` entry; `search_mode ∈ {fts, vector, hybrid}` | Three disconnected surfaces; only FTS legs ever return results |
+| Hybrid = RRF (k=60) + alpha-weighted blend, alpha=0.7 vector-weighted (`database_retrievers.py:2044-2092`) | Ad-hoc weighted merge; vector leg empty in practice (task-206) |
+| ChromaDB default store, per-user collections; indexing at ingestion via worker pipeline (chunk → embed → upsert) | In-memory store default; **no indexing path wired at all** (tasks 196, 197) |
+| `all-MiniLM-L6-v2` @ 384 dims default; provider auto-resolution | Embeddings wrapper exists; only ever embeds queries against empty stores |
+| Reranking ON by default (flashrank) | Reranker module is imported by `enhanced_rag_service_v2` but that service only runs on the dead-in-practice semantic path |
+| Profiles fast / balanced / accuracy | Profiles exist (`config_profiles.py`) but can't change the empty-store reality |
+
+## Second store, invisible to search
+
+There are **two disconnected Chroma stacks**: `Embeddings/Chroma_Lib.py` (`ChromaDBManager`, used by RAG_Admin and the legacy embeddings-management UI) and `RAG_Search/simplified/vector_store.py` (`ChromaVectorStore`, the one RAG search actually queries). Different clients, different collection conventions — embeddings created via one path are invisible to the other. (task-198)
+
+## Dead / unreachable surface (misleads reviewers)
+
+- `RAG_Search/late_chunking_service.py`, `late_chunking_integration.py`, `context_assembler.py`, `query_expansion.py` — zero importers outside each other; the `enable_late_chunking` config keys and the query-expansion Settings handler (`app.py:7679`, a stub that stores a string) never reach these modules. (task-202)
+- `UI/SearchWindow.py` — imported by nothing; it is the **only** mount point for `SearchEmbeddingsWindow`, `Embeddings_Management_Window`, the embeddings wizards, and the chunking-template widgets, so the entire manual-embeddings UI is unreachable. Plus `SearchRAGWindow.py.bak`. (task-203)
+- `RAG_Admin` services — eagerly constructed on every launch (`app.py:2545-2559`) while all their UI consumers are unreachable. (task-204)
+- `research` route — registered (`screen_registry.py:90`) with no navigation path to it. (task-205)
+
+Not dead (verified): `reranker.py` and `parallel_processor.py` are imported by `enhanced_rag_service_v2.py:20-21`; `chunking_service.py` is live in media ingestion.
+
+## Recommended sequencing
+
+Foundations: **196** (persistent Chroma default) → **197** (ingestion-time indexing + backfill) unlock everything. Then **198** (single store), **199** (Library RAG-answer mode), **200** (no silent-empty semantic), **206** (server-parity RRF fusion). Cleanup in parallel: **201–205**.
+
+The honest alternative — if local semantic RAG is *not* a goal — is to drop the pretense: ship FTS5 as "Search", remove the semantic modes and the ~20 dead files, and route "RAG Answer" through the tldw server API instead. That decision should be made explicitly before anyone picks up 196/197.
+
+## Method note
+
+Initial findings were traced on a stale checkout and then **re-verified line-by-line against `origin/dev` @ `6a9c624a`**; two claims changed in the interim (Library `search` mode got a real FTS backend via `LibraryLocalRagSearchService`; the reranker/parallel-processor modules gained a real importer) and are reflected above. If you re-audit, check assignment sites (`git grep "_rag_service ="`), indexing callers (`git grep "embed_documents\|index_document"`), and the store default (`simplified/config.py`) first — those three facts decide whether anything semantic is real.

--- a/backlog/tasks/task-196 - Default-RAG-vector-store-to-persistent-ChromaDB-when-embeddings-deps-are-installed.md
+++ b/backlog/tasks/task-196 - Default-RAG-vector-store-to-persistent-ChromaDB-when-embeddings-deps-are-installed.md
@@ -1,0 +1,28 @@
+---
+id: TASK-196
+title: >-
+  Default RAG vector store to persistent ChromaDB when embeddings deps are
+  installed
+status: To Do
+assignee: []
+created_date: '2026-07-12 14:11'
+labels:
+  - rag
+  - embeddings
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The RAG vector store defaults to type memory (RAG_Search/simplified/config.py:48) and the hybrid_basic runtime profile does not override it, so the semantic index starts empty on every launch and nothing can persist across sessions. tldw_server uses persistent ChromaDB as its default store. When the embeddings_rag extra is installed, the chatbook RAG service should default to a persistent ChromaDB store under the user data directory so indexed content survives restarts. Filed from the 2026-07-12 RAG module audit (see backlog/docs/rag-module-audit-2026-07-12.md).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 With embeddings_rag installed the RAG service vector store persists across app restarts (ChromaDB with a persist directory under the user data dir)
+- [ ] #2 Without embeddings deps behavior is unchanged: plain FTS5 search works and no import errors occur
+- [ ] #3 Config still allows an explicit override back to the in-memory store
+- [ ] #4 Store selection logic is covered by tests for both with-deps and without-deps cases
+<!-- AC:END -->

--- a/backlog/tasks/task-197 - Index-ingested-content-into-the-RAG-vector-store.md
+++ b/backlog/tasks/task-197 - Index-ingested-content-into-the-RAG-vector-store.md
@@ -16,7 +16,7 @@ priority: high
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Nothing in the app ever populates the RAG vector store: the only indexing entry point (index_documents_modular in Event_Handlers/Chat_Events/chat_rag_integration.py:300, which calls rag_service.embed_documents) has zero callers, and no app code invokes index_document/index_batch on any RAG service. Semantic and hybrid search therefore query an empty store and the vector leg always contributes nothing. Mirror the tldw_server design where chunking plus embedding plus storage happens at ingestion time via a background worker so semantic search has something to search. Filed from the 2026-07-12 RAG module audit.
+Nothing in the app ever populates the RAG vector store: the only indexing entry point (index_documents_modular in Event_Handlers/Chat_Events/chat_rag_integration.py:300, which calls the non-existent `rag_service.embed_documents` method) has zero callers, and no app code invokes index_document/index_batch on any RAG service. Semantic and hybrid search therefore query an empty store and the vector leg always contributes nothing. Mirror the tldw_server design where chunking plus embedding plus storage happens at ingestion time via a background worker so semantic search has something to search. Filed from the 2026-07-12 RAG module audit.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria

--- a/backlog/tasks/task-197 - Index-ingested-content-into-the-RAG-vector-store.md
+++ b/backlog/tasks/task-197 - Index-ingested-content-into-the-RAG-vector-store.md
@@ -20,10 +20,12 @@ Nothing in the app ever populates the RAG vector store: the only indexing entry 
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
+## Acceptance Criteria
 <!-- AC:BEGIN -->
 - [ ] #1 Newly ingested media is chunked and embedded and indexed into the RAG vector store when embeddings deps are installed via a non-blocking background worker
 - [ ] #2 A semantic search for distinctive content of a newly ingested document returns that document
 - [ ] #3 A bulk backfill path exists to index pre-existing media/notes/conversations
 - [ ] #4 Indexing failures are logged and surfaced without breaking ingestion
 - [ ] #5 When embeddings deps are missing no indexing is attempted and ingestion is unaffected
+- [ ] #6 The broken/dead `index_documents_modular` entry point in `chat_rag_integration.py` is either removed or corrected to use the valid `RAGService` batch indexing API (e.g., `index_batch_optimized`)
 <!-- AC:END -->

--- a/backlog/tasks/task-197 - Index-ingested-content-into-the-RAG-vector-store.md
+++ b/backlog/tasks/task-197 - Index-ingested-content-into-the-RAG-vector-store.md
@@ -1,0 +1,29 @@
+---
+id: TASK-197
+title: Index ingested content into the RAG vector store
+status: To Do
+assignee: []
+created_date: '2026-07-12 14:11'
+labels:
+  - rag
+  - embeddings
+  - ingest
+dependencies:
+  - TASK-196
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Nothing in the app ever populates the RAG vector store: the only indexing entry point (index_documents_modular in Event_Handlers/Chat_Events/chat_rag_integration.py:300, which calls rag_service.embed_documents) has zero callers, and no app code invokes index_document/index_batch on any RAG service. Semantic and hybrid search therefore query an empty store and the vector leg always contributes nothing. Mirror the tldw_server design where chunking plus embedding plus storage happens at ingestion time via a background worker so semantic search has something to search. Filed from the 2026-07-12 RAG module audit.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Newly ingested media is chunked and embedded and indexed into the RAG vector store when embeddings deps are installed via a non-blocking background worker
+- [ ] #2 A semantic search for distinctive content of a newly ingested document returns that document
+- [ ] #3 A bulk backfill path exists to index pre-existing media/notes/conversations
+- [ ] #4 Indexing failures are logged and surfaced without breaking ingestion
+- [ ] #5 When embeddings deps are missing no indexing is attempted and ingestion is unaffected
+<!-- AC:END -->

--- a/backlog/tasks/task-198 - Unify-the-two-disconnected-vector-store-stacks-so-RAG-search-reads-what-the-embeddings-stack-writes.md
+++ b/backlog/tasks/task-198 - Unify-the-two-disconnected-vector-store-stacks-so-RAG-search-reads-what-the-embeddings-stack-writes.md
@@ -1,0 +1,29 @@
+---
+id: TASK-198
+title: >-
+  Unify the two disconnected vector-store stacks so RAG search reads what the
+  embeddings stack writes
+status: To Do
+assignee: []
+created_date: '2026-07-12 14:11'
+labels:
+  - rag
+  - embeddings
+dependencies:
+  - TASK-196
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The codebase has two parallel Chroma stacks: Embeddings/Chroma_Lib.py (ChromaDBManager, used by the embeddings management surfaces and RAG_Admin local service) and RAG_Search/simplified/vector_store.py (ChromaVectorStore, which RAGService._semantic_search actually queries). They use different clients and collection conventions, so embeddings created via one path are invisible to RAG search. Converge on a single store and collection layout so every embedding created in the app is searchable. tldw_server uses one ChromaDB with per-user collections as the reference model. Filed from the 2026-07-12 RAG module audit.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Embeddings created through any app path are queryable by RAG semantic search
+- [ ] #2 Only one Chroma client / collection convention remains (the other stack is removed or delegates to the survivor)
+- [ ] #3 A migration or documented reset path exists for pre-existing collections
+- [ ] #4 Tests cover write-via-one-path read-via-search
+<!-- AC:END -->

--- a/backlog/tasks/task-199 - Make-Library-RAG-answer-mode-functional-end-to-end.md
+++ b/backlog/tasks/task-199 - Make-Library-RAG-answer-mode-functional-end-to-end.md
@@ -1,0 +1,27 @@
+---
+id: TASK-199
+title: Make Library RAG-answer mode functional end-to-end
+status: To Do
+assignee: []
+created_date: '2026-07-12 14:11'
+labels:
+  - rag
+  - library
+dependencies:
+  - TASK-197
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The Library Search canvas is wired to LibraryLocalRagSearchService (app.py:3128): search mode runs real FTS5 over the notes/media/conversations seams and works today. But rag mode (RAG Answer) delegates to app._rag_service (library_local_rag_search_service.py:239), which is only ever created by the chat sidebar path (chat_rag_events.py get_or_initialize_rag_service, its sole caller is chat_rag_events.py:339). The Library screen never initializes it, so RAG Answer always returns the RAG-unavailable recovery state; and even when a prior chat semantic search created the service, the vector index is empty (see task-197) so it returns zero rows. Initialize the RAG runtime from the Library path when embeddings deps are present and return real semantic results. Filed from the 2026-07-12 RAG module audit.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Selecting RAG Answer mode with embeddings deps installed initializes the RAG runtime instead of returning the RAG-unavailable recovery state
+- [ ] #2 With indexed content present a RAG Answer query returns semantic results with citations in the evidence rows
+- [ ] #3 Without embeddings deps the existing recovery state still routes the user to setup
+- [ ] #4 When the RAG runtime is available but the index is empty the outcome says so instead of showing a bare zero-results state
+<!-- AC:END -->

--- a/backlog/tasks/task-200 - Semantic-and-hybrid-pipeline-search-must-not-silently-return-empty-when-the-RAG-service-is-uninitialized.md
+++ b/backlog/tasks/task-200 - Semantic-and-hybrid-pipeline-search-must-not-silently-return-empty-when-the-RAG-service-is-uninitialized.md
@@ -1,0 +1,27 @@
+---
+id: TASK-200
+title: >-
+  Semantic and hybrid pipeline search must not silently return empty when the
+  RAG service is uninitialized
+status: To Do
+assignee: []
+created_date: '2026-07-12 14:11'
+labels:
+  - rag
+  - ux
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+search_semantic returns an empty list whenever app._rag_service is unset (RAG_Search/pipeline_functions_simple.py:184-186, logged only as a warning). The standalone SearchRAGWindow never initializes the service, so its contextual mode always returns nothing and hybrid quietly degrades to FTS-only; the chat sidebar initializes it lazily but other callers do not. Users cannot distinguish no-matches from not-initialized from missing-deps. The Library canvas already surfaces honest recovery states for this (library_local_rag_search_service.py); the chat and standalone Search surfaces should reach the same bar. Filed from the 2026-07-12 RAG module audit.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Selecting semantic or contextual or hybrid mode in chat or standalone Search either initializes the RAG service or visibly reports why semantic retrieval is unavailable (missing deps or uninitialized runtime or empty index)
+- [ ] #2 Hybrid results clearly indicate when they are FTS-only because the vector leg was unavailable
+- [ ] #3 No code path remains where a user-triggered semantic search silently returns an empty result due to an uninitialized service
+<!-- AC:END -->

--- a/backlog/tasks/task-201 - Wire-or-remove-the-dead-Start-Indexing-controls-in-SearchRAGWindow.md
+++ b/backlog/tasks/task-201 - Wire-or-remove-the-dead-Start-Indexing-controls-in-SearchRAGWindow.md
@@ -1,0 +1,25 @@
+---
+id: TASK-201
+title: Wire or remove the dead Start Indexing controls in SearchRAGWindow
+status: To Do
+assignee: []
+created_date: '2026-07-12 14:11'
+labels:
+  - rag
+  - ux
+dependencies:
+  - TASK-197
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The standalone Search window (UI/Views/RAGSearch/search_rag_window.py) renders Index New Content controls whose start-indexing button (line 474) has no event handler anywhere in the codebase, along with index-stats controls that never update. The UI advertises indexing that cannot happen. Once a real bulk-index path exists (task-197) these controls should trigger it and reflect real index stats; otherwise they must be removed. Filed from the 2026-07-12 RAG module audit.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The Search window contains no controls that do nothing when activated
+- [ ] #2 If indexing controls remain they trigger real indexing and display actual index statistics
+<!-- AC:END -->

--- a/backlog/tasks/task-202 - Delete-dead-RAG_Search-modules-late-chunking-context-assembler-query-expansion.md
+++ b/backlog/tasks/task-202 - Delete-dead-RAG_Search-modules-late-chunking-context-assembler-query-expansion.md
@@ -1,0 +1,28 @@
+---
+id: TASK-202
+title: >-
+  Delete dead RAG_Search modules (late chunking, context assembler, query
+  expansion)
+status: To Do
+assignee: []
+created_date: '2026-07-12 14:11'
+labels:
+  - rag
+  - cleanup
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Four RAG_Search modules have zero importers in app code: late_chunking_service.py and late_chunking_integration.py and context_assembler.py (only imported by each other) and query_expansion.py (no importers at all; the query-expansion Settings handler in app.py:7679 is a UI stub that stores a string and never imports the module). Config keys like enable_late_chunking reference the concept but never reach these modules. This inflates the module and misleads reviewers into thinking the features are live. Note reranker.py and parallel_processor.py are NOT dead: enhanced_rag_service_v2.py imports create_reranker and the parallel processor. Repo precedent for removal: commit 628b1b8b deleted zero-importer legacy modules. Filed from the 2026-07-12 RAG module audit.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 late_chunking_service.py and late_chunking_integration.py and context_assembler.py and query_expansion.py are removed or an explicit decision doc records why they stay
+- [ ] #2 Orphaned config keys and UI stubs that only fed the removed modules are cleaned up or explicitly kept with a comment
+- [ ] #3 Full test suite passes with no import errors after removal
+- [ ] #4 ENHANCED_RAG_FEATURES.md and README_enhanced_services.md are updated or removed to match what actually exists
+<!-- AC:END -->

--- a/backlog/tasks/task-203 - Remove-the-unreachable-legacy-SearchWindow-UI-stack.md
+++ b/backlog/tasks/task-203 - Remove-the-unreachable-legacy-SearchWindow-UI-stack.md
@@ -1,0 +1,26 @@
+---
+id: TASK-203
+title: Remove the unreachable legacy SearchWindow UI stack
+status: To Do
+assignee: []
+created_date: '2026-07-12 14:12'
+labels:
+  - rag
+  - cleanup
+  - ui
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+UI/SearchWindow.py is imported by nothing after the master-shell redesign, yet it is the only mount point for SearchEmbeddingsWindow, Embeddings_Management_Window, the embeddings wizards and the chunking-template widgets - none of which are reachable from any registered route. UI/SearchRAGWindow.py.bak also lingers. Per the redesign rule legacy widgets are not reused unless fully redone Console-style; if manual embeddings management is still wanted it should be rebuilt as a new Console-parity screen in a separate task. Remove the dead stack so the codebase reflects the real UI surface. Filed from the 2026-07-12 RAG module audit.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 UI/SearchWindow.py and screens/widgets reachable only through it (SearchEmbeddingsWindow, Embeddings_Management_Window, embeddings wizards, chunking-template widgets) are removed along with SearchRAGWindow.py.bak
+- [ ] #2 No route registry or import references to the removed screens remain
+- [ ] #3 Full test suite passes after removal
+<!-- AC:END -->

--- a/backlog/tasks/task-204 - Stop-constructing-unreachable-RAG_Admin-services-at-every-launch.md
+++ b/backlog/tasks/task-204 - Stop-constructing-unreachable-RAG_Admin-services-at-every-launch.md
@@ -1,0 +1,25 @@
+---
+id: TASK-204
+title: Stop constructing unreachable RAG_Admin services at every launch
+status: To Do
+assignee: []
+created_date: '2026-07-12 14:12'
+labels:
+  - rag
+  - cleanup
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+app.py:2545-2559 instantiates server_rag_admin_service, local_rag_admin_service and rag_admin_scope_service on every startup, but every UI consumer of these services (Embeddings_Management_Window, chunking-template widgets) is only mounted by the dead legacy SearchWindow stack and is unreachable. This adds startup cost and implies a live admin surface that does not exist. Either construct them lazily when a reachable surface actually needs them or expose a real reachable surface. Filed from the 2026-07-12 RAG module audit.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 RAG admin services are no longer eagerly constructed at startup unless a reachable UI surface consumes them
+- [ ] #2 Any surface that does consume them is reachable through shell navigation
+- [ ] #3 App startup and test suite pass unchanged otherwise
+<!-- AC:END -->

--- a/backlog/tasks/task-205 - Remove-or-wire-the-orphan-research-route.md
+++ b/backlog/tasks/task-205 - Remove-or-wire-the-orphan-research-route.md
@@ -1,0 +1,24 @@
+---
+id: TASK-205
+title: Remove or wire the orphan research route
+status: To Do
+assignee: []
+created_date: '2026-07-12 14:12'
+labels:
+  - cleanup
+  - ui
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The research route is registered in UI/Navigation/screen_registry.py:90 and resolves to ResearchScreen, but no shell destination, legacy-route mapping or navigation call ever targets it. A registered screen with no entry point is dead weight and confuses route audits. Either give it a real navigation entry or remove the registration. Filed from the 2026-07-12 RAG module audit.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The research route is reachable via shell navigation or its registration is removed
+- [ ] #2 Route inventory and screen registry are consistent with each other
+<!-- AC:END -->

--- a/backlog/tasks/task-206 - Align-hybrid-retrieval-fusion-with-the-tldw_server-design-RRF-plus-alpha-weighting.md
+++ b/backlog/tasks/task-206 - Align-hybrid-retrieval-fusion-with-the-tldw_server-design-RRF-plus-alpha-weighting.md
@@ -1,0 +1,27 @@
+---
+id: TASK-206
+title: >-
+  Align hybrid retrieval fusion with the tldw_server design (RRF plus alpha
+  weighting)
+status: To Do
+assignee: []
+created_date: '2026-07-12 14:12'
+labels:
+  - rag
+dependencies:
+  - TASK-197
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+tldw_server fuses hybrid results with Reciprocal Rank Fusion (k=60) followed by an alpha-weighted blend of the FTS and vector RRF scores, with alpha=0.7 weighting the vector side (tldw_server2 database_retrievers.py:2044-2092). The chatbook hybrid pipeline is an ad-hoc weighted merge whose vector leg has always been empty in practice. Once indexing makes the vector leg real (task-197), align the fusion math and defaults with the server so hybrid result quality and behavior match the reference design. Filed from the 2026-07-12 RAG module audit.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Hybrid mode fuses FTS and vector rankings via RRF with an alpha-weighted blend matching server defaults (k=60, alpha=0.7 vector-weighted)
+- [ ] #2 Fusion is covered by unit tests using known input rankings
+- [ ] #3 Alpha is exposed in config with a server-consistent default and documented semantics (0 = FTS only, 1 = vector only)
+<!-- AC:END -->


### PR DESCRIPTION
## Summary

Review of the Search/RAG screen + module against the RAG + Embeddings design in tldw_server. Headline: **every retrieval a user can trigger today resolves to SQLite FTS5 keyword search** — the semantic/vector stack (embeddings wrapper, vector stores, citations, reranking) is fully coded but dead at runtime.

Three root causes, verified line-by-line against `dev` @ `6a9c624a`:
- **Nothing ever indexes into the vector store** — the only entry point (`index_documents_modular` → `embed_documents`) has zero callers.
- **The store defaults to in-memory** (`RAG_Search/simplified/config.py:48`), so it starts empty every launch.
- **Only the chat sidebar lazily initializes the RAG runtime**; the Library RAG-Answer mode and the standalone Search window never do, so they return recovery states or silent empties.

## What this PR adds

- `backlog/docs/rag-module-audit-2026-07-12.md` — the full audit: per-surface runtime traces, divergence table vs the tldw_server unified-pipeline design (RRF hybrid fusion, ChromaDB-default store, ingestion-time indexing), dead/unreachable code inventory, and recommended sequencing.
- **Backlog tasks 196–206** — the remediation plan:
  - 196 persistent ChromaDB store default → 197 ingestion-time indexing + backfill (the two foundations)
  - 198 unify the two disconnected Chroma stacks, 199 make Library RAG-Answer functional, 200 kill silent-empty semantic results, 206 server-parity RRF fusion
  - 201–205 cleanup: dead Start-Indexing controls, dead RAG_Search modules, unreachable SearchWindow/embeddings-UI stack, eager RAG_Admin construction, orphan research route

Docs + backlog only; no code changes. Before anyone picks up 196/197, the doc flags one explicit decision to make: invest in local semantic RAG, or ship honest FTS and route RAG-Answer through the server API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a focused audit of the Search/RAG module and a remediation plan that explains why semantic/vector retrieval is inactive and how to fix it. Updates include evidence-backed findings and backlog tasks 196–206 to move from FTS-only to a persistent, indexed `ChromaDB`-backed hybrid search.

- Default to persistent `ChromaDB` when embeddings deps are installed; add ingestion-time background indexing + backfill; unify the two Chroma stacks; make Library RAG Answer work; prevent silent-empty results; remove unreachable code/UI and orphan routes; stop eager RAG_Admin construction; align hybrid fusion with server RRF; and fix/remove the broken indexing entry point.

<sup>Written for commit 3ad0a46d035b3983c97daba7cf1c5d0276cff239. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

