### PR TITLE
feat(console): transcript tail-follow via Textual anchor (task-298)

### DIFF
--- a/Tests/UI/test_console_transcript_tail_follow.py
+++ b/Tests/UI/test_console_transcript_tail_follow.py
@@ -1,0 +1,131 @@
+"""Tests for task-298: transcript tail-follow.
+
+A streamed reply taller than the viewport used to finish below the fold
+with no scroll (pre-existing, confirmed by the task-259 base A/B). The
+transcript now engages Textual's anchor at mount — pinned to the newest
+content while the reader is at the bottom, released when they scroll up,
+re-engaged when they return — and a NEW user message (a send) re-anchors
+even from a scrolled-up position.
+"""
+
+import pytest
+from textual.app import App, ComposeResult
+
+from tldw_chatbook.Chat.console_chat_models import ConsoleChatMessage, ConsoleMessageRole
+from tldw_chatbook.Widgets.Console.console_transcript import ConsoleTranscript
+
+
+class TailFollowHarness(App):
+    """Small viewport so a handful of messages overflow it."""
+
+    CSS = "ConsoleTranscript { height: 10; }"
+
+    def compose(self) -> ComposeResult:
+        yield ConsoleTranscript(id="console-native-transcript")
+
+
+def _msg(i: int, role: ConsoleMessageRole = ConsoleMessageRole.ASSISTANT) -> ConsoleChatMessage:
+    return ConsoleChatMessage(
+        role=role,
+        content="\n".join(f"line {i}.{j}" for j in range(4)),
+        id=f"m{i}",
+    )
+
+
+def _messages(n: int) -> list[ConsoleChatMessage]:
+    return [
+        _msg(i, ConsoleMessageRole.USER if i % 2 == 0 else ConsoleMessageRole.ASSISTANT)
+        for i in range(n)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_transcript_anchors_at_mount_and_follows_growth():
+    """Content growing past the viewport keeps the view at the bottom."""
+    app = TailFollowHarness()
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        assert transcript.is_anchored
+
+        history = _messages(12)
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        await pilot.pause()
+
+        assert transcript.max_scroll_y > 0, "seed must overflow the viewport"
+        assert transcript.scroll_y == transcript.max_scroll_y
+
+
+@pytest.mark.asyncio
+async def test_scrolled_up_reader_is_not_yanked_by_assistant_growth():
+    """A reader who scrolled up stays put while the reply keeps streaming."""
+    app = TailFollowHarness()
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        history = _messages(12)
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        await pilot.pause()
+
+        transcript.release_anchor()
+        transcript.scroll_to(y=0, animate=False)
+        await pilot.pause()
+        reading_position = transcript.scroll_y
+
+        history = history + [_msg(12, ConsoleMessageRole.ASSISTANT)]
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        await pilot.pause()
+
+        assert transcript.scroll_y == reading_position, (
+            "assistant growth must not yank a scrolled-up reader"
+        )
+
+
+@pytest.mark.asyncio
+async def test_new_user_message_reanchors_from_scrolled_up_position():
+    """A send jumps to the tail even after the reader scrolled up."""
+    app = TailFollowHarness()
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        history = _messages(12)
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        await pilot.pause()
+
+        transcript.release_anchor()
+        transcript.scroll_to(y=0, animate=False)
+        await pilot.pause()
+
+        history = history + [_msg(13, ConsoleMessageRole.USER)]
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        await pilot.pause()
+
+        assert transcript.scroll_y == transcript.max_scroll_y, (
+            "a new user message (a send) must re-engage tail-follow"
+        )
+
+
+@pytest.mark.asyncio
+async def test_same_tail_user_message_updates_do_not_reanchor():
+    """Ticks that merely UPDATE the tail user message never re-anchor."""
+    app = TailFollowHarness()
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        history = _messages(11) + [_msg(11, ConsoleMessageRole.USER)]
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        await pilot.pause()
+
+        transcript.release_anchor()
+        transcript.scroll_to(y=0, animate=False)
+        await pilot.pause()
+        reading_position = transcript.scroll_y
+
+        # Same ids re-set (the streaming tick re-sets the message list).
+        transcript.set_messages(list(history))
+        await transcript.refresh_messages()
+        await pilot.pause()
+
+        assert transcript.scroll_y == reading_position

--- a/Tests/UI/test_console_transcript_tail_follow.py
+++ b/Tests/UI/test_console_transcript_tail_follow.py
@@ -21,6 +21,11 @@ class TailFollowHarness(App):
     CSS = "ConsoleTranscript { height: 10; }"
 
     def compose(self) -> ComposeResult:
+        """Yield the transcript under test.
+
+        Returns:
+            The compose result mounting one ConsoleTranscript.
+        """
         yield ConsoleTranscript(id="console-native-transcript")
 
 
@@ -104,6 +109,40 @@ async def test_new_user_message_reanchors_from_scrolled_up_position():
 
         assert transcript.scroll_y == transcript.max_scroll_y, (
             "a new user message (a send) must re-engage tail-follow"
+        )
+
+
+@pytest.mark.asyncio
+async def test_send_with_assistant_placeholder_still_reanchors():
+    """The REAL send shape: USER + ASSISTANT placeholder appended together.
+
+    The first polled update after a send can already have the assistant
+    placeholder at the tail; the user message is one back. Re-anchoring
+    must key on newly-seen user ids anywhere, not the tail (PR #697
+    review finding).
+    """
+    app = TailFollowHarness()
+    async with app.run_test() as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        history = _messages(12)
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        await pilot.pause()
+
+        transcript.release_anchor()
+        transcript.scroll_to(y=0, animate=False)
+        await pilot.pause()
+
+        history = history + [
+            _msg(13, ConsoleMessageRole.USER),
+            _msg(14, ConsoleMessageRole.ASSISTANT),
+        ]
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        await pilot.pause()
+
+        assert transcript.scroll_y == transcript.max_scroll_y, (
+            "a send observed with its assistant placeholder must still re-anchor"
         )
 
 

--- a/backlog/tasks/task-298 - Console-transcript-tail-follow-during-streams.md
+++ b/backlog/tasks/task-298 - Console-transcript-tail-follow-during-streams.md
@@ -1,0 +1,42 @@
+---
+id: TASK-298
+title: Console transcript follows the stream tail (anchor), without yanking readers
+status: Done
+assignee: ['@claude']
+created_date: '2026-07-18 00:40'
+labels: [console, ux]
+dependencies: [task-259]
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Observed during task-259's live-rig A/B (pre-existing on base, not a 259 regression): when a streamed reply grows taller than the transcript viewport, the view never scrolls — the stream finishes below the fold and the user sees a frozen top-of-message while tokens arrive off-screen. Standard terminal/chat UX is tail-follow with reader courtesy: pinned to the newest content while the user is at the bottom, released the moment they scroll up, re-engaged when they return to the bottom — and an explicit send always jumps to the tail. Textual 8's built-in anchor implements exactly the pin/release/re-engage lifecycle, so the transcript should engage it at mount and re-anchor on new user messages.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A streamed reply taller than the viewport keeps the newest content visible while the reader is at the bottom
+- [x] #2 A reader who scrolled up is never yanked by stream growth; returning to the bottom re-engages follow
+- [x] #3 A new user message (a send) jumps to the tail even from a scrolled-up position; mere tail-message updates do not
+- [x] #4 Verified live on the streaming rig
+<!-- AC:END -->
+
+## Implementation Plan
+<!-- SECTION:PLAN:BEGIN -->
+1. Engage Textual's anchor on ConsoleTranscript at mount (pin/release/re-engage handled natively).
+2. Re-anchor in set_messages when a NEW user-role message appears at the tail (send semantics); track the tail id so tick re-sets of the same list never re-anchor.
+3. Harness tests for all three behaviors + the no-re-anchor tick case; live-rig verification by controller.
+
+Live-rig results (2026-07-18, llama.cpp gateway + textual-serve/playwright, same recipe as task-259): 40-line stream now finishes with the TAIL visible (base A/B froze at 36 with the rest below the fold); 150-line run captured FOLLOW-IN-MOTION mid-stream (view tracking 112->150 with Stop active, through a spawned sub-agent tool flow); finalize keeps the newest content on screen. AC#2/#3 (no-yank + send-re-anchor) pinned deterministically by the harness tests (xterm can't drive scroll reliably).
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+<!-- SECTION:NOTES:BEGIN -->
+Two-line mechanism, no scroll bookkeeping of our own: `on_mount` calls `self.anchor()` (Textual keeps the view at the bottom on content growth, releases on user scroll, re-engages when the user returns to the bottom — verified against the 8.2.7 source: `release_anchor`/`_check_anchor`); `set_messages` calls `anchor()` again only when the tail message id CHANGES to a user-role message (a send), tracked via `_tail_message_id` so the 0.2s streaming tick re-setting the same list can never re-anchor a scrolled-up reader. The transcript performs no programmatic scrolling anywhere (selection mounts an inline action row without moving the viewport), so no anchor conflicts exist.
+
+Tests: Tests/UI/test_console_transcript_tail_follow.py — 4 (mount-anchor + follow growth past the viewport, scrolled-up reader not yanked by assistant growth, send re-anchors from scrolled-up, same-tail tick re-set stays put).
+
+Files: Widgets/Console/console_transcript.py, Tests/UI/test_console_transcript_tail_follow.py.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -393,11 +393,12 @@ class ConsoleTranscript(VerticalScroll):
         # Lives on the widget instance so a recompose starts it fresh.
         self._message_signature_cache: dict[str, tuple[tuple, tuple]] = {}
         self._signature_compute_counts: dict[str, int] = {}
-        # TASK-298: id of the newest message seen by set_messages, so a
-        # NEW user message (a send) can re-engage tail-follow even after
-        # the user scrolled up (reading history shouldn't survive an
-        # explicit send).
-        self._tail_message_id: str | None = None
+        # TASK-298: every message id seen by set_messages, so a NEW
+        # user-role message ANYWHERE in the update (a send) re-engages
+        # tail-follow even after the user scrolled up. The send path
+        # appends USER + ASSISTANT placeholder together, so the tail
+        # alone can miss the send (PR #697 review).
+        self._seen_message_ids: set[str] = set()
 
     def on_mount(self) -> None:
         """Engage tail-follow: stay scrolled to the newest content.
@@ -429,18 +430,21 @@ class ConsoleTranscript(VerticalScroll):
         """
         self._messages = list(messages)
         message_ids = {message.id for message in self._messages}
-        newest = self._messages[-1] if self._messages else None
-        if (
-            self.is_mounted
-            and newest is not None
-            and newest.id != self._tail_message_id
-            and newest.role == "user"
-        ):
+        new_user_send = any(
+            message.id not in self._seen_message_ids
+            and message.role == ConsoleMessageRole.USER
+            for message in self._messages
+        )
+        if self.is_mounted and new_user_send:
             # A send: jump to the tail even if the user had scrolled up
             # (anchor() also re-engages follow for the reply that streams
-            # in next). Appended assistant/tool rows never yank a reader.
+            # in next). Checked against ALL newly-seen ids, not just the
+            # tail -- the send path appends USER + ASSISTANT placeholder
+            # together and the first polled update can already have the
+            # placeholder at the tail. Appended assistant/tool rows alone
+            # never yank a reader.
             self.anchor()
-        self._tail_message_id = None if newest is None else newest.id
+        self._seen_message_ids = message_ids
         if self.selected_message_id not in message_ids:
             self.selected_message_id = None
         for stale_id in [

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -393,6 +393,21 @@ class ConsoleTranscript(VerticalScroll):
         # Lives on the widget instance so a recompose starts it fresh.
         self._message_signature_cache: dict[str, tuple[tuple, tuple]] = {}
         self._signature_compute_counts: dict[str, int] = {}
+        # TASK-298: id of the newest message seen by set_messages, so a
+        # NEW user message (a send) can re-engage tail-follow even after
+        # the user scrolled up (reading history shouldn't survive an
+        # explicit send).
+        self._tail_message_id: str | None = None
+
+    def on_mount(self) -> None:
+        """Engage tail-follow: stay scrolled to the newest content.
+
+        Textual's anchor keeps the view pinned to the bottom while content
+        grows, releases when the user scrolls up, and re-engages when they
+        return to the bottom (TASK-298 -- streamed replies taller than the
+        viewport used to finish below the fold with no scroll).
+        """
+        self.anchor()
 
     def compose(self) -> ComposeResult:
         self._row_widgets.clear()
@@ -414,6 +429,18 @@ class ConsoleTranscript(VerticalScroll):
         """
         self._messages = list(messages)
         message_ids = {message.id for message in self._messages}
+        newest = self._messages[-1] if self._messages else None
+        if (
+            self.is_mounted
+            and newest is not None
+            and newest.id != self._tail_message_id
+            and newest.role == "user"
+        ):
+            # A send: jump to the tail even if the user had scrolled up
+            # (anchor() also re-engages follow for the reply that streams
+            # in next). Appended assistant/tool rows never yank a reader.
+            self.anchor()
+        self._tail_message_id = None if newest is None else newest.id
         if self.selected_message_id not in message_ids:
             self.selected_message_id = None
         for stale_id in [


### PR DESCRIPTION
## Summary
Streamed replies taller than the viewport used to finish below the fold with no scroll — the reader watched a frozen top-of-message while tokens arrived off-screen (pre-existing; confirmed by the task-259 base A/B, filed from that observation as task-298).

Two-line mechanism, zero scroll bookkeeping of our own, riding Textual 8's native anchor lifecycle (verified against the 8.2.7 source: `release_anchor`/`_check_anchor`):
- `on_mount`: `self.anchor()` — pinned to the newest content while the reader is at the bottom, **released the moment they scroll up, re-engaged when they return to the bottom**
- `set_messages`: re-anchor ONLY when the tail message id changes to a user-role message (a send jumps to the tail even from a scrolled-up position); tick re-sets of the same list can never yank a reader. `is_mounted`-gated (harnesses set messages pre-mount)

The transcript performs no programmatic scrolling anywhere (selection mounts an inline action row without moving the viewport), so no anchor conflicts exist.

## Verification
- New: `Tests/UI/test_console_transcript_tail_follow.py` — 4/4 (mount-anchor + follow past the viewport, scrolled-up reader not yanked by assistant growth, send re-anchors, same-tail tick re-set stays put)
- Suites: transcript + inspector + store files **126/126**; `test_console_native_chat_flow.py` **187/187**
- Live rig (llama.cpp gateway, task-259 recipe): 40-line stream finishes with the tail visible (base froze at 36); 150-line run captured **follow-in-motion** mid-stream (view tracking 112→150, Stop active, through a spawned sub-agent tool flow); finalize keeps the newest content on screen — screenshots with the controller, pending user approval per the Console gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable tail-follow in the Console transcript using `Textual`’s anchor so long streams stay visible without manual scroll. Addresses Linear task-298 by following the tail at the bottom, never yanking when scrolled up, and re-anchoring on a new user send (now based on any newly-seen user message, not just the tail).

- **New Features**
  - Engage anchor on `on_mount` to auto-follow; releases on user scroll and re-engages at the bottom.
  - In `set_messages`, re-anchor when any newly-seen `USER` message appears (send), including when `USER` + assistant placeholder are appended together; assistant/tool-only updates don’t move the view.

<sup>Written for commit c76cee7e2b1e7467ab24a1cb411fc0a3a355720b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

