### PR TITLE
fix(rag): rewire pipeline notes search to the real store + live-DB resolution (task-295)

### DIFF
--- a/Tests/RAG_Search/test_pipeline_notes_search.py
+++ b/Tests/RAG_Search/test_pipeline_notes_search.py
@@ -1,0 +1,113 @@
+"""Tests for task-295: RAG pipeline notes search + DB resolution seams.
+
+``search_notes_fts5`` used to import a ``Notes_DB`` module that does not
+exist anywhere in the tree and call an API shape (``user_id=``) the real
+store never had — invisible to mocked tests, so everything here runs
+against a REAL CharactersRAGDB. Also covers the task-295 wiring decision:
+the app's live ``chachanotes_db`` instance is preferred, with the
+``db_config['chacha_db_path']`` construction seam kept for tests/probes.
+"""
+
+import pytest
+
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.RAG_Search.pipeline_functions_simple import (
+    _resolve_chacha_db,
+    search_conversations_fts5,
+    search_notes_fts5,
+)
+
+
+class _LiveDbApp:
+    """App double exposing only the live-instance seam."""
+
+    def __init__(self, db: CharactersRAGDB):
+        self.chachanotes_db = db
+
+
+class _PathApp:
+    """App double exposing only the db_config construction seam."""
+
+    def __init__(self, db_path):
+        self.db_config = {"chacha_db_path": str(db_path)}
+
+
+@pytest.fixture()
+def db(tmp_path):
+    return CharactersRAGDB(tmp_path / "task295.db", client_id="task-295-test")
+
+
+def _seed_notes(db: CharactersRAGDB) -> list[str]:
+    ids = []
+    for i in range(3):
+        note_id = db.add_note(
+            title=f"Moon note {i}",
+            content=f"starlight observation {i}: tides follow the moon.",
+        )
+        ids.append(note_id)
+    db.add_note(title="Unrelated", content="grocery list: bread, eggs.")
+    return ids
+
+
+@pytest.mark.asyncio
+async def test_search_notes_fts5_end_to_end_live_instance(db):
+    """The rewired notes search returns real FTS hits via the live-DB seam."""
+    seeded = _seed_notes(db)
+
+    results = await search_notes_fts5(_LiveDbApp(db), "starlight", limit=10)
+
+    assert {r.id for r in results} == set(seeded)
+    for r in results:
+        assert r.source == "note"
+        assert r.title.startswith("Moon note")
+        assert "starlight observation" in r.content
+        assert r.metadata["created_at"] is not None
+        assert r.metadata["last_modified"] is not None
+
+
+@pytest.mark.asyncio
+async def test_search_notes_fts5_end_to_end_db_config_path(db, tmp_path):
+    """The db_config construction seam still works for notes."""
+    seeded = _seed_notes(db)
+
+    results = await search_notes_fts5(_PathApp(tmp_path / "task295.db"), "starlight")
+
+    assert {r.id for r in results} == set(seeded)
+
+
+@pytest.mark.asyncio
+async def test_search_conversations_fts5_uses_live_instance(db):
+    """The conversations search prefers the live instance too (no ctor)."""
+    conv_id = db.add_conversation({"title": "Live seam conversation"})
+    db.add_message({
+        "conversation_id": conv_id,
+        "sender": "User",
+        "content": "glimmerfish sighting confirmed",
+    })
+
+    results = await search_conversations_fts5(_LiveDbApp(db), "glimmerfish")
+
+    assert [r.id for r in results] == [conv_id]
+    assert "glimmerfish sighting confirmed" in results[0].content
+
+
+def test_resolver_prefers_live_instance_over_db_config(db, tmp_path):
+    """When both seams are present the live instance wins (no reconstruction)."""
+
+    class _BothApp:
+        chachanotes_db = db
+        db_config = {"chacha_db_path": str(tmp_path / "other.db")}
+
+    assert _resolve_chacha_db(_BothApp()) is db
+    # And the other.db file was never created by a fallback construction.
+    assert not (tmp_path / "other.db").exists()
+
+
+@pytest.mark.asyncio
+async def test_search_notes_fts5_no_seams_returns_empty():
+    """No live instance and no db_config -> quiet empty result."""
+
+    class _Bare:
+        pass
+
+    assert await search_notes_fts5(_Bare(), "anything") == []

--- a/backlog/tasks/task-295 - RAG-pipeline-notes-search-imports-nonexistent-NotesDB-module.md
+++ b/backlog/tasks/task-295 - RAG-pipeline-notes-search-imports-nonexistent-NotesDB-module.md
@@ -1,8 +1,8 @@
 ---
 id: TASK-295
 title: RAG pipeline notes search imports nonexistent NotesDB module — dead path
-status: To Do
-assignee: []
+status: Done
+assignee: ['@claude']
 created_date: '2026-07-17 21:50'
 labels: [bug, rag, notes]
 dependencies: []
@@ -17,6 +17,24 @@ Found during task-260: `RAG_Search/pipeline_functions_simple.py`'s `search_notes
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 search_notes_fts5 queries the real notes store and returns results end-to-end (unmocked test)
-- [ ] #2 A decision is recorded on wiring app.db_config (or replacing the seam) so the pipeline paths are reachable in-app
+- [x] #1 search_notes_fts5 queries the real notes store and returns results end-to-end (unmocked test)
+- [x] #2 A decision is recorded on wiring app.db_config (or replacing the seam) so the pipeline paths are reachable in-app
 <!-- AC:END -->
+
+## Implementation Plan
+<!-- SECTION:PLAN:BEGIN -->
+1. Decide the DB seam: prefer the app's live chachanotes_db instance; keep db_config['chacha_db_path'] as construction fallback for tests/probes; do NOT wire db_config in production.
+2. Rewire search_notes_fts5 to CharactersRAGDB.search_notes (notes live in ChaChaNotes; the imported Notes_DB module doesn't exist and its user_id call shape never matched the real API).
+3. Route both pipeline searches through one _resolve_chacha_db resolver; unmocked real-DB tests for every seam.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+<!-- SECTION:NOTES:BEGIN -->
+AC#2 wiring decision, recorded in _resolve_chacha_db's docstring: the pipeline now prefers TldwCli.chachanotes_db — the live instance the app resolves at startup (thread-local connections open, schema checked) — which makes both pipeline paths reachable IN-APP with zero startup changes and no per-search CharactersRAGDB construction. db_config stays as a documented construction seam for tests/probes only; wiring it in production was rejected as a second source of truth for a path the app already owns.
+
+search_notes_fts5 rewired: resolver DB + CharactersRAGDB.search_notes(search_term, limit) (no user_id — that gate came from the phantom Notes_DB API and always returned [] anyway); metadata now carries the real columns (created_at, last_modified) instead of nonexistent updated_at/tags. search_conversations_fts5 switched to the same resolver; its task-260 db_config-seam tests pass unmodified, pinning back-compat.
+
+Tests: Tests/RAG_Search/test_pipeline_notes_search.py — 5, all real-DB unmocked (notes e2e via live seam, notes e2e via db_config seam, conversations via live seam, resolver-preference proof incl. no-fallback-construction, no-seam guard).
+
+Files: RAG_Search/pipeline_functions_simple.py, Tests/RAG_Search/test_pipeline_notes_search.py.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/RAG_Search/pipeline_functions_simple.py
+++ b/tldw_chatbook/RAG_Search/pipeline_functions_simple.py
@@ -80,6 +80,35 @@ async def search_media_fts5(
     return results[:limit]
 
 
+def _resolve_chacha_db(app: Any):
+    """Resolve the ChaChaNotes DB for pipeline searches.
+
+    Wiring decision (task-295): the app's LIVE instance
+    (``TldwCli.chachanotes_db``, thread-local connections already open,
+    schema already checked) is preferred; the ``db_config['chacha_db_path']``
+    seam stays as a construction fallback for tests and probes. Nothing in
+    production populates ``db_config``, and wiring it would add a second
+    source of truth for a path the app already resolves at startup.
+
+    Args:
+        app: App-like object; either ``chachanotes_db`` (live instance) or
+            ``db_config['chacha_db_path']`` (construction path) may be set.
+
+    Returns:
+        A CharactersRAGDB, or None when neither seam is available.
+    """
+    db = getattr(app, "chachanotes_db", None)
+    if db is not None:
+        return db
+    db_config = getattr(app, "db_config", None)
+    path = db_config.get("chacha_db_path") if isinstance(db_config, dict) else None
+    if not path:
+        return None
+    from ..DB.ChaChaNotes_DB import CharactersRAGDB
+
+    return CharactersRAGDB(path, client_id="rag_pipeline")
+
+
 async def search_conversations_fts5(
     app: Any,
     query: str,
@@ -96,19 +125,11 @@ async def search_conversations_fts5(
         SearchResult entries in content-relevance order, each carrying a
         snippet built from the conversation's first messages.
     """
-    if not hasattr(app, 'db_config') or not app.db_config.get('chacha_db_path'):
+    db = _resolve_chacha_db(app)
+    if db is None:
         return []
     
     logger.debug(f"Searching conversations for: {query}")
-    
-    # Two dots, not three: this module was flattened out of simplified/ and
-    # the old ...DB import resolved beyond the top-level package, raising
-    # ImportError at call time (task-260).
-    from ..DB.ChaChaNotes_DB import CharactersRAGDB
-    
-    # client_id is a required ctor arg (was missing here -- third latent
-    # defect in this never-exercised path, caught by the task-260 tests).
-    db = CharactersRAGDB(app.db_config['chacha_db_path'], client_id='rag_pipeline')
     conv_results = await asyncio.to_thread(
         db.search_conversations_by_content,
         search_query=query,
@@ -152,24 +173,29 @@ async def search_notes_fts5(
     query: str,
     limit: int = 10
 ) -> List[SearchResult]:
-    """Search notes using FTS5."""
-    if not hasattr(app, 'db_config') or not app.db_config.get('notes_db_path'):
+    """Search notes using FTS5.
+
+    task-295: this used to import a ``Notes_DB`` module that no longer
+    exists anywhere (and called a ``user_id`` API shape the real store
+    never had) -- notes live in ChaChaNotes, so it now routes through the
+    same resolved DB as the conversations search.
+
+    Args:
+        app: App-like object; see ``_resolve_chacha_db`` for the seams.
+        query: FTS search text (matched as a literal phrase).
+        limit: Maximum number of note results to return.
+
+    Returns:
+        SearchResult entries for matching notes.
+    """
+    db = _resolve_chacha_db(app)
+    if db is None:
         return []
     
     logger.debug(f"Searching notes for: {query}")
     
-    from ...Notes.DB.Notes_DB import NotesDB
-    
-    db = NotesDB(app.db_config['notes_db_path'])
-    
-    # Get user ID if available
-    user_id = getattr(app, 'notes_user_id', None)
-    if not user_id:
-        return []
-    
     note_results = await asyncio.to_thread(
         db.search_notes,
-        user_id=user_id,
         search_term=query,
         limit=limit
     )
@@ -183,8 +209,7 @@ async def search_notes_fts5(
             content=note.get('content', ''),
             metadata={
                 'created_at': note.get('created_at'),
-                'updated_at': note.get('updated_at'),
-                'tags': note.get('tags', [])
+                'last_modified': note.get('last_modified')
             }
         ))
     


### PR DESCRIPTION
## Summary
Closes out the pipeline defects task-260 exposed (`search_notes_fts5` was broken three ways) plus the `db_config` wiring decision:

- **Notes search rewired to reality**: the function imported `Notes_DB` — a module that doesn't exist anywhere in the tree — and called `search_notes(user_id=…)`, a signature the real store never had (its `notes_user_id` gate meant it always returned `[]` before it could even crash). Notes live in ChaChaNotes; it now routes through `CharactersRAGDB.search_notes(search_term, limit)` and returns real columns in metadata (`created_at`/`last_modified` instead of the nonexistent `updated_at`/`tags`).
- **Wiring decision (AC#2, recorded in `_resolve_chacha_db`'s docstring)**: both pipeline searches now prefer the app's LIVE `TldwCli.chachanotes_db` instance — reachable in-app with zero startup changes and no per-search `CharactersRAGDB` construction (schema check per search avoided). `db_config['chacha_db_path']` stays as a documented construction seam for tests/probes; wiring it in production was rejected as a second source of truth for a path the app already resolves at startup.

## Verification
- New: `Tests/RAG_Search/test_pipeline_notes_search.py` — 5/5, all against a REAL `CharactersRAGDB` (notes e2e via live seam, notes e2e via db_config seam, conversations via live seam, resolver-preference proof including no-fallback-construction, no-seam guard)
- task-260's `test_conversation_search_batch.py` passes **unmodified** — pins that the resolver refactor kept the db_config seam byte-compatible
- `Tests/RAG_Search/` + `Tests/RAG/`: **379 passed, 19 skipped**

Task file: Done, both ACs checked, decision recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes RAG notes search by routing `search_notes_fts5` to the real ChaChaNotes store and resolving the DB via the live `chachanotes_db` instance; keeps `db_config['chacha_db_path']` as a fallback seam. Also switches `search_conversations_fts5` to the same resolver and adds real-DB tests. Addresses task-295.

- **Bug Fixes**
  - Replaced phantom notes module with `CharactersRAGDB.search_notes` in `search_notes_fts5`.
  - Returns correct note metadata (`created_at`, `last_modified`).
  - Returns `[]` when no DB seam is available.

- **Refactors**
  - Added `_resolve_chacha_db`: prefer live `chachanotes_db`; fallback to `db_config['chacha_db_path']` for tests/probes.
  - Routed `search_conversations_fts5` through the resolver to avoid per-search DB construction.
  - Added `Tests/RAG_Search/test_pipeline_notes_search.py` with real-DB coverage for both seams and resolver preference.

<sup>Written for commit 6dbb04680c6e559ba9aae5721d60e6e7e6d0766f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

