### PR TITLE
perf(startup): defer optional-feature imports — chromadb, web-search chain, format processors (TASK-257)

### DIFF
--- a/Tests/Utils/test_optional_import_deferral.py
+++ b/Tests/Utils/test_optional_import_deferral.py
@@ -1,0 +1,419 @@
+# Tests/Utils/test_optional_import_deferral.py
+"""
+Regression tests for task-257: defer optional-feature imports (chromadb,
+the web-search chain [playwright/trafilatura], and PDF/document/ebook
+per-format processors) out of `import tldw_chatbook.app`'s hot path.
+
+Before this task, a plain `import tldw_chatbook.app` eagerly paid for three
+chains (~550ms combined, see Docs/Design/2026-07-16-performance-audit.md
+S2 C2) even when the corresponding feature was never used in the session:
+
+1. `Embeddings/Chroma_Lib.py` did module-scope `get_safe_import('chromadb')`
+   (a REAL import), reachable via `RAG_Admin/local_rag_admin_service.py`
+   which `app.py` imports unconditionally (~154ms: chromadb -> OTel -> gRPC
+   -> protobuf). Now deferred into `ChromaDBManager.__init__` via the
+   `_ensure_numpy()`/`_ensure_chromadb()` helpers.
+2. `Tools/__init__.py` eagerly imported `WebSearchTool` (and other optional
+   tool classes), which pulled in `Web_Scraping/Article_Extractor_Lib.py`'s
+   module-scope playwright + trafilatura imports (~197ms), even though
+   `web_search_enabled` defaults to False. `Tools/__init__.py` now uses a
+   PEP 562 `__getattr__` lazy re-export layer, and Article_Extractor_Lib's
+   playwright/trafilatura imports are deferred behind
+   `_ensure_playwright()`/`_ensure_trafilatura()` helpers (mirroring that
+   file's pre-existing pandas `find_spec` deferral).
+3. `app.py` imports `Local_Ingestion.local_file_ingestion` directly (for
+   `classify_ingest_source`/`persist_parsed_media`), which bypasses
+   `Local_Ingestion`'s own lazy `__init__.py` -- standard Python import
+   semantics run `local_file_ingestion.py`'s module body regardless of
+   which name was requested. Its top-of-file imports of
+   `process_pdf`/`process_document`/`process_ebook`/`LocalAudioProcessor`/
+   `LocalVideoProcessor` (~230ms: pymupdf/onnxruntime + Document/ebook
+   stack) are now deferred behind module-level `_ensure_*()` helpers called
+   from `parse_local_file_for_ingest()`'s per-`file_type` branches.
+
+This file has two kinds of coverage:
+  - Subprocess-based `sys.modules` assertions after a plain
+    `import tldw_chatbook.app`, in an isolated HOME/XDG sandbox (never the
+    real `~/.config/tldw_cli`).
+  - In-process functional smoke tests proving each chain still works when
+    actually used, plus one graceful-absence (simulated missing dependency)
+    case.
+"""
+from __future__ import annotations
+
+import asyncio
+import builtins
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# The five sys.modules names named in the task-257 AC. None of these may be
+# resident after a plain `import tldw_chatbook.app`.
+DEFERRED_MODULES = (
+    "chromadb",
+    "playwright",
+    "trafilatura",
+    "pymupdf",
+    "fitz",
+    "dateparser",
+)
+
+
+def _run_isolated_python(tmp_path: Path, code: str) -> "subprocess.CompletedProcess[str]":
+    """Run a Python snippet in a fresh interpreter with isolated config/data
+    dirs -- NEVER the real `~/.config/tldw_cli`.
+
+    A fresh interpreter is required because `sys.modules` is process-global:
+    once chromadb/playwright/etc. are imported by anything else (e.g. an
+    earlier test in the same pytest session), they would stay cached
+    in-process and this guard would give a false pass.
+
+    Args:
+        tmp_path: pytest fixture; isolated dir for the subprocess's
+            HOME/XDG_CONFIG_HOME/XDG_DATA_HOME.
+        code: Python source to run via `python -c`.
+    """
+    data_home = tmp_path / "data"
+    config_home = tmp_path / "config"
+    home = tmp_path / "home"
+    for path in (data_home, config_home, home):
+        path.mkdir(parents=True, exist_ok=True)
+
+    env = {
+        **os.environ,
+        "TLDW_TEST_MODE": "1",
+        "XDG_DATA_HOME": str(data_home),
+        "XDG_CONFIG_HOME": str(config_home),
+        "HOME": str(home),
+        "PYTHONPATH": str(REPO_ROOT),
+    }
+    env.pop("PYTEST_CURRENT_TEST", None)
+
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=120,
+    )
+
+
+# --- 1. sys.modules assertions after `import tldw_chatbook.app` -------------
+
+_MEASURE_SNIPPET = """
+import json
+import sys
+
+import tldw_chatbook.app
+
+deferred = {deferred_modules!r}
+loaded = sorted(m for m in deferred if m in sys.modules)
+print(json.dumps({{"loaded": loaded}}))
+""".format(deferred_modules=DEFERRED_MODULES)
+
+
+def test_app_import_does_not_load_any_deferred_module(tmp_path: Path) -> None:
+    """Plain `import tldw_chatbook.app` must not load chromadb, playwright,
+    trafilatura, pymupdf/fitz, or dateparser.
+
+    Args:
+        tmp_path: pytest fixture; isolated dir for the subprocess's HOME/XDG.
+    """
+    result = _run_isolated_python(tmp_path, _MEASURE_SNIPPET)
+    assert result.returncode == 0, (
+        f"import tldw_chatbook.app failed in isolated subprocess:\n"
+        f"stdout={result.stdout}\nstderr={result.stderr}"
+    )
+    last_line = result.stdout.strip().splitlines()[-1]
+    payload = json.loads(last_line)
+    assert payload["loaded"] == [], (
+        f"import tldw_chatbook.app eagerly loaded deferred modules: {payload['loaded']}"
+    )
+
+
+@pytest.mark.parametrize("module_name", DEFERRED_MODULES)
+def test_app_import_does_not_load_module_individually(tmp_path: Path, module_name: str) -> None:
+    """Per-module variant of the guard above, so a regression in any single
+    chain produces an obviously-scoped failure message.
+
+    Args:
+        tmp_path: pytest fixture; isolated dir for the subprocess's HOME/XDG.
+        module_name: one of DEFERRED_MODULES.
+    """
+    result = _run_isolated_python(tmp_path, _MEASURE_SNIPPET)
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout.strip().splitlines()[-1])
+    assert module_name not in payload["loaded"], (
+        f"import tldw_chatbook.app eagerly loaded {module_name!r}"
+    )
+
+
+# --- 2. Functional smoke: chromadb chain (ChromaDBManager) ------------------
+
+
+def test_chromadb_manager_still_constructs_and_resolves_real_chromadb(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ChromaDBManager must still construct successfully (chromadb IS
+    installed in this venv) once its optional-deps gate is satisfied, and
+    `_ensure_chromadb()` must resolve the real chromadb module/Settings/etc.
+    -- the deferral only changes *when* the import happens, not whether it
+    eventually happens for a real construction.
+
+    Args:
+        monkeypatch: pytest fixture; used to force the `embeddings_rag`
+            optional-deps gate True without requiring a real torch/
+            transformers verification pass (out of scope here -- see
+            task-163).
+    """
+    import importlib.util
+
+    if importlib.util.find_spec("chromadb") is None:
+        pytest.skip("chromadb not installed in this environment")
+
+    from tldw_chatbook.Embeddings import Chroma_Lib
+    from tldw_chatbook.Utils.optional_deps import DEPENDENCIES_AVAILABLE
+
+    monkeypatch.setitem(DEPENDENCIES_AVAILABLE, "embeddings_rag", True)
+
+    with tempfile.TemporaryDirectory() as td:
+        config = {
+            "USER_DB_BASE_DIR": td,
+            "embedding_config": {
+                "default_model_id": "test-model",
+                "models": {
+                    "test-model": {
+                        "provider": "huggingface",
+                        "model_name_or_path": "sentence-transformers/all-MiniLM-L6-v2",
+                    }
+                },
+            },
+        }
+        mgr = Chroma_Lib.ChromaDBManager(user_id="task257-smoke-test", user_embedding_config=config)
+
+    assert mgr is not None
+    assert mgr.client is not None
+    # _ensure_chromadb() must have resolved the real module onto the
+    # module-level placeholders (not left them as the unavailable-feature
+    # fallbacks from before __init__ ran).
+    assert Chroma_Lib.chromadb is not None
+    assert Chroma_Lib.chromadb.__name__ == "chromadb"
+    assert "chromadb" in sys.modules
+
+
+def test_chromadb_manager_still_raises_cleanly_when_deps_gate_is_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Preserve the pre-existing graceful-unavailable behavior: when the
+    `embeddings_rag` optional-deps gate is False, construction must still
+    raise a clear ImportError -- unaffected by the chromadb import having
+    become lazy (the gate check runs before `_ensure_chromadb()`).
+
+    Args:
+        monkeypatch: pytest fixture; forces the `embeddings_rag` gate False.
+    """
+    from tldw_chatbook.Embeddings import Chroma_Lib
+    from tldw_chatbook.Utils.optional_deps import DEPENDENCIES_AVAILABLE
+
+    monkeypatch.setitem(DEPENDENCIES_AVAILABLE, "embeddings_rag", False)
+
+    with pytest.raises(ImportError, match="embeddings/RAG dependencies"):
+        Chroma_Lib.ChromaDBManager(user_id="task257-gate-test", user_embedding_config={"unused": True})
+
+
+# --- 3. Functional smoke: web-search chain (Tools.__getattr__) --------------
+
+
+def test_tools_getattr_resolves_web_search_tool() -> None:
+    """`tldw_chatbook.Tools.WebSearchTool` must still resolve via the PEP 562
+    `__getattr__` lazy layer, from its real defining submodule."""
+    import tldw_chatbook.Tools as Tools
+
+    web_search_tool_cls = Tools.WebSearchTool
+    assert web_search_tool_cls is not None
+    assert web_search_tool_cls.__module__ == "tldw_chatbook.Tools.web_search_tool"
+    assert web_search_tool_cls.__name__ == "WebSearchTool"
+    # Cached on the module after first resolution (no repeated __getattr__).
+    assert "WebSearchTool" in vars(Tools)
+
+
+def test_tools_dunder_all_names_all_resolve() -> None:
+    """Every name in Tools.__all__ (the lazy re-export surface) must resolve
+    with no exceptions -- regression net against a stale `_SUBMODULE_BY_NAME`
+    mapping."""
+    import tldw_chatbook.Tools as Tools
+
+    failed = []
+    for name in Tools.__all__:
+        try:
+            getattr(Tools, name)
+        except Exception as exc:  # pragma: no cover - failure path
+            failed.append((name, repr(exc)))
+    assert not failed, f"{len(failed)} of {len(Tools.__all__)} names failed to resolve: {failed}"
+
+
+def test_tools_unknown_attribute_raises_attribute_error() -> None:
+    """Unknown attributes must raise AttributeError, per PEP 562."""
+    import tldw_chatbook.Tools as Tools
+
+    with pytest.raises(AttributeError, match="tldw_chatbook.Tools"):
+        getattr(Tools, "NoSuchToolNameXYZ")
+
+
+def test_scrape_article_degrades_gracefully_when_playwright_import_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Graceful-absence case: simulate a broken/partial playwright install
+    (module directory present so `find_spec` succeeds, but the real import
+    raises) via `builtins.__import__`, matching the existing
+    `TestParseCsvUrlsPandasGuard` pattern for pandas in
+    Tests/Web_Scraping/test_article_extractor.py. `scrape_article()` must
+    degrade to its existing "Playwright not installed" error dict rather
+    than raising or crashing.
+
+    Args:
+        monkeypatch: pytest fixture; used to force `PLAYWRIGHT_AVAILABLE`
+            True and to make `import playwright...` raise ImportError.
+    """
+    import tldw_chatbook.Web_Scraping.Article_Extractor_Lib as mod
+
+    monkeypatch.setattr(mod, "PLAYWRIGHT_AVAILABLE", True)
+    monkeypatch.setattr(mod, "async_playwright", None)
+    monkeypatch.setattr(mod, "sync_playwright", None)
+
+    real_import = builtins.__import__
+
+    def _fail_playwright(name, *args, **kwargs):
+        if name == "playwright" or name.startswith("playwright."):
+            raise ImportError("simulated broken playwright install")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _fail_playwright)
+
+    result = asyncio.run(mod.scrape_article("https://example.com/some-article"))
+
+    assert result["extraction_successful"] is False
+    assert result["error"] == "Playwright not installed"
+
+
+# --- 4. Functional smoke: PDF/document processors (dispatch-time import) ----
+
+
+def test_parse_local_file_for_ingest_processes_plaintext_without_optional_deps(tmp_path: Path) -> None:
+    """The plaintext dispatch branch needs none of the five deferred
+    per-format processors (process_pdf/process_document/process_ebook/
+    LocalAudioProcessor/LocalVideoProcessor) -- it must work standalone.
+
+    Note: this does NOT also assert `'pymupdf' not in sys.modules` here --
+    that would be order-dependent within a shared pytest process (an
+    unrelated earlier test in the same session may have already imported
+    pymupdf for its own reasons, e.g. Tests/Utils/test_optional_deps.py's
+    dependency-check tests). That exact assertion is covered correctly, in
+    isolation, by test_app_import_does_not_load_any_deferred_module above.
+
+    Args:
+        tmp_path: pytest fixture; holds the small .txt fixture file.
+    """
+    from tldw_chatbook.Local_Ingestion.local_file_ingestion import parse_local_file_for_ingest
+
+    source = tmp_path / "note.txt"
+    source.write_text("Deferred-import smoke test content.", encoding="utf-8")
+
+    payload = parse_local_file_for_ingest(str(source), {"perform_analysis": False})
+
+    assert payload["content"] == "Deferred-import smoke test content."
+
+
+def test_parse_local_file_for_ingest_pdf_branch_still_resolves_process_pdf(tmp_path: Path) -> None:
+    """The pdf dispatch branch must still resolve and call the real
+    `process_pdf` via `_ensure_process_pdf()` when a `.pdf` file is routed
+    to it -- proving the deferral didn't break the wiring, without needing
+    a real PDF fixture (process_pdf itself is monkeypatched, matching the
+    existing `test_process_pdf_error_key_presence_vs_truthiness`-style
+    pattern in Tests/Local_Ingestion/test_ingest_parse_worker.py).
+
+    Args:
+        tmp_path: pytest fixture; holds the (stub-content) .pdf fixture file.
+    """
+    import tldw_chatbook.Local_Ingestion.local_file_ingestion as lfi
+
+    source = tmp_path / "doc.pdf"
+    source.write_bytes(b"%PDF-1.4 stub bytes, never actually parsed (process_pdf is mocked).")
+
+    calls = []
+
+    def _fake_process_pdf(**kwargs):
+        calls.append(kwargs)
+        return {
+            "status": "Success",
+            "content": "Fake PDF content.",
+            "title": "Fake title",
+            "author": "Fake author",
+            "keywords": [],
+            "chunks": [],
+            "analysis": "",
+            "metadata": {},
+            "error": None,
+        }
+
+    # local_file_ingestion.process_pdf starts as the module-level `None`
+    # placeholder; _ensure_process_pdf() must not clobber an already-bound
+    # (here, test-provided) value -- same contract exercised by
+    # Tests/Local_Ingestion/test_ingest_parse_worker.py's monkeypatch of
+    # this exact attribute.
+    original = lfi.process_pdf
+    lfi.process_pdf = _fake_process_pdf
+    try:
+        payload = lfi.parse_local_file_for_ingest(str(source), {"perform_analysis": False})
+    finally:
+        lfi.process_pdf = original
+
+    assert len(calls) == 1
+    assert payload["content"] == "Fake PDF content."
+
+
+# --- 5. Graceful-absence: simulated missing chromadb -------------------------
+
+
+def test_ensure_chromadb_degrades_gracefully_when_import_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Graceful-absence case for the chromadb chain: simulate a broken
+    install (`get_safe_import` returns None, matching a real ImportError
+    inside it) and confirm `_ensure_chromadb()` returns None without
+    raising, and without mutating ChromaError/Settings/etc. any further.
+
+    Args:
+        monkeypatch: pytest fixture; forces `get_safe_import('chromadb')`
+            to return None (its real behavior on ImportError) without
+            needing to actually uninstall chromadb.
+    """
+    from tldw_chatbook.Embeddings import Chroma_Lib
+
+    # Reset module-level state so _ensure_chromadb() actually re-attempts
+    # the import instead of short-circuiting on an already-cached value.
+    monkeypatch.setattr(Chroma_Lib, "chromadb", None)
+    monkeypatch.setattr(Chroma_Lib, "numpy", None)
+
+    def _fake_get_safe_import(module_name, *args, **kwargs):
+        # Real get_safe_import() returns None on ImportError; this test
+        # only ever exercises _ensure_chromadb(), which calls it with
+        # 'numpy' and 'chromadb'.
+        return None
+
+    monkeypatch.setattr(Chroma_Lib, "get_safe_import", _fake_get_safe_import)
+
+    # Capture whatever ChromaError/Settings/etc. were bound to beforehand
+    # (they may already be the real chromadb classes if an earlier test in
+    # this process constructed a real ChromaDBManager -- module globals are
+    # process-wide) so this assertion is order-independent: the only thing
+    # under test is that THIS failed _ensure_chromadb() call doesn't mutate
+    # them further.
+    expected_chroma_error = Chroma_Lib.ChromaError
+
+    result = Chroma_Lib._ensure_chromadb()
+
+    assert result is None
+    assert Chroma_Lib.chromadb is None
+    assert Chroma_Lib.ChromaError is expected_chroma_error

--- a/backlog/tasks/task-257 - Defer-optional-feature-imports-chromadb-websearch-pdf.md
+++ b/backlog/tasks/task-257 - Defer-optional-feature-imports-chromadb-websearch-pdf.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-257
 title: Defer optional-feature imports: chromadb, web-search chain, PDF/document processors (~550ms)
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-16 14:30'
 labels: [performance, startup]
@@ -17,8 +17,137 @@ Three eager chains for features unused by default: Chroma_Lib module-scope get_s
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 chromadb imports only when ChromaDBManager is instantiated
-- [ ] #2 Web-search chain imports only when the tool is enabled/used (find_spec probe for availability)
-- [ ] #3 Per-format ingestion processors import at dispatch time
-- [ ] #4 Measured app-import delta reported (expected >400ms); optional-deps availability semantics unchanged (extras absent still degrade gracefully)
+- [x] #1 chromadb imports only when ChromaDBManager is instantiated
+- [x] #2 Web-search chain imports only when the tool is enabled/used (find_spec probe for availability)
+- [x] #3 Per-format ingestion processors import at dispatch time
+- [x] #4 Measured app-import delta reported (expected >400ms); optional-deps availability semantics unchanged (extras absent still degrade gracefully)
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Read the current state of `Embeddings/Chroma_Lib.py` (another session's RAG
+   program had touched this area recently) before changing anything.
+2. Chain 1 (chromadb): defer `get_safe_import('numpy')`/`get_safe_import('chromadb')`
+   into `_ensure_numpy()`/`_ensure_chromadb()` helpers called from
+   `ChromaDBManager.__init__`, preserving the existing unavailable-feature
+   placeholders.
+3. Chain 2 (web-search): convert `Tools/__init__.py`'s eager optional-tool
+   imports to a PEP 562 lazy `__getattr__` re-export layer (mirroring
+   `Local_Ingestion/__init__.py`/`tldw_api/__init__.py`); defer
+   `Web_Scraping/Article_Extractor_Lib.py`'s module-scope playwright/
+   trafilatura imports behind `find_spec` probes + `_ensure_playwright()`/
+   `_ensure_trafilatura()` helpers, mirroring that file's existing pandas
+   `find_spec` deferral.
+4. Chain 3 (PDF/document/ebook/audio/video): move
+   `Local_Ingestion/local_file_ingestion.py`'s five per-format processor
+   imports (process_pdf/process_document/process_ebook/LocalAudioProcessor/
+   LocalVideoProcessor) off module scope into `_ensure_*()` helpers invoked
+   from `parse_local_file_for_ingest()`'s per-`file_type` dispatch branches.
+5. Write `Tests/Utils/test_optional_import_deferral.py`: isolated-subprocess
+   `sys.modules` assertions for all five deferred modules, functional smoke
+   per chain, and a graceful-absence (simulated missing dependency) case.
+6. Measure app-import wall time/module count/`sys.modules` residency
+   before (detached `origin/dev` worktree) vs after, in a scratch HOME/XDG
+   sandbox; report deltas.
+7. Run the full affected test suites and confirm no existing test files
+   were modified.
+
+## Implementation Notes
+
+**Chain 1 -- chromadb (`Embeddings/Chroma_Lib.py`)**: module-scope
+`numpy = get_safe_import('numpy')` / `chromadb = get_safe_import('chromadb')`
+(and the `Settings`/`ChromaError`/`InvalidDimensionException`/`Collection`/
+`QueryResult` names derived from `chromadb`) are now `None`/unavailable-feature
+placeholders at import time, resolved by `_ensure_numpy()`/`_ensure_chromadb()`
+helpers (mirroring `Embeddings_Lib.py`'s `_ensure_torch()` pattern) called at
+the top of `ChromaDBManager.__init__`. The entire rest of the 1,231-line file
+is inside `ChromaDBManager` methods, reachable only after `__init__`, so no
+other module-scope code needed changes. This chain's `_ensure_*()` work was
+already present, uncommitted, in the worktree when this session started
+(apparently a prior partial run of this exact task) -- it was reviewed,
+verified correct against the current file state, and left as-is.
+
+**Chain 2 -- web-search (`Tools/__init__.py` + `Web_Scraping/Article_Extractor_Lib.py`)**:
+`Tools/__init__.py`'s eager `try/except` imports of `WebSearchTool`/
+`ReadFileTool`/`ListDirectoryTool`/`WriteFileTool`/`RAGSearchTool`/
+`CreateNoteTool`/`SearchNotesTool`/`UpdateNoteTool` are replaced with a PEP 562
+`__getattr__` + `_SUBMODULE_BY_NAME` mapping (same pattern as
+`Local_Ingestion/__init__.py`/`tldw_api/__init__.py`); `Tool`/`ToolExecutor`/
+`DateTimeTool`/`CalculatorTool`/`get_tool_executor`/`reload_tool_executor` stay
+eager (lightweight, always-needed). `tool_executor.get_tool_executor()` was
+already unaffected -- it imports each optional tool directly from its own
+submodule, gated by per-tool config flags, never through this package's names.
+`Article_Extractor_Lib.py`'s module-scope `try: from playwright... / import
+trafilatura` blocks are replaced with `find_spec`-based `PLAYWRIGHT_AVAILABLE`/
+`TRAFILATURA_AVAILABLE` probes (mirroring the file's existing pandas
+deferral) plus `_ensure_playwright()`/`_ensure_trafilatura()` helpers, called
+at the top of `scrape_article()` (guards `async_playwright`/`TimeoutError`/
+`trafilatura.extract`/`extract_metadata` use) and `recursive_scrape()` (guards
+its direct `async_playwright()` call). `TimeoutError` is intentionally
+shadowed at module scope (unchanged pre-existing behavior) so `except
+TimeoutError` clauses transparently pick up playwright's real exception once
+ensured. The `_ensure_*()` guards no-op when the name is already bound to
+something other than `None` (e.g. a test's `unittest.mock.patch`), so the
+existing `Tests/Web_Scraping/test_article_extractor.py` mocks of
+`async_playwright` continue to work unmodified.
+
+**Chain 3 -- PDF/document/ebook/audio/video (`Local_Ingestion/local_file_ingestion.py`)**:
+the five per-format processor imports moved from module scope into
+module-level `None` placeholders + `_ensure_process_pdf()`/
+`_ensure_process_document()`/`_ensure_process_ebook()`/
+`_ensure_local_audio_processor()`/`_ensure_local_video_processor()` helpers,
+called from `parse_local_file_for_ingest()`'s matching `file_type` branch.
+Plain local `from .X import Y` statements inside each branch were considered
+and rejected: two existing tests
+(`Tests/Local_Ingestion/test_parse_url_routing.py::test_video_url_routes_to_audio_video_branch`,
+`Tests/Local_Ingestion/test_ingest_parse_worker.py`'s `process_pdf`
+monkeypatch, plus a third `monkeypatch.setattr(lfi, "LocalAudioProcessor",
+...)` in the same file) patch these names as **module attributes** of
+`local_file_ingestion`, which requires the name to already exist at module
+scope -- the `_ensure_*()`-with-module-global pattern (matching the chromadb/
+playwright precedent in this same task) satisfies both the laziness goal and
+existing-test patchability: each `_ensure_*()` no-ops when its name is
+already bound to something other than the placeholder, so a patched/mocked
+value is never clobbered.
+
+**Tests**: new `Tests/Utils/test_optional_import_deferral.py` (16 tests) --
+isolated-subprocess `sys.modules` assertions (whole-set + one parametrized
+test per module) after `import tldw_chatbook.app`, using a scratch HOME/XDG
+sandbox (never the real `~/.config/tldw_cli`); functional smoke per chain
+(real `ChromaDBManager` construction resolving real chromadb, `Tools`
+PEP 562 `__getattr__` resolving `WebSearchTool` + full `__all__`/unknown-name
+checks, `parse_local_file_for_ingest` processing a plaintext file with none of
+the five processors touched, a PDF-branch wiring check via a mocked
+`process_pdf`); two graceful-absence cases (simulated broken playwright via
+`builtins.__import__` interception -- mirrors the file's existing pandas-guard
+test pattern -- and simulated broken chromadb via a faked `get_safe_import`).
+All existing tests were left read-only (`git diff origin/dev --diff-filter=M
+--name-only -- Tests/` is empty).
+
+**Measured deltas** (5x `import tldw_chatbook.app` in a fresh interpreter per
+run, scratch HOME/XDG, cwd = tree under test so the editable install resolves
+locally; baseline = detached `origin/dev` worktree at the same commit this
+branch started from, removed after measurement):
+
+| | baseline (before) | after | delta |
+|---|---|---|---|
+| wall time (steady-state avg, runs 2-5) | ~1.542s | ~0.980s | **~562ms faster** |
+| wall time (all 5 runs incl. cold run 1) | ~1.774s | ~0.999s | ~775ms faster |
+| module count | 3,294 | 1,992 | **-1,302 modules (-39.5%)** |
+| `chromadb`/`playwright`/`trafilatura`/`pymupdf`/`dateparser` resident? | all 5 loaded | **none loaded** | -- |
+
+Exceeds the >400ms AC #4 target. `fitz` (pymupdf's import name) was never
+separately resident in either run (pymupdf's own top-level package name
+covers it). Optional-deps availability semantics are unchanged: each chain's
+existing unavailable-feature fallback path (ImportError with an install hint
+for chromadb/ChromaDBManager; error-dict degrade for
+scrape_article/scrape_and_summarize_multiple; internal per-module
+try/except in PDF_Processing_Lib/Document_Processing_Lib/Book_Ingestion_Lib/
+audio_processing/video_processing) is untouched -- only *when* the real
+import is attempted moved, not *whether* it degrades gracefully when absent.
+
+**Files modified**: `tldw_chatbook/Embeddings/Chroma_Lib.py`,
+`tldw_chatbook/Tools/__init__.py`,
+`tldw_chatbook/Web_Scraping/Article_Extractor_Lib.py`,
+`tldw_chatbook/Local_Ingestion/local_file_ingestion.py`.
+**Files added**: `Tests/Utils/test_optional_import_deferral.py`.

--- a/tldw_chatbook/Embeddings/Chroma_Lib.py
+++ b/tldw_chatbook/Embeddings/Chroma_Lib.py
@@ -169,7 +169,14 @@ class ChromaDBManager:
         # Import numpy/chromadb (and Settings/ChromaError/etc.) now that we
         # know this instance actually needs them -- see _ensure_chromadb()
         # docstring at module scope for why this is deferred this far.
-        _ensure_chromadb()
+        if _ensure_chromadb() is None:
+            # PR #672 review: a None chromadb would surface later as a
+            # cryptic AttributeError on .PersistentClient — fail cleanly at
+            # the boundary instead.
+            raise ImportError(
+                "chromadb is required for ChromaDBManager but is not "
+                "installed (pip install tldw_chatbook[embeddings_rag])."
+            )
 
         if not user_id:
             logger.error("Initialization failed: user_id cannot be empty for ChromaDBManager.")

--- a/tldw_chatbook/Embeddings/Chroma_Lib.py
+++ b/tldw_chatbook/Embeddings/Chroma_Lib.py
@@ -35,9 +35,22 @@ from ..Utils.optional_deps import (
     DEPENDENCIES_AVAILABLE, create_unavailable_feature_handler
 )
 
-# Import optional dependencies safely
-numpy = get_safe_import('numpy')
-chromadb = get_safe_import('chromadb')
+# numpy/chromadb are heavy optional dependencies -- chromadb alone
+# transitively pulls in OTel/gRPC/protobuf (~150ms). They used to be
+# imported at module scope via get_safe_import(), which meant a plain
+# `import tldw_chatbook.app` paid the full cost (this module is reachable
+# via RAG_Admin/local_rag_admin_service.py, which app.py imports
+# unconditionally) even though no ChromaDBManager had been constructed.
+# They are now imported lazily on first real use via the _ensure_*()
+# helpers below (mirroring Embeddings_Lib.py's _ensure_torch()/
+# _ensure_numpy() pattern), called at the top of ChromaDBManager.__init__.
+# All other module-level code that dereferences np/chromadb/Settings/
+# ChromaError/InvalidDimensionException/Collection/QueryResult is inside
+# ChromaDBManager instance methods, which are only reachable after
+# __init__ has already run _ensure_chromadb(), so the module-level
+# fallback placeholders below only matter transiently before __init__.
+numpy = None
+chromadb = None
 
 
 def _current_dependencies_available() -> Dict[str, bool]:
@@ -48,29 +61,66 @@ def _current_dependencies_available() -> Dict[str, bool]:
         return current_registry
     return DEPENDENCIES_AVAILABLE
 
-# Create safe imports with fallbacks
-if numpy is not None:
-    np = numpy
-else:
-    # Create a basic np-like object for type annotations
-    class _NumpyPlaceholder:
-        @staticmethod
-        def asarray(*args, **kwargs):
-            raise ImportError("NumPy not available. Install with: pip install tldw_chatbook[embeddings_rag]")
-    np = _NumpyPlaceholder()
 
-if chromadb is not None:
-    from chromadb import Settings
-    from chromadb.errors import ChromaError, InvalidDimensionException
-    from chromadb.api.models import Collection
-    from chromadb.api.types import QueryResult
-else:
-    # Create placeholder classes
-    Settings = create_unavailable_feature_handler('chromadb', 'pip install tldw_chatbook[embeddings_rag]')
-    ChromaError = Exception
-    InvalidDimensionException = Exception
-    Collection = Any
-    QueryResult = Any
+# Create a basic np-like object for type annotations / pre-_ensure_numpy() access
+class _NumpyPlaceholder:
+    @staticmethod
+    def asarray(*args, **kwargs):
+        raise ImportError("NumPy not available. Install with: pip install tldw_chatbook[embeddings_rag]")
+np = _NumpyPlaceholder()
+
+# Placeholder classes -- overwritten by _ensure_chromadb() once chromadb is
+# actually imported (or re-set to these same fallbacks if it's unavailable).
+Settings = create_unavailable_feature_handler('chromadb', 'pip install tldw_chatbook[embeddings_rag]')
+ChromaError = Exception
+InvalidDimensionException = Exception
+Collection = Any
+QueryResult = Any
+
+
+def _ensure_numpy():
+    """Import numpy on first actual use. No-op on repeated calls."""
+    global numpy, np
+    if numpy is not None:
+        return numpy
+    _numpy = get_safe_import('numpy')
+    if _numpy is not None:
+        # Bind `np` BEFORE the gate global (`numpy`), so a racing thread that
+        # observes `numpy is not None` never finds `np` still the placeholder.
+        np = _numpy
+        numpy = _numpy
+    return numpy
+
+
+def _ensure_chromadb():
+    """Import chromadb (and the Settings/error/type names derived from it)
+    on first actual use. No-op on repeated calls.
+
+    Preserves the previous eager-import fallback semantics: when chromadb
+    isn't installed, Settings/ChromaError/InvalidDimensionException/
+    Collection/QueryResult stay bound to the module-level placeholders set
+    above.
+    """
+    global chromadb, Settings, ChromaError, InvalidDimensionException, Collection, QueryResult
+    if chromadb is not None:
+        return chromadb
+    _ensure_numpy()
+    _chromadb = get_safe_import('chromadb')
+    if _chromadb is not None:
+        from chromadb import Settings as _Settings
+        from chromadb.errors import ChromaError as _ChromaError, InvalidDimensionException as _InvalidDimensionException
+        from chromadb.api.models import Collection as _Collection
+        from chromadb.api.types import QueryResult as _QueryResult
+        # Bind the derived names BEFORE the gate global (`chromadb`), so a
+        # racing thread that observes `chromadb is not None` is guaranteed to
+        # also see Settings/ChromaError/etc. fully bound.
+        Settings = _Settings
+        ChromaError = _ChromaError
+        InvalidDimensionException = _InvalidDimensionException
+        Collection = _Collection
+        QueryResult = _QueryResult
+        chromadb = _chromadb
+    return chromadb
 
 # Configure logger with context
 logger = logger.bind(module="Chroma_Lib")
@@ -115,7 +165,12 @@ class ChromaDBManager:
                 "ChromaDBManager requires embeddings/RAG dependencies. "
                 "Install with: pip install tldw_chatbook[embeddings_rag]"
             )
-            
+
+        # Import numpy/chromadb (and Settings/ChromaError/etc.) now that we
+        # know this instance actually needs them -- see _ensure_chromadb()
+        # docstring at module scope for why this is deferred this far.
+        _ensure_chromadb()
+
         if not user_id:
             logger.error("Initialization failed: user_id cannot be empty for ChromaDBManager.")
             raise ValueError("user_id cannot be empty for ChromaDBManager.")

--- a/tldw_chatbook/Local_Ingestion/local_file_ingestion.py
+++ b/tldw_chatbook/Local_Ingestion/local_file_ingestion.py
@@ -13,12 +13,85 @@ from typing import Dict, List, Optional, Any, Union
 from datetime import datetime
 from loguru import logger
 
-# Import processing libraries
-from .PDF_Processing_Lib import process_pdf
-from .Document_Processing_Lib import process_document
-from .Book_Ingestion_Lib import process_ebook
-from .audio_processing import LocalAudioProcessor
-from .video_processing import LocalVideoProcessor
+# Per-format processing libraries (process_pdf/process_document/process_ebook/
+# LocalAudioProcessor/LocalVideoProcessor) are intentionally NOT imported at
+# module scope here. This module is imported directly by app.py (for
+# classify_ingest_source/persist_parsed_media), which bypasses
+# Local_Ingestion's own lazy `__init__.py` (PEP 562 `__getattr__`) --
+# standard Python import semantics run this file's module body regardless of
+# which name was requested. Before this deferral, that meant pymupdf/
+# onnxruntime (~170ms, via PDF_Processing_Lib) and the Document/ebook
+# processing stack (~59ms) were paid on every app startup even when no PDF/
+# document/ebook ingestion had happened (see task-257).
+#
+# Each processor is now imported lazily via the module-level placeholders +
+# `_ensure_*()` helpers below (mirroring the pattern already used by
+# `Embeddings/Chroma_Lib.py` and `Web_Scraping/Article_Extractor_Lib.py`),
+# called at the top of `parse_local_file_for_ingest()`'s branch for that
+# `file_type`, once per process (Python caches `sys.modules`, so repeated
+# calls don't re-pay the cost). The module-level names are kept (rather than
+# using plain local `from .X import Y` statements inside each branch) so
+# that `unittest.mock.patch("...local_file_ingestion.process_pdf", ...)` /
+# `monkeypatch.setattr("...local_file_ingestion.LocalVideoProcessor", ...)`
+# -- used by existing tests -- continue to work: each `_ensure_*()` helper
+# no-ops when its name is already bound to something other than the
+# placeholder (e.g. a test's mock), so a patched value is never clobbered.
+process_pdf = None
+process_document = None
+process_ebook = None
+LocalAudioProcessor = None
+LocalVideoProcessor = None
+
+
+def _ensure_process_pdf():
+    """Import PDF_Processing_Lib.process_pdf on first actual use (or return
+    an already-bound value, e.g. a test's mock)."""
+    global process_pdf
+    if process_pdf is None:
+        from .PDF_Processing_Lib import process_pdf as _process_pdf
+        process_pdf = _process_pdf
+    return process_pdf
+
+
+def _ensure_process_document():
+    """Import Document_Processing_Lib.process_document on first actual use
+    (or return an already-bound value, e.g. a test's mock)."""
+    global process_document
+    if process_document is None:
+        from .Document_Processing_Lib import process_document as _process_document
+        process_document = _process_document
+    return process_document
+
+
+def _ensure_process_ebook():
+    """Import Book_Ingestion_Lib.process_ebook on first actual use (or
+    return an already-bound value, e.g. a test's mock)."""
+    global process_ebook
+    if process_ebook is None:
+        from .Book_Ingestion_Lib import process_ebook as _process_ebook
+        process_ebook = _process_ebook
+    return process_ebook
+
+
+def _ensure_local_audio_processor():
+    """Import audio_processing.LocalAudioProcessor on first actual use (or
+    return an already-bound value, e.g. a test's mock)."""
+    global LocalAudioProcessor
+    if LocalAudioProcessor is None:
+        from .audio_processing import LocalAudioProcessor as _LocalAudioProcessor
+        LocalAudioProcessor = _LocalAudioProcessor
+    return LocalAudioProcessor
+
+
+def _ensure_local_video_processor():
+    """Import video_processing.LocalVideoProcessor on first actual use (or
+    return an already-bound value, e.g. a test's mock)."""
+    global LocalVideoProcessor
+    if LocalVideoProcessor is None:
+        from .video_processing import LocalVideoProcessor as _LocalVideoProcessor
+        LocalVideoProcessor = _LocalVideoProcessor
+    return LocalVideoProcessor
+
 
 # Import database
 from ..DB.Client_Media_DB_v2 import MediaDatabase
@@ -371,7 +444,7 @@ def parse_local_file_for_ingest(file_path: Union[str, Path], options: Dict[str, 
         
         # Process based on file type
         if file_type == 'pdf':
-            result = process_pdf(
+            result = _ensure_process_pdf()(
                 file_input=str(file_path),
                 filename=file_path.name,
                 title_override=title,
@@ -387,7 +460,7 @@ def parse_local_file_for_ingest(file_path: Union[str, Path], options: Dict[str, 
             )
             
         elif file_type == 'document':
-            result = process_document(
+            result = _ensure_process_document()(
                 file_path=str(file_path),
                 title_override=title,
                 author_override=author,
@@ -401,7 +474,7 @@ def parse_local_file_for_ingest(file_path: Union[str, Path], options: Dict[str, 
             )
             
         elif file_type == 'ebook':
-            result = process_ebook(
+            result = _ensure_process_ebook()(
                 file_path=str(file_path),
                 title_override=title,
                 author_override=author,
@@ -424,7 +497,7 @@ def parse_local_file_for_ingest(file_path: Union[str, Path], options: Dict[str, 
             # via content-hash dedup and no-ops against -- returning
             # media_id=None for every audio ingest (see the docstring's
             # bug-mechanism paragraph and the regression test named there).
-            audio_processor = LocalAudioProcessor(None)
+            audio_processor = _ensure_local_audio_processor()(None)
 
             # Process single audio file
             results = audio_processor.process_audio_files(
@@ -472,7 +545,7 @@ def parse_local_file_for_ingest(file_path: Union[str, Path], options: Dict[str, 
         elif file_type == 'video':
             # Initialize video processor. media_db is intentionally None --
             # see the matching comment in the 'audio' branch above.
-            video_processor = LocalVideoProcessor(None)
+            video_processor = _ensure_local_video_processor()(None)
 
             # Process single video file
             results = video_processor.process_videos(

--- a/tldw_chatbook/Tools/__init__.py
+++ b/tldw_chatbook/Tools/__init__.py
@@ -1,7 +1,30 @@
 # Tools module initialization
 """
 Tool execution framework for LLM function calling.
+
+Lazy re-exports (PEP 562). The optional tool classes below resolve on
+first attribute access rather than at package-import time, via module
+``__getattr__`` -- the same pattern used by ``Local_Ingestion/__init__.py``
+and ``tldw_api/__init__.py`` (see those modules' docstrings for the
+general rationale). This matters here specifically because
+``WebSearchTool`` used to be imported eagerly here, which pulls in
+``Article_Extractor_Lib.py``'s module-scope playwright + trafilatura
+imports (~197ms, see task-257) even though ``web_search_enabled`` defaults
+to ``False`` and no user session had touched web search yet. The actual
+tool-registration path (``tool_executor.get_tool_executor()``) already
+imports each optional tool class directly from its own submodule, gated
+by per-tool config flags -- it never goes through this package's names.
+The remaining optional tool classes (file ops, RAG search, note
+management) are made lazy too, for consistency and because there is no
+reason to pay any submodule's import cost for a tool nobody asked for.
+
+``Tool``/``ToolExecutor``/``DateTimeTool``/``CalculatorTool``/
+``get_tool_executor``/``reload_tool_executor`` stay eager: they are
+lightweight (defined directly in ``tool_executor.py``, no heavy
+transitive deps) and are the framework's core, always-needed surface.
 """
+
+from typing import Any
 
 from .tool_executor import (
     Tool,
@@ -12,61 +35,49 @@ from .tool_executor import (
     reload_tool_executor
 )
 
-# Import optional tools
-try:
-    from .web_search_tool import WebSearchTool
-except ImportError:
-    WebSearchTool = None
-
-try:
-    from .file_operation_tools import ReadFileTool, ListDirectoryTool, WriteFileTool
-except ImportError:
-    ReadFileTool = None
-    ListDirectoryTool = None
-    WriteFileTool = None
-
-try:
-    from .rag_search_tool import RAGSearchTool
-except ImportError:
-    RAGSearchTool = None
-
-try:
-    from .note_management_tools import CreateNoteTool, SearchNotesTool, UpdateNoteTool
-except ImportError:
-    CreateNoteTool = None
-    SearchNotesTool = None
-    UpdateNoteTool = None
-
 __all__ = [
     'Tool',
     'ToolExecutor',
     'DateTimeTool',
     'CalculatorTool',
     'get_tool_executor',
-    'reload_tool_executor'
+    'reload_tool_executor',
+    'WebSearchTool',
+    'ReadFileTool',
+    'ListDirectoryTool',
+    'WriteFileTool',
+    'RAGSearchTool',
+    'CreateNoteTool',
+    'SearchNotesTool',
+    'UpdateNoteTool',
 ]
 
-# Add optional tools to __all__ if they're available
-if WebSearchTool is not None:
-    __all__.append('WebSearchTool')
+# Name -> submodule providing it. Kept as a flat mapping (rather than a
+# `from .x import *`-style block per submodule) so `__getattr__` only ever
+# imports the one submodule that actually owns the requested name.
+_SUBMODULE_BY_NAME = {
+    'WebSearchTool': 'web_search_tool',
+    'ReadFileTool': 'file_operation_tools',
+    'ListDirectoryTool': 'file_operation_tools',
+    'WriteFileTool': 'file_operation_tools',
+    'RAGSearchTool': 'rag_search_tool',
+    'CreateNoteTool': 'note_management_tools',
+    'SearchNotesTool': 'note_management_tools',
+    'UpdateNoteTool': 'note_management_tools',
+}
 
-if ReadFileTool is not None:
-    __all__.append('ReadFileTool')
 
-if ListDirectoryTool is not None:
-    __all__.append('ListDirectoryTool')
-
-if WriteFileTool is not None:
-    __all__.append('WriteFileTool')
-
-if RAGSearchTool is not None:
-    __all__.append('RAGSearchTool')
-
-if CreateNoteTool is not None:
-    __all__.append('CreateNoteTool')
-
-if SearchNotesTool is not None:
-    __all__.append('SearchNotesTool')
-
-if UpdateNoteTool is not None:
-    __all__.append('UpdateNoteTool')
+def __getattr__(name: str) -> Any:
+    submodule_name = _SUBMODULE_BY_NAME.get(name)
+    if submodule_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    import importlib
+    try:
+        submodule = importlib.import_module(f".{submodule_name}", __name__)
+        value = getattr(submodule, name)
+    except ImportError:
+        # Preserve the previous eager-import fallback semantics: the
+        # optional dependency backing this tool isn't installed.
+        value = None
+    globals()[name] = value  # cache so subsequent lookups skip __getattr__
+    return value

--- a/tldw_chatbook/Tools/__init__.py
+++ b/tldw_chatbook/Tools/__init__.py
@@ -26,6 +26,8 @@ transitive deps) and are the framework's core, always-needed surface.
 
 from typing import Any
 
+from loguru import logger
+
 from .tool_executor import (
     Tool,
     ToolExecutor,
@@ -76,8 +78,15 @@ def __getattr__(name: str) -> Any:
         submodule = importlib.import_module(f".{submodule_name}", __name__)
         value = getattr(submodule, name)
     except ImportError:
-        # Preserve the previous eager-import fallback semantics: the
-        # optional dependency backing this tool isn't installed.
+        # Preserve the previous eager-import fallback semantics (the name
+        # binds to None when its optional dependency isn't installed) — but
+        # keep the original traceback visible so a genuine import-time BUG
+        # in the tool module can't hide behind a later NoneType error
+        # (PR #672 review). Non-ImportError exceptions propagate.
+        logger.debug(
+            f"Optional tool {name!r} unavailable; binding to None.",
+            exc_info=True,
+        )
         value = None
     globals()[name] = value  # cache so subsequent lookups skip __getattr__
     return value

--- a/tldw_chatbook/Web_Scraping/Article_Extractor_Lib.py
+++ b/tldw_chatbook/Web_Scraping/Article_Extractor_Lib.py
@@ -65,27 +65,81 @@ except ImportError:
 PANDAS_AVAILABLE = importlib.util.find_spec("pandas") is not None
 pd = None
 
-try:
-    from playwright.async_api import (
-        TimeoutError,
-        async_playwright
-    )
-    from playwright.sync_api import sync_playwright
-    PLAYWRIGHT_AVAILABLE = True
-except ImportError:
-    PLAYWRIGHT_AVAILABLE = False
-    TimeoutError = Exception
-    async_playwright = None
-    sync_playwright = None
+# playwright and trafilatura are the two heaviest optional deps in this
+# module (playwright's browser-automation stack + trafilatura's own
+# dateparser/htmldate transitive deps, ~197ms combined -- see task-257).
+# They used to be imported at module scope via a real try/except import,
+# which meant a plain `import tldw_chatbook.app` paid the full cost
+# whenever web_search was installed, even though `web_search_enabled`
+# defaults to False and nothing had scraped yet. Probe availability
+# cheaply via find_spec (no import, mirrors PANDAS_AVAILABLE above) and
+# defer the real imports to the _ensure_playwright()/_ensure_trafilatura()
+# helpers below, called at the top of every function that actually uses
+# them (scrape_article, recursive_scrape). `TimeoutError` is intentionally
+# shadowed at module scope (as it was previously) so `except TimeoutError`
+# clauses transparently pick up playwright's TimeoutError once ensured, or
+# fall back to the builtin Exception placeholder when playwright is
+# unavailable -- unchanged behavior from before this deferral.
+PLAYWRIGHT_AVAILABLE = importlib.util.find_spec("playwright") is not None
+TimeoutError = Exception
+async_playwright = None
+sync_playwright = None
 
 import requests
 
-try:
-    import trafilatura
-    TRAFILATURA_AVAILABLE = True
-except ImportError:
-    TRAFILATURA_AVAILABLE = False
-    trafilatura = None
+TRAFILATURA_AVAILABLE = importlib.util.find_spec("trafilatura") is not None
+trafilatura = None
+
+
+def _ensure_playwright() -> bool:
+    """Import playwright on first actual use. No-op on repeated calls.
+
+    Returns:
+        True if `async_playwright`/`sync_playwright`/`TimeoutError` are
+        (now) bound to the real playwright objects, False if playwright is
+        unavailable or unimportable (e.g. a broken/partial install where
+        `find_spec` succeeds but the real import still fails).
+    """
+    global async_playwright, sync_playwright, TimeoutError
+    if async_playwright is not None:
+        # Already ensured -- or a test/caller has patched this module's
+        # `async_playwright` directly (e.g. via unittest.mock.patch), which
+        # must not be clobbered.
+        return True
+    if not PLAYWRIGHT_AVAILABLE:
+        return False
+    try:
+        from playwright.async_api import (
+            TimeoutError as _TimeoutError,
+            async_playwright as _async_playwright,
+        )
+        from playwright.sync_api import sync_playwright as _sync_playwright
+    except ImportError:
+        return False
+    TimeoutError = _TimeoutError
+    async_playwright = _async_playwright
+    sync_playwright = _sync_playwright
+    return True
+
+
+def _ensure_trafilatura() -> bool:
+    """Import trafilatura on first actual use. No-op on repeated calls.
+
+    Returns:
+        True if `trafilatura` is (now) bound to the real module, False if
+        it is unavailable or unimportable.
+    """
+    global trafilatura
+    if trafilatura is not None:
+        return True
+    if not TRAFILATURA_AVAILABLE:
+        return False
+    try:
+        import trafilatura as _trafilatura
+    except ImportError:
+        return False
+    trafilatura = _trafilatura
+    return True
 
 try:
     from tqdm import tqdm
@@ -314,8 +368,9 @@ async def scrape_article(url: str, custom_cookies: Optional[List[Dict[str, Any]]
     
     logging.info(f"Scraping article from URL: {url}")
     
-    # Check required dependencies
-    if not PLAYWRIGHT_AVAILABLE:
+    # Check required dependencies (find_spec probe first, avoids the real
+    # import for the common "not installed" case; then actually import).
+    if not PLAYWRIGHT_AVAILABLE or not _ensure_playwright():
         logging.error("Playwright not available. Install with: pip install tldw_chatbook[websearch]")
         return {
             'title': 'Error',
@@ -326,8 +381,8 @@ async def scrape_article(url: str, custom_cookies: Optional[List[Dict[str, Any]]
             'extraction_successful': False,
             'error': 'Playwright not installed'
         }
-    
-    if not TRAFILATURA_AVAILABLE:
+
+    if not TRAFILATURA_AVAILABLE or not _ensure_trafilatura():
         logging.error("Trafilatura not available. Install with: pip install tldw_chatbook[websearch]")
         return {
             'title': 'Error',
@@ -338,7 +393,7 @@ async def scrape_article(url: str, custom_cookies: Optional[List[Dict[str, Any]]
             'extraction_successful': False,
             'error': 'Trafilatura not installed'
         }
-    
+
     async def fetch_html(url: str) -> str:
             # Load and log the configuration
             loaded_config = load_and_log_configs()
@@ -1470,6 +1525,12 @@ async def recursive_scrape(
         custom_cookies: Optional[List[Dict[str, Any]]] = None,
         progress_callback: Optional[callable] = None
 ) -> List[Dict]:
+    # Ensure playwright is imported before it's dereferenced below. Preserves
+    # pre-existing behavior when unavailable: this function has never guarded
+    # against a missing playwright (calling `async_playwright()` when it is
+    # still `None` raises TypeError, same as before this deferral).
+    _ensure_playwright()
+
     async def save_progress():
         temp_file = resume_file + ".tmp"
         with open(temp_file, 'w') as f:

--- a/tldw_chatbook/Web_Scraping/Article_Extractor_Lib.py
+++ b/tldw_chatbook/Web_Scraping/Article_Extractor_Lib.py
@@ -1529,7 +1529,13 @@ async def recursive_scrape(
     # pre-existing behavior when unavailable: this function has never guarded
     # against a missing playwright (calling `async_playwright()` when it is
     # still `None` raises TypeError, same as before this deferral).
-    _ensure_playwright()
+    if not _ensure_playwright():
+        # PR #672 review: a silent False would surface as a cryptic
+        # "'NoneType' object is not callable" on async_playwright() below.
+        raise ImportError(
+            "playwright is required for browser-based scraping but is not "
+            "installed (pip install tldw_chatbook[websearch])."
+        )
 
     async def save_progress():
         temp_file = resume_file + ".tmp"


### PR DESCRIPTION
## Summary

Audit finding C2: three optional-feature import chains loaded eagerly at startup despite lazy patterns existing in the same files/packages — ~550ms of the ~1.5s app import for features that are disabled by default or never used in a session.

- **chromadb (~154ms)**: `Chroma_Lib.py`'s module-scope `get_safe_import('chromadb')` (a REAL import, pulling OTel→gRPC→protobuf) moved into `ChromaDBManager.__init__`; not-installed placeholders preserved.
- **Web-search chain (~197ms)**: `Tools/__init__.py` now lazily resolves the tool classes via PEP 562 (the executor's config gate was already correct — web search defaults off); `Article_Extractor_Lib`'s module-scope playwright/trafilatura imports get the same `find_spec` probe + deferred-import treatment the file already applied to pandas.
- **Format processors (~230ms)**: `local_file_ingestion.py` (whose direct import from app.py bypassed `Local_Ingestion`'s lazy `__init__`) now imports pymupdf/document/ebook/audio/video processors at dispatch time, when the file type is known.

## Measured (scratch HOME, A/B against a detached dev baseline, correct-cwd protocol)

- `import tldw_chatbook.app`: **1.542s → 0.980s steady-state (−562ms, −36%)**; controller re-verified independently (~1.05s warm).
- Resident modules after app import: **3,294 → 1,992 (−39.5%)**.
- `chromadb`, `playwright`, `trafilatura`, `pymupdf`/`fitz`, `dateparser` all verifiably absent from `sys.modules` post-import (regression-tested in subprocesses).

## Tests

New `Tests/Utils/test_optional_import_deferral.py` (16): per-module absence nets, deferred-but-working smokes (ChromaDBManager constructs, `Tools.__getattr__` resolves WebSearchTool, text-file dispatch works), graceful-absence degradation. Suites: Local_Ingestion 63 ✓, Web_Scraping 69 ✓, RAG_Admin 22 ✓, Utils 204 ✓, RAG_Search 54 ✓, Chat 905 ✓ — zero failures, zero existing-test edits. Pre-existing conditions left untouched and noted: `TimeoutError` builtin shadowing and `recursive_scrape()`'s missing playwright guard.

Closes TASK-257.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers optional imports for `chromadb`, the web-search chain, and per-format ingestion processors to speed up startup and cut memory. App import time drops ~1.54s → ~0.98s (−562ms, −36%); `chromadb`, `playwright`, `trafilatura`, `pymupdf`/`fitz`, `dateparser` no longer load on app import. Closes TASK-257.

- **Refactors**
  - ChromaDB: moved `numpy`/`chromadb` into `_ensure_*` called from `ChromaDBManager.__init__`; binds `Settings`/error types on first use; fallbacks preserved.
  - Web search: `tldw_chatbook.Tools` lazily re-exports optional tools via PEP 562 `__getattr__`; `Article_Extractor_Lib` defers `playwright`/`trafilatura` with `find_spec` probes and `_ensure_*` in `scrape_article`/`recursive_scrape`.
  - Local ingestion: import `process_pdf`/`process_document`/`process_ebook`/`LocalAudioProcessor`/`LocalVideoProcessor` at dispatch time in `parse_local_file_for_ingest`, keeping existing monkeypatch patterns.
  - Tests: added `Tests/Utils/test_optional_import_deferral.py` for `sys.modules` absence checks and smokes, including graceful-absence cases.

- **Bug Fixes**
  - `ChromaDBManager` now raises a clear `ImportError` if `chromadb` is missing at construction time.
  - Web scraping: `recursive_scrape` raises a clear `ImportError` when `playwright` isn’t installed; `Tools.__getattr__` binds missing optional tools to `None` while preserving the original traceback.

<sup>Written for commit 6c03174914cf93757f44d06356c782c189afa7cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

