### PR TITLE
feat(ingest): persistent ingest job history across restarts (task 161)

### DIFF
--- a/Docs/superpowers/plans/2026-07-12-library-persistent-job-history.md
+++ b/Docs/superpowers/plans/2026-07-12-library-persistent-job-history.md
@@ -1,0 +1,664 @@
+# Persistent ingest job history — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax. Spec: `Docs/superpowers/specs/2026-07-12-library-persistent-job-history-design.md`. Branch `claude/followups-job-history` off dev `d8c9bec1`. Anchors exact at branch point; grep symbols, line numbers drift.
+
+**Goal:** Persist the Library ingest job registry to SQLite so history survives restarts (and crashes), interrupted jobs come back as retryable FAILED, and each job carries a `retry_count`.
+
+**Architecture:** A small `BaseDB`-subclass store (`LibraryIngestJobsDB`) with ONE persistent WAL connection (single-threaded UI access) persists every visible job. The registry gets an optional `store` hook and writes through on each mutation; a pure `plan_restore()` transforms the loaded rows (normalize interrupted → FAILED, prune to a cap) and the app seeds the registry from it in `on_mount`.
+
+**Tech Stack:** Python ≥3.11, sqlite3, pytest.
+
+## Global Constraints
+
+- **No behavior change with `store=None`:** the registry with no store behaves exactly as today; every existing registry test stays green unchanged.
+- **Persisted fields only round-trippable ones** — the `time.monotonic()` fields `submitted_at`/`started_at`/`finished_at` are NOT persisted (restored `submitted_at=0.0`, `started_at`/`finished_at=None`); only `finished_at_wall` (ISO) round-trips.
+- **`state` column has `CHECK (state IN ('queued','parsing','writing','done','failed'))`.**
+- **`retry_count`:** `LibraryIngestJob.retry_count: int = 0`; `submit` → 0; `requeue` → `source.retry_count + 1`; persisted; surfaced as `· retry {n}` (n>0) on the ingest job row. No cap / no auto-retry / no backoff.
+- **Interrupted-on-restart:** QUEUED/PARSING/WRITING → `FAILED`, `error="Interrupted by app restart"`, `permanent=False`, `finished_at_wall=<restore time>`.
+- **Prune cap:** `_MAX_PERSISTED_JOBS = 500` (keep most recent by `seq`).
+- **Best-effort persistence:** store errors are caught + debug-logged; a mutation never fails on a store error. A corrupt store at load → start empty + warn.
+- **Single-threaded store:** all registry mutations run on the UI thread (verified: writer marshals `mark_done`/`mark_failed` via `call_from_thread`), so the persistent connection needs no cross-thread handling.
+- **Staging:** explicit paths only. Every commit ends with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- **Test command** (venv, isolated HOME):
+  ```
+  HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+    /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest <files> \
+    -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+  ```
+
+---
+
+### Task 1: `LibraryIngestJobsDB` store (new)
+
+**Files:**
+- Create: `tldw_chatbook/DB/Library_Ingest_Jobs_DB.py`
+- Modify: `tldw_chatbook/Library/library_ingest_jobs.py` (add the one `retry_count` field the store persists — the rest of the retry/hook logic is Task 2)
+- Test: `Tests/DB/test_library_ingest_jobs_db.py` (create)
+
+**Interfaces:**
+- Produces: `LibraryIngestJob.retry_count: int = 0` (dataclass field only); `LibraryIngestJobsDB(db_path, client_id="default")` with `upsert_job(job)`, `delete_job(job_id)`, `all_jobs() -> list[dict]` (seq-ascending), `close()`. Consumes `LibraryIngestJob` (reads its attributes) — imported from `tldw_chatbook.Library.library_ingest_jobs`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/DB/test_library_ingest_jobs_db.py`:
+```python
+import sqlite3
+import pytest
+
+from tldw_chatbook.DB.Library_Ingest_Jobs_DB import LibraryIngestJobsDB
+from tldw_chatbook.Library.library_ingest_jobs import LibraryIngestJobRegistry, IngestJobState
+
+
+def _db(tmp_path):
+    return LibraryIngestJobsDB(tmp_path / "jobs.db")
+
+
+def test_upsert_and_all_jobs_roundtrip_ordered(tmp_path):
+    reg = LibraryIngestJobRegistry()
+    j1 = reg.submit(source_path="/a.mp3", title="A", keywords=("k1", "k2"), detected_type="audio")
+    j2 = reg.submit(source_path="/b.txt", title="B")
+    db = _db(tmp_path)
+    db.upsert_job(j1)
+    db.upsert_job(j2)
+    rows = db.all_jobs()
+    assert [r["job_id"] for r in rows] == [j1.job_id, j2.job_id]     # seq order
+    assert rows[0]["source_path"] == "/a.mp3" and rows[0]["detected_type"] == "audio"
+    assert rows[0]["keywords"] == '["k1", "k2"]'
+    assert rows[0]["state"] == "queued" and rows[0]["retry_count"] == 0
+    db.close()
+
+
+def test_upsert_is_idempotent_update_in_place(tmp_path):
+    reg = LibraryIngestJobRegistry()
+    j = reg.submit(source_path="/a.mp3")
+    db = _db(tmp_path)
+    db.upsert_job(j)
+    reg.mark_parsing(j.job_id, detected_type="audio")
+    db.upsert_job(reg.jobs()[0])          # same job_id, now PARSING
+    rows = db.all_jobs()
+    assert len(rows) == 1 and rows[0]["state"] == "parsing"
+    db.close()
+
+
+def test_delete_job(tmp_path):
+    reg = LibraryIngestJobRegistry()
+    j = reg.submit(source_path="/a.mp3")
+    db = _db(tmp_path)
+    db.upsert_job(j)
+    db.delete_job(j.job_id)
+    assert db.all_jobs() == []
+    db.close()
+
+
+def test_state_check_constraint_rejects_bad_state(tmp_path):
+    db = _db(tmp_path)
+    conn = db._get_connection()
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO ingest_jobs (seq, job_id, source_path, state) VALUES (1,'x','/p','bogus')"
+        )
+    db.close()
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run:
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/DB/test_library_ingest_jobs_db.py -q -p no:cacheprovider -o addopts="" --timeout=120
+```
+Expected: FAIL — `ModuleNotFoundError: tldw_chatbook.DB.Library_Ingest_Jobs_DB`.
+
+- [ ] **Step 3: Implement the store**
+
+FIRST add the `retry_count` field the store persists — in `tldw_chatbook/Library/library_ingest_jobs.py`, add `retry_count: int = 0` to the `LibraryIngestJob` dataclass (after `permanent`, keep it last for field-order back-compat). (Task 2 adds the requeue-carry + store hook; this task only needs the field to exist so `upsert_job` can read it.) Then create `tldw_chatbook/DB/Library_Ingest_Jobs_DB.py`:
+```python
+"""SQLite persistence for the Library ingest job registry.
+
+Single-user, UI-thread-only: keeps ONE persistent WAL connection reused across
+all reads/writes (safe because every registry mutation runs on the UI thread),
+rather than opening/closing per operation.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Union
+
+from loguru import logger
+
+from .base_db import BaseDB
+
+
+class LibraryIngestJobsDB(BaseDB):
+    _CURRENT_SCHEMA_VERSION = 1
+
+    def __init__(self, db_path: Union[str, Path], client_id: str = "default") -> None:
+        self._conn: sqlite3.Connection | None = None
+        super().__init__(db_path, client_id)  # calls _initialize_schema()
+
+    def _get_connection(self) -> sqlite3.Connection:
+        if self._conn is None:
+            self._conn = sqlite3.connect(self.db_path_str, check_same_thread=False)
+            self._conn.row_factory = sqlite3.Row
+            self._conn.execute("PRAGMA journal_mode=WAL")
+        return self._conn
+
+    def close(self) -> None:
+        if self._conn is not None:
+            try:
+                self._conn.close()
+            except Exception:
+                logger.opt(exception=True).debug("LibraryIngestJobsDB: close failed")
+            finally:
+                self._conn = None
+
+    def _initialize_schema(self) -> None:
+        conn = self._get_connection()
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS schema_version (version INTEGER PRIMARY KEY NOT NULL);
+            INSERT OR IGNORE INTO schema_version (version) VALUES (1);
+
+            CREATE TABLE IF NOT EXISTS ingest_jobs (
+                seq INTEGER PRIMARY KEY,
+                job_id TEXT UNIQUE NOT NULL,
+                source_path TEXT NOT NULL,
+                title TEXT NOT NULL DEFAULT '',
+                author TEXT NOT NULL DEFAULT '',
+                keywords TEXT NOT NULL DEFAULT '[]',
+                perform_analysis INTEGER NOT NULL DEFAULT 0,
+                chunk_enabled INTEGER NOT NULL DEFAULT 0,
+                chunk_size INTEGER NOT NULL DEFAULT 0,
+                state TEXT NOT NULL CHECK (state IN ('queued','parsing','writing','done','failed')),
+                retry_count INTEGER NOT NULL DEFAULT 0,
+                detected_type TEXT NOT NULL DEFAULT '',
+                error TEXT NOT NULL DEFAULT '',
+                finished_at_wall TEXT NOT NULL DEFAULT '',
+                media_id INTEGER,
+                superseded INTEGER NOT NULL DEFAULT 0,
+                dismissed INTEGER NOT NULL DEFAULT 0,
+                permanent INTEGER NOT NULL DEFAULT 0
+            );
+            """
+        )
+        conn.commit()
+
+    @staticmethod
+    def _seq_of(job_id: str) -> int:
+        # "ingest-job-{n}" -> n
+        return int(job_id.rsplit("-", 1)[-1])
+
+    def upsert_job(self, job) -> None:
+        conn = self._get_connection()
+        conn.execute(
+            """
+            INSERT INTO ingest_jobs
+              (seq, job_id, source_path, title, author, keywords, perform_analysis,
+               chunk_enabled, chunk_size, state, retry_count, detected_type, error,
+               finished_at_wall, media_id, superseded, dismissed, permanent)
+            VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+            ON CONFLICT(job_id) DO UPDATE SET
+              source_path=excluded.source_path, title=excluded.title, author=excluded.author,
+              keywords=excluded.keywords, perform_analysis=excluded.perform_analysis,
+              chunk_enabled=excluded.chunk_enabled, chunk_size=excluded.chunk_size,
+              state=excluded.state, retry_count=excluded.retry_count,
+              detected_type=excluded.detected_type, error=excluded.error,
+              finished_at_wall=excluded.finished_at_wall, media_id=excluded.media_id,
+              superseded=excluded.superseded, dismissed=excluded.dismissed, permanent=excluded.permanent
+            """,
+            (
+                self._seq_of(job.job_id), job.job_id, job.source_path, job.title, job.author,
+                json.dumps(list(job.keywords)), int(job.perform_analysis), int(job.chunk_enabled),
+                job.chunk_size, job.state.value, job.retry_count, job.detected_type, job.error,
+                job.finished_at_wall, job.media_id, int(job.superseded), int(job.dismissed),
+                int(job.permanent),
+            ),
+        )
+        conn.commit()
+
+    def delete_job(self, job_id: str) -> None:
+        conn = self._get_connection()
+        conn.execute("DELETE FROM ingest_jobs WHERE job_id = ?", (job_id,))
+        conn.commit()
+
+    def all_jobs(self) -> list[dict]:
+        conn = self._get_connection()
+        rows = conn.execute("SELECT * FROM ingest_jobs ORDER BY seq ASC").fetchall()
+        return [dict(r) for r in rows]
+```
+- [ ] **Step 4: Run to verify it passes + registry suite (field addition is back-compat)**
+
+Run the Step-1 store tests AND the existing registry suite (the new `retry_count` field defaults to 0, so no existing test changes):
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/DB/test_library_ingest_jobs_db.py Tests/Library/test_library_ingest_jobs.py \
+  -q -p no:cacheprovider -o addopts="" --timeout=180
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/DB/Library_Ingest_Jobs_DB.py tldw_chatbook/Library/library_ingest_jobs.py Tests/DB/test_library_ingest_jobs_db.py
+git commit -m "feat(ingest): SQLite store for persistent ingest job history + retry_count field (161)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Registry — `retry_count`, store hook, restore, `plan_restore` (pure)
+
+**Files:**
+- Modify: `tldw_chatbook/Library/library_ingest_jobs.py`
+- Test: `Tests/Library/test_library_ingest_jobs.py`
+
+**Interfaces:**
+- Produces:
+  - `LibraryIngestJob.retry_count: int = 0` (new field).
+  - `IngestJobStore` Protocol: `upsert_job(job)`, `delete_job(job_id)`.
+  - `LibraryIngestJobRegistry.attach_store(store)`; per-mutation write-through; `restore(jobs, next_id)`.
+  - module fn `plan_restore(rows: list[dict], *, max_persisted: int, now_iso: str) -> RestorePlan` where `RestorePlan` is a dataclass `(jobs: list[LibraryIngestJob], next_id: int, upsert: list[LibraryIngestJob], delete_ids: list[str])`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `Tests/Library/test_library_ingest_jobs.py`:
+```python
+class _FakeStore:
+    def __init__(self):
+        self.upserts = []
+        self.deletes = []
+    def upsert_job(self, job):
+        self.upserts.append(job.job_id)
+    def delete_job(self, job_id):
+        self.deletes.append(job_id)
+
+
+def test_submit_starts_retry_count_zero_and_requeue_increments():
+    from tldw_chatbook.Library.library_ingest_jobs import IngestJobState
+    reg = LibraryIngestJobRegistry()
+    j = reg.submit(source_path="/a.mp3")
+    assert j.retry_count == 0
+    reg.mark_parsing(j.job_id); reg.mark_failed(j.job_id, error="boom")
+    r = reg.requeue(j.job_id)
+    assert r.retry_count == 1
+    reg.mark_parsing(r.job_id); reg.mark_failed(r.job_id, error="boom2")
+    r2 = reg.requeue(r.job_id)
+    assert r2.retry_count == 2
+
+
+def test_store_hook_writes_through_on_mutations():
+    store = _FakeStore()
+    reg = LibraryIngestJobRegistry()
+    reg.attach_store(store)
+    j = reg.submit(source_path="/a.mp3")
+    reg.mark_parsing(j.job_id)
+    assert store.upserts.count(j.job_id) >= 2       # submit + mark_parsing
+    reg.mark_done(j.job_id, media_id=1)
+    reg.clear_finished()
+    assert j.job_id in store.deletes
+
+
+def test_store_hook_none_is_pure_and_errors_swallowed():
+    reg = LibraryIngestJobRegistry()          # no store
+    reg.submit(source_path="/a.mp3")          # must not raise
+    class _Boom:
+        def upsert_job(self, job): raise RuntimeError("disk full")
+        def delete_job(self, job_id): raise RuntimeError("disk full")
+    reg2 = LibraryIngestJobRegistry()
+    reg2.attach_store(_Boom())
+    j = reg2.submit(source_path="/b.mp3")     # store raises, mutation still succeeds
+    assert j.state.value == "queued"
+
+
+def test_plan_restore_normalizes_interrupted_and_prunes():
+    from tldw_chatbook.Library.library_ingest_jobs import plan_restore, IngestJobState
+    rows = [
+        {"seq": 1, "job_id": "ingest-job-1", "source_path": "/a", "title": "", "author": "",
+         "keywords": "[]", "perform_analysis": 0, "chunk_enabled": 0, "chunk_size": 0,
+         "state": "done", "retry_count": 0, "detected_type": "", "error": "",
+         "finished_at_wall": "2026-07-12T00:00:00+00:00", "media_id": 7,
+         "superseded": 0, "dismissed": 0, "permanent": 0},
+        {"seq": 2, "job_id": "ingest-job-2", "source_path": "/b", "title": "", "author": "",
+         "keywords": "[]", "perform_analysis": 0, "chunk_enabled": 0, "chunk_size": 0,
+         "state": "parsing", "retry_count": 1, "detected_type": "audio", "error": "",
+         "finished_at_wall": "", "media_id": None, "superseded": 0, "dismissed": 0, "permanent": 0},
+    ]
+    plan = plan_restore(rows, max_persisted=500, now_iso="2026-07-12T09:00:00+00:00")
+    by_id = {j.job_id: j for j in plan.jobs}
+    assert by_id["ingest-job-1"].state == IngestJobState.DONE and by_id["ingest-job-1"].media_id == 7
+    assert by_id["ingest-job-2"].state == IngestJobState.FAILED
+    assert by_id["ingest-job-2"].error == "Interrupted by app restart"
+    assert by_id["ingest-job-2"].finished_at_wall == "2026-07-12T09:00:00+00:00"
+    assert by_id["ingest-job-2"].retry_count == 1          # count preserved, not reset
+    assert plan.next_id == 3
+    assert "ingest-job-2" in [j.job_id for j in plan.upsert]   # normalized -> re-persist
+    assert plan.delete_ids == []
+
+
+def test_plan_restore_prune_cap_drops_oldest():
+    rows = [
+        {"seq": i, "job_id": f"ingest-job-{i}", "source_path": "/p", "title": "", "author": "",
+         "keywords": "[]", "perform_analysis": 0, "chunk_enabled": 0, "chunk_size": 0,
+         "state": "done", "retry_count": 0, "detected_type": "", "error": "",
+         "finished_at_wall": "", "media_id": None, "superseded": 0, "dismissed": 0, "permanent": 0}
+        for i in range(1, 6)
+    ]
+    plan = plan_restore(rows, max_persisted=3, now_iso="2026-07-12T09:00:00+00:00")
+    assert [j.job_id for j in plan.jobs] == ["ingest-job-3", "ingest-job-4", "ingest-job-5"]
+    assert plan.delete_ids == ["ingest-job-1", "ingest-job-2"]
+    assert plan.next_id == 6
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run:
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Library/test_library_ingest_jobs.py -q -p no:cacheprovider -o addopts="" --timeout=120
+```
+Expected: FAIL — no `retry_count` / no `attach_store` / no `plan_restore`.
+
+- [ ] **Step 3: Add `retry_count` + `IngestJobStore` + store plumbing**
+
+In `library_ingest_jobs.py` (`LibraryIngestJob.retry_count` already exists from Task 1):
+- Add imports: `from typing import Protocol` (extend the existing typing import); `replace`/`dataclass` are already imported.
+- Define near the top:
+```python
+class IngestJobStore(Protocol):
+    def upsert_job(self, job: "LibraryIngestJob") -> None: ...
+    def delete_job(self, job_id: str) -> None: ...
+```
+- In `__init__`, add `self._store: IngestJobStore | None = None`.
+- Add methods:
+```python
+    def attach_store(self, store: IngestJobStore) -> None:
+        self._store = store
+
+    def _persist(self, job: LibraryIngestJob) -> None:
+        if self._store is None:
+            return
+        try:
+            self._store.upsert_job(job)
+        except Exception:
+            logger.opt(exception=True).debug(f"ingest job persist failed: {job.job_id}")
+
+    def _persist_delete(self, job_id: str) -> None:
+        if self._store is None:
+            return
+        try:
+            self._store.delete_job(job_id)
+        except Exception:
+            logger.opt(exception=True).debug(f"ingest job delete-persist failed: {job_id}")
+```
+- At the end of each mutation (`submit`, `mark_parsing`, `mark_writing`, `mark_done`, `mark_failed`, `dismiss`), after updating `self._jobs` and before/after `self._notify_listeners()`, call `self._persist(self._jobs[index])` (for `submit`, the appended job). For `requeue`, persist BOTH the superseded original and the new copy. For `clear_finished`, call `self._persist_delete(job_id)` for each removed job.
+- `requeue`'s new-copy constructor already copies `detected_type` (task-160 fix) — ADD `retry_count=source.retry_count + 1,`.
+
+- [ ] **Step 4: Add `restore` + `plan_restore`**
+
+```python
+@dataclass
+class RestorePlan:
+    jobs: list["LibraryIngestJob"]
+    next_id: int
+    upsert: list["LibraryIngestJob"]     # normalized jobs to re-persist
+    delete_ids: list[str]                # pruned jobs to delete from the store
+
+
+_INTERRUPTED_STATES = (IngestJobState.QUEUED, IngestJobState.PARSING, IngestJobState.WRITING)
+
+
+def _job_from_row(row: dict) -> "LibraryIngestJob":
+    return LibraryIngestJob(
+        job_id=row["job_id"],
+        source_path=row["source_path"],
+        title=row["title"] or "",
+        author=row["author"] or "",
+        keywords=tuple(json.loads(row["keywords"] or "[]")),
+        perform_analysis=bool(row["perform_analysis"]),
+        chunk_enabled=bool(row["chunk_enabled"]),
+        chunk_size=int(row["chunk_size"]),
+        state=IngestJobState(row["state"]),
+        detected_type=row["detected_type"] or "",
+        media_id=row["media_id"],
+        error=row["error"] or "",
+        finished_at_wall=row["finished_at_wall"] or "",
+        superseded=bool(row["superseded"]),
+        dismissed=bool(row["dismissed"]),
+        permanent=bool(row["permanent"]),
+        retry_count=int(row["retry_count"]),
+        # monotonic fields are not round-trippable -- leave defaults.
+        submitted_at=0.0, started_at=None, finished_at=None,
+    )
+
+
+def plan_restore(rows: list[dict], *, max_persisted: int, now_iso: str) -> RestorePlan:
+    jobs = [_job_from_row(r) for r in rows]            # rows are seq-ascending
+    normalized_ids: set[str] = set()
+    for i, job in enumerate(jobs):
+        if job.state in _INTERRUPTED_STATES:
+            jobs[i] = replace(
+                job, state=IngestJobState.FAILED,
+                error="Interrupted by app restart", permanent=False,
+                finished_at_wall=now_iso,
+            )
+            normalized_ids.add(job.job_id)
+    delete_ids: list[str] = []
+    if len(jobs) > max_persisted:
+        pruned = jobs[:-max_persisted]
+        delete_ids = [j.job_id for j in pruned]
+        jobs = jobs[-max_persisted:]
+    upsert = [j for j in jobs if j.job_id in normalized_ids]   # kept + normalized
+    next_id = max((int(j.job_id.rsplit("-", 1)[-1]) for j in jobs), default=0) + 1
+    return RestorePlan(jobs=jobs, next_id=next_id, upsert=upsert, delete_ids=delete_ids)
+```
+And the registry seeder (does NOT fire per-job persist — bulk restore):
+```python
+    def restore(self, jobs: list[LibraryIngestJob], next_id: int) -> None:
+        self._jobs = list(jobs)
+        self._next_id = next_id
+        self._notify_listeners()
+```
+(Add `import json` and confirm `replace` is imported — it already is.)
+
+- [ ] **Step 5: Run to verify it passes + the full registry suite**
+
+Run:
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Library/test_library_ingest_jobs.py -q -p no:cacheprovider -o addopts="" --timeout=180
+```
+Expected: PASS (new tests + all pre-existing registry tests unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/Library/library_ingest_jobs.py Tests/Library/test_library_ingest_jobs.py
+git commit -m "feat(ingest): registry retry_count + store write-through hook + restore/plan_restore (161)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: App wiring — config path, on_mount restore, teardown close, retry indicator + backlog Done
+
+**Files:**
+- Modify: `tldw_chatbook/config.py` (path helper)
+- Modify: `tldw_chatbook/app.py` (`_restore_ingest_jobs`, `on_mount` call, teardown close)
+- Modify: `tldw_chatbook/Home/active_work_adapter.py` (`· retry {n}` indicator)
+- Modify: `backlog/tasks/task-161 - Persistent-ingest-job-history-across-restarts.md`
+- Test: `Tests/Library/test_library_ingest_jobs_restore.py` (create) + `Tests/Home/` retry-indicator unit
+
+**Interfaces:**
+- Consumes: `LibraryIngestJobsDB` (Task 1); `attach_store`/`restore`/`plan_restore`/`RestorePlan` + `retry_count` (Task 2); `get_user_data_dir` (existing).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/Library/test_library_ingest_jobs_restore.py` (end-to-end store↔registry round-trip via the real store):
+```python
+from tldw_chatbook.DB.Library_Ingest_Jobs_DB import LibraryIngestJobsDB
+from tldw_chatbook.Library.library_ingest_jobs import (
+    LibraryIngestJobRegistry, IngestJobState, plan_restore,
+)
+
+
+def _restore(store, max_persisted=500, now_iso="2026-07-12T09:00:00+00:00"):
+    reg = LibraryIngestJobRegistry()
+    reg.attach_store(store)
+    plan = plan_restore(store.all_jobs(), max_persisted=max_persisted, now_iso=now_iso)
+    reg.restore(plan.jobs, plan.next_id)
+    for j in plan.upsert:
+        store.upsert_job(j)
+    for jid in plan.delete_ids:
+        store.delete_job(jid)
+    return reg
+
+
+def test_history_survives_restart_interrupted_normalized(tmp_path):
+    store = LibraryIngestJobsDB(tmp_path / "jobs.db")
+    a = LibraryIngestJobRegistry(); a.attach_store(store)
+    done = a.submit(source_path="/done.pdf"); a.mark_parsing(done.job_id); a.mark_writing(done.job_id); a.mark_done(done.job_id, media_id=5)
+    interrupted = a.submit(source_path="/x.mp4"); a.mark_parsing(interrupted.job_id)   # left PARSING (quit)
+    failed = a.submit(source_path="/y.mp3"); a.mark_parsing(failed.job_id); a.mark_failed(failed.job_id, error="bad codec")
+    store.close()
+
+    store2 = LibraryIngestJobsDB(tmp_path / "jobs.db")            # reopen (restart)
+    reg = _restore(store2)
+    by_id = {j.job_id: j for j in reg.jobs()}
+    assert by_id[done.job_id].state == IngestJobState.DONE and by_id[done.job_id].media_id == 5
+    assert by_id[interrupted.job_id].state == IngestJobState.FAILED
+    assert by_id[interrupted.job_id].error == "Interrupted by app restart"
+    assert by_id[failed.job_id].state == IngestJobState.FAILED and by_id[failed.job_id].error == "bad codec"
+    # _next_id advanced past the max so a new submit doesn't collide
+    fresh = reg.submit(source_path="/z.txt")
+    assert fresh.job_id == "ingest-job-4"
+    store2.close()
+
+
+def test_interrupted_retry_after_restart_requeues(tmp_path):
+    store = LibraryIngestJobsDB(tmp_path / "jobs.db")
+    a = LibraryIngestJobRegistry(); a.attach_store(store)
+    j = a.submit(source_path="/x.mp4"); a.mark_parsing(j.job_id)     # interrupted
+    store.close()
+    reg = _restore(LibraryIngestJobsDB(tmp_path / "jobs.db"))
+    restored = reg.jobs()[0]
+    assert restored.state == IngestJobState.FAILED
+    requeued = reg.requeue(restored.job_id)                          # AC2: retryable
+    assert requeued.state == IngestJobState.QUEUED and requeued.retry_count == 1
+```
+
+Add a retry-indicator unit to `Tests/Home/` (find the existing active-work adapter test file via `ls Tests/Home/`; if none, create `Tests/Home/test_active_work_ingest_retry.py`) asserting a FAILED job with `retry_count=2` yields a `status_detail` containing `retry 2`. (Match the adapter's construction — see Step 4 for the exact field.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run the two files; Expected: FAIL — `_restore` uses real store (exists) but the retry-indicator assertion fails (no indicator yet), and the round-trip may need the app path helper only in later steps. The restore tests should PASS already if Tasks 1–2 are done (they use only library + DB) — if so, they're a regression guard; the retry-indicator test is the RED for this task.
+
+- [ ] **Step 3: Config path helper**
+
+In `config.py`, next to `get_library_collections_db_path` (~:3597), add:
+```python
+def get_library_ingest_jobs_db_path() -> Path:
+    custom_path = get_cli_setting("database", "library_ingest_jobs_db_path", None)
+    if custom_path and custom_path != DEFAULT_CONFIG_FROM_TOML.get("database", {}).get("library_ingest_jobs_db_path"):
+        db_path = validate_path_simple(Path(str(custom_path)).expanduser(), require_exists=False).resolve()
+    else:
+        db_path = get_user_data_dir() / "tldw_chatbook_library_ingest_jobs.db"
+    return db_path
+```
+
+- [ ] **Step 4: `_restore_ingest_jobs` + on_mount + teardown + retry indicator**
+
+In `app.py`, add the constant `_MAX_PERSISTED_INGEST_JOBS = 500` near the ingest constants, and a method on `LibraryIngestQueueMixin`:
+```python
+    def _restore_ingest_jobs(self) -> None:
+        """One-time on_mount restore of persisted ingest job history."""
+        from datetime import datetime, timezone
+        from tldw_chatbook.DB.Library_Ingest_Jobs_DB import LibraryIngestJobsDB
+        from tldw_chatbook.Library.library_ingest_jobs import plan_restore
+        try:
+            store = LibraryIngestJobsDB(get_library_ingest_jobs_db_path())
+            self._library_ingest_jobs_store = store
+            self.library_ingest_jobs.attach_store(store)
+            plan = plan_restore(
+                store.all_jobs(),
+                max_persisted=_MAX_PERSISTED_INGEST_JOBS,
+                now_iso=datetime.now(timezone.utc).isoformat(),
+            )
+            self.library_ingest_jobs.restore(plan.jobs, plan.next_id)
+            for job in plan.upsert:
+                store.upsert_job(job)
+            for job_id in plan.delete_ids:
+                store.delete_job(job_id)
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Failed to restore persisted ingest job history; starting empty."
+            )
+```
+Call `self._restore_ingest_jobs()` once in `on_mount` (`app.py:5421`), after the registry exists (it's created in `__init__`), early in the Library-related setup. Import `get_library_ingest_jobs_db_path` from `.config` (extend the existing config import). In `on_unmount` (`app.py:6029`), after the pool shutdown, close the store:
+```python
+        store = getattr(self, "_library_ingest_jobs_store", None)
+        if store is not None:
+            store.close()
+```
+Retry indicator — in `Home/active_work_adapter.py._local_ingest_job_items` (~:621), change the `status_detail` to append the retry suffix. Add a tiny helper near the module's other job helpers (`~:787`):
+```python
+def _ingest_retry_suffix(job) -> str:
+    return f" · retry {job.retry_count}" if job.retry_count else ""
+```
+and build the detail as:
+```python
+                    status_detail=(
+                        (short_ingest_error(job.error)
+                         if job.state == IngestJobState.FAILED and job.error else "")
+                        + _ingest_retry_suffix(job)
+                    ),
+```
+(The suffix is markup-safe plain text — consistent with the existing `markup=False` rendering.) If `library_screen.py`'s ingest queue row builds a parallel detail line from `short_ingest_error`, apply the same suffix there (grep `short_ingest_error` in `library_screen.py`).
+
+- [ ] **Step 5: Run to verify it passes + import smoke**
+
+Run:
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Library/test_library_ingest_jobs_restore.py Tests/DB/test_library_ingest_jobs_db.py Tests/Library/test_library_ingest_jobs.py Tests/Home/ \
+  -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+HOME=/private/tmp/tldw-chatbook-test-home PYTHONPATH=$(pwd) \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -c "import tldw_chatbook.app; print('import ok')"
+```
+Expected: PASS + `import ok`.
+
+- [ ] **Step 6: Mark backlog Done + commit**
+
+```bash
+perl -0pi -e 's/- \[ \] (#\d)/- [x] $1/g' "backlog/tasks/task-161 - Persistent-ingest-job-history-across-restarts.md"
+perl -0pi -e 's/^status: .*/status: Done/m' "backlog/tasks/task-161 - Persistent-ingest-job-history-across-restarts.md"
+```
+Add a short `## Implementation Notes` (store + write-through hook + on_mount restore/normalize/prune + retry_count).
+```bash
+git add tldw_chatbook/config.py tldw_chatbook/app.py tldw_chatbook/Home/active_work_adapter.py \
+  Tests/Library/test_library_ingest_jobs_restore.py Tests/Home/ \
+  "backlog/tasks/task-161 - Persistent-ingest-job-history-across-restarts.md"
+git commit -m "feat(ingest): persist + restore ingest job history on restart; retry indicator; task 161 done (161)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Final gate (after Task 3)
+
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/DB/test_library_ingest_jobs_db.py Tests/Library/ Tests/Home/ Tests/DB/ \
+  -q -p no:cacheprovider -o addopts="" --timeout=600 --timeout-method=thread
+```
+Plus `python -c "import tldw_chatbook.app"`. Then the whole-branch review (opus) and finishing-a-development-branch. Served-TUI visual QA (submit a job, quit mid-parse, relaunch → job shows "interrupted by restart" + Retry works) is worthwhile but optional.

--- a/Docs/superpowers/specs/2026-07-12-library-persistent-job-history-design.md
+++ b/Docs/superpowers/specs/2026-07-12-library-persistent-job-history-design.md
@@ -17,6 +17,8 @@
 
 A small SQLite store persists every visible ingest job; the registry **writes through** on each mutation and is **loaded once at startup**. Interrupted in-flight jobs (QUEUED/PARSING/WRITING at quit) normalize to `FAILED("Interrupted by app restart")` on load, so the app is idle on launch and the user retries manually (chosen over auto-resume in brainstorm — no surprise heavy work on launch). Done/failed jobs restore as-is. Mechanism follows the existing `LibraryCollectionsDB` template.
 
+**Crash recovery (bonus):** because the store writes through on every transition — including the transient PARSING/WRITING — a job caught mid-parse by a *crash* (not just a clean quit) is already persisted as PARSING and comes back as retryable FAILED-interrupted on the next launch. This is why the transient states are persisted rather than only terminal ones.
+
 ### Why per-mutation write-through is safe (threading)
 
 Every registry mutation runs on the **UI thread**: `submit`/`mark_parsing`/`mark_writing` in UI-thread coordinator methods, and the writer thread marshals `mark_done`/`mark_failed` back via `self.call_from_thread(...)` (`app.py:2113`/`2128`), as do the pool-completion (`_on_ingest_parse_complete`) and broken-pool paths. So the store is accessed from a single thread — per-mutation synchronous SQLite writes need no cross-thread connection handling.
@@ -25,7 +27,7 @@ Every registry mutation runs on the **UI thread**: `submit`/`mark_parsing`/`mark
 
 ### 1. `LibraryIngestJobsDB` (`tldw_chatbook/DB/Library_Ingest_Jobs_DB.py`, new)
 
-A `BaseDB` subclass mirroring `LibraryCollectionsDB`: `_CURRENT_SCHEMA_VERSION = 1`, a `transaction()` context manager, `_initialize_schema()` via `executescript` with a `schema_version` table. **WAL mode** enabled for fast, low-contention writes. One table `ingest_jobs`:
+A `BaseDB` subclass mirroring `LibraryCollectionsDB`: `_CURRENT_SCHEMA_VERSION = 1`, a `transaction()` context manager, `_initialize_schema()` via `executescript` with a `schema_version` table. **WAL mode** enabled. Because writes fire per mutation and store access is single-threaded (UI thread), the store keeps a **persistent connection** (opened once at `attach_store`, reused, closed on app shutdown) rather than opening/closing per write — a large drop (e.g. 100 files → ~100 `submit` upserts plus per-transition writes) then pays only the ~sub-ms write, not connection setup each time. (`close()` on app teardown.) One table `ingest_jobs`:
 
 | column | type | notes |
 |---|---|---|
@@ -62,7 +64,7 @@ Persistence is **best-effort**: `_persist`/`_delete` wrap the store call in `try
 2. Rebuild `LibraryIngestJob`s (keywords JSON→tuple, ints→bools, monotonic fields defaulted: `submitted_at` re-seeded to a fresh `time.monotonic()`, `started_at`/`finished_at` = None).
 3. **Normalize interrupted states:** any job whose stored `state` ∈ {QUEUED, PARSING, WRITING} → `FAILED`, `error="Interrupted by app restart"`, `permanent=False` (retryable), and stamp `finished_at_wall = datetime.now(timezone.utc).isoformat()`.
 4. **Prune cap:** keep at most the most recent `_MAX_PERSISTED_JOBS` (constant, 500) rows by `seq`; older terminal rows are dropped from the load AND deleted from the store.
-5. Seed the registry via `restore(jobs, next_id=max(seq)+1)`, then **re-persist the normalized/pruned set** (upsert the interrupted→FAILED jobs; delete the pruned ones) so the store reflects the post-restart truth.
+5. Seed the registry via `restore(jobs, next_id=max(seq)+1)`, then **incrementally** reconcile the store to the post-restart truth: `upsert_job` ONLY the jobs whose state was normalized (interrupted→FAILED) and `delete_job` ONLY the pruned rows. Everything else already loaded is current — do NOT re-write all rows (no startup write storm).
 6. No auto-dispatch: `_top_up_ingest_parse_pool()` is NOT called at startup — the app is idle until the user retries.
 
 The registry stays store-less in `TldwCli.__init__` (`app.py:3190`, unchanged, no DB I/O at construction); `_restore_ingest_jobs()` runs once in `on_mount`, where it creates the `LibraryIngestJobsDB` (independent of `media_db`), `attach_store`s it to the registry, then loads/normalizes/restores. No submits happen between `__init__` and `on_mount`, so nothing is lost by attaching late.
@@ -98,5 +100,5 @@ user Retry (existing) → requeue → upsert both → _top_up dispatches (alread
 
 - No auto-resume / startup auto-dispatch; interrupted jobs come back as retryable FAILED.
 - No new UI — the existing Home/Library ingest list + Retry control render whatever's in the registry.
-- `time.monotonic()` timestamps deliberately not preserved; only `finished_at_wall` round-trips.
+- `time.monotonic()` timestamps deliberately not preserved; only `finished_at_wall` round-trips. Known cosmetic limit: restored rows lose their original *submit* wall-time (`submitted_at` is re-seeded to a fresh monotonic), so a relative "submitted N ago" reads ~now for restored jobs; terminal jobs still show a real finished time. Not adding a `submitted_at_wall` field (scope creep).
 - Prune cap is a fixed constant (500), not user-configurable (YAGNI); `clear_finished()` remains the manual purge.

--- a/Docs/superpowers/specs/2026-07-12-library-persistent-job-history-design.md
+++ b/Docs/superpowers/specs/2026-07-12-library-persistent-job-history-design.md
@@ -38,7 +38,8 @@ A `BaseDB` subclass mirroring `LibraryCollectionsDB`: `_CURRENT_SCHEMA_VERSION =
 | `keywords` | TEXT | JSON array of strings |
 | `perform_analysis`,`chunk_enabled`,`superseded`,`dismissed`,`permanent` | INTEGER | 0/1 |
 | `chunk_size` | INTEGER | |
-| `state` | TEXT | IngestJobState value |
+| `state` | TEXT NOT NULL | IngestJobState value; `CHECK (state IN ('queued','parsing','writing','done','failed'))` — documents valid states + catches corruption (borrowed from the server jobs schema's status CHECK) |
+| `retry_count` | INTEGER NOT NULL DEFAULT 0 | how many times this job's lineage has been retried (see §2a) |
 | `detected_type`,`error`,`finished_at_wall` | TEXT | |
 | `media_id` | INTEGER | nullable |
 
@@ -57,6 +58,10 @@ Methods: `upsert_job(job: LibraryIngestJob) -> None`, `delete_job(job_id: str) -
 - A `restore(jobs: list[LibraryIngestJob], next_id: int)` method seeds `self._jobs` + `self._next_id` without firing per-job upserts (bulk restore is not a mutation to re-persist, except the interrupted-normalization — see §3).
 
 Persistence is **best-effort**: `_persist`/`_delete` wrap the store call in `try/except` and log at debug on failure — the in-memory registry stays the live source of truth; a store error never breaks a mutation or blocks the UI.
+
+### 2a. Retry-count tracking (borrowed from the server jobs schema)
+
+`LibraryIngestJob` gains `retry_count: int = 0`. A fresh `submit` starts at 0; `requeue` (the retry path) sets the new queued copy's `retry_count = source.retry_count + 1`, so the count carries forward through the supersede chain and survives restart (persisted). No `max_attempts` cap — retries are manual (the user clicks), so there is no auto-retry to gate; the count is informational. It is surfaced minimally in the existing ingest job row (the secondary line appends `· retry {n}` when `retry_count > 0`) — no new widget/screen. This is the desktop-simplified take on the server's `retry_count`/`retry_now_jobs` (`manager.py:6386`): a plain counter, no exponential backoff.
 
 ### 3. Startup restore (`app.py`, `_restore_ingest_jobs()` called from `on_mount`)
 
@@ -95,10 +100,13 @@ user Retry (existing) → requeue → upsert both → _top_up dispatches (alread
 - **Registry-with-store (`Tests/Library/test_library_ingest_jobs.py`):** with a fake in-memory store, each mutation calls `upsert_job` with the right job; `clear_finished` calls `delete_job`; `store=None` fires nothing (existing tests unchanged); a store that raises does not break the mutation.
 - **Round-trip + restore (`Tests/Library/`):** build a mix (queued, parsing, writing, done, failed, superseded, dismissed) in registry A + a real tmp store; run the restore path into registry B; assert QUEUED/PARSING/WRITING → FAILED("Interrupted by app restart"), DONE/FAILED/superseded/dismissed preserved, `jobs()`/`counts()` match the expected post-normalization set, `_next_id` = max(seq)+1, and the prune cap drops the oldest beyond `_MAX_PERSISTED_JOBS`.
 - **Retry-after-restart (AC2, coordinator harness `Tests/Library/test_library_ingest_runner.py`):** a restored interrupted→FAILED job, when retried (`retry_library_ingest_job` → `requeue`), dispatches to the pool (mirrors the existing retry tests).
+- **Retry-count (`Tests/Library/test_library_ingest_jobs.py`):** `submit` → `retry_count == 0`; `requeue` of a job with `retry_count == k` → new copy has `retry_count == k+1`; the count round-trips through the store; the CHECK constraint rejects an out-of-enum `state` on direct insert.
 
 ## Scope / non-goals
 
 - No auto-resume / startup auto-dispatch; interrupted jobs come back as retryable FAILED.
-- No new UI — the existing Home/Library ingest list + Retry control render whatever's in the registry.
+- No new UI screens/widgets — the existing Home/Library ingest list + Retry control render whatever's in the registry; the only copy change is the minimal `· retry {n}` indicator on a job's existing secondary line (§2a).
+- Retry-count is a plain counter only: no `max_attempts` cap / no auto-retry / no backoff (all deferred with the server's richer retry machinery — out of scope).
+- `progress_percent`/`progress_message` (live parse progress) and `source_path` idempotency/dedup — both good server ideas, logged as separate backlog follow-ups, not built here.
 - `time.monotonic()` timestamps deliberately not preserved; only `finished_at_wall` round-trips. Known cosmetic limit: restored rows lose their original *submit* wall-time (`submitted_at` is re-seeded to a fresh monotonic), so a relative "submitted N ago" reads ~now for restored jobs; terminal jobs still show a real finished time. Not adding a `submitted_at_wall` field (scope creep).
 - Prune cap is a fixed constant (500), not user-configurable (YAGNI); `clear_finished()` remains the manual purge.

--- a/Docs/superpowers/specs/2026-07-12-library-persistent-job-history-design.md
+++ b/Docs/superpowers/specs/2026-07-12-library-persistent-job-history-design.md
@@ -1,0 +1,102 @@
+# Persistent ingest job history across restarts (task 161)
+
+**Status:** Design approved (brainstorm), pending spec review.
+**Backlog:** task-161 — "Persistent ingest job history across restarts".
+**Builds on:** F3 parallel-parse ingest (PR #594) + the in-memory `LibraryIngestJobRegistry`.
+
+## Problem
+
+`LibraryIngestJobRegistry` (`tldw_chatbook/Library/library_ingest_jobs.py`) stores jobs in an in-memory `list`; queued/failed/done history is lost on quit, and a job interrupted mid-processing simply vanishes. We want job history to survive a restart and interrupted/failed jobs to be retryable afterward.
+
+## Goal / Acceptance
+
+- **AC1** — ingest job history survives an app restart.
+- **AC2** — failed/queued jobs can be retried after restart.
+
+## Chosen approach
+
+A small SQLite store persists every visible ingest job; the registry **writes through** on each mutation and is **loaded once at startup**. Interrupted in-flight jobs (QUEUED/PARSING/WRITING at quit) normalize to `FAILED("Interrupted by app restart")` on load, so the app is idle on launch and the user retries manually (chosen over auto-resume in brainstorm — no surprise heavy work on launch). Done/failed jobs restore as-is. Mechanism follows the existing `LibraryCollectionsDB` template.
+
+### Why per-mutation write-through is safe (threading)
+
+Every registry mutation runs on the **UI thread**: `submit`/`mark_parsing`/`mark_writing` in UI-thread coordinator methods, and the writer thread marshals `mark_done`/`mark_failed` back via `self.call_from_thread(...)` (`app.py:2113`/`2128`), as do the pool-completion (`_on_ingest_parse_complete`) and broken-pool paths. So the store is accessed from a single thread — per-mutation synchronous SQLite writes need no cross-thread connection handling.
+
+## Components
+
+### 1. `LibraryIngestJobsDB` (`tldw_chatbook/DB/Library_Ingest_Jobs_DB.py`, new)
+
+A `BaseDB` subclass mirroring `LibraryCollectionsDB`: `_CURRENT_SCHEMA_VERSION = 1`, a `transaction()` context manager, `_initialize_schema()` via `executescript` with a `schema_version` table. **WAL mode** enabled for fast, low-contention writes. One table `ingest_jobs`:
+
+| column | type | notes |
+|---|---|---|
+| `seq` | INTEGER PRIMARY KEY | the numeric `n` parsed from `job_id` ("ingest-job-{n}") — the submission-order key; `ORDER BY seq ASC` restores insertion order and `max(seq)+1` restores `_next_id` |
+| `job_id` | TEXT UNIQUE NOT NULL | "ingest-job-{n}" |
+| `source_path` | TEXT NOT NULL | |
+| `title`,`author` | TEXT | |
+| `keywords` | TEXT | JSON array of strings |
+| `perform_analysis`,`chunk_enabled`,`superseded`,`dismissed`,`permanent` | INTEGER | 0/1 |
+| `chunk_size` | INTEGER | |
+| `state` | TEXT | IngestJobState value |
+| `detected_type`,`error`,`finished_at_wall` | TEXT | |
+| `media_id` | INTEGER | nullable |
+
+**Not stored (can't round-trip):** the `time.monotonic()` fields `submitted_at`/`started_at`/`finished_at` — meaningless across restart. `finished_at_wall` (real ISO-8601 UTC) is the one preserved timestamp.
+
+Methods: `upsert_job(job: LibraryIngestJob) -> None`, `delete_job(job_id: str) -> None`, `all_jobs() -> list[dict]` (ordered by `seq`), `transaction()`. `upsert_job` derives `seq` from `job_id`.
+
+### 2. Registry ↔ store hook (`library_ingest_jobs.py`)
+
+`LibraryIngestJobRegistry(store: IngestJobStore | None = None)` where `IngestJobStore` is a small `Protocol` (`upsert_job(job)`, `delete_job(job_id)`). **Default `None` preserves today's pure, DB-free behavior — every existing registry test is unchanged.**
+
+- Each mutation point (`submit`, `mark_parsing`, `mark_writing`, `mark_done`, `mark_failed`, `requeue`, `dismiss`) upserts the *stored* job object (`self._jobs[index]`, not the returned copy) after mutating.
+- `requeue` upserts BOTH the superseded original and the new queued copy.
+- `clear_finished` calls `store.delete_job(job_id)` for each hard-removed job.
+- `attach_store(store)` sets `self._store` after construction (so the app can defer DB I/O to `on_mount`); the constructor param stays for tests.
+- A `restore(jobs: list[LibraryIngestJob], next_id: int)` method seeds `self._jobs` + `self._next_id` without firing per-job upserts (bulk restore is not a mutation to re-persist, except the interrupted-normalization — see §3).
+
+Persistence is **best-effort**: `_persist`/`_delete` wrap the store call in `try/except` and log at debug on failure — the in-memory registry stays the live source of truth; a store error never breaks a mutation or blocks the UI.
+
+### 3. Startup restore (`app.py`, `_restore_ingest_jobs()` called from `on_mount`)
+
+1. `rows = store.all_jobs()` (ordered by `seq`).
+2. Rebuild `LibraryIngestJob`s (keywords JSON→tuple, ints→bools, monotonic fields defaulted: `submitted_at` re-seeded to a fresh `time.monotonic()`, `started_at`/`finished_at` = None).
+3. **Normalize interrupted states:** any job whose stored `state` ∈ {QUEUED, PARSING, WRITING} → `FAILED`, `error="Interrupted by app restart"`, `permanent=False` (retryable), and stamp `finished_at_wall = datetime.now(timezone.utc).isoformat()`.
+4. **Prune cap:** keep at most the most recent `_MAX_PERSISTED_JOBS` (constant, 500) rows by `seq`; older terminal rows are dropped from the load AND deleted from the store.
+5. Seed the registry via `restore(jobs, next_id=max(seq)+1)`, then **re-persist the normalized/pruned set** (upsert the interrupted→FAILED jobs; delete the pruned ones) so the store reflects the post-restart truth.
+6. No auto-dispatch: `_top_up_ingest_parse_pool()` is NOT called at startup — the app is idle until the user retries.
+
+The registry stays store-less in `TldwCli.__init__` (`app.py:3190`, unchanged, no DB I/O at construction); `_restore_ingest_jobs()` runs once in `on_mount`, where it creates the `LibraryIngestJobsDB` (independent of `media_db`), `attach_store`s it to the registry, then loads/normalizes/restores. No submits happen between `__init__` and `on_mount`, so nothing is lost by attaching late.
+
+### 4. Path / config (`config.py`)
+
+`get_library_ingest_jobs_db_path()` mirroring `get_library_collections_db_path()` (`config.py:~3597`): file `tldw_chatbook_library_ingest_jobs.db` under `get_user_data_dir()`, with an optional `[database] library_ingest_jobs_db_path` custom-path key.
+
+## Data flow
+
+```
+mutation (UI thread) → registry updates self._jobs → _persist(job) → store.upsert_job  (best-effort)
+clear_finished       → registry removes rows        → store.delete_job each
+app start (on_mount) → store.all_jobs() → rebuild + normalize-interrupted + prune
+                     → registry.restore(...) → re-persist normalized/pruned
+user Retry (existing) → requeue → upsert both → _top_up dispatches (already wired)
+```
+
+## Error handling
+
+- Store writes/deletes are best-effort (try/except + debug log); the registry never fails a mutation on a store error.
+- A corrupt/unreadable store at load → log a warning and start with an empty registry (never crash `on_mount`).
+- WAL mode + short per-transaction connections (the `LibraryCollectionsDB` pattern) keep writes fast and non-blocking of readers.
+
+## Testing
+
+- **Store unit (`Tests/DB/test_library_ingest_jobs_db.py`):** `upsert_job`/`all_jobs`/`delete_job` round-trip over a tmp sqlite file; `all_jobs()` returns `seq`-ascending; schema init + WAL; keywords JSON round-trip; `upsert` is idempotent (update-in-place on the same `job_id`).
+- **Registry-with-store (`Tests/Library/test_library_ingest_jobs.py`):** with a fake in-memory store, each mutation calls `upsert_job` with the right job; `clear_finished` calls `delete_job`; `store=None` fires nothing (existing tests unchanged); a store that raises does not break the mutation.
+- **Round-trip + restore (`Tests/Library/`):** build a mix (queued, parsing, writing, done, failed, superseded, dismissed) in registry A + a real tmp store; run the restore path into registry B; assert QUEUED/PARSING/WRITING → FAILED("Interrupted by app restart"), DONE/FAILED/superseded/dismissed preserved, `jobs()`/`counts()` match the expected post-normalization set, `_next_id` = max(seq)+1, and the prune cap drops the oldest beyond `_MAX_PERSISTED_JOBS`.
+- **Retry-after-restart (AC2, coordinator harness `Tests/Library/test_library_ingest_runner.py`):** a restored interrupted→FAILED job, when retried (`retry_library_ingest_job` → `requeue`), dispatches to the pool (mirrors the existing retry tests).
+
+## Scope / non-goals
+
+- No auto-resume / startup auto-dispatch; interrupted jobs come back as retryable FAILED.
+- No new UI — the existing Home/Library ingest list + Retry control render whatever's in the registry.
+- `time.monotonic()` timestamps deliberately not preserved; only `finished_at_wall` round-trips.
+- Prune cap is a fixed constant (500), not user-configurable (YAGNI); `clear_finished()` remains the manual purge.

--- a/Tests/DB/test_library_ingest_jobs_db.py
+++ b/Tests/DB/test_library_ingest_jobs_db.py
@@ -1,0 +1,56 @@
+import sqlite3
+import pytest
+
+from tldw_chatbook.DB.Library_Ingest_Jobs_DB import LibraryIngestJobsDB
+from tldw_chatbook.Library.library_ingest_jobs import LibraryIngestJobRegistry, IngestJobState
+
+
+def _db(tmp_path):
+    return LibraryIngestJobsDB(tmp_path / "jobs.db")
+
+
+def test_upsert_and_all_jobs_roundtrip_ordered(tmp_path):
+    reg = LibraryIngestJobRegistry()
+    j1 = reg.submit(source_path="/a.mp3", title="A", keywords=("k1", "k2"), detected_type="audio")
+    j2 = reg.submit(source_path="/b.txt", title="B")
+    db = _db(tmp_path)
+    db.upsert_job(j1)
+    db.upsert_job(j2)
+    rows = db.all_jobs()
+    assert [r["job_id"] for r in rows] == [j1.job_id, j2.job_id]     # seq order
+    assert rows[0]["source_path"] == "/a.mp3" and rows[0]["detected_type"] == "audio"
+    assert rows[0]["keywords"] == '["k1", "k2"]'
+    assert rows[0]["state"] == "queued" and rows[0]["retry_count"] == 0
+    db.close()
+
+
+def test_upsert_is_idempotent_update_in_place(tmp_path):
+    reg = LibraryIngestJobRegistry()
+    j = reg.submit(source_path="/a.mp3")
+    db = _db(tmp_path)
+    db.upsert_job(j)
+    reg.mark_parsing(j.job_id, detected_type="audio")
+    db.upsert_job(reg.jobs()[0])          # same job_id, now PARSING
+    rows = db.all_jobs()
+    assert len(rows) == 1 and rows[0]["state"] == "parsing"
+    db.close()
+
+
+def test_delete_job(tmp_path):
+    reg = LibraryIngestJobRegistry()
+    j = reg.submit(source_path="/a.mp3")
+    db = _db(tmp_path)
+    db.upsert_job(j)
+    db.delete_job(j.job_id)
+    assert db.all_jobs() == []
+    db.close()
+
+
+def test_state_check_constraint_rejects_bad_state(tmp_path):
+    db = _db(tmp_path)
+    conn = db._get_connection()
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO ingest_jobs (seq, job_id, source_path, state) VALUES (1,'x','/p','bogus')"
+        )
+    db.close()

--- a/Tests/Home/test_active_work_adapter.py
+++ b/Tests/Home/test_active_work_adapter.py
@@ -1387,6 +1387,35 @@ def test_local_notification_adapter_status_detail_is_not_markup_escaped():
     assert item.status_detail == "failed near [bold]tag[/bold] marker"
 
 
+def test_local_notification_adapter_status_detail_appends_retry_suffix():
+    """(Task 3, backlog 161) A FAILED job that has been retried at least once
+    (``retry_count > 0``, set by ``LibraryIngestJobRegistry.requeue``) carries
+    a `` · retry {n}`` suffix on Home's status_detail line, so a job restored
+    after an app restart and requeued from Home shows it has already been
+    retried."""
+    jobs = (
+        LibraryIngestJob(
+            job_id="ingest-job-7",
+            source_path="/tmp/retry.pdf",
+            state=IngestJobState.FAILED,
+            error="bad codec",
+            retry_count=2,
+        ),
+    )
+    adapter = LocalNotificationHomeActiveWorkAdapter(ingest_jobs_provider=lambda: jobs)
+
+    dashboard_input = adapter.build_dashboard_input(
+        providers_models={"OpenAI": ["gpt-4.1"]},
+        has_recent_work=False,
+    )
+
+    item = next(
+        i for i in dashboard_input.active_work_items
+        if i.item_id == "local:ingest:ingest-job-7"
+    )
+    assert item.status_detail == "bad codec · retry 2"
+
+
 def test_local_notification_adapter_sorts_done_ingest_jobs_into_recent_by_finished_at_wall():
     jobs = (
         LibraryIngestJob(

--- a/Tests/Library/test_library_ingest_jobs.py
+++ b/Tests/Library/test_library_ingest_jobs.py
@@ -757,3 +757,90 @@ def test_parsing_count_for_types_counts_only_inflight_heavy():
     registry.mark_parsing(d1.job_id, detected_type="plaintext")
     assert registry.parsing_count_for_types(heavy) == 1        # only a1 is heavy+parsing
     assert a2.job_id                                            # a2 still QUEUED, not counted
+
+
+class _FakeStore:
+    def __init__(self):
+        self.upserts = []
+        self.deletes = []
+    def upsert_job(self, job):
+        self.upserts.append(job.job_id)
+    def delete_job(self, job_id):
+        self.deletes.append(job_id)
+
+
+def test_submit_starts_retry_count_zero_and_requeue_increments():
+    from tldw_chatbook.Library.library_ingest_jobs import IngestJobState
+    reg = LibraryIngestJobRegistry()
+    j = reg.submit(source_path="/a.mp3")
+    assert j.retry_count == 0
+    reg.mark_parsing(j.job_id); reg.mark_failed(j.job_id, error="boom")
+    r = reg.requeue(j.job_id)
+    assert r.retry_count == 1
+    reg.mark_parsing(r.job_id); reg.mark_failed(r.job_id, error="boom2")
+    r2 = reg.requeue(r.job_id)
+    assert r2.retry_count == 2
+
+
+def test_store_hook_writes_through_on_mutations():
+    store = _FakeStore()
+    reg = LibraryIngestJobRegistry()
+    reg.attach_store(store)
+    j = reg.submit(source_path="/a.mp3")
+    reg.mark_parsing(j.job_id)
+    assert store.upserts.count(j.job_id) >= 2       # submit + mark_parsing
+    reg.mark_done(j.job_id, media_id=1)
+    reg.clear_finished()
+    assert j.job_id in store.deletes
+
+
+def test_store_hook_none_is_pure_and_errors_swallowed():
+    reg = LibraryIngestJobRegistry()          # no store
+    reg.submit(source_path="/a.mp3")          # must not raise
+    class _Boom:
+        def upsert_job(self, job): raise RuntimeError("disk full")
+        def delete_job(self, job_id): raise RuntimeError("disk full")
+    reg2 = LibraryIngestJobRegistry()
+    reg2.attach_store(_Boom())
+    j = reg2.submit(source_path="/b.mp3")     # store raises, mutation still succeeds
+    assert j.state.value == "queued"
+
+
+def test_plan_restore_normalizes_interrupted_and_prunes():
+    from tldw_chatbook.Library.library_ingest_jobs import plan_restore, IngestJobState
+    rows = [
+        {"seq": 1, "job_id": "ingest-job-1", "source_path": "/a", "title": "", "author": "",
+         "keywords": "[]", "perform_analysis": 0, "chunk_enabled": 0, "chunk_size": 0,
+         "state": "done", "retry_count": 0, "detected_type": "", "error": "",
+         "finished_at_wall": "2026-07-12T00:00:00+00:00", "media_id": 7,
+         "superseded": 0, "dismissed": 0, "permanent": 0},
+        {"seq": 2, "job_id": "ingest-job-2", "source_path": "/b", "title": "", "author": "",
+         "keywords": "[]", "perform_analysis": 0, "chunk_enabled": 0, "chunk_size": 0,
+         "state": "parsing", "retry_count": 1, "detected_type": "audio", "error": "",
+         "finished_at_wall": "", "media_id": None, "superseded": 0, "dismissed": 0, "permanent": 0},
+    ]
+    plan = plan_restore(rows, max_persisted=500, now_iso="2026-07-12T09:00:00+00:00")
+    by_id = {j.job_id: j for j in plan.jobs}
+    assert by_id["ingest-job-1"].state == IngestJobState.DONE and by_id["ingest-job-1"].media_id == 7
+    assert by_id["ingest-job-2"].state == IngestJobState.FAILED
+    assert by_id["ingest-job-2"].error == "Interrupted by app restart"
+    assert by_id["ingest-job-2"].finished_at_wall == "2026-07-12T09:00:00+00:00"
+    assert by_id["ingest-job-2"].retry_count == 1          # count preserved, not reset
+    assert plan.next_id == 3
+    assert "ingest-job-2" in [j.job_id for j in plan.upsert]   # normalized -> re-persist
+    assert plan.delete_ids == []
+
+
+def test_plan_restore_prune_cap_drops_oldest():
+    from tldw_chatbook.Library.library_ingest_jobs import plan_restore
+    rows = [
+        {"seq": i, "job_id": f"ingest-job-{i}", "source_path": "/p", "title": "", "author": "",
+         "keywords": "[]", "perform_analysis": 0, "chunk_enabled": 0, "chunk_size": 0,
+         "state": "done", "retry_count": 0, "detected_type": "", "error": "",
+         "finished_at_wall": "", "media_id": None, "superseded": 0, "dismissed": 0, "permanent": 0}
+        for i in range(1, 6)
+    ]
+    plan = plan_restore(rows, max_persisted=3, now_iso="2026-07-12T09:00:00+00:00")
+    assert [j.job_id for j in plan.jobs] == ["ingest-job-3", "ingest-job-4", "ingest-job-5"]
+    assert plan.delete_ids == ["ingest-job-1", "ingest-job-2"]
+    assert plan.next_id == 6

--- a/Tests/Library/test_library_ingest_jobs.py
+++ b/Tests/Library/test_library_ingest_jobs.py
@@ -844,3 +844,43 @@ def test_plan_restore_prune_cap_drops_oldest():
     assert [j.job_id for j in plan.jobs] == ["ingest-job-3", "ingest-job-4", "ingest-job-5"]
     assert plan.delete_ids == ["ingest-job-1", "ingest-job-2"]
     assert plan.next_id == 6
+
+
+def _done_rows(n):
+    return [
+        {"seq": i, "job_id": f"ingest-job-{i}", "source_path": "/p", "title": "", "author": "",
+         "keywords": "[]", "perform_analysis": 0, "chunk_enabled": 0, "chunk_size": 0,
+         "state": "done", "retry_count": 0, "detected_type": "", "error": "",
+         "finished_at_wall": "", "media_id": None, "superseded": 0, "dismissed": 0, "permanent": 0}
+        for i in range(1, n + 1)
+    ]
+
+
+def test_plan_restore_zero_cap_keeps_all_history():
+    # A non-positive cap must NEVER wipe all history (a `0` misconfig is the
+    # safe-keep case, not a delete-everything case).
+    from tldw_chatbook.Library.library_ingest_jobs import plan_restore
+    plan = plan_restore(_done_rows(2), max_persisted=0, now_iso="2026-07-12T09:00:00+00:00")
+    assert [j.job_id for j in plan.jobs] == ["ingest-job-1", "ingest-job-2"]
+    assert plan.delete_ids == []
+    assert plan.next_id == 3
+
+
+def test_plan_restore_negative_cap_keeps_all_history():
+    # The genuine footgun: with the unguarded `len(jobs) > max_persisted`
+    # block, a negative cap slices with a positive `-max_persisted` and
+    # deletes the oldest rows. The `>= 1` guard must keep everything instead.
+    from tldw_chatbook.Library.library_ingest_jobs import plan_restore
+    plan = plan_restore(_done_rows(2), max_persisted=-1, now_iso="2026-07-12T09:00:00+00:00")
+    assert [j.job_id for j in plan.jobs] == ["ingest-job-1", "ingest-job-2"]
+    assert plan.delete_ids == []
+    assert plan.next_id == 3
+
+
+def test_plan_restore_cap_one_prunes_to_newest():
+    # The `>= 1` branch still prunes normally for a positive cap.
+    from tldw_chatbook.Library.library_ingest_jobs import plan_restore
+    plan = plan_restore(_done_rows(2), max_persisted=1, now_iso="2026-07-12T09:00:00+00:00")
+    assert [j.job_id for j in plan.jobs] == ["ingest-job-2"]
+    assert plan.delete_ids == ["ingest-job-1"]
+    assert plan.next_id == 3

--- a/Tests/Library/test_library_ingest_jobs_restore.py
+++ b/Tests/Library/test_library_ingest_jobs_restore.py
@@ -1,0 +1,49 @@
+from tldw_chatbook.DB.Library_Ingest_Jobs_DB import LibraryIngestJobsDB
+from tldw_chatbook.Library.library_ingest_jobs import (
+    LibraryIngestJobRegistry, IngestJobState, plan_restore,
+)
+
+
+def _restore(store, max_persisted=500, now_iso="2026-07-12T09:00:00+00:00"):
+    reg = LibraryIngestJobRegistry()
+    reg.attach_store(store)
+    plan = plan_restore(store.all_jobs(), max_persisted=max_persisted, now_iso=now_iso)
+    reg.restore(plan.jobs, plan.next_id)
+    for j in plan.upsert:
+        store.upsert_job(j)
+    for jid in plan.delete_ids:
+        store.delete_job(jid)
+    return reg
+
+
+def test_history_survives_restart_interrupted_normalized(tmp_path):
+    store = LibraryIngestJobsDB(tmp_path / "jobs.db")
+    a = LibraryIngestJobRegistry(); a.attach_store(store)
+    done = a.submit(source_path="/done.pdf"); a.mark_parsing(done.job_id); a.mark_writing(done.job_id); a.mark_done(done.job_id, media_id=5)
+    interrupted = a.submit(source_path="/x.mp4"); a.mark_parsing(interrupted.job_id)   # left PARSING (quit)
+    failed = a.submit(source_path="/y.mp3"); a.mark_parsing(failed.job_id); a.mark_failed(failed.job_id, error="bad codec")
+    store.close()
+
+    store2 = LibraryIngestJobsDB(tmp_path / "jobs.db")            # reopen (restart)
+    reg = _restore(store2)
+    by_id = {j.job_id: j for j in reg.jobs()}
+    assert by_id[done.job_id].state == IngestJobState.DONE and by_id[done.job_id].media_id == 5
+    assert by_id[interrupted.job_id].state == IngestJobState.FAILED
+    assert by_id[interrupted.job_id].error == "Interrupted by app restart"
+    assert by_id[failed.job_id].state == IngestJobState.FAILED and by_id[failed.job_id].error == "bad codec"
+    # _next_id advanced past the max so a new submit doesn't collide
+    fresh = reg.submit(source_path="/z.txt")
+    assert fresh.job_id == "ingest-job-4"
+    store2.close()
+
+
+def test_interrupted_retry_after_restart_requeues(tmp_path):
+    store = LibraryIngestJobsDB(tmp_path / "jobs.db")
+    a = LibraryIngestJobRegistry(); a.attach_store(store)
+    j = a.submit(source_path="/x.mp4"); a.mark_parsing(j.job_id)     # interrupted
+    store.close()
+    reg = _restore(LibraryIngestJobsDB(tmp_path / "jobs.db"))
+    restored = reg.jobs()[0]
+    assert restored.state == IngestJobState.FAILED
+    requeued = reg.requeue(restored.job_id)                          # AC2: retryable
+    assert requeued.state == IngestJobState.QUEUED and requeued.retry_count == 1

--- a/Tests/Library/test_library_ingest_state.py
+++ b/Tests/Library/test_library_ingest_state.py
@@ -347,6 +347,24 @@ def test_failed_row_line_without_marker_passes_through_whole():
     assert row.line == "✗ failed · report.txt · Media database is unavailable."
 
 
+def test_failed_row_line_appends_retry_suffix():
+    """(Task 3, backlog 161) Mirrors Home's status_detail retry suffix --
+    single source of truth per short_ingest_error's docstring."""
+    jobs = (
+        _job(
+            state=IngestJobState.FAILED,
+            source_path="/tmp/report.txt",
+            started_at=100.0,
+            finished_at=101.0,
+            error="bad codec",
+            retry_count=2,
+        ),
+    )
+    state = build_library_ingest_state(jobs, form=LibraryIngestFormState())
+    row = state.queue_rows[0]
+    assert row.line == "✗ failed · report.txt · bad codec · retry 2"
+
+
 def test_supported_types_line_present_and_derived_from_live_registry():
     state = build_library_ingest_state((), form=LibraryIngestFormState())
     assert state.supported_types_line.startswith("Supported: ")

--- a/backlog/tasks/task-161 - Persistent-ingest-job-history-across-restarts.md
+++ b/backlog/tasks/task-161 - Persistent-ingest-job-history-across-restarts.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-161
 title: Persistent ingest job history across restarts
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-11 22:02'
 labels:
@@ -18,6 +18,18 @@ The Library ingest job registry is in-memory only; queued/failed jobs are lost o
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Ingest job history survives an app restart
-- [ ] #2 Failed/queued jobs can be retried after restart
+- [x] #1 Ingest job history survives an app restart
+- [x] #2 Failed/queued jobs can be retried after restart
 <!-- AC:END -->
+
+## Implementation Notes
+
+Delivered across three commits (SQLite store, registry restore/plan_restore + retry_count carry, app wiring):
+
+- `DB/Library_Ingest_Jobs_DB.py`: a small `BaseDB` subclass persisting each `LibraryIngestJob` row (including `retry_count`), single reused WAL connection.
+- `Library/library_ingest_jobs.py`: `LibraryIngestJobRegistry.attach_store` write-through hook (upsert/delete on every mutation), `restore()` to seed an in-memory registry from rows, and the pure `plan_restore()` helper that normalizes non-terminal (`PARSING`/`WRITING`) jobs left over from a hard quit into `FAILED` (`"Interrupted by app restart"`, AC1+AC2: retryable via `requeue`) and prunes the oldest jobs past `max_persisted`.
+- `config.py`: `get_library_ingest_jobs_db_path()` (same custom-path/default pattern as the other `get_*_db_path` helpers) → `~/.local/share/tldw_cli/.../tldw_chatbook_library_ingest_jobs.db`.
+- `app.py`: `LibraryIngestQueueMixin._restore_ingest_jobs()` opens the store, attaches it to the already-constructed `self.library_ingest_jobs`, runs `plan_restore`/`restore`, and writes back the plan's normalize/prune diffs — wrapped in try/except so a corrupt store logs a warning and starts empty rather than crashing `on_mount`. Called once, early in `on_mount`; the store is closed in `on_unmount` after the ingest parse pool shuts down. `_MAX_PERSISTED_INGEST_JOBS = 500`.
+- `Home/active_work_adapter.py` + `Library/library_ingest_state.py`: a `· retry {n}` suffix (helper duplicated in each module — Library must stay Home-import-free) appended to a FAILED job's status line once `retry_count > 0`, so a job restored after a restart and retried again still shows its retry count on both the Home card and the Library ingest queue row.
+
+Tests: `Tests/Library/test_library_ingest_jobs_restore.py` (new — end-to-end store↔registry round-trip covering interrupted-job normalization and post-restart retry), plus retry-indicator regression tests added to `Tests/Home/test_active_work_adapter.py` and `Tests/Library/test_library_ingest_state.py`. Full `Tests/DB/ Tests/Library/ Tests/Home/` suite (608 tests) passes; `import tldw_chatbook.app` smoke-tested clean.

--- a/backlog/tasks/task-207 - Live-parse-progress-for-ingest-jobs-progress_percent-progress_message.md
+++ b/backlog/tasks/task-207 - Live-parse-progress-for-ingest-jobs-progress_percent-progress_message.md
@@ -1,0 +1,17 @@
+---
+id: TASK-207
+title: Live parse progress for ingest jobs (progress_percent/progress_message)
+status: To Do
+assignee: []
+created_date: '2026-07-12 17:34'
+labels:
+  - follow-up
+  - ingest
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Ingest jobs show only a coarse state (parsing/writing). Borrow the server jobs schema's progress_percent/progress_message idea: let the parse worker report incremental progress (e.g. per-file %, or a stage message like 'transcribing 3/5') surfaced on the job row, without adding new job states. Discovered while mining tldw_server2 core Jobs module during task 161. Requires a progress field on LibraryIngestJob + a worker→UI progress channel (call_from_thread) + persistence if desired.
+<!-- SECTION:DESCRIPTION:END -->

--- a/backlog/tasks/task-208 - Optional-source_path-dedup-for-ingest-submissions-idempotency.md
+++ b/backlog/tasks/task-208 - Optional-source_path-dedup-for-ingest-submissions-idempotency.md
@@ -1,0 +1,17 @@
+---
+id: TASK-208
+title: Optional source_path dedup for ingest submissions (idempotency)
+status: To Do
+assignee: []
+created_date: '2026-07-12 17:34'
+labels:
+  - follow-up
+  - ingest
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The ingest registry allows submitting the same source_path multiple times (N duplicate jobs). Borrow the server jobs schema's idempotency_key/partial-unique-index idea as an OPTIONAL guard: warn/skip when a source_path is already queued or in-flight (NOT a hard unique constraint — re-ingesting a changed file is legitimate). Design decision needed: dedup scope (in-flight only vs all-history), and opt-in vs default. Discovered while mining tldw_server2 core Jobs module during task 161.
+<!-- SECTION:DESCRIPTION:END -->

--- a/tldw_chatbook/DB/Library_Ingest_Jobs_DB.py
+++ b/tldw_chatbook/DB/Library_Ingest_Jobs_DB.py
@@ -1,0 +1,114 @@
+"""SQLite persistence for the Library ingest job registry.
+
+Single-user, UI-thread-only: keeps ONE persistent WAL connection reused across
+all reads/writes (safe because every registry mutation runs on the UI thread),
+rather than opening/closing per operation.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Union
+
+from loguru import logger
+
+from .base_db import BaseDB
+
+
+class LibraryIngestJobsDB(BaseDB):
+    _CURRENT_SCHEMA_VERSION = 1
+
+    def __init__(self, db_path: Union[str, Path], client_id: str = "default") -> None:
+        self._conn: sqlite3.Connection | None = None
+        super().__init__(db_path, client_id)  # calls _initialize_schema()
+
+    def _get_connection(self) -> sqlite3.Connection:
+        if self._conn is None:
+            self._conn = sqlite3.connect(self.db_path_str, check_same_thread=False)
+            self._conn.row_factory = sqlite3.Row
+            self._conn.execute("PRAGMA journal_mode=WAL")
+        return self._conn
+
+    def close(self) -> None:
+        if self._conn is not None:
+            try:
+                self._conn.close()
+            except Exception:
+                logger.opt(exception=True).debug("LibraryIngestJobsDB: close failed")
+            finally:
+                self._conn = None
+
+    def _initialize_schema(self) -> None:
+        conn = self._get_connection()
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS schema_version (version INTEGER PRIMARY KEY NOT NULL);
+            INSERT OR IGNORE INTO schema_version (version) VALUES (1);
+
+            CREATE TABLE IF NOT EXISTS ingest_jobs (
+                seq INTEGER PRIMARY KEY,
+                job_id TEXT UNIQUE NOT NULL,
+                source_path TEXT NOT NULL,
+                title TEXT NOT NULL DEFAULT '',
+                author TEXT NOT NULL DEFAULT '',
+                keywords TEXT NOT NULL DEFAULT '[]',
+                perform_analysis INTEGER NOT NULL DEFAULT 0,
+                chunk_enabled INTEGER NOT NULL DEFAULT 0,
+                chunk_size INTEGER NOT NULL DEFAULT 0,
+                state TEXT NOT NULL CHECK (state IN ('queued','parsing','writing','done','failed')),
+                retry_count INTEGER NOT NULL DEFAULT 0,
+                detected_type TEXT NOT NULL DEFAULT '',
+                error TEXT NOT NULL DEFAULT '',
+                finished_at_wall TEXT NOT NULL DEFAULT '',
+                media_id INTEGER,
+                superseded INTEGER NOT NULL DEFAULT 0,
+                dismissed INTEGER NOT NULL DEFAULT 0,
+                permanent INTEGER NOT NULL DEFAULT 0
+            );
+            """
+        )
+        conn.commit()
+
+    @staticmethod
+    def _seq_of(job_id: str) -> int:
+        # "ingest-job-{n}" -> n
+        return int(job_id.rsplit("-", 1)[-1])
+
+    def upsert_job(self, job) -> None:
+        conn = self._get_connection()
+        conn.execute(
+            """
+            INSERT INTO ingest_jobs
+              (seq, job_id, source_path, title, author, keywords, perform_analysis,
+               chunk_enabled, chunk_size, state, retry_count, detected_type, error,
+               finished_at_wall, media_id, superseded, dismissed, permanent)
+            VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+            ON CONFLICT(job_id) DO UPDATE SET
+              source_path=excluded.source_path, title=excluded.title, author=excluded.author,
+              keywords=excluded.keywords, perform_analysis=excluded.perform_analysis,
+              chunk_enabled=excluded.chunk_enabled, chunk_size=excluded.chunk_size,
+              state=excluded.state, retry_count=excluded.retry_count,
+              detected_type=excluded.detected_type, error=excluded.error,
+              finished_at_wall=excluded.finished_at_wall, media_id=excluded.media_id,
+              superseded=excluded.superseded, dismissed=excluded.dismissed, permanent=excluded.permanent
+            """,
+            (
+                self._seq_of(job.job_id), job.job_id, job.source_path, job.title, job.author,
+                json.dumps(list(job.keywords)), int(job.perform_analysis), int(job.chunk_enabled),
+                job.chunk_size, job.state.value, job.retry_count, job.detected_type, job.error,
+                job.finished_at_wall, job.media_id, int(job.superseded), int(job.dismissed),
+                int(job.permanent),
+            ),
+        )
+        conn.commit()
+
+    def delete_job(self, job_id: str) -> None:
+        conn = self._get_connection()
+        conn.execute("DELETE FROM ingest_jobs WHERE job_id = ?", (job_id,))
+        conn.commit()
+
+    def all_jobs(self) -> list[dict]:
+        conn = self._get_connection()
+        rows = conn.execute("SELECT * FROM ingest_jobs ORDER BY seq ASC").fetchall()
+        return [dict(r) for r in rows]

--- a/tldw_chatbook/DB/Library_Ingest_Jobs_DB.py
+++ b/tldw_chatbook/DB/Library_Ingest_Jobs_DB.py
@@ -28,6 +28,10 @@ class LibraryIngestJobsDB(BaseDB):
             self._conn = sqlite3.connect(self.db_path_str, check_same_thread=False)
             self._conn.row_factory = sqlite3.Row
             self._conn.execute("PRAGMA journal_mode=WAL")
+            # NORMAL is safe under WAL and avoids an fsync per commit -- writes
+            # are per-mutation on the UI thread (a bulk drop = many small
+            # commits), so FULL's per-commit fsync would add avoidable latency.
+            self._conn.execute("PRAGMA synchronous=NORMAL")
         return self._conn
 
     def close(self) -> None:

--- a/tldw_chatbook/Home/active_work_adapter.py
+++ b/tldw_chatbook/Home/active_work_adapter.py
@@ -619,9 +619,9 @@ class LocalNotificationHomeActiveWorkAdapter(UnavailableHomeActiveWorkAdapter):
                     # any brackets in the error. Titles stay escaped -- they
                     # DO reach a markup-parsing Button label in the rail.
                     status_detail=(
-                        short_ingest_error(job.error)
-                        if job.state == IngestJobState.FAILED and job.error
-                        else ""
+                        (short_ingest_error(job.error)
+                         if job.state == IngestJobState.FAILED and job.error else "")
+                        + _ingest_retry_suffix(job)
                     ),
                     # M4 (fix batch F1b): a permanent (validation-class)
                     # failure fails the same way on every retry -- Home
@@ -785,6 +785,18 @@ def _ingest_job_title(job: LibraryIngestJob) -> str:
     Chatbook artifact titles.
     """
     return escape(Path(str(job.source_path)).name or str(job.source_path))
+
+
+def _ingest_retry_suffix(job) -> str:
+    """Return a `` · retry {n}`` suffix once a job has been requeued.
+
+    ``job.retry_count`` (0 until ``LibraryIngestJobRegistry.requeue`` bumps
+    it -- see ``library_ingest_jobs.py``) survives an app restart via the
+    persisted store (backlog 161), so a job restored after a restart and
+    retried again from Home still shows how many attempts it has had.
+    Markup-safe plain text, consistent with ``status_detail``'s
+    ``markup=False`` rendering (no escaping needed/wanted here either)."""
+    return f" · retry {job.retry_count}" if job.retry_count else ""
 
 
 def _item_updated_at(record: Any) -> str:

--- a/tldw_chatbook/Library/library_ingest_jobs.py
+++ b/tldw_chatbook/Library/library_ingest_jobs.py
@@ -159,6 +159,12 @@ class LibraryIngestJob:
             (returns ``None``) as defense in depth, matching the queue
             row's own ``can_retry = failed and not permanent`` gating in
             ``library_ingest_state.py``.
+        retry_count: Number of times this job has been retried via
+            ``requeue``. Persisted by :class:`~tldw_chatbook.DB.
+            Library_Ingest_Jobs_DB.LibraryIngestJobsDB` for job-history
+            display; not yet incremented anywhere in this module (that is
+            wired up alongside the requeue-carry logic). ``0`` for every
+            job unless explicitly set.
     """
 
     job_id: str
@@ -180,6 +186,7 @@ class LibraryIngestJob:
     superseded: bool = False
     dismissed: bool = False
     permanent: bool = False
+    retry_count: int = 0
 
 
 class LibraryIngestJobRegistry:

--- a/tldw_chatbook/Library/library_ingest_jobs.py
+++ b/tldw_chatbook/Library/library_ingest_jobs.py
@@ -61,11 +61,12 @@ a "replaced-on-transition" job is always safe to hand out to callers, too.
 
 from __future__ import annotations
 
+import json
 import time
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Callable
+from typing import Callable, Protocol
 
 from loguru import logger
 
@@ -160,10 +161,10 @@ class LibraryIngestJob:
             row's own ``can_retry = failed and not permanent`` gating in
             ``library_ingest_state.py``.
         retry_count: Number of times this job has been retried via
-            ``requeue``. Persisted by :class:`~tldw_chatbook.DB.
-            Library_Ingest_Jobs_DB.LibraryIngestJobsDB` for job-history
-            display; not yet incremented anywhere in this module (that is
-            wired up alongside the requeue-carry logic). ``0`` for every
+            ``requeue`` (incremented on the new copy: ``source.retry_count
+            + 1``, never on the superseded original). Persisted by
+            :class:`~tldw_chatbook.DB.Library_Ingest_Jobs_DB.
+            LibraryIngestJobsDB` for job-history display. ``0`` for every
             job unless explicitly set.
     """
 
@@ -189,6 +190,20 @@ class LibraryIngestJob:
     retry_count: int = 0
 
 
+class IngestJobStore(Protocol):
+    """Write-through persistence sink for :class:`LibraryIngestJobRegistry`.
+
+    Optional -- a registry with no store attached (the default) is 100%
+    pure/in-memory, matching every pre-existing behavior byte-for-byte.
+    When attached (``attach_store``), every mutation best-effort persists
+    the affected job(s); a store exception is caught and logged, never
+    allowed to break the mutation itself (see ``_persist``/``_persist_delete``).
+    """
+
+    def upsert_job(self, job: "LibraryIngestJob") -> None: ...
+    def delete_job(self, job_id: str) -> None: ...
+
+
 class LibraryIngestJobRegistry:
     """In-memory, UI-thread-only registry for Library ingest jobs.
 
@@ -206,6 +221,10 @@ class LibraryIngestJobRegistry:
         # worker). No locking -- see the module docstring's threading
         # contract; this attribute is UI-thread-only like everything else.
         self.runner_active: bool = False
+        # Optional write-through persistence sink (Task 2, 161). ``None`` by
+        # default so a registry with no ``attach_store`` call stays 100%
+        # pure/in-memory -- every pre-existing test's behavior is unchanged.
+        self._store: IngestJobStore | None = None
 
     # -- id allocation -----------------------------------------------------
 
@@ -213,6 +232,67 @@ class LibraryIngestJobRegistry:
         job_id = f"ingest-job-{self._next_id}"
         self._next_id += 1
         return job_id
+
+    # -- persistence (Task 2, 161) -----------------------------------------
+
+    def attach_store(self, store: IngestJobStore) -> None:
+        """Attach a write-through persistence sink.
+
+        Args:
+            store: An object implementing ``IngestJobStore``
+                (``upsert_job``/``delete_job``). Once attached, every
+                mutation best-effort persists the affected job(s) -- see
+                ``_persist``/``_persist_delete``. Not attaching one (the
+                default) keeps the registry 100% pure/in-memory.
+        """
+        self._store = store
+
+    def _persist(self, job: LibraryIngestJob) -> None:
+        """Best-effort write ``job`` through to the attached store, if any.
+
+        A store exception is caught and debug-logged, never allowed to
+        propagate -- a persistence failure must never break the in-memory
+        mutation that already succeeded.
+        """
+        if self._store is None:
+            return
+        try:
+            self._store.upsert_job(job)
+        except Exception:
+            logger.opt(exception=True).debug(f"ingest job persist failed: {job.job_id}")
+
+    def _persist_delete(self, job_id: str) -> None:
+        """Best-effort delete ``job_id`` from the attached store, if any.
+
+        Same swallow-and-log contract as ``_persist``.
+        """
+        if self._store is None:
+            return
+        try:
+            self._store.delete_job(job_id)
+        except Exception:
+            logger.opt(exception=True).debug(f"ingest job delete-persist failed: {job_id}")
+
+    def restore(self, jobs: list[LibraryIngestJob], next_id: int) -> None:
+        """Seed the registry from a prior session's persisted jobs.
+
+        Args:
+            jobs: The jobs to seed ``self._jobs`` with, in the same
+                seq-ascending (insertion) order the registry itself
+                maintains internally.
+            next_id: The next ``job_id`` sequence number to allocate.
+
+        This is a bulk operation (app-startup only) -- unlike every other
+        mutation in this class, it does NOT fire a per-job ``_persist``
+        call (the jobs are, by definition, already in the store; re-
+        persisting all of them here would be redundant work on every
+        launch). Callers that need to write through normalized/pruned
+        jobs (see ``plan_restore``) do so explicitly via the store before
+        calling this method.
+        """
+        self._jobs = list(jobs)
+        self._next_id = next_id
+        self._notify_listeners()
 
     # -- listeners -----------------------------------------------------
 
@@ -314,6 +394,7 @@ class LibraryIngestJobRegistry:
         )
         self._jobs.append(job)
         self._notify_listeners()
+        self._persist(job)
         return replace(job)
 
     def next_queued(self, *, skip_types: frozenset[str] = frozenset()) -> LibraryIngestJob | None:
@@ -381,6 +462,7 @@ class LibraryIngestJobRegistry:
         )
         self._jobs[index] = updated
         self._notify_listeners()
+        self._persist(updated)
         return replace(updated)
 
     def mark_writing(self, job_id: str) -> LibraryIngestJob | None:
@@ -412,6 +494,7 @@ class LibraryIngestJobRegistry:
         updated = replace(current, state=IngestJobState.WRITING)
         self._jobs[index] = updated
         self._notify_listeners()
+        self._persist(updated)
         return replace(updated)
 
     def mark_done(self, job_id: str, *, media_id: int) -> LibraryIngestJob | None:
@@ -449,6 +532,7 @@ class LibraryIngestJobRegistry:
         )
         self._jobs[index] = updated
         self._notify_listeners()
+        self._persist(updated)
         return replace(updated)
 
     def mark_failed(
@@ -495,6 +579,7 @@ class LibraryIngestJobRegistry:
         )
         self._jobs[index] = updated
         self._notify_listeners()
+        self._persist(updated)
         return replace(updated)
 
     def requeue(self, job_id: str) -> LibraryIngestJob | None:
@@ -556,10 +641,14 @@ class LibraryIngestJobRegistry:
             detected_type=source.detected_type,
             state=IngestJobState.QUEUED,
             submitted_at=time.monotonic(),
+            retry_count=source.retry_count + 1,
         )
-        self._jobs[index] = replace(source, superseded=True)
+        superseded_source = replace(source, superseded=True)
+        self._jobs[index] = superseded_source
         self._jobs.append(new_job)
         self._notify_listeners()
+        self._persist(superseded_source)
+        self._persist(new_job)
         return replace(new_job)
 
     def dismiss(self, job_id: str) -> LibraryIngestJob | None:
@@ -593,6 +682,7 @@ class LibraryIngestJobRegistry:
         updated = replace(current, dismissed=True)
         self._jobs[index] = updated
         self._notify_listeners()
+        self._persist(updated)
         return replace(updated)
 
     def clear_finished(self) -> int:
@@ -610,15 +700,21 @@ class LibraryIngestJobRegistry:
             The number of jobs actually removed (0 when there was nothing
             to clear -- a no-op that does not fire the listener).
         """
-        before = len(self._jobs)
+        removed_jobs = [
+            job
+            for job in self._jobs
+            if job.state in (IngestJobState.DONE, IngestJobState.FAILED)
+        ]
         self._jobs = [
             job
             for job in self._jobs
             if job.state not in (IngestJobState.DONE, IngestJobState.FAILED)
         ]
-        removed = before - len(self._jobs)
+        removed = len(removed_jobs)
         if removed:
             self._notify_listeners()
+            for job in removed_jobs:
+                self._persist_delete(job.job_id)
         return removed
 
     # -- reads -----------------------------------------------------
@@ -680,3 +776,112 @@ class LibraryIngestJobRegistry:
             and not job.dismissed
             and job.detected_type in types
         )
+
+
+# -- restore (Task 2, 161) --------------------------------------------------
+
+
+@dataclass
+class RestorePlan:
+    """The pure result of :func:`plan_restore`, ready to feed a registry/store.
+
+    Attributes:
+        jobs: The full seq-ascending job list to hand to
+            ``LibraryIngestJobRegistry.restore`` -- interrupted jobs
+            normalized to ``FAILED`` and the oldest jobs pruned when the
+            persisted row count exceeds ``max_persisted``.
+        next_id: The next ``job_id`` sequence number the registry should
+            resume allocating from.
+        upsert: The subset of ``jobs`` that changed relative to the
+            persisted rows (only the normalized-to-``FAILED`` jobs) and so
+            must be re-persisted to the store to keep it in sync.
+        delete_ids: The ``job_id``s of jobs pruned for exceeding
+            ``max_persisted`` -- must be deleted from the store.
+    """
+
+    jobs: list["LibraryIngestJob"]
+    next_id: int
+    upsert: list["LibraryIngestJob"]  # normalized jobs to re-persist
+    delete_ids: list[str]  # pruned jobs to delete from the store
+
+
+_INTERRUPTED_STATES = (IngestJobState.QUEUED, IngestJobState.PARSING, IngestJobState.WRITING)
+
+
+def _job_from_row(row: dict) -> "LibraryIngestJob":
+    """Rebuild a :class:`LibraryIngestJob` from a persisted store row.
+
+    Args:
+        row: A dict-like row as returned by
+            ``LibraryIngestJobsDB`` (see that module for the schema).
+
+    Returns:
+        The reconstructed job. The monotonic-clock fields
+        (``submitted_at``/``started_at``/``finished_at``) are NOT
+        round-trippable across a process restart (``time.monotonic()`` has
+        no fixed epoch) -- they are left at their dataclass defaults
+        (``0.0``/``None``/``None``).
+    """
+    return LibraryIngestJob(
+        job_id=row["job_id"],
+        source_path=row["source_path"],
+        title=row["title"] or "",
+        author=row["author"] or "",
+        keywords=tuple(json.loads(row["keywords"] or "[]")),
+        perform_analysis=bool(row["perform_analysis"]),
+        chunk_enabled=bool(row["chunk_enabled"]),
+        chunk_size=int(row["chunk_size"]),
+        state=IngestJobState(row["state"]),
+        detected_type=row["detected_type"] or "",
+        media_id=row["media_id"],
+        error=row["error"] or "",
+        finished_at_wall=row["finished_at_wall"] or "",
+        superseded=bool(row["superseded"]),
+        dismissed=bool(row["dismissed"]),
+        permanent=bool(row["permanent"]),
+        retry_count=int(row["retry_count"]),
+        # monotonic fields are not round-trippable -- leave defaults.
+        submitted_at=0.0, started_at=None, finished_at=None,
+    )
+
+
+def plan_restore(rows: list[dict], *, max_persisted: int, now_iso: str) -> RestorePlan:
+    """Pure planning step for restoring a registry from persisted rows.
+
+    Args:
+        rows: Persisted job rows, seq-ascending (oldest first) -- the same
+            order ``LibraryIngestJobRegistry._jobs`` maintains internally.
+        max_persisted: The maximum number of rows to keep; anything beyond
+            this, oldest-by-seq first, is pruned.
+        now_iso: The wall-clock timestamp (``datetime.now(timezone.utc).
+            isoformat()``) to stamp onto jobs normalized as interrupted.
+
+    Returns:
+        A :class:`RestorePlan` with jobs still ``QUEUED``/``PARSING``/
+        ``WRITING`` at the time of persistence normalized to ``FAILED``
+        (an app restart abandons those jobs -- see the module docstring's
+        accepted v1 limits on parse/write loss on quit) with the error
+        ``"Interrupted by app restart"``, ``permanent=False`` (so they
+        remain retryable), and ``finished_at_wall=now_iso``. ``retry_count``
+        is preserved, not reset. When ``len(rows) > max_persisted``, the
+        oldest-by-seq rows beyond the cap are dropped from ``jobs`` and
+        their ids returned in ``delete_ids``.
+    """
+    jobs = [_job_from_row(r) for r in rows]  # rows are seq-ascending
+    normalized_ids: set[str] = set()
+    for i, job in enumerate(jobs):
+        if job.state in _INTERRUPTED_STATES:
+            jobs[i] = replace(
+                job, state=IngestJobState.FAILED,
+                error="Interrupted by app restart", permanent=False,
+                finished_at_wall=now_iso,
+            )
+            normalized_ids.add(job.job_id)
+    delete_ids: list[str] = []
+    if len(jobs) > max_persisted:
+        pruned = jobs[:-max_persisted]
+        delete_ids = [j.job_id for j in pruned]
+        jobs = jobs[-max_persisted:]
+    upsert = [j for j in jobs if j.job_id in normalized_ids]  # kept + normalized
+    next_id = max((int(j.job_id.rsplit("-", 1)[-1]) for j in jobs), default=0) + 1
+    return RestorePlan(jobs=jobs, next_id=next_id, upsert=upsert, delete_ids=delete_ids)

--- a/tldw_chatbook/Library/library_ingest_jobs.py
+++ b/tldw_chatbook/Library/library_ingest_jobs.py
@@ -852,7 +852,9 @@ def plan_restore(rows: list[dict], *, max_persisted: int, now_iso: str) -> Resto
         rows: Persisted job rows, seq-ascending (oldest first) -- the same
             order ``LibraryIngestJobRegistry._jobs`` maintains internally.
         max_persisted: The maximum number of rows to keep; anything beyond
-            this, oldest-by-seq first, is pruned.
+            this, oldest-by-seq first, is pruned. A non-positive cap
+            (``<= 0``) is treated as "keep everything" -- a misconfigured
+            cap must never wipe all history.
         now_iso: The wall-clock timestamp (``datetime.now(timezone.utc).
             isoformat()``) to stamp onto jobs normalized as interrupted.
 
@@ -863,9 +865,9 @@ def plan_restore(rows: list[dict], *, max_persisted: int, now_iso: str) -> Resto
         accepted v1 limits on parse/write loss on quit) with the error
         ``"Interrupted by app restart"``, ``permanent=False`` (so they
         remain retryable), and ``finished_at_wall=now_iso``. ``retry_count``
-        is preserved, not reset. When ``len(rows) > max_persisted``, the
-        oldest-by-seq rows beyond the cap are dropped from ``jobs`` and
-        their ids returned in ``delete_ids``.
+        is preserved, not reset. When ``max_persisted >= 1`` and
+        ``len(rows) > max_persisted``, the oldest-by-seq rows beyond the cap
+        are dropped from ``jobs`` and their ids returned in ``delete_ids``.
     """
     jobs = [_job_from_row(r) for r in rows]  # rows are seq-ascending
     normalized_ids: set[str] = set()
@@ -878,7 +880,13 @@ def plan_restore(rows: list[dict], *, max_persisted: int, now_iso: str) -> Resto
             )
             normalized_ids.add(job.job_id)
     delete_ids: list[str] = []
-    if len(jobs) > max_persisted:
+    # Guard the cap: only prune for a positive cap that is actually exceeded.
+    # A non-positive cap keeps everything (never wipe all history on a
+    # misconfig) -- and it also sidesteps Python's ``-0 == 0`` footgun, where
+    # ``jobs[:-max_persisted]``/``jobs[-max_persisted:]`` with ``max_persisted
+    # == 0`` would slice ``[:0]``/``[0:]`` (prune nothing) and a NEGATIVE cap
+    # would slice with a positive index and silently delete the oldest rows.
+    if max_persisted >= 1 and len(jobs) > max_persisted:
         pruned = jobs[:-max_persisted]
         delete_ids = [j.job_id for j in pruned]
         jobs = jobs[-max_persisted:]

--- a/tldw_chatbook/Library/library_ingest_state.py
+++ b/tldw_chatbook/Library/library_ingest_state.py
@@ -82,6 +82,18 @@ def short_ingest_error(error: str) -> str:
     return error.split(_SUPPORTED_TYPES_ERROR_MARKER)[0].rstrip()
 
 
+def _retry_suffix(job: LibraryIngestJob) -> str:
+    """Return a `` · retry {n}`` suffix once a job has been requeued.
+
+    Mirrors ``active_work_adapter._ingest_retry_suffix`` -- kept as a
+    separate (Library-side) copy rather than a shared import so this
+    module's Textual-free, importable-in-isolation contract (see the module
+    docstring) never has to reach into ``Home`` (the dependency runs the
+    other way: ``Home`` already imports from ``Library``).
+    """
+    return f" · retry {job.retry_count}" if job.retry_count else ""
+
+
 @lru_cache(maxsize=1)
 def _supported_types_line() -> str:
     """Build the ingest form's supported-extensions line.
@@ -325,7 +337,8 @@ def _build_queue_row(job: LibraryIngestJob, *, now: float) -> IngestQueueRow:
       ``" Supported types: ..."`` tail from ``job.error`` -- that list now
       lives on the form as ``supported_types_line`` instead, always visible
       rather than repeated on every failed row. An error without that exact
-      marker passes through whole.
+      marker passes through whole. Once ``job.retry_count`` is nonzero
+      (task 161), a `` · retry {n}`` suffix is appended.
     """
     basename = _basename(job.source_path)
     if job.state == IngestJobState.PARSING:
@@ -376,7 +389,7 @@ def _build_queue_row(job: LibraryIngestJob, *, now: float) -> IngestQueueRow:
     return IngestQueueRow(
         job_id=job.job_id,
         glyph=_GLYPH_FAILED,
-        line=f"{_GLYPH_FAILED} failed · {basename} · {short_error}",
+        line=f"{_GLYPH_FAILED} failed · {basename} · {short_error}{_retry_suffix(job)}",
         can_open=False,
         can_retry=not job.permanent,
         can_dismiss=True,

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -1312,21 +1312,22 @@ class LibraryIngestQueueMixin:
         try:
             store = LibraryIngestJobsDB(get_library_ingest_jobs_db_path())
             self._library_ingest_jobs_store = store
-            # Load + plan BEFORE attaching the store: if a corrupt DB makes
-            # all_jobs()/plan_restore() throw, the registry stays pure in-memory
-            # (store never attached) instead of a live-but-empty store whose
-            # new low-seq submits could clobber surviving rows.
+            # Do ALL fallible work -- corrupt read, plan, and the store
+            # reconcile writes -- BEFORE touching the in-memory registry, so any
+            # failure leaves the registry empty + store unattached: a clean
+            # in-memory fallback that matches the "starting empty" warning below
+            # (rather than a half-restored registry contradicting the log).
             plan = plan_restore(
                 store.all_jobs(),
                 max_persisted=_MAX_PERSISTED_INGEST_JOBS,
                 now_iso=datetime.now(timezone.utc).isoformat(),
             )
-            self.library_ingest_jobs.restore(plan.jobs, plan.next_id)
-            self.library_ingest_jobs.attach_store(store)
             for job in plan.upsert:
                 store.upsert_job(job)
             for job_id in plan.delete_ids:
                 store.delete_job(job_id)
+            self.library_ingest_jobs.restore(plan.jobs, plan.next_id)
+            self.library_ingest_jobs.attach_store(store)
         except Exception:
             logger.opt(exception=True).warning(
                 "Failed to restore persisted ingest job history; starting empty."

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -70,6 +70,7 @@ from .Widgets.AppFooterStatus import AppFooterStatus
 from .config import (
     get_cli_setting,
     get_library_collections_db_path,
+    get_library_ingest_jobs_db_path,
     get_media_db_path,
     get_notifications_db_path,
     get_prompts_db_path,
@@ -1198,6 +1199,11 @@ def _stream_fileno(stream: Any) -> int:
 # heavy-lane cap limits how many of these parse concurrently.
 _INGEST_HEAVY_TYPES = frozenset({"audio", "video"})
 
+# Cap on how many persisted ingest jobs `_restore_ingest_jobs` carries
+# forward on restart (see `Library.library_ingest_jobs.plan_restore`) --
+# keeps startup and the in-memory registry bounded for a long-lived store.
+_MAX_PERSISTED_INGEST_JOBS = 500
+
 
 # Keep-alive singleton for `_ingest_pool_real_stderr`'s devnull fallback.
 # Module-level on purpose: the multiprocessing resource tracker inherits this
@@ -1297,6 +1303,30 @@ class LibraryIngestQueueMixin:
     share no resources (parse workers never touch ``media_db``; the writer
     never touches the pool).
     """
+
+    def _restore_ingest_jobs(self) -> None:
+        """One-time on_mount restore of persisted ingest job history."""
+        from datetime import datetime, timezone
+        from tldw_chatbook.DB.Library_Ingest_Jobs_DB import LibraryIngestJobsDB
+        from tldw_chatbook.Library.library_ingest_jobs import plan_restore
+        try:
+            store = LibraryIngestJobsDB(get_library_ingest_jobs_db_path())
+            self._library_ingest_jobs_store = store
+            self.library_ingest_jobs.attach_store(store)
+            plan = plan_restore(
+                store.all_jobs(),
+                max_persisted=_MAX_PERSISTED_INGEST_JOBS,
+                now_iso=datetime.now(timezone.utc).isoformat(),
+            )
+            self.library_ingest_jobs.restore(plan.jobs, plan.next_id)
+            for job in plan.upsert:
+                store.upsert_job(job)
+            for job_id in plan.delete_ids:
+                store.delete_job(job_id)
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Failed to restore persisted ingest job history; starting empty."
+            )
 
     def submit_library_ingest_job(
         self,
@@ -5421,7 +5451,12 @@ class TldwCli(LibraryIngestQueueMixin, App[None]):  # Specify return type for ru
     def on_mount(self) -> None:
         """Configure logging and schedule post-mount setup."""
         mount_start = time.perf_counter()
-        
+
+        # Restore persisted Library ingest job history (self.library_ingest_jobs
+        # already exists -- constructed store-less in __init__). Never raises:
+        # a corrupt/unreadable store falls back to starting empty.
+        self._restore_ingest_jobs()
+
         # Update splash screen progress only if splash screen is active
         if self.splash_screen_active and self._splash_screen_widget:
             try:
@@ -6276,7 +6311,13 @@ class TldwCli(LibraryIngestQueueMixin, App[None]):  # Specify return type for ru
                             self.loguru_logger.error(f"Error stopping thread {thread.name}: {e}")
         except Exception as e:
             self.loguru_logger.error(f"Error checking active threads: {e}")
-        
+
+        # Close the persisted Library ingest job history store (after pool
+        # shutdown, above -- no more job writes are in flight by this point).
+        store = getattr(self, "_library_ingest_jobs_store", None)
+        if store is not None:
+            store.close()
+
         logging.shutdown()
         self.loguru_logger.info("--- App Unmounted (Loguru) ---")
 

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -1312,13 +1312,17 @@ class LibraryIngestQueueMixin:
         try:
             store = LibraryIngestJobsDB(get_library_ingest_jobs_db_path())
             self._library_ingest_jobs_store = store
-            self.library_ingest_jobs.attach_store(store)
+            # Load + plan BEFORE attaching the store: if a corrupt DB makes
+            # all_jobs()/plan_restore() throw, the registry stays pure in-memory
+            # (store never attached) instead of a live-but-empty store whose
+            # new low-seq submits could clobber surviving rows.
             plan = plan_restore(
                 store.all_jobs(),
                 max_persisted=_MAX_PERSISTED_INGEST_JOBS,
                 now_iso=datetime.now(timezone.utc).isoformat(),
             )
             self.library_ingest_jobs.restore(plan.jobs, plan.next_id)
+            self.library_ingest_jobs.attach_store(store)
             for job in plan.upsert:
                 store.upsert_job(job)
             for job_id in plan.delete_ids:

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -3603,6 +3603,14 @@ def get_library_collections_db_path() -> Path:
         db_path = user_dir / "tldw_chatbook_library_collections.db"
     return db_path
 
+def get_library_ingest_jobs_db_path() -> Path:
+    custom_path = get_cli_setting("database", "library_ingest_jobs_db_path", None)
+    if custom_path and custom_path != DEFAULT_CONFIG_FROM_TOML.get("database", {}).get("library_ingest_jobs_db_path"):
+        db_path = validate_path_simple(Path(str(custom_path)).expanduser(), require_exists=False).resolve()
+    else:
+        db_path = get_user_data_dir() / "tldw_chatbook_library_ingest_jobs.db"
+    return db_path
+
 def get_workspaces_db_path() -> Path:
     custom_path = get_cli_setting("database", "workspaces_db_path", None)
     if custom_path and custom_path != DEFAULT_CONFIG_FROM_TOML.get("database", {}).get("workspaces_db_path"):


### PR DESCRIPTION
## Summary

Backlog **task 161** (follow-up from #598). The Library ingest job registry was in-memory only — queued/failed/done history (and a mid-parse job) vanished on quit. This persists it to SQLite so history survives restarts **and crashes**, interrupted jobs come back retryable, and each job now tracks a `retry_count`.

Spec: `Docs/superpowers/specs/2026-07-12-library-persistent-job-history-design.md`
Plan: `Docs/superpowers/plans/2026-07-12-library-persistent-job-history.md`

## How it works

- **`LibraryIngestJobsDB`** — a small `BaseDB` store with ONE persistent WAL connection (safe: every registry mutation runs on the UI thread), `seq` PK, a `state` CHECK, and `retry_count`. Only round-trippable fields persist — the `time.monotonic()` timestamps are dropped; `finished_at_wall` (ISO) is kept.
- **Write-through** — the registry gets an optional `store` hook and upserts each job on every mutation (best-effort; a store error never breaks a mutation). Persisting the transient PARSING/WRITING states means a **crash** mid-parse also recovers.
- **Restore on launch** — `_restore_ingest_jobs` (on_mount) loads history, normalizes anything still in-flight (QUEUED/PARSING/WRITING) → `FAILED("Interrupted by app restart")` (retryable, no auto-dispatch — the app is idle on launch), prunes to the most-recent 500, and incrementally reconciles the store. A corrupt DB is caught → starts empty, never crashes.
- **`retry_count`** — carried `+1` through `requeue` across the supersede chain, persisted, and shown as a minimal `· retry {n}` indicator on both ingest job-row surfaces (Home active-work + Library queue row).

## Design input

Mined the mature server jobs system (`tldw_server2` core `Jobs`) for patterns: **borrowed** the `state` CHECK, `retry_count`, and the single-process "normalize in-flight at startup" (no leases needed); **validated** wall-clock-only persisted timestamps; **skipped** leases/priority/RLS/quarantine/TTL-scheduler as multi-worker overkill. Logged `progress_percent/message` (task 207) and `source_path` dedup (task 208) as separate follow-ups.

## Testing

Subagent-driven, TDD: store round-trip/idempotency/CHECK units, registry write-through + `plan_restore` (normalize/prune, incl. a non-positive-cap guard) units, and end-to-end **restart round-trip** (AC1) + **retry-after-restart** (AC2) tests.

- Per-task reviews clean (fixes: the `plan_restore` `-0`-cap guard).
- **Whole-branch review (opus): APPROVE** — traced the restart lifecycle, threading (store stays UI-thread-only), and no-collision `_next_id`; two minors folded in (`PRAGMA synchronous=NORMAL`; attach store only after a successful load).
- **Final gate: 689 passed** across `Tests/DB/ Tests/Library/ Tests/Home/`; `import tldw_chatbook.app` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist Library ingest job history to SQLite so queued/failed/done jobs survive restarts and crashes. In‑flight jobs become FAILED on launch and are retryable, with `retry_count` tracked and shown in the UI (task 161).

- **New Features**
  - Added Library ingest jobs SQLite store (WAL, `synchronous=NORMAL`, `state` CHECK) and a registry `attach_store` hook for write‑through persistence.
  - Added `retry_count`; `requeue` increments it; UI appends " · retry {n}" on Home and Library rows.
  - Implemented `plan_restore` + `restore` to load history on startup, normalize QUEUED/PARSING/WRITING → FAILED ("Interrupted by app restart"), and prune to 500.
  - Hardened startup restore: reconcile store changes (upsert normalized, delete pruned) before seeding the registry, and attach the store only after a successful load; on failure, start empty and leave the store unattached.
  - Wired app startup via `_restore_ingest_jobs` in `on_mount`; added `get_library_ingest_jobs_db_path`; store closes on unmount. Added tests for DB round‑trip, restore/normalize/prune, write‑through, and retry indicator.

- **Migration**
  - No action required; with no store attached, behavior is unchanged.
  - On first launch with the store, in‑flight jobs will appear as FAILED (retryable).
  - DB path is configurable via `get_library_ingest_jobs_db_path`; the default file is created under the user data dir.

<sup>Written for commit af767be30214de866199fdbac4a1c66f100f93df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

