### PR TITLE
fix(chat): legacy attach handler crashed the picker — FileOpen has no context kwarg (TASK-219)

### DIFF
--- a/Tests/UI/test_legacy_attach_picker.py
+++ b/Tests/UI/test_legacy_attach_picker.py
@@ -1,0 +1,61 @@
+"""Legacy attach handler's picker must construct (TASK-219).
+
+Pre-existing dead code from before PR #621: the handler called
+``FileOpen(..., context="chat_images")``, but the ``FileOpen`` re-exported
+from Third_Party.textual_fspicker accepts no ``context`` kwarg — the call
+raised ``TypeError`` the moment the picker branch was exercised (reachable
+from Chat_Window_Enhanced's attach button whenever the legacy
+``#image-file-path-input`` isn't present). Every other picker surface uses
+``EnhancedFileOpen``, which supports ``context`` (recents/bookmarks).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_chatbook.UI.Chat_Modules.chat_attachment_handler import ChatAttachmentHandler
+from tldw_chatbook.Widgets.enhanced_file_picker import EnhancedFileOpen
+
+
+def _handler_with_recording_app():
+    """Build the handler over stubs that force the picker branch."""
+    pushed: list = []
+
+    def _query_one(_selector):
+        raise LookupError("no legacy file input in this layout")
+
+    app_instance = SimpleNamespace(
+        push_screen=lambda screen, callback=None: pushed.append(screen),
+        call_later=lambda fn: None,
+    )
+    chat_window = SimpleNamespace(
+        app_instance=app_instance,
+        _file_path_input=None,
+        is_attached=False,
+        query_one=_query_one,
+    )
+    return ChatAttachmentHandler(chat_window), pushed
+
+
+@pytest.mark.asyncio
+async def test_attach_button_constructs_and_pushes_the_picker():
+    """The picker branch must not raise, and must push a context-capable
+    EnhancedFileOpen (TypeError here = the TASK-219 regression)."""
+    handler, pushed = _handler_with_recording_app()
+
+    await handler.handle_attach_image_button(event=None)
+
+    assert len(pushed) == 1
+    assert isinstance(pushed[0], EnhancedFileOpen)
+
+
+def test_picker_kwargs_match_the_console_surface():
+    """The exact kwargs the handler uses must remain constructible — pinned
+    against the picker's signature drifting (the original bug's mechanism)."""
+    picker = EnhancedFileOpen(
+        location=".",
+        title="Select File to Attach",
+        filters=None,
+        context="chat_images",
+    )
+    assert picker is not None

--- a/Tests/UI/test_legacy_attach_picker.py
+++ b/Tests/UI/test_legacy_attach_picker.py
@@ -17,6 +17,25 @@ from tldw_chatbook.UI.Chat_Modules.chat_attachment_handler import ChatAttachment
 from tldw_chatbook.Widgets.enhanced_file_picker import EnhancedFileOpen
 
 
+@pytest.fixture(autouse=True)
+def _isolate_picker_config(monkeypatch):
+    """Keep picker recents/bookmarks I/O away from the real config file.
+
+    Constructing EnhancedFileOpen initializes RecentLocations and
+    BookmarksManager, which read and WRITE ``[filepicker]`` settings through
+    the live config module — a test must never touch the developer's real
+    config.toml.
+    """
+    monkeypatch.setattr(
+        "tldw_chatbook.Widgets.enhanced_file_picker.get_cli_setting",
+        lambda section, key, default=None: default,
+    )
+    monkeypatch.setattr(
+        "tldw_chatbook.Widgets.enhanced_file_picker.save_setting_to_cli_config",
+        lambda section, key, value: None,
+    )
+
+
 def _handler_with_recording_app():
     """Build the handler over stubs that force the picker branch."""
     pushed: list = []
@@ -39,8 +58,11 @@ def _handler_with_recording_app():
 
 @pytest.mark.asyncio
 async def test_attach_button_constructs_and_pushes_the_picker():
-    """The picker branch must not raise, and must push a context-capable
-    EnhancedFileOpen (TypeError here = the TASK-219 regression)."""
+    """Exercise the picker branch end to end without raising.
+
+    A TypeError here is the TASK-219 regression; the pushed screen must be
+    the context-capable EnhancedFileOpen.
+    """
     handler, pushed = _handler_with_recording_app()
 
     await handler.handle_attach_image_button(event=None)
@@ -50,8 +72,11 @@ async def test_attach_button_constructs_and_pushes_the_picker():
 
 
 def test_picker_kwargs_match_the_console_surface():
-    """The exact kwargs the handler uses must remain constructible — pinned
-    against the picker's signature drifting (the original bug's mechanism)."""
+    """Pin the handler's picker kwargs against signature drift.
+
+    The original bug's mechanism was exactly this: a kwarg the constructed
+    class did not accept.
+    """
     picker = EnhancedFileOpen(
         location=".",
         title="Select File to Attach",

--- a/backlog/tasks/task-219 - Remove-latent-broken-FileOpen-context-call-in-legacy-attach-handler.md
+++ b/backlog/tasks/task-219 - Remove-latent-broken-FileOpen-context-call-in-legacy-attach-handler.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-219
 title: Remove latent broken FileOpen context call in legacy attach handler
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-07-13 09:30'
-updated_date: '2026-07-16 15:02'
+updated_date: '2026-07-16 15:07'
 labels:
   - chat
   - tech-debt
@@ -21,6 +21,12 @@ Pre-existing dead code surfaced during Console attachments Phase 1 review (PR #6
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Legacy attach button opens a picker without TypeError (test constructs the real dialog class)
-- [ ] #2 Picker choice (EnhancedFileOpen vs plain) documented and consistent with repo convention
+- [x] #1 Legacy attach button opens a picker without TypeError (test constructs the real dialog class)
+- [x] #2 Picker choice (EnhancedFileOpen vs plain) documented and consistent with repo convention
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Switched the legacy handler's picker branch to EnhancedFileOpen with the exact kwargs the Console surface uses (context=chat_images → recents/bookmarks now work here too). RED-first: test constructing the picker through the handler's real branch failed with the exact TypeError pre-fix (stub chat_window forces the branch: no _file_path_input, is_attached False, query_one raising); second test pins the kwargs against picker-signature drift. Reachability confirmed: Chat_Window_Enhanced:468/673 → handle_attach_image_button → picker branch whenever the legacy input is absent. Sweep 795/69/0 (new + comprehensive attachment + image gate + Tests/Chat). Files: UI/Chat_Modules/chat_attachment_handler.py, Tests/UI/test_legacy_attach_picker.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-219 - Remove-latent-broken-FileOpen-context-call-in-legacy-attach-handler.md
+++ b/backlog/tasks/task-219 - Remove-latent-broken-FileOpen-context-call-in-legacy-attach-handler.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-219
 title: Remove latent broken FileOpen context call in legacy attach handler
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-07-13 09:30'
+updated_date: '2026-07-16 15:02'
 labels:
   - chat
   - tech-debt

--- a/tldw_chatbook/UI/Chat_Modules/chat_attachment_handler.py
+++ b/tldw_chatbook/UI/Chat_Modules/chat_attachment_handler.py
@@ -57,7 +57,7 @@ class ChatAttachmentHandler:
             return
         
         from fnmatch import fnmatch
-        from ...Widgets.enhanced_file_picker import FileOpen, Filters
+        from ...Widgets.enhanced_file_picker import EnhancedFileOpen, Filters
         
         def on_file_selected(file_path: Optional[Path]):
             if file_path:
@@ -81,13 +81,17 @@ class ChatAttachmentHandler:
             ("All Files", lambda path: True),
         )
         
-        # Push the FileOpen dialog directly
+        # Push the picker directly — EnhancedFileOpen like every other picker
+        # surface: the plain FileOpen re-export accepts no `context` kwarg and
+        # raised TypeError the moment this branch was exercised (TASK-219).
         self.app_instance.push_screen(
-            FileOpen(location=".",
+            EnhancedFileOpen(
+                location=".",
                 title="Select File to Attach",
                 filters=file_filters,
-                context="chat_images"),
-            callback=on_file_selected
+                context="chat_images",
+            ),
+            callback=on_file_selected,
         )
     
     async def handle_clear_image_button(self, event):


### PR DESCRIPTION
## Summary

Pre-existing latent crash surfaced by PR #621's review: the legacy chat attach handler's picker branch constructed `FileOpen(..., context="chat_images")`, but the `FileOpen` re-exported from `Third_Party.textual_fspicker` accepts no `context` kwarg — `TypeError` the moment the branch is exercised. The branch is reachable from `Chat_Window_Enhanced`'s attach button whenever the legacy `#image-file-path-input` isn't in the layout.

Fix: push `EnhancedFileOpen` with the exact kwargs the Console surface uses (`chat_screen.py`) — same dialog family as every other picker, and the `chat_images` context now actually provides recents/bookmarks here.

## Tests

RED-first `Tests/UI/test_legacy_attach_picker.py`: constructing the picker through the handler's real branch reproduced the exact `TypeError` pre-fix; a second test pins the kwargs against picker-signature drift. Sweep: 795 passed / 69 skipped / 0 failed (attachment suites + image gate + Tests/Chat).

Closes TASK-219.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash when pressing Attach in legacy chat by switching the picker to EnhancedFileOpen with supported args. The attach dialog now opens reliably and uses the `chat_images` context for recents/bookmarks. Addresses TASK-219.

- **Bug Fixes**
  - Replace `FileOpen(..., context="chat_images")` with `EnhancedFileOpen` to avoid TypeError and match other picker surfaces.
  - Add tests that exercise the handler’s picker branch, pin the picker kwargs, and isolate picker config I/O.

<sup>Written for commit 2882f1b2f2ac2d4cfddcc3c044de24915d4ec6ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

