### PR TITLE
docs(qa): native tool-calls live gate completed — A/B/C PASS on rerun (task-243)

### DIFF
--- a/Docs/superpowers/qa/native-tool-calls-2026-07/README.md
+++ b/Docs/superpowers/qa/native-tool-calls-2026-07/README.md
@@ -22,19 +22,27 @@ Evidence: `case-A-native-single-2026-07-16.txt` + run DB `A-native-single.db` (s
 - Transcript carries the real `⚙ calculator → …` TOOL marker — native calls render identically to fence calls.
 - This is `ModelTurn.tool_calls` populated from a real native provider response, dispatched through `run_agent_loop`, answered as a `role="tool"` history message, end-to-end through the Console reply engine (AC #2 substance; provider caveat above).
 
-## Case B — native multi-call attempt: **INCOMPLETE** (best-effort)
+## Case B — native multi-call attempt: **INCOMPLETE** (best-effort) → **PASS on rerun**
 
-The multi-call prompt hit the 300s provider read-timeout mid-generation (27B thinking model); the run ended honestly as `error` ("Provider error from custom") with no wedge — and the llama.cpp server itself died around this point. AC #3 (multi-call batch dispatched in one turn) is demonstrated end-to-end by tests at both the engine level (`test_native_multi_call_batch_dispatches_both_in_one_turn`) and the service level (`test_native_multi_call_reply_dispatches_both_tools_in_one_turn`) against the exact OpenAI response shape case A proved real. Live multi-call remains provider/model-dependent (Qwen tends to serialize calls).
+First run (2026-07-16, Qwen3.6-27B): the multi-call prompt hit the 300s provider read-timeout mid-generation; the run ended honestly as `error` ("Provider error from custom") with no wedge — and the llama.cpp server itself died around this point. AC #3 (multi-call batch dispatched in one turn) is demonstrated end-to-end by tests at both the engine level (`test_native_multi_call_batch_dispatches_both_in_one_turn`) and the service level (`test_native_multi_call_reply_dispatches_both_tools_in_one_turn`) against the exact OpenAI response shape case A proved real. See the rerun below.
 
-## Case C — fence regression on llama_cpp: **PARTIAL** (server died)
+## Case C — fence regression on llama_cpp: **PARTIAL** (server died) → **PASS on rerun**
 
-Before the connection failed, the recorder captured the half that this branch changed: `tools=None` on the wire and `fence_in_system=True` — the `llama_cpp` provider correctly stays on the fence path (AC #1 fallback, AC #4 routing). The round-trip itself could not complete because the server was already down (`All connection attempts failed`, 0.0s — infrastructure, not code). The fence round-trip behavior is otherwise pinned by the unchanged pre-existing suites (1,576-test sweep family; `Tests/Chat/test_console_agent_bridge.py` fence tests byte-identical) and by the #629/#636 live gates on the same engine.
+First run: before the connection failed, the recorder captured the half that this branch changed: `tools=None` on the wire and `fence_in_system=True` — the `llama_cpp` provider correctly stays on the fence path (AC #1 fallback, AC #4 routing). The round-trip itself could not complete because the server was already down (`All connection attempts failed`, 0.0s — infrastructure, not code). See the rerun below.
+
+## Rerun 2026-07-17 (post-merge, PR #648 on dev): **GATE PASS — A, B, C all green**
+
+Evidence: `rerun-A-B-C-2026-07-17.txt`. Server back up with a different model (gemma-4-26B-A4B, Q4; the harness now reads the served model from `/v1/models`), which also natively honors `tools=` — a second real model exercising the same native path.
+
+- **A (native round-trip): PASS**, 5.4s — `tools=` on both turns, `fence_in_system=False`, calculator round-trip, final answer `18018`.
+- **B (native multi-tool): PASS**, 5.6s — both tools genuinely round-tripped natively (`get_current_datetime` then `calculator`), correct combined final answer ("The current date is 2026-07-17 and 91 * 7 is 637"), 2 ⚙ TOOL markers. The model serialized the calls across two turns rather than batching them in one reply — parallel single-turn batching remains pinned by the engine/service tests above (whether a model emits it is model-dependent).
+- **C (fence regression): PASS**, 3.8s — the previously missing half completed: fence protocol in the system prompt, `tools=None` on the wire, the reply arrived as a real ` ```tool_call ` fence, parsed and round-tripped to the same `18018`. The `llama_cpp` provider path is confirmed fence-only end-to-end on the merged code.
 
 ## Suites at gate HEAD
 
-`Tests/Agents/ + test_console_agent_bridge.py + test_console_provider_gateway.py + test_console_agent_swap.py + Tests/LLM_Provider_Catalog/` → **337 passed / 0 failed**.
+`Tests/Agents/ + test_console_agent_bridge.py + test_console_provider_gateway.py + test_console_agent_swap.py + Tests/LLM_Provider_Catalog/` → **337 passed / 0 failed** (350 after the PR-review additions).
 
 ## Residuals
 
-- Re-run `native_gate.py B C` once the llama.cpp server is back (or `A` against a real cloud key for the literal AC #2 wording).
+- Optional: re-run `native_gate.py A` against a real cloud key if one is ever wired (AC #2 was accepted on the native-capable-provider evidence per the 2026-07-16 user decision).
 - task-263 filed: Anthropic/Google/Cohere handlers normalize away tool-use blocks; they stay fence-only until their normalizers build `message.tool_calls`.

--- a/Docs/superpowers/qa/native-tool-calls-2026-07/native_gate.py
+++ b/Docs/superpowers/qa/native-tool-calls-2026-07/native_gate.py
@@ -27,8 +27,16 @@ from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
 from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
 from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
 
-MODEL = "Qwen3.6-27B-Uncensored-HauhauCS-Aggressive-Q8_K_P.gguf"
 BASE = "http://127.0.0.1:9099"
+
+def _served_model() -> str:
+    import urllib.request
+    with urllib.request.urlopen(f"{BASE}/v1/models", timeout=5) as r:
+        data = json.load(r)
+    entries = data.get("models") or data.get("data") or []
+    return entries[0].get("model") or entries[0].get("id")
+
+MODEL = _served_model()
 
 
 class RecordingGateway:

--- a/Docs/superpowers/qa/native-tool-calls-2026-07/rerun-A-B-C-2026-07-17.txt
+++ b/Docs/superpowers/qa/native-tool-calls-2026-07/rerun-A-B-C-2026-07-17.txt
@@ -1,0 +1,59 @@
+evidence db dir: /private/tmp/claude-501/-Users-macbook-dev-Documents-GitHub-tldw-chatbook/0c177be4-8a91-43dd-9244-5945679ee3ae/scratchpad/gate-evidence
+
+===== A-native-single (5.4s) =====
+status: done
+final answer: "18018"
+provider calls:
+  turn 0: tools=['spawn_subagent', 'calculator', 'get_current_datetime'] fence_in_system=False
+  turn 1: tools=['spawn_subagent', 'calculator', 'get_current_datetime'] fence_in_system=False
+run steps:
+  [model]  :: 
+  [tool_call] calculator :: 
+  [tool_result] calculator :: {"expression": "234 * 77", "result": 18018, "result_type": "int"}
+  [model]  :: 18018
+TOOL markers in transcript: 1
+    ⚙ calculator → {"expression": "234 * 77", "result": 18018, "result_type": "int"}
+A native (tools= sent, no fence protocol): True
+A tool round-trip done: True
+
+===== B-native-multi (5.6s) =====
+status: done
+final answer: "The current date is 2026-07-17 and 91 * 7 is 637."
+provider calls:
+  turn 0: tools=['spawn_subagent', 'calculator', 'get_current_datetime'] fence_in_system=False
+  turn 1: tools=['spawn_subagent', 'calculator', 'get_current_datetime'] fence_in_system=False
+  turn 2: tools=['spawn_subagent', 'calculator', 'get_current_datetime'] fence_in_system=False
+run steps:
+  [model]  :: 
+  [tool_call] get_current_datetime :: 
+  [tool_result] get_current_datetime :: {"datetime": "2026-07-17T00:57:39.512867+00:00", "timezone": "UTC", "date": "2026-07-17", "time": "00:57:39.512867", "we
+  [model]  :: 
+  [tool_call] calculator :: 
+  [tool_result] calculator :: {"expression": "91 * 7", "result": 637, "result_type": "int"}
+  [model]  :: The current date is 2026-07-17 and 91 * 7 is 637.
+TOOL markers in transcript: 2
+    ⚙ get_current_datetime → {"datetime": "2026-07-17T00:57:39.512867+00:00", "timezone": "UTC", "date": "2026-07-
+    ⚙ calculator → {"expression": "91 * 7", "result": 637, "result_type": "int"}
+B tool calls made: 2 | status: done
+
+===== C-fence-llamacpp (3.8s) =====
+status: done
+final answer: "18018"
+provider calls:
+  turn 0: tools=None fence_in_system=True
+  turn 1: tools=None fence_in_system=True
+run steps:
+  [model]  :: ```tool_call
+{"name": "calculator", "arguments": {"expression": "234 * 77"}}
+```
+  [tool_call] calculator :: 
+  [tool_result] calculator :: {"expression": "234 * 77", "result": 18018, "result_type": "int"}
+  [model]  :: 18018
+TOOL markers in transcript: 1
+    ⚙ calculator → {"expression": "234 * 77", "result": 18018, "result_type": "int"}
+C fence path (no tools=, protocol present): True
+C tool round-trip done: True
+
+===== VERDICTS =====
+results: {'A': True, 'B': True, 'C': True}
+GATE: PASS


### PR DESCRIPTION
Completes the task-243 live gate that PR #648 shipped with two infrastructure-blocked cases. The llama.cpp server came back (now serving gemma-4-26B-A4B — a second real model that natively honors `tools=`; the harness now reads the served model from `/v1/models`):

- **A (native round-trip): PASS**, 5.4s — `tools=` both turns, no fence protocol, calculator round-trip, correct answer.
- **B (native multi-tool): PASS**, 5.6s — both tools round-tripped natively (datetime + calculator), correct combined answer; model serialized the calls across turns (single-turn parallel batching stays pinned by engine/service tests).
- **C (fence regression): PASS**, 3.8s — the previously missing half: `llama_cpp` provider stayed fence-only end-to-end (protocol in system prompt, `tools=None` on the wire, real fence reply parsed and round-tripped) on the merged code.

Docs-only: gate README updated + rerun transcript + refreshed harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes the native tool-calls live gate (task-243). Rerun shows A, B, and C all PASS on llama.cpp (gemma-4-26B-A4B), meeting ACs for native round-trip, multi-tool, and fence fallback; docs and evidence updated.

- **Refactors**
  - `Docs/superpowers/qa/native-tool-calls-2026-07/README.md` updated with rerun results; added `rerun-A-B-C-2026-07-17.txt` evidence.
  - `Docs/superpowers/qa/native-tool-calls-2026-07/native_gate.py`: auto-detect the served model via `/v1/models` and set `MODEL` dynamically.

<sup>Written for commit 46e75102774a79ea848383078e3bb73de5e95e8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

