### PR TITLE
fix(config): dotted-section get_cli_setting reads never resolved nested TOML tables (TASK-229)

### DIFF
--- a/Tests/Utils/test_config_nested_settings.py
+++ b/Tests/Utils/test_config_nested_settings.py
@@ -1,0 +1,172 @@
+"""Nested-table resolution for get_cli_setting (TASK-229).
+
+TOML ``[chat.images]`` loads as ``config["chat"]["images"]`` — but
+``get_cli_setting(section, key, default)`` did a FLAT ``config.get(section)``,
+so every caller passing a dotted section silently got its default forever
+(``show_attach_button``, ``save_location``, ``show_mic_button``,
+``[mcp.hub_state] advanced_open``, and the three-level
+``prompts.document_generation.*`` document configs). TASK-222 hit the same
+bug (C1) and worked around it locally; this fixes the accessor itself.
+
+Every test here drives the REAL loader via TLDW_CONFIG_PATH + force_reload —
+zero monkeypatching of the accessor (the C1 lesson: accessor mocks hid an
+inert feature through five review gates).
+"""
+
+import os
+from contextlib import contextmanager
+
+import pytest
+
+import tldw_chatbook.config as config_mod
+from tldw_chatbook.config import get_cli_setting
+
+
+SCRATCH_TOML = """
+[general]
+default_tab = "chat"
+
+[chat.images]
+show_attach_button = false
+save_location = "~/Pictures/tldw"
+
+[chat.voice]
+show_mic_button = false
+
+[mcp.hub_state]
+advanced_open = true
+
+[prompts.document_generation.timeline]
+prompt = "Configured timeline prompt."
+temperature = 0.9
+max_tokens = 123
+
+[splash_screen]
+custom_image_path = "/tmp/custom.png"
+"""
+
+
+@contextmanager
+def _real_config(tmp_path, monkeypatch, toml_text: str):
+    """Point the real loader at a scratch TOML; restore + reload afterwards."""
+    config_path = tmp_path / "scratch-nested-config.toml"
+    config_path.write_text(toml_text, encoding="utf-8")
+    original_env = os.environ.get("TLDW_CONFIG_PATH")
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    config_mod.load_cli_config_and_ensure_existence(force_reload=True)
+    try:
+        yield
+    finally:
+        if original_env is not None:
+            monkeypatch.setenv("TLDW_CONFIG_PATH", original_env)
+        else:
+            monkeypatch.delenv("TLDW_CONFIG_PATH", raising=False)
+        config_mod.load_cli_config_and_ensure_existence(force_reload=True)
+
+
+class TestRepairedReaderTuples:
+    """The exact (section, key, default) tuples of every production caller
+    the audit found broken — each must now read the real nested table."""
+
+    def test_chat_images_show_attach_button(self, tmp_path, monkeypatch):
+        with _real_config(tmp_path, monkeypatch, SCRATCH_TOML):
+            assert get_cli_setting("chat.images", "show_attach_button", True) is False
+
+    def test_chat_images_save_location(self, tmp_path, monkeypatch):
+        with _real_config(tmp_path, monkeypatch, SCRATCH_TOML):
+            assert (
+                get_cli_setting("chat.images", "save_location", "~/Downloads")
+                == "~/Pictures/tldw"
+            )
+
+    def test_chat_voice_show_mic_button(self, tmp_path, monkeypatch):
+        with _real_config(tmp_path, monkeypatch, SCRATCH_TOML):
+            assert get_cli_setting("chat.voice", "show_mic_button", True) is False
+
+    def test_mcp_hub_state_advanced_open(self, tmp_path, monkeypatch):
+        with _real_config(tmp_path, monkeypatch, SCRATCH_TOML):
+            assert get_cli_setting("mcp.hub_state", "advanced_open", False) is True
+
+    def test_three_level_document_generation_dict_form(self, tmp_path, monkeypatch):
+        """document_generator.py's exact shape: dotted three-level section
+        with the default dict as the second positional argument."""
+        default = {"prompt": "fallback", "temperature": 0.3, "max_tokens": 2000}
+        with _real_config(tmp_path, monkeypatch, SCRATCH_TOML):
+            value = get_cli_setting("prompts.document_generation.timeline", default)
+            assert value == {
+                "prompt": "Configured timeline prompt.",
+                "temperature": 0.9,
+                "max_tokens": 123,
+            }
+
+    def test_missing_nested_key_returns_default(self, tmp_path, monkeypatch):
+        with _real_config(tmp_path, monkeypatch, SCRATCH_TOML):
+            assert get_cli_setting("chat.images", "nope", "fallback") == "fallback"
+
+    def test_missing_nested_section_returns_default(self, tmp_path, monkeypatch):
+        with _real_config(tmp_path, monkeypatch, SCRATCH_TOML):
+            assert get_cli_setting("chat.absent", "key", 7) == 7
+            default = {"prompt": "fallback"}
+            assert (
+                get_cli_setting("prompts.document_generation.absent", default)
+                is default
+            )
+
+
+class TestWorkingShapesUnchanged:
+    """The shapes that already worked must keep their exact semantics."""
+
+    def test_traditional_flat_section(self, tmp_path, monkeypatch):
+        with _real_config(tmp_path, monkeypatch, SCRATCH_TOML):
+            assert get_cli_setting("general", "default_tab", "notes") == "chat"
+            assert get_cli_setting("general", "absent", "d") == "d"
+            assert get_cli_setting("absent_section", "key", "d") == "d"
+
+    def test_one_arg_single_dot(self, tmp_path, monkeypatch):
+        with _real_config(tmp_path, monkeypatch, SCRATCH_TOML):
+            assert get_cli_setting("general.default_tab") == "chat"
+            assert (
+                get_cli_setting("splash_screen.custom_image_path", None, "")
+                == "/tmp/custom.png"
+            )
+
+    def test_dotted_with_non_string_default_second_arg(self, tmp_path, monkeypatch):
+        with _real_config(tmp_path, monkeypatch, SCRATCH_TOML):
+            assert get_cli_setting("prompts.document_generation.timeline", 500) == {
+                "prompt": "Configured timeline prompt.",
+                "temperature": 0.9,
+                "max_tokens": 123,
+            }
+            assert get_cli_setting("general.absent_number", 500) == 500
+
+    def test_flat_key_shadows_nested(self, tmp_path, monkeypatch):
+        """A literal flat "chat.images" top-level key must win over nested
+        navigation (impossible from TOML, but code-merged dicts can carry it;
+        flat-first preserves every previously-working lookup bit-for-bit)."""
+        with _real_config(tmp_path, monkeypatch, SCRATCH_TOML):
+            config = config_mod.load_cli_config_and_ensure_existence()
+            config["chat.images"] = {"show_attach_button": "flat-wins"}
+            try:
+                assert (
+                    get_cli_setting("chat.images", "show_attach_button", True)
+                    == "flat-wins"
+                )
+            finally:
+                config.pop("chat.images", None)
+
+
+class TestConsumerPath:
+    """One repaired reader exercised through its real consumer (AC #3):
+    DocumentGenerator's ctor reads the three-level document configs."""
+
+    def test_document_generator_reads_configured_prompt(self, tmp_path, monkeypatch):
+        from tldw_chatbook.Chat.document_generator import DocumentGenerator
+
+        with _real_config(tmp_path, monkeypatch, SCRATCH_TOML):
+            generator = DocumentGenerator(
+                str(tmp_path / "docgen-test.db"), client_id="task-229-test"
+            )
+            assert generator.timeline_config["prompt"] == "Configured timeline prompt."
+            assert generator.timeline_config["max_tokens"] == 123
+            # briefing has no override in the scratch TOML -> ctor default
+            assert generator.briefing_config["max_tokens"] == 2500

--- a/Tests/Utils/test_optional_deps.py
+++ b/Tests/Utils/test_optional_deps.py
@@ -357,24 +357,30 @@ def test_mcp_deps():
 def test_initialize_dependency_checks():
     """Test that initialize_dependency_checks calls all check functions."""
     from tldw_chatbook.Utils.optional_deps import initialize_dependency_checks, DEPENDENCIES_AVAILABLE
-    
-    # Clear all dependencies first
+
+    # Clear all dependencies first — and restore afterwards: this module dict
+    # is shared process-global state, and initialize_dependency_checks() only
+    # repopulates the checked categories, not static registry keys (e.g.
+    # 'svg_rendering'), so leaving it cleared poisons later tests.
+    snapshot = dict(DEPENDENCIES_AVAILABLE)
     DEPENDENCIES_AVAILABLE.clear()
-    
-    # Initialize should populate all dependencies
-    initialize_dependency_checks()
-    
-    # Check that all major categories are present with the correct keys
-    assert 'embeddings_rag' in DEPENDENCIES_AVAILABLE
-    assert 'websearch' in DEPENDENCIES_AVAILABLE  # Changed from web_scraping
-    assert 'pdf_processing' in DEPENDENCIES_AVAILABLE
-    assert 'ebook_processing' in DEPENDENCIES_AVAILABLE
-    assert 'ocr_processing' in DEPENDENCIES_AVAILABLE  # Changed from ocr
-    assert 'local_llm' in DEPENDENCIES_AVAILABLE
-    assert 'tts_processing' in DEPENDENCIES_AVAILABLE  # Changed from tts
-    assert 'stt_processing' in DEPENDENCIES_AVAILABLE  # Changed from stt
-    assert 'image_processing' in DEPENDENCIES_AVAILABLE
-    assert 'mcp' in DEPENDENCIES_AVAILABLE
+    try:
+        # Initialize should populate all dependencies
+        initialize_dependency_checks()
+
+        # Check that all major categories are present with the correct keys
+        assert 'embeddings_rag' in DEPENDENCIES_AVAILABLE
+        assert 'websearch' in DEPENDENCIES_AVAILABLE  # Changed from web_scraping
+        assert 'pdf_processing' in DEPENDENCIES_AVAILABLE
+        assert 'ebook_processing' in DEPENDENCIES_AVAILABLE
+        assert 'ocr_processing' in DEPENDENCIES_AVAILABLE  # Changed from ocr
+        assert 'local_llm' in DEPENDENCIES_AVAILABLE
+        assert 'tts_processing' in DEPENDENCIES_AVAILABLE  # Changed from tts
+        assert 'stt_processing' in DEPENDENCIES_AVAILABLE  # Changed from stt
+        assert 'image_processing' in DEPENDENCIES_AVAILABLE
+        assert 'mcp' in DEPENDENCIES_AVAILABLE
+    finally:
+        DEPENDENCIES_AVAILABLE.update(snapshot)
 
 
 def test_pdf_processing_lib_import_handling():

--- a/backlog/tasks/task-229 - Repair-dotted-section-get_cli_setting-chat.images-readers.md
+++ b/backlog/tasks/task-229 - Repair-dotted-section-get_cli_setting-chat.images-readers.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-229
 title: Repair dotted-section get_cli_setting("chat.images") readers
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-07-14 10:30'
-updated_date: '2026-07-16 14:11'
+updated_date: '2026-07-16 14:34'
 labels:
   - config
   - bug
@@ -22,9 +22,9 @@ TASK-222's final review proved that `get_cli_setting(section, key, default)` per
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 show_attach_button and save_location honor the live config values end-to-end (verified through the real loader, no mocked accessors)
-- [ ] #2 No production caller passes a dotted section to a flat get_cli_setting lookup (repo-wide audit; either callers migrate or the accessor gains nested resolution with all affected callers reviewed)
-- [ ] #3 At least one unmocked integration test per repaired reader pins the real config path (scratch TOML through the real loader)
+- [x] #1 show_attach_button and save_location honor the live config values end-to-end (verified through the real loader, no mocked accessors)
+- [x] #2 No production caller passes a dotted section to a flat get_cli_setting lookup (repo-wide audit; either callers migrate or the accessor gains nested resolution with all affected callers reviewed)
+- [x] #3 At least one unmocked integration test per repaired reader pins the real config path (scratch TOML through the real loader)
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -32,3 +32,9 @@ TASK-222's final review proved that `get_cli_setting(section, key, default)` per
 <!-- SECTION:PLAN:BEGIN -->
 1. RED: unmocked real-loader tests (TLDW_CONFIG_PATH + force_reload, zero accessor mocks) for every broken caller tuple: (chat.images, show_attach_button/save_location), (chat.voice, show_mic_button), (mcp.hub_state, advanced_open), three-level prompts.document_generation.* dict form; + working-shape regressions (traditional, 1-arg single-dot, dotted+default) and flat-key-shadowing precedence\n2. Fix get_cli_setting: nested-path fallback after the flat lookup misses (dotted section OR dotted key navigates the real TOML tree); flat hit always wins\n3. Consumer-path test: DocumentGenerator picks up a configured [prompts.document_generation.timeline] prompt through the real loader (in-memory DB)\n4. Behavior-flip review of all repaired callers (defaults match template values → no visible change on default configs)\n5. Sweep + repo audit re-run; PR
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Fixed the ACCESSOR rather than migrating callers: get_cli_setting now falls back to nested-tree navigation when the flat lookup misses and the section/key carries dots (flat hit always wins — bit-for-bit preservation of every working shape, incl. the 1-arg single-dot and dotted+non-str-default forms). All 11 broken callers repaired at once: show_attach_button (Chat_Window_Enhanced, chat_session, both sidebars), show_mic_button (Chat_Window_Enhanced, settings_sidebar), save_location (chat_screen Save Image), [mcp.hub_state] advanced_open (mcp_inspector), and document_generator's three-level prompts.document_generation.{timeline,study_guide,briefing} dict-default form (audit found these additionally broken: the first-dot split left a dotted KEY that flat-missed). Behavior flips all intent-restoring; template/live defaults equal code defaults so default configs see no change. RED-first unmocked tests (Tests/Utils/test_config_nested_settings.py, 12) drive the REAL loader (TLDW_CONFIG_PATH + force_reload, zero accessor mocks — the T222 C1 lesson) over every repaired tuple + working-shape regressions + flat-shadow precedence + a DocumentGenerator consumer path. Rider fix discovered by the sweep: production reset_dependency_checks() restored DEPENDENCIES_AVAILABLE from a stale duplicated literal, silently dropping newer keys (svg_rendering from T222) — single-sourced via pristine module-level copy + cached-probe reset + test-pollution hygiene (snapshot/finally in test_initialize_dependency_checks; one sanctioned existing-test edit). Sweep: 1167 passed / 95 skipped / 0 failed across Utils+Chat+Event_Handlers+DB+unit. attachment_core._chat_images_setting left as-is (works either way; consolidation optional later). Files: config.py, Utils/optional_deps.py, Tests/Utils/test_config_nested_settings.py, Tests/Utils/test_optional_deps.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-229 - Repair-dotted-section-get_cli_setting-chat.images-readers.md
+++ b/backlog/tasks/task-229 - Repair-dotted-section-get_cli_setting-chat.images-readers.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-229
 title: Repair dotted-section get_cli_setting("chat.images") readers
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-07-14 10:30'
+updated_date: '2026-07-16 14:11'
 labels:
   - config
   - bug
@@ -24,3 +26,9 @@ TASK-222's final review proved that `get_cli_setting(section, key, default)` per
 - [ ] #2 No production caller passes a dotted section to a flat get_cli_setting lookup (repo-wide audit; either callers migrate or the accessor gains nested resolution with all affected callers reviewed)
 - [ ] #3 At least one unmocked integration test per repaired reader pins the real config path (scratch TOML through the real loader)
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. RED: unmocked real-loader tests (TLDW_CONFIG_PATH + force_reload, zero accessor mocks) for every broken caller tuple: (chat.images, show_attach_button/save_location), (chat.voice, show_mic_button), (mcp.hub_state, advanced_open), three-level prompts.document_generation.* dict form; + working-shape regressions (traditional, 1-arg single-dot, dotted+default) and flat-key-shadowing precedence\n2. Fix get_cli_setting: nested-path fallback after the flat lookup misses (dotted section OR dotted key navigates the real TOML tree); flat hit always wins\n3. Consumer-path test: DocumentGenerator picks up a configured [prompts.document_generation.timeline] prompt through the real loader (in-memory DB)\n4. Behavior-flip review of all repaired callers (defaults match template values → no visible change on default configs)\n5. Sweep + repo audit re-run; PR
+<!-- SECTION:PLAN:END -->

--- a/tldw_chatbook/Utils/optional_deps.py
+++ b/tldw_chatbook/Utils/optional_deps.py
@@ -1023,8 +1023,13 @@ def create_unavailable_feature_handler(feature_name: str, suggestion: str = "") 
     return handler
 
 # Initialize dependency checks
-def reset_dependency_checks():
-    """Reset all dependency checks - useful for testing."""
+def reset_dependency_checks() -> None:
+    """Reset all dependency checks to their pristine unchecked state.
+
+    Restores ``DEPENDENCIES_AVAILABLE`` from the pristine copy of the module
+    literal, clears the cached SVG probe and imported-module registry.
+    Useful for testing.
+    """
     global MODULES, _svg_rendering_available
     DEPENDENCIES_AVAILABLE.clear()
     DEPENDENCIES_AVAILABLE.update(_INITIAL_DEPENDENCIES_AVAILABLE)

--- a/tldw_chatbook/Utils/optional_deps.py
+++ b/tldw_chatbook/Utils/optional_deps.py
@@ -98,6 +98,12 @@ DEPENDENCIES_AVAILABLE = {
     'tqdm': False,
 }
 
+# Pristine copy of the registry above — reset_dependency_checks() restores
+# from THIS, so new keys need only be added to the literal once. (A stale
+# duplicated literal inside reset used to silently drop newer keys, e.g.
+# 'svg_rendering'.)
+_INITIAL_DEPENDENCIES_AVAILABLE = dict(DEPENDENCIES_AVAILABLE)
+
 # Store actual modules for conditional use
 MODULES = {}
 
@@ -1019,91 +1025,10 @@ def create_unavailable_feature_handler(feature_name: str, suggestion: str = "") 
 # Initialize dependency checks
 def reset_dependency_checks():
     """Reset all dependency checks - useful for testing."""
-    global MODULES
+    global MODULES, _svg_rendering_available
     DEPENDENCIES_AVAILABLE.clear()
-    DEPENDENCIES_AVAILABLE.update({
-        'torch': False,
-        'transformers': False,
-        'numpy': False,
-        'chromadb': False,
-        'embeddings_rag': False,
-        'websearch': False,
-        'jieba': False,
-        'fugashi': False,
-        'flashrank': False,
-        'sentence_transformers': False,
-        'chunker': False,
-        'chinese_chunking': False,
-        'japanese_chunking': False,
-        'token_chunking': False,
-        'cohere': False,
-        # Audio/Video processing
-        'audio_processing': False,
-        'video_processing': False,
-        'faster_whisper': False,
-        'lightning_whisper_mlx': False,
-        'parakeet_mlx': False,
-        'yt_dlp': False,
-        'soundfile': False,
-        'scipy': False,
-        'qwen2audio': False,
-        # PDF processing
-        'pdf_processing': False,
-        'pymupdf': False,
-        'pymupdf4llm': False,
-        'docling': False,
-        # E-book processing
-        'ebook_processing': False,
-        'ebooklib': False,
-        'defusedxml': False,
-        'html2text': False,
-        'lxml': False,
-        'beautifulsoup4': False,
-        # Web scraping - additional
-        'pandas': False,
-        'playwright': False,
-        'trafilatura': False,
-        'aiohttp': False,
-        # Local LLM
-        'local_llm': False,
-        'mlx_lm': False,
-        'vllm': False,
-        'onnxruntime': False,
-        # MCP
-        'mcp': False,
-        # TTS
-        'tts_processing': False,
-        'kokoro_onnx': False,
-        'chatterbox': False,
-        'pydub': False,
-        'pyaudio': False,
-        'av': False,
-        # STT
-        'stt_processing': False,
-        'nemo_toolkit': False,
-        # OCR
-        'ocr_processing': False,
-        'docext': False,
-        'gradio_client': False,
-        'openai': False,
-        # Image processing
-        'image_processing': False,
-        'PIL': False,
-        'pillow': False,
-        'textual_image': False,
-        'rich_pixels': False,
-        # Mindmap
-        'mindmap': False,
-        'anytree': False,
-        # Subscriptions
-        'subscriptions': False,
-        'markdown': False,
-        'schedule': False,
-        'feedparser': False,
-        # Web server
-        'web': False,
-        'textual_serve': False,
-    })
+    DEPENDENCIES_AVAILABLE.update(_INITIAL_DEPENDENCIES_AVAILABLE)
+    _svg_rendering_available = None
     MODULES = {}
     logger.debug("Reset dependency checks")
 

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -3123,8 +3123,21 @@ def get_cli_setting(section: str, key: str = None, default: Any = None) -> Any:
         else:
             return default
     
-    # Use `config.get(section, {})` to safely access potentially missing sections
+    # Flat lookup first: preserves every previously-working shape bit-for-bit
+    # (a literal dotted top-level key, while impossible from TOML, wins).
     section_data = config.get(section)
+    if isinstance(section_data, dict) and isinstance(key, str) and key in section_data:
+        return section_data[key]
+    # Nested fallback: TOML `[chat.images]` loads as config["chat"]["images"],
+    # never config["chat.images"], so dotted sections/keys that miss the flat
+    # lookup are resolved by walking the real tree segment by segment.
+    if isinstance(key, str) and ("." in section or "." in key):
+        node: Any = config
+        for part in (*section.split("."), *key.split(".")):
+            if not isinstance(node, dict) or part not in node:
+                return default
+            node = node[part]
+        return node
     if isinstance(section_data, dict):
         return section_data.get(key, default)
     # If section is not a dict or not found, return default

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -3095,10 +3095,24 @@ def save_setting_to_cli_config(section: str, key: str, value: Any) -> bool:
 # --- CLI Setting Getter ---
 def get_cli_setting(section: str, key: str = None, default: Any = None) -> Any:
     """Helper to get a specific setting from the loaded CLI configuration.
-    
+
     Can be called in two ways:
     1. get_cli_setting("section", "key", default)  # Traditional format
     2. get_cli_setting("section.key", default)     # Dotted format
+
+    Dotted sections/keys that miss the flat top-level lookup are resolved
+    against the nested TOML tree (``[chat.images]`` loads as
+    ``config["chat"]["images"]``); a flat top-level hit always wins.
+
+    Args:
+        section: Top-level section name, or a dotted path into nested tables.
+        key: Setting key within the section; in the dotted call shape this
+            positional slot may carry the default instead.
+        default: Value returned when the setting cannot be resolved.
+
+    Returns:
+        The resolved setting value, or ``default`` when the section/key does
+        not exist.
     """
     config = load_cli_config_and_ensure_existence() # Ensures config is loaded
     
@@ -3131,7 +3145,11 @@ def get_cli_setting(section: str, key: str = None, default: Any = None) -> Any:
     # Nested fallback: TOML `[chat.images]` loads as config["chat"]["images"],
     # never config["chat.images"], so dotted sections/keys that miss the flat
     # lookup are resolved by walking the real tree segment by segment.
-    if isinstance(key, str) and ("." in section or "." in key):
+    if (
+        isinstance(section, str)
+        and isinstance(key, str)
+        and ("." in section or "." in key)
+    ):
         node: Any = config
         for part in (*section.split("."), *key.split(".")):
             if not isinstance(node, dict) or part not in node:


### PR DESCRIPTION
## Summary

`get_cli_setting("chat.images", "show_attach_button", True)` — and every call like it — has silently returned its default forever: the accessor does a flat `config.get(section)`, but TOML `[chat.images]` loads as `config["chat"]["images"]`. Found during TASK-222's final review (which fixed its own reads locally); this repairs the accessor itself so all callers work.

**The fix:** after the flat lookup misses, a dotted section or key is resolved by walking the real config tree segment by segment. The flat lookup always wins (bit-for-bit preservation of every previously-working shape, including the 1-arg `"section.key"` form and the dotted-plus-non-string-default form).

**Callers repaired at once** (repo-wide audit; all behavior flips are intent-restoring, and template/live defaults equal code defaults so default configs see no visible change):
- `show_attach_button` — `Chat_Window_Enhanced`, `chat_session`, both settings sidebars (the attach-button visibility toggle never worked from config)
- `show_mic_button` — `Chat_Window_Enhanced`, `settings_sidebar`
- `save_location` — Console Save Image (always fell back to `~/Downloads`)
- `[mcp.hub_state] advanced_open` — the persisted MCP inspector state now actually restores across restarts
- `prompts.document_generation.{timeline,study_guide,briefing}` — the audit found these **additionally** broken: the first-dot split leaves a dotted *key* that flat-misses, so user-configured document prompts were never honored

## Rider fix (found by the sweep)

Production `reset_dependency_checks()` restored `DEPENDENCIES_AVAILABLE` from a **stale duplicated literal** that never learned newer keys — `svg_rendering` (added by TASK-222) silently vanished on every reset. Now restores from a pristine module-level copy of the single literal and resets the cached svg probe. One deliberate existing-test edit rides along: `test_initialize_dependency_checks` leaked a cleared registry into later tests (snapshot + finally-restore added).

## Tests

- New `Tests/Utils/test_config_nested_settings.py` (12, RED-first): every repaired caller tuple driven through the **real loader** (`TLDW_CONFIG_PATH` + `force_reload`, zero accessor mocks — the TASK-222 C1 lesson: accessor mocks hid an inert feature through five review gates), plus working-shape regressions, flat-key-shadowing precedence, and a `DocumentGenerator` consumer-path test over a real SQLite DB.
- Broad sweep: **1167 passed / 95 skipped / 0 failed** (Utils, Chat, Event_Handlers, DB, unit).

Closes TASK-229 (filed from PR #634's final review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dotted TOML section reads in `get_cli_setting` by resolving nested tables, restoring intended behavior for multiple settings. Also single-sources `reset_dependency_checks()` so newer keys (e.g., `svg_rendering`) aren’t lost. Addresses TASK-229.

- **Bug Fixes**
  - `get_cli_setting`: flat lookup still first; if it misses and section/key has dots, walk the nested dict to resolve the value. Keeps existing shapes working (including the one-arg `"section.key"` form and dotted+non-string defaults).
  - Repaired readers: `chat.images.show_attach_button`, `chat.voice.show_mic_button`, `chat.images.save_location`, `[mcp.hub_state] advanced_open`, and `prompts.document_generation.{timeline,study_guide,briefing}` now pull from user config.
  - Tests: added `Tests/Utils/test_config_nested_settings.py` that drives the real loader and a `DocumentGenerator` consumer path; updated `test_initialize_dependency_checks` to snapshot/restore globals.
  - Optional deps: `reset_dependency_checks()` restores from a single module-level registry copy and resets the cached SVG probe, preventing loss of keys like `svg_rendering`.

- **Refactors**
  - Docs/typing: converted `get_cli_setting` to Google-style docs, added section/key type guards, and annotated `reset_dependency_checks()` with `-> None`.

<sup>Written for commit ee6e0c26fd4ab0f6d1ed429b91ee548481fd85bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

