### PR TITLE
feat(rag): make Library RAG Answer mode functional end-to-end (task-249)

### DIFF
--- a/Tests/Library/test_library_local_rag_search_service.py
+++ b/Tests/Library/test_library_local_rag_search_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import sqlite3
 from types import SimpleNamespace
 
@@ -11,6 +12,7 @@ from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
 from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
 from tldw_chatbook.DB.Prompts_DB import PromptsDatabase
 from tldw_chatbook.Library.library_fts_query import build_fts_match_query, expand_keyword_term
+from tldw_chatbook.Library import library_local_rag_search_service as rag_service_module
 from tldw_chatbook.Library.library_local_rag_search_service import (
     LibraryLocalRagSearchService,
     _prompt_row,
@@ -404,9 +406,18 @@ async def test_all_seams_missing_returns_blocked_outcome():
     assert result.recovery_state.stable_selector == "library-rag-service-error"
 
 
-# (d) rag mode with _rag_service=None -> blocked outcome; next_action mentions switching to Search.
+# (d) AC #3 (task-249): rag mode without a runtime AND without embeddings deps
+# keeps the existing "RAG unavailable" recovery state routing to setup, and
+# never touches the shared-service factory (the deps gate short-circuits
+# before any heavy work).
 @pytest.mark.asyncio
-async def test_rag_mode_without_rag_service_returns_blocked_outcome():
+async def test_rag_mode_without_deps_returns_blocked_outcome_and_skips_factory(monkeypatch):
+    monkeypatch.setattr(rag_service_module, "embeddings_rag_deps_installed", lambda: False)
+
+    def _fail_factory(*args, **kwargs):
+        raise AssertionError("get_shared_rag_service must not run when deps are missing")
+
+    monkeypatch.setattr(rag_service_module, "get_shared_rag_service", _fail_factory)
     app = SimpleNamespace(_rag_service=None)
     service = LibraryLocalRagSearchService(app)
 
@@ -418,6 +429,7 @@ async def test_rag_mode_without_rag_service_returns_blocked_outcome():
     assert result.recovery_state.status_label == "RAG unavailable"
     assert "switch mode to Search" in result.recovery_state.next_action
     assert result.recovery_state.recovery_action == "Settings > RAG"
+    assert getattr(app, "_rag_service", None) is None
 
 
 # (e) scope filtering: scope=("notes",) never touches the media fake.
@@ -646,6 +658,227 @@ async def test_rag_mode_delegates_and_maps_results():
     assert row["provenance"]["source_type"] == "note"
 
 
+# --- task-249: rag mode initializes the RAG runtime lazily -----------------
+
+
+class FakeVectorStore:
+    """Mirrors the VectorStore stats seam used for empty-index detection."""
+
+    def __init__(self, stats=None, error: Exception | None = None):
+        self.stats = stats if stats is not None else {"count": 0}
+        self.error = error
+        self.calls = 0
+
+    def get_collection_stats(self):
+        self.calls += 1
+        if self.error is not None:
+            raise self.error
+        return self.stats
+
+
+_SEMANTIC_RESULT = {
+    "id": "chunk-1",
+    "score": 0.87,
+    "document": "Rotate the credential immediately.",
+    "metadata": {"title": "Runbook", "source_id": "note-1", "source_type": "note"},
+}
+
+
+# AC #1: rag mode with deps installed and no app._rag_service initializes the
+# runtime through the shared factory instead of returning the RAG-unavailable
+# recovery state, and caches it on the app for subsequent queries/gates.
+@pytest.mark.asyncio
+async def test_rag_mode_lazily_initializes_shared_runtime(monkeypatch):
+    monkeypatch.setattr(rag_service_module, "embeddings_rag_deps_installed", lambda: True)
+    shared_service = FakeRagService(results=[_SEMANTIC_RESULT])
+    factory_calls = []
+
+    def _factory(*args, **kwargs):
+        factory_calls.append(1)
+        return shared_service
+
+    monkeypatch.setattr(rag_service_module, "get_shared_rag_service", _factory)
+    app = SimpleNamespace(_rag_service=None)
+    service = LibraryLocalRagSearchService(app)
+
+    result = await service.search("credential", ("notes",), "rag", top_k=5)
+
+    assert not isinstance(result, LibraryRagSearchOutcome)
+    assert result["runtime_backend"] == "rag-semantic"
+    assert result["results"][0]["source_id"] == "note-1"
+    assert factory_calls == [1]
+    assert app._rag_service is shared_service
+
+    # Second query reuses the cached runtime without re-resolving.
+    await service.search("credential", ("notes",), "rag", top_k=5)
+    assert factory_calls == [1]
+
+
+# A factory that cannot produce a service (e.g. construction failed even with
+# deps installed) still lands on the existing recovery state.
+@pytest.mark.asyncio
+async def test_rag_mode_factory_returning_none_yields_blocked_outcome(monkeypatch):
+    monkeypatch.setattr(rag_service_module, "embeddings_rag_deps_installed", lambda: True)
+    monkeypatch.setattr(rag_service_module, "get_shared_rag_service", lambda *a, **k: None)
+    app = SimpleNamespace(_rag_service=None)
+    service = LibraryLocalRagSearchService(app)
+
+    result = await service.search("credential", ("notes",), "rag", top_k=5)
+
+    assert isinstance(result, LibraryRagSearchOutcome)
+    assert result.status == "blocked"
+    assert result.recovery_state.status_label == "RAG unavailable"
+
+
+# An injected app._rag_service always wins: no deps probe, no factory call
+# (pre-task-249 behavior for every existing caller/test fake).
+@pytest.mark.asyncio
+async def test_rag_mode_prefers_existing_app_rag_service(monkeypatch):
+    def _fail_probe():
+        raise AssertionError("deps probe must not run when a runtime already exists")
+
+    monkeypatch.setattr(rag_service_module, "embeddings_rag_deps_installed", _fail_probe)
+    monkeypatch.setattr(rag_service_module, "get_shared_rag_service", _fail_probe)
+    injected = FakeRagService(results=[_SEMANTIC_RESULT])
+    app = SimpleNamespace(_rag_service=injected)
+    service = LibraryLocalRagSearchService(app)
+
+    result = await service.search("credential", ("notes",), "rag", top_k=5)
+
+    assert result["results"][0]["source_id"] == "note-1"
+    assert injected.calls
+
+
+# Race (task-249): two Library rag queries racing first-time initialization
+# must construct exactly one shared service. Uses the REAL
+# get_shared_rag_service (its process-wide lock is the guarantee) with a
+# slow, counting create_rag_service fake underneath.
+@pytest.mark.asyncio
+async def test_concurrent_rag_queries_initialize_one_shared_service(monkeypatch):
+    import threading
+    import time
+
+    from tldw_chatbook.RAG_Search import ingestion_indexing
+    from tldw_chatbook.RAG_Search import simplified as simplified_module
+
+    monkeypatch.setattr(rag_service_module, "embeddings_rag_deps_installed", lambda: True)
+    constructions = []
+    construction_lock = threading.Lock()
+
+    def _slow_create(profile_name=None, **kwargs):
+        with construction_lock:
+            constructions.append(profile_name)
+        time.sleep(0.05)
+        return FakeRagService(results=[_SEMANTIC_RESULT])
+
+    monkeypatch.setattr(simplified_module, "create_rag_service", _slow_create)
+    ingestion_indexing.reset_shared_rag_service()
+    try:
+        app = SimpleNamespace(_rag_service=None)
+        service = LibraryLocalRagSearchService(app)
+
+        first, second = await asyncio.gather(
+            service.search("credential", ("notes",), "rag", top_k=5),
+            service.search("credential rotation", ("notes",), "rag", top_k=5),
+        )
+
+        assert len(constructions) == 1
+        assert first["results"] and second["results"]
+        assert app._rag_service is ingestion_indexing.get_shared_rag_service()
+    finally:
+        ingestion_indexing.reset_shared_rag_service()
+
+
+# --- task-249 AC #4: empty semantic index is reported honestly -------------
+
+
+class FakeRagServiceWithStore(FakeRagService):
+    def __init__(self, results=None, stats=None, stats_error=None):
+        super().__init__(results=results)
+        self.vector_store = FakeVectorStore(stats=stats, error=stats_error)
+
+
+@pytest.mark.asyncio
+async def test_rag_mode_empty_index_returns_distinct_empty_outcome():
+    rag_service = FakeRagServiceWithStore(results=[], stats={"count": 0})
+    app = SimpleNamespace(_rag_service=rag_service)
+    service = LibraryLocalRagSearchService(app)
+
+    result = await service.search("credential", ("notes",), "rag", top_k=5)
+
+    assert isinstance(result, LibraryRagSearchOutcome)
+    assert result.status == "empty"
+    assert result.runtime_backend == "rag-semantic"
+    recovery = result.recovery_state
+    assert recovery is not None
+    assert recovery.status_label == "Index empty"
+    assert recovery.stable_selector == "library-rag-empty-state"
+    assert "semantic index has no content yet" in recovery.why
+    assert "backfill" in recovery.next_action
+
+
+# A populated index with zero matches stays a plain zero-results payload
+# (run_library_rag_search owns the generic "No results" recovery for it).
+@pytest.mark.asyncio
+async def test_rag_mode_zero_results_with_populated_index_stays_generic():
+    rag_service = FakeRagServiceWithStore(results=[], stats={"count": 12})
+    app = SimpleNamespace(_rag_service=rag_service)
+    service = LibraryLocalRagSearchService(app)
+
+    result = await service.search("credential", ("notes",), "rag", top_k=5)
+
+    assert not isinstance(result, LibraryRagSearchOutcome)
+    assert result == {"results": [], "runtime_backend": "rag-semantic"}
+
+
+# Stats that cannot be trusted (probe raised, error payload, or no
+# vector_store at all) must not claim an empty index.
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "rag_service",
+    [
+        FakeRagService(results=[]),
+        FakeRagServiceWithStore(results=[], stats_error=RuntimeError("stats exploded")),
+        FakeRagServiceWithStore(results=[], stats={"count": 0, "error": "collection lost"}),
+    ],
+    ids=["no-vector-store", "stats-raises", "stats-error-payload"],
+)
+async def test_rag_mode_unverifiable_stats_fall_back_to_generic_empty(rag_service):
+    app = SimpleNamespace(_rag_service=rag_service)
+    service = LibraryLocalRagSearchService(app)
+
+    result = await service.search("credential", ("notes",), "rag", top_k=5)
+
+    assert not isinstance(result, LibraryRagSearchOutcome)
+    assert result == {"results": [], "runtime_backend": "rag-semantic"}
+
+
+# Results that were only removed by scope post-filtering prove the index has
+# content -- the outcome must stay the generic zero-results payload without
+# probing the store.
+@pytest.mark.asyncio
+async def test_rag_mode_scope_filtered_to_zero_is_not_index_empty():
+    rag_service = FakeRagServiceWithStore(
+        results=[
+            {
+                "id": "media-chunk",
+                "score": 0.8,
+                "document": "Media evidence.",
+                "metadata": {"title": "Media doc", "source_id": "media-1", "source_type": "media"},
+            }
+        ],
+        stats={"count": 0},  # deliberately lying: it must never be consulted
+    )
+    app = SimpleNamespace(_rag_service=rag_service)
+    service = LibraryLocalRagSearchService(app)
+
+    result = await service.search("credential", ("notes",), "rag", top_k=5)
+
+    assert not isinstance(result, LibraryRagSearchOutcome)
+    assert result["results"] == []
+    assert rag_service.vector_store.calls == 0
+
+
 # (task-185) The keyword-search conversation row's secondary line pluralizes
 # its message count instead of the fixed "N messages" template.
 def test_conversation_row_secondary_line_pluralizes_message_count():
@@ -872,3 +1105,121 @@ async def test_prompts_deselected_yields_zero_prompt_rows(real_prompts_app):
 
     assert not isinstance(result, LibraryRagSearchOutcome)
     assert all(row["provenance"]["source_type"] != "prompt" for row in result["results"])
+
+
+# --- task-249 AC #2: real-runtime semantic results with citations -----------
+# Same pattern as Tests/RAG/test_ingestion_indexing.py: a real RAGService with
+# the deterministic mock embedding backend, published as the process-wide
+# shared service, queried end-to-end through run_library_rag_search.
+
+from tldw_chatbook.Utils.optional_deps import embeddings_rag_deps_installed as _deps_installed
+
+_DISTINCTIVE_CONTENT = (
+    "The zanzibar quokka manifesto describes how quokkas organise snorkeling "
+    "expeditions near flamingo lagoons. Zanzibar quokka snorkeling requires "
+    "specialised flamingo-approved equipment and a manifesto committee."
+)
+
+
+def _make_real_rag_service():
+    from tldw_chatbook.RAG_Search.simplified.config import RAGConfig
+    from tldw_chatbook.RAG_Search.simplified.rag_service import RAGService
+
+    cfg = RAGConfig()
+    cfg.embedding.model = "mock"  # deterministic bag-of-words backend, offline
+    cfg.embedding.device = "cpu"
+    cfg.vector_store.type = "memory"
+    cfg.vector_store.persist_directory = None
+    cfg.chunking.chunk_size = 60
+    cfg.chunking.chunk_overlap = 10
+    cfg.search.enable_cache = False
+    return RAGService(cfg)
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not _deps_installed(), reason="embeddings_rag deps not installed")
+class TestLibraryRagAnswerRealRuntime:
+    @pytest.fixture(autouse=True)
+    def _isolated_shared_service(self):
+        from tldw_chatbook.RAG_Search import ingestion_indexing
+
+        ingestion_indexing.reset_shared_rag_service()
+        yield
+        ingestion_indexing.reset_shared_rag_service()
+
+    @pytest.mark.asyncio
+    async def test_rag_answer_returns_semantic_rows_with_citations(self):
+        """AC #1 + #2 end-to-end: an uninitialized app resolves the shared
+        runtime lazily, and indexed content comes back as evidence rows whose
+        citations survive normalization into LibraryRagResultRow."""
+        from tldw_chatbook.RAG_Search import ingestion_indexing
+
+        real_service = _make_real_rag_service()
+        await real_service.index_batch_optimized(
+            [
+                {
+                    "id": "media_9",
+                    "content": _DISTINCTIVE_CONTENT,
+                    "title": "Quokka Manifesto",
+                    "metadata": {
+                        "source_id": "9",
+                        "title": "Quokka Manifesto",
+                        "source_type": "media",
+                    },
+                }
+            ],
+            show_progress=False,
+        )
+        ingestion_indexing.set_shared_rag_service(real_service)
+
+        app = SimpleNamespace()  # no _rag_service attribute at all
+        app.library_rag_search_service = LibraryLocalRagSearchService(app)
+        request = LibraryRagSearchRequest(
+            query="zanzibar quokka snorkeling manifesto",
+            source_types=("notes", "media", "conversations"),
+            mode="rag",
+            top_k=3,
+            include_citations=True,
+        )
+
+        outcome = await run_library_rag_search(app, request)
+
+        assert outcome.status == "ready"
+        assert outcome.runtime_backend == "rag-semantic"
+        assert app._rag_service is real_service
+        row = outcome.results[0]
+        assert row.source_id == "9"
+        assert row.title == "Quokka Manifesto"
+        assert row.provenance.get("source_type") == "media"
+        assert row.score is not None
+        # Citations must serialize all the way into the evidence row.
+        assert row.citations, "semantic evidence row lost its citations"
+        assert row.citation_labels[0] == "Quokka Manifesto"
+        assert row.citations[0].source_id == "media_9"
+        assert row.citations[0].chunk_id
+        assert "1 citation" in row.citation_count_badge_label
+
+    @pytest.mark.asyncio
+    async def test_rag_answer_empty_real_store_reports_index_empty(self):
+        """AC #4 against the real vector-store stats API: an available
+        runtime over an empty store says so instead of a bare zero-results
+        state."""
+        from tldw_chatbook.RAG_Search import ingestion_indexing
+
+        ingestion_indexing.set_shared_rag_service(_make_real_rag_service())
+
+        app = SimpleNamespace()
+        app.library_rag_search_service = LibraryLocalRagSearchService(app)
+        request = LibraryRagSearchRequest(
+            query="zanzibar quokka snorkeling manifesto",
+            source_types=("notes", "media", "conversations"),
+            mode="rag",
+            top_k=3,
+        )
+
+        outcome = await run_library_rag_search(app, request)
+
+        assert outcome.status == "empty"
+        assert outcome.recovery_state is not None
+        assert outcome.recovery_state.status_label == "Index empty"
+        assert outcome.recovery_state.stable_selector == "library-rag-empty-state"

--- a/Tests/Library/test_library_local_rag_search_service.py
+++ b/Tests/Library/test_library_local_rag_search_service.py
@@ -730,6 +730,31 @@ async def test_rag_mode_factory_returning_none_yields_blocked_outcome(monkeypatc
     assert result.recovery_state.status_label == "RAG unavailable"
 
 
+# PR #671 review (gemini): a factory that RAISES during first initialization
+# (model load failure, config error, DB corruption) must degrade to the same
+# RAG-unavailable recovery state -- not propagate. Without the guard the
+# exception would surface as run_library_rag_search's generic "Retrieval
+# failed / Retry" outcome, which is wrong for an init failure retrying cannot
+# fix (and non-UI callers of the service would see a raw exception).
+@pytest.mark.asyncio
+async def test_rag_mode_factory_raising_yields_blocked_outcome(monkeypatch):
+    monkeypatch.setattr(rag_service_module, "embeddings_rag_deps_installed", lambda: True)
+
+    def _exploding_factory(*args, **kwargs):
+        raise RuntimeError("embedding model load exploded")
+
+    monkeypatch.setattr(rag_service_module, "get_shared_rag_service", _exploding_factory)
+    app = SimpleNamespace(_rag_service=None)
+    service = LibraryLocalRagSearchService(app)
+
+    result = await service.search("credential", ("notes",), "rag", top_k=5)
+
+    assert isinstance(result, LibraryRagSearchOutcome)
+    assert result.status == "blocked"
+    assert result.recovery_state.status_label == "RAG unavailable"
+    assert getattr(app, "_rag_service", None) is None
+
+
 # An injected app._rag_service always wins: no deps probe, no factory call
 # (pre-task-249 behavior for every existing caller/test fake).
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -700,10 +700,11 @@ async def test_library_shell_search_mode_toggle_cycles_mode():
 
 
 @pytest.mark.asyncio
-async def test_library_shell_search_rag_mode_blocks_run_without_provider():
-    """Default ``search`` mode keeps Run enabled without a provider; cycling
-    to ``rag`` mode blocks Run behind the provider gate, and cycling back
-    re-enables it -- the app fake here has no ``_rag_service`` attribute.
+async def test_library_shell_search_rag_mode_keeps_run_enabled_without_runtime():
+    """Cycling to ``rag`` mode keeps Run enabled even though the app fake has
+    no ``_rag_service`` attribute (task-249): the runtime initializes lazily
+    at query time, and the retrieval service owns the recovery state when it
+    cannot -- the old provider gate that pre-disabled Run is retired.
     """
     app = _build_test_app()
     assert getattr(app, "_rag_service", None) is None
@@ -723,22 +724,18 @@ async def test_library_shell_search_rag_mode_blocks_run_without_provider():
 
         screen.query_one("#library-rag-mode-toggle", Button).press()
         for _ in range(120):
-            run_buttons = list(screen.query("#library-rag-run-query"))
-            if run_buttons and run_buttons[0].disabled:
+            toggles = list(screen.query("#library-rag-mode-toggle"))
+            if toggles and str(toggles[0].label) == "mode: RAG Answer ▸":
                 break
             await pilot.pause(0.02)
         else:
-            raise AssertionError("RAG mode never disabled Run without a provider.")
-        assert "Select a provider/model" in _visible_text(screen)
+            raise AssertionError("Mode toggle never switched to RAG Answer.")
 
-        screen.query_one("#library-rag-mode-toggle", Button).press()
-        for _ in range(120):
-            run_buttons = list(screen.query("#library-rag-run-query"))
-            if run_buttons and not run_buttons[0].disabled:
-                break
-            await pilot.pause(0.02)
-        else:
-            raise AssertionError("Search mode never re-enabled Run.")
+        # A few extra pauses so any pending query-state refresh settles.
+        await pilot.pause()
+        await pilot.pause()
+        assert screen.query_one("#library-rag-run-query", Button).disabled is False
+        assert "Select a provider/model" not in _visible_text(screen)
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_product_maturity_gate16_library_search_rag.py
+++ b/Tests/UI/test_product_maturity_gate16_library_search_rag.py
@@ -744,17 +744,29 @@ async def test_library_search_rag_server_result_launches_server_console_live_wor
 
 
 @pytest.mark.asyncio
-async def test_library_search_rag_run_query_renders_persistent_recovery_without_service() -> None:
-    """RAG mode with no ``_rag_service`` on the app is blocked at the
-    query-readiness gate itself (``provider_ready``), never reaching the
-    retrieval service -- the provider gate added in L3a front-runs the
-    previous service-level "RAG unavailable" recovery for this scenario
-    (the retrieval service still double-guards internally for non-UI
-    callers, but the Run button is disabled before that code can run). The
-    default canvas mode is "search" (keyword, always available given
-    seeded local seams), so reaching this state requires explicitly
-    cycling to RAG mode first.
+async def test_library_search_rag_run_query_renders_persistent_recovery_without_service(
+    monkeypatch,
+) -> None:
+    """RAG mode without embeddings support runs the query and renders the
+    retrieval service's persistent "RAG unavailable" recovery state (task-249).
+
+    The L3a provider gate that pre-disabled Run when ``app._rag_service`` was
+    unset is retired: the runtime now initializes lazily at query time, so
+    the Run button stays enabled and the real production service
+    (``LibraryLocalRagSearchService``, wired by ``_build_test_app``'s real
+    ``TldwCli``) owns the recovery copy routing the user to setup. The deps
+    probe is pinned False so the lazy path never constructs a real embedding
+    runtime inside a UI test. The default canvas mode is "search" (keyword,
+    always available given seeded local seams), so reaching this state
+    requires explicitly cycling to RAG mode first.
     """
+    from tldw_chatbook.Library import library_local_rag_search_service
+
+    monkeypatch.setattr(
+        library_local_rag_search_service,
+        "embeddings_rag_deps_installed",
+        lambda: False,
+    )
     app = _build_test_app()
     _seed_library_sources(app)
     host = DestinationHarness(app, "library")
@@ -779,22 +791,19 @@ async def test_library_search_rag_run_query_renders_persistent_recovery_without_
             raise AssertionError("Mode toggle never switched to RAG Answer.")
 
         screen.query_one("#library-rag-query-input", Input).value = query
-        # `.value` lands on the widget synchronously, but the screen's own
-        # query state (and therefore the disabled reason) only catches up
-        # once the Input.Changed handler runs -- poll for the settled
-        # blocked reason rather than the transient "no query yet" one.
-        for _ in range(150):
-            if "provider/model before asking for a RAG answer" in _visible_text(screen):
-                break
-            await pilot.pause(0.02)
-        else:
-            raise AssertionError(
-                f"RAG mode never blocked Run without a provider. "
-                f"Visible text: {_visible_text(screen)}"
-            )
+        await _wait_for_query_ready(screen, pilot, query)
 
-        assert screen.query_one("#library-rag-run-query", Button).disabled is True
-        assert not screen.query("#library-rag-service-error")
+        run_button = screen.query_one("#library-rag-run-query", Button)
+        assert run_button.disabled is False
+
+        run_button.press()
+        await _wait_for_selector(screen, pilot, "#library-rag-service-error")
+
+        visible_text = _visible_text(screen)
+        assert "RAG unavailable" in visible_text
+        assert "Install embeddings support or switch mode to Search" in visible_text
+        # The display sanitizer HTML-escapes the recovery route's ">".
+        assert "Recovery: Settings &gt; RAG." in visible_text
 
 
 @pytest.mark.asyncio

--- a/backlog/tasks/task-249 - Make-Library-RAG-answer-mode-functional-end-to-end.md
+++ b/backlog/tasks/task-249 - Make-Library-RAG-answer-mode-functional-end-to-end.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-249
 title: Make Library RAG-answer mode functional end-to-end
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-12 14:11'
 labels:
   - rag
@@ -20,8 +21,33 @@ The Library Search canvas is wired to LibraryLocalRagSearchService (app.py:3128)
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Selecting RAG Answer mode with embeddings deps installed initializes the RAG runtime instead of returning the RAG-unavailable recovery state
-- [ ] #2 With indexed content present a RAG Answer query returns semantic results with citations in the evidence rows
-- [ ] #3 Without embeddings deps the existing recovery state still routes the user to setup
-- [ ] #4 When the RAG runtime is available but the index is empty the outcome says so instead of showing a bare zero-results state
+- [x] #1 Selecting RAG Answer mode with embeddings deps installed initializes the RAG runtime instead of returning the RAG-unavailable recovery state
+- [x] #2 With indexed content present a RAG Answer query returns semantic results with citations in the evidence rows
+- [x] #3 Without embeddings deps the existing recovery state still routes the user to setup
+- [x] #4 When the RAG runtime is available but the index is empty the outcome says so instead of showing a bare zero-results state
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Failing tests first (Tests/Library/test_library_local_rag_search_service.py, conventions of the existing suite):
+   - AC #1: rag mode on an app without `_rag_service` lazily resolves the runtime via `get_shared_rag_service()` (monkeypatched fake), caches it on `app._rag_service`, and returns semantic rows instead of the RAG-unavailable recovery state.
+   - AC #3: with `embeddings_rag_deps_installed()` returning False, rag mode returns the existing `_rag_mode_unavailable_recovery_state` and never calls `get_shared_rag_service()` (update the existing no-service test to pin the deps gate explicitly).
+   - AC #4: runtime available, search returns zero rows, `vector_store.get_collection_stats()` reports `count == 0` -> outcome status `empty` with distinct "index empty" recovery copy (stable selector `library-rag-empty-state`); `count > 0` with zero rows keeps the generic zero-results path; stats errors/missing stats fall back to the generic path.
+   - Race: two concurrent rag queries against the real `get_shared_rag_service` with a slow counting `create_rag_service` fake -> exactly one construction, both queries share the instance.
+   - AC #2 (integration, skipif no embeddings deps, mock embedding model per Tests/RAG/test_ingestion_indexing.py): index a real document via `RAGService.index_batch_optimized`, publish it via `set_shared_rag_service`, run a Library rag query end-to-end through `run_library_rag_search` -> evidence rows carry real citations (`LibraryRagResultRow.citations` labels) and metadata contract fields; empty real store variant proves the index-empty outcome against the real stats API.
+2. Implement in `Library/library_local_rag_search_service.py`:
+   - `_resolve_rag_runtime()`: return `app._rag_service` when usable; else gate on `embeddings_rag_deps_installed()` (cheap probe, before any heavy work); else construct via `await asyncio.to_thread(get_shared_rag_service)` (blocking model load off the UI event loop; the shared factory is process-lock idempotent) and cache on `app._rag_service`.
+   - `_search_semantic()`: use the resolved runtime; on zero raw results probe `vector_store.get_collection_stats()` (in a thread) and return an honest index-empty `LibraryRagSearchOutcome(status="empty", recovery_state=...)` distinct from generic zero-results.
+3. Open the Library UI run gate: `library_screen.py` `provider_ready` currently requires a pre-existing `app._rag_service`, which would make lazy init unreachable; make it deliberately-always-ready like `dependencies_ready`/`index_ready` (service double-guards and owns recovery copy). Update the two UI tests pinning the old gate (`test_library_shell.py` mode-toggle gate test, gate16 persistent-recovery test) to pin the new end-to-end behavior: rag mode Run stays enabled, and without deps the service-level "RAG unavailable" recovery renders under `#library-rag-service-error`.
+4. Run: new tests, Tests/Library/, Tests/RAG/, the two updated UI suites, `python -c "import tldw_chatbook.app"`.
+
+## Implementation Notes
+
+Followed the plan; the "RAG Answer" gap closes at the retrieval-service seam, so both the Library Search canvas and the Console `run-library-rag` action (same `run_library_rag_search` funnel) inherit the fix.
+
+- **Lazy runtime initialization** (`Library/library_local_rag_search_service.py`): new `_resolve_rag_runtime()` — an existing usable `app._rag_service` always wins; otherwise the `embeddings_rag_deps_installed()` probe short-circuits before any heavy work (AC #3 keeps the exact `_rag_mode_unavailable_recovery_state` copy); otherwise the runtime is created via `await asyncio.to_thread(get_shared_rag_service)` so the first-time embedding-model load never runs on the UI event loop, then cached on `app._rag_service` for every other RAG surface. Concurrency is owned by `get_shared_rag_service`'s double-checked process lock (task-247); a dedicated race test proves two concurrent Library rag queries construct exactly one service.
+- **Honest empty-index outcome (AC #4)**: on zero raw semantic results, `_semantic_index_is_empty()` probes `vector_store.get_collection_stats()` in a thread; only a trustworthy `count == 0` (no error payload) returns the new `LibraryRagSearchOutcome(status="empty", recovery_state=_rag_index_empty_recovery_state())` ("Index empty" / next action: ingest content — auto-indexed — or run a semantic backfill, stable selector `library-rag-empty-state`). Unverifiable stats, populated stores, and scope-filtered-to-zero results keep the generic zero-results path.
+- **UI run gate** (`UI/Screens/library_screen.py`): `provider_ready` was `app._rag_service is not None`, which made the lazy path unreachable from the Run button; it now joins `dependencies_ready`/`index_ready` as deliberately-always-ready — the retrieval service double-guards and owns recovery copy (a disabled button could not carry the "Install embeddings support" routing).
+- **Citations verified end-to-end (AC #2)**: a with-deps integration test (mock embedding backend, per Tests/RAG conventions) indexes a real document through `RAGService.index_batch_optimized`, resolves the runtime lazily from an uninitialized app, and asserts the `SearchResultWithCitations.citations` objects survive `_semantic_row` → `LibraryRagResultRow` normalization into evidence-row citation labels/badges.
+- **Tests**: 12 new/updated tests in `Tests/Library/test_library_local_rag_search_service.py` (61 pass); rewrote the two UI tests pinning the retired provider gate (`Tests/UI/test_library_shell.py`, `Tests/UI/test_product_maturity_gate16_library_search_rag.py`). Full runs: Tests/Library 547 passed; Tests/RAG 264 passed/8 skipped; gate16 16 passed; test_library_shell 256 passed + 1 unrelated flake (`note_conflict_during_preview`, passes in isolation); `import tldw_chatbook.app` OK.
+- **Modified files**: `tldw_chatbook/Library/library_local_rag_search_service.py`, `tldw_chatbook/UI/Screens/library_screen.py`, `Tests/Library/test_library_local_rag_search_service.py`, `Tests/UI/test_library_shell.py`, `Tests/UI/test_product_maturity_gate16_library_search_rag.py`.

--- a/tldw_chatbook/Library/library_local_rag_search_service.py
+++ b/tldw_chatbook/Library/library_local_rag_search_service.py
@@ -314,7 +314,12 @@ class LibraryLocalRagSearchService:
            seconds), so it runs in ``asyncio.to_thread`` -- never on the UI
            event loop. The factory is double-checked-locked, so concurrent
            Library queries racing here serialize inside it and share one
-           instance.
+           instance. The factory already converts construction failures to
+           None; the guard here additionally maps anything it might still
+           raise to None, so a failed first initialization always renders
+           the RAG-unavailable recovery state (setup routing) rather than
+           ``run_library_rag_search``'s generic "Retrieval failed / Retry"
+           outcome -- retrying cannot fix a runtime that will not build.
 
         Returns:
             The RAG runtime, or None when it is unavailable (missing deps or
@@ -325,7 +330,14 @@ class LibraryLocalRagSearchService:
             return rag_service
         if not embeddings_rag_deps_installed():
             return None
-        service = await asyncio.to_thread(get_shared_rag_service)
+        try:
+            service = await asyncio.to_thread(get_shared_rag_service)
+        except Exception:
+            logger.opt(exception=True).error(
+                "Library RAG: shared RAG service initialization raised; "
+                "treating the runtime as unavailable."
+            )
+            return None
         if service is None or not callable(getattr(service, "search", None)):
             return None
         try:

--- a/tldw_chatbook/Library/library_local_rag_search_service.py
+++ b/tldw_chatbook/Library/library_local_rag_search_service.py
@@ -12,11 +12,18 @@ from tldw_chatbook.Library.library_fts_query import build_fts_match_query
 from tldw_chatbook.Library.library_notes_sync_state import count_noun
 from tldw_chatbook.Library.library_rag_service import LibraryRagSearchOutcome
 from tldw_chatbook.Library.library_rag_state import (
+    LIBRARY_RAG_EMPTY_STATE_SELECTOR,
     LIBRARY_RAG_QUERY_MAX_LENGTH,
     LIBRARY_RAG_SERVICE_ERROR_SELECTOR,
 )
+# The shared factory is the single process-wide RAG service constructor
+# (task-247): resolving through it guarantees Library RAG Answer queries read
+# the exact vector store / collection / embedding model that ingestion-time
+# indexing writes to.
+from tldw_chatbook.RAG_Search.ingestion_indexing import get_shared_rag_service
 from tldw_chatbook.UI.destination_recovery import DestinationRecoveryState
 from tldw_chatbook.Utils.input_validation import sanitize_string, validate_text_input
+from tldw_chatbook.Utils.optional_deps import embeddings_rag_deps_installed
 
 logger = logger.bind(module="LibraryLocalRagSearchService")
 
@@ -67,9 +74,11 @@ class LibraryLocalRagSearchService:
     """Keyword-first Library retrieval over the app's local source seams.
 
     `search` mode fans out over notes/media/conversations/prompts FTS seams and
-    always works when at least one seam is available. `rag` mode delegates
-    to the app's `_rag_service` and degrades to a blocked outcome with
-    setup routing when that runtime is absent.
+    always works when at least one seam is available. `rag` mode uses the
+    app's `_rag_service`, lazily initializing it from the process-wide
+    shared RAG service on first use when the embeddings deps are installed
+    (task-249), and degrades to a blocked outcome with setup routing when
+    the runtime is unavailable.
     """
 
     def __init__(self, app_instance: Any) -> None:
@@ -246,7 +255,7 @@ class LibraryLocalRagSearchService:
         top_k: int,
         kwargs: Mapping[str, Any],
     ) -> Any:
-        """Delegate to the app's optional RAG runtime, or report it as absent.
+        """Query the RAG runtime, initializing it lazily on first use (task-249).
 
         The RAG runtime's index is not itself scoped by source type, so
         results are post-filtered here: each row's provenance
@@ -260,16 +269,20 @@ class LibraryLocalRagSearchService:
         occasionally over-including it. An empty `scope` disables filtering
         entirely as a defensive guard; in practice the Search canvas's run
         gate never lets a query reach this method with no source selected.
+
+        Zero raw results over a verifiably empty vector store return a
+        distinct "Index empty" outcome instead of the bare zero-results
+        state (AC #4): "no evidence for this query" and "nothing has been
+        indexed yet" demand different user actions.
         """
-        rag_service = getattr(self._app, "_rag_service", None)
-        search = getattr(rag_service, "search", None)
-        if rag_service is None or not callable(search):
+        rag_service = await self._resolve_rag_runtime()
+        if rag_service is None:
             return LibraryRagSearchOutcome(
                 status="blocked",
                 recovery_state=_rag_mode_unavailable_recovery_state(),
             )
         include_citations = bool(kwargs.get("include_citations", True))
-        raw_results = await search(
+        raw_results = await rag_service.search(
             query=query,
             top_k=top_k,
             search_type="semantic",
@@ -278,7 +291,76 @@ class LibraryLocalRagSearchService:
         rows = [_semantic_row(item) for item in raw_results or ()]
         if scope:
             rows = [row for row in rows if _semantic_row_matches_scope(row, scope)]
+        if not raw_results and await self._semantic_index_is_empty(rag_service):
+            return LibraryRagSearchOutcome(
+                status="empty",
+                recovery_state=_rag_index_empty_recovery_state(),
+                runtime_backend=_RAG_RUNTIME_BACKEND,
+            )
         return {"results": rows, "runtime_backend": _RAG_RUNTIME_BACKEND}
+
+    async def _resolve_rag_runtime(self) -> Any:
+        """Return a usable RAG runtime, lazily creating the shared one.
+
+        Resolution order:
+
+        1. An existing ``app._rag_service`` with a callable ``search`` always
+           wins (already initialized by any surface, or injected by tests).
+        2. The ``embeddings_rag`` deps gate (cheap ``find_spec`` probe, no
+           imports) short-circuits BEFORE any heavy work, so missing-deps
+           installs keep the existing recovery routing at zero cost (AC #3).
+        3. ``get_shared_rag_service()`` constructs the process-wide runtime.
+           First-time construction loads an embedding model (can take
+           seconds), so it runs in ``asyncio.to_thread`` -- never on the UI
+           event loop. The factory is double-checked-locked, so concurrent
+           Library queries racing here serialize inside it and share one
+           instance.
+
+        Returns:
+            The RAG runtime, or None when it is unavailable (missing deps or
+            failed construction) -- the caller renders the recovery state.
+        """
+        rag_service = getattr(self._app, "_rag_service", None)
+        if rag_service is not None and callable(getattr(rag_service, "search", None)):
+            return rag_service
+        if not embeddings_rag_deps_installed():
+            return None
+        service = await asyncio.to_thread(get_shared_rag_service)
+        if service is None or not callable(getattr(service, "search", None)):
+            return None
+        try:
+            # Cache on the app so every RAG surface (chat sidebar readiness,
+            # repeat Library queries) sees the initialized runtime.
+            self._app._rag_service = service
+        except Exception:
+            logger.opt(exception=True).debug(
+                "Could not cache the shared RAG service on the app instance."
+            )
+        return service
+
+    async def _semantic_index_is_empty(self, rag_service: Any) -> bool:
+        """True only when the runtime's vector store verifiably has 0 documents.
+
+        Anything short of a trustworthy zero -- no ``vector_store``, stats
+        call failing, an ``error`` payload, a non-integer count -- returns
+        False so the caller falls back to the generic zero-results outcome
+        rather than claiming an empty index it cannot verify.
+        """
+        get_stats = getattr(getattr(rag_service, "vector_store", None), "get_collection_stats", None)
+        if not callable(get_stats):
+            return False
+        try:
+            # ChromaDB-backed stats can touch disk; keep it off the event loop.
+            stats = await asyncio.to_thread(get_stats)
+        except Exception:
+            logger.opt(exception=True).debug("Library RAG: vector store stats probe failed.")
+            return False
+        if not isinstance(stats, Mapping) or stats.get("error"):
+            return False
+        try:
+            return int(stats.get("count")) == 0
+        except (TypeError, ValueError):
+            return False
 
 
 def _note_row(item: Mapping[str, Any]) -> dict[str, Any]:
@@ -447,5 +529,31 @@ def _rag_mode_unavailable_recovery_state() -> DestinationRecoveryState:
         disabled_tooltip=(
             "RAG runtime is unavailable in this app instance. "
             "Install embeddings support or switch mode to Search."
+        ),
+    )
+
+
+def _rag_index_empty_recovery_state() -> DestinationRecoveryState:
+    """Recovery copy for a working RAG runtime over an empty semantic index.
+
+    Distinct from the generic zero-results state (AC #4): the runtime is
+    fine, there is simply nothing indexed yet, so the next action is to add
+    content (ingestion indexes automatically, task-247) or backfill existing
+    content -- not to rephrase the query.
+    """
+    return DestinationRecoveryState(
+        status_label="Index empty",
+        unavailable_what="Library RAG Answer evidence",
+        why="The semantic index has no content yet",
+        next_action=(
+            "Ingest content to index it automatically, run a semantic index "
+            "backfill, or switch mode to Search"
+        ),
+        recovery_action="Library ingest",
+        authority_owner="Library retrieval service",
+        stable_selector=LIBRARY_RAG_EMPTY_STATE_SELECTOR,
+        disabled_tooltip=(
+            "The semantic index has no content yet. "
+            "Ingest content to index it automatically or run a semantic index backfill."
         ),
     )

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -2863,9 +2863,14 @@ class LibraryScreen(BaseAppScreen):
             # Deliberately always ready: the UI path never imports torch (or
             # any other optional Search/RAG dependency), and the retrieval
             # service double-guards missing runtimes/indexes at call time.
+            # `provider_ready` joined that contract in task-249: rag mode now
+            # lazily initializes the shared RAG runtime at query time, and
+            # when embeddings support is missing the retrieval service itself
+            # returns the "RAG unavailable" recovery state routing to setup
+            # -- honest copy a disabled Run button could not carry.
             dependencies_ready=True,
             index_ready=True,
-            provider_ready=(getattr(self.app_instance, "_rag_service", None) is not None),
+            provider_ready=True,
             selected_source_types=selected_source_types,
             history=self._library_search_history,
             history_collapsed=self._library_rag_history_collapsed,


### PR DESCRIPTION
## Summary

Closes the last user-facing gap from the 2026-07-12 RAG module audit's Library findings (ADR-005, task-249): **"RAG Answer" mode now actually works.** Previously `LibraryLocalRagSearchService._search_semantic` only read `app._rag_service` — which the Library screen never initialized — so RAG Answer always returned the "RAG unavailable" recovery state even with embeddings deps installed and content indexed (task-247). The Console's `run-library-rag` action funnels through the same `run_library_rag_search` seam and inherits the fix.

### What changed

- **Lazy runtime initialization at the retrieval seam** (`Library/library_local_rag_search_service.py`, new `_resolve_rag_runtime()`):
  1. An existing usable `app._rag_service` always wins (unchanged for every current caller/test fake).
  2. The `embeddings_rag_deps_installed()` probe (cheap `find_spec`, no imports) short-circuits **before any heavy work** — missing-deps installs keep the exact existing `RAG unavailable → Install embeddings support or switch mode to Search → Settings > RAG` recovery copy (AC #3).
  3. Otherwise the process-wide shared runtime (`get_shared_rag_service`, task-247 — same store/collection/model that ingestion-time indexing writes to) is constructed via `asyncio.to_thread`, so the first-time embedding-model load **never runs on the UI event loop**, then cached on `app._rag_service` for every other RAG surface. Races are owned by the factory's double-checked process lock; a dedicated test proves two concurrent Library queries construct exactly one service.
- **Honest empty-index outcome (AC #4)**: zero semantic results over a *verifiably* empty vector store (`vector_store.get_collection_stats()` in a thread, trusted only with no error payload) return a distinct outcome — status `empty`, selector `library-rag-empty-state`, copy `Index empty / Why: The semantic index has no content yet. / Next: Ingest content to index it automatically, run a semantic index backfill, or switch mode to Search.` Unverifiable stats, populated stores, and scope-filtered-to-zero results keep the generic zero-results state.
- **Library Run gate** (`UI/Screens/library_screen.py`): `provider_ready` required a pre-existing `app._rag_service`, which would have made lazy init unreachable from the Run button; it now joins `dependencies_ready`/`index_ready` as deliberately-always-ready — the retrieval service double-guards and owns recovery copy (a disabled button could not carry the install-routing).
- **Citations verified end-to-end (AC #2)**: a with-deps integration test (mock embedding backend, per `Tests/RAG/test_ingestion_indexing.py` conventions) indexes a real document through `RAGService.index_batch_optimized`, resolves the runtime lazily from an uninitialized app, and asserts `SearchResultWithCitations` citations survive `_semantic_row` → `LibraryRagResultRow` normalization into evidence-row citation labels and badges — the audit had never seen this path run.

### Tests

- 12 new/updated tests in `Tests/Library/test_library_local_rag_search_service.py` covering all 4 ACs plus the initialization race and stats-fallback matrix.
- Rewrote the two UI tests that pinned the retired provider gate: `Tests/UI/test_library_shell.py` (RAG mode keeps Run enabled without a runtime) and the gate16 persistent-recovery test (Run without deps renders the service-level `#library-rag-service-error` recovery).

Verified locally post-rebase onto `aedaccc1` (CI is intentionally cancelled):

| Suite | Result |
| --- | --- |
| `Tests/Library/` | 547 passed |
| `Tests/RAG/` (incl. `test_ingestion_indexing.py`) | 264 passed, 8 skipped |
| `Tests/UI/test_product_maturity_gate16_library_search_rag.py` | 16 passed |
| `Tests/UI/test_library_shell.py` | 256 passed, 1 unrelated flake (`note_conflict_during_preview`, passes in isolation) |
| `python -c "import tldw_chatbook.app"` | OK |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Library “RAG Answer” work end-to-end by lazily resolving the shared RAG runtime and returning real semantic results with citations. Addresses task-249 and removes the pre-run provider gate, showing clear “RAG unavailable” or “Index empty” states when appropriate.

- **New Features**
  - Lazy runtime initialization at retrieval (`_resolve_rag_runtime()`): prefers existing `app._rag_service`, gates on `embeddings_rag_deps_installed()`, otherwise builds via `get_shared_rag_service` in `asyncio.to_thread` and caches on the app.
  - Distinct empty-index outcome: zero results over a store with `count == 0` returns `status: empty` (selector `library-rag-empty-state`); unverifiable stats fall back to generic zero-results.
  - UX and surfaces: Run stays enabled in RAG mode; missing deps render “RAG unavailable → Settings > RAG”; citations are preserved in `LibraryRagResultRow`; the Console `run-library-rag` path inherits the fix via `run_library_rag_search`.

- **Bug Fixes**
  - Guard lazy runtime creation: a raising `get_shared_rag_service` now maps to the same “RAG unavailable” recovery state instead of the generic “Retrieval failed / Retry” outcome.

<sup>Written for commit cb5b847e19e3062d77ac1aa034bbd8ff14c297f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

