### PR TITLE
perf(mcp): single store load for the external-server catalog (task-236)

### DIFF
--- a/Tests/MCP/test_external_catalog_single_load.py
+++ b/Tests/MCP/test_external_catalog_single_load.py
@@ -1,0 +1,89 @@
+"""Tests for task-236: get_external_servers reads the store exactly once.
+
+Uses the REAL LocalMCPStore on a tmp file with a counting wrapper around
+``load()`` — no fakes of the store contract, so a regression back to
+per-profile snapshot loads (or a signature drift) fails here.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.MCP.local_control_service import LocalMCPControlService
+from tldw_chatbook.MCP.local_store import LocalExternalMCPProfile, LocalMCPStore
+
+
+class _LoadCountingStore(LocalMCPStore):
+    """Real store that counts full state loads."""
+
+    def __init__(self, path: Path):
+        super().__init__(path)
+        self.load_calls = 0
+
+    def load(self):
+        self.load_calls += 1
+        return super().load()
+
+
+def _service(store: LocalMCPStore) -> LocalMCPControlService:
+    return LocalMCPControlService(store=store, manifest_provider=lambda: {})
+
+
+def _seed(store: LocalMCPStore, n: int = 4) -> list[str]:
+    ids = []
+    for i in range(n):
+        profile = LocalExternalMCPProfile.from_input_dict(
+            {"profile_id": f"profile-{i}", "command": "echo", "args": ["hi"]}
+        )
+        store.save_profile(profile)
+        ids.append(profile.profile_id)
+    # Snapshots for half the profiles: the None-snapshot path must survive.
+    for pid in ids[: n // 2]:
+        store.save_discovery_snapshot(pid, {"tools": [{"name": f"tool-{pid}"}]})
+    return ids
+
+
+def test_get_external_servers_is_single_store_load(tmp_path):
+    """AC#1: the full catalog read performs exactly one state load."""
+    store = _LoadCountingStore(tmp_path / "mcp-store.json")
+    ids = _seed(store, n=4)
+    service = _service(store)
+
+    store.load_calls = 0
+    servers = service.get_external_servers()
+
+    assert store.load_calls == 1, (
+        f"expected exactly one store load for the whole catalog, got {store.load_calls}"
+    )
+    assert [s["profile_id"] for s in servers] == ids
+
+
+def test_get_external_servers_shape_unchanged(tmp_path):
+    """The joined read returns byte-identical content to the per-item APIs."""
+    store = LocalMCPStore(tmp_path / "mcp-store.json")
+    ids = _seed(store, n=4)
+    service = _service(store)
+
+    servers = {s["profile_id"]: s for s in service.get_external_servers()}
+
+    for pid in ids:
+        reference_snapshot = store.get_discovery_snapshot(pid)
+        assert servers[pid]["discovery_snapshot"] == reference_snapshot
+        assert servers[pid]["is_connected"] is False
+    with_snapshot = [pid for pid in ids if servers[pid]["discovery_snapshot"]]
+    without = [pid for pid in ids if servers[pid]["discovery_snapshot"] is None]
+    assert with_snapshot and without, "seed must cover both snapshot states"
+
+
+def test_store_catalog_matches_individual_accessors(tmp_path):
+    """Store-level equivalence: get_external_catalog == list+get per item."""
+    store = LocalMCPStore(tmp_path / "mcp-store.json")
+    _seed(store, n=3)
+
+    catalog = store.get_external_catalog()
+
+    reference = [
+        (p.profile_id, store.get_discovery_snapshot(p.profile_id))
+        for p in store.list_profiles()
+    ]
+    assert [(p.profile_id, snap) for p, snap in catalog] == reference

--- a/backlog/tasks/task-236 - Batch-the-residual-N1-store-loads-in-get_external_servers.md
+++ b/backlog/tasks/task-236 - Batch-the-residual-N1-store-loads-in-get_external_servers.md
@@ -1,8 +1,8 @@
 ---
 id: TASK-236
 title: Batch the residual N+1 store loads in get_external_servers
-status: To Do
-assignee: []
+status: Done
+assignee: ['@claude']
 created_date: '2026-07-16 15:19'
 labels:
   - mcp
@@ -18,5 +18,23 @@ Phase 3's get_catalog_bundle() cut local_external_catalog from 2N+1 to N+2 store
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Full external-server catalog read performs a single store load,Governance gating unchanged,Existing control-plane tests stay green unmodified
+- [x] #1 Full external-server catalog read performs a single store load,Governance gating unchanged,Existing control-plane tests stay green unmodified
 <!-- AC:END -->
+
+## Implementation Plan
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a store-level joined reader (one load) with the exact key normalization get_discovery_snapshot uses.
+2. Rewire get_external_servers to it, keeping governance gating and the returned shape unchanged; duck-typed fallback for legacy store doubles.
+3. Unmocked load-counting + shape-equivalence tests on the real store.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+<!-- SECTION:NOTES:BEGIN -->
+Note: the description's get_catalog_bundle()/local_external_catalog names no longer exist on dev (post-#639 refactors); the residual N+1 it describes was live in LocalMCPControlService.get_external_servers — list_profiles (1 full state load) + get_discovery_snapshot per profile (N loads; every LocalMCPStore accessor re-reads and re-parses the store file).
+
+Fix: LocalMCPStore.get_external_catalog() joins profiles with snapshots from ONE load(), using the same _text(profile_id) key normalization as get_discovery_snapshot. get_external_servers consumes the pairs; governance gate (mcp.external_profiles.list.local) and the returned dict shape are unchanged. A getattr fallback keeps duck-typed store doubles (e.g. test_local_control_service's FakeLocalStore) on the legacy per-item path — required to keep existing control-plane tests green UNMODIFIED per the AC.
+
+Tests: Tests/MCP/test_external_catalog_single_load.py — 3, real LocalMCPStore on tmp_path (load-count == 1 for the whole catalog, per-profile shape equivalence vs the individual accessors incl. None-snapshot profiles, store-level join equivalence). Full Tests/MCP/: 314 passed, zero modified.
+
+Files: MCP/local_store.py, MCP/local_control_service.py, Tests/MCP/test_external_catalog_single_load.py.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/MCP/local_control_service.py
+++ b/tldw_chatbook/MCP/local_control_service.py
@@ -113,15 +113,36 @@ class LocalMCPControlService:
         return inventory
 
     def get_external_servers(self) -> list[dict[str, Any]]:
+        """List external server profiles with their discovery snapshots.
+
+        task-236: reads the whole catalog from ONE store load via
+        ``get_external_catalog`` (was 1 + N loads: ``list_profiles`` plus a
+        ``get_discovery_snapshot`` per profile). Governance gating and the
+        returned shape are unchanged.
+
+        Returns:
+            One dict per profile: the profile fields plus
+            ``discovery_snapshot`` and ``is_connected``.
+        """
         self._require_allowed("mcp.external_profiles.list.local")
         servers: list[dict[str, Any]] = []
         client = self.client
         active_sessions = getattr(client, "sessions", {}) if client is not None else {}
-        for profile in self.store.list_profiles():
+        catalog_reader = getattr(self.store, "get_external_catalog", None)
+        if catalog_reader is not None:
+            catalog = catalog_reader()
+        else:
+            # Duck-typed store double without the joined reader (the store is
+            # a constructor-injected dependency): legacy per-item reads.
+            catalog = [
+                (profile, self.store.get_discovery_snapshot(profile.profile_id))
+                for profile in self.store.list_profiles()
+            ]
+        for profile, snapshot in catalog:
             servers.append(
                 {
                     **profile.to_dict(),
-                    "discovery_snapshot": self.store.get_discovery_snapshot(profile.profile_id),
+                    "discovery_snapshot": snapshot,
                     "is_connected": profile.profile_id in active_sessions,
                 }
             )

--- a/tldw_chatbook/MCP/local_store.py
+++ b/tldw_chatbook/MCP/local_store.py
@@ -633,6 +633,27 @@ class LocalMCPStore:
     def list_profiles(self) -> list[LocalExternalMCPProfile]:
         return list(self.load().profiles)
 
+    def get_external_catalog(
+        self,
+    ) -> list[tuple[LocalExternalMCPProfile, dict[str, Any] | None]]:
+        """Return every profile paired with its discovery snapshot, one load.
+
+        task-236: ``get_external_servers`` used to call ``list_profiles``
+        plus one ``get_discovery_snapshot`` PER profile — N+1 full state
+        loads (each accessor re-reads and re-parses the store file). This
+        joins both from a single ``load()`` with the exact per-profile key
+        normalization ``get_discovery_snapshot`` uses.
+
+        Returns:
+            (profile, snapshot-or-None) pairs in ``list_profiles`` order.
+        """
+        state = self.load()
+        snapshots = state.discovery_snapshots
+        return [
+            (profile, snapshots.get(_text(profile.profile_id)))
+            for profile in state.profiles
+        ]
+
     def get_profile(self, profile_id: str) -> LocalExternalMCPProfile | None:
         normalized_profile_id = _text(profile_id)
         for profile in self.list_profiles():


### PR DESCRIPTION
## Summary
- `get_external_servers` performed **N+1 full store loads** per catalog read (`list_profiles` + one `get_discovery_snapshot` per profile; every `LocalMCPStore` accessor re-reads and re-parses the store file). New `LocalMCPStore.get_external_catalog()` joins profiles with their snapshots from **one** `load()`, using the exact `_text(profile_id)` key normalization `get_discovery_snapshot` uses.
- Governance gating (`mcp.external_profiles.list.local`) and the returned dict shape are unchanged. A `getattr` fallback keeps duck-typed store doubles on the legacy per-item path — the AC requires existing control-plane tests green **unmodified**, and `test_local_control_service`'s `FakeLocalStore` predates the joined reader.
- Note: the task description's `get_catalog_bundle()` naming no longer exists on dev (post-#639 refactors); this lands the same batching where the residual N+1 actually lives today.
- No overlap with the in-flight MCP hub phase-6 work (verified: phase-6 touches only `UI/MCP_Modules/*`; this PR touches only the service/store layer).

## Verification
- New: `Tests/MCP/test_external_catalog_single_load.py` — 3/3 on the REAL store (load-count == 1 for the whole catalog, shape equivalence vs individual accessors incl. None-snapshot profiles, store-level join equivalence)
- Full `Tests/MCP/`: **314 passed**, zero existing tests modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batched the external-server catalog read to a single store load to remove N+1 loads in `get_external_servers`. Adds `LocalMCPStore.get_external_catalog()` and rewires the service to use it; satisfies TASK-236 (single load, governance and response shape unchanged, no existing tests modified).

- **Performance**
  - Joins profiles and snapshots in one `load()` via `get_external_catalog()` using the same key normalization as `get_discovery_snapshot`.
  - Duck-typed stores fall back to the legacy per-item path.
  - Added `Tests/MCP/test_external_catalog_single_load.py` to assert single-load behavior and shape equivalence.

<sup>Written for commit 75a80ecdb6ef68dc41d78d54b4b423f537bc98ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

