### PR TITLE
feat(console): staged attachments survive screen navigation (TASK-218)

### DIFF
--- a/Tests/UI/test_console_pending_attachment_stash.py
+++ b/Tests/UI/test_console_pending_attachment_stash.py
@@ -1,0 +1,135 @@
+"""Pending Console attachments survive screen navigation (TASK-218).
+
+Phase 1 (#621) deliberately dropped staged-but-unsent attachments on
+navigation: screen-state serialization is metadata-only by spec (raw bytes
+never serialize), and the staging list lived only on the screen-owned store.
+The preservation strategy (user-approved): a bounded app-level in-memory
+stash — full ``PendingAttachment`` objects (bytes included, clipboard grabs
+too) snapshot onto the app object at save time and re-adopt into the store at
+restore time. The stash is process-memory only: it never serializes, and it
+dies with the app (restart drops pendings, which is the accepted trade).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+    ConsoleHarness,
+)
+from Tests.UI.test_console_native_chat_flow import (
+    RestoredConsoleHarness,
+    _select_llamacpp_console,
+)
+from tldw_chatbook.Chat.attachment_core import PendingAttachment
+
+
+def _image_pending(name: str, *, path: str) -> PendingAttachment:
+    data = f"png-bytes-{name}".encode()
+    return PendingAttachment(
+        file_path=path,
+        display_name=name,
+        file_type="image",
+        insert_mode="attachment",
+        data=data,
+        mime_type="image/png",
+        text_content=None,
+        original_size=len(data),
+        processed_size=len(data),
+    )
+
+
+def _assert_no_bytes(node, crumb="state"):
+    """AC #2: raw attachment bytes never enter screen-state serialization."""
+    if isinstance(node, (bytes, bytearray)):
+        raise AssertionError(f"raw bytes leaked into screen state at {crumb}")
+    if isinstance(node, dict):
+        for key, value in node.items():
+            _assert_no_bytes(value, f"{crumb}.{key}")
+    elif isinstance(node, (list, tuple)):
+        for index, value in enumerate(node):
+            _assert_no_bytes(value, f"{crumb}[{index}]")
+
+
+@pytest.mark.asyncio
+async def test_pending_attachments_survive_screen_recreation():
+    """Stage a path-backed pending AND a clipboard-style one (no file path),
+    recreate the screen from saved state, and find both staged again with
+    the composer indicator rebuilt."""
+    app = _build_test_app()
+    app.chat_api_provider_value = "llama_cpp"
+    app.chat_api_model_value = "test-model"
+
+    saved_state: dict | None = None
+    session_id: str | None = None
+    disk_pending = _image_pending("photo.png", path="/tmp/photo.png")
+    clipboard_pending = _image_pending("clipboard-grab.png", path="")
+
+    host = ConsoleHarness(app)
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        _select_llamacpp_console(console)
+        store = console._ensure_console_chat_store()
+        session_id = store.ensure_session().id
+        assert store.add_pending_attachment(session_id, disk_pending)
+        assert store.add_pending_attachment(session_id, clipboard_pending)
+        await console._sync_native_console_chat_ui()
+        saved_state = console.save_state()
+
+    assert saved_state is not None and session_id is not None
+    _assert_no_bytes(saved_state)
+
+    restored_host = RestoredConsoleHarness(app, saved_state)
+    async with restored_host.run_test(size=(160, 48)) as pilot:
+        console = restored_host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        store = console._ensure_console_chat_store()
+        pendings = store.pending_attachments(session_id)
+        assert [p.display_name for p in pendings] == [
+            "photo.png", "clipboard-grab.png",
+        ]
+        # Bytes preserved verbatim — including the path-less clipboard grab.
+        assert pendings[0].data == disk_pending.data
+        assert pendings[1].data == clipboard_pending.data
+        await console._sync_native_console_chat_ui()
+        composer = console.query_one("#console-native-composer")
+        assert "2 files" in (composer._pending_attachment_label or "")
+
+
+@pytest.mark.asyncio
+async def test_stash_prunes_dead_sessions_and_empties_after_adoption():
+    """A stash entry for a session that no longer exists must not crash the
+    restore or linger in the stash."""
+    app = _build_test_app()
+    app.chat_api_provider_value = "llama_cpp"
+    app.chat_api_model_value = "test-model"
+
+    host = ConsoleHarness(app)
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        _select_llamacpp_console(console)
+        store = console._ensure_console_chat_store()
+        session_id = store.ensure_session().id
+        assert store.add_pending_attachment(
+            session_id, _image_pending("keep.png", path="")
+        )
+        saved_state = console.save_state()
+
+    stash = getattr(app, "_console_pending_attachment_stash", None)
+    assert isinstance(stash, dict) and session_id in stash
+    stash["dead-session-id"] = stash[session_id]  # simulate a stale entry
+
+    restored_host = RestoredConsoleHarness(app, saved_state)
+    async with restored_host.run_test(size=(160, 48)) as pilot:
+        console = restored_host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        store = console._ensure_console_chat_store()
+        assert [p.display_name for p in store.pending_attachments(session_id)] == [
+            "keep.png"
+        ]
+        assert "dead-session-id" not in store._sessions
+
+    assert getattr(app, "_console_pending_attachment_stash", None) == {}

--- a/Tests/UI/test_console_pending_attachment_stash.py
+++ b/Tests/UI/test_console_pending_attachment_stash.py
@@ -133,3 +133,25 @@ async def test_stash_prunes_dead_sessions_and_empties_after_adoption():
         assert "dead-session-id" not in store._sessions
 
     assert getattr(app, "_console_pending_attachment_stash", None) == {}
+
+
+def test_adopt_resets_malformed_stash_without_crashing():
+    """A corrupted stash value must be replaced with an empty dict on the
+    first adopt attempt, releasing whatever it referenced (self-healing)."""
+    from types import SimpleNamespace as _NS
+
+    from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+    from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+    screen = ChatScreen.__new__(ChatScreen)
+    screen.app_instance = _NS(_console_pending_attachment_stash="not-a-dict")
+    store = ConsoleChatStore()
+    screen._adopt_console_pending_attachments(store)
+    assert screen.app_instance._console_pending_attachment_stash == {}
+
+    # Malformed VALUES inside a well-formed dict are skipped, dict still reset.
+    session_id = store.ensure_session().id
+    screen.app_instance._console_pending_attachment_stash = {session_id: "junk"}
+    screen._adopt_console_pending_attachments(store)
+    assert screen.app_instance._console_pending_attachment_stash == {}
+    assert store.pending_attachments(session_id) == []

--- a/backlog/tasks/task-218 - Preserve-pending-Console-attachment-across-screen-navigation.md
+++ b/backlog/tasks/task-218 - Preserve-pending-Console-attachment-across-screen-navigation.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-218
 title: Preserve pending Console attachment across screen navigation
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-07-13 09:30'
-updated_date: '2026-07-16 15:14'
+updated_date: '2026-07-16 15:34'
 labels:
   - console
   - ux
@@ -21,7 +21,13 @@ Phase 1 (PR #621) deliberately drops a staged-but-unsent attachment when the use
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Staging an attachment, visiting another destination, and returning to Console preserves the pending attachment (or shows an explicit, honest notice if the source file vanished)
-- [ ] #2 Raw attachment bytes still never enter screen-state serialization
-- [ ] #3 Behavior covered by a mounted navigation round-trip test
+- [x] #1 Staging an attachment, visiting another destination, and returning to Console preserves the pending attachment (or shows an explicit, honest notice if the source file vanished)
+- [x] #2 Raw attachment bytes still never enter screen-state serialization
+- [x] #3 Behavior covered by a mounted navigation round-trip test
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+User-approved design: bounded app-level in-memory stash (chosen over drop-with-toast for clipboard grabs). ChatScreen._stash_console_pending_attachments snapshots every session's staged PendingAttachment objects (bytes included) onto app_instance._console_pending_attachment_stash at _serialize_native_console_state time, overwriting whole each save (no stale entries); _adopt_console_pending_attachments re-stages them after store.restore_state, dropping dead-session entries and emptying the stash. Bytes never enter screen-state serialization — the round-trip test walks the whole saved payload asserting no bytes instances (AC#2); the composer '2 files' indicator rebuilds via the normal sync path (label derives from store pendings, no extra wiring). AC#1's vanished-file notice is moot under this design: bytes are preserved in memory, nothing re-processes from disk; app restart drops pendings (accepted trade). Helpers degrade gracefully on bare/unit screens (no app_instance → no-op) so the existing _bare_console_screen round-trip tests run unedited. Mounted AC#3 tests: ConsoleHarness→save_state→RestoredConsoleHarness preservation (path-backed + path-less clipboard pending, byte-identical), dead-session pruning + stash emptied. Sweep 270/0 across stash+native-flow+screen-state+store suites. Files: UI/Screens/chat_screen.py, Tests/UI/test_console_pending_attachment_stash.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-218 - Preserve-pending-Console-attachment-across-screen-navigation.md
+++ b/backlog/tasks/task-218 - Preserve-pending-Console-attachment-across-screen-navigation.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-218
 title: Preserve pending Console attachment across screen navigation
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-07-13 09:30'
+updated_date: '2026-07-16 15:14'
 labels:
   - console
   - ux

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -6503,21 +6503,29 @@ class ChatScreen(BaseAppScreen):
 
     def _adopt_console_pending_attachments(self, store: ConsoleChatStore) -> None:
         """Re-stage stashed attachments into the restored store, then empty
-        the stash. Entries for sessions that no longer exist are dropped."""
+        the stash. Entries for sessions that no longer exist are dropped.
+
+        The stash attribute is reset the moment it is read — every adopt
+        attempt releases the byte references, even when the stash turned out
+        malformed or nothing could be adopted (self-healing; the bytes must
+        never outlive their one restore opportunity).
+        """
         app = getattr(self, "app_instance", None)
         if app is None:
             return
         stash = getattr(app, self._CONSOLE_PENDING_STASH_ATTR, None)
+        setattr(app, self._CONSOLE_PENDING_STASH_ATTR, {})
         if not isinstance(stash, dict) or not stash:
             return
         live_ids = {session.id for session in store.sessions()}
         for session_id, pendings in stash.items():
             if session_id not in live_ids:
                 continue
+            if not isinstance(pendings, (list, tuple)):
+                continue
             for pending in pendings:
                 if not store.add_pending_attachment(session_id, pending):
                     break  # staging cap reached — matches live staging semantics
-        setattr(app, self._CONSOLE_PENDING_STASH_ATTR, {})
 
     def _serialize_native_console_state(self) -> dict[str, Any] | None:
         """Return the native Console in-session state for screen restoration."""

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -6474,12 +6474,58 @@ class ChatScreen(BaseAppScreen):
             attachments=attachments,
         )
 
+    # App-object attribute holding staged-but-unsent attachments across screen
+    # recreation. Full PendingAttachment objects (bytes included, so clipboard
+    # grabs survive too) live in process memory ONLY — the stash never enters
+    # screen-state serialization (the no-bytes-in-screen-state spec constraint)
+    # and dies with the app (restart drops pendings; accepted trade, TASK-218).
+    _CONSOLE_PENDING_STASH_ATTR = "_console_pending_attachment_stash"
+
+    def _stash_console_pending_attachments(self, store: ConsoleChatStore) -> None:
+        """Snapshot every session's staged attachments onto the app object.
+
+        Overwrites the whole stash each save, so cleared/sent attachments and
+        closed sessions never leave stale entries behind. Bounded by the
+        staging cap (5/session) times the live session count.
+        """
+        app = getattr(self, "app_instance", None)
+        if app is None:
+            return  # bare/unit harness: nowhere to stash — nothing to preserve
+        stash: dict[str, tuple[Any, ...]] = {}
+        for session in store.sessions():
+            try:
+                pendings = store.pending_attachments(session.id)
+            except KeyError:
+                continue
+            if pendings:
+                stash[session.id] = tuple(pendings)
+        setattr(app, self._CONSOLE_PENDING_STASH_ATTR, stash)
+
+    def _adopt_console_pending_attachments(self, store: ConsoleChatStore) -> None:
+        """Re-stage stashed attachments into the restored store, then empty
+        the stash. Entries for sessions that no longer exist are dropped."""
+        app = getattr(self, "app_instance", None)
+        if app is None:
+            return
+        stash = getattr(app, self._CONSOLE_PENDING_STASH_ATTR, None)
+        if not isinstance(stash, dict) or not stash:
+            return
+        live_ids = {session.id for session in store.sessions()}
+        for session_id, pendings in stash.items():
+            if session_id not in live_ids:
+                continue
+            for pending in pendings:
+                if not store.add_pending_attachment(session_id, pending):
+                    break  # staging cap reached — matches live staging semantics
+        setattr(app, self._CONSOLE_PENDING_STASH_ATTR, {})
+
     def _serialize_native_console_state(self) -> dict[str, Any] | None:
         """Return the native Console in-session state for screen restoration."""
         store = self._console_chat_store
         if store is None or not store.sessions():
             return None
 
+        self._stash_console_pending_attachments(store)
         visible_session_id = self._console_visible_draft_session_id
         composer = self._console_composer_or_none()
         if composer is not None and visible_session_id is not None:
@@ -6595,6 +6641,7 @@ class ChatScreen(BaseAppScreen):
             messages_by_session=restored_messages_by_session,
             active_session_id=active_session_id,
         )
+        self._adopt_console_pending_attachments(store)
         self._console_visible_draft_session_id = None
         self._last_native_transcript_refresh_key = None
 


### PR DESCRIPTION
## Summary

Phase 1 (#621) deliberately dropped staged-but-unsent attachments when the user navigated away from Console — screen-state serialization is metadata-only by spec (raw bytes never serialize), and the staging list lived only on the screen-owned store. User-approved design: a **bounded app-level in-memory stash**.

- At `save_state` time, every session's staged `PendingAttachment` objects (bytes included — **clipboard grabs survive too**, which pure re-process-from-path could never cover) snapshot onto the app object. The stash overwrites whole each save, so cleared/sent attachments and closed sessions never leave stale entries; bound = staging cap (5/session) × live sessions.
- At restore time the stash re-stages into the rebuilt store (dead-session entries dropped, stash emptied); the composer's `📎 N files` indicator rebuilds through the normal sync path with zero extra wiring.
- The spec constraint holds: bytes still never enter screen-state serialization — the round-trip test walks the entire saved payload asserting no `bytes` anywhere. The stash is process-memory only; app restart drops pendings (the accepted trade of this design).
- Helpers degrade gracefully on bare unit-harness screens (no `app_instance` → no-op), so the existing round-trip unit tests run unedited.

## Tests

RED-first mounted round-trips (`Tests/UI/test_console_pending_attachment_stash.py`, ConsoleHarness → `save_state` → RestoredConsoleHarness): path-backed + path-less clipboard pendings preserved byte-identical with the indicator rebuilt; dead-session stash entries pruned without crash and the stash emptied after adoption; the no-bytes serialization invariant. Sweep: 270 passed / 0 failed (stash + native console flow + screen state + store suites).

Closes TASK-218.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves staged-but-unsent Console attachments across navigation using a bounded app-level in-memory stash. Implements TASK-218 while keeping bytes out of screen-state serialization; the stash resets on restore.

- **New Features**
  - Snapshots full `PendingAttachment` objects (including clipboard) to the app on save, then re-stages them on restore; bounded by per-session staging caps.
  - Prunes dead-session entries and empties the stash after adoption; process-memory only (attachments are lost on app restart).
  - Composer’s “N files” indicator rebuilds via the existing sync path without extra wiring.

- **Bug Fixes**
  - Stash now clears as soon as adopt runs and self-heals malformed values; malformed per-session entries are skipped to avoid lingering byte refs.

<sup>Written for commit 41d56ebaabfd5c5032c24f8fc7cf61123c66927b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

