### PR TITLE
perf(rag): batch conversation-context fetch + BLOB-skip for text-only reads (task-260)

### DIFF
--- a/Tests/RAG_Search/test_conversation_search_batch.py
+++ b/Tests/RAG_Search/test_conversation_search_batch.py
@@ -1,0 +1,135 @@
+"""Tests for task-260: RAG conversation search batch fetch + BLOB skip.
+
+All tests run against a REAL file-backed CharactersRAGDB — no mocks. This is
+also the regression net for the flattened-module import defect: the pipeline
+function used to do ``from ...DB.ChaChaNotes_DB import ...`` (written when the
+module lived one package deeper, in ``simplified/``), which raised
+``ImportError: attempted relative import beyond top-level package`` at call
+time; any end-to-end call below would resurface that class of break.
+"""
+
+import asyncio
+
+import pytest
+
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.RAG_Search.pipeline_functions_simple import search_conversations_fts5
+
+_PNG_STUB = b"\x89PNG\r\n\x1a\n" + b"\x00" * 64
+
+
+class _FakeApp:
+    """Bare app double carrying only the db_config the pipeline reads."""
+
+    def __init__(self, db_path):
+        self.db_config = {"chacha_db_path": str(db_path)}
+
+
+def _seed(db: CharactersRAGDB, *, n_convs: int = 3, msgs_per_conv: int = 4) -> list[str]:
+    """Seed conversations whose messages embed a searchable marker word."""
+    conv_ids = []
+    for c in range(n_convs):
+        conv_id = db.add_conversation({"title": f"Conversation {c}"})
+        conv_ids.append(conv_id)
+        for m in range(msgs_per_conv):
+            db.add_message({
+                "conversation_id": conv_id,
+                "sender": "User" if m % 2 == 0 else "AI",
+                "content": f"glimmerfish message {m} of conversation {c}",
+                # Explicit distinct timestamps: deterministic ordering.
+                "timestamp": f"2026-07-17T10:0{c}:{m:02d}Z",
+                # One BLOB-bearing message per conversation proves the
+                # text-only path skips (not breaks on) image rows.
+                **({"image_data": _PNG_STUB, "image_mime_type": "image/png"} if m == 1 else {}),
+            })
+    return conv_ids
+
+
+@pytest.fixture()
+def db(tmp_path):
+    return CharactersRAGDB(tmp_path / "task260.db", client_id="task-260-test")
+
+
+def test_batch_matches_per_conversation_loop(db):
+    """AC#1/#3: the batch method returns exactly what the old loop fetched."""
+    conv_ids = _seed(db)
+
+    batched = db.get_messages_for_conversations_batch(
+        conversation_ids=conv_ids, limit_per_conversation=5
+    )
+
+    for conv_id in conv_ids:
+        loop_rows = db.get_messages_for_conversation(conversation_id=conv_id, limit=5)
+        batch_rows = batched[conv_id]
+        assert len(batch_rows) == len(loop_rows)
+        # Compare on the columns both queries select (the batch query
+        # predates the variant columns and doesn't return them).
+        common = ("id", "conversation_id", "sender", "content", "timestamp", "image_data")
+        for lr, br in zip(loop_rows, batch_rows):
+            for key in common:
+                assert br[key] == lr[key], (conv_id, key)
+
+
+def test_include_image_data_false_skips_blob_both_methods(db):
+    """AC#2: BLOB column comes back None, mime type and shape survive."""
+    conv_ids = _seed(db, n_convs=1)
+    conv_id = conv_ids[0]
+
+    with_blob = db.get_messages_for_conversation(conversation_id=conv_id, limit=5)
+    without_blob = db.get_messages_for_conversation(
+        conversation_id=conv_id, limit=5, include_image_data=False
+    )
+    batch_without = db.get_messages_for_conversations_batch(
+        conversation_ids=[conv_id], limit_per_conversation=5, include_image_data=False
+    )[conv_id]
+
+    image_rows = [r for r in with_blob if r["image_data"] is not None]
+    assert image_rows, "seed must include a BLOB-bearing message"
+    assert image_rows[0]["image_data"] == _PNG_STUB
+
+    for rows in (without_blob, batch_without):
+        assert [r["id"] for r in rows] == [r["id"] for r in with_blob]
+        assert all(r["image_data"] is None for r in rows)
+        # Callers can still tell an image exists.
+        assert any(r["image_mime_type"] == "image/png" for r in rows)
+        assert [r["content"] for r in rows] == [r["content"] for r in with_blob]
+
+
+@pytest.mark.asyncio
+async def test_search_conversations_fts5_end_to_end(db, tmp_path):
+    """AC#3: the real pipeline function returns the same results the old
+    per-conversation loop produced — snippet text, titles, and relevance
+    order — via one batched query. Also pins the flattened-module import."""
+    _seed(db)
+    app = _FakeApp(tmp_path / "task260.db")
+
+    results = await search_conversations_fts5(app, "glimmerfish", limit=10)
+
+    assert results, "expected conversation hits for the seeded marker word"
+    reference_order = [
+        str(c["id"]) for c in db.search_conversations_by_content(
+            search_query="glimmerfish", limit=20
+        )
+    ]
+    assert [r.id for r in results] == reference_order[: len(results)]
+
+    for result in results:
+        assert result.source == "conversation"
+        assert result.title.startswith("Conversation ")
+        # Snippet identical to the old loop: first-5 ASC messages joined
+        # as "sender: content" lines.
+        expected = "\n".join(
+            f"{m['sender']}: {m['content']}"
+            for m in db.get_messages_for_conversation(conversation_id=result.id, limit=5)
+        )
+        assert result.content == expected
+
+
+@pytest.mark.asyncio
+async def test_search_conversations_fts5_no_db_config_returns_empty(tmp_path):
+    """The production guard: no db_config on the app -> quiet empty result."""
+
+    class _Bare:
+        pass
+
+    assert await search_conversations_fts5(_Bare(), "anything") == []

--- a/backlog/tasks/task-260 - RAG-conversation-search-batch-fetch-skip-BLOBs.md
+++ b/backlog/tasks/task-260 - RAG-conversation-search-batch-fetch-skip-BLOBs.md
@@ -1,8 +1,8 @@
 ---
 id: TASK-260
 title: RAG conversation search: batch fetch + skip image BLOBs
-status: To Do
-assignee: []
+status: Done
+assignee: ['@claude']
 created_date: '2026-07-16 14:30'
 labels: [performance, rag]
 dependencies: []
@@ -17,7 +17,25 @@ pipeline_functions_simple.search_conversations_fts5 (96-115) issues one get_mess
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 One batched query replaces the per-conversation loop
-- [ ] #2 Text-only callers no longer fetch BLOB columns
-- [ ] #3 RAG search results unchanged (tests)
+- [x] #1 One batched query replaces the per-conversation loop
+- [x] #2 Text-only callers no longer fetch BLOB columns
+- [x] #3 RAG search results unchanged (tests)
 <!-- AC:END -->
+
+## Implementation Plan
+<!-- SECTION:PLAN:BEGIN -->
+1. Probe the live path end-to-end against a real DB before touching it (unmocked), then wire get_messages_for_conversations_batch into search_conversations_fts5.
+2. Add include_image_data (default True) to both fetch methods; pass False from the pipeline and mindmap text-only callers.
+3. Equivalence + BLOB-skip + end-to-end tests on a real file-backed CharactersRAGDB.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+<!-- SECTION:NOTES:BEGIN -->
+The pre-work probe found the function had NEVER worked end-to-end — three latent defects, all invisible to mocked tests: `from ...DB.ChaChaNotes_DB` resolves beyond the top-level package (leftover from the simplified/ flattening; raises ImportError at call time), and the ctor call was missing the required client_id. Both fixed here (the lines were being rewritten anyway); `search_notes_fts5` has the same class of breakage plus a nonexistent target module — filed as task-295 rather than widened scope. In production none of this crashed because nothing sets app.db_config, so the function short-circuited to [] — that wiring decision is also part of task-295.
+
+The batch rewrite: one get_messages_for_conversations_batch call (include_image_data=False) replaces the per-conversation loop; results are assembled by iterating the relevance-ordered conv_results and looking up the batch dict, so content and order are byte-identical to the old loop (test-asserted against a reference loop on a seeded real DB). BLOB skip: include_image_data=False swaps the SELECT column for NULL AS image_data — key present, value None, image_mime_type still returned so callers can tell an image exists (dict-shape-stable choice; consumers do .get()-style reads). Mindmap's text-only fetch (Tools/Mind_Map/mindmap_integration.py — the task file's RAG_Search path was stale) also passes include_image_data=False.
+
+Tests: Tests/RAG_Search/test_conversation_search_batch.py (4, all real-DB unmocked). Suites: ChaChaNotesDB + chat persistence/conversation/functions + Chatbooks 385 passed; 3 failures reproduced identically at the base commit (pre-existing legacy-parity drift, listed in PR).
+
+Files: DB/ChaChaNotes_DB.py, RAG_Search/pipeline_functions_simple.py, Tools/Mind_Map/mindmap_integration.py, Tests/RAG_Search/test_conversation_search_batch.py, backlog/tasks/task-295 (new bug filing).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-295 - RAG-pipeline-notes-search-imports-nonexistent-NotesDB-module.md
+++ b/backlog/tasks/task-295 - RAG-pipeline-notes-search-imports-nonexistent-NotesDB-module.md
@@ -1,0 +1,22 @@
+---
+id: TASK-295
+title: RAG pipeline notes search imports nonexistent NotesDB module — dead path
+status: To Do
+assignee: []
+created_date: '2026-07-17 21:50'
+labels: [bug, rag, notes]
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found during task-260: `RAG_Search/pipeline_functions_simple.py`'s `search_notes_fts5` is broken three ways — (1) `from ...Notes.DB.Notes_DB import NotesDB` resolves beyond the top-level package (flattened-module leftover, same class as the conversations defect fixed in task-260), (2) no `Notes_DB.py` module exists anywhere in the tree (notes live in ChaChaNotes), and (3) its call contract (`NotesDB(path)` + `search_notes(user_id=...)`) doesn't match the real `CharactersRAGDB.search_notes(search_term, limit, fts_match_query)` API. Today the function always returns `[]` before crashing because nothing sets `app.db_config['notes_db_path']` — the whole `db_config` seam is never populated by the app, which also keeps the (now-fixed) conversations path returning `[]` in production. Fixing this properly means deciding how the v2 pipeline should reach the notes store (route through `CharactersRAGDB.search_notes` at the chacha path, or the Library RAG search service) and whether/where `app.db_config` should be wired. Unmocked end-to-end tests required (this file's defects were all invisible to mocked tests).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 search_notes_fts5 queries the real notes store and returns results end-to-end (unmocked test)
+- [ ] #2 A decision is recorded on wiring app.db_config (or replacing the seam) so the pipeline paths are reachable in-app
+<!-- AC:END -->

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -5975,20 +5975,40 @@ UPDATE db_schema_version
         return result
 
     def get_messages_for_conversation(self, conversation_id: str, limit: int = 100, offset: int = 0,
-                                      order_by_timestamp: str = "ASC") -> List[Dict[str, Any]]:
-        """
-        Lists messages for a specific conversation.
-        Returns non-deleted messages, ordered by `timestamp` according to `order_by_timestamp`.
-        Crucially, it also ensures the parent conversation is not soft-deleted.
+                                      order_by_timestamp: str = "ASC",
+                                      include_image_data: bool = True) -> List[Dict[str, Any]]:
+        """Lists non-deleted messages for a non-deleted conversation.
+
+        Ordered by ``timestamp`` according to ``order_by_timestamp``. The
+        JOIN also ensures the parent conversation is not soft-deleted.
+
+        Args:
+            conversation_id: Conversation UUID to fetch messages for.
+            limit: Maximum number of messages to return.
+            offset: Number of messages to skip (pagination).
+            order_by_timestamp: "ASC" or "DESC".
+            include_image_data: When False, the ``image_data`` BLOB column is
+                returned as None (key still present) so text-only callers --
+                snippet builders, mindmaps -- skip the BLOB I/O (task-260).
+                ``image_mime_type`` is always returned, so callers can still
+                tell an image exists.
+
+        Returns:
+            A list of message dicts in the requested order.
+
+        Raises:
+            InputError: If ``order_by_timestamp`` is not "ASC"/"DESC".
+            CharactersRAGDBError: For database errors.
         """
         if order_by_timestamp.upper() not in ["ASC", "DESC"]:
             raise InputError("order_by_timestamp must be 'ASC' or 'DESC'.")
 
-        # The new query joins with conversations to check its 'deleted' status.
+        image_col = "m.image_data" if include_image_data else "NULL AS image_data"
+        # The query joins with conversations to check its 'deleted' status.
         # Now includes variant fields for message variant support
         query = f"""
             SELECT m.id, m.conversation_id, m.parent_message_id, m.sender, m.content, 
-                   m.image_data, m.image_mime_type, m.timestamp, m.ranking, 
+                   {image_col}, m.image_mime_type, m.timestamp, m.ranking, 
                    m.last_modified, m.version, m.client_id, m.deleted, m.feedback, m.role,
                    m.variant_of, m.variant_number, m.is_selected_variant, m.total_variants
             FROM messages m
@@ -6007,7 +6027,8 @@ UPDATE db_schema_version
             raise
 
     def get_messages_for_conversations_batch(self, conversation_ids: List[str], limit_per_conversation: int = 100,
-                                           order_by_timestamp: str = "ASC") -> Dict[str, List[Dict[str, Any]]]:
+                                           order_by_timestamp: str = "ASC",
+                                           include_image_data: bool = True) -> Dict[str, List[Dict[str, Any]]]:
         """
         Batch fetch messages for multiple conversations to avoid N+1 queries.
         
@@ -6015,6 +6036,10 @@ UPDATE db_schema_version
             conversation_ids: List of conversation IDs to fetch messages for
             limit_per_conversation: Maximum messages per conversation
             order_by_timestamp: Order by timestamp ASC or DESC
+            include_image_data: When False, the ``image_data`` BLOB column is
+                returned as None (key still present) so text-only callers skip
+                the BLOB I/O (task-260). ``image_mime_type`` is always
+                returned.
             
         Returns:
             Dictionary mapping conversation_id to list of messages
@@ -6025,12 +6050,13 @@ UPDATE db_schema_version
         if order_by_timestamp.upper() not in ["ASC", "DESC"]:
             raise InputError("order_by_timestamp must be 'ASC' or 'DESC'.")
         
+        image_col = "m.image_data" if include_image_data else "NULL AS image_data"
         # Use ROW_NUMBER() window function to limit messages per conversation
         placeholders = ','.join('?' * len(conversation_ids))
         query = f"""
             WITH ranked_messages AS (
                 SELECT m.id, m.conversation_id, m.parent_message_id, m.sender, m.content, 
-                       m.image_data, m.image_mime_type, m.timestamp, m.ranking, 
+                       {image_col}, m.image_mime_type, m.timestamp, m.ranking, 
                        m.last_modified, m.version, m.client_id, m.deleted, m.feedback, m.role,
                        ROW_NUMBER() OVER (PARTITION BY m.conversation_id ORDER BY m.timestamp {order_by_timestamp}) as row_num
                 FROM messages m

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -6043,6 +6043,10 @@ UPDATE db_schema_version
             
         Returns:
             Dictionary mapping conversation_id to list of messages
+            
+        Raises:
+            InputError: If ``order_by_timestamp`` is not "ASC"/"DESC".
+            CharactersRAGDBError: For database errors.
         """
         if not conversation_ids:
             return {}

--- a/tldw_chatbook/RAG_Search/pipeline_functions_simple.py
+++ b/tldw_chatbook/RAG_Search/pipeline_functions_simple.py
@@ -85,33 +85,51 @@ async def search_conversations_fts5(
     query: str,
     limit: int = 10
 ) -> List[SearchResult]:
-    """Search conversations database using FTS5."""
+    """Search conversations database using FTS5.
+
+    Args:
+        app: App-like object exposing ``db_config['chacha_db_path']``.
+        query: FTS search text.
+        limit: Maximum number of conversation results to return.
+
+    Returns:
+        SearchResult entries in content-relevance order, each carrying a
+        snippet built from the conversation's first messages.
+    """
     if not hasattr(app, 'db_config') or not app.db_config.get('chacha_db_path'):
         return []
     
     logger.debug(f"Searching conversations for: {query}")
     
-    from ...DB.ChaChaNotes_DB import CharactersRAGDB
+    # Two dots, not three: this module was flattened out of simplified/ and
+    # the old ...DB import resolved beyond the top-level package, raising
+    # ImportError at call time (task-260).
+    from ..DB.ChaChaNotes_DB import CharactersRAGDB
     
-    db = CharactersRAGDB(app.db_config['chacha_db_path'])
+    # client_id is a required ctor arg (was missing here -- third latent
+    # defect in this never-exercised path, caught by the task-260 tests).
+    db = CharactersRAGDB(app.db_config['chacha_db_path'], client_id='rag_pipeline')
     conv_results = await asyncio.to_thread(
         db.search_conversations_by_content,
         search_query=query,
         limit=limit * 2
     )
     
+    # task-260: one batched query for all matched conversations' context
+    # messages (was one query per conversation), and text-only snippets
+    # never fetch image BLOBs.
+    messages_by_conv = await asyncio.to_thread(
+        db.get_messages_for_conversations_batch,
+        conversation_ids=[conv['id'] for conv in conv_results],
+        limit_per_conversation=5,
+        include_image_data=False,
+    )
+    
     results = []
     for conv in conv_results:
-        # Get some messages for context
-        messages = await asyncio.to_thread(
-            db.get_messages_for_conversation,
-            conversation_id=conv['id'],
-            limit=5
-        )
-        
         # Build content from messages
         content_parts = []
-        for msg in messages:
+        for msg in messages_by_conv.get(conv['id'], []):
             content_parts.append(f"{msg['sender']}: {msg['content']}")
         
         results.append(SearchResult(

--- a/tldw_chatbook/Tools/Mind_Map/mindmap_integration.py
+++ b/tldw_chatbook/Tools/Mind_Map/mindmap_integration.py
@@ -85,7 +85,9 @@ class MindmapIntegration:
         
         # Add messages if requested
         if include_messages:
-            messages = self.db.get_messages_for_conversation(conversation_id, limit=max_messages)
+            messages = self.db.get_messages_for_conversation(
+                conversation_id, limit=max_messages, include_image_data=False
+            )
             
             if messages:
                 messages_node = Node(


### PR DESCRIPTION
## Summary
- `search_conversations_fts5` replaces its per-conversation message loop (≤20 queries/search) with one `get_messages_for_conversations_batch` call; results assembled in the original relevance order so output is byte-identical (test-asserted against a reference loop).
- Both `get_messages_for_conversation` and `get_messages_for_conversations_batch` gain `include_image_data: bool = True`; when False the SELECT returns `NULL AS image_data` — dict shape stable (key present, value None), `image_mime_type` still returned so callers can tell an image exists. Text-only callers (pipeline snippets, `Tools/Mind_Map/mindmap_integration.py`) pass False.

## Latent defects the unmocked tests exposed (this path had NEVER worked)
1. `from ...DB.ChaChaNotes_DB import …` — leftover from the `simplified/` flattening, resolves beyond the top-level package → `ImportError` at call time. Fixed (two dots).
2. `CharactersRAGDB(path)` missing the required `client_id` ctor arg. Fixed (`client_id='rag_pipeline'`).
3. Sibling `search_notes_fts5` is broken the same way **plus** imports a module (`Notes_DB`) that doesn't exist anywhere and calls an API signature that doesn't match the real `search_notes` — filed as **task-295** (also covers the never-wired `app.db_config` seam that keeps these paths returning `[]` in production) rather than widening this perf task.

## Verification
- New: `Tests/RAG_Search/test_conversation_search_batch.py` — 4/4, all against a REAL file-backed `CharactersRAGDB`, zero mocks (batch≡loop equivalence, BLOB-skip both methods, end-to-end pipeline call, guard path).
- Suites: ChaChaNotesDB + Chat persistence/conversation/functions + Chatbooks — **385 passed**, 3 failed; all 3 reproduced identically at the base commit (pre-existing legacy-parity drift: `test_legacy_v13_rows_default_runtime_and_discovery_metadata`, `test_legacy_rows_default_to_global_scope_and_null_workspace`, `test_legacy_character_rows_backfill_character_assistant_identity`).

Task file updated (Done, plan+notes); task-295 minted after verifying 295 is free on origin/dev (max 294) and in all open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batched conversation-context fetch for RAG search and skipped image BLOBs for text-only reads to speed up queries without changing results. Meets task-260 ACs and adds real-DB tests.

- **Refactors**
  - `search_conversations_fts5` now uses one `get_messages_for_conversations_batch` call and keeps relevance order/snippets identical.
  - Added `include_image_data` to `get_messages_for_conversation` and `get_messages_for_conversations_batch`; `False` returns `None` for `image_data` while keeping `image_mime_type`.
  - Text-only callers pass `include_image_data=False` in `RAG_Search/pipeline_functions_simple.py` and `Tools/Mind_Map/mindmap_integration.py`.
  - Expanded DB method docstrings with a `Raises` section for clearer error contracts.

- **Bug Fixes**
  - Fixed relative import to `..DB.ChaChaNotes_DB` and supplied required `client_id` in `search_conversations_fts5`.
  - Logged a follow-up for broken notes search (`search_notes_fts5`) as task-295.

<sup>Written for commit 0e62d3b01cfa9f91daa7616e5f937ab0f022d9ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

