### PR TITLE
Roleplay P2c — entry priority + priority-aware token budget (Lore)

### DIFF
--- a/Docs/superpowers/plans/2026-07-17-roleplay-p2c-priority-budget.md
+++ b/Docs/superpowers/plans/2026-07-17-roleplay-p2c-priority-budget.md
@@ -1,0 +1,436 @@
+# Roleplay P2c — entry priority + priority-aware budget — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give world-book entries a `priority` so important lore survives token-budget pressure and injects first, and fix the `token_budget`/`scan_depth` floor.
+
+**Architecture:** Add a `priority` column (schema v20→v21 migration), thread it through `WorldBookManager`, and make `world_info_processor` sort matched entries by `(-priority, insertion_order)` for both budget survival and injection order; surface priority in the diagnostics + the Lore editor/Try-it.
+
+**Tech Stack:** Python 3.11+, Textual, SQLite (ChaChaNotes DB, `db_schema_version` table), `WorldBookManager` + `WorldInfoProcessor`, pytest.
+
+**Spec:** `Docs/superpowers/specs/2026-07-17-roleplay-p2c-priority-budget-design.md` (`87300806`). Branch `claude/roleplay-p2c-priority-budget` off dev `5c0de75a`.
+
+## Global Constraints
+
+- **Migration is idempotent.** SQLite has no `ADD COLUMN IF NOT EXISTS`, so guard the ALTER with `PRAGMA table_info`; recreate triggers with `DROP TRIGGER IF EXISTS` + `CREATE` (the P1e lesson). A replayed/downgrade migration must not error.
+- **Base DDL == migrated DB.** Update both the `world_book_entries` base DDL and the migration so a fresh DB and a migrated DB end identical (column + both sync triggers carrying `priority`).
+- **Priority is `(-priority, insertion_order)`.** The sort key for both budget survival and injection order. Priority is int-coerced, default `0`, clamped `0–100` at the editor.
+- **Nearly inert for existing data.** Every existing entry defaults to `priority = 0`, and Python's sort is stable, so at equal priorities + default `insertion_order` the sort is a no-op — the P2a budget/recursion pins hold **unchanged** (`test_diagnostics_classifies_disabled_secondary_and_budget`, `test_diagnostics_reports_recursively_fired_entries`). The one behavior change at default priority is the recursive-scan reorder (a recursively-matched entry re-orders by its own `insertion_order` instead of always trailing) — pinned by a new test.
+- **`token_budget = 0` means unlimited** (pre-existing: `_apply_token_budget` early-returns when `token_budget <= 0`). The floor fix seeds `token_budget`/`scan_depth` to `0` so lower book values win `max(…)`; a book that *omits* the field still defaults to 500/3.
+- **⚠️ Schema-version collision:** claim v21. Re-verify at merge time that no parallel branch also minted v21 (the v19-collision lesson).
+- **Test env** (prefix every pytest run): `HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest <targets> -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread`
+- **Staging:** stage only each task's own files. Never `git add -A`; never stage `.superpowers/`.
+
+## File structure
+
+- `tldw_chatbook/DB/ChaChaNotes_DB.py` — base DDL + `_MIGRATE_V20_TO_V21_SQL` + `_migrate_from_v20_to_v21` + version bump + `migration_steps` (Task 1)
+- `tldw_chatbook/DB/migrations/chachanotes_v20_to_v21_world_book_entry_priority.sql` — doc-mirror (Task 1)
+- `tldw_chatbook/Character_Chat/world_book_manager.py` — priority in create/update/get/export/import (Task 2)
+- `tldw_chatbook/Character_Chat/world_info_processor.py` — priority carry + `(-priority, insertion_order)` sort + floor fix (Task 3)
+- `tldw_chatbook/Character_Chat/world_info_diagnostics.py` + `Widgets/Persona_Widgets/personas_lore_detail.py` + `personas_lore_tryit.py` — priority surfacing (Task 4)
+- Tests: `Tests/DB/test_chachanotes_world_book_priority_migration.py` (Task 1), `Tests/Character_Chat/test_world_book_manager.py` (Task 2), `Tests/Character_Chat/test_world_info_diagnostics.py` (Task 3), `Tests/UI/test_personas_lore.py` (Task 4)
+
+---
+
+## Task 1: Schema migration v20→v21 (`priority` column + sync triggers)
+
+**Files:**
+- Modify: `tldw_chatbook/DB/ChaChaNotes_DB.py`
+- Create: `tldw_chatbook/DB/migrations/chachanotes_v20_to_v21_world_book_entry_priority.sql`
+- Test: `Tests/DB/test_chachanotes_world_book_priority_migration.py` (create)
+
+**Interfaces:**
+- Produces: `world_book_entries.priority INTEGER DEFAULT 0` on fresh + migrated DBs; `_CURRENT_SCHEMA_VERSION = 21`. Consumed by Tasks 2–4.
+
+- [ ] **Step 1: Write the failing migration test.** Create `Tests/DB/test_chachanotes_world_book_priority_migration.py` (mirrors `Tests/Chat/test_conversation_local_marks_service.py::test_local_marks_migrate_from_v16_to_v17_with_expected_schema`):
+
+```python
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+
+def test_world_book_entries_priority_migrate_v20_to_v21(tmp_path):
+    db_path = tmp_path / "chacha.sqlite"
+    db = CharactersRAGDB(str(db_path), client_id="test-client")
+    conn = db.get_connection()
+    # Simulate a V20-shaped DB: drop the V21 additions.
+    conn.execute("DROP TRIGGER IF EXISTS world_book_entries_sync_create")
+    conn.execute("DROP TRIGGER IF EXISTS world_book_entries_sync_update")
+    conn.execute("ALTER TABLE world_book_entries DROP COLUMN priority")
+    conn.execute(
+        "UPDATE db_schema_version SET version = 20 WHERE schema_name = ?",
+        (db._SCHEMA_NAME,),
+    )
+    conn.commit()
+    db.close_connection()
+
+    # Reopen → auto-migrates V20→V21.
+    migrated = CharactersRAGDB(str(db_path), client_id="test-client")
+    mconn = migrated.get_connection()
+    version = mconn.execute(
+        "SELECT version FROM db_schema_version WHERE schema_name = ?",
+        (migrated._SCHEMA_NAME,),
+    ).fetchone()
+    assert version["version"] == migrated._CURRENT_SCHEMA_VERSION == 21
+    cols = {r[1] for r in mconn.execute("PRAGMA table_info(world_book_entries)").fetchall()}
+    assert "priority" in cols
+    create_sql = mconn.execute(
+        "SELECT sql FROM sqlite_master WHERE name = 'world_book_entries_sync_create'"
+    ).fetchone()["sql"]
+    assert "priority" in create_sql
+    update_sql = mconn.execute(
+        "SELECT sql FROM sqlite_master WHERE name = 'world_book_entries_sync_update'"
+    ).fetchone()["sql"]
+    assert "priority" in update_sql
+
+
+def test_fresh_db_has_priority_column_and_triggers(tmp_path):
+    db = CharactersRAGDB(str(tmp_path / "fresh.sqlite"), client_id="test-client")
+    conn = db.get_connection()
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(world_book_entries)").fetchall()}
+    assert "priority" in cols
+    create_sql = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE name = 'world_book_entries_sync_create'"
+    ).fetchone()["sql"]
+    assert "priority" in create_sql
+```
+
+- [ ] **Step 2: Run — expect FAIL** (fresh DB is still v20; no `priority`).
+
+Run: `... -m pytest Tests/DB/test_chachanotes_world_book_priority_migration.py -q`
+
+- [ ] **Step 3: Implement.** In `ChaChaNotes_DB.py`:
+  - **Base DDL** — in the `world_book_entries` `CREATE TABLE` (~`:1194`), add `priority INTEGER DEFAULT 0,` after `insertion_order INTEGER DEFAULT 0,`. In the base `world_book_entries_sync_create` trigger's `json_object(...)` add `'priority', NEW.priority,` (before `'created_at'`). In `world_book_entries_sync_update`: add `OR OLD.priority IS NOT NEW.priority` to the `WHEN` clause, and `'priority', NEW.priority,` to its `json_object(...)`.
+  - **Version** — bump `_CURRENT_SCHEMA_VERSION = 21` (`:143`).
+  - **Migration SQL constant** — add near the other `_MIGRATE_*` constants:
+
+```python
+    _MIGRATE_V20_TO_V21_SQL = """
+DROP TRIGGER IF EXISTS world_book_entries_sync_create;
+DROP TRIGGER IF EXISTS world_book_entries_sync_update;
+
+CREATE TRIGGER world_book_entries_sync_create
+AFTER INSERT ON world_book_entries BEGIN
+  INSERT INTO sync_log(entity, entity_id, operation, timestamp, client_id, version, payload)
+  VALUES('world_book_entries', CAST(NEW.id AS TEXT), 'create', NEW.last_modified,
+         (SELECT client_id FROM world_books WHERE id = NEW.world_book_id), 1,
+         json_object('id', NEW.id, 'world_book_id', NEW.world_book_id, 'keys', NEW.keys,
+                     'content', NEW.content, 'enabled', NEW.enabled, 'position', NEW.position,
+                     'insertion_order', NEW.insertion_order, 'priority', NEW.priority,
+                     'selective', NEW.selective, 'secondary_keys', NEW.secondary_keys,
+                     'case_sensitive', NEW.case_sensitive, 'extensions', NEW.extensions,
+                     'created_at', NEW.created_at, 'last_modified', NEW.last_modified));
+END;
+
+CREATE TRIGGER world_book_entries_sync_update
+AFTER UPDATE ON world_book_entries
+WHEN OLD.keys IS NOT NEW.keys OR
+     OLD.content IS NOT NEW.content OR
+     OLD.enabled IS NOT NEW.enabled OR
+     OLD.position IS NOT NEW.position OR
+     OLD.insertion_order IS NOT NEW.insertion_order OR
+     OLD.priority IS NOT NEW.priority OR
+     OLD.selective IS NOT NEW.selective OR
+     OLD.secondary_keys IS NOT NEW.secondary_keys OR
+     OLD.case_sensitive IS NOT NEW.case_sensitive OR
+     OLD.extensions IS NOT NEW.extensions
+BEGIN
+  INSERT INTO sync_log(entity, entity_id, operation, timestamp, client_id, version, payload)
+  VALUES('world_book_entries', CAST(NEW.id AS TEXT), 'update', NEW.last_modified,
+         (SELECT client_id FROM world_books WHERE id = NEW.world_book_id), 1,
+         json_object('id', NEW.id, 'world_book_id', NEW.world_book_id, 'keys', NEW.keys,
+                     'content', NEW.content, 'enabled', NEW.enabled, 'position', NEW.position,
+                     'insertion_order', NEW.insertion_order, 'priority', NEW.priority,
+                     'selective', NEW.selective, 'secondary_keys', NEW.secondary_keys,
+                     'case_sensitive', NEW.case_sensitive, 'extensions', NEW.extensions,
+                     'created_at', NEW.created_at, 'last_modified', NEW.last_modified));
+END;
+
+UPDATE db_schema_version SET version = 21 WHERE schema_name = 'rag_char_chat_schema';
+"""
+```
+
+  - **Migration method** — add (mirroring `_migrate_from_v19_to_v20` at `:3256`):
+
+```python
+    def _migrate_from_v20_to_v21(self, conn: sqlite3.Connection):
+        """Migrate schema V20 → V21: add ``world_book_entries.priority`` (entry
+        injection priority / budget-survival weight) and redefine the two
+        ``world_book_entries_sync_*`` triggers so the new column is synced."""
+        logger.info(f"Migrating schema from V20 to V21 for '{self._SCHEMA_NAME}' in DB: {self.db_path_str}...")
+        try:
+            existing_columns = {
+                row[1] for row in conn.execute("PRAGMA table_info(world_book_entries)").fetchall()
+            }
+            if "priority" not in existing_columns:
+                conn.execute("ALTER TABLE world_book_entries ADD COLUMN priority INTEGER DEFAULT 0")
+            conn.executescript(self._MIGRATE_V20_TO_V21_SQL)
+            final_version = self._get_db_version(conn)
+            if final_version != 21:
+                raise SchemaError(
+                    f"[{self._SCHEMA_NAME} V20→V21] Migration version check failed. Expected 21, got: {final_version}"
+                )
+            logger.info(f"[{self._SCHEMA_NAME} V20→V21] Migration completed for DB: {self.db_path_str}.")
+        except sqlite3.Error as e:
+            logger.opt(exception=True).error(f"[{self._SCHEMA_NAME} V20→V21] Migration failed: {e}")
+            raise SchemaError(f"Migration from V20 to V21 failed for '{self._SCHEMA_NAME}': {e}") from e
+```
+
+  - **Register** — in the `migration_steps` dict (`:3390`), add `20: self._migrate_from_v20_to_v21,` after the `19:` entry.
+  - **Doc-mirror** — create `tldw_chatbook/DB/migrations/chachanotes_v20_to_v21_world_book_entry_priority.sql` containing the `ALTER TABLE world_book_entries ADD COLUMN priority INTEGER DEFAULT 0;` line + the `_MIGRATE_V20_TO_V21_SQL` body (for documentation; the code path runs the constant).
+
+- [ ] **Step 4: Run — PASS** (2 tests). Then the world-book/DB regression:
+  `... -m pytest Tests/DB/test_chachanotes_world_book_priority_migration.py Tests/Character_Chat/test_world_book_manager.py -q`
+
+- [ ] **Step 5: Commit.**
+```bash
+git add tldw_chatbook/DB/ChaChaNotes_DB.py tldw_chatbook/DB/migrations/chachanotes_v20_to_v21_world_book_entry_priority.sql Tests/DB/test_chachanotes_world_book_priority_migration.py
+git commit -m "feat(lore): schema v20->v21 — world_book_entries.priority + synced triggers"
+```
+
+---
+
+## Task 2: `WorldBookManager` — carry `priority`
+
+**Files:**
+- Modify: `tldw_chatbook/Character_Chat/world_book_manager.py`
+- Test: `Tests/Character_Chat/test_world_book_manager.py` (add priority round-trip tests)
+
+**Interfaces:**
+- Consumes: the `priority` column (Task 1).
+- Produces: `create_world_book_entry(..., priority: int = 0)`, `update_world_book_entry(**kwargs)` accepting `priority`, `get_world_book_entries` rows include `priority`, `export_world_book`/`import_world_book` carry `priority`.
+
+- [ ] **Step 1: Write the failing tests.** Add to `Tests/Character_Chat/test_world_book_manager.py`:
+
+```python
+def test_entry_priority_round_trips(wb_manager):
+    book_id = wb_manager.create_world_book("B")
+    eid = wb_manager.create_world_book_entry(book_id, ["Warden"], "grim jailer", priority=75)
+    assert wb_manager.get_world_book_entries(book_id)[0]["priority"] == 75
+    wb_manager.update_world_book_entry(eid, priority=20)
+    assert wb_manager.get_world_book_entries(book_id)[0]["priority"] == 20
+
+
+def test_entry_priority_default_zero(wb_manager):
+    book_id = wb_manager.create_world_book("B")
+    wb_manager.create_world_book_entry(book_id, ["k"], "c")
+    assert wb_manager.get_world_book_entries(book_id)[0]["priority"] == 0
+
+
+def test_export_import_preserves_priority(wb_manager):
+    book_id = wb_manager.create_world_book("B")
+    wb_manager.create_world_book_entry(book_id, ["Warden"], "grim jailer", priority=90)
+    data = wb_manager.export_world_book(book_id)
+    assert data["entries"][0]["priority"] == 90
+    new_id = wb_manager.import_world_book(data, name_override="B copy")
+    assert wb_manager.get_world_book_entries(new_id)[0]["priority"] == 90
+```
+
+(These use the module's existing `wb_manager` fixture — a `WorldBookManager` over a real `CharactersRAGDB` — at `test_world_book_manager.py:35`. Add them as module-level functions or as `TestWorldBookManager` methods; the fixture resolves either way.)
+
+- [ ] **Step 2: Run — expect FAIL** (`TypeError`/missing `priority` key).
+
+- [ ] **Step 3: Implement** in `world_book_manager.py`:
+  - `create_world_book_entry`: add `priority: int = 0` to the signature; add `priority` to the INSERT column list and a `?`; pass `int(priority)` in the params tuple (position matching the column order).
+  - `update_world_book_entry`: add `priority` to the list of allowed update fields (it's an int, not JSON — coerce `int(kwargs["priority"])`).
+  - `get_world_book_entries`: add `priority` to the `SELECT` column list and `'priority': row[<index>]` to the row dict (respect the new column's position in the SELECT).
+  - `export_world_book`: add `'priority': entry['priority']` to the per-entry dict.
+  - `import_world_book`: pass `priority=entry.get('priority', 0)` when creating each entry.
+
+- [ ] **Step 4: Run — PASS.** Then `... -m pytest Tests/Character_Chat/test_world_book_manager.py -q`.
+
+- [ ] **Step 5: Commit.**
+```bash
+git add tldw_chatbook/Character_Chat/world_book_manager.py Tests/Character_Chat/test_world_book_manager.py
+git commit -m "feat(lore): WorldBookManager carries entry priority (CRUD + export/import)"
+```
+
+---
+
+## Task 3: `world_info_processor` — priority-aware order + floor fix
+
+**Files:**
+- Modify: `tldw_chatbook/Character_Chat/world_info_processor.py`
+- Test: `Tests/Character_Chat/test_world_info_diagnostics.py`
+
+**Interfaces:**
+- Consumes: entries carrying `priority` (Task 2). Produces: processed entries + candidates tagged with `priority`; matched entries ordered by `(-priority, insertion_order)` before budget + injection.
+
+- [ ] **Step 1: Write the failing tests.** Add to `Tests/Character_Chat/test_world_info_diagnostics.py`:
+
+```python
+def test_high_priority_entry_survives_budget_over_low_priority():
+    """Priority (not FIFO) decides budget survival: the high-priority entry
+    fires even though a low-priority one comes first by insertion_order."""
+    book = _book(1, "B", [
+        _entry(1, ["low"], "AAAA " * 200, insertion_order=0, priority=0),    # ~250 tok, first by order
+        _entry(2, ["high"], "BBBB " * 200, insertion_order=1, priority=90),  # ~250 tok, high priority
+    ], token_budget=300)   # fits exactly one entry, not two
+    proc = WorldInfoProcessor(world_books=[book])
+    result = proc.process_messages("low high", [])
+    fired = result["injections"]["before_char"]
+    assert any("BBBB" in c for c in fired)   # high-priority survives
+    assert all("AAAA" not in c for c in fired)  # low-priority dropped
+
+
+def test_low_book_token_budget_is_honored():
+    """A book token_budget below the old 500 default is honored (floor fix)."""
+    book = _book(1, "B", [
+        _entry(1, ["a"], "AAAA " * 30, insertion_order=0),   # ~30 tok
+        _entry(2, ["b"], "BBBB " * 30, insertion_order=1),   # ~30 tok, over a 40-token budget
+    ], token_budget=40)
+    proc = WorldInfoProcessor(world_books=[book])
+    result = proc.process_messages("a b", [])
+    fired = result["injections"]["before_char"]
+    assert any("AAAA" in c for c in fired) and all("BBBB" not in c for c in fired)
+
+
+def test_injection_order_reflects_priority():
+    book = _book(1, "B", [
+        _entry(1, ["a"], "content-a", insertion_order=0, priority=1),
+        _entry(2, ["b"], "content-b", insertion_order=1, priority=99),
+    ])
+    proc = WorldInfoProcessor(world_books=[book])
+    result = proc.process_messages("a b", [])
+    injected = result["injections"]["before_char"]
+    assert injected == ["content-b", "content-a"]   # priority 99 before priority 1
+
+
+def test_recursive_entry_reorders_by_insertion_order():
+    """Recursive-scan normalization: an entry that fires via recursion but has
+    a LOWER insertion_order than a direct match now orders ahead of it."""
+    book = _book(1, "B", [
+        _entry(1, ["castle"], "the castle guards a dragon", insertion_order=5),
+        _entry(2, ["dragon"], "a fearsome dragon", insertion_order=0),
+    ], recursive_scanning=True)
+    proc = WorldInfoProcessor(world_books=[book])
+    result = proc.process_messages("the castle", [])
+    injected = result["injections"]["before_char"]
+    # entry 2 (insertion_order 0, fired via recursion) now precedes entry 1 (order 5).
+    assert injected.index("a fearsome dragon") < injected.index("the castle guards a dragon")
+```
+
+Ensure the `_entry` helper accepts `priority` (it uses `**kw` — pass `priority=…`), and `_book` accepts `token_budget`/`recursive_scanning` (it already does via `**kw`).
+
+- [ ] **Step 2: Run — expect FAIL** (FIFO/floor behavior).
+
+- [ ] **Step 3: Implement** in `world_info_processor.py`:
+  - `__init__`: change `self.scan_depth = 3` → `self.scan_depth = 0` and `self.token_budget = 500` → `self.token_budget = 0` (so `_process_world_books`'s `max(…)` honors lower book values; `_process_character_book` assigns directly).
+  - `_process_entry`: add `'priority': _coerce_int(entry.get('priority', 0))` to the returned dict (add a small local `_coerce_int(v, default=0)` helper or inline `int(entry.get('priority') or 0)` in a try/except → default 0).
+  - `process_messages`: right after `matched_entries = self._find_matching_entries(scan_text)`, add:
+    ```python
+    matched_entries = sorted(
+        matched_entries,
+        key=lambda e: (-int(e.get('priority', 0) or 0), e.get('insertion_order', 0)),
+    )
+    ```
+    (This precedes both `_apply_token_budget` and `_organize_by_position`.) Update the stale `# Sort by insertion order (already done in initialization)` comment in `_apply_token_budget`.
+
+- [ ] **Step 4: Run — PASS** (4 new). Then confirm the P2a equal-priority pins still pass:
+  `... -m pytest Tests/Character_Chat/test_world_info_diagnostics.py Tests/Character_Chat/test_world_info.py -q`
+  Expected: all pass (including `test_diagnostics_classifies_disabled_secondary_and_budget`, `test_diagnostics_reports_recursively_fired_entries`, `test_diagnostics_result_equals_plain_process_messages` — the stable-no-op property).
+
+- [ ] **Step 5: Commit.**
+```bash
+git add tldw_chatbook/Character_Chat/world_info_processor.py Tests/Character_Chat/test_world_info_diagnostics.py
+git commit -m "feat(lore): priority-aware budget survival + injection order + budget/scan floor fix"
+```
+
+---
+
+## Task 4: Diagnostics + Lore editor/Try-it surface `priority`
+
+**Files:**
+- Modify: `tldw_chatbook/Character_Chat/world_info_diagnostics.py`, `tldw_chatbook/Character_Chat/world_info_processor.py` (populate), `tldw_chatbook/Widgets/Persona_Widgets/personas_lore_detail.py`, `tldw_chatbook/Widgets/Persona_Widgets/personas_lore_tryit.py`
+- Test: `Tests/Character_Chat/test_world_info_diagnostics.py`, `Tests/UI/test_personas_lore.py`
+
+**Interfaces:**
+- Consumes: `priority` on candidates (Task 3). Produces: `WorldBookEntryDiagnostic.priority`; the editor's `#personas-lore-entry-priority` field + `entry_form_payload()["priority"]`; Try-it fired rows showing priority.
+
+- [ ] **Step 1: Write the failing tests.** Add a diagnostics test:
+
+```python
+def test_diagnostic_record_carries_priority():
+    book = _book(1, "B", [_entry(1, ["Warden"], "grim jailer", priority=42)])
+    proc = WorldInfoProcessor(world_books=[book])
+    _result, diag = proc.process_messages_with_diagnostics("The Warden.", [])
+    fired = next(e for e in diag.entries if e.status == "fired")
+    assert fired.priority == 42
+    assert fired.to_dict()["priority"] == 42
+```
+
+And a widget test (in `Tests/UI/test_personas_lore.py`):
+
+```python
+@pytest.mark.asyncio
+async def test_entry_priority_round_trips_through_form():
+    app = _DetailHost()
+    async with app.run_test(size=(140, 40)) as pilot:
+        widget = app.query_one(PersonasLoreDetailWidget)
+        widget.load_book({"id": 1, "name": "B", "description": "", "scan_depth": 3,
+                          "token_budget": 500, "recursive_scanning": False, "enabled": True})
+        app.query_one("#personas-lore-entry-keys", Input).value = "Warden"
+        app.query_one("#personas-lore-entry-content", TextArea).text = "grim jailer"
+        app.query_one("#personas-lore-entry-priority", Input).value = "80"
+        await pilot.pause()
+        await pilot.click("#personas-lore-entry-add")
+        await pilot.pause()
+        assert app.posted[-1]["priority"] == 80
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`AttributeError: priority` / `NoMatches`).
+
+- [ ] **Step 3: Implement.**
+  - `world_info_diagnostics.py`: add `priority: int = 0` to `WorldBookEntryDiagnostic` (after `keys`), and `"priority": self.priority,` to its `to_dict()`.
+  - `world_info_processor.py` `process_messages_with_diagnostics`: in BOTH the fired-record and near-miss-record `WorldBookEntryDiagnostic(...)` constructions, add `priority=int(cand.get('priority', 0) or 0),`.
+  - `personas_lore_detail.py`:
+    - In the Entries form row, add `yield Input(placeholder="Priority", id="personas-lore-entry-priority", value="0")`.
+    - `entry_form_payload()`: read priority — `raw_pri = self.query_one("#personas-lore-entry-priority", Input).value.strip() or "0"; try: priority = max(0, min(100, int(raw_pri))) except ValueError: priority = 0`; include `"priority": priority` in the returned dict.
+    - `on_mount` columns: add `"priority"` to `table.add_columns(...)`.
+    - `update_entries`: add a `Text(str(entry.get("priority") or 0), style=style)` cell (raw string in a `Text`, per the P2a no-double-escape lesson).
+    - `_fill_form_from_entry`: set `#personas-lore-entry-priority` to `str(entry.get("priority") or 0)`.
+  - `personas_lore_tryit.py` `_render_diagnostics`: in the fired-row string, include priority, e.g. `f"{', '.join(keys)} → {content_preview} · pri {int(e.get('priority', 0) or 0)} · {token_cost} tok"`.
+
+- [ ] **Step 4: Run — PASS.** Then `... -m pytest Tests/UI/test_personas_lore.py Tests/Character_Chat/test_world_info_diagnostics.py -q`.
+
+- [ ] **Step 5: Commit.**
+```bash
+git add tldw_chatbook/Character_Chat/world_info_diagnostics.py tldw_chatbook/Character_Chat/world_info_processor.py tldw_chatbook/Widgets/Persona_Widgets/personas_lore_detail.py tldw_chatbook/Widgets/Persona_Widgets/personas_lore_tryit.py Tests/Character_Chat/test_world_info_diagnostics.py Tests/UI/test_personas_lore.py
+git commit -m "feat(lore): surface entry priority in diagnostics + Lore editor + Try-it"
+```
+
+---
+
+## Task 5: Full gate + spec status
+
+**Files:**
+- Modify: `Docs/superpowers/specs/2026-07-17-roleplay-p2c-priority-budget-design.md` (status line)
+
+- [ ] **Step 1: Full gate.**
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Character_Chat/ Tests/DB/test_chachanotes_world_book_priority_migration.py \
+  Tests/UI/test_personas_lore.py Tests/UI/test_personas_dictionaries.py \
+  -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: all pass (record counts). Then the import smoke:
+```
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -c "import tldw_chatbook.app; print('IMPORT OK')"
+```
+
+- [ ] **Step 2: Flip spec status** — `**Status:** Design approved (brainstorm), pending spec review.` → `**Status:** Implemented (P2c).`
+
+- [ ] **Step 3: Commit.**
+```bash
+git add Docs/superpowers/specs/2026-07-17-roleplay-p2c-priority-budget-design.md
+git commit -m "docs(roleplay): mark P2c priority+budget spec implemented"
+```
+
+---
+
+## Notes for the executor
+
+- **Load-bearing tests:** Task 1 migration (idempotent + downgrade-replay: column + triggers present, re-run no-op); Task 3 priority-survival budget (high-priority fires over a first-by-order low-priority one) + the floor fix (book budget < 500 honored) + injection-order-by-priority + the recursive-reorder pin; and the **P2a equal-priority pins still passing unchanged** (the stable-no-op property — do NOT rewrite them).
+- **The change is opt-in.** At default priority (0) + default `insertion_order`, the sort is a stable no-op — existing behavior is preserved. Behavior changes only when a user sets differing priorities or a book uses an explicit low budget/scan-depth (and the recursive-reorder edge).
+- **Base DDL and migration must end identical** — a fresh DB (base DDL) and a migrated V20 DB must both have the `priority` column and the two sync triggers carrying it.
+- **Markup-safety** (Task 4 DataTable cell): pass the priority string raw into a `rich.text.Text` — do NOT `escape()` (the P2a lesson).
+- **Scope:** priority + budget only. No regex/selective/secondary editing, no attach, no native-send (deferred to P2d–g).

--- a/Docs/superpowers/specs/2026-07-17-roleplay-p2c-priority-budget-design.md
+++ b/Docs/superpowers/specs/2026-07-17-roleplay-p2c-priority-budget-design.md
@@ -1,0 +1,98 @@
+# Roleplay P2c — entry priority + priority-aware token budget (Lore)
+
+**Status:** Design approved (brainstorm), pending spec review.
+
+**Program:** Roleplay (Personas) redesign — P2 (Lore mode), third sub-project. Mirrors P1c (dictionary entry priority). Follows P2a (Lore foundation + diagnostics, merged PR #673).
+
+## Why
+
+P2a's diagnostics exposed two budget-correctness gaps in `world_info_processor` (also flagged by Qodo on #673):
+
+1. **FIFO hard-break** — `_apply_token_budget` walks matched entries and `break`s at the first over-budget one, dropping *every* remaining entry regardless of importance.
+2. **Budget/scan-depth floor** — `WorldInfoProcessor.__init__` seeds `token_budget=500`/`scan_depth=3` and only raises them via `max(…)`, so a book configured with *lower* values is silently floored (a Settings field that doesn't take effect).
+
+P2c gives entries a `priority` so important lore survives budget pressure and injects first, and fixes the floor so a book's configured budget/scan-depth is honoured.
+
+## Scope
+
+**In scope:** entry-level `priority` (schema + manager + processor + diagnostics + editor), a priority-aware budget/injection order, and the floor fix.
+
+**Deferred (later P2 sub-projects):** regex + selective/secondary/case editing (P2d); import/export UI (P2d — though export/import *serialization* of priority is done here so Duplicate doesn't drop it); conversation attach (P2e); character attach (P2f); Console "what's in play" + native-Console send + retiring legacy world-book UIs + the conversation-only legacy-send-bug (P2g). Constant/sticky entries: never.
+
+## Behavior-change framing (important)
+
+Unlike P2a (which held the legacy send byte-identical), P2c *may* change the live legacy send (`chat_events.py:1000`) — but the change is **opt-in and nearly inert for existing data**:
+
+- Every existing entry gets `priority = 0` (column default). The new sort key is `(-priority, insertion_order)`, which for all-equal priorities collapses to an insertion-order sort — what the send already effectively does. So for all-priority-0 books (every book today), output is unchanged **except** the recursive-scan normalization below.
+- **Recursive-scan normalization (the one order change at default priority):** today `_find_matching_entries` *appends* recursively-matched entries after the direct matches; the new global `(-priority, insertion_order)` sort re-orders all matched entries by their own fields, so a recursively-fired entry may move ahead of direct matches. This is accepted as more consistent (order by the entry, not by how it matched) and is pinned by an explicit test. `recursive_scanning` is opt-in and uncommon.
+
+So P2a's existing budget/order pins largely survive (equal-priority data); P2c mostly **adds** priority tests, and updates only the recursive-order expectation.
+
+## Ground truths (verified at dev `5c0de75a`)
+
+- **Schema:** `ChaChaNotes_DB._CURRENT_SCHEMA_VERSION = 20`. `world_book_entries` base DDL (`:1194`) has `insertion_order INTEGER DEFAULT 0`, **no `priority`**. The migration system: `migration_steps` dict + per-step methods like `_migrate_from_v19_to_v20` (PRAGMA-`table_info` guard + `executescript`).
+- **Sync triggers:** `world_book_entries_sync_create` and `world_book_entries_sync_update` build a `json_object(...)` payload enumerating the entry's columns explicitly, and `sync_update`'s `WHEN OLD.x IS NOT NEW.x` clause enumerates them too. The FTS triggers (`world_book_entries_ai/au/ad`) index only `keys`/`content`. So a new column needs the two **sync** triggers recreated (payload + WHEN), not the FTS ones.
+- **Budget:** `_apply_token_budget` (`world_info_processor.py`) is a walk-and-stop with a hard `break`. `_process_world_books` does `self.token_budget = max(self.token_budget, book.get('token_budget', 500))` (init 500 → floor); same for `scan_depth` (init 3). `_apply_token_budget` early-returns when `token_budget <= 0` (so `0` = unlimited — pre-existing).
+- **P1c mirror:** `ChatDictionary.priority` (int, `_coerce_int` default 0); `enforce_token_budget` (`Chat_Dictionary_Lib.py:504`) is *also* a walk-and-stop hard `break` — P1c's fix was purely the ordering *before* the walk. `WorldBookManager` (`create/update/get_world_book_entry`, `export/import_world_book`) has no `priority` today.
+
+## Architecture
+
+### 1. Schema migration v20→v21 (`ChaChaNotes_DB.py`)
+
+- Add `_MIGRATE_V20_TO_V21_SQL` and `_migrate_from_v20_to_v21(conn)`:
+  - `ALTER TABLE world_book_entries ADD COLUMN priority INTEGER DEFAULT 0`, guarded by a `PRAGMA table_info(world_book_entries)` check (SQLite has no `ADD COLUMN IF NOT EXISTS`; idempotent so a re-run/downgrade-replay is safe — the P1e lesson).
+  - `DROP TRIGGER IF EXISTS world_book_entries_sync_create; CREATE TRIGGER …` and same for `world_book_entries_sync_update`, adding `'priority', NEW.priority` to both payloads and `OR OLD.priority IS NOT NEW.priority` to the update `WHEN` clause.
+- Bump `_CURRENT_SCHEMA_VERSION = 21`; register `20: self._migrate_from_v20_to_v21` in `migration_steps`.
+- Update the **base DDL** (`world_book_entries` table + the two sync triggers) so a fresh DB matches a migrated one exactly.
+- Mirror to `migrations/*.sql` (doc-mirror, per the P1e pattern). **Next ChaChaNotes migration = v21→v22.**
+
+### 2. `WorldBookManager` (`world_book_manager.py`)
+
+- `create_world_book_entry(..., priority: int = 0)` and `update_world_book_entry(**kwargs)` accept `priority` (int-coerced, default 0); the INSERT/UPDATE write it.
+- `get_world_book_entries` returns `priority` in each row dict.
+- `export_world_book` serializes `priority` per entry; `import_world_book` reads it (default 0 when absent) — so P2a's Duplicate (export+import) preserves priorities.
+
+### 3. `world_info_processor.py`
+
+- `_process_entry` carries `priority` (from the entry, `int`-coerced, default 0) in the processed dict; `_make_candidate` therefore tags candidates with it too.
+- **Priority-aware order (survival + injection):** in `process_messages`, after `_find_matching_entries`, sort the matched list by `(-int(priority or 0), insertion_order)` before `_apply_token_budget` *and* `_organize_by_position`. The budget walk-and-stop then keeps the highest-priority entries, and `_organize_by_position` injects survivors in that same order.
+- **Floor fix:** `__init__` seeds `token_budget = 0` and `scan_depth = 0` (not 500/3), so `_process_world_books`'s `max(…)` honours a book's lower values. (`_process_character_book` already assigns directly; a book that *omits* the field still defaults to 500/3, and `token_budget = 0` still means "no cap".)
+
+### 4. Diagnostics (`world_info_diagnostics.py` + processor)
+
+- `WorldBookEntryDiagnostic` gains a `priority: int = 0` field (in `to_dict()`); `process_messages_with_diagnostics` populates it from the candidate. The fired list's `injection_order` already reflects the new priority order (fired is derived from the priority-sorted `result["matched_entries"]`).
+- The `result == plain` pin still holds by construction (diagnostics uses the plain path).
+
+### 5. UI
+
+- **`PersonasLoreDetailWidget`** — an entry priority field `#personas-lore-entry-priority` (`Input`, default "0", int-coerced 0–100 clamp); `entry_form_payload()` includes `priority`; a `priority` column in the entries `DataTable`; `_fill_form_from_entry` populates it.
+- **`PersonasLoreTryItWidget`** — the fired-list row shows priority, e.g. `"{keys} → {preview} · pri {priority} · {tok} tok"`.
+
+## Data flow (send / Try-it)
+
+matched entries → **sort by (−priority, insertion_order)** → `_apply_token_budget` (walk-and-stop keeps highest-priority) → `_organize_by_position` (inject survivors in that order). The diagnostics path runs the same `process_messages` and additionally tags each candidate with its priority.
+
+## Error handling
+
+- Priority coercion never raises: non-int / null → 0 (mirrors `_coerce_int`).
+- The migration is idempotent (PRAGMA guard + `DROP … IF EXISTS`); a partial/re-run leaves a consistent schema.
+- The processor changes preserve the never-raise contract (a bad entry is skipped, never crashes a send or Try-it).
+
+## Testing
+
+- **Migration:** v20→v21 adds the `priority` column (default 0 on existing rows) and recreates the two sync triggers with `priority` in the payload; idempotent (re-running the step is a no-op); a downgrade-replay test (column already present) doesn't error.
+- **Manager:** create/get/update round-trip `priority`; export includes it; import restores it (and defaults to 0 when absent).
+- **Processor (load-bearing):** a high-priority entry survives budget pressure over a low-priority one that a FIFO order would have kept (the core fix); a book with `token_budget < 500` is honoured (floor fix); a book with `scan_depth < 3` is honoured; injection order reflects priority; **equal-priority behavior matches today** (the P2a pins) except the **recursive-scan normalization**, which gets its own updated expectation.
+- **Diagnostics:** `priority` surfaced in the record; fired order reflects priority.
+- **UI:** the priority field round-trips through `entry_form_payload`/`_fill_form_from_entry`; the Try-it fired row shows priority.
+- Full gate (Character_Chat + world-info + ChaChaNotes DB migration tests + personas UI) + `import tldw_chatbook.app`.
+
+## Acceptance criteria
+
+- [ ] `world_book_entries` has a `priority INTEGER DEFAULT 0` column on both fresh (base DDL) and migrated (v20→v21) DBs, with the two sync triggers carrying `priority`; the migration is idempotent.
+- [ ] `WorldBookManager` create/update/get/export/import carry `priority`.
+- [ ] A higher-priority entry survives token-budget pressure over a lower-priority one; a book's `token_budget`/`scan_depth` below the old defaults is honoured; survivors inject in `(-priority, insertion_order)` order.
+- [ ] Equal-priority (default) data reproduces today's send output, except recursively-matched entries now order by `(-priority, insertion_order)` (pinned).
+- [ ] `WorldBookEntryDiagnostic` exposes `priority`; the Detail editor edits it; the Try-it fired list shows it.
+- [ ] No regex/selective editing, no attach, no native-send (deferred).
+- [ ] Full gate green; `import tldw_chatbook.app` OK.

--- a/Docs/superpowers/specs/2026-07-17-roleplay-p2c-priority-budget-design.md
+++ b/Docs/superpowers/specs/2026-07-17-roleplay-p2c-priority-budget-design.md
@@ -23,10 +23,10 @@ P2c gives entries a `priority` so important lore survives budget pressure and in
 
 Unlike P2a (which held the legacy send byte-identical), P2c *may* change the live legacy send (`chat_events.py:1000`) — but the change is **opt-in and nearly inert for existing data**:
 
-- Every existing entry gets `priority = 0` (column default). The new sort key is `(-priority, insertion_order)`, which for all-equal priorities collapses to an insertion-order sort — what the send already effectively does. So for all-priority-0 books (every book today), output is unchanged **except** the recursive-scan normalization below.
-- **Recursive-scan normalization (the one order change at default priority):** today `_find_matching_entries` *appends* recursively-matched entries after the direct matches; the new global `(-priority, insertion_order)` sort re-orders all matched entries by their own fields, so a recursively-fired entry may move ahead of direct matches. This is accepted as more consistent (order by the entry, not by how it matched) and is pinned by an explicit test. `recursive_scanning` is opt-in and uncommon.
+- Every existing entry gets `priority = 0` (column default). The new sort key is `(-priority, insertion_order)`; Python's sort is **stable**, so with all-equal priorities and the entries already in `insertion_order`, the sort is a **no-op** — output is unchanged for existing data.
+- **Recursive-scan normalization (the one possible order change at default priority):** today `_find_matching_entries` *appends* recursively-matched entries after the direct matches. The new global sort re-orders all matched entries by `(-priority, insertion_order)`, so a recursively-matched entry re-orders by its own `insertion_order` instead of always trailing. This only *visibly* changes output when a recursively-matched entry has a **lower `insertion_order` than a directly-matched one** (uncommon); it is accepted as more consistent (order by the entry, not by how it matched).
 
-So P2a's existing budget/order pins largely survive (equal-priority data); P2c mostly **adds** priority tests, and updates only the recursive-order expectation.
+So P2a's existing budget/order pins hold **unchanged** — they use default `insertion_order`, where the sort is a stable no-op (verified against `test_diagnostics_classifies_disabled_secondary_and_budget` and `test_diagnostics_reports_recursively_fired_entries`). P2c is almost purely **additive** tests; it adds one test pinning the recursive-normalization case explicitly.
 
 ## Ground truths (verified at dev `5c0de75a`)
 
@@ -44,7 +44,7 @@ So P2a's existing budget/order pins largely survive (equal-priority data); P2c m
   - `DROP TRIGGER IF EXISTS world_book_entries_sync_create; CREATE TRIGGER …` and same for `world_book_entries_sync_update`, adding `'priority', NEW.priority` to both payloads and `OR OLD.priority IS NOT NEW.priority` to the update `WHEN` clause.
 - Bump `_CURRENT_SCHEMA_VERSION = 21`; register `20: self._migrate_from_v20_to_v21` in `migration_steps`.
 - Update the **base DDL** (`world_book_entries` table + the two sync triggers) so a fresh DB matches a migrated one exactly.
-- Mirror to `migrations/*.sql` (doc-mirror, per the P1e pattern). **Next ChaChaNotes migration = v21→v22.**
+- Mirror to `tldw_chatbook/DB/migrations/chachanotes_v20_to_v21_world_book_entry_priority.sql` (doc-mirror, matching the `chachanotes_v19_to_v20_conversation_metadata.sql` convention). **Next ChaChaNotes migration = v21→v22.** Test by mirroring the existing migration-test precedent (`Tests/DB/…::test_existing_database_migration` / the P1e v19→v20 downgrade-replay test): assert the column + recreated triggers exist post-migration and that re-running the step is a no-op.
 
 ### 2. `WorldBookManager` (`world_book_manager.py`)
 

--- a/Docs/superpowers/specs/2026-07-17-roleplay-p2c-priority-budget-design.md
+++ b/Docs/superpowers/specs/2026-07-17-roleplay-p2c-priority-budget-design.md
@@ -1,6 +1,6 @@
 # Roleplay P2c — entry priority + priority-aware token budget (Lore)
 
-**Status:** Design approved (brainstorm), pending spec review.
+**Status:** Implemented (P2c).
 
 **Program:** Roleplay (Personas) redesign — P2 (Lore mode), third sub-project. Mirrors P1c (dictionary entry priority). Follows P2a (Lore foundation + diagnostics, merged PR #673).
 

--- a/Tests/Character_Chat/test_world_book_manager.py
+++ b/Tests/Character_Chat/test_world_book_manager.py
@@ -485,7 +485,30 @@ class TestWorldInfoProcessorIntegration:
             "Tell me about the character trait in this world",
             []
         )
-        
+
         assert len(result['matched_entries']) == 2
         assert 'before_char' in result['injections']
         assert 'at_start' in result['injections']
+
+
+def test_entry_priority_round_trips(wb_manager):
+    book_id = wb_manager.create_world_book("B")
+    eid = wb_manager.create_world_book_entry(book_id, ["Warden"], "grim jailer", priority=75)
+    assert wb_manager.get_world_book_entries(book_id)[0]["priority"] == 75
+    wb_manager.update_world_book_entry(eid, priority=20)
+    assert wb_manager.get_world_book_entries(book_id)[0]["priority"] == 20
+
+
+def test_entry_priority_default_zero(wb_manager):
+    book_id = wb_manager.create_world_book("B")
+    wb_manager.create_world_book_entry(book_id, ["k"], "c")
+    assert wb_manager.get_world_book_entries(book_id)[0]["priority"] == 0
+
+
+def test_export_import_preserves_priority(wb_manager):
+    book_id = wb_manager.create_world_book("B")
+    wb_manager.create_world_book_entry(book_id, ["Warden"], "grim jailer", priority=90)
+    data = wb_manager.export_world_book(book_id)
+    assert data["entries"][0]["priority"] == 90
+    new_id = wb_manager.import_world_book(data, name_override="B copy")
+    assert wb_manager.get_world_book_entries(new_id)[0]["priority"] == 90

--- a/Tests/Character_Chat/test_world_book_manager.py
+++ b/Tests/Character_Chat/test_world_book_manager.py
@@ -512,3 +512,10 @@ def test_export_import_preserves_priority(wb_manager):
     assert data["entries"][0]["priority"] == 90
     new_id = wb_manager.import_world_book(data, name_override="B copy")
     assert wb_manager.get_world_book_entries(new_id)[0]["priority"] == 90
+
+def test_create_entry_null_priority_defaults_zero(wb_manager):
+    """A null priority (e.g. from a hand-edited import file) must not crash —
+    int(None or 0) == 0 (P2c whole-branch-review Minor)."""
+    book_id = wb_manager.create_world_book("B")
+    wb_manager.create_world_book_entry(book_id, ["k"], "c", priority=None)
+    assert wb_manager.get_world_book_entries(book_id)[0]["priority"] == 0

--- a/Tests/Character_Chat/test_world_book_manager.py
+++ b/Tests/Character_Chat/test_world_book_manager.py
@@ -519,3 +519,35 @@ def test_create_entry_null_priority_defaults_zero(wb_manager):
     book_id = wb_manager.create_world_book("B")
     wb_manager.create_world_book_entry(book_id, ["k"], "c", priority=None)
     assert wb_manager.get_world_book_entries(book_id)[0]["priority"] == 0
+
+
+def test_create_entry_non_numeric_priority_defaults_zero(wb_manager):
+    """A non-numeric priority (e.g. "high" from a hand-edited import) must coerce
+    to 0 rather than raising ValueError (Qodo #682)."""
+    book_id = wb_manager.create_world_book("B")
+    wb_manager.create_world_book_entry(book_id, ["k"], "c", priority="high")
+    assert wb_manager.get_world_book_entries(book_id)[0]["priority"] == 0
+
+
+def test_update_entry_non_numeric_priority_defaults_zero(wb_manager):
+    """update_world_book_entry coerces a malformed priority to 0, never raises."""
+    book_id = wb_manager.create_world_book("B")
+    eid = wb_manager.create_world_book_entry(book_id, ["k"], "c", priority=50)
+    wb_manager.update_world_book_entry(eid, priority="bogus")
+    assert wb_manager.get_world_book_entries(book_id)[0]["priority"] == 0
+
+
+def test_import_book_malformed_priority_and_null_order_coerced(wb_manager):
+    """A hand-edited import whose entry has a non-numeric priority and a null
+    insertion_order must not crash; both coerce to 0 so later processing (which
+    sorts on insertion_order) is safe (Qodo #682)."""
+    data = {
+        "name": "Imported",
+        "entries": [
+            {"keys": ["k"], "content": "c", "priority": "high", "insertion_order": None},
+        ],
+    }
+    new_id = wb_manager.import_world_book(data, name_override="Imported copy")
+    row = wb_manager.get_world_book_entries(new_id)[0]
+    assert row["priority"] == 0
+    assert row["insertion_order"] == 0

--- a/Tests/Character_Chat/test_world_info_diagnostics.py
+++ b/Tests/Character_Chat/test_world_info_diagnostics.py
@@ -274,3 +274,19 @@ def test_diagnostic_record_carries_priority():
     fired = next(e for e in diag.entries if e.status == "fired")
     assert fired.priority == 42
     assert fired.to_dict()["priority"] == 42
+
+
+def test_null_insertion_order_does_not_crash_sort():
+    """An imported/hand-edited entry with insertion_order=None (or a non-numeric
+    priority) must not raise a TypeError. Equal priorities force the sort to
+    compare the insertion_order key element; None must be coerced first (Qodo
+    #682). The processor also sorts self.entries at construction, so a bad value
+    would otherwise crash before process_messages() even runs."""
+    book = _book(1, "B", [
+        _entry(1, ["a"], "content-a", insertion_order=None, priority="bad"),
+        _entry(2, ["b"], "content-b", insertion_order=1, priority=0),
+    ])
+    proc = WorldInfoProcessor(world_books=[book])   # must not raise
+    result = proc.process_messages("a b", [])       # must not raise
+    injected = result["injections"]["before_char"]
+    assert "content-a" in injected and "content-b" in injected

--- a/Tests/Character_Chat/test_world_info_diagnostics.py
+++ b/Tests/Character_Chat/test_world_info_diagnostics.py
@@ -201,6 +201,57 @@ def test_classify_entry_match_tolerates_null_keys():
     assert p is True and pk == "Warden" and sr is False
 
 
+def test_high_priority_entry_survives_budget_over_low_priority():
+    """Priority (not FIFO) decides budget survival: the high-priority entry
+    fires even though a low-priority one comes first by insertion_order."""
+    book = _book(1, "B", [
+        _entry(1, ["low"], "AAAA " * 200, insertion_order=0, priority=0),    # ~250 tok, first by order
+        _entry(2, ["high"], "BBBB " * 200, insertion_order=1, priority=90),  # ~250 tok, high priority
+    ], token_budget=300)   # fits exactly one entry, not two
+    proc = WorldInfoProcessor(world_books=[book])
+    result = proc.process_messages("low high", [])
+    fired = result["injections"]["before_char"]
+    assert any("BBBB" in c for c in fired)   # high-priority survives
+    assert all("AAAA" not in c for c in fired)  # low-priority dropped
+
+
+def test_low_book_token_budget_is_honored():
+    """A book token_budget below the old 500 default is honored (floor fix)."""
+    book = _book(1, "B", [
+        _entry(1, ["a"], "AAAA " * 30, insertion_order=0),   # ~30 tok
+        _entry(2, ["b"], "BBBB " * 30, insertion_order=1),   # ~30 tok, over a 40-token budget
+    ], token_budget=40)
+    proc = WorldInfoProcessor(world_books=[book])
+    result = proc.process_messages("a b", [])
+    fired = result["injections"]["before_char"]
+    assert any("AAAA" in c for c in fired) and all("BBBB" not in c for c in fired)
+
+
+def test_injection_order_reflects_priority():
+    book = _book(1, "B", [
+        _entry(1, ["a"], "content-a", insertion_order=0, priority=1),
+        _entry(2, ["b"], "content-b", insertion_order=1, priority=99),
+    ])
+    proc = WorldInfoProcessor(world_books=[book])
+    result = proc.process_messages("a b", [])
+    injected = result["injections"]["before_char"]
+    assert injected == ["content-b", "content-a"]   # priority 99 before priority 1
+
+
+def test_recursive_entry_reorders_by_insertion_order():
+    """Recursive-scan normalization: an entry that fires via recursion but has
+    a LOWER insertion_order than a direct match now orders ahead of it."""
+    book = _book(1, "B", [
+        _entry(1, ["castle"], "the castle guards a dragon", insertion_order=5),
+        _entry(2, ["dragon"], "a fearsome dragon", insertion_order=0),
+    ], recursive_scanning=True)
+    proc = WorldInfoProcessor(world_books=[book])
+    result = proc.process_messages("the castle", [])
+    injected = result["injections"]["before_char"]
+    # entry 2 (insertion_order 0, fired via recursion) now precedes entry 1 (order 5).
+    assert injected.index("a fearsome dragon") < injected.index("the castle guards a dragon")
+
+
 def test_diagnostics_duplicate_signature_entries_keep_distinct_ids():
     """Two entries sharing an identical (insertion_order, content, position)
     signature that BOTH fire must each be attributed to their own entry_id, not

--- a/Tests/Character_Chat/test_world_info_diagnostics.py
+++ b/Tests/Character_Chat/test_world_info_diagnostics.py
@@ -16,7 +16,7 @@ def test_entry_diagnostic_to_dict_round_trips_fields():
     )
     assert rec.to_dict() == {
         "entry_id": 7, "source_book_id": 3, "source_book_name": "Blackreach",
-        "keys": ["Warden"], "activation_reason": "matched key 'Warden'", "status": "fired",
+        "keys": ["Warden"], "priority": 0, "activation_reason": "matched key 'Warden'", "status": "fired",
         "token_cost": 12, "injection_order": 0, "position": "before_char",
         "content_preview": "The grim jailer…", "depth_level": 0,
     }
@@ -265,3 +265,12 @@ def test_diagnostics_duplicate_signature_entries_keep_distinct_ids():
     fired = [e for e in diag.entries if e.status == "fired"]
     assert len(fired) == 2
     assert {e.entry_id for e in fired} == {1, 2}
+
+
+def test_diagnostic_record_carries_priority():
+    book = _book(1, "B", [_entry(1, ["Warden"], "grim jailer", priority=42)])
+    proc = WorldInfoProcessor(world_books=[book])
+    _result, diag = proc.process_messages_with_diagnostics("The Warden.", [])
+    fired = next(e for e in diag.entries if e.status == "fired")
+    assert fired.priority == 42
+    assert fired.to_dict()["priority"] == 42

--- a/Tests/DB/test_chachanotes_world_book_priority_migration.py
+++ b/Tests/DB/test_chachanotes_world_book_priority_migration.py
@@ -1,0 +1,47 @@
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+
+def test_world_book_entries_priority_migrate_v20_to_v21(tmp_path):
+    db_path = tmp_path / "chacha.sqlite"
+    db = CharactersRAGDB(str(db_path), client_id="test-client")
+    conn = db.get_connection()
+    # Simulate a V20-shaped DB: drop the V21 additions.
+    conn.execute("DROP TRIGGER IF EXISTS world_book_entries_sync_create")
+    conn.execute("DROP TRIGGER IF EXISTS world_book_entries_sync_update")
+    conn.execute("ALTER TABLE world_book_entries DROP COLUMN priority")
+    conn.execute(
+        "UPDATE db_schema_version SET version = 20 WHERE schema_name = ?",
+        (db._SCHEMA_NAME,),
+    )
+    conn.commit()
+    db.close_connection()
+
+    # Reopen → auto-migrates V20→V21.
+    migrated = CharactersRAGDB(str(db_path), client_id="test-client")
+    mconn = migrated.get_connection()
+    version = mconn.execute(
+        "SELECT version FROM db_schema_version WHERE schema_name = ?",
+        (migrated._SCHEMA_NAME,),
+    ).fetchone()
+    assert version["version"] == migrated._CURRENT_SCHEMA_VERSION == 21
+    cols = {r[1] for r in mconn.execute("PRAGMA table_info(world_book_entries)").fetchall()}
+    assert "priority" in cols
+    create_sql = mconn.execute(
+        "SELECT sql FROM sqlite_master WHERE name = 'world_book_entries_sync_create'"
+    ).fetchone()["sql"]
+    assert "priority" in create_sql
+    update_sql = mconn.execute(
+        "SELECT sql FROM sqlite_master WHERE name = 'world_book_entries_sync_update'"
+    ).fetchone()["sql"]
+    assert "priority" in update_sql
+
+
+def test_fresh_db_has_priority_column_and_triggers(tmp_path):
+    db = CharactersRAGDB(str(tmp_path / "fresh.sqlite"), client_id="test-client")
+    conn = db.get_connection()
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(world_book_entries)").fetchall()}
+    assert "priority" in cols
+    create_sql = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE name = 'world_book_entries_sync_create'"
+    ).fetchone()["sql"]
+    assert "priority" in create_sql

--- a/Tests/UI/test_personas_lore.py
+++ b/Tests/UI/test_personas_lore.py
@@ -107,6 +107,22 @@ async def test_bracket_text_in_entries_not_backslash_escaped():
         assert "\\" not in content_cell.plain and "[aside]" in content_cell.plain
 
 
+@pytest.mark.asyncio
+async def test_entry_priority_round_trips_through_form():
+    app = _DetailHost()
+    async with app.run_test(size=(140, 40)) as pilot:
+        widget = app.query_one(PersonasLoreDetailWidget)
+        widget.load_book({"id": 1, "name": "B", "description": "", "scan_depth": 3,
+                          "token_budget": 500, "recursive_scanning": False, "enabled": True})
+        app.query_one("#personas-lore-entry-keys", Input).value = "Warden"
+        app.query_one("#personas-lore-entry-content", TextArea).text = "grim jailer"
+        app.query_one("#personas-lore-entry-priority", Input).value = "80"
+        await pilot.pause()
+        await pilot.click("#personas-lore-entry-add")
+        await pilot.pause()
+        assert app.posted[-1]["priority"] == 80
+
+
 class _TryItHost(App):
     def compose(self) -> ComposeResult:
         yield PersonasLoreTryItWidget(id="personas-lore-tryit")

--- a/Tests/UI/test_personas_lore.py
+++ b/Tests/UI/test_personas_lore.py
@@ -503,3 +503,27 @@ async def test_new_entry_appends_after_max_insertion_order():
         assert app.posted, "add must post LoreEntryAddRequested"
         # max(0, 10) + 1 == 11 — NOT len()==2 nor the selected row's order.
         assert app.posted[-1]["insertion_order"] == 11
+
+
+@pytest.mark.asyncio
+async def test_add_entry_persists_priority_through_real_screen_handler(
+    mock_app_instance, stub_characters_lore, lore_db, seeded_lore_book
+):
+    """The real _handle_lore_entry_add must forward priority to the DB (not just
+    the widget post) — regression for the P2c whole-branch-review Important."""
+    mock_app_instance.chachanotes_db = lore_db
+    app = LorePersonasTestApp(mock_app_instance)
+    async with app.run_test(size=(200, 60)) as pilot:
+        screen = await _enter_lore(pilot)
+        await _select_first_lore(pilot, screen)
+        screen.query_one("#personas-lore-entry-keys", Input).value = "Ghost"
+        screen.query_one("#personas-lore-entry-content", TextArea).text = "a pale spirit"
+        screen.query_one("#personas-lore-entry-priority", Input).value = "80"
+        await pilot.pause()
+        await pilot.click("#personas-lore-entry-add")
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        entries = WorldBookManager(lore_db).get_world_book_entries(seeded_lore_book["book_id"])
+        ghost = next(e for e in entries if e["keys"] == ["Ghost"])
+        assert ghost["priority"] == 80

--- a/tldw_chatbook/Character_Chat/world_book_manager.py
+++ b/tldw_chatbook/Character_Chat/world_book_manager.py
@@ -360,7 +360,7 @@ class WorldBookManager:
                 json.dumps(clean_secondary) if clean_secondary else None,
                 case_sensitive,
                 json.dumps(extensions) if extensions else None,
-                int(priority)
+                int(priority or 0)
             ))
             entry_id = cursor.lastrowid
             logger.info(f"Created world book entry {entry_id} for book {world_book_id}")
@@ -437,7 +437,7 @@ class WorldBookManager:
                 if field in ['keys', 'secondary_keys', 'extensions']:
                     value = json.dumps(value) if value else None
                 elif field == 'priority':
-                    value = int(value)
+                    value = int(value or 0)
                 updates.append(f"{field} = ?")
                 params.append(value)
         

--- a/tldw_chatbook/Character_Chat/world_book_manager.py
+++ b/tldw_chatbook/Character_Chat/world_book_manager.py
@@ -16,6 +16,27 @@ from loguru import logger
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB, InputError, ConflictError, CharactersRAGDBError
 
 
+def _coerce_int(value: Any, default: int = 0) -> int:
+    """Best-effort int coercion for loosely-typed entry fields.
+
+    Import/duplicate flows forward external ``priority``/``insertion_order``
+    values straight into DB writes; a non-numeric value (e.g. ``"high"`` from a
+    hand-edited export) must default rather than raise ``ValueError`` and abort
+    the operation.
+
+    Args:
+        value: Raw value from a payload or imported JSON.
+        default: Fallback when the value is missing or malformed.
+
+    Returns:
+        The coerced int, or ``default`` on None/non-numeric input.
+    """
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
 class WorldBookManager:
     """Manages world books and their entries in the database."""
     
@@ -355,12 +376,12 @@ class WorldBookManager:
                 content.strip(),
                 enabled,
                 position,
-                insertion_order,
+                _coerce_int(insertion_order, 0),
                 selective,
                 json.dumps(clean_secondary) if clean_secondary else None,
                 case_sensitive,
                 json.dumps(extensions) if extensions else None,
-                int(priority or 0)
+                _coerce_int(priority, 0)
             ))
             entry_id = cursor.lastrowid
             logger.info(f"Created world book entry {entry_id} for book {world_book_id}")
@@ -436,8 +457,8 @@ class WorldBookManager:
                 value = kwargs[field]
                 if field in ['keys', 'secondary_keys', 'extensions']:
                     value = json.dumps(value) if value else None
-                elif field == 'priority':
-                    value = int(value or 0)
+                elif field in ('priority', 'insertion_order'):
+                    value = _coerce_int(value, 0)
                 updates.append(f"{field} = ?")
                 params.append(value)
         

--- a/tldw_chatbook/Character_Chat/world_book_manager.py
+++ b/tldw_chatbook/Character_Chat/world_book_manager.py
@@ -308,10 +308,11 @@ class WorldBookManager:
                                insertion_order: int = 0, selective: bool = False,
                                secondary_keys: Optional[List[str]] = None,
                                case_sensitive: bool = False,
-                               extensions: Optional[Dict[str, Any]] = None) -> int:
+                               extensions: Optional[Dict[str, Any]] = None,
+                               priority: int = 0) -> int:
         """
         Create a new world book entry.
-        
+
         Args:
             world_book_id: The ID of the world book this entry belongs to
             keys: List of keywords that trigger this entry
@@ -323,10 +324,11 @@ class WorldBookManager:
             secondary_keys: Additional keys required if selective
             case_sensitive: Whether keyword matching is case sensitive
             extensions: Additional data for future features
-            
+            priority: Priority for budget-aware inclusion (higher wins under token pressure)
+
         Returns:
             The ID of the created entry
-            
+
         Raises:
             InputError: If keys or content are empty
         """
@@ -334,18 +336,18 @@ class WorldBookManager:
             raise InputError("Entry must have at least one non-empty key")
         if not content or not content.strip():
             raise InputError("Entry content cannot be empty")
-        
+
         # Clean and validate keys
         clean_keys = [k.strip() for k in keys if k.strip()]
         clean_secondary = [k.strip() for k in (secondary_keys or [])] if secondary_keys else []
-        
+
         query = """
         INSERT INTO world_book_entries (world_book_id, keys, content, enabled, position,
                                        insertion_order, selective, secondary_keys,
-                                       case_sensitive, extensions)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                                       case_sensitive, extensions, priority)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """
-        
+
         with self.db.transaction() as cursor:
             cursor.execute(query, (
                 world_book_id,
@@ -357,7 +359,8 @@ class WorldBookManager:
                 selective,
                 json.dumps(clean_secondary) if clean_secondary else None,
                 case_sensitive,
-                json.dumps(extensions) if extensions else None
+                json.dumps(extensions) if extensions else None,
+                int(priority)
             ))
             entry_id = cursor.lastrowid
             logger.info(f"Created world book entry {entry_id} for book {world_book_id}")
@@ -376,19 +379,20 @@ class WorldBookManager:
         """
         query = """
         SELECT id, world_book_id, keys, content, enabled, position, insertion_order,
-               selective, secondary_keys, case_sensitive, extensions, created_at, last_modified
+               selective, secondary_keys, case_sensitive, extensions, created_at, last_modified,
+               priority
         FROM world_book_entries
         WHERE world_book_id = ?
         """
-        
+
         if enabled_only:
             query += " AND enabled = 1"
-        
+
         query += " ORDER BY insertion_order, id"
-        
+
         with self.db.transaction() as cursor:
             cursor.execute(query, (world_book_id,))
-            
+
             entries = []
             for row in cursor.fetchall():
                 entries.append({
@@ -404,9 +408,10 @@ class WorldBookManager:
                     'case_sensitive': bool(row[9]),
                     'extensions': json.loads(row[10]) if row[10] else {},
                     'created_at': row[11],
-                    'last_modified': row[12]
+                    'last_modified': row[12],
+                    'priority': row[13]
                 })
-            
+
             return entries
     
     def update_world_book_entry(self, entry_id: int, **kwargs) -> bool:
@@ -426,11 +431,13 @@ class WorldBookManager:
         
         # Handle each possible field
         for field in ['keys', 'content', 'enabled', 'position', 'insertion_order',
-                     'selective', 'secondary_keys', 'case_sensitive', 'extensions']:
+                     'selective', 'secondary_keys', 'case_sensitive', 'extensions', 'priority']:
             if field in kwargs:
                 value = kwargs[field]
                 if field in ['keys', 'secondary_keys', 'extensions']:
                     value = json.dumps(value) if value else None
+                elif field == 'priority':
+                    value = int(value)
                 updates.append(f"{field} = ?")
                 params.append(value)
         
@@ -589,9 +596,10 @@ class WorldBookManager:
                 'selective': entry['selective'],
                 'secondary_keys': entry['secondary_keys'],
                 'case_sensitive': entry['case_sensitive'],
-                'extensions': entry['extensions']
+                'extensions': entry['extensions'],
+                'priority': entry['priority']
             })
-        
+
         return export_data
     
     def import_world_book(self, data: Dict[str, Any], name_override: Optional[str] = None) -> int:
@@ -634,7 +642,8 @@ class WorldBookManager:
                 selective=entry.get('selective', False),
                 secondary_keys=entry.get('secondary_keys', []),
                 case_sensitive=entry.get('case_sensitive', False),
-                extensions=entry.get('extensions', {})
+                extensions=entry.get('extensions', {}),
+                priority=entry.get('priority', 0)
             )
         
         logger.info(f"Imported world book '{name}' with {len(entries)} entries")

--- a/tldw_chatbook/Character_Chat/world_info_diagnostics.py
+++ b/tldw_chatbook/Character_Chat/world_info_diagnostics.py
@@ -11,6 +11,27 @@ from typing import Any, Dict, List, Optional
 
 @dataclass
 class WorldBookEntryDiagnostic:
+    """One world-info (Lore) entry's activation record for the Try-it panel.
+
+    Captures why an entry did or did not fire on a scan — its keys, priority,
+    activation reason, status, token cost, and resolved injection order — so the
+    read model can explain budget survival and injection ordering.
+
+    Attributes:
+        entry_id: Source entry id, or None for character-embedded entries.
+        source_book_id: Owning world-book id, or None.
+        source_book_name: Owning world-book display name.
+        keys: Primary keys evaluated for this entry.
+        priority: Entry priority; higher wins under token-budget pressure.
+        activation_reason: Human-readable reason for the status.
+        status: "fired" | "skipped:disabled" | "skipped:secondary" | "skipped:budget".
+        token_cost: Estimated tokens the entry's content contributes.
+        injection_order: Resolved order among fired entries, or None if skipped.
+        position: Injection position (e.g. "before_char").
+        content_preview: Truncated content for display.
+        depth_level: Recursion depth at which the entry fired (0 = direct).
+    """
+
     entry_id: Optional[int]
     source_book_id: Optional[int]
     source_book_name: str

--- a/tldw_chatbook/Character_Chat/world_info_diagnostics.py
+++ b/tldw_chatbook/Character_Chat/world_info_diagnostics.py
@@ -15,8 +15,9 @@ class WorldBookEntryDiagnostic:
     source_book_id: Optional[int]
     source_book_name: str
     keys: List[str]
-    activation_reason: str
-    status: str  # "fired" | "skipped:disabled" | "skipped:secondary" | "skipped:budget"
+    priority: int = 0
+    activation_reason: str = ""
+    status: str = ""  # "fired" | "skipped:disabled" | "skipped:secondary" | "skipped:budget"
     token_cost: int = 0
     injection_order: Optional[int] = None
     position: str = "before_char"
@@ -34,6 +35,7 @@ class WorldBookEntryDiagnostic:
             "source_book_id": self.source_book_id,
             "source_book_name": self.source_book_name,
             "keys": list(self.keys),
+            "priority": self.priority,
             "activation_reason": self.activation_reason,
             "status": self.status,
             "token_cost": self.token_cost,

--- a/tldw_chatbook/Character_Chat/world_info_processor.py
+++ b/tldw_chatbook/Character_Chat/world_info_processor.py
@@ -310,7 +310,9 @@ class WorldInfoProcessor:
             records.append(WorldBookEntryDiagnostic(
                 entry_id=cand.get("_entry_id"), source_book_id=cand.get("_book_id"),
                 source_book_name=str(cand.get("_book_name") or ""),
-                keys=list(cand.get("keys") or []), activation_reason=reason, status="fired",
+                keys=list(cand.get("keys") or []),
+                priority=int(cand.get('priority', 0) or 0),
+                activation_reason=reason, status="fired",
                 token_cost=self._estimate_entry_tokens(cand), injection_order=order,
                 position=cand.get("position", "before_char"),
                 content_preview=(cand.get("content", "") or "")[:80], depth_level=depth_level,
@@ -340,7 +342,9 @@ class WorldInfoProcessor:
             records.append(WorldBookEntryDiagnostic(
                 entry_id=cand.get("_entry_id"), source_book_id=cand.get("_book_id"),
                 source_book_name=str(cand.get("_book_name") or ""),
-                keys=list(cand.get("keys") or []), activation_reason=reason, status=status,
+                keys=list(cand.get("keys") or []),
+                priority=int(cand.get('priority', 0) or 0),
+                activation_reason=reason, status=status,
                 token_cost=self._estimate_entry_tokens(cand), injection_order=None,
                 position=cand.get("position", "before_char"),
                 content_preview=(cand.get("content", "") or "")[:80], depth_level=0,

--- a/tldw_chatbook/Character_Chat/world_info_processor.py
+++ b/tldw_chatbook/Character_Chat/world_info_processor.py
@@ -21,8 +21,8 @@ class WorldInfoProcessor:
             world_books: List of standalone world books with their entries
         """
         self.entries = []
-        self.scan_depth = 3  # Default scan depth
-        self.token_budget = 500  # Default token budget
+        self.scan_depth = 0  # Seed; raised by book/character-book scan_depth (never floors a lower value)
+        self.token_budget = 0  # Seed; raised by book/character-book token_budget (never floors a lower value)
         self.recursive_scanning = False
 
         # Parallel diagnostics candidate list: ALL entries (incl. disabled), each
@@ -145,6 +145,11 @@ class WorldInfoProcessor:
                 secondary_keys = sec_keys
             secondary_keys = [k.strip() for k in secondary_keys if k and k.strip()]
         
+        try:
+            priority = int(entry.get('priority') or 0)
+        except (TypeError, ValueError):
+            priority = 0
+
         return {
             'keys': keys,
             'secondary_keys': secondary_keys,
@@ -153,7 +158,8 @@ class WorldInfoProcessor:
             'position': entry.get('position', 'before_char'),
             'insertion_order': entry.get('insertion_order', 0),
             'case_sensitive': entry.get('case_sensitive', False),
-            'extensions': entry.get('extensions', {})
+            'extensions': entry.get('extensions', {}),
+            'priority': priority
         }
 
     def _make_candidate(self, entry: Dict[str, Any], book_id: Optional[Any], book_name: str,
@@ -197,7 +203,15 @@ class WorldInfoProcessor:
         
         # Find matching entries
         matched_entries = self._find_matching_entries(scan_text)
-        
+
+        # Order by priority (descending) then insertion order (ascending), so
+        # priority drives both budget survival (_apply_token_budget) and
+        # injection order (_organize_by_position).
+        matched_entries = sorted(
+            matched_entries,
+            key=lambda e: (-int(e.get('priority', 0) or 0), e.get('insertion_order', 0)),
+        )
+
         # Apply token budget if enabled
         if apply_token_budget and self.token_budget > 0:
             matched_entries = self._apply_token_budget(matched_entries)
@@ -488,7 +502,9 @@ class WorldInfoProcessor:
         if not matched_entries or self.token_budget <= 0:
             return matched_entries
         
-        # Sort by insertion order (already done in initialization)
+        # Entries arrive pre-sorted by (priority desc, insertion_order asc)
+        # from process_messages, so walking in order and stopping at the
+        # budget break honors priority for survival.
         # Estimate tokens for each entry
         selected_entries = []
         total_tokens = 0

--- a/tldw_chatbook/Character_Chat/world_info_processor.py
+++ b/tldw_chatbook/Character_Chat/world_info_processor.py
@@ -8,6 +8,26 @@ from typing import Dict, List, Any, Optional, Tuple
 from loguru import logger
 
 
+def _coerce_int(value: Any, default: int = 0) -> int:
+    """Best-effort int coercion for loosely-typed entry fields.
+
+    Imported/hand-edited world books may carry ``None`` or non-numeric values
+    for numeric fields (``priority``, ``insertion_order``); those must never
+    crash the sort/budget path on a live send.
+
+    Args:
+        value: Raw value from a processed entry or persisted/imported JSON.
+        default: Fallback when the value is missing or malformed.
+
+    Returns:
+        The coerced int, or ``default`` on None/non-numeric input.
+    """
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
 class WorldInfoProcessor:
     """Process and inject world info/lorebook entries into chat conversations."""
     
@@ -145,21 +165,16 @@ class WorldInfoProcessor:
                 secondary_keys = sec_keys
             secondary_keys = [k.strip() for k in secondary_keys if k and k.strip()]
         
-        try:
-            priority = int(entry.get('priority') or 0)
-        except (TypeError, ValueError):
-            priority = 0
-
         return {
             'keys': keys,
             'secondary_keys': secondary_keys,
             'content': entry.get('content', ''),
             'selective': entry.get('selective', False),
             'position': entry.get('position', 'before_char'),
-            'insertion_order': entry.get('insertion_order', 0),
+            'insertion_order': _coerce_int(entry.get('insertion_order'), 0),
             'case_sensitive': entry.get('case_sensitive', False),
             'extensions': entry.get('extensions', {}),
-            'priority': priority
+            'priority': _coerce_int(entry.get('priority'), 0),
         }
 
     def _make_candidate(self, entry: Dict[str, Any], book_id: Optional[Any], book_name: str,
@@ -209,7 +224,7 @@ class WorldInfoProcessor:
         # injection order (_organize_by_position).
         matched_entries = sorted(
             matched_entries,
-            key=lambda e: (-int(e.get('priority', 0) or 0), e.get('insertion_order', 0)),
+            key=lambda e: (-_coerce_int(e.get('priority'), 0), _coerce_int(e.get('insertion_order'), 0)),
         )
 
         # Apply token budget if enabled

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -140,7 +140,7 @@ class CharactersRAGDB:
         is_memory_db (bool): True if the database is in-memory.
         db_path_str (str): String representation of the database path for SQLite connection.
     """
-    _CURRENT_SCHEMA_VERSION = 20  # Adds per-conversation metadata (P1e).
+    _CURRENT_SCHEMA_VERSION = 21  # Adds world_book_entries.priority (P2c).
     _SCHEMA_NAME = "rag_char_chat_schema"  # Used for the db_schema_version table
     _ALLOWED_CONVERSATION_STATES = ("in-progress", "resolved", "backlog", "non-viable")
     _DEFAULT_CONVERSATION_STATE = "in-progress"
@@ -1199,6 +1199,7 @@ CREATE TABLE IF NOT EXISTS world_book_entries(
   enabled         BOOLEAN  DEFAULT 1,
   position        TEXT     DEFAULT 'before_char', -- before_char, after_char, at_start, at_end
   insertion_order INTEGER  DEFAULT 0,
+  priority        INTEGER  DEFAULT 0,
   selective       BOOLEAN  DEFAULT 0,
   secondary_keys  TEXT,    -- JSON array of secondary keywords
   case_sensitive  BOOLEAN  DEFAULT 0,
@@ -1346,14 +1347,14 @@ END;
 CREATE TRIGGER world_book_entries_sync_create
 AFTER INSERT ON world_book_entries BEGIN
   INSERT INTO sync_log(entity, entity_id, operation, timestamp, client_id, version, payload)
-  VALUES('world_book_entries', CAST(NEW.id AS TEXT), 'create', NEW.last_modified, 
+  VALUES('world_book_entries', CAST(NEW.id AS TEXT), 'create', NEW.last_modified,
          (SELECT client_id FROM world_books WHERE id = NEW.world_book_id), 1,
          json_object('id', NEW.id, 'world_book_id', NEW.world_book_id, 'keys', NEW.keys,
                      'content', NEW.content, 'enabled', NEW.enabled, 'position', NEW.position,
-                     'insertion_order', NEW.insertion_order, 'selective', NEW.selective,
-                     'secondary_keys', NEW.secondary_keys, 'case_sensitive', NEW.case_sensitive,
-                     'extensions', NEW.extensions, 'created_at', NEW.created_at,
-                     'last_modified', NEW.last_modified));
+                     'insertion_order', NEW.insertion_order, 'priority', NEW.priority,
+                     'selective', NEW.selective, 'secondary_keys', NEW.secondary_keys,
+                     'case_sensitive', NEW.case_sensitive, 'extensions', NEW.extensions,
+                     'created_at', NEW.created_at, 'last_modified', NEW.last_modified));
 END;
 
 CREATE TRIGGER world_book_entries_sync_update
@@ -1363,6 +1364,7 @@ WHEN OLD.keys IS NOT NEW.keys OR
      OLD.enabled IS NOT NEW.enabled OR
      OLD.position IS NOT NEW.position OR
      OLD.insertion_order IS NOT NEW.insertion_order OR
+     OLD.priority IS NOT NEW.priority OR
      OLD.selective IS NOT NEW.selective OR
      OLD.secondary_keys IS NOT NEW.secondary_keys OR
      OLD.case_sensitive IS NOT NEW.case_sensitive OR
@@ -1373,10 +1375,10 @@ BEGIN
          (SELECT client_id FROM world_books WHERE id = NEW.world_book_id), 1,
          json_object('id', NEW.id, 'world_book_id', NEW.world_book_id, 'keys', NEW.keys,
                      'content', NEW.content, 'enabled', NEW.enabled, 'position', NEW.position,
-                     'insertion_order', NEW.insertion_order, 'selective', NEW.selective,
-                     'secondary_keys', NEW.secondary_keys, 'case_sensitive', NEW.case_sensitive,
-                     'extensions', NEW.extensions, 'created_at', NEW.created_at,
-                     'last_modified', NEW.last_modified));
+                     'insertion_order', NEW.insertion_order, 'priority', NEW.priority,
+                     'selective', NEW.selective, 'secondary_keys', NEW.secondary_keys,
+                     'case_sensitive', NEW.case_sensitive, 'extensions', NEW.extensions,
+                     'created_at', NEW.created_at, 'last_modified', NEW.last_modified));
 END;
 
 CREATE TRIGGER world_book_entries_sync_delete
@@ -2329,6 +2331,55 @@ UPDATE db_schema_version
    SET version = 20
  WHERE schema_name = 'rag_char_chat_schema'
    AND version = 19;
+"""
+
+    # Keep this runner SQL aligned with
+    # tldw_chatbook/DB/migrations/chachanotes_v20_to_v21_world_book_entry_priority.sql.
+    _MIGRATE_V20_TO_V21_SQL = """
+DROP TRIGGER IF EXISTS world_book_entries_sync_create;
+DROP TRIGGER IF EXISTS world_book_entries_sync_update;
+
+CREATE TRIGGER world_book_entries_sync_create
+AFTER INSERT ON world_book_entries BEGIN
+  INSERT INTO sync_log(entity, entity_id, operation, timestamp, client_id, version, payload)
+  VALUES('world_book_entries', CAST(NEW.id AS TEXT), 'create', NEW.last_modified,
+         (SELECT client_id FROM world_books WHERE id = NEW.world_book_id), 1,
+         json_object('id', NEW.id, 'world_book_id', NEW.world_book_id, 'keys', NEW.keys,
+                     'content', NEW.content, 'enabled', NEW.enabled, 'position', NEW.position,
+                     'insertion_order', NEW.insertion_order, 'priority', NEW.priority,
+                     'selective', NEW.selective, 'secondary_keys', NEW.secondary_keys,
+                     'case_sensitive', NEW.case_sensitive, 'extensions', NEW.extensions,
+                     'created_at', NEW.created_at, 'last_modified', NEW.last_modified));
+END;
+
+CREATE TRIGGER world_book_entries_sync_update
+AFTER UPDATE ON world_book_entries
+WHEN OLD.keys IS NOT NEW.keys OR
+     OLD.content IS NOT NEW.content OR
+     OLD.enabled IS NOT NEW.enabled OR
+     OLD.position IS NOT NEW.position OR
+     OLD.insertion_order IS NOT NEW.insertion_order OR
+     OLD.priority IS NOT NEW.priority OR
+     OLD.selective IS NOT NEW.selective OR
+     OLD.secondary_keys IS NOT NEW.secondary_keys OR
+     OLD.case_sensitive IS NOT NEW.case_sensitive OR
+     OLD.extensions IS NOT NEW.extensions
+BEGIN
+  INSERT INTO sync_log(entity, entity_id, operation, timestamp, client_id, version, payload)
+  VALUES('world_book_entries', CAST(NEW.id AS TEXT), 'update', NEW.last_modified,
+         (SELECT client_id FROM world_books WHERE id = NEW.world_book_id), 1,
+         json_object('id', NEW.id, 'world_book_id', NEW.world_book_id, 'keys', NEW.keys,
+                     'content', NEW.content, 'enabled', NEW.enabled, 'position', NEW.position,
+                     'insertion_order', NEW.insertion_order, 'priority', NEW.priority,
+                     'selective', NEW.selective, 'secondary_keys', NEW.secondary_keys,
+                     'case_sensitive', NEW.case_sensitive, 'extensions', NEW.extensions,
+                     'created_at', NEW.created_at, 'last_modified', NEW.last_modified));
+END;
+
+UPDATE db_schema_version
+   SET version = 21
+ WHERE schema_name = 'rag_char_chat_schema'
+   AND version = 20;
 """
 
     # Keep this runner SQL aligned with
@@ -3287,6 +3338,42 @@ UPDATE db_schema_version
             logger.opt(exception=True).error(f"[{self._SCHEMA_NAME} V19→V20] Unexpected error during migration: {e}")
             raise SchemaError(f"Unexpected error migrating from V19 to V20 for '{self._SCHEMA_NAME}': {e}") from e
 
+    def _migrate_from_v20_to_v21(self, conn: sqlite3.Connection):
+        """
+        Migrates the database schema from version 20 to version 21.
+
+        This migration adds a ``priority`` column to ``world_book_entries``
+        (entry injection priority / budget-survival weight), and redefines
+        the ``world_book_entries_sync_*`` triggers so edits to the new
+        column are reflected in ``sync_log``.
+        """
+        logger.info(f"Migrating schema from V20 to V21 for '{self._SCHEMA_NAME}' in DB: {self.db_path_str}...")
+        try:
+            # Idempotent column add: SQLite has no ``ADD COLUMN IF NOT EXISTS``, so
+            # skip the ALTER when a replayed/partial migration already left the
+            # column in place (mirrors the v19->v20 ``metadata`` column guard).
+            existing_columns = {
+                row[1] for row in conn.execute("PRAGMA table_info(world_book_entries)").fetchall()
+            }
+            if "priority" not in existing_columns:
+                conn.execute("ALTER TABLE world_book_entries ADD COLUMN priority INTEGER DEFAULT 0")
+            conn.executescript(self._MIGRATE_V20_TO_V21_SQL)
+            logger.debug(f"[{self._SCHEMA_NAME} V20→V21] Migration script executed.")
+
+            final_version = self._get_db_version(conn)
+            if final_version != 21:
+                raise SchemaError(
+                    f"[{self._SCHEMA_NAME} V20→V21] Migration version check failed. Expected 21, got: {final_version}"
+                )
+
+            logger.info(f"[{self._SCHEMA_NAME} V20→V21] Migration completed successfully for DB: {self.db_path_str}.")
+        except sqlite3.Error as e:
+            logger.opt(exception=True).error(f"[{self._SCHEMA_NAME} V20→V21] Migration failed: {e}")
+            raise SchemaError(f"Migration from V20 to V21 failed for '{self._SCHEMA_NAME}': {e}") from e
+        except Exception as e:
+            logger.opt(exception=True).error(f"[{self._SCHEMA_NAME} V20→V21] Unexpected error during migration: {e}")
+            raise SchemaError(f"Unexpected error migrating from V20 to V21 for '{self._SCHEMA_NAME}': {e}") from e
+
     def _migrate_from_v18_to_v19(self, conn: sqlite3.Connection):
         """
         Migrates the database schema from version 18 to version 19.
@@ -3404,6 +3491,7 @@ UPDATE db_schema_version
                     17: self._migrate_from_v17_to_v18,
                     18: self._migrate_from_v18_to_v19,
                     19: self._migrate_from_v19_to_v20,
+                    20: self._migrate_from_v20_to_v21,
                 }
 
                 if current_db_version == 0:

--- a/tldw_chatbook/DB/migrations/chachanotes_v20_to_v21_world_book_entry_priority.sql
+++ b/tldw_chatbook/DB/migrations/chachanotes_v20_to_v21_world_book_entry_priority.sql
@@ -1,0 +1,54 @@
+-- Migration: ChaChaNotes V20 to V21 world_book_entries priority
+-- Adds an `priority INTEGER DEFAULT 0` column to `world_book_entries` for
+-- entry injection priority / budget-survival weight (Roleplay P2c), and
+-- redefines the world_book_entries_sync_* triggers so edits to the new
+-- column are reflected in sync_log. The runner guards the ADD COLUMN with a
+-- PRAGMA check (SQLite has no ADD COLUMN IF NOT EXISTS) so replayed/partial
+-- migrations are idempotent.
+
+ALTER TABLE world_book_entries ADD COLUMN priority INTEGER DEFAULT 0;
+
+DROP TRIGGER IF EXISTS world_book_entries_sync_create;
+DROP TRIGGER IF EXISTS world_book_entries_sync_update;
+
+CREATE TRIGGER world_book_entries_sync_create
+AFTER INSERT ON world_book_entries BEGIN
+  INSERT INTO sync_log(entity, entity_id, operation, timestamp, client_id, version, payload)
+  VALUES('world_book_entries', CAST(NEW.id AS TEXT), 'create', NEW.last_modified,
+         (SELECT client_id FROM world_books WHERE id = NEW.world_book_id), 1,
+         json_object('id', NEW.id, 'world_book_id', NEW.world_book_id, 'keys', NEW.keys,
+                     'content', NEW.content, 'enabled', NEW.enabled, 'position', NEW.position,
+                     'insertion_order', NEW.insertion_order, 'priority', NEW.priority,
+                     'selective', NEW.selective, 'secondary_keys', NEW.secondary_keys,
+                     'case_sensitive', NEW.case_sensitive, 'extensions', NEW.extensions,
+                     'created_at', NEW.created_at, 'last_modified', NEW.last_modified));
+END;
+
+CREATE TRIGGER world_book_entries_sync_update
+AFTER UPDATE ON world_book_entries
+WHEN OLD.keys IS NOT NEW.keys OR
+     OLD.content IS NOT NEW.content OR
+     OLD.enabled IS NOT NEW.enabled OR
+     OLD.position IS NOT NEW.position OR
+     OLD.insertion_order IS NOT NEW.insertion_order OR
+     OLD.priority IS NOT NEW.priority OR
+     OLD.selective IS NOT NEW.selective OR
+     OLD.secondary_keys IS NOT NEW.secondary_keys OR
+     OLD.case_sensitive IS NOT NEW.case_sensitive OR
+     OLD.extensions IS NOT NEW.extensions
+BEGIN
+  INSERT INTO sync_log(entity, entity_id, operation, timestamp, client_id, version, payload)
+  VALUES('world_book_entries', CAST(NEW.id AS TEXT), 'update', NEW.last_modified,
+         (SELECT client_id FROM world_books WHERE id = NEW.world_book_id), 1,
+         json_object('id', NEW.id, 'world_book_id', NEW.world_book_id, 'keys', NEW.keys,
+                     'content', NEW.content, 'enabled', NEW.enabled, 'position', NEW.position,
+                     'insertion_order', NEW.insertion_order, 'priority', NEW.priority,
+                     'selective', NEW.selective, 'secondary_keys', NEW.secondary_keys,
+                     'case_sensitive', NEW.case_sensitive, 'extensions', NEW.extensions,
+                     'created_at', NEW.created_at, 'last_modified', NEW.last_modified));
+END;
+
+UPDATE db_schema_version
+   SET version = 21
+ WHERE schema_name = 'rag_char_chat_schema'
+   AND version = 20;

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -1975,6 +1975,7 @@ class PersonasScreen(BaseAppScreen):
                 enabled=payload.get("enabled", True),
                 position=payload.get("position", "before_char"),
                 insertion_order=payload.get("insertion_order", 0),
+                priority=payload.get("priority", 0),
             ),
             "Could not add the entry",
         )

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_lore_detail.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_lore_detail.py
@@ -274,7 +274,8 @@ class PersonasLoreDetailWidget(Vertical):
         Returns:
             dict | None: The entry payload keyed by API field names
             (``keys``, ``content``, ``position``, ``enabled``,
-            ``insertion_order``), or ``None`` if keys or content are empty.
+            ``insertion_order``, ``priority``), or ``None`` if keys or content
+            are empty.
         """
         raw_keys = self.query_one("#personas-lore-entry-keys", Input).value
         keys = [k.strip() for k in raw_keys.split(",") if k.strip()]

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_lore_detail.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_lore_detail.py
@@ -119,6 +119,7 @@ class PersonasLoreDetailWidget(Vertical):
                             value="before_char",
                             allow_blank=False,
                         )
+                        yield Input(placeholder="Priority", id="personas-lore-entry-priority", value="0")
                         yield Switch(value=True, id="personas-lore-entry-enabled", tooltip="Entry enabled")
                     yield TextArea(id="personas-lore-entry-content")
                     with Horizontal(classes="personas-lore-form-row"):
@@ -148,7 +149,7 @@ class PersonasLoreDetailWidget(Vertical):
             None.
         """
         table = self.query_one("#personas-lore-entries-table", DataTable)
-        table.add_columns("keys", "content", "position", "enabled")
+        table.add_columns("keys", "content", "position", "priority", "enabled")
 
     # ----- public API -----
 
@@ -196,6 +197,7 @@ class PersonasLoreDetailWidget(Vertical):
                 Text(keys, style=style),
                 Text(preview, style=style),
                 Text(str(entry.get("position") or "before_char"), style=style),
+                Text(str(entry.get("priority") or 0), style=style),
                 Text("yes" if enabled else "no", style=style),
                 key=str(entry.get("id")),
             )
@@ -280,6 +282,11 @@ class PersonasLoreDetailWidget(Vertical):
         if not keys or not content.strip():
             return None
         position = str(self.query_one("#personas-lore-entry-position", Select).value)
+        raw_pri = self.query_one("#personas-lore-entry-priority", Input).value.strip() or "0"
+        try:
+            priority = max(0, min(100, int(raw_pri)))
+        except ValueError:
+            priority = 0
         enabled = bool(self.query_one("#personas-lore-entry-enabled", Switch).value)
         selected_id = self.selected_entry_id
         entry = (
@@ -296,6 +303,7 @@ class PersonasLoreDetailWidget(Vertical):
             "keys": keys,
             "content": content,
             "position": position,
+            "priority": priority,
             "enabled": enabled,
             "insertion_order": insertion_order,
         }
@@ -337,6 +345,7 @@ class PersonasLoreDetailWidget(Vertical):
         position = str(entry.get("position") or "before_char")
         if position in {p[0] for p in POSITIONS}:
             self.query_one("#personas-lore-entry-position", Select).value = position
+        self.query_one("#personas-lore-entry-priority", Input).value = str(entry.get("priority") or 0)
         self.query_one("#personas-lore-entry-enabled", Switch).value = bool(entry.get("enabled", True))
 
     @on(DataTable.RowSelected, "#personas-lore-entries-table")

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_lore_tryit.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_lore_tryit.py
@@ -171,6 +171,7 @@ class PersonasLoreTryItWidget(Vertical):
                 keys_str = ", ".join(str(k) for k in (record.get("keys") or []))
                 fired_text.append(
                     f"{keys_str} → {record.get('content_preview')}"
+                    f" · pri {int(record.get('priority', 0) or 0)}"
                     f" · {int(record.get('token_cost') or 0)} tok\n"
                 )
             fired_area.update(fired_text)


### PR DESCRIPTION
## Roleplay P2c — entry priority + priority-aware token budget (Lore)

Third P2 (Lore) sub-project, mirroring P1c. Gives world-book entries a `priority` so important lore **survives token-budget pressure and injects first**, and fixes the `token_budget`/`scan_depth` **floor** — the two budget-correctness gaps P2a's diagnostics exposed (and Qodo flagged on #673).

Branch off dev `5c0de75a`. 5 TDD tasks; per-task reviews + an opus whole-branch review → **APPROVE-WITH-FIXES** (the Important fixed + re-reviewed). Gate: **361 passed**, `import tldw_chatbook.app` OK. **Schema v20→v21** (dev is at v20 — no version collision; next migration becomes v21→v22).

### What shipped
- **Schema migration v20→v21** — `world_book_entries.priority INTEGER DEFAULT 0` (idempotent PRAGMA-guarded ALTER; the two `world_book_entries_sync_{create,update}` triggers recreated to carry `priority`; FTS triggers untouched; base DDL + doc-mirror kept identical to a migrated DB).
- **`WorldBookManager`** — priority through create/update/get/export/import (named columns, so the migrated-DB column order is irrelevant; export/import so Duplicate keeps priority).
- **`world_info_processor`** — `process_messages` sorts matched entries by `(−priority, insertion_order)` before both the budget walk *and* injection, so priority drives survival **and** order; `__init__` seeds `token_budget`/`scan_depth` to 0 so a book's lower configured value is honored (the floor fix).
- **Diagnostics + UI** — `WorldBookEntryDiagnostic.priority`, a priority field/column in the Lore entry editor (0–100 clamp), and priority in the Try-it fired rows.

### The key safety property
This deliberately changes the live legacy send's budget/order behavior — but it's **opt-in and inert for existing data**: every existing entry defaults to `priority = 0`, and the sort is stable, so at equal priorities + default `insertion_order` it's a **no-op**. The P2a budget/recursion pins (`test_diagnostics_classifies_disabled_secondary_and_budget`, `test_diagnostics_reports_recursively_fired_entries`, `test_diagnostics_result_equals_plain_process_messages`) pass **unmodified**. The one order change at default priority (a recursively-matched entry re-ordering by its own `insertion_order`) is pinned by a dedicated test.

### Reviewed invariants (verified live)
- **Migration consistency** — a fresh DB and a migrated V20 DB round-trip priority identically (named-column reads + `NEW.priority` triggers), despite the ALTER appending the column at a different physical ordinal.
- **Stable-no-op** — the three P2a pins are untouched and pass.
- **Floor fix** — `max(0, book)` honors lower values; an omitted field still defaults to 500/3; `token_budget = 0` still means unlimited.

### Notable fix (whole-branch review)
The Lore editor's **Add** handler passed an explicit kwarg list to `create_world_book_entry` that omitted `priority` — so newly-created entries silently got priority 0 (the create path of the headline feature). Fixed; a regression test now drives the **real** screen handler. Plus a null-safe `int(priority or 0)` so a hand-edited `priority: null` import doesn't crash.

### Scope / deferred
Priority + budget only. No regex/selective editing (P2d), attach (P2e/f), or native-send (P2g). Forward note: the character-scope service doesn't carry priority yet (P2f).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds entry priority to world-book lore so important entries survive token budgets and inject first, fixes the token budget/scan-depth floor, and hardens integer coercion so malformed imports never crash. Includes schema migration to v21 and small UI updates to edit and display priority.

- **New Features**
  - Schema v21: add `world_book_entries.priority INTEGER DEFAULT 0`; recreated sync triggers to include `priority`.
  - `WorldBookManager`: CRUD + export/import carry `priority` (safe int coercion, default 0).
  - `world_info_processor`: sorts matched entries by (-priority, insertion_order) before budgeting and injection; diagnostics include `priority`.
  - UI: Lore editor adds a priority field (clamped 0–100); Try-it shows priority in fired rows.
  - Backward compatible: existing entries default to priority 0; equal-priority behavior is unchanged.

- **Bug Fixes**
  - Budget/scan-depth floor: seed `token_budget` and `scan_depth` to 0 so lower per-book values are honored (0 still means unlimited).
  - Personas screen Add handler forwards `priority` to `create_world_book_entry`.
  - Crash-proof imports: coerce `priority` and `insertion_order` to ints in manager and processor; tolerate `None`/non-numeric values so create/update, import, and priority-based sorting never raise.

<sup>Written for commit f843e8b301c30f1af04affa8cec5759f0e7ddfdc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

