### PR TITLE
perf(rag): build the RAG admin service trio lazily instead of at every launch (task-254)

### DIFF
--- a/Docs/Development/server-client-provider-migration-audit.md
+++ b/Docs/Development/server-client-provider-migration-audit.md
@@ -71,7 +71,7 @@ These `from_config(...)` call sites continue to use public compatibility APIs, b
 
 | Module | Audit lines | Notes |
 | --- | ---: | --- |
-| `tldw_chatbook/app.py` | 1460 | App wiring compatibility adapter use. Semantic match: `self.server_rag_admin_service = ServerRAGAdminService.from_config(`. |
+| `tldw_chatbook/app.py` | 2708 | App wiring compatibility adapter use (lazy RAG-admin builder, task-254). Semantic match: `server_service = ServerRAGAdminService.from_config(`. |
 | `tldw_chatbook/app.py` | 1594 | App wiring compatibility adapter use. Semantic match: `self.server_writing_service = ServerWritingService.from_config(`. |
 | `tldw_chatbook/app.py` | 1647 | App wiring compatibility adapter use. Semantic match: `self.server_evaluation_service = ServerEvaluationsService.from_config(`. |
 | `tldw_chatbook/app.py` | 1689, 1699 | App wiring compatibility adapter uses. Semantic matches: `self.server_study_service = ServerStudyService.from_config(`, `self.server_quiz_service = ServerQuizService.from_config(`. |

--- a/Tests/RAG_Admin/test_app_lazy_rag_admin_wiring.py
+++ b/Tests/RAG_Admin/test_app_lazy_rag_admin_wiring.py
@@ -1,0 +1,176 @@
+"""App-wiring guard for lazy RAG admin service construction (task-254).
+
+The RAG admin trio (``server_rag_admin_service`` / ``local_rag_admin_service``
+/ ``rag_admin_scope_service``) has no reachable UI consumer since the legacy
+SearchWindow stack was deleted (PR #669), so ``TldwCli.__init__`` must not pay
+for constructing it at every launch. The services are instead built lazily on
+first property access and cached, so any future surface (e.g. a rebuilt admin
+screen or task-251 indexing controls) still gets the identically-wired trio.
+
+These tests construct a real ``TldwCli`` (with the same heavy-init patches the
+screen-navigation wiring tests use) while the three service classes are
+replaced with mocks in the ``tldw_chatbook.app`` namespace, then assert:
+
+1. zero constructions after ``__init__`` (startup pays nothing), and
+2. exactly-once construction, caching, and correct trio wiring on access.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from tldw_chatbook.app import TldwCli
+from tldw_chatbook.runtime_policy.types import RuntimeSourceState
+
+
+@contextlib.contextmanager
+def _cheap_app_init_patches():
+    """Patch heavy ``TldwCli.__init__`` collaborators, mirroring the proven
+    ``_build_test_app`` recipe in ``Tests/UI/test_screen_navigation.py``."""
+    user_data_dir = Path(tempfile.mkdtemp(prefix="tldw-chatbook-rag254-test-"))
+
+    def fake_runtime_policy(app):
+        context = SimpleNamespace(
+            state=RuntimeSourceState(active_source="local", server_configured=True),
+            persist=lambda: None,
+        )
+        app.runtime_policy = context
+        app.current_runtime_source = "local"
+        app.current_runtime_backend = "local"
+        return context
+
+    def fake_cli_setting(_section, _key=None, default=None):
+        return default
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                "tldw_chatbook.app.load_settings",
+                return_value={"tldw_api": {"base_url": "http://localhost:8000"}},
+            )
+        )
+        stack.enter_context(patch("tldw_chatbook.app.get_cli_setting", side_effect=fake_cli_setting))
+        stack.enter_context(patch("tldw_chatbook.app.get_chachanotes_db_lazy", return_value=None))
+        stack.enter_context(
+            patch("tldw_chatbook.app.ServerNotesWorkspaceService.from_config", return_value=MagicMock())
+        )
+        stack.enter_context(
+            patch("tldw_chatbook.app.ServerCharacterPersonaService.from_config", return_value=MagicMock())
+        )
+        stack.enter_context(
+            patch.object(TldwCli, "_init_notes_service", lambda self, _user: setattr(self, "notes_service", None))
+        )
+        stack.enter_context(
+            patch.object(
+                TldwCli, "_init_prompts_service", lambda self: setattr(self, "prompts_service_initialized", False)
+            )
+        )
+        stack.enter_context(
+            patch.object(TldwCli, "_init_providers_models", lambda self: setattr(self, "providers_models", {}))
+        )
+        stack.enter_context(
+            patch.object(
+                TldwCli,
+                "_init_media_db",
+                lambda self: (
+                    setattr(self, "media_db", None),
+                    setattr(self, "_media_types_for_ui", ["All Media"]),
+                ),
+            )
+        )
+        stack.enter_context(
+            patch("tldw_chatbook.app.load_runtime_policy_for_app", side_effect=fake_runtime_policy)
+        )
+        stack.enter_context(patch("tldw_chatbook.app.get_notifications_db_path", return_value=":memory:"))
+        stack.enter_context(patch("tldw_chatbook.app.get_subscriptions_db_path", return_value=":memory:"))
+        stack.enter_context(patch("tldw_chatbook.app.get_research_db_path", return_value=":memory:"))
+        stack.enter_context(patch("tldw_chatbook.app.get_writing_db_path", return_value=":memory:"))
+        stack.enter_context(patch("tldw_chatbook.app.get_user_data_dir", return_value=user_data_dir))
+        stack.enter_context(
+            patch(
+                "tldw_chatbook.app.get_workspaces_db_path",
+                return_value=user_data_dir / "workspaces.sqlite",
+            )
+        )
+        yield
+
+
+@contextlib.contextmanager
+def _patched_rag_admin_classes():
+    """Replace the RAG admin service classes referenced by the lazy builder."""
+    with patch("tldw_chatbook.app.ServerRAGAdminService") as server_cls, patch(
+        "tldw_chatbook.app.LocalRAGAdminService"
+    ) as local_cls, patch("tldw_chatbook.app.RAGAdminScopeService") as scope_cls:
+        yield server_cls, local_cls, scope_cls
+
+
+def test_app_init_does_not_construct_rag_admin_services():
+    """Startup must not build the RAG admin trio (task-254 AC #1)."""
+    with _cheap_app_init_patches(), _patched_rag_admin_classes() as (server_cls, local_cls, scope_cls):
+        app = TldwCli()
+
+        assert server_cls.from_config.call_count == 0
+        assert server_cls.call_count == 0
+        assert local_cls.call_count == 0
+        assert scope_cls.call_count == 0
+        # The lazy slots exist but are unbuilt.
+        assert app._server_rag_admin_service is None
+        assert app._local_rag_admin_service is None
+        assert app._rag_admin_scope_service is None
+
+
+def test_first_access_builds_and_caches_rag_admin_trio_exactly_once():
+    """First property access builds the identically-wired trio; later accesses reuse it."""
+    with _cheap_app_init_patches(), _patched_rag_admin_classes() as (server_cls, local_cls, scope_cls):
+        app = TldwCli()
+
+        scope = app.rag_admin_scope_service
+
+        # Config-driven server service, local service over the media DB, scope
+        # service routing between them — same semantics as the old eager wiring.
+        server_cls.from_config.assert_called_once_with(
+            app.app_config,
+            policy_enforcer=app.service_policy_enforcer,
+        )
+        local_cls.assert_called_once_with(
+            app.media_db,
+            media_service=app.local_media_reading_service,
+        )
+        scope_cls.assert_called_once_with(
+            local_service=local_cls.return_value,
+            server_service=server_cls.from_config.return_value,
+            policy_enforcer=app.service_policy_enforcer,
+        )
+        assert scope is scope_cls.return_value
+
+        # Every property is cached: repeated/companion access constructs nothing new.
+        assert app.rag_admin_scope_service is scope
+        assert app.server_rag_admin_service is server_cls.from_config.return_value
+        assert app.local_rag_admin_service is local_cls.return_value
+        assert server_cls.from_config.call_count == 1
+        assert local_cls.call_count == 1
+        assert scope_cls.call_count == 1
+
+
+def test_server_service_config_failure_falls_back_to_clientless_service():
+    """A ValueError from ``from_config`` must fall back to ``client=None`` wiring."""
+    with _cheap_app_init_patches(), _patched_rag_admin_classes() as (server_cls, local_cls, scope_cls):
+        server_cls.from_config.side_effect = ValueError("no server configured")
+        app = TldwCli()
+
+        server = app.server_rag_admin_service
+
+        server_cls.assert_called_once_with(
+            client=None,
+            policy_enforcer=app.service_policy_enforcer,
+        )
+        assert server is server_cls.return_value
+        scope_cls.assert_called_once_with(
+            local_service=local_cls.return_value,
+            server_service=server_cls.return_value,
+            policy_enforcer=app.service_policy_enforcer,
+        )

--- a/backlog/tasks/task-254 - Stop-constructing-unreachable-RAG_Admin-services-at-every-launch.md
+++ b/backlog/tasks/task-254 - Stop-constructing-unreachable-RAG_Admin-services-at-every-launch.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-254
 title: Stop constructing unreachable RAG_Admin services at every launch
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-12 14:12'
 labels:
@@ -19,7 +19,86 @@ app.py:2545-2559 instantiates server_rag_admin_service, local_rag_admin_service 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 RAG admin services are no longer eagerly constructed at startup unless a reachable UI surface consumes them
-- [ ] #2 Any surface that does consume them is reachable through shell navigation
-- [ ] #3 App startup and test suite pass unchanged otherwise
+- [x] #1 RAG admin services are no longer eagerly constructed at startup unless a reachable UI surface consumes them
+- [x] #2 Any surface that does consume them is reachable through shell navigation
+- [x] #3 App startup and test suite pass unchanged otherwise
 <!-- AC:END -->
+
+## Implementation Plan
+
+Re-scoping (2026-07-17): the landscape moved since this task was filed. PR #669 deleted the
+legacy SearchWindow UI stack (Embeddings_Management_Window, chunking-template widgets) — the
+consumers named in the description no longer exist at all. PR #677 repointed
+LocalRAGAdminService's collection surface at the shared RAG vector store. A fresh
+`git grep` inventory on current dev shows ZERO production readers of
+`app.server_rag_admin_service` / `app.local_rag_admin_service` / `app.rag_admin_scope_service`
+outside the construction site in `app.py` (now lines 2652-2670): the only other references are
+the RAG_Admin module itself and tests that construct the services directly (never via app
+attributes). No MCP/tools/event-handler consumer appeared. AC #2 is therefore satisfied
+vacuously; the honest reading of AC #1 is "defer construction so launch pays nothing", while
+keeping the trio available for future surfaces (e.g. task-251 indexing controls). Deleting the
+services outright is a larger product decision and out of scope here.
+
+1. Replace the eager construction in `TldwCli.__init__` with three private `None` slots plus
+   a lock, and add cached lazy properties `server_rag_admin_service` /
+   `local_rag_admin_service` / `rag_admin_scope_service` backed by a single
+   `_build_rag_admin_services()` builder that preserves the exact prior constructor semantics
+   (config-driven `ServerRAGAdminService.from_config` with `client=None` fallback on
+   ValueError, `LocalRAGAdminService(media_db, media_service=...)`, scope service wiring with
+   the policy enforcer). Build under a lock so a racing first access cannot produce a
+   mixed trio.
+2. Update `Docs/Development/server-client-provider-migration-audit.md`'s app.py row — the
+   drift guard (`Tests/RuntimePolicy/test_server_client_provider_migration_audit.py`) matches
+   the normalized `ServerRAGAdminService.from_config(` source line semantically, and that
+   line changes shape when it moves into the builder.
+3. Tests (`Tests/RAG_Admin/test_app_lazy_rag_admin_wiring.py`): patch the three service
+   classes in the `tldw_chatbook.app` namespace, construct `TldwCli()` (repo convention:
+   bare construction under Tests/conftest.py's isolated TLDW_CONFIG_PATH), assert zero
+   constructions after `__init__`; then access the properties and assert exactly-once
+   construction, caching (same instance on second access), and correct wiring of the scope
+   service to the cached local/server instances.
+4. Verify: new tests, `Tests/RAG_Admin/`, `Tests/RuntimePolicy/test_server_client_provider_migration_audit.py`,
+   `Tests/Performance/test_app_import_weight.py`, `Tests/test_smoke.py`,
+   `python -c "import tldw_chatbook.app"`.
+
+## Implementation Notes
+
+Deferred the RAG admin trio from eager `TldwCli.__init__` construction to lazy, cached,
+lock-guarded properties. Startup now only initializes three `None` slots plus a
+`threading.Lock`; the first access to any of `app.server_rag_admin_service` /
+`app.local_rag_admin_service` / `app.rag_admin_scope_service` runs
+`_build_rag_admin_services()`, which reproduces the previous wiring byte-for-byte in
+semantics (config-driven `ServerRAGAdminService.from_config` with `client=None` fallback on
+`ValueError`, `LocalRAGAdminService(self.media_db, media_service=self.local_media_reading_service)`,
+scope service over both with `self.service_policy_enforcer`) and caches the trio; the lock
+prevents a racing first access from producing a mixed trio.
+
+Re-scoping vs. the original description: the "unreachable UI consumers" (legacy SearchWindow
+stack) were deleted entirely by PR #669, so on current dev there are ZERO production readers
+of these three app attributes — the construction site itself was the only reference
+(`git grep` evidence in the Implementation Plan). AC #2 is satisfied vacuously (no consuming
+surface exists; nothing unreachable implies a live admin surface anymore). The lazy accessor
+was deliberately chosen over deleting the services: the RAG_Admin module is still the
+designated seam for a future Console-parity admin surface and task-251's indexing controls,
+and removing it is a bigger product decision that is out of scope for this cleanup rider.
+The eager construction had no observable side effects (no health checks, no attribute reads
+at startup), verified by grep and by the full app-wiring test passing.
+
+Modified files: `tldw_chatbook/app.py` (lazy slots + builder + three properties; module-level
+imports kept — heavy transitive imports were already deferred by task-163/248 work),
+`Docs/Development/server-client-provider-migration-audit.md` (the drift guard in
+`Tests/RuntimePolicy/test_server_client_provider_migration_audit.py` matches the normalized
+`ServerRAGAdminService.from_config(` source line semantically, and the line changed shape
+moving into the builder), new `Tests/RAG_Admin/test_app_lazy_rag_admin_wiring.py` (3 tests:
+zero construction after `__init__`, exactly-once build + caching + trio wiring on access,
+`ValueError` fallback to clientless server service — real `TldwCli()` construction using the
+proven heavy-init patch recipe from `Tests/UI/test_screen_navigation.py`).
+
+Verification (local, CI intentionally cancelled): new tests 3 passed;
+`Tests/RAG_Admin/ + Tests/RuntimePolicy/test_server_client_provider_migration_audit.py +
+Tests/test_smoke.py` 58 passed / 1 skipped; `Tests/Performance/test_app_import_weight.py +
+Tests/Utils/test_optional_import_deferral.py` 19 passed;
+`Tests/UI/test_screen_navigation.py` 56 passed; `python -c "import tldw_chatbook.app"` OK.
+Startup-perf linkage: this eager construction was also flagged in the 2026-07-16 performance
+audit (import/startup lane); this change removes it from the launch path without renumbering
+or editing any perf tasks.

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -2728,21 +2728,36 @@ class TldwCli(LibraryIngestQueueMixin, App[None]):  # Specify return type for ru
 
     @property
     def server_rag_admin_service(self) -> "ServerRAGAdminService":
-        """Server-backed RAG admin service, built lazily and cached (task-254)."""
+        """Server-backed RAG admin service, built lazily and cached (task-254).
+
+        Returns:
+            ServerRAGAdminService: The cached service, constructed together
+            with the local and scope services on first access.
+        """
         if self._server_rag_admin_service is None:
             self._build_rag_admin_services()
         return self._server_rag_admin_service
 
     @property
     def local_rag_admin_service(self) -> "LocalRAGAdminService":
-        """Local RAG admin service, built lazily and cached (task-254)."""
+        """Local RAG admin service, built lazily and cached (task-254).
+
+        Returns:
+            LocalRAGAdminService: The cached service, constructed together
+            with the server and scope services on first access.
+        """
         if self._local_rag_admin_service is None:
             self._build_rag_admin_services()
         return self._local_rag_admin_service
 
     @property
     def rag_admin_scope_service(self) -> "RAGAdminScopeService":
-        """Local/server RAG admin scope router, built lazily and cached (task-254)."""
+        """Local/server RAG admin scope router, built lazily and cached (task-254).
+
+        Returns:
+            RAGAdminScopeService: The cached scope router wired to the cached
+            local and server services, constructed on first access.
+        """
         if self._rag_admin_scope_service is None:
             self._build_rag_admin_services()
         return self._rag_admin_scope_service

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -2649,25 +2649,15 @@ class TldwCli(LibraryIngestQueueMixin, App[None]):  # Specify return type for ru
             policy_enforcer=self.service_policy_enforcer,
             sync_scope_service=getattr(self, "sync_scope_service", None),
         )
-        try:
-            self.server_rag_admin_service = ServerRAGAdminService.from_config(
-                self.app_config,
-                policy_enforcer=self.service_policy_enforcer,
-            )
-        except ValueError:
-            self.server_rag_admin_service = ServerRAGAdminService(
-                client=None,
-                policy_enforcer=self.service_policy_enforcer,
-            )
-        self.local_rag_admin_service = LocalRAGAdminService(
-            self.media_db,
-            media_service=self.local_media_reading_service,
-        )
-        self.rag_admin_scope_service = RAGAdminScopeService(
-            local_service=self.local_rag_admin_service,
-            server_service=self.server_rag_admin_service,
-            policy_enforcer=self.service_policy_enforcer,
-        )
+        # RAG admin trio (server/local/scope) is built lazily on first access
+        # (task-254): its legacy UI consumers were deleted and nothing reads
+        # these services at startup, so eager construction only added launch
+        # cost. See the server_rag_admin_service / local_rag_admin_service /
+        # rag_admin_scope_service properties.
+        self._server_rag_admin_service: Optional[ServerRAGAdminService] = None
+        self._local_rag_admin_service: Optional[LocalRAGAdminService] = None
+        self._rag_admin_scope_service: Optional[RAGAdminScopeService] = None
+        self._rag_admin_services_lock = threading.Lock()
         self._wire_evaluation_services()
         self._wire_study_services()
         self._wire_writing_services()
@@ -2699,6 +2689,63 @@ class TldwCli(LibraryIngestQueueMixin, App[None]):  # Specify return type for ru
         
         # Final memory check
         log_resource_usage()
+
+    def _build_rag_admin_services(self) -> None:
+        """Construct the RAG admin service trio on first access (task-254).
+
+        Constructor semantics are identical to the eager wiring this replaced:
+        a config-driven ``ServerRAGAdminService.from_config`` with a
+        ``client=None`` fallback when config resolution raises ``ValueError``,
+        a ``LocalRAGAdminService`` over the media DB and local media reading
+        service, and the scope service routing between them with the policy
+        enforcer. Built under a lock so a racing first access from a worker
+        thread cannot produce a mixed trio; idempotent once built.
+        """
+        with self._rag_admin_services_lock:
+            if self._rag_admin_scope_service is not None:
+                return
+            try:
+                server_service = ServerRAGAdminService.from_config(
+                    self.app_config,
+                    policy_enforcer=self.service_policy_enforcer,
+                )
+            except ValueError:
+                server_service = ServerRAGAdminService(
+                    client=None,
+                    policy_enforcer=self.service_policy_enforcer,
+                )
+            local_service = LocalRAGAdminService(
+                self.media_db,
+                media_service=self.local_media_reading_service,
+            )
+            self._server_rag_admin_service = server_service
+            self._local_rag_admin_service = local_service
+            self._rag_admin_scope_service = RAGAdminScopeService(
+                local_service=local_service,
+                server_service=server_service,
+                policy_enforcer=self.service_policy_enforcer,
+            )
+
+    @property
+    def server_rag_admin_service(self) -> "ServerRAGAdminService":
+        """Server-backed RAG admin service, built lazily and cached (task-254)."""
+        if self._server_rag_admin_service is None:
+            self._build_rag_admin_services()
+        return self._server_rag_admin_service
+
+    @property
+    def local_rag_admin_service(self) -> "LocalRAGAdminService":
+        """Local RAG admin service, built lazily and cached (task-254)."""
+        if self._local_rag_admin_service is None:
+            self._build_rag_admin_services()
+        return self._local_rag_admin_service
+
+    @property
+    def rag_admin_scope_service(self) -> "RAGAdminScopeService":
+        """Local/server RAG admin scope router, built lazily and cached (task-254)."""
+        if self._rag_admin_scope_service is None:
+            self._build_rag_admin_services()
+        return self._rag_admin_scope_service
 
     def _wire_server_context_provider(self) -> None:
         self.unified_mcp_target_store = ConfiguredServerTargetStore(


### PR DESCRIPTION
## Summary

Cleanup rider of the local-RAG program (audit: `backlog/docs/rag-module-audit-2026-07-12.md`), implementing **task-254**.

`TldwCli.__init__` eagerly constructed `server_rag_admin_service`, `local_rag_admin_service` and `rag_admin_scope_service` at every launch. When the task was filed, their only UI consumers lived in the dead legacy SearchWindow stack; since then PR #669 deleted that stack entirely, so on current dev there are **zero production readers** of the three app attributes outside the construction site itself (grep evidence in the task file's Implementation Plan — the only other references are the `RAG_Admin` module and tests that construct the services directly, never via app attributes).

This PR replaces the eager wiring with **cached, lock-guarded lazy properties** backed by a single `_build_rag_admin_services()` builder:

- Startup now only initializes three `None` slots plus a `threading.Lock` — nothing is constructed at launch.
- First access to any of the three properties builds the trio with **identical constructor semantics** (config-driven `ServerRAGAdminService.from_config` with `client=None` fallback on `ValueError`, `LocalRAGAdminService(media_db, media_service=local_media_reading_service)`, scope service over both with the policy enforcer) and caches it; the lock's double-check is on the last-assigned slot, so a racing first access cannot observe a mixed trio.
- Lazy-accessor was deliberately chosen over deletion: `RAG_Admin` remains the seam for a future Console-parity admin surface and task-251's indexing controls; removing the services is a larger product decision, out of scope here.
- The eager construction had no observable side effects (no health checks, no startup attribute reads) — verified by grep and by the full app-wiring suite.

Also updates the `Docs/Development/server-client-provider-migration-audit.md` app.py row — the RuntimePolicy drift guard matches the normalized `ServerRAGAdminService.from_config(` source line semantically, and the line changed shape moving into the builder.

Startup-perf linkage: this eager construction was also flagged in the 2026-07-16 performance audit (import/startup lane); this removes it from the launch path without renumbering or editing any perf tasks.

## Tests

New `Tests/RAG_Admin/test_app_lazy_rag_admin_wiring.py` (real `TldwCli()` construction using the proven heavy-init patch recipe from `Tests/UI/test_screen_navigation.py`):

1. app `__init__` constructs none of the three services (zero calls on patched classes),
2. first property access builds exactly once, caches (same instance on repeat/companion access), and wires the scope service to the cached local/server instances,
3. `ValueError` from `from_config` falls back to the clientless server service.

Local verification (CI is intentionally cancelled on this repo):

- `Tests/RAG_Admin/test_app_lazy_rag_admin_wiring.py` — **3 passed**
- `Tests/RAG_Admin/ + Tests/RuntimePolicy/test_server_client_provider_migration_audit.py + Tests/test_smoke.py` — **58 passed, 1 skipped**
- `Tests/Performance/test_app_import_weight.py + Tests/Utils/test_optional_import_deferral.py` — **19 passed**
- `Tests/UI/test_screen_navigation.py` (full app-wiring construction) — **56 passed**
- `python -c "import tldw_chatbook.app"` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build the RAG admin service trio lazily on first access to cut startup cost while preserving behavior. Implements Linear task-254 by deferring construction for services with no current UI consumers.

- **Refactors**
  - Replaced eager init in `TldwCli.__init__` with cached, lock-guarded lazy properties backed by `_build_rag_admin_services()`.
  - Preserves prior wiring: `ServerRAGAdminService.from_config` with `client=None` on `ValueError`, `LocalRAGAdminService(media_db, media_service=local_media_reading_service)`, and `RAGAdminScopeService` over both with the policy enforcer.
  - Startup now only sets `None` slots and a `threading.Lock`; no side effects at launch. Added concise Returns docstrings to the lazy properties.
  - Updated `Docs/Development/server-client-provider-migration-audit.md`; added tests for zero construction at init, exactly-once caching, and the fallback path.

<sup>Written for commit c1399a96d1221cca96639fc2a19a261c3439faa3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

