### PR TITLE
feat(roleplay): P0 — reframe Personas→Roleplay + honest mode strip + workbench north-star

### DIFF
--- a/Docs/superpowers/plans/2026-07-13-roleplay-p0-reframe.md
+++ b/Docs/superpowers/plans/2026-07-13-roleplay-p0-reframe.md
@@ -20,9 +20,10 @@
 - **Test command** (venv, isolated HOME):
   ```
   HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
-    /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest <target> \
+    .venv/bin/python -m pytest <target> \
     -q -p no:cacheprovider -o addopts="" --timeout=180 --timeout-method=thread
   ```
+  (Run from the repo root with the venv activated, or use the venv's python directly. From a git worktree the venv lives in the main checkout, so substitute that checkout's `.venv/bin/python` absolute path.)
 
 ---
 
@@ -113,7 +114,7 @@ Then add these methods to `class TestWorkbenchShell:` (reusing its `mock_app_ins
 Run:
 ```
 HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
-  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  .venv/bin/python -m pytest \
   "Tests/UI/test_personas_workbench.py::TestWorkbenchShell::test_title_reframed_to_roleplay_keeps_state_suffix" \
   "Tests/UI/test_personas_workbench.py::TestWorkbenchShell::test_purpose_shows_active_mode_descriptor_and_updates_on_switch" \
   -q -p no:cacheprovider -o addopts="" --timeout=120 --timeout-method=thread
@@ -171,7 +172,7 @@ Then in `_apply_mode`, right after the existing status-row refresh (`self.query_
 Run the full personas workbench suite (catches the exact-title assertion at ~:4056 and `test_route_renders_destination_workbench`) plus the phase6 replay test (whose fragments you updated):
 ```
 HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
-  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  .venv/bin/python -m pytest \
   Tests/UI/test_personas_workbench.py \
   "Tests/UI/test_unified_shell_phase6_first_time_replay.py" \
   -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
@@ -239,7 +240,7 @@ Then add to `class TestWorkbenchShell:`:
 Run:
 ```
 HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
-  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  .venv/bin/python -m pytest \
   "Tests/UI/test_personas_workbench.py::TestWorkbenchShell::test_mode_chips_are_self_explaining_and_mark_coming_soon" \
   "Tests/UI/test_personas_workbench.py::TestWorkbenchShell::test_coming_soon_mode_shows_inviting_copy" \
   -q -p no:cacheprovider -o addopts="" --timeout=120 --timeout-method=thread
@@ -299,7 +300,7 @@ In `_apply_mode`, at the branch that shows the placeholder for not-yet-built mod
 Run:
 ```
 HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
-  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  .venv/bin/python -m pytest \
   Tests/UI/test_personas_workbench.py \
   -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
 ```
@@ -320,7 +321,7 @@ Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
 
 ```
 HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
-  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  .venv/bin/python -m pytest \
   Tests/UI/test_personas_workbench.py Tests/UI/test_personas_workbench_foundation.py \
   -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
 ```

--- a/Docs/superpowers/plans/2026-07-13-roleplay-p0-reframe.md
+++ b/Docs/superpowers/plans/2026-07-13-roleplay-p0-reframe.md
@@ -1,0 +1,327 @@
+# Roleplay P0 — reframe + honest mode strip Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax. Spec: `Docs/superpowers/specs/2026-07-13-roleplay-p0-reframe-northstar-design.md`. Branch `claude/personas-redesign` off dev `ea88ff95`. Line numbers exact at branch point; grep symbols if they drift.
+
+**Goal:** Reframe the Personas screen's *display* to "Roleplay" with a self-explaining, honest 4-mode strip — no behavior change to the working Characters/Personas modes, and no touching of any file the parallel Library-Prompts branch owns.
+
+**Architecture:** All edits are display-only, inside `tldw_chatbook/UI/Screens/personas_screen.py` (+ its existing UI tests). Task 1 reframes the identity (title base string) and turns the static purpose line into a per-mode descriptor that updates on mode switch. Task 2 makes the mode strip honest (self-explaining chip tooltips reusing Task 1's descriptor copy, a "· soon" marker + per-mode "coming soon" body for the not-yet-built Dictionaries/Lore modes). No CSS changes; no new files.
+
+**Tech Stack:** Python, Textual, pytest + `app.run_test()` (the existing `Tests/UI/test_personas_workbench.py` harness).
+
+## Global Constraints
+
+- **Display-only, Personas-owned.** Edit ONLY `personas_screen.py` (+ its tests). Do NOT touch `screen_registry.py`, `shell_destinations.py`, `route_inventory.py`, the route id `personas`, or `MODE_LABELS`/`MODE_CHIP_ORDER`'s membership.
+- **Leave "prompts" alone.** `MODE_CHIP_ORDER` still contains `"prompts"` on this branch; removing it is the parallel branch's Task 7. Do NOT remove it. New copy must be correct whether or not "prompts" is present (use a generic fallback for any mode without an explicit descriptor).
+- **Name = "Roleplay"** (never "Studio" — collides with the existing `Prompt_Studio_Interop` "Prompt Studio").
+- **Keep the dynamic title suffixes.** `_title_text()` appends ` | New {character|persona}` / ` | Editing {name}` / ` | Ready` and a ` - unsaved` suffix — change ONLY the `base` string.
+- **DRY:** the four mode meanings live in ONE dict (`_MODE_DESCRIPTORS`, Task 1), reused by both the purpose descriptor and the chip tooltips.
+- **No behavior regression:** Characters/Personas modes still compose, switch, and edit exactly as before.
+- Every commit ends with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- **Test command** (venv, isolated HOME):
+  ```
+  HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+    /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest <target> \
+    -q -p no:cacheprovider -o addopts="" --timeout=180 --timeout-method=thread
+  ```
+
+---
+
+### Task 1: Identity reframe + per-mode descriptor
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/personas_screen.py` (`_title_text` base `:887`; add `_MODE_DESCRIPTORS` + `_mode_descriptor_text`; `#personas-purpose` compose value `:355`; `_apply_mode` update `~:863`)
+- Modify: `Tests/UI/test_personas_workbench.py` (update TWO existing assertions that pin the old copy + add reframe tests)
+- Modify: `Tests/UI/test_unified_shell_phase6_first_time_replay.py` (update the personas nav-row expected text fragments — old title/purpose copy)
+
+**Interfaces:**
+- Produces: `_MODE_DESCRIPTORS: dict[str, str]` (module-level) and `PersonasScreen._mode_descriptor_text(self, mode: str) -> str` — the one-line meaning of a mode (falls back to `MODE_LABELS.get(mode, mode)` for modes without an explicit entry, e.g. "prompts"). Task 2 reuses these for chip tooltips.
+
+- [ ] **Step 1: Write/adjust the tests (RED)**
+
+First update the existing assertions that pin the old copy — the reframe *will* break them, so they're part of this change:
+
+(a) In `Tests/UI/test_personas_workbench.py`, `TestWorkbenchShell.test_route_renders_destination_workbench` (~`:148`):
+```python
+            assert "Personas" in str(title.renderable)      # OLD
+```
+→
+```python
+            assert "Roleplay" in str(title.renderable)      # NEW
+```
+
+(b) In `Tests/UI/test_personas_workbench.py` (~`:4054-4057`), the exact-title assertion:
+```python
+            assert (
+                str(title.renderable)
+                == "Personas | Behavior profiles for chat and agents | Ready"      # OLD
+            )
+```
+→
+```python
+            assert (
+                str(title.renderable)
+                == "Roleplay | Author the pieces that shape a chat | Ready"         # NEW
+            )
+```
+
+(c) In `Tests/UI/test_unified_shell_phase6_first_time_replay.py` (~`:157-163`), the `"nav-personas"` row's expected-fragments tuple (which pins the old title + old purpose copy) — replace the fragment tuple:
+```python
+                    (
+                        "Personas",
+                        "Behavior profiles for chat and agents",
+                        "characters, personas, prompts, dictionaries, and lore",
+                        "Attach to Console",
+                    ),
+```
+→ fragments that are actually rendered after the reframe (title tagline + a chip that's always present):
+```python
+                    (
+                        "Roleplay",
+                        "Author the pieces that shape a chat",
+                        "Characters",
+                        "Lore",
+                    ),
+```
+
+Then add these methods to `class TestWorkbenchShell:` (reusing its `mock_app_instance`/`stub_characters` fixtures + `_mounted`/`PersonasTestApp`):
+```python
+    async def test_title_reframed_to_roleplay_keeps_state_suffix(self, mock_app_instance, stub_characters):
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            assert str(screen.query_one("#personas-title", Static).renderable).startswith("Roleplay")
+            # dynamic suffix still appends in create mode
+            screen._edit_mode = "create"
+            screen._update_title()
+            await pilot.pause()
+            title = str(screen.query_one("#personas-title", Static).renderable)
+            assert title.startswith("Roleplay") and "New character" in title
+
+    async def test_purpose_shows_active_mode_descriptor_and_updates_on_switch(self, mock_app_instance, stub_characters):
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            purpose = screen.query_one("#personas-purpose", Static)
+            assert "Who the AI plays" in str(purpose.renderable)   # characters is the default mode
+            await screen._apply_mode("personas")
+            await pilot.pause()
+            assert "Who you are" in str(screen.query_one("#personas-purpose", Static).renderable)
+```
+
+- [ ] **Step 2: Run to verify RED**
+
+Run:
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  "Tests/UI/test_personas_workbench.py::TestWorkbenchShell::test_title_reframed_to_roleplay_keeps_state_suffix" \
+  "Tests/UI/test_personas_workbench.py::TestWorkbenchShell::test_purpose_shows_active_mode_descriptor_and_updates_on_switch" \
+  -q -p no:cacheprovider -o addopts="" --timeout=120 --timeout-method=thread
+```
+Expected: FAIL — title still starts with "Personas"; `#personas-purpose` holds the old static "Create and manage…" copy.
+
+- [ ] **Step 3: Reframe the title base**
+
+In `personas_screen.py:887`, change:
+```python
+        base = "Personas | Behavior profiles for chat and agents"
+```
+to:
+```python
+        base = "Roleplay | Author the pieces that shape a chat"
+```
+(Leave the rest of `_title_text` — the `suffix`/`create`/`edit`/`Ready` branches — untouched.)
+
+- [ ] **Step 4: Add the mode-descriptor source of truth**
+
+Near the other module-level constants (by `MODE_CHIP_ORDER`/`PLACEHOLDER_COPY`, ~`:85`), add:
+```python
+#: One-line "what this mode is" copy, shown under the title and as chip tooltips.
+_MODE_DESCRIPTORS: dict[str, str] = {
+    "characters": "Characters — who the AI plays.",
+    "personas": "Personas — who you are.",
+    "dictionaries": "Dictionaries — text find/replace rules.",
+    "lore": "Lore — world facts injected on keywords.",
+}
+```
+And add this method to `PersonasScreen` (next to `_title_text`):
+```python
+    def _mode_descriptor_text(self, mode: str) -> str:
+        """The visible one-line meaning of a mode (falls back for un-described modes)."""
+        return _MODE_DESCRIPTORS.get(mode, MODE_LABELS.get(mode, mode))
+```
+
+- [ ] **Step 5: Make `#personas-purpose` the per-mode descriptor**
+
+In `compose_content` (`:355-359`), replace the static purpose Static's text so it starts on the active mode's descriptor:
+```python
+            yield Static(
+                self._mode_descriptor_text(self.state.active_mode),
+                id="personas-purpose",
+                classes="destination-purpose",
+            )
+```
+Then in `_apply_mode`, right after the existing status-row refresh (`self.query_one("#personas-status-row", Static).update(self._status_row_text())`, ~`:863`), add:
+```python
+        self.query_one("#personas-purpose", Static).update(self._mode_descriptor_text(mode))
+```
+
+- [ ] **Step 6: Run to verify GREEN (incl. all updated assertions)**
+
+Run the full personas workbench suite (catches the exact-title assertion at ~:4056 and `test_route_renders_destination_workbench`) plus the phase6 replay test (whose fragments you updated):
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/UI/test_personas_workbench.py \
+  "Tests/UI/test_unified_shell_phase6_first_time_replay.py" \
+  -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: all pass (2 new reframe tests + the 3 updated assertions + all pre-existing personas + phase6 tests). If the phase6 test fails on a fragment, the reframed screen simply doesn't render that literal — adjust the fragment to one that is present (e.g. a chip label) rather than reverting the reframe.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tldw_chatbook/UI/Screens/personas_screen.py Tests/UI/test_personas_workbench.py
+git commit -m "feat(roleplay): reframe title to Roleplay + per-mode descriptor line (P0)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Honest mode strip — self-explaining chips + coming-soon
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/personas_screen.py` (chip loop tooltip + label `:367-379`; `PLACEHOLDER_COPY`→per-mode `_MODE_COMING_SOON` `:87`; `_apply_mode` placeholder text `~:866`)
+- Modify: `Tests/UI/test_personas_workbench.py` (add tests)
+
+**Interfaces:**
+- Consumes: `_MODE_DESCRIPTORS` / `_mode_descriptor_text` from Task 1 (chip tooltips reuse them).
+- Produces: `_MODE_COMING_SOON: dict[str, str]` (module-level) and `PersonasScreen._coming_soon_text(self, mode: str) -> str`.
+
+- [ ] **Step 1: Write/adjust the tests (RED)**
+
+First update the existing placeholder assertion the new copy breaks — in `Tests/UI/test_personas_workbench.py` (~`:362`, the test that clicks a placeholder mode and checks the copy):
+```python
+            assert "not available yet" in str(placeholder.renderable)      # OLD
+```
+→
+```python
+            assert "coming soon" in str(placeholder.renderable).lower()    # NEW
+```
+(That test currently clicks `#personas-mode-prompts`; leave the mode it clicks alone — `_coming_soon_text("prompts")` returns the generic "This mode is coming soon." fallback, which satisfies the updated assertion. Removing the prompts chip is the parallel branch's job, not P0's.)
+
+Then add to `class TestWorkbenchShell:`:
+```python
+    async def test_mode_chips_are_self_explaining_and_mark_coming_soon(self, mock_app_instance, stub_characters):
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            dict_chip = screen.query_one("#personas-mode-dictionaries", Button)
+            assert dict_chip.tooltip == "Dictionaries — text find/replace rules."   # meaning, not "switch to…"
+            assert "soon" in str(dict_chip.label).lower()                            # planned marker
+            char_chip = screen.query_one("#personas-mode-characters", Button)
+            assert "soon" not in str(char_chip.label).lower()                        # built modes unmarked
+
+    async def test_coming_soon_mode_shows_inviting_copy(self, mock_app_instance, stub_characters):
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            await screen._apply_mode("dictionaries")
+            await pilot.pause()
+            body = str(screen.query_one("#personas-mode-placeholder", Static).renderable)
+            assert "coming soon" in body.lower()
+            assert "not available yet" not in body.lower()
+```
+
+- [ ] **Step 2: Run to verify RED**
+
+Run:
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  "Tests/UI/test_personas_workbench.py::TestWorkbenchShell::test_mode_chips_are_self_explaining_and_mark_coming_soon" \
+  "Tests/UI/test_personas_workbench.py::TestWorkbenchShell::test_coming_soon_mode_shows_inviting_copy" \
+  -q -p no:cacheprovider -o addopts="" --timeout=120 --timeout-method=thread
+```
+Expected: FAIL — chip tooltip is the generic "Switch the workbench to …", labels lack "soon", and the placeholder still reads "not available yet".
+
+- [ ] **Step 3: Add the coming-soon source of truth**
+
+Replace the `PLACEHOLDER_COPY` constant (`:87`) with a per-mode map + keep a generic fallback:
+```python
+#: Inviting "coming soon" body per not-yet-built mode; generic fallback for others.
+_MODE_COMING_SOON: dict[str, str] = {
+    "dictionaries": "Dictionaries — author text find/replace rules for your chats. Coming soon.",
+    "lore": "Lore — build world facts that get injected when keywords appear. Coming soon.",
+}
+_COMING_SOON_FALLBACK = "This mode is coming soon."
+```
+And add to `PersonasScreen`:
+```python
+    def _coming_soon_text(self, mode: str) -> str:
+        return _MODE_COMING_SOON.get(mode, _COMING_SOON_FALLBACK)
+```
+Update the initial placeholder Static in `compose_content` (currently `yield Static(PLACEHOLDER_COPY, id="personas-mode-placeholder")`, `:418`) to a neutral default (it is hidden until a coming-soon mode is selected):
+```python
+                    yield Static(self._coming_soon_text("dictionaries"), id="personas-mode-placeholder")
+```
+
+- [ ] **Step 4: Self-explaining chips + planned marker**
+
+In the mode-chip loop in `compose_content` (`:368-379`), change the `Button` so the label marks planned modes and the tooltip states the meaning:
+```python
+                for mode in MODE_CHIP_ORDER:
+                    classes = "personas-mode-chip"
+                    if mode == self.state.active_mode:
+                        classes = f"{classes} is-active"
+                    label = MODE_LABELS[mode]
+                    if mode in _MODE_COMING_SOON:
+                        label = f"{label} · soon"
+                    yield Button(
+                        label,
+                        id=f"personas-mode-{mode}",
+                        classes=classes,
+                        tooltip=self._mode_descriptor_text(mode),
+                    )
+```
+
+- [ ] **Step 5: Show the per-mode coming-soon body on switch**
+
+In `_apply_mode`, at the branch that shows the placeholder for not-yet-built modes (currently `self._show_center("#personas-mode-placeholder")`, ~`:866`), set its text first:
+```python
+            self.query_one("#personas-mode-placeholder", Static).update(self._coming_soon_text(mode))
+            self._show_center("#personas-mode-placeholder")
+```
+
+- [ ] **Step 6: Run to verify GREEN + no regression**
+
+Run:
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/UI/test_personas_workbench.py \
+  -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: the whole `test_personas_workbench.py` suite passes (new tests + the reframed one + all pre-existing workbench tests — no regression to the working modes).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tldw_chatbook/UI/Screens/personas_screen.py Tests/UI/test_personas_workbench.py
+git commit -m "feat(roleplay): self-explaining mode chips + honest per-mode coming-soon (P0)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Final gate (after Task 2)
+
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/UI/test_personas_workbench.py Tests/UI/test_personas_workbench_foundation.py \
+  -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Plus `python -c "import tldw_chatbook.app"`. Then the whole-branch review and finishing-a-development-branch. (This is a display-only reframe; a served-TUI visual glance to confirm the header reads "Roleplay" and the coming-soon chips read as planned is worthwhile but optional.)

--- a/Docs/superpowers/research/2026-07-13-server-dictionaries-port.md
+++ b/Docs/superpowers/research/2026-07-13-server-dictionaries-port.md
@@ -1,0 +1,32 @@
+# tldw_server2 → Chat Dictionaries port research (digest)
+
+Source of full analysis: research agent over `/Users/macbook-dev/Documents/GitHub/tldw_server2` (canonical, not `.next/standalone`) vs tldw_chatbook.
+
+## Meta-finding
+tldw_chatbook's dictionary backend is **already built** (local + server) via `chat_dictionary_scope_service.py` + `local_chat_dictionary_service.py` + `server_chat_dictionary_service.py`: CRUD, `reorder_entries`, **`process_text` (the preview/test-substitution call)**, `import/export_markdown`, `import/export_json`, `list_activity`, `list_versions`/`get_version`/`revert_version`, `get_statistics`, and `list_unsupported_capabilities` (degraded-capability reporter). **So the Dictionaries workbench is UI construction, not backend.** One backend gap: `bulk_entries` (server-only; no local impl / no scope wrapper).
+
+## Server entry model — fields tldw_chatbook's `entries_json` lacks
+Per-entry: explicit `type` literal|regex (+ regex flags i/m/s/x), `probability` 0–1, `case_sensitive`, `group` (best-of-group scoring), `timed_effects` {cooldown, delay} (SKIP `sticky` — unimplemented server-side too), `max_replacements`, per-entry `enabled`, `priority`/`sort_order` (distinct from group), per-entry usage_count/last_used, Jinja templates (gated).
+Dictionary-level: `category` + `tags`, `included_dictionary_ids` (composition, cycle-checked), `default_token_budget`, `version` (optimistic lock), `processing_priority`, used-by-chat summary.
+Regex safety: ReDoS heuristic blocklist + 500-char cap + timeout-capable `regex` compile that degrades to no-op instead of hanging.
+
+## UX the server settled on
+- **List:** sortable table, inline active/inactive Switch (not read-only), used-by count + scope badges, entry-count + regex/literal split badge, Duplicate, empty-state starter templates (Medical Abbrev / Chat-Speak / Custom Terminology / Character Speech).
+- **Entry editor:** inline drawer (NOT modal-in-modal — was an audit defect); Simple ⇄ Advanced toggle (advanced = probability, group autocomplete, timed effects, case-sensitivity, max replacements); bulk multi-select actions; LIVE ReDoS validation as you type a regex.
+- **Regex vs literal:** explicit `type` badge, never inferred from `/…/`.
+- **Validation panel:** structured `{code, field, message}` errors/warnings + entry_stats + partial/timeout flag → a portable **validation taxonomy** (codes, not prose) that maps to a TUI results list with jump-to-entry.
+- **Import/export:** JSON (full) + Markdown (LOSSY for advanced fields → warn banner); import preview/confirm + 409 rename/replace/cancel.
+- **Attach-to-conversation:** searchable chat picker, count-labeled confirm ("Assign to 3 chats"). CAVEAT: server's version has a bug (omits workspace chats) + no reverse "which dicts attach to THIS conversation" index — don't copy the bug; DO add the reverse index.
+
+## Prioritized ports (TUI, keyboard-first)
+- **HIGH:** (1) **substitution preview/"Try it" panel** (paste text → diff + fired entries; backed by wired `process_text`). (2) inline enable/disable toggles (list-level + entry-level). (3) validation panel with structured codes. (4) expose per-entry `type`/`case_sensitive`/`enabled`/`priority` in the editor (backend dataclass mostly supports; add `type`/`case_sensitive`/`enabled`).
+- **MED:** regex/literal badge; timed-effects (cooldown/delay) fields; Duplicate; bulk ops (needs local `bulk_entries` backend); import/export reuse + lossy-Markdown warning; attach-to-conversation + reverse used-by index.
+- **LOW:** starter templates; statistics (incl. portable ~140-line pattern-conflict detector); version history/revert (verify local capability-gate isn't stale); activity trail; dictionary composition (backend gap); category/tags (backend gap).
+- **DO NOT PORT:** server's quick-assign workspace-chat omission (a bug).
+
+## "Try it" (substitution preview) — TUI design brief
+Inputs: multiline sample text; optional token-budget + max-passes (advanced); **saved test-cases** (name+text, persisted). Run = a visible keybinding (not hidden in a collapsed accordion — server audit flagged that).
+Output (from `process_text`/`ProcessTextResponse`): (1) **diff** — original with removals struck/dim + processed with additions highlighted (two Rich panes, or unified if narrow; explicit "No differences" empty state); (2) processed text (copyable); (3) stats strip — replacements, iterations, **entries_used (clickable → jump to entry)**, token_budget_exceeded warning badge. Graceful degradation: a bad regex → "entry did not fire", never a hard error. Plus a lightweight per-entry "test" (row keybinding `t` → matches yes/no + first-match highlight).
+
+## Chatbooks (brief)
+Export/import **bundle** feature (job-based, versioned manifest); `DICTIONARY` is a first-class ContentType serialized via the dictionary's own `export_json`. No management-UX pattern to mine; transferable idea = a dictionary is already a portable bundle unit (reuse its JSON export shape for any future backup/export).

--- a/Docs/superpowers/research/2026-07-13-server-worldbooks-port.md
+++ b/Docs/superpowers/research/2026-07-13-server-worldbooks-port.md
@@ -1,0 +1,34 @@
+# tldw_server2 → World Books / Lorebooks (Lore) port research (digest)
+
+Source: research agent over `/Users/macbook-dev/Documents/GitHub/tldw_server2` (canonical) vs tldw_chatbook (`world_book_manager.py`, `world_info_processor.py`, `ChaChaNotes_DB.py` V8→V9).
+
+## Baseline correction (important)
+tldw_chatbook is **AHEAD** of the server on world-book *structure*: it already implements `position` (before_char/after_char/at_start/at_end), `insertion_order`, `selective` + `secondary_keys` (AND-logic), and FTS5 tables — the server has NONE of these (flattens all lore into one block). tldw_chatbook is **BEHIND** on: regex matching, priority-aware budget survival, per-match diagnostics, attachment model (character-level), and any management UI.
+
+## Server fields to port (tldw_chatbook lacks)
+- **`priority` (0–100)** entry-level, drives injection order AND which entries survive token-budget truncation. tldw_chatbook only has `insertion_order` + walk-and-stop budget → arbitrary loss under pressure. **Real correctness gap.**
+- **regex_match** + ReDoS-safe compile (`regex_safety.py` denylist + bounded test + timeout). tldw_chatbook: literal keyword only.
+- **Per-match diagnostics**: `activation_reason`, matched `keyword`/`secondary_key`, `token_cost`, `depth_level`, `content_preview` + response-level `budget_exhausted`/`skipped_entries_due_to_budget`. tldw_chatbook's `_find_matching_entries`/`process_messages()` DISCARD all this → **biggest functional gap; blocks diagnostics UI**.
+- whole_word toggle (chatbook hardcodes word-boundary); per-entry `recursive_scanning` opt-in seed (chatbook: book-level all-or-nothing, depth hardcoded 3 vs server configurable); `appendable` (no-separator concat); entry `group`/category; bulk ops; statistics; SillyTavern/Kobold IMPORT (chatbook only round-trips its own JSON).
+- **NOT a real server feature (don't port as shipped):** "constant/always-on" entries — server has inert cache-hint metadata only, no CRUD field. `sticky` timed-effect also unimplemented.
+
+## UX the server settled on
+- **Two-panel List + tabbed Detail** (replaced 8+ modals): List (~35%: checkbox/Name+Desc/Entries/Status/Modified/Actions) + Detail (~65%, **tabs: Entries · Attachments · Stats · Settings**). Only Create / Relationship-Matrix / Test-Matching / Import stay modal. → Textual: DataTable left + TabbedContent right.
+- **Progressive disclosure:** two-tier labels + "show technical labels" toggle ("Scan Depth"→"Messages to search", "Token Budget"→"Context size limit", "Recursive Scanning"→"Chain matching"); matching options (case/regex/whole-word) collapsed by default — only Keywords/Content/Priority shown for 90% of entries.
+- **Empty state:** 3-step (Create → Add keyword entries → Attach) + concrete worked example ("keyword 'magic system' → user asks about it → AI receives your lore") + template quick-starts (Fantasy/Sci-Fi/Product-KB).
+- **Import/export:** JSON round-trip + client-side format detection for SillyTavern V2 (`character_book.entries`) and Kobold; lossy fields surfaced as warnings.
+- **Attach-to-character:** character shows attached-book chips; Relationship Matrix (scales poorly >10 — avoid). Audit P1: chat dictionaries NOT character-visible like worldbooks are.
+
+## UNIQUE tldw_chatbook opportunity (server never built this)
+tldw_chatbook has Characters + Personas + Dictionaries + Lore as **sibling modes in ONE workbench**. The server scatters them. → Studio can offer a shared **"what's in play"** / attachments view: for a given character or conversation, show the persona + lore books + dictionaries that apply. Also adopt **character-level attachment** (not just conversation) so one lorebook/dictionary serves all a character's chats.
+
+## Prioritized ports
+- **HIGH:** (1) **Trigger-diagnostics "Test Match" panel** (the Lore "Try it"). (2) surface match diagnostics from `world_info_processor` (activation_reason/keyword/token_cost/depth + budget_exhausted/skipped IDs) — prerequisite. (3) entry `priority` + priority-aware budget trim (correctness). (4) two-panel List+tabbed-Detail layout. (5) character-level attachment.
+- **MED:** expose selective/secondary_keys + position in editor (**UI-only — data model already supports!**); regex + safety; bulk ops; statistics; token-budget bar; onboarding empty state; wire existing FTS5 to search.
+- **LOW:** group/category+filter; SillyTavern/Kobold import + lossy warnings; appendable; duplicate; cross-book stats; defer AI-gen; surface runtime constants in help.
+
+## "Try it" (Trigger diagnostics) — TUI design brief
+**Stage 1 — ad-hoc Test Match pane** (Lore mode, keybinding `t`): inputs = sample-text TextArea (+ "pull last N turns from active conversation" toggle), a checklist of which books to test (default = attached to active character/conversation), scan_depth/token_budget steppers + recursive toggle (prefilled from book settings). Run → new diagnostics-returning match fn.
+Results top→bottom: (a) summary strip — entries matched, books used, tokens used/budget (color bar), skipped-due-to-budget (amber if >0); (b) DataTable of matched entries in injection order — content preview, source book, **activation_reason** ("keyword: dragon" / "secondary+primary: fire+dragon" / "regex: /drag.n/i" / "depth 1 (recursive): ember"), token cost, priority; (c) empty state.
+**Beyond the server (answers "why did X NOT fire"):** a **"near misses"** section — entries that matched a primary key but were skipped (disabled / failed required secondary key / dropped by budget). Server only reports *matched* entries; extend the scan to keep skipped IDs+reasons, not just a count. Export diagnostics as text/JSON (one keystroke).
+**Stage 2 (later):** live per-turn indicator ("Lore: 3 entries, 210/500 tok") reusing Stage 1's results view with real last-turn diagnostics. Depends on Stage-1 diagnostics plumbing landing first.

--- a/Docs/superpowers/specs/2026-07-13-roleplay-p0-reframe-northstar-design.md
+++ b/Docs/superpowers/specs/2026-07-13-roleplay-p0-reframe-northstar-design.md
@@ -1,4 +1,4 @@
-# Studio (Personas redesign) — P0: reframe + north-star (design)
+# Roleplay (Personas redesign) — P0: reframe + north-star (design)
 
 **Status:** Design approved (brainstorm), pending spec review.
 **Program:** Personas workbench redesign, sub-project **P0** of `P0 → P1 → P2 → P3`. P0 is the thin foundation (identity reframe + the binding interaction contract); P1 = Dictionaries mode, P2 = Lore mode, P3 = Characters/Personas flow polish — each its own spec → plan → PR.
@@ -11,13 +11,13 @@ The Personas screen is a 3-column workbench (`personas_screen.py`) with a 5-chip
 
 ## Goal / Acceptance
 
-- **AC1 (reframe, shippable):** The screen presents as **"Studio"** with an honest, self-explaining 4-mode strip — every chip says what it *is*, and not-yet-built modes read as an inviting "coming soon," never a dead "not available yet."
+- **AC1 (reframe, shippable):** The screen presents as **"Roleplay"** with an honest, self-explaining 4-mode strip — every chip says what it *is*, and not-yet-built modes read as an inviting "coming soon," never a dead "not available yet."
 - **AC2 (north-star, documented):** This spec defines the binding **List → Detail → Try-it** interaction pattern (below) that P1/P2/P3 implement, so the four modes are consistent instead of each reinventing a layout.
 - **AC3 (no collision):** P0 edits only Personas-owned display in `personas_screen.py`. The route id `personas`, the screen registry, and nav/shell files (`screen_registry.py`, `shell_destinations.py`, `route_inventory.py`) are **not touched** — they're owned by the parallel Library-Prompts branch.
 
 ## Part A — The north-star interaction pattern (binding contract)
 
-Every Studio mode inherits one three-pane skeleton. This is the contract P1/P2/P3 build to; P0 does not build a shared framework speculatively — shared widgets get extracted when the *second* mode needs them, not before.
+Every Roleplay mode inherits one three-pane skeleton. This is the contract P1/P2/P3 build to; P0 does not build a shared framework speculatively — shared widgets get extracted when the *second* mode needs them, not before.
 
 ```
  LIST (left rail)        DETAIL (center)                 TRY-IT (right)
@@ -43,17 +43,17 @@ Every Studio mode inherits one three-pane skeleton. This is the contract P1/P2/P
 - **Honest list + empty states.** Inline enable/disable (never buried in the editor), scannable badges, a Duplicate action, and empty states that offer starter templates instead of a blank void.
 - **Structured validation.** Problems surface as a jump-to-entry list of `{code, field, message}` items, not opaque prose.
 
-**Two things Studio does *better than the server* (seeded now, built in P1/P2):**
-- **"What's in play."** Because Studio holds all four modes in one workbench (the server scatters them), it can answer *"for this character / conversation, which persona + lorebooks + dictionaries apply?"* — a cross-mode attachments summary the server never built. Direction: also support **character-level attachment** (not only per-conversation), so one lorebook/dictionary serves all a character's chats.
+**Two things Roleplay does *better than the server* (seeded now, built in P1/P2):**
+- **"What's in play."** Because Roleplay holds all four modes in one workbench (the server scatters them), it can answer *"for this character / conversation, which persona + lorebooks + dictionaries apply?"* — a cross-mode attachments summary the server never built. Direction: also support **character-level attachment** (not only per-conversation), so one lorebook/dictionary serves all a character's chats.
 - **Near-misses in diagnostics.** The Lore Try-it shows not just what fired but what *matched-yet-was-skipped* — answering *"why did X NOT fire,"* which the server's diagnostics can't.
 
 ## Part B — P0 shippable scope (the reframe, display-only)
 
 All in `personas_screen.py` (Personas-owned), no behavior change to the working modes:
 
-1. **Identity.** `#personas-title` (`_title_text()`) → **"Studio"**; the `#personas-purpose` tagline → *"Author the pieces that shape a chat — characters, personas, dictionaries, and lore — and attach them to Console."* (drop the stale "prompts" mention; see collision note).
-2. **Self-explaining mode strip.** Each chip's `tooltip` becomes what the mode *is*, not "switch to X": *Characters* → "Who the AI plays," *Personas* → "Who you are," *Dictionaries* → "Text find/replace rules," *Lore* → "World facts injected on keywords."
-3. **Honest coming-soon.** The `PLACEHOLDER_COPY` for not-yet-built modes (Dictionaries, Lore) changes from *"not available yet"* to an inviting one-liner per mode — what it will do + "coming soon" — so the chips advertise the roadmap honestly instead of dead-ending. (P1/P2 replace the placeholder with the real workbench.)
+1. **Identity.** `_title_text()` is a *live* header — currently `base = "Personas | Behavior profiles for chat and agents"` with dynamic ` | New {character|persona}` and ` - unsaved` suffixes appended. Reframe **only the base string** → `"Roleplay | Author the pieces that shape a chat"`, preserving the create-mode/unsaved suffix logic verbatim. The `#personas-purpose` tagline → *"Characters, personas, dictionaries, and lore — the pieces that shape a chat. Attach them to Console."*
+2. **Self-explaining mode strip — visible, not tooltip-only.** Tooltips are hover-only and useless to keyboard users, so the active mode's meaning must be **visible on selection**: on mode switch, update a persistent one-line descriptor (extend `#personas-purpose` or add a subtitle under the strip) to what the *active* mode is — *Characters* → "Who the AI plays," *Personas* → "Who you are," *Dictionaries* → "Text find/replace rules," *Lore* → "World facts injected on keywords." Keep the chip `tooltip`s too (as the same copy) for mouse users, but the visible descriptor is the primary affordance and doubles as a "where am I" cue.
+3. **Honest coming-soon.** The `PLACEHOLDER_COPY` for not-yet-built modes (Dictionaries, Lore) changes from a flat *"not available yet"* to an inviting, per-mode one-liner — what it will do + "coming soon" — and the chips are visually de-emphasized (dimmed/planned-looking) so they read as *roadmap*, not *broken*. **Fallback:** if P1/P2 slip well past P0, prefer *hiding* the two chips over a stale "coming soon" (don't advertise nav that doesn't work); coming-soon is the default only because the builds are imminent. P1/P2 replace the placeholder with the real workbench.
 4. **Keep the three-pane frame.** No structural change to the shell in P0; it already matches the north-star's skeleton.
 
 ## Data flow / error handling
@@ -63,11 +63,12 @@ None — P0 changes display copy/labels only; the working Characters/Personas fl
 ## Collision constraints (parallel Library-Prompts branch)
 
 - **Do not touch** `screen_registry.py` / `shell_destinations.py` / `route_inventory.py` / the route id `personas`. P0 is display-only inside `personas_screen.py`.
-- `MODE_CHIP_ORDER` and the `#personas-purpose` copy both still name **"prompts"**; the parallel branch's Task 7 removes it. P0 should **not fight that** — leave the `prompts` entry in `MODE_CHIP_ORDER` for P0 (its removal is the other branch's job) and expect a trivial one-line reconcile of `MODE_CHIP_ORDER` + the purpose copy at the eventual rebase. P0's reframe copy is written to be correct *whether or not* "prompts" is still present.
+- **Exact overlap (verified):** the parallel branch's Task 7 edits the *same three sites* P0 touches — `MODE_CHIP_ORDER` (drops "prompts"), the class docstring, and the `#personas-purpose` copy (drops "prompts"). So a rebase conflict on these lines is *guaranteed but trivial*. P0 should **not fight the prompts removal** — leave the `prompts` entry in `MODE_CHIP_ORDER` for P0 (removing it is the other branch's job), and write P0's new purpose/title copy **prompts-free as its final form**, so the reconcile is simply "take P0's Roleplay copy" regardless of merge order (P0's copy already omits prompts, superseding the other branch's copy edit on that line).
+- Name check: **"Roleplay"** was chosen specifically to avoid colliding with the existing **"Prompt Studio"** feature (`Prompt_Studio_Interop/`); do not reintroduce "Studio" for this workbench.
 
 ## Testing
 
-- Harness-free / `app.run_test()` smoke on `PersonasScreen`: `#personas-title` renders **"Studio"**; `#personas-purpose` contains the new tagline; each mode chip carries its "what it is" tooltip; selecting a not-yet-built mode shows the "coming soon" copy (not "not available yet"); Characters/Personas modes still compose + switch unchanged (no regression).
+- Harness-free / `app.run_test()` smoke on `PersonasScreen`: the header (`_title_text()`/`#personas-title`) leads with **"Roleplay"** and still appends the `New …`/`- unsaved` suffixes in create/dirty states; switching modes updates the **visible mode descriptor** to the active mode's meaning (a direct assertion, not tooltip inspection); selecting a not-yet-built mode shows the "coming soon" copy (not "not available yet"); Characters/Personas modes still compose + switch unchanged (no regression).
 - Follow the existing Personas UI test patterns (`Tests/UI/` personas tests) + the project's CSS-presence pin discipline if any class names change.
 
 ## Scope / non-goals

--- a/Docs/superpowers/specs/2026-07-13-studio-p0-reframe-northstar-design.md
+++ b/Docs/superpowers/specs/2026-07-13-studio-p0-reframe-northstar-design.md
@@ -1,0 +1,76 @@
+# Studio (Personas redesign) — P0: reframe + north-star (design)
+
+**Status:** Design approved (brainstorm), pending spec review.
+**Program:** Personas workbench redesign, sub-project **P0** of `P0 → P1 → P2 → P3`. P0 is the thin foundation (identity reframe + the binding interaction contract); P1 = Dictionaries mode, P2 = Lore mode, P3 = Characters/Personas flow polish — each its own spec → plan → PR.
+**Research inputs (drive P1/P2):** `Docs/superpowers/research/2026-07-13-server-dictionaries-port.md`, `Docs/superpowers/research/2026-07-13-server-worldbooks-port.md`.
+**Worktree/branch:** `.claude/worktrees/personas-redesign`, `claude/personas-redesign` off dev `ea88ff95`.
+
+## Problem
+
+The Personas screen is a 3-column workbench (`personas_screen.py`) with a 5-chip mode strip — `Characters · Personas · Prompts · Dictionaries · Lore`. Only **Characters** and **Personas** work; the placeholder literally reads *"This mode is not available yet."* **Prompts** is being moved to Library by a parallel branch; **Dictionaries** and **Lore** are dead chips over real, unused backends (`chat_dictionaries` + services; `world_books` + `WorldBookManager`/`world_info_processor`). And the screen is titled **"Personas"** while its default mode is **Characters** — a container/content mismatch. Once the two dead modes become real (P1/P2), "Personas" is plainly the wrong container name.
+
+## Goal / Acceptance
+
+- **AC1 (reframe, shippable):** The screen presents as **"Studio"** with an honest, self-explaining 4-mode strip — every chip says what it *is*, and not-yet-built modes read as an inviting "coming soon," never a dead "not available yet."
+- **AC2 (north-star, documented):** This spec defines the binding **List → Detail → Try-it** interaction pattern (below) that P1/P2/P3 implement, so the four modes are consistent instead of each reinventing a layout.
+- **AC3 (no collision):** P0 edits only Personas-owned display in `personas_screen.py`. The route id `personas`, the screen registry, and nav/shell files (`screen_registry.py`, `shell_destinations.py`, `route_inventory.py`) are **not touched** — they're owned by the parallel Library-Prompts branch.
+
+## Part A — The north-star interaction pattern (binding contract)
+
+Every Studio mode inherits one three-pane skeleton. This is the contract P1/P2/P3 build to; P0 does not build a shared framework speculatively — shared widgets get extracted when the *second* mode needs them, not before.
+
+```
+ LIST (left rail)        DETAIL (center)                 TRY-IT (right)
+ search / sort / filter  the selected entity             "what does this DO?"
+ inline enable toggle    (tabbed where it has sub-parts)  per-mode verify surface
+ type/count/used badges  progressive disclosure           
+ Duplicate · + New       (Simple ⇄ Advanced)             
+ empty → starter templates
+```
+
+**Per-mode instantiation:**
+
+| Mode | List | Detail | Try-it (right pane) |
+|---|---|---|---|
+| **Characters** | character cards | card view / editor | **chat preview** (existing, kept — now framed as the mode's verify surface, not a bolt-on) |
+| **Personas** | user personas | persona editor | sample-turn preview |
+| **Dictionaries** (P1) | dictionaries + enable toggle, regex/literal + entry-count badge, used-by | **tabbed:** Entries · Attachments · Stats · Settings | **substitution preview** — paste sample text → diff (removed struck / added highlighted) + which entries fired (backed by the already-wired `process_text`) |
+| **Lore** (P2) | world books + enable toggle, entry-count, used-by | **tabbed:** Entries · Attachments · Stats · Settings | **Test-Match trigger diagnostics** — paste a sample message → which lore fired, *why* (keyword/secondary/regex/recursion), token cost, budget bar, **+ "near-misses"** (matched-but-skipped: disabled / failed secondary key / dropped by budget) |
+
+**Shared affordances (defined here, realized per mode):**
+- **Right pane = "Try it."** The right pane always answers *"what does this thing actually do?"* — a mode-specific verify/test surface. This is the principled replacement for today's over-built chat "preview," and it's the single strongest lesson from the tldw_server UX audits (their #1 finding for both dictionaries and world-books).
+- **Progressive disclosure.** The Detail editor shows a **Simple** view (the 2–3 fields most people touch) with an **Advanced** toggle for power fields, using plain-language labels (e.g. "Scan depth" → "Messages to search"). Both server audits independently landed on this — strong signal, and it directly de-clutters the Characters/Personas editor.
+- **Honest list + empty states.** Inline enable/disable (never buried in the editor), scannable badges, a Duplicate action, and empty states that offer starter templates instead of a blank void.
+- **Structured validation.** Problems surface as a jump-to-entry list of `{code, field, message}` items, not opaque prose.
+
+**Two things Studio does *better than the server* (seeded now, built in P1/P2):**
+- **"What's in play."** Because Studio holds all four modes in one workbench (the server scatters them), it can answer *"for this character / conversation, which persona + lorebooks + dictionaries apply?"* — a cross-mode attachments summary the server never built. Direction: also support **character-level attachment** (not only per-conversation), so one lorebook/dictionary serves all a character's chats.
+- **Near-misses in diagnostics.** The Lore Try-it shows not just what fired but what *matched-yet-was-skipped* — answering *"why did X NOT fire,"* which the server's diagnostics can't.
+
+## Part B — P0 shippable scope (the reframe, display-only)
+
+All in `personas_screen.py` (Personas-owned), no behavior change to the working modes:
+
+1. **Identity.** `#personas-title` (`_title_text()`) → **"Studio"**; the `#personas-purpose` tagline → *"Author the pieces that shape a chat — characters, personas, dictionaries, and lore — and attach them to Console."* (drop the stale "prompts" mention; see collision note).
+2. **Self-explaining mode strip.** Each chip's `tooltip` becomes what the mode *is*, not "switch to X": *Characters* → "Who the AI plays," *Personas* → "Who you are," *Dictionaries* → "Text find/replace rules," *Lore* → "World facts injected on keywords."
+3. **Honest coming-soon.** The `PLACEHOLDER_COPY` for not-yet-built modes (Dictionaries, Lore) changes from *"not available yet"* to an inviting one-liner per mode — what it will do + "coming soon" — so the chips advertise the roadmap honestly instead of dead-ending. (P1/P2 replace the placeholder with the real workbench.)
+4. **Keep the three-pane frame.** No structural change to the shell in P0; it already matches the north-star's skeleton.
+
+## Data flow / error handling
+
+None — P0 changes display copy/labels only; the working Characters/Personas flows are untouched. The north-star (Part A) is documentation, not code.
+
+## Collision constraints (parallel Library-Prompts branch)
+
+- **Do not touch** `screen_registry.py` / `shell_destinations.py` / `route_inventory.py` / the route id `personas`. P0 is display-only inside `personas_screen.py`.
+- `MODE_CHIP_ORDER` and the `#personas-purpose` copy both still name **"prompts"**; the parallel branch's Task 7 removes it. P0 should **not fight that** — leave the `prompts` entry in `MODE_CHIP_ORDER` for P0 (its removal is the other branch's job) and expect a trivial one-line reconcile of `MODE_CHIP_ORDER` + the purpose copy at the eventual rebase. P0's reframe copy is written to be correct *whether or not* "prompts" is still present.
+
+## Testing
+
+- Harness-free / `app.run_test()` smoke on `PersonasScreen`: `#personas-title` renders **"Studio"**; `#personas-purpose` contains the new tagline; each mode chip carries its "what it is" tooltip; selecting a not-yet-built mode shows the "coming soon" copy (not "not available yet"); Characters/Personas modes still compose + switch unchanged (no regression).
+- Follow the existing Personas UI test patterns (`Tests/UI/` personas tests) + the project's CSS-presence pin discipline if any class names change.
+
+## Scope / non-goals
+
+- **P0 does NOT** build Dictionaries or Lore (P1/P2), polish Characters/Personas flows (P3), pre-build a shared-widget framework, or change the route/registry/nav.
+- **Forward map:** **P1** — Dictionaries mode over the existing backend + the dictionaries research digest (substitution preview, per-entry type/case/enabled/priority, validation codes, inline toggles, import/export). **P2** — Lore mode + the worldbooks digest (Test-Match diagnostics + near-misses, priority-aware budgeting, expose the already-present selective/secondary-keys/position in the editor, character-level attachment). **P3** — Characters/Personas flow polish across all four dimensions (editor progressive disclosure/discard, the Try-it preview, navigation, find), inheriting this pattern.

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -147,7 +147,7 @@ class TestWorkbenchShell:
         async with app.run_test() as pilot:
             screen = await _mounted(pilot)
             title = screen.query_one("#personas-title", Static)
-            assert "Personas" in str(title.renderable)
+            assert "Roleplay" in str(title.renderable)
             assert "ds-destination-header" in title.classes
             assert screen.query_one("#personas-mode-strip")
             assert screen.query_one("#personas-library-pane")
@@ -361,6 +361,28 @@ class TestWorkbenchShell:
             assert placeholder.display is True
             assert "not available yet" in str(placeholder.renderable)
             assert "is-active" in screen.query_one("#personas-mode-prompts", Button).classes
+
+    async def test_title_reframed_to_roleplay_keeps_state_suffix(self, mock_app_instance, stub_characters):
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            assert str(screen.query_one("#personas-title", Static).renderable).startswith("Roleplay")
+            # dynamic suffix still appends in create mode
+            screen._edit_mode = "create"
+            screen._update_title()
+            await pilot.pause()
+            title = str(screen.query_one("#personas-title", Static).renderable)
+            assert title.startswith("Roleplay") and "New character" in title
+
+    async def test_purpose_shows_active_mode_descriptor_and_updates_on_switch(self, mock_app_instance, stub_characters):
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            purpose = screen.query_one("#personas-purpose", Static)
+            assert "who the AI plays" in str(purpose.renderable)   # characters is the default mode
+            await screen._apply_mode("personas")
+            await pilot.pause()
+            assert "who you are" in str(screen.query_one("#personas-purpose", Static).renderable)
 
 
 class TestCharacterSelectionAndEdit:
@@ -4053,7 +4075,7 @@ class TestDirtyTracking:
             # already carries "Source: Local").
             assert (
                 str(title.renderable)
-                == "Personas | Behavior profiles for chat and agents | Ready"
+                == "Roleplay | Author the pieces that shape a chat | Ready"
             )
 
     async def test_active_row_gets_unsaved_badge(

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -359,8 +359,28 @@ class TestWorkbenchShell:
             assert screen.state.active_mode == "prompts"
             placeholder = screen.query_one("#personas-mode-placeholder", Static)
             assert placeholder.display is True
-            assert "not available yet" in str(placeholder.renderable)
+            assert "coming soon" in str(placeholder.renderable).lower()
             assert "is-active" in screen.query_one("#personas-mode-prompts", Button).classes
+
+    async def test_mode_chips_are_self_explaining_and_mark_coming_soon(self, mock_app_instance, stub_characters):
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            dict_chip = screen.query_one("#personas-mode-dictionaries", Button)
+            assert dict_chip.tooltip == "Dictionaries — text find/replace rules."   # meaning, not "switch to…"
+            assert "soon" in str(dict_chip.label).lower()                            # planned marker
+            char_chip = screen.query_one("#personas-mode-characters", Button)
+            assert "soon" not in str(char_chip.label).lower()                        # built modes unmarked
+
+    async def test_coming_soon_mode_shows_inviting_copy(self, mock_app_instance, stub_characters):
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            await screen._apply_mode("dictionaries")
+            await pilot.pause()
+            body = str(screen.query_one("#personas-mode-placeholder", Static).renderable)
+            assert "coming soon" in body.lower()
+            assert "not available yet" not in body.lower()
 
     async def test_title_reframed_to_roleplay_keeps_state_suffix(self, mock_app_instance, stub_characters):
         app = PersonasTestApp(mock_app_instance)

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -359,8 +359,27 @@ class TestWorkbenchShell:
             assert screen.state.active_mode == "prompts"
             placeholder = screen.query_one("#personas-mode-placeholder", Static)
             assert placeholder.display is True
-            assert "coming soon" in str(placeholder.renderable).lower()
+            # Prompts is departing to the Library — its copy is honest about that,
+            # never a "coming soon" that implies it is arriving in Roleplay.
+            body = str(placeholder.renderable).lower()
+            assert "library" in body
+            assert "coming soon" not in body
             assert "is-active" in screen.query_one("#personas-mode-prompts", Button).classes
+
+    async def test_prompts_chip_reads_as_departing_not_coming_soon(self, mock_app_instance, stub_characters):
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            prompts_chip = screen.query_one("#personas-mode-prompts", Button)
+            # Departing mode: honest descriptor tooltip, never the bare fallback label…
+            assert prompts_chip.tooltip == "Prompts — moving to the Library."
+            # …and no "· soon" marker (it is leaving, not arriving).
+            assert "soon" not in str(prompts_chip.label).lower()
+            # Selecting it surfaces the same honest descriptor in the visible purpose line.
+            await screen._apply_mode("prompts")
+            await pilot.pause()
+            purpose = str(screen.query_one("#personas-purpose", Static).renderable)
+            assert purpose == "Prompts — moving to the Library."
 
     async def test_mode_chips_are_self_explaining_and_mark_coming_soon(self, mock_app_instance, stub_characters):
         app = PersonasTestApp(mock_app_instance)

--- a/Tests/UI/test_unified_shell_phase6_first_time_replay.py
+++ b/Tests/UI/test_unified_shell_phase6_first_time_replay.py
@@ -157,10 +157,10 @@ async def test_first_time_shell_replay_exposes_home_console_and_orientation_path
                     "personas",
                     "PersonasScreen",
                     (
-                        "Personas",
-                        "Behavior profiles for chat and agents",
-                        "characters, personas, prompts, dictionaries, and lore",
-                        "Attach to Console",
+                        "Roleplay",
+                        "Author the pieces that shape a chat",
+                        "Characters",
+                        "Lore",
                     ),
                 ),
                 (

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -84,6 +84,14 @@ logger = logger.bind(module="PersonasScreen")
 #: excluded until import/export is wired as an action rather than a mode.
 MODE_CHIP_ORDER: tuple[str, ...] = ("characters", "personas", "prompts", "dictionaries", "lore")
 
+#: One-line "what this mode is" copy, shown under the title and as chip tooltips.
+_MODE_DESCRIPTORS: dict[str, str] = {
+    "characters": "Characters — who the AI plays.",
+    "personas": "Personas — who you are.",
+    "dictionaries": "Dictionaries — text find/replace rules.",
+    "lore": "Lore — world facts injected on keywords.",
+}
+
 PLACEHOLDER_COPY = "This mode is not available yet. Characters and Personas are the supported modes."
 PERSONAS_SEARCH_DEBOUNCE_SECONDS = 0.2
 PERSONAS_AVATAR_IMAGE_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".webp", ".gif"})
@@ -353,8 +361,7 @@ class PersonasScreen(BaseAppScreen):
                 classes="ds-destination-header",
             )
             yield Static(
-                "Create and manage behavior profiles - characters, personas, prompts, "
-                "dictionaries, and lore - and attach them to Console.",
+                self._mode_descriptor_text(self.state.active_mode),
                 id="personas-purpose",
                 classes="destination-purpose",
             )
@@ -860,6 +867,7 @@ class PersonasScreen(BaseAppScreen):
                 chip_mode == mode, "is-active"
             )
         self.query_one("#personas-status-row", Static).update(self._status_row_text())
+        self.query_one("#personas-purpose", Static).update(self._mode_descriptor_text(mode))
         library = self.query_one(PersonasLibraryPane)
         library.set_mode(mode)
         # clear_selection empties the conversations panel; drop the caches too.
@@ -884,7 +892,7 @@ class PersonasScreen(BaseAppScreen):
         "Local" deliberately stays out of the title - the status row directly
         below already says "Source: Local" (de-dup, P3-15).
         """
-        base = "Personas | Behavior profiles for chat and agents"
+        base = "Roleplay | Author the pieces that shape a chat"
         suffix = " - unsaved" if self.state.has_unsaved_changes else ""
         if self._edit_mode == "create":
             noun = "persona" if self.state.active_mode == "personas" else "character"
@@ -893,6 +901,10 @@ class PersonasScreen(BaseAppScreen):
             name = self.state.selected_entity_name or "item"
             return f"{base} | Editing {name}{suffix}"
         return f"{base} | Ready"
+
+    def _mode_descriptor_text(self, mode: str) -> str:
+        """The visible one-line meaning of a mode (falls back for un-described modes)."""
+        return _MODE_DESCRIPTORS.get(mode, MODE_LABELS.get(mode, mode))
 
     def _update_title(self) -> None:
         """Refresh the header line; tolerate updates racing teardown."""

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -88,16 +88,22 @@ MODE_CHIP_ORDER: tuple[str, ...] = ("characters", "personas", "prompts", "dictio
 _MODE_DESCRIPTORS: dict[str, str] = {
     "characters": "Characters — who the AI plays.",
     "personas": "Personas — who you are.",
+    "prompts": "Prompts — moving to the Library.",
     "dictionaries": "Dictionaries — text find/replace rules.",
     "lore": "Lore — world facts injected on keywords.",
 }
 
-#: Inviting "coming soon" body per not-yet-built mode; generic fallback for others.
-_MODE_COMING_SOON: dict[str, str] = {
+#: Modes genuinely coming to Roleplay — their chips carry the "· soon" marker.
+#: Departing modes (prompts) are deliberately excluded: they are leaving, not arriving.
+_COMING_SOON_MODES: frozenset[str] = frozenset({"dictionaries", "lore"})
+
+#: Placeholder body per not-yet-built (or departing) mode; generic fallback for others.
+_MODE_PLACEHOLDER_BODY: dict[str, str] = {
     "dictionaries": "Dictionaries — author text find/replace rules for your chats. Coming soon.",
     "lore": "Lore — build world facts that get injected when keywords appear. Coming soon.",
+    "prompts": "Prompts are moving to the Library — you'll manage them there.",
 }
-_COMING_SOON_FALLBACK = "This mode is coming soon."
+_PLACEHOLDER_FALLBACK = "This mode is coming soon."
 PERSONAS_SEARCH_DEBOUNCE_SECONDS = 0.2
 PERSONAS_AVATAR_IMAGE_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".webp", ".gif"})
 PERSONAS_AVATAR_IMAGE_SUFFIX_COPY = "PNG, JPG, JPEG, WEBP, or GIF"
@@ -157,7 +163,7 @@ class PersonasScreen(BaseAppScreen):
             Binding(
                 f"ctrl+{index + 1}",
                 f"personas_mode('{mode}')",
-                MODE_LABELS[mode],
+                MODE_LABELS.get(mode, mode),
                 show=False,
             )
             for index, mode in enumerate(MODE_CHIP_ORDER)
@@ -381,8 +387,8 @@ class PersonasScreen(BaseAppScreen):
                     classes = "personas-mode-chip"
                     if mode == self.state.active_mode:
                         classes = f"{classes} is-active"
-                    label = MODE_LABELS[mode]
-                    if mode in _MODE_COMING_SOON:
+                    label = MODE_LABELS.get(mode, mode)
+                    if mode in _COMING_SOON_MODES:
                         label = f"{label} · soon"
                     yield Button(
                         label,
@@ -430,7 +436,7 @@ class PersonasScreen(BaseAppScreen):
                                 id="personas-conversation-open-library",
                             )
                         yield PersonasConversationTranscriptWidget()
-                        yield Static(self._coming_soon_text("dictionaries"), id="personas-mode-placeholder")
+                        yield Static(self._mode_placeholder_text("dictionaries"), id="personas-mode-placeholder")
                     yield PersonasPreviewPane(id="personas-preview-pane")
 
                 inspector_pane = PersonasInspectorPane(
@@ -891,8 +897,8 @@ class PersonasScreen(BaseAppScreen):
             self._show_center(None)
             self._refresh_profile_rows_worker()
         else:
-            await library.update_rows((), total=0, noun=MODE_LABELS[mode].lower())
-            self.query_one("#personas-mode-placeholder", Static).update(self._coming_soon_text(mode))
+            await library.update_rows((), total=0, noun=MODE_LABELS.get(mode, mode).lower())
+            self.query_one("#personas-mode-placeholder", Static).update(self._mode_placeholder_text(mode))
             self._show_center("#personas-mode-placeholder")
 
     def _title_text(self) -> str:
@@ -915,9 +921,9 @@ class PersonasScreen(BaseAppScreen):
         """The visible one-line meaning of a mode (falls back for un-described modes)."""
         return _MODE_DESCRIPTORS.get(mode, MODE_LABELS.get(mode, mode))
 
-    def _coming_soon_text(self, mode: str) -> str:
-        """The inviting placeholder body for a not-yet-built mode."""
-        return _MODE_COMING_SOON.get(mode, _COMING_SOON_FALLBACK)
+    def _mode_placeholder_text(self, mode: str) -> str:
+        """The inviting placeholder body for a not-yet-built (or departing) mode."""
+        return _MODE_PLACEHOLDER_BODY.get(mode, _PLACEHOLDER_FALLBACK)
 
     def _update_title(self) -> None:
         """Refresh the header line; tolerate updates racing teardown."""
@@ -932,7 +938,7 @@ class PersonasScreen(BaseAppScreen):
             return f"Characters: {len(self._characters)} | Source: Local | Attachments: Console"
         if mode == "personas":
             return f"Personas: {len(self._profiles)} | Source: Local | Attachments: Console"
-        return f"Mode: {MODE_LABELS[mode]} | Source: Local | Attachments: Console"
+        return f"Mode: {MODE_LABELS.get(mode, mode)} | Source: Local | Attachments: Console"
 
     def _update_status_row(self) -> None:
         """Refresh the status row text; tolerate refreshes racing teardown."""

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -92,7 +92,12 @@ _MODE_DESCRIPTORS: dict[str, str] = {
     "lore": "Lore — world facts injected on keywords.",
 }
 
-PLACEHOLDER_COPY = "This mode is not available yet. Characters and Personas are the supported modes."
+#: Inviting "coming soon" body per not-yet-built mode; generic fallback for others.
+_MODE_COMING_SOON: dict[str, str] = {
+    "dictionaries": "Dictionaries — author text find/replace rules for your chats. Coming soon.",
+    "lore": "Lore — build world facts that get injected when keywords appear. Coming soon.",
+}
+_COMING_SOON_FALLBACK = "This mode is coming soon."
 PERSONAS_SEARCH_DEBOUNCE_SECONDS = 0.2
 PERSONAS_AVATAR_IMAGE_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".webp", ".gif"})
 PERSONAS_AVATAR_IMAGE_SUFFIX_COPY = "PNG, JPG, JPEG, WEBP, or GIF"
@@ -376,11 +381,14 @@ class PersonasScreen(BaseAppScreen):
                     classes = "personas-mode-chip"
                     if mode == self.state.active_mode:
                         classes = f"{classes} is-active"
+                    label = MODE_LABELS[mode]
+                    if mode in _MODE_COMING_SOON:
+                        label = f"{label} · soon"
                     yield Button(
-                        MODE_LABELS[mode],
+                        label,
                         id=f"personas-mode-{mode}",
                         classes=classes,
-                        tooltip=f"Switch the workbench to {MODE_LABELS[mode]}.",
+                        tooltip=self._mode_descriptor_text(mode),
                     )
             with Horizontal(id="personas-workbench", classes="ds-panel destination-workbench"):
                 library_handle = ConsoleRailHandle(
@@ -422,7 +430,7 @@ class PersonasScreen(BaseAppScreen):
                                 id="personas-conversation-open-library",
                             )
                         yield PersonasConversationTranscriptWidget()
-                        yield Static(PLACEHOLDER_COPY, id="personas-mode-placeholder")
+                        yield Static(self._coming_soon_text("dictionaries"), id="personas-mode-placeholder")
                     yield PersonasPreviewPane(id="personas-preview-pane")
 
                 inspector_pane = PersonasInspectorPane(
@@ -884,6 +892,7 @@ class PersonasScreen(BaseAppScreen):
             self._refresh_profile_rows_worker()
         else:
             await library.update_rows((), total=0, noun=MODE_LABELS[mode].lower())
+            self.query_one("#personas-mode-placeholder", Static).update(self._coming_soon_text(mode))
             self._show_center("#personas-mode-placeholder")
 
     def _title_text(self) -> str:
@@ -905,6 +914,10 @@ class PersonasScreen(BaseAppScreen):
     def _mode_descriptor_text(self, mode: str) -> str:
         """The visible one-line meaning of a mode (falls back for un-described modes)."""
         return _MODE_DESCRIPTORS.get(mode, MODE_LABELS.get(mode, mode))
+
+    def _coming_soon_text(self, mode: str) -> str:
+        """The inviting placeholder body for a not-yet-built mode."""
+        return _MODE_COMING_SOON.get(mode, _COMING_SOON_FALLBACK)
 
     def _update_title(self) -> None:
         """Refresh the header line; tolerate updates racing teardown."""


### PR DESCRIPTION
## Roleplay (Personas redesign) — P0: reframe + workbench north-star

First slice of a Personas-screen redesign done as a senior-UX exercise, informed by mining **tldw_server2**'s World Books & Dictionaries UX work. This PR is the **thin foundation** (P0); the substantial builds are follow-on PRs.

### Why
The Personas screen is a 3-pane workbench with a 5-chip mode strip, but **60% of it is dead**: the placeholder literally read *"This mode is not available yet"* for Prompts (being moved to Library by a parallel branch), Dictionaries, and Lore — the latter two over *real, unused backends*. And it's titled "Personas" while its default mode is Characters. Once the dead modes become real, "Personas" is the wrong container name.

### What P0 ships (display-only)
- **Reframe → "Roleplay."** Title becomes **"Roleplay | Author the pieces that shape a chat"** (the dynamic `_title_text()` base only — `New …`/`- unsaved` suffixes preserved). "Roleplay" was chosen over "Studio" specifically to avoid colliding with the existing **Prompt Studio** (`Prompt_Studio_Interop`).
- **Self-explaining, honest mode strip.** `#personas-purpose` becomes a **per-mode descriptor** that updates on switch (*Characters — who the AI plays.*, *Personas — who you are.*, *Dictionaries — text find/replace rules.*, *Lore — world facts injected on keywords.*) — a *visible* affordance, not a hover-only tooltip. The two not-yet-built modes get a **"· soon"** chip marker + an inviting per-mode "coming soon" body instead of a dead "not available yet."

### What P0 documents (the north-star)
The design doc defines the binding **List → Detail → Try-it** pattern every mode inherits (list rail → tabbed detail → a per-mode "what does this DO?" verify pane: chat preview for Characters/Personas, substitution preview for Dictionaries, trigger-diagnostics for Lore), plus two things this unified workbench can do *better than the server* — a cross-mode **"What's in play"** attachments view and **"near-misses"** in Lore diagnostics. Two research digests (`Docs/superpowers/research/`) capture the server port priorities that drive **P1 (Dictionaries)** and **P2 (Lore)**; **P3** is Characters/Personas flow polish.

### Collision discipline (parallel Library-Prompts branch)
Strictly **Personas-owned display** in `personas_screen.py`. **Not touched:** the route id `personas`, `screen_registry.py`, `shell_destinations.py`, `route_inventory.py`, `MODE_LABELS`, or `MODE_CHIP_ORDER` *membership*. The `"prompts"` chip is left in place (its removal is the other branch's Task 7); P0's new copy is written prompts-free as its final form, so the rebase reconcile is a trivial "take P0's version."

### Testing
`Tests/UI/test_personas_workbench.py` — new reframe tests (title + suffix, per-mode descriptor updates on switch, self-explaining chips + "· soon", coming-soon copy) + updated the assertions that pinned the old copy (incl. one in `test_unified_shell_phase6_first_time_replay.py`). Gate: **personas suites 170 passed**, `import tldw_chatbook.app` OK. (One pre-existing, unrelated `phase6` **Library**-nav-fragment failure is not from this personas-only change — the diff touches zero Library/nav lines.)

### Review
Subagent-Driven; both tasks per-task-reviewed **Approved** (suffix logic intact, DRY descriptor/coming-soon dicts, non-vacuous tests, strict scope, no "Studio", `prompts` intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reframes the Personas workbench to “Roleplay” with clear, honest mode guidance. Adds a visible per-mode descriptor and truthful copy for unfinished and departing modes.

- **New Features**
  - Header now reads “Roleplay | Author the pieces that shape a chat,” keeping New/Edit/unsaved suffixes.
  - Purpose line shows the active mode’s meaning and updates on switch; chip tooltips use the same copy.
  - `dictionaries` and `lore` chips show “· soon,” with inviting per-mode “coming soon” text when selected.
  - `prompts` chip now reads as “moving to the Library” (no “· soon”); selecting it shows the same honest message. Routing and chip membership remain unchanged to avoid parallel-branch conflicts.
  - Documented the List → Detail → Try-it north-star and research for P1 (Dictionaries) and P2 (Lore).

- **Bug Fixes**
  - Guarded `MODE_LABELS` lookups with `.get` across chip labels, keybinding descriptions, status row, and `_apply_mode` to prevent KeyErrors if labels and chip order drift.

<sup>Written for commit 1fed4d4f24b6816bcc5f2163e341079bea5a8ed0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

