### PR TITLE
test(library): de-flake note-conflict shell tests via deadline-based waiting (task 192)

### DIFF
--- a/Docs/superpowers/plans/2026-07-12-note-conflict-deflake.md
+++ b/Docs/superpowers/plans/2026-07-12-note-conflict-deflake.md
@@ -1,0 +1,183 @@
+# De-flake the library note-conflict shell tests — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax. Spec: `Docs/superpowers/specs/2026-07-12-note-conflict-deflake-design.md`. Branch `claude/followups-note-conflict-flake` off dev `c5e9886d`. All changes are in `Tests/UI/test_library_shell.py`; line numbers drift as edits land, so key each conversion on the test name + predicate/message shown below, not on line numbers.
+
+**Goal:** Replace the fixed-iteration (~3s) poll loops in the 7 note-conflict shell tests with a wall-clock-deadline `_wait_for_condition` helper, so they stop flaking under CPU contention while staying fast in isolation.
+
+**Architecture:** Add one async helper next to the existing `_wait_for_*` helpers, then mechanically convert all 12 conflict-family `for _ in range(150):` condition-poll loops to call it. Test-only; no production code changes. All 7 tests currently pass in isolation (verified), so this is a pure refactor.
+
+**Tech Stack:** pytest + pytest-asyncio, Textual `Pilot`, `time.monotonic` (already imported at `test_library_shell.py:7`).
+
+## Global Constraints
+
+- **Helper mirrors the original `break` exactly** — check predicate first, return the instant it is truthy with NO trailing settle pause, else `await pilot.pause(interval)` and re-check; the only change vs the loops is a wall-clock deadline replacing `range(150)`.
+- **`message` may be a str OR a zero-arg callable** — the callable is evaluated at raise time so the two dynamic diagnostic messages still report the *stuck* state at timeout.
+- **Preserve each loop's original `AssertionError` message verbatim** (as a string, or wrapped in `lambda:` for the two f-string diagnostics).
+- **Scope: only the 12 conflict-family loops in the 7 named tests.** Do NOT touch the bare `for _ in range(10): await pilot.pause(0.02)` drain in `..._during_preview_reads_live_text` (no predicate). Do NOT touch `_wait_for_library_shell`/`_wait_for_selector`/`_wait_for_library_rag_query_ready` or any other file's loops. No production code changes.
+- **Staging:** explicit paths only. Every commit ends with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- **Test command** (venv, isolated HOME):
+  ```
+  HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+    /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest <target> \
+    -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+  ```
+
+---
+
+### Task 1: `_wait_for_condition` helper + convert the 7 note-conflict tests
+
+**Files:**
+- Modify: `Tests/UI/test_library_shell.py` (add helper ~`:210` after the other `_wait_for_*` helpers; add helper unit tests; convert 12 loops in 7 tests)
+- Modify: `backlog/tasks/task-192 - De-flake-library-note-conflict-shell-test-under-CPU-contention.md`
+
+- [ ] **Step 1: Write the failing unit tests for the helper**
+
+Add near the top of `Tests/UI/test_library_shell.py` (after the imports / existing `_wait_for_*` helpers). These are self-contained (a no-op fake pilot):
+```python
+class _FakePilot:
+    """Minimal pilot stand-in for unit-testing _wait_for_condition (pause is a no-op)."""
+    async def pause(self, delay: float = 0) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test__wait_for_condition_returns_immediately_when_true():
+    calls = {"n": 0}
+
+    def pred() -> bool:
+        calls["n"] += 1
+        return True
+
+    await _wait_for_condition(_FakePilot(), pred, message="must not raise")
+    assert calls["n"] == 1  # checked once, returned without pausing
+
+
+@pytest.mark.asyncio
+async def test__wait_for_condition_raises_with_message_on_timeout():
+    with pytest.raises(AssertionError, match="boom"):
+        await _wait_for_condition(_FakePilot(), lambda: False, timeout=0.05, message="boom")
+
+
+@pytest.mark.asyncio
+async def test__wait_for_condition_evaluates_callable_message_at_raise():
+    with pytest.raises(AssertionError, match="dynamic 42"):
+        await _wait_for_condition(
+            _FakePilot(), lambda: False, timeout=0.05, message=lambda: f"dynamic {6 * 7}"
+        )
+```
+
+- [ ] **Step 2: Run the unit tests to verify they FAIL**
+
+Run:
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  "Tests/UI/test_library_shell.py::test__wait_for_condition_returns_immediately_when_true" \
+  "Tests/UI/test_library_shell.py::test__wait_for_condition_raises_with_message_on_timeout" \
+  "Tests/UI/test_library_shell.py::test__wait_for_condition_evaluates_callable_message_at_raise" \
+  -q -p no:cacheprovider -o addopts="" --timeout=60
+```
+Expected: FAIL — `NameError: name '_wait_for_condition' is not defined`.
+
+- [ ] **Step 3: Add the `_wait_for_condition` helper**
+
+Add immediately after `_wait_for_selector` (~`Tests/UI/test_library_shell.py:210`):
+```python
+async def _wait_for_condition(pilot, predicate, *, timeout=15.0, message, interval=0.02):
+    """Await until ``predicate()`` is truthy, or raise once ``timeout`` wall-clock seconds elapse.
+
+    A deadline (not a fixed iteration count) so the wait survives CPU contention
+    yet returns the instant the condition is met. ``message`` may be a string or a
+    zero-arg callable (evaluated at raise time, so dynamic diagnostics report the
+    stuck state).
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        await pilot.pause(interval)
+    raise AssertionError(message() if callable(message) else message)
+```
+
+- [ ] **Step 4: Run the unit tests to verify they PASS**
+
+Run the Step-2 command. Expected: 3 passed.
+
+- [ ] **Step 5: Convert the 12 conflict-family poll loops**
+
+In each of the 7 tests below, replace every block of the form
+```python
+        for _ in range(150):
+            if <PREDICATE>:
+                break
+            await pilot.pause(0.02)
+        else:
+            raise AssertionError(<MESSAGE>)
+```
+with a single line
+```python
+        await _wait_for_condition(pilot, lambda: <PREDICATE>, message=<MESSAGE>)
+```
+Do them one test at a time. The exact `(PREDICATE, MESSAGE)` pairs — 12 loops:
+
+- **`test_library_shell_rail_search_submit_aborts_on_note_conflict`** (1 loop):
+  - `screen._library_note_autosave_state == "conflict"` → `message="The version conflict was never reached."`
+- **`test_library_shell_note_conflict_shows_overwrite_reload_and_keeps_user_text`** (1 loop — the named AC test):
+  - `screen._library_note_autosave_state == "conflict"` → `message="The version conflict was never reached."`
+- **`test_library_shell_note_conflict_during_preview_reads_live_text`** (2 loops; leave the `for _ in range(10): await pilot.pause(0.02)` drain untouched):
+  - `screen._library_note_autosave_state == "conflict"` → `message="The version conflict was never reached."`
+  - `len(service.save_calls) > calls_before_second_save` → `message="The second Save press never called the seam."`
+- **`test_library_shell_note_conflict_overwrite_resaves_with_fresh_version`** (2 loops):
+  - `screen._library_note_autosave_state == "conflict"` → `message="The version conflict was never reached."`
+  - `screen._library_note_autosave_state == "saved"` → `message="Overwrite never completed."`
+- **`test_library_shell_note_conflict_reload_discards_local_edits`** (2 loops; the second is a compound predicate):
+  - `screen._library_note_autosave_state == "conflict"` → `message="The version conflict was never reached."`
+  - `screen._library_note_autosave_state == "idle" and screen._library_notes_view == "editor"` → `message="Reload never completed."`
+- **`test_library_shell_note_conflict_reload_falls_back_to_list_when_note_missing`** (2 loops; the second has a dynamic message → use a `lambda:`):
+  - `screen._library_note_autosave_state == "conflict"` → `message="The version conflict was never reached."`
+  - `screen._library_notes_view == "list"` → `message=lambda: ("Reload never fell back to the list view for a missing note " f"(stuck: view={screen._library_notes_view!r}, " f"autosave_state={screen._library_note_autosave_state!r}).")`
+- **`test_library_shell_note_conflict_overwrite_falls_back_to_list_when_note_missing`** (2 loops; the second has a dynamic message → use a `lambda:`):
+  - `screen._library_note_autosave_state == "conflict"` → `message="The version conflict was never reached."`
+  - `screen._library_notes_view == "list"` → `message=lambda: ("Overwrite never fell back to the list view for a missing note " f"(stuck: view={screen._library_notes_view!r}, " f"autosave_state={screen._library_note_autosave_state!r}).")`
+
+Verify no conflict-family fixed-iteration loop remains: `grep -nE 'for _ in range\(150\):' Tests/UI/test_library_shell.py` should show only loops OUTSIDE the 7 tests above (the ~120 other-feature loops are out of scope and stay).
+
+- [ ] **Step 6: Run all 7 note-conflict tests + the helper unit tests to verify GREEN**
+
+Run:
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  "Tests/UI/test_library_shell.py" -k "note_conflict or _wait_for_condition" \
+  -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: 10 passed (7 note-conflict tests + 3 helper unit tests), 0 failed. If a conflict test fails, a predicate/message was mis-mapped — compare against the pairs in Step 5.
+
+- [ ] **Step 7: Mark backlog task 192 Done**
+
+```bash
+perl -0pi -e 's/- \[ \] #1/- [x] #1/' "backlog/tasks/task-192 - De-flake-library-note-conflict-shell-test-under-CPU-contention.md" 2>/dev/null
+perl -0pi -e 's/^status: .*/status: Done/mi' "backlog/tasks/task-192 - De-flake-library-note-conflict-shell-test-under-CPU-contention.md"
+```
+(If task-192 has no `## Acceptance Criteria` checkbox, only the status line changes — that's fine.) Add a short `## Implementation Notes` section: replaced the fixed-iteration conflict polls across the 7 note-conflict tests with a deadline-based `_wait_for_condition` helper (str-or-callable message); bare drain loop + other-feature loops left as-is. Confirm the status changed (`grep -n "status:" "backlog/tasks/task-192 - De-flake"*.md`).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Tests/UI/test_library_shell.py "backlog/tasks/task-192 - De-flake-library-note-conflict-shell-test-under-CPU-contention.md"
+git commit -m "test(library): deadline-based _wait_for_condition to de-flake note-conflict polls; task 192 done (192)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Final gate (after Task 1)
+
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  "Tests/UI/test_library_shell.py" -k "note_conflict or _wait_for_condition" \
+  -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected 10 passed. Then the whole-branch review and finishing-a-development-branch. (Optional extra confidence: run the full `Tests/UI/test_library_shell.py` once to confirm no unrelated regression from the shared-helper edit.)

--- a/Docs/superpowers/plans/2026-07-12-note-conflict-deflake.md
+++ b/Docs/superpowers/plans/2026-07-12-note-conflict-deflake.md
@@ -18,7 +18,7 @@
 - **Test command** (venv, isolated HOME):
   ```
   HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
-    /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest <target> \
+    .venv/bin/python -m pytest <target> \
     -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
   ```
 
@@ -71,7 +71,7 @@ async def test__wait_for_condition_evaluates_callable_message_at_raise():
 Run:
 ```
 HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
-  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  .venv/bin/python -m pytest \
   "Tests/UI/test_library_shell.py::test__wait_for_condition_returns_immediately_when_true" \
   "Tests/UI/test_library_shell.py::test__wait_for_condition_raises_with_message_on_timeout" \
   "Tests/UI/test_library_shell.py::test__wait_for_condition_evaluates_callable_message_at_raise" \
@@ -147,7 +147,7 @@ Verify no conflict-family fixed-iteration loop remains: `grep -nE 'for _ in rang
 Run:
 ```
 HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
-  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  .venv/bin/python -m pytest \
   "Tests/UI/test_library_shell.py" -k "note_conflict or _wait_for_condition" \
   -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
 ```
@@ -176,7 +176,7 @@ Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
 
 ```
 HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
-  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  .venv/bin/python -m pytest \
   "Tests/UI/test_library_shell.py" -k "note_conflict or _wait_for_condition" \
   -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
 ```

--- a/Docs/superpowers/specs/2026-07-12-note-conflict-deflake-design.md
+++ b/Docs/superpowers/specs/2026-07-12-note-conflict-deflake-design.md
@@ -36,13 +36,14 @@ async def _wait_for_condition(pilot, predicate, *, timeout=15.0, message, interv
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         if predicate():
-            await pilot.pause()
             return
         await pilot.pause(interval)
     raise AssertionError(message)
 ```
 
-Why a deadline (not "bump `range(150)` → `range(1000)`"): a wall-clock deadline decouples the budget from *iterations × per-pause-time* (which is itself unpredictable under contention), returns the instant the condition is met (so the isolation case stays fast), and replaces a magic number with an intention-revealing call. This is the condition-based-waiting pattern the debugging playbook prescribes. `15.0s` is generous enough for a starved worker yet bounded.
+This mirrors the original loop **exactly** — check the predicate first, return the instant it is truthy (no extra settle pause — the loops `break` without one), otherwise `await pilot.pause(interval)` and re-check — with the only change being a wall-clock deadline in place of the fixed iteration count. (Unlike `_wait_for_selector`, which does a trailing `pilot.pause()` to settle the widget it returns, a state-poll returns nothing to settle, so no trailing pause is added — keeping the conversion behavior-identical.)
+
+Why a deadline (not "bump `range(150)` → `range(1000)`"): a wall-clock deadline decouples the budget from *iterations × per-pause-time* (which is itself unpredictable under contention), returns the instant the condition is met (so the isolation case stays fast), and replaces a magic number with an intention-revealing call. This is the condition-based-waiting pattern the debugging playbook prescribes. `15.0s` is generous enough for a starved worker yet bounded. Baseline: all 7 note-conflict tests currently pass in isolation, so this is a pure refactor over known-green tests.
 
 Then mechanically replace each conflict-family condition-poll loop:
 ```python

--- a/Docs/superpowers/specs/2026-07-12-note-conflict-deflake-design.md
+++ b/Docs/superpowers/specs/2026-07-12-note-conflict-deflake-design.md
@@ -1,0 +1,96 @@
+# De-flake the library note-conflict shell tests (task 192)
+
+**Status:** Design approved (brainstorm — mechanism: condition-based waiting; scope: whole note-conflict family), pending spec review.
+**Backlog:** task-192 — "De-flake library note-conflict shell test under CPU contention".
+**Discovered:** during task 159 (unrelated to that diff).
+
+## Problem
+
+`test_library_shell_note_conflict_shows_overwrite_reload_and_keeps_user_text` (`Tests/UI/test_library_shell.py`) intermittently fails under concurrent CPU load but passes in isolation. Root cause: it presses Save (which drives an async worker that sets `_library_note_autosave_state = "conflict"` once the conflict seam returns `False`), then waits with a **fixed-iteration** poll loop:
+
+```python
+for _ in range(150):
+    if screen._library_note_autosave_state == "conflict":
+        break
+    await pilot.pause(0.02)
+else:
+    raise AssertionError("The version conflict was never reached.")
+```
+
+150 iterations × `pilot.pause(0.02)` gives the worker only ~3s of budget. Under CPU contention the worker is starved, the iterations exhaust before the state flips, and the `else` fires. It passes in isolation because 3s is ample when the CPU is free.
+
+The identical pattern is not unique to that one test: **12 condition-poll loops across 7 note-conflict tests** share it (and ~132 fixed-iteration loops exist file-wide). The approved scope is the note-conflict family.
+
+## Goal / Acceptance
+
+- **AC1** — the note-conflict tests no longer rely on a fixed-iteration budget; their condition waits use a wall-clock deadline that returns immediately when the condition is met and tolerates CPU contention.
+- **AC2** — the named test (`..._shows_overwrite_reload_and_keeps_user_text`) and the other six note-conflict tests all still pass.
+
+## Chosen approach: condition-based waiting on a wall-clock deadline
+
+Add one async helper near the existing `_wait_for_*` helpers in the test module (`time` is already imported at `Tests/UI/test_library_shell.py:7`):
+
+```python
+async def _wait_for_condition(pilot, predicate, *, timeout=15.0, message, interval=0.02):
+    """Await until predicate() is truthy or `timeout` wall-clock seconds elapse."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            await pilot.pause()
+            return
+        await pilot.pause(interval)
+    raise AssertionError(message)
+```
+
+Why a deadline (not "bump `range(150)` → `range(1000)`"): a wall-clock deadline decouples the budget from *iterations × per-pause-time* (which is itself unpredictable under contention), returns the instant the condition is met (so the isolation case stays fast), and replaces a magic number with an intention-revealing call. This is the condition-based-waiting pattern the debugging playbook prescribes. `15.0s` is generous enough for a starved worker yet bounded.
+
+Then mechanically replace each conflict-family condition-poll loop:
+```python
+for _ in range(150):
+    if <PREDICATE>:
+        break
+    await pilot.pause(0.02)
+else:
+    raise AssertionError("<MESSAGE>")
+```
+with:
+```python
+await _wait_for_condition(pilot, lambda: <PREDICATE>, message="<MESSAGE>")
+```
+The `lambda` closes over the same locals the loop referenced (`screen`, `service`, `calls_before_second_save`, …); the compound predicate (idle-and-editor) becomes `lambda: screen._library_note_autosave_state == "idle" and screen._library_notes_view == "editor"`. Each call keeps that loop's original `AssertionError` message verbatim.
+
+## Components
+
+1. **`_wait_for_condition` helper** — added once, near `_wait_for_library_shell`/`_wait_for_selector` (~`:187-210`).
+2. **12 loop conversions across 7 tests** (all `for _ in range(150):` condition polls with a predicate + `else: raise`):
+   - `test_library_shell_rail_search_submit_aborts_on_note_conflict` — 1 (`conflict`).
+   - `test_library_shell_note_conflict_shows_overwrite_reload_and_keeps_user_text` — 1 (`conflict`) — the named AC test.
+   - `test_library_shell_note_conflict_during_preview_reads_live_text` — 2 (`conflict`; `len(service.save_calls) > calls_before_second_save`).
+   - `test_library_shell_note_conflict_overwrite_resaves_with_fresh_version` — 2 (`conflict`; `saved`).
+   - `test_library_shell_note_conflict_reload_discards_local_edits` — 2 (`conflict`; `idle` and `editor`).
+   - `test_library_shell_note_conflict_reload_falls_back_to_list_when_note_missing` — 2 (`conflict`; `_library_notes_view == "list"`).
+   - `test_library_shell_note_conflict_overwrite_falls_back_to_list_when_note_missing` — 2 (`conflict`; `_library_notes_view == "list"`).
+
+## Data flow
+
+Unchanged — the tests exercise the same UI flow; only the *wait mechanism* between an action and its assertion changes. No production code is touched.
+
+## Error handling
+
+`_wait_for_condition` raises `AssertionError(message)` on timeout — the same failure type and message the loops raised, so a genuinely-broken flow still fails loudly with the same diagnostic (not silently hangs). The `predicate` is a plain sync callable (all conditions here are attribute checks); it is called on each poll.
+
+## Scope / non-goals
+
+- **Only the 7 note-conflict tests' condition-poll loops.** The bare settle loop `for _ in range(10): await pilot.pause(0.02)` in `..._during_preview_reads_live_text` has no predicate/assertion — it is a deliberate event-loop drain, not a flaky condition wait — and is left untouched.
+- The existing `_wait_for_library_shell` / `_wait_for_selector` / `_wait_for_library_rag_query_ready` helpers (also fixed-iteration but not reported flaky) are left as-is; reimplementing them on `_wait_for_condition` is a possible future consolidation, out of scope.
+- The other ~120 fixed-iteration loops elsewhere in the file are out of scope.
+- No production code changes; no change to what any test asserts.
+
+## Testing
+
+- **Unit test the helper (RED→GREEN):** a fast, deterministic test with a minimal fake pilot (`async def pause(self, delay=0): ...`):
+  - an already-true predicate returns without waiting;
+  - a never-true predicate with a tiny `timeout` (e.g. `0.05`) raises `AssertionError` carrying the exact `message`.
+  RED before `_wait_for_condition` exists (import/attribute error), GREEN after.
+- **Regression:** run all 7 converted note-conflict tests — they must still pass (functional behavior preserved). Each still asserts the same conditions; only the wait mechanism changed.
+- Reproducing the contention flake deterministically is impractical, so the de-flake is validated by (a) the deadline-based mechanism (no fixed iteration budget) and (b) the 7 tests passing unchanged in behavior.

--- a/Docs/superpowers/specs/2026-07-12-note-conflict-deflake-design.md
+++ b/Docs/superpowers/specs/2026-07-12-note-conflict-deflake-design.md
@@ -38,8 +38,10 @@ async def _wait_for_condition(pilot, predicate, *, timeout=15.0, message, interv
         if predicate():
             return
         await pilot.pause(interval)
-    raise AssertionError(message)
+    raise AssertionError(message() if callable(message) else message)
 ```
+
+`message` accepts a plain string OR a zero-arg callable. Two of the conflict loops raise an **f-string diagnostic** that interpolates the *stuck* screen state at timeout (`view=…, autosave_state=…`); those pass `message=lambda: f"…"` so the interpolation happens at raise time, not call time. The other ten pass their original plain-string message.
 
 This mirrors the original loop **exactly** — check the predicate first, return the instant it is truthy (no extra settle pause — the loops `break` without one), otherwise `await pilot.pause(interval)` and re-check — with the only change being a wall-clock deadline in place of the fixed iteration count. (Unlike `_wait_for_selector`, which does a trailing `pilot.pause()` to settle the widget it returns, a state-poll returns nothing to settle, so no trailing pause is added — keeping the conversion behavior-identical.)
 

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -225,9 +225,13 @@ async def _wait_for_condition(pilot, predicate, *, timeout=15.0, message, interv
 
 
 class _FakePilot:
-    """Minimal pilot stand-in for unit-testing _wait_for_condition (pause is a no-op)."""
+    """Minimal pilot stand-in for unit-testing _wait_for_condition (pause is a no-op, but counted)."""
+
+    def __init__(self) -> None:
+        self.pause_calls = 0
 
     async def pause(self, delay: float = 0) -> None:
+        self.pause_calls += 1
         return None
 
 
@@ -239,8 +243,10 @@ async def test__wait_for_condition_returns_immediately_when_true():
         calls["n"] += 1
         return True
 
-    await _wait_for_condition(_FakePilot(), pred, message="must not raise")
-    assert calls["n"] == 1  # checked once, returned without pausing
+    pilot = _FakePilot()
+    await _wait_for_condition(pilot, pred, message="must not raise")
+    assert calls["n"] == 1  # checked once...
+    assert pilot.pause_calls == 0  # ...and returned before ever pausing
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -208,6 +208,55 @@ async def _wait_for_selector(screen, pilot, selector, *, attempts=120):
     )
 
 
+async def _wait_for_condition(pilot, predicate, *, timeout=15.0, message, interval=0.02):
+    """Await until ``predicate()`` is truthy, or raise once ``timeout`` wall-clock seconds elapse.
+
+    A deadline (not a fixed iteration count) so the wait survives CPU contention
+    yet returns the instant the condition is met. ``message`` may be a string or a
+    zero-arg callable (evaluated at raise time, so dynamic diagnostics report the
+    stuck state).
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        await pilot.pause(interval)
+    raise AssertionError(message() if callable(message) else message)
+
+
+class _FakePilot:
+    """Minimal pilot stand-in for unit-testing _wait_for_condition (pause is a no-op)."""
+
+    async def pause(self, delay: float = 0) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test__wait_for_condition_returns_immediately_when_true():
+    calls = {"n": 0}
+
+    def pred() -> bool:
+        calls["n"] += 1
+        return True
+
+    await _wait_for_condition(_FakePilot(), pred, message="must not raise")
+    assert calls["n"] == 1  # checked once, returned without pausing
+
+
+@pytest.mark.asyncio
+async def test__wait_for_condition_raises_with_message_on_timeout():
+    with pytest.raises(AssertionError, match="boom"):
+        await _wait_for_condition(_FakePilot(), lambda: False, timeout=0.05, message="boom")
+
+
+@pytest.mark.asyncio
+async def test__wait_for_condition_evaluates_callable_message_at_raise():
+    with pytest.raises(AssertionError, match="dynamic 42"):
+        await _wait_for_condition(
+            _FakePilot(), lambda: False, timeout=0.05, message=lambda: f"dynamic {6 * 7}"
+        )
+
+
 def _two_conversations():
     return [
         {
@@ -1415,12 +1464,11 @@ async def test_library_shell_rail_search_submit_aborts_on_note_conflict():
         await pilot.pause()
 
         screen.query_one("#library-note-save").press()
-        for _ in range(150):
-            if screen._library_note_autosave_state == "conflict":
-                break
-            await pilot.pause(0.02)
-        else:
-            raise AssertionError("The version conflict was never reached.")
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_note_autosave_state == "conflict",
+            message="The version conflict was never reached.",
+        )
 
         history_before = screen._library_search_history
         search_input = screen.query_one("#library-search-input", Input)
@@ -5831,12 +5879,11 @@ async def test_library_shell_note_conflict_shows_overwrite_reload_and_keeps_user
         await pilot.pause()
 
         screen.query_one("#library-note-save").press()
-        for _ in range(150):
-            if screen._library_note_autosave_state == "conflict":
-                break
-            await pilot.pause(0.02)
-        else:
-            raise AssertionError("The version conflict was never reached.")
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_note_autosave_state == "conflict",
+            message="The version conflict was never reached.",
+        )
 
         assert screen.query("#library-note-conflict-overwrite")
         assert screen.query("#library-note-conflict-reload")
@@ -5879,12 +5926,11 @@ async def test_library_shell_note_conflict_during_preview_reads_live_text():
         _bump_note_version_externally(service, "n-1")  # now stored at v3; screen still has v2
 
         screen.query_one("#library-note-save").press()
-        for _ in range(150):
-            if screen._library_note_autosave_state == "conflict":
-                break
-            await pilot.pause(0.02)
-        else:
-            raise AssertionError("The version conflict was never reached.")
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_note_autosave_state == "conflict",
+            message="The version conflict was never reached.",
+        )
 
         # The conflict UI always shows the live TextArea, never the
         # read-only Markdown preview, regardless of the Preview flag.
@@ -5896,12 +5942,11 @@ async def test_library_shell_note_conflict_during_preview_reads_live_text():
 
         calls_before_second_save = len(service.save_calls)
         screen.query_one("#library-note-save").press()
-        for _ in range(150):
-            if len(service.save_calls) > calls_before_second_save:
-                break
-            await pilot.pause(0.02)
-        else:
-            raise AssertionError("The second Save press never called the seam.")
+        await _wait_for_condition(
+            pilot,
+            lambda: len(service.save_calls) > calls_before_second_save,
+            message="The second Save press never called the seam.",
+        )
         # Give the resulting conflict recompose a few cycles to settle.
         for _ in range(10):
             await pilot.pause(0.02)
@@ -5937,20 +5982,18 @@ async def test_library_shell_note_conflict_overwrite_resaves_with_fresh_version(
         await pilot.pause()
 
         screen.query_one("#library-note-save").press()
-        for _ in range(150):
-            if screen._library_note_autosave_state == "conflict":
-                break
-            await pilot.pause(0.02)
-        else:
-            raise AssertionError("The version conflict was never reached.")
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_note_autosave_state == "conflict",
+            message="The version conflict was never reached.",
+        )
 
         (await _wait_for_selector(screen, pilot, "#library-note-conflict-overwrite")).press()
-        for _ in range(150):
-            if screen._library_note_autosave_state == "saved":
-                break
-            await pilot.pause(0.02)
-        else:
-            raise AssertionError("Overwrite never completed.")
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_note_autosave_state == "saved",
+            message="Overwrite never completed.",
+        )
 
         assert not screen.query("#library-note-conflict-overwrite")
         stored = next(note for note in service.notes if note["id"] == "n-1")
@@ -5982,23 +6025,21 @@ async def test_library_shell_note_conflict_reload_discards_local_edits():
         await pilot.pause()
 
         screen.query_one("#library-note-save").press()
-        for _ in range(150):
-            if screen._library_note_autosave_state == "conflict":
-                break
-            await pilot.pause(0.02)
-        else:
-            raise AssertionError("The version conflict was never reached.")
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_note_autosave_state == "conflict",
+            message="The version conflict was never reached.",
+        )
 
         (await _wait_for_selector(screen, pilot, "#library-note-conflict-reload")).press()
-        for _ in range(150):
-            if (
+        await _wait_for_condition(
+            pilot,
+            lambda: (
                 screen._library_note_autosave_state == "idle"
                 and screen._library_notes_view == "editor"
-            ):
-                break
-            await pilot.pause(0.02)
-        else:
-            raise AssertionError("Reload never completed.")
+            ),
+            message="Reload never completed.",
+        )
 
         assert not screen.query("#library-note-conflict-reload")
         assert screen.query_one("#library-note-body", TextArea).text == "Server-side content"
@@ -6029,28 +6070,26 @@ async def test_library_shell_note_conflict_reload_falls_back_to_list_when_note_m
         await pilot.pause()
 
         screen.query_one("#library-note-save").press()
-        for _ in range(150):
-            if screen._library_note_autosave_state == "conflict":
-                break
-            await pilot.pause(0.02)
-        else:
-            raise AssertionError("The version conflict was never reached.")
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_note_autosave_state == "conflict",
+            message="The version conflict was never reached.",
+        )
 
         # The note is now gone entirely (not just bumped again) before
         # Reload's silent re-fetch runs.
         _remove_note_externally(service, "n-1")
 
         (await _wait_for_selector(screen, pilot, "#library-note-conflict-reload")).press()
-        for _ in range(150):
-            if screen._library_notes_view == "list":
-                break
-            await pilot.pause(0.02)
-        else:
-            raise AssertionError(
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_notes_view == "list",
+            message=lambda: (
                 "Reload never fell back to the list view for a missing note "
                 f"(stuck: view={screen._library_notes_view!r}, "
                 f"autosave_state={screen._library_note_autosave_state!r})."
-            )
+            ),
+        )
 
         assert screen._selected_note_id == ""
         assert screen._library_note_detail is None
@@ -6081,26 +6120,24 @@ async def test_library_shell_note_conflict_overwrite_falls_back_to_list_when_not
         await pilot.pause()
 
         screen.query_one("#library-note-save").press()
-        for _ in range(150):
-            if screen._library_note_autosave_state == "conflict":
-                break
-            await pilot.pause(0.02)
-        else:
-            raise AssertionError("The version conflict was never reached.")
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_note_autosave_state == "conflict",
+            message="The version conflict was never reached.",
+        )
 
         _remove_note_externally(service, "n-1")
 
         (await _wait_for_selector(screen, pilot, "#library-note-conflict-overwrite")).press()
-        for _ in range(150):
-            if screen._library_notes_view == "list":
-                break
-            await pilot.pause(0.02)
-        else:
-            raise AssertionError(
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_notes_view == "list",
+            message=lambda: (
                 "Overwrite never fell back to the list view for a missing note "
                 f"(stuck: view={screen._library_notes_view!r}, "
                 f"autosave_state={screen._library_note_autosave_state!r})."
-            )
+            ),
+        )
 
         assert screen._selected_note_id == ""
         assert screen._library_note_detail is None

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -208,18 +208,26 @@ async def _wait_for_selector(screen, pilot, selector, *, attempts=120):
     )
 
 
-async def _wait_for_condition(pilot, predicate, *, timeout=15.0, message, interval=0.02):
+async def _wait_for_condition(pilot, predicate, *, timeout=15.0, message, interval=0.02) -> None:
     """Await until ``predicate()`` is truthy, or raise once ``timeout`` wall-clock seconds elapse.
 
     A deadline (not a fixed iteration count) so the wait survives CPU contention
     yet returns the instant the condition is met. ``message`` may be a string or a
     zero-arg callable (evaluated at raise time, so dynamic diagnostics report the
     stuck state).
+
+    The predicate is checked FIRST each iteration -- before the deadline test and
+    before pausing -- so it is evaluated at least once (even at ``timeout=0``) and
+    is always given a final chance after a ``pause`` that overshoots the deadline
+    under contention (which is exactly when a state transition it is waiting for
+    may have just landed).
     """
     deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
+    while True:
         if predicate():
             return
+        if time.monotonic() >= deadline:
+            break
         await pilot.pause(interval)
     raise AssertionError(message() if callable(message) else message)
 
@@ -236,7 +244,8 @@ class _FakePilot:
 
 
 @pytest.mark.asyncio
-async def test__wait_for_condition_returns_immediately_when_true():
+async def test__wait_for_condition_returns_immediately_when_true() -> None:
+    """An already-true predicate returns on the first check, without ever pausing."""
     calls = {"n": 0}
 
     def pred() -> bool:
@@ -250,13 +259,25 @@ async def test__wait_for_condition_returns_immediately_when_true():
 
 
 @pytest.mark.asyncio
-async def test__wait_for_condition_raises_with_message_on_timeout():
+async def test__wait_for_condition_checks_predicate_before_raising() -> None:
+    """The predicate is checked at least once before the deadline is enforced, so a
+    condition that is already satisfied returns even when the deadline has elapsed
+    (guards against a false timeout when a pause overshoots the deadline)."""
+    pilot = _FakePilot()
+    await _wait_for_condition(pilot, lambda: True, timeout=0.0, message="must not raise")
+    assert pilot.pause_calls == 0
+
+
+@pytest.mark.asyncio
+async def test__wait_for_condition_raises_with_message_on_timeout() -> None:
+    """A never-true predicate raises AssertionError carrying the given message on timeout."""
     with pytest.raises(AssertionError, match="boom"):
         await _wait_for_condition(_FakePilot(), lambda: False, timeout=0.05, message="boom")
 
 
 @pytest.mark.asyncio
-async def test__wait_for_condition_evaluates_callable_message_at_raise():
+async def test__wait_for_condition_evaluates_callable_message_at_raise() -> None:
+    """A callable message is evaluated at raise time (so dynamic diagnostics report the stuck state)."""
     with pytest.raises(AssertionError, match="dynamic 42"):
         await _wait_for_condition(
             _FakePilot(), lambda: False, timeout=0.05, message=lambda: f"dynamic {6 * 7}"

--- a/backlog/tasks/task-192 - De-flake-library-note-conflict-shell-test-under-CPU-contention.md
+++ b/backlog/tasks/task-192 - De-flake-library-note-conflict-shell-test-under-CPU-contention.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-192
 title: De-flake library note-conflict shell test under CPU contention
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-12 14:05'
 labels:
@@ -15,3 +15,7 @@ dependencies: []
 <!-- SECTION:DESCRIPTION:BEGIN -->
 test_library_shell_note_conflict_shows_overwrite_reload_and_keeps_user_text intermittently fails under concurrent CPU load (passes in isolation). Widen its polling/timeout budget or replace the timing loop with condition-based waiting. Discovered during task 159; unrelated to that diff.
 <!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Notes
+
+Replaced the fixed-iteration (`for _ in range(150): ... else: raise`) conflict polls across the 7 note-conflict tests in `Tests/UI/test_library_shell.py` with a deadline-based `_wait_for_condition(pilot, predicate, *, timeout=15.0, message, interval=0.02)` helper: it checks the predicate first and returns immediately (no trailing pause) once true, otherwise polls on a wall-clock `time.monotonic()` deadline instead of a fixed iteration count, so the wait survives CPU contention. `message` accepts a plain string or a zero-arg callable evaluated at raise time (used by the two "falls back to list" tests so the diagnostic reports the actually-stuck state). Added 3 unit tests (`test__wait_for_condition_*`) against a minimal `_FakePilot` covering: immediate-true (checked once, no pause), timeout-raises-with-message, and callable-message-evaluated-at-raise. Converted all 12 conflict-family loops across the 7 named tests; left the bare `for _ in range(10): await pilot.pause(0.02)` settle-drain in the preview test and the ~91 other-feature `range(150)`/`range(N)` loops elsewhere in the file untouched (out of scope). All 10 tests (7 note-conflict + 3 helper) pass; confirmed via TDD RED (NameError) -> GREEN, then per-test conversion with the full gate green throughout.


### PR DESCRIPTION
## Task 192 — de-flake the library note-conflict shell tests under CPU contention

`test_library_shell_note_conflict_shows_overwrite_reload_and_keeps_user_text` (and its sibling note-conflict tests) intermittently failed under concurrent CPU load but passed in isolation. Root cause: after pressing Save (which drives an async worker that sets `_library_note_autosave_state = "conflict"`), each test waited with a **fixed-iteration** poll:

```python
for _ in range(150):
    if screen._library_note_autosave_state == "conflict": break
    await pilot.pause(0.02)
else:
    raise AssertionError("The version conflict was never reached.")
```

150 × `pause(0.02)` ≈ 3s of budget — under contention the worker is starved and the `else` fires.

### Fix: condition-based waiting on a wall-clock deadline
New test helper `_wait_for_condition(pilot, predicate, *, timeout=15.0, message, interval=0.02)` — a byte-faithful port of the loop (check predicate first, return the instant it's truthy with **no** trailing settle pause, else `pause(interval)` and re-check) with the fixed count replaced by a `time.monotonic()` deadline. A deadline decouples the budget from *iterations × per-pause-time* (unpredictable under contention), returns immediately when the condition is met (isolation stays fast), and replaces a magic number with an intention-revealing call. `message` accepts a str **or** a zero-arg callable, so the two dynamic diagnostic messages still interpolate the *stuck* state at raise time.

Converted the **12** conflict-family poll loops across the **7** note-conflict tests to `await _wait_for_condition(...)`, each preserving its verbatim message and predicate (incl. one compound `idle and editor` predicate and the two `save_calls` / dynamic-message loops).

### Scope
- **Test-only** — no production code changed.
- Left untouched: the bare `for _ in range(10): await pilot.pause(0.02)` drain (no predicate), the existing `_wait_for_library_shell` / `_wait_for_selector` / `_wait_for_library_rag_query_ready` helpers, and the ~120 other-feature `range(N)` loops in the file. Reimplementing those on the new helper is a possible future consolidation, out of scope.

### Testing
- 3 helper unit tests (fake pilot, RED→GREEN): immediate-true returns without pausing (asserts 0 pauses); never-true raises the message on timeout; callable message evaluated at raise time.
- Baseline verified: all 7 note-conflict tests passed in isolation *before* the change (pure refactor).
- Gate: `-k "note_conflict or _wait_for_condition"` = **10 passed**; the **full `Tests/UI/test_library_shell.py` = 253 passed** (no collateral).

### Review
Subagent-Driven; per-task review independently traced all 12 predicate/message mappings to source (faithful helper, correct compound predicate + deferred dynamic messages, contained scope). Whole-branch review intentionally not run separately — a single-task, test-only refactor already covered comprehensively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilized the library note-conflict shell tests under CPU contention by replacing fixed-iteration polls with a deadline-based wait helper. Adds predicate-first evaluation to avoid false timeouts, keeping tests fast in isolation and addressing task 192.

- **Bug Fixes**
  - Added async `_wait_for_condition(pilot, predicate, *, timeout=15.0, message, interval=0.02)` that checks the predicate first (and after any pause that overshoots the deadline); `message` accepts a string or zero-arg callable.
  - Replaced 12 polling loops across 7 note-conflict tests with the helper, preserving all predicates and messages (including compound and dynamic cases); left the preview drain loop and other `_wait_for_*` helpers unchanged.
  - Expanded helper tests to 4: immediate return with 0 pauses, timeout raises message, callable message evaluated at raise, and timeout=0 still succeeds when already true (using a pause-counting `_FakePilot`).
  - Test-only change; added implementation plan and design spec; marked task-192 as Done.

<sup>Written for commit 7e76d2f02e52410adef5e2a1309841471748bc56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

