### PR TITLE
fix(chat): reject config-excluded image formats instead of a silent generic placeholder (TASK-230)

### DIFF
--- a/Tests/Chat/test_attachment_core.py
+++ b/Tests/Chat/test_attachment_core.py
@@ -161,31 +161,10 @@ def test_image_url_part_and_content_parts_agree():
     assert combined[-1] == part
 
 
-def test_process_attachment_bytes_falls_back_to_original_on_processing_failure(monkeypatch):
-    """When ChatImageHandler._process_image_data raises, keep the original
-    bytes instead of failing the attachment (mirrors process_image_file's
-    fallback at chat_image_events.py:71-80)."""
-    import asyncio
-    from io import BytesIO
-
-    from PIL import Image as PILImage
-
-    from tldw_chatbook.Chat.attachment_core import process_attachment_bytes
-    from tldw_chatbook.Event_Handlers.Chat_Events.chat_image_events import (
-        ChatImageHandler,
-    )
-
-    async def _boom(*args, **kwargs):
-        raise RuntimeError("simulated processing failure")
-
-    monkeypatch.setattr(ChatImageHandler, "_process_image_data", _boom)
-
-    buffer = BytesIO()
-    PILImage.new("RGB", (16, 16), (10, 20, 30)).save(buffer, format="PNG")
-    data = buffer.getvalue()
-
-    attachment = asyncio.run(
-        process_attachment_bytes(data, display_name="clipboard-fallback.png")
-    )
-    assert attachment.data == data
-    assert attachment.processed_size == len(data)
+# The bytes-fallback fault-injection test that lived here monkeypatched
+# ChatImageHandler._process_image_data, which process_attachment_bytes stopped
+# calling in TASK-222 — the test passed vacuously (its fixture PNG succeeds
+# through the real pipeline either way). Superseded by
+# Tests/Chat/test_image_payload.py::test_process_attachment_bytes_fallback_probes_mime,
+# which injects the failure at the seam actually called (prepare_image_payload)
+# and additionally asserts the fallback's probed mime. Removed per TASK-230.

--- a/Tests/Chat/test_attachment_exclusion_routing.py
+++ b/Tests/Chat/test_attachment_exclusion_routing.py
@@ -1,0 +1,107 @@
+"""Explicit rejection for config-excluded image formats (TASK-230).
+
+With a narrowed ``[chat.images].supported_formats``, a known-image extension
+picked via the pickers' "All Files" row used to slide past ImageFileHandler
+into DefaultFileHandler, inlining a ``[File: x.tiff (…) - image/tiff]``
+placeholder that reads as success while sending useless text (TASK-222 final
+review, finding M1). The registry now rejects known-image extensions the
+config excluded — the legacy error-toast behavior — while truly unknown
+extensions keep the generic-file fallthrough.
+"""
+
+from io import BytesIO
+
+import pytest
+from PIL import Image as PILImage
+
+import tldw_chatbook.config as config_mod
+from tldw_chatbook.Chat import attachment_core
+from tldw_chatbook.Utils.file_handlers import file_handler_registry
+
+
+@pytest.fixture
+def png_only_config(monkeypatch):
+    """[chat.images].supported_formats narrowed to [".png"]."""
+    monkeypatch.setattr(
+        config_mod, "get_cli_setting",
+        lambda section, k=None, default=None: (
+            {"supported_formats": [".png"]}
+            if (section, k) == ("chat", "images")
+            else default
+        ),
+    )
+
+
+def _write_png_bytes(path, size=(8, 8)):
+    buffer = BytesIO()
+    PILImage.new("RGB", size, "red").save(buffer, format="PNG")
+    path.write_bytes(buffer.getvalue())
+
+
+@pytest.mark.asyncio
+async def test_excluded_image_extension_rejects(tmp_path, png_only_config):
+    tiff = tmp_path / "scan.tiff"
+    PILImage.new("RGB", (8, 8), "red").save(tiff, format="TIFF")
+    with pytest.raises(ValueError, match="Unsupported image format: .tiff"):
+        await file_handler_registry.process_file(tiff)
+
+
+@pytest.mark.asyncio
+async def test_excluded_rejection_names_config_key(tmp_path, png_only_config):
+    gif = tmp_path / "anim.gif"
+    PILImage.new("RGB", (8, 8), "red").save(gif, format="GIF")
+    with pytest.raises(ValueError, match=r"supported_formats"):
+        await file_handler_registry.process_file(gif)
+
+
+@pytest.mark.asyncio
+async def test_svg_capability_absent_rejects_not_placeholder(tmp_path, monkeypatch):
+    """cairosvg-missing machines: .svg must reject, never placeholder."""
+    monkeypatch.setattr(
+        config_mod, "get_cli_setting", lambda s, k=None, default=None: default
+    )
+    monkeypatch.setattr(attachment_core, "svg_rendering_available", lambda: False)
+    svg = tmp_path / "logo.svg"
+    svg.write_text("<svg xmlns='http://www.w3.org/2000/svg'/>")
+    with pytest.raises(ValueError, match="Unsupported image format: .svg"):
+        await file_handler_registry.process_file(svg)
+
+
+@pytest.mark.asyncio
+async def test_unknown_extension_keeps_generic_fallthrough(tmp_path, png_only_config):
+    blob = tmp_path / "artifact.xyz"
+    blob.write_bytes(b"opaque")
+    processed = await file_handler_registry.process_file(blob)
+    assert processed.file_type == "file"
+    assert processed.insert_mode == "inline"
+    assert "[File: artifact.xyz" in (processed.content or "")
+
+
+@pytest.mark.asyncio
+async def test_effective_extension_still_routes_to_image_handler(
+    tmp_path, png_only_config
+):
+    png = tmp_path / "pic.png"
+    _write_png_bytes(png)
+    processed = await file_handler_registry.process_file(png)
+    assert processed.file_type == "image"
+    assert processed.attachment_data is not None
+
+
+@pytest.mark.asyncio
+async def test_extra_configured_format_routes_not_rejects(tmp_path, monkeypatch):
+    """A user-added format beyond the defaults (e.g. .heic) must route to the
+    image handler when configured — the rejection only fires for KNOWN image
+    formats the config excluded."""
+    monkeypatch.setattr(
+        config_mod, "get_cli_setting",
+        lambda section, k=None, default=None: (
+            {"supported_formats": [".png", ".heic"]}
+            if (section, k) == ("chat", "images")
+            else default
+        ),
+    )
+    heic = tmp_path / "photo.heic"
+    _write_png_bytes(heic)  # PNG bytes with a .heic name: routing is by suffix
+    processed = await file_handler_registry.process_file(heic)
+    assert processed.file_type == "image"

--- a/backlog/tasks/task-230 - Attachment-pipeline-housekeeping-—-vacuous-test-and-excluded-format-routing-UX.md
+++ b/backlog/tasks/task-230 - Attachment-pipeline-housekeeping-—-vacuous-test-and-excluded-format-routing-UX.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-230
 title: Attachment pipeline housekeeping — vacuous test and excluded-format routing UX
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-07-14 10:30'
+updated_date: '2026-07-16 14:35'
 labels:
   - chat
   - tests
@@ -23,3 +25,9 @@ Two small riders from TASK-222's reviews, deferred because existing tests were r
 - [ ] #1 The bytes-fallback test exercises the real fault-injection seam (prepare_image_payload) or is removed in favor of the superseding test
 - [ ] #2 The excluded-image-extension pick behavior is an explicit, tested decision (rejection copy or documented generic-file fallthrough), not an accident of registry ordering
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Delete the vacuous bytes-fallback test (superseded by test_process_attachment_bytes_fallback_probes_mime — reviewer-endorsed removal)\n2. Registry-level rejection: file_handler_registry.process_file raises the unsupported-format ValueError (naming the effective list + [chat.images].supported_formats) when a file would fall to DefaultFileHandler but its extension is a known image format excluded by config — restores the legacy error toast instead of a silent [File: …] placeholder; can_handle semantics (routing == effective formats) untouched\n3. RED tests: excluded-known-image ext → ValueError; unknown ext (.xyz) → still DefaultFileHandler placeholder; effective ext → ImageFileHandler (regression)\n4. Sweep; PR
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-230 - Attachment-pipeline-housekeeping-—-vacuous-test-and-excluded-format-routing-UX.md
+++ b/backlog/tasks/task-230 - Attachment-pipeline-housekeeping-—-vacuous-test-and-excluded-format-routing-UX.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-230
 title: Attachment pipeline housekeeping — vacuous test and excluded-format routing UX
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-07-14 10:30'
-updated_date: '2026-07-16 14:35'
+updated_date: '2026-07-16 14:46'
 labels:
   - chat
   - tests
@@ -31,3 +31,9 @@ Two small riders from TASK-222's reviews, deferred because existing tests were r
 <!-- SECTION:PLAN:BEGIN -->
 1. Delete the vacuous bytes-fallback test (superseded by test_process_attachment_bytes_fallback_probes_mime — reviewer-endorsed removal)\n2. Registry-level rejection: file_handler_registry.process_file raises the unsupported-format ValueError (naming the effective list + [chat.images].supported_formats) when a file would fall to DefaultFileHandler but its extension is a known image format excluded by config — restores the legacy error toast instead of a silent [File: …] placeholder; can_handle semantics (routing == effective formats) untouched\n3. RED tests: excluded-known-image ext → ValueError; unknown ext (.xyz) → still DefaultFileHandler placeholder; effective ext → ImageFileHandler (regression)\n4. Sweep; PR
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Decision (AC#2): explicit rejection. FileHandlerRegistry.process_file now raises the unsupported-format ValueError (naming the effective list AND the [chat.images].supported_formats key) when a file would fall to DefaultFileHandler but its extension is in DEFAULT_SUPPORTED_IMAGE_FORMATS — reaching the fallback with a known image suffix already implies config excluded it, since ImageFileHandler claims every effective format first. Routing semantics (can_handle == effective formats) untouched, so TASK-222's routing tests stay green; truly unknown extensions keep the generic [File: …] fallthrough; user-added extra formats (e.g. .heic) still route to the image handler. ValueError propagation is the registry's established contract (sole consumer: attachment_core.load_processed_file, documented Raises). Load-bearing verified by neuter-probe: neutered → old placeholder; live → rejection. (AC#1): removed the vacuous bytes-fallback test (monkeypatched _process_image_data, off-path since TASK-222; passed vacuously — superseded by test_image_payload.py::test_process_attachment_bytes_fallback_probes_mime which injects at the real seam and asserts the probed mime; tombstone comment left in place). New Tests/Chat/test_attachment_exclusion_routing.py (6). Sweep 968/70 with 1 known cross-branch ordering flake (svg_rendering registry key dropped by reset_dependency_checks' stale literal — pre-existing, FIXED on PR #638's branch; passes in isolation 8/8). Files: Utils/file_handlers.py, Tests/Chat/test_attachment_core.py (removal), Tests/Chat/test_attachment_exclusion_routing.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-230 - Attachment-pipeline-housekeeping-—-vacuous-test-and-excluded-format-routing-UX.md
+++ b/backlog/tasks/task-230 - Attachment-pipeline-housekeeping-—-vacuous-test-and-excluded-format-routing-UX.md
@@ -22,8 +22,8 @@ Two small riders from TASK-222's reviews, deferred because existing tests were r
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The bytes-fallback test exercises the real fault-injection seam (prepare_image_payload) or is removed in favor of the superseding test
-- [ ] #2 The excluded-image-extension pick behavior is an explicit, tested decision (rejection copy or documented generic-file fallthrough), not an accident of registry ordering
+- [x] #1 The bytes-fallback test exercises the real fault-injection seam (prepare_image_payload) or is removed in favor of the superseding test
+- [x] #2 The excluded-image-extension pick behavior is an explicit, tested decision (rejection copy or documented generic-file fallthrough), not an accident of registry ordering
 <!-- AC:END -->
 
 ## Implementation Plan

--- a/tldw_chatbook/Utils/file_handlers.py
+++ b/tldw_chatbook/Utils/file_handlers.py
@@ -476,6 +476,8 @@ class FileHandlerRegistry:
         # Find the first handler that can process this file
         for handler in self.handlers:
             if handler.can_handle(file_path):
+                if isinstance(handler, DefaultFileHandler):
+                    self._reject_config_excluded_image(file_path)
                 logger.debug(f"Using {handler.__class__.__name__} for {file_path.name}")
                 return await handler.process(file_path)
         
@@ -486,6 +488,36 @@ class FileHandlerRegistry:
             display_name=file_path.name,
             insert_mode="inline",
             file_type="error"
+        )
+
+    @staticmethod
+    def _reject_config_excluded_image(file_path: Path) -> None:
+        """Reject known-image files that config excluded, before the generic
+        fallback inlines a ``[File: …]`` placeholder that reads as success
+        while sending useless text (legacy behavior was an explicit error).
+
+        Reaching the fallback with a known image suffix already implies the
+        effective ``[chat.images].supported_formats`` list excluded it —
+        ImageFileHandler (first in the chain) claims every effective format.
+
+        Raises:
+            ValueError: When the extension is a known image format excluded
+                by the current configuration.
+        """
+        # Lazy import: attachment_core imports this module at module level.
+        from ..Chat.attachment_core import (
+            DEFAULT_SUPPORTED_IMAGE_FORMATS,
+            supported_image_formats,
+        )
+
+        suffix = file_path.suffix.lower()
+        if suffix not in DEFAULT_SUPPORTED_IMAGE_FORMATS:
+            return
+        effective = supported_image_formats()
+        raise ValueError(
+            f"Unsupported image format: {suffix}. "
+            f"Supported formats: {', '.join(effective)} "
+            "([chat.images].supported_formats controls this list)"
         )
 
 

--- a/tldw_chatbook/Utils/file_handlers.py
+++ b/tldw_chatbook/Utils/file_handlers.py
@@ -422,6 +422,7 @@ class DefaultFileHandler(FileHandler):
     
     async def process(self, file_path: Path) -> ProcessedFile:
         """Just reference the file by name and path."""
+        self._reject_config_excluded_image(file_path)
         file_size = file_path.stat().st_size
         size_str = self._format_size(file_size)
         
@@ -441,6 +442,37 @@ class DefaultFileHandler(FileHandler):
                 return f"{size:.1f}{unit}"
             size /= 1024.0
         return f"{size:.1f}TB"
+
+    @staticmethod
+    def _reject_config_excluded_image(file_path: Path) -> None:
+        """Reject known-image files that config excluded, instead of inlining
+        a ``[File: …]`` placeholder that reads as success while sending
+        useless text (legacy behavior was an explicit error).
+
+        Reaching this fallback with a known image suffix already implies the
+        effective ``[chat.images].supported_formats`` list excluded it —
+        ImageFileHandler (first in the registry chain) claims every effective
+        format.
+
+        Raises:
+            ValueError: When the extension is a known image format excluded
+                by the current configuration.
+        """
+        # Lazy import: attachment_core imports this module at module level.
+        from ..Chat.attachment_core import (
+            DEFAULT_SUPPORTED_IMAGE_FORMATS,
+            supported_image_formats,
+        )
+
+        suffix = file_path.suffix.lower()
+        if suffix not in DEFAULT_SUPPORTED_IMAGE_FORMATS:
+            return
+        effective = supported_image_formats()
+        raise ValueError(
+            f"Unsupported image format: {suffix}. "
+            f"Supported formats: {', '.join(effective)} "
+            "([chat.images].supported_formats controls this list)"
+        )
 
 
 class FileHandlerRegistry:
@@ -476,8 +508,6 @@ class FileHandlerRegistry:
         # Find the first handler that can process this file
         for handler in self.handlers:
             if handler.can_handle(file_path):
-                if isinstance(handler, DefaultFileHandler):
-                    self._reject_config_excluded_image(file_path)
                 logger.debug(f"Using {handler.__class__.__name__} for {file_path.name}")
                 return await handler.process(file_path)
         
@@ -488,36 +518,6 @@ class FileHandlerRegistry:
             display_name=file_path.name,
             insert_mode="inline",
             file_type="error"
-        )
-
-    @staticmethod
-    def _reject_config_excluded_image(file_path: Path) -> None:
-        """Reject known-image files that config excluded, before the generic
-        fallback inlines a ``[File: …]`` placeholder that reads as success
-        while sending useless text (legacy behavior was an explicit error).
-
-        Reaching the fallback with a known image suffix already implies the
-        effective ``[chat.images].supported_formats`` list excluded it —
-        ImageFileHandler (first in the chain) claims every effective format.
-
-        Raises:
-            ValueError: When the extension is a known image format excluded
-                by the current configuration.
-        """
-        # Lazy import: attachment_core imports this module at module level.
-        from ..Chat.attachment_core import (
-            DEFAULT_SUPPORTED_IMAGE_FORMATS,
-            supported_image_formats,
-        )
-
-        suffix = file_path.suffix.lower()
-        if suffix not in DEFAULT_SUPPORTED_IMAGE_FORMATS:
-            return
-        effective = supported_image_formats()
-        raise ValueError(
-            f"Unsupported image format: {suffix}. "
-            f"Supported formats: {', '.join(effective)} "
-            "([chat.images].supported_formats controls this list)"
         )
 
 


### PR DESCRIPTION
## Summary

Two riders from TASK-222's reviews (finding M1 + the vacuous-test note), deferred because existing tests were read-only on that branch.

**1. Excluded-image UX (the decision AC #2 asked for): explicit rejection.** With a narrowed `[chat.images].supported_formats`, picking a known-image extension via the pickers' "All Files" row slid past `ImageFileHandler` into `DefaultFileHandler`, inlining `[File: x.tiff (…) - image/tiff]` — reads as success, sends useless text. `FileHandlerRegistry.process_file` now raises the unsupported-format `ValueError` (naming the effective list **and** the config key) when a file would hit the generic fallback with an extension in `DEFAULT_SUPPORTED_IMAGE_FORMATS` — reaching the fallback with a known image suffix already implies config excluded it, since `ImageFileHandler` claims every effective format first. This restores the legacy error-toast behavior with better copy, while:
- routing semantics (`can_handle` == effective formats) stay untouched — TASK-222's routing tests unchanged and green
- truly unknown extensions (`.xyz`) keep the generic fallthrough
- user-added extra formats (e.g. `.heic` in config) still route to the image handler
- `ValueError` is the registry's established contract (sole consumer `attachment_core.load_processed_file` documents it)

Load-bearing verified by neuter-probe: with the rejection stubbed out, the old placeholder behavior returns; live, the rejection fires.

**2. Vacuous test removed (AC #1).** The bytes-fallback fault-injection test monkeypatched `ChatImageHandler._process_image_data`, which `process_attachment_bytes` stopped calling in TASK-222 — it passed vacuously ever since (its fixture PNG succeeds through the real pipeline either way). Superseded by `test_image_payload.py::test_process_attachment_bytes_fallback_probes_mime`, which injects at the seam actually called and additionally asserts the fallback's probed mime. A tombstone comment marks the removal.

## Tests

New `Tests/Chat/test_attachment_exclusion_routing.py` (6): excluded-tiff/gif rejection with config-key copy, capability-absent `.svg` rejection, unknown-extension fallthrough regression, effective-extension routing regression, extra-configured-format routing.

Sweep: 968 passed / 70 skipped across Chat+Utils+legacy image gate, with **1 known cross-branch ordering flake** — `test_registered_in_dependencies_available` fails when ordered after `reset_dependency_checks()` callers because that production function restores the registry from a stale duplicated literal missing `svg_rendering`; the fix is on PR #638's branch (this branch is based on dev, which doesn't have it yet). Passes 8/8 in isolation here; green once #638 merges.

Closes TASK-230.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects config‑excluded image formats instead of inserting a generic file placeholder. Restores clear errors for excluded images, moves logic into `DefaultFileHandler.process`, and removes a vacuous test (TASK-230).

- **Bug Fixes**
  - `DefaultFileHandler.process` now rejects files with known image extensions excluded by `[chat.images].supported_formats`, raising a `ValueError` that names the effective list and the config key.
  - Preserves routing: unknown extensions still fall through; user‑added formats (e.g. `.heic`) still route to the image handler; `.svg` rejects when SVG rendering is unavailable.

- **Refactors**
  - Moved the rejection from registry dispatch to the fallback handler via `_reject_config_excluded_image` to keep the registry as pure routing.
  - Removed the obsolete bytes‑fallback test in `Tests/Chat/test_attachment_core.py` (coverage lives in `test_image_payload.py::test_process_attachment_bytes_fallback_probes_mime`).

<sup>Written for commit ac290110f8ff93d4a7230494fcde3a6f20b9e951. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

