### PR TITLE
test(ui): pin footer CSS-subset and personas-no-recompose invariants (task-289)

### DIFF
--- a/Tests/UI/test_screen_footer_hints.py
+++ b/Tests/UI/test_screen_footer_hints.py
@@ -14,6 +14,10 @@ app. These tests pin that contract directly against the real screens/
 registration methods, not a hand-rolled fake.
 """
 
+import ast
+import re
+from pathlib import Path
+
 import pytest
 from textual.app import App, ComposeResult
 from textual.widgets import Static
@@ -193,3 +197,151 @@ async def test_settings_registration_updates_the_screens_own_footer():
         screen_footer = screen.query_one(AppFooterStatus)
         for token in ("save category", "revert category", "test category"):
             assert token in screen_footer.shortcut_text
+
+
+# ---------------------------------------------------------------------------
+# task-289 drift guards: two invariants task-264 left as comments become
+# red tests here.
+
+_CSS_ROOT = Path(__file__).resolve().parents[2] / "tldw_chatbook" / "css"
+# Full comment text, NOT the bare marker: splitting on a marker that sits
+# INSIDE a comment leaves a dangling `*/` in the section, which corrupts the
+# first parsed selector.
+_FOOTER_SECTION_START = "/* --- Window Footer Widget --- */"
+_FOOTER_SECTION_END = "/* --- End of Window Footer Widget --- */"
+
+
+def _parse_css_blocks(css_text: str) -> dict[str, dict[str, str]]:
+    """Parse flat (non-nested) tcss into {selector: {property: value}}.
+
+    Comments are stripped first; selectors and values are whitespace-
+    normalized. Good enough for the simple declaration blocks under test --
+    NOT a general CSS parser.
+    """
+    text = re.sub(r"/\*.*?\*/", "", css_text, flags=re.DOTALL)
+    blocks: dict[str, dict[str, str]] = {}
+    for match in re.finditer(r"([^{}]+)\{([^{}]*)\}", text):
+        selector = " ".join(match.group(1).split())
+        declarations: dict[str, str] = {}
+        for declaration in match.group(2).split(";"):
+            if ":" not in declaration:
+                continue
+            prop, value = declaration.split(":", 1)
+            declarations[prop.strip()] = " ".join(value.split())
+        blocks[selector] = declarations
+    return blocks
+
+
+def _footer_section_blocks(css_path: Path) -> dict[str, dict[str, str]]:
+    """The parsed footer-section blocks of a css file, keyed by selector."""
+    text = css_path.read_text(encoding="utf-8")
+    assert _FOOTER_SECTION_START in text and _FOOTER_SECTION_END in text, (
+        f"{css_path.name} lost its '{_FOOTER_SECTION_START}' section markers -- "
+        "the DEFAULT_CSS drift guard needs them to find the footer block."
+    )
+    section = text.split(_FOOTER_SECTION_START, 1)[1].split(_FOOTER_SECTION_END, 1)[0]
+    return _parse_css_blocks(section)
+
+
+def _default_css_divergences(bundle_blocks: dict[str, dict[str, str]]) -> list[str]:
+    """Every DEFAULT_CSS declaration missing/different in the bundle blocks.
+
+    DEFAULT_CSS scopes child selectors as ``AppFooterStatus #id``; the bundle
+    declares the same ids unscoped, so the scope prefix is stripped before
+    matching. DEFAULT_CSS is allowed to be a SUBSET (the bundle carries
+    extras); a declaration present in DEFAULT_CSS but absent or different in
+    the bundle is drift.
+    """
+    divergences = []
+    for selector, declarations in _parse_css_blocks(AppFooterStatus.DEFAULT_CSS).items():
+        bundle_selector = selector.replace("AppFooterStatus #", "#")
+        bundle_declarations = bundle_blocks.get(bundle_selector)
+        if bundle_declarations is None:
+            divergences.append(f"selector {bundle_selector!r} missing from footer section")
+            continue
+        for prop, value in declarations.items():
+            bundle_value = bundle_declarations.get(prop)
+            if bundle_value != value:
+                divergences.append(
+                    f"{bundle_selector} {{ {prop}: {value} }} vs bundle "
+                    f"{bundle_value!r}"
+                )
+    return divergences
+
+
+def test_default_css_matches_the_live_bundle_source():
+    """AppFooterStatus.DEFAULT_CSS must stay a faithful subset of the live
+    bundle source (css/components/_widgets.tcss footer block) -- otherwise
+    stylesheet-less harnesses silently diverge from production geometry
+    (task-264's KEEP-IN-SYNC contract, previously comment-only)."""
+    divergences = _default_css_divergences(
+        _footer_section_blocks(_CSS_ROOT / "components" / "_widgets.tcss")
+    )
+    assert divergences == [], (
+        "AppFooterStatus.DEFAULT_CSS diverged from _widgets.tcss's footer "
+        f"block: {divergences}. Update BOTH sides (they are KEEP-IN-SYNC) "
+        "and rebuild the bundle (python3 tldw_chatbook/css/build_css.py)."
+    )
+
+
+def test_built_bundle_carries_the_footer_rules():
+    """The BUILT bundle (tldw_cli_modular.tcss, what production loads) must
+    carry the same footer declarations -- catches an edited _widgets.tcss
+    that was never rebuilt into the bundle."""
+    divergences = _default_css_divergences(
+        _footer_section_blocks(_CSS_ROOT / "tldw_cli_modular.tcss")
+    )
+    assert divergences == [], (
+        "The built bundle's footer block diverged from AppFooterStatus."
+        f"DEFAULT_CSS: {divergences}. If _widgets.tcss is already correct, "
+        "the bundle is stale -- rerun python3 tldw_chatbook/css/build_css.py."
+    )
+
+
+def test_personas_screen_has_no_recompose_path_while_footer_hints_are_non_persisting():
+    """PersonasScreen drives its footer through the NON-persisting
+    ``set_shortcut_context`` path (its hint set is dynamic, re-registered on
+    editing/selection transitions). That is only safe while the screen never
+    recomposes -- a screen-level recompose replaces the footer widget and
+    silently resets its hints (the task-264 fix-wave bug, solved for the
+    static screens by BaseAppScreen's persisting registration).
+
+    Guard: fail if any BaseAppScreen subclass in personas_screen.py gains a
+    ``recompose=True`` call (a recompose reactive or refresh(recompose=True))
+    while the file still lacks the persisting ``register_footer_shortcuts``
+    API. Scoped to BaseAppScreen subclasses because recompose on a child
+    WIDGET only rebuilds that widget's children, never the screen's footer.
+    """
+    import tldw_chatbook.UI.Screens.personas_screen as personas_module
+
+    source = Path(personas_module.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    recompose_sites: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        base_names = {
+            base.id if isinstance(base, ast.Name) else getattr(base, "attr", "")
+            for base in node.bases
+        }
+        if "BaseAppScreen" not in base_names:
+            continue
+        for inner in ast.walk(node):
+            if isinstance(inner, ast.Call) and any(
+                keyword.arg == "recompose"
+                and isinstance(keyword.value, ast.Constant)
+                and keyword.value.value is True
+                for keyword in inner.keywords
+            ):
+                recompose_sites.append(inner.lineno)
+
+    uses_persisting_api = "register_footer_shortcuts" in source
+    assert not (recompose_sites and not uses_persisting_api), (
+        f"personas_screen.py gained recompose=True at line(s) {recompose_sites} "
+        "while its footer hints still use the non-persisting "
+        "set_shortcut_context path -- a recompose will silently reset them. "
+        "Migrate the footer registration to BaseAppScreen."
+        "register_footer_shortcuts (persisting) before adding a recompose "
+        "path (see task-264 / task-289)."
+    )

--- a/Tests/UI/test_screen_footer_hints.py
+++ b/Tests/UI/test_screen_footer_hints.py
@@ -216,7 +216,10 @@ def _parse_css_blocks(css_text: str) -> dict[str, dict[str, str]]:
 
     Comments are stripped first; selectors and values are whitespace-
     normalized. Good enough for the simple declaration blocks under test --
-    NOT a general CSS parser.
+    NOT a general CSS parser. Known limit: a selector LIST (``#a, #b { }``)
+    is kept as one compound key, so regrouping rules across the two files
+    reports as "missing from footer section" (a loud false-fail, never a
+    silent pass) -- split the list back out if you hit that.
     """
     text = re.sub(r"/\*.*?\*/", "", css_text, flags=re.DOTALL)
     blocks: dict[str, dict[str, str]] = {}
@@ -306,37 +309,71 @@ def test_personas_screen_has_no_recompose_path_while_footer_hints_are_non_persis
     silently resets its hints (the task-264 fix-wave bug, solved for the
     static screens by BaseAppScreen's persisting registration).
 
-    Guard: fail if any BaseAppScreen subclass in personas_screen.py gains a
-    ``recompose=True`` call (a recompose reactive or refresh(recompose=True))
-    while the file still lacks the persisting ``register_footer_shortcuts``
-    API. Scoped to BaseAppScreen subclasses because recompose on a child
-    WIDGET only rebuilds that widget's children, never the screen's footer.
+    Guard, two rules (both literal-True only -- the house AST-guard style):
+    - any ``recompose=True`` call inside a BaseAppScreen subclass body
+      (recompose reactives, self.refresh(recompose=True)); non-screen child
+      widget classes are excluded because a child-widget recompose only
+      rebuilds that widget's children, never the screen's footer;
+    - any ``.refresh(recompose=True)`` call OUTSIDE class bodies -- the
+      library_screen.py precedent is module-level helpers that take the
+      screen and call ``screen.refresh(recompose=True)``, invisible to a
+      class-body-only walk (task-289 review).
+
+    Escape hatch: an ACTUAL ``.register_footer_shortcuts(...)`` call in the
+    file (the persisting API) disarms the guard -- checked as an AST call,
+    not a substring, so a comment mentioning the API cannot disarm it.
     """
     import tldw_chatbook.UI.Screens.personas_screen as personas_module
 
     source = Path(personas_module.__file__).read_text(encoding="utf-8")
     tree = ast.parse(source)
 
-    recompose_sites: list[int] = []
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.ClassDef):
-            continue
-        base_names = {
-            base.id if isinstance(base, ast.Name) else getattr(base, "attr", "")
-            for base in node.bases
-        }
-        if "BaseAppScreen" not in base_names:
-            continue
-        for inner in ast.walk(node):
-            if isinstance(inner, ast.Call) and any(
-                keyword.arg == "recompose"
-                and isinstance(keyword.value, ast.Constant)
-                and keyword.value.value is True
-                for keyword in inner.keywords
-            ):
-                recompose_sites.append(inner.lineno)
+    def _has_literal_true_recompose(call: ast.Call) -> bool:
+        return any(
+            keyword.arg == "recompose"
+            and isinstance(keyword.value, ast.Constant)
+            and keyword.value.value is True
+            for keyword in call.keywords
+        )
 
-    uses_persisting_api = "register_footer_shortcuts" in source
+    recompose_sites: list[int] = []
+    uses_persisting_api = False
+    for top_level in tree.body:
+        if isinstance(top_level, ast.ClassDef):
+            base_names = {
+                base.id if isinstance(base, ast.Name) else getattr(base, "attr", "")
+                for base in top_level.bases
+            }
+            is_screen_class = "BaseAppScreen" in base_names
+            for inner in ast.walk(top_level):
+                if not isinstance(inner, ast.Call):
+                    continue
+                if (
+                    isinstance(inner.func, ast.Attribute)
+                    and inner.func.attr == "register_footer_shortcuts"
+                ):
+                    uses_persisting_api = True
+                if is_screen_class and _has_literal_true_recompose(inner):
+                    recompose_sites.append(inner.lineno)
+        else:
+            # Module-level statements/functions: only .refresh(recompose=True)
+            # counts here (a bare reactive() at module scope isn't a screen
+            # reactive), but the persisting-API call disarms from anywhere.
+            for inner in ast.walk(top_level):
+                if not isinstance(inner, ast.Call):
+                    continue
+                if (
+                    isinstance(inner.func, ast.Attribute)
+                    and inner.func.attr == "register_footer_shortcuts"
+                ):
+                    uses_persisting_api = True
+                if (
+                    isinstance(inner.func, ast.Attribute)
+                    and inner.func.attr == "refresh"
+                    and _has_literal_true_recompose(inner)
+                ):
+                    recompose_sites.append(inner.lineno)
+
     assert not (recompose_sites and not uses_persisting_api), (
         f"personas_screen.py gained recompose=True at line(s) {recompose_sites} "
         "while its footer hints still use the non-persisting "

--- a/Tests/UI/test_screen_footer_hints.py
+++ b/Tests/UI/test_screen_footer_hints.py
@@ -231,7 +231,11 @@ def _parse_css_blocks(css_text: str) -> dict[str, dict[str, str]]:
                 continue
             prop, value = declaration.split(":", 1)
             declarations[prop.strip()] = " ".join(value.split())
-        blocks[selector] = declarations
+        # CSS merges duplicate selector blocks in source order (later
+        # properties win per-property); mirror that instead of overwriting
+        # the whole block, so a legitimate split of one selector across two
+        # blocks cannot false-fail the drift guard (Qodo #687-2).
+        blocks.setdefault(selector, {}).update(declarations)
     return blocks
 
 
@@ -338,6 +342,7 @@ def test_personas_screen_has_no_recompose_path_while_footer_hints_are_non_persis
 
     recompose_sites: list[int] = []
     uses_persisting_api = False
+    screen_classes_found = 0
     for top_level in tree.body:
         if isinstance(top_level, ast.ClassDef):
             base_names = {
@@ -345,6 +350,7 @@ def test_personas_screen_has_no_recompose_path_while_footer_hints_are_non_persis
                 for base in top_level.bases
             }
             is_screen_class = "BaseAppScreen" in base_names
+            screen_classes_found += is_screen_class
             for inner in ast.walk(top_level):
                 if not isinstance(inner, ast.Call):
                     continue
@@ -373,6 +379,22 @@ def test_personas_screen_has_no_recompose_path_while_footer_hints_are_non_persis
                     and _has_literal_true_recompose(inner)
                 ):
                     recompose_sites.append(inner.lineno)
+
+    # Self-check: the walk identifies screen classes by the literal direct
+    # base name "BaseAppScreen". If personas ever inherits via an alias or an
+    # intermediate class, this guard goes blind -- fail loudly instead of
+    # silently scanning nothing (Qodo #687-3a). Runtime truth check keeps the
+    # assertion honest against renames.
+    from tldw_chatbook.UI.Screens.personas_screen import PersonasScreen
+
+    assert issubclass(PersonasScreen, BaseAppScreen)
+    assert screen_classes_found >= 1, (
+        "The recompose guard found no class with a direct 'BaseAppScreen' "
+        "base in personas_screen.py, but PersonasScreen IS a BaseAppScreen "
+        "subclass at runtime -- the inheritance is no longer literal/direct "
+        "and this guard's AST detection is blind. Update the guard's "
+        "screen-class detection to match the new inheritance shape."
+    )
 
     assert not (recompose_sites and not uses_persisting_api), (
         f"personas_screen.py gained recompose=True at line(s) {recompose_sites} "

--- a/backlog/tasks/task-289 - Pin-footer-CSS-recompose-drift-guards-with-tests.md
+++ b/backlog/tasks/task-289 - Pin-footer-CSS-recompose-drift-guards-with-tests.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-289
 title: Pin footer CSS/recompose drift guards with tests
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-17 15:17'
+updated_date: '2026-07-17 20:34'
 labels:
   - ux
   - testing
@@ -19,6 +21,18 @@ task-264's final review left two comment-only invariants unguarded: (1) AppFoote
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A test fails when AppFooterStatus.DEFAULT_CSS core rules diverge from the _widgets.tcss footer block
-- [ ] #2 A test fails if PersonasScreen gains a screen-level recompose path while still using the non-persisting footer registration
+- [x] #1 A test fails when AppFooterStatus.DEFAULT_CSS core rules diverge from the _widgets.tcss footer block
+- [x] #2 A test fails if PersonasScreen gains a screen-level recompose path while still using the non-persisting footer registration
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. AST-based guard: any call with recompose=True in personas_screen.py while it still uses the non-persisting set_shortcut_context path fails. 2. CSS-subset guard: parse AppFooterStatus.DEFAULT_CSS and the _widgets.tcss footer block; every DEFAULT_CSS declaration must appear in the matching bundle-source block (and in the built tldw_cli_modular.tcss, catching forgot-to-rebuild). 3. Mutation-check both tests actually fail when the invariant breaks; run the footer suites.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Two drift guards in Tests/UI/test_screen_footer_hints.py (the footer contract file; AST-guard style precedent per test_console_workbench_parity_matrix.py). CSS: parsed-declaration subset comparison of AppFooterStatus.DEFAULT_CSS against BOTH the _widgets.tcss footer section and the built tldw_cli_modular.tcss (catches forgot-to-rebuild); section markers use the full comment text (bare markers sit inside comments — splitting there leaves a dangling */ corrupting the first selector). Personas: AST guard — recompose=True inside BaseAppScreen subclasses OR module-level .refresh(recompose=True) helpers (library_screen precedent), disarmed only by an actual .register_footer_shortcuts() call (AST match, not substring — a comment cannot disarm it); child-widget classes excluded (their recompose never touches the screen footer). All rules mutation-verified in both directions. Review (sonnet): 'with fixes (optional)' — both Importants applied (substring hatch, module-level scope gap) + parser-limitation comment. Commits bab438cd/87e0f110 on claude/footer-drift-guards-289.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary

task-264 left two safety invariants as comments; this turns both into red tests (test-only change, +190 lines in `Tests/UI/test_screen_footer_hints.py`).

**Guard 1 — CSS drift.** `AppFooterStatus.DEFAULT_CSS` (the widget-baked layout rules that keep stylesheet-less harnesses matching production geometry) must stay a faithful *subset* of the live bundle source (`css/components/_widgets.tcss` footer section) **and** of the built `tldw_cli_modular.tcss` — the second check catches an edited source that was never rebuilt. Implemented as a parsed-declaration comparison (comments stripped, whitespace-normalized), not string matching; the section markers use the full comment text because the bare marker sits *inside* a comment and splitting there leaves a dangling `*/` that corrupts the first selector.

**Guard 2 — personas recompose.** `PersonasScreen` drives its footer through the non-persisting `set_shortcut_context` path (its hint set is dynamic), which is only safe while the screen never recomposes — a screen-level recompose replaces the footer widget and silently resets hints (the task-264 fix-wave bug). AST-based guard fails if the file gains `recompose=True` inside a `BaseAppScreen` subclass **or** a module-level `.refresh(recompose=True)` helper (the exact pattern living in `library_screen.py`), unless an actual `.register_footer_shortcuts()` call (the persisting API) is present — matched as an AST call, not a substring, so a comment mentioning the API cannot disarm it. Child-widget classes are excluded: their recompose never touches the screen's footer.

## Verification

- **Every rule mutation-verified in both directions:** `height: 1 → 2` in DEFAULT_CSS fails both CSS guards; a recompose reactive injected into `PersonasScreen` fails; a module-level `screen.refresh(recompose=True)` helper fails; that helper plus a `# TODO: migrate to register_footer_shortcuts` comment **still fails**; an actual `register_footer_shortcuts(...)` call passes. Clean tree: 9/9 (whole file) + `test_app_footer_shortcut_context.py` 3/3.
- Independent review (probing parser false-pass/false-fail modes, escape-hatch bypass, scope gaps): verdict "with fixes (optional)" — both Important findings applied (substring escape hatch → AST call-match; class-body-only scope → module-level refresh coverage) and the parser's selector-list limitation documented (it produces a *loud* false-fail, never a silent pass).

Closes task-289.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two test-only drift guards for the footer: keep `AppFooterStatus.DEFAULT_CSS` a subset of the live and built bundles, and block `PersonasScreen` recomposes while using non-persisting hints unless the persisting API is used. Hardened the CSS parser to merge duplicate selector blocks and added a self-check to prevent blind AST detection. Addresses task-289.

- **New Features**
  - CSS drift guard: parsed-declaration subset check against `_widgets.tcss` footer and built `tldw_cli_modular.tcss`; parser now merges duplicate selector blocks in source order.
  - Personas recompose guard: fails on any `recompose=True` in a `BaseAppScreen` subclass or module-level `screen.refresh(recompose=True)`; escape hatch requires an AST-detected `.register_footer_shortcuts(...)`; adds a runtime-backed self-check to ensure direct `BaseAppScreen` detection.

<sup>Written for commit 0ac37f833a3bf1ab96ac23811d3e11b2067c9c0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

