### PR TITLE
perf(sundries): bg-effect frame cache, token-count gate, idle-gated SELECT-1 ping, I/O-free picker ctor (task-261)

### DIFF
--- a/Tests/Chat/test_footer_token_dirty_gate.py
+++ b/Tests/Chat/test_footer_token_dirty_gate.py
@@ -1,0 +1,123 @@
+"""Footer token-count dirty gate (task-261).
+
+The footer's 10 s interval timer used to re-run the full tokenizer over the
+entire visible chat history every tick even when nothing had changed. These
+tests prove `_estimate_tokens_cached` skips re-tokenizing for unchanged
+inputs, recomputes for any changed input, and always returns exactly what the
+real `estimate_remaining_tokens` returns (behavior unchanged). The tokenizer
+spy delegates to the REAL implementation — no fakes.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_chatbook.Event_Handlers.Chat_Events import chat_token_events
+from tldw_chatbook.Utils.token_counter import estimate_remaining_tokens
+
+SETTINGS = dict(
+    model="gpt-3.5-turbo",
+    provider="openai",
+    max_tokens_response=2048,
+    system_prompt="Be concise.",
+)
+
+
+@pytest.fixture
+def tokenizer_spy(monkeypatch):
+    """Count calls into the real tokenizer without changing its behavior."""
+    calls: list = []
+    real = chat_token_events.estimate_remaining_tokens
+
+    def spy(*args, **kwargs):
+        calls.append((args, kwargs))
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(chat_token_events, "estimate_remaining_tokens", spy)
+    return calls
+
+
+def _history():
+    return [
+        {"role": "user", "content": "hello there"},
+        {"role": "assistant", "content": "hi, how can I help?"},
+    ]
+
+
+def test_unchanged_history_skips_retokenizing(tokenizer_spy):
+    app = SimpleNamespace()
+    history = _history()
+
+    first = chat_token_events._estimate_tokens_cached(app, history, **SETTINGS)
+    second = chat_token_events._estimate_tokens_cached(app, history, **SETTINGS)
+
+    assert len(tokenizer_spy) == 1, "unchanged inputs must not re-tokenize"
+    assert second == first
+
+
+def test_cached_result_matches_direct_tokenizer_output(tokenizer_spy):
+    app = SimpleNamespace()
+    history = _history()
+
+    cached = chat_token_events._estimate_tokens_cached(app, history, **SETTINGS)
+    direct = estimate_remaining_tokens(history, **SETTINGS)
+
+    assert cached == direct
+
+
+def test_history_growth_retokenizes(tokenizer_spy):
+    app = SimpleNamespace()
+    history = _history()
+
+    chat_token_events._estimate_tokens_cached(app, history, **SETTINGS)
+    history.append({"role": "user", "content": "one more question"})
+    grown = chat_token_events._estimate_tokens_cached(app, history, **SETTINGS)
+
+    assert len(tokenizer_spy) == 2, "a new message must re-tokenize"
+    assert grown == estimate_remaining_tokens(history, **SETTINGS)
+
+
+def test_last_message_edit_retokenizes(tokenizer_spy):
+    app = SimpleNamespace()
+    history = _history()
+
+    chat_token_events._estimate_tokens_cached(app, history, **SETTINGS)
+    history[-1] = {"role": "assistant", "content": "a completely different, much longer reply"}
+    edited = chat_token_events._estimate_tokens_cached(app, history, **SETTINGS)
+
+    assert len(tokenizer_spy) == 2, "an edited last message must re-tokenize"
+    assert edited == estimate_remaining_tokens(history, **SETTINGS)
+
+
+def test_settings_change_retokenizes(tokenizer_spy):
+    app = SimpleNamespace()
+    history = _history()
+
+    chat_token_events._estimate_tokens_cached(app, history, **SETTINGS)
+    changed = dict(SETTINGS, system_prompt="Answer in French.")
+    chat_token_events._estimate_tokens_cached(app, history, **changed)
+
+    assert len(tokenizer_spy) == 2, "a settings change must re-tokenize"
+
+
+def test_cache_is_per_app_instance(tokenizer_spy):
+    history = _history()
+
+    chat_token_events._estimate_tokens_cached(SimpleNamespace(), history, **SETTINGS)
+    chat_token_events._estimate_tokens_cached(SimpleNamespace(), history, **SETTINGS)
+
+    assert len(tokenizer_spy) == 2, "each app instance keeps its own cache"
+
+
+def test_attribute_rejecting_app_still_returns_counts(tokenizer_spy):
+    """A frozen/slotted app double must degrade to compute-every-time."""
+
+    class Frozen:
+        __slots__ = ()
+
+    app = Frozen()
+    history = _history()
+
+    result = chat_token_events._estimate_tokens_cached(app, history, **SETTINGS)
+
+    assert result == estimate_remaining_tokens(history, **SETTINGS)

--- a/Tests/Chat/test_footer_token_dirty_gate.py
+++ b/Tests/Chat/test_footer_token_dirty_gate.py
@@ -55,6 +55,36 @@ def test_unchanged_history_skips_retokenizing(tokenizer_spy):
     assert second == first
 
 
+def test_same_length_edit_retokenizes(tokenizer_spy):
+    """A same-length edit to an EARLIER message must invalidate the cache.
+
+    Length-based signatures miss this (message count, last-message length,
+    and total chars all survive a same-length swap); the per-message content
+    hashes catch it (PR #688 review finding).
+    """
+    app = SimpleNamespace()
+    history = _history()
+
+    chat_token_events._estimate_tokens_cached(app, history, **SETTINGS)
+    assert len(history[0]["content"]) == len("HELLO THERE")
+    history[0]["content"] = "HELLO THERE"  # same length, different content
+    chat_token_events._estimate_tokens_cached(app, history, **SETTINGS)
+
+    assert len(tokenizer_spy) == 2, "same-length content edit must re-tokenize"
+
+
+def test_role_flip_retokenizes(tokenizer_spy):
+    """Changing only a message's role must invalidate the cache."""
+    app = SimpleNamespace()
+    history = _history()
+
+    chat_token_events._estimate_tokens_cached(app, history, **SETTINGS)
+    history[0]["role"] = "system"
+    chat_token_events._estimate_tokens_cached(app, history, **SETTINGS)
+
+    assert len(tokenizer_spy) == 2, "role change must re-tokenize"
+
+
 def test_cached_result_matches_direct_tokenizer_output(tokenizer_spy):
     app = SimpleNamespace()
     history = _history()

--- a/Tests/DB/test_connection_liveness_ping_gate.py
+++ b/Tests/DB/test_connection_liveness_ping_gate.py
@@ -1,0 +1,114 @@
+"""Idle-gated `SELECT 1` liveness ping (task-261).
+
+`_get_thread_connection` in CharactersRAGDB / MediaDatabase / PromptsDatabase
+used to run a `SELECT 1` liveness ping on EVERY `get_connection()` call,
+roughly doubling raw statement counts on query-heavy paths. The ping is now
+gated behind `_LIVENESS_PING_IDLE_SECONDS`. These tests run against real
+on-disk SQLite databases (no mocks; the seam is the DB) and use sqlite3's
+trace callback to count the pings actually executed, proving:
+
+- a burst of recently-used calls issues zero pings;
+- a connection idle past the threshold is pinged exactly once, then the
+  window resets;
+- the transparent reopen of a dead connection (the ping's whole purpose)
+  still works.
+"""
+
+import time
+
+import pytest
+
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
+from tldw_chatbook.DB.Prompts_DB import PromptsDatabase
+
+DB_FACTORIES = [
+    pytest.param(
+        lambda tmp: CharactersRAGDB(tmp / "chachanotes.db", "ping-gate-test"),
+        id="chachanotes",
+    ),
+    pytest.param(
+        lambda tmp: MediaDatabase(tmp / "media.db", "ping-gate-test"),
+        id="media",
+    ),
+    pytest.param(
+        lambda tmp: PromptsDatabase(tmp / "prompts.db", "ping-gate-test"),
+        id="prompts",
+    ),
+]
+
+
+def _trace_pings(conn) -> list:
+    """Attach a trace callback recording every `SELECT 1` liveness ping."""
+    statements: list = []
+    conn.set_trace_callback(statements.append)
+    return statements
+
+
+def _ping_count(statements: list) -> int:
+    return sum(1 for statement in statements if statement.strip() == "SELECT 1")
+
+
+def _mark_idle(db) -> None:
+    """Backdate the connection's last-used stamp past the ping threshold."""
+    db._local.conn_last_used = time.monotonic() - (
+        type(db)._LIVENESS_PING_IDLE_SECONDS + 1.0
+    )
+
+
+@pytest.mark.parametrize("factory", DB_FACTORIES)
+def test_recently_used_connection_burst_skips_the_ping(tmp_path, factory):
+    db = factory(tmp_path)
+    try:
+        conn = db.get_connection()
+        statements = _trace_pings(conn)
+
+        for _ in range(10):
+            db.get_connection().execute(
+                "SELECT count(*) FROM sqlite_master"
+            ).fetchone()
+
+        assert _ping_count(statements) == 0, (
+            "a recently-used connection must not be pinged per call"
+        )
+    finally:
+        db.close_connection()
+
+
+@pytest.mark.parametrize("factory", DB_FACTORIES)
+def test_idle_connection_is_pinged_once_then_window_resets(tmp_path, factory):
+    db = factory(tmp_path)
+    try:
+        conn = db.get_connection()
+        statements = _trace_pings(conn)
+
+        _mark_idle(db)
+        assert db.get_connection() is conn
+        assert _ping_count(statements) == 1, (
+            "an idle connection must get exactly one liveness ping"
+        )
+
+        # The successful call refreshed the window: no further pings.
+        db.get_connection().execute("SELECT count(*) FROM sqlite_master").fetchone()
+        assert _ping_count(statements) == 1
+    finally:
+        db.close_connection()
+
+
+@pytest.mark.parametrize("factory", DB_FACTORIES)
+def test_dead_idle_connection_is_transparently_reopened(tmp_path, factory):
+    db = factory(tmp_path)
+    try:
+        dead = db.get_connection()
+        # Kill the connection behind the manager's back, then age it past the
+        # threshold so the gate re-verifies it.
+        dead.close()
+        _mark_idle(db)
+
+        fresh = db.get_connection()
+
+        assert fresh is not dead
+        row = fresh.execute("SELECT count(*) FROM sqlite_master").fetchone()
+        assert row[0] >= 0
+    finally:
+        db.close_connection()

--- a/Tests/UI/test_console_background_effects.py
+++ b/Tests/UI/test_console_background_effects.py
@@ -206,3 +206,85 @@ async def test_console_workbench_scope_does_not_start_transcript_effect():
             ConsoleBackgroundEffect,
         )
         assert effect.is_effect_active is False
+
+
+# --- task-261: per-frame grid cache -----------------------------------------
+#
+# `render_line` used to rebuild the full W×H grid via `frame_text()` once PER
+# LINE (O(W·H²) per repaint). These tests prove the cache engages (one grid
+# build per frame regardless of line count) and that the rendered output is
+# byte-identical to the uncached `frame_text()` result.
+
+
+@pytest.mark.asyncio
+async def test_render_line_builds_the_frame_grid_once_per_repaint():
+    app = EffectHarness(
+        ConsoleBackgroundEffectSettings(enabled=True, effect="snow", fps=6)
+    )
+
+    async with app.run_test(size=(60, 18)) as pilot:
+        effect = app.query_one("#console-background-effect", ConsoleBackgroundEffect)
+        await pilot.pause(0.1)
+        # Drive frames manually so the interval timer can't advance the frame
+        # serial between render_line calls.
+        effect._stop_timer()
+
+        width, height = effect.size.width, effect.size.height
+        assert width > 0 and height > 0
+
+        real_frame_text = effect.frame_text
+        calls: list[tuple[int, int]] = []
+
+        def counting_frame_text(w: int, h: int) -> str:
+            calls.append((w, h))
+            return real_frame_text(w, h)
+
+        effect.frame_text = counting_frame_text
+        effect._invalidate_frame_cache()
+
+        strips = [effect.render_line(y) for y in range(height)]
+
+        assert calls == [(width, height)], (
+            "a full repaint must compute the frame grid exactly once"
+        )
+
+        # Behavior parity: every rendered line matches the uncached grid.
+        expected_lines = real_frame_text(width, height).splitlines()
+        rendered_lines = [strip.text for strip in strips]
+        assert rendered_lines == expected_lines
+
+
+@pytest.mark.asyncio
+async def test_frame_cache_invalidates_on_tick_settings_and_resize():
+    app = EffectHarness(
+        ConsoleBackgroundEffectSettings(enabled=True, effect="rain", fps=6)
+    )
+
+    async with app.run_test(size=(60, 18)) as pilot:
+        effect = app.query_one("#console-background-effect", ConsoleBackgroundEffect)
+        await pilot.pause(0.1)
+        effect._stop_timer()
+
+        width, height = effect.size.width, effect.size.height
+        first = effect._frame_lines(width, height)
+        assert effect._frame_lines(width, height) is first, (
+            "same frame + same size must reuse the cached lines"
+        )
+
+        # A frame tick must produce a fresh grid.
+        effect._advance_frame()
+        after_tick = effect._frame_lines(width, height)
+        assert after_tick is not first
+
+        # A resize (different requested dimensions) must produce a fresh grid.
+        smaller = effect._frame_lines(width - 5, height - 3)
+        assert smaller is not after_tick
+        assert len(smaller) == height - 3
+        assert all(len(line) == width - 5 for line in smaller)
+
+        # A settings change must produce a fresh grid.
+        effect.update_settings(
+            ConsoleBackgroundEffectSettings(enabled=True, effect="matrix", fps=6)
+        )
+        after_settings = effect._frame_lines(width - 5, height - 3)
+        assert after_settings is not smaller

--- a/Tests/UI/test_file_picker_bookmarks_lazy.py
+++ b/Tests/UI/test_file_picker_bookmarks_lazy.py
@@ -1,0 +1,116 @@
+"""BookmarksManager constructor must be I/O-free (task-261).
+
+`BookmarksManager.__init__` used to run five synchronous ``Path.exists()``
+probes (a stall hazard when $HOME directories live on a cloud mount) plus, on
+first run, a full TOML config write — on EVERY picker construction. These
+tests prove construction now touches neither the config module nor the
+filesystem, and that the first actual use performs exactly the old eager
+behavior (defaults computed, first-run defaults written once, saved lists
+honored).
+"""
+
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.Widgets import enhanced_file_picker as efp
+from tldw_chatbook.Widgets.enhanced_file_picker import BookmarksManager
+
+REAL_HOME = Path.home()
+
+
+@pytest.fixture
+def config_recorder(monkeypatch):
+    """Record config reads/writes; serve first-run (nothing saved) by default."""
+    state = {"reads": [], "writes": [], "saved": None}
+
+    def fake_get(section, key, default=None):
+        state["reads"].append((section, key))
+        return state["saved"] if state["saved"] is not None else default
+
+    def fake_save(section, key, value):
+        state["writes"].append((section, key, value))
+
+    monkeypatch.setattr(efp, "get_cli_setting", fake_get)
+    monkeypatch.setattr(efp, "save_setting_to_cli_config", fake_save)
+    return state
+
+
+@pytest.fixture
+def home_call_counter(monkeypatch):
+    """Count Path.home() calls — the gateway to the default-bookmark stats."""
+    calls = []
+
+    def counting_home(cls):
+        calls.append(1)
+        return REAL_HOME
+
+    monkeypatch.setattr(Path, "home", classmethod(counting_home))
+    return calls
+
+
+def test_constructor_performs_no_config_or_filesystem_io(
+    config_recorder, home_call_counter
+):
+    BookmarksManager(context="lazy_test")
+
+    assert config_recorder["reads"] == [], "constructor must not read config"
+    assert config_recorder["writes"] == [], "constructor must not write config"
+    assert home_call_counter == [], (
+        "constructor must not compute defaults (Path.home()/Path.exists())"
+    )
+
+
+def test_first_use_loads_defaults_and_writes_them_once(
+    config_recorder, home_call_counter
+):
+    manager = BookmarksManager(context="lazy_test")
+
+    bookmarks = manager.get_bookmarks()
+
+    # Old eager behavior, now at first use: defaults computed and persisted.
+    assert config_recorder["reads"] == [("filepicker", "bookmarks_lazy_test")]
+    assert len(config_recorder["writes"]) == 1
+    assert len(home_call_counter) >= 1
+    assert any(entry["name"] == "Home" for entry in bookmarks)
+    assert any(entry["path"] == str(REAL_HOME) for entry in bookmarks)
+
+    # Second use: already loaded — no further reads or writes.
+    manager.get_bookmarks()
+    assert config_recorder["reads"] == [("filepicker", "bookmarks_lazy_test")]
+    assert len(config_recorder["writes"]) == 1
+
+
+def test_saved_bookmarks_are_honored_without_a_defaults_write(config_recorder):
+    saved = [{"name": "Projects", "path": "/tmp/projects", "icon": "📁"}]
+    config_recorder["saved"] = saved
+    manager = BookmarksManager(context="lazy_test")
+
+    assert manager.get_bookmarks() == saved
+    assert config_recorder["writes"] == [], (
+        "a saved list must not trigger the first-run defaults write"
+    )
+
+
+def test_add_and_is_bookmarked_trigger_lazy_load(config_recorder, tmp_path):
+    manager = BookmarksManager(context="lazy_test")
+
+    assert manager.add(tmp_path, name="Scratch") is True
+    assert manager.is_bookmarked(tmp_path) is True
+    assert manager.add(tmp_path) is False, "duplicate add must be rejected"
+
+    # One load (which wrote first-run defaults) + one write for the add.
+    assert config_recorder["reads"] == [("filepicker", "bookmarks_lazy_test")]
+    assert len(config_recorder["writes"]) == 2
+    saved_paths = [b["path"] for b in config_recorder["writes"][-1][2]]
+    assert str(tmp_path.resolve()) in saved_paths
+
+
+def test_save_on_unloaded_manager_is_a_noop(config_recorder):
+    manager = BookmarksManager(context="lazy_test")
+
+    manager.save_to_config()
+
+    assert config_recorder["writes"] == [], (
+        "saving an unloaded manager must not persist anything"
+    )

--- a/backlog/tasks/task-261 - Performance-sundries-batch.md
+++ b/backlog/tasks/task-261 - Performance-sundries-batch.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-261
 title: Performance sundries: bg-effect frame cache, token-count gate, SELECT-1 ping, picker ctor I/O, MCP rebuild diffing, browser indexes
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-16 14:30'
 labels: [performance, ui]
@@ -17,6 +17,55 @@ Bounded small fixes from the audit: console_background_effect render_line recomp
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Each listed item fixed or explicitly declined with reasoning in the task notes
-- [ ] #2 No behavior changes (existing suites green)
+- [x] #1 Each listed item fixed or explicitly declined with reasoning in the task notes
+- [x] #2 No behavior changes (existing suites green)
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. **console_background_effect** — cache the computed frame lines on the widget instance, keyed by
+   (frame serial, width, height); `_advance_frame` and `update_settings` bump the serial, resize
+   changes the key. `render_line` reuses the cached lines instead of recomputing the W×H grid per line.
+2. **Footer token-count** — extract a `_estimate_tokens_cached` helper in
+   `Event_Handlers/Chat_Events/chat_token_events.py` with a cheap input signature
+   (provider/model/limits/system prompt + message count/last-length/total chars) cached on the app
+   instance; unchanged history reuses the previous counts, the footer is still updated every tick.
+3. **SELECT 1 ping** — idle-threshold gate in `_get_thread_connection` for CharactersRAGDB,
+   MediaDatabase, and PromptsDatabase (the three copies of the pattern): ping only when the
+   thread-local connection has been idle ≥30 s; dead-connection transparent reopen preserved.
+4. **BookmarksManager** — constructor becomes I/O-free; defaults (5× `Path.exists()`) computed
+   lazily and cached, config load + first-run TOML write deferred to first actual use.
+5. **MCP rebuild diffing** — read the code, decline if no clean targeted improvement (expected;
+   reasoning pointing at task-236).
+6. **Browser indexes** — grep for non-migration DDL precedent in ChaChaNotes; decline in favour of
+   the next coordinated migration if none (migration numbers contested across sessions).
+7. Regression tests per fixed item (spies over real implementations, unmocked sqlite/config seams);
+   run module-local suites; commit + push.
+
+## Implementation Notes
+
+Four items fixed, two declined with reasoning. No behavior changes: every fixed item's test suite
+asserts both that the optimization engages AND that output/behavior is byte-identical to the
+pre-change path.
+
+| # | Item | Outcome | Detail |
+|---|------|---------|--------|
+| 1 | console_background_effect O(W·H²) repaint | **FIXED** | `render_line` now reads `_frame_lines()`, a per-widget-instance cache keyed by (frame serial, width, height). The serial bumps on `_advance_frame` (tick) and `update_settings`; a resize changes the key. One `frame_text()` grid build per repaint instead of one per line; rendered strips proven byte-identical to the uncached grid. |
+| 2 | Footer token-count re-tokenizing every 10 s tick | **FIXED** | New `_estimate_tokens_cached()` in `chat_token_events.py`: signature over provider/model/max-tokens/system-prompt + message count/last-message length/total chars, cached on the app instance. Unchanged history reuses the previous `(used, limit, remaining)`; the footer widget is STILL updated every tick (per-screen footers, task-264), so display behavior is unchanged. The typing (`_with_pending`) path is untouched — it changes every keystroke by construction. |
+| 3 | `SELECT 1` liveness ping per `get_connection` | **FIXED** | The pattern lives in three copies — `CharactersRAGDB` (the audit's measured one), `MediaDatabase`, `PromptsDatabase` — not `base_db.py`. Chose the idle-threshold reduction (`_LIVENESS_PING_IDLE_SECONDS = 30 s`, `time.monotonic` stamp on `_local`): least behavior-changing because connections are thread-local/long-lived and `close_connection()` always clears the thread-local ref, so a recently-used connection is known-good; a long-idle one still gets ping + transparent reopen (covered by a real-sqlite recovery test using `set_trace_callback` to count actual pings). |
+| 4 | `BookmarksManager.__init__` sync I/O | **FIXED** | Constructor is now I/O-free (verified by test: zero config reads/writes, zero `Path.home()` calls). Defaults (the 5× `Path.exists()` cloud-stall hazard) compute lazily via a cached property; config load and the first-run defaults TOML write happen on first actual use (`get_bookmarks`/`add`/`remove`/`is_bookmarked`), preserving the old first-use-visible behavior exactly. `save_to_config()` on a never-loaded manager is a no-op. |
+| 5 | MCP rebuild diffing (rail/servers-table/hidden Tools canvas ×2 per lifecycle action) | **DECLINED** | Read the code first, per instructions. (a) The ×2 is two *different intentional states*, not a duplicate: `_start_lifecycle` fires an optimistic-CHECKING resync and a completion resync (documented in `_sync_children`'s T7 lock notes), so an equality-skip gate would never fire. (b) The rail's full recompose is load-bearing for the mount-echo guard machinery (`_displayed_scope_*` per-generation slots, per-instance `_mcp_mount_echo_value` tags — each guard's comments document real races that diffing would reopen). (c) `update_overview`'s from-scratch table rebuild is an explicitly documented decision ("simpler than tracking the previously rendered column set... not a hot path"), and the always-refresh of hidden canvases is a stated invariant ("switching INTO Audit mode never shows a stale window", `_sync_audit_mode` docstring). (d) The measured cost driver — N+2 store loads per pass — is already tracked as **task-236**; T10 already dedupes `_collect_hub_tools`/`_resolve_effective_states` to once per pass. A targeted diff here is exactly the risky churn on locked, extensively-adjudicated MCP UI the task warns against, for small residual gain. |
+| 6 | Indexes on `conversations.deleted`/`last_modified` | **DECLINED** | Grepped for `CREATE INDEX` outside the migration path first, as required: within ChaChaNotes every index lives inside `_FULL_SCHEMA_SQL_V4` or a versioned `_MIGRATE_*` script, and `_initialize_schema()` returns without executing ANY DDL when the stored version equals `_CURRENT_SCHEMA_VERSION` — there is no existing non-migration DDL hook to ride. (Other DB modules that executescript idempotent schemas per-init are a different design, not precedent for out-of-band DDL layered onto a versioned schema.) Adding a new unconditional DDL step to the repo's most migration-contested schema (v21 now; parallel sessions have collided on version numbers twice) is not worth it for a P3 at-scale concern. Recommendation: the next coordinated ChaChaNotes migration (v21→v22, whoever claims it) should include `CREATE INDEX IF NOT EXISTS idx_conversations_deleted_last_modified ON conversations(deleted, last_modified)` to cover the browser's `WHERE deleted = 0 ... ORDER BY last_modified DESC` list queries in `ChaChaNotes_DB.py`. |
+
+**Files modified**: `tldw_chatbook/Widgets/Console/console_background_effect.py`,
+`tldw_chatbook/Event_Handlers/Chat_Events/chat_token_events.py`,
+`tldw_chatbook/DB/ChaChaNotes_DB.py`, `tldw_chatbook/DB/Client_Media_DB_v2.py`,
+`tldw_chatbook/DB/Prompts_DB.py`, `tldw_chatbook/Widgets/enhanced_file_picker.py`.
+**Tests added**: 2 in `Tests/UI/test_console_background_effects.py` (now 11 total),
+`Tests/Chat/test_footer_token_dirty_gate.py` (7), `Tests/DB/test_connection_liveness_ping_gate.py`
+(9, parametrized over all three DB classes, real on-disk sqlite + trace-callback ping counting),
+`Tests/UI/test_file_picker_bookmarks_lazy.py` (5).
+**Suites run green**: Tests/DB + Tests/Prompts_DB (162), Tests/Media_DB (59+6s), Tests/Chat
+(959+69s), Tests/Event_Handlers + config-console-defaults (112+26s), picker consumers (7).
+Tests/ChaChaNotesDB: 156 passed + exactly the 3 known pre-existing legacy-parity failures listed in
+the audit brief — no new failures.

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -148,6 +148,11 @@ class CharactersRAGDB:
     _ALLOWED_PERSONA_MEMORY_MODES = ("read_only", "read_write")
     _ALLOWED_CONVERSATION_CHARACTER_SCOPES = ("all", "character", "generic")
     _ALLOWED_SCOPE_TYPES = ("global", "workspace")
+    # task-261: how long a thread-local connection may sit unused before the
+    # next `get_connection()` re-verifies it with a `SELECT 1` liveness ping.
+    # Within this window the ping is skipped (it used to run on every call,
+    # ~doubling raw statement counts on query-heavy paths).
+    _LIVENESS_PING_IDLE_SECONDS = 30.0
 
     _FULL_SCHEMA_SQL_V4 = """
 /*───────────────────────────────────────────────────────────────
@@ -2474,6 +2479,15 @@ UPDATE db_schema_version
         Enables WAL mode for file-based databases and sets PRAGMA foreign_keys=ON.
         Sets a timeout for database operations.
 
+        task-261: the ``SELECT 1`` liveness ping used to run on EVERY call,
+        roughly doubling the raw statement count for query-heavy paths. It is
+        now gated behind an idle threshold (``_LIVENESS_PING_IDLE_SECONDS``):
+        connections here are thread-local and long-lived, and
+        ``close_connection()`` always clears the thread-local reference, so a
+        recently-used connection is known-good without a ping. A connection
+        idle past the threshold still gets the full ping + transparent-reopen
+        treatment.
+
         Returns:
             A thread-local sqlite3.Connection object.
 
@@ -2482,17 +2496,19 @@ UPDATE db_schema_version
         """
         conn = getattr(self._local, 'conn', None)
         if conn:
-            try:
-                conn.execute("SELECT 1")  # Check if connection is still alive
-            except (sqlite3.ProgrammingError, sqlite3.OperationalError):
-                logger.warning(
-                    f"Thread-local connection for {self.db_path_str} was closed or became unusable. Reopening.")
+            last_used = getattr(self._local, 'conn_last_used', None)
+            if last_used is None or (time.monotonic() - last_used) >= self._LIVENESS_PING_IDLE_SECONDS:
                 try:
-                    conn.close()
-                except sqlite3.Error:
-                    # Ignore connection close errors - connection may already be closed
-                    pass
-                conn = None
+                    conn.execute("SELECT 1")  # Check if connection is still alive
+                except (sqlite3.ProgrammingError, sqlite3.OperationalError):
+                    logger.warning(
+                        f"Thread-local connection for {self.db_path_str} was closed or became unusable. Reopening.")
+                    try:
+                        conn.close()
+                    except sqlite3.Error:
+                        # Ignore connection close errors - connection may already be closed
+                        pass
+                    conn = None
 
         if not conn:
             try:
@@ -2514,6 +2530,7 @@ UPDATE db_schema_version
                 logger.opt(exception=True).error(f"Failed to connect to database {self.db_path_str}: {e}")
                 self._local.conn = None
                 raise CharactersRAGDBError(f"Failed to connect to database '{self.db_path_str}': {e}") from e
+        self._local.conn_last_used = time.monotonic()
         return self._local.conn
 
     def get_connection(self) -> sqlite3.Connection:

--- a/tldw_chatbook/DB/Client_Media_DB_v2.py
+++ b/tldw_chatbook/DB/Client_Media_DB_v2.py
@@ -150,7 +150,11 @@ class MediaDatabase:
     Requires client_id on initialization. Includes schema versioning.
     """
     _CURRENT_SCHEMA_VERSION = 4  # Define the version this code supports
-    
+    # task-261: idle window within which the per-call `SELECT 1` liveness
+    # ping is skipped for a recently-used thread-local connection (see
+    # `_get_thread_connection`).
+    _LIVENESS_PING_IDLE_SECONDS = 30.0
+
     # Migration registry - maps from_version to migration details
     _MIGRATIONS = {
         0: {
@@ -589,22 +593,39 @@ class MediaDatabase:
                 # Logging here provides context that the __init__ block finished, albeit with failure.
                 logging.error(f"Database initialization block finished for {self.db_path_str}, but failed.")
 
-    # --- Connection Management (Unchanged) ---
+    # --- Connection Management ---
     def _get_thread_connection(self) -> sqlite3.Connection:
+        """Retrieve or create the current thread's SQLite connection.
+
+        task-261: the ``SELECT 1`` liveness ping is gated behind an idle
+        threshold (``_LIVENESS_PING_IDLE_SECONDS``) instead of running on
+        every call — connections are thread-local and long-lived, and
+        ``close_connection()`` always clears the thread-local reference, so
+        a recently-used connection is known-good without a ping. A
+        connection idle past the threshold still gets the ping +
+        transparent-reopen treatment.
+
+        Returns:
+            sqlite3.Connection: The thread-local database connection.
+
+        Raises:
+            DatabaseError: If connecting to the database fails.
+        """
         conn = getattr(self._local, 'conn', None)
-        is_closed = True
+        is_closed = conn is None
         if conn:
-            try:
-                conn.execute("SELECT 1")  # Simple check
-                is_closed = False
-            except (sqlite3.ProgrammingError, sqlite3.OperationalError):
-                logging.warning(f"Thread-local connection to {self.db_path_str} was closed. Reopening.")
-                is_closed = True
+            last_used = getattr(self._local, 'conn_last_used', None)
+            if last_used is None or (time.monotonic() - last_used) >= self._LIVENESS_PING_IDLE_SECONDS:
                 try:
-                    conn.close()
-                except Exception:
-                    pass
-                self._local.conn = None
+                    conn.execute("SELECT 1")  # Simple check
+                except (sqlite3.ProgrammingError, sqlite3.OperationalError):
+                    logging.warning(f"Thread-local connection to {self.db_path_str} was closed. Reopening.")
+                    is_closed = True
+                    try:
+                        conn.close()
+                    except Exception:
+                        pass
+                    self._local.conn = None
 
         if is_closed:
             try:
@@ -624,6 +645,7 @@ class MediaDatabase:
                 logging.error(f"Failed to connect to database at {self.db_path_str}: {e}", exc_info=True)
                 self._local.conn = None
                 raise DatabaseError(f"Failed to connect to database '{self.db_path_str}': {e}") from e
+        self._local.conn_last_used = time.monotonic()
         return self._local.conn
 
     def get_connection(self) -> sqlite3.Connection:

--- a/tldw_chatbook/DB/Prompts_DB.py
+++ b/tldw_chatbook/DB/Prompts_DB.py
@@ -90,6 +90,10 @@ class ConflictError(DatabaseError):
 # --- Database Class ---
 class PromptsDatabase:
     _CURRENT_SCHEMA_VERSION = 2
+    # task-261: idle window within which the per-call `SELECT 1` liveness
+    # ping is skipped for a recently-used thread-local connection (see
+    # `_get_thread_connection`).
+    _LIVENESS_PING_IDLE_SECONDS = 30.0
 
     _TABLES_SQL_V1 = """
     PRAGMA foreign_keys = ON;
@@ -301,20 +305,37 @@ class PromptsDatabase:
 
     # --- Connection Management ---
     def _get_thread_connection(self) -> sqlite3.Connection:
+        """Retrieve or create the current thread's SQLite connection.
+
+        task-261: the ``SELECT 1`` liveness ping is gated behind an idle
+        threshold (``_LIVENESS_PING_IDLE_SECONDS``) instead of running on
+        every call — connections are thread-local and long-lived, and
+        ``close_connection()`` always clears the thread-local reference, so
+        a recently-used connection is known-good without a ping. A
+        connection idle past the threshold still gets the ping +
+        transparent-reopen treatment.
+
+        Returns:
+            sqlite3.Connection: The thread-local database connection.
+
+        Raises:
+            DatabaseError: If connecting to the database fails.
+        """
         conn = getattr(self._local, 'conn', None)
-        is_closed = True
+        is_closed = conn is None
         if conn:
-            try:
-                conn.execute("SELECT 1")
-                is_closed = False
-            except (sqlite3.ProgrammingError, sqlite3.OperationalError):
-                logging.warning(f"Thread-local connection to {self.db_path_str} was closed. Reopening.")
-                is_closed = True
+            last_used = getattr(self._local, 'conn_last_used', None)
+            if last_used is None or (time.monotonic() - last_used) >= self._LIVENESS_PING_IDLE_SECONDS:
                 try:
-                    conn.close()
-                except Exception:
-                    pass
-                self._local.conn = None
+                    conn.execute("SELECT 1")
+                except (sqlite3.ProgrammingError, sqlite3.OperationalError):
+                    logging.warning(f"Thread-local connection to {self.db_path_str} was closed. Reopening.")
+                    is_closed = True
+                    try:
+                        conn.close()
+                    except Exception:
+                        pass
+                    self._local.conn = None
 
         if is_closed:
             try:
@@ -335,6 +356,7 @@ class PromptsDatabase:
                 logging.opt(exception=True).error(f"Failed to connect to database at {self.db_path_str}: {e}")
                 self._local.conn = None
                 raise DatabaseError(f"Failed to connect to database '{self.db_path_str}': {e}") from e
+        self._local.conn_last_used = time.monotonic()
         return self._local.conn
 
     def get_connection(self) -> sqlite3.Connection:

--- a/tldw_chatbook/Event_Handlers/Chat_Events/chat_token_events.py
+++ b/tldw_chatbook/Event_Handlers/Chat_Events/chat_token_events.py
@@ -23,6 +23,68 @@ if TYPE_CHECKING:
 #
 # Functions:
 
+def _estimate_tokens_cached(
+    app: 'TldwCli',
+    chat_history: list,
+    *,
+    model: str,
+    provider: str,
+    max_tokens_response: int,
+    system_prompt: str,
+):
+    """Estimate token usage, reusing the last result when the inputs are unchanged.
+
+    task-261 dirty gate: the footer's 10 s interval timer re-ran the full
+    tokenizer over the entire visible history every tick even when nothing
+    had changed. A cheap signature over every input that influences the
+    estimate — settings plus message count, last-message length, and total
+    character count — is compared against the previous tick's; on a match
+    the cached counts are returned without re-tokenizing. The cache lives on
+    the app instance (one live history per app), and the caller still
+    refreshes the footer widget every tick, so display behavior is
+    unchanged.
+
+    Args:
+        app: The running app instance the cache is stored on.
+        chat_history: Completed messages as ``{"role", "content"}`` dicts.
+        model: Model name the tokenizer estimate is computed for.
+        provider: Provider name the tokenizer estimate is computed for.
+        max_tokens_response: Reserved response-token budget.
+        system_prompt: System prompt text included in the estimate.
+
+    Returns:
+        The ``(used_tokens, total_limit, remaining)`` tuple from
+        ``estimate_remaining_tokens``.
+    """
+    last_content = chat_history[-1].get("content", "") if chat_history else ""
+    signature = (
+        model,
+        provider,
+        max_tokens_response,
+        system_prompt,
+        len(chat_history),
+        len(last_content),
+        sum(len(message.get("content", "")) for message in chat_history),
+    )
+    cached = getattr(app, "_footer_token_estimate_cache", None)
+    if cached is not None and cached[0] == signature:
+        return cached[1]
+    result = estimate_remaining_tokens(
+        chat_history,
+        model=model,
+        provider=provider,
+        max_tokens_response=max_tokens_response,
+        system_prompt=system_prompt,
+    )
+    try:
+        app._footer_token_estimate_cache = (signature, result)
+    except Exception:
+        # A slot-restricted or frozen test double can refuse the attribute;
+        # caching is best-effort and never worth failing the update over.
+        logger.debug("Footer token-estimate cache not stored on app instance.")
+    return result
+
+
 async def update_chat_token_counter(app: 'TldwCli') -> None:
     """
     Update the token counter display in the chat window.
@@ -65,16 +127,18 @@ async def update_chat_token_counter(app: 'TldwCli') -> None:
                         chat_history.append({"role": role_for_api, "content": content})
         except QueryError as e:
             logger.debug(f"Could not get chat messages for token counting: {e}")
-        
-        # Calculate tokens
-        used_tokens, total_limit, remaining = estimate_remaining_tokens(
+
+        # Calculate tokens (task-261: skips re-tokenizing when history and
+        # settings are unchanged since the last periodic tick).
+        used_tokens, total_limit, remaining = _estimate_tokens_cached(
+            app,
             chat_history,
             model=model,
             provider=provider,
             max_tokens_response=max_tokens_response,
             system_prompt=system_prompt
         )
-        
+
         # Use max_tokens_response as the display limit instead of model's total limit
         # This allows users to see how their conversation measures against their configured limit
         display_limit = max_tokens_response

--- a/tldw_chatbook/Event_Handlers/Chat_Events/chat_token_events.py
+++ b/tldw_chatbook/Event_Handlers/Chat_Events/chat_token_events.py
@@ -37,8 +37,8 @@ def _estimate_tokens_cached(
     task-261 dirty gate: the footer's 10 s interval timer re-ran the full
     tokenizer over the entire visible history every tick even when nothing
     had changed. A cheap signature over every input that influences the
-    estimate — settings plus message count, last-message length, and total
-    character count — is compared against the previous tick's; on a match
+    estimate — settings plus message count and a per-message (role, content)
+    hash tuple — is compared against the previous tick's; on a match
     the cached counts are returned without re-tokenizing. The cache lives on
     the app instance (one live history per app), and the caller still
     refreshes the footer widget every tick, so display behavior is
@@ -56,15 +56,20 @@ def _estimate_tokens_cached(
         The ``(used_tokens, total_limit, remaining)`` tuple from
         ``estimate_remaining_tokens``.
     """
-    last_content = chat_history[-1].get("content", "") if chat_history else ""
     signature = (
         model,
         provider,
         max_tokens_response,
         system_prompt,
         len(chat_history),
-        len(last_content),
-        sum(len(message.get("content", "")) for message in chat_history),
+        # Per-message content hashes, not lengths: a same-length edit to an
+        # earlier message (or a role flip) must invalidate the cache too
+        # (PR #688 review). CPython caches str.__hash__ on the string object,
+        # so for an unchanged history this stays O(1) amortized per message.
+        tuple(
+            (hash(message.get("role", "")), hash(message.get("content", "")))
+            for message in chat_history
+        ),
     )
     cached = getattr(app, "_footer_token_estimate_cache", None)
     if cached is not None and cached[0] == signature:

--- a/tldw_chatbook/Widgets/Console/console_background_effect.py
+++ b/tldw_chatbook/Widgets/Console/console_background_effect.py
@@ -60,6 +60,15 @@ class ConsoleBackgroundEffect(Widget):
         self._random = random.Random(seed)
         self._particles: list[_Particle] = []
         self._timer: Timer | None = None
+        # task-261: `render_line` used to call `frame_text()` (a full W×H
+        # grid build) once PER LINE, making each repaint O(W·H²). The frame
+        # is instead computed once per (frame serial, width, height) and the
+        # split lines reused for every `render_line` call of that repaint.
+        # The serial bumps on every particle step (`_advance_frame`) and on
+        # `update_settings`; width/height live in the key, so a resize
+        # invalidates naturally. The cache lives on the widget instance.
+        self._frame_serial: int = 0
+        self._frame_cache: tuple[int, int, int, list[str]] | None = None
 
     @property
     def is_effect_active(self) -> bool:
@@ -83,9 +92,14 @@ class ConsoleBackgroundEffect(Widget):
         self._stop_timer()
 
     def update_settings(self, settings: ConsoleBackgroundEffectSettings) -> None:
-        """Apply new settings, reset particles, and refresh the renderer."""
+        """Apply new settings, reset particles, and refresh the renderer.
+
+        Args:
+            settings: The new background-effect settings to render with.
+        """
         self.settings = settings
         self._particles.clear()
+        self._invalidate_frame_cache()
         self._sync_timer()
         self.refresh(layout=False)
 
@@ -105,15 +119,51 @@ class ConsoleBackgroundEffect(Widget):
         return "\n".join("".join(row) for row in grid)
 
     def render_line(self, y: int) -> Strip:
-        """Render a single background frame line."""
+        """Render a single background frame line.
+
+        Args:
+            y: Zero-based line index within the widget to render.
+
+        Returns:
+            The rendered strip for line ``y`` of the current frame.
+        """
         width = self.size.width
         height = self.size.height
         if width <= 0 or height <= 0:
             return Strip.blank(max(0, width))
-        lines = self.frame_text(width, height).splitlines()
+        lines = self._frame_lines(width, height)
         text = lines[y] if 0 <= y < len(lines) else " " * width
         style = _EFFECT_STYLES.get(self.settings.effect, Style(dim=True))
         return Strip([Segment(text, style)], width)
+
+    def _frame_lines(self, width: int, height: int) -> list[str]:
+        """Return the current frame's lines, computing them at most once per frame.
+
+        The full-grid ``frame_text()`` build runs only when the cached frame's
+        (serial, width, height) key no longer matches — i.e. after a particle
+        step, a settings change, or a resize — so a repaint's H ``render_line``
+        calls share one grid computation instead of building H grids.
+
+        Args:
+            width: Frame width in cells.
+            height: Frame height in cells.
+
+        Returns:
+            The frame's rows, one string of length ``width`` per row.
+        """
+        cached = self._frame_cache
+        if cached is not None:
+            serial, cached_width, cached_height, lines = cached
+            if serial == self._frame_serial and cached_width == width and cached_height == height:
+                return lines
+        lines = self.frame_text(width, height).splitlines()
+        self._frame_cache = (self._frame_serial, width, height, lines)
+        return lines
+
+    def _invalidate_frame_cache(self) -> None:
+        """Drop the cached frame so the next render recomputes the grid."""
+        self._frame_serial += 1
+        self._frame_cache = None
 
     def _sync_timer(self) -> None:
         self._stop_timer()
@@ -134,6 +184,7 @@ class ConsoleBackgroundEffect(Widget):
             self.refresh(layout=False)
             return
         self._step_particles(width, height)
+        self._invalidate_frame_cache()
         self.refresh(layout=False)
 
     def _target_particle_count(self, width: int, height: int) -> int:

--- a/tldw_chatbook/Widgets/enhanced_file_picker.py
+++ b/tldw_chatbook/Widgets/enhanced_file_picker.py
@@ -80,14 +80,35 @@ class RecentLocations:
 
 
 class BookmarksManager:
-    """Manages bookmarked directories for quick access"""
-    
+    """Manages bookmarked directories for quick access.
+
+    task-261: the constructor is I/O-free. It used to run five synchronous
+    ``Path.exists()`` probes (a stall hazard when $HOME dirs live on a cloud
+    mount) plus, on first run, a full TOML config write — on EVERY picker
+    construction. Default computation and the config load (including the
+    first-run defaults write) are now deferred to the first call that
+    actually needs bookmark data.
+    """
+
     def __init__(self, context: str = "default"):
+        """Initialize the manager without touching the filesystem or config.
+
+        Args:
+            context: Names the ``[filepicker] bookmarks_<context>`` config key
+                so different picker surfaces keep separate bookmark lists.
+        """
         self.context = context
-        self._bookmarks: List[Dict[str, Any]] = []
-        self._default_bookmarks = self._get_default_bookmarks()
-        self.load_from_config()
-    
+        # None = not loaded yet; load_from_config() always leaves a list.
+        self._bookmarks: Optional[List[Dict[str, Any]]] = None
+        self._default_bookmarks_cache: Optional[List[Dict[str, Any]]] = None
+
+    @property
+    def _default_bookmarks(self) -> List[Dict[str, Any]]:
+        """Platform default bookmarks, computed (with I/O) at most once."""
+        if self._default_bookmarks_cache is None:
+            self._default_bookmarks_cache = self._get_default_bookmarks()
+        return self._default_bookmarks_cache
+
     def _get_default_bookmarks(self) -> List[Dict[str, Any]]:
         """Get platform-specific default bookmarks"""
         home = Path.home()
@@ -97,15 +118,20 @@ class BookmarksManager:
             {"name": "Documents", "path": str(home / "Documents"), "icon": "📄"},
             {"name": "Downloads", "path": str(home / "Downloads"), "icon": "⬇️"},
         ]
-        
+
         # Add platform-specific paths
         if os.name == 'posix':  # Unix/Linux/Mac
             if (home / "Pictures").exists():
                 bookmarks.append({"name": "Pictures", "path": str(home / "Pictures"), "icon": "🖼️"})
-        
+
         # Filter out non-existent directories
         return [b for b in bookmarks if Path(b["path"]).exists()]
-    
+
+    def _ensure_loaded(self) -> None:
+        """Load bookmarks from config on first actual use (task-261)."""
+        if self._bookmarks is None:
+            self.load_from_config()
+
     def load_from_config(self):
         """Load bookmarks from config"""
         try:
@@ -121,48 +147,80 @@ class BookmarksManager:
         except Exception as e:
             logger.error(f"Failed to load bookmarks: {e}")
             self._bookmarks = self._default_bookmarks.copy()
-    
+
     def save_to_config(self):
         """Save bookmarks to config"""
+        if self._bookmarks is None:
+            # Never loaded, so there is nothing to persist -- and saving here
+            # would break the constructor's I/O-free guarantee (task-261).
+            return
         try:
             save_setting_to_cli_config("filepicker", f"bookmarks_{self.context}", self._bookmarks)
         except Exception as e:
             logger.error(f"Failed to save bookmarks: {e}")
-    
+
     def add(self, path: Path, name: Optional[str] = None, icon: str = "📁"):
-        """Add a bookmark"""
+        """Add a bookmark.
+
+        Args:
+            path: Directory to bookmark.
+            name: Display name; defaults to the path's basename.
+            icon: Emoji shown next to the bookmark.
+
+        Returns:
+            True if the bookmark was added, False if it already existed.
+        """
+        self._ensure_loaded()
         path_str = str(path.resolve())
-        
+
         # Check if already bookmarked
         if any(b.get("path") == path_str for b in self._bookmarks):
             return False
-        
+
         bookmark = {
             "name": name or path.name,
             "path": path_str,
             "icon": icon,
             "custom": True  # Mark as user-added
         }
-        
+
         self._bookmarks.append(bookmark)
         self.save_to_config()
         return True
-    
+
     def remove(self, path: Path):
-        """Remove a bookmark"""
+        """Remove a bookmark.
+
+        Args:
+            path: Bookmarked directory to remove.
+        """
+        self._ensure_loaded()
         path_str = str(path.resolve())
         self._bookmarks = [b for b in self._bookmarks if b.get("path") != path_str]
         self.save_to_config()
-    
+
     def is_bookmarked(self, path: Path) -> bool:
-        """Check if a path is bookmarked"""
+        """Check if a path is bookmarked.
+
+        Args:
+            path: Directory to look up.
+
+        Returns:
+            True if the path is currently bookmarked.
+        """
+        self._ensure_loaded()
         path_str = str(path.resolve())
         return any(b.get("path") == path_str for b in self._bookmarks)
-    
+
     def get_bookmarks(self) -> List[Dict[str, Any]]:
-        """Get all bookmarks"""
+        """Get all bookmarks.
+
+        Returns:
+            A copy of the current bookmark records.
+        """
+        self._ensure_loaded()
         return self._bookmarks.copy()
-    
+
     def reset_to_defaults(self):
         """Reset bookmarks to defaults"""
         self._bookmarks = self._default_bookmarks.copy()


### PR DESCRIPTION
## Summary — task-261, 4 fixed / 2 declined-with-reasoning
| # | Item | Outcome |
|---|---|---|
| 1 | console_background_effect O(W·H²) repaint | **Fixed** — per-widget frame-line cache keyed by (frame serial, width, height); serial bumps on particle step + settings change, resize invalidates via the key; strips byte-identical (tested) |
| 2 | Footer token-count re-tokenizing whole history every 10s | **Fixed** — dirty gate in `chat_token_events.py` (settings + message count/last-length/total-chars signature, cached on the app instance); unchanged history skips tokenization, footer refresh cadence preserved |
| 3 | `SELECT 1` liveness ping per `get_connection` (~2× raw statement count) | **Fixed** — 30s idle-threshold gate (`time.monotonic` on the thread-local), applied to all three copies of the pattern: `CharactersRAGDB`, `MediaDatabase` (Library hot path), `PromptsDatabase`; idle connections still get full ping + transparent reopen (tested with real on-disk sqlite + `set_trace_callback` ping counting) |
| 4 | `BookmarksManager.__init__` — 5 sync `Path.exists()` + first-run TOML write per picker construction | **Fixed** — constructor now I/O-free; defaults/config-load/first-run write deferred to first actual use; unloaded `save_to_config()` is a no-op |
| 5 | MCP rebuild diffing | **Declined** — the ×2 is two intentional states (optimistic CHECKING → completion); full rebuilds are documented invariants entangled with the mount-echo guard + hidden-canvas anti-staleness contract; the real cost driver (N+2 store loads) is already tracked as task-236 |
| 6 | Indexes on conversations.deleted/last_modified | **Declined** — zero non-migration DDL precedent in ChaChaNotes (all DDL versioned; schema-check early-returns), and migration numbers are contested across concurrent sessions (v21 now); recommended the index ride the next coordinated migration |

## Verification
- New tests: bg-effect 2 (file 11 total), token gate 7, ping gate 9 (parametrized ×3 DB classes, unmocked), bookmarks lazy 5 — 32/32 after rebase onto latest dev
- Suites (implementer run at base): Tests/DB+Prompts_DB 162; Tests/Media_DB 59+6s; Tests/Chat 959+69s; Tests/Event_Handlers 112+26s; picker consumers 7. Tests/ChaChaNotesDB: 156 + exactly the 3 known pre-existing legacy-parity failures — no new failures.

Task file updated (Done, ACs checked, per-item table in notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Performance fixes for task-261: cached console background frames, stricter token-counter caching, idle-gated DB liveness pings, and an I/O-free file picker bookmarks constructor. No behavior changes; new tests cover each change.

- **Bug Fixes**
  - Console background effect: cache per-frame grid by (frame serial, width, height); one grid build per repaint; ticks/settings/resize invalidate.
  - Footer token count: `_estimate_tokens_cached` skips re-tokenizing when inputs are unchanged; signature now includes per-message role/content hashes to catch same-length edits and role flips; footer still refreshes every 10s.
  - DB liveness ping: gate `SELECT 1` behind a 30s idle window in `CharactersRAGDB`, `MediaDatabase`, and `PromptsDatabase`; transparent reopen preserved.
  - File picker bookmarks: `BookmarksManager` ctor is I/O-free; defaults/config load and first-run write happen on first use; `save_to_config()` is a no-op if never loaded.

<sup>Written for commit 9adb4d05adcf865562dd9f0001d85131f43878c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

