### PR TITLE
feat(ingest): parse-pool heavy-lane cap for concurrent transcriptions (task 160)

### DIFF
--- a/Docs/superpowers/plans/2026-07-12-library-ingest-heavy-lane.md
+++ b/Docs/superpowers/plans/2026-07-12-library-ingest-heavy-lane.md
@@ -1,0 +1,422 @@
+# Ingest heavy-lane cap — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax. Spec: `Docs/superpowers/specs/2026-07-12-library-ingest-heavy-lane-design.md`. Branch `claude/followups-ingest-heavy-lane` off dev `b87fc0e9`. Anchors exact at branch point; grep symbols, line numbers drift.
+
+**Goal:** Cap concurrent audio/video transcription parses (default 1, config-controlled) independently of document parses in the F3 parse pool, with skip-ahead so documents keep filling the pool past a blocked transcription.
+
+**Architecture:** Keep the single parse pool; make the dispatcher heavy-lane-aware. Classify each file once at enqueue (`detect_file_type`) and store `detected_type` on the QUEUED job row. The registry gains a type-filtered `next_queued(skip_types=…)` and a `parsing_count_for_types()`. The dispatcher skips heavy jobs when the heavy lane is full and dispatches lighter jobs past them.
+
+**Tech Stack:** Python ≥3.11, multiprocessing, pytest. No new third-party deps.
+
+## Global Constraints
+
+- **No behavior change with defaults:** `next_queued()` (no args), `submit(...)` without `detected_type`, and an unset config all behave exactly as today. Every existing ingest test stays green unchanged.
+- **Heavy set:** `_INGEST_HEAVY_TYPES = frozenset({"audio", "video"})` — a module constant in `app.py`, the exact `detect_file_type` values that transcribe. Not configurable.
+- **Config:** `library.ingest_heavy_lane_max_workers`, default **1**, values `<=0` clamp to **1** (never starve heavy work). A cap `> worker_count` is harmless.
+- **Classify once:** `detect_file_type` runs at enqueue (`submit_library_ingest_job`), stored on the QUEUED row; the dispatch-time recompute (`app.py:1574`) is removed and `mark_parsing` receives the stored `job.detected_type`.
+- **Skip-ahead** ⇒ jobs may complete out of enqueue order (accepted). The `mark_parsing`-rejected `break` guard and one-dispatch-per-iteration structure are preserved (no `continue`).
+- **`parsing_count_for_types` mirrors `counts()`** — excludes `superseded`/`dismissed` jobs, so the heavy count aligns with the total-slot accounting.
+- **Staging:** explicit paths only. Every commit ends with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- **Test command** (venv, isolated HOME):
+  ```
+  HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+    /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest <files> \
+    -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+  ```
+
+---
+
+### Task 1: Registry seam — `detected_type` at submit, `next_queued(skip_types)`, `parsing_count_for_types` (pure)
+
+**Files:**
+- Modify: `tldw_chatbook/Library/library_ingest_jobs.py`
+- Test: `Tests/Library/test_library_ingest_jobs.py`
+
+**Interfaces:**
+- Produces:
+  - `LibraryIngestJobRegistry.submit(..., detected_type: str = "")` — stores it on the created `QUEUED` job.
+  - `LibraryIngestJobRegistry.next_queued(*, skip_types: frozenset[str] = frozenset())` — oldest QUEUED job whose `detected_type ∉ skip_types`; `None` if none.
+  - `LibraryIngestJobRegistry.parsing_count_for_types(types: frozenset[str]) -> int` — count of visible (non-superseded, non-dismissed) `PARSING` jobs whose `detected_type ∈ types`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `Tests/Library/test_library_ingest_jobs.py`:
+```python
+def test_submit_stores_detected_type():
+    registry = LibraryIngestJobRegistry()
+    job = registry.submit(source_path="a.mp3", detected_type="audio")
+    assert job.detected_type == "audio"
+    assert registry.next_queued().detected_type == "audio"
+
+
+def test_next_queued_skip_types_skips_heavy_returns_next_light():
+    registry = LibraryIngestJobRegistry()
+    a1 = registry.submit(source_path="a1.mp3", detected_type="audio")
+    a2 = registry.submit(source_path="a2.mp3", detected_type="audio")
+    d1 = registry.submit(source_path="d1.txt", detected_type="plaintext")
+    heavy = frozenset({"audio", "video"})
+    # default: oldest queued regardless of type
+    assert registry.next_queued().job_id == a1.job_id
+    # skipping heavy: first non-heavy queued job
+    assert registry.next_queued(skip_types=heavy).job_id == d1.job_id
+
+
+def test_next_queued_skip_types_none_when_only_heavy_left():
+    registry = LibraryIngestJobRegistry()
+    registry.submit(source_path="a1.mp3", detected_type="audio")
+    registry.submit(source_path="a2.mp3", detected_type="video")
+    assert registry.next_queued(skip_types=frozenset({"audio", "video"})) is None
+
+
+def test_parsing_count_for_types_counts_only_inflight_heavy():
+    registry = LibraryIngestJobRegistry()
+    a1 = registry.submit(source_path="a1.mp3", detected_type="audio")
+    a2 = registry.submit(source_path="a2.mp3", detected_type="audio")
+    d1 = registry.submit(source_path="d1.txt", detected_type="plaintext")
+    heavy = frozenset({"audio", "video"})
+    assert registry.parsing_count_for_types(heavy) == 0        # all still QUEUED
+    registry.mark_parsing(a1.job_id, detected_type="audio")
+    registry.mark_parsing(d1.job_id, detected_type="plaintext")
+    assert registry.parsing_count_for_types(heavy) == 1        # only a1 is heavy+parsing
+    assert a2.job_id                                            # a2 still QUEUED, not counted
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run:
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Library/test_library_ingest_jobs.py -q -p no:cacheprovider -o addopts="" --timeout=120
+```
+Expected: FAIL — `submit() got an unexpected keyword argument 'detected_type'` / `next_queued() got an unexpected keyword argument 'skip_types'` / no attribute `parsing_count_for_types`.
+
+- [ ] **Step 3: Add `detected_type` to `submit`**
+
+In `library_ingest_jobs.py`, add `detected_type: str = "",` to `submit`'s keyword-only params (after `chunk_size`), and pass `detected_type=detected_type,` into the `LibraryIngestJob(...)` constructor inside `submit`.
+
+- [ ] **Step 4: Add `skip_types` to `next_queued`**
+
+Replace `next_queued`:
+```python
+    def next_queued(self, *, skip_types: frozenset[str] = frozenset()) -> LibraryIngestJob | None:
+        """Return the oldest still-``QUEUED`` job, or ``None`` if none.
+
+        Args:
+            skip_types: ``detected_type`` values to skip. Empty (default)
+                returns the oldest queued job of any type; a non-empty set
+                returns the oldest queued job whose ``detected_type`` is not
+                in the set (skip-ahead for the heavy-lane cap).
+        """
+        for job in self._jobs:
+            if job.state == IngestJobState.QUEUED and job.detected_type not in skip_types:
+                return replace(job)
+        return None
+```
+
+- [ ] **Step 5: Add `parsing_count_for_types`**
+
+Add next to `counts` (mirror its superseded/dismissed exclusion):
+```python
+    def parsing_count_for_types(self, types: frozenset[str]) -> int:
+        """Count visible ``PARSING`` jobs whose ``detected_type`` is in ``types``.
+
+        Excludes ``superseded``/``dismissed`` jobs, matching ``counts()`` so
+        the heavy-lane in-flight count aligns with the total-slot accounting.
+        """
+        return sum(
+            1
+            for job in self._jobs
+            if job.state == IngestJobState.PARSING
+            and not job.superseded
+            and not job.dismissed
+            and job.detected_type in types
+        )
+```
+
+- [ ] **Step 6: Run to verify it passes + full registry suite**
+
+Run:
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Library/test_library_ingest_jobs.py -q -p no:cacheprovider -o addopts="" --timeout=120
+```
+Expected: PASS (new tests green; the existing `next_queued()`/`submit()` tests unchanged).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tldw_chatbook/Library/library_ingest_jobs.py Tests/Library/test_library_ingest_jobs.py
+git commit -m "feat(ingest): registry detected_type at submit + type-filtered queue selection (160)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Config helper + `[library]` template docs
+
+**Files:**
+- Modify: `tldw_chatbook/app.py` (add `_ingest_heavy_lane_max_workers` next to `_ingest_parse_worker_count` ~:1371)
+- Modify: `tldw_chatbook/config.py` (`CONFIG_TOML_CONTENT` ~:1465)
+- Test: `Tests/Library/test_ingest_heavy_lane_config.py` (create)
+
+**Interfaces:**
+- Produces: `LibraryIngestQueueMixin._ingest_heavy_lane_max_workers(self) -> int` — configured value, else 1; `<=0` → 1.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/Library/test_ingest_heavy_lane_config.py`:
+```python
+import tomllib
+from types import SimpleNamespace
+
+import tldw_chatbook.app as app_module
+from tldw_chatbook.app import LibraryIngestQueueMixin
+from tldw_chatbook.config import CONFIG_TOML_CONTENT
+
+
+def test_heavy_lane_default_when_unset(monkeypatch):
+    monkeypatch.setattr(app_module, "get_cli_setting", lambda *a, **k: None)
+    assert LibraryIngestQueueMixin._ingest_heavy_lane_max_workers(SimpleNamespace()) == 1
+
+
+def test_heavy_lane_uses_configured_value(monkeypatch):
+    monkeypatch.setattr(app_module, "get_cli_setting", lambda *a, **k: 2)
+    assert LibraryIngestQueueMixin._ingest_heavy_lane_max_workers(SimpleNamespace()) == 2
+
+
+def test_heavy_lane_clamps_non_positive_to_one(monkeypatch):
+    monkeypatch.setattr(app_module, "get_cli_setting", lambda *a, **k: 0)
+    assert LibraryIngestQueueMixin._ingest_heavy_lane_max_workers(SimpleNamespace()) == 1
+
+
+def test_config_template_valid_toml_and_heavy_lane_key_commented():
+    parsed = tomllib.loads(CONFIG_TOML_CONTENT)   # must not raise
+    # The key is documented as a COMMENT, so a fresh template parse must not
+    # set it -- keeping the runtime default (1) in force.
+    assert "ingest_heavy_lane_max_workers" not in parsed.get("library", {})
+    assert "ingest_heavy_lane_max_workers" in CONFIG_TOML_CONTENT  # documented (commented)
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run:
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Library/test_ingest_heavy_lane_config.py -q -p no:cacheprovider -o addopts="" --timeout=120
+```
+Expected: FAIL — `LibraryIngestQueueMixin` has no `_ingest_heavy_lane_max_workers`; and the `ingest_heavy_lane_max_workers in CONFIG_TOML_CONTENT` assertion fails.
+
+- [ ] **Step 3: Add the config helper**
+
+In `app.py`, directly below `_ingest_parse_worker_count` (~:1393), add:
+```python
+    def _ingest_heavy_lane_max_workers(self) -> int:
+        """Resolve the heavy-lane (audio/video transcription) cap from config.
+
+        UI-thread only. Reads ``library.ingest_heavy_lane_max_workers`` via the
+        dotted 1-arg ``get_cli_setting`` form (same reason as
+        ``_ingest_parse_worker_count``). Defaults to 1; a missing, invalid, or
+        non-positive value clamps to 1 so heavy work is never permanently
+        starved.
+        """
+        try:
+            configured = int(get_cli_setting("library.ingest_heavy_lane_max_workers"))
+        except (TypeError, ValueError):
+            configured = 0
+        return configured if configured > 0 else 1
+```
+
+- [ ] **Step 4: Document both keys in the template**
+
+In `config.py`, inside the `CONFIG_TOML_CONTENT` string (~:1465), add a `[library]` section near the existing ingest/media config (find a stable spot between two existing top-level sections; place it as its own block):
+```toml
+[library]
+# Parallel ingest parse workers. Default: min(3, cpu-1). Uncomment to override.
+# ingest_parse_workers = 3
+# Max concurrent heavy (audio/video transcription) parses; document parses fan
+# out past this cap to fill the remaining pool workers. Default: 1.
+# ingest_heavy_lane_max_workers = 1
+```
+Keep both keys commented so the shipped defaults stay in force.
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run the Step-1 tests. Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/app.py tldw_chatbook/config.py Tests/Library/test_ingest_heavy_lane_config.py
+git commit -m "feat(ingest): heavy-lane cap config helper + documented [library] keys (160)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Dispatcher — classify at enqueue + heavy-lane skip-ahead gate
+
+**Files:**
+- Modify: `tldw_chatbook/app.py` (`_INGEST_HEAVY_TYPES` constant; `submit_library_ingest_job` ~:1295; `_top_up_ingest_parse_pool` ~:1542)
+- Modify: `Tests/Library/test_library_ingest_runner.py` (harness `heavy_lane` override + scenario test)
+
+**Interfaces:**
+- Consumes: `next_queued(skip_types=…)`, `parsing_count_for_types(…)`, `submit(..., detected_type=…)` (Task 1); `_ingest_heavy_lane_max_workers()` (Task 2).
+
+- [ ] **Step 1: Write the failing test**
+
+First extend the test harness. In `Tests/Library/test_library_ingest_runner.py`, add a `heavy_lane=None` param to `_IngestRunnerHarness.__init__` (alongside `worker_count`), store `self._heavy_lane_override = heavy_lane`, and add the override method next to `_ingest_parse_worker_count`:
+```python
+    def _ingest_heavy_lane_max_workers(self) -> int:
+        if self._heavy_lane_override is not None:
+            return self._heavy_lane_override
+        return super()._ingest_heavy_lane_max_workers()
+```
+Then add the scenario test (mirrors `test_submit_cap_backpressure_*`; uses the fake pool in manual mode). Match the existing test's fixtures/imports (the `db` fixture, `_FakeIngestParsePool`, `tmp_path`):
+```python
+@pytest.mark.asyncio
+async def test_heavy_lane_caps_transcriptions_while_documents_fill_pool(db, tmp_path):
+    pool = _FakeIngestParsePool(auto_run=False)
+    app = _IngestRunnerHarness(db, pool_factory=lambda: pool, worker_count=3, heavy_lane=1)
+    async with app.run_test():
+        paths = {}
+        for name in ("a1.mp3", "a2.mp3", "d1.txt", "d2.txt", "d3.txt"):
+            p = tmp_path / name
+            p.write_text("x", encoding="utf-8")
+            paths[name] = app.submit_library_ingest_job(source_path=str(p))
+
+        # pool holds exactly 3: audio1 (heavy) + doc1 + doc2. audio2 is
+        # skipped (heavy lane full); doc3 waits (pool full).
+        assert len(pool.calls) == 3
+        states = {j.job_id: j.state for j in app.library_ingest_jobs.jobs()}
+        assert states[paths["a1.mp3"].job_id] == IngestJobState.PARSING
+        assert states[paths["d1.txt"].job_id] == IngestJobState.PARSING
+        assert states[paths["d2.txt"].job_id] == IngestJobState.PARSING
+        assert states[paths["a2.mp3"].job_id] == IngestJobState.QUEUED
+        assert states[paths["d3.txt"].job_id] == IngestJobState.QUEUED
+
+        # completing audio1 frees the heavy slot -> audio2 is admitted next.
+        pool.trigger_success(0, {"ok": True, "payload": {}})
+        assert len(pool.calls) == 4
+        states_after = {j.job_id: j.state for j in app.library_ingest_jobs.jobs()}
+        assert states_after[paths["a2.mp3"].job_id] == IngestJobState.PARSING
+```
+(Match `trigger_success`'s exact signature + the completion-result shape from `_FakeIngestParsePool`/the sibling `test_submit_cap_backpressure_*` test — grep the file. `IngestJobState` and the `db` fixture are already imported/available in this test module; reuse them.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run:
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  "Tests/Library/test_library_ingest_runner.py::test_heavy_lane_caps_transcriptions_while_documents_fill_pool" \
+  -q -p no:cacheprovider -o addopts="" --timeout=180
+```
+Expected: FAIL — without the dispatcher gate, all 3 pool slots fill with `[a1, a2, d1]` (a2 not skipped), so `states[a2] == PARSING` (not QUEUED) and the assertions fail. (The harness `heavy_lane` override + `_ingest_heavy_lane_max_workers` you added make the test *run*; the missing dispatcher logic makes it *fail on the assertions* — the intended RED.)
+
+- [ ] **Step 3: Add the heavy-types constant**
+
+In `app.py`, near the other ingest module constants (top of the file or just above `LibraryIngestQueueMixin`), add:
+```python
+# The detect_file_type() values whose parse worker runs transcription
+# (see Local_Ingestion/local_file_ingestion.py audio/video branches). The
+# heavy-lane cap limits how many of these parse concurrently.
+_INGEST_HEAVY_TYPES = frozenset({"audio", "video"})
+```
+
+- [ ] **Step 4: Classify at enqueue, drop the dispatch recompute**
+
+In `submit_library_ingest_job` (~:1295), before the `self.library_ingest_jobs.submit(...)` call, compute the type and pass it in:
+```python
+        try:
+            detected_type = detect_file_type(source_path) or ""
+        except Exception:
+            detected_type = ""
+        job = self.library_ingest_jobs.submit(
+            source_path=source_path,
+            title=title,
+            author=author,
+            keywords=keywords,
+            perform_analysis=perform_analysis,
+            chunk_enabled=chunk_enabled,
+            chunk_size=chunk_size,
+            detected_type=detected_type,
+        )
+```
+In `_top_up_ingest_parse_pool` (~:1567), DELETE the dispatch-time recompute block:
+```python
+            try:
+                detected_type = detect_file_type(job.source_path) or ""
+            except Exception:
+                detected_type = ""
+```
+and change the claim to use the stored type:
+```python
+            claimed = self.library_ingest_jobs.mark_parsing(
+                job.job_id, detected_type=job.detected_type
+            )
+```
+(Update the method's docstring paragraph about "detect_file_type is called here" — it now happens at enqueue.)
+
+- [ ] **Step 5: Add the heavy-lane gate to the top-up loop**
+
+Replace the loop header + selection in `_top_up_ingest_parse_pool`:
+```python
+        worker_count = self._ingest_parse_worker_count()
+        heavy_cap = self._ingest_heavy_lane_max_workers()
+        while self.library_ingest_jobs.counts().get("parsing", 0) < worker_count:
+            heavy_full = (
+                self.library_ingest_jobs.parsing_count_for_types(_INGEST_HEAVY_TYPES)
+                >= heavy_cap
+            )
+            job = self.library_ingest_jobs.next_queued(
+                skip_types=_INGEST_HEAVY_TYPES if heavy_full else frozenset()
+            )
+            if job is None:
+                return
+            # ... existing mark_parsing (now with job.detected_type) + break guard
+            #     + options/pool/apply_async body UNCHANGED ...
+```
+Everything from `mark_parsing` onward (the `claimed is None` break guard, options build, `_ensure_ingest_parse_pool`, `apply_async`) stays exactly as-is.
+
+- [ ] **Step 6: Run to verify it passes + the full runner suite**
+
+Run:
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Library/test_library_ingest_runner.py Tests/Library/test_library_ingest_jobs.py \
+  -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: PASS (the new scenario test green; every existing runner/registry test — including `test_submit_cap_backpressure_*` — unchanged, since `heavy_lane` defaults to a real cap of 1 but those tests use light-type or single-job paths). If a pre-existing runner test used an audio/video extension in a way the cap now changes, adjust that test's expectation ONLY if it's a genuine consequence of the cap (note it in the report).
+
+- [ ] **Step 7: Mark backlog Done + commit**
+
+```bash
+perl -0pi -e 's/- \[ \] (#\d)/- [x] $1/g' "backlog/tasks/task-160 - Ingest-parallelism-heavy-lane-cap-for-concurrent-transcriptions.md"
+perl -0pi -e 's/^status: .*/status: Done/m' "backlog/tasks/task-160 - Ingest-parallelism-heavy-lane-cap-for-concurrent-transcriptions.md"
+```
+Add a short `## Implementation Notes` section (classify-at-enqueue; registry `next_queued(skip_types)`/`parsing_count_for_types`; skip-ahead dispatcher; config key + template docs).
+```bash
+git add tldw_chatbook/app.py Tests/Library/test_library_ingest_runner.py \
+  "backlog/tasks/task-160 - Ingest-parallelism-heavy-lane-cap-for-concurrent-transcriptions.md"
+git commit -m "feat(ingest): heavy-lane skip-ahead cap in the parse-pool dispatcher; task 160 done (160)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Final gate (after Task 3)
+
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Library/test_library_ingest_jobs.py Tests/Library/test_library_ingest_runner.py Tests/Library/test_ingest_heavy_lane_config.py Tests/Local_Ingestion/ \
+  -q -p no:cacheprovider -o addopts="" --timeout=600 --timeout-method=thread
+```
+Plus `python -c "import tldw_chatbook.app"`. Then the whole-branch review (opus) and finishing-a-development-branch. No visual QA (no UI change).

--- a/Docs/superpowers/specs/2026-07-12-library-ingest-heavy-lane-design.md
+++ b/Docs/superpowers/specs/2026-07-12-library-ingest-heavy-lane-design.md
@@ -1,0 +1,165 @@
+# Ingest parallelism — heavy-lane cap (task 160)
+
+**Status:** Design approved (brainstorm), pending spec review.
+**Backlog:** task-160 — "Ingest parallelism: heavy-lane cap for concurrent transcriptions".
+**Builds on:** F3 parallel-parse pool (PR #594).
+
+## Problem
+
+F3 fans all ingest media types through a single multiprocessing parse pool
+sized `min(3, max(1, cpu-1))`. Audio/video parses run Whisper transcription and
+are RAM/CPU heavy; two of them at once can thrash a machine while document
+parses are comparatively light. We want to cap concurrent **transcription**
+parses (default 1) independently of document parses, which keep fanning out to
+fill the pool.
+
+## Goal / Acceptance
+
+- **AC1** — concurrent transcription (audio/video) parses are capped
+  independently of document/pdf/ebook/text parses.
+- **AC2** — a config key controls the heavy-lane cap.
+
+## Chosen approach
+
+Keep the single parse pool; make the **dispatcher** heavy-lane-aware. "Heavy" =
+`{"audio", "video"}` (the only `detect_file_type` values that transcribe). The
+dispatcher fills the pool up to `worker_count` total as today, but caps
+concurrent heavy parses at `heavy_cap`, and when the heavy lane is full it
+**skips heavy jobs and dispatches lighter jobs past them** (skip-ahead, approved
+in brainstorm) so pool slots never idle. Jobs may therefore complete out of
+enqueue order — acceptable, each ingest job is independent.
+
+## Components
+
+### 1. Config (`tldw_chatbook/app.py`)
+
+Add `_ingest_heavy_lane_max_workers()` next to `_ingest_parse_worker_count`
+(`app.py:1371-1393`), mirroring its parse/clamp:
+
+```python
+def _ingest_heavy_lane_max_workers(self) -> int:
+    try:
+        configured = int(get_cli_setting("library.ingest_heavy_lane_max_workers"))
+    except (TypeError, ValueError):
+        configured = 0
+    return configured if configured > 0 else 1   # default 1; <=0 clamps to 1
+```
+`<=0 → 1` so a mis-set value can never permanently starve heavy work. A cap
+larger than `worker_count` is harmless (the pool total still bounds everything).
+
+### 2. Classify once at enqueue (`app.py` + registry)
+
+`detect_file_type` (a pure extension map, `local_file_ingestion.py:35-84`) is
+computed **at enqueue** and stored on the QUEUED job row, so the dispatcher can
+select by type without re-deriving:
+
+- `LibraryIngestJobs.submit(...)` (`library_ingest_jobs.py:266`) gains a
+  `detected_type: str = ""` keyword param, stored on the created
+  `LibraryIngestJob` (the dataclass already has `detected_type: str = ""` at
+  `library_ingest_jobs.py:173`). The registry does NOT import `detect_file_type`
+  — the caller passes the string, keeping the registry decoupled.
+- The single `submit(...)` call site (`app.py:1326`) computes
+  `detect_file_type(source_path)` (wrapped `try/except → ""`, same guard the
+  dispatch loop uses today) and passes `detected_type=...`.
+- **Remove the now-redundant dispatch-time recompute** (`app.py:1574`): the
+  claim passes the job's stored type instead —
+  `mark_parsing(job.job_id, detected_type=job.detected_type)`. Classifying twice
+  (and risking drift) is eliminated. `mark_parsing`'s signature is unchanged.
+
+### 3. Registry selection (`library_ingest_jobs.py`)
+
+- **Extend `next_queued`** (not a new method) with an optional filter:
+  ```python
+  def next_queued(self, *, skip_types: frozenset[str] = frozenset()) -> LibraryIngestJob | None:
+      for job in self._jobs:
+          if job.state == IngestJobState.QUEUED and job.detected_type not in skip_types:
+              return replace(job)
+      return None
+  ```
+  `skip_types=frozenset()` (default) → today's "oldest QUEUED" behavior, so the
+  four existing `next_queued()` unit tests and callers are unaffected. A
+  non-empty `skip_types` returns the oldest QUEUED job whose `detected_type` is
+  not skipped (skip-ahead).
+- **Add** `parsing_count_for_types(types)`:
+  ```python
+  def parsing_count_for_types(self, types: frozenset[str]) -> int:
+      return sum(1 for j in self._jobs
+                 if j.state == IngestJobState.PARSING and j.detected_type in types)
+  ```
+
+### 4. Dispatcher (`_top_up_ingest_parse_pool`, `app.py:1542+`)
+
+```python
+HEAVY_TYPES = frozenset({"audio", "video"})   # module/class constant
+...
+worker_count = self._ingest_parse_worker_count()
+heavy_cap = self._ingest_heavy_lane_max_workers()
+while self.library_ingest_jobs.counts().get("parsing", 0) < worker_count:
+    heavy_full = self.library_ingest_jobs.parsing_count_for_types(HEAVY_TYPES) >= heavy_cap
+    job = self.library_ingest_jobs.next_queued(
+        skip_types=HEAVY_TYPES if heavy_full else frozenset()
+    )
+    if job is None:
+        return   # queue empty, or only heavy jobs remain and the lane is full
+    claimed = self.library_ingest_jobs.mark_parsing(job.job_id, detected_type=job.detected_type)
+    if claimed is None:
+        ... existing break-with-log guard (unchanged) ...
+    ... existing apply_async submit (unchanged) ...
+```
+`heavy_full` is re-evaluated each iteration — a heavy job just claimed via
+`mark_parsing` (synchronous, UI thread) is reflected in
+`parsing_count_for_types` on the next pass, so within one top-up a single heavy
++ N light fill correctly. When the loop finds nothing dispatchable (only
+heavy-and-full remain) it returns with pool slots deliberately idle; the next
+completion re-runs top-up, and a freed heavy slot admits the next transcription.
+
+## Data flow
+
+```
+submit(source_path) → detect_file_type → detected_type on QUEUED row
+top-up loop:
+  heavy_full = parsing_count_for_types({audio,video}) >= heavy_cap
+  job = next_queued(skip_types = {audio,video} if heavy_full else ∅)   # skip-ahead
+  mark_parsing(job, job.detected_type) → apply_async(run_parse_job)
+completion → mark done/failed → top-up re-evaluates (freed heavy slot admits next)
+```
+
+## Error handling
+
+Unchanged. The heavy lane is pure dispatch **selection** — no new failure modes.
+Per-job parse failures stay isolated (`run_parse_job` returns a structured
+error, never raises across the process boundary); a broken pool still fails only
+the in-flight jobs of that generation. The `mark_parsing`-rejected `break` guard
+and the "one dispatch per iteration, re-evaluate at top" structure are
+preserved, so no `continue`/infinite-loop risk is introduced. Unknown extensions
+classify to `""` (not heavy) and fan out as light — correct, since only
+audio/video transcribe.
+
+## Testing
+
+- **Registry units (`Tests/Library/test_library_ingest_jobs.py`):**
+  - `next_queued(skip_types={"audio","video"})` returns the oldest QUEUED
+    non-heavy job, skipping heavy ones; returns `None` when only heavy queued
+    jobs remain; `next_queued()` (no args) is unchanged.
+  - `parsing_count_for_types({"audio","video"})` counts only PARSING heavy jobs;
+    ignores QUEUED/DONE/FAILED and light PARSING jobs.
+  - `submit(..., detected_type="audio")` stores the type on the QUEUED row.
+- **Config unit:** `_ingest_heavy_lane_max_workers` returns the configured value,
+  defaults to 1 when unset, clamps `0`/negative to 1.
+- **Coordinator (fake-pool harness, `Tests/Library/test_library_ingest_runner.py`):**
+  the headline scenario — `worker_count=3`, `heavy_cap=1`, enqueue five jobs
+  whose `source_path` extensions classify as `[audio1, audio2, doc1, doc2, doc3]`
+  → in-flight (`len(pool.calls)`) = 3 = `{audio1, doc1, doc2}`; `audio2` stays
+  QUEUED (heavy lane full); `doc3` stays QUEUED (pool full). Then
+  `trigger_success(audio1)` → top-up promotes `audio2` to PARSING. Mirrors the
+  existing `test_submit_cap_backpressure_*` test; the harness already supports a
+  `worker_count` override — add a `heavy_lane` override the same way.
+
+## Scope / non-goals
+
+- Heavy set is hardcoded `{"audio", "video"}` (the two transcription types) — not
+  configurable (YAGNI); only the cap count is config-controlled.
+- One pool (the cap is a dispatch-selection policy, not a second pool).
+- Skip-ahead ⇒ out-of-enqueue-order completion is accepted.
+- No change to the parse worker (`run_parse_job`) or the real-spawn integration
+  test — the cap is entirely coordinator/registry-side.

--- a/Docs/superpowers/specs/2026-07-12-library-ingest-heavy-lane-design.md
+++ b/Docs/superpowers/specs/2026-07-12-library-ingest-heavy-lane-design.md
@@ -47,6 +47,21 @@ def _ingest_heavy_lane_max_workers(self) -> int:
 `<=0 → 1` so a mis-set value can never permanently starve heavy work. A cap
 larger than `worker_count` is harmless (the pool total still bounds everything).
 
+**Discoverability (AC2):** add a `[library]` section to the shipped default
+template `CONFIG_TOML_CONTENT` (`config.py:1465`) documenting BOTH ingest-tuning
+keys, commented so defaults still apply (the F3 sibling
+`ingest_parse_workers` currently ships undocumented — this closes that gap too):
+```toml
+[library]
+# Parallel ingest parse workers. Default: min(3, cpu-1). Uncomment to override.
+# ingest_parse_workers = 3
+# Max concurrent heavy (audio/video transcription) parses; documents fan out
+# past this cap to fill the remaining pool workers. Default: 1.
+# ingest_heavy_lane_max_workers = 1
+```
+Place it near the existing ingest/media config in the template. The keys stay
+runtime-optional — commenting them keeps every default unchanged.
+
 ### 2. Classify once at enqueue (`app.py` + registry)
 
 `detect_file_type` (a pure extension map, `local_file_ingestion.py:35-84`) is
@@ -90,14 +105,18 @@ select by type without re-deriving:
 ### 4. Dispatcher (`_top_up_ingest_parse_pool`, `app.py:1542+`)
 
 ```python
-HEAVY_TYPES = frozenset({"audio", "video"})   # module/class constant
+# Module-level constant near the coordinator. The two values are exactly the
+# `detect_file_type` return values whose parse worker runs transcription
+# (local_file_ingestion.py audio/video branches) -- anchored by a comment there
+# so it can't silently drift if a new media type is added.
+_INGEST_HEAVY_TYPES = frozenset({"audio", "video"})
 ...
 worker_count = self._ingest_parse_worker_count()
 heavy_cap = self._ingest_heavy_lane_max_workers()
 while self.library_ingest_jobs.counts().get("parsing", 0) < worker_count:
-    heavy_full = self.library_ingest_jobs.parsing_count_for_types(HEAVY_TYPES) >= heavy_cap
+    heavy_full = self.library_ingest_jobs.parsing_count_for_types(_INGEST_HEAVY_TYPES) >= heavy_cap
     job = self.library_ingest_jobs.next_queued(
-        skip_types=HEAVY_TYPES if heavy_full else frozenset()
+        skip_types=_INGEST_HEAVY_TYPES if heavy_full else frozenset()
     )
     if job is None:
         return   # queue empty, or only heavy jobs remain and the lane is full
@@ -146,6 +165,10 @@ audio/video transcribe.
   - `submit(..., detected_type="audio")` stores the type on the QUEUED row.
 - **Config unit:** `_ingest_heavy_lane_max_workers` returns the configured value,
   defaults to 1 when unset, clamps `0`/negative to 1.
+- **Template unit:** `CONFIG_TOML_CONTENT` still parses as valid TOML after the
+  `[library]` section is added, and — because the new keys are commented — a
+  fresh config loaded from the template yields the defaults (the heavy-lane
+  helper returns 1). Guards against a malformed-template regression.
 - **Coordinator (fake-pool harness, `Tests/Library/test_library_ingest_runner.py`):**
   the headline scenario — `worker_count=3`, `heavy_cap=1`, enqueue five jobs
   whose `source_path` extensions classify as `[audio1, audio2, doc1, doc2, doc3]`

--- a/Tests/Library/test_ingest_heavy_lane_config.py
+++ b/Tests/Library/test_ingest_heavy_lane_config.py
@@ -1,0 +1,29 @@
+import tomllib
+from types import SimpleNamespace
+
+import tldw_chatbook.app as app_module
+from tldw_chatbook.app import LibraryIngestQueueMixin
+from tldw_chatbook.config import CONFIG_TOML_CONTENT
+
+
+def test_heavy_lane_default_when_unset(monkeypatch):
+    monkeypatch.setattr(app_module, "get_cli_setting", lambda *a, **k: None)
+    assert LibraryIngestQueueMixin._ingest_heavy_lane_max_workers(SimpleNamespace()) == 1
+
+
+def test_heavy_lane_uses_configured_value(monkeypatch):
+    monkeypatch.setattr(app_module, "get_cli_setting", lambda *a, **k: 2)
+    assert LibraryIngestQueueMixin._ingest_heavy_lane_max_workers(SimpleNamespace()) == 2
+
+
+def test_heavy_lane_clamps_non_positive_to_one(monkeypatch):
+    monkeypatch.setattr(app_module, "get_cli_setting", lambda *a, **k: 0)
+    assert LibraryIngestQueueMixin._ingest_heavy_lane_max_workers(SimpleNamespace()) == 1
+
+
+def test_config_template_valid_toml_and_heavy_lane_key_commented():
+    parsed = tomllib.loads(CONFIG_TOML_CONTENT)   # must not raise
+    # The key is documented as a COMMENT, so a fresh template parse must not
+    # set it -- keeping the runtime default (1) in force.
+    assert "ingest_heavy_lane_max_workers" not in parsed.get("library", {})
+    assert "ingest_heavy_lane_max_workers" in CONFIG_TOML_CONTENT  # documented (commented)

--- a/Tests/Library/test_library_ingest_jobs.py
+++ b/Tests/Library/test_library_ingest_jobs.py
@@ -699,3 +699,42 @@ def test_clear_finished_fires_listener_once() -> None:
     registry.clear_finished()
 
     assert len(calls) == 1
+
+
+def test_submit_stores_detected_type():
+    registry = LibraryIngestJobRegistry()
+    job = registry.submit(source_path="a.mp3", detected_type="audio")
+    assert job.detected_type == "audio"
+    assert registry.next_queued().detected_type == "audio"
+
+
+def test_next_queued_skip_types_skips_heavy_returns_next_light():
+    registry = LibraryIngestJobRegistry()
+    a1 = registry.submit(source_path="a1.mp3", detected_type="audio")
+    a2 = registry.submit(source_path="a2.mp3", detected_type="audio")
+    d1 = registry.submit(source_path="d1.txt", detected_type="plaintext")
+    heavy = frozenset({"audio", "video"})
+    # default: oldest queued regardless of type
+    assert registry.next_queued().job_id == a1.job_id
+    # skipping heavy: first non-heavy queued job
+    assert registry.next_queued(skip_types=heavy).job_id == d1.job_id
+
+
+def test_next_queued_skip_types_none_when_only_heavy_left():
+    registry = LibraryIngestJobRegistry()
+    registry.submit(source_path="a1.mp3", detected_type="audio")
+    registry.submit(source_path="a2.mp3", detected_type="video")
+    assert registry.next_queued(skip_types=frozenset({"audio", "video"})) is None
+
+
+def test_parsing_count_for_types_counts_only_inflight_heavy():
+    registry = LibraryIngestJobRegistry()
+    a1 = registry.submit(source_path="a1.mp3", detected_type="audio")
+    a2 = registry.submit(source_path="a2.mp3", detected_type="audio")
+    d1 = registry.submit(source_path="d1.txt", detected_type="plaintext")
+    heavy = frozenset({"audio", "video"})
+    assert registry.parsing_count_for_types(heavy) == 0        # all still QUEUED
+    registry.mark_parsing(a1.job_id, detected_type="audio")
+    registry.mark_parsing(d1.job_id, detected_type="plaintext")
+    assert registry.parsing_count_for_types(heavy) == 1        # only a1 is heavy+parsing
+    assert a2.job_id                                            # a2 still QUEUED, not counted

--- a/Tests/Library/test_library_ingest_jobs.py
+++ b/Tests/Library/test_library_ingest_jobs.py
@@ -341,8 +341,11 @@ def test_requeue_failed_job_appends_fresh_queued_copy() -> None:
     assert requeued.perform_analysis is True
     assert requeued.chunk_enabled is True
     assert requeued.chunk_size == 750
+    # detected_type is a pure function of source_path (task 160), so it is
+    # carried forward too -- the dispatcher no longer re-derives it, and a
+    # retried audio/video job must stay bound by the heavy-lane cap.
+    assert requeued.detected_type == "plaintext"
     # Fresh state -- not a copy of the failed job's runtime fields.
-    assert requeued.detected_type == ""
     assert requeued.media_id is None
     assert requeued.error == ""
     assert requeued.started_at is None
@@ -353,6 +356,22 @@ def test_requeue_failed_job_appends_fresh_queued_copy() -> None:
     # supersedes the failed original, so it no longer appears in jobs().
     jobs_by_id = {j.job_id: j for j in registry.jobs()}
     assert failed.job_id not in jobs_by_id
+
+
+def test_requeue_preserves_detected_type_for_the_heavy_lane_cap() -> None:
+    """(task 160) ``detected_type`` is a pure function of ``source_path``, so a
+    requeued (retried) job must carry it forward -- the dispatcher no longer
+    re-derives the type at dispatch, so a lost ``detected_type`` would let a
+    retried audio/video job bypass the heavy-lane cap."""
+    registry = LibraryIngestJobRegistry()
+    job = registry.submit(source_path="/tmp/a.mp3", detected_type="audio")
+    registry.mark_parsing(job.job_id, detected_type="audio")
+    failed = registry.mark_failed(job.job_id, error="boom", permanent=False)
+
+    requeued = registry.requeue(failed.job_id)
+
+    assert requeued is not None
+    assert requeued.detected_type == "audio"
 
 
 def test_jobs_returns_newest_first_immutable_snapshot() -> None:

--- a/Tests/Library/test_library_ingest_runner.py
+++ b/Tests/Library/test_library_ingest_runner.py
@@ -796,6 +796,56 @@ async def test_heavy_lane_caps_transcriptions_while_documents_fill_pool(
 
 
 @pytest.mark.asyncio
+async def test_retried_transcription_still_obeys_the_heavy_lane_cap(
+    tmp_path: Path,
+) -> None:
+    """(task 160) The heavy-lane cap must hold on the retry path too. A
+    requeued audio job carries its ``detected_type`` forward, so retrying a
+    failed transcription while another transcription is already PARSING must
+    leave the retry QUEUED -- not dispatch a second concurrent transcription
+    (which the dropped-``detected_type`` bug allowed via the Home Retry
+    control)."""
+    db = _make_db(tmp_path)
+    pool = _FakeIngestParsePool(auto_run=False)
+    app = _IngestRunnerHarness(db, pool_factory=lambda: pool, worker_count=3, heavy_lane=1)
+
+    async with app.run_test() as pilot:
+        a1_path = tmp_path / "a1.mp3"
+        a1_path.write_text("x", encoding="utf-8")
+        a2_path = tmp_path / "a2.mp3"
+        a2_path.write_text("x", encoding="utf-8")
+        a1 = app.submit_library_ingest_job(source_path=str(a1_path))
+        a2 = app.submit_library_ingest_job(source_path=str(a2_path))
+        await pilot.pause()
+
+        # Only one transcription parses at a time: a1 PARSING, a2 blocked.
+        assert len(pool.calls) == 1
+        states = {j.job_id: j.state for j in app.library_ingest_jobs.jobs()}
+        assert states[a1.job_id] == IngestJobState.PARSING
+        assert states[a2.job_id] == IngestJobState.QUEUED
+
+        # Fail a1 (per-job structured failure, like the retry tests) -> its
+        # heavy slot frees and a2 is admitted to PARSING.
+        pool.trigger_success(
+            0, {"ok": False, "error": "boom", "permanent": False}
+        )
+        await _wait_for_job_state(app, pilot, a2.job_id, IngestJobState.PARSING)
+        await _wait_for_job_state(app, pilot, a1.job_id, IngestJobState.FAILED)
+        assert len(pool.calls) == 2
+
+        # Retry a1 while a2 is still PARSING: the heavy lane is full, so the
+        # requeued a1 must stay QUEUED (its detected_type='audio' is skipped),
+        # NOT be dispatched as a second concurrent transcription.
+        requeued = app.retry_library_ingest_job(a1.job_id)
+        assert requeued is not None
+        await pilot.pause()
+        assert len(pool.calls) == 2
+        states_after = {j.job_id: j.state for j in app.library_ingest_jobs.jobs()}
+        assert states_after[requeued.job_id] == IngestJobState.QUEUED
+        assert states_after[a2.job_id] == IngestJobState.PARSING
+
+
+@pytest.mark.asyncio
 async def test_shutdown_flag_stops_late_parse_completion_callbacks(tmp_path: Path) -> None:
     """(F3 pilot) Once ``_ingest_shutdown`` is set, a parse completion (or
     pool-level error) that lands afterward -- e.g. already in flight when

--- a/Tests/Library/test_library_ingest_runner.py
+++ b/Tests/Library/test_library_ingest_runner.py
@@ -157,6 +157,7 @@ class _IngestRunnerHarness(LibraryIngestQueueMixin, App):
         *,
         pool_factory: Optional[Callable[[], Any]] = None,
         worker_count: Optional[int] = None,
+        heavy_lane: Optional[int] = None,
     ) -> None:
         super().__init__()
         self.library_ingest_jobs = LibraryIngestJobRegistry()
@@ -170,6 +171,7 @@ class _IngestRunnerHarness(LibraryIngestQueueMixin, App):
         self._pool_factory = pool_factory or (lambda: _FakeIngestParsePool())
         self._pool_create_count = 0
         self._worker_count_override = worker_count
+        self._heavy_lane_override = heavy_lane
 
     def _create_ingest_parse_pool(self):
         self._pool_create_count += 1
@@ -179,6 +181,11 @@ class _IngestRunnerHarness(LibraryIngestQueueMixin, App):
         if self._worker_count_override is not None:
             return self._worker_count_override
         return super()._ingest_parse_worker_count()
+
+    def _ingest_heavy_lane_max_workers(self) -> int:
+        if self._heavy_lane_override is not None:
+            return self._heavy_lane_override
+        return super()._ingest_heavy_lane_max_workers()
 
 
 def _make_db(tmp_path: Path, name: str = "library_ingest.db") -> MediaDatabase:
@@ -747,6 +754,45 @@ async def test_submit_cap_backpressure_second_job_stays_queued_until_first_compl
         done1 = await _wait_for_job_state(app, pilot, job1.job_id, IngestJobState.DONE)
         assert done1.media_id is not None
         await _wait_for_runner_idle(app, pilot)
+
+
+@pytest.mark.asyncio
+async def test_heavy_lane_caps_transcriptions_while_documents_fill_pool(
+    tmp_path: Path,
+) -> None:
+    """(F3 pilot, heavy-lane cap) With worker_count=3 and heavy_lane=1, only
+    one audio/video parse may run at a time -- a second transcription is
+    skipped ahead of by queued documents, which fill the remaining pool
+    slots. Completing the in-flight transcription frees the heavy slot and
+    promotes the skipped one."""
+    db = _make_db(tmp_path)
+    pool = _FakeIngestParsePool(auto_run=False)
+    app = _IngestRunnerHarness(db, pool_factory=lambda: pool, worker_count=3, heavy_lane=1)
+
+    async with app.run_test() as pilot:
+        paths = {}
+        for name in ("a1.mp3", "a2.mp3", "d1.txt", "d2.txt", "d3.txt"):
+            p = tmp_path / name
+            p.write_text("x", encoding="utf-8")
+            paths[name] = app.submit_library_ingest_job(source_path=str(p))
+        await pilot.pause()
+
+        # pool holds exactly 3: audio1 (heavy) + doc1 + doc2. audio2 is
+        # skipped (heavy lane full); doc3 waits (pool full).
+        assert len(pool.calls) == 3
+        states = {j.job_id: j.state for j in app.library_ingest_jobs.jobs()}
+        assert states[paths["a1.mp3"].job_id] == IngestJobState.PARSING
+        assert states[paths["d1.txt"].job_id] == IngestJobState.PARSING
+        assert states[paths["d2.txt"].job_id] == IngestJobState.PARSING
+        assert states[paths["a2.mp3"].job_id] == IngestJobState.QUEUED
+        assert states[paths["d3.txt"].job_id] == IngestJobState.QUEUED
+
+        # completing audio1 frees the heavy slot -> audio2 is admitted next.
+        pool.trigger_success(0, {"ok": True, "payload": {}})
+        await _wait_for_job_state(
+            app, pilot, paths["a2.mp3"].job_id, IngestJobState.PARSING
+        )
+        assert len(pool.calls) == 4
 
 
 @pytest.mark.asyncio

--- a/backlog/tasks/task-160 - Ingest-parallelism-heavy-lane-cap-for-concurrent-transcriptions.md
+++ b/backlog/tasks/task-160 - Ingest-parallelism-heavy-lane-cap-for-concurrent-transcriptions.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-160
 title: 'Ingest parallelism: heavy-lane cap for concurrent transcriptions'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-11 22:02'
+updated_date: '2026-07-12 16:34'
 labels:
   - follow-up
   - ingest
@@ -18,6 +19,16 @@ F3's parallel parse pool runs all media types through one pool (default min(3, c
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Concurrent transcription parses are capped independently of document parses
-- [ ] #2 Config controls the heavy-lane cap
+- [x] #1 Concurrent transcription parses are capped independently of document parses
+- [x] #2 Config controls the heavy-lane cap
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Split across three tasks. Task 1 added detected_type to LibraryIngestJob/the registry's submit(), plus next_queued(skip_types=...) and parsing_count_for_types(...) for type-filtered queue selection. Task 2 added LibraryIngestQueueMixin._ingest_heavy_lane_max_workers(), reading library.ingest_heavy_lane_max_workers (default/invalid/non-positive -> 1) via the same dotted get_cli_setting form as _ingest_parse_worker_count(), plus documented the config key in the [library] template docs.
+
+Task 3 (this pass) wired it together in app.py: submit_library_ingest_job now classifies detect_file_type() once at enqueue and stores it on the job; _top_up_ingest_parse_pool no longer recomputes the type at dispatch, and its claim uses the stored job.detected_type. The dispatch loop reads heavy_cap once per top-up pass, and on each iteration asks next_queued(skip_types=_INGEST_HEAVY_TYPES) whenever parsing_count_for_types(_INGEST_HEAVY_TYPES) >= heavy_cap, letting a queued document fill the slot instead of a second transcription. _INGEST_HEAVY_TYPES = frozenset({"audio", "video"}) is a module-level constant in app.py. Everything from mark_parsing onward (break guard, options build, pool ensure, apply_async) is unchanged -- pure dispatch selection.
+
+Added test_heavy_lane_caps_transcriptions_while_documents_fill_pool to Tests/Library/test_library_ingest_runner.py (pool=3, heavy_lane=1, jobs [a1.mp3, a2.mp3, d1.txt, d2.txt, d3.txt] -> in-flight {a1, d1, d2}, a2 and d3 queued; completing a1 promotes a2), plus a heavy_lane override on _IngestRunnerHarness mirroring the existing worker_count override. Full Tests/Library + Tests/Local_Ingestion suites (117 tests) pass with no pre-existing test needing an expectation change -- other runner tests use single/light-type jobs that never exercise the heavy lane.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Library/library_ingest_jobs.py
+++ b/tldw_chatbook/Library/library_ingest_jobs.py
@@ -656,6 +656,14 @@ class LibraryIngestJobRegistry:
 
         Excludes ``superseded``/``dismissed`` jobs, matching ``counts()`` so
         the heavy-lane in-flight count aligns with the total-slot accounting.
+
+        Args:
+            types: The ``detected_type`` values to count (e.g. the heavy set
+                ``{"audio", "video"}`` for the transcription cap).
+
+        Returns:
+            The number of currently-``PARSING``, non-hidden jobs whose
+            ``detected_type`` is in ``types``.
         """
         return sum(
             1

--- a/tldw_chatbook/Library/library_ingest_jobs.py
+++ b/tldw_chatbook/Library/library_ingest_jobs.py
@@ -273,6 +273,7 @@ class LibraryIngestJobRegistry:
         perform_analysis: bool = False,
         chunk_enabled: bool = False,
         chunk_size: int = DEFAULT_CHUNK_SIZE,
+        detected_type: str = "",
     ) -> LibraryIngestJob:
         """Append a new ``QUEUED`` job.
 
@@ -284,6 +285,9 @@ class LibraryIngestJobRegistry:
             perform_analysis: Whether to run post-ingest analysis.
             chunk_enabled: Whether to chunk the ingested content.
             chunk_size: Requested chunk size when ``chunk_enabled``.
+            detected_type: The file type detected by the ingest seam, when
+                already known at submission time. Optional; defaults to
+                ``""`` when not yet known.
 
         Returns:
             The newly created ``QUEUED`` job (a registry-owned copy).
@@ -299,20 +303,28 @@ class LibraryIngestJobRegistry:
             chunk_size=chunk_size,
             state=IngestJobState.QUEUED,
             submitted_at=time.monotonic(),
+            detected_type=detected_type,
         )
         self._jobs.append(job)
         self._notify_listeners()
         return replace(job)
 
-    def next_queued(self) -> LibraryIngestJob | None:
+    def next_queued(self, *, skip_types: frozenset[str] = frozenset()) -> LibraryIngestJob | None:
         """Return the oldest still-``QUEUED`` job, or ``None`` if none.
 
+        Args:
+            skip_types: ``detected_type`` values to skip. Empty (default)
+                returns the oldest queued job of any type; a non-empty set
+                returns the oldest queued job whose ``detected_type`` is not
+                in the set (skip-ahead for the heavy-lane cap).
+
         Returns:
-            A copy of the oldest queued job in FIFO submission order, or
-            ``None`` when no job is queued.
+            A copy of the oldest queued job in FIFO submission order whose
+            ``detected_type`` is not in ``skip_types``, or ``None`` when no
+            such job is queued.
         """
         for job in self._jobs:
-            if job.state == IngestJobState.QUEUED:
+            if job.state == IngestJobState.QUEUED and job.detected_type not in skip_types:
                 return replace(job)
         return None
 
@@ -632,3 +644,18 @@ class LibraryIngestJobRegistry:
                 continue
             counts[job.state.value] += 1
         return counts
+
+    def parsing_count_for_types(self, types: frozenset[str]) -> int:
+        """Count visible ``PARSING`` jobs whose ``detected_type`` is in ``types``.
+
+        Excludes ``superseded``/``dismissed`` jobs, matching ``counts()`` so
+        the heavy-lane in-flight count aligns with the total-slot accounting.
+        """
+        return sum(
+            1
+            for job in self._jobs
+            if job.state == IngestJobState.PARSING
+            and not job.superseded
+            and not job.dismissed
+            and job.detected_type in types
+        )

--- a/tldw_chatbook/Library/library_ingest_jobs.py
+++ b/tldw_chatbook/Library/library_ingest_jobs.py
@@ -508,10 +508,15 @@ class LibraryIngestJobRegistry:
         point on, and every further ``mark_parsing``/``mark_writing``/
         ``mark_done``/``mark_failed``/``requeue``/``dismiss`` call against
         its ``job_id`` becomes a safe no-op. A brand-new job with a
-        brand-new ``job_id`` and fresh timestamps is appended, copying only the form fields
+        brand-new ``job_id`` and fresh timestamps is appended, copying the form fields
         (``source_path``/``title``/``author``/``keywords``/
-        ``perform_analysis``/``chunk_enabled``/``chunk_size``) -- so the
-        canvas queue shows exactly ONE row per retried file, not two.
+        ``perform_analysis``/``chunk_enabled``/``chunk_size``) plus the
+        ``detected_type`` classification -- a pure function of
+        ``source_path`` (task 160): the dispatcher no longer re-derives the
+        type at dispatch, so carrying it forward is what keeps a retried
+        audio/video job bound by the heavy-lane cap. Runtime fields
+        (``media_id``/``error``/``started_at``/``finished_at``/...) reset --
+        so the canvas queue shows exactly ONE row per retried file, not two.
 
         Args:
             job_id: The failed job to requeue.
@@ -541,6 +546,7 @@ class LibraryIngestJobRegistry:
             perform_analysis=source.perform_analysis,
             chunk_enabled=source.chunk_enabled,
             chunk_size=source.chunk_size,
+            detected_type=source.detected_type,
             state=IngestJobState.QUEUED,
             submitted_at=time.monotonic(),
         )

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -118,7 +118,7 @@ from tldw_chatbook.Library.library_ingest_jobs import (
     LibraryIngestJobRegistry,
 )
 from tldw_chatbook.Library.library_local_rag_search_service import LibraryLocalRagSearchService
-from tldw_chatbook.Local_Ingestion import detect_file_type
+from tldw_chatbook.Local_Ingestion import detect_file_type, FileIngestionError
 from tldw_chatbook.Local_Ingestion.ingest_parse_worker import classify_parse_failure, run_parse_job
 from tldw_chatbook.Local_Ingestion.local_file_ingestion import persist_parsed_media
 from tldw_chatbook.Home.active_work_adapter import (
@@ -1331,7 +1331,18 @@ class LibraryIngestQueueMixin:
         """
         try:
             detected_type = detect_file_type(source_path) or ""
+        except FileIngestionError:
+            # Expected for an unsupported extension -- treat as light work.
+            detected_type = ""
         except Exception:
+            # An UNEXPECTED classification failure must not silently disable the
+            # heavy-lane cap (an empty type is treated as light work, so a
+            # misclassified audio/video job would bypass the transcription cap).
+            # Log it so a regression is observable, then fall back to light.
+            logger.opt(exception=True).warning(
+                f"detect_file_type failed unexpectedly for {source_path!r}; "
+                "treating as light work (heavy-lane cap may not apply)."
+            )
             detected_type = ""
         job = self.library_ingest_jobs.submit(
             source_path=source_path,
@@ -1602,11 +1613,17 @@ class LibraryIngestQueueMixin:
             return
         worker_count = self._ingest_parse_worker_count()
         heavy_cap = self._ingest_heavy_lane_max_workers()
-        while self.library_ingest_jobs.counts().get("parsing", 0) < worker_count:
-            heavy_full = (
-                self.library_ingest_jobs.parsing_count_for_types(_INGEST_HEAVY_TYPES)
-                >= heavy_cap
-            )
+        # Read the total + heavy in-flight counts ONCE, then track them locally
+        # as we dispatch. This whole method is UI-thread-only and synchronous,
+        # so nothing but our own mark_parsing() calls can change these counts
+        # mid-loop -- re-scanning the registry (O(N)) every iteration would make
+        # the loop O(worker_count * N) on the UI thread for no benefit.
+        parsing_count = self.library_ingest_jobs.counts().get("parsing", 0)
+        heavy_parsing_count = self.library_ingest_jobs.parsing_count_for_types(
+            _INGEST_HEAVY_TYPES
+        )
+        while parsing_count < worker_count:
+            heavy_full = heavy_parsing_count >= heavy_cap
             job = self.library_ingest_jobs.next_queued(
                 skip_types=_INGEST_HEAVY_TYPES if heavy_full else frozenset()
             )
@@ -1635,6 +1652,12 @@ class LibraryIngestQueueMixin:
                     f"this top-up pass."
                 )
                 break
+            # Track the just-claimed job locally (mirrors what a fresh
+            # counts()/parsing_count_for_types() scan would report next
+            # iteration) so the loop stays O(N), not O(worker_count * N).
+            parsing_count += 1
+            if job.detected_type in _INGEST_HEAVY_TYPES:
+                heavy_parsing_count += 1
             options = self._ingest_job_options(claimed)
             job_id = claimed.job_id
             source_path = claimed.source_path

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -1392,6 +1392,21 @@ class LibraryIngestQueueMixin:
         cpu_count = os.cpu_count() or 2
         return min(3, max(1, cpu_count - 1))
 
+    def _ingest_heavy_lane_max_workers(self) -> int:
+        """Resolve the heavy-lane (audio/video transcription) cap from config.
+
+        UI-thread only. Reads ``library.ingest_heavy_lane_max_workers`` via the
+        dotted 1-arg ``get_cli_setting`` form (same reason as
+        ``_ingest_parse_worker_count``). Defaults to 1; a missing, invalid, or
+        non-positive value clamps to 1 so heavy work is never permanently
+        starved.
+        """
+        try:
+            configured = int(get_cli_setting("library.ingest_heavy_lane_max_workers"))
+        except (TypeError, ValueError):
+            configured = 0
+        return configured if configured > 0 else 1
+
     def _create_ingest_parse_pool(self):
         """Create the Library ingest parse pool.
 

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -1193,6 +1193,12 @@ def _stream_fileno(stream: Any) -> int:
     return fd if isinstance(fd, int) and fd >= 0 else -1
 
 
+# The detect_file_type() values whose parse worker runs transcription
+# (see Local_Ingestion/local_file_ingestion.py audio/video branches). The
+# heavy-lane cap limits how many of these parse concurrently.
+_INGEST_HEAVY_TYPES = frozenset({"audio", "video"})
+
+
 # Keep-alive singleton for `_ingest_pool_real_stderr`'s devnull fallback.
 # Module-level on purpose: the multiprocessing resource tracker inherits this
 # fd ONCE at its (process-global, once-per-process) launch and keeps writing
@@ -1323,6 +1329,10 @@ class LibraryIngestQueueMixin:
             The newly created job: ``QUEUED`` normally, or immediately
             ``FAILED`` when ``media_db`` is unavailable.
         """
+        try:
+            detected_type = detect_file_type(source_path) or ""
+        except Exception:
+            detected_type = ""
         job = self.library_ingest_jobs.submit(
             source_path=source_path,
             title=title,
@@ -1331,6 +1341,7 @@ class LibraryIngestQueueMixin:
             perform_analysis=perform_analysis,
             chunk_enabled=chunk_enabled,
             chunk_size=chunk_size,
+            detected_type=detected_type,
         )
         if self.media_db is None:
             failed = self.library_ingest_jobs.mark_failed(
@@ -1567,30 +1578,42 @@ class LibraryIngestQueueMixin:
         no new parse work should be handed to a pool that's about to be
         terminated).
 
-        For each job claimed off the queue, ``detect_file_type`` is called
-        here (cheap: a pure extension check, never touches the filesystem
-        beyond ``Path.suffix``) purely to stamp a cosmetic ``detected_type``
-        onto the ``PARSING`` row for the queue-row copy -- an unsupported
-        extension here is silently ignored (left ``""``) rather than
+        ``detect_file_type`` is called once, at enqueue time (in
+        ``submit_library_ingest_job``), and its result is stamped onto the
+        job's ``detected_type`` -- not recomputed here. Dispatch reuses that
+        stored value both to claim the job (``mark_parsing``) and to decide
+        eligibility under the heavy-lane gate below; an unsupported
+        extension at enqueue time is silently left ``""`` rather than
         fast-failing the job: real classification (permanent vs. retryable)
         happens inside the pool worker, where the authoritative exception
         is available (see ``classify_parse_failure``), matching the F3
         design spec's "permanent-vs-retryable classification happens inside
         the worker" decision.
+
+        Heavy-lane gate: at most ``_ingest_heavy_lane_max_workers()`` jobs
+        whose ``detected_type`` is in ``_INGEST_HEAVY_TYPES`` (audio/video
+        transcription) may be ``PARSING`` at once, independent of the
+        overall pool cap -- when that lane is full, ``next_queued`` is asked
+        to skip those types so a queued document can fill the slot instead,
+        letting document parses fan out wide while transcriptions stay
+        capped.
         """
         if self._ingest_shutdown:
             return
         worker_count = self._ingest_parse_worker_count()
+        heavy_cap = self._ingest_heavy_lane_max_workers()
         while self.library_ingest_jobs.counts().get("parsing", 0) < worker_count:
-            job = self.library_ingest_jobs.next_queued()
+            heavy_full = (
+                self.library_ingest_jobs.parsing_count_for_types(_INGEST_HEAVY_TYPES)
+                >= heavy_cap
+            )
+            job = self.library_ingest_jobs.next_queued(
+                skip_types=_INGEST_HEAVY_TYPES if heavy_full else frozenset()
+            )
             if job is None:
                 return
-            try:
-                detected_type = detect_file_type(job.source_path) or ""
-            except Exception:
-                detected_type = ""
             claimed = self.library_ingest_jobs.mark_parsing(
-                job.job_id, detected_type=detected_type
+                job.job_id, detected_type=job.detected_type
             )
             if claimed is None:
                 # Invariant violation (Task-3 reviewer's guard note): the

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -1504,6 +1504,13 @@ base_url = "http://127.0.0.1:8000" # Or your actual default remote endpoint
 # Default auth token can be stored here, or leave empty if user must always provide
 auth_token = "default-secret-key-for-single-user"
 
+[library]
+# Parallel ingest parse workers. Default: min(3, cpu-1). Uncomment to override.
+# ingest_parse_workers = 3
+# Max concurrent heavy (audio/video transcription) parses; document parses fan
+# out past this cap to fill the remaining pool workers. Default: 1.
+# ingest_heavy_lane_max_workers = 1
+
 [splash_screen]
 # Splash screen configuration for startup animations
 # See Docs/Examples/SPLASH_SCREENS_CATALOG.md for all available splash screens


### PR DESCRIPTION
## Summary

Backlog **task 160** (follow-up from #598). F3's parallel parse pool fans all media types through one pool (`min(3, cpu-1)`); two concurrent audio/video **transcriptions** are RAM/CPU heavy. This caps concurrent transcription parses (default 1, config-controlled) independently of document parses, with **skip-ahead** so documents keep filling the pool past a blocked transcription.

Spec: `Docs/superpowers/specs/2026-07-12-library-ingest-heavy-lane-design.md`
Plan: `Docs/superpowers/plans/2026-07-12-library-ingest-heavy-lane.md`

## How it works

Heavy = `{audio, video}` (the only `detect_file_type` values that transcribe). The dispatcher fills the pool up to `worker_count` as before, but caps concurrent heavy parses at `heavy_cap`; when the heavy lane is full it **skips heavy jobs and dispatches lighter jobs past them** so pool slots never idle.

```
pool 3, heavy cap 1, queue [a1.mp3, a2.mp3, d1.txt, d2.txt, d3.txt]
→ in flight: a1 (heavy), d1, d2      a2 waits for the heavy slot; d3 waits for a pool slot
→ complete a1 → a2 admitted next
```

## Design

- **`ExportScope`-free, dispatch-side** — no second pool. The registry gains `next_queued(skip_types=…)` (FIFO-preserving skip-ahead) and `parsing_count_for_types()` (mirrors `counts()`'s superseded/dismissed filter).
- **Classify once at enqueue** — `detect_file_type` runs at `submit_library_ingest_job`, stored as `detected_type` on the QUEUED row; the dispatch-time recompute is removed and `mark_parsing` gets the stored value.
- **Config** — `library.ingest_heavy_lane_max_workers` (default 1, ≤0→1), documented alongside `ingest_parse_workers` in a new `[library]` block in the shipped config template.

## Testing

Built subagent-driven (TDD, RED-first): registry units (skip-ahead selection, heavy count, `submit` stores type, **requeue preserves type**), config helper + template validity, and the fake-pool headline scenario (pool 3 / cap 1 → `{a1,d1,d2}` in flight, a2 heavy-blocked, d3 pool-blocked, complete a1 → a2 promotes).

- **Whole-branch review (opus): found + fixed 1 Critical** — `requeue` (the Home Retry path) dropped `detected_type`, so a retried transcription bypassed the cap; fixed (`detected_type=source.detected_type`) with a registry unit + a runner retry-of-heavy scenario test, both RED-verified. The review otherwise confirmed dispatch termination, the re-trigger chain (no starvation), and superseded/dismissed accounting.
- **Final gate green** across the ingest registry/runner/config/Local_Ingestion suites; `import tldw_chatbook.app` clean.

Base was `b87fc0e9`; rebased onto latest dev before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps concurrent audio/video transcriptions with a configurable “heavy lane” (default 1) and adds skip-ahead so documents keep filling the pool. Addresses task 160 and also speeds up the dispatcher loop and hardens file-type classification.

- **New Features**
  - Dispatcher enforces a heavy cap using `_INGEST_HEAVY_TYPES = {"audio","video"}` with `parsing_count_for_types(...)` and `next_queued(skip_types=...)` to skip heavy jobs when the lane is full.
  - Classify once at enqueue: `detected_type` is set in `submit_library_ingest_job` and stored on the job; dispatch uses the stored type (no recompute).
  - Config: `_ingest_heavy_lane_max_workers()` reads `library.ingest_heavy_lane_max_workers` (default 1; ≤0 clamps to 1). `[library]` docs in the template cover both `ingest_parse_workers` and `ingest_heavy_lane_max_workers`.

- **Bug Fixes**
  - `requeue` preserves `detected_type`, keeping retried transcriptions bound by the heavy-lane cap.
  - More robust classification at submit: `FileIngestionError` is treated as light; unexpected `detect_file_type` failures are logged to avoid silent cap bypass.
  - Performance: the top-up loop now hoists in-flight counts and tracks them locally, cutting UI-thread work on large queues.

<sup>Written for commit fb29d48d34a33055200134e969d2e7a6fba13689. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

