### PR TITLE
Roleplay P2d-1: edit selective/secondary_keys/case_sensitive in the Lore entry editor

### DIFF
--- a/Docs/superpowers/plans/2026-07-17-roleplay-p2d1-matching-editor.md
+++ b/Docs/superpowers/plans/2026-07-17-roleplay-p2d1-matching-editor.md
@@ -1,0 +1,569 @@
+# Roleplay P2d-1 — Lore matching-controls editor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a user edit a Lore entry's `selective`, `secondary_keys`, and `case_sensitive` matching fields from the `PersonasLoreDetailWidget` entry editor (they already work end-to-end in the schema, matcher, and manager — only the editor doesn't expose them).
+
+**Architecture:** Pure UI surfacing. Task 1 adds three form controls to the detail widget and threads them through `entry_form_payload()` / `_fill_form_from_entry()`, plus a `_sync_secondary_keys_disabled()` visual hint. Task 2 threads the three fields through the screen's `_handle_lore_entry_add` (its explicit-kwarg call to `create_world_book_entry` silently drops anything not named — the exact P2c-priority bug); update already forwards `**payload`. Task 3 is one end-to-end integration test proving an editor-created selective entry gates matching in `WorldInfoProcessor`.
+
+**Tech Stack:** Python ≥3.11, Textual, pytest + pytest-asyncio, SQLite (`CharactersRAGDB`).
+
+## Global Constraints
+
+- No schema migration — ChaChaNotes stays at `_CURRENT_SCHEMA_VERSION = 21`.
+- No change to `WorldInfoProcessor` (matcher), `world_book_manager.py` (manager), or `ChaChaNotes_DB.py` (schema). `create_world_book_entry` already accepts `selective`/`secondary_keys`/`case_sensitive`; `update_world_book_entry(**kwargs)` already handles them; `get_world_book_entries` already returns them; `_entry_matches` already matches on them.
+- `entry_form_payload()` must never raise (boolean switches + never-raising comma-split; empty → `[]`).
+- `secondary_keys` is read/stored **regardless** of the Selective switch state (data fidelity — toggling Selective off must not erase typed secondary keys).
+- No new `DataTable` column.
+- No `rich.markup.escape()` here — the new `Static` labels are plain constant strings and the `Switch`/`Input` widgets carry no user markup.
+- Implementers stage ONLY their task's files (`git add <explicit paths>`; never `git add -A`; never stage `.superpowers/`).
+- **Test environment (run from the worktree root):**
+  ```bash
+  HOME=/private/tmp/tldw-chatbook-test-home \
+  XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest <targets> \
+  -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+  ```
+  The venv lives in the MAIN checkout, not the worktree; `import tldw_chatbook` resolves to the worktree source because the worktree root (cwd) is on `sys.path`.
+
+## File Structure
+
+- `tldw_chatbook/Widgets/Persona_Widgets/personas_lore_detail.py` — the detail widget: compose (`:110-143`), `on_mount` (`:145-153`), `entry_form_payload` (`:271-310`), `_fill_form_from_entry` (`:337-350`), event handlers (`:368-434`). All of Task 1's production code.
+- `tldw_chatbook/UI/Screens/personas_screen.py` — `_handle_lore_entry_add` (the explicit-kwarg call to `create_world_book_entry`). Task 2's one-spot change.
+- `Tests/UI/test_personas_lore.py` — all tests. Widget-only tests use the `_DetailHost` harness (`:21-30`); real-DB tests use `LorePersonasTestApp` (`:246-265`) + fixtures `lore_db` (`:215`), `seeded_lore_book` (`:222`), `stub_characters_lore` (`:237`), `mock_app_instance` (from `Tests/UI/conftest.py:97`), and helpers `_enter_lore` (`:273`) / `_select_first_lore` (`:282`).
+
+---
+
+### Task 1: Detail-widget matching controls
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/Persona_Widgets/personas_lore_detail.py` (compose `:114-124`, `on_mount` `:145-153`, `entry_form_payload` `:271-310`, `_fill_form_from_entry` `:337-350`, add a helper + a `Switch.Changed` handler near `:426`)
+- Test: `Tests/UI/test_personas_lore.py`
+
+**Interfaces:**
+- Consumes: nothing new. `Static`, `Switch`, `Input`, `Horizontal` are already imported (`:10-22`); `@on` from `textual` (`:8`).
+- Produces (for Task 2): `entry_form_payload()` returns a dict that now also contains `"case_sensitive": bool`, `"selective": bool`, `"secondary_keys": list[str]`. New widget ids: `#personas-lore-entry-case-sensitive` (Switch), `#personas-lore-entry-selective` (Switch), `#personas-lore-entry-secondary-keys` (Input). New method `_sync_secondary_keys_disabled(self) -> None`.
+
+- [ ] **Step 1: Write the failing widget tests**
+
+Add these four tests to `Tests/UI/test_personas_lore.py`. First ensure `Switch` is imported — change the widget import line (`:10`) from
+`from textual.widgets import Button, DataTable, Input, ListView, Static, TextArea`
+to
+`from textual.widgets import Button, DataTable, Input, ListView, Static, Switch, TextArea`.
+
+Then append after `test_entry_priority_round_trips_through_form` (`:123`):
+
+```python
+@pytest.mark.asyncio
+async def test_matching_controls_round_trip_through_form():
+    app = _DetailHost()
+    async with app.run_test(size=(140, 40)) as pilot:
+        widget = app.query_one(PersonasLoreDetailWidget)
+        widget.load_book({"id": 1, "name": "B", "description": "", "scan_depth": 3,
+                          "token_budget": 500, "recursive_scanning": False, "enabled": True})
+        app.query_one("#personas-lore-entry-keys", Input).value = "Warden"
+        app.query_one("#personas-lore-entry-content", TextArea).text = "grim jailer"
+        app.query_one("#personas-lore-entry-case-sensitive", Switch).value = True
+        app.query_one("#personas-lore-entry-selective", Switch).value = True
+        app.query_one("#personas-lore-entry-secondary-keys", Input).value = " sword , shield ,"
+        await pilot.pause()
+        await pilot.click("#personas-lore-entry-add")
+        await pilot.pause()
+        payload = app.posted[-1]
+        assert payload["case_sensitive"] is True
+        assert payload["selective"] is True
+        assert payload["secondary_keys"] == ["sword", "shield"]  # trimmed, blank dropped
+
+
+@pytest.mark.asyncio
+async def test_blank_secondary_keys_is_empty_list():
+    """A blank secondary-keys field yields [] (never raises)."""
+    app = _DetailHost()
+    async with app.run_test(size=(140, 40)) as pilot:
+        widget = app.query_one(PersonasLoreDetailWidget)
+        widget.load_book({"id": 1, "name": "B", "description": "", "scan_depth": 3,
+                          "token_budget": 500, "recursive_scanning": False, "enabled": True})
+        app.query_one("#personas-lore-entry-keys", Input).value = "Warden"
+        app.query_one("#personas-lore-entry-content", TextArea).text = "grim jailer"
+        # secondary-keys left blank
+        await pilot.pause()
+        await pilot.click("#personas-lore-entry-add")
+        await pilot.pause()
+        assert app.posted[-1]["secondary_keys"] == []
+
+
+@pytest.mark.asyncio
+async def test_secondary_keys_stored_even_when_not_selective():
+    """Data fidelity: secondary keys are stored regardless of the Selective
+    switch, so toggling Selective off does not erase them."""
+    app = _DetailHost()
+    async with app.run_test(size=(140, 40)) as pilot:
+        widget = app.query_one(PersonasLoreDetailWidget)
+        widget.load_book({"id": 1, "name": "B", "description": "", "scan_depth": 3,
+                          "token_budget": 500, "recursive_scanning": False, "enabled": True})
+        app.query_one("#personas-lore-entry-keys", Input).value = "Warden"
+        app.query_one("#personas-lore-entry-content", TextArea).text = "grim jailer"
+        app.query_one("#personas-lore-entry-selective", Switch).value = False
+        app.query_one("#personas-lore-entry-secondary-keys", Input).value = "sword"
+        await pilot.pause()
+        await pilot.click("#personas-lore-entry-add")
+        await pilot.pause()
+        payload = app.posted[-1]
+        assert payload["selective"] is False
+        assert payload["secondary_keys"] == ["sword"]
+
+
+@pytest.mark.asyncio
+async def test_fill_form_populates_matching_controls():
+    """Selecting a row fills the three controls; an entry with selective=False
+    but stored secondary keys keeps its keys (fidelity) and shows them disabled."""
+    app = _DetailHost()
+    async with app.run_test(size=(140, 40)) as pilot:
+        widget = app.query_one(PersonasLoreDetailWidget)
+        widget.load_book({"id": 1, "name": "B", "description": "", "scan_depth": 3,
+                          "token_budget": 500, "recursive_scanning": False, "enabled": True})
+        widget.update_entries([
+            {"id": 7, "keys": ["Warden"], "content": "grim jailer",
+             "position": "before_char", "enabled": True, "insertion_order": 0,
+             "case_sensitive": True, "selective": False,
+             "secondary_keys": ["alpha", "beta"]},
+        ])
+        await pilot.pause()
+        table = app.query_one("#personas-lore-entries-table", DataTable)
+        table.move_cursor(row=0)
+        await pilot.pause()
+        assert app.query_one("#personas-lore-entry-case-sensitive", Switch).value is True
+        assert app.query_one("#personas-lore-entry-selective", Switch).value is False
+        sec = app.query_one("#personas-lore-entry-secondary-keys", Input)
+        assert sec.value == "alpha, beta"   # preserved even though selective is False
+        assert sec.disabled is True          # selective off → disabled hint
+
+
+@pytest.mark.asyncio
+async def test_secondary_keys_disabled_hint_tracks_selective():
+    app = _DetailHost()
+    async with app.run_test(size=(140, 40)) as pilot:
+        widget = app.query_one(PersonasLoreDetailWidget)
+        widget.load_book({"id": 1, "name": "B", "description": "", "scan_depth": 3,
+                          "token_budget": 500, "recursive_scanning": False, "enabled": True})
+        await pilot.pause()
+        sec = app.query_one("#personas-lore-entry-secondary-keys", Input)
+        sel = app.query_one("#personas-lore-entry-selective", Switch)
+        assert sec.disabled is True          # selective defaults off → disabled on mount
+        sec.value = "kept"
+        sel.value = True
+        await pilot.pause()
+        assert sec.disabled is False         # selective on → enabled
+        assert sec.value == "kept"
+        sel.value = False
+        await pilot.pause()
+        assert sec.disabled is True          # selective off → disabled again
+        assert sec.value == "kept"           # value survives the toggle (fidelity)
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+```bash
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+Tests/UI/test_personas_lore.py -k "matching_controls or secondary_keys or fill_form_populates" \
+-q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: FAIL — `NoMatches` querying `#personas-lore-entry-case-sensitive` (the controls don't exist yet).
+
+- [ ] **Step 3: Add the three form controls to compose**
+
+In `personas_lore_detail.py`, the entry-form block currently reads (`:114-124`):
+
+```python
+                    with Horizontal(classes="personas-lore-form-row"):
+                        yield Input(placeholder="Keys (comma-separated)", id="personas-lore-entry-keys")
+                        yield Select(
+                            [(label, value) for value, label in POSITIONS],
+                            id="personas-lore-entry-position",
+                            value="before_char",
+                            allow_blank=False,
+                        )
+                        yield Input(placeholder="Priority", id="personas-lore-entry-priority", value="0")
+                        yield Switch(value=True, id="personas-lore-entry-enabled", tooltip="Entry enabled")
+                    yield TextArea(id="personas-lore-entry-content")
+```
+
+Insert a second form-row and the secondary-keys input between the first `Horizontal` and the content `TextArea`:
+
+```python
+                    with Horizontal(classes="personas-lore-form-row"):
+                        yield Input(placeholder="Keys (comma-separated)", id="personas-lore-entry-keys")
+                        yield Select(
+                            [(label, value) for value, label in POSITIONS],
+                            id="personas-lore-entry-position",
+                            value="before_char",
+                            allow_blank=False,
+                        )
+                        yield Input(placeholder="Priority", id="personas-lore-entry-priority", value="0")
+                        yield Switch(value=True, id="personas-lore-entry-enabled", tooltip="Entry enabled")
+                    with Horizontal(classes="personas-lore-form-row"):
+                        yield Static("Case-sensitive", markup=False)
+                        yield Switch(value=False, id="personas-lore-entry-case-sensitive")
+                        yield Static("Selective", markup=False)
+                        yield Switch(value=False, id="personas-lore-entry-selective")
+                    yield Input(
+                        placeholder="Secondary keys (comma-separated)",
+                        id="personas-lore-entry-secondary-keys",
+                    )
+                    yield TextArea(id="personas-lore-entry-content")
+```
+
+- [ ] **Step 4: Add the `_sync_secondary_keys_disabled` helper and wire on_mount + a Switch.Changed handler**
+
+The current `on_mount` (`:145-153`) is:
+
+```python
+    def on_mount(self) -> None:
+        """Register the entries table's columns once the widget is mounted.
+
+        Returns:
+            None.
+        """
+        table = self.query_one("#personas-lore-entries-table", DataTable)
+        table.add_columns("keys", "content", "position", "priority", "enabled")
+```
+
+Append the initial sync call (leave the docstring/columns as-is, add the last line):
+
+```python
+        table = self.query_one("#personas-lore-entries-table", DataTable)
+        table.add_columns("keys", "content", "position", "priority", "enabled")
+        self._sync_secondary_keys_disabled()
+```
+
+Add the helper method (place it right after `on_mount`, before `# ----- public API -----` at `:155`):
+
+```python
+    def _sync_secondary_keys_disabled(self) -> None:
+        """Grey the secondary-keys input when Selective is off (pure visual hint;
+        the stored value is preserved either way).
+
+        Called from on_mount, from _fill_form_from_entry (Textual does NOT fire
+        Switch.Changed when a switch is set to the value it already holds — the
+        same hazard _set_enabled_switch guards against), and from the Selective
+        switch's Changed handler.
+        """
+        selective = self.query_one("#personas-lore-entry-selective", Switch).value
+        self.query_one("#personas-lore-entry-secondary-keys", Input).disabled = not selective
+```
+
+Add the live-toggle handler next to the existing `_enabled_changed` handler (`:426-434`):
+
+```python
+    @on(Switch.Changed, "#personas-lore-entry-selective")
+    def _selective_changed(self, event: Switch.Changed) -> None:
+        event.stop()
+        self._sync_secondary_keys_disabled()
+```
+
+- [ ] **Step 5: Add the three fields to `entry_form_payload`**
+
+The current method (`:271-310`) computes `enabled` at `:291` then builds the return dict at `:303-310`. Add the three reads after `enabled = ...` (`:291`):
+
+```python
+        enabled = bool(self.query_one("#personas-lore-entry-enabled", Switch).value)
+        case_sensitive = bool(self.query_one("#personas-lore-entry-case-sensitive", Switch).value)
+        selective = bool(self.query_one("#personas-lore-entry-selective", Switch).value)
+        raw_secondary = self.query_one("#personas-lore-entry-secondary-keys", Input).value
+        secondary_keys = [k.strip() for k in raw_secondary.split(",") if k.strip()]
+```
+
+Add the three keys to the returned dict (`:303-310`):
+
+```python
+        return {
+            "keys": keys,
+            "content": content,
+            "position": position,
+            "priority": priority,
+            "enabled": enabled,
+            "insertion_order": insertion_order,
+            "case_sensitive": case_sensitive,
+            "selective": selective,
+            "secondary_keys": secondary_keys,
+        }
+```
+
+Update the method docstring's field list (`:274-278`) to end with `..., ``priority``, ``case_sensitive``, ``selective``, ``secondary_keys``), or ``None`` if keys or content are empty.`
+
+- [ ] **Step 6: Populate the three controls in `_fill_form_from_entry`**
+
+The current method ends (`:349-350`) with:
+
+```python
+        self.query_one("#personas-lore-entry-priority", Input).value = str(entry.get("priority") or 0)
+        self.query_one("#personas-lore-entry-enabled", Switch).value = bool(entry.get("enabled", True))
+```
+
+Append:
+
+```python
+        self.query_one("#personas-lore-entry-case-sensitive", Switch).value = bool(entry.get("case_sensitive", False))
+        self.query_one("#personas-lore-entry-selective", Switch).value = bool(entry.get("selective", False))
+        self.query_one("#personas-lore-entry-secondary-keys", Input).value = ", ".join(
+            str(k) for k in (entry.get("secondary_keys") or [])
+        )
+        self._sync_secondary_keys_disabled()
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run:
+```bash
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+Tests/UI/test_personas_lore.py -k "matching_controls or secondary_keys or fill_form_populates" \
+-q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: PASS (4 tests). Then run the whole file to confirm no regressions:
+```bash
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+Tests/UI/test_personas_lore.py -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: all pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tldw_chatbook/Widgets/Persona_Widgets/personas_lore_detail.py Tests/UI/test_personas_lore.py
+git commit -m "feat(lore): edit selective/secondary_keys/case_sensitive in the entry editor"
+```
+
+---
+
+### Task 2: Screen add-handler threads the three fields
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/personas_screen.py` (`_handle_lore_entry_add` — the `create_world_book_entry` call)
+- Test: `Tests/UI/test_personas_lore.py`
+
+**Interfaces:**
+- Consumes: `entry_form_payload()` now carries `case_sensitive`/`selective`/`secondary_keys` (Task 1). `create_world_book_entry(..., selective=False, secondary_keys=None, case_sensitive=False, ...)` (existing manager signature). `update_world_book_entry(entry_id, **kwargs)` already handles the three fields (no change).
+- Produces: entries created through the real screen add-handler persist all three fields.
+
+- [ ] **Step 1: Write the failing real-handler tests**
+
+Append to `Tests/UI/test_personas_lore.py` (after `test_add_entry_persists_priority_through_real_screen_handler`, `:529`). These use the real `LorePersonasTestApp` + real DB. `Switch` is already imported after Task 1.
+
+```python
+@pytest.mark.asyncio
+async def test_add_entry_persists_matching_fields_through_real_screen_handler(
+    mock_app_instance, stub_characters_lore, lore_db, seeded_lore_book
+):
+    """The real _handle_lore_entry_add must forward selective/secondary_keys/
+    case_sensitive to the DB — regression against the explicit-kwarg drop that
+    bit `priority` in P2c."""
+    mock_app_instance.chachanotes_db = lore_db
+    app = LorePersonasTestApp(mock_app_instance)
+    async with app.run_test(size=(200, 60)) as pilot:
+        screen = await _enter_lore(pilot)
+        await _select_first_lore(pilot, screen)
+        screen.query_one("#personas-lore-entry-keys", Input).value = "Ghost"
+        screen.query_one("#personas-lore-entry-content", TextArea).text = "a pale spirit"
+        screen.query_one("#personas-lore-entry-case-sensitive", Switch).value = True
+        screen.query_one("#personas-lore-entry-selective", Switch).value = True
+        screen.query_one("#personas-lore-entry-secondary-keys", Input).value = "sword"
+        await pilot.pause()
+        await pilot.click("#personas-lore-entry-add")
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        entries = WorldBookManager(lore_db).get_world_book_entries(seeded_lore_book["book_id"])
+        ghost = next(e for e in entries if e["keys"] == ["Ghost"])
+        assert ghost["case_sensitive"] is True
+        assert ghost["selective"] is True
+        assert ghost["secondary_keys"] == ["sword"]
+
+
+@pytest.mark.asyncio
+async def test_update_entry_persists_matching_fields_through_real_screen_handler(
+    mock_app_instance, stub_characters_lore, lore_db, seeded_lore_book
+):
+    """_handle_lore_entry_update forwards the three fields via **payload."""
+    mock_app_instance.chachanotes_db = lore_db
+    app = LorePersonasTestApp(mock_app_instance)
+    async with app.run_test(size=(200, 60)) as pilot:
+        screen = await _enter_lore(pilot)
+        await _select_first_lore(pilot, screen)
+        table = screen.query_one("#personas-lore-entries-table", DataTable)
+        table.move_cursor(row=0)          # select the seeded "Warden" entry → fills form
+        await pilot.pause()
+        screen.query_one("#personas-lore-entry-case-sensitive", Switch).value = True
+        screen.query_one("#personas-lore-entry-selective", Switch).value = True
+        screen.query_one("#personas-lore-entry-secondary-keys", Input).value = "prison"
+        await pilot.pause()
+        await pilot.click("#personas-lore-entry-update")
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        entries = WorldBookManager(lore_db).get_world_book_entries(seeded_lore_book["book_id"])
+        warden = next(e for e in entries if e["keys"] == ["Warden"])
+        assert warden["case_sensitive"] is True
+        assert warden["selective"] is True
+        assert warden["secondary_keys"] == ["prison"]
+```
+
+- [ ] **Step 2: Run the tests to verify the add test fails**
+
+Run:
+```bash
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+Tests/UI/test_personas_lore.py -k "persists_matching_fields" \
+-q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: `test_add_entry_persists_matching_fields_through_real_screen_handler` FAILS — the persisted entry has `case_sensitive=False`/`selective=False`/`secondary_keys=[]` because the add-handler drops the fields. (`test_update_...` may already PASS, since update uses `**payload` — that is fine; it pins the update path.)
+
+- [ ] **Step 3: Thread the three fields into `_handle_lore_entry_add`**
+
+In `personas_screen.py`, `_handle_lore_entry_add` calls `create_world_book_entry` with an explicit kwarg list. Add the three fields:
+
+```python
+        await self._run_lore_entry_op(
+            lambda manager: asyncio.to_thread(
+                manager.create_world_book_entry,
+                int(entity_id),
+                keys=payload.get("keys", []),
+                content=payload.get("content", ""),
+                enabled=payload.get("enabled", True),
+                position=payload.get("position", "before_char"),
+                insertion_order=payload.get("insertion_order", 0),
+                priority=payload.get("priority", 0),
+                selective=payload.get("selective", False),
+                secondary_keys=payload.get("secondary_keys", []),
+                case_sensitive=payload.get("case_sensitive", False),
+            ),
+            "Could not add the entry",
+        )
+```
+
+Leave `_handle_lore_entry_update` unchanged (it already forwards `**payload`).
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run:
+```bash
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+Tests/UI/test_personas_lore.py -k "persists_matching_fields" \
+-q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/UI/Screens/personas_screen.py Tests/UI/test_personas_lore.py
+git commit -m "fix(lore): add-handler forwards selective/secondary_keys/case_sensitive to the DB"
+```
+
+---
+
+### Task 3: End-to-end matching integration test
+
+**Files:**
+- Test: `Tests/UI/test_personas_lore.py`
+
+**Interfaces:**
+- Consumes: the real editor→add-handler path (Tasks 1-2) persisting a selective entry; `WorldBookManager.get_world_book` + `get_world_book_entries`; `WorldInfoProcessor(world_books=[...]).process_messages(...)`.
+- Produces: nothing (leaf test).
+
+This is one integration test that proves the surfaced config actually changes matching behavior end to end — not a broad matcher re-test (the matcher's selective/secondary logic is already covered by `Tests/Character_Chat/test_world_info.py`).
+
+- [ ] **Step 1: Write the failing integration test**
+
+Add the `WorldInfoProcessor` import next to the other Task-6 imports (near `:203`, after `from tldw_chatbook.Character_Chat.world_book_manager import WorldBookManager`):
+
+```python
+from tldw_chatbook.Character_Chat.world_info_processor import WorldInfoProcessor
+```
+
+Append the test to `Tests/UI/test_personas_lore.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_selective_entry_created_via_editor_gates_matching(
+    mock_app_instance, stub_characters_lore, lore_db, seeded_lore_book
+):
+    """A selective entry created through the real editor/add-handler path gates
+    matching in WorldInfoProcessor: it fires only when a secondary key is present
+    in the scan text. Proves editor config → DB → matcher end to end."""
+    mock_app_instance.chachanotes_db = lore_db
+    app = LorePersonasTestApp(mock_app_instance)
+    async with app.run_test(size=(200, 60)) as pilot:
+        screen = await _enter_lore(pilot)
+        await _select_first_lore(pilot, screen)
+        screen.query_one("#personas-lore-entry-keys", Input).value = "hero"
+        screen.query_one("#personas-lore-entry-content", TextArea).text = "the brave hero"
+        screen.query_one("#personas-lore-entry-selective", Switch).value = True
+        screen.query_one("#personas-lore-entry-secondary-keys", Input).value = "sword"
+        await pilot.pause()
+        await pilot.click("#personas-lore-entry-add")
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+    manager = WorldBookManager(lore_db)
+    book = manager.get_world_book(seeded_lore_book["book_id"])
+    entries = manager.get_world_book_entries(seeded_lore_book["book_id"])
+    world_book = {**book, "entries": entries}
+    proc = WorldInfoProcessor(world_books=[world_book])
+
+    # primary key "hero" present but secondary "sword" absent → selective entry does NOT fire
+    r1 = proc.process_messages("the hero walks alone", [])
+    assert all("brave hero" not in c for c in r1["injections"]["before_char"])
+    # primary + secondary present → fires
+    r2 = proc.process_messages("the hero draws a sword", [])
+    assert any("brave hero" in c for c in r2["injections"]["before_char"])
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+With Tasks 1-2 done this should PASS immediately (it depends on their code). Run:
+```bash
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+Tests/UI/test_personas_lore.py::test_selective_entry_created_via_editor_gates_matching \
+-q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: PASS. If it fails at the `r1` assertion (entry fired without the secondary key), the selective/secondary_keys did not reach the DB — revisit Task 2. To prove the test has teeth, temporarily set the Selective switch line to `False` and confirm `r1` then fails (the entry fires on primary alone), then restore `True`.
+
+- [ ] **Step 3: Run the full gate**
+
+```bash
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+Tests/UI/test_personas_lore.py Tests/Character_Chat/test_world_book_manager.py \
+Tests/Character_Chat/test_world_info_diagnostics.py Tests/Character_Chat/test_world_info.py \
+-q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: all pass. Then the import smoke:
+```bash
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -c "import tldw_chatbook.app; print('APP IMPORT OK')"
+```
+Expected: `APP IMPORT OK`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Tests/UI/test_personas_lore.py
+git commit -m "test(lore): editor-created selective entry gates matching end to end"
+```
+
+---
+
+## Notes for the reviewer
+
+- **No production code outside the two named files.** Any change to `world_info_processor.py`, `world_book_manager.py`, or `ChaChaNotes_DB.py` is out of scope for P2d-1 and should be rejected.
+- **The add-handler regression (Task 2 Step 2) must be seen RED before the fix.** If it passed before Step 3, the test isn't exercising the real handler.
+- **`secondary_keys` fidelity:** the value must be stored regardless of the Selective switch. A design that clears `secondary_keys` when Selective is off is a defect against the spec.
+- **Disabled hint via helper, not the event alone:** `_sync_secondary_keys_disabled()` is called from `on_mount`, `_fill_form_from_entry`, AND the Changed handler — because Textual does not fire `Switch.Changed` on a no-op set (the `_set_enabled_switch` comment at `personas_lore_detail.py:225-235` documents this exact hazard). Relying only on the Changed handler would leave the hint stale after selecting a row.

--- a/Docs/superpowers/specs/2026-07-17-roleplay-p2d1-matching-editor-design.md
+++ b/Docs/superpowers/specs/2026-07-17-roleplay-p2d1-matching-editor-design.md
@@ -1,0 +1,124 @@
+# Roleplay P2d-1 — surface selective / secondary_keys / case_sensitive in the Lore entry editor
+
+**Status:** Design.
+
+**Program:** Roleplay (Personas) redesign — P2 (Lore mode). First half of P2d (the "richer Lore entry editor + import/export" sub-project), split into P2d-1 (matching-controls editor) and P2d-2 (import/export UI). Follows P2c (entry priority + priority-aware budget, PR #682 merged; schema now v21).
+
+## Why
+
+The Lore entry editor (`PersonasLoreDetailWidget`) lets a user edit an entry's keys, position, priority, enabled flag, and content — but **not** its three matching controls (`selective`, `secondary_keys`, `case_sensitive`), even though those fields already exist and work end-to-end in the schema, the processor, and the manager. A user can't configure case-sensitive matching or selective (require-a-secondary-key) matching from the redesigned editor; they can only be set by import or by the legacy UI. P2d-1 closes that gap.
+
+## Scope
+
+**In scope:** editing controls for `selective`, `secondary_keys`, and `case_sensitive` in the entry form, threaded through `entry_form_payload()`, `_fill_form_from_entry()`, and the screen's add handler; a visual "secondary keys inactive" hint that never destroys stored data.
+
+**Explicitly NOT in scope (deferred):**
+- **Regex matching** — the only genuinely new matching capability; deferred to its own sub-project (needs storage + a ReDoS-safe branch in the live matcher). Not touched here.
+- **Import/export UI** — P2d-2.
+- **No new DataTable column** for matching flags (keeps the entries table narrow; the form is the source of truth).
+- Conversation attach (P2e), character attach (P2f), Console "what's in play" + native-send (P2g).
+
+## Behavior-change framing
+
+This is a **pure UI surfacing** change over capability that already exists and is already exercised on the live send path. It adds **no** schema migration (stays v21), **no** processor/matcher code, and **no** manager code. The only behavior change is that the editor can now write three fields it previously left at their defaults; entries created/edited before P2d-1 are unaffected (their stored `selective`/`secondary_keys`/`case_sensitive` values are already honored by the matcher and are simply now visible/editable).
+
+## Ground truths (verified at dev tip, post-#682)
+
+- **Schema** (`ChaChaNotes_DB.py:1194`, `world_book_entries`, v21): already has `selective BOOLEAN DEFAULT 0`, `secondary_keys TEXT` (JSON array), `case_sensitive BOOLEAN DEFAULT 0`. No `regex` column.
+- **Processor** (`world_info_processor.py`): `_entry_matches` already honors `case_sensitive` (via `_keyword_in_text`, word-boundary `\b…\b` matching), `selective`, and `secondary_keys` (a selective entry with secondary keys requires at least one secondary hit; a selective entry with **no** secondary keys falls back to primary-only). No change needed.
+- **Manager** (`world_book_manager.py`):
+  - `create_world_book_entry(..., selective: bool = False, secondary_keys: Optional[List[str]] = None, case_sensitive: bool = False, ...)` — already accepts all three.
+  - `update_world_book_entry(**kwargs)` — its field loop already includes `'selective'`, `'secondary_keys'`, `'case_sensitive'` (`secondary_keys` is JSON-encoded in the `['keys','secondary_keys','extensions']` group; empty list → `NULL`).
+  - `get_world_book_entries` — already returns `selective` (bool), `secondary_keys` (list), `case_sensitive` (bool) in each row dict.
+- **Widget** (`personas_lore_detail.py`): entry form composed at `:114-124` (one Horizontal row: keys / position / priority / enabled, then a content `TextArea`); `entry_form_payload()` at `:271`; `_fill_form_from_entry()` at `:337`; `on_mount` at `:145` (registers DataTable columns). None of the three matching fields are exposed.
+- **Textual `Switch` behavior** (verified against installed Textual): `Switch.Changed` carries `.value` (bool) and `.switch`. Textual does **not** fire `Switch.Changed` when a switch is set to the value it already holds — the widget already compensates for this for the book-enabled switch via `_set_enabled_switch` (`:221-237`, comment at `:231`), and has a scoped `@on(Switch.Changed, "#personas-lore-enabled")` handler at `:426`.
+- **Screen** (`personas_screen.py`): `_handle_lore_entry_add` calls `create_world_book_entry` with an **explicit kwarg list** (keys, content, enabled, position, insertion_order, priority) — so any field not named is silently dropped (this is the exact bug fixed for `priority` in P2c). `_handle_lore_entry_update` calls `update_world_book_entry(int(entry_id), **payload)`, so it picks up any new payload key automatically.
+
+## Architecture
+
+### 1. Form controls (`personas_lore_detail.py`, compose)
+
+Add **two rows** immediately after the existing keys/position/priority/enabled row and **before** the content `TextArea` (grouping all key/matching config above the content area), to avoid crowding at the QA resolution (2050×1240) and give secondary keys room:
+
+- **Row 2** (`Horizontal`, `classes="personas-lore-form-row"`): a labeled Case-sensitive switch and a labeled Selective switch. The Settings tab already uses `Static + Switch` inside `personas-lore-form-row` (`:136-141`), so this reuses a proven layout.
+  - `Static("Case-sensitive", markup=False)` + `Switch(value=False, id="personas-lore-entry-case-sensitive")`
+  - `Static("Selective", markup=False)` + `Switch(value=False, id="personas-lore-entry-selective")`
+- **Secondary-keys input**: a full-width `Input(placeholder="Secondary keys (comma-separated)", id="personas-lore-entry-secondary-keys")` yielded as a **direct child** of the entries `VerticalScroll` (like the content `TextArea` and the Name input at `:132`), **not** wrapped in a single-child Horizontal — a lone child in a horizontal form-row does not fill the row cleanly.
+
+Resulting entries-tab child order: DataTable → Row 1 (keys/position/priority/enabled) → Row 2 (case-sensitive/selective) → secondary-keys `Input` → content `TextArea` → button row.
+
+Both switches default `False` (matching the schema defaults `selective`/`case_sensitive` DEFAULT 0).
+
+### 2. `entry_form_payload()` (`personas_lore_detail.py:271`)
+
+After the existing keys/content guard, read the three controls and add them to the returned dict:
+
+- `case_sensitive = bool(query_one("#personas-lore-entry-case-sensitive", Switch).value)`
+- `selective = bool(query_one("#personas-lore-entry-selective", Switch).value)`
+- `secondary_keys = [k.strip() for k in query_one("#personas-lore-entry-secondary-keys", Input).value.split(",") if k.strip()]` (same never-raise comma-split as `keys`)
+
+**Data fidelity:** `secondary_keys` is read and stored **regardless** of the Selective switch state, so toggling Selective off does not erase typed secondary keys (they persist in the DB and are simply inactive in matching until Selective is on). Update the docstring's field list to include `case_sensitive`, `selective`, `secondary_keys`.
+
+### 3. `_fill_form_from_entry()` (`personas_lore_detail.py:337`)
+
+Populate the three controls from the entry dict (never raises; missing → default):
+
+- `#personas-lore-entry-case-sensitive`.value = `bool(entry.get("case_sensitive", False))`
+- `#personas-lore-entry-selective`.value = `bool(entry.get("selective", False))`
+- `#personas-lore-entry-secondary-keys`.value = `", ".join(str(k) for k in (entry.get("secondary_keys") or []))`
+
+Setting the Selective switch value here re-fires `Switch.Changed`, which re-syncs the secondary-keys disabled hint (see §5).
+
+### 4. Add handler threads the three fields (`personas_screen.py::_handle_lore_entry_add`)
+
+Add three explicit kwargs to the `create_world_book_entry` call (the P2c-priority lesson — the explicit kwarg list drops anything not named):
+
+- `selective=payload.get("selective", False)`
+- `secondary_keys=payload.get("secondary_keys", [])`
+- `case_sensitive=payload.get("case_sensitive", False)`
+
+`_handle_lore_entry_update` needs **no change**: it already forwards `**payload`, and the manager's update field-loop already handles the three fields.
+
+### 5. Secondary-keys "inactive" visual hint (`personas_lore_detail.py`)
+
+`secondary_keys` only affects matching when `selective` is on. Disable the secondary-keys `Input` (grays it) when Selective is off, as a pure visual hint — the stored value is preserved either way (§2).
+
+**Use a helper, not the event alone.** Textual does **not** fire `Switch.Changed` when a switch is programmatically set to the value it already holds — the widget already works around this exact hazard for the book-enabled switch via `_set_enabled_switch` (`:221-237`). So relying only on a `Switch.Changed` handler would leave the disabled state stale when `_fill_form_from_entry` sets Selective to a value it already had. Instead:
+
+- Add `_sync_secondary_keys_disabled()`: sets `#personas-lore-entry-secondary-keys`.disabled = `not #personas-lore-entry-selective`.value.
+- Call it from **`on_mount`** (initial state — Selective defaults off → input starts disabled), from **`_fill_form_from_entry`** (after setting the Selective switch, so the state is correct even when `Changed` doesn't fire), and from the **`@on(Switch.Changed, "#personas-lore-entry-selective")`** handler (`event.stop()`; handles live user toggles). The widget already has a scoped `@on(Switch.Changed, "#personas-lore-enabled")` handler (`:426`) for the book-enabled switch, so a second scoped handler for a different id follows the established pattern and cannot collide.
+- A disabled `Input` still returns its `.value` on query, so `entry_form_payload()` reads it correctly even while disabled — the stored value is never lost.
+
+## Data flow
+
+Editor form → `entry_form_payload()` (adds `case_sensitive`/`selective`/`secondary_keys`) → `LoreEntryAddRequested` / `LoreEntryUpdateRequested` → screen handler → `WorldBookManager.create_world_book_entry(...)` (add, explicit kwargs) or `update_world_book_entry(**payload)` (update) → DB. On selection, `get_world_book_entries` → `_fill_form_from_entry()` repopulates the three controls. The live matcher (`_entry_matches`) already reads these fields — no processor change.
+
+## Error handling
+
+- Switches yield booleans; the secondary-keys parse is a never-raising comma-split (empty → `[]`). The `entry_form_payload` never-raise contract is preserved.
+- The disabled-input hint cannot lose data (value is read regardless of disabled state).
+- No new failure surface on the send path (no matcher change).
+
+## Testing
+
+Real-DB + real-widget, per program rules (`HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=…/.local/share .venv/bin/python -m pytest … -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread`):
+
+1. **Widget payload round-trip** (`Tests/UI/test_personas_lore.py`): setting the three controls makes `entry_form_payload()` return `case_sensitive`/`selective`/`secondary_keys` correctly (incl. comma-split and empty → `[]`).
+2. **Fill-from-entry**: `_fill_form_from_entry` populates all three from a persisted entry (incl. `secondary_keys` join, and an entry with `selective=False` but stored secondary keys — the data-fidelity case).
+3. **Real add-handler regression** (the P2c-lesson guard): driving `_handle_lore_entry_add` with a payload carrying the three fields persists them via the real screen handler + real `WorldBookManager` (would fail if the explicit kwargs were dropped).
+4. **Update round-trip**: `_handle_lore_entry_update` persists changes to the three fields via `**payload`.
+5. **Secondary-keys hint**: the input is disabled when Selective is off and enabled when on — verified on mount, after a live toggle, and after selecting an entry via `_fill_form_from_entry` (the case where `Switch.Changed` does not fire because the value is unchanged, which the `_sync_secondary_keys_disabled()` helper covers). Its stored value survives a toggle-off (fidelity).
+6. **One integration test** (spans widget→DB→matcher, not a broad matcher re-test): an entry created through the real add-handler path with `selective=True` + secondary keys gates matching in `WorldInfoProcessor` (fires only when a secondary key is present in scan text), proving the surfaced config actually changes matching behavior.
+
+Full gate: `Tests/UI/test_personas_lore.py`, `Tests/Character_Chat/test_world_book_manager.py`, `Tests/Character_Chat/test_world_info_diagnostics.py`, `Tests/Character_Chat/test_world_info.py`, plus `import tldw_chatbook.app`.
+
+## Acceptance criteria
+
+- [ ] The Lore entry editor exposes editable Case-sensitive and Selective switches and a Secondary-keys input.
+- [ ] `entry_form_payload()` returns `case_sensitive` (bool), `selective` (bool), and `secondary_keys` (list); `secondary_keys` is stored as typed regardless of the Selective switch state.
+- [ ] `_fill_form_from_entry()` repopulates all three controls from a persisted entry, including an entry whose `selective=False` but has stored secondary keys.
+- [ ] Creating an entry through the real screen add-handler persists all three fields (regression against a dropped kwarg); updating an entry persists changes to all three.
+- [ ] The Secondary-keys input is disabled (visual hint) when Selective is off and enabled when on, without ever losing its stored value.
+- [ ] A `selective=True` entry created through the editor path gates matching in `WorldInfoProcessor` as expected.
+- [ ] No schema migration (stays v21), no processor/matcher change, no manager change, no new DataTable column.
+- [ ] Full gate green; `import tldw_chatbook.app` OK.

--- a/Tests/UI/test_personas_lore.py
+++ b/Tests/UI/test_personas_lore.py
@@ -313,6 +313,7 @@ async def test_tryit_bracket_tag_content_not_backslash_escaped():
 # PersonasScreen against it.
 
 from tldw_chatbook.Character_Chat.world_book_manager import WorldBookManager
+from tldw_chatbook.Character_Chat.world_info_processor import WorldInfoProcessor
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
 from tldw_chatbook.UI.Screens.personas_screen import PersonasScreen
 from tldw_chatbook.Widgets.AppFooterStatus import AppFooterStatus
@@ -691,3 +692,39 @@ async def test_update_entry_persists_matching_fields_through_real_screen_handler
         assert warden["case_sensitive"] is True
         assert warden["selective"] is True
         assert warden["secondary_keys"] == ["prison"]
+
+
+@pytest.mark.asyncio
+async def test_selective_entry_created_via_editor_gates_matching(
+    mock_app_instance, stub_characters_lore, lore_db, seeded_lore_book
+):
+    """A selective entry created through the real editor/add-handler path gates
+    matching in WorldInfoProcessor: it fires only when a secondary key is present
+    in the scan text. Proves editor config → DB → matcher end to end."""
+    mock_app_instance.chachanotes_db = lore_db
+    app = LorePersonasTestApp(mock_app_instance)
+    async with app.run_test(size=(200, 60)) as pilot:
+        screen = await _enter_lore(pilot)
+        await _select_first_lore(pilot, screen)
+        screen.query_one("#personas-lore-entry-keys", Input).value = "hero"
+        screen.query_one("#personas-lore-entry-content", TextArea).text = "the brave hero"
+        screen.query_one("#personas-lore-entry-selective", Switch).value = True
+        screen.query_one("#personas-lore-entry-secondary-keys", Input).value = "sword"
+        await pilot.pause()
+        await pilot.click("#personas-lore-entry-add")
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+    manager = WorldBookManager(lore_db)
+    book = manager.get_world_book(seeded_lore_book["book_id"])
+    entries = manager.get_world_book_entries(seeded_lore_book["book_id"])
+    world_book = {**book, "entries": entries}
+    proc = WorldInfoProcessor(world_books=[world_book])
+
+    # primary key "hero" present but secondary "sword" absent → selective entry does NOT fire
+    r1 = proc.process_messages("the hero walks alone", [])
+    assert all("brave hero" not in c for c in r1["injections"]["before_char"])
+    # primary + secondary present → fires
+    r2 = proc.process_messages("the hero draws a sword", [])
+    assert any("brave hero" in c for c in r2["injections"]["before_char"])

--- a/Tests/UI/test_personas_lore.py
+++ b/Tests/UI/test_personas_lore.py
@@ -7,7 +7,7 @@ test_personas_dictionaries.py's PersonasTestApp harness)."""
 import pytest
 from textual.app import App, ComposeResult
 from textual.coordinate import Coordinate
-from textual.widgets import Button, DataTable, Input, ListView, Static, TextArea
+from textual.widgets import Button, DataTable, Input, ListView, Static, Switch, TextArea
 
 from tldw_chatbook.Widgets.Persona_Widgets.personas_lore_detail import (
     PersonasLoreDetailWidget,
@@ -121,6 +121,113 @@ async def test_entry_priority_round_trips_through_form():
         await pilot.click("#personas-lore-entry-add")
         await pilot.pause()
         assert app.posted[-1]["priority"] == 80
+
+
+@pytest.mark.asyncio
+async def test_matching_controls_round_trip_through_form():
+    app = _DetailHost()
+    async with app.run_test(size=(140, 40)) as pilot:
+        widget = app.query_one(PersonasLoreDetailWidget)
+        widget.load_book({"id": 1, "name": "B", "description": "", "scan_depth": 3,
+                          "token_budget": 500, "recursive_scanning": False, "enabled": True})
+        app.query_one("#personas-lore-entry-keys", Input).value = "Warden"
+        app.query_one("#personas-lore-entry-content", TextArea).text = "grim jailer"
+        app.query_one("#personas-lore-entry-case-sensitive", Switch).value = True
+        app.query_one("#personas-lore-entry-selective", Switch).value = True
+        app.query_one("#personas-lore-entry-secondary-keys", Input).value = " sword , shield ,"
+        await pilot.pause()
+        await pilot.click("#personas-lore-entry-add")
+        await pilot.pause()
+        payload = app.posted[-1]
+        assert payload["case_sensitive"] is True
+        assert payload["selective"] is True
+        assert payload["secondary_keys"] == ["sword", "shield"]  # trimmed, blank dropped
+
+
+@pytest.mark.asyncio
+async def test_blank_secondary_keys_is_empty_list():
+    """A blank secondary-keys field yields [] (never raises)."""
+    app = _DetailHost()
+    async with app.run_test(size=(140, 40)) as pilot:
+        widget = app.query_one(PersonasLoreDetailWidget)
+        widget.load_book({"id": 1, "name": "B", "description": "", "scan_depth": 3,
+                          "token_budget": 500, "recursive_scanning": False, "enabled": True})
+        app.query_one("#personas-lore-entry-keys", Input).value = "Warden"
+        app.query_one("#personas-lore-entry-content", TextArea).text = "grim jailer"
+        # secondary-keys left blank
+        await pilot.pause()
+        await pilot.click("#personas-lore-entry-add")
+        await pilot.pause()
+        assert app.posted[-1]["secondary_keys"] == []
+
+
+@pytest.mark.asyncio
+async def test_secondary_keys_stored_even_when_not_selective():
+    """Data fidelity: secondary keys are stored regardless of the Selective
+    switch, so toggling Selective off does not erase them."""
+    app = _DetailHost()
+    async with app.run_test(size=(140, 40)) as pilot:
+        widget = app.query_one(PersonasLoreDetailWidget)
+        widget.load_book({"id": 1, "name": "B", "description": "", "scan_depth": 3,
+                          "token_budget": 500, "recursive_scanning": False, "enabled": True})
+        app.query_one("#personas-lore-entry-keys", Input).value = "Warden"
+        app.query_one("#personas-lore-entry-content", TextArea).text = "grim jailer"
+        app.query_one("#personas-lore-entry-selective", Switch).value = False
+        app.query_one("#personas-lore-entry-secondary-keys", Input).value = "sword"
+        await pilot.pause()
+        await pilot.click("#personas-lore-entry-add")
+        await pilot.pause()
+        payload = app.posted[-1]
+        assert payload["selective"] is False
+        assert payload["secondary_keys"] == ["sword"]
+
+
+@pytest.mark.asyncio
+async def test_fill_form_populates_matching_controls():
+    """Selecting a row fills the three controls; an entry with selective=False
+    but stored secondary keys keeps its keys (fidelity) and shows them disabled."""
+    app = _DetailHost()
+    async with app.run_test(size=(140, 40)) as pilot:
+        widget = app.query_one(PersonasLoreDetailWidget)
+        widget.load_book({"id": 1, "name": "B", "description": "", "scan_depth": 3,
+                          "token_budget": 500, "recursive_scanning": False, "enabled": True})
+        widget.update_entries([
+            {"id": 7, "keys": ["Warden"], "content": "grim jailer",
+             "position": "before_char", "enabled": True, "insertion_order": 0,
+             "case_sensitive": True, "selective": False,
+             "secondary_keys": ["alpha", "beta"]},
+        ])
+        await pilot.pause()
+        table = app.query_one("#personas-lore-entries-table", DataTable)
+        table.move_cursor(row=0)
+        await pilot.pause()
+        assert app.query_one("#personas-lore-entry-case-sensitive", Switch).value is True
+        assert app.query_one("#personas-lore-entry-selective", Switch).value is False
+        sec = app.query_one("#personas-lore-entry-secondary-keys", Input)
+        assert sec.value == "alpha, beta"   # preserved even though selective is False
+        assert sec.disabled is True          # selective off → disabled hint
+
+
+@pytest.mark.asyncio
+async def test_secondary_keys_disabled_hint_tracks_selective():
+    app = _DetailHost()
+    async with app.run_test(size=(140, 40)) as pilot:
+        widget = app.query_one(PersonasLoreDetailWidget)
+        widget.load_book({"id": 1, "name": "B", "description": "", "scan_depth": 3,
+                          "token_budget": 500, "recursive_scanning": False, "enabled": True})
+        await pilot.pause()
+        sec = app.query_one("#personas-lore-entry-secondary-keys", Input)
+        sel = app.query_one("#personas-lore-entry-selective", Switch)
+        assert sec.disabled is True          # selective defaults off → disabled on mount
+        sec.value = "kept"
+        sel.value = True
+        await pilot.pause()
+        assert sec.disabled is False         # selective on → enabled
+        assert sec.value == "kept"
+        sel.value = False
+        await pilot.pause()
+        assert sec.disabled is True          # selective off → disabled again
+        assert sec.value == "kept"           # value survives the toggle (fidelity)
 
 
 class _TryItHost(App):

--- a/Tests/UI/test_personas_lore.py
+++ b/Tests/UI/test_personas_lore.py
@@ -634,3 +634,60 @@ async def test_add_entry_persists_priority_through_real_screen_handler(
         entries = WorldBookManager(lore_db).get_world_book_entries(seeded_lore_book["book_id"])
         ghost = next(e for e in entries if e["keys"] == ["Ghost"])
         assert ghost["priority"] == 80
+
+
+@pytest.mark.asyncio
+async def test_add_entry_persists_matching_fields_through_real_screen_handler(
+    mock_app_instance, stub_characters_lore, lore_db, seeded_lore_book
+):
+    """The real _handle_lore_entry_add must forward selective/secondary_keys/
+    case_sensitive to the DB — regression against the explicit-kwarg drop that
+    bit `priority` in P2c."""
+    mock_app_instance.chachanotes_db = lore_db
+    app = LorePersonasTestApp(mock_app_instance)
+    async with app.run_test(size=(200, 60)) as pilot:
+        screen = await _enter_lore(pilot)
+        await _select_first_lore(pilot, screen)
+        screen.query_one("#personas-lore-entry-keys", Input).value = "Ghost"
+        screen.query_one("#personas-lore-entry-content", TextArea).text = "a pale spirit"
+        screen.query_one("#personas-lore-entry-case-sensitive", Switch).value = True
+        screen.query_one("#personas-lore-entry-selective", Switch).value = True
+        screen.query_one("#personas-lore-entry-secondary-keys", Input).value = "sword"
+        await pilot.pause()
+        await pilot.click("#personas-lore-entry-add")
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        entries = WorldBookManager(lore_db).get_world_book_entries(seeded_lore_book["book_id"])
+        ghost = next(e for e in entries if e["keys"] == ["Ghost"])
+        assert ghost["case_sensitive"] is True
+        assert ghost["selective"] is True
+        assert ghost["secondary_keys"] == ["sword"]
+
+
+@pytest.mark.asyncio
+async def test_update_entry_persists_matching_fields_through_real_screen_handler(
+    mock_app_instance, stub_characters_lore, lore_db, seeded_lore_book
+):
+    """_handle_lore_entry_update forwards the three fields via **payload."""
+    mock_app_instance.chachanotes_db = lore_db
+    app = LorePersonasTestApp(mock_app_instance)
+    async with app.run_test(size=(200, 60)) as pilot:
+        screen = await _enter_lore(pilot)
+        await _select_first_lore(pilot, screen)
+        table = screen.query_one("#personas-lore-entries-table", DataTable)
+        table.move_cursor(row=0)          # select the seeded "Warden" entry → fills form
+        await pilot.pause()
+        screen.query_one("#personas-lore-entry-case-sensitive", Switch).value = True
+        screen.query_one("#personas-lore-entry-selective", Switch).value = True
+        screen.query_one("#personas-lore-entry-secondary-keys", Input).value = "prison"
+        await pilot.pause()
+        await pilot.click("#personas-lore-entry-update")
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        entries = WorldBookManager(lore_db).get_world_book_entries(seeded_lore_book["book_id"])
+        warden = next(e for e in entries if e["keys"] == ["Warden"])
+        assert warden["case_sensitive"] is True
+        assert warden["selective"] is True
+        assert warden["secondary_keys"] == ["prison"]

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -1976,6 +1976,9 @@ class PersonasScreen(BaseAppScreen):
                 position=payload.get("position", "before_char"),
                 insertion_order=payload.get("insertion_order", 0),
                 priority=payload.get("priority", 0),
+                selective=payload.get("selective", False),
+                secondary_keys=payload.get("secondary_keys", []),
+                case_sensitive=payload.get("case_sensitive", False),
             ),
             "Could not add the entry",
         )

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_lore_detail.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_lore_detail.py
@@ -121,6 +121,15 @@ class PersonasLoreDetailWidget(Vertical):
                         )
                         yield Input(placeholder="Priority", id="personas-lore-entry-priority", value="0")
                         yield Switch(value=True, id="personas-lore-entry-enabled", tooltip="Entry enabled")
+                    with Horizontal(classes="personas-lore-form-row"):
+                        yield Static("Case-sensitive", markup=False)
+                        yield Switch(value=False, id="personas-lore-entry-case-sensitive")
+                        yield Static("Selective", markup=False)
+                        yield Switch(value=False, id="personas-lore-entry-selective")
+                    yield Input(
+                        placeholder="Secondary keys (comma-separated)",
+                        id="personas-lore-entry-secondary-keys",
+                    )
                     yield TextArea(id="personas-lore-entry-content")
                     with Horizontal(classes="personas-lore-form-row"):
                         yield Button("Add", id="personas-lore-entry-add", classes="console-action-secondary")
@@ -150,6 +159,19 @@ class PersonasLoreDetailWidget(Vertical):
         """
         table = self.query_one("#personas-lore-entries-table", DataTable)
         table.add_columns("keys", "content", "position", "priority", "enabled")
+        self._sync_secondary_keys_disabled()
+
+    def _sync_secondary_keys_disabled(self) -> None:
+        """Grey the secondary-keys input when Selective is off (pure visual hint;
+        the stored value is preserved either way).
+
+        Called from on_mount, from _fill_form_from_entry (Textual does NOT fire
+        Switch.Changed when a switch is set to the value it already holds — the
+        same hazard _set_enabled_switch guards against), and from the Selective
+        switch's Changed handler.
+        """
+        selective = self.query_one("#personas-lore-entry-selective", Switch).value
+        self.query_one("#personas-lore-entry-secondary-keys", Input).disabled = not selective
 
     # ----- public API -----
 
@@ -274,8 +296,8 @@ class PersonasLoreDetailWidget(Vertical):
         Returns:
             dict | None: The entry payload keyed by API field names
             (``keys``, ``content``, ``position``, ``enabled``,
-            ``insertion_order``, ``priority``), or ``None`` if keys or content
-            are empty.
+            ``insertion_order``, ``priority``, ``case_sensitive``, ``selective``,
+            ``secondary_keys``), or ``None`` if keys or content are empty.
         """
         raw_keys = self.query_one("#personas-lore-entry-keys", Input).value
         keys = [k.strip() for k in raw_keys.split(",") if k.strip()]
@@ -289,6 +311,10 @@ class PersonasLoreDetailWidget(Vertical):
         except ValueError:
             priority = 0
         enabled = bool(self.query_one("#personas-lore-entry-enabled", Switch).value)
+        case_sensitive = bool(self.query_one("#personas-lore-entry-case-sensitive", Switch).value)
+        selective = bool(self.query_one("#personas-lore-entry-selective", Switch).value)
+        raw_secondary = self.query_one("#personas-lore-entry-secondary-keys", Input).value
+        secondary_keys = [k.strip() for k in raw_secondary.split(",") if k.strip()]
         selected_id = self.selected_entry_id
         entry = (
             next((e for e in self._entries if str(e.get("id")) == selected_id), None)
@@ -307,6 +333,9 @@ class PersonasLoreDetailWidget(Vertical):
             "priority": priority,
             "enabled": enabled,
             "insertion_order": insertion_order,
+            "case_sensitive": case_sensitive,
+            "selective": selective,
+            "secondary_keys": secondary_keys,
         }
 
     def settings_payload(self) -> dict:
@@ -348,6 +377,12 @@ class PersonasLoreDetailWidget(Vertical):
             self.query_one("#personas-lore-entry-position", Select).value = position
         self.query_one("#personas-lore-entry-priority", Input).value = str(entry.get("priority") or 0)
         self.query_one("#personas-lore-entry-enabled", Switch).value = bool(entry.get("enabled", True))
+        self.query_one("#personas-lore-entry-case-sensitive", Switch).value = bool(entry.get("case_sensitive", False))
+        self.query_one("#personas-lore-entry-selective", Switch).value = bool(entry.get("selective", False))
+        self.query_one("#personas-lore-entry-secondary-keys", Input).value = ", ".join(
+            str(k) for k in (entry.get("secondary_keys") or [])
+        )
+        self._sync_secondary_keys_disabled()
 
     @on(DataTable.RowSelected, "#personas-lore-entries-table")
     def _row_selected(self, event: DataTable.RowSelected) -> None:
@@ -432,6 +467,11 @@ class PersonasLoreDetailWidget(Vertical):
             self._suppress_enabled_toggle = False
             return
         self.post_message(LoreBookEnableToggled(bool(event.value)))
+
+    @on(Switch.Changed, "#personas-lore-entry-selective")
+    def _selective_changed(self, event: Switch.Changed) -> None:
+        event.stop()
+        self._sync_secondary_keys_disabled()
 
 
 __all__ = [


### PR DESCRIPTION
## Roleplay P2d-1 — Lore matching-controls editor

First half of **P2d** (richer Lore editor + import/export), split into P2d-1 (matching controls) and P2d-2 (import/export UI). Follows P2c (#682).

### Why
The Lore entry editor let you edit keys/position/priority/enabled/content but **not** the three matching controls — `selective`, `secondary_keys`, `case_sensitive` — even though the schema (v21), the matcher (`WorldInfoProcessor._entry_matches`), and `WorldBookManager` already support them end-to-end. This surfaces them in the editor. **Pure UI wiring: no schema migration (stays v21), no matcher change, no manager change.**

### What changed
- **`personas_lore_detail.py`** — Case-sensitive + Selective switches and a full-width Secondary-keys input in the entry form; threaded through `entry_form_payload()` and `_fill_form_from_entry()`. `secondary_keys` is stored **regardless** of the Selective switch (data fidelity — toggling Selective off never erases typed keys). A `_sync_secondary_keys_disabled()` helper greys the secondary-keys input when Selective is off, called from `on_mount`, `_fill_form_from_entry`, and a scoped `Switch.Changed` handler (Textual doesn't fire `Switch.Changed` on a no-op set — same hazard the existing `_set_enabled_switch` guards).
- **`personas_screen.py`** — `_handle_lore_entry_add` now forwards the three fields as explicit kwargs to `create_world_book_entry` (regression guard against the P2c bug where the explicit-kwarg list silently dropped `priority`). Update was already correct via `**payload`.

### Testing
- New widget tests (payload round-trip incl. blank→`[]` and fidelity; fill-from-entry; disabled-hint on mount/toggle/fill; value-survives-toggle).
- Real-DB screen-handler regression tests (add persists all three — RED before the fix; update round-trips via `**payload`).
- One end-to-end integration test: an editor-created selective entry gates matching in `WorldInfoProcessor` (fires only when a secondary key is present).
- Full gate: `test_personas_lore`, `test_world_book_manager`, `test_world_info_diagnostics`, `test_world_info` = **83 passed**; `import tldw_chatbook.app` OK.

### Review
Built with subagent-driven development (implementer + reviewer per task, opus whole-branch review = **Ready to merge**, no Critical/Important). One Minor (a test blind-spot on genuinely-defensive, spec-mandated code) was reviewed and **kept as-is** (a discriminating test would require an unreachable state — YAGNI).

Spec: `Docs/superpowers/specs/2026-07-17-roleplay-p2d1-matching-editor-design.md`
Plan: `Docs/superpowers/plans/2026-07-17-roleplay-p2d1-matching-editor.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Case-sensitive, Selective, and Secondary keys controls to the Lore entry editor and threads them through add/update so entries persist and match as configured. No schema or matcher changes.

- **New Features**
  - Added Case-sensitive and Selective switches, plus a Secondary keys input to the entry form.
  - Payload now includes `case_sensitive`, `selective`, and `secondary_keys` (comma-split; values persist even if Selective is off).
  - Secondary-keys input disables when Selective is off as a visual hint only.

- **Bug Fixes**
  - `_handle_lore_entry_add` now forwards `selective`, `secondary_keys`, and `case_sensitive` to `create_world_book_entry`.

<sup>Written for commit 6e4b2257086cdf2652c8c9a6c1ebacbb2afcc3d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

