### PR TITLE
chore(backlog): file RAG-program follow-up tasks 287-288

### DIFF
--- a/backlog/tasks/task-287 - Fix-EmbeddingFactory-refusal-in-bare-processes-DEPENDENCIES_AVAILABLE-registry-never-populated.md
+++ b/backlog/tasks/task-287 - Fix-EmbeddingFactory-refusal-in-bare-processes-DEPENDENCIES_AVAILABLE-registry-never-populated.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-287
 title: >-
-  Fix EmbeddingFactory refusal in bare processes — DEPENDENCIES_AVAILABLE
+  Fix EmbeddingFactory refusal in bare processes - DEPENDENCIES_AVAILABLE
   registry never populated
 status: To Do
 assignee: []

--- a/backlog/tasks/task-287 - Fix-EmbeddingFactory-refusal-in-bare-processes-—-DEPENDENCIES_AVAILABLE-registry-never-populated.md
+++ b/backlog/tasks/task-287 - Fix-EmbeddingFactory-refusal-in-bare-processes-—-DEPENDENCIES_AVAILABLE-registry-never-populated.md
@@ -1,0 +1,28 @@
+---
+id: TASK-287
+title: >-
+  Fix EmbeddingFactory refusal in bare processes — DEPENDENCIES_AVAILABLE
+  registry never populated
+status: To Do
+assignee: []
+created_date: '2026-07-17 14:56'
+labels:
+  - rag
+  - embeddings
+  - bug
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The lazy optional-deps registry (Utils/optional_deps.py DEPENDENCIES_AVAILABLE) starts all-False and nothing populates it in a bare process, so Embeddings/Embeddings_Lib.EmbeddingFactory raises a false 'dependencies not installed' ImportError even when the embeddings_rag extra is fully installed. Discovered during task-246 (PR #656): the config-layer probe now populates the registry as a side effect on the auto path, which masks the bug there, but any path that reaches EmbeddingFactory without first running vector-store type resolution (e.g. explicit type=memory config, direct service construction in scripts/tests) still hits the false refusal. The cheap probe embeddings_rag_deps_installed() (find_spec) exists since #656 — EmbeddingFactory's gate should use it or trigger real registry population instead of trusting a registry nothing fills. Pre-existing on dev before the RAG program; verified identical on unmodified origin/dev.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 EmbeddingFactory constructs successfully in a bare process with embeddings deps installed regardless of which code path reaches it first
+- [ ] #2 Without the extra installed the ImportError message still points at pip install tldw_chatbook[embeddings_rag]
+- [ ] #3 A regression test constructs the factory in a subprocess (or with a reset registry) for both cases
+<!-- AC:END -->

--- a/backlog/tasks/task-288 - Canonicalize-current_tab-through-route-aliases-at-startup.md
+++ b/backlog/tasks/task-288 - Canonicalize-current_tab-through-route-aliases-at-startup.md
@@ -1,0 +1,26 @@
+---
+id: TASK-288
+title: Canonicalize current_tab through route aliases at startup
+status: To Do
+assignee: []
+created_date: '2026-07-17 14:56'
+labels:
+  - ui
+  - navigation
+  - cleanup
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Startup can mount an aliased route's target screen while leaving app.current_tab set to the raw configured route id: _push_initial_screen sets the canonical tab, then _post_mount_setup and the deferred _set_initial_tab overwrite it with the raw _resolve_initial_shell_route() value. Affects every legacy alias (notes/prompts/ccp/tools_settings/subscription and now research from task-255) — e.g. default_tab=notes mounts LibraryScreen while current_tab stays 'notes', violating the canonical-tab invariant until the first real navigation re-canonicalizes in handle_screen_navigation. Currently low-impact because watch_current_tab early-returns under _use_screen_navigation, and the raw value is pinned by existing tests (test_returning_user_initial_route_preserves_configured_default) — fixing means deliberately changing that pinned behavior for all aliases at once. Surfaced by Qodo on PR #653 (comment 3599800204) and deferred there with evidence as a pre-existing cross-alias property.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 After startup with any aliased default route current_tab equals the canonical destination of the alias and matches the mounted screen
+- [ ] #2 The tests pinning raw-route preservation are updated to pin canonical behavior for every legacy alias
+- [ ] #3 Startup with a canonical (non-aliased) route is unchanged
+<!-- AC:END -->


### PR DESCRIPTION
Files the two follow-up findings surfaced during the ADR-005 RAG remediation program as proper backlog tasks, so they don't live only in PR threads:

- **task-287** — `EmbeddingFactory` falsely refuses in bare processes because the lazy `DEPENDENCIES_AVAILABLE` registry is never populated; pre-existing, partially masked since #656's probe side effect. Medium priority: it blocks any direct service construction outside the auto-resolution path.
- **task-288** — startup leaves `current_tab` holding the raw aliased route while the canonical screen mounts; pre-existing cross-alias property surfaced by Qodo on #653 and deferred there with evidence. Low priority: bounded impact, but the pinned tests should eventually pin canonical behavior.

Backlog-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filed two backlog tasks from the ADR-005 RAG follow-up; no code changes.
TASK-287 tracks `EmbeddingFactory` refusing in bare processes due to the unpopulated `DEPENDENCIES_AVAILABLE` registry; TASK-288 tracks canonicalizing `current_tab` through route aliases at startup; also normalized TASK-287 filename/title to ASCII-only.

<sup>Written for commit 6c53afbe911c04a15a9e97a73e686463e4822a59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

