### PR TITLE
fix(llm): migrate summarize_with_cohere to the v2 /chat API (task-297)

### DIFF
--- a/Tests/Chat/test_cohere_summarize_v2.py
+++ b/Tests/Chat/test_cohere_summarize_v2.py
@@ -202,3 +202,40 @@ def test_streaming_parses_raw_json_lines_without_sse_framing(mock_post):
     ))
 
     assert chunks == ["Raw ", "lines."]
+
+
+@patch("requests.Session.post")
+def test_non_200_with_non_json_body_keeps_pinned_error_format(mock_post):
+    """Gemini/Qodo #698-2: a gateway/CDN HTML error body must not break the
+    pinned failure format via a JSONDecodeError into the outer except."""
+    mock_response = Mock()
+    mock_response.status_code = 502
+    mock_response.text = "<html>Bad gateway</html>"
+    mock_response.json.side_effect = json.JSONDecodeError("x", "<html>", 0)
+    mock_post.return_value = mock_response
+
+    result = summarize_with_cohere("test-key", "Text.", "Prompt.")
+
+    assert result == "Cohere: API request failed: <html>Bad gateway</html>"
+
+
+@patch("requests.Session.post")
+def test_streaming_skips_non_object_json_and_closes_response(mock_post):
+    """Gemini #698-1 + Qodo #698-1: a JSON list/primitive line must not crash
+    the generator, and the response is closed when the stream ends."""
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = Mock()
+    mock_response.iter_lines.return_value = [
+        b'[1, 2, 3]',
+        b'"just a string"',
+        b'{"type": "content-delta", "delta": {"message": {"content": {"text": "Still works."}}}}',
+    ]
+    mock_post.return_value = mock_response
+
+    chunks = list(summarize_with_cohere(
+        "test-key", "Text.", "Prompt.", streaming=True,
+    ))
+
+    assert chunks == ["Still works."]
+    mock_response.close.assert_called_once()

--- a/Tests/Chat/test_cohere_summarize_v2.py
+++ b/Tests/Chat/test_cohere_summarize_v2.py
@@ -1,0 +1,139 @@
+"""task-297: ``summarize_with_cohere`` on the Cohere v2 /chat API.
+
+``chat_with_cohere`` migrated to v2 in task-267 (PR #690, live-gated);
+this helper was the repo's last v1 ``/chat`` caller. These tests pin the
+migrated behavior contract at the ``requests`` boundary: request shape
+(v2 endpoint, messages array, stream flag), non-streaming parts-array
+parsing, streaming content-delta extraction, and the unchanged error
+string formats callers already rely on.
+"""
+
+import json
+from unittest.mock import Mock, patch
+
+from tldw_chatbook.LLM_Calls.Summarization_General_Lib import summarize_with_cohere
+
+V2_URL = "https://api.cohere.com/v2/chat"
+
+
+def _text_response(text="A concise summary."):
+    return {
+        "id": "resp_1",
+        "message": {"role": "assistant", "content": [{"type": "text", "text": text}]},
+        "finish_reason": "COMPLETE",
+    }
+
+
+def _mock_post(mock_post, response_json, status_code=200):
+    mock_response = Mock()
+    mock_response.json.return_value = response_json
+    mock_response.status_code = status_code
+    mock_response.text = json.dumps(response_json)
+    mock_response.raise_for_status = Mock()
+    mock_post.return_value = mock_response
+    return mock_response
+
+
+@patch("requests.Session.post")
+def test_non_streaming_hits_v2_with_messages_array(mock_post):
+    _mock_post(mock_post, _text_response())
+
+    summary = summarize_with_cohere(
+        "test-key", "Some article text.", "Summarize this.",
+        temp=0.2, system_message="Be terse.", streaming=False,
+    )
+
+    assert summary == "A concise summary."
+    assert mock_post.call_args[0][0] == V2_URL
+    payload = mock_post.call_args[1]["json"]
+    assert payload["messages"] == [
+        {"role": "system", "content": "Be terse."},
+        {"role": "user", "content": "Some article text. \n\n\n\nSummarize this."},
+    ]
+    assert payload["stream"] is False
+    assert payload["temperature"] == 0.2
+    for v1_only_key in ("preamble", "message", "streaming"):
+        assert v1_only_key not in payload
+
+
+@patch("requests.Session.post")
+def test_blank_system_message_is_omitted(mock_post):
+    _mock_post(mock_post, _text_response())
+
+    summarize_with_cohere("test-key", "Text.", "Prompt.", system_message="")
+
+    payload = mock_post.call_args[1]["json"]
+    # A blank system message must not become an empty system turn; the
+    # helper's own default fills None, so only explicit blanks are omitted.
+    assert all(m["role"] != "system" or m["content"].strip() for m in payload["messages"])
+
+
+@patch("requests.Session.post")
+def test_non_streaming_concatenates_multiple_text_parts(mock_post):
+    _mock_post(mock_post, {
+        "message": {"role": "assistant", "content": [
+            {"type": "text", "text": "Part one. "},
+            {"type": "text", "text": "Part two."},
+        ]},
+    })
+
+    summary = summarize_with_cohere("test-key", "Text.", "Prompt.")
+
+    assert summary == "Part one. Part two."
+
+
+@patch("requests.Session.post")
+def test_non_streaming_missing_content_reports_expected_data_error(mock_post):
+    _mock_post(mock_post, {"message": {"role": "assistant", "content": []}})
+
+    result = summarize_with_cohere("test-key", "Text.", "Prompt.")
+
+    assert result == "Cohere: Expected data not found in API response."
+
+
+@patch("requests.Session.post")
+def test_non_200_reports_api_request_failed(mock_post):
+    _mock_post(mock_post, {"message": "bad request"}, status_code=400)
+
+    result = summarize_with_cohere("test-key", "Text.", "Prompt.")
+
+    assert result.startswith("Cohere: API request failed:")
+
+
+@patch("requests.Session.post")
+def test_streaming_yields_content_delta_text(mock_post):
+    events = [
+        {"type": "message-start"},
+        {"type": "content-delta",
+         "delta": {"message": {"content": {"text": "Summary "}}}},
+        {"type": "content-delta",
+         "delta": {"message": {"content": {"text": "chunks."}}}},
+        {"type": "message-end", "delta": {"finish_reason": "COMPLETE"}},
+    ]
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = Mock()
+    mock_response.iter_lines.return_value = [
+        f"data: {json.dumps(e)}".encode() for e in events
+    ]
+    mock_post.return_value = mock_response
+
+    chunks = list(summarize_with_cohere(
+        "test-key", "Text.", "Prompt.", streaming=True,
+    ))
+
+    assert chunks == ["Summary ", "chunks."]
+    assert mock_post.call_args[0][0] == V2_URL
+    assert mock_post.call_args[1]["json"]["stream"] is True
+
+
+@patch("tldw_chatbook.LLM_Calls.Summarization_General_Lib.get_cli_setting")
+@patch("requests.Session.post")
+def test_missing_api_key_short_circuits_without_network(mock_post, mock_setting):
+    # The config fallback must also come up empty regardless of whether
+    # THIS machine's real config carries a cohere key.
+    mock_setting.return_value = None
+    result = summarize_with_cohere(None, "Text.", "Prompt.")
+
+    assert result == "Cohere: API Key Not Provided/Found in Config file or is empty"
+    mock_post.assert_not_called()

--- a/Tests/Chat/test_cohere_summarize_v2.py
+++ b/Tests/Chat/test_cohere_summarize_v2.py
@@ -179,3 +179,26 @@ def test_streaming_non_200_reports_the_same_pinned_error_format(mock_post):
     )
 
     assert result == 'Cohere: API request failed: {"message": "bad request"}'
+
+
+@patch("requests.Session.post")
+def test_streaming_parses_raw_json_lines_without_sse_framing(mock_post):
+    """task-297 live-smoke regression: with 'accept: application/json' the
+    REAL v2 stream is raw JSON lines (no 'data:' prefix) — a strict
+    SSE-only filter dropped every line and yielded zero chunks live."""
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = Mock()
+    mock_response.iter_lines.return_value = [
+        b'{"type": "message-start"}',
+        b'{"type": "content-delta", "delta": {"message": {"content": {"text": "Raw "}}}}',
+        b'{"type": "content-delta", "delta": {"message": {"content": {"text": "lines."}}}}',
+        b'{"type": "message-end", "delta": {"finish_reason": "COMPLETE"}}',
+    ]
+    mock_post.return_value = mock_response
+
+    chunks = list(summarize_with_cohere(
+        "test-key", "Text.", "Prompt.", streaming=True,
+    ))
+
+    assert chunks == ["Raw ", "lines."]

--- a/Tests/Chat/test_cohere_summarize_v2.py
+++ b/Tests/Chat/test_cohere_summarize_v2.py
@@ -137,3 +137,45 @@ def test_missing_api_key_short_circuits_without_network(mock_post, mock_setting)
 
     assert result == "Cohere: API Key Not Provided/Found in Config file or is empty"
     mock_post.assert_not_called()
+
+
+@patch("requests.Session.post")
+def test_streaming_skips_interleaved_event_lines_without_log_noise(mock_post):
+    """task-297 review: Cohere v2 SSE interleaves standalone 'event: <type>'
+    lines; they must be skipped before json.loads, not logged as decode
+    errors."""
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = Mock()
+    mock_response.iter_lines.return_value = [
+        b"event: message-start",
+        b'data: {"type": "message-start"}',
+        b"event: content-delta",
+        b'data: {"type": "content-delta", "delta": {"message": {"content": {"text": "Hi."}}}}',
+        b"event: message-end",
+        b'data: {"type": "message-end", "delta": {"finish_reason": "COMPLETE"}}',
+    ]
+    mock_post.return_value = mock_response
+
+    chunks = list(summarize_with_cohere(
+        "test-key", "Text.", "Prompt.", streaming=True,
+    ))
+
+    assert chunks == ["Hi."]
+
+
+@patch("requests.Session.post")
+def test_streaming_non_200_reports_the_same_pinned_error_format(mock_post):
+    """task-297 review: a streaming-path 4xx must report the same
+    'Cohere: API request failed: ...' format as the non-streaming path
+    (raise_for_status used to surface a bodyless HTTPError instead)."""
+    mock_response = Mock()
+    mock_response.status_code = 400
+    mock_response.text = '{"message": "bad request"}'
+    mock_post.return_value = mock_response
+
+    result = summarize_with_cohere(
+        "test-key", "Text.", "Prompt.", streaming=True,
+    )
+
+    assert result == 'Cohere: API request failed: {"message": "bad request"}'

--- a/backlog/tasks/task-297 - Migrate-the-Cohere-summarization-helper-to-the-v2-chat-API.md
+++ b/backlog/tasks/task-297 - Migrate-the-Cohere-summarization-helper-to-the-v2-chat-API.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-297
 title: Migrate the Cohere summarization helper to the v2 /chat API
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-17 21:47'
+updated_date: '2026-07-17 23:27'
 labels:
   - providers
   - maintenance
@@ -19,6 +21,12 @@ task-267 migrated chat_with_cohere to Cohere v2 /chat, but Summarization_General
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 No tldw_chatbook code path calls Cohere v1 /chat
-- [ ] #2 Summarization behavior pinned by tests before and after the migration
+- [x] #1 No tldw_chatbook code path calls Cohere v1 /chat
+- [x] #2 Summarization behavior pinned by tests before and after the migration
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+summarize_with_cohere migrated v1->v2 /chat (repo's last v1 caller after task-267): messages array w/ system inline (blank omitted), stream flag, parts-array content parse, streaming content-delta loop. Error string formats preserved for the dispatcher; inline default model aligned to config's command-a-03-2025; dead second system_message default removed; streaming 4xx now reports the same pinned error format as non-streaming. KEY FINDING (live smoke caught a review-introduced regression): with 'accept: application/json' the REAL v2 stream is raw JSON lines with NO SSE framing (unlike chat_with_cohere which negotiates SSE) — a strict data:-only filter dropped every line to zero chunks; parser handles both framings, pinned by framing-specific tests. 10 tests at the requests boundary; grep-verified zero cohere.ai/v1 references remain. Live smoke: both paths return real summaries (streaming 18 chunks). Review (sonnet) 'with fixes' — Important (event-line skip) + 2 adjacent Minors applied; latent test-env coupling noted not blocking. Branch claude/cohere-summarize-v2-297.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/LLM_Calls/Summarization_General_Lib.py
+++ b/tldw_chatbook/LLM_Calls/Summarization_General_Lib.py
@@ -1001,15 +1001,19 @@ def summarize_with_cohere(api_key, input_data, custom_prompt_arg, temp=None, sys
                     if not line:
                         continue
                     decoded_line = line.decode('utf-8').strip()
-                    if not decoded_line.startswith("data:"):
-                        # Cohere v2 SSE interleaves standalone "event: <type>"
-                        # lines; without this skip they reach json.loads and
-                        # log a misleading decode "error" per line (mirrors
-                        # chat_with_cohere's filter, task-297 review).
-                        if not decoded_line.startswith("event:"):
-                            logging.warning(f"Cohere: Unexpected SSE line: {decoded_line[:120]}")
+                    # This request sends "accept: application/json", so the
+                    # LIVE v2 stream is raw JSON lines (no SSE framing) --
+                    # proven by the task-297 live smoke, where a strict
+                    # data:-only filter dropped every line. Handle both
+                    # framings: strip a data: prefix when present, skip
+                    # standalone event:/comment lines, parse bare JSON.
+                    if decoded_line.startswith("data:"):
+                        decoded_line = decoded_line[len("data:"):].strip()
+                    elif decoded_line.startswith("event:"):
                         continue
-                    decoded_line = decoded_line[len("data:"):].strip()
+                    elif not decoded_line.startswith("{"):
+                        logging.warning(f"Cohere: Unexpected stream line: {decoded_line[:120]}")
+                        continue
                     if not decoded_line or decoded_line == "[DONE]":
                         continue
                     try:

--- a/tldw_chatbook/LLM_Calls/Summarization_General_Lib.py
+++ b/tldw_chatbook/LLM_Calls/Summarization_General_Lib.py
@@ -931,8 +931,6 @@ def summarize_with_cohere(api_key, input_data, custom_prompt_arg, temp=None, sys
         if temp is None:
             temp = 0.3
         temp = float(temp)
-        if system_message is None:
-            system_message = "You are a helpful AI assistant who does whatever the user requests."
 
         headers = {
             'accept': 'application/json',
@@ -986,7 +984,13 @@ def summarize_with_cohere(api_key, input_data, custom_prompt_arg, temp=None, sys
                 json=data,
                 stream=True  # Enable response streaming
             )
-            response.raise_for_status()
+            if response.status_code != 200:
+                # Same pinned format as the non-streaming path -- the old
+                # raise_for_status() surfaced a bodyless HTTPError through
+                # the outer except with a different string (task-297 review).
+                logging.error(
+                    f"Cohere: API request failed with status code {response.status_code}: {response.text}")
+                return f"Cohere: API request failed: {response.text}"
 
             def stream_generator():
                 # v2 streams SSE "data: {...}" events discriminated by
@@ -997,8 +1001,15 @@ def summarize_with_cohere(api_key, input_data, custom_prompt_arg, temp=None, sys
                     if not line:
                         continue
                     decoded_line = line.decode('utf-8').strip()
-                    if decoded_line.startswith("data:"):
-                        decoded_line = decoded_line[len("data:"):].strip()
+                    if not decoded_line.startswith("data:"):
+                        # Cohere v2 SSE interleaves standalone "event: <type>"
+                        # lines; without this skip they reach json.loads and
+                        # log a misleading decode "error" per line (mirrors
+                        # chat_with_cohere's filter, task-297 review).
+                        if not decoded_line.startswith("event:"):
+                            logging.warning(f"Cohere: Unexpected SSE line: {decoded_line[:120]}")
+                        continue
+                    decoded_line = decoded_line[len("data:"):].strip()
                     if not decoded_line or decoded_line == "[DONE]":
                         continue
                     try:

--- a/tldw_chatbook/LLM_Calls/Summarization_General_Lib.py
+++ b/tldw_chatbook/LLM_Calls/Summarization_General_Lib.py
@@ -924,7 +924,9 @@ def summarize_with_cohere(api_key, input_data, custom_prompt_arg, temp=None, sys
         else:
             raise ValueError("Cohere: Invalid input data format")
 
-        cohere_model = get_cli_setting('cohere_api', 'model', 'command-r-plus')
+        # Aligned with config.py's cohere_api section default (the old
+        # inline 'command-r-plus' fallback disagreed with it) -- task-297.
+        cohere_model = get_cli_setting('cohere_api', 'model', 'command-a-03-2025')
 
         if temp is None:
             temp = 0.3
@@ -941,13 +943,19 @@ def summarize_with_cohere(api_key, input_data, custom_prompt_arg, temp=None, sys
         cohere_prompt = f"{text} \n\n\n\n{custom_prompt_arg}"
         logging.debug(f"Cohere: Prompt being sent is {cohere_prompt}")
 
+        # Cohere v2 /chat (task-297): the last v1 /chat caller in the repo --
+        # chat_with_cohere migrated in task-267 (PR #690); v2 takes a
+        # messages array (system inline) instead of preamble/message, and
+        # the stream flag is named "stream".
+        messages = []
+        if str(system_message or "").strip():
+            messages.append({"role": "system", "content": system_message})
+        messages.append({"role": "user", "content": cohere_prompt})
         data = {
-            "preamble": system_message,
-            "message": cohere_prompt,
             "model": cohere_model,
-#            "connectors": [{"id": "web-search"}],
+            "messages": messages,
             "temperature": temp,
-            "streaming": streaming
+            "stream": streaming,
         }
 
         if streaming:
@@ -973,7 +981,7 @@ def summarize_with_cohere(api_key, input_data, custom_prompt_arg, temp=None, sys
             session.mount("https://", adapter)
             logging.debug("Cohere: Submitting streaming request to API endpoint")
             response = session.post(
-                'https://api.cohere.ai/v1/chat',
+                'https://api.cohere.com/v2/chat',
                 headers=headers,
                 json=data,
                 stream=True  # Enable response streaming
@@ -981,27 +989,33 @@ def summarize_with_cohere(api_key, input_data, custom_prompt_arg, temp=None, sys
             response.raise_for_status()
 
             def stream_generator():
+                # v2 streams SSE "data: {...}" events discriminated by
+                # "type"; summary text arrives as content-delta events at
+                # delta.message.content.text (mirrors chat_with_cohere's
+                # live-gated v2 loop, task-267).
                 for line in response.iter_lines():
-                    if line:
-                        decoded_line = line.decode('utf-8').strip()
-                        try:
-                            data_json = json.loads(decoded_line)
-                            if 'response' in data_json:
-                                chunk = data_json['response']
-                                yield chunk
-                            elif 'token' in data_json:
-                                # For token-based streaming (if applicable)
-                                chunk = data_json['token']
-                                yield chunk
-                            elif 'text' in data_json:
-                                # For text-based streaming
-                                chunk = data_json['text']
-                                yield chunk
-                            else:
-                                logging.debug(f"Cohere: Unhandled streaming data: {data_json}")
-                        except json.JSONDecodeError:
-                            logging.error(f"Cohere: Error decoding JSON from line: {decoded_line}")
-                            continue
+                    if not line:
+                        continue
+                    decoded_line = line.decode('utf-8').strip()
+                    if decoded_line.startswith("data:"):
+                        decoded_line = decoded_line[len("data:"):].strip()
+                    if not decoded_line or decoded_line == "[DONE]":
+                        continue
+                    try:
+                        event = json.loads(decoded_line)
+                    except json.JSONDecodeError:
+                        logging.error(f"Cohere: Error decoding JSON from line: {decoded_line}")
+                        continue
+                    if event.get("type") == "content-delta":
+                        chunk = (
+                            (((event.get("delta") or {}).get("message") or {})
+                             .get("content") or {})
+                            .get("text")
+                        )
+                        if chunk:
+                            yield chunk
+                    else:
+                        logging.debug(f"Cohere: Unhandled streaming event type: {event.get('type')}")
 
             return stream_generator()
         else:
@@ -1026,23 +1040,24 @@ def summarize_with_cohere(api_key, input_data, custom_prompt_arg, temp=None, sys
             session.mount("http://", adapter)
             session.mount("https://", adapter)
             logging.debug("Cohere: Submitting request to API endpoint")
-            response = session.post('https://api.cohere.ai/v1/chat', headers=headers, json=data)
+            response = session.post('https://api.cohere.com/v2/chat', headers=headers, json=data)
             response_data = response.json()
             logging.debug(f"API Response Data: {response_data}")
 
             if response.status_code == 200:
-                if 'text' in response_data:
-                    summary = response_data['text'].strip()
+                # v2 returns message.content as a parts array; concatenate
+                # the text parts (mirrors chat_with_cohere, task-267).
+                content_parts = (response_data.get('message') or {}).get('content') or []
+                summary = "".join(
+                    part.get('text') or ''
+                    for part in content_parts
+                    if isinstance(part, dict)
+                ).strip()
+                if summary:
                     logging.debug("Cohere: Summarization successful")
                     return summary
-                elif 'response' in response_data:
-                    # Adjust if the API returns 'response' field instead of 'text'
-                    summary = response_data['response'].strip()
-                    logging.debug("Cohere: Summarization successful")
-                    return summary
-                else:
-                    logging.error("Cohere: Expected data not found in API response.")
-                    return "Cohere: Expected data not found in API response."
+                logging.error("Cohere: Expected data not found in API response.")
+                return "Cohere: Expected data not found in API response."
             else:
                 logging.error(f"Cohere: API request failed with status code {response.status_code}: {response.text}")
                 return f"Cohere: API request failed: {response.text}"

--- a/tldw_chatbook/LLM_Calls/Summarization_General_Lib.py
+++ b/tldw_chatbook/LLM_Calls/Summarization_General_Lib.py
@@ -997,6 +997,14 @@ def summarize_with_cohere(api_key, input_data, custom_prompt_arg, temp=None, sys
                 # "type"; summary text arrives as content-delta events at
                 # delta.message.content.text (mirrors chat_with_cohere's
                 # live-gated v2 loop, task-267).
+                try:
+                    yield from _stream_events()
+                finally:
+                    # Deterministic close even if the consumer abandons the
+                    # generator mid-stream (Qodo #698-1; sibling parity).
+                    response.close()
+
+            def _stream_events():
                 for line in response.iter_lines():
                     if not line:
                         continue
@@ -1012,7 +1020,10 @@ def summarize_with_cohere(api_key, input_data, custom_prompt_arg, temp=None, sys
                     elif decoded_line.startswith("event:"):
                         continue
                     elif not decoded_line.startswith("{"):
-                        logging.warning(f"Cohere: Unexpected stream line: {decoded_line[:120]}")
+                        # SSE transports may interleave metadata/comment lines
+                        # (id:, retry:, ": keep-alive") -- harmless, so debug
+                        # not warning (Qodo #698-3).
+                        logging.debug(f"Cohere: Skipping non-JSON stream line: {decoded_line[:120]}")
                         continue
                     if not decoded_line or decoded_line == "[DONE]":
                         continue
@@ -1020,6 +1031,11 @@ def summarize_with_cohere(api_key, input_data, custom_prompt_arg, temp=None, sys
                         event = json.loads(decoded_line)
                     except json.JSONDecodeError:
                         logging.error(f"Cohere: Error decoding JSON from line: {decoded_line}")
+                        continue
+                    if not isinstance(event, dict):
+                        # A JSON list/primitive line would crash .get() and
+                        # kill the generator (Gemini #698-1).
+                        logging.debug(f"Cohere: Skipping non-object stream event: {decoded_line[:120]}")
                         continue
                     if event.get("type") == "content-delta":
                         chunk = (
@@ -1056,10 +1072,13 @@ def summarize_with_cohere(api_key, input_data, custom_prompt_arg, temp=None, sys
             session.mount("https://", adapter)
             logging.debug("Cohere: Submitting request to API endpoint")
             response = session.post('https://api.cohere.com/v2/chat', headers=headers, json=data)
-            response_data = response.json()
-            logging.debug(f"API Response Data: {response_data}")
 
             if response.status_code == 200:
+                # json() only on success: a non-JSON error body (gateway/CDN
+                # HTML) would raise into the outer except and break the
+                # pinned failure format (Gemini/Qodo #698-2).
+                response_data = response.json()
+                logging.debug(f"API Response Data: {response_data}")
                 # v2 returns message.content as a parts array; concatenate
                 # the text parts (mirrors chat_with_cohere, task-267).
                 content_parts = (response_data.get('message') or {}).get('content') or []


### PR DESCRIPTION
## Summary

`summarize_with_cohere` was the repo's **last Cohere v1 `/chat` caller** (the chat handler migrated in task-267 / PR #690, live-gated) — the two Cohere code paths had diverged on API version, flagged by #690's final review. This closes the divergence: grep-verified zero `cohere.ai`/v1 references remain in `tldw_chatbook/`.

## Changes

- v2 request shape: `messages` array (system inline, blank omitted), `stream` flag, `api.cohere.com/v2/chat` on both paths. Error string formats preserved exactly for the dispatcher caller.
- Non-streaming: v2 parts-array `message.content` parsing. Streaming: `content-delta` extraction.
- Inline default model aligned to the config section's own `command-a-03-2025` (the old `command-r-plus` fallback disagreed with it); dead second `system_message` default removed; streaming 4xx now reports the same pinned `Cohere: API request failed: <body>` format as non-streaming (previously a bodyless `HTTPError` through the outer except).

## The interesting finding

The independent review prescribed mirroring `chat_with_cohere`'s strict SSE `data:`-line filter — and the **live smoke caught that fix breaking real streaming to zero chunks**: this helper sends `accept: application/json`, so the real v2 stream is **raw JSON lines with no SSE framing** (unlike the chat handler, which negotiates SSE on the same endpoint). The parser now handles both framings — strips a `data:` prefix when present, skips standalone `event:` lines, parses bare JSON — with framing-specific regression tests for each shape. Another data point for the live-verification rule: same endpoint, different `Accept`, different wire format.

## Verification

- 10 tests at the `requests` boundary (`Tests/Chat/test_cohere_summarize_v2.py`): request shape, both stream framings, interleaved event lines, parts-array concat, error formats, no-key short-circuit (config-fallback patched so a machine's real key can't skew it).
- **Live smoke against the real API, re-run after every fix wave:** both paths return genuine summaries; streaming reassembles identically from 18 chunks.
- Independent review (sonnet): "with fixes" — the Important + two adjacent Minors applied; the AC (no v1 caller remains) independently grep-verified by the reviewer.

Closes task-297.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated `summarize_with_cohere` to Cohere v2 `/chat`, unifying request/stream behavior and hardening streaming/error handling. Removes the last v1 path, preserves error strings, and sets the default model to `command-a-03-2025`.

- **Migration**
  - Uses `https://api.cohere.com/v2/chat` with a `messages` array (blank system omitted) and `stream` flag.
  - Non-streaming: concatenates text from v2 `message.content` parts.
  - Default model set to `command-a-03-2025`.
  - Satisfies task-297; 12 tests pin request shape, both streaming framings, and error formats.

- **Bug Fixes**
  - Streaming parser handles SSE `data:` lines and raw JSON lines; skips `event:` and non-JSON metadata; guards non-dict JSON events.
  - Streaming 4xx returns the same "Cohere: API request failed: <body>" format as non-streaming; `response.json()` only on 200 to keep that format on non-JSON bodies.
  - Streaming response closes deterministically even if the consumer drops early.

<sup>Written for commit f0c9e989f0c030cbbc9d49418a4cbfe19b6154ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

