### PR TITLE
fix(console): attachment riders — vision-gate dedup, omitted-image placeholder, escaped save toasts (TASK-223/224/225)

### DIFF
--- a/Tests/Chat/test_console_attachment_riders.py
+++ b/Tests/Chat/test_console_attachment_riders.py
@@ -1,0 +1,222 @@
+"""Console attachment riders (TASK-223/224/225).
+
+- 223: submit_draft's vision gate must make ONE capability decision — the
+  controller's documented ``is_vision_capable`` seam is injected into
+  ``vision_block_reason`` instead of being re-checked around it. Previously
+  the two seams could disagree under test: the controller's pre-check said
+  "not capable" while ``vision_block_reason``'s internal check said
+  "capable", returning None and letting the send THROUGH the gate.
+- 224: an image-only user turn whose images all fall outside the budget
+  (over-cap, or a non-vision model) must appear in provider payloads as a
+  text placeholder instead of silently vanishing.
+- 225: the Save Image toasts escape the interpolated filesystem path.
+"""
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from Tests.Chat.test_console_chat_controller import (
+    RecordingStreamingGateway,
+    _pending_image,
+)
+from tldw_chatbook.Chat import attachment_core
+from tldw_chatbook.Chat import console_chat_controller as controller_module
+from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
+from tldw_chatbook.Chat.console_chat_models import (
+    ConsoleMessageRole,
+    MessageAttachment,
+)
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+
+
+def _controller(store, gateway, model="test-model"):
+    return ConsoleChatController(store=store, provider_gateway=gateway, model=model)
+
+
+class TestVisionGateSingleSeam:
+    """TASK-223 — the controller seam alone decides the gate."""
+
+    def test_diverging_seams_still_block(self, monkeypatch):
+        """The exact hazard the dedup removes: controller seam says
+        non-vision, attachment_core's internal seam says vision. The old
+        pre-check-then-recheck let the send THROUGH; the gate must block."""
+        monkeypatch.setattr(controller_module, "is_vision_capable", lambda p, m: False)
+        monkeypatch.setattr(attachment_core, "is_vision_capable", lambda p, m: True)
+        store = ConsoleChatStore()
+        controller = _controller(store, RecordingStreamingGateway())
+        session = store.ensure_session()
+        store.set_pending_attachment(session.id, _pending_image())
+
+        result = asyncio.run(controller.submit_draft("look"))
+
+        assert not result.accepted
+        assert "can't accept images" in result.visible_copy
+
+    def test_controller_seam_capable_sends(self, monkeypatch):
+        """Inverse divergence: controller seam capable must send even when
+        attachment_core's internal seam claims otherwise."""
+        monkeypatch.setattr(controller_module, "is_vision_capable", lambda p, m: True)
+        monkeypatch.setattr(attachment_core, "is_vision_capable", lambda p, m: False)
+        store = ConsoleChatStore()
+        gateway = RecordingStreamingGateway()
+        controller = _controller(store, gateway)
+        session = store.ensure_session()
+        store.set_pending_attachment(session.id, _pending_image())
+
+        result = asyncio.run(controller.submit_draft("look"))
+
+        assert result.accepted
+        assert gateway.messages_seen is not None
+
+
+class TestOmittedImagePlaceholder:
+    """TASK-224 — image-only turns outside the budget must not vanish."""
+
+    @staticmethod
+    def _image_only_message(store, session_id, count=1):
+        attachments = tuple(
+            MessageAttachment(
+                data=f"img-{index}".encode(),
+                mime_type="image/png",
+                display_name=f"img{index}.png",
+                position=index,
+            )
+            for index in range(count)
+        )
+        return store.append_message(
+            session_id,
+            role=ConsoleMessageRole.USER,
+            content="",
+            attachments=attachments,
+        )
+
+    def test_non_vision_image_only_turn_becomes_placeholder(self, monkeypatch):
+        monkeypatch.setattr(controller_module, "is_vision_capable", lambda p, m: False)
+        store = ConsoleChatStore()
+        gateway = RecordingStreamingGateway()
+        controller = _controller(store, gateway)
+        session = store.ensure_session()
+        self._image_only_message(store, session.id)
+
+        result = asyncio.run(controller.submit_draft("and now?"))
+
+        assert result.accepted
+        contents = [m["content"] for m in gateway.messages_seen]
+        assert "[image omitted]" in contents
+        assert contents[-1] == "and now?"
+
+    def test_over_cap_image_only_turn_becomes_placeholder(self, monkeypatch):
+        monkeypatch.setattr(controller_module, "is_vision_capable", lambda p, m: True)
+        monkeypatch.setattr(controller_module, "max_history_images", lambda p, m: 1)
+        store = ConsoleChatStore()
+        gateway = RecordingStreamingGateway()
+        controller = _controller(store, gateway)
+        session = store.ensure_session()
+        self._image_only_message(store, session.id)  # older: loses the budget
+        self._image_only_message(store, session.id)  # newer: takes the budget
+
+        result = asyncio.run(controller.submit_draft("compare them"))
+
+        assert result.accepted
+        contents = [m["content"] for m in gateway.messages_seen]
+        assert "[image omitted]" in contents  # the older turn survives as text
+        image_part_payloads = [c for c in contents if isinstance(c, list)]
+        assert len(image_part_payloads) == 1  # the newer turn kept its image
+
+    def test_multiple_omitted_images_pluralize(self, monkeypatch):
+        monkeypatch.setattr(controller_module, "is_vision_capable", lambda p, m: False)
+        store = ConsoleChatStore()
+        gateway = RecordingStreamingGateway()
+        controller = _controller(store, gateway)
+        session = store.ensure_session()
+        self._image_only_message(store, session.id, count=3)
+
+        result = asyncio.run(controller.submit_draft("next"))
+
+        assert result.accepted
+        contents = [m["content"] for m in gateway.messages_seen]
+        assert "[3 images omitted]" in contents
+
+    def test_captioned_image_message_keeps_its_text(self, monkeypatch):
+        monkeypatch.setattr(controller_module, "is_vision_capable", lambda p, m: False)
+        store = ConsoleChatStore()
+        gateway = RecordingStreamingGateway()
+        controller = _controller(store, gateway)
+        session = store.ensure_session()
+        store.append_message(
+            session.id,
+            role=ConsoleMessageRole.USER,
+            content="the caption",
+            image_data=b"img",
+            image_mime_type="image/png",
+        )
+
+        result = asyncio.run(controller.submit_draft("next"))
+
+        assert result.accepted
+        contents = [m["content"] for m in gateway.messages_seen]
+        assert "the caption" in contents
+        assert not any("omitted" in str(c) for c in contents)
+
+
+class TestSaveImageToastEscaping:
+    """TASK-225 — the save-path toasts render markup-like paths literally."""
+
+    @staticmethod
+    def _screen_with_message(tmp_path, monkeypatch, attachment_count=1):
+        from tldw_chatbook.UI.Screens import chat_screen as chat_screen_module
+        from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+        markup_dir = tmp_path / "sav[e]dir"
+        markup_dir.mkdir()
+        monkeypatch.setattr(
+            chat_screen_module,
+            "get_cli_setting",
+            lambda section, key=None, default=None: str(markup_dir),
+        )
+        store = ConsoleChatStore()
+        session = store.ensure_session()
+        attachments = tuple(
+            MessageAttachment(
+                data=f"img-{index}".encode(),
+                mime_type="image/png",
+                display_name=f"img{index}.png",
+                position=index,
+            )
+            for index in range(attachment_count)
+        )
+        message = store.append_message(
+            session.id,
+            role=ConsoleMessageRole.USER,
+            content="pic",
+            attachments=attachments,
+        )
+        notices: list[str] = []
+        screen = ChatScreen.__new__(ChatScreen)
+        screen._console_chat_store = store
+        screen._ensure_console_chat_store = lambda: store
+        screen.app_instance = SimpleNamespace(
+            notify=lambda text, **kwargs: notices.append(str(text)),
+            chachanotes_db=None,
+        )
+        return screen, message, notices
+
+    def test_single_save_toast_escapes_path(self, tmp_path, monkeypatch):
+        screen, message, notices = self._screen_with_message(tmp_path, monkeypatch)
+        asyncio.run(screen._save_console_message_image(message.id))
+        assert notices, "no toast fired"
+        # Rich's escape only needs to neutralize the opening bracket.
+        assert "sav\\[e]dir" in notices[-1]
+        assert "sav[e]dir" not in notices[-1]
+
+    def test_multi_save_toast_escapes_path(self, tmp_path, monkeypatch):
+        screen, message, notices = self._screen_with_message(
+            tmp_path, monkeypatch, attachment_count=2
+        )
+        asyncio.run(screen._save_console_message_image(message.id))
+        assert notices, "no toast fired"
+        assert notices[-1].startswith("Saved 2 images to ")
+        assert "sav\\[e]dir" in notices[-1]

--- a/backlog/tasks/task-223 - Deduplicate-vision-gate-in-Console-controller.md
+++ b/backlog/tasks/task-223 - Deduplicate-vision-gate-in-Console-controller.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-223
 title: Deduplicate vision gate in Console controller
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-07-13 11:15'
+updated_date: '2026-07-16 20:18'
 labels:
   - console
   - tech-debt

--- a/backlog/tasks/task-223 - Deduplicate-vision-gate-in-Console-controller.md
+++ b/backlog/tasks/task-223 - Deduplicate-vision-gate-in-Console-controller.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-223
 title: Deduplicate vision gate in Console controller
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-07-13 11:15'
-updated_date: '2026-07-16 20:18'
+updated_date: '2026-07-16 20:31'
 labels:
   - console
   - tech-debt
@@ -21,6 +21,12 @@ ConsoleChatController.submit_draft re-implements the vision-capability check via
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Single capability check in submit_draft; blocked copy still comes from vision_block_reason
-- [ ] #2 Existing controller vision tests pass against one documented patch seam
+- [x] #1 Single capability check in submit_draft; blocked copy still comes from vision_block_reason
+- [x] #2 Existing controller vision tests pass against one documented patch seam
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+vision_block_reason gains optional is_capable predicate (additive kwarg, attachment_core internal seam remains the default for the screen-side caller); submit_draft injects controller_module.is_vision_capable — one check, one documented seam, blocked copy unchanged. Divergence tests pin both directions (controller-says-no blocks even when attachment_core-says-yes, and vice versa sends). Existing controller vision tests pass unedited.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-224 - Placeholder-for-images-omitted-from-provider-history.md
+++ b/backlog/tasks/task-224 - Placeholder-for-images-omitted-from-provider-history.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-224
 title: Placeholder for images omitted from provider history
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-07-13 11:15'
-updated_date: '2026-07-16 20:18'
+updated_date: '2026-07-16 20:31'
 labels:
   - console
 dependencies: []
@@ -20,7 +20,13 @@ In the Console provider payload builder (PR #621), an image-only user message th
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Over-cap and non-vision image-only turns appear in provider payloads as a text placeholder instead of vanishing
-- [ ] #2 Captioned image messages keep their existing text-fallback behavior
-- [ ] #3 Controller payload tests cover both placeholder paths
+- [x] #1 Over-cap and non-vision image-only turns appear in provider payloads as a text placeholder instead of vanishing
+- [x] #2 Captioned image messages keep their existing text-fallback behavior
+- [x] #3 Controller payload tests cover both placeholder paths
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+In _provider_message_payloads' no-text branch: USER messages with usable-but-unbudgeted attachments emit '[image omitted]' (or '[N images omitted]') instead of being skipped. Covers both paths: non-vision model (budget 0) and over-cap (older turn loses the newest-first reservation). Captioned messages keep the existing text fallback; assistant messages unchanged. Tests drive the real submit path via RecordingStreamingGateway.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-224 - Placeholder-for-images-omitted-from-provider-history.md
+++ b/backlog/tasks/task-224 - Placeholder-for-images-omitted-from-provider-history.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-224
 title: Placeholder for images omitted from provider history
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-07-13 11:15'
+updated_date: '2026-07-16 20:18'
 labels:
   - console
 dependencies: []

--- a/backlog/tasks/task-225 - Escape-save-path-toast-in-Save-Image-worker.md
+++ b/backlog/tasks/task-225 - Escape-save-path-toast-in-Save-Image-worker.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-225
 title: Escape save path toast in Save Image worker
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-07-13 11:15'
+updated_date: '2026-07-16 20:18'
 labels:
   - console
   - tech-debt

--- a/backlog/tasks/task-225 - Escape-save-path-toast-in-Save-Image-worker.md
+++ b/backlog/tasks/task-225 - Escape-save-path-toast-in-Save-Image-worker.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-225
 title: Escape save path toast in Save Image worker
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-07-13 11:15'
-updated_date: '2026-07-16 20:18'
+updated_date: '2026-07-16 20:31'
 labels:
   - console
   - tech-debt
@@ -21,6 +21,12 @@ The Save Image worker's success toast notify(f"Image saved to {target}") interpo
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Save-path toast escapes the interpolated path per repo convention
-- [ ] #2 A path containing markup-like tokens displays literally
+- [x] #1 Save-path toast escapes the interpolated path per repo convention
+- [x] #2 A path containing markup-like tokens displays literally
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Both Save Image toasts (single 'Image saved to …' and multi 'Saved N images to …') now escape_markup the interpolated path, matching the sibling toasts from f1824513. Tests exercise the real _save_console_message_image worker over a bare ChatScreen with a markup-token directory (sav[e]dir) and assert the opening bracket is escaped (Rich only needs the opening bracket neutralized). Sweep 1018/69/0.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/attachment_core.py
+++ b/tldw_chatbook/Chat/attachment_core.py
@@ -355,19 +355,29 @@ async def process_attachment_bytes(
     )
 
 
-def vision_block_reason(provider: str, model: str | None) -> str | None:
+def vision_block_reason(
+    provider: str,
+    model: str | None,
+    *,
+    is_capable: Any | None = None,
+) -> str | None:
     """Return user-facing blocked-send copy when the model can't accept images.
 
     Args:
         provider: Provider key for the capability lookup (e.g. "llama_cpp").
         model: Selected model identifier, or None when no model is chosen.
+        is_capable: Optional capability predicate ``(provider, model) -> bool``
+            overriding this module's ``is_vision_capable`` — callers with
+            their own patchable capability seam (the Console controller)
+            inject it so ONE check decides both the gate and the copy.
 
     Returns:
         None when the model is vision-capable; otherwise the blocked-send
         copy, which names the model and the [model_capabilities.models]
         config override escape hatch.
     """
-    if model and is_vision_capable(provider, model):
+    checker = is_capable if is_capable is not None else is_vision_capable
+    if model and checker(provider, model):
         return None
     model_label = model or "the selected model"
     return (

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -214,13 +214,15 @@ class ConsoleChatController:
             return self._block(session.id, validation_error)
         if has_pending_attachment:
             vision_model = self.model or self.configured_model
-            model_is_vision_capable = bool(vision_model) and is_vision_capable(
-                self.provider, vision_model or ""
+            # ONE capability check decides the gate AND the copy: this
+            # module's is_vision_capable (the documented monkeypatch seam) is
+            # injected into vision_block_reason instead of being re-checked
+            # around it — the two seams could otherwise disagree under test.
+            block_reason = vision_block_reason(
+                self.provider, vision_model, is_capable=is_vision_capable
             )
-            if not model_is_vision_capable:
-                block_reason = vision_block_reason(self.provider, vision_model)
-                if block_reason is not None:
-                    return self._block(session.id, block_reason)
+            if block_reason is not None:
+                return self._block(session.id, block_reason)
         if self.store.workspace_context.has_policy_blocks:
             return self._block(session.id, self.store.workspace_context.recovery_copy)
 
@@ -1303,6 +1305,24 @@ class ConsoleChatController:
                 payloads.append({"role": message.role.value, "content": parts})
                 continue
             if not text:
+                # An image-only user turn whose images all fell outside the
+                # budget (over-cap, or a non-vision model) must not vanish —
+                # a silently dropped turn distorts the conversation shape the
+                # model sees. Emit a text placeholder instead.
+                omitted = [
+                    attachment
+                    for attachment in message.attachments
+                    if attachment.data is not None
+                ]
+                if message.role is ConsoleMessageRole.USER and omitted:
+                    placeholder = (
+                        "[image omitted]"
+                        if len(omitted) == 1
+                        else f"[{len(omitted)} images omitted]"
+                    )
+                    payloads.append(
+                        {"role": message.role.value, "content": placeholder}
+                    )
                 continue
             payloads.append({"role": message.role.value, "content": text})
         return payloads

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -9056,9 +9056,11 @@ class ChatScreen(BaseAppScreen):
             )
             return
         if len(written) == 1:
-            self.app_instance.notify(f"Image saved to {written[0]}")
+            self.app_instance.notify(f"Image saved to {escape_markup(str(written[0]))}")
         else:
-            self.app_instance.notify(f"Saved {len(written)} images to {save_location}")
+            self.app_instance.notify(
+                f"Saved {len(written)} images to {escape_markup(str(save_location))}"
+            )
 
     async def _save_console_message_as_note(self, message_id: str) -> None:
         """Persist one selected Console message as a local Note."""


### PR DESCRIPTION
## Summary

The last three minor riders from the Console attachments program (#621), bundled as one PR.

**TASK-223 — single-seam vision gate.** `submit_draft` re-implemented the capability check via the controller's module seam and then called `vision_block_reason`, which re-checks internally through attachment_core's seam — under test the two could disagree, and in the diverging case (controller says non-vision, attachment_core says vision) the old shape **let the send through the gate** (probe-verified). `vision_block_reason` gains an optional `is_capable` predicate (additive; the screen-side caller is unchanged) and the controller injects its documented seam: one check decides both the gate and the copy. Divergence tests pin both directions; existing controller vision tests pass unedited.

**TASK-224 — omitted-image placeholder.** An image-only user turn whose images all fell outside the budget (over-cap, or a non-vision model) vanished from provider payloads entirely, distorting the conversation shape the model sees. Such turns now emit `[image omitted]` / `[N images omitted]`. Captioned messages keep their existing text fallback; assistant messages unchanged. Tests drive the real submit path (non-vision, over-cap with newest-first budget, plural, caption regression).

**TASK-225 — escaped save toasts.** Both Save Image toasts (`Image saved to …`, `Saved N images to …`) now `escape_markup` the interpolated path, matching the sibling toasts. Tests run the real save worker against a `sav[e]dir` directory and assert literal rendering.

## Tests

New `Tests/Chat/test_console_attachment_riders.py` (8). Sweep: **1018 passed / 69 skipped / 0 failed** (Tests/Chat + native console flow); zero edits to existing test files.

Closes TASK-223, TASK-224, TASK-225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three Console attachment issues: a single-seam vision gate, placeholders for omitted images in provider payloads, and escaped paths in Save Image toasts. Prevents false sends/blocks, preserves history shape, and renders file paths safely. Addresses TASK-223, TASK-224, and TASK-225.

- **Bug Fixes**
  - Vision gate (TASK-223): Controller injects its capability seam into `vision_block_reason` so one check decides both the gate and the copy, removing divergence between seams.
  - Omitted-image placeholder (TASK-224): Image-only user turns dropped by non-vision models or over-cap budgets now emit “[image omitted]” or “[N images omitted]”; captioned messages keep their text.
  - Save toasts (TASK-225): Both single and multi-image success toasts escape markup in the destination path.

<sup>Written for commit 1a05708aee4635a2780a3f2c7e74505f175c8a47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

