### PR TITLE
feat(rag): server-parity RRF+alpha hybrid fusion, one shared helper (task-256)

### DIFF
--- a/Docs/Development/RAG/RAG-Documentation.md
+++ b/Docs/Development/RAG/RAG-Documentation.md
@@ -173,9 +173,15 @@ Search Mode: [Dropdown]
 
 **Configuration**:
 ```toml
-[AppRAGSearchConfig.rag.search]
-hybrid_alpha = 0.5  # Balance between semantic (0.0) and keyword (1.0)
+[AppRAGSearchConfig.rag.retriever]
+# Hybrid fusion alpha: weight of the vector/semantic leg in the RRF blend
+# (0 = FTS/keyword only, 1 = vector/semantic only). 0.7 = tldw_server default.
+hybrid_alpha = 0.7
 ```
+
+Hybrid results are fused with Reciprocal Rank Fusion (k=60) per leg, then
+blended: `final = (1 - alpha) * fts_rrf + alpha * vector_rrf`, matching the
+tldw_server reference design.
 
 ### Document Indexing
 

--- a/Tests/RAG/test_fusion.py
+++ b/Tests/RAG/test_fusion.py
@@ -155,6 +155,27 @@ class TestReciprocalRankFusion:
         )
         assert fused[0].score == pytest.approx(1.0)  # 1/(0+1)
 
+    def test_out_of_range_alpha_is_clamped_never_negative(self):
+        # Last-resort invariant: no call site can produce negative blend
+        # weights. alpha=1.3 behaves as 1.0, alpha=-0.2 as 0.0.
+        fts = [Doc("A")]
+        vector = [Doc("B")]
+        over = reciprocal_rank_fusion(fts, vector, key=lambda d: d.id, alpha=1.3)
+        exact_one = reciprocal_rank_fusion(fts, vector, key=lambda d: d.id, alpha=1.0)
+        assert _scores(over) == _scores(exact_one)
+        assert all(entry.score >= 0.0 for entry in over)
+
+        under = reciprocal_rank_fusion(fts, vector, key=lambda d: d.id, alpha=-0.2)
+        exact_zero = reciprocal_rank_fusion(fts, vector, key=lambda d: d.id, alpha=0.0)
+        assert _scores(under) == _scores(exact_zero)
+
+    def test_negative_rrf_k_falls_back_no_zero_division(self):
+        # rrf_k=-1 with rank 1 would divide by zero; must fall back to 60.
+        fused = reciprocal_rank_fusion(
+            [Doc("A")], [], key=lambda d: d.id, alpha=0.0, rrf_k=-1
+        )
+        assert fused[0].score == pytest.approx(1 / (K + 1))
+
     def test_duplicate_key_within_leg_keeps_best_rank(self):
         fts = [Doc("A"), Doc("A"), Doc("B")]
         fused = reciprocal_rank_fusion(fts, [], key=lambda d: d.id, alpha=0.0)
@@ -247,6 +268,23 @@ class TestResolveHybridAlpha:
     @pytest.mark.parametrize("edge", [0.0, 1.0])
     def test_bounds_are_valid(self, edge):
         assert resolve_hybrid_alpha(edge) == edge
+
+
+class TestResolveRrfK:
+    def test_none_returns_default(self):
+        from tldw_chatbook.RAG_Search.fusion import resolve_rrf_k
+        assert resolve_rrf_k(None) == DEFAULT_RRF_K
+        assert resolve_rrf_k() == DEFAULT_RRF_K
+
+    @pytest.mark.parametrize("value,expected", [(60, 60), (0, 0), ("42", 42), (59.5, 59)])
+    def test_valid_values_coerced(self, value, expected):
+        from tldw_chatbook.RAG_Search.fusion import resolve_rrf_k
+        assert resolve_rrf_k(value) == expected
+
+    @pytest.mark.parametrize("bad", ["abc", -1, -60, object(), None])
+    def test_invalid_values_fall_back_to_default(self, bad):
+        from tldw_chatbook.RAG_Search.fusion import resolve_rrf_k
+        assert resolve_rrf_k(bad) == DEFAULT_RRF_K
 
 
 class TestRAGServiceFusion:
@@ -342,6 +380,33 @@ class TestRAGServiceFusion:
         )
         assert [r.id for r in results] == ["B", "A"]
         assert results[0].score == pytest.approx(1 / (K + 1))
+
+    def test_out_of_range_config_alpha_falls_back_to_default(self):
+        """An unvalidated config alpha (e.g. 1.3) must not distort scores.
+
+        config.search.hybrid_alpha is not range-checked at load time
+        (RAGConfig.validate() has no callers), so the fuse seam resolves it:
+        out-of-range values behave exactly like the 0.7 default.
+        """
+        from tldw_chatbook.RAG_Search.simplified.rag_service import RAGService
+
+        def run(alpha):
+            keyword, semantic = self._make_results()
+            return RAGService._fuse_hybrid_results(
+                keyword_results=keyword, semantic_results=semantic,
+                top_k=10, alpha=alpha, include_citations=True,
+            )
+
+        for bad in (1.3, -0.2):
+            results = run(bad)
+            expected = run(DEFAULT_HYBRID_ALPHA)
+            assert [r.id for r in results] == [r.id for r in expected]
+            assert [r.score for r in results] == pytest.approx(
+                [r.score for r in expected]
+            )
+            assert all(r.score >= 0.0 for r in results)
+            # Provenance records the resolved alpha, not the bad input
+            assert results[0].metadata['hybrid_fusion']['alpha'] == DEFAULT_HYBRID_ALPHA
 
 
 class TestPipelineRrfMerge:
@@ -544,3 +609,90 @@ class TestPipelineRrfMerge:
 
         assert [r.id for r in results] == ["m1", "m2"]
         assert results[0].score == pytest.approx(0.3 / (K + 1))
+
+    @pytest.mark.parametrize("bad_k", ["abc", -1])
+    def test_bad_rrf_k_config_does_not_abort_pipeline(self, monkeypatch, bad_k):
+        """Misconfigured steps[].config.rrf_k must fall back to 60, not crash.
+
+        Unguarded int() raised ValueError on non-numeric values, and a
+        negative k (e.g. -1 with rank 1) divided by zero — both aborted the
+        whole pipeline at merge time.
+        """
+        from tldw_chatbook.RAG_Search import pipeline_builder_simple as pbs
+
+        async def fake_media(app, query, top_k, keyword_filter=None):
+            return [self._pipeline_result("media", "m1")]
+
+        monkeypatch.setitem(pbs.RETRIEVAL_FUNCTIONS, 'search_media_fts5', fake_media)
+
+        step_config = {
+            'type': 'parallel',
+            'functions': [{'function': 'search_media_fts5', 'config': {'top_k': 20}}],
+            'merge': 'rrf_merge',
+            'config': {'alpha': 0.0, 'rrf_k': bad_k},
+        }
+        context = {
+            'app': object(), 'query': 'q', 'sources': {}, 'params': {}, 'results': [],
+        }
+
+        results = asyncio.run(pbs._execute_parallel_step(step_config, context))
+
+        assert [r.id for r in results] == ["m1"]
+        assert results[0].score == pytest.approx(1 / (K + 1))  # default k=60
+        assert results[0].metadata['hybrid_fusion']['rrf_k'] == K
+
+    def test_overlap_keeps_semantic_citation_metadata(self, monkeypatch):
+        """A doc in both legs must keep the vector leg's citation metadata.
+
+        The fused primary item is the FTS one; search_semantic stores its
+        citations as metadata['_has_citations']/['_citations'], which
+        _results_to_dicts surfaces as the 'citations' key. Fusion must carry
+        them across even though the FTS item wins as primary.
+        """
+        from tldw_chatbook.RAG_Search import pipeline_builder_simple as pbs
+        from tldw_chatbook.RAG_Search.pipeline_types import SearchResult
+
+        fts_item = self._pipeline_result("media", "shared")
+        semantic_item = SearchResult(
+            source="media", id="shared", title="shared", content="content shared",
+            metadata={
+                '_has_citations': True,
+                '_citations': [{'document_id': 'shared', 'text': 'snippet'}],
+            },
+        )
+
+        async def fake_media(app, query, top_k, keyword_filter=None):
+            return [fts_item]
+
+        async def fake_semantic(app, query, sources, **config):
+            return [semantic_item]
+
+        monkeypatch.setitem(pbs.RETRIEVAL_FUNCTIONS, 'search_media_fts5', fake_media)
+        monkeypatch.setitem(pbs.RETRIEVAL_FUNCTIONS, 'search_semantic', fake_semantic)
+
+        step_config = {
+            'type': 'parallel',
+            'functions': [
+                {'function': 'search_media_fts5', 'config': {'top_k': 20}},
+                {'function': 'search_semantic', 'config': {'top_k': 20}},
+            ],
+            'merge': 'rrf_merge',
+            'config': {'alpha': 0.7},
+        }
+        context = {
+            'app': object(), 'query': 'q', 'sources': {}, 'params': {}, 'results': [],
+        }
+
+        results = asyncio.run(pbs._execute_parallel_step(step_config, context))
+
+        assert len(results) == 1
+        fused = results[0]
+        assert fused is fts_item  # FTS item stays primary
+        assert fused.metadata['_has_citations'] is True
+        assert fused.metadata['_citations'] == [
+            {'document_id': 'shared', 'text': 'snippet'}
+        ]
+        # And they surface through the pipeline's dict conversion
+        dicts = pbs._results_to_dicts(results)
+        assert dicts[0]['citations'] == [{'document_id': 'shared', 'text': 'snippet'}]
+        assert '_citations' not in dicts[0]['metadata']

--- a/Tests/RAG/test_fusion.py
+++ b/Tests/RAG/test_fusion.py
@@ -1,0 +1,546 @@
+"""
+Unit tests for hybrid retrieval fusion (task-256).
+
+Covers the pure RRF + alpha-blend math in tldw_chatbook.RAG_Search.fusion
+with hand-computed rankings, plus the two integration seams that consume it:
+RAGService._fuse_hybrid_results and the pipeline rrf_merge parallel step.
+
+Server-parity reference (tldw_server database_retrievers.py):
+    leg_rrf(doc) = 1 / (k + rank)   # rank 1-based within the leg
+    final(doc)   = (1 - alpha) * fts_rrf + alpha * vector_rrf
+with k = 60 and alpha = 0.7 (vector-weighted) as defaults.
+"""
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+import pytest
+
+from tldw_chatbook.RAG_Search.fusion import (
+    DEFAULT_HYBRID_ALPHA,
+    DEFAULT_RRF_K,
+    interleave_rankings,
+    reciprocal_rank_fusion,
+    resolve_hybrid_alpha,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@dataclass
+class Doc:
+    """Minimal ranked item for fusion tests."""
+    id: str
+    score: float = 1.0
+    metadata: Optional[Dict[str, Any]] = field(default_factory=dict)
+
+
+def _ids(fused):
+    return [entry.key for entry in fused]
+
+
+def _scores(fused):
+    return {entry.key: entry.score for entry in fused}
+
+
+K = DEFAULT_RRF_K  # 60
+
+
+class TestServerParityDefaults:
+    def test_defaults_match_tldw_server(self):
+        assert DEFAULT_RRF_K == 60
+        assert DEFAULT_HYBRID_ALPHA == 0.7
+
+
+class TestReciprocalRankFusion:
+    """Hand-computed rankings: A rank1 FTS only, B rank1 vector only, C rank2 both."""
+
+    @staticmethod
+    def _fuse(alpha):
+        fts = [Doc("A"), Doc("C")]
+        vector = [Doc("B"), Doc("C")]
+        return reciprocal_rank_fusion(
+            fts, vector, key=lambda d: d.id, alpha=alpha
+        )
+
+    def test_alpha_zero_is_fts_only_ordering(self):
+        fused = self._fuse(alpha=0.0)
+        # A = 1/(K+1), C = 1/(K+2), B = 0 (vector-only doc contributes nothing)
+        assert _ids(fused) == ["A", "C", "B"]
+        scores = _scores(fused)
+        assert scores["A"] == pytest.approx(1 / (K + 1))
+        assert scores["C"] == pytest.approx(1 / (K + 2))
+        assert scores["B"] == 0.0
+
+    def test_alpha_one_is_vector_only_ordering(self):
+        fused = self._fuse(alpha=1.0)
+        assert _ids(fused) == ["B", "C", "A"]
+        scores = _scores(fused)
+        assert scores["B"] == pytest.approx(1 / (K + 1))
+        assert scores["C"] == pytest.approx(1 / (K + 2))
+        assert scores["A"] == 0.0
+
+    def test_alpha_half_both_legs_beat_single_leg(self):
+        fused = self._fuse(alpha=0.5)
+        # C = 0.5/(K+2) + 0.5/(K+2) = 1/(K+2) beats A = B = 0.5/(K+1)
+        assert _ids(fused) == ["C", "A", "B"]
+        scores = _scores(fused)
+        assert scores["C"] == pytest.approx(1 / (K + 2))
+        assert scores["A"] == pytest.approx(0.5 / (K + 1))
+        assert scores["B"] == pytest.approx(0.5 / (K + 1))
+
+    def test_alpha_default_07_vector_weighted(self):
+        fused = self._fuse(alpha=0.7)
+        # C = 0.3/(K+2) + 0.7/(K+2) = 1/(K+2) ~ 0.01613
+        # B = 0.7/(K+1) ~ 0.01148, A = 0.3/(K+1) ~ 0.00492
+        assert _ids(fused) == ["C", "B", "A"]
+        scores = _scores(fused)
+        assert scores["C"] == pytest.approx(1 / (K + 2))
+        assert scores["B"] == pytest.approx(0.7 / (K + 1))
+        assert scores["A"] == pytest.approx(0.3 / (K + 1))
+
+    def test_tie_between_legs_breaks_deterministically_fts_first(self):
+        # A only in FTS at rank 1, B only in vector at rank 1, alpha=0.5:
+        # identical scores; the FTS-side doc must sort first, stably.
+        fused = reciprocal_rank_fusion(
+            [Doc("A")], [Doc("B")], key=lambda d: d.id, alpha=0.5
+        )
+        assert _ids(fused) == ["A", "B"]
+        assert fused[0].score == pytest.approx(fused[1].score)
+        # Repeat runs give the same order (determinism, not dict luck)
+        for _ in range(5):
+            again = reciprocal_rank_fusion(
+                [Doc("A")], [Doc("B")], key=lambda d: d.id, alpha=0.5
+            )
+            assert _ids(again) == ["A", "B"]
+
+    def test_empty_vector_leg_preserves_fts_ordering(self):
+        fts = [Doc("A"), Doc("B"), Doc("C")]
+        fused = reciprocal_rank_fusion(fts, [], key=lambda d: d.id, alpha=0.7)
+        assert _ids(fused) == ["A", "B", "C"]
+        for rank, entry in enumerate(fused, start=1):
+            assert entry.score == pytest.approx((1 - 0.7) * (1 / (K + rank)))
+            assert entry.vector_rank is None
+            assert entry.vector_rrf == 0.0
+
+    def test_empty_fts_leg_preserves_vector_ordering(self):
+        vector = [Doc("X"), Doc("Y")]
+        fused = reciprocal_rank_fusion([], vector, key=lambda d: d.id, alpha=0.7)
+        assert _ids(fused) == ["X", "Y"]
+        assert fused[0].score == pytest.approx(0.7 / (K + 1))
+
+    def test_alpha_one_with_empty_vector_leg_keeps_fts_order_at_zero_score(self):
+        # Degenerate but must stay deterministic: all scores 0, FTS order kept.
+        fused = reciprocal_rank_fusion(
+            [Doc("A"), Doc("B")], [], key=lambda d: d.id, alpha=1.0
+        )
+        assert _ids(fused) == ["A", "B"]
+        assert all(entry.score == 0.0 for entry in fused)
+
+    def test_both_legs_empty(self):
+        assert reciprocal_rank_fusion([], [], key=lambda d: d.id) == []
+
+    def test_max_results_caps_output(self):
+        fts = [Doc(f"f{i}") for i in range(10)]
+        vector = [Doc(f"v{i}") for i in range(10)]
+        fused = reciprocal_rank_fusion(
+            fts, vector, key=lambda d: d.id, alpha=0.7, max_results=5
+        )
+        assert len(fused) == 5
+
+    def test_custom_rrf_k(self):
+        fused = reciprocal_rank_fusion(
+            [Doc("A")], [], key=lambda d: d.id, alpha=0.0, rrf_k=0
+        )
+        assert fused[0].score == pytest.approx(1.0)  # 1/(0+1)
+
+    def test_duplicate_key_within_leg_keeps_best_rank(self):
+        fts = [Doc("A"), Doc("A"), Doc("B")]
+        fused = reciprocal_rank_fusion(fts, [], key=lambda d: d.id, alpha=0.0)
+        assert _ids(fused) == ["A", "B"]
+        assert fused[0].fts_rank == 1
+        assert fused[1].fts_rank == 3  # B keeps its position in the returned order
+
+    def test_provenance_and_items_preserved(self):
+        a_fts = Doc("A", metadata={"leg": "fts"})
+        a_vec = Doc("A", metadata={"leg": "vector"})
+        fused = reciprocal_rank_fusion(
+            [a_fts], [a_vec], key=lambda d: d.id, alpha=0.7
+        )
+        entry = fused[0]
+        assert entry.fts_item is a_fts
+        assert entry.vector_item is a_vec
+        assert entry.item is a_fts  # FTS item is primary, matching the server
+        assert entry.fts_rank == 1 and entry.vector_rank == 1
+        assert entry.fts_rrf == pytest.approx(1 / (K + 1))
+        assert entry.vector_rrf == pytest.approx(1 / (K + 1))
+        assert entry.provenance() == {
+            "fts_rank": 1,
+            "vector_rank": 1,
+            "fts_rrf": entry.fts_rrf,
+            "vector_rrf": entry.vector_rrf,
+        }
+
+    def test_inputs_not_mutated(self):
+        doc = Doc("A", score=0.42)
+        reciprocal_rank_fusion([doc], [doc], key=lambda d: d.id, alpha=0.7)
+        assert doc.score == 0.42
+
+    def test_rank_based_not_score_based(self):
+        # Leg raw scores must not influence fusion: only order matters.
+        fts_hi = [Doc("A", score=100.0), Doc("B", score=0.001)]
+        fts_lo = [Doc("A", score=0.001), Doc("B", score=100.0)]
+        fused_hi = reciprocal_rank_fusion(fts_hi, [], key=lambda d: d.id, alpha=0.0)
+        fused_lo = reciprocal_rank_fusion(fts_lo, [], key=lambda d: d.id, alpha=0.0)
+        assert _scores(fused_hi) == _scores(fused_lo)
+
+
+class TestInterleaveRankings:
+    def test_round_robin_by_rank(self):
+        a = [Doc("a1"), Doc("a2")]
+        b = [Doc("b1")]
+        c = [Doc("c1"), Doc("c2"), Doc("c3")]
+        merged = interleave_rankings([a, b, c], key=lambda d: d.id)
+        assert [d.id for d in merged] == ["a1", "b1", "c1", "a2", "c2", "c3"]
+
+    def test_deduplicates_keeping_earliest(self):
+        a = [Doc("x"), Doc("a2")]
+        b = [Doc("x"), Doc("b2")]
+        merged = interleave_rankings([a, b], key=lambda d: d.id)
+        assert [d.id for d in merged] == ["x", "a2", "b2"]
+        assert merged[0] is a[0]
+
+    def test_empty_inputs(self):
+        assert interleave_rankings([], key=lambda d: d.id) == []
+        assert interleave_rankings([[], []], key=lambda d: d.id) == []
+
+
+class TestResolveHybridAlpha:
+    def test_explicit_value_wins(self, monkeypatch):
+        import tldw_chatbook.config as app_config
+        monkeypatch.setattr(
+            app_config, "get_cli_setting",
+            lambda *a, **k: {"retriever": {"hybrid_alpha": 0.2}},
+        )
+        assert resolve_hybrid_alpha(0.4) == 0.4
+
+    def test_reads_authoritative_config_knob(self, monkeypatch):
+        import tldw_chatbook.config as app_config
+
+        def fake_get_cli_setting(section, key=None, default=None):
+            assert (section, key) == ("AppRAGSearchConfig", "rag")
+            return {"retriever": {"hybrid_alpha": 0.25}}
+
+        monkeypatch.setattr(app_config, "get_cli_setting", fake_get_cli_setting)
+        assert resolve_hybrid_alpha() == 0.25
+
+    def test_defaults_to_server_parity_when_unset(self, monkeypatch):
+        import tldw_chatbook.config as app_config
+        monkeypatch.setattr(app_config, "get_cli_setting", lambda *a, **k: {})
+        assert resolve_hybrid_alpha() == DEFAULT_HYBRID_ALPHA
+
+    @pytest.mark.parametrize("bad", [-0.1, 1.5, "not-a-number", object()])
+    def test_invalid_values_fall_back_to_default(self, bad):
+        assert resolve_hybrid_alpha(bad) == DEFAULT_HYBRID_ALPHA
+
+    @pytest.mark.parametrize("edge", [0.0, 1.0])
+    def test_bounds_are_valid(self, edge):
+        assert resolve_hybrid_alpha(edge) == edge
+
+
+class TestRAGServiceFusion:
+    """RAGService._fuse_hybrid_results applies the shared fusion math."""
+
+    @staticmethod
+    def _make_results():
+        from tldw_chatbook.RAG_Search.simplified.citations import (
+            Citation, CitationType, SearchResultWithCitations,
+        )
+
+        def cite(doc_id, start, confidence, match_type):
+            return Citation(
+                document_id=doc_id, document_title=doc_id, chunk_id=f"{doc_id}_0",
+                text="snippet", start_char=start, end_char=start + 7,
+                confidence=confidence, match_type=match_type,
+            )
+
+        keyword = [
+            SearchResultWithCitations(
+                id="A", score=0.8, document="doc a", metadata={},
+                citations=[cite("A", 0, 0.9, CitationType.KEYWORD)],
+            ),
+            SearchResultWithCitations(
+                id="C", score=0.7, document="doc c", metadata={},
+                citations=[cite("C", 0, 0.8, CitationType.KEYWORD)],
+            ),
+        ]
+        semantic = [
+            SearchResultWithCitations(
+                id="B", score=0.95, document="doc b", metadata={},
+                citations=[cite("B", 0, 0.9, CitationType.SEMANTIC)],
+            ),
+            SearchResultWithCitations(
+                id="C", score=0.9, document="doc c", metadata={},
+                citations=[cite("C", 100, 0.85, CitationType.SEMANTIC)],
+            ),
+        ]
+        return keyword, semantic
+
+    def test_rrf_scores_replace_leg_scores_and_citations_merge(self):
+        from tldw_chatbook.RAG_Search.simplified.rag_service import RAGService
+
+        keyword, semantic = self._make_results()
+        results = RAGService._fuse_hybrid_results(
+            keyword_results=keyword,
+            semantic_results=semantic,
+            top_k=10,
+            alpha=0.7,
+            include_citations=True,
+        )
+
+        assert [r.id for r in results] == ["C", "B", "A"]
+        by_id = {r.id: r for r in results}
+        assert by_id["C"].score == pytest.approx(1 / (K + 2))
+        assert by_id["B"].score == pytest.approx(0.7 / (K + 1))
+        assert by_id["A"].score == pytest.approx(0.3 / (K + 1))
+        # C appeared in both legs: citations merged from both
+        assert len(by_id["C"].citations) == 2
+        # Leg provenance recorded
+        fusion_meta = by_id["C"].metadata["hybrid_fusion"]
+        assert fusion_meta["fts_rank"] == 2
+        assert fusion_meta["vector_rank"] == 2
+        assert fusion_meta["alpha"] == 0.7
+        assert fusion_meta["rrf_k"] == K
+
+    def test_top_k_cap_and_alpha_zero(self):
+        from tldw_chatbook.RAG_Search.simplified.rag_service import RAGService
+
+        keyword, semantic = self._make_results()
+        results = RAGService._fuse_hybrid_results(
+            keyword_results=keyword,
+            semantic_results=semantic,
+            top_k=2,
+            alpha=0.0,
+            include_citations=True,
+        )
+        # alpha=0: pure FTS ordering (A then C), capped at 2
+        assert [r.id for r in results] == ["A", "C"]
+
+    def test_basic_results_without_citations(self):
+        from tldw_chatbook.RAG_Search.simplified.rag_service import RAGService
+        from tldw_chatbook.RAG_Search.simplified.vector_store import SearchResult
+
+        keyword = [SearchResult(id="A", score=0.5, document="a", metadata={})]
+        semantic = [SearchResult(id="B", score=0.9, document="b", metadata={})]
+        results = RAGService._fuse_hybrid_results(
+            keyword_results=keyword,
+            semantic_results=semantic,
+            top_k=10,
+            alpha=1.0,
+            include_citations=False,
+        )
+        assert [r.id for r in results] == ["B", "A"]
+        assert results[0].score == pytest.approx(1 / (K + 1))
+
+
+class TestPipelineRrfMerge:
+    """The pipeline 'rrf_merge' parallel step fuses FTS5 legs vs semantic leg."""
+
+    @staticmethod
+    def _pipeline_result(source, doc_id):
+        from tldw_chatbook.RAG_Search.pipeline_types import SearchResult
+        return SearchResult(
+            source=source, id=doc_id, title=doc_id, content=f"content {doc_id}"
+        )
+
+    def test_builtin_hybrid_pipeline_uses_rrf_merge(self):
+        from tldw_chatbook.RAG_Search.pipeline_builder_simple import BUILTIN_PIPELINES
+
+        parallel_steps = [
+            s for s in BUILTIN_PIPELINES['hybrid']['steps']
+            if s.get('type') == 'parallel'
+        ]
+        assert len(parallel_steps) == 1
+        assert parallel_steps[0].get('merge') == 'rrf_merge'
+
+    def test_parallel_step_rrf_merge_fuses_legs(self, monkeypatch):
+        from tldw_chatbook.RAG_Search import pipeline_builder_simple as pbs
+
+        media = [self._pipeline_result("media", "m1"), self._pipeline_result("media", "shared")]
+        conversations = [self._pipeline_result("conversation", "c1")]
+        notes = []
+        semantic = [self._pipeline_result("media", "shared"), self._pipeline_result("media", "s2")]
+
+        async def fake_media(app, query, top_k, keyword_filter=None):
+            return list(media)
+
+        async def fake_conversations(app, query, top_k):
+            return list(conversations)
+
+        async def fake_notes(app, query, top_k):
+            return list(notes)
+
+        async def fake_semantic(app, query, sources, **config):
+            return list(semantic)
+
+        monkeypatch.setitem(pbs.RETRIEVAL_FUNCTIONS, 'search_media_fts5', fake_media)
+        monkeypatch.setitem(pbs.RETRIEVAL_FUNCTIONS, 'search_conversations_fts5', fake_conversations)
+        monkeypatch.setitem(pbs.RETRIEVAL_FUNCTIONS, 'search_notes_fts5', fake_notes)
+        monkeypatch.setitem(pbs.RETRIEVAL_FUNCTIONS, 'search_semantic', fake_semantic)
+
+        step_config = {
+            'type': 'parallel',
+            'functions': [
+                {'function': 'search_media_fts5', 'config': {'top_k': 20}},
+                {'function': 'search_conversations_fts5', 'config': {'top_k': 20}},
+                {'function': 'search_notes_fts5', 'config': {'top_k': 20}},
+                {'function': 'search_semantic', 'config': {'top_k': 20}},
+            ],
+            'merge': 'rrf_merge',
+            'config': {'alpha': 0.7},
+        }
+        context = {
+            'app': object(), 'query': 'q', 'sources': {}, 'params': {}, 'results': [],
+        }
+
+        results = asyncio.run(pbs._execute_parallel_step(step_config, context))
+
+        # FTS leg (interleaved): m1, c1, shared -> ranks 1, 2, 3
+        # Vector leg: shared, s2 -> ranks 1, 2
+        expected = {
+            ("media", "m1"): 0.3 / (K + 1),
+            ("conversation", "c1"): 0.3 / (K + 2),
+            ("media", "shared"): 0.3 / (K + 3) + 0.7 / (K + 1),
+            ("media", "s2"): 0.7 / (K + 2),
+        }
+        got = {(r.source, r.id): r.score for r in results}
+        assert set(got) == set(expected)
+        for key, score in expected.items():
+            assert got[key] == pytest.approx(score), key
+        # Sorted by fused score descending
+        scores = [r.score for r in results]
+        assert scores == sorted(scores, reverse=True)
+        assert [r.id for r in results][0] == "shared"
+        # Provenance attached
+        shared = next(r for r in results if r.id == "shared")
+        assert shared.metadata['hybrid_fusion']['fts_rank'] == 3
+        assert shared.metadata['hybrid_fusion']['vector_rank'] == 1
+        assert shared.metadata['hybrid_fusion']['alpha'] == 0.7
+
+    def test_vector_leg_live_with_real_search_semantic(self, monkeypatch):
+        """Regression: the vector leg must survive the pipeline param splat.
+
+        Before task-256 the parallel step called search_semantic(**config)
+        with the full pipeline params; the duplicated top_k raised TypeError
+        inside the leg, gather() swallowed it, and hybrid silently degraded
+        to FTS-only. Uses the REAL search_semantic with a strict-signature
+        stub RAG service (no **kwargs) so stray params fail loudly.
+        """
+        from types import SimpleNamespace
+        from tldw_chatbook.RAG_Search import pipeline_builder_simple as pbs
+        from tldw_chatbook.RAG_Search.simplified.vector_store import SearchResult as VSResult
+
+        class StrictRagService:
+            async def search(self, query, top_k=None, search_type="semantic",
+                             filter_metadata=None, include_citations=None,
+                             score_threshold=None):
+                assert search_type == "semantic"
+                return [VSResult(id="v1", score=0.9, document="vector doc", metadata={})]
+
+        async def fake_media(app, query, top_k, keyword_filter=None):
+            return [self._pipeline_result("media", "m1")]
+
+        monkeypatch.setitem(pbs.RETRIEVAL_FUNCTIONS, 'search_media_fts5', fake_media)
+        # search_semantic stays the REAL implementation.
+
+        step_config = {
+            'type': 'parallel',
+            'functions': [
+                {'function': 'search_media_fts5', 'config': {'top_k': 20}},
+                {'function': 'search_semantic', 'config': {'top_k': 20, 'score_threshold': 0.0}},
+            ],
+            'merge': 'rrf_merge',
+            'config': {'alpha': 1.0},
+        }
+        # The exact param soup perform_hybrid_rag_search feeds the pipeline
+        context = {
+            'app': SimpleNamespace(_rag_service=StrictRagService()),
+            'query': 'q',
+            'sources': {'media': True},
+            'params': {
+                'top_k': 5, 'max_context_length': 10000, 'chunk_size': 400,
+                'chunk_overlap': 100, 'chunk_type': 'words', 'keyword_filter': None,
+            },
+            'results': [],
+        }
+
+        results = asyncio.run(pbs._execute_parallel_step(step_config, context))
+
+        # alpha=1.0: the vector-leg doc must rank first with a real RRF score
+        assert results[0].id == "v1"
+        assert results[0].score == pytest.approx(1 / (K + 1))
+        assert {r.id for r in results} == {"v1", "m1"}
+
+    def test_perform_hybrid_rag_search_end_to_end_smoke(self):
+        """perform_hybrid_rag_search runs the full RRF pipeline without mutating builtins."""
+        from types import SimpleNamespace
+        from tldw_chatbook.Event_Handlers.Chat_Events.chat_rag_events import (
+            perform_hybrid_rag_search,
+        )
+        from tldw_chatbook.RAG_Search.pipeline_builder_simple import BUILTIN_PIPELINES
+        from tldw_chatbook.RAG_Search.simplified.vector_store import SearchResult as VSResult
+
+        class StrictRagService:
+            async def search(self, query, top_k=None, search_type="semantic",
+                             filter_metadata=None, include_citations=None,
+                             score_threshold=None):
+                return [VSResult(id="v1", score=0.9, document="vector doc", metadata={})]
+
+        # FTS legs all guard out; the vector leg is live.
+        app = SimpleNamespace(media_db=None, db_config={}, _rag_service=StrictRagService())
+
+        results, context = asyncio.run(perform_hybrid_rag_search(
+            app, "query", {"media": True},
+            top_k=5, enable_rerank=False, hybrid_alpha=0.7,
+        ))
+
+        assert [r['id'] for r in results] == ["v1"]
+        assert results[0]['score'] == pytest.approx(0.7 / (K + 1))
+        assert results[0]['metadata']['hybrid_fusion']['vector_rank'] == 1
+        assert isinstance(context, str)
+        # The builtin definition must not have been mutated by the call
+        parallel = next(
+            s for s in BUILTIN_PIPELINES['hybrid']['steps'] if s.get('type') == 'parallel'
+        )
+        assert 'alpha' not in parallel.get('config', {})
+
+    def test_vector_leg_failure_degrades_to_fts_ordering(self, monkeypatch):
+        from tldw_chatbook.RAG_Search import pipeline_builder_simple as pbs
+
+        async def fake_media(app, query, top_k, keyword_filter=None):
+            return [self._pipeline_result("media", "m1"), self._pipeline_result("media", "m2")]
+
+        async def fake_semantic(app, query, sources, **config):
+            raise RuntimeError("vector store unavailable")
+
+        monkeypatch.setitem(pbs.RETRIEVAL_FUNCTIONS, 'search_media_fts5', fake_media)
+        monkeypatch.setitem(pbs.RETRIEVAL_FUNCTIONS, 'search_semantic', fake_semantic)
+
+        step_config = {
+            'type': 'parallel',
+            'functions': [
+                {'function': 'search_media_fts5', 'config': {'top_k': 20}},
+                {'function': 'search_semantic', 'config': {'top_k': 20}},
+            ],
+            'merge': 'rrf_merge',
+            'config': {'alpha': 0.7},
+        }
+        context = {
+            'app': object(), 'query': 'q', 'sources': {}, 'params': {}, 'results': [],
+        }
+
+        results = asyncio.run(pbs._execute_parallel_step(step_config, context))
+
+        assert [r.id for r in results] == ["m1", "m2"]
+        assert results[0].score == pytest.approx(0.3 / (K + 1))

--- a/Tests/UI/test_settings_library_rag_defaults.py
+++ b/Tests/UI/test_settings_library_rag_defaults.py
@@ -69,7 +69,7 @@ def test_load_library_rag_defaults_uses_safe_defaults():
     assert defaults.default_top_k == 10
     assert defaults.fts_top_k == 10
     assert defaults.vector_top_k == 10
-    assert defaults.hybrid_alpha == 0.5
+    assert defaults.hybrid_alpha == 0.7  # server-parity RRF default (task-256)
     assert defaults.score_threshold == 0.0
     assert defaults.include_citations is True
     assert defaults.citation_style == "inline"

--- a/backlog/tasks/task-256 - Align-hybrid-retrieval-fusion-with-the-tldw_server-design-RRF-plus-alpha-weighting.md
+++ b/backlog/tasks/task-256 - Align-hybrid-retrieval-fusion-with-the-tldw_server-design-RRF-plus-alpha-weighting.md
@@ -3,8 +3,9 @@ id: TASK-256
 title: >-
   Align hybrid retrieval fusion with the tldw_server design (RRF plus alpha
   weighting)
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-12 14:12'
 labels:
   - rag
@@ -21,7 +22,43 @@ tldw_server fuses hybrid results with Reciprocal Rank Fusion (k=60) followed by 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Hybrid mode fuses FTS and vector rankings via RRF with an alpha-weighted blend matching server defaults (k=60, alpha=0.7 vector-weighted)
-- [ ] #2 Fusion is covered by unit tests using known input rankings
-- [ ] #3 Alpha is exposed in config with a server-consistent default and documented semantics (0 = FTS only, 1 = vector only)
+- [x] #1 Hybrid mode fuses FTS and vector rankings via RRF with an alpha-weighted blend matching server defaults (k=60, alpha=0.7 vector-weighted)
+- [x] #2 Fusion is covered by unit tests using known input rankings
+- [x] #3 Alpha is exposed in config with a server-consistent default and documented semantics (0 = FTS only, 1 = vector only)
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Add a shared pure fusion helper `RAG_Search/simplified/fusion.py`:
+   - `reciprocal_rank_fusion(fts_results, vector_results, key=..., alpha=0.7, rrf_k=60, max_results=None)` implementing the exact server math (`database_retrievers.py:2047-2105`): per-leg RRF score `1/(k + rank)` with rank starting at 1 in each leg's returned order, docs missing from a leg contribute 0, final = `(1-alpha)*fts_rrf + alpha*vector_rrf`. Returns fused entries carrying both leg items, leg ranks/RRF contributions (provenance), and the fused score; deterministic tie-break.
+   - `interleave_rankings(...)` to collapse the pipeline's multiple per-source FTS5 lists into one rank-fair FTS leg before fusion.
+   - `resolve_hybrid_alpha(...)`: explicit value -> `[AppRAGSearchConfig.rag.retriever] hybrid_alpha` -> default 0.7.
+2. Rewire `RAGService._hybrid_search` (`RAG_Search/simplified/rag_service.py`) to fuse the keyword (FTS) and semantic (vector) legs via the helper, replacing the ad-hoc citation-count-weighted / max-score merges. Citations still merge when a doc appears in both legs; fused RRF score replaces leg scores; leg provenance stored in result metadata. Both enhanced services inherit this via `super().search()`.
+3. Rewire the `hybrid` builtin pipeline (`RAG_Search/pipeline_builder_simple.py`): replace the `weighted_merge` [0.25 x4] step with a new `rrf_merge` parallel-step merge that partitions legs by function (`*_fts5` lists interleaved = FTS leg; `search_semantic` = vector leg) and fuses via the same helper. `perform_hybrid_rag_search` (`chat_rag_events.py`) exposes `hybrid_alpha` (legacy `bm25_weight`/`vector_weight` mapped to alpha for back-compat).
+4. TOML pipelines: fold standalone `type = "merge"` steps into the preceding parallel step at load time (they are silently skipped today), and ship `hybrid_v2` in `Config_Files/rag_pipelines.toml` with `rrf_merge`.
+5. Config: single authoritative knob `[AppRAGSearchConfig.rag.retriever] hybrid_alpha` -> `RAGConfig.search.hybrid_alpha`; default migrated 0.5 -> 0.7 (server parity, deliberate) in `simplified/config.py`, `config.py` (DEFAULT_RAG_SEARCH_CONFIG + config template), `rag_config_example.toml`, Settings fallbacks (`settings_library_rag_defaults.py`, `Tools_Settings_Window.py`); semantics documented as 0 = FTS only, 1 = vector only.
+6. Unit tests `Tests/RAG/simplified/test_fusion.py` with hand-computed rankings (alpha in {0, 0.5, 0.7, 1}, empty legs, ties, k, max_results, provenance), plus coverage of the `RAGService` merge path and the pipeline `rrf_merge` step; update existing tests asserting the 0.5 default.
+
+## Implementation Notes
+
+Server-parity RRF fusion is now the single hybrid merge everywhere, implemented once as a pure module and consumed by both hybrid sites.
+
+**Shared fusion helper — `tldw_chatbook/RAG_Search/fusion.py`** (moved up from the planned `simplified/fusion.py`: the `simplified` package `__init__` eagerly imports the embeddings stack and can `ImportError` without the `embeddings_rag` extra, and `pipeline_builder_simple` must import fusion unconditionally). Contains:
+- `reciprocal_rank_fusion(fts, vector, key=..., alpha=0.7, rrf_k=60, max_results=None)` — exact server math (`database_retrievers.py:2047-2105`): per-leg `1/(k + rank)` with 1-based ranks in each leg's returned order, missing leg contributes 0, `final = (1-alpha)*fts_rrf + alpha*vector_rrf`. Returns `FusedResult` entries carrying both leg items, per-leg ranks/RRF contributions (provenance), fused score; deterministic tie-break (score desc, then FTS rank, then vector rank). Two deliberate strictness improvements over the server: duplicates within a leg keep the best rank (server overwrites with the worse one), and ordering is fully deterministic (server sorts over a set).
+- `interleave_rankings(...)` — rank-fair round-robin collapse of the pipeline's three FTS5 source lists (their raw scores are constant 1.0 / not comparable) into one FTS leg.
+- `resolve_hybrid_alpha(explicit)` — explicit -> `[AppRAGSearchConfig.rag.retriever] hybrid_alpha` -> 0.7; invalid/out-of-range values warn and fall back.
+
+**Fusion sites unified:**
+1. `RAGService._hybrid_search` (`simplified/rag_service.py`) — replaced the citation-count-weighted / max-score merges (`_merge_results_with_citations`/`_merge_basic_results`, deleted) with `_fuse_hybrid_results` using the shared helper and `config.search.hybrid_alpha`. Citations still merge when a chunk appears in both legs; leg provenance stored in `metadata['hybrid_fusion']`. Enhanced services inherit via `super().search()`.
+2. Builtin `hybrid` pipeline (`pipeline_builder_simple.py`) — parallel step's `weighted_merge` [0.25 x4] replaced with `rrf_merge` (FTS5 legs interleaved vs `search_semantic` leg); `perform_hybrid_rag_search` (`chat_rag_events.py`) resolves alpha (new `hybrid_alpha` param; legacy `bm25_weight`/`vector_weight` map to `vector/(bm25+vector)`) and now deep-copies the builtin config (the old shallow copy mutated `BUILTIN_PIPELINES` across calls).
+3. TOML pipelines — standalone `type = "merge"` steps were silently skipped by `execute_pipeline` (no such step type); they now fold into the preceding parallel step at load time, and shipped `hybrid_v2` uses `rrf_merge`. Shipped/legacy pipeline params dropped `bm25_weight/vector_weight = 0.5` (would have pinned alpha to 0.5 past the knob); `technical_docs` and the custom example carry `hybrid_alpha = 0.4` preserving their old 0.6/0.4 intent. `weighted_merge` remains supported for user TOML.
+
+**Drive-by fix required for AC#1 to be real on the pipeline path:** the parallel step called `search_semantic(app, query, sources, **config)` with the full pipeline param soup; the duplicated `top_k` raised `TypeError` inside the leg, `gather(return_exceptions=True)` swallowed it, and the hybrid pipeline's vector leg was ALWAYS silently empty (independent of task-247's indexing). The parallel step now passes `limit` plus a whitelist (`score_threshold`, `filter_metadata`). Regression-tested with the real `search_semantic` against a strict-signature stub service (no `**kwargs` fake). The equivalent bug in the `retrieve`-step path (pure `semantic` pipeline) is task-250's scope and was left untouched.
+
+**Config knob story (deliberate default migration 0.5 -> 0.7):** one authoritative knob `[AppRAGSearchConfig.rag.retriever] hybrid_alpha` -> `RAGConfig.search.hybrid_alpha` (dataclass default now `DEFAULT_HYBRID_ALPHA` = 0.7). Aligned every other surface that advertised 0.5: `config.py` `DEFAULT_RAG_SEARCH_CONFIG` + `[rag.retriever]` template, `rag_config_example.toml`, `Tools_Settings_Window` fallback, `SettingsLibraryRagDefaults` dataclass default, and the `EXAMPLE_TOML_CONFIG` docstring (which had `hybrid_alpha` under `.rag.search`, a section the loader never reads — moved to `.rag.retriever`). `Docs/Development/RAG/RAG-Documentation.md` had the semantics inverted ("semantic (0.0) and keyword (1.0)") and the wrong section — fixed. Semantics documented everywhere as 0 = FTS only, 1 = vector only.
+
+**Tests** (`Tests/RAG/test_fusion.py`, 36 tests): hand-computed A/B/C rankings for alpha in {0, 0.5, 0.7, 1} with exact scores, empty-leg/both-empty cases, deterministic ties, `rrf_k`, `max_results`, in-leg dupes, provenance, no-mutation, rank-not-score invariance; `RAGService._fuse_hybrid_results` (citation merge, cap, alpha=0); pipeline `rrf_merge` (hand-computed interleaved-leg scores, vector-leg failure degrades to FTS ordering, live-vector-leg regression, `perform_hybrid_rag_search` end-to-end smoke incl. builtin-non-mutation). Updated `Tests/UI/test_settings_library_rag_defaults.py` default assertion to 0.7.
+
+**Results:** Tests/RAG + Tests/RAG_Search: 354 passed, 19 skipped. Tests/UI settings suites (library_rag_defaults + configuration_hub): 255 passed. `import tldw_chatbook.app` OK.
+
+**Modified:** `RAG_Search/fusion.py` (new), `RAG_Search/simplified/rag_service.py`, `RAG_Search/simplified/config.py`, `RAG_Search/pipeline_builder_simple.py`, `Event_Handlers/Chat_Events/chat_rag_events.py`, `config.py`, `Config_Files/rag_pipelines.toml`, `Config_Files/pipeline_configs/custom_pipelines_example.toml`, `RAG_Search/rag_config_example.toml`, `UI/Screens/settings_library_rag_defaults.py`, `UI/Tools_Settings_Window.py`, `Docs/Development/RAG/RAG-Documentation.md`, `Tests/RAG/test_fusion.py` (new), `Tests/UI/test_settings_library_rag_defaults.py`.

--- a/tldw_chatbook/Config_Files/pipeline_configs/custom_pipelines_example.toml
+++ b/tldw_chatbook/Config_Files/pipeline_configs/custom_pipelines_example.toml
@@ -32,8 +32,7 @@ tags = ["legal", "contracts", "compliance"]
 [pipelines.legal_search.parameters]
 chunk_size = 800  # Larger chunks to preserve legal context
 chunk_type = "paragraphs"  # Preserve paragraph structure
-bm25_weight = 0.6  # Favor exact term matching
-vector_weight = 0.4
+hybrid_alpha = 0.4  # Vector-leg weight (0 = FTS only, 1 = vector only); favors exact term matching
 preserve_formatting = true
 include_line_numbers = true  # For legal citations
 

--- a/tldw_chatbook/Config_Files/rag_pipelines.toml
+++ b/tldw_chatbook/Config_Files/rag_pipelines.toml
@@ -50,8 +50,9 @@ reranker_model = "flashrank"
 chunk_size = 400
 chunk_overlap = 100
 chunk_type = "words"
-bm25_weight = 0.5
-vector_weight = 0.5
+# Fusion alpha defaults to [AppRAGSearchConfig.rag.retriever] hybrid_alpha
+# (0.7, tldw_server parity). Uncomment to pin per-pipeline:
+# hybrid_alpha = 0.7  # 0 = FTS only, 1 = vector only
 
 # Profile-based Pipeline Configurations
 [pipelines.fast_search]
@@ -138,8 +139,7 @@ chunk_size = 512
 chunk_type = "structural"
 preserve_tables = true
 clean_artifacts = true
-bm25_weight = 0.6
-vector_weight = 0.4
+hybrid_alpha = 0.4  # Vector-leg weight (0 = FTS only, 1 = vector only); favors exact term matching
 
 [pipelines.technical_docs.middleware]
 before = ["code_syntax_enhancer", "technical_term_detector"]
@@ -342,10 +342,14 @@ config = { top_k = 20 }
 function = "retrieve_semantic"
 config = { top_k = 20, score_threshold = 0.0 }
 
+# Server-parity fusion: Reciprocal Rank Fusion (k=60) + alpha-weighted blend.
+# alpha weights the vector leg (0 = FTS only, 1 = vector only); it defaults to
+# [AppRAGSearchConfig.rag.retriever] hybrid_alpha (0.7). Override per-pipeline
+# with e.g. config = { alpha = 0.5 }.
 [[pipelines.hybrid_v2.steps]]
 type = "merge"
-function = "weighted_merge"
-config = { weights = [0.5, 0.5] }
+function = "rrf_merge"
+config = {}
 
 [[pipelines.hybrid_v2.steps]]
 type = "process"

--- a/tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
+++ b/tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
@@ -124,8 +124,7 @@ async def perform_hybrid_rag_search(
     vector_weight: Optional[float] = None,
     keyword_filter_list: Optional[List[str]] = None
 ) -> Tuple[List[Dict[str, Any]], str]:
-    """
-    Perform a hybrid RAG search using the pipeline system.
+    """Perform a hybrid RAG search using the pipeline system.
 
     The FTS5 and semantic legs are fused via Reciprocal Rank Fusion (k=60)
     plus an alpha-weighted blend, matching the tldw_server design. Alpha
@@ -134,6 +133,28 @@ async def perform_hybrid_rag_search(
     Alpha precedence: ``hybrid_alpha`` argument -> legacy ``bm25_weight`` /
     ``vector_weight`` (mapped to ``vector / (bm25 + vector)``) ->
     ``[AppRAGSearchConfig.rag.retriever] hybrid_alpha`` config knob (0.7).
+
+    Args:
+        app: The TldwCli app instance providing database handles.
+        query: Search query text.
+        sources: Which sources to search (e.g. media/conversations/notes).
+        top_k: Maximum number of fused results to return.
+        max_context_length: Character budget for the formatted context.
+        enable_rerank: Whether to run the reranking step after fusion.
+        reranker_model: Reranker model name when reranking is enabled.
+        chunk_size: Chunk size forwarded to the pipeline parameters.
+        chunk_overlap: Chunk overlap forwarded to the pipeline parameters.
+        chunk_type: Chunking method forwarded to the pipeline parameters.
+        hybrid_alpha: Explicit fusion alpha (0 = FTS only, 1 = vector only);
+            overrides the legacy weights and the config knob.
+        bm25_weight: Legacy FTS-leg weight; mapped onto alpha together with
+            vector_weight when hybrid_alpha is not given.
+        vector_weight: Legacy vector-leg weight; see bm25_weight.
+        keyword_filter_list: Optional keywords the media FTS leg must match.
+
+    Returns:
+        Tuple of (result dicts sorted by fused score, formatted context
+        string for the LLM).
     """
     logger.info(f"Performing hybrid RAG search for query: '{query}'")
 

--- a/tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
+++ b/tldw_chatbook/Event_Handlers/Chat_Events/chat_rag_events.py
@@ -4,12 +4,14 @@
 # Imports
 from typing import TYPE_CHECKING, Dict, Any, List, Optional, Tuple
 import asyncio
+import copy
 from loguru import logger
 import os
 
 # Local Imports
 from ...RAG_Search.pipeline_builder_simple import execute_pipeline, BUILTIN_PIPELINES
 from ...RAG_Search.pipeline_loader import get_pipeline_loader
+from ...RAG_Search.fusion import resolve_hybrid_alpha
 
 if TYPE_CHECKING:
     from ...app import TldwCli
@@ -117,33 +119,37 @@ async def perform_hybrid_rag_search(
     chunk_size: int = 400,
     chunk_overlap: int = 100,
     chunk_type: str = "words",
-    bm25_weight: float = 0.5,
-    vector_weight: float = 0.5,
+    hybrid_alpha: Optional[float] = None,
+    bm25_weight: Optional[float] = None,
+    vector_weight: Optional[float] = None,
     keyword_filter_list: Optional[List[str]] = None
 ) -> Tuple[List[Dict[str, Any]], str]:
     """
     Perform a hybrid RAG search using the pipeline system.
+
+    The FTS5 and semantic legs are fused via Reciprocal Rank Fusion (k=60)
+    plus an alpha-weighted blend, matching the tldw_server design. Alpha
+    weights the vector leg: 0 = FTS only, 1 = vector only.
+
+    Alpha precedence: ``hybrid_alpha`` argument -> legacy ``bm25_weight`` /
+    ``vector_weight`` (mapped to ``vector / (bm25 + vector)``) ->
+    ``[AppRAGSearchConfig.rag.retriever] hybrid_alpha`` config knob (0.7).
     """
     logger.info(f"Performing hybrid RAG search for query: '{query}'")
-    
-    # Normalize weights
-    total_weight = bm25_weight + vector_weight
-    if total_weight > 0:
-        bm25_weight = bm25_weight / total_weight
-        vector_weight = vector_weight / total_weight
-    else:
-        bm25_weight = 0.5
-        vector_weight = 0.5
-    
-    # Build pipeline configuration
-    config = BUILTIN_PIPELINES['hybrid'].copy()
-    
-    # Update weights based on sources and user preferences
-    # FTS5 gets 3/4 of bm25_weight (split among media, conv, notes)
-    # Semantic gets vector_weight
-    fts_weight_per_source = bm25_weight / 3
-    weights = [fts_weight_per_source, fts_weight_per_source, fts_weight_per_source, vector_weight]
-    
+
+    # Map legacy weight parameters onto alpha for backwards compatibility
+    if hybrid_alpha is None and (bm25_weight is not None or vector_weight is not None):
+        bm25 = bm25_weight if bm25_weight is not None else 0.5
+        vector = vector_weight if vector_weight is not None else 0.5
+        total_weight = bm25 + vector
+        if total_weight > 0:
+            hybrid_alpha = vector / total_weight
+    alpha = resolve_hybrid_alpha(hybrid_alpha)
+
+    # Build pipeline configuration (deep copy: steps are nested dicts and the
+    # builtin definition must not be mutated across calls)
+    config = copy.deepcopy(BUILTIN_PIPELINES['hybrid'])
+
     # Update config
     config['parameters'] = {
         'top_k': top_k,
@@ -153,11 +159,11 @@ async def perform_hybrid_rag_search(
         'chunk_type': chunk_type,
         'keyword_filter': keyword_filter_list
     }
-    
-    # Update weights in parallel step
+
+    # Pin the resolved alpha on the fusion step
     for step in config['steps']:
-        if step.get('type') == 'parallel':
-            step['config']['weights'] = weights
+        if step.get('type') == 'parallel' and step.get('merge') == 'rrf_merge':
+            step['config'] = {**step.get('config', {}), 'alpha': alpha}
     
     # Adjust reranking step if needed
     if not enable_rerank:

--- a/tldw_chatbook/RAG_Search/fusion.py
+++ b/tldw_chatbook/RAG_Search/fusion.py
@@ -1,0 +1,235 @@
+"""
+Hybrid retrieval fusion: Reciprocal Rank Fusion with alpha weighting.
+
+This is the single authoritative implementation of hybrid (FTS + vector)
+result fusion for the chatbook, mirroring the tldw_server design
+(tldw_Server_API .. rag_service/database_retrievers.py, RRF k=60 plus an
+alpha-weighted blend of the two per-leg RRF scores):
+
+    fts_rrf(doc)    = 1 / (k + rank_in_fts_leg)      # rank starts at 1
+    vector_rrf(doc) = 1 / (k + rank_in_vector_leg)   # rank starts at 1
+    final(doc)      = (1 - alpha) * fts_rrf + alpha * vector_rrf
+
+Documents missing from a leg contribute 0 from that leg.
+
+Alpha semantics (server-consistent): ``alpha`` weights the VECTOR side.
+``alpha = 0`` -> FTS-only ordering, ``alpha = 1`` -> vector-only ordering.
+The server default is ``alpha = 0.7`` (vector-weighted), ``k = 60``.
+
+The fusion math is rank-based: only each leg's returned ordering matters,
+never the leg's raw scores. This makes fusion robust to the incomparable
+score scales of SQLite FTS5 and cosine similarity.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Hashable, List, Optional, Sequence, TypeVar
+
+from loguru import logger
+
+__all__ = [
+    "DEFAULT_RRF_K",
+    "DEFAULT_HYBRID_ALPHA",
+    "FusedResult",
+    "reciprocal_rank_fusion",
+    "interleave_rankings",
+    "resolve_hybrid_alpha",
+]
+
+# Server-parity constants (tldw_server database_retrievers.py)
+DEFAULT_RRF_K = 60
+DEFAULT_HYBRID_ALPHA = 0.7
+
+T = TypeVar("T")
+
+
+@dataclass
+class FusedResult:
+    """A single fused result with per-leg provenance.
+
+    Attributes:
+        key: Deduplication key shared by both legs.
+        fts_item: The item as returned by the FTS leg, if present there.
+        vector_item: The item as returned by the vector leg, if present there.
+        fts_rank: 1-based rank in the FTS leg, or None if absent.
+        vector_rank: 1-based rank in the vector leg, or None if absent.
+        fts_rrf: RRF contribution of the FTS leg (0.0 if absent).
+        vector_rrf: RRF contribution of the vector leg (0.0 if absent).
+        score: Final fused score: (1 - alpha) * fts_rrf + alpha * vector_rrf.
+    """
+    key: Hashable
+    fts_item: Optional[Any]
+    vector_item: Optional[Any]
+    fts_rank: Optional[int]
+    vector_rank: Optional[int]
+    fts_rrf: float
+    vector_rrf: float
+    score: float
+
+    @property
+    def item(self) -> Any:
+        """Primary item for this key (FTS leg wins, matching the server)."""
+        return self.fts_item if self.fts_item is not None else self.vector_item
+
+    def provenance(self) -> Dict[str, Any]:
+        """Cheap leg-provenance dict suitable for stashing in metadata."""
+        return {
+            "fts_rank": self.fts_rank,
+            "vector_rank": self.vector_rank,
+            "fts_rrf": self.fts_rrf,
+            "vector_rrf": self.vector_rrf,
+        }
+
+
+def _leg_ranks(
+    results: Sequence[T],
+    key: Callable[[T], Hashable],
+) -> Dict[Hashable, tuple]:
+    """Map key -> (1-based rank, item) for a leg, keeping the best rank on dupes."""
+    ranks: Dict[Hashable, tuple] = {}
+    for rank, item in enumerate(results, start=1):
+        k = key(item)
+        if k not in ranks:  # keep the best (earliest) rank for duplicates
+            ranks[k] = (rank, item)
+    return ranks
+
+
+def reciprocal_rank_fusion(
+    fts_results: Sequence[T],
+    vector_results: Sequence[T],
+    *,
+    key: Callable[[T], Hashable],
+    alpha: float = DEFAULT_HYBRID_ALPHA,
+    rrf_k: int = DEFAULT_RRF_K,
+    max_results: Optional[int] = None,
+) -> List[FusedResult]:
+    """Fuse an FTS ranking and a vector ranking via RRF + alpha blend.
+
+    Pure function; the input orderings are treated as the rankings (best
+    first) and input items are never mutated.
+
+    Args:
+        fts_results: FTS/keyword leg results, best first.
+        vector_results: Vector/semantic leg results, best first.
+        key: Extracts the deduplication key (document identity) from an item.
+        alpha: Weight of the vector leg; 0 = FTS only, 1 = vector only.
+        rrf_k: RRF constant (typically 60).
+        max_results: Optional cap on the number of fused results returned.
+
+    Returns:
+        FusedResult list sorted by fused score descending. Ties break
+        deterministically: better FTS rank first, then better vector rank
+        (absent legs sort last).
+    """
+    fts_ranks = _leg_ranks(fts_results, key)
+    vector_ranks = _leg_ranks(vector_results, key)
+
+    fused: List[FusedResult] = []
+    # FTS keys first, then vector-only keys, preserving leg order (deterministic).
+    all_keys = list(fts_ranks.keys())
+    all_keys.extend(k for k in vector_ranks.keys() if k not in fts_ranks)
+
+    for k in all_keys:
+        fts_entry = fts_ranks.get(k)
+        vector_entry = vector_ranks.get(k)
+        fts_rank = fts_entry[0] if fts_entry else None
+        vector_rank = vector_entry[0] if vector_entry else None
+        fts_rrf = (1.0 / (rrf_k + fts_rank)) if fts_rank is not None else 0.0
+        vector_rrf = (1.0 / (rrf_k + vector_rank)) if vector_rank is not None else 0.0
+        fused.append(FusedResult(
+            key=k,
+            fts_item=fts_entry[1] if fts_entry else None,
+            vector_item=vector_entry[1] if vector_entry else None,
+            fts_rank=fts_rank,
+            vector_rank=vector_rank,
+            fts_rrf=fts_rrf,
+            vector_rrf=vector_rrf,
+            score=(1.0 - alpha) * fts_rrf + alpha * vector_rrf,
+        ))
+
+    infinity = float("inf")
+    fused.sort(key=lambda f: (
+        -f.score,
+        f.fts_rank if f.fts_rank is not None else infinity,
+        f.vector_rank if f.vector_rank is not None else infinity,
+    ))
+
+    if max_results is not None:
+        fused = fused[:max_results]
+    return fused
+
+
+def interleave_rankings(
+    rankings: Sequence[Sequence[T]],
+    *,
+    key: Callable[[T], Hashable],
+) -> List[T]:
+    """Round-robin merge several per-source rankings into one ranking.
+
+    Used to collapse the pipeline's parallel FTS5 legs (media, conversations,
+    notes) into a single rank-fair FTS leg before fusion: the sources' raw
+    FTS5 scores are not comparable, so rank position is the only meaningful
+    cross-source signal. Duplicates (by key) keep their earliest position.
+
+    Args:
+        rankings: Per-source rankings, each best first.
+        key: Extracts the deduplication key from an item.
+
+    Returns:
+        A single ranking, best first.
+    """
+    merged: List[T] = []
+    seen: set = set()
+    longest = max((len(r) for r in rankings), default=0)
+    for position in range(longest):
+        for ranking in rankings:
+            if position >= len(ranking):
+                continue
+            item = ranking[position]
+            k = key(item)
+            if k in seen:
+                continue
+            seen.add(k)
+            merged.append(item)
+    return merged
+
+
+def resolve_hybrid_alpha(explicit: Optional[float] = None) -> float:
+    """Resolve the hybrid alpha from the single authoritative config knob.
+
+    Precedence: explicit value -> ``[AppRAGSearchConfig.rag.retriever]
+    hybrid_alpha`` in the user's config.toml -> ``DEFAULT_HYBRID_ALPHA``
+    (0.7, server parity). Semantics: 0 = FTS only, 1 = vector only.
+
+    Invalid or out-of-range values fall back to the default with a warning.
+
+    Args:
+        explicit: Caller-supplied alpha override, if any.
+
+    Returns:
+        A validated alpha in [0.0, 1.0].
+    """
+    value = explicit
+    if value is None:
+        try:
+            from tldw_chatbook.config import get_cli_setting
+            rag_section = get_cli_setting("AppRAGSearchConfig", "rag", {}) or {}
+            retriever_section = rag_section.get("retriever", {}) or {}
+            value = retriever_section.get("hybrid_alpha")
+        except Exception as e:  # config loading must never break search
+            logger.warning(f"Could not read hybrid_alpha from config: {e}")
+            value = None
+    if value is None:
+        return DEFAULT_HYBRID_ALPHA
+    try:
+        alpha = float(value)
+    except (TypeError, ValueError):
+        logger.warning(
+            f"Invalid hybrid_alpha {value!r}; falling back to {DEFAULT_HYBRID_ALPHA}"
+        )
+        return DEFAULT_HYBRID_ALPHA
+    if not 0.0 <= alpha <= 1.0:
+        logger.warning(
+            f"hybrid_alpha {alpha} outside [0, 1]; falling back to {DEFAULT_HYBRID_ALPHA}"
+        )
+        return DEFAULT_HYBRID_ALPHA
+    return alpha

--- a/tldw_chatbook/RAG_Search/fusion.py
+++ b/tldw_chatbook/RAG_Search/fusion.py
@@ -33,6 +33,7 @@ __all__ = [
     "reciprocal_rank_fusion",
     "interleave_rankings",
     "resolve_hybrid_alpha",
+    "resolve_rrf_k",
 ]
 
 # Server-parity constants (tldw_server database_retrievers.py)
@@ -119,7 +120,27 @@ def reciprocal_rank_fusion(
         FusedResult list sorted by fused score descending. Ties break
         deterministically: better FTS rank first, then better vector rank
         (absent legs sort last).
+
+    Note:
+        As a last-resort invariant (config-sourced values should already be
+        validated via resolve_hybrid_alpha / resolve_rrf_k), out-of-range
+        inputs are sanitized rather than propagated into the math: alpha is
+        clamped into [0, 1] and a negative rrf_k falls back to
+        DEFAULT_RRF_K, so no call site can produce negative blend weights
+        or a zero/negative RRF denominator.
     """
+    if not 0.0 <= alpha <= 1.0:
+        clamped = min(1.0, max(0.0, alpha))
+        logger.warning(
+            f"reciprocal_rank_fusion: alpha {alpha} outside [0, 1]; clamping to {clamped}"
+        )
+        alpha = clamped
+    if rrf_k < 0:
+        logger.warning(
+            f"reciprocal_rank_fusion: rrf_k {rrf_k} is negative; using {DEFAULT_RRF_K}"
+        )
+        rrf_k = DEFAULT_RRF_K
+
     fts_ranks = _leg_ranks(fts_results, key)
     vector_ranks = _leg_ranks(vector_results, key)
 
@@ -233,3 +254,29 @@ def resolve_hybrid_alpha(explicit: Optional[float] = None) -> float:
         )
         return DEFAULT_HYBRID_ALPHA
     return alpha
+
+
+def resolve_rrf_k(value: Optional[Any] = None) -> int:
+    """Resolve the RRF constant k from an untrusted (config) value.
+
+    Args:
+        value: Caller/config-supplied k, if any (e.g. a TOML pipeline's
+            ``steps[].config.rrf_k``).
+
+    Returns:
+        A non-negative int; ``DEFAULT_RRF_K`` (60, server parity) when the
+        value is missing, non-numeric, or negative. Invalid values are
+        logged, never raised: a misconfigured pipeline must not abort
+        search at merge time.
+    """
+    if value is None:
+        return DEFAULT_RRF_K
+    try:
+        k = int(float(value))
+    except (TypeError, ValueError):
+        logger.warning(f"Invalid rrf_k {value!r}; falling back to {DEFAULT_RRF_K}")
+        return DEFAULT_RRF_K
+    if k < 0:
+        logger.warning(f"rrf_k {k} is negative; falling back to {DEFAULT_RRF_K}")
+        return DEFAULT_RRF_K
+    return k

--- a/tldw_chatbook/RAG_Search/pipeline_builder_simple.py
+++ b/tldw_chatbook/RAG_Search/pipeline_builder_simple.py
@@ -21,7 +21,7 @@ from .pipeline_functions_simple import (
 )
 from .fusion import (
     reciprocal_rank_fusion, interleave_rankings, resolve_hybrid_alpha,
-    DEFAULT_RRF_K,
+    resolve_rrf_k,
 )
 
 # Retrieval functions whose results form the vector (semantic) leg of hybrid
@@ -273,7 +273,7 @@ def _rrf_merge_parallel_results(
     alpha = resolve_hybrid_alpha(
         merge_config.get('alpha', context['params'].get('hybrid_alpha'))
     )
-    rrf_k = int(merge_config.get('rrf_k', DEFAULT_RRF_K))
+    rrf_k = resolve_rrf_k(merge_config.get('rrf_k'))
 
     fused_entries = reciprocal_rank_fusion(
         fts_leg, vector_leg, key=result_key, alpha=alpha, rrf_k=rrf_k
@@ -283,8 +283,23 @@ def _rrf_merge_parallel_results(
     for entry in fused_entries:
         result = entry.item
         result.score = entry.score
+        merged_metadata = dict(result.metadata or {})
+        # When a doc surfaced in both legs the FTS item is primary; carry the
+        # other leg's citation metadata (search_semantic stashes citations as
+        # _has_citations/_citations) so citations survive fusion and reach
+        # _results_to_dicts.
+        if entry.fts_item is not None and entry.vector_item is not None:
+            other = entry.vector_item if result is entry.fts_item else entry.fts_item
+            other_metadata = other.metadata or {}
+            if other_metadata.get('_has_citations'):
+                combined_citations = (
+                    list(merged_metadata.get('_citations') or [])
+                    + list(other_metadata.get('_citations') or [])
+                )
+                merged_metadata['_citations'] = combined_citations
+                merged_metadata['_has_citations'] = True
         result.metadata = {
-            **(result.metadata or {}),
+            **merged_metadata,
             'hybrid_fusion': {**entry.provenance(), 'alpha': alpha, 'rrf_k': rrf_k},
         }
         fused_results.append(result)

--- a/tldw_chatbook/RAG_Search/pipeline_builder_simple.py
+++ b/tldw_chatbook/RAG_Search/pipeline_builder_simple.py
@@ -19,6 +19,14 @@ from .pipeline_types import SearchResult, StepType, PipelineContext
 from .pipeline_functions_simple import (
     RETRIEVAL_FUNCTIONS, PROCESSING_FUNCTIONS, FORMATTING_FUNCTIONS
 )
+from .fusion import (
+    reciprocal_rank_fusion, interleave_rankings, resolve_hybrid_alpha,
+    DEFAULT_RRF_K,
+)
+
+# Retrieval functions whose results form the vector (semantic) leg of hybrid
+# fusion; every other retrieval function is treated as an FTS/keyword leg.
+VECTOR_RETRIEVAL_FUNCTIONS = {'search_semantic'}
 
 
 async def execute_pipeline(
@@ -139,12 +147,13 @@ async def _execute_parallel_step(
         return []
     
     tasks = []
+    task_func_names = []
     for func_config in functions:
         func_name = func_config.get('function')
         if func_name and func_name in RETRIEVAL_FUNCTIONS:
             func = RETRIEVAL_FUNCTIONS[func_name]
             config = {**context['params'], **func_config.get('config', {})}
-            
+
             # Create appropriate task based on function
             if func_name.endswith('_fts5'):
                 # Only search_media_fts5 accepts keyword_filter
@@ -162,6 +171,24 @@ async def _execute_parallel_step(
                         context['query'],
                         config.get('top_k', 10)
                     )
+            elif func_name == 'search_semantic':
+                # Vector leg: forward only kwargs the RAG service accepts.
+                # Splatting the full pipeline params (top_k alongside
+                # search_semantic's own limit->top_k, chunk_*, ...) raises
+                # TypeError inside search_semantic, which gather() swallows
+                # and the vector leg comes back silently empty.
+                semantic_kwargs = {
+                    key: config[key]
+                    for key in ('score_threshold', 'filter_metadata')
+                    if key in config
+                }
+                task = func(
+                    context['app'],
+                    context['query'],
+                    context['sources'],
+                    limit=config.get('top_k', 10),
+                    **semantic_kwargs
+                )
             else:
                 task = func(
                     context['app'],
@@ -170,10 +197,11 @@ async def _execute_parallel_step(
                     **config
                 )
             tasks.append(task)
-    
+            task_func_names.append(func_name)
+
     # Execute in parallel
     results_lists = await asyncio.gather(*tasks, return_exceptions=True)
-    
+
     # Combine results
     all_results = []
     for results in results_lists:
@@ -181,17 +209,91 @@ async def _execute_parallel_step(
             logger.error(f"Parallel search failed: {results}")
             continue
         all_results.extend(results)
-    
+
     # Apply merge if specified
     merge_func = step_config.get('merge')
+    if merge_func == 'rrf_merge':
+        return _rrf_merge_parallel_results(
+            task_func_names, results_lists,
+            step_config.get('config', {}) or {},
+            context,
+        )
     if merge_func == 'weighted_merge' and 'weights' in step_config.get('config', {}):
         # Split results back into lists for weighted merge
         weights = step_config['config']['weights']
         if len(results_lists) == len(weights):
             valid_results = [r for r in results_lists if not isinstance(r, Exception)]
             return PROCESSING_FUNCTIONS['weighted_merge'](valid_results, weights)
-    
+
     return all_results
+
+
+def _rrf_merge_parallel_results(
+    func_names: List[str],
+    results_lists: List[Any],
+    merge_config: Dict[str, Any],
+    context: PipelineContext
+) -> List[SearchResult]:
+    """Fuse parallel retrieval legs via RRF + alpha (tldw_server parity).
+
+    The FTS5 source lists (media, conversations, notes) are interleaved
+    rank-fairly into a single FTS leg; ``search_semantic`` results form the
+    vector leg. The two legs are fused with Reciprocal Rank Fusion (k=60 by
+    default) and an alpha-weighted blend where alpha weights the vector leg
+    (0 = FTS only, 1 = vector only).
+
+    Alpha precedence: step ``config.alpha`` -> ``hybrid_alpha`` runtime
+    param -> ``[AppRAGSearchConfig.rag.retriever] hybrid_alpha`` -> 0.7.
+
+    Args:
+        func_names: Retrieval function name per results list, same order.
+        results_lists: Per-function results (exceptions already logged).
+        merge_config: The parallel step's merge config.
+        context: Pipeline execution context.
+
+    Returns:
+        Fused results sorted by fused score descending.
+    """
+    fts_lists: List[List[SearchResult]] = []
+    vector_lists: List[List[SearchResult]] = []
+    for func_name, results in zip(func_names, results_lists):
+        if isinstance(results, Exception):
+            continue
+        if func_name in VECTOR_RETRIEVAL_FUNCTIONS:
+            vector_lists.append(results)
+        else:
+            fts_lists.append(results)
+
+    def result_key(result: SearchResult):
+        return (result.source, result.id)
+
+    fts_leg = interleave_rankings(fts_lists, key=result_key)
+    vector_leg = interleave_rankings(vector_lists, key=result_key)
+
+    alpha = resolve_hybrid_alpha(
+        merge_config.get('alpha', context['params'].get('hybrid_alpha'))
+    )
+    rrf_k = int(merge_config.get('rrf_k', DEFAULT_RRF_K))
+
+    fused_entries = reciprocal_rank_fusion(
+        fts_leg, vector_leg, key=result_key, alpha=alpha, rrf_k=rrf_k
+    )
+
+    fused_results = []
+    for entry in fused_entries:
+        result = entry.item
+        result.score = entry.score
+        result.metadata = {
+            **(result.metadata or {}),
+            'hybrid_fusion': {**entry.provenance(), 'alpha': alpha, 'rrf_k': rrf_k},
+        }
+        fused_results.append(result)
+
+    logger.debug(
+        f"RRF fusion merged {len(fused_results)} results "
+        f"(fts_leg={len(fts_leg)}, vector_leg={len(vector_leg)}, alpha={alpha}, k={rrf_k})"
+    )
+    return fused_results
 
 
 def _execute_process_step(
@@ -300,8 +402,12 @@ BUILTIN_PIPELINES = {
                     {'function': 'search_notes_fts5', 'config': {'top_k': 20}},
                     {'function': 'search_semantic', 'config': {'top_k': 20}}
                 ],
-                'merge': 'weighted_merge',
-                'config': {'weights': [0.25, 0.25, 0.25, 0.25]}  # Equal weights
+                # Server-parity fusion: RRF (k=60) + alpha blend, alpha
+                # weights the vector leg (0 = FTS only, 1 = vector only).
+                # Alpha resolves from [AppRAGSearchConfig.rag.retriever]
+                # hybrid_alpha (default 0.7) unless overridden here.
+                'merge': 'rrf_merge',
+                'config': {}
             },
             {'type': 'process', 'function': 'deduplicate_results'},
             {'type': 'process', 'function': 'rerank_results'},
@@ -391,6 +497,18 @@ def load_pipelines_from_toml():
                             'merge': step.get('merge', 'concat'),
                             'config': step.get('config', {})
                         })
+                    elif step["type"] == "merge":
+                        # Fold a standalone merge step into the preceding
+                        # parallel step: execute_pipeline has no 'merge' step
+                        # type, so these were silently skipped before.
+                        if steps and steps[-1].get('type') == 'parallel':
+                            steps[-1]['merge'] = step.get('function', 'concat')
+                            steps[-1]['config'] = step.get('config', {})
+                        else:
+                            logger.warning(
+                                f"Pipeline '{pipeline_id}': merge step without a "
+                                f"preceding parallel step is ignored"
+                            )
                     else:
                         # Regular step - map function names
                         func_name = step.get('function')

--- a/tldw_chatbook/RAG_Search/rag_config_example.toml
+++ b/tldw_chatbook/RAG_Search/rag_config_example.toml
@@ -15,7 +15,7 @@ log_performance_metrics = false
 # Retriever configuration
 fts_top_k = 10  # Number of results from full-text search
 vector_top_k = 10  # Number of results from vector search
-hybrid_alpha = 0.5  # Balance between FTS and vector (0=FTS only, 1=vector only)
+hybrid_alpha = 0.7  # Hybrid RRF fusion: vector-leg weight (0=FTS only, 1=vector only); 0.7 = tldw_server default
 
 # Collection names in ChromaDB
 media_collection = "media_embeddings"

--- a/tldw_chatbook/RAG_Search/simplified/config.py
+++ b/tldw_chatbook/RAG_Search/simplified/config.py
@@ -15,6 +15,9 @@ from loguru import logger
 # Import the main config module to access existing configuration
 from tldw_chatbook.config import get_cli_setting, load_cli_config_and_ensure_existence, get_user_data_dir
 
+# Server-parity hybrid fusion default (alpha weights the vector leg)
+from ..fusion import DEFAULT_HYBRID_ALPHA
+
 
 def _coerce_int_setting(value: Any, default: int) -> int:
     """Coerce user-editable integer settings without raising on bad config."""
@@ -237,7 +240,11 @@ class SearchConfig:
     # Search-specific settings
     fts_top_k: int = 10  # For keyword search
     vector_top_k: int = 10  # For semantic search
-    hybrid_alpha: float = 0.5  # Weight for hybrid search (0=keyword only, 1=semantic only)
+    # Hybrid fusion alpha: weight of the vector leg in the RRF blend
+    # (0 = FTS/keyword only, 1 = vector/semantic only). Default 0.7 matches
+    # tldw_server. Authoritative TOML knob:
+    # [AppRAGSearchConfig.rag.retriever] hybrid_alpha
+    hybrid_alpha: float = DEFAULT_HYBRID_ALPHA
     # Re-ranking
     enable_reranking: bool = False
     reranker_model: Optional[str] = None
@@ -876,7 +883,6 @@ default_search_mode = "semantic"  # "plain", "semantic", or "hybrid"
 max_context_size = 16000
 fts_top_k = 10
 vector_top_k = 10
-hybrid_alpha = 0.5
 cache_size = 100
 cache_ttl = 3600  # 1 hour default for all search types
 # Optional search-type specific cache TTLs
@@ -885,8 +891,11 @@ cache_ttl = 3600  # 1 hour default for all search types
 # hybrid_cache_ttl = 3600    # 1 hour for hybrid search
 fts5_connection_pool_size = 3  # Adjust based on concurrent search load
 
-# Legacy configuration locations (still supported)
+# Retriever configuration (authoritative location for hybrid_alpha)
 [AppRAGSearchConfig.rag.retriever]
+# Hybrid fusion alpha: weight of the vector leg in the RRF blend
+# (0 = FTS only, 1 = vector only). Default 0.7 matches tldw_server.
+hybrid_alpha = 0.7
 media_collection = "media_embeddings"
 chat_collection = "chat_embeddings"
 notes_collection = "notes_embeddings"

--- a/tldw_chatbook/RAG_Search/simplified/rag_service.py
+++ b/tldw_chatbook/RAG_Search/simplified/rag_service.py
@@ -30,6 +30,7 @@ from .vector_store import (
 )
 from .citations import Citation, CitationType, merge_citations
 from .config import RAGConfig
+from ..fusion import reciprocal_rank_fusion, DEFAULT_RRF_K
 from ..chunking_service import ChunkingService
 from .simple_cache import SimpleRAGCache, get_rag_cache
 from .db_connection_pool import get_connection_pool
@@ -732,10 +733,13 @@ class RAGService:
                             include_citations: bool = True,
                             score_threshold: float = 0.0) -> Union[List[SearchResult], List[SearchResultWithCitations]]:
         """
-        Perform hybrid search combining semantic and keyword.
-        
-        Merges results from both search types, removing duplicates and
-        combining citations when the same chunk appears in both.
+        Perform hybrid search combining semantic (vector) and keyword (FTS5) legs.
+
+        The legs run in parallel and are fused with Reciprocal Rank Fusion
+        (k=60) plus an alpha-weighted blend of the per-leg RRF scores,
+        matching the tldw_server reference design. Alpha comes from
+        ``config.search.hybrid_alpha`` (0 = FTS only, 1 = vector only).
+        Citations are combined when the same chunk appears in both legs.
         """
         # Get results from both search types
         semantic_task = self._semantic_search(
@@ -744,78 +748,75 @@ class RAGService:
         keyword_task = self._keyword_search(
             query, top_k * SEARCH_RESULT_MULTIPLIER, filter_metadata, include_citations
         )
-        
+
         # Run both searches in parallel
         semantic_results, keyword_results = await asyncio.gather(
             semantic_task, keyword_task
         )
-        
-        if include_citations:
-            # Merge results with citations
-            return self._merge_results_with_citations(
-                semantic_results, keyword_results, top_k
-            )
-        else:
-            # Simple merging for basic results
-            return self._merge_basic_results(
-                semantic_results, keyword_results, top_k
-            )
-    
-    def _merge_results_with_citations(self,
-                                    semantic_results: List[SearchResultWithCitations],
-                                    keyword_results: List[SearchResultWithCitations],
-                                    top_k: int) -> List[SearchResultWithCitations]:
-        """Merge results while combining citations from both sources."""
-        merged = {}
-        
-        # Process semantic results
-        for result in semantic_results:
-            merged[result.id] = result
-        
-        # Merge keyword results
-        for result in keyword_results:
-            if result.id in merged:
-                # Combine citations from both
-                existing = merged[result.id]
-                # Merge citations, keeping highest confidence for duplicates
-                all_citations = existing.citations + result.citations
-                existing.citations = merge_citations([existing.citations, result.citations])
-                # Update score (weighted average based on number of citations)
-                total_citations = len(existing.citations) + len(result.citations)
-                if total_citations > 0:
-                    existing.score = (
-                        existing.score * len(existing.citations) + 
-                        result.score * len(result.citations)
-                    ) / total_citations
-            else:
-                merged[result.id] = result
-        
-        # Sort by score and return top-k
-        sorted_results = sorted(merged.values(), key=lambda x: x.score, reverse=True)
-        return sorted_results[:top_k]
-    
-    def _merge_basic_results(self,
-                           semantic_results: List[SearchResult],
-                           keyword_results: List[SearchResult],
-                           top_k: int) -> List[SearchResult]:
-        """Simple merging for basic results."""
-        # Use dict to track seen IDs and keep highest score
-        merged = {}
-        
-        for result in semantic_results:
-            merged[result.id] = result
-        
-        for result in keyword_results:
-            if result.id in merged:
-                # Keep the one with higher score
-                if result.score > merged[result.id].score:
-                    merged[result.id] = result
-            else:
-                merged[result.id] = result
-        
-        # Sort by score and return top-k
-        sorted_results = sorted(merged.values(), key=lambda x: x.score, reverse=True)
-        return sorted_results[:top_k]
+
+        return self._fuse_hybrid_results(
+            keyword_results=keyword_results,
+            semantic_results=semantic_results,
+            top_k=top_k,
+            alpha=self.config.search.hybrid_alpha,
+            include_citations=include_citations,
+        )
+
+    @staticmethod
+    def _fuse_hybrid_results(keyword_results: Union[List[SearchResult], List[SearchResultWithCitations]],
+                             semantic_results: Union[List[SearchResult], List[SearchResultWithCitations]],
+                             top_k: int,
+                             alpha: float,
+                             include_citations: bool = True) -> Union[List[SearchResult], List[SearchResultWithCitations]]:
+        """Fuse the FTS (keyword) and vector (semantic) legs via RRF + alpha.
+
+        Rank-based fusion (server parity): each leg's returned ordering is
+        the ranking; the fused score replaces the leg scores. Leg provenance
+        (per-leg rank and RRF contribution) is stored in
+        ``metadata['hybrid_fusion']``. When a chunk appears in both legs its
+        citations are merged.
+
+        Args:
+            keyword_results: FTS/keyword leg, best first.
+            semantic_results: Vector/semantic leg, best first.
+            top_k: Maximum number of fused results to return.
+            alpha: Vector-leg weight (0 = FTS only, 1 = vector only).
+            include_citations: Whether results carry citations to merge.
+
+        Returns:
+            Fused results sorted by fused score descending.
+        """
+        fused = reciprocal_rank_fusion(
+            keyword_results,
+            semantic_results,
+            key=lambda r: r.id,
+            alpha=alpha,
+            rrf_k=DEFAULT_RRF_K,
+            max_results=top_k,
+        )
+
+        results = []
+        for entry in fused:
+            result = entry.item
+            # Combine citations when the same chunk surfaced in both legs
+            if (include_citations
+                    and entry.fts_item is not None
+                    and entry.vector_item is not None
+                    and hasattr(result, 'citations')):
+                result.citations = merge_citations(
+                    [entry.fts_item.citations, entry.vector_item.citations]
+                )
+            result.score = entry.score
+            result.metadata = {
+                **(result.metadata or {}),
+                'hybrid_fusion': {
+                    **entry.provenance(),
+                    'alpha': alpha,
+                    'rrf_k': DEFAULT_RRF_K,
+                },
+            }
+            results.append(result)
+        return results
     
     # === Helper Methods ===
     

--- a/tldw_chatbook/RAG_Search/simplified/rag_service.py
+++ b/tldw_chatbook/RAG_Search/simplified/rag_service.py
@@ -30,7 +30,7 @@ from .vector_store import (
 )
 from .citations import Citation, CitationType, merge_citations
 from .config import RAGConfig
-from ..fusion import reciprocal_rank_fusion, DEFAULT_RRF_K
+from ..fusion import reciprocal_rank_fusion, resolve_hybrid_alpha, DEFAULT_RRF_K
 from ..chunking_service import ChunkingService
 from .simple_cache import SimpleRAGCache, get_rag_cache
 from .db_connection_pool import get_connection_pool
@@ -781,11 +781,18 @@ class RAGService:
             semantic_results: Vector/semantic leg, best first.
             top_k: Maximum number of fused results to return.
             alpha: Vector-leg weight (0 = FTS only, 1 = vector only).
+                Validated via resolve_hybrid_alpha: out-of-range/invalid
+                config values fall back to the 0.7 default, matching the
+                pipeline path.
             include_citations: Whether results carry citations to merge.
 
         Returns:
             Fused results sorted by fused score descending.
         """
+        # config.search.hybrid_alpha is not range-checked at load time
+        # (RAGConfig.validate() has no callers); resolve here so this path
+        # gets the same fallback semantics as the pipeline merge.
+        alpha = resolve_hybrid_alpha(alpha)
         fused = reciprocal_rank_fusion(
             keyword_results,
             semantic_results,

--- a/tldw_chatbook/UI/Screens/settings_library_rag_defaults.py
+++ b/tldw_chatbook/UI/Screens/settings_library_rag_defaults.py
@@ -34,7 +34,7 @@ class SettingsLibraryRagDefaults:
     default_top_k: int = 10
     fts_top_k: int = 10
     vector_top_k: int = 10
-    hybrid_alpha: float = 0.5
+    hybrid_alpha: float = 0.7
     score_threshold: float = 0.0
     include_citations: bool = True
     citation_style: str = DEFAULT_CITATION_STYLE

--- a/tldw_chatbook/UI/Tools_Settings_Window.py
+++ b/tldw_chatbook/UI/Tools_Settings_Window.py
@@ -1540,7 +1540,7 @@ class ToolsSettingsWindow(Container):
         
         retriever_widgets.append(Label("Hybrid Alpha (0.0-1.0):", classes="form-label"))
         retriever_widgets.append(Input(
-            value=str(retriever_config.get("hybrid_alpha", 0.5)),
+            value=str(retriever_config.get("hybrid_alpha", 0.7)),
             id="config-rag-retriever-hybrid-alpha"
         ))
         

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -83,7 +83,9 @@ DEFAULT_RAG_SEARCH_CONFIG = {
     "retriever": {
         "fts_top_k": 10,
         "vector_top_k": 10,
-        "hybrid_alpha": 0.5,
+        # Hybrid fusion alpha (RRF blend): 0 = FTS only, 1 = vector only.
+        # 0.7 matches the tldw_server default (vector-weighted).
+        "hybrid_alpha": 0.7,
         "chunk_size": 512,
         "chunk_overlap": 128,
         "media_collection": "media_embeddings",
@@ -2238,7 +2240,7 @@ cache_size_limit_gb = 10.0
     [rag.retriever]
     fts_top_k = 10              # Number of results from full-text search
     vector_top_k = 10           # Number of results from vector search
-    hybrid_alpha = 0.5          # Weight for hybrid search (0=FTS only, 1=vector only)
+    hybrid_alpha = 0.7          # Hybrid RRF fusion: vector-leg weight (0=FTS only, 1=vector only); 0.7 = tldw_server default
     chunk_size = 512            # Size of text chunks for indexing
     chunk_overlap = 128         # Overlap between chunks
     


### PR DESCRIPTION
## Summary

Implements **task-256** (local-RAG program, ADR-005): hybrid retrieval now fuses the FTS and vector legs with **Reciprocal Rank Fusion (k=60) plus an alpha-weighted blend**, matching the tldw_server reference (`database_retrievers.py:2047-2105`):

```
leg_rrf(doc) = 1 / (k + rank)          # 1-based rank within each leg's ordering
final(doc)   = (1 - alpha) * fts_rrf + alpha * vector_rrf
```

Alpha weights the **vector** side: `0 = FTS only, 1 = vector only`; default `0.7` (server parity).

## One shared fusion helper

New pure module **`tldw_chatbook/RAG_Search/fusion.py`** (`reciprocal_rank_fusion`, `interleave_rankings`, `resolve_hybrid_alpha`) — placed at the `RAG_Search/` top level rather than inside `simplified/` because that package's `__init__` eagerly imports the embeddings stack and can `ImportError` without the `embeddings_rag` extra. Deterministic tie-breaks; per-leg rank/RRF provenance preserved in `metadata['hybrid_fusion']`.

## Fusion sites unified

1. **`RAGService._hybrid_search`** (`simplified/rag_service.py`) — replaces the ad-hoc citation-count-weighted / max-score merges. Citations still merge when a chunk appears in both legs. Enhanced services inherit via `super().search()`.
2. **Builtin `hybrid` pipeline** (`pipeline_builder_simple.py`) — `weighted_merge [0.25 x4]` step replaced with `rrf_merge`: the three FTS5 source lists are interleaved rank-fairly into one FTS leg (their raw scores are constant/incomparable), fused against the `search_semantic` leg. `perform_hybrid_rag_search` gains `hybrid_alpha` (legacy `bm25_weight`/`vector_weight` map to `vector/(bm25+vector)` for back-compat) and now **deep-copies** the builtin config — the old shallow copy mutated `BUILTIN_PIPELINES` across calls.
3. **TOML pipelines** — standalone `type = "merge"` steps were silently skipped by `execute_pipeline` (no such step type existed); they now fold into the preceding parallel step at load time, and the shipped `hybrid_v2` uses `rrf_merge`. Shipped pipeline params drop `bm25_weight/vector_weight = 0.5` defaults that would have silently pinned alpha to 0.5 past the config knob (`technical_docs` / the custom example keep their 0.6/0.4 intent as `hybrid_alpha = 0.4`). `weighted_merge` remains supported.

## Bug found & fixed: pipeline vector leg was ALWAYS empty

The parallel step called `search_semantic(app, query, sources, **config)` with the full pipeline param soup; the duplicated `top_k` raised `TypeError` inside the leg, `asyncio.gather(return_exceptions=True)` swallowed it, and the hybrid pipeline silently degraded to FTS-only — independent of task-247's indexing. The step now passes `limit` plus whitelisted kwargs (`score_threshold`, `filter_metadata`). Regression-tested with the **real** `search_semantic` against a strict-signature stub service (no `**kwargs` fake). The analogous bug on the `retrieve`-step path (pure `semantic` pipeline) is task-250's scope and was left untouched.

## Config knob (deliberate default migration 0.5 → 0.7)

**One authoritative knob:** `[AppRAGSearchConfig.rag.retriever] hybrid_alpha` → `RAGConfig.search.hybrid_alpha`. Default deliberately migrated **0.5 → 0.7** (server parity) across: `simplified/config.py` dataclass, `config.py` (`DEFAULT_RAG_SEARCH_CONFIG` + `[rag.retriever]` template), `rag_config_example.toml`, `Tools_Settings_Window` fallback, `SettingsLibraryRagDefaults` dataclass. Doc fixes: the `EXAMPLE_TOML_CONFIG` docstring listed `hybrid_alpha` under `.rag.search` (a section the loader never reads) — moved to `.rag.retriever`; `Docs/Development/RAG/RAG-Documentation.md` had the semantics **inverted** ("semantic (0.0) and keyword (1.0)") — corrected.

## Tests

New `Tests/RAG/test_fusion.py` — **36 tests**: hand-computed A/B/C rankings asserting exact scores for alpha ∈ {0, 0.5, 0.7, 1}; empty-leg / both-empty; deterministic ties; `rrf_k`; `max_results`; in-leg duplicates; provenance; input non-mutation; rank-not-score invariance; `RAGService._fuse_hybrid_results` (citation merge, cap, alpha=0); pipeline `rrf_merge` with hand-computed interleaved-leg scores; vector-leg failure degradation; live-vector-leg regression; `perform_hybrid_rag_search` end-to-end smoke incl. builtin-non-mutation.

## Verification (local; CI intentionally cancelled)

- `Tests/RAG/ Tests/RAG_Search/`: **354 passed, 19 skipped**
- `Tests/UI/test_settings_library_rag_defaults.py`: **18 passed** (default assertion updated 0.5 → 0.7)
- `Tests/UI/test_settings_configuration_hub.py`: **237 passed**
- `python -c "import tldw_chatbook.app"`: OK
- Rebased onto `origin/dev` @ `a63db6ca`; suites re-run post-rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements task-256: hybrid RAG now fuses FTS and vector legs with Reciprocal Rank Fusion (k=60) plus an alpha-weighted blend, matching the server (alpha weights the vector leg, default 0.7). Adds one shared fusion helper used by the service and pipeline, hardens config handling, and preserves citations on overlap.

- **New Features**
  - Server-parity hybrid fusion via `tldw_chatbook/RAG_Search/fusion.py` (`reciprocal_rank_fusion`, `interleave_rankings`, `resolve_hybrid_alpha`); deterministic ties and per-leg provenance in `metadata['hybrid_fusion']`.
  - `RAGService._hybrid_search` uses the shared fusion; builtin `hybrid` pipeline switches to `rrf_merge` (FTS5 source lists interleaved vs `search_semantic`); `perform_hybrid_rag_search` resolves `hybrid_alpha` (maps legacy weights) and deep-copies pipeline config; TOML `type="merge"` folds into the preceding `parallel` step and shipped `hybrid_v2` uses `rrf_merge`.
  - Default `hybrid_alpha` moved to 0.7 across config, examples, and UI; docs updated with the RRF+alpha formula and correct knob location.

- **Bug Fixes**
  - Fixed the pipeline bug that made the vector leg always empty (duplicate `top_k` raised and was swallowed); `search_semantic` now receives `limit` plus whitelisted args.
  - Fusion inputs validated at every boundary: out-of-range `alpha` resolves via config and is clamped; non-numeric/negative `rrf_k` falls back to 60 so misconfigured pipelines don’t crash.
  - Pipeline `rrf_merge` now carries the semantic leg’s citation metadata when a doc appears in both legs; service path still merges citations.
  - Expanded tests for fusion math, alpha/rrf_k resolution, pipeline seams, and defaults (UI default updated to 0.7).

<sup>Written for commit e0900318819c6813495fbd3e013b0b4e32c5c225. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

