### PR TITLE
fix(ingest): loosen validate_url (212) + URL-payload persist test (213) + dedupe task-192 id

### DIFF
--- a/Docs/superpowers/plans/2026-07-13-url-ingest-followups-212-213.md
+++ b/Docs/superpowers/plans/2026-07-13-url-ingest-followups-212-213.md
@@ -1,0 +1,215 @@
+# URL-ingest follow-up hardening (212 + 213) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax. Spec: `Docs/superpowers/specs/2026-07-13-url-ingest-followups-212-213-design.md`. Branch `claude/followups-212-213` off dev `2c5aa25a` (already carries the task-192→214 id-fix commit).
+
+**Goal:** Replace `validate_url`'s brittle regex with `urllib.parse`-based validation (long TLDs / IPv6 / IDN supported, no caller regression), and add the one missing URL-ingest edge test (a URL payload through `persist_parsed_media`).
+
+**Architecture:** Task 1 rewrites `Utils/input_validation.py:validate_url` (production) + extends its unit tests. Task 2 adds one characterization test locking the URL-payload persist seam. Both changes are small and independent.
+
+**Tech Stack:** Python `urllib.parse`, pytest, `MediaDatabase(":memory:")`.
+
+## Global Constraints
+
+- **`validate_url` stays `(str) -> bool`, never raises**, and preserves its existing metrics calls (`log_counter`/`log_histogram`) and the `len(url) > 2000` cap — only the *validation mechanism* changes.
+- **No regression:** the existing `Tests/Web_Scraping/test_input_validation.py`, `Tests/Web_Scraping/test_security.py`, and `Tests/UI/test_library_url_ingest_submit.py` suites must stay green **unchanged** (verified empirically: every `valid_urls` → True, every `invalid_urls` + malicious URL → False, all AC cases → True).
+- **Security property preserved:** `scheme in ("http","https")` rejects `file:`/`javascript:`/`data:`/`vbscript:`/`about:`/`chrome:`/`ftp:`.
+- **No production change for 213** — test-only; `persist_parsed_media` already handles URL payloads.
+- **`persist_parsed_media` reads these payload keys** (a missing one `KeyError`s): `file_type, title, media_type, content, keywords, url, analysis_content, author, chunks, chunk_options`. It does NOT read `file_path`.
+- **Staging:** explicit paths only. Every commit ends with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- **Test command** (venv, isolated HOME):
+  ```
+  HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+    .venv/bin/python -m pytest <target> -q -p no:cacheprovider -o addopts="" --timeout=120
+  ```
+  (Use the repo-root-relative `.venv/bin/python`.)
+
+---
+
+### Task 1: urlparse-based `validate_url` + unit tests (task 212)
+
+**Files:**
+- Modify: `tldw_chatbook/Utils/input_validation.py` (`validate_url` body + a module-level import)
+- Modify: `Tests/Web_Scraping/test_input_validation.py` (add test methods to `TestURLValidation`)
+- Modify: `backlog/tasks/task-212 - Loosen-validate_url-for-URL-ingest-long-TLDs-IPv6-IDN.md`
+
+**Interfaces:**
+- Produces: `validate_url(url: str) -> bool` — unchanged signature; now accepts long-TLD/IPv6/IDN/single-label http(s) URLs and rejects whitespace / malformed-or-out-of-range ports.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these methods inside `class TestURLValidation:` in `Tests/Web_Scraping/test_input_validation.py`:
+```python
+    def test_loosened_urls_now_accepted(self):
+        """URLs the old TLD/IPv6/IDN-blind regex wrongly rejected must now validate."""
+        for url in [
+            "https://blog.example.software/post",   # long TLD (>6 chars)
+            "https://[::1]/x",                       # IPv6 literal host
+            "https://münchen.de/p",                  # IDN (Unicode host)
+            "https://foo",                           # single-label host (internal/docker)
+        ]:
+            assert validate_url(url) is True, f"URL should now be valid: {url}"
+
+    def test_whitespace_and_bad_ports_rejected(self):
+        """Raw whitespace and malformed/out-of-range ports are rejected."""
+        for url in [
+            "http://exam ple.com",                   # space in host
+            "https://example.com\t/x",               # tab
+            "https://example.com:foo/",              # non-integer port
+            "https://example.com:99999999999/x",     # out-of-range port
+        ]:
+            assert validate_url(url) is False, f"URL should be invalid: {url}"
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run:
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  .venv/bin/python -m pytest \
+  "Tests/Web_Scraping/test_input_validation.py::TestURLValidation::test_loosened_urls_now_accepted" \
+  "Tests/Web_Scraping/test_input_validation.py::TestURLValidation::test_whitespace_and_bad_ports_rejected" \
+  -q -p no:cacheprovider -o addopts="" --timeout=60
+```
+Expected: FAIL — the old regex rejects the long-TLD/IPv6/IDN/single-label URLs (accepted test fails) and accepts `:99999999999` (rejected test fails on that line).
+
+- [ ] **Step 3: Rewrite `validate_url` (urlparse-based)**
+
+In `tldw_chatbook/Utils/input_validation.py`, add a module-level import near the top (with the other imports, e.g. after `import time`):
+```python
+from urllib.parse import urlparse
+```
+Then replace the regex block in `validate_url` — everything from the `# Basic URL pattern` comment through `result = bool(pattern.match(url))` — with:
+```python
+    if any(c.isspace() for c in url):
+        # A valid URL contains no raw whitespace (spaces are %-encoded).
+        result = False
+    else:
+        try:
+            parsed = urlparse(url)
+            _ = parsed.port  # raises ValueError on a malformed/out-of-range port
+            result = parsed.scheme in ("http", "https") and bool(parsed.hostname)
+        except ValueError:
+            result = False
+```
+Leave the `if not url or len(url) > 2000:` guard above it and the metrics tail below it (`log_histogram("input_validation_url_duration", ...)`, `log_counter("input_validation_url_result", ...)`, `log_histogram("input_validation_url_length", ...)`, `return result`) exactly as they are. The now-unused `re` import may stay if other functions in the file use it (do NOT remove `re` without confirming no other user).
+
+- [ ] **Step 4: Run the new tests to verify they pass**
+
+Run the Step-2 command. Expected: 2 passed.
+
+- [ ] **Step 5: Run the full regression gate**
+
+Run:
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  .venv/bin/python -m pytest \
+  Tests/Web_Scraping/test_input_validation.py Tests/Web_Scraping/test_security.py \
+  Tests/UI/test_library_url_ingest_submit.py \
+  -q -p no:cacheprovider -o addopts="" --timeout=120
+```
+Expected: ALL pass (the existing `valid_urls`/`invalid_urls`/malicious-URL assertions still hold — the rewrite is a verified superset-of-accepts that still rejects every previously-rejected URL, incl. `http://exam ple.com`).
+
+- [ ] **Step 6: Mark backlog task 212 Done**
+
+```bash
+perl -0pi -e 's/- \[ \] #1/- [x] #1/' "backlog/tasks/task-212 - Loosen-validate_url-for-URL-ingest-long-TLDs-IPv6-IDN.md"
+perl -0pi -e 's/^status: .*/status: Done/mi' "backlog/tasks/task-212 - Loosen-validate_url-for-URL-ingest-long-TLDs-IPv6-IDN.md"
+```
+Add a short `## Implementation Notes`: replaced the regex with urlparse-based validation (scheme + host + port-guard + whitespace-reject); long-TLD/IPv6/IDN now supported; verified no regression against the three existing suites; single-label hosts now accepted and out-of-range ports now rejected (both intentional).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tldw_chatbook/Utils/input_validation.py Tests/Web_Scraping/test_input_validation.py \
+  "backlog/tasks/task-212 - Loosen-validate_url-for-URL-ingest-long-TLDs-IPv6-IDN.md"
+git commit -m "fix(validation): urlparse-based validate_url (long TLD / IPv6 / IDN); task 212 done (212)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: URL-payload persist test (task 213)
+
+**Files:**
+- Modify: `Tests/Local_Ingestion/test_ingest_parse_worker.py` (add one test near `test_persist_writes_payload_and_returns_media_id`)
+- Modify: `backlog/tasks/task-213 - Add-URL-ingest-edge-path-tests-DNS-permanent-persist-URL-payload.md`
+
+**Interfaces:**
+- Consumes: `persist_parsed_media(payload, media_db)` and `MediaDatabase` (both already imported in the test module at lines ~32/42).
+
+- [ ] **Step 1: Write the coverage-lock test**
+
+Add to `Tests/Local_Ingestion/test_ingest_parse_worker.py` (after `test_persist_writes_payload_and_returns_media_id`):
+```python
+def test_persist_url_payload_writes_article_row_no_filesystem() -> None:
+    """A URL-source payload (media_type=article, canonical url, URL string as
+    file_path) persists to a media row without any filesystem access -- the
+    payload's file_path is a URL that is not a real file, and persist never
+    stats/opens it (it only forwards url/content/etc. to the DB)."""
+    payload = {
+        "file_type": "article",
+        "media_type": "article",
+        "title": "Kept article",
+        "content": "Extracted article body.",
+        "keywords": [],
+        "url": "https://example.com/post",
+        "analysis_content": "",
+        "author": "Unknown",
+        "chunks": None,
+        "chunk_options": None,
+        "file_path": "https://example.com/post",  # a URL, NOT a real file -> never accessed
+    }
+
+    db = MediaDatabase(":memory:", client_id="test-url-persist")
+    media_id, media_uuid, message = persist_parsed_media(payload, db)
+
+    assert isinstance(media_id, int)
+    assert isinstance(media_uuid, str) and media_uuid
+    row = db.get_media_by_id(media_id)
+    assert row is not None
+    assert row["url"] == "https://example.com/post"
+    assert row["type"] == "article"
+```
+
+- [ ] **Step 2: Run to verify it PASSES (coverage lock, not RED-first)**
+
+Run:
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  .venv/bin/python -m pytest \
+  "Tests/Local_Ingestion/test_ingest_parse_worker.py::test_persist_url_payload_writes_article_row_no_filesystem" \
+  -q -p no:cacheprovider -o addopts="" --timeout=60
+```
+Expected: PASS. This is a **characterization/coverage test** — `persist_parsed_media` already handles URL payloads (that is exactly the hand-verified seam #614's review wanted locked), so there is no RED phase. The test succeeding with a non-existent-file URL as `file_path` is itself the "no filesystem access" proof. If the DB assertion names differ (e.g. `row["type"]` vs `row["media_type"]`), align to what `get_media_by_id` returns — the existing `test_persist_writes_payload_and_returns_media_id` uses `row["type"]`.
+
+- [ ] **Step 3: Mark backlog task 213 Done**
+
+```bash
+perl -0pi -e 's/- \[ \] #1/- [x] #1/' "backlog/tasks/task-213 - Add-URL-ingest-edge-path-tests-DNS-permanent-persist-URL-payload.md"
+perl -0pi -e 's/^status: .*/status: Done/mi' "backlog/tasks/task-213 - Add-URL-ingest-edge-path-tests-DNS-permanent-persist-URL-payload.md"
+```
+Add a short `## Implementation Notes`: AC #1 (DNS→permanent) was already covered by `test_dns_failure_is_permanent` (shipped in #614); this task adds the missing URL-payload `persist_parsed_media` coverage test.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Tests/Local_Ingestion/test_ingest_parse_worker.py \
+  "backlog/tasks/task-213 - Add-URL-ingest-edge-path-tests-DNS-permanent-persist-URL-payload.md"
+git commit -m "test(ingest): lock URL-payload persist_parsed_media seam; task 213 done (213)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Final gate (after Task 2)
+
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  .venv/bin/python -m pytest \
+  Tests/Web_Scraping/test_input_validation.py Tests/Web_Scraping/test_security.py \
+  Tests/UI/test_library_url_ingest_submit.py Tests/Local_Ingestion/test_ingest_parse_worker.py \
+  -q -p no:cacheprovider -o addopts="" --timeout=180
+```
+Expected all pass. Then the whole-branch review and finishing-a-development-branch.

--- a/Docs/superpowers/specs/2026-07-13-url-ingest-followups-212-213-design.md
+++ b/Docs/superpowers/specs/2026-07-13-url-ingest-followups-212-213-design.md
@@ -29,7 +29,6 @@ def validate_url(url: str) -> bool:
     if any(c.isspace() for c in url):          # a valid URL contains no raw whitespace
         result = False
     else:
-        from urllib.parse import urlparse
         try:
             parsed = urlparse(url)
             _ = parsed.port                     # raises ValueError on a malformed/out-of-range port
@@ -39,6 +38,8 @@ def validate_url(url: str) -> bool:
     # ... existing duration/result/length metrics unchanged ...
     return result
 ```
+
+Add `from urllib.parse import urlparse` at module level (`input_validation.py` already imports `re`/`time`/`ipaddress`; it is not a spawn-worker module, so a top-level import is cleaner than a deferred one). The regex `pattern` block is removed.
 
 **Why urlparse over patching the regex:** it natively handles long TLDs, IPv6 (`[::1]` → host `::1`), IDN (Unicode host), localhost, IPs, and ports — cleanly satisfying the AC's "supported" branch, versus a growing, fragile regex. The `scheme in ("http","https")` check preserves the security property (rejects `file:`/`javascript:`/`data:`/`vbscript:`/`about:`/`chrome:`/`ftp:`).
 
@@ -56,7 +57,7 @@ def validate_url(url: str) -> bool:
 
 Add one test near `test_persist_writes_payload_and_returns_media_id` in `Tests/Local_Ingestion/test_ingest_parse_worker.py` (which currently covers only a *file* payload):
 
-- Build a URL payload dict directly (mirroring the URL-source tail of `parse_local_file_for_ingest`): `media_type='article'`, `file_type='article'`, `url='https://example.com/post'`, `file_path='https://example.com/post'`, `title`, `content`, `keywords=[]`, `analysis_content=''`, `chunks=None`, `chunk_options=None`.
+- Build a URL payload dict directly (mirroring the URL-source tail of `parse_local_file_for_ingest`) with the exact keys `persist_parsed_media` reads — `file_type='article'`, `title`, `media_type='article'`, `content`, `keywords=[]`, `url='https://example.com/post'`, `analysis_content=''`, `author='Unknown'`, `chunks=None`, `chunk_options=None` — plus `file_path='https://example.com/post'` (which `persist_parsed_media` does NOT read — its presence-but-non-use is the point). (Omitting `author` would `KeyError`.)
 - `persist_parsed_media(payload, MediaDatabase(":memory:", client_id="test-url-persist"))`.
 - Assert the returned `media_id` is an int and `db.get_media_by_id(media_id)` has `row["url"] == "https://example.com/post"` and `row["type"] == "article"`.
 - **No-filesystem-access proof:** the payload's `file_path` is a URL string that is *not* a real file. `persist_parsed_media` never stats/opens it (it only passes `url`/`content`/… to `add_media_with_keywords`), so the test succeeding is itself the proof — no file exists at `https://example.com/post`, so any filesystem dependency on `file_path` would fail. `MediaDatabase(":memory:")` keeps the DB write in RAM.

--- a/Docs/superpowers/specs/2026-07-13-url-ingest-followups-212-213-design.md
+++ b/Docs/superpowers/specs/2026-07-13-url-ingest-followups-212-213-design.md
@@ -1,0 +1,81 @@
+# URL-ingest follow-up hardening (tasks 212 + 213)
+
+**Status:** Design approved (brainstorm), pending spec review.
+**Backlog:** task-212 (loosen `validate_url`) + task-213 (URL-ingest edge tests) — both from #614's whole-branch review of task 162.
+**Branch:** `claude/followups-212-213` off dev `2c5aa25a` (already carries the task-192→214 id-fix commit).
+
+## Problem
+
+Task 162 made `Utils/input_validation.py:validate_url` load-bearing at the Library ingest form. Its regex requires a 2-6 char TLD and has no IPv6/IDN support, so valid URLs — `https://blog.example.software/post` (long TLD), `https://[::1]/x` (IPv6), Unicode-domain URLs (IDN) — are falsely rejected there. It's a **shared** validator (~13 call sites: LLM/provider endpoint URLs, article scraping, RAG state, console gateway, settings probes), so any change must not regress those.
+
+Separately, #614's review verified two ingest seams by hand that needed automated coverage. One — a `socket.gaierror`-caused httpx error mapping to `PermanentIngestError` — was **already covered** by tests added during #614's bot-resolution (`test_dns_failure_is_permanent`). The other — a URL payload flowing through `persist_parsed_media` with no filesystem access — is still uncovered (the existing persist test is file-only).
+
+## Goal / Acceptance
+
+- **AC1 (212)** — a long-TLD URL (e.g. `.software`) is accepted by the Library ingest form; IPv6 and IDN hosts are supported; existing `validate_url` callers are unaffected (no regression).
+- **AC2 (213)** — a URL payload (`media_type='article'`, canonical url, `file_path`=URL string) is accepted end-to-end by `persist_parsed_media` with no filesystem access. (The DNS→permanent seam is already covered — see Non-goals.)
+
+## Component 1 (212): urlparse-based `validate_url`
+
+Replace the brittle regex with `urllib.parse`-based validation, preserving the length cap and the metrics/logging:
+
+```python
+def validate_url(url: str) -> bool:
+    start_time = time.time()
+    log_counter("input_validation_url_attempt")
+    if not url or len(url) > 2000:
+        log_counter("input_validation_url_invalid", labels={"reason": "empty" if not url else "too_long"})
+        return False
+    if any(c.isspace() for c in url):          # a valid URL contains no raw whitespace
+        result = False
+    else:
+        from urllib.parse import urlparse
+        try:
+            parsed = urlparse(url)
+            _ = parsed.port                     # raises ValueError on a malformed/out-of-range port
+            result = parsed.scheme in ("http", "https") and bool(parsed.hostname)
+        except ValueError:
+            result = False
+    # ... existing duration/result/length metrics unchanged ...
+    return result
+```
+
+**Why urlparse over patching the regex:** it natively handles long TLDs, IPv6 (`[::1]` → host `::1`), IDN (Unicode host), localhost, IPs, and ports — cleanly satisfying the AC's "supported" branch, versus a growing, fragile regex. The `scheme in ("http","https")` check preserves the security property (rejects `file:`/`javascript:`/`data:`/`vbscript:`/`about:`/`chrome:`/`ftp:`).
+
+**Verified no-regression (empirical):** the proposed function was run against every existing assertion — all 7 `valid_urls` → True, all 13 `invalid_urls` → False, all 7 `test_security.py` malicious URLs → False, and all 3 AC cases → True. Zero regressions.
+
+**The whitespace guard is load-bearing:** `http://exam ple.com` (space in domain) is in the existing "should be False" list, and urlparse alone gives it a non-empty hostname → it would wrongly pass. Rejecting any raw-whitespace URL fixes that (and rejects tabs/newlines, which the old regex tolerated via `$`-before-`\n` — an accepted, more-correct change).
+
+**Two intentional broadenings** (no test or caller depends on the old behavior; security unchanged):
+- single-label hosts (`https://foo`) now validate — correct for internal/docker hosts;
+- out-of-range ports (`:99999999999`) now rejected — the old `:\d+` regex accepted them.
+
+**Testing:** extend `Tests/Web_Scraping/test_input_validation.py` with the new accept cases (long-TLD, IPv6, IDN) and the whitespace-/bad-port-reject cases. The existing `test_input_validation.py`, `Tests/Web_Scraping/test_security.py`, and `Tests/UI/test_library_url_ingest_submit.py` suites are the regression gate — all must stay green unchanged.
+
+## Component 2 (213): URL-payload persist test
+
+Add one test near `test_persist_writes_payload_and_returns_media_id` in `Tests/Local_Ingestion/test_ingest_parse_worker.py` (which currently covers only a *file* payload):
+
+- Build a URL payload dict directly (mirroring the URL-source tail of `parse_local_file_for_ingest`): `media_type='article'`, `file_type='article'`, `url='https://example.com/post'`, `file_path='https://example.com/post'`, `title`, `content`, `keywords=[]`, `analysis_content=''`, `chunks=None`, `chunk_options=None`.
+- `persist_parsed_media(payload, MediaDatabase(":memory:", client_id="test-url-persist"))`.
+- Assert the returned `media_id` is an int and `db.get_media_by_id(media_id)` has `row["url"] == "https://example.com/post"` and `row["type"] == "article"`.
+- **No-filesystem-access proof:** the payload's `file_path` is a URL string that is *not* a real file. `persist_parsed_media` never stats/opens it (it only passes `url`/`content`/… to `add_media_with_keywords`), so the test succeeding is itself the proof — no file exists at `https://example.com/post`, so any filesystem dependency on `file_path` would fail. `MediaDatabase(":memory:")` keeps the DB write in RAM.
+
+## Data flow
+
+212 changes only the internal validation mechanism of `validate_url`; its `(str) -> bool` contract and metrics are unchanged. 213 adds a test only. No production behavior changes beyond `validate_url` accepting the previously-rejected valid URLs.
+
+## Error handling
+
+`validate_url` returns `False` (never raises) for every invalid input, including a malformed/out-of-range port (the `.port` `ValueError` is caught) and `None`/empty/over-length — matching the current contract.
+
+## Testing summary
+
+- `validate_url` unit tests (new accepts + rejects) in `test_input_validation.py`; existing `test_input_validation` / `test_security` / `test_library_url_ingest_submit` as the regression gate.
+- One URL-payload `persist_parsed_media` test in `test_ingest_parse_worker.py`.
+
+## Scope / non-goals
+
+- **213 test #1 (DNS→permanent) is already done** (`test_dns_failure_is_permanent` + `test_connection_error_without_dns_cause_is_retryable`, shipped in #614). Not re-implemented.
+- No changes to the ~13 `validate_url` callers, no UI copy changes (the AC's "actionable rejection copy" branch is moot — IPv6/IDN are now *supported*, so the form accepts them).
+- The `_has_valid_url_port` helper in `console_session_settings.py` (an extra per-caller port check) is left as-is.

--- a/Tests/Local_Ingestion/test_ingest_parse_worker.py
+++ b/Tests/Local_Ingestion/test_ingest_parse_worker.py
@@ -220,6 +220,36 @@ def test_persist_writes_payload_and_returns_media_id(tmp_path: Path) -> None:
     assert row["type"] == "plaintext"
 
 
+def test_persist_url_payload_writes_article_row_no_filesystem() -> None:
+    """A URL-source payload (media_type=article, canonical url, URL string as
+    file_path) persists to a media row without any filesystem access -- the
+    payload's file_path is a URL that is not a real file, and persist never
+    stats/opens it (it only forwards url/content/etc. to the DB)."""
+    payload = {
+        "file_type": "article",
+        "media_type": "article",
+        "title": "Kept article",
+        "content": "Extracted article body.",
+        "keywords": [],
+        "url": "https://example.com/post",
+        "analysis_content": "",
+        "author": "Unknown",
+        "chunks": None,
+        "chunk_options": None,
+        "file_path": "https://example.com/post",  # a URL, NOT a real file -> never accessed
+    }
+
+    db = MediaDatabase(":memory:", client_id="test-url-persist")
+    media_id, media_uuid, message = persist_parsed_media(payload, db)
+
+    assert isinstance(media_id, int)
+    assert isinstance(media_uuid, str) and media_uuid
+    row = db.get_media_by_id(media_id)
+    assert row is not None
+    assert row["url"] == "https://example.com/post"
+    assert row["type"] == "article"
+
+
 def test_persist_db_failure_is_wrapped_as_file_ingestion_error(tmp_path: Path) -> None:
     source = tmp_path / "note.txt"
     source.write_text("content", encoding="utf-8")

--- a/Tests/Web_Scraping/test_input_validation.py
+++ b/Tests/Web_Scraping/test_input_validation.py
@@ -68,6 +68,26 @@ class TestURLValidation:
         ]
         # These might fail with basic regex, which is acceptable for security
 
+    def test_loosened_urls_now_accepted(self):
+        """URLs the old TLD/IPv6/IDN-blind regex wrongly rejected must now validate."""
+        for url in [
+            "https://blog.example.software/post",   # long TLD (>6 chars)
+            "https://[::1]/x",                       # IPv6 literal host
+            "https://münchen.de/p",                  # IDN (Unicode host)
+            "https://foo",                           # single-label host (internal/docker)
+        ]:
+            assert validate_url(url) is True, f"URL should now be valid: {url}"
+
+    def test_whitespace_and_bad_ports_rejected(self):
+        """Raw whitespace and malformed/out-of-range ports are rejected."""
+        for url in [
+            "http://exam ple.com",                   # space in host
+            "https://example.com\t/x",               # tab
+            "https://example.com:foo/",              # non-integer port
+            "https://example.com:99999999999/x",     # out-of-range port
+        ]:
+            assert validate_url(url) is False, f"URL should be invalid: {url}"
+
 
 class TestTextInputValidation:
     """Test text input validation and sanitization."""

--- a/Tests/Web_Scraping/test_input_validation.py
+++ b/Tests/Web_Scraping/test_input_validation.py
@@ -88,6 +88,20 @@ class TestURLValidation:
         ]:
             assert validate_url(url) is False, f"URL should be invalid: {url}"
 
+    def test_security_hardening_rejected(self):
+        """urlparse is lenient about these; the hardening rejects them (as the
+        old regex did): backslash hosts (\\-vs-/ parser-discrepancy SSRF),
+        malformed dotted hosts, and credential-bearing URLs (secret leakage)."""
+        for url in [
+            "https://example.com\\path",             # backslash (browsers normalise \\->/)
+            "https://..",                            # bare dots
+            "https://.example.com",                  # leading-dot host
+            "https://example..com",                  # consecutive-dot host
+            "https://user:pass@example.com/path",    # embedded credentials
+            "https://user@example.com/path",         # embedded username
+        ]:
+            assert validate_url(url) is False, f"URL should be invalid: {url}"
+
 
 class TestTextInputValidation:
     """Test text input validation and sanitization."""

--- a/backlog/tasks/task-212 - Loosen-validate_url-for-URL-ingest-long-TLDs-IPv6-IDN.md
+++ b/backlog/tasks/task-212 - Loosen-validate_url-for-URL-ingest-long-TLDs-IPv6-IDN.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-212
 title: Loosen validate_url for URL ingest (long TLDs / IPv6 / IDN)
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-12 20:58'
+updated_date: '2026-07-13 02:45'
 labels:
   - library
   - ingest
@@ -19,5 +20,11 @@ URL ingest (task 162) made Utils/input_validation.py:validate_url load-bearing a
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A URL with a long TLD (e.g. .software) is accepted by the Library ingest form,IPv6 and IDN host handling is either supported or the rejection copy is made actionable,Existing validate_url callers are unaffected (no regression)
+- [x] #1 A URL with a long TLD (e.g. .software) is accepted by the Library ingest form,IPv6 and IDN host handling is either supported or the rejection copy is made actionable,Existing validate_url callers are unaffected (no regression)
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Replaced the regex with urlparse-based validation (scheme + host + port-guard + whitespace-reject); long-TLD/IPv6/IDN now supported; verified no regression against the three existing suites; single-label hosts now accepted and out-of-range ports now rejected (both intentional).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-213 - Add-URL-ingest-edge-path-tests-DNS-permanent-persist-URL-payload.md
+++ b/backlog/tasks/task-213 - Add-URL-ingest-edge-path-tests-DNS-permanent-persist-URL-payload.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-213
 title: 'Add URL-ingest edge-path tests (DNS-permanent, persist URL payload)'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-12 20:58'
 labels:
@@ -20,5 +20,9 @@ The whole-branch review verified two seams by hand that lack automated coverage:
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A test asserts a socket.gaierror-caused httpx error yields PermanentIngestError (permanent),A test drives a URL payload through persist_parsed_media and asserts a media row with the canonical url and correct media_type,No filesystem access occurs for a URL payload
+- [x] #1 A test asserts a socket.gaierror-caused httpx error yields PermanentIngestError (permanent),A test drives a URL payload through persist_parsed_media and asserts a media row with the canonical url and correct media_type,No filesystem access occurs for a URL payload
 <!-- AC:END -->
+
+## Implementation Notes
+
+AC #1 (DNS→permanent) was already covered by `test_dns_failure_is_permanent` (shipped in #614). This task adds the missing URL-payload `persist_parsed_media` coverage test: `test_persist_url_payload_writes_article_row_no_filesystem` in `Tests/Local_Ingestion/test_ingest_parse_worker.py`. The test drives a URL payload with all required keys through `persist_parsed_media`, verifies the media row persists with correct canonical URL and `type='article'`, and confirms no filesystem access occurs (file_path is a URL string, never accessed).

--- a/backlog/tasks/task-214 - Settings-reflects-saved-default-provider-instead-of-boot-app-selection.md
+++ b/backlog/tasks/task-214 - Settings-reflects-saved-default-provider-instead-of-boot-app-selection.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-192
+id: TASK-214
 title: Settings reflects saved default provider instead of boot app selection
 status: To Do
 assignee: []

--- a/tldw_chatbook/Utils/input_validation.py
+++ b/tldw_chatbook/Utils/input_validation.py
@@ -4,9 +4,10 @@ Input validation utilities for secure user input handling.
 import re
 import ipaddress
 import time
-from typing import Union, Optional
 from pathlib import Path
+from typing import Union, Optional
 from urllib.parse import urlparse
+
 from ..Metrics.metrics_logger import log_counter, log_histogram
 
 
@@ -102,24 +103,50 @@ def validate_port(port: Union[str, int]) -> bool:
 
 
 def validate_url(url: str) -> bool:
-    """Basic URL validation."""
+    """Validate an http/https URL by scheme and host.
+
+    Uses ``urllib.parse`` (so long TLDs, IPv6 literals, IDN/Unicode hosts, IPs,
+    and localhost all validate) but rejects inputs that ``urlparse`` is too
+    lenient about: raw whitespace, backslashes (browsers normalise ``\\``→``/``,
+    a parser-discrepancy SSRF vector), embedded credentials (``user:pass@host``,
+    which would carry secrets into logged/forwarded URLs), and malformed hosts
+    (leading/consecutive dots) or ports. Only ``http``/``https`` schemes pass.
+
+    Args:
+        url: The candidate URL string.
+
+    Returns:
+        ``True`` if ``url`` is a well-formed http/https URL with a valid host
+        and no whitespace/backslashes/credentials/malformed host or port;
+        ``False`` otherwise (never raises).
+    """
     start_time = time.time()
     log_counter("input_validation_url_attempt")
-    
+
     if not url or len(url) > 2000:
         log_counter("input_validation_url_invalid", labels={
             "reason": "empty" if not url else "too_long"
         })
         return False
-    
-    if any(c.isspace() for c in url):
-        # A valid URL contains no raw whitespace (spaces are %-encoded).
+
+    if any(c.isspace() for c in url) or "\\" in url:
+        # A valid URL has no raw whitespace (spaces are %-encoded) and no
+        # backslashes (which HTTP clients may normalise to "/", enabling
+        # parser-discrepancy SSRF/open-redirect bypasses).
         result = False
     else:
         try:
             parsed = urlparse(url)
             _ = parsed.port  # raises ValueError on a malformed/out-of-range port
-            result = parsed.scheme in ("http", "https") and bool(parsed.hostname)
+            hostname = parsed.hostname
+            result = (
+                parsed.scheme in ("http", "https")
+                and bool(hostname)
+                and not hostname.startswith(".")   # reject ".example.com" / ".."
+                and ".." not in hostname            # reject "example..com"
+                and parsed.username is None         # reject embedded credentials
+                and parsed.password is None
+            )
         except ValueError:
             result = False
     

--- a/tldw_chatbook/Utils/input_validation.py
+++ b/tldw_chatbook/Utils/input_validation.py
@@ -6,6 +6,7 @@ import ipaddress
 import time
 from typing import Union, Optional
 from pathlib import Path
+from urllib.parse import urlparse
 from ..Metrics.metrics_logger import log_counter, log_histogram
 
 
@@ -111,16 +112,16 @@ def validate_url(url: str) -> bool:
         })
         return False
     
-    # Basic URL pattern
-    pattern = re.compile(
-        r'^https?://'  # http:// or https://
-        r'(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+[A-Z]{2,6}\.?|'  # domain...
-        r'localhost|'  # localhost...
-        r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})'  # ...or ip
-        r'(?::\d+)?'  # optional port
-        r'(?:/?|[/?]\S+)$', re.IGNORECASE)
-    
-    result = bool(pattern.match(url))
+    if any(c.isspace() for c in url):
+        # A valid URL contains no raw whitespace (spaces are %-encoded).
+        result = False
+    else:
+        try:
+            parsed = urlparse(url)
+            _ = parsed.port  # raises ValueError on a malformed/out-of-range port
+            result = parsed.scheme in ("http", "https") and bool(parsed.hostname)
+        except ValueError:
+            result = False
     
     # Log result
     duration = time.time() - start_time


### PR DESCRIPTION
## URL-ingest follow-up hardening (tasks 212 + 213) + a duplicate task-id fix

Three items from the wrap-up of task 162 / PR #614's whole-branch review.

### Backlog hygiene — resolve the duplicate `task-192` id
Two task files both carried `id: TASK-192` (the de-flake task, shipped in #617, and a still-open "Settings reflects saved default provider" task). Renumbered the **still-open Settings task to 214** (next free id above the 211-213 URL-ingest follow-ups); the de-flake task keeps 192. A clean count confirms zero duplicate `id:` values remain.

### 212 — loosen `validate_url` (long TLD / IPv6 / IDN)
Task 162 made `Utils/input_validation.py:validate_url` load-bearing at the Library ingest form, but its regex required a 2-6 char TLD and had no IPv6/IDN support — so `https://blog.example.software/post`, `https://[::1]/x`, and Unicode-domain URLs were falsely rejected.

Replaced the regex with `urllib.parse`-based validation:
```python
if any(c.isspace() for c in url): result = False        # raw whitespace → invalid
else:
    try:
        parsed = urlparse(url); _ = parsed.port          # ValueError on a bad/out-of-range port → reject
        result = parsed.scheme in ("http","https") and bool(parsed.hostname)
    except ValueError: result = False
```
This natively handles long TLDs, IPv6, IDN, localhost, IPs, and ports — cleaner and more correct than a growing regex. The `(str)->bool` contract, the `len>2000` cap, and the metrics/logging are unchanged. The `scheme in ("http","https")` check preserves the security gate (rejects `file:`/`javascript:`/`data:`/`vbscript:`/`about:`/`chrome:`/`ftp:`).

`validate_url` is a **shared** validator (~13 callers). **No regression, verified two ways:** empirically against every existing assertion (all `valid_urls`→True, all `invalid_urls`+malicious→False, all AC cases→True), and by an opus whole-branch trace of every caller (each user-text caller strips/normalizes before validating, so the two intentional hardenings — reject trailing-whitespace URLs, reject out-of-range ports — can't regress any live flow; `:0` stays accepted). The `http://exam ple.com` (space-in-domain) case in the existing "invalid" list is what the whitespace guard preserves.

### 213 — URL-ingest edge test
#614's review verified two seams by hand. AC #1 (a `socket.gaierror`-caused httpx error → `PermanentIngestError`) was **already covered** by `test_dns_failure_is_permanent` (shipped in #614's bot-resolution). This adds the remaining one: a coverage-lock test driving a URL payload (`media_type='article'`, canonical url, URL string as `file_path`) through `persist_parsed_media` — asserting an article media row with the canonical url and **no filesystem access** (the URL `file_path` is never a real file, and persist never receives it). Test-only.

### Testing
- New `validate_url` accept/reject tests + the existing `test_input_validation` / `test_security` / `test_library_url_ingest_submit` suites as the regression gate.
- New URL-payload `persist_parsed_media` test.
- Gate (all four files): **48 passed**; 212's regression gate was 25/25 RED→GREEN.

### Review
Subagent-Driven. 212 per-task review: Approved (metrics/length/security intact, no leftover regex). Whole-branch **opus** review: **Ready to merge — Yes**, no Critical/Important. It flagged two *pre-existing, out-of-scope* minors (a dead `international_urls` assertion loop in `test_edge_cases`; a case-sensitive metrics `scheme` label) — left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Loosened and hardened URL validation: accepts long TLDs, IPv6, IDN, and single‑label hosts using `urllib.parse`, and now rejects backslashes, credential-bearing URLs, and malformed dotted hosts. Added a test to ensure URL-based ingest persists without filesystem access, and fixed a duplicate backlog task ID.

- **Bug Fixes**
  - Replaced the URL regex with `urlparse` in `validate_url`: accepts long TLDs, IPv6 (`[::1]`), IDN, and single-label hosts; only `http/https`; rejects raw whitespace, backslashes, embedded credentials (`user[:pass]@`), leading/consecutive-dot hosts, and malformed/out-of-range ports; keeps `(str)->bool`, metrics, and 2000-char cap. Meets TASK-212.
  - Expanded tests in `Tests/Web_Scraping/test_input_validation.py` (including security hardening rejects) and added `test_persist_url_payload_writes_article_row_no_filesystem` to verify URL-payload persistence with no file access. Meets TASK-213.
  - Renumbered the still-open Settings task from `TASK-192` to `TASK-214` to remove a duplicate.

<sup>Written for commit 2cd30193a291a54f946b88c33c0f07eab1137ac8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

