### PR TITLE
perf(agents): memoize fence-protocol render per active-set change + prompt-caching prep note (task-245)

### DIFF
--- a/.superpowers/sdd/progress.md
+++ b/.superpowers/sdd/progress.md
@@ -186,3 +186,6 @@ Post-merge sweep: 549/550 x2 — test_console_native_generic_provider_send_rende
 Task 1: complete (d0cd469a..d7623c55, review clean; tie-break unreachability proof verified against real loop — steps >= turns always). Notes: child budgets now carry max_model_turns=8 (more generous than old implied ~5-turn ceiling for tool runs — intended); heavy NATIVE multi-call batches could make the 32-step backstop bind before 8 turns (rare shape, awareness only).
 Task 2: complete (d7623c55..ce6f085f, review clean — collision/stale-cache/security traces all verified independently). Both plan tasks DONE.
 FINAL WHOLE-BRANCH REVIEW (opus): APPROVE — composition verified (no RunBudget reconstruction from persisted dicts anywhere; rail UI shows raw counts; native task-243 interaction strictly more permissive; DB suite 212 green). 2 Minors: docstring example list FIXED inline; backstop-vs-native-batch comment precision noted (awareness only). task-244 Done, ACs 1-4 checked. NEXT: PR.
+
+---
+# task-245 [2026-07-17] — protocol render memoization + prompt-caching note. Branch claude/protocol-memoize-245 off origin/dev bbca2db8 (post-#655). Plan: Docs/superpowers/plans/2026-07-17-protocol-render-memoization.md (1 task). Invariants: byte-identical output (memo only skips recompute); per-run closure cache (never on self); native branch untouched.

--- a/.superpowers/sdd/progress.md
+++ b/.superpowers/sdd/progress.md
@@ -189,3 +189,4 @@ FINAL WHOLE-BRANCH REVIEW (opus): APPROVE — composition verified (no RunBudget
 
 ---
 # task-245 [2026-07-17] — protocol render memoization + prompt-caching note. Branch claude/protocol-memoize-245 off origin/dev bbca2db8 (post-#655). Plan: Docs/superpowers/plans/2026-07-17-protocol-render-memoization.md (1 task). Invariants: byte-identical output (memo only skips recompute); per-run closure cache (never on self); native branch untouched.
+Task 1: complete (fadf8836..44f6b710, review APPROVED — key-correctness/ordering verified against real loop incl. frozen ToolSchema + monotonic extend; RED claims independently reproduced from the pre-impl tree; design note fact-checked). Branch = 1 task, so the task review doubles as whole-branch. task-245 Done, ACs checked. NEXT: PR.

--- a/Docs/superpowers/plans/2026-07-17-protocol-render-memoization.md
+++ b/Docs/superpowers/plans/2026-07-17-protocol-render-memoization.md
@@ -1,0 +1,139 @@
+# Tool-Protocol Render Memoization + Prompt-Caching Prep Note — Implementation Plan (task-245)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The fence-protocol system-prompt section is rendered once per active-set change within a run (byte-stable across unchanged turns — the precondition for provider-side prompt caching), and a design note records what provider-side caching would additionally need.
+
+**Architecture:** `_make_call_model` already builds one `call_model` closure per run (`_run_one` constructs it once), so the memo is plain closure state: a name-tuple key + the cached rendered string, re-rendered only when the key changes (which is exactly when `load_tools` admits a new schema — AC #2). Native mode (task-243) never renders the protocol and is untouched. The note (AC #3) is a standalone doc, explicitly out-of-scope work.
+
+**Tech Stack:** Python 3.11, existing agent service, pytest.
+
+## Global Constraints
+
+- Backlog ACs (task-245): (1) the rendered protocol string is cached/reused across consecutive turns within one run when the active schema set (BY NAME) has not changed since the last render; (2) the cache invalidates the moment `load_tools` admits a new schema into the active set; (3) a short design note records what provider-side prompt caching (e.g. Anthropic `cache_control`) would additionally need, as a distinct follow-up.
+- Rendered output byte-identical to today for every turn (memoization must never change WHAT is sent, only avoid re-computing it); fence tests pass unchanged; native mode untouched.
+- The cache must be per-run (closure state in `call_model`, built per `_run_one`) — never on `self` (AgentService is shared across runs incl. sub-agents, and a run's sub-agent gets its OWN closure via its own `_run_one`).
+- Worktree `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/agent-runtime`, branch `claude/protocol-memoize-245` (off origin/dev bbca2db8). Tests via `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest`, FOREGROUND; `timeout` unavailable.
+
+---
+
+### Task 1: Memoize the per-run protocol render + design note
+
+**Files:**
+- Modify: `tldw_chatbook/Agents/agent_service.py` (`_make_call_model`, ~lines 119-162)
+- Create: `Docs/superpowers/reviews/2026-07-17-provider-prompt-caching-note.md`
+- Test: `Tests/Agents/test_agent_service.py`
+
+**Interfaces:**
+- Consumes: `render_tool_protocol(schemas) -> str` (imported by name into agent_service — patchable at `tldw_chatbook.Agents.agent_service.render_tool_protocol`).
+- Produces: no signature changes anywhere.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `Tests/Agents/test_agent_service.py` (reuse `make_service`, `fence`, `CFG`, `FakeBigProvider`, and the find/load fixtures already present):
+
+```python
+def test_protocol_render_memoized_across_unchanged_turns(db, monkeypatch):
+    """AC #1: three fence turns with an unchanged active set must render the
+    protocol exactly once; the payload text stays byte-identical per turn."""
+    import tldw_chatbook.Agents.agent_service as svc
+    real_render = svc.render_tool_protocol
+    calls = []
+
+    def counting_render(schemas):
+        calls.append(tuple(s.name for s in schemas))
+        return real_render(schemas)
+
+    monkeypatch.setattr(svc, "render_tool_protocol", counting_render)
+    # script: two calculator fence rounds + final answer = 3 model turns,
+    # active set never changes (direct-disclose catalog, no load_tools).
+    service, chat = make_service(db, [
+        fence("calculator", {"expression": "1+1"}),
+        fence("calculator", {"expression": "2+2"}),
+        "done"])
+    _run_id, outcome = service.run_turn(
+        conversation_id="c", messages=[{"role": "user", "content": "go"}],
+        config=CFG, api_endpoint="llama_cpp", should_cancel=lambda: False)
+    assert outcome.status == RUN_DONE
+    assert len(calls) == 1                       # rendered once, reused twice
+    first_system = chat.calls[0]["messages_payload"][0]["content"]
+    for later in chat.calls[1:]:
+        assert later["messages_payload"][0]["content"] == first_system  # byte-stable
+
+
+def test_protocol_rerenders_when_load_tools_admits_new_schema(db, monkeypatch):
+    """AC #2: the cache invalidates the moment load_tools grows the active
+    set — the very next turn's protocol includes the new tool."""
+    # Mirror the file's existing find/load test setup (FakeBigProvider forces
+    # the load path). Script: load_tools fence -> calculator fence -> "done".
+    # Assert: counting_render was called exactly twice; the second recorded
+    # name-tuple includes the newly loaded tool; the post-load turn's system
+    # content contains the new tool's name while the pre-load turn's does not.
+```
+
+Write the second test fully against the file's real find/load fixtures.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pytest Tests/Agents/test_agent_service.py -v -k "memoized or rerenders"`
+Expected: the first FAILS on `len(calls) == 1` (currently one render per turn); the second's render-count assert FAILS (currently 3).
+
+- [ ] **Step 3: Implement**
+
+In `_make_call_model`, fence branch only (native branch untouched):
+
+```python
+    def _make_call_model(self, config: AgentConfig, api_endpoint: str,
+                         runtime_schemas: list):
+        native = (config.native_tools
+                  and provider_supports_native_tools(api_endpoint))
+        # task-245: one render per active-set change, not per turn. Keyed by
+        # schema NAMES (the set only ever grows via load_tools — AC #2), and
+        # scoped to this closure = this run, so sub-agents (their own
+        # _run_one -> their own closure) never share a cache. Byte-stable
+        # repeated turns are the precondition for provider-side prompt
+        # caching (see Docs/superpowers/reviews/
+        # 2026-07-17-provider-prompt-caching-note.md).
+        protocol_key: tuple | None = None
+        protocol_text = ""
+
+        def call_model(messages: list[dict], active_schemas: tuple) -> ModelTurn:
+            nonlocal protocol_key, protocol_text
+            schemas = runtime_schemas + list(active_schemas)
+            system_content = config.system_prompt
+            call_kwargs: dict = {}
+            if native:
+                tools = schemas_to_openai_tools(schemas)
+                if tools:
+                    call_kwargs["tools"] = tools
+            else:
+                key = tuple(s.name for s in schemas)
+                if key != protocol_key:
+                    protocol_text = render_tool_protocol(schemas)
+                    protocol_key = key
+                if protocol_text:
+                    system_content = f"{config.system_prompt}\n\n{protocol_text}"
+            ...rest unchanged...
+```
+
+(Preserve the native branch and everything below exactly as-is; only the fence-side render is keyed.)
+
+Create `Docs/superpowers/reviews/2026-07-17-provider-prompt-caching-note.md` (~40 lines): what provider-side caching additionally needs, as a follow-up — (a) Anthropic: `cache_control: {"type": "ephemeral"}` breakpoints on the system block, which requires the system prompt as structured content blocks (list form) rather than a plain string, set inside `chat_with_anthropic`'s payload build — moot until task-263 makes Anthropic tool-capable, but equally applicable to plain chats; (b) OpenAI/compatible: automatic prefix caching needs no API marks — this task's byte-stability plus the stable `[system, ...history]` message ordering already qualifies the prefix; note that history APPEND-only growth (never rewriting earlier messages) is the other half, which the loop already satisfies; (c) native mode symmetry: `schemas_to_openai_tools` is likewise recomputed per turn and byte-stable per active set — a follow-up could memo it identically, and provider-side `tools` arrays participate in OpenAI prefix caching only if serialized stably (dict insertion order already deterministic here); (d) measurement hook suggestion: log prompt-cache hit metrics from provider usage fields (`cached_tokens` etc.) before investing further.
+
+- [ ] **Step 4: Run the suites**
+
+Run: `pytest Tests/Agents/ -q` then `pytest Tests/Chat/test_console_agent_bridge.py Tests/Chat/test_console_agent_swap.py -q`
+Expected: PASS (all — repeated-turn payloads were already byte-identical, so no existing assertion can change).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Agents/agent_service.py Tests/Agents/test_agent_service.py Docs/superpowers/reviews/2026-07-17-provider-prompt-caching-note.md
+git commit -m "perf(agents): memoize fence-protocol render per active-set change + prompt-caching prep note (task-245)"
+```
+
+## Self-Review
+
+- AC #1 → memo test (1 render / 3 turns + byte-stability assert). AC #2 → invalidation test (re-render on load, new tool present). AC #3 → the note, explicitly follow-up-scoped.
+- Per-run scoping constraint encoded in the comment and guaranteed by construction (closure per `_run_one`).
+- Byte-identity: render function unchanged; memo returns the identical string object — no output change possible.

--- a/Docs/superpowers/reviews/2026-07-17-provider-prompt-caching-note.md
+++ b/Docs/superpowers/reviews/2026-07-17-provider-prompt-caching-note.md
@@ -1,0 +1,50 @@
+# Provider-side prompt caching: what task-245 sets up, and what is follow-up
+
+task-245 memoizes `_make_call_model`'s fence-protocol render per active-set
+change instead of per turn (`AgentService._make_call_model`,
+`tldw_chatbook/Agents/agent_service.py`). The payload text was already
+byte-identical turn to turn before this change — the memo only removes
+redundant recomputation, it does not alter what gets sent. That byte-
+stability is the *precondition* for provider-side prompt caching, not the
+caching itself. None of the below is implemented by task-245; it is
+explicit follow-up.
+
+## (a) Anthropic: `cache_control` breakpoints
+
+Anthropic's prompt caching needs an explicit `cache_control: {"type":
+"ephemeral"}` marker on a content block, which requires the system
+prompt as structured content blocks (a list of `{"type": "text", "text":
+...}` dicts) rather than the plain string built today. That change
+belongs in `chat_with_anthropic`'s payload build, not in
+`agent_service.py`. It is moot for the agent loop specifically until
+task-263 makes Anthropic tool-capable (fence mode is provider-agnostic;
+native mode is Anthropic-shaped tool use) — but equally applicable to
+plain, non-agent chats through the same provider call today.
+
+## (b) OpenAI/compatible: automatic prefix caching
+
+Needs no API-side markers — it keys off a stable prompt *prefix*. This
+task's byte-stable system prompt plus the loop's already-stable
+`[system, ...history]` message ordering already satisfies half of what
+prefix caching wants. The other half — history growing by **append
+only**, never rewriting/reordering earlier messages — the loop already
+satisfies unchanged; no further work needed there.
+
+## (c) Native-mode symmetry
+
+`schemas_to_openai_tools(schemas)` (native branch, same closure) is
+likewise recomputed every turn and byte-stable per unchanged active set,
+exactly like the fence branch was before this task. A follow-up could
+memoize it identically. Provider-side `tools` arrays only participate in
+OpenAI's prefix caching if serialized stably; dict insertion order is
+already deterministic here, so that precondition is likely already met —
+worth confirming, not assuming, when that follow-up lands.
+
+## (d) Measurement before further investment
+
+Before spending more effort on caching plumbing, log provider-reported
+cache-hit usage fields (e.g. `cached_tokens` / `cache_read_input_tokens`,
+naming is provider-dependent) from the response `usage` block. That
+tells us whether this task's byte-stability is already earning cache
+hits on providers needing no explicit markers (OpenAI-compatible) before
+deciding whether (a)/(c) are worth building.

--- a/Tests/Agents/test_agent_service.py
+++ b/Tests/Agents/test_agent_service.py
@@ -599,3 +599,77 @@ def test_load_tools_same_batch_name_and_id_aliases_load_once(db):
     load_result = [s for s in run["steps"] if s["kind"] == "tool_result"][0]
     # Exactly one mention: "loaded: calculator" — not "calculator, calculator".
     assert load_result["result"] == "loaded: calculator"
+
+
+# --- task-245: memoize the per-run fence-protocol render so an unchanged
+# active tool set is rendered once, not once per model turn. ---
+
+def test_protocol_render_memoized_across_unchanged_turns(db, monkeypatch):
+    """AC #1: three fence turns with an unchanged active set must render the
+    protocol exactly once; the payload text stays byte-identical per turn."""
+    import tldw_chatbook.Agents.agent_service as svc
+    real_render = svc.render_tool_protocol
+    calls = []
+
+    def counting_render(schemas):
+        calls.append(tuple(s.name for s in schemas))
+        return real_render(schemas)
+
+    monkeypatch.setattr(svc, "render_tool_protocol", counting_render)
+    # script: two calculator fence rounds + final answer = 3 model turns,
+    # active set never changes (direct-disclose catalog, no load_tools).
+    service, chat = make_service(db, [
+        fence("calculator", {"expression": "1+1"}),
+        fence("calculator", {"expression": "2+2"}),
+        "done"])
+    _run_id, outcome = service.run_turn(
+        conversation_id="c", messages=[{"role": "user", "content": "go"}],
+        config=CFG, api_endpoint="llama_cpp", should_cancel=lambda: False)
+    assert outcome.status == RUN_DONE
+    assert len(calls) == 1                       # rendered once, reused twice
+    first_system = chat.calls[0]["messages_payload"][0]["content"]
+    for later in chat.calls[1:]:
+        assert later["messages_payload"][0]["content"] == first_system  # byte-stable
+
+
+def test_protocol_rerenders_when_load_tools_admits_new_schema(db, monkeypatch):
+    """AC #2: the cache invalidates the moment load_tools grows the active
+    set — the very next turn's protocol includes the new tool."""
+    import tldw_chatbook.Agents.agent_service as svc
+    real_render = svc.render_tool_protocol
+    calls = []
+
+    def counting_render(schemas):
+        calls.append(tuple(s.name for s in schemas))
+        return real_render(schemas)
+
+    monkeypatch.setattr(svc, "render_tool_protocol", counting_render)
+    # Mirror the file's existing find/load test setup (FakeBigProvider forces
+    # the load path). Script: load_tools fence -> calculator fence -> "done".
+    registry = ToolCatalogRegistry()
+    registry.register_provider(BuiltinToolProvider())
+    registry.register_provider(FakeBigProvider())  # catalog > threshold: forces find/load
+    config = AgentConfig(
+        model="m", system_prompt="s",
+        allowed_tools=("calculator", "get_current_datetime"),
+        budget=RunBudget(max_active_tools=8, max_steps=20))
+    chat = ScriptedChat([
+        fence(LOAD_TOOLS_NAME, {"ids": ["calculator"]}),
+        fence("calculator", {"expression": "2+2"}),
+        "done",
+    ])
+    service = AgentService(db=db, registry=registry, chat_call=chat)
+    _run_id, outcome = service.run_turn(
+        conversation_id="c", messages=[{"role": "user", "content": "2+2?"}],
+        config=config, api_endpoint="llama_cpp")
+
+    assert outcome.status == RUN_DONE and outcome.final_text == "done"
+    # Assert: counting_render was called exactly twice; the second recorded
+    # name-tuple includes the newly loaded tool; the post-load turn's system
+    # content contains the new tool's name while the pre-load turn's does not.
+    assert len(calls) == 2
+    assert "calculator" in calls[1]
+    pre_load_system = chat.calls[0]["messages_payload"][0]["content"]
+    post_load_system = chat.calls[1]["messages_payload"][0]["content"]
+    assert "calculator" not in pre_load_system
+    assert "calculator" in post_load_system

--- a/backlog/tasks/task-245 - Memoize-per-turn-tool-protocol-render-and-prepare-for-provider-prompt-caching.md
+++ b/backlog/tasks/task-245 - Memoize-per-turn-tool-protocol-render-and-prepare-for-provider-prompt-caching.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-245
 title: Memoize per-turn tool-protocol render and prepare for provider prompt-caching
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-07-16 16:00'
-updated_date: '2026-07-17 01:42'
+updated_date: '2026-07-17 01:51'
 labels:
   - agents
   - console
@@ -21,9 +21,9 @@ _make_call_model re-renders render_tool_protocol(runtime_schemas + active_schema
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The rendered protocol string is cached/reused across consecutive turns within one run when the active schema set (by name) has not changed since the last render
-- [ ] #2 A cache invalidates correctly the moment load_tools admits a new schema into the active set
-- [ ] #3 A short design note records what would be needed to additionally mark this stable prefix for provider-side prompt caching, as a distinct follow-up rather than in-scope work here
+- [x] #1 The rendered protocol string is cached/reused across consecutive turns within one run when the active schema set (by name) has not changed since the last render
+- [x] #2 A cache invalidates correctly the moment load_tools admits a new schema into the active set
+- [x] #3 A short design note records what would be needed to additionally mark this stable prefix for provider-side prompt caching, as a distinct follow-up rather than in-scope work here
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -31,3 +31,9 @@ _make_call_model re-renders render_tool_protocol(runtime_schemas + active_schema
 <!-- SECTION:PLAN:BEGIN -->
 Plan at Docs/superpowers/plans/2026-07-17-protocol-render-memoization.md — 1 SDD task: per-run closure memo in _make_call_model keyed by schema-name tuple (fence branch only; native untouched; per-run scoping by construction), invalidates when load_tools grows the active set; + Docs/superpowers/reviews/2026-07-17-provider-prompt-caching-note.md for AC#3 (Anthropic cache_control needs structured system blocks — moot until task-263; OpenAI prefix caching needs only the byte-stability this delivers; native tools= symmetry as follow-up).
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Per-run closure memo in AgentService._make_call_model (fence branch only; native untouched): the protocol renders once per active-set change, keyed by the schema-name tuple over runtime+active schemas — safe because ToolSchema is frozen and the loop's active list only ever grows monotonically via load_tools with both across-round and in-batch name dedupe (no in-place replacement, no reordering), so a name tuple uniquely identifies content within a run. Invalidation is exactly the load_tools-admits moment (AC#2 test: pre-load system content lacks the tool, post-load contains it, render count == 2). Byte-identity structural: the memo returns the same string render_tool_protocol would produce (AC#1 test also pins payload byte-stability across turns). AC#3: Docs/superpowers/reviews/2026-07-17-provider-prompt-caching-note.md — Anthropic cache_control needs structured system blocks (moot until task-263), OpenAI implicit prefix caching needs only the byte-stability + append-only history this run already has, native tools= memo symmetry as follow-up, measure cached_tokens before investing. Reviewer RED-verified both tests against the pre-implementation tree. Modified: agent_service.py, test_agent_service.py, + note doc.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-245 - Memoize-per-turn-tool-protocol-render-and-prepare-for-provider-prompt-caching.md
+++ b/backlog/tasks/task-245 - Memoize-per-turn-tool-protocol-render-and-prepare-for-provider-prompt-caching.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-245
 title: Memoize per-turn tool-protocol render and prepare for provider prompt-caching
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-07-16 16:00'
+updated_date: '2026-07-17 01:42'
 labels:
   - agents
   - console
@@ -23,3 +25,9 @@ _make_call_model re-renders render_tool_protocol(runtime_schemas + active_schema
 - [ ] #2 A cache invalidates correctly the moment load_tools admits a new schema into the active set
 - [ ] #3 A short design note records what would be needed to additionally mark this stable prefix for provider-side prompt caching, as a distinct follow-up rather than in-scope work here
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Plan at Docs/superpowers/plans/2026-07-17-protocol-render-memoization.md — 1 SDD task: per-run closure memo in _make_call_model keyed by schema-name tuple (fence branch only; native untouched; per-run scoping by construction), invalidates when load_tools grows the active set; + Docs/superpowers/reviews/2026-07-17-provider-prompt-caching-note.md for AC#3 (Anthropic cache_control needs structured system blocks — moot until task-263; OpenAI prefix caching needs only the byte-stability this delivers; native tools= symmetry as follow-up).
+<!-- SECTION:PLAN:END -->

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -120,8 +120,18 @@ class AgentService:
                          runtime_schemas: list):
         native = (config.native_tools
                   and provider_supports_native_tools(api_endpoint))
+        # task-245: one render per active-set change, not per turn. Keyed by
+        # schema NAMES (the set only ever grows via load_tools — AC #2), and
+        # scoped to this closure = this run, so sub-agents (their own
+        # _run_one -> their own closure) never share a cache. Byte-stable
+        # repeated turns are the precondition for provider-side prompt
+        # caching (see Docs/superpowers/reviews/
+        # 2026-07-17-provider-prompt-caching-note.md).
+        protocol_key: tuple | None = None
+        protocol_text = ""
 
         def call_model(messages: list[dict], active_schemas: tuple) -> ModelTurn:
+            nonlocal protocol_key, protocol_text
             schemas = runtime_schemas + list(active_schemas)
             system_content = config.system_prompt
             call_kwargs: dict = {}
@@ -132,9 +142,12 @@ class AgentService:
                 if tools:
                     call_kwargs["tools"] = tools
             else:
-                protocol = render_tool_protocol(schemas)
-                if protocol:
-                    system_content = f"{config.system_prompt}\n\n{protocol}"
+                key = tuple(s.name for s in schemas)
+                if key != protocol_key:
+                    protocol_text = render_tool_protocol(schemas)
+                    protocol_key = key
+                if protocol_text:
+                    system_content = f"{config.system_prompt}\n\n{protocol_text}"
             payload = [{"role": "system", "content": system_content}]
             payload.extend(messages)
             resp = self.chat_call(


### PR DESCRIPTION
Closes task-245 — the last of the three task-231 tool-call-flow follow-ups (#648 native tool-calls, #655 tiered budgets, now this).

### What
`AgentService._make_call_model` re-rendered `render_tool_protocol(...)` on every provider call within a run (measured in the task-231 review: ~1,329 tokens of byte-identical text re-computed per turn at a 16-tool catalog). It now renders **once per active-set change**, keyed by the schema-name tuple as per-run closure state:

- **Correct by construction:** `ToolSchema` is frozen and the loop's active list only grows monotonically via `load_tools` (with across-round + in-batch name dedupe from #655) — a name tuple uniquely identifies content within a run; no reordering, no in-place replacement. The memo returns the identical string, so every turn's payload is byte-identical to before (pinned by a test).
- **Invalidation** is exactly the `load_tools`-admits moment (AC #2): test asserts the pre-load system content lacks the new tool, the post-load content contains it, and the render ran exactly twice.
- **Scope:** fence branch only; the native `tools=` path (#648) is untouched; each run (and each sub-agent, via its own `_run_one` closure) gets its own cache — nothing on the shared service.

### Prompt-caching prep note (AC #3)
`Docs/superpowers/reviews/2026-07-17-provider-prompt-caching-note.md` records what provider-side caching would additionally need, as distinct follow-ups: Anthropic `cache_control` requires structured system blocks in `chat_with_anthropic` (moot for tools until task-263); OpenAI-compatible implicit prefix caching needs only the byte-stability + append-only history this run now guarantees; native `tools=` conversion could be memoized symmetrically; measure `cached_tokens` from usage fields before investing further.

### Verification
TDD (reviewer independently reproduced RED from the pre-implementation tree); independent review APPROVED with key-correctness and ordering traced against the real loop; Tests/Agents 135 passed + Console bridge/swap 57 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Memoized the fence-protocol system prompt in `AgentService._make_call_model` so it renders once per active tool-set change, removing redundant work while keeping payloads byte-identical. Adds a short provider prompt-caching note; native `tools=` path is unchanged. (Linear: task-245)

- **Performance**
  - Cache keyed by schema-name tuple; invalidates exactly when `load_tools` admits a new schema.
  - Per-run closure scope; sub-agents get isolated caches; no shared state on the service.
  - Tests assert 1 render across unchanged turns and re-render on load; payload stability pinned.
  - Doc note outlines next steps for provider-side caching (Anthropic `cache_control`, OpenAI prefix).

<sup>Written for commit ffabc5e91c07cdd9871c4dd4477eb4883ba24f05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

