### PR TITLE
fix(export): keep Select/Done toggle pressable at 0 rows in select mode (159 follow-up)

### DIFF
--- a/Tests/UI/test_library_multiselect_media.py
+++ b/Tests/UI/test_library_multiselect_media.py
@@ -113,6 +113,39 @@ async def test_canvas_select_mode_renders_action_row_and_disables_export():
         assert export_selected_btn.disabled is True
 
 
+def _empty_select_mode_state() -> LibraryMediaCanvasState:
+    # Select mode is active but the list rendered zero rows (e.g. a background
+    # refresh emptied it). "Done" must stay pressable so the user can exit.
+    return LibraryMediaCanvasState(
+        rows=(),
+        type_options=("All",),
+        active_type="All",
+        status_copy="",
+        empty_copy="No media in your Library yet.",
+        selected_id="",
+        preview_lines=(),
+        count=0,
+        select_mode=True,
+        selected_count=0,
+    )
+
+
+class _EmptySelectModeCanvasApp(App):
+    def compose(self):
+        yield LibraryMediaCanvas(canvas=_empty_select_mode_state(), id="library-media-canvas")
+
+
+@pytest.mark.asyncio
+async def test_done_toggle_stays_enabled_at_zero_rows_in_select_mode():
+    # Regression: the Select/Done toggle must NOT be disabled at 0 rendered rows
+    # while select mode is active, or the user is stuck with no way to exit.
+    app = _EmptySelectModeCanvasApp()
+    async with app.run_test() as pilot:
+        toggle = pilot.app.query_one("#library-media-select-toggle", Button)
+        assert toggle.disabled is False
+        assert str(toggle.label) == "Done"
+
+
 def _filtered_select_mode_state() -> LibraryMediaCanvasState:
     # Two media types; filtering to "video" renders ONE row while
     # ``count`` (the pre-filter total across all types) stays at 3.

--- a/tldw_chatbook/Widgets/Library/library_conversations_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_conversations_canvas.py
@@ -67,7 +67,10 @@ class LibraryConversationsCanvas(Vertical):
         select_btn = Button("Done" if select_mode else "Select",
                             id="library-conversations-select-toggle",
                             classes="library-canvas-action", compact=True)
-        select_btn.disabled = rendered_count == 0
+        # Disable only when nothing to select AND not already in select mode --
+        # in select mode "Done" must stay pressable so the user can always exit,
+        # even if the rows dropped to zero (e.g. a background snapshot refresh).
+        select_btn.disabled = rendered_count == 0 and not select_mode
         yield select_btn
         if select_mode:
             action_row = Horizontal(classes="ds-toolbar")

--- a/tldw_chatbook/Widgets/Library/library_media_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_media_canvas.py
@@ -74,7 +74,11 @@ class LibraryMediaCanvas(Vertical):
         select_btn = Button("Done" if select_mode else "Select",
                             id="library-media-select-toggle",
                             classes="library-canvas-action", compact=True)
-        select_btn.disabled = rendered_count == 0
+        # Disable only when there's nothing to select AND we're not already in
+        # select mode -- in select mode the button is "Done" and must always be
+        # pressable so the user can exit even if the rows dropped to zero
+        # (e.g. a background snapshot refresh emptied the list).
+        select_btn.disabled = rendered_count == 0 and not select_mode
         yield select_btn
         if select_mode:
             action_row = Horizontal(classes="ds-toolbar")

--- a/tldw_chatbook/Widgets/Library/library_notes_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_notes_canvas.py
@@ -151,7 +151,10 @@ class LibraryNotesCanvas(Vertical):
                 id="library-notes-select-toggle",
                 classes="library-canvas-action", compact=True,
             )
-            select_btn.disabled = rendered_count == 0
+            # Disable only when nothing to select AND not already in select mode
+            # -- in select mode "Done" must stay pressable so the user can exit
+            # even if the rows dropped to zero (e.g. a background refresh).
+            select_btn.disabled = rendered_count == 0 and not select_mode
             yield select_btn
         if select_mode:
             action_row = Horizontal(classes="ds-toolbar")


### PR DESCRIPTION
## Summary

Post-merge review follow-up to PR #609 (Library multi-select export). A Qodo review flagged a correctness bug: the **Select/Done toggle was disabled whenever the rendered row count was 0 — even while select mode was active.**

So if the rows dropped to zero *while in select mode* — a background ingest snapshot refresh empties the list, or the user returns to a now-empty canvas with `select_mode` still true — the "Done" button was disabled and the user had **no way to exit select mode** from that canvas.

## Fix

Gate the toggle's disable on `rendered_count == 0 and not select_mode` in all three browse canvases (Media / Conversations / Notes): only disable when there's nothing to select *and* select mode is off. In select mode the button is "Done" and always stays pressable.

## Testing

RED-verified regression test (`test_done_toggle_stays_enabled_at_zero_rows_in_select_mode`): mounts the media canvas in select mode with zero rendered rows and asserts the toggle is enabled and labelled "Done". Fails on the pre-fix code (`assert True is False`), passes after. All three multi-select suites green (13 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the Select/Done toggle enabled when select mode is active, even if the list shows 0 rows, so users can always exit select mode. Applies to Media, Conversations, and Notes canvases.

- **Bug Fixes**
  - Only disable the toggle when `rendered_count == 0` and `select_mode` is false across all Library canvases.
  - Added a regression test to ensure the "Done" button stays enabled at 0 rows in select mode.

<sup>Written for commit 975bd31d02bcf3438e35241b93b2f99d5b4b532f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

