### PR TITLE
docs(perf): performance & snappiness audit — findings + fix backlog (tasks 246-262)

### DIFF
--- a/Docs/Design/2026-07-16-performance-audit.md
+++ b/Docs/Design/2026-07-16-performance-audit.md
@@ -9,6 +9,9 @@ as snappy as possible **without affecting functionality**.
 
 Fix tracking: backlog tasks **246–262** (each finding names its task).
 
+Path convention: file references are relative to the `tldw_chatbook/` package
+root (e.g. `DB/ChaChaNotes_DB.py` = `tldw_chatbook/DB/ChaChaNotes_DB.py`).
+
 ## Headline diagnosis
 
 Three structural patterns account for most of the perceived sluggishness:
@@ -46,7 +49,7 @@ not debugging") so the f-string — including `str(params)` over raw
 4.96 ms @1 MB, **14.3 ms @3 MB**, paid on the send-completion persist path of
 every image message. Systemic: same pattern at `DB/Prompts_DB.py:433`,
 `DB/Client_Media_DB_v2.py:626` (full ingested document text), and
-`DB/Sync_Client.py:667,674`. Fix: restore the guard / loguru lazy form;
+`DB/Sync_Client.py:667,674`. Fix: loguru has no isEnabledFor — use logger.opt(lazy=True) with callables (or a loguru min-level check);
 truncate params *before* stringifying. Risk: none (logging-only).
 
 ### A2. Console `save_state()` runs twice per tab-switch-away — task-247

--- a/Docs/Design/2026-07-16-performance-audit.md
+++ b/Docs/Design/2026-07-16-performance-audit.md
@@ -1,0 +1,267 @@
+# Performance & Snappiness Audit — 2026-07-16
+
+Five parallel read-only audits (render/refresh paths, timers/workers, DB access
+patterns, startup/imports, non-Console screens) against dev @ `006345bf`.
+Every finding below was verified against the actual code (file:line quoted) and
+the load-bearing numbers were **measured** with probe scripts against real
+classes / synthetic data, not estimated. Goal per the product ask: make the UX
+as snappy as possible **without affecting functionality**.
+
+Fix tracking: backlog tasks **246–262** (each finding names its task).
+
+## Headline diagnosis
+
+Three structural patterns account for most of the perceived sluggishness:
+
+1. **The Console 0.2 s streaming tick does unconditional work** — including
+   real sqlite queries and full widget recomposes — on the event loop, five
+   times a second, for the entire duration of every streaming response.
+   Measured: **11.2 ms median per tick** (3 k conversations / 8 workspaces,
+   empty search), **~70 ms per tick with an active browser search string** —
+   i.e. up to a third of wall-clock time during a stream spent off-render.
+2. **Whole-screen `refresh(recompose=True)` instead of targeted updates** —
+   Library has **124** whole-screen recompose sites (including per-checkbox
+   handlers) while its purpose-built `sync_state()` methods have **zero
+   callers**; Home, MCP, and two Console widgets have smaller instances of the
+   same pattern.
+3. **~1.3 s of the ~1.8–2.3 s cold start is import-time work for features the
+   session never uses** — 469 ms building 1,313 Pydantic models for the
+   remote-server API, ~550 ms of optional-extra machinery (chromadb/OTel/gRPC,
+   playwright/trafilatura/dateparser, pymupdf/onnxruntime) imported eagerly
+   despite existing lazy patterns in the same files/packages.
+
+A fourth, self-inflicted one: a **commented-out log guard** in the DB layer
+stringifies every query's params unconditionally — up to **14 ms per
+image-message insert** to build a debug string that is never emitted.
+
+---
+
+## P0 — Quick wins (trivial diffs, immediate effect)
+
+### A1. DB layer stringifies every query's params for a disabled debug log — task-246
+`DB/ChaChaNotes_DB.py:2635-2636`: the `isEnabledFor(logging.DEBUG)` guard is
+**commented out** (its comment still says "Avoid formatting query/params if
+not debugging") so the f-string — including `str(params)` over raw
+`image_data` BLOBs — runs on *every* query. Measured: 0.87 ms @200 KB,
+4.96 ms @1 MB, **14.3 ms @3 MB**, paid on the send-completion persist path of
+every image message. Systemic: same pattern at `DB/Prompts_DB.py:433`,
+`DB/Client_Media_DB_v2.py:626` (full ingested document text), and
+`DB/Sync_Client.py:667,674`. Fix: restore the guard / loguru lazy form;
+truncate params *before* stringifying. Risk: none (logging-only).
+
+### A2. Console `save_state()` runs twice per tab-switch-away — task-247
+`app.py:4611-4621` calls `save_state()` explicitly and stores the result;
+Textual's `ScreenSuspend` then fires `ChatScreen.on_screen_suspend`
+(`chat_screen.py:10651-10655`) which calls `save_state()` **again and
+discards the result**. `save_state` walks O(sessions × messages) serializing
+every native Console message. Fix: delete the suspend-hook call. Risk: none
+(return value provably unused).
+
+### A3. 100 ms guaranteed event-loop freeze every 2 s on the Embeddings screen — task-248
+`Widgets/performance_metrics.py:196` calls
+`psutil.Process.cpu_percent(interval=0.1)` inside a sync `set_interval(2.0)`
+callback — `interval=0.1` **sleeps 100 ms on the event loop** every tick while
+Embeddings Management is open (`Embeddings_Management_Window.py:288`). The
+correct non-blocking form (`interval=None`) is already used at
+`Metrics/metrics.py:200`. Latent copies (currently no UI callers):
+`metrics_logger.py:153`, `RAG_Search/simplified/health_check.py:277`.
+
+### A4. Conversation search uses a correlated `LIKE` scan; the FTS index already exists — task-249
+`DB/ChaChaNotes_DB.py:4924-4936` (`search_conversations_page`) matches
+message content with `EXISTS(SELECT 1 … m.content LIKE '%q%')` — per-candidate
+correlated scan, index-hostile leading wildcard — while the schema defines and
+triggers `messages_fts` (line 326-356) and `search_messages_by_content`
+(6336-6360) already uses it correctly. Measured: 1.4 ms → **7.8 ms per scope**
+with a search string; multiplied by the P1-B1 tick this hits ~70 ms/tick.
+Fix: join `messages_fts MATCH`. Risk: low (in-schema template exists).
+
+### A5. Chatbook import commits ~1,500 transactions for a 50×30 import — task-250
+`Chatbooks/chatbook_importer.py:314-388` never opens an outer transaction;
+`add_conversation`/`add_message` each commit individually.
+`TransactionContextManager` is depth-tracked/reentrant
+(`ChaChaNotes_DB.py:9703-9722`) so wrapping the loop is a pure win.
+
+---
+
+## P1 — Interaction hot paths
+
+### B1. The Console 0.2 s sync tick — task-251 (umbrella)
+`chat_screen.py:7419-7431` arms `set_interval(0.2, _poll_transcript)` for the
+duration of any active run; the tick runs `_sync_native_console_chat_ui`
+(7356-7381) = **10 sub-syncs, most unconditional**:
+
+- **Worst**: `_sync_console_workspace_context` → `_sync_persisted_console_browser_rows`
+  (3386-3520) re-queries the DB — `search_conversations_page` +
+  `count_messages_for_conversations` + keywords — **per scope (global + every
+  workspace), every tick, on the event loop** (the sync worker is a coroutine,
+  not `thread=True`), then `ConsoleWorkspaceContextTray.sync_state`
+  (console_workspace_context.py:203-221) does `refresh(recompose=True)`
+  **unconditionally**. Measured 11.2 ms/tick median; ~70 ms/tick with an
+  active search. The template fix exists 700 lines away: the sub-agent badge
+  count was previously ~75 queries/tick and got batched + TTL-cached
+  ("Finding A", chat_screen.py:4037-4068). Apply the same gate/TTL — or drop
+  this sub-sync from the tick entirely (8 explicit invalidation sites exist).
+- `ConsoleSettingsSummary.sync_state` (console_settings_summary.py:33-54) has
+  **no equality guard** (sibling `ConsoleRunInspector` has one) → ~13 forced
+  `Static.update()`/`refresh(layout=True)` per tick with agent-section and
+  system-line helpers (chat_screen.py:1897-1909, 1778-1786).
+- `ConsoleRunInspector` recomposes wholesale on any change; selecting the
+  streaming message makes its excerpt change every tick → full panel teardown
+  5×/s; it is also synced while `display:none` (6163-6164).
+- Store-side per-tick tax: `messages_for_session` dataclass-copies **every
+  message** per tick (console_chat_store.py:529-534, 1187-1188);
+  `_materialize_stream_buffer` re-joins the entire chunk list per tick
+  (1175-1184) — measured negligible at chat sizes, structural fix cheap.
+- Guidance copy-blocks `.update()` unconditionally (5398-5417); rail-state
+  tuple computed twice per tick (7372-74 + 9477).
+
+Good news preserved: the transcript itself is properly fingerprint-gated and
+its row reconciler is genuinely incremental (`_reconcile_rows`,
+console_transcript.py:695-738); streaming does **not** hit sqlite per chunk
+(persist = one INSERT at first content + one UPDATE at finalize) — keep both.
+
+### B2. Library: 124 whole-screen recomposes; targeted `sync_state()` has zero callers — task-252
+`library_screen.py` calls `self.refresh(recompose=True)` (BaseAppScreen: full
+remove-and-remount of nav bar, footer, ~20-row rail, and 50–100-row canvas)
+from per-row checkbox/select handlers (5926-5956, 6020-6045, 10268-10312) and
+~110 more sites. `LibraryRail.sync_state()`, `LibraryMediaCanvas.sync_state()`,
+`LibraryConversationsCanvas.sync_state()` exist for exactly this and are never
+invoked. This pattern already caused the app-wide mouse-capture bug that
+`base_app_screen.py:52-84` defensively works around. Fix: route state changes
+through the existing `sync_state` methods; patch single-row toggles directly.
+Risk: moderate (rail counts must stay in sync) — stage by interaction class.
+
+### B3. Home dashboard: 3 sync DB queries on the UI thread per visit/click — task-253
+`home_screen.py:417-444` inline-executes watchlist snapshot, notification
+queue (limit 100), and server-event feed queries synchronously at every
+compose, triage sync, and rail click — while the sibling
+`_home_content_seam_call` (350-383) already does `asyncio.to_thread`
+correctly. Also `HomeRail`/`HomeCanvas.sync_state()` always recompose
+(home_rail.py:64, home_canvas.py:47). Fix: thread + cache the seam calls;
+targeted rail/canvas patches.
+
+### B4. Debounced searches run sync sqlite/FTS on the event loop — task-254
+`run_worker(coroutine)` is **not** a thread. Console browser search
+(chat_screen.py:661-671 → chat_conversation_scope_service.py:144-147 →
+`chat_conversation_service.list_conversations`, a plain `def`) blocks the loop
+×(1 + workspaces) per debounce fire (~3 ms p50 @1.5 k conversations, grows
+with data). Same shape: CCP search (conv_char_events.py:615/1248), media
+search (media_events.py:363/518). The `_maybe_await` plumbing looks async but
+the local mode never yields. Fix: `asyncio.to_thread` at the service leaf.
+Risk: medium — thread-local connections are fine; note `exclusive=True`
+cancellation cannot interrupt an in-flight thread call.
+
+### B5. Library RAG panel rebuilds ~100+ widgets per keystroke — task-255
+`library_screen.py:11821-11827`: `Input.Changed` on the RAG query box calls
+`_refresh_search_rag_panel_state_widgets` (12375-12425), which tears down and
+remounts the whole Evidence results list and Recent-searches history
+(individually awaited `remove()`/`mount()`) even though neither depends on
+unsubmitted text. Fix: per-keystroke path updates only the run-button/status
+line (already a separable function).
+
+---
+
+## P2 — Startup (~1.8–2.3 s to first paint; import time dominates, `TldwCli()` warm is only ~31 ms)
+
+### C1. `tldw_api` package: 1,313 eager Pydantic models, ~469 ms (31 % of import) — task-256
+`tldw_api/__init__.py` (1,681 lines) eagerly imports 54 schema files
+(16,376 lines). Forced by `app.py:353` and **69 other files**. Fix: PEP 562
+lazy `__getattr__` re-exports — the pattern already exists, documented, in
+`Local_Ingestion/__init__.py` — plus `Server*Service` modules importing their
+own schema submodule directly. Longer-term: don't construct ~30
+`Server*Service` objects in `TldwCli.__init__` in local-only mode.
+
+### C2. Optional-feature imports paid eagerly, ~550 ms — task-257
+- `Embeddings/Chroma_Lib.py:39-40`: module-scope `get_safe_import('chromadb')`
+  does a **real import** (chromadb → OTel → gRPC → protobuf, ~154 ms via
+  RAG_Admin which app.py imports unconditionally). Move into
+  `ChromaDBManager.__init__`.
+- `Tools/__init__.py:17` eagerly imports `WebSearchTool` →
+  `Article_Extractor_Lib.py:69-73` module-scope playwright + trafilatura
+  (dateparser 75 ms, htmldate 78 ms) — **~197 ms** for a feature disabled by
+  default (`web_search_enabled=False`; the executor gate at
+  tool_executor.py:643 is already correct). The same file already fixed
+  pandas with a `find_spec` probe — apply identically.
+- `app.py:124` direct-submodule import of `local_file_ingestion` bypasses
+  Local_Ingestion's own lazy `__init__` → pymupdf/onnxruntime (~170 ms) +
+  Document lib (~59 ms) for optional `pdf`/`ebook` extras. Fix:
+  import-per-format at dispatch (classify/dispatch split already exists).
+
+### C3. `config.py` import hygiene — task-258
+The 1,285-line embedded default TOML is parsed **twice** (2753 and 3840 —
+the second just to read `providers`); `load_cli_config_and_ensure_existence()`
+and `load_settings()` each independently re-open, re-parse, and re-merge the
+same user config at import (3865-3866); `Utils/Utils.py:48` imports `chardet`
+(~21 ms, 40 submodules) for two rarely-called functions. Fix: reuse the parse,
+consolidate the double load (watch `_CONFIG_CACHE`/`_SETTINGS_CACHE`
+semantics), lazy-import chardet. Related, lower value for the app itself:
+`tldw_chatbook/__init__.py:24`'s compatibility shim imports `textual.widgets`
+(~53 ms) for every non-UI consumer (tests, tooling) — guard it.
+
+### C4. Monolithic CSS parse ~90–130 ms before first paint — task-262 (investigation)
+16,064 lines / 2,278 rules parsed unconditionally. Textual supports
+per-`Screen` CSS; splitting needs a cross-screen selector audit and
+per-screen visual QA — staged work, not a quick win. (Related but larger:
+`chat_screen.py`'s 11 k lines cost ~161 ms of pure module-exec as the default
+tab — a file split is noted for future consideration, no task filed.)
+
+---
+
+## P3 — Targeted polish
+
+### D1. Console transcript/stream polish — task-259
+Per-message row-signature cache (`_transcript_rows` re-derives every row per
+changed tick: 0.86 ms @200 msgs → **5.15 ms @1,000 msgs**, measured);
+stream-buffer collapse-after-join; `_stage_console_library_rag_launch`
+(chat_screen.py:5729-5731) currently recomposes the **entire ChatScreen** for
+one pending card → targeted widget; `ConsoleRunInspector` per-row updates +
+skip-when-hidden.
+
+### D2. RAG conversation search: N+1 + BLOB overfetch — task-260
+`RAG_Search/pipeline_functions_simple.py:96-115`: one
+`get_messages_for_conversation` per matched conversation (≤20 queries/search),
+each SELECTing `image_data` BLOBs to build text snippets.
+`get_messages_for_conversations_batch` (ChaChaNotes_DB.py:5870-5929) exists,
+unused. Add `include_image_data=False` variant for text-only callers (also:
+mindmap_integration.py:88).
+
+### D3. Sundries — task-261
+Background-effect `render_line` recomputes the full W×H grid **per line** =
+O(W·H²)/repaint (console_background_effect.py:92-116; cache per frame tick);
+10 s footer token-count re-tokenizes the whole visible history without a
+dirty check (app.py:5950-5954); `SELECT 1` liveness ping per `get_connection`
+per query (~2× raw call count, ChaChaNotes_DB.py:2431-2434);
+`BookmarksManager.__init__` sync `Path.exists()`×5 (cloud dirs can stall) +
+first-run TOML write on every picker construction
+(enhanced_file_picker.py:85-123); MCP full rebuilds ×2 per lifecycle action
+incl. hidden Tools canvas (mcp_rail.py:198, mcp_servers_mode.py:459-500) —
+N+2 store loads already tracked as task-236; missing indexes on
+`conversations.deleted`/`last_modified` (browser ORDER BY) for large tables.
+
+---
+
+## Verified-fine (do not "fix"; preserve as templates)
+
+- Transcript row reconciler is genuinely incremental; streaming persists
+  exactly twice per turn (no per-chunk sqlite).
+- No search-as-you-type DB hits anywhere in Library (all `Input.Submitted`);
+  console browser search is properly debounced with a cancellation token.
+- Library pagination is real, gathered, capped, `include_keywords=False`;
+  mount is instant-then-reconcile with a 5 s TTL cache.
+- `list_conversations` batches counts+keywords (no N+1);
+  `set_message_attachments` is DELETE+executemany in one transaction.
+- Subscriptions scheduler is the correct `thread=True` periodic-sync-DB
+  template; rail-preference prune is one-shot + threaded.
+- Screen registry lazy-imports correctly; no torch/transformers on the start
+  path; config reads are cache-backed; picker directory scans are threaded.
+- Composer cursor-blink and setup-modal snow timers are correctly paused.
+- All non-Console screens' `save_state`/`restore_state` are O(1)-cheap.
+- File-picker search box is **unwired** (silent no-op) — a correctness
+  follow-up, not a perf issue.
+
+## Measurement provenance
+
+Probe scripts (scratch, not committed): `probe_search_cost.py`,
+`probe_sqlite_write.py`, `probe_console_rail.py`, `bench_transcript*.py`,
+plus `python -X importtime` traces under isolated `HOME`. Synthetic data
+sizes stated inline with each number.

--- a/backlog/tasks/task-246 - Restore-lazy-DB-debug-logging-eager-param-stringify.md
+++ b/backlog/tasks/task-246 - Restore-lazy-DB-debug-logging-eager-param-stringify.md
@@ -1,0 +1,23 @@
+---
+id: TASK-246
+title: Restore lazy DB debug logging (eager param stringify on every query)
+status: To Do
+assignee: []
+created_date: '2026-07-16 14:30'
+labels: [performance, db]
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+ChaChaNotes_DB.execute_query's isEnabledFor guard is commented out, so the debug f-string — including str(params) over raw image BLOBs — is built on EVERY query regardless of log level: measured 14.3ms per 3MB image-message INSERT, on the send-completion persist path. Same pattern in Prompts_DB.py:433, Client_Media_DB_v2.py:626 (full ingested document text), Sync_Client.py:667/674. Full analysis with measurements: Docs/Design/2026-07-16-performance-audit.md (§P0 A1).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 No query/param stringification occurs when debug logging is disabled, across all four DB modules
+- [ ] #2 Param values are truncated before stringification when debug IS enabled
+- [ ] #3 A regression test proves an image-bearing insert does not stringify its BLOB at default log level
+<!-- AC:END -->

--- a/backlog/tasks/task-246 - Restore-lazy-DB-debug-logging-eager-param-stringify.md
+++ b/backlog/tasks/task-246 - Restore-lazy-DB-debug-logging-eager-param-stringify.md
@@ -12,7 +12,7 @@ priority: high
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-ChaChaNotes_DB.execute_query's isEnabledFor guard is commented out, so the debug f-string — including str(params) over raw image BLOBs — is built on EVERY query regardless of log level: measured 14.3ms per 3MB image-message INSERT, on the send-completion persist path. Same pattern in Prompts_DB.py:433, Client_Media_DB_v2.py:626 (full ingested document text), Sync_Client.py:667/674. Full analysis with measurements: Docs/Design/2026-07-16-performance-audit.md (§P0 A1).
+ChaChaNotes_DB.execute_query's isEnabledFor guard is commented out, so the debug f-string — including str(params) over raw image BLOBs — is built on EVERY query regardless of log level: measured 14.3ms per 3MB image-message INSERT, on the send-completion persist path. Same pattern in Prompts_DB.py:433, Client_Media_DB_v2.py:626 (full ingested document text), Sync_Client.py:667/674. NOTE (review-verified): `logger` in these modules is LOGURU (ChaChaNotes_DB.py:49) — it has no isEnabledFor(), so restoring the commented guard verbatim would AttributeError; use loguru's lazy form (logger.opt(lazy=True).debug with callables) or a min-level check via loguru's mechanism instead. Full analysis with measurements: Docs/Design/2026-07-16-performance-audit.md (§P0 A1).
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria

--- a/backlog/tasks/task-247 - Remove-duplicate-Console-save_state-on-screen-suspend.md
+++ b/backlog/tasks/task-247 - Remove-duplicate-Console-save_state-on-screen-suspend.md
@@ -1,0 +1,22 @@
+---
+id: TASK-247
+title: Remove duplicate Console save_state on screen suspend
+status: To Do
+assignee: []
+created_date: '2026-07-16 14:30'
+labels: [performance, console]
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+app.py:4611-4621 calls save_state() and stores the result before switch_screen; Textual's ScreenSuspend then fires ChatScreen.on_screen_suspend (chat_screen.py:10651-10655) which calls save_state() AGAIN and discards the result — a full O(sessions×messages) native-console serialization wasted on every tab switch away from Console. Full analysis with measurements: Docs/Design/2026-07-16-performance-audit.md (§P0 A2).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Console save_state runs exactly once per tab-switch-away (test counts invocations)
+- [ ] #2 State restoration behavior unchanged (existing round-trip tests green)
+<!-- AC:END -->

--- a/backlog/tasks/task-248 - Fix-cpu_percent-event-loop-freeze-in-PerformanceMetricsWidget.md
+++ b/backlog/tasks/task-248 - Fix-cpu_percent-event-loop-freeze-in-PerformanceMetricsWidget.md
@@ -1,0 +1,22 @@
+---
+id: TASK-248
+title: Fix cpu_percent event-loop freeze in PerformanceMetricsWidget
+status: To Do
+assignee: []
+created_date: '2026-07-16 14:30'
+labels: [performance, ui]
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+performance_metrics.py:196 calls psutil cpu_percent(interval=0.1) inside a sync set_interval(2.0) callback — a guaranteed 100ms event-loop sleep every 2s while Embeddings Management is open (whole app hitches metronomically). Correct non-blocking form already at Metrics/metrics.py:200. Latent copies (no UI callers today): metrics_logger.py:153, RAG_Search/simplified/health_check.py:277. Full analysis with measurements: Docs/Design/2026-07-16-performance-audit.md (§P0 A3).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 No blocking interval= form remains in the widget path; metrics still update
+- [ ] #2 Latent copies fixed or documented as non-wired
+<!-- AC:END -->

--- a/backlog/tasks/task-249 - Use-messages_fts-in-search_conversations_page.md
+++ b/backlog/tasks/task-249 - Use-messages_fts-in-search_conversations_page.md
@@ -12,7 +12,7 @@ priority: high
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-ChaChaNotes_DB.search_conversations_page (4924-4936) matches message content via correlated EXISTS + leading-wildcard LIKE per candidate row; the schema already maintains messages_fts and search_messages_by_content (6336-6360) uses it correctly. Measured 1.4→7.8ms per scope with an active query; multiplied by Console's per-tick scope loop this reaches ~70ms/tick during streams (see task-251). Full analysis with measurements: Docs/Design/2026-07-16-performance-audit.md (§P0 A4).
+ChaChaNotes_DB.search_conversations_page (4924-4936) matches message content via correlated EXISTS + leading-wildcard LIKE per candidate row; the schema already maintains messages_fts and search_messages_by_content (6336-6360) uses it correctly. Measured 1.4→7.8ms per scope with an active query; multiplied by Console's per-tick scope loop this reaches ~70ms/tick during streams (see task-251). NOTE (review): LIKE '%q%' matches arbitrary substrings (mid-word) while FTS5 MATCH is token/prefix-based — format the query for prefix matching (append *) and document the residual semantic difference; AC#1 binds representative queries, not mid-word substrings. Full analysis with measurements: Docs/Design/2026-07-16-performance-audit.md (§P0 A4).
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria

--- a/backlog/tasks/task-249 - Use-messages_fts-in-search_conversations_page.md
+++ b/backlog/tasks/task-249 - Use-messages_fts-in-search_conversations_page.md
@@ -1,0 +1,23 @@
+---
+id: TASK-249
+title: Use messages_fts in search_conversations_page instead of correlated LIKE
+status: To Do
+assignee: []
+created_date: '2026-07-16 14:30'
+labels: [performance, db]
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+ChaChaNotes_DB.search_conversations_page (4924-4936) matches message content via correlated EXISTS + leading-wildcard LIKE per candidate row; the schema already maintains messages_fts and search_messages_by_content (6336-6360) uses it correctly. Measured 1.4→7.8ms per scope with an active query; multiplied by Console's per-tick scope loop this reaches ~70ms/tick during streams (see task-251). Full analysis with measurements: Docs/Design/2026-07-16-performance-audit.md (§P0 A4).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Content matching goes through messages_fts MATCH; results equivalent for representative queries (incl. no-match, special chars)
+- [ ] #2 Measured per-scope query time with an active search string drops by >2x on a seeded large DB
+- [ ] #3 Existing conversation-search tests green
+<!-- AC:END -->

--- a/backlog/tasks/task-250 - Wrap-chatbook-import-in-a-single-transaction.md
+++ b/backlog/tasks/task-250 - Wrap-chatbook-import-in-a-single-transaction.md
@@ -1,0 +1,22 @@
+---
+id: TASK-250
+title: Wrap chatbook import in a single transaction
+status: To Do
+assignee: []
+created_date: '2026-07-16 14:30'
+labels: [performance, chatbooks]
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+chatbook_importer._import_conversations commits per add_conversation/add_message/set_message_attachments — ~1,500 commits for a 50-conversation × 30-message import. TransactionContextManager is reentrant (ChaChaNotes_DB.py:9703-9722), so one outer transaction per chatbook (or per conversation) is a pure win. Full analysis with measurements: Docs/Design/2026-07-16-performance-audit.md (§P0 A5).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Import runs under an outer transaction; commit count measured before/after on a synthetic chatbook
+- [ ] #2 Round-trip + conflict-resolution tests green; partial-failure semantics documented
+<!-- AC:END -->

--- a/backlog/tasks/task-251 - Gate-the-Console-0.2s-sync-tick.md
+++ b/backlog/tasks/task-251 - Gate-the-Console-0.2s-sync-tick.md
@@ -1,0 +1,24 @@
+---
+id: TASK-251
+title: Gate the Console 0.2s sync tick (stop per-tick DB queries and unconditional recomposes)
+status: To Do
+assignee: []
+created_date: '2026-07-16 14:30'
+labels: [performance, console]
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+During any active run, the 0.2s _poll_transcript tick runs 10 sub-syncs, most unconditional: _sync_console_workspace_context re-queries the DB per scope per tick ON the event loop (measured 11.2ms/tick @3k convs/8 workspaces; ~70ms/tick with an active search) and ConsoleWorkspaceContextTray.sync_state recomposes unconditionally; ConsoleSettingsSummary/agent-section/system-line update ~13 Statics per tick with no equality guard; ConsoleRunInspector recomposes wholesale per change (streaming-excerpt selection = 5 teardowns/s) and syncs while hidden. In-file templates exist: the subagent-badge TTL cache (chat_screen 4037-4068) and RunInspector's own equality guard. Preserve: transcript fingerprint gate, incremental row reconciler, twice-per-turn persist. Full analysis with measurements: Docs/Design/2026-07-16-performance-audit.md (§P1 B1).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 No DB query executes from the 0.2s tick when the conversation set is unchanged (TTL/signature gate or removal from the tick)
+- [ ] #2 Settings-summary/agent/system-line/guidance sub-syncs no-op when their state is unchanged (equality guards)
+- [ ] #3 Inspector skips sync while hidden and no longer full-recomposes per streaming tick when the streaming message is selected
+- [ ] #4 Live QA: streaming remains smooth and all synced surfaces still update on real changes (send/finish/rename/switch)
+<!-- AC:END -->

--- a/backlog/tasks/task-252 - Library-targeted-updates-instead-of-whole-screen-recompose.md
+++ b/backlog/tasks/task-252 - Library-targeted-updates-instead-of-whole-screen-recompose.md
@@ -1,0 +1,24 @@
+---
+id: TASK-252
+title: Library: targeted sync_state updates instead of 124 whole-screen recomposes
+status: To Do
+assignee: []
+created_date: '2026-07-16 14:30'
+labels: [performance, library]
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+library_screen.py calls self.refresh(recompose=True) — full remove/remount of nav, footer, ~20-row rail, and 50-100-row canvas — from 124 sites including per-row checkbox handlers. LibraryRail/LibraryMediaCanvas/LibraryConversationsCanvas.sync_state() exist for targeted updates and have ZERO callers. This exact pattern caused the app-wide mouse-capture bug base_app_screen.py works around. Stage by interaction class (checkbox toggles first). Full analysis with measurements: Docs/Design/2026-07-16-performance-audit.md (§P1 B2).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Per-row selection/checkbox interactions no longer recompose the screen (targeted row/canvas updates; verified by interaction tests)
+- [ ] #2 Rail counts stay consistent with canvas state across the converted interactions
+- [ ] #3 Remaining recompose sites inventoried with a justification or follow-up
+- [ ] #4 Live QA on the converted flows
+<!-- AC:END -->

--- a/backlog/tasks/task-253 - Home-dashboard-thread-and-cache-seam-queries.md
+++ b/backlog/tasks/task-253 - Home-dashboard-thread-and-cache-seam-queries.md
@@ -1,0 +1,23 @@
+---
+id: TASK-253
+title: Home: thread + cache dashboard seam queries; targeted rail/canvas updates
+status: To Do
+assignee: []
+created_date: '2026-07-16 14:30'
+labels: [performance, home]
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+home_screen._build_dashboard_input runs 3 synchronous DB/repository queries (watchlist snapshot, notification queue limit=100, server-event feed) on the UI thread at every compose, triage sync, and rail click with no cross-visit cache — while the sibling _home_content_seam_call already uses asyncio.to_thread correctly. HomeRail/HomeCanvas.sync_state also always recompose. Full analysis with measurements: Docs/Design/2026-07-16-performance-audit.md (§P1 B3).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Dashboard seam queries run off the event loop with a short-TTL cache; Home still reflects fresh data per its seam contract
+- [ ] #2 Selection/count-only changes patch targeted widgets instead of recomposing rail/canvas
+- [ ] #3 Existing Home triage tests green
+<!-- AC:END -->

--- a/backlog/tasks/task-254 - Move-debounced-search-DB-work-off-the-event-loop.md
+++ b/backlog/tasks/task-254 - Move-debounced-search-DB-work-off-the-event-loop.md
@@ -1,0 +1,23 @@
+---
+id: TASK-254
+title: Move debounced search DB work off the event loop
+status: To Do
+assignee: []
+created_date: '2026-07-16 14:30'
+labels: [performance, chat]
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+run_worker(coroutine) is NOT a thread: Console browser search (chat_screen 661-671 → chat_conversation_scope_service._maybe_await → SYNC list_conversations ×(1+workspaces)), CCP search (conv_char_events 615/1248), and media search (media_events 363/518) all execute sync sqlite/FTS on the event loop when their debounce fires (~3ms p50 @1.5k convs, grows with data). Fix at the service leaf with asyncio.to_thread; connections are thread-local. Note exclusive=True cancellation cannot interrupt an in-flight thread call — guard result application with the existing tokens. Full analysis with measurements: Docs/Design/2026-07-16-performance-audit.md (§P1 B4).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The three search paths execute their DB work off the event loop (asserted via a loop-blocking probe or thread-name check in tests)
+- [ ] #2 Stale results are still discarded via the existing cancellation tokens
+- [ ] #3 Existing search tests green
+<!-- AC:END -->

--- a/backlog/tasks/task-254 - Move-debounced-search-DB-work-off-the-event-loop.md
+++ b/backlog/tasks/task-254 - Move-debounced-search-DB-work-off-the-event-loop.md
@@ -12,7 +12,7 @@ priority: medium
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-run_worker(coroutine) is NOT a thread: Console browser search (chat_screen 661-671 → chat_conversation_scope_service._maybe_await → SYNC list_conversations ×(1+workspaces)), CCP search (conv_char_events 615/1248), and media search (media_events 363/518) all execute sync sqlite/FTS on the event loop when their debounce fires (~3ms p50 @1.5k convs, grows with data). Fix at the service leaf with asyncio.to_thread; connections are thread-local. Note exclusive=True cancellation cannot interrupt an in-flight thread call — guard result application with the existing tokens. Full analysis with measurements: Docs/Design/2026-07-16-performance-audit.md (§P1 B4).
+run_worker(coroutine) is NOT a thread: Console browser search (chat_screen 661-671 → chat_conversation_scope_service._maybe_await → SYNC list_conversations ×(1+workspaces)), CCP search (conv_char_events 615/1248), and media search (media_events 363/518) all execute sync sqlite/FTS on the event loop when their debounce fires (~3ms p50 @1.5k convs, grows with data). Fix at the service leaf with asyncio.to_thread; connections are thread-local. Note exclusive=True cancellation cannot interrupt an in-flight thread call — guard result application with the existing tokens. NOTE (review): sqlite :memory: databases are per-connection, so unconditional asyncio.to_thread at the leaf would hand test DBs a separate EMPTY database — gate the offload on `not db.is_memory_db` (the attribute already exists on CharactersRAGDB). Full analysis with measurements: Docs/Design/2026-07-16-performance-audit.md (§P1 B4).
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria

--- a/backlog/tasks/task-255 - Library-RAG-panel-stop-rebuilding-results-per-keystroke.md
+++ b/backlog/tasks/task-255 - Library-RAG-panel-stop-rebuilding-results-per-keystroke.md
@@ -1,0 +1,22 @@
+---
+id: TASK-255
+title: Library RAG panel: stop rebuilding results/history per keystroke
+status: To Do
+assignee: []
+created_date: '2026-07-16 14:30'
+labels: [performance, library]
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Input.Changed on the RAG query box (library_screen 11821-11827) calls the full panel-state refresh, tearing down and remounting the Evidence results list + Recent-searches history (~100+ widgets via awaited remove/mount) on every keystroke of an unsubmitted query — neither depends on unsubmitted text (search runs on Submitted). The status-line refresh is already a separable cheap function. Full analysis with measurements: Docs/Design/2026-07-16-performance-audit.md (§P1 B5).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Typing in the query box updates only the run-button/status line; results/history refresh only on submit or outcome application
+- [ ] #2 Existing RAG panel tests green
+<!-- AC:END -->

--- a/backlog/tasks/task-256 - Lazy-tldw_api-package-imports.md
+++ b/backlog/tasks/task-256 - Lazy-tldw_api-package-imports.md
@@ -1,0 +1,23 @@
+---
+id: TASK-256
+title: Lazy tldw_api package imports (~469ms of startup)
+status: To Do
+assignee: []
+created_date: '2026-07-16 14:30'
+labels: [performance, startup]
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+tldw_api/__init__.py eagerly imports 54 schema files = 1,313 Pydantic models, ~469ms (31% of the ~1.5-2.0s app import), forced by app.py:353 plus 69 files importing names from the package. Fix: PEP 562 lazy __getattr__ re-exports (working, documented pattern in Local_Ingestion/__init__.py) and/or Server*Service modules importing their own schema submodules. Longer-term note: TldwCli.__init__ constructs ~30 Server*Service objects even in local-only mode. Full analysis with measurements: Docs/Design/2026-07-16-performance-audit.md (§P2 C1).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 import tldw_chatbook.app no longer pays the full tldw_api package cost (measured importtime delta reported, expected >300ms)
+- [ ] #2 All existing consumers keep working (full test suite green; no import cycles)
+- [ ] #3 Remote-server mode still functions (schema names resolve on demand)
+<!-- AC:END -->

--- a/backlog/tasks/task-257 - Defer-optional-feature-imports-chromadb-websearch-pdf.md
+++ b/backlog/tasks/task-257 - Defer-optional-feature-imports-chromadb-websearch-pdf.md
@@ -1,0 +1,24 @@
+---
+id: TASK-257
+title: Defer optional-feature imports: chromadb, web-search chain, PDF/document processors (~550ms)
+status: To Do
+assignee: []
+created_date: '2026-07-16 14:30'
+labels: [performance, startup]
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Three eager chains for features unused by default: Chroma_Lib module-scope get_safe_import('chromadb') pulls chromadb→OTel→gRPC→protobuf (~154ms) via RAG_Admin; Tools/__init__ imports WebSearchTool → Article_Extractor_Lib module-scope playwright/trafilatura/dateparser (~197ms) though web_search_enabled defaults False (executor gate at tool_executor.py:643 is already correct, and the SAME FILE already fixed pandas with find_spec); app.py:124's direct submodule import bypasses Local_Ingestion's own lazy __init__, loading pymupdf/onnxruntime (~170ms) + Document lib (~59ms) for optional pdf/ebook extras. Full analysis with measurements: Docs/Design/2026-07-16-performance-audit.md (§P2 C2).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 chromadb imports only when ChromaDBManager is instantiated
+- [ ] #2 Web-search chain imports only when the tool is enabled/used (find_spec probe for availability)
+- [ ] #3 Per-format ingestion processors import at dispatch time
+- [ ] #4 Measured app-import delta reported (expected >400ms); optional-deps availability semantics unchanged (extras absent still degrade gracefully)
+<!-- AC:END -->

--- a/backlog/tasks/task-258 - config.py-import-hygiene.md
+++ b/backlog/tasks/task-258 - config.py-import-hygiene.md
@@ -1,0 +1,24 @@
+---
+id: TASK-258
+title: config.py import hygiene: single TOML parse, consolidated load, lazy chardet
+status: To Do
+assignee: []
+created_date: '2026-07-16 14:30'
+labels: [performance, startup]
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+config.py import parses the 1,285-line embedded default TOML twice (2753 + 3840, the latter only for providers); load_cli_config_and_ensure_existence() and load_settings() each independently re-open/re-parse/re-merge the same user config at import (3865-3866); Utils/Utils.py:48 imports chardet (~21ms) for two rarely-used functions. Also (lower value): tldw_chatbook/__init__'s shim imports textual.widgets (~53ms) for every non-UI consumer. Watch _CONFIG_CACHE/_SETTINGS_CACHE semantics — unmocked integration tests required for any loader consolidation (T229 rule). Full analysis with measurements: Docs/Design/2026-07-16-performance-audit.md (§P2 C3).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Embedded default TOML parsed exactly once per process
+- [ ] #2 User config read+parsed once at startup, both caches serving from it (unmocked real-loader tests pin behavior)
+- [ ] #3 chardet imports only inside its two callers
+- [ ] #4 Measured config-import delta reported
+<!-- AC:END -->

--- a/backlog/tasks/task-259 - Console-transcript-and-stream-polish.md
+++ b/backlog/tasks/task-259 - Console-transcript-and-stream-polish.md
@@ -1,0 +1,24 @@
+---
+id: TASK-259
+title: Console transcript/stream polish (signature cache, buffer collapse, targeted RAG-launch card, inspector rows)
+status: To Do
+assignee: []
+created_date: '2026-07-16 14:30'
+labels: [performance, console]
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Four bounded improvements from the audit: _transcript_rows re-derives every row per changed tick (measured 0.86ms@200 msgs → 5.15ms@1000; cache per-message signatures keyed on id/content-len/status); _materialize_stream_buffer re-joins the whole chunk list per tick (collapse after join); _stage_console_library_rag_launch recomposes the ENTIRE ChatScreen for one pending card (5729-5731 — make it a targeted widget; several _build_console_*_state builders read _pending_console_launch_context, so verify); ConsoleRunInspector per-row updates instead of wholesale recompose. Depends on task-251 landing first (shared code region). Full analysis with measurements: Docs/Design/2026-07-16-performance-audit.md (§P3 D1).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Transcript row derivation is O(changed messages) per tick with correctness preserved for delete/reorder/variant-switch
+- [ ] #2 Library-RAG launch no longer recomposes the screen
+- [ ] #3 Inspector updates changed rows only
+- [ ] #4 Streaming behavior verified live (rig)
+<!-- AC:END -->

--- a/backlog/tasks/task-260 - RAG-conversation-search-batch-fetch-skip-BLOBs.md
+++ b/backlog/tasks/task-260 - RAG-conversation-search-batch-fetch-skip-BLOBs.md
@@ -1,0 +1,23 @@
+---
+id: TASK-260
+title: RAG conversation search: batch fetch + skip image BLOBs
+status: To Do
+assignee: []
+created_date: '2026-07-16 14:30'
+labels: [performance, rag]
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+pipeline_functions_simple.search_conversations_fts5 (96-115) issues one get_messages_for_conversation per matched conversation (≤20 queries/search) and every call SELECTs image_data BLOBs only to build text snippets. get_messages_for_conversations_batch (ChaChaNotes_DB 5870-5929) exists unused. Add an include_image_data=False variant for text-only callers (also mindmap_integration.py:88). Full analysis with measurements: Docs/Design/2026-07-16-performance-audit.md (§P3 D2).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 One batched query replaces the per-conversation loop
+- [ ] #2 Text-only callers no longer fetch BLOB columns
+- [ ] #3 RAG search results unchanged (tests)
+<!-- AC:END -->

--- a/backlog/tasks/task-261 - Performance-sundries-batch.md
+++ b/backlog/tasks/task-261 - Performance-sundries-batch.md
@@ -1,0 +1,22 @@
+---
+id: TASK-261
+title: Performance sundries: bg-effect frame cache, token-count gate, SELECT-1 ping, picker ctor I/O, MCP rebuild diffing, browser indexes
+status: To Do
+assignee: []
+created_date: '2026-07-16 14:30'
+labels: [performance, ui]
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Bounded small fixes from the audit: console_background_effect render_line recomputes the full W×H grid PER LINE = O(W·H²)/repaint (cache per frame tick); the 10s footer token-count re-tokenizes the whole visible history without a dirty check (app.py:5950-5954); get_connection pings SELECT 1 per query (~2× raw call count); BookmarksManager.__init__ does 5 sync Path.exists() (cloud-dir stalls) + first-run TOML write on every picker construction; MCP rail/servers-table/hidden-Tools-canvas full rebuilds ×2 per lifecycle action (N+2 store loads already tracked in task-236); consider indexes on conversations.deleted/last_modified for the browser ORDER BY at scale. Full analysis with measurements: Docs/Design/2026-07-16-performance-audit.md (§P3 D3).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Each listed item fixed or explicitly declined with reasoning in the task notes
+- [ ] #2 No behavior changes (existing suites green)
+<!-- AC:END -->

--- a/backlog/tasks/task-262 - Investigate-per-screen-CSS-split.md
+++ b/backlog/tasks/task-262 - Investigate-per-screen-CSS-split.md
@@ -1,0 +1,23 @@
+---
+id: TASK-262
+title: Investigate splitting the monolithic stylesheet per screen (~90-130ms first paint)
+status: To Do
+assignee: []
+created_date: '2026-07-16 14:30'
+labels: [performance, startup]
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The bundled tldw_cli_modular.tcss (16,064 lines / 2,278 rules) parses in 88-130ms before first paint. Textual supports per-Screen CSS_PATH/DEFAULT_CSS. Splitting requires a cross-screen selector-dependency audit and per-screen visual QA (regressions are visual, not crashes) — investigation first, then staged extraction starting with the largest per-screen rule blocks. Related future consideration (no task): chat_screen.py's 11k-line module costs ~161ms of pure import as the default tab. Full analysis with measurements: Docs/Design/2026-07-16-performance-audit.md (§P2 C4).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Selector-dependency audit documents which rules are shared vs per-screen
+- [ ] #2 A staged split plan (or a reasoned decision not to split) recorded
+- [ ] #3 If split: measured first-paint delta + per-screen visual QA
+<!-- AC:END -->


### PR DESCRIPTION
## Summary

Full-app performance audit aimed at making the UX as snappy as possible without functional changes. Five parallel read-only audits (render/refresh paths, timers/workers, DB access patterns, startup/imports, non-Console screens) against dev `006345bf`; every load-bearing claim verified against code (file:line) and the key numbers **measured** with probes against real classes.

**Deliverables:** `Docs/Design/2026-07-16-performance-audit.md` + backlog tasks **246–262** (each finding → one task with severity, fix shape, risk).

### Headline diagnosis (all measured)

1. **Console 0.2s streaming tick does unconditional work on the event loop** — including per-scope sqlite queries and full widget recomposes — 5×/s for the duration of every streamed response: **11.2ms/tick median** (3k conversations / 8 workspaces), **~70ms/tick with an active browser search**. → task-251 (+249 for the LIKE→FTS query fix).
2. **Whole-screen `recompose` instead of targeted updates** — Library: **124** whole-screen recompose sites (incl. per-checkbox) while its purpose-built `sync_state()` methods have **zero callers**; smaller instances in Home, MCP, two Console widgets. → tasks 252/253/255/259/261.
3. **~1.3s of the ~1.8–2.3s cold start is import-time work for unused features** — 469ms building 1,313 Pydantic models for the remote API, ~550ms of optional extras (chromadb/OTel/gRPC, playwright/trafilatura, pymupdf/onnxruntime) imported eagerly despite correct lazy patterns existing in the same files. → tasks 256/257/258/262.
4. **A commented-out log guard in the DB layer** stringifies every query's params unconditionally — **14.3ms per 3MB image-message insert** for a debug string that's never logged; same pattern in 3 more DB modules. → task-246.

Plus quick wins: Console `save_state` runs **twice** per tab-switch (result discarded, task-247); a guaranteed **100ms event-loop freeze every 2s** on the Embeddings screen from `cpu_percent(interval=0.1)` (task-248); chatbook import committing ~1,500 transactions (task-250); debounced searches running sync sqlite on the loop (task-254).

The doc also records **verified-fine** patterns (incremental transcript reconciler, twice-per-turn stream persist, Library pagination, debounce/cancellation-token pattern, threaded picker scans) so future work doesn't "fix" them.

No production code changes in this PR — audit + backlog only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a full-app performance audit doc and backlog tasks 246–262 to fix measured UX bottlenecks; no production code changes. Key issues include a per-tick Console DB/recompose loop, whole-screen recomposes in Library, startup costs from eager imports (e.g., `tldw_api`, `chromadb` chain), and a disabled DB-log guard that stringifies params.

- **Highlights**
  - Gate the Console 0.2s streaming tick to stop per-tick DB work and unconditional recomposes (task-251; FTS switch in task-249).
  - Replace Library whole-screen recomposes with targeted `sync_state` updates (task-252).
  - Cut cold start by deferring optional imports and lazifying `tldw_api` and feature chains (tasks 256–258, 262).
  - Restore DB debug-log guard with correct loguru lazy pattern to avoid param stringification on every query (task-246).
  - Quick wins: duplicate `save_state`, `cpu_percent` event-loop sleep, chatbook transaction batching, move debounced searches off the loop, plus RAG/search and sundries (tasks 247–255, 260–261).
  - Doc/task clarifications added: loguru guard usage, FTS MATCH vs LIKE semantics and query formatting, sqlite `:memory:` to_thread caveat, and a file path convention.

<sup>Written for commit 569648d3e2c05f3fb6fba18b03a33101c97db158. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

