### PR TITLE
feat(rag): default vector store to persistent ChromaDB when embeddings deps are installed (task-246)

### DIFF
--- a/Tests/RAG/simplified/test_vector_store_selection.py
+++ b/Tests/RAG/simplified/test_vector_store_selection.py
@@ -137,16 +137,26 @@ class TestDefaultWithoutEmbeddingsDeps:
         _patch_environment(monkeypatch)
         monkeypatch.setattr(rag_config_module, "_EMBEDDINGS_RAG_AVAILABLE", None)
 
-        def broken_check():
+        def broken_probe():
             raise RuntimeError("dependency probe exploded")
 
         import tldw_chatbook.Utils.optional_deps as optional_deps
-        monkeypatch.setattr(optional_deps, "check_embeddings_rag_deps", broken_check)
+        monkeypatch.setattr(optional_deps, "embeddings_rag_deps_installed", broken_probe)
 
         config = VectorStoreConfig()
 
         assert config.type == "memory"
         assert config.persist_directory is None
+
+    def test_installed_probe_is_find_spec_based_and_fails_closed(self, monkeypatch):
+        """The installed-probe must answer without imports and fail closed."""
+        import importlib.util
+        from tldw_chatbook.Utils.optional_deps import embeddings_rag_deps_installed
+
+        assert isinstance(embeddings_rag_deps_installed(), bool)
+
+        monkeypatch.setattr(importlib.util, "find_spec", lambda name: None)
+        assert embeddings_rag_deps_installed() is False
 
 
 # === Explicit overrides (AC #3) ===
@@ -241,6 +251,144 @@ class TestExplicitOverrides:
         config = VectorStoreConfig(type="chroma")
 
         assert config.persist_directory == Path("/tmp/tldw-rag-user-dir") / "chromadb"
+
+
+# === Normalization of explicit values (PR #656 review) ===
+
+@pytest.mark.unit
+class TestExplicitValueNormalization:
+    """Explicit env/config values are normalized; 'auto'/blank run detection."""
+
+    def test_explicit_auto_env_var_runs_detection(self, monkeypatch):
+        _patch_environment(monkeypatch)
+        _patch_deps(monkeypatch, True)
+        monkeypatch.setenv("RAG_VECTOR_STORE", "auto")
+
+        config = VectorStoreConfig()
+
+        assert config.type == "chroma"
+        assert config.persist_directory is not None
+
+    def test_explicit_auto_in_user_config_runs_detection(self, monkeypatch):
+        _patch_environment(monkeypatch, rag_settings={"vector_store": {"type": "auto"}})
+        _patch_deps(monkeypatch, False)
+
+        config = VectorStoreConfig()
+
+        assert config.type == "memory"
+
+    def test_auto_env_var_falls_through_to_explicit_config(self, monkeypatch):
+        """env 'auto' means automatic behavior, which still honors user config."""
+        _patch_environment(monkeypatch, rag_settings={"vector_store": {"type": "memory"}})
+        _patch_deps(monkeypatch, True)
+        monkeypatch.setenv("RAG_VECTOR_STORE", "auto")
+
+        config = VectorStoreConfig()
+
+        assert config.type == "memory"
+
+    def test_mixed_case_and_whitespace_type_is_canonicalized(self, monkeypatch):
+        _patch_environment(monkeypatch)
+        _patch_deps(monkeypatch, False)
+        monkeypatch.setenv("RAG_VECTOR_STORE", "  Chroma ")
+
+        config = VectorStoreConfig()
+
+        assert config.type == "chroma"
+        assert config.persist_directory is not None
+        assert RAGConfig(vector_store=config).validate() == []
+
+    def test_uppercase_memory_in_user_config_is_canonicalized(self, monkeypatch):
+        _patch_environment(monkeypatch, rag_settings={"vector_store": {"type": "MEMORY"}})
+        _patch_deps(monkeypatch, True)
+
+        config = VectorStoreConfig()
+
+        assert config.type == "memory"
+
+    def test_blank_type_env_var_runs_detection(self, monkeypatch):
+        _patch_environment(monkeypatch)
+        _patch_deps(monkeypatch, True)
+        monkeypatch.setenv("RAG_VECTOR_STORE", "   ")
+
+        config = VectorStoreConfig()
+
+        assert config.type == "chroma"
+
+    def test_whitespace_only_persist_dir_env_var_is_ignored(self, monkeypatch):
+        _patch_environment(monkeypatch, user_data_dir="/tmp/tldw-rag-user-dir")
+        _patch_deps(monkeypatch, True)
+        monkeypatch.setenv("RAG_PERSIST_DIR", "   ")
+
+        config = VectorStoreConfig()
+
+        assert config.persist_directory == Path("/tmp/tldw-rag-user-dir") / "chromadb"
+
+    def test_whitespace_only_persist_dir_in_config_is_ignored(self, monkeypatch):
+        _patch_environment(
+            monkeypatch,
+            rag_settings={"vector_store": {"persist_directory": "  "}},
+            user_data_dir="/tmp/tldw-rag-user-dir",
+        )
+        _patch_deps(monkeypatch, True)
+
+        config = VectorStoreConfig()
+
+        assert config.persist_directory == Path("/tmp/tldw-rag-user-dir") / "chromadb"
+
+    def test_persist_dir_values_are_stripped(self, monkeypatch):
+        _patch_environment(monkeypatch)
+        _patch_deps(monkeypatch, True)
+        monkeypatch.setenv("RAG_PERSIST_DIR", "  /tmp/padded-chroma-dir  ")
+
+        config = VectorStoreConfig()
+
+        assert config.persist_directory == Path("/tmp/padded-chroma-dir")
+
+
+# === Legacy [AppRAGSearchConfig.rag.chroma] compatibility (PR #656 review) ===
+
+@pytest.mark.unit
+class TestLegacyChromaSection:
+    """Profile-built configs must honor the legacy chroma persist location."""
+
+    def test_legacy_chroma_persist_directory_is_honored(self, monkeypatch):
+        _patch_environment(
+            monkeypatch,
+            rag_settings={"chroma": {"persist_directory": "/tmp/legacy-chroma-home"}},
+        )
+        _patch_deps(monkeypatch, True)
+
+        config = VectorStoreConfig()
+
+        assert config.persist_directory == Path("/tmp/legacy-chroma-home")
+
+    def test_legacy_key_matches_from_settings_resolution(self, monkeypatch):
+        """Plain RAGConfig() and from_settings() must persist to the same place."""
+        _patch_environment(
+            monkeypatch,
+            rag_settings={"chroma": {"persist_directory": "/tmp/legacy-chroma-home"}},
+        )
+        _patch_deps(monkeypatch, True)
+
+        plain = RAGConfig()
+        loaded = RAGConfig.from_settings()
+
+        assert plain.vector_store.persist_directory == loaded.vector_store.persist_directory
+
+    def test_explicit_vector_store_key_beats_legacy_key(self, monkeypatch):
+        _patch_environment(
+            monkeypatch,
+            rag_settings={
+                "vector_store": {"persist_directory": "/tmp/new-style-dir"},
+                "chroma": {"persist_directory": "/tmp/legacy-chroma-home"},
+            },
+        )
+        _patch_deps(monkeypatch, True)
+
+        config = VectorStoreConfig()
+
+        assert config.persist_directory == Path("/tmp/new-style-dir")
 
 
 # === Persistence round-trip (AC #1 evidence; requires real chromadb) ===

--- a/Tests/RAG/simplified/test_vector_store_selection.py
+++ b/Tests/RAG/simplified/test_vector_store_selection.py
@@ -1,0 +1,288 @@
+"""
+Tests for RAG vector store default selection (task-246).
+
+The vector store should default to persistent ChromaDB when the
+`embeddings_rag` optional dependencies are installed, with the persist
+directory under the app's user data dir, while:
+- staying on the in-memory store when the deps are missing, and
+- honoring an explicit user override back to `type = "memory"`.
+
+These tests exercise the selection logic with the dependency check
+monkeypatched, so they do not require chromadb/torch to be importable
+(except the importorskip-gated persistence round-trip at the bottom).
+"""
+
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.RAG_Search.simplified import config as rag_config_module
+from tldw_chatbook.RAG_Search.simplified.config import RAGConfig, VectorStoreConfig
+
+
+# === Helpers ===
+
+def _patch_environment(monkeypatch, rag_settings=None, user_data_dir="/tmp/tldw-rag-selection-test"):
+    """Isolate the selection logic from the host machine's config and env."""
+    app_config = {"AppRAGSearchConfig": {"rag": rag_settings or {}}}
+
+    def fake_get_cli_setting(section, key, default=None):
+        return app_config.get(section, {}).get(key, default)
+
+    monkeypatch.setattr(rag_config_module, "load_cli_config_and_ensure_existence", lambda: app_config)
+    monkeypatch.setattr(rag_config_module, "get_cli_setting", fake_get_cli_setting)
+    monkeypatch.setattr(rag_config_module, "get_user_data_dir", lambda: Path(user_data_dir))
+    monkeypatch.delenv("RAG_VECTOR_STORE", raising=False)
+    monkeypatch.delenv("RAG_PERSIST_DIR", raising=False)
+    monkeypatch.delenv("RAG_EMBEDDING_MODEL", raising=False)
+    monkeypatch.delenv("RAG_DEVICE", raising=False)
+
+
+def _patch_deps(monkeypatch, available: bool):
+    """Force the embeddings_rag availability check to a known value."""
+    monkeypatch.setattr(rag_config_module, "_embeddings_rag_available", lambda: available)
+
+
+# === Default selection: deps installed ===
+
+@pytest.mark.unit
+class TestDefaultWithEmbeddingsDeps:
+    """With embeddings_rag installed, default to persistent ChromaDB."""
+
+    def test_vector_store_config_defaults_to_chroma(self, monkeypatch):
+        _patch_environment(monkeypatch)
+        _patch_deps(monkeypatch, True)
+
+        config = VectorStoreConfig()
+
+        assert config.type == "chroma"
+
+    def test_persist_directory_defaults_under_user_data_dir(self, monkeypatch):
+        _patch_environment(monkeypatch, user_data_dir="/tmp/tldw-rag-user-dir")
+        _patch_deps(monkeypatch, True)
+
+        config = VectorStoreConfig()
+
+        assert config.persist_directory == Path("/tmp/tldw-rag-user-dir") / "chromadb"
+
+    def test_rag_config_default_is_valid_chroma_config(self, monkeypatch):
+        """Plain RAGConfig() (what runtime profiles build) must validate cleanly."""
+        _patch_environment(monkeypatch)
+        _patch_deps(monkeypatch, True)
+
+        config = RAGConfig()
+
+        assert config.vector_store.type == "chroma"
+        assert config.vector_store.persist_directory is not None
+        assert config.validate() == []
+
+    def test_from_settings_defaults_to_chroma(self, monkeypatch):
+        _patch_environment(monkeypatch)
+        _patch_deps(monkeypatch, True)
+
+        config = RAGConfig.from_settings()
+
+        assert config.vector_store.type == "chroma"
+        assert config.vector_store.persist_directory == Path("/tmp/tldw-rag-selection-test") / "chromadb"
+
+    def test_hybrid_basic_profile_inherits_persistent_default(self, monkeypatch):
+        """The runtime profile used by chat RAG must pick up the persistent default."""
+        _patch_environment(monkeypatch)
+        _patch_deps(monkeypatch, True)
+
+        from tldw_chatbook.RAG_Search.config_profiles import ConfigProfileManager
+
+        manager = ConfigProfileManager()
+        profile = manager.get_profile("hybrid_basic")
+
+        assert profile is not None
+        assert profile.rag_config.vector_store.type == "chroma"
+        assert profile.rag_config.vector_store.persist_directory is not None
+
+
+# === Default selection: deps missing ===
+
+@pytest.mark.unit
+class TestDefaultWithoutEmbeddingsDeps:
+    """Without embeddings deps, behavior is unchanged: in-memory store."""
+
+    def test_vector_store_config_defaults_to_memory(self, monkeypatch):
+        _patch_environment(monkeypatch)
+        _patch_deps(monkeypatch, False)
+
+        config = VectorStoreConfig()
+
+        assert config.type == "memory"
+        assert config.persist_directory is None
+
+    def test_rag_config_default_is_valid_memory_config(self, monkeypatch):
+        _patch_environment(monkeypatch)
+        _patch_deps(monkeypatch, False)
+
+        config = RAGConfig()
+
+        assert config.vector_store.type == "memory"
+        assert config.validate() == []
+
+    def test_from_settings_defaults_to_memory(self, monkeypatch):
+        _patch_environment(monkeypatch)
+        _patch_deps(monkeypatch, False)
+
+        config = RAGConfig.from_settings()
+
+        assert config.vector_store.type == "memory"
+
+    def test_availability_check_failure_falls_back_to_memory(self, monkeypatch):
+        """If the optional-deps probe itself blows up, default must stay memory."""
+        _patch_environment(monkeypatch)
+        monkeypatch.setattr(rag_config_module, "_EMBEDDINGS_RAG_AVAILABLE", None)
+
+        def broken_check():
+            raise RuntimeError("dependency probe exploded")
+
+        import tldw_chatbook.Utils.optional_deps as optional_deps
+        monkeypatch.setattr(optional_deps, "check_embeddings_rag_deps", broken_check)
+
+        config = VectorStoreConfig()
+
+        assert config.type == "memory"
+        assert config.persist_directory is None
+
+
+# === Explicit overrides (AC #3) ===
+
+@pytest.mark.unit
+class TestExplicitOverrides:
+    """Explicit user configuration must always win over the deps-based default."""
+
+    def test_explicit_memory_in_user_config_wins_over_deps(self, monkeypatch):
+        _patch_environment(monkeypatch, rag_settings={"vector_store": {"type": "memory"}})
+        _patch_deps(monkeypatch, True)
+
+        config = RAGConfig()
+
+        assert config.vector_store.type == "memory"
+        assert config.vector_store.persist_directory is None
+
+    def test_explicit_memory_in_user_config_wins_in_from_settings(self, monkeypatch):
+        _patch_environment(monkeypatch, rag_settings={"vector_store": {"type": "memory"}})
+        _patch_deps(monkeypatch, True)
+
+        config = RAGConfig.from_settings()
+
+        assert config.vector_store.type == "memory"
+
+    def test_explicit_memory_applies_to_runtime_profiles(self, monkeypatch):
+        """User `type = \"memory\"` must also govern profile-built configs."""
+        _patch_environment(monkeypatch, rag_settings={"vector_store": {"type": "memory"}})
+        _patch_deps(monkeypatch, True)
+
+        from tldw_chatbook.RAG_Search.config_profiles import ConfigProfileManager
+
+        manager = ConfigProfileManager()
+        profile = manager.get_profile("hybrid_basic")
+
+        assert profile is not None
+        assert profile.rag_config.vector_store.type == "memory"
+
+    def test_env_var_memory_override_wins_over_deps(self, monkeypatch):
+        _patch_environment(monkeypatch)
+        _patch_deps(monkeypatch, True)
+        monkeypatch.setenv("RAG_VECTOR_STORE", "memory")
+
+        config = VectorStoreConfig()
+
+        assert config.type == "memory"
+
+    def test_explicit_persist_directory_in_user_config_wins(self, monkeypatch):
+        _patch_environment(
+            monkeypatch,
+            rag_settings={"vector_store": {"persist_directory": "/tmp/custom-chroma-home"}},
+        )
+        _patch_deps(monkeypatch, True)
+
+        config = VectorStoreConfig()
+
+        assert config.type == "chroma"
+        assert config.persist_directory == Path("/tmp/custom-chroma-home")
+
+    def test_env_var_persist_directory_wins(self, monkeypatch):
+        _patch_environment(monkeypatch)
+        _patch_deps(monkeypatch, True)
+        monkeypatch.setenv("RAG_PERSIST_DIR", "/tmp/env-chroma-dir")
+
+        config = VectorStoreConfig()
+
+        assert config.persist_directory == Path("/tmp/env-chroma-dir")
+
+    def test_constructor_arguments_bypass_auto_selection(self, monkeypatch):
+        """Explicitly constructed configs (tests, fixtures) must be untouched."""
+        _patch_environment(monkeypatch)
+        _patch_deps(monkeypatch, True)
+
+        config = VectorStoreConfig(type="memory", persist_directory=None)
+
+        assert config.type == "memory"
+        assert config.persist_directory is None
+
+    def test_from_dict_explicit_type_wins(self, monkeypatch):
+        _patch_environment(monkeypatch)
+        _patch_deps(monkeypatch, True)
+
+        config = RAGConfig.from_dict({"vector_store": {"type": "memory"}})
+
+        assert config.vector_store.type == "memory"
+
+    def test_explicit_chroma_gets_default_persist_directory(self, monkeypatch):
+        """type='chroma' without a persist dir gets the user-data-dir default."""
+        _patch_environment(monkeypatch, user_data_dir="/tmp/tldw-rag-user-dir")
+        _patch_deps(monkeypatch, False)
+
+        config = VectorStoreConfig(type="chroma")
+
+        assert config.persist_directory == Path("/tmp/tldw-rag-user-dir") / "chromadb"
+
+
+# === Persistence round-trip (AC #1 evidence; requires real chromadb) ===
+
+@pytest.mark.integration
+class TestChromaPersistenceRoundTrip:
+    """Documents added to the chroma store survive a store restart."""
+
+    def test_documents_survive_store_recreation(self, tmp_path):
+        pytest.importorskip("chromadb")
+        pytest.importorskip("numpy")
+
+        from tldw_chatbook.RAG_Search.simplified.vector_store import create_vector_store
+
+        persist_dir = tmp_path / "chromadb"
+        collection = "persistence_roundtrip"
+        embeddings = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]
+
+        store = create_vector_store(
+            store_type="chroma",
+            persist_directory=persist_dir,
+            collection_name=collection,
+        )
+        store.add(
+            ids=["doc-1", "doc-2"],
+            embeddings=embeddings,
+            documents=["first document", "second document"],
+            metadata=[{"source": "test"}, {"source": "test"}],
+        )
+        store.close()
+        del store
+
+        # Simulate an app restart: a brand-new store over the same directory.
+        reopened = create_vector_store(
+            store_type="chroma",
+            persist_directory=persist_dir,
+            collection_name=collection,
+        )
+        try:
+            results = reopened.search([1.0, 0.0, 0.0], top_k=2)
+            result_ids = {r.id for r in results}
+            assert "doc-1" in result_ids
+            assert len(results) == 2
+        finally:
+            reopened.close()

--- a/Tests/test_smoke.py
+++ b/Tests/test_smoke.py
@@ -266,8 +266,8 @@ class TestRAGFunctionality:
             # deps are installed; redirect persistence to keep the test hermetic.
             config = RAGConfig()
             config.vector_store.persist_directory = tmp_path / "chromadb"
-            service = RAGService(config)
-            assert service is not None
+            with RAGService(config) as service:
+                assert service is not None
 
         except ImportError:
             pytest.skip("RAG dependencies not installed")

--- a/Tests/test_smoke.py
+++ b/Tests/test_smoke.py
@@ -255,17 +255,20 @@ class TestSecurity:
 class TestRAGFunctionality:
     """Smoke tests for RAG functionality."""
     
-    def test_rag_service_initialization(self):
+    def test_rag_service_initialization(self, tmp_path):
         """Test that RAG service can be initialized."""
         try:
             from tldw_chatbook.RAG_Search.simplified.rag_service import RAGService
             from tldw_chatbook.RAG_Search.simplified.config import RAGConfig
-            
-            # Create service with config (will skip if dependencies missing)
+
+            # Create service with config (will skip if dependencies missing).
+            # The vector store defaults to persistent chroma when embeddings
+            # deps are installed; redirect persistence to keep the test hermetic.
             config = RAGConfig()
+            config.vector_store.persist_directory = tmp_path / "chromadb"
             service = RAGService(config)
             assert service is not None
-            
+
         except ImportError:
             pytest.skip("RAG dependencies not installed")
     

--- a/backlog/tasks/task-246 - Default-RAG-vector-store-to-persistent-ChromaDB-when-embeddings-deps-are-installed.md
+++ b/backlog/tasks/task-246 - Default-RAG-vector-store-to-persistent-ChromaDB-when-embeddings-deps-are-installed.md
@@ -63,10 +63,10 @@ Implemented as planned — all changes live in `RAG_Search/simplified/config.py`
 
 - `VectorStoreConfig.type` now defaults to an `"auto"` sentinel resolved in
   `__post_init__` via `default_vector_store_type()`: `RAG_VECTOR_STORE` env var >
-  explicit `[AppRAGSearchConfig.rag.vector_store].type` > `"chroma"` when
-  `optional_deps.check_embeddings_rag_deps()` (feature key 'embeddings_rag') passes >
-  `"memory"`. A `None` persist_directory is auto-filled for chroma stores via
-  `default_chroma_persist_directory()` (`RAG_PERSIST_DIR` > explicit config >
+  explicit `[AppRAGSearchConfig.rag.vector_store].type` > `"chroma"` when the
+  embeddings_rag deps are installed > `"memory"`. A `None` persist_directory is
+  auto-filled for chroma stores via `default_chroma_persist_directory()`
+  (`RAG_PERSIST_DIR` > explicit config > legacy `[rag.chroma].persist_directory` >
   `get_user_data_dir()/"chromadb"`, matching the app DB path convention). The deps
   probe is memoized (`_EMBEDDINGS_RAG_AVAILABLE`) and fails closed to memory.
 - Resolving in the dataclass constructor (rather than in profiles or the factory) means
@@ -74,20 +74,33 @@ Implemented as planned — all changes live in `RAG_Search/simplified/config.py`
   `from_settings()`, `from_dict()` — inherits the persistent default, while explicitly
   passed values always win, so an explicit `type = "memory"` in user config now wins on
   the profile path too (it previously wasn't consulted there at all).
-- Side benefit: the deps probe populates the lazy `DEPENDENCIES_AVAILABLE` registry, so
-  `Tests/test_smoke.py::test_rag_service_initialization` now genuinely initializes the
-  service instead of skipping on a false "dependencies not installed" ImportError
-  (registry was never populated in a bare process). That smoke test got a tmp_path
-  persist dir to stay hermetic under the new default.
-- New tests: `Tests/RAG/simplified/test_vector_store_selection.py` (19 tests) — with-deps
+- PR #656 review revisions: the availability probe is `find_spec`-based
+  (`optional_deps.embeddings_rag_deps_installed()`, ~0.19s vs ~4.6s for the import-based
+  deep check in a fresh process, no env-var mutation); explicit type values are
+  normalized (strip/lower; blank or "auto" falls through to detection) and the
+  now-redundant raw type chain in `from_settings` was removed so normalization is
+  consistent across paths; whitespace-only persist-dir values are treated as unset; the
+  legacy `[AppRAGSearchConfig.rag.chroma].persist_directory` key joined the persist-dir
+  priority chain so profile-built configs resolve the same directory as
+  `from_settings()`; magic strings became `VECTOR_STORE_TYPE_*` constants. Known
+  pre-existing issue (unchanged, exists on origin/dev): in a bare process nothing
+  populates `DEPENDENCIES_AVAILABLE`, so `EmbeddingFactory` refuses with ImportError
+  until some flow runs `check_embeddings_rag_deps()`; the RAG smoke test therefore
+  skips in isolation. The smoke test uses a tmp_path persist dir and a `with` block for
+  hermetic cleanup.
+- New tests: `Tests/RAG/simplified/test_vector_store_selection.py` (32 tests) — with-deps
   default (chroma under user data dir, valid config), without-deps default (memory, probe
-  failure fails closed), explicit overrides (TOML, env var, constructor, from_dict,
-  profile path), persist-dir overrides, and an importorskip-gated chroma persistence
-  round-trip proving documents survive store recreation.
+  failure fails closed, find_spec probe fails closed), explicit overrides (TOML, env var,
+  constructor, from_dict, profile path), normalization ("auto"/case/whitespace),
+  persist-dir overrides + legacy chroma section parity with from_settings, and an
+  importorskip-gated chroma persistence round-trip proving documents survive store
+  recreation.
 - Verified: `Tests/RAG/ Tests/RAG_Search/ Tests/UI/test_settings_library_rag_defaults.py
-  Tests/test_smoke.py` → 329 passed / 19 skipped (baseline 310 passed / 20 skipped, delta
-  = 19 new tests + smoke skip→pass). Runtime check: `create_rag_service("hybrid_basic")`
+  Tests/test_smoke.py` → 342 passed / 19 skipped (baseline 310 passed / 20 skipped;
+  delta = 32 new tests, smoke skip→pass only when the registry is populated by earlier
+  tests in the same session). Runtime check: `create_rag_service("hybrid_basic")`
   now yields `ChromaVectorStore` (persistent) by default and `InMemoryVectorStore` with
   `RAG_VECTOR_STORE=memory`.
 - Files: `tldw_chatbook/RAG_Search/simplified/config.py`,
+  `tldw_chatbook/Utils/optional_deps.py` (cheap probe + shared module list),
   `Tests/RAG/simplified/test_vector_store_selection.py` (new), `Tests/test_smoke.py`.

--- a/backlog/tasks/task-246 - Default-RAG-vector-store-to-persistent-ChromaDB-when-embeddings-deps-are-installed.md
+++ b/backlog/tasks/task-246 - Default-RAG-vector-store-to-persistent-ChromaDB-when-embeddings-deps-are-installed.md
@@ -3,8 +3,9 @@ id: TASK-246
 title: >-
   Default RAG vector store to persistent ChromaDB when embeddings deps are
   installed
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-12 14:11'
 labels:
   - rag
@@ -21,8 +22,72 @@ The RAG vector store defaults to type memory (RAG_Search/simplified/config.py:48
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 With embeddings_rag installed the RAG service vector store persists across app restarts (ChromaDB with a persist directory under the user data dir)
-- [ ] #2 Without embeddings deps behavior is unchanged: plain FTS5 search works and no import errors occur
-- [ ] #3 Config still allows an explicit override back to the in-memory store
-- [ ] #4 Store selection logic is covered by tests for both with-deps and without-deps cases
+- [x] #1 With embeddings_rag installed the RAG service vector store persists across app restarts (ChromaDB with a persist directory under the user data dir)
+- [x] #2 Without embeddings deps behavior is unchanged: plain FTS5 search works and no import errors occur
+- [x] #3 Config still allows an explicit override back to the in-memory store
+- [x] #4 Store selection logic is covered by tests for both with-deps and without-deps cases
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Add store-selection helpers to `tldw_chatbook/RAG_Search/simplified/config.py`:
+   - `_embeddings_rag_available()` — memoized wrapper around
+     `Utils.optional_deps.check_embeddings_rag_deps()` (the 'embeddings_rag' feature key),
+     returning False on any failure so environments without the extras never error.
+   - `default_vector_store_type()` — resolution order: `RAG_VECTOR_STORE` env var >
+     explicit `[AppRAGSearchConfig.rag.vector_store].type` in user config > "chroma"
+     when embeddings_rag deps are installed > "memory" fallback.
+   - `default_chroma_persist_directory()` — `RAG_PERSIST_DIR` env var > explicit
+     `persist_directory` in user config > `get_user_data_dir() / "chromadb"` (same
+     user-data-dir convention as the ChaChaNotes/Media DB paths).
+2. Change `VectorStoreConfig` to resolve its defaults in `__post_init__`: the `type`
+   field defaults to an "auto" sentinel that resolves via `default_vector_store_type()`,
+   and a `None` `persist_directory` is auto-filled for chroma stores. Explicitly passed
+   values (constructor args, `from_dict`, TOML via `from_settings`) always win, so an
+   explicit `type = "memory"` keeps today's behavior. Because runtime profiles
+   (`config_profiles.py`, e.g. `hybrid_basic`) build plain `RAGConfig()` objects, they
+   inherit the new default with no profile changes — keeping the diff off the files a
+   parallel agent is editing.
+3. TDD: new `Tests/RAG/simplified/test_vector_store_selection.py` covering with-deps
+   default (chroma + persist dir under user data dir), without-deps default (memory,
+   no chromadb import required), explicit memory override via config and env var,
+   explicit persist-directory override, `from_settings` behavior, `hybrid_basic`
+   profile inheritance, and a chroma persistence round-trip (importorskip-gated).
+4. Run targeted suites (`Tests/RAG/`, new tests, related smoke tests) and verify no
+   regressions against the recorded baseline (239 passed / 8 skipped).
+
+## Implementation Notes
+
+Implemented as planned — all changes live in `RAG_Search/simplified/config.py` plus tests;
+`config_profiles.py`, `rag_factory.py`, and `vector_store.py` are untouched.
+
+- `VectorStoreConfig.type` now defaults to an `"auto"` sentinel resolved in
+  `__post_init__` via `default_vector_store_type()`: `RAG_VECTOR_STORE` env var >
+  explicit `[AppRAGSearchConfig.rag.vector_store].type` > `"chroma"` when
+  `optional_deps.check_embeddings_rag_deps()` (feature key 'embeddings_rag') passes >
+  `"memory"`. A `None` persist_directory is auto-filled for chroma stores via
+  `default_chroma_persist_directory()` (`RAG_PERSIST_DIR` > explicit config >
+  `get_user_data_dir()/"chromadb"`, matching the app DB path convention). The deps
+  probe is memoized (`_EMBEDDINGS_RAG_AVAILABLE`) and fails closed to memory.
+- Resolving in the dataclass constructor (rather than in profiles or the factory) means
+  every construction path — runtime profiles like `hybrid_basic` (plain `RAGConfig()`),
+  `from_settings()`, `from_dict()` — inherits the persistent default, while explicitly
+  passed values always win, so an explicit `type = "memory"` in user config now wins on
+  the profile path too (it previously wasn't consulted there at all).
+- Side benefit: the deps probe populates the lazy `DEPENDENCIES_AVAILABLE` registry, so
+  `Tests/test_smoke.py::test_rag_service_initialization` now genuinely initializes the
+  service instead of skipping on a false "dependencies not installed" ImportError
+  (registry was never populated in a bare process). That smoke test got a tmp_path
+  persist dir to stay hermetic under the new default.
+- New tests: `Tests/RAG/simplified/test_vector_store_selection.py` (19 tests) — with-deps
+  default (chroma under user data dir, valid config), without-deps default (memory, probe
+  failure fails closed), explicit overrides (TOML, env var, constructor, from_dict,
+  profile path), persist-dir overrides, and an importorskip-gated chroma persistence
+  round-trip proving documents survive store recreation.
+- Verified: `Tests/RAG/ Tests/RAG_Search/ Tests/UI/test_settings_library_rag_defaults.py
+  Tests/test_smoke.py` → 329 passed / 19 skipped (baseline 310 passed / 20 skipped, delta
+  = 19 new tests + smoke skip→pass). Runtime check: `create_rag_service("hybrid_basic")`
+  now yields `ChromaVectorStore` (persistent) by default and `InMemoryVectorStore` with
+  `RAG_VECTOR_STORE=memory`.
+- Files: `tldw_chatbook/RAG_Search/simplified/config.py`,
+  `Tests/RAG/simplified/test_vector_store_selection.py` (new), `Tests/test_smoke.py`.

--- a/tldw_chatbook/RAG_Search/simplified/config.py
+++ b/tldw_chatbook/RAG_Search/simplified/config.py
@@ -29,6 +29,91 @@ def _coerce_int_setting(value: Any, default: int) -> int:
     return int(parsed)
 
 
+# Cached result of the embeddings_rag optional-deps probe. Availability cannot
+# change without a restart, and the underlying check imports heavy modules
+# (torch, chromadb, ...), so probe at most once per process.
+_EMBEDDINGS_RAG_AVAILABLE: Optional[bool] = None
+
+
+def _embeddings_rag_available() -> bool:
+    """Return True when the `embeddings_rag` optional dependencies are installed.
+
+    Wraps `Utils.optional_deps.check_embeddings_rag_deps()` (the
+    'embeddings_rag' feature key) and caches the result. Any failure is
+    treated as "not available" so environments without the extras never error.
+
+    Returns:
+        True if all embeddings/RAG dependencies are importable.
+    """
+    global _EMBEDDINGS_RAG_AVAILABLE
+    if _EMBEDDINGS_RAG_AVAILABLE is None:
+        try:
+            from tldw_chatbook.Utils.optional_deps import check_embeddings_rag_deps
+            _EMBEDDINGS_RAG_AVAILABLE = bool(check_embeddings_rag_deps())
+        except Exception as e:
+            logger.debug(f"embeddings_rag availability check failed, assuming unavailable: {e}")
+            _EMBEDDINGS_RAG_AVAILABLE = False
+    return _EMBEDDINGS_RAG_AVAILABLE
+
+
+def _explicit_vector_store_setting(key: str) -> Optional[Any]:
+    """Read an explicit `[AppRAGSearchConfig.rag.vector_store]` user setting.
+
+    Args:
+        key: Setting name within the vector_store section (e.g. 'type').
+
+    Returns:
+        The configured value, or None when not explicitly set (or on any
+        config read failure).
+    """
+    try:
+        rag_section = get_cli_setting("AppRAGSearchConfig", "rag", {}) or {}
+        if not isinstance(rag_section, dict):
+            return None
+        vector_store_section = rag_section.get('vector_store', {})
+        if not isinstance(vector_store_section, dict):
+            return None
+        return vector_store_section.get(key)
+    except Exception as e:
+        logger.debug(f"Could not read vector_store.{key} from user config: {e}")
+        return None
+
+
+def default_vector_store_type() -> str:
+    """Resolve the default vector store type.
+
+    Priority: RAG_VECTOR_STORE env var > explicit
+    `[AppRAGSearchConfig.rag.vector_store].type` in user config > persistent
+    ChromaDB when the `embeddings_rag` optional deps are installed >
+    in-memory fallback. An explicit `type = "memory"` therefore always wins.
+
+    Returns:
+        Vector store type string ("chroma" or "memory", or the explicit
+        user-configured value).
+    """
+    explicit = os.getenv("RAG_VECTOR_STORE") or _explicit_vector_store_setting('type')
+    if explicit:
+        return str(explicit)
+    return "chroma" if _embeddings_rag_available() else "memory"
+
+
+def default_chroma_persist_directory() -> Path:
+    """Resolve the default persist directory for the ChromaDB store.
+
+    Priority: RAG_PERSIST_DIR env var > explicit
+    `[AppRAGSearchConfig.rag.vector_store].persist_directory` in user config >
+    `<user data dir>/chromadb` (the same user-data-dir convention as the
+    application databases).
+
+    Returns:
+        Path to the ChromaDB persist directory.
+    """
+    explicit = os.getenv("RAG_PERSIST_DIR") or _explicit_vector_store_setting('persist_directory')
+    if explicit:
+        return Path(str(explicit)).expanduser()
+    return get_user_data_dir() / "chromadb"
+
+
 @dataclass
 class EmbeddingConfig:
     """Configuration for embedding generation."""
@@ -44,8 +129,15 @@ class EmbeddingConfig:
 
 @dataclass
 class VectorStoreConfig:
-    """Configuration for vector storage."""
-    type: str = "memory"  # default to in-memory; set to "chroma" when persistence is configured
+    """Configuration for vector storage.
+
+    The default `type` is the "auto" sentinel, resolved on construction to
+    persistent ChromaDB when the `embeddings_rag` optional deps are installed
+    (persisting under the user data dir), and the in-memory store otherwise.
+    Explicit values — constructor arguments, `RAG_VECTOR_STORE` env var, or
+    `[AppRAGSearchConfig.rag.vector_store]` in the user config — always win.
+    """
+    type: str = "auto"  # resolved in __post_init__: chroma (persistent) with embeddings deps, else memory
     persist_directory: Optional[Path] = None
     collection_name: str = "default"
     distance_metric: str = "cosine"  # "cosine", "l2", "ip"
@@ -54,6 +146,12 @@ class VectorStoreConfig:
     chat_collection: str = "chat_embeddings"
     notes_collection: str = "notes_embeddings"
     character_collection: str = "character_embeddings"
+
+    def __post_init__(self):
+        if self.type == "auto":
+            self.type = default_vector_store_type()
+        if self.persist_directory is None and self.type == "chroma":
+            self.persist_directory = default_chroma_persist_directory()
 
 
 @dataclass

--- a/tldw_chatbook/RAG_Search/simplified/config.py
+++ b/tldw_chatbook/RAG_Search/simplified/config.py
@@ -29,38 +29,45 @@ def _coerce_int_setting(value: Any, default: int) -> int:
     return int(parsed)
 
 
-# Cached result of the embeddings_rag optional-deps probe. Availability cannot
-# change without a restart, and the underlying check imports heavy modules
-# (torch, chromadb, ...), so probe at most once per process.
+# Canonical vector store type values used by the selection logic below.
+# "auto" is a sentinel meaning "resolve from env/config/installed deps".
+VECTOR_STORE_TYPE_AUTO = "auto"
+VECTOR_STORE_TYPE_CHROMA = "chroma"
+VECTOR_STORE_TYPE_MEMORY = "memory"
+
+# Cached result of the embeddings_rag installed-probe. Availability cannot
+# change without a restart, so probe at most once per process.
 _EMBEDDINGS_RAG_AVAILABLE: Optional[bool] = None
 
 
 def _embeddings_rag_available() -> bool:
     """Return True when the `embeddings_rag` optional dependencies are installed.
 
-    Wraps `Utils.optional_deps.check_embeddings_rag_deps()` (the
-    'embeddings_rag' feature key) and caches the result. Any failure is
-    treated as "not available" so environments without the extras never error.
+    Wraps `Utils.optional_deps.embeddings_rag_deps_installed()` (a cheap
+    `find_spec`-based probe of the 'embeddings_rag' feature group — no heavy
+    imports, no side effects) and caches the result. Any failure is treated
+    as "not available" so environments without the extras never error.
 
     Returns:
-        True if all embeddings/RAG dependencies are importable.
+        True if all embeddings/RAG dependencies are installed.
     """
     global _EMBEDDINGS_RAG_AVAILABLE
     if _EMBEDDINGS_RAG_AVAILABLE is None:
         try:
-            from tldw_chatbook.Utils.optional_deps import check_embeddings_rag_deps
-            _EMBEDDINGS_RAG_AVAILABLE = bool(check_embeddings_rag_deps())
+            from tldw_chatbook.Utils.optional_deps import embeddings_rag_deps_installed
+            _EMBEDDINGS_RAG_AVAILABLE = bool(embeddings_rag_deps_installed())
         except Exception as e:
             logger.debug(f"embeddings_rag availability check failed, assuming unavailable: {e}")
             _EMBEDDINGS_RAG_AVAILABLE = False
     return _EMBEDDINGS_RAG_AVAILABLE
 
 
-def _explicit_vector_store_setting(key: str) -> Optional[Any]:
-    """Read an explicit `[AppRAGSearchConfig.rag.vector_store]` user setting.
+def _explicit_rag_setting(section: str, key: str) -> Optional[Any]:
+    """Read an explicit `[AppRAGSearchConfig.rag.<section>].<key>` user setting.
 
     Args:
-        key: Setting name within the vector_store section (e.g. 'type').
+        section: Subsection name within the rag config (e.g. 'vector_store').
+        key: Setting name within that subsection (e.g. 'type').
 
     Returns:
         The configured value, or None when not explicitly set (or on any
@@ -70,13 +77,46 @@ def _explicit_vector_store_setting(key: str) -> Optional[Any]:
         rag_section = get_cli_setting("AppRAGSearchConfig", "rag", {}) or {}
         if not isinstance(rag_section, dict):
             return None
-        vector_store_section = rag_section.get('vector_store', {})
-        if not isinstance(vector_store_section, dict):
+        subsection = rag_section.get(section, {})
+        if not isinstance(subsection, dict):
             return None
-        return vector_store_section.get(key)
+        return subsection.get(key)
     except Exception as e:
-        logger.debug(f"Could not read vector_store.{key} from user config: {e}")
+        logger.debug(f"Could not read rag.{section}.{key} from user config: {e}")
         return None
+
+
+def _normalized_type_setting(value: Any) -> Optional[str]:
+    """Normalize an explicit vector store type setting.
+
+    Args:
+        value: Raw setting value from env/config.
+
+    Returns:
+        Stripped, lowercased type string, or None when the value is unset,
+        blank, or the "auto" sentinel (which means "run auto-detection").
+    """
+    if value is None:
+        return None
+    normalized = str(value).strip().lower()
+    if not normalized or normalized == VECTOR_STORE_TYPE_AUTO:
+        return None
+    return normalized
+
+
+def _cleaned_path_setting(value: Any) -> Optional[str]:
+    """Strip an explicit path setting, treating blank values as unset.
+
+    Args:
+        value: Raw setting value from env/config.
+
+    Returns:
+        Stripped path string, or None when unset or whitespace-only.
+    """
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
 
 
 def default_vector_store_type() -> str:
@@ -86,31 +126,42 @@ def default_vector_store_type() -> str:
     `[AppRAGSearchConfig.rag.vector_store].type` in user config > persistent
     ChromaDB when the `embeddings_rag` optional deps are installed >
     in-memory fallback. An explicit `type = "memory"` therefore always wins.
+    Explicit values are normalized (stripped/lowercased); blank or "auto"
+    values fall through to the next source, ending in auto-detection.
 
     Returns:
-        Vector store type string ("chroma" or "memory", or the explicit
-        user-configured value).
+        Vector store type string ("chroma" or "memory", or the normalized
+        explicit user-configured value).
     """
-    explicit = os.getenv("RAG_VECTOR_STORE") or _explicit_vector_store_setting('type')
+    explicit = (
+        _normalized_type_setting(os.getenv("RAG_VECTOR_STORE"))
+        or _normalized_type_setting(_explicit_rag_setting('vector_store', 'type'))
+    )
     if explicit:
-        return str(explicit)
-    return "chroma" if _embeddings_rag_available() else "memory"
+        return explicit
+    return VECTOR_STORE_TYPE_CHROMA if _embeddings_rag_available() else VECTOR_STORE_TYPE_MEMORY
 
 
 def default_chroma_persist_directory() -> Path:
     """Resolve the default persist directory for the ChromaDB store.
 
     Priority: RAG_PERSIST_DIR env var > explicit
-    `[AppRAGSearchConfig.rag.vector_store].persist_directory` in user config >
-    `<user data dir>/chromadb` (the same user-data-dir convention as the
-    application databases).
+    `[AppRAGSearchConfig.rag.vector_store].persist_directory` > legacy
+    `[AppRAGSearchConfig.rag.chroma].persist_directory` (still honored by
+    `RAGConfig.from_settings`) > `<user data dir>/chromadb` (the same
+    user-data-dir convention as the application databases). Blank or
+    whitespace-only values are treated as unset.
 
     Returns:
         Path to the ChromaDB persist directory.
     """
-    explicit = os.getenv("RAG_PERSIST_DIR") or _explicit_vector_store_setting('persist_directory')
+    explicit = (
+        _cleaned_path_setting(os.getenv("RAG_PERSIST_DIR"))
+        or _cleaned_path_setting(_explicit_rag_setting('vector_store', 'persist_directory'))
+        or _cleaned_path_setting(_explicit_rag_setting('chroma', 'persist_directory'))  # Legacy location
+    )
     if explicit:
-        return Path(str(explicit)).expanduser()
+        return Path(explicit).expanduser()
     return get_user_data_dir() / "chromadb"
 
 
@@ -137,7 +188,7 @@ class VectorStoreConfig:
     Explicit values — constructor arguments, `RAG_VECTOR_STORE` env var, or
     `[AppRAGSearchConfig.rag.vector_store]` in the user config — always win.
     """
-    type: str = "auto"  # resolved in __post_init__: chroma (persistent) with embeddings deps, else memory
+    type: str = VECTOR_STORE_TYPE_AUTO  # resolved in __post_init__: chroma (persistent) with embeddings deps, else memory
     persist_directory: Optional[Path] = None
     collection_name: str = "default"
     distance_metric: str = "cosine"  # "cosine", "l2", "ip"
@@ -148,9 +199,9 @@ class VectorStoreConfig:
     character_collection: str = "character_embeddings"
 
     def __post_init__(self):
-        if self.type == "auto":
+        if self.type == VECTOR_STORE_TYPE_AUTO:
             self.type = default_vector_store_type()
-        if self.persist_directory is None and self.type == "chroma":
+        if self.persist_directory is None and self.type == VECTOR_STORE_TYPE_CHROMA:
             self.persist_directory = default_chroma_persist_directory()
 
 
@@ -432,13 +483,12 @@ class RAGConfig:
         
         # === Vector Store Configuration ===
         vector_store_section = rag_config.get('vector_store', {})
-        
-        config.vector_store.type = (
-            os.getenv("RAG_VECTOR_STORE") or
-            vector_store_section.get('type') or
-            config.vector_store.type
-        )
-        
+
+        # vector_store.type is already resolved by VectorStoreConfig.__post_init__
+        # with the same precedence (RAG_VECTOR_STORE env > explicit config >
+        # installed-deps default) plus normalization; re-applying the raw
+        # env/config values here would undo that normalization.
+
         # Persist directory (priority: override > env > config > default)
         persist_dir = (
             override_persist_dir or
@@ -693,10 +743,10 @@ class RAGConfig:
             errors.append("hybrid_alpha must be between 0 and 1")
         
         # Validate vector store
-        if self.vector_store.type not in ["chroma", "memory"]:
+        if self.vector_store.type not in [VECTOR_STORE_TYPE_CHROMA, VECTOR_STORE_TYPE_MEMORY]:
             errors.append(f"Unknown vector store type: {self.vector_store.type}")
-        
-        if self.vector_store.type == "chroma" and not self.vector_store.persist_directory:
+
+        if self.vector_store.type == VECTOR_STORE_TYPE_CHROMA and not self.vector_store.persist_directory:
             errors.append("persist_directory is required for chroma vector store")
         
         if self.vector_store.distance_metric not in ["cosine", "l2", "ip"]:

--- a/tldw_chatbook/Utils/optional_deps.py
+++ b/tldw_chatbook/Utils/optional_deps.py
@@ -487,13 +487,41 @@ def ensure_svg_rendering() -> bool:
         _svg_rendering_available = False
     return _svg_rendering_available
 
+# Modules that must be installed for the 'embeddings_rag' feature group.
+# Shared by the deep import check below and the cheap installed-probe.
+EMBEDDINGS_RAG_REQUIRED_MODULES = ('torch', 'transformers', 'numpy', 'chromadb', 'sentence_transformers')
+
+
+def embeddings_rag_deps_installed() -> bool:
+    """Cheap probe: are the embeddings_rag dependencies installed?
+
+    Uses `importlib.util.find_spec` only — no module imports, no side
+    effects, and no mutation of the DEPENDENCIES_AVAILABLE registry — so it
+    is safe to call from configuration/default-resolution code paths.
+    For a deep check that actually imports the modules (and updates the
+    registry), use `check_embeddings_rag_deps()`.
+
+    Returns:
+        True when every module in EMBEDDINGS_RAG_REQUIRED_MODULES resolves
+        to an installed distribution.
+    """
+    for dep in EMBEDDINGS_RAG_REQUIRED_MODULES:
+        try:
+            if importlib.util.find_spec(dep) is None:
+                return False
+        except Exception as e:
+            logger.debug(f"find_spec probe failed for {dep}: {e}")
+            return False
+    return True
+
+
 def check_embeddings_rag_deps() -> bool:
     """Check all dependencies needed for embeddings and RAG functionality."""
     # Always recheck dependencies - don't return cached False value
     # This ensures we actually check if dependencies are installed
-    
+
     # Check each dependency more thoroughly
-    required_deps = ['torch', 'transformers', 'numpy', 'chromadb', 'sentence_transformers']
+    required_deps = list(EMBEDDINGS_RAG_REQUIRED_MODULES)
     all_available = True
     missing_deps = []
     


### PR DESCRIPTION
## Summary

From the 2026-07-12 RAG audit (ADR-005: invest in full local RAG mirroring tldw_server): the RAG vector store defaulted to `type = "memory"` (`RAG_Search/simplified/config.py`) and the `hybrid_basic` runtime profile never overrode it, so the semantic index started empty on every launch and nothing persisted across sessions.

`VectorStoreConfig.type` now defaults to an `"auto"` sentinel resolved on construction (`__post_init__`), with this priority:

1. `RAG_VECTOR_STORE` env var
2. explicit `[AppRAGSearchConfig.rag.vector_store].type` in user config
3. **persistent ChromaDB** when the `embeddings_rag` optional deps are installed (probed via `Utils/optional_deps.embeddings_rag_deps_installed()` — a cheap `find_spec`-only check, memoized, fails closed)
4. in-memory fallback

Explicit type values are normalized (strip/lower); blank or `"auto"` values fall through to the next source. A `None` `persist_directory` is auto-filled for chroma stores: `RAG_PERSIST_DIR` env var > explicit `[rag.vector_store].persist_directory` > legacy `[rag.chroma].persist_directory` (kept consistent with `from_settings()`) > `<user data dir>/chromadb` (same user-data-dir convention as the ChaChaNotes/Media DBs); whitespace-only values are treated as unset.

Resolving in the dataclass constructor means every construction path inherits the default — runtime profiles like `hybrid_basic` (which build plain `RAGConfig()` and ignore user config), `from_settings()`, and `from_dict()` — while explicitly passed values always win. As a result, an explicit `type = "memory"` in user config now also governs the profile path, which previously never consulted user config at all.

`config_profiles.py`, `rag_factory.py`, and `vector_store.py` are untouched (kept the diff off files a parallel agent is editing).

## Acceptance criteria (task-246)

- **AC1** with `embeddings_rag` installed the store defaults to ChromaDB persisting under the user data dir — verified by unit tests plus a chroma persistence round-trip test (documents survive store recreation), and a runtime check: `create_rag_service("hybrid_basic")` now yields `ChromaVectorStore`
- **AC2** without embeddings deps behavior is unchanged: default stays `memory`, the probe fails closed (no import errors), plain FTS5 path untouched
- **AC3** explicit override back to in-memory wins everywhere (TOML, env var, constructor args, `from_dict`, and — newly — profile-built configs)
- **AC4** selection logic covered by 32 new tests for both with-deps and without-deps cases (deps probe monkeypatched; without-deps tests don't require chromadb importable)

## Review revisions (b76f7810)

Addressed all seven PR review comments: `find_spec`-based availability probe (~0.19s vs ~4.6s for the import-based check in a fresh process, no env mutation), explicit-value normalization with `"auto"`/blank falling through to detection (and removal of the redundant raw type chain in `from_settings` that would have undone it), whitespace persist-dir handling, legacy `[rag.chroma].persist_directory` in the priority chain (profile-built configs now resolve the identical directory as `from_settings()`), `VECTOR_STORE_TYPE_*` constants, and a `with RAGService(...)` block in the smoke test (its context manager shuts down a real thread pool).

Known pre-existing issue, unchanged by this PR: nothing populates the lazy `DEPENDENCIES_AVAILABLE` registry in a bare process, so `EmbeddingFactory` refuses with ImportError until some flow runs `check_embeddings_rag_deps()` — the RAG smoke test therefore skips in isolation, exactly as on current dev. Worth a separate follow-up (e.g. `EmbeddingFactory` running the deep check itself instead of passively reading the registry).

## Testing

```
source .venv/bin/activate
python -m pytest Tests/RAG/ Tests/RAG_Search/ Tests/UI/test_settings_library_rag_defaults.py Tests/test_smoke.py -q --timeout=600
# 342 passed, 19 skipped
```

Baseline before the change on the same suites: 310 passed / 20 skipped — delta is the 32 new tests (the RAG smoke test passes when earlier tests in the session have populated the deps registry, and skips in isolation as on dev). CI on GitHub gets cancelled intentionally; verified locally. Rebased onto latest origin/dev (7b227601) with all suites re-run green.

Closes backlog task-246 (Default RAG vector store to persistent ChromaDB when embeddings deps are installed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default the RAG vector store to persistent `chromadb` when embeddings deps are installed, with auto selection and clear env/config overrides; falls back to in-memory. `hybrid_basic` and other paths now persist across sessions (task-246).

- **New Features**
  - `VectorStoreConfig.type` now `"auto"`, resolved as: `RAG_VECTOR_STORE` > user config > `chromadb` if deps present via cheap `embeddings_rag_deps_installed()` probe > `memory`.
  - Chroma persist dir priority: `RAG_PERSIST_DIR` > `rag.vector_store.persist_directory` > legacy `rag.chroma.persist_directory` > `<user data dir>/chromadb`; values are normalized and whitespace-only ignored.
  - Applies to all `RAGConfig` paths (`from_settings`, `from_dict`, `hybrid_basic`); explicit overrides always win. `from_settings` no longer re-overrides the normalized default.

- **Bug Fixes**
  - Index no longer resets on each launch when deps are installed; data persists by default.
  - Smoke test uses a tmp persist dir and a context manager for clean shutdown; new tests cover selection logic, normalization, legacy chroma dir, and a `chromadb` persistence round-trip.

<sup>Written for commit b76f7810357132f07bf09744ec6b96868615b142. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
