### PR TITLE
fix(media): media search always errored — deleted UI.MediaWindow import (task-292)

### DIFF
--- a/Tests/Media_DB/test_media_search_display.py
+++ b/Tests/Media_DB/test_media_search_display.py
@@ -1,0 +1,90 @@
+"""Regression tests for task-292: media search display path.
+
+``perform_media_search_and_display`` used to import the legacy
+``UI.MediaWindow`` module (deleted in the Library redesign) from inside its
+body; the resulting ``ModuleNotFoundError`` was swallowed by the handler's
+broad ``except Exception`` and rendered as a permanent "Error loading" list
+item, so media search always failed on dev even though ``search_media_db``
+itself worked. These tests drive the REAL handler end-to-end -- real
+``MediaDatabase`` (file-backed, so the ``asyncio.to_thread`` path runs),
+no mocks -- which is exactly the coverage that would have caught the
+deleted-module import.
+"""
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Label, ListView
+from loguru import logger as loguru_logger
+
+from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
+from tldw_chatbook.Event_Handlers.media_events import perform_media_search_and_display
+
+TYPE_SLUG = "video"
+
+
+class _MediaSearchHarness(App):
+    """Minimal host exposing exactly the app surface the handler touches."""
+
+    def __init__(self, media_db: MediaDatabase):
+        super().__init__()
+        self.media_db = media_db
+        self.loguru_logger = loguru_logger
+        self.media_current_page = 1
+        self._media_search_generation = {}
+
+    def compose(self) -> ComposeResult:
+        yield ListView(id=f"media-list-view-{TYPE_SLUG}")
+
+
+def _seeded_db(tmp_path) -> MediaDatabase:
+    db = MediaDatabase(tmp_path / "media-292.db", client_id="task-292-test")
+    media_id, _uuid, msg = db.add_media_with_keywords(
+        title="Tides Explained",
+        media_type=TYPE_SLUG,
+        content="Tides are driven by the moon's gravity.",
+        author="QA",
+    )
+    assert media_id is not None, msg
+    return db
+
+
+def _rendered_labels(list_view: ListView) -> list[str]:
+    return [str(label.renderable) for label in list_view.query(Label)]
+
+
+@pytest.mark.asyncio
+async def test_media_search_end_to_end_renders_results_not_error(tmp_path):
+    """The unmocked handler renders the seeded item, never "Error loading".
+
+    Pins the deleted-module import class: any import of a nonexistent
+    module inside the handler body resurfaces here as the "Error loading"
+    row this asserts against.
+    """
+    db = _seeded_db(tmp_path)
+    app = _MediaSearchHarness(db)
+    async with app.run_test():
+        await perform_media_search_and_display(app, TYPE_SLUG, "")
+
+        list_view = app.query_one(ListView)
+        labels = _rendered_labels(list_view)
+        assert any("Tides Explained" in text for text in labels), labels
+        assert not any("Error loading" in text for text in labels), labels
+        # The row the click handlers consume carries the DB record.
+        assert list_view.children, "expected at least one result row"
+        assert getattr(list_view.children[0], "media_data", {}).get("title") == "Tides Explained"
+
+
+@pytest.mark.asyncio
+async def test_media_search_end_to_end_search_term_filters(tmp_path):
+    """A real FTS search term flows through search_media_db unmocked."""
+    db = _seeded_db(tmp_path)
+    app = _MediaSearchHarness(db)
+    async with app.run_test():
+        await perform_media_search_and_display(app, TYPE_SLUG, "gravity")
+        labels = _rendered_labels(app.query_one(ListView))
+        assert any("Tides Explained" in text for text in labels), labels
+
+        await perform_media_search_and_display(app, TYPE_SLUG, "zebra-nonmatch")
+        labels = _rendered_labels(app.query_one(ListView))
+        assert any("No media items found" in text for text in labels), labels
+        assert not any("Error loading" in text for text in labels), labels

--- a/backlog/tasks/task-292 - Media-search-imports-deleted-UI.MediaWindow-module.md
+++ b/backlog/tasks/task-292 - Media-search-imports-deleted-UI.MediaWindow-module.md
@@ -1,8 +1,8 @@
 ---
 id: TASK-292
 title: Media search imports deleted UI.MediaWindow module — always errors
-status: To Do
-assignee: []
+status: Done
+assignee: ['@claude']
 created_date: '2026-07-17 21:30'
 labels: [bug, media, library]
 dependencies: []
@@ -17,6 +17,22 @@ Found during task-283 (PR review sweep of the debounced-search paths): Event_Han
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Media search displays results through a module that exists; the handler imports cleanly
-- [ ] #2 An unmocked test drives perform_media_search_and_display end-to-end (import failure class pinned)
+- [x] #1 Media search displays results through a module that exists; the handler imports cleanly
+- [x] #2 An unmocked test drives perform_media_search_and_display end-to-end (import failure class pinned)
 <!-- AC:END -->
+
+## Implementation Plan
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce: unmocked end-to-end test drives the real handler with a real file-backed MediaDatabase; confirm it fails on dev (renders "Error loading: No module named ...").
+2. Remove the dead show-deleted block (the legacy UI.MediaWindow import + show_deleted_items read); default show_deleted=False, the only surviving behavior since no current surface exposes the toggle.
+3. Verify the regression test passes post-fix and media suites stay green.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+<!-- SECTION:NOTES:BEGIN -->
+Root cause: perform_media_search_and_display's body imported the legacy UI.MediaWindow (deleted in the Library redesign) to read a show_deleted_items toggle; the ModuleNotFoundError escaped the local `except QueryError` and was swallowed by the function's broad `except Exception`, rendering every search as "Error loading". `show_deleted_items` exists nowhere else in the codebase, so the block was fully dead: it is removed and show_deleted stays False (deleted items were already excluded in practice for the pre-redesign UI too, since the toggle's owner no longer mounted).
+
+Regression net: Tests/Media_DB/test_media_search_display.py drives the REAL handler end-to-end (real file-backed MediaDatabase so the asyncio.to_thread path runs, minimal Textual harness app, no mocks) — verified to FAIL against the unfixed handler and pass after. Any future deleted-module import inside the handler resurfaces as the "Error loading" row the test asserts against.
+
+Files: tldw_chatbook/Event_Handlers/media_events.py (block removal), Tests/Media_DB/test_media_search_display.py (new).
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Event_Handlers/media_events.py
+++ b/tldw_chatbook/Event_Handlers/media_events.py
@@ -573,11 +573,14 @@ async def perform_media_search_and_display(app: 'TldwCli', type_slug: str, searc
         if keyword_filter:
             keywords_list = [k.strip() for k in keyword_filter.split(',') if k.strip()]
 
-        # Deleted items are never included. The show-deleted toggle lived on
-        # the legacy UI.MediaWindow, removed in the Library redesign; its
-        # import here raised ModuleNotFoundError, which the broad handler
-        # below rendered as a permanent "Error loading" list (task-292). No
-        # current surface exposes such a toggle.
+        # Deleted items are never included HERE. The toggle this block used
+        # to read lived on the legacy UI.MediaWindow, removed in the Library
+        # redesign; its import raised ModuleNotFoundError, which the broad
+        # handler below rendered as a permanent "Error loading" list
+        # (task-292). MediaWindow_v2 does have its own "Show deleted"
+        # checkbox, but that flows through its own search call (it passes
+        # include_deleted directly), never through this handler -- none of
+        # this handler's callers carry such a toggle.
         show_deleted = False
 
         search_kwargs = dict(

--- a/tldw_chatbook/Event_Handlers/media_events.py
+++ b/tldw_chatbook/Event_Handlers/media_events.py
@@ -573,15 +573,12 @@ async def perform_media_search_and_display(app: 'TldwCli', type_slug: str, searc
         if keyword_filter:
             keywords_list = [k.strip() for k in keyword_filter.split(',') if k.strip()]
 
-        # Check if we should show deleted items
+        # Deleted items are never included. The show-deleted toggle lived on
+        # the legacy UI.MediaWindow, removed in the Library redesign; its
+        # import here raised ModuleNotFoundError, which the broad handler
+        # below rendered as a permanent "Error loading" list (task-292). No
+        # current surface exposes such a toggle.
         show_deleted = False
-        try:
-            # Try to get the MediaWindow and check its show_deleted_items state
-            from ..UI.MediaWindow import MediaWindow
-            media_window = app.query_one(MediaWindow)
-            show_deleted = media_window.show_deleted_items
-        except QueryError:
-            logger.debug("MediaWindow not found, using default show_deleted=False")
 
         search_kwargs = dict(
             search_query=query_arg,


### PR DESCRIPTION
## Summary
- **Bug (production, high):** every media search on dev rendered `Error loading: No module named 'tldw_chatbook.UI.MediaWindow'` — `perform_media_search_and_display` imported the legacy `UI.MediaWindow` (deleted in the Library redesign) inside its body to read a `show_deleted_items` toggle. The `ModuleNotFoundError` escaped the local `except QueryError` and was swallowed by the function's broad `except Exception`, which converted it into the permanent error row. The search itself (`search_media_db`) was fine; only the display path was broken.
- **Fix:** the block is fully dead — `show_deleted_items` exists nowhere else in the codebase — so it's removed and `show_deleted` stays `False` (the only surviving behavior).
- **Regression net:** `Tests/Media_DB/test_media_search_display.py` drives the REAL handler end-to-end — real file-backed `MediaDatabase` (so the `asyncio.to_thread` path from task-283 runs), minimal Textual harness, zero mocks. Verified to FAIL against the unfixed handler (both tests hit the error row) and pass after. Any future deleted-module import inside the handler resurfaces as the asserted-against "Error loading" row.

## Verification
- New tests: 2/2, and confirmed red on the unfixed handler
- `Tests/Media_DB/`: 61 passed, 6 skipped

Found during the task-283 review sweep (PR #683); filed as task-292 (renumbered from 289 to avoid the IDs minted by open PRs #678/#680).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a production bug where every media search failed due to importing deleted `UI.MediaWindow` inside `perform_media_search_and_display` (task-292). Removed the dead code; searches render again and deleted items stay hidden.

- **Bug Fixes**
  - Removed the legacy `UI.MediaWindow` import and `show_deleted_items` toggle read; default to `show_deleted=False`.
  - Eliminates the swallowed `ModuleNotFoundError` that showed as a permanent "Error loading" row.
  - Added end-to-end regression tests with a real file-backed `MediaDatabase`.

- **Refactors**
  - Clarified comments that `MediaWindow_v2` has its own "Show deleted" toggle and path; no behavior change.

<sup>Written for commit 16c7cd491614b33f5a8c38dd3beef07e06e157f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

