### PR TITLE
Roleplay — native Console send applies conversation chat dictionaries

### DIFF
--- a/Docs/superpowers/plans/2026-07-16-roleplay-native-console-dict-apply.md
+++ b/Docs/superpowers/plans/2026-07-16-roleplay-native-console-dict-apply.md
@@ -1,0 +1,697 @@
+# Native Console send-path chat-dictionary application — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Apply the conversation chat dictionaries the P1g Console inspector shows to the actual native Console send, so "shown = applied" holds on the surface users chat in.
+
+**Architecture:** Mirror the existing skill-substitution transform in `ConsoleChatController`: a new `async _apply_chat_dictionaries(provider_messages, session_id)` runs right after `_apply_skill_substitution` at all four send sites, offloads the synchronous dictionary work to a thread, and rewrites only the ephemeral provider payload (the persisted transcript keeps the raw text). `ChatScreen` injects a db-bound applier callable; the substitution primitive lives in `Chat_Dictionary_Lib`.
+
+**Tech Stack:** Python 3.11+, Textual, `Chat_Dictionary_Lib` (`collect_active_chatdict_entries` + `process_user_input`), `ConsoleChatController`, pytest.
+
+**Spec:** `Docs/superpowers/specs/2026-07-16-roleplay-native-console-dict-apply-design.md` (committed `f08ea7c3`). Branch `claude/roleplay-native-console-dict-apply` off dev `7b227601`.
+
+## Global Constraints
+
+- **Conversation dictionaries only.** `char_data` is always `None` from the native caller (native sessions carry no character card). Character-dict application is deferred; keep the `char_data` param so the later cycle plugs in.
+- **Ephemeral.** Only the provider payload for the turn is transformed; the persisted `ConsoleChatStore` transcript keeps the raw user text. Never mutate a stored message or an input dict/list — build fresh copies.
+- **Silent.** No per-send diagnostics, no new user-facing enable/disable toggle. Presence of the injected applier is the only gate.
+- **Never break a send.** The applier and the transform must not raise: any failure returns the text/payload unchanged. The transform must **not** swallow `asyncio.CancelledError` (Stop mid-send must still cancel).
+- **Off the UI event loop.** Native sends run as async workers on the app's event loop (`run_worker(<coroutine>, …)`, `chat_screen.py:7983`). The synchronous DB read + regex matching must be offloaded via `asyncio.to_thread`.
+- **Constants (legacy parity):** `max_tokens = 500`, `strategy = "sorted_evenly"`.
+- **Roles/keys:** final `role == "user"` message only; `ConsoleMessageRole.USER.value == "user"`; `COMMAND_PREFIX == "/"`; message content is either a `str` or a parts list `[{"type": "text", "text": …}, <image parts>]`.
+- **Test env** (prefix every pytest run):
+  `HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest <targets> -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread`
+- **Staging:** stage only each task's own files. Never `git add -A`; never stage anything under `.superpowers/`.
+
+---
+
+## File structure
+
+- `tldw_chatbook/Character_Chat/Chat_Dictionary_Lib.py` — add `apply_active_chatdicts_to_text` (the never-raise substitution primitive). (Task 1)
+- `tldw_chatbook/Chat/console_chat_controller.py` — add the applier constructor param + `_apply_chat_dictionaries` + 4 call-site additions. (Task 2)
+- `tldw_chatbook/UI/Screens/chat_screen.py` — add the two constants, `_console_chat_dictionary_applier`, and the injection at the single controller construction site. (Task 3)
+- `Tests/Character_Chat/test_apply_active_chatdicts_to_text.py` — new (Task 1)
+- `Tests/Chat/test_console_dictionary_application.py` — new (Task 2)
+- `Tests/UI/test_console_dictionary_send_integration.py` — new (Task 3)
+
+---
+
+## Task 1: `apply_active_chatdicts_to_text` substitution primitive
+
+**Files:**
+- Modify: `tldw_chatbook/Character_Chat/Chat_Dictionary_Lib.py` (add one module-level function; place it directly after `collect_active_chatdict_entries`)
+- Test: `Tests/Character_Chat/test_apply_active_chatdicts_to_text.py` (create)
+
+**Interfaces:**
+- Consumes: `collect_active_chatdict_entries(db, conversation_id, char_data) -> List[ChatDictionary]`; `process_user_input(user_input: str, entries: List[ChatDictionary], max_tokens: int, strategy: str) -> str`; both already in this module.
+- Produces: `apply_active_chatdicts_to_text(db, conversation_id, char_data, text, *, max_tokens=500, strategy="sorted_evenly") -> str` — never raises; returns `text` unchanged when `text` is not a str, no entries apply, or anything fails.
+
+- [ ] **Step 1: Write the failing test.** Create `Tests/Character_Chat/test_apply_active_chatdicts_to_text.py`:
+
+```python
+import pytest
+
+from tldw_chatbook.Character_Chat import Chat_Dictionary_Lib as cdl
+from tldw_chatbook.Character_Chat.local_chat_dictionary_service import LocalChatDictionaryService
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    database = CharactersRAGDB(tmp_path / "apply_chatdicts.db", "test-client")
+    yield database
+    database.close_connection()
+
+
+def _attach_matching_dict(db, conv_id, name="Slang", key="Warden", content="grim jailer"):
+    dict_id = cdl.save_chat_dictionary(
+        db, name, entries=[cdl.ChatDictionary(key=key, content=content)]
+    )
+    assert dict_id is not None
+    LocalChatDictionaryService(db).attach_to_conversation(dict_id, conv_id)
+    return dict_id
+
+
+def test_applies_attached_conversation_dictionary(db):
+    conv_id = db.add_conversation({"title": "Attach"})
+    _attach_matching_dict(db, conv_id)
+    out = cdl.apply_active_chatdicts_to_text(
+        db, conv_id, None, "The Warden nods.", max_tokens=500, strategy="sorted_evenly"
+    )
+    assert out == "The grim jailer nods."
+
+
+def test_no_conversation_returns_text_unchanged(db):
+    out = cdl.apply_active_chatdicts_to_text(
+        db, None, None, "The Warden nods.", max_tokens=500, strategy="sorted_evenly"
+    )
+    assert out == "The Warden nods."
+
+
+def test_conversation_without_dicts_returns_text_unchanged(db):
+    conv_id = db.add_conversation({"title": "Empty"})
+    out = cdl.apply_active_chatdicts_to_text(
+        db, conv_id, None, "The Warden nods.", max_tokens=500, strategy="sorted_evenly"
+    )
+    assert out == "The Warden nods."
+
+
+def test_non_string_text_returned_unchanged(db):
+    conv_id = db.add_conversation({"title": "T"})
+    _attach_matching_dict(db, conv_id)
+    sentinel = ["not", "a", "string"]
+    assert cdl.apply_active_chatdicts_to_text(db, conv_id, None, sentinel) is sentinel
+
+
+def test_never_raises_when_collect_fails(db, monkeypatch):
+    conv_id = db.add_conversation({"title": "T"})
+    _attach_matching_dict(db, conv_id)
+
+    def _boom(*a, **k):
+        raise RuntimeError("collect exploded")
+
+    monkeypatch.setattr(cdl, "collect_active_chatdict_entries", _boom)
+    out = cdl.apply_active_chatdicts_to_text(db, conv_id, None, "The Warden nods.")
+    assert out == "The Warden nods."
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`AttributeError: module ... has no attribute 'apply_active_chatdicts_to_text'`).
+
+Run: `... -m pytest Tests/Character_Chat/test_apply_active_chatdicts_to_text.py -q`
+
+- [ ] **Step 3: Implement.** In `tldw_chatbook/Character_Chat/Chat_Dictionary_Lib.py`, directly after the `collect_active_chatdict_entries` function, add:
+
+```python
+def apply_active_chatdicts_to_text(
+    db: "CharactersRAGDB",
+    conversation_id: Optional[str],
+    char_data: Optional[Dict[str, Any]],
+    text: str,
+    *,
+    max_tokens: int = 500,
+    strategy: str = "sorted_evenly",
+) -> str:
+    """Apply the active chat dictionaries to ``text`` for a send (never raises).
+
+    Collects the dictionary union that applies to ``conversation_id`` (+
+    ``char_data``, always ``None`` for the native Console today) and runs the
+    standard ``process_user_input`` substitution. Returns ``text`` unchanged
+    when it is not a string, no dictionaries apply, or anything fails -- a
+    dictionary problem must never break a chat send.
+    """
+    if not isinstance(text, str):
+        return text
+    try:
+        entries = collect_active_chatdict_entries(db, conversation_id, char_data)
+        if not entries:
+            return text
+        return process_user_input(text, entries, max_tokens=max_tokens, strategy=strategy)
+    except Exception:
+        logger.opt(exception=True).warning(
+            "apply_active_chatdicts_to_text failed; returning text unmodified."
+        )
+        return text
+```
+
+(This module already imports `from loguru import logger` at line 16, plus `Optional`, `Dict`, `Any`, and `CharactersRAGDB` under `TYPE_CHECKING` — no new imports needed.)
+
+- [ ] **Step 4: Run — PASS.**
+
+Run: `... -m pytest Tests/Character_Chat/test_apply_active_chatdicts_to_text.py -q`
+Expected: 5 passed.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add tldw_chatbook/Character_Chat/Chat_Dictionary_Lib.py Tests/Character_Chat/test_apply_active_chatdicts_to_text.py
+git commit -m "feat(chat-dictionaries): apply_active_chatdicts_to_text send-path primitive (never-raise)"
+```
+
+---
+
+## Task 2: `ConsoleChatController._apply_chat_dictionaries` + call sites
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py` (constructor param + `self._chat_dictionary_applier`; new `_apply_chat_dictionaries`; 4 call-site additions at `submit_draft`, `retry_message`, `continue_from_message`, `regenerate_message`)
+- Test: `Tests/Chat/test_console_dictionary_application.py` (create)
+
+**Interfaces:**
+- Consumes: injected `chat_dictionary_applier: Callable[[str | None, str], str] | None` (Task 3 supplies the real one); `self.store.sessions()` (each session has `.id` and `.persisted_conversation_id`); `ConsoleMessageRole.USER.value`, `COMMAND_PREFIX`, `asyncio` (all already imported).
+- Produces: `async _apply_chat_dictionaries(provider_messages: list[dict], session_id: str) -> list[dict]`; a `chat_dictionary_applier=None` keyword-only constructor param.
+
+- [ ] **Step 1: Write the failing tests.** Create `Tests/Chat/test_console_dictionary_application.py`:
+
+```python
+import threading
+
+import pytest
+
+from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+
+
+class _Gateway:
+    async def resolve_for_send(self, _selection):
+        class _R:
+            ready = True
+            visible_copy = ""
+        return _R()
+
+    async def stream_chat(self, _resolution, _messages):
+        if False:
+            yield ""
+
+
+def _controller(applier):
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=_Gateway(),
+        provider="llama_cpp",
+        model="test-model",
+        chat_dictionary_applier=applier,
+    )
+    return controller, store
+
+
+def _session_with_conv(store, conv_id="conv-1"):
+    session = store.create_session(title="t")
+    session.persisted_conversation_id = conv_id
+    return session
+
+
+def _warden(conv_id, text):
+    return text.replace("Warden", "grim jailer")
+
+
+@pytest.mark.asyncio
+async def test_substitutes_final_user_string(warden_applier=_warden):
+    controller, store = _controller(warden_applier)
+    session = _session_with_conv(store)
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": ConsoleMessageRole.USER.value, "content": "The Warden nods."},
+    ]
+    out = await controller._apply_chat_dictionaries(messages, session.id)
+    assert out[-1]["content"] == "The grim jailer nods."
+    # Input list/dicts untouched (fresh copies only).
+    assert messages[-1]["content"] == "The Warden nods."
+
+
+@pytest.mark.asyncio
+async def test_substitutes_text_part_of_parts_list_leaving_images():
+    controller, store = _controller(_warden)
+    session = _session_with_conv(store)
+    image_part = {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}
+    messages = [
+        {
+            "role": ConsoleMessageRole.USER.value,
+            "content": [{"type": "text", "text": "The Warden nods."}, image_part],
+        }
+    ]
+    out = await controller._apply_chat_dictionaries(messages, session.id)
+    parts = out[-1]["content"]
+    assert parts[0] == {"type": "text", "text": "The grim jailer nods."}
+    assert parts[1] is image_part
+
+
+@pytest.mark.asyncio
+async def test_skips_skill_command_message():
+    controller, store = _controller(_warden)
+    session = _session_with_conv(store)
+    messages = [{"role": ConsoleMessageRole.USER.value, "content": "/Warden do a thing"}]
+    out = await controller._apply_chat_dictionaries(messages, session.id)
+    assert out[-1]["content"] == "/Warden do a thing"
+
+
+@pytest.mark.asyncio
+async def test_only_final_user_message_substituted():
+    controller, store = _controller(_warden)
+    session = _session_with_conv(store)
+    messages = [
+        {"role": ConsoleMessageRole.USER.value, "content": "The Warden earlier."},
+        {"role": "assistant", "content": "ok"},
+        {"role": ConsoleMessageRole.USER.value, "content": "The Warden now."},
+    ]
+    out = await controller._apply_chat_dictionaries(messages, session.id)
+    assert out[0]["content"] == "The Warden earlier."
+    assert out[-1]["content"] == "The grim jailer now."
+
+
+@pytest.mark.asyncio
+async def test_no_applier_returns_input_unchanged():
+    controller, store = _controller(None)
+    session = _session_with_conv(store)
+    messages = [{"role": ConsoleMessageRole.USER.value, "content": "The Warden nods."}]
+    out = await controller._apply_chat_dictionaries(messages, session.id)
+    assert out[-1]["content"] == "The Warden nods."
+
+
+@pytest.mark.asyncio
+async def test_unsaved_session_returns_input_unchanged():
+    controller, store = _controller(_warden)
+    session = store.create_session(title="t")  # persisted_conversation_id stays None
+    messages = [{"role": ConsoleMessageRole.USER.value, "content": "The Warden nods."}]
+    out = await controller._apply_chat_dictionaries(messages, session.id)
+    assert out[-1]["content"] == "The Warden nods."
+
+
+@pytest.mark.asyncio
+async def test_applier_runs_off_the_event_loop():
+    loop_thread = threading.get_ident()
+    seen = {}
+
+    def _recording_applier(conv_id, text):
+        seen["thread"] = threading.get_ident()
+        return text.replace("Warden", "grim jailer")
+
+    controller, store = _controller(_recording_applier)
+    session = _session_with_conv(store)
+    messages = [{"role": ConsoleMessageRole.USER.value, "content": "The Warden nods."}]
+    out = await controller._apply_chat_dictionaries(messages, session.id)
+    assert out[-1]["content"] == "The grim jailer nods."
+    assert seen["thread"] != loop_thread  # offloaded via asyncio.to_thread
+
+
+@pytest.mark.asyncio
+async def test_applier_exception_returns_input_unchanged():
+    def _boom(conv_id, text):
+        raise RuntimeError("applier exploded")
+
+    controller, store = _controller(_boom)
+    session = _session_with_conv(store)
+    messages = [{"role": ConsoleMessageRole.USER.value, "content": "The Warden nods."}]
+    out = await controller._apply_chat_dictionaries(messages, session.id)
+    assert out[-1]["content"] == "The Warden nods."
+```
+
+(`ConsoleMessageRole` lives in `tldw_chatbook.Chat.console_chat_models` — the same module the controller imports it from at `console_chat_controller.py:14-18`.)
+
+- [ ] **Step 2: Run — expect FAIL.** The constructor rejects `chat_dictionary_applier` (TypeError) and/or `_apply_chat_dictionaries` is missing (AttributeError).
+
+Run: `... -m pytest Tests/Chat/test_console_dictionary_application.py -q`
+
+- [ ] **Step 3a: Add the constructor param.** In `console_chat_controller.py`, in `__init__`'s keyword-only block, add after `skill_substitution_enabled: bool = True,`:
+
+```python
+        chat_dictionary_applier: "Callable[[str | None, str], str] | None" = None,
+```
+
+and in the body, after `self._skill_substitution_enabled = skill_substitution_enabled` (near the other `self._…` assignments), add:
+
+```python
+        self._chat_dictionary_applier = chat_dictionary_applier
+```
+
+- [ ] **Step 3b: Add the transform.** Add this method to `ConsoleChatController` (place it directly after `_apply_skill_substitution`):
+
+```python
+    async def _apply_chat_dictionaries(
+        self, provider_messages: list[dict[str, Any]], session_id: str
+    ) -> list[dict[str, Any]]:
+        """Apply the active conversation chat dictionaries to the final user
+        message of the ephemeral provider payload (never the stored transcript).
+
+        Mirrors `_apply_skill_substitution` (final `role == "user"` message
+        only, one rule for fresh sends AND retry/continue/regenerate). The
+        synchronous DB read + regex substitution are offloaded via
+        `asyncio.to_thread` because native sends run as async workers on the UI
+        event loop. Skill commands are left untouched. Any failure returns the
+        payload unchanged so a dictionary problem can never break a send;
+        `asyncio.CancelledError` is re-raised so a mid-send Stop still cancels.
+        """
+        applier = self._chat_dictionary_applier
+        if applier is None:
+            return provider_messages
+
+        session = next((s for s in self.store.sessions() if s.id == session_id), None)
+        conversation_id = session.persisted_conversation_id if session is not None else None
+        if not conversation_id:
+            return provider_messages
+
+        final_index: int | None = None
+        for index in range(len(provider_messages) - 1, -1, -1):
+            if provider_messages[index].get("role") == ConsoleMessageRole.USER.value:
+                final_index = index
+                break
+        if final_index is None:
+            return provider_messages
+
+        message = provider_messages[final_index]
+        content = message.get("content")
+        if isinstance(content, str) and content.startswith(COMMAND_PREFIX):
+            return provider_messages
+
+        try:
+            if isinstance(content, str):
+                new_content: Any = await asyncio.to_thread(applier, conversation_id, content)
+                if new_content == content:
+                    return provider_messages
+            elif isinstance(content, list):
+                new_parts: list[Any] = []
+                changed = False
+                for part in content:
+                    if (
+                        isinstance(part, dict)
+                        and part.get("type") == "text"
+                        and isinstance(part.get("text"), str)
+                    ):
+                        new_text = await asyncio.to_thread(applier, conversation_id, part["text"])
+                        if new_text != part["text"]:
+                            changed = True
+                            new_parts.append({**part, "text": new_text})
+                            continue
+                    new_parts.append(part)
+                if not changed:
+                    return provider_messages
+                new_content = new_parts
+            else:
+                return provider_messages
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            return provider_messages
+
+        new_messages = list(provider_messages)
+        new_messages[final_index] = {**message, "content": new_content}
+        return new_messages
+```
+
+- [ ] **Step 3c: Add the 4 call sites.** In each send method, immediately after the existing `if refuse is not None: return self._block(...)` (or `return …`) that follows `_apply_skill_substitution`, add the transform. Use the local session variable that already exists at each site:
+
+  - `submit_draft` (after the skill-sub refuse check, before `self._notify_submission_accepted()`):
+    ```python
+        provider_messages = await self._apply_chat_dictionaries(provider_messages, session.id)
+    ```
+  - `retry_message` (after `if refuse is not None: return self._block(session_id, refuse)`):
+    ```python
+        provider_messages = await self._apply_chat_dictionaries(provider_messages, session_id)
+    ```
+  - `continue_from_message` (after its skill-sub refuse check, before appending the assistant message):
+    ```python
+        provider_messages = await self._apply_chat_dictionaries(provider_messages, session_id)
+    ```
+  - `regenerate_message` (after its skill-sub refuse check):
+    ```python
+        provider_messages = await self._apply_chat_dictionaries(provider_messages, session_id)
+    ```
+
+- [ ] **Step 4: Run — PASS.**
+
+Run: `... -m pytest Tests/Chat/test_console_dictionary_application.py -q`
+Expected: 8 passed.
+
+Then the controller regression:
+`... -m pytest Tests/Chat/test_console_chat_controller.py Tests/Chat/test_console_skill_substitution.py Tests/Chat/test_console_variant_stream.py Tests/Chat/test_console_agent_swap.py -q`
+Expected: all pass.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add tldw_chatbook/Chat/console_chat_controller.py Tests/Chat/test_console_dictionary_application.py
+git commit -m "feat(console): apply conversation chat dictionaries to native send payload (all send paths)"
+```
+
+---
+
+## Task 3: `ChatScreen` applier injection + load-bearing integration test
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py` (two module-level constants; `_console_chat_dictionary_applier` method; `chat_dictionary_applier=` kwarg at the construction site in `_ensure_console_chat_controller`, ~`:2393`)
+- Test: `Tests/UI/test_console_dictionary_send_integration.py` (create)
+
+**Interfaces:**
+- Consumes: Task 1 `cdl.apply_active_chatdicts_to_text`; Task 2 `chat_dictionary_applier` constructor param; `self.app_instance.chachanotes_db`.
+- Produces: `ChatScreen._console_chat_dictionary_applier(conversation_id, text) -> str` (a sync callable passed to the controller).
+
+- [ ] **Step 1: Write the failing integration test.** Create `Tests/UI/test_console_dictionary_send_integration.py`:
+
+```python
+import pytest
+
+from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import ConsoleHarness
+from tldw_chatbook.Character_Chat import Chat_Dictionary_Lib as cdl
+from tldw_chatbook.Character_Chat.chat_dictionary_scope_service import ChatDictionaryScopeService
+from tldw_chatbook.Character_Chat.local_chat_dictionary_service import LocalChatDictionaryService
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+
+@pytest.fixture
+def dictionary_db(tmp_path):
+    db = CharactersRAGDB(tmp_path / "console_dict_send.db", "test-client")
+    yield db
+    db.close_connection()
+
+
+def _active_native_session(console):
+    store = console._ensure_console_chat_store()
+    return next(s for s in store.sessions() if s.id == store.active_session_id)
+
+
+class _CapturingGateway:
+    """Records the provider_messages the send would transmit; yields one chunk."""
+
+    def __init__(self):
+        self.captured = None
+
+    async def resolve_for_send(self, _selection):
+        class _R:
+            ready = True
+            visible_copy = ""
+        return _R()
+
+    async def stream_chat(self, _resolution, provider_messages):
+        self.captured = [dict(m) for m in provider_messages]
+        yield "ok"
+
+
+def _final_user_content(messages):
+    for message in reversed(messages):
+        if message.get("role") == ConsoleMessageRole.USER.value:
+            return message.get("content")
+    return None
+
+
+@pytest.mark.asyncio
+async def test_native_send_applies_conversation_dictionary_provider_branch(dictionary_db):
+    app = _build_test_app()
+    app.chachanotes_db = dictionary_db
+    app.chat_dictionary_scope_service = ChatDictionaryScopeService(
+        local_service=LocalChatDictionaryService(dictionary_db), server_service=None
+    )
+
+    conv_id = dictionary_db.add_conversation({"title": "Send flow"})
+    dict_id = cdl.save_chat_dictionary(
+        dictionary_db, "Slang", entries=[cdl.ChatDictionary(key="Warden", content="grim jailer")]
+    )
+    LocalChatDictionaryService(dictionary_db).attach_to_conversation(dict_id, conv_id)
+
+    async with ConsoleHarness(app).run_test(size=(180, 48)) as pilot:
+        screen = pilot.app.screen_stack[-1]
+        await _wait_for_selector(screen, pilot, "#console-native-composer")
+        _active_native_session(screen).persisted_conversation_id = conv_id
+
+        controller = screen._ensure_console_chat_controller()
+        gateway = _CapturingGateway()
+        controller.provider_gateway = gateway
+        controller._agent_runtime_enabled = False  # force the provider branch
+
+        result = await controller.submit_draft("The Warden nods.")
+        assert result.accepted
+
+        # Model received the SUBSTITUTED text...
+        assert _final_user_content(gateway.captured) == "The grim jailer nods."
+        # ...while the persisted transcript keeps the RAW text.
+        store = screen._ensure_console_chat_store()
+        stored = [m for m in store.messages_for_session(_active_native_session(screen).id)
+                  if m.role is ConsoleMessageRole.USER]
+        assert stored[-1].content == "The Warden nods."
+
+
+@pytest.mark.asyncio
+async def test_native_send_applies_conversation_dictionary_agent_branch(dictionary_db):
+    app = _build_test_app()
+    app.chachanotes_db = dictionary_db
+    app.chat_dictionary_scope_service = ChatDictionaryScopeService(
+        local_service=LocalChatDictionaryService(dictionary_db), server_service=None
+    )
+
+    conv_id = dictionary_db.add_conversation({"title": "Agent send"})
+    dict_id = cdl.save_chat_dictionary(
+        dictionary_db, "Slang", entries=[cdl.ChatDictionary(key="Warden", content="grim jailer")]
+    )
+    LocalChatDictionaryService(dictionary_db).attach_to_conversation(dict_id, conv_id)
+
+    async with ConsoleHarness(app).run_test(size=(180, 48)) as pilot:
+        screen = pilot.app.screen_stack[-1]
+        await _wait_for_selector(screen, pilot, "#console-native-composer")
+        _active_native_session(screen).persisted_conversation_id = conv_id
+
+        controller = screen._ensure_console_chat_controller()
+        gateway = _CapturingGateway()
+        controller.provider_gateway = gateway
+
+        captured = {}
+
+        def _fake_run_reply(*, agent_messages, assistant_message_id, **kwargs):
+            captured["agent_messages"] = [dict(m) for m in agent_messages]
+            from tldw_chatbook.Chat.console_chat_controller import ConsoleSubmitResult
+            store = screen._ensure_console_chat_store()
+            store.append_stream_chunk(assistant_message_id, "ok")
+            return ConsoleSubmitResult(True, False, "ok")
+
+        class _Bridge:
+            run_reply = staticmethod(_fake_run_reply)
+
+        controller._agent_bridge = _Bridge()
+        controller._agent_runtime_enabled = True
+
+        result = await controller.submit_draft("The Warden nods.")
+        assert result.accepted
+        assert _final_user_content(captured["agent_messages"]) == "The grim jailer nods."
+```
+
+Note: if `_fake_run_reply`'s signature or `ConsoleSubmitResult` construction does not match the real `ConsoleAgentBridge.run_reply` contract, mirror the fake used in `Tests/Chat/test_console_agent_swap.py` (the canonical agent-bridge double) instead — the load-bearing assertion is only that `agent_messages` carries the substituted text.
+
+- [ ] **Step 2: Run — expect FAIL.** With no applier injected, the model receives the raw text: `assert _final_user_content(...) == "The grim jailer nods."` fails (it equals `"The Warden nods."`).
+
+Run: `... -m pytest Tests/UI/test_console_dictionary_send_integration.py -q`
+
+- [ ] **Step 3a: Add constants.** Near the other module-level constants at the top of `chat_screen.py` (after imports), add:
+
+```python
+_CHATDICT_MAX_TOKENS = 500
+_CHATDICT_STRATEGY = "sorted_evenly"
+```
+
+- [ ] **Step 3b: Add the applier method.** Add to `ChatScreen` (near `_dictionary_scope_service` / the other P1g dictionary helpers):
+
+```python
+    def _console_chat_dictionary_applier(self, conversation_id: str | None, text: str) -> str:
+        """Bound applier handed to the native Console controller: apply the
+        active CONVERSATION chat dictionaries to a send's text (never raises).
+
+        Resolves the db lazily (at call time), so a controller built before the
+        db is ready still works. Conversation-only: ``char_data`` is ``None``
+        (native sessions carry no character card yet).
+        """
+        db = getattr(self.app_instance, "chachanotes_db", None)
+        if db is None or not conversation_id or not isinstance(text, str):
+            return text
+        from ...Character_Chat import Chat_Dictionary_Lib as cdl
+        return cdl.apply_active_chatdicts_to_text(
+            db,
+            conversation_id,
+            None,
+            text,
+            max_tokens=_CHATDICT_MAX_TOKENS,
+            strategy=_CHATDICT_STRATEGY,
+        )
+```
+
+- [ ] **Step 3c: Inject at the construction site.** In `_ensure_console_chat_controller` (`chat_screen.py`, the `ConsoleChatController(...)` call ~`:2369`-`:2393`), add after `skills_service=getattr(self.app_instance, "skills_scope_service", None),`:
+
+```python
+                chat_dictionary_applier=self._console_chat_dictionary_applier,
+```
+
+- [ ] **Step 4: Run — PASS.**
+
+Run: `... -m pytest Tests/UI/test_console_dictionary_send_integration.py -q`
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add tldw_chatbook/UI/Screens/chat_screen.py Tests/UI/test_console_dictionary_send_integration.py
+git commit -m "feat(console): wire native send to apply conversation dictionaries (ChatScreen applier)"
+```
+
+---
+
+## Task 4: Full gate + spec status
+
+**Files:**
+- Modify: `Docs/superpowers/specs/2026-07-16-roleplay-native-console-dict-apply-design.md` (status line)
+
+- [ ] **Step 1: Full gate.**
+
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Character_Chat/ Tests/Chat/test_chat_functions.py \
+  Tests/Chat/test_console_chat_controller.py Tests/Chat/test_console_skill_substitution.py \
+  Tests/Chat/test_console_variant_stream.py Tests/Chat/test_console_agent_swap.py \
+  Tests/Chat/test_console_dictionary_application.py \
+  Tests/Character_Chat/test_apply_active_chatdicts_to_text.py \
+  Tests/UI/test_console_dictionary_send_integration.py Tests/UI/test_console_native_chat_flow.py \
+  -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+
+Expected: all pass (record exact counts). Then the import smoke:
+
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -c "import tldw_chatbook.app; print('IMPORT OK')"
+```
+
+- [ ] **Step 2: Flip spec status** — `**Status:** Design approved (brainstorm), pending spec review.` → `**Status:** Implemented.`
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add Docs/superpowers/specs/2026-07-16-roleplay-native-console-dict-apply-design.md
+git commit -m "docs(roleplay): mark native Console dict-application spec implemented"
+```
+
+---
+
+## Notes for the executor
+
+- **Load-bearing tests** (do not accept a fake substitute): Task 1 real-DB substitution (attach a matching dict → text is substituted; no conv / no dicts / collect-raises → raw); Task 2 the off-loop assertion (`asyncio.to_thread`) and the ephemeral/no-mutation assertions; Task 3 the real-seam integration (a real `ChatScreen` + real DB + real controller, provider branch AND agent branch both receive the substituted text while the stored transcript keeps the raw text). These pin the two things the feature exists for: "shown = applied" on the native send, and "the transcript is never rewritten."
+- **Do not block the UI loop.** The transform must offload the applier via `asyncio.to_thread`; it must never call the synchronous applier directly on the event loop. (Native sends are async workers on that loop — `chat_screen.py:7983`.)
+- **Never break a send.** Both the lib primitive and the controller transform swallow ordinary exceptions and return the input unchanged; the controller transform must re-raise `asyncio.CancelledError`.
+- **Ephemeral only.** Assert (Task 3) that the stored `ConsoleChatStore` user message keeps the raw text after a send — the transform must never touch stored messages or mutate its input list/dicts.
+- **Scope.** Conversation dictionaries only (`char_data=None`); no character dicts, no diagnostics, no new toggle. Do not add config surfaces — use the `500` / `"sorted_evenly"` constants.
+```

--- a/Docs/superpowers/specs/2026-07-16-roleplay-native-console-dict-apply-design.md
+++ b/Docs/superpowers/specs/2026-07-16-roleplay-native-console-dict-apply-design.md
@@ -25,7 +25,8 @@ This cycle wires the native Console send to apply the same shared-resolver union
 - **Both branches covered pre-split.** `_stream_assistant_response` dispatches to `_run_agent_reply` (agent runtime) or the provider stream. The agent path splits the leading system message off `provider_messages` and forwards the rest as `agent_messages=` to `run_reply` (:994-1035). So a transform applied to `provider_messages` *before* `_stream_assistant_response` reaches both branches.
 - **Message content shape.** `_provider_message_payloads` emits a user turn's `content` as a **str** for text-only turns (:1327) and as a **parts list** (`{"type":"text","text":…}` + image parts) when the turn carries budgeted images (:1305); an over-budget image-only turn becomes a str placeholder (:1324).
 - **Controller has no db and no character.** Constructor deps include `store`, `provider_gateway`, `_skills_service`, `_agent_bridge` — no `chachanotes_db`. `session.persisted_conversation_id` is the DB conversation id (None for an unsaved session). `_agent_conversation_id()` returns `persisted_conversation_id or session_id` — the fallback is **not** a DB conversation and must not be used for dictionary lookup.
-- **Applier primitives.** `Chat_Dictionary_Lib.collect_active_chatdict_entries(db, conversation_id, char_data)` (never-raise union) + `process_user_input(text, entries, max_tokens, strategy) -> str` (never-raise text substitution). The legacy send uses `max_tokens=500`, `strategy="sorted_evenly"`.
+- **Applier primitives.** `Chat_Dictionary_Lib.collect_active_chatdict_entries(db, conversation_id, char_data) -> List[ChatDictionary]` (never-raise union) + `process_user_input(text, entries: List[ChatDictionary], max_tokens, strategy) -> str` (never-raise text substitution). The legacy send uses `max_tokens=500`, `strategy="sorted_evenly"`, and applies them on a `thread=True` worker (`chat_events.py:1258`).
+- **Native sends run on the UI event loop.** `_submit_console_native_draft` (and the retry/continue/regenerate handlers) are dispatched via `run_worker(<coroutine>, …)` — an **async** worker, NOT `thread=True` (`chat_screen.py:7983`), so it runs on the app's event loop. Any synchronous DB/CPU work in the send path therefore blocks the UI loop and must be offloaded (`asyncio.to_thread`). `collect_active_chatdict_entries` (DB read) + `process_user_input` (regex matching) are synchronous.
 - **Single construction site.** `ChatScreen` builds the controller once at `chat_screen.py:2369` (injecting `skills_service=`, `agent_bridge=`, …). `self.app_instance.chachanotes_db` is the db handle.
 - `COMMAND_PREFIX = "/"` (`console_command_grammar.py:25`).
 
@@ -39,11 +40,11 @@ Mirror the established skill-substitution pattern: a post-assembly, pre-stream t
 
 2. **`ConsoleChatController`** gains:
    - a constructor param `chat_dictionary_applier: Callable[[str | None, str], str] | None = None` (a bound `(conversation_id, text) -> substituted_text`), stored as `self._chat_dictionary_applier`. Presence is the enable gate (mirrors `_skills_service`).
-   - `_apply_chat_dictionaries(provider_messages, session_id) -> list[dict]` (new): returns `provider_messages` unchanged when no applier; resolves `conversation_id = <active session>.persisted_conversation_id` (None → unchanged); finds the final `role == "user"` message; **skips** if that message's pre-substitution content is a str starting with `COMMAND_PREFIX` (a skill command — leave the skill mechanism untouched); otherwise substitutes:
-     - **str content** → `applier(conversation_id, content)`;
-     - **parts list** → for each `{"type": "text"}` part, replace its `"text"` with `applier(conversation_id, part_text)`;
-     - writes the result into a **new** message dict (never mutates the stored message or the input dict) and returns a new list with only that message replaced.
-   - a call `provider_messages = self._apply_chat_dictionaries(provider_messages, session_id)` added at each of the 4 sites, immediately after the `if refuse is not None: return …` skill-substitution guard.
+   - `async _apply_chat_dictionaries(provider_messages, session_id) -> list[dict]` (new): returns `provider_messages` unchanged when no applier; resolves `conversation_id = <active session>.persisted_conversation_id` (None → unchanged); finds the final `role == "user"` message; **skips** if that message's pre-substitution content is a str starting with `COMMAND_PREFIX` (a skill command — leave the skill mechanism untouched); otherwise substitutes each substitutable text via `await asyncio.to_thread(self._chat_dictionary_applier, conversation_id, text)` — **offloaded** so the synchronous DB read + regex matching never block the UI event loop (native sends are async workers on that loop):
+     - **str content** → substitute the whole string;
+     - **parts list** → substitute each `{"type": "text"}` part's `"text"` (image parts untouched);
+     - writes the result into a **new** message dict (never mutates the stored message or the input dict) and returns a new list with only that message replaced. The message-shape logic (find final user message, command check, extract text, rebuild) is cheap and stays on the loop; only the applier call is offloaded.
+   - a call `provider_messages = await self._apply_chat_dictionaries(provider_messages, session_id)` added at each of the 4 sites, immediately after the `if refuse is not None: return …` skill-substitution guard.
 
 3. **`ChatScreen`** gains `_console_chat_dictionary_applier(conversation_id, text) -> str`: resolves `db = getattr(self.app_instance, "chachanotes_db", None)` **at call time**; returns `text` if `db is None` or `not conversation_id`; else `cdl.apply_active_chatdicts_to_text(db, conversation_id, None, text, max_tokens=_CHATDICT_MAX_TOKENS, strategy=_CHATDICT_STRATEGY)`. It is passed as `chat_dictionary_applier=self._console_chat_dictionary_applier` at the controller construction site. Constants `_CHATDICT_MAX_TOKENS = 500`, `_CHATDICT_STRATEGY = "sorted_evenly"` (legacy parity).
 
@@ -53,7 +54,7 @@ Mirror the established skill-substitution pattern: a post-assembly, pre-stream t
 stored messages (raw)
   → _provider_messages_for_session / _through_message   (assembly)
   → _apply_skill_substitution                            (existing; may refuse → abort)
-  → _apply_chat_dictionaries(provider_messages, session_id)   (NEW, ephemeral)
+  → await _apply_chat_dictionaries(provider_messages, session_id)   (NEW, ephemeral, applier offloaded via asyncio.to_thread)
         · conv_id = session.persisted_conversation_id  (None → no-op)
         · final user message: skip if "/command", else substitute str / text-parts
   → _stream_assistant_response
@@ -72,13 +73,13 @@ The stored transcript is never touched; only the ephemeral payload for this turn
 ### Error handling
 
 - `apply_active_chatdicts_to_text` and `_console_chat_dictionary_applier` never raise; any failure returns the raw text so a send always proceeds.
-- `_apply_chat_dictionaries` never mutates stored messages or the input list/dicts; it builds fresh copies.
+- `_apply_chat_dictionaries` catches any unexpected `Exception` (from the offloaded applier call or shape handling) and returns `provider_messages` unchanged — a dictionary problem must never break a send. It does **not** swallow `asyncio.CancelledError` (a Stop mid-send must still cancel the run). It never mutates stored messages or the input list/dicts; it builds fresh copies.
 - Unsaved session (`persisted_conversation_id is None`), missing db, or no attached dicts → the payload is returned unchanged.
 
 ## Testing
 
 - **Lib (`apply_active_chatdicts_to_text`), real DB:** a conversation with an attached dict whose pattern matches → substituted; no conversation / no attached dicts / conversation with a hostile (malformed) dict row → raw text returned; never raises.
-- **Controller (`_apply_chat_dictionaries`), fake applier:** final user message substituted (str content); text part of a **parts-list** content substituted while image parts are untouched; a `"/command"` final message left unchanged; earlier (non-final) user messages untouched; no applier / no `persisted_conversation_id` → unchanged; the stored `ConsoleChatStore` messages are unchanged after the transform; parametrized so the transform is exercised for `submit`/`retry`/`continue`/`regenerate` structure.
+- **Controller (`_apply_chat_dictionaries`), fake applier:** final user message substituted (str content); text part of a **parts-list** content substituted while image parts are untouched; a `"/command"` final message left unchanged; earlier (non-final) user messages untouched; no applier / no `persisted_conversation_id` → unchanged; the stored `ConsoleChatStore` messages are unchanged after the transform; the applier is invoked off the event loop (e.g. a fake applier that records its thread differs from the loop thread, or simply that a synchronous-blocking fake applier does not stall the run); parametrized so the transform is exercised for `submit`/`retry`/`continue`/`regenerate` structure.
 - **Integration (load-bearing), real `ChatScreen` + real DB + real controller:** attach a conversation dict via the P1g seam, submit a native draft whose text matches the dict pattern, and assert — through a fake `provider_gateway.stream_chat` capturing the payload — that the model received the **substituted** text while the stored transcript kept the **raw** text. Include a second assertion (or a sibling test) that the **agent** branch's `agent_messages` also carries the substituted text (both branches derive from the same post-transform `provider_messages`).
 
 ## Task shape

--- a/Docs/superpowers/specs/2026-07-16-roleplay-native-console-dict-apply-design.md
+++ b/Docs/superpowers/specs/2026-07-16-roleplay-native-console-dict-apply-design.md
@@ -1,0 +1,100 @@
+# Roleplay — Native Console send-path chat-dictionary application
+
+**Status:** Design approved (brainstorm), pending spec review.
+
+**Program:** Roleplay (Personas) redesign. Follow-up filed from P1g (#661).
+
+## Why
+
+The native Console send path applies **no** chat dictionaries. `collect_active_chatdict_entries` has exactly one caller — `Event_Handlers/Chat_Events/chat_events.py:981`, the **legacy** sidebar send. `ConsoleChatController.submit_draft` (and the agent bridge / provider gateway) never apply dictionaries. So dictionaries authored in Roleplay and attached via the P1g Console inspector show as "in play" but do **not** shape the actual model call on the native Console — the primary chat surface. The written `metadata.active_dictionaries` is correct and *does* apply if the conversation is opened in the legacy chat surface, but not in the Console itself.
+
+This cycle wires the native Console send to apply the same shared-resolver union the P1g summary shows, so **"shown = applied"** holds end-to-end on the surface users actually chat in.
+
+## Scope
+
+**In scope:** apply **conversation** chat dictionaries (`metadata.active_dictionaries`) on every native Console send path (fresh submit, retry, continue, regenerate), covering both the provider and agent-bridge branches. Substitution is **ephemeral** — the provider payload for that turn is transformed; the persisted transcript keeps the raw text (matching the legacy send and the existing skill-substitution behavior).
+
+**Deferred (explicitly out of scope):**
+- **Character** dictionaries on the native send. Native sessions carry only a free-text `character_label` (`console_session_settings.py:162`), never a character card/id, so `char_data` is always `None` and no character dicts resolve. Character-dict application on native sends requires native sessions to first *carry* a real character — its own later cycle. The applier keeps a `char_data` parameter (always `None` now) so that cycle plugs in without a rename.
+- **Per-send diagnostics** (which entries fired / near-misses). Application is silent; the P1g inspector "What's in play" remains the sole surfacing. A "Console dictionary diagnostics" surface can be a later cycle.
+- No new user-facing enable/disable toggle. Parity with the legacy send, which applies whenever entries exist.
+
+## Ground truths (verified at dev `7b227601`)
+
+- **Single seam.** `ConsoleChatController` builds `provider_messages` (from stored raw messages) then runs `_apply_skill_substitution(provider_messages)` at **4 sites**: `submit_draft` (:255), `retry_message` (:528), `continue_from_message` (:561), `regenerate_message` (:604). Each site has `session_id` (or `session.id`) in scope, checks `refuse`, then calls `_stream_assistant_response`.
+- **Both branches covered pre-split.** `_stream_assistant_response` dispatches to `_run_agent_reply` (agent runtime) or the provider stream. The agent path splits the leading system message off `provider_messages` and forwards the rest as `agent_messages=` to `run_reply` (:994-1035). So a transform applied to `provider_messages` *before* `_stream_assistant_response` reaches both branches.
+- **Message content shape.** `_provider_message_payloads` emits a user turn's `content` as a **str** for text-only turns (:1327) and as a **parts list** (`{"type":"text","text":…}` + image parts) when the turn carries budgeted images (:1305); an over-budget image-only turn becomes a str placeholder (:1324).
+- **Controller has no db and no character.** Constructor deps include `store`, `provider_gateway`, `_skills_service`, `_agent_bridge` — no `chachanotes_db`. `session.persisted_conversation_id` is the DB conversation id (None for an unsaved session). `_agent_conversation_id()` returns `persisted_conversation_id or session_id` — the fallback is **not** a DB conversation and must not be used for dictionary lookup.
+- **Applier primitives.** `Chat_Dictionary_Lib.collect_active_chatdict_entries(db, conversation_id, char_data)` (never-raise union) + `process_user_input(text, entries, max_tokens, strategy) -> str` (never-raise text substitution). The legacy send uses `max_tokens=500`, `strategy="sorted_evenly"`.
+- **Single construction site.** `ChatScreen` builds the controller once at `chat_screen.py:2369` (injecting `skills_service=`, `agent_bridge=`, …). `self.app_instance.chachanotes_db` is the db handle.
+- `COMMAND_PREFIX = "/"` (`console_command_grammar.py:25`).
+
+## Architecture
+
+Mirror the established skill-substitution pattern: a post-assembly, pre-stream transform on `provider_messages`, driven by an injected callable.
+
+### Components
+
+1. **`Chat_Dictionary_Lib.apply_active_chatdicts_to_text(db, conversation_id, char_data, text, *, max_tokens, strategy) -> str`** (new). Never-raise convenience: `entries = collect_active_chatdict_entries(db, conversation_id, char_data)`; if no entries, return `text` unchanged; else `return process_user_input(text, entries, max_tokens=max_tokens, strategy=strategy)`. Any exception → return the original `text`. `char_data` is accepted (always `None` from the native caller) for the deferred character cycle.
+
+2. **`ConsoleChatController`** gains:
+   - a constructor param `chat_dictionary_applier: Callable[[str | None, str], str] | None = None` (a bound `(conversation_id, text) -> substituted_text`), stored as `self._chat_dictionary_applier`. Presence is the enable gate (mirrors `_skills_service`).
+   - `_apply_chat_dictionaries(provider_messages, session_id) -> list[dict]` (new): returns `provider_messages` unchanged when no applier; resolves `conversation_id = <active session>.persisted_conversation_id` (None → unchanged); finds the final `role == "user"` message; **skips** if that message's pre-substitution content is a str starting with `COMMAND_PREFIX` (a skill command — leave the skill mechanism untouched); otherwise substitutes:
+     - **str content** → `applier(conversation_id, content)`;
+     - **parts list** → for each `{"type": "text"}` part, replace its `"text"` with `applier(conversation_id, part_text)`;
+     - writes the result into a **new** message dict (never mutates the stored message or the input dict) and returns a new list with only that message replaced.
+   - a call `provider_messages = self._apply_chat_dictionaries(provider_messages, session_id)` added at each of the 4 sites, immediately after the `if refuse is not None: return …` skill-substitution guard.
+
+3. **`ChatScreen`** gains `_console_chat_dictionary_applier(conversation_id, text) -> str`: resolves `db = getattr(self.app_instance, "chachanotes_db", None)` **at call time**; returns `text` if `db is None` or `not conversation_id`; else `cdl.apply_active_chatdicts_to_text(db, conversation_id, None, text, max_tokens=_CHATDICT_MAX_TOKENS, strategy=_CHATDICT_STRATEGY)`. It is passed as `chat_dictionary_applier=self._console_chat_dictionary_applier` at the controller construction site. Constants `_CHATDICT_MAX_TOKENS = 500`, `_CHATDICT_STRATEGY = "sorted_evenly"` (legacy parity).
+
+### Data flow (per send)
+
+```
+stored messages (raw)
+  → _provider_messages_for_session / _through_message   (assembly)
+  → _apply_skill_substitution                            (existing; may refuse → abort)
+  → _apply_chat_dictionaries(provider_messages, session_id)   (NEW, ephemeral)
+        · conv_id = session.persisted_conversation_id  (None → no-op)
+        · final user message: skip if "/command", else substitute str / text-parts
+  → _stream_assistant_response
+        ├─ provider branch: stream_chat(resolution, provider_messages)
+        └─ agent branch:    run_reply(agent_messages = provider_messages[1:])
+```
+
+The stored transcript is never touched; only the ephemeral payload for this turn changes.
+
+### Ordering / interaction
+
+- Dictionaries apply **after** skill substitution (the `/command` is already consumed/rendered), and are **skipped** entirely when the final user message is a skill command — so the two mechanisms never cross-contaminate.
+- On retry/regenerate/continue, `provider_messages` are rebuilt from the raw stored messages and re-substituted with the **currently** attached dictionaries. This is intentional (apply what is currently "in play"), idempotent given unchanged attachments, and consistent with the inspector summary.
+- On **continue** from an assistant message, `_ensure_user_continuation_instruction` (which runs before skill-substitution) appends a synthesized `CONSOLE_CONTINUE_INSTRUCTION` user message, so the "final user message" the transform targets is that synthesized instruction (there is no new user prose on a continue). This is the same message skill-substitution targets on continue, so the two transforms stay consistent; substituting into the ephemeral continuation instruction is acceptable (payload-only, never persisted). No special-casing of continue.
+
+### Error handling
+
+- `apply_active_chatdicts_to_text` and `_console_chat_dictionary_applier` never raise; any failure returns the raw text so a send always proceeds.
+- `_apply_chat_dictionaries` never mutates stored messages or the input list/dicts; it builds fresh copies.
+- Unsaved session (`persisted_conversation_id is None`), missing db, or no attached dicts → the payload is returned unchanged.
+
+## Testing
+
+- **Lib (`apply_active_chatdicts_to_text`), real DB:** a conversation with an attached dict whose pattern matches → substituted; no conversation / no attached dicts / conversation with a hostile (malformed) dict row → raw text returned; never raises.
+- **Controller (`_apply_chat_dictionaries`), fake applier:** final user message substituted (str content); text part of a **parts-list** content substituted while image parts are untouched; a `"/command"` final message left unchanged; earlier (non-final) user messages untouched; no applier / no `persisted_conversation_id` → unchanged; the stored `ConsoleChatStore` messages are unchanged after the transform; parametrized so the transform is exercised for `submit`/`retry`/`continue`/`regenerate` structure.
+- **Integration (load-bearing), real `ChatScreen` + real DB + real controller:** attach a conversation dict via the P1g seam, submit a native draft whose text matches the dict pattern, and assert — through a fake `provider_gateway.stream_chat` capturing the payload — that the model received the **substituted** text while the stored transcript kept the **raw** text. Include a second assertion (or a sibling test) that the **agent** branch's `agent_messages` also carries the substituted text (both branches derive from the same post-transform `provider_messages`).
+
+## Task shape
+
+One plan, ~4 tasks, no decomposition:
+1. `apply_active_chatdicts_to_text` lib function + real-DB tests.
+2. `ConsoleChatController` applier param + `_apply_chat_dictionaries` + 4 call sites + controller tests (fake applier).
+3. `ChatScreen` applier method + constants + injection at the construction site + load-bearing integration test.
+4. Full gate (Console + Character_Chat suites + import smoke) + flip spec status.
+
+## Acceptance criteria
+
+- [ ] A native Console send whose active session has an attached conversation dictionary sends the **substituted** text to the model (provider and agent branches), while the persisted transcript keeps the raw text.
+- [ ] Substitution applies on all four send paths (submit, retry, continue, regenerate).
+- [ ] Text part of an image+text (parts-list) user turn is substituted; image parts are untouched.
+- [ ] A `/command` final user message is not dict-substituted.
+- [ ] Unsaved session / no attached dicts / missing db / applier error → the send proceeds with unchanged text (never raises).
+- [ ] Character dictionaries are not applied (deferred), and no per-send diagnostic surface is added.
+- [ ] Full gate suite green; `import tldw_chatbook.app` OK.

--- a/Docs/superpowers/specs/2026-07-16-roleplay-native-console-dict-apply-design.md
+++ b/Docs/superpowers/specs/2026-07-16-roleplay-native-console-dict-apply-design.md
@@ -1,6 +1,6 @@
 # Roleplay — Native Console send-path chat-dictionary application
 
-**Status:** Design approved (brainstorm), pending spec review.
+**Status:** Implemented.
 
 **Program:** Roleplay (Personas) redesign. Follow-up filed from P1g (#661).
 

--- a/Tests/Character_Chat/test_apply_active_chatdicts_to_text.py
+++ b/Tests/Character_Chat/test_apply_active_chatdicts_to_text.py
@@ -1,0 +1,64 @@
+import pytest
+
+from tldw_chatbook.Character_Chat import Chat_Dictionary_Lib as cdl
+from tldw_chatbook.Character_Chat.local_chat_dictionary_service import LocalChatDictionaryService
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    database = CharactersRAGDB(tmp_path / "apply_chatdicts.db", "test-client")
+    yield database
+    database.close_connection()
+
+
+def _attach_matching_dict(db, conv_id, name="Slang", key="Warden", content="grim jailer"):
+    dict_id = cdl.save_chat_dictionary(
+        db, name, entries=[cdl.ChatDictionary(key=key, content=content)]
+    )
+    assert dict_id is not None
+    LocalChatDictionaryService(db).attach_to_conversation(dict_id, conv_id)
+    return dict_id
+
+
+def test_applies_attached_conversation_dictionary(db):
+    conv_id = db.add_conversation({"title": "Attach"})
+    _attach_matching_dict(db, conv_id)
+    out = cdl.apply_active_chatdicts_to_text(
+        db, conv_id, None, "The Warden nods.", max_tokens=500, strategy="sorted_evenly"
+    )
+    assert out == "The grim jailer nods."
+
+
+def test_no_conversation_returns_text_unchanged(db):
+    out = cdl.apply_active_chatdicts_to_text(
+        db, None, None, "The Warden nods.", max_tokens=500, strategy="sorted_evenly"
+    )
+    assert out == "The Warden nods."
+
+
+def test_conversation_without_dicts_returns_text_unchanged(db):
+    conv_id = db.add_conversation({"title": "Empty"})
+    out = cdl.apply_active_chatdicts_to_text(
+        db, conv_id, None, "The Warden nods.", max_tokens=500, strategy="sorted_evenly"
+    )
+    assert out == "The Warden nods."
+
+
+def test_non_string_text_returned_unchanged(db):
+    conv_id = db.add_conversation({"title": "T"})
+    _attach_matching_dict(db, conv_id)
+    sentinel = ["not", "a", "string"]
+    assert cdl.apply_active_chatdicts_to_text(db, conv_id, None, sentinel) is sentinel
+
+
+def test_never_raises_when_collect_fails(db, monkeypatch):
+    conv_id = db.add_conversation({"title": "T"})
+    _attach_matching_dict(db, conv_id)
+
+    def _boom(*a, **k):
+        raise RuntimeError("collect exploded")
+
+    monkeypatch.setattr(cdl, "collect_active_chatdict_entries", _boom)
+    out = cdl.apply_active_chatdicts_to_text(db, conv_id, None, "The Warden nods.")
+    assert out == "The Warden nods."

--- a/Tests/Chat/test_console_dictionary_application.py
+++ b/Tests/Chat/test_console_dictionary_application.py
@@ -1,0 +1,142 @@
+import threading
+
+import pytest
+
+from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+
+
+class _Gateway:
+    async def resolve_for_send(self, _selection):
+        class _R:
+            ready = True
+            visible_copy = ""
+        return _R()
+
+    async def stream_chat(self, _resolution, _messages):
+        if False:
+            yield ""
+
+
+def _controller(applier):
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=_Gateway(),
+        provider="llama_cpp",
+        model="test-model",
+        chat_dictionary_applier=applier,
+    )
+    return controller, store
+
+
+def _session_with_conv(store, conv_id="conv-1"):
+    session = store.create_session(title="t")
+    session.persisted_conversation_id = conv_id
+    return session
+
+
+def _warden(conv_id, text):
+    return text.replace("Warden", "grim jailer")
+
+
+@pytest.mark.asyncio
+async def test_substitutes_final_user_string(warden_applier=_warden):
+    controller, store = _controller(warden_applier)
+    session = _session_with_conv(store)
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": ConsoleMessageRole.USER.value, "content": "The Warden nods."},
+    ]
+    out = await controller._apply_chat_dictionaries(messages, session.id)
+    assert out[-1]["content"] == "The grim jailer nods."
+    # Input list/dicts untouched (fresh copies only).
+    assert messages[-1]["content"] == "The Warden nods."
+
+
+@pytest.mark.asyncio
+async def test_substitutes_text_part_of_parts_list_leaving_images():
+    controller, store = _controller(_warden)
+    session = _session_with_conv(store)
+    image_part = {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}
+    messages = [
+        {
+            "role": ConsoleMessageRole.USER.value,
+            "content": [{"type": "text", "text": "The Warden nods."}, image_part],
+        }
+    ]
+    out = await controller._apply_chat_dictionaries(messages, session.id)
+    parts = out[-1]["content"]
+    assert parts[0] == {"type": "text", "text": "The grim jailer nods."}
+    assert parts[1] is image_part
+
+
+@pytest.mark.asyncio
+async def test_skips_skill_command_message():
+    controller, store = _controller(_warden)
+    session = _session_with_conv(store)
+    messages = [{"role": ConsoleMessageRole.USER.value, "content": "/Warden do a thing"}]
+    out = await controller._apply_chat_dictionaries(messages, session.id)
+    assert out[-1]["content"] == "/Warden do a thing"
+
+
+@pytest.mark.asyncio
+async def test_only_final_user_message_substituted():
+    controller, store = _controller(_warden)
+    session = _session_with_conv(store)
+    messages = [
+        {"role": ConsoleMessageRole.USER.value, "content": "The Warden earlier."},
+        {"role": "assistant", "content": "ok"},
+        {"role": ConsoleMessageRole.USER.value, "content": "The Warden now."},
+    ]
+    out = await controller._apply_chat_dictionaries(messages, session.id)
+    assert out[0]["content"] == "The Warden earlier."
+    assert out[-1]["content"] == "The grim jailer now."
+
+
+@pytest.mark.asyncio
+async def test_no_applier_returns_input_unchanged():
+    controller, store = _controller(None)
+    session = _session_with_conv(store)
+    messages = [{"role": ConsoleMessageRole.USER.value, "content": "The Warden nods."}]
+    out = await controller._apply_chat_dictionaries(messages, session.id)
+    assert out[-1]["content"] == "The Warden nods."
+
+
+@pytest.mark.asyncio
+async def test_unsaved_session_returns_input_unchanged():
+    controller, store = _controller(_warden)
+    session = store.create_session(title="t")  # persisted_conversation_id stays None
+    messages = [{"role": ConsoleMessageRole.USER.value, "content": "The Warden nods."}]
+    out = await controller._apply_chat_dictionaries(messages, session.id)
+    assert out[-1]["content"] == "The Warden nods."
+
+
+@pytest.mark.asyncio
+async def test_applier_runs_off_the_event_loop():
+    loop_thread = threading.get_ident()
+    seen = {}
+
+    def _recording_applier(conv_id, text):
+        seen["thread"] = threading.get_ident()
+        return text.replace("Warden", "grim jailer")
+
+    controller, store = _controller(_recording_applier)
+    session = _session_with_conv(store)
+    messages = [{"role": ConsoleMessageRole.USER.value, "content": "The Warden nods."}]
+    out = await controller._apply_chat_dictionaries(messages, session.id)
+    assert out[-1]["content"] == "The grim jailer nods."
+    assert seen["thread"] != loop_thread  # offloaded via asyncio.to_thread
+
+
+@pytest.mark.asyncio
+async def test_applier_exception_returns_input_unchanged():
+    def _boom(conv_id, text):
+        raise RuntimeError("applier exploded")
+
+    controller, store = _controller(_boom)
+    session = _session_with_conv(store)
+    messages = [{"role": ConsoleMessageRole.USER.value, "content": "The Warden nods."}]
+    out = await controller._apply_chat_dictionaries(messages, session.id)
+    assert out[-1]["content"] == "The Warden nods."

--- a/Tests/UI/test_console_dictionary_send_integration.py
+++ b/Tests/UI/test_console_dictionary_send_integration.py
@@ -1,0 +1,149 @@
+"""Load-bearing integration test: the native Console send path applies the
+active CONVERSATION chat dictionaries to the model-bound payload while the
+persisted transcript keeps the raw text (Roleplay P1h Task 3).
+
+Exercises the real ``ChatScreen`` -> ``_ensure_console_chat_controller`` wiring
+(``chat_dictionary_applier=self._console_chat_dictionary_applier``) end to
+end: a real ``CharactersRAGDB`` + ``ChatDictionaryScopeService`` seeded with a
+conversation-attached dictionary (the P1e attach seam), a native session
+pinned to that conversation, and a capturing double standing in for the
+provider/agent transport so the actual outbound payload can be inspected.
+"""
+import pytest
+
+from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import ConsoleHarness
+from tldw_chatbook.Character_Chat import Chat_Dictionary_Lib as cdl
+from tldw_chatbook.Character_Chat.chat_dictionary_scope_service import ChatDictionaryScopeService
+from tldw_chatbook.Character_Chat.local_chat_dictionary_service import LocalChatDictionaryService
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+
+@pytest.fixture
+def dictionary_db(tmp_path):
+    db = CharactersRAGDB(tmp_path / "console_dict_send.db", "test-client")
+    yield db
+    db.close_connection()
+
+
+def _active_native_session(console):
+    store = console._ensure_console_chat_store()
+    return next(s for s in store.sessions() if s.id == store.active_session_id)
+
+
+class _CapturingGateway:
+    """Records the provider_messages the send would transmit; yields one chunk."""
+
+    def __init__(self):
+        self.captured = None
+
+    async def resolve_for_send(self, _selection):
+        class _R:
+            ready = True
+            visible_copy = ""
+        return _R()
+
+    async def stream_chat(self, _resolution, provider_messages):
+        self.captured = [dict(m) for m in provider_messages]
+        yield "ok"
+
+
+def _final_user_content(messages):
+    for message in reversed(messages):
+        if message.get("role") == ConsoleMessageRole.USER.value:
+            return message.get("content")
+    return None
+
+
+@pytest.mark.asyncio
+async def test_native_send_applies_conversation_dictionary_provider_branch(dictionary_db):
+    app = _build_test_app()
+    app.chachanotes_db = dictionary_db
+    app.chat_dictionary_scope_service = ChatDictionaryScopeService(
+        local_service=LocalChatDictionaryService(dictionary_db), server_service=None
+    )
+
+    conv_id = dictionary_db.add_conversation({"title": "Send flow"})
+    dict_id = cdl.save_chat_dictionary(
+        dictionary_db, "Slang", entries=[cdl.ChatDictionary(key="Warden", content="grim jailer")]
+    )
+    LocalChatDictionaryService(dictionary_db).attach_to_conversation(dict_id, conv_id)
+
+    async with ConsoleHarness(app).run_test(size=(180, 48)) as pilot:
+        screen = pilot.app.screen_stack[-1]
+        await _wait_for_selector(screen, pilot, "#console-native-composer")
+        _active_native_session(screen).persisted_conversation_id = conv_id
+
+        controller = screen._ensure_console_chat_controller()
+        gateway = _CapturingGateway()
+        controller.provider_gateway = gateway
+        controller._agent_runtime_enabled = False  # force the provider branch
+
+        result = await controller.submit_draft("The Warden nods.")
+        assert result.accepted
+
+        # Model received the SUBSTITUTED text...
+        assert _final_user_content(gateway.captured) == "The grim jailer nods."
+        # ...while the persisted transcript keeps the RAW text.
+        store = screen._ensure_console_chat_store()
+        stored = [m for m in store.messages_for_session(_active_native_session(screen).id)
+                  if m.role is ConsoleMessageRole.USER]
+        assert stored[-1].content == "The Warden nods."
+
+
+@pytest.mark.asyncio
+async def test_native_send_applies_conversation_dictionary_agent_branch(dictionary_db):
+    app = _build_test_app()
+    app.chachanotes_db = dictionary_db
+    app.chat_dictionary_scope_service = ChatDictionaryScopeService(
+        local_service=LocalChatDictionaryService(dictionary_db), server_service=None
+    )
+
+    conv_id = dictionary_db.add_conversation({"title": "Agent send"})
+    dict_id = cdl.save_chat_dictionary(
+        dictionary_db, "Slang", entries=[cdl.ChatDictionary(key="Warden", content="grim jailer")]
+    )
+    LocalChatDictionaryService(dictionary_db).attach_to_conversation(dict_id, conv_id)
+
+    async with ConsoleHarness(app).run_test(size=(180, 48)) as pilot:
+        screen = pilot.app.screen_stack[-1]
+        await _wait_for_selector(screen, pilot, "#console-native-composer")
+        _active_native_session(screen).persisted_conversation_id = conv_id
+
+        controller = screen._ensure_console_chat_controller()
+        gateway = _CapturingGateway()
+        controller.provider_gateway = gateway
+
+        captured = {}
+
+        # Mirrors the real `ConsoleAgentBridge.run_reply` contract (see
+        # `Tests/Chat/test_console_agent_swap.py`'s canonical double): the
+        # brief's originally sketched fake returned a `ConsoleSubmitResult`
+        # directly, but `_run_agent_reply` (console_chat_controller.py)
+        # awaits `asyncio.to_thread(self._agent_bridge.run_reply, ...)` and
+        # feeds the RETURN VALUE into `_finalize_agent_reply`, which reads
+        # `outcome.status` against `RunOutcome`'s `RUN_DONE`/`RUN_CANCELLED`
+        # sentinels -- not a `ConsoleSubmitResult`. This fake appends the
+        # streamed content to the store itself (as the real bridge does
+        # internally) and returns a `RunOutcome(status=RUN_DONE, ...)` so
+        # `_finalize_agent_reply`'s success path (`store.mark_message_complete`)
+        # runs unmodified against a real placeholder message.
+        def _fake_run_reply(*, conversation_id, session_id, resolution, assistant_message_id,
+                             model, session_system_prompt, agent_messages, should_cancel,
+                             supersede_previous=False):
+            captured["agent_messages"] = [dict(m) for m in agent_messages]
+            from tldw_chatbook.Agents.agent_models import RunOutcome, RUN_DONE
+            store = screen._ensure_console_chat_store()
+            store.append_stream_chunk(assistant_message_id, "ok")
+            return RunOutcome(status=RUN_DONE, steps=[])
+
+        class _Bridge:
+            run_reply = staticmethod(_fake_run_reply)
+
+        controller._agent_bridge = _Bridge()
+        controller._agent_runtime_enabled = True
+
+        result = await controller.submit_draft("The Warden nods.")
+        assert result.accepted
+        assert _final_user_content(captured["agent_messages"]) == "The grim jailer nods."

--- a/tldw_chatbook/Character_Chat/Chat_Dictionary_Lib.py
+++ b/tldw_chatbook/Character_Chat/Chat_Dictionary_Lib.py
@@ -1241,6 +1241,37 @@ def collect_active_chatdict_entries(
     return entries
 
 
+def apply_active_chatdicts_to_text(
+    db: "CharactersRAGDB",
+    conversation_id: Optional[str],
+    char_data: Optional[Dict[str, Any]],
+    text: str,
+    *,
+    max_tokens: int = 500,
+    strategy: str = "sorted_evenly",
+) -> str:
+    """Apply the active chat dictionaries to ``text`` for a send (never raises).
+
+    Collects the dictionary union that applies to ``conversation_id`` (+
+    ``char_data``, always ``None`` for the native Console today) and runs the
+    standard ``process_user_input`` substitution. Returns ``text`` unchanged
+    when it is not a string, no dictionaries apply, or anything fails -- a
+    dictionary problem must never break a chat send.
+    """
+    if not isinstance(text, str):
+        return text
+    try:
+        entries = collect_active_chatdict_entries(db, conversation_id, char_data)
+        if not entries:
+            return text
+        return process_user_input(text, entries, max_tokens=max_tokens, strategy=strategy)
+    except Exception:
+        logger.opt(exception=True).warning(
+            "apply_active_chatdicts_to_text failed; returning text unmodified."
+        )
+        return text
+
+
 def summarize_active_dictionaries(
     db: "CharactersRAGDB",
     conversation_id: Optional[str],

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -146,6 +146,7 @@ class ConsoleChatController:
         agent_runtime_enabled: bool = True,
         skills_service: Any | None = None,
         skill_substitution_enabled: bool = True,
+        chat_dictionary_applier: "Callable[[str | None, str], str] | None" = None,
     ) -> None:
         self.store = store
         self.provider_gateway = provider_gateway
@@ -172,6 +173,7 @@ class ConsoleChatController:
         self._agent_runtime_enabled = agent_runtime_enabled
         self._skills_service = skills_service
         self._skill_substitution_enabled = skill_substitution_enabled
+        self._chat_dictionary_applier = chat_dictionary_applier
         self.run_state = ConsoleRunState()
         self.run_state_history: list[ConsoleRunStatus] = [self.run_state.status]
         #: Optional owner hook invoked once a submit is accepted (user message
@@ -255,6 +257,7 @@ class ConsoleChatController:
         provider_messages, refuse = await self._apply_skill_substitution(provider_messages)
         if refuse is not None:
             return self._block(session.id, refuse)
+        provider_messages = await self._apply_chat_dictionaries(provider_messages, session.id)
         # The accepted-hook fires only once the turn is confirmed to
         # actually proceed (Qodo finding 3, PR #636 bot review): it used to
         # fire right after the USER row was appended, BEFORE this skill
@@ -528,6 +531,7 @@ class ConsoleChatController:
         provider_messages, refuse = await self._apply_skill_substitution(provider_messages)
         if refuse is not None:
             return self._block(session_id, refuse)
+        provider_messages = await self._apply_chat_dictionaries(provider_messages, session_id)
         return await self._stream_assistant_response(
             resolution=resolution,
             provider_messages=provider_messages,
@@ -561,6 +565,7 @@ class ConsoleChatController:
         provider_messages, refuse = await self._apply_skill_substitution(provider_messages)
         if refuse is not None:
             return self._block(session_id, refuse)
+        provider_messages = await self._apply_chat_dictionaries(provider_messages, session_id)
         assistant = self.store.append_message(
             session_id,
             role=ConsoleMessageRole.ASSISTANT,
@@ -604,6 +609,7 @@ class ConsoleChatController:
         provider_messages, refuse = await self._apply_skill_substitution(provider_messages)
         if refuse is not None:
             return self._block(session_id, refuse)
+        provider_messages = await self._apply_chat_dictionaries(provider_messages, session_id)
         return await self._stream_assistant_response(
             resolution=resolution,
             provider_messages=provider_messages,
@@ -738,6 +744,76 @@ class ConsoleChatController:
         new_messages = list(provider_messages)
         new_messages[final_index] = rendered_message
         return new_messages, None
+
+    async def _apply_chat_dictionaries(
+        self, provider_messages: list[dict[str, Any]], session_id: str
+    ) -> list[dict[str, Any]]:
+        """Apply the active conversation chat dictionaries to the final user
+        message of the ephemeral provider payload (never the stored transcript).
+
+        Mirrors `_apply_skill_substitution` (final `role == "user"` message
+        only, one rule for fresh sends AND retry/continue/regenerate). The
+        synchronous DB read + regex substitution are offloaded via
+        `asyncio.to_thread` because native sends run as async workers on the UI
+        event loop. Skill commands are left untouched. Any failure returns the
+        payload unchanged so a dictionary problem can never break a send;
+        `asyncio.CancelledError` is re-raised so a mid-send Stop still cancels.
+        """
+        applier = self._chat_dictionary_applier
+        if applier is None:
+            return provider_messages
+
+        session = next((s for s in self.store.sessions() if s.id == session_id), None)
+        conversation_id = session.persisted_conversation_id if session is not None else None
+        if not conversation_id:
+            return provider_messages
+
+        final_index: int | None = None
+        for index in range(len(provider_messages) - 1, -1, -1):
+            if provider_messages[index].get("role") == ConsoleMessageRole.USER.value:
+                final_index = index
+                break
+        if final_index is None:
+            return provider_messages
+
+        message = provider_messages[final_index]
+        content = message.get("content")
+        if isinstance(content, str) and content.startswith(COMMAND_PREFIX):
+            return provider_messages
+
+        try:
+            if isinstance(content, str):
+                new_content: Any = await asyncio.to_thread(applier, conversation_id, content)
+                if new_content == content:
+                    return provider_messages
+            elif isinstance(content, list):
+                new_parts: list[Any] = []
+                changed = False
+                for part in content:
+                    if (
+                        isinstance(part, dict)
+                        and part.get("type") == "text"
+                        and isinstance(part.get("text"), str)
+                    ):
+                        new_text = await asyncio.to_thread(applier, conversation_id, part["text"])
+                        if new_text != part["text"]:
+                            changed = True
+                            new_parts.append({**part, "text": new_text})
+                            continue
+                    new_parts.append(part)
+                if not changed:
+                    return provider_messages
+                new_content = new_parts
+            else:
+                return provider_messages
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            return provider_messages
+
+        new_messages = list(provider_messages)
+        new_messages[final_index] = {**message, "content": new_content}
+        return new_messages
 
     @staticmethod
     def _skill_candidates_from_context(

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -320,6 +320,10 @@ CONSOLE_SKILL_NEEDS_REVIEW_HINT_TEMPLATE = (
 CONSOLE_PROVIDER_CONFIGURE_API_KEY_LABEL = "Set up provider"
 CONSOLE_PROVIDER_ACTION_ARROW = " ---------------------->"
 NATIVE_CONSOLE_STATE_VERSION = "1.0"
+# Roleplay P1h: bounds passed to `Chat_Dictionary_Lib.apply_active_chatdicts_to_text`
+# for the native Console send-path applier (`_console_chat_dictionary_applier`).
+_CHATDICT_MAX_TOKENS = 500
+_CHATDICT_STRATEGY = "sorted_evenly"
 # Statuses during which the 0.2s transcript poll is actively ticking
 # (see `_start_console_transcript_sync_timer`) -- also used by the
 # sub-agent badge-count cache (Finding A) to decide whether a live run
@@ -2391,6 +2395,7 @@ class ChatScreen(BaseAppScreen):
                 agent_bridge=self._ensure_console_agent_bridge(),
                 agent_runtime_enabled=self._console_agent_runtime_enabled(),
                 skills_service=getattr(self.app_instance, "skills_scope_service", None),
+                chat_dictionary_applier=self._console_chat_dictionary_applier,
             )
         self._console_chat_controller.on_submission_accepted = (
             self._on_console_submission_accepted
@@ -5102,6 +5107,27 @@ class ChatScreen(BaseAppScreen):
     def _dictionary_scope_service(self) -> Any:
         """The app-level chat-dictionary scope service, or None when absent."""
         return getattr(self.app_instance, "chat_dictionary_scope_service", None)
+
+    def _console_chat_dictionary_applier(self, conversation_id: str | None, text: str) -> str:
+        """Bound applier handed to the native Console controller: apply the
+        active CONVERSATION chat dictionaries to a send's text (never raises).
+
+        Resolves the db lazily (at call time), so a controller built before the
+        db is ready still works. Conversation-only: ``char_data`` is ``None``
+        (native sessions carry no character card yet).
+        """
+        db = getattr(self.app_instance, "chachanotes_db", None)
+        if db is None or not conversation_id or not isinstance(text, str):
+            return text
+        from ...Character_Chat import Chat_Dictionary_Lib as cdl
+        return cdl.apply_active_chatdicts_to_text(
+            db,
+            conversation_id,
+            None,
+            text,
+            max_tokens=_CHATDICT_MAX_TOKENS,
+            strategy=_CHATDICT_STRATEGY,
+        )
 
     def _active_console_dictionary_scope_ids(self) -> tuple[str | None, int | None]:
         """Return (conversation_id, character_id) for the active native


### PR DESCRIPTION
## Roleplay — native Console send-path chat-dictionary application

Closes the "shown ≠ applied" gap P1g exposed: the **native** Console send now applies the conversation chat dictionaries the P1g inspector shows. Before this branch, `collect_active_chatdict_entries` had a single caller — the *legacy* sidebar send — so dictionaries attached via the Console inspector showed as "in play" but never shaped the native send (the primary chat surface).

Branch off dev `7b227601`. 4 TDD tasks; per-task reviews + an opus whole-branch review → **APPROVE, 0 findings**. Purely additive (3 source files, zero deletions). No schema migration (stays v20).

### What shipped
- **`Chat_Dictionary_Lib.apply_active_chatdicts_to_text`** — never-raise substitution primitive (`collect_active_chatdict_entries` + `process_user_input`); returns the text unchanged on non-str / no-conversation / no-dicts / any error.
- **`ConsoleChatController._apply_chat_dictionaries`** — a transform on the ephemeral `provider_messages`, added at all 4 send sites (submit / retry / continue / regenerate), right after `_apply_skill_substitution`. Runs before the agent/provider split, so both branches are covered. Offloads the synchronous DB read + regex matching via `asyncio.to_thread` (native sends are async workers on the UI event loop). Substitutes the final user message's str content, or the text part(s) of a multimodal parts-list (image parts untouched); skips `/command` messages; never mutates stored messages or its input; re-raises `CancelledError` but swallows other errors so a dictionary problem can never break a send.
- **`ChatScreen`** — injects a lazy, db-bound applier (`_console_chat_dictionary_applier`, `char_data=None` — conversation-only) at the single controller construction site; constants `500` / `"sorted_evenly"` (legacy parity).

### Invariants (verified in review)
- **Shown = applied** — the model receives the substituted text via the same shared union the inspector shows.
- **Ephemeral** — the persisted transcript keeps the raw user text; only the provider payload for the turn is transformed.
- **Never break a send** — applier + transform never raise (except `CancelledError`, which propagates so Stop still cancels).
- **Off the UI loop** — the applier is offloaded via `asyncio.to_thread`.

### Scope / deferred
Conversation dictionaries only (native sessions carry no character card → `char_data=None`). **Character**-dict application on native sends and **per-send diagnostics** stay deferred (own later cycles); silent application, no new toggle.

### Tests
Load-bearing integration test (real `ChatScreen` + real DB + real controller): attach a conversation dict via the P1e seam, submit a native draft, assert the captured provider payload (and the agent branch's `agent_messages`) carries the **substituted** text while the stored transcript keeps the **raw** text; RED verified by the reviewer (removing the injection fails both branches). Full gate **334 passed**; `import tldw_chatbook.app` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Native Console sends now apply conversation chat dictionaries to the outgoing model payload, matching what the inspector shows. The stored transcript stays raw; this runs on submit, retry, continue, and regenerate across both provider and agent paths.

- **New Features**
  - Added `apply_active_chatdicts_to_text` in `Chat_Dictionary_Lib` (never raises; returns input on non-str/no-dicts/errors; uses `max_tokens=500`, `strategy="sorted_evenly"`).
  - `ConsoleChatController`: new `chat_dictionary_applier` param and `_apply_chat_dictionaries` transform; substitutes the final user message (string or text parts), skips `/command`, never mutates inputs, offloads via `asyncio.to_thread`, re-raises `CancelledError`; applied at all four send sites before the agent/provider split.
  - `ChatScreen`: injects `_console_chat_dictionary_applier` (lazy DB lookup; conversation-only) into the controller so dictionaries shown in the inspector are applied on native sends.

<sup>Written for commit 2b34f36766789459b9fd53703065c0cbff2a17cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

