### PR TITLE
feat(rag): wire the Search window's indexing controls to the real backfill path (task-251)

### DIFF
--- a/Tests/RAG/test_ingestion_indexing.py
+++ b/Tests/RAG/test_ingestion_indexing.py
@@ -635,6 +635,19 @@ class TestSharedRagService:
         finally:
             ingestion_indexing.reset_shared_rag_service()
 
+    def test_peek_shared_service_never_creates(self):
+        """peek returns the existing service or None; it must not construct one (task-251)."""
+        ingestion_indexing.reset_shared_rag_service()
+        assert ingestion_indexing.peek_shared_rag_service() is None
+
+        fake = FakeRAGService()
+        ingestion_indexing.set_shared_rag_service(fake)
+        try:
+            assert ingestion_indexing.peek_shared_rag_service() is fake
+        finally:
+            ingestion_indexing.reset_shared_rag_service()
+        assert ingestion_indexing.peek_shared_rag_service() is None
+
     def test_chat_rag_events_uses_shared_service(self):
         from types import SimpleNamespace
 

--- a/Tests/RAG/test_semantic_honest_states.py
+++ b/Tests/RAG/test_semantic_honest_states.py
@@ -29,6 +29,7 @@ from tldw_chatbook.RAG_Search.semantic_availability import (
     SEMANTIC_UNAVAILABLE_MESSAGES,
     resolve_semantic_rag_service,
     semantic_index_is_empty,
+    trustworthy_collection_count,
 )
 
 pytestmark = pytest.mark.unit
@@ -196,6 +197,30 @@ class TestSemanticIndexIsEmpty:
     def test_nonzero_count_is_not_empty(self):
         service = StrictRagService(stats={"count": 3})
         assert asyncio.run(semantic_index_is_empty(service)) is False
+
+
+class TestTrustworthyCollectionCount:
+    """Shared trustworthy-count rule for stats displays (task-251)."""
+
+    @pytest.mark.parametrize("stats,expected", [
+        ({"count": 0}, 0),
+        ({"count": 42}, 42),
+        ({"count": 0, "error": "stats failed"}, None),
+        ({"count": None}, None),
+        ({"count": 0.0}, None),
+        ({"count": False}, None),
+        ({"count": "0"}, None),
+        ({"count": -1}, None),
+        ("not-a-mapping", None),
+        (None, None),
+    ])
+    def test_only_genuine_nonnegative_ints_are_trusted(self, stats, expected):
+        result = trustworthy_collection_count(stats)
+        if expected is None:
+            assert result is None
+        else:
+            assert result == expected
+            assert isinstance(result, int) and not isinstance(result, bool)
 
 
 class TestSearchSemanticHonestStates:

--- a/Tests/UI/test_search_rag_window.py
+++ b/Tests/UI/test_search_rag_window.py
@@ -50,7 +50,12 @@ def temp_user_data_dir(tmp_path: Path) -> Path:
 
 @pytest.fixture
 def search_rag_test_env(temp_user_data_dir: Path):
-    """Patch Search/RAG persistence and optional dependency state for tests."""
+    """Patch Search/RAG persistence and optional dependency state for tests.
+
+    Also stubs the shared-RAG-service pre-resolution seam used by the Start
+    Indexing worker so tests never construct a real embeddings runtime as a
+    side effect of pressing the button.
+    """
     with patch.dict(
         search_rag_window_module.DEPENDENCIES_AVAILABLE,
         {"embeddings_rag": True},
@@ -64,7 +69,15 @@ def search_rag_test_env(temp_user_data_dir: Path):
                 "tldw_chatbook.UI.Views.RAGSearch.saved_searches_panel.get_user_data_dir",
                 return_value=temp_user_data_dir,
             ):
-                yield
+                with patch(
+                    "tldw_chatbook.UI.Views.RAGSearch.search_rag_window.semantic_indexing_available",
+                    return_value=True,
+                ):
+                    with patch(
+                        "tldw_chatbook.UI.Views.RAGSearch.search_rag_window.get_shared_rag_service",
+                        return_value=MagicMock(name="shared_rag_service"),
+                    ):
+                        yield
 
 
 @pytest.mark.ui
@@ -931,6 +944,42 @@ class TestIndexingControls:
                 assert any("embeddings" in message for message in messages)
 
     @pytest.mark.asyncio
+    async def test_service_preresolution_failure_short_circuits_before_backfill(
+        self,
+        mock_app_instance: MagicMock,
+        search_rag_test_env,
+        widget_pilot,
+    ) -> None:
+        """A failed shared-service pre-resolution never enters the backfill loop.
+
+        The worker resolves the shared RAG service OUTSIDE its transient
+        asyncio.run loop (PR #700 review); when that fails, the run reports
+        service-unavailable honestly instead of retrying construction inside
+        the loop.
+        """
+        backfill = MagicMock()
+        with patch.object(search_rag_window_module, "backfill_semantic_index", backfill):
+            with patch.object(
+                search_rag_window_module, "get_shared_rag_service", return_value=None
+            ):
+                async with await widget_pilot(
+                    SearchRAGWindow, app_instance=mock_app_instance
+                ) as pilot:
+                    window = pilot.app.test_widget
+
+                    window.query_one("#start-indexing", Button).press()
+                    await _wait_for_indexing_cycle(pilot)
+
+                    backfill.assert_not_called()
+                    messages = _notify_messages(mock_app_instance)
+                    assert any(
+                        "RAG service could not be created" in message
+                        for message in messages
+                    )
+                    assert window._indexing_in_flight is False
+                    assert window.query_one("#start-indexing", Button).disabled is False
+
+    @pytest.mark.asyncio
     async def test_backfill_crash_is_caught_and_reported(
         self,
         mock_app_instance: MagicMock,
@@ -1035,6 +1084,35 @@ class TestWiredSearchChromeControls:
             assert not window.query("#delete-collection")
             assert not window.query("#refresh-results")
             assert not window.query("#indexing-progress")
+
+    @pytest.mark.asyncio
+    async def test_mixin_on_handlers_are_dispatched_for_real_presses(
+        self,
+        mock_app_instance: MagicMock,
+        search_rag_test_env,
+        widget_pilot,
+    ) -> None:
+        """Guard the mixin @on registration mechanism with a real button press.
+
+        SearchEventHandlersMixin only gets its @on handlers dispatched because
+        it is created through Textual's message-pump metaclass (derived via
+        type(Container), task-251). If a Textual upgrade changes the
+        registration mechanism, this public-behavior test fails loudly:
+        pressing Search with an empty query must run handle_search and notify.
+        """
+        async with await widget_pilot(SearchRAGWindow, app_instance=mock_app_instance) as pilot:
+            window = pilot.app.test_widget
+            window.query_one("#search-query-input", Input).value = ""
+
+            window.query_one("#search-button", Button).press()
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            assert any(
+                "Please enter a search query" in message
+                for message in _notify_messages(mock_app_instance)
+            )
 
     @pytest.mark.asyncio
     async def test_pagination_buttons_page_through_results(

--- a/Tests/UI/test_search_rag_window.py
+++ b/Tests/UI/test_search_rag_window.py
@@ -4,14 +4,20 @@
 from __future__ import annotations
 
 import json
+import threading
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-from textual.widgets import Button, Checkbox, Input, ListView, Select, Static
+from textual.widgets import Button, Checkbox, DataTable, Input, ListView, Select, Static
 
 from Tests.textual_test_utils import widget_pilot
 from tldw_chatbook.DB.search_history_db import SearchHistoryDB
+from tldw_chatbook.RAG_Search.ingestion_indexing import (
+    ITEM_TYPE_CONVERSATION,
+    ITEM_TYPE_MEDIA,
+    ITEM_TYPE_NOTE,
+)
 from tldw_chatbook.UI.SearchRAGWindow import (
     SearchHistoryDropdown,
     SearchRAGWindow,
@@ -695,3 +701,437 @@ class TestSearchResult:
             assert "Test Title" in _text(title)
             assert "preview content" in _text(preview).lower()
             assert "95.0%" == _text(score)
+
+
+def _notify_messages(mock_app: MagicMock) -> list[str]:
+    """Return the text of every notification sent to the mock app."""
+    return [str(call.args[0]) for call in mock_app.notify.call_args_list if call.args]
+
+
+async def _wait_for_indexing_cycle(pilot) -> None:
+    """Let a Start Indexing press run its worker plus the follow-up stats refresh."""
+    await pilot.pause()
+    await pilot.app.workers.wait_for_complete()
+    await pilot.pause()
+    # Completion schedules the stats-refresh worker; let it finish too.
+    await pilot.app.workers.wait_for_complete()
+    await pilot.pause()
+
+
+def _ok_summary(**overrides) -> dict:
+    summary = {"status": "ok", "indexed": 0, "skipped": 0, "failed": 0, "errors": [], "by_type": {}}
+    summary.update(overrides)
+    return summary
+
+
+@pytest.mark.ui
+class TestIndexingControls:
+    """Task-251: the Maintenance-tab indexing controls trigger real indexing."""
+
+    @pytest.mark.asyncio
+    async def test_missing_embeddings_dependency_disables_indexing_controls_with_recovery(
+        self,
+        mock_app_instance: MagicMock,
+        search_rag_test_env,
+        widget_pilot,
+    ) -> None:
+        """Without embeddings deps the indexing controls are disabled with honest recovery copy."""
+        with patch.dict(
+            search_rag_window_module.DEPENDENCIES_AVAILABLE,
+            {"embeddings_rag": False},
+            clear=False,
+        ):
+            async with await widget_pilot(SearchRAGWindow, app_instance=mock_app_instance) as pilot:
+                window = pilot.app.test_widget
+
+                start_button = window.query_one("#start-indexing", Button)
+                source_select = window.query_one("#index-source-select", Select)
+
+                assert start_button.disabled is True
+                tooltip = str(start_button.tooltip)
+                assert "Missing optional dependencies: embeddings_rag" in tooltip
+                assert 'pip install "tldw_chatbook[embeddings_rag]"' in tooltip
+                assert source_select.disabled is True
+                assert "embeddings_rag" in str(source_select.tooltip)
+
+    @pytest.mark.asyncio
+    async def test_start_indexing_runs_backfill_for_selected_source_and_refreshes_stats(
+        self,
+        mock_app_instance: MagicMock,
+        search_rag_test_env,
+        widget_pilot,
+    ) -> None:
+        """Pressing Start Indexing runs the real backfill path and re-reads real stats."""
+        calls: list[dict] = []
+
+        async def fake_backfill(**kwargs):
+            calls.append(kwargs)
+            return _ok_summary(indexed=3, skipped=1)
+
+        rag_service = MagicMock()
+        rag_service.vector_store.get_collection_stats.return_value = {
+            "name": "tldw_rag",
+            "count": 42,
+        }
+        mock_app_instance._rag_service = None
+
+        with patch.object(search_rag_window_module, "backfill_semantic_index", fake_backfill):
+            with patch.object(
+                search_rag_window_module, "peek_shared_rag_service", return_value=None
+            ):
+                async with await widget_pilot(
+                    SearchRAGWindow, app_instance=mock_app_instance
+                ) as pilot:
+                    window = pilot.app.test_widget
+                    await pilot.app.workers.wait_for_complete()
+                    await pilot.pause()
+
+                    # Before any runtime exists, stats honestly say so.
+                    table = window.query_one("#index-stats-table", DataTable)
+                    assert table.row_count == 1
+                    assert any(
+                        "not initialized" in str(cell) for cell in table.get_row_at(0)
+                    )
+
+                    # Once a runtime exists, completion re-reads real stats from it.
+                    mock_app_instance._rag_service = rag_service
+                    window.query_one("#index-source-select", Select).value = "notes"
+                    await pilot.pause()
+
+                    window.query_one("#start-indexing", Button).press()
+                    await _wait_for_indexing_cycle(pilot)
+
+                    assert len(calls) == 1
+                    assert calls[0]["item_types"] == (ITEM_TYPE_NOTE,)
+                    assert calls[0]["chachanotes_db"] is mock_app_instance.chachanotes_db
+                    assert calls[0]["media_db"] is None
+
+                    assert window.query_one("#start-indexing", Button).disabled is False
+                    messages = _notify_messages(mock_app_instance)
+                    assert any(
+                        "Indexing complete" in message and "3" in message
+                        for message in messages
+                    )
+
+                    row = [str(cell) for cell in table.get_row_at(0)]
+                    assert "tldw_rag" in row
+                    assert "42" in row
+
+    @pytest.mark.asyncio
+    async def test_index_source_select_maps_to_backfill_item_types(
+        self,
+        mock_app_instance: MagicMock,
+        search_rag_test_env,
+        widget_pilot,
+    ) -> None:
+        """Every source option maps onto the real backfill item-type contract."""
+        async with await widget_pilot(SearchRAGWindow, app_instance=mock_app_instance) as pilot:
+            window = pilot.app.test_widget
+            select = window.query_one("#index-source-select", Select)
+
+            expectations = {
+                "media": (ITEM_TYPE_MEDIA,),
+                "conversations": (ITEM_TYPE_CONVERSATION,),
+                "notes": (ITEM_TYPE_NOTE,),
+                "all": (ITEM_TYPE_MEDIA, ITEM_TYPE_NOTE, ITEM_TYPE_CONVERSATION),
+            }
+            for value, expected in expectations.items():
+                select.value = value
+                await pilot.pause()
+                assert window._selected_index_item_types() == expected
+
+    @pytest.mark.asyncio
+    async def test_start_indexing_is_single_flight(
+        self,
+        mock_app_instance: MagicMock,
+        search_rag_test_env,
+        widget_pilot,
+    ) -> None:
+        """A second activation during a run cannot start a second backfill."""
+        gate = threading.Event()
+        started = threading.Event()
+        calls: list[dict] = []
+
+        async def gated_backfill(**kwargs):
+            calls.append(kwargs)
+            started.set()
+            gate.wait(timeout=5)
+            return _ok_summary()
+
+        with patch.object(search_rag_window_module, "backfill_semantic_index", gated_backfill):
+            async with await widget_pilot(SearchRAGWindow, app_instance=mock_app_instance) as pilot:
+                window = pilot.app.test_widget
+
+                window.query_one("#start-indexing", Button).press()
+                await pilot.pause()
+                assert started.wait(timeout=5) is True
+
+                # While the run is in flight the button is disabled...
+                start_button = window.query_one("#start-indexing", Button)
+                assert start_button.disabled is True
+                # ...and even a programmatic re-activation is refused honestly.
+                window._start_indexing_run()
+                messages = _notify_messages(mock_app_instance)
+                assert any("already running" in message for message in messages)
+
+                gate.set()
+                await _wait_for_indexing_cycle(pilot)
+
+                assert len(calls) == 1
+                assert window.query_one("#start-indexing", Button).disabled is False
+
+    @pytest.mark.asyncio
+    async def test_backfill_failures_surface_last_error(
+        self,
+        mock_app_instance: MagicMock,
+        search_rag_test_env,
+        widget_pilot,
+    ) -> None:
+        """Failed items produce an honest warning carrying the last error."""
+
+        async def failing_backfill(**kwargs):
+            return _ok_summary(
+                status="partial", indexed=1, failed=2, errors=["media 3: boom"]
+            )
+
+        with patch.object(search_rag_window_module, "backfill_semantic_index", failing_backfill):
+            async with await widget_pilot(SearchRAGWindow, app_instance=mock_app_instance) as pilot:
+                window = pilot.app.test_widget
+
+                window.query_one("#start-indexing", Button).press()
+                await _wait_for_indexing_cycle(pilot)
+
+                messages = _notify_messages(mock_app_instance)
+                assert any("boom" in message for message in messages)
+                assert window.query_one("#start-indexing", Button).disabled is False
+
+    @pytest.mark.asyncio
+    async def test_backfill_unavailable_status_notifies_recovery(
+        self,
+        mock_app_instance: MagicMock,
+        search_rag_test_env,
+        widget_pilot,
+    ) -> None:
+        """An unavailable backfill (deps/kill switch) reports why instead of silence."""
+
+        async def unavailable_backfill(**kwargs):
+            return _ok_summary(status="unavailable")
+
+        with patch.object(
+            search_rag_window_module, "backfill_semantic_index", unavailable_backfill
+        ):
+            async with await widget_pilot(SearchRAGWindow, app_instance=mock_app_instance) as pilot:
+                window = pilot.app.test_widget
+
+                window.query_one("#start-indexing", Button).press()
+                await _wait_for_indexing_cycle(pilot)
+
+                messages = _notify_messages(mock_app_instance)
+                assert any("did not run" in message for message in messages)
+                assert any("embeddings" in message for message in messages)
+
+    @pytest.mark.asyncio
+    async def test_backfill_crash_is_caught_and_reported(
+        self,
+        mock_app_instance: MagicMock,
+        search_rag_test_env,
+        widget_pilot,
+    ) -> None:
+        """A raising backfill never kills the app; it notifies and re-enables the button."""
+
+        async def crashing_backfill(**kwargs):
+            raise RuntimeError("kapow")
+
+        with patch.object(search_rag_window_module, "backfill_semantic_index", crashing_backfill):
+            async with await widget_pilot(SearchRAGWindow, app_instance=mock_app_instance) as pilot:
+                window = pilot.app.test_widget
+
+                window.query_one("#start-indexing", Button).press()
+                await _wait_for_indexing_cycle(pilot)
+
+                messages = _notify_messages(mock_app_instance)
+                assert any("kapow" in message for message in messages)
+                assert window._indexing_in_flight is False
+                assert window.query_one("#start-indexing", Button).disabled is False
+
+    @pytest.mark.asyncio
+    async def test_start_indexing_without_source_databases_reports_honestly(
+        self,
+        mock_app_instance: MagicMock,
+        search_rag_test_env,
+        widget_pilot,
+    ) -> None:
+        """No reachable source database means an honest error, not a fake run."""
+        mock_app_instance.media_db = None
+        mock_app_instance.chachanotes_db = None
+
+        with patch.object(
+            search_rag_window_module, "backfill_semantic_index", MagicMock()
+        ) as backfill:
+            async with await widget_pilot(SearchRAGWindow, app_instance=mock_app_instance) as pilot:
+                window = pilot.app.test_widget
+
+                window.query_one("#start-indexing", Button).press()
+                await pilot.pause()
+
+                backfill.assert_not_called()
+                messages = _notify_messages(mock_app_instance)
+                assert any("no source database" in message for message in messages)
+
+    @pytest.mark.asyncio
+    async def test_apply_index_stats_renders_honest_states(
+        self,
+        mock_app_instance: MagicMock,
+        search_rag_test_env,
+        widget_pilot,
+    ) -> None:
+        """The stats table shows real counts and honest not-ready/error states."""
+        async with await widget_pilot(SearchRAGWindow, app_instance=mock_app_instance) as pilot:
+            window = pilot.app.test_widget
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            table = window.query_one("#index-stats-table", DataTable)
+
+            def row_text() -> str:
+                return " ".join(str(cell) for cell in table.get_row_at(0))
+
+            window._apply_index_stats(None)
+            assert table.row_count == 1
+            assert "not initialized" in row_text()
+
+            window._apply_index_stats({"name": "tldw_rag", "error": "stats exploded"})
+            assert table.row_count == 1
+            assert "stats exploded" in row_text()
+
+            window._apply_index_stats({"name": "tldw_rag", "count": 7})
+            assert table.row_count == 1
+            assert "tldw_rag" in row_text()
+            assert "7" in row_text()
+
+            window._apply_index_stats({"name": "tldw_rag", "count": 0})
+            assert "empty" in row_text()
+
+            # Untrustworthy counts are never displayed as real numbers.
+            window._apply_index_stats({"name": "tldw_rag", "count": "7"})
+            assert "unavailable" in row_text()
+
+
+@pytest.mark.ui
+class TestWiredSearchChromeControls:
+    """Task-251: previously dead chrome either acts for real or is gone."""
+
+    @pytest.mark.asyncio
+    async def test_dead_placeholder_controls_are_removed(
+        self,
+        mock_app_instance: MagicMock,
+        search_rag_test_env,
+        widget_pilot,
+    ) -> None:
+        """Placeholder controls with no cheap real backing are no longer rendered."""
+        async with await widget_pilot(SearchRAGWindow, app_instance=mock_app_instance) as pilot:
+            window = pilot.app.test_widget
+
+            assert not window.query("#create-collection")
+            assert not window.query("#delete-collection")
+            assert not window.query("#refresh-results")
+            assert not window.query("#indexing-progress")
+
+    @pytest.mark.asyncio
+    async def test_pagination_buttons_page_through_results(
+        self,
+        mock_app_instance: MagicMock,
+        search_rag_test_env,
+        widget_pilot,
+    ) -> None:
+        """Previous/Next actually navigate result pages."""
+        async with await widget_pilot(SearchRAGWindow, app_instance=mock_app_instance) as pilot:
+            window = pilot.app.test_widget
+
+            window.search_results = [
+                {"title": f"Result {index}", "content": "c", "source": "media", "score": 0.5}
+                for index in range(12)
+            ]
+            window.total_results = 12
+            await window._display_results()
+            await pilot.pause()
+
+            window.query_one("#next-page", Button).press()
+            await pilot.pause()
+
+            assert window.current_page == 2
+            assert "Page 2 of 2" in _text(window.query_one("#page-info", Static))
+            assert len(window.query_one("#results-list-enhanced").children) == 2
+
+            window.query_one("#prev-page", Button).press()
+            await pilot.pause()
+
+            assert window.current_page == 1
+            assert "Page 1 of 2" in _text(window.query_one("#page-info", Static))
+
+    @pytest.mark.asyncio
+    async def test_export_results_button_uses_export_action(
+        self,
+        mock_app_instance: MagicMock,
+        search_rag_test_env,
+        widget_pilot,
+    ) -> None:
+        """The results-header Export button triggers the real export action."""
+        async with await widget_pilot(SearchRAGWindow, app_instance=mock_app_instance) as pilot:
+            window = pilot.app.test_widget
+            window.search_results = []
+
+            window.query_one("#export-results", Button).press()
+            await pilot.pause()
+
+            assert any(
+                "No results to export" in message
+                for message in _notify_messages(mock_app_instance)
+            )
+
+    @pytest.mark.asyncio
+    async def test_refresh_history_controls_honor_selected_range(
+        self,
+        mock_app_instance: MagicMock,
+        search_rag_test_env,
+        widget_pilot,
+    ) -> None:
+        """History refresh reloads through the DB honoring the selected time range."""
+        async with await widget_pilot(SearchRAGWindow, app_instance=mock_app_instance) as pilot:
+            window = pilot.app.test_widget
+            window.search_history_db = MagicMock()
+            window.search_history_db.get_search_history.return_value = []
+
+            window.query_one("#history-range-select", Select).value = "7"
+            await pilot.pause()
+            window.query_one("#refresh-history", Button).press()
+            await pilot.pause()
+
+            assert (
+                window.search_history_db.get_search_history.call_args.kwargs["days_back"] == 7
+            )
+
+            window.query_one("#history-range-select", Select).value = "all"
+            await pilot.pause()
+
+            assert (
+                window.search_history_db.get_search_history.call_args.kwargs["days_back"] is None
+            )
+
+    @pytest.mark.asyncio
+    async def test_refresh_collections_button_triggers_real_refresh(
+        self,
+        mock_app_instance: MagicMock,
+        search_rag_test_env,
+        widget_pilot,
+    ) -> None:
+        """The Maintenance refresh button reloads collections and index stats."""
+        async with await widget_pilot(SearchRAGWindow, app_instance=mock_app_instance) as pilot:
+            window = pilot.app.test_widget
+            window._refresh_collections_list = MagicMock()
+            window._refresh_index_stats = MagicMock()
+
+            window.query_one("#refresh-collections", Button).press()
+            await pilot.pause()
+
+            window._refresh_collections_list.assert_called_once()
+            window._refresh_index_stats.assert_called_once()

--- a/backlog/tasks/task-251 - Wire-or-remove-the-dead-Start-Indexing-controls-in-SearchRAGWindow.md
+++ b/backlog/tasks/task-251 - Wire-or-remove-the-dead-Start-Indexing-controls-in-SearchRAGWindow.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-251
 title: Wire or remove the dead Start Indexing controls in SearchRAGWindow
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-12 14:11'
 labels:
   - rag
@@ -20,6 +21,115 @@ The standalone Search window (UI/Views/RAGSearch/search_rag_window.py) renders I
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The Search window contains no controls that do nothing when activated
-- [ ] #2 If indexing controls remain they trigger real indexing and display actual index statistics
+- [x] #1 The Search window contains no controls that do nothing when activated
+- [x] #2 If indexing controls remain they trigger real indexing and display actual index statistics
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Audit every control in SearchRAGWindow (compose + all @on handlers in the
+   RAGSearch package) and record a wire-vs-remove disposition per dead control.
+2. Wire #start-indexing to the real bulk-index path from task-247
+   (`backfill_semantic_index`) on a thread worker (`@work(thread=True,
+   exclusive=True, group=...)` + in-flight guard) with `asyncio.run`, exactly
+   like the CLI entry point; honor #index-source-select via `item_types`;
+   surface per-batch progress through the existing #indexing-status text via
+   `call_from_thread`; catch all exceptions inside the worker.
+3. Deps gate: when `embeddings_rag` is unavailable, disable the indexing
+   controls in on_mount with the shared optional-dependency recovery tooltip
+   (same copy as the disabled Search button); honest notify on the backfill
+   summary (`unavailable` / failures with last error / indexed+skipped counts),
+   re-enable the button and refresh stats on completion.
+4. Make #index-stats-table real: read
+   `vector_store.get_collection_stats()` from an ALREADY-initialized runtime
+   only (`app._rag_service` or a new non-creating
+   `peek_shared_rag_service()` accessor — never construct the embedding
+   runtime just to render stats), with the trustworthy-count rule factored
+   into `semantic_availability.trustworthy_collection_count()` and reused by
+   `semantic_index_is_empty`. Honest "not initialized" / error rows otherwise.
+5. Remove dead controls that have no cheap real backing: #create-collection,
+   #delete-collection, #refresh-results, and the fake #indexing-progress bar.
+6. Wire the remaining dead-but-cheap controls: #export-results -> existing
+   export action, #prev-page/#next-page -> real pagination,
+   #refresh-history + #history-range-select -> history reload with
+   `days_back`, #refresh-collections -> existing collections+stats refresh
+   workers.
+7. TDD: failing tests first in Tests/UI/test_search_rag_window.py (deps-missing
+   disable+tooltip, click -> backfill via worker with selected types,
+   double-start guard, completion -> stats refresh, failure/unavailable ->
+   honest notify, removed-controls assertions, pagination/history/export
+   wiring); then run the full window suite + RAG ingestion/honest-state suites.
+
+## Implementation Notes
+
+Every rendered control in the standalone Search window now routes to a real
+implementation or was removed. Per-control disposition (all were verified
+dead: no `@on` selector or name-based handler anywhere in the codebase):
+
+WIRED
+- `#start-indexing` -> real bulk indexing via task-247's
+  `backfill_semantic_index` on a thread worker (`@work(thread=True,
+  exclusive=True, group="rag-index-backfill", exit_on_error=False)`) running
+  `asyncio.run` exactly like the CLI entry point, with `_indexing_in_flight`
+  single-flight guard, button disabled during the run, all exceptions caught
+  inside the worker, and honest completion notifies (unavailable-with-install
+  copy / failures with last error / indexed+up-to-date counts).
+- `#index-source-select` -> read at press and mapped onto the backfill
+  `item_types` contract (media / conversations / notes / all).
+- `#index-stats-table` (previously populated with hard-coded zeros behind an
+  always-None `self.rag_service` early-return) -> real
+  `vector_store.get_collection_stats()` numbers read off-thread from an
+  ALREADY-initialized runtime (`app._rag_service` or the new non-creating
+  `peek_shared_rag_service()`); honest "not initialized" / error /
+  untrustworthy-count rows otherwise; columns reduced to
+  Collection/Chunks/Status (Documents/Size/Last-Updated had no real source).
+- `#indexing-status` + `#indexing-status-text` -> shown during a run with
+  real per-batch indexed/up-to-date/failed counts via the backfill
+  progress callback marshalled through `call_from_thread`.
+- `#refresh-collections` (relabeled "Refresh") -> existing collections-list
+  worker plus the stats refresh.
+- `#export-results` -> the existing Ctrl+E export action.
+- `#prev-page` / `#next-page` -> real result pagination (pages beyond 1 were
+  previously unreachable by mouse).
+- `#refresh-history` + `#history-range-select` -> history-table reload
+  honoring the selected range via `get_search_history(days_back=...)`.
+
+REMOVED
+- `#create-collection` / `#delete-collection`: no cheap real backing -- the
+  simplified RAG service manages exactly one collection per profile.
+- `#refresh-results`: re-running the query is exactly the Search button.
+- `#indexing-progress` ProgressBar: the backfill total is unknown up front,
+  so any percentage would be fake; real counts go to the status text.
+
+ROOT-CAUSE FIX (made the whole window's mixin handlers real): none of
+`SearchEventHandlersMixin`'s `@on` handlers -- including the Search button's
+`handle_search` -- were EVER dispatched, because `@on` registration happens in
+Textual's `_MessagePumpMeta` at class creation and dispatch walks each MRO
+class's own `_decorated_handlers`; a plain mixin class never got either. The
+mixin now uses `metaclass=_MessagePumpMeta` (identical to `Container`'s, so
+no metaclass conflict). Also fixed the task-228-class hazard
+`run_worker(exclusive=True)` without `group=` in the collections-apply seam
+(it cancelled unrelated default-group workers, observable as
+`WorkerCancelled` in tests and able to kill an in-flight search).
+
+Deps gate: with `embeddings_rag` missing, `#start-indexing` and
+`#index-source-select` are disabled in on_mount with the same shared
+optional-dependency recovery tooltip as the Search button; the press path
+re-checks and notifies with install copy, and `backfill_semantic_index`
+itself re-gates via `semantic_indexing_available()`.
+
+Left as-is (not activation no-ops): `#collection-select` / `#temperature-input`
+still feed saved-search config only (search-flow scope stabilized by PR #692),
+and `#search-progress` is a passive indicator in the search status row.
+
+Files: `tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py`,
+`tldw_chatbook/UI/Views/RAGSearch/search_event_handlers.py`,
+`tldw_chatbook/RAG_Search/ingestion_indexing.py` (new
+`peek_shared_rag_service`), `tldw_chatbook/RAG_Search/semantic_availability.py`
+(new `trustworthy_collection_count`, reused by `semantic_index_is_empty`),
+plus tests in `Tests/UI/test_search_rag_window.py` (14 new),
+`Tests/RAG/test_ingestion_indexing.py`, `Tests/RAG/test_semantic_honest_states.py`.
+
+Verification: Tests/UI/test_search_rag_window.py 37 passed (23 baseline + 14
+new), Tests/RAG/test_ingestion_indexing.py + test_semantic_honest_states.py
+73 passed, combined 110 passed; `python -c "import tldw_chatbook.app"` OK.

--- a/tldw_chatbook/RAG_Search/ingestion_indexing.py
+++ b/tldw_chatbook/RAG_Search/ingestion_indexing.py
@@ -152,6 +152,16 @@ def get_shared_rag_service(profile_name: Optional[str] = None) -> Optional[Any]:
     return _shared_service
 
 
+def peek_shared_rag_service() -> Optional[Any]:
+    """Return the shared RAG service only if it already exists (never creates).
+
+    Read-only accessor for surfaces that display runtime state (e.g. the
+    Search window's index statistics, task-251) and must not pay the
+    embedding-model construction cost as a side effect of rendering.
+    """
+    return _shared_service
+
+
 def set_shared_rag_service(service: Optional[Any]) -> None:
     """Inject a shared RAG service instance (primarily for tests)."""
     global _shared_service

--- a/tldw_chatbook/RAG_Search/ingestion_indexing.py
+++ b/tldw_chatbook/RAG_Search/ingestion_indexing.py
@@ -158,6 +158,10 @@ def peek_shared_rag_service() -> Optional[Any]:
     Read-only accessor for surfaces that display runtime state (e.g. the
     Search window's index statistics, task-251) and must not pay the
     embedding-model construction cost as a side effect of rendering.
+
+    Returns:
+        The already-constructed shared RAG service, or None when no service
+        has been created (or injected) in this process yet.
     """
     return _shared_service
 

--- a/tldw_chatbook/RAG_Search/semantic_availability.py
+++ b/tldw_chatbook/RAG_Search/semantic_availability.py
@@ -181,6 +181,30 @@ async def resolve_semantic_rag_service(
     return service, None
 
 
+def trustworthy_collection_count(stats: Any) -> Optional[int]:
+    """Return the vector-store chunk count only when it is trustworthy.
+
+    Trustworthy means: an error-free stats mapping whose ``count`` is a
+    genuine non-negative int -- ``bool``, floats, and numeric strings are all
+    rejected (bool is an int subclass, and coercion would accept ``0.0`` /
+    ``"0"``). Shared by ``semantic_index_is_empty`` and the Search window's
+    index-statistics display (task-251), so both surfaces apply the same
+    strictness before showing or acting on a count.
+
+    Args:
+        stats: Whatever ``vector_store.get_collection_stats()`` returned.
+
+    Returns:
+        The count as an int, or None when it cannot be trusted.
+    """
+    if not isinstance(stats, Mapping) or stats.get("error"):
+        return None
+    count = stats.get("count")
+    if isinstance(count, int) and not isinstance(count, bool) and count >= 0:
+        return count
+    return None
+
+
 async def semantic_index_is_empty(rag_service: Any) -> bool:
     """True only when the runtime's vector store verifiably has 0 documents.
 
@@ -212,9 +236,7 @@ async def semantic_index_is_empty(rag_service: Any) -> bool:
     except Exception:
         logger.opt(exception=True).debug("Vector store stats probe failed.")
         return False
-    if not isinstance(stats, Mapping) or stats.get("error"):
-        return False
-    count = stats.get("count")
-    # Strict integer check: bool is an int subclass, and int(...) coercion
-    # would accept 0.0 / "0" -- none of those are a trustworthy zero.
-    return isinstance(count, int) and not isinstance(count, bool) and count == 0
+    # Strict shared rule (trustworthy_collection_count): bool is an int
+    # subclass, and int(...) coercion would accept 0.0 / "0" -- none of
+    # those are a trustworthy zero.
+    return trustworthy_collection_count(stats) == 0

--- a/tldw_chatbook/UI/Views/RAGSearch/search_event_handlers.py
+++ b/tldw_chatbook/UI/Views/RAGSearch/search_event_handlers.py
@@ -12,6 +12,7 @@ import tempfile
 from pathlib import Path
 
 from textual import on, work
+from textual.message_pump import _MessagePumpMeta
 from textual.widgets import Button, Select, Checkbox, Input, ListView, ListItem, DataTable, Static
 from textual.css.query import NoMatches
 from rich.text import Text
@@ -39,8 +40,16 @@ except ImportError:
     RAG_EVENTS_AVAILABLE = False
 
 
-class SearchEventHandlersMixin:
-    """Mixin class containing all event handlers for SearchRAGWindow"""
+class SearchEventHandlersMixin(metaclass=_MessagePumpMeta):
+    """Mixin class containing all event handlers for SearchRAGWindow.
+
+    The mixin must be created through Textual's message-pump metaclass:
+    ``@on`` registration happens per-class at class-creation time and message
+    dispatch walks each MRO class's own ``_decorated_handlers``. As a plain
+    class, NONE of these ``@on`` handlers (including the Search button's)
+    were ever dispatched -- found and fixed in task-251. ``Container`` uses
+    exactly this metaclass, so combining the two bases stays conflict-free.
+    """
     
     @on(Button.Pressed, "#search-button")
     @work(exclusive=True)
@@ -258,7 +267,54 @@ class SearchEventHandlersMixin:
                 "Hybrid search combines keyword and semantic search",
                 severity="information"
             )
-    
+
+    # Results-header, pagination, history, and Maintenance controls (task-251):
+    # every rendered control routes to a real implementation.
+
+    @on(Button.Pressed, "#export-results")
+    def handle_export_results(self, event: Button.Pressed) -> None:
+        """Export the current results (same path as the Ctrl+E action)."""
+        self.action_export()
+
+    @on(Button.Pressed, "#prev-page")
+    async def handle_prev_page(self, event: Button.Pressed) -> None:
+        """Show the previous page of search results."""
+        if self.current_page > 1:
+            self.current_page -= 1
+            await self._display_results()
+
+    @on(Button.Pressed, "#next-page")
+    async def handle_next_page(self, event: Button.Pressed) -> None:
+        """Show the next page of search results."""
+        total_pages = max(
+            1,
+            (self.total_results + self.results_per_page - 1) // self.results_per_page,
+        )
+        if self.current_page < total_pages:
+            self.current_page += 1
+            await self._display_results()
+
+    @on(Button.Pressed, "#refresh-history")
+    def handle_refresh_history(self, event: Button.Pressed) -> None:
+        """Reload the history table for the selected time range."""
+        self._refresh_history_view()
+
+    @on(Select.Changed, "#history-range-select")
+    def handle_history_range_change(self, event: Select.Changed) -> None:
+        """Apply a newly selected history time range immediately."""
+        self._refresh_history_view()
+
+    @on(Button.Pressed, "#refresh-collections")
+    def handle_refresh_collections(self, event: Button.Pressed) -> None:
+        """Refresh the Maintenance tab's collections list and index statistics."""
+        self._refresh_collections_list()
+        self._refresh_index_stats()
+
+    @on(Button.Pressed, "#start-indexing")
+    def handle_start_indexing(self, event: Button.Pressed) -> None:
+        """Run the real bulk semantic-index backfill (task-251)."""
+        self._start_indexing_run()
+
     # Helper methods for search functionality
     def _get_search_config(self) -> Dict[str, Any]:
         """Get current search configuration from UI"""

--- a/tldw_chatbook/UI/Views/RAGSearch/search_event_handlers.py
+++ b/tldw_chatbook/UI/Views/RAGSearch/search_event_handlers.py
@@ -12,7 +12,7 @@ import tempfile
 from pathlib import Path
 
 from textual import on, work
-from textual.message_pump import _MessagePumpMeta
+from textual.containers import Container
 from textual.widgets import Button, Select, Checkbox, Input, ListView, ListItem, DataTable, Static
 from textual.css.query import NoMatches
 from rich.text import Text
@@ -40,15 +40,22 @@ except ImportError:
     RAG_EVENTS_AVAILABLE = False
 
 
-class SearchEventHandlersMixin(metaclass=_MessagePumpMeta):
+class SearchEventHandlersMixin(metaclass=type(Container)):
     """Mixin class containing all event handlers for SearchRAGWindow.
 
     The mixin must be created through Textual's message-pump metaclass:
     ``@on`` registration happens per-class at class-creation time and message
-    dispatch walks each MRO class's own ``_decorated_handlers``. As a plain
+    dispatch walks each MRO class's own registered handlers. As a plain
     class, NONE of these ``@on`` handlers (including the Search button's)
-    were ever dispatched -- found and fixed in task-251. ``Container`` uses
-    exactly this metaclass, so combining the two bases stays conflict-free.
+    were ever dispatched -- found and fixed in task-251.
+
+    ``type(Container)`` derives that metaclass from Textual's public
+    ``Container`` (the other base of ``SearchRAGWindow``) without importing
+    a private symbol, and by construction can never conflict with the
+    combined class's metaclass across Textual upgrades. Dispatch of these
+    handlers is regression-tested via real button presses in
+    Tests/UI/test_search_rag_window.py, so a future Textual change to the
+    registration mechanism fails loudly there.
     """
     
     @on(Button.Pressed, "#search-button")

--- a/tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py
+++ b/tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py
@@ -45,6 +45,13 @@ from ....Chat.chat_handoff_messages import (
 )
 from ....Chat.chat_handoff_models import ChatHandoffPayload
 from ....Utils.optional_deps import DEPENDENCIES_AVAILABLE
+from ....RAG_Search.ingestion_indexing import (
+    ITEM_TYPE_CONVERSATION,
+    ITEM_TYPE_MEDIA,
+    ITEM_TYPE_NOTE,
+    backfill_semantic_index,
+    peek_shared_rag_service,
+)
 from ....RAG_Search.semantic_availability import (
     SEMANTIC_DIAGNOSTICS_KEY,
     SEMANTIC_EMPTY_INDEX_MESSAGE,
@@ -52,6 +59,7 @@ from ....RAG_Search.semantic_availability import (
     SEMANTIC_STATUS_EMPTY_INDEX,
     SEMANTIC_STATUS_UNAVAILABLE,
     SEMANTIC_UNAVAILABLE_MESSAGES,
+    trustworthy_collection_count,
 )
 from ....DB.search_history_db import SearchHistoryDB
 from ....Utils.input_validation import sanitize_string
@@ -62,6 +70,28 @@ WEB_SEARCH_AVAILABLE = DEPENDENCIES_AVAILABLE.get('websearch', False)
 USE_IN_CONSOLE_UNAVAILABLE_RECOVERY = (
     "Use in Console is unavailable because the Console live-work surface is not mounted. "
     "Open Console from the navigation, then try again."
+)
+
+#: Map of the #index-source-select options onto the backfill item-type
+#: contract from RAG_Search.ingestion_indexing (task-251).
+INDEX_SOURCE_ITEM_TYPES: Dict[str, Tuple[str, ...]] = {
+    "media": (ITEM_TYPE_MEDIA,),
+    "conversations": (ITEM_TYPE_CONVERSATION,),
+    "notes": (ITEM_TYPE_NOTE,),
+    "all": (ITEM_TYPE_MEDIA, ITEM_TYPE_NOTE, ITEM_TYPE_CONVERSATION),
+}
+
+INDEXING_ALREADY_RUNNING_MESSAGE = (
+    "Semantic indexing is already running. Wait for the current run to finish."
+)
+INDEXING_UNAVAILABLE_MESSAGE = (
+    "semantic indexing is unavailable. Install embeddings support "
+    "(pip install 'tldw_chatbook[embeddings_rag]') and ensure "
+    "[AppRAGSearchConfig.rag.indexing].enabled is not false."
+)
+INDEXING_NO_DATABASE_MESSAGE = (
+    "Cannot index: no source database is available in this session for the "
+    "selected content type."
 )
 
 
@@ -197,6 +227,8 @@ class SearchRAGWindow(SearchEventHandlersMixin, Container):
         # Semantic-leg availability diagnostics from the last pipeline run
         # (task-250); read by _semantic_leg_notice to report honest states.
         self.last_search_diagnostics: Dict[str, Any] = {}
+        # Single-flight guard for the Maintenance-tab bulk index run (task-251).
+        self._indexing_in_flight = False
         
         # Performance tracking
         self.last_search_time = 0.0
@@ -397,8 +429,9 @@ class SearchRAGWindow(SearchEventHandlersMixin, Container):
                                 yield Static("", id="results-count", classes="results-count")
                                 yield Static("", id="search-time", classes="search-time")
                                 with Horizontal(classes="results-actions"):
+                                    # Refresh was removed (task-251): re-running
+                                    # the query is exactly the Search button.
                                     yield Button("📤 Export", id="export-results", classes="results-action-button")
-                                    yield Button("🔄 Refresh", id="refresh-results", classes="results-action-button")
                             
                             # Results list
                             with VerticalScroll(id="results-list-enhanced", classes="results-list-enhanced"):
@@ -454,20 +487,22 @@ class SearchRAGWindow(SearchEventHandlersMixin, Container):
                         with Container(classes="maintenance-tab-content"):
                             yield Static("🔧 Index Management", classes="maintenance-title")
                             
-                            # Collection management
+                            # Collection management (display + refresh only:
+                            # the simplified RAG service manages one
+                            # collection per profile, so create/delete had no
+                            # real backing and were removed, task-251)
                             with Container(classes="collection-management"):
                                 yield Label("Available Collections:", classes="maintenance-label")
                                 yield ListView(id="collections-list", classes="collections-list")
-                                
+
                                 with Horizontal(classes="collection-actions"):
-                                    yield Button("➕ Create Collection", id="create-collection", classes="maintenance-button")
-                                    yield Button("🗑️ Delete Collection", id="delete-collection", classes="maintenance-button danger")
-                                    yield Button("🔄 Refresh Collections", id="refresh-collections", classes="maintenance-button")
-                            
-                            # Indexing controls
+                                    yield Button("🔄 Refresh", id="refresh-collections", classes="maintenance-button")
+
+                            # Indexing controls (wired to the real bulk
+                            # backfill path from task-247, task-251)
                             with Container(classes="indexing-controls"):
                                 yield Static("📥 Index New Content", classes="indexing-title")
-                                
+
                                 yield Select(
                                     [
                                         ("Index Media", "media"),
@@ -479,20 +514,22 @@ class SearchRAGWindow(SearchEventHandlersMixin, Container):
                                     id="index-source-select",
                                     classes="index-source-select"
                                 )
-                                
+
                                 yield Button(
                                     "🚀 Start Indexing",
                                     id="start-indexing",
                                     variant="primary",
                                     classes="indexing-button"
                                 )
-                                
-                                # Indexing status
+
+                                # Indexing status (no progress bar: the
+                                # backfill total is unknown up front, so a
+                                # percentage would be fake -- real per-batch
+                                # counts go into the status text instead)
                                 with Container(id="indexing-status", classes="indexing-status hidden"):
                                     yield LoadingIndicator()
                                     yield Static("", id="indexing-status-text")
-                                    yield ProgressBar(id="indexing-progress", total=100)
-                            
+
                             # Index statistics
                             with Container(classes="index-statistics"):
                                 yield Static("📊 Index Statistics", classes="statistics-title")
@@ -548,7 +585,18 @@ class SearchRAGWindow(SearchEventHandlersMixin, Container):
                 search_button.tooltip = recovery_state.disabled_tooltip
             except NoMatches:
                 pass
-        
+            # The Maintenance-tab indexing controls need the same runtime the
+            # searches do; disable them with the same recovery copy (task-251).
+            try:
+                start_indexing = self.query_one("#start-indexing", Button)
+                start_indexing.disabled = True
+                start_indexing.tooltip = recovery_state.disabled_tooltip
+                index_source = self.query_one("#index-source-select", Select)
+                index_source.disabled = True
+                index_source.tooltip = recovery_state.disabled_tooltip
+            except NoMatches:
+                pass
+
         # Setup UI components after all widgets are created
         self._setup_history_table()
         self._setup_analytics()
@@ -740,7 +788,7 @@ class SearchRAGWindow(SearchEventHandlersMixin, Container):
         """Setup index statistics table"""
         if RAG_SERVICES_AVAILABLE:
             table = self.query_one("#index-stats-table", DataTable)
-            table.add_columns("Collection", "Documents", "Chunks", "Size", "Last Updated")
+            table.add_columns("Collection", "Chunks", "Status")
             self._refresh_index_stats()
 
     def _load_available_collections(self) -> list[str]:
@@ -772,40 +820,232 @@ class SearchRAGWindow(SearchEventHandlersMixin, Container):
         """Refresh the list of available collections"""
         try:
             collections = self._load_available_collections()
-            self.app.call_from_thread(lambda: self.run_worker(self._apply_available_collections(collections), exclusive=True))
+            # Dedicated group: an exclusive worker in the DEFAULT group would
+            # cancel unrelated default-group workers (e.g. an in-flight
+            # search) whenever a collections refresh lands (task-251).
+            self.app.call_from_thread(
+                lambda: self.run_worker(
+                    self._apply_available_collections(collections),
+                    exclusive=True,
+                    group="rag-collections-apply",
+                )
+            )
         except Exception as e:
             logger.error(f"Error refreshing collections: {e}")
     
-    @work(thread=True)
-    async def _refresh_index_stats(self) -> None:
-        """Refresh index statistics"""
+    def _load_index_stats(self) -> Optional[Dict[str, Any]]:
+        """Read collection stats from an ALREADY-initialized RAG runtime.
+
+        Never constructs the runtime: rendering statistics must not load an
+        embedding model as a side effect. Safe to run off the UI thread
+        (ChromaDB-backed stats can touch disk).
+
+        Returns:
+            The raw stats dict, an ``{"error": ...}`` dict when the read
+            failed, or None when no runtime exists yet.
+        """
+        service = getattr(self.app_instance, "_rag_service", None)
+        if service is None:
+            service = peek_shared_rag_service()
+        get_stats = getattr(getattr(service, "vector_store", None), "get_collection_stats", None)
+        if not callable(get_stats):
+            return None
         try:
-            if not self.rag_service:
-                return
-                
-            # Get stats for each collection
-            table = self.query_one("#index-stats-table", DataTable)
-            table.clear()
-            
-            for collection in self.available_collections:
-                # Get collection stats (placeholder - implement actual stats retrieval)
-                stats = {
-                    "documents": 0,
-                    "chunks": 0,
-                    "size": "0 MB",
-                    "last_updated": "N/A"
-                }
-                
-                table.add_row(
-                    collection,
-                    str(stats["documents"]),
-                    str(stats["chunks"]),
-                    stats["size"],
-                    stats["last_updated"]
-                )
+            stats = get_stats()
+        except Exception as e:
+            logger.error(f"Vector-store stats read failed: {e}")
+            return {"error": str(e)}
+        if not isinstance(stats, dict):
+            return {"error": "vector store returned malformed statistics"}
+        return stats
+
+    @work(thread=True, exclusive=True, group="rag-index-stats", exit_on_error=False)
+    def _refresh_index_stats(self) -> None:
+        """Refresh index statistics off the UI thread, then apply on it (task-251)."""
+        try:
+            stats = self._load_index_stats()
+            self.app.call_from_thread(self._apply_index_stats, stats)
         except Exception as e:
             logger.error(f"Error refreshing index stats: {e}")
-    
+
+    def _apply_index_stats(self, stats: Optional[Dict[str, Any]]) -> None:
+        """Render index statistics honestly: real counts or the actual state.
+
+        Args:
+            stats: Result of :meth:`_load_index_stats` (raw stats dict,
+                ``{"error": ...}``, or None when no runtime exists yet).
+        """
+        try:
+            table = self.query_one("#index-stats-table", DataTable)
+        except NoMatches:
+            return
+        table.clear()
+        if stats is None:
+            table.add_row(
+                "semantic index",
+                "—",
+                "not initialized — run Start Indexing or a semantic search",
+            )
+            return
+        name = str(stats.get("name") or "semantic index")
+        error = stats.get("error")
+        if error:
+            table.add_row(name, "—", f"statistics unavailable: {error}")
+            return
+        count = trustworthy_collection_count(stats)
+        if count is None:
+            table.add_row(name, "—", "statistics unavailable: untrustworthy chunk count")
+            return
+        table.add_row(
+            name,
+            str(count),
+            "empty — no content indexed yet" if count == 0 else "ready",
+        )
+
+    # Bulk indexing (task-251): #start-indexing runs the real backfill path
+    def _selected_index_item_types(self) -> Tuple[str, ...]:
+        """Map the #index-source-select value onto backfill item types."""
+        try:
+            raw = self.query_one("#index-source-select", Select).value
+        except NoMatches:
+            raw = "all"
+        return INDEX_SOURCE_ITEM_TYPES.get(str(raw), INDEX_SOURCE_ITEM_TYPES["all"])
+
+    def _set_indexing_ui_running(self, running: bool, status: str = "") -> None:
+        """Toggle the Start Indexing button and status row for an active run."""
+        try:
+            self.query_one("#start-indexing", Button).disabled = running
+            status_container = self.query_one("#indexing-status")
+            if running:
+                status_container.remove_class("hidden")
+            else:
+                status_container.add_class("hidden")
+            self.query_one("#indexing-status-text", Static).update(status)
+        except NoMatches:
+            pass
+
+    def _start_indexing_run(self) -> None:
+        """Validate preconditions and launch the bulk semantic-index worker.
+
+        Honest by construction: refuses (with WHY) when embeddings support is
+        missing, a run is already in flight, or no source database backs the
+        selected content type -- it never pretends to index.
+        """
+        if not DEPENDENCIES_AVAILABLE.get('embeddings_rag', False):
+            self.app_instance.notify(
+                f"Indexing did not run: {INDEXING_UNAVAILABLE_MESSAGE}",
+                severity="warning",
+            )
+            return
+        if self._indexing_in_flight:
+            self.app_instance.notify(INDEXING_ALREADY_RUNNING_MESSAGE, severity="warning")
+            return
+
+        item_types = self._selected_index_item_types()
+        media_db = (
+            getattr(self.app_instance, "media_db", None)
+            if ITEM_TYPE_MEDIA in item_types else None
+        )
+        chachanotes_db = (
+            getattr(self.app_instance, "chachanotes_db", None)
+            if (ITEM_TYPE_NOTE in item_types or ITEM_TYPE_CONVERSATION in item_types)
+            else None
+        )
+        if media_db is None and chachanotes_db is None:
+            self.app_instance.notify(INDEXING_NO_DATABASE_MESSAGE, severity="error")
+            return
+
+        self._indexing_in_flight = True
+        self._set_indexing_ui_running(True, "Starting semantic indexing…")
+        self._run_index_backfill(item_types, media_db, chachanotes_db)
+
+    @work(thread=True, exclusive=True, group="rag-index-backfill", exit_on_error=False)
+    def _run_index_backfill(
+        self,
+        item_types: Tuple[str, ...],
+        media_db: Optional[Any],
+        chachanotes_db: Optional[Any],
+    ) -> None:
+        """Thread worker: run the real bulk backfill; exceptions never escape.
+
+        Runs ``backfill_semantic_index`` inside its own event loop on this
+        worker thread (exactly like the CLI entry point), so the source-DB
+        pagination and embedding work never touch the UI event loop. Both DB
+        classes use thread-local sqlite connections, so cross-thread use is
+        safe. Progress and completion are marshalled back with
+        ``call_from_thread``.
+        """
+        def _progress(update: Dict[str, Any]) -> None:
+            try:
+                self.app.call_from_thread(self._update_indexing_progress, dict(update))
+            except Exception as e:
+                logger.debug(f"Indexing progress update failed: {e}")
+
+        try:
+            summary = asyncio.run(
+                backfill_semantic_index(
+                    media_db=media_db,
+                    chachanotes_db=chachanotes_db,
+                    item_types=item_types,
+                    progress_callback=_progress,
+                )
+            )
+        except Exception as e:
+            logger.opt(exception=True).error(f"Semantic index backfill crashed: {e}")
+            summary = {
+                "status": "error",
+                "indexed": 0,
+                "skipped": 0,
+                "failed": 0,
+                "errors": [str(e)],
+            }
+        try:
+            self.app.call_from_thread(self._finish_indexing_run, summary)
+        except Exception as e:
+            logger.error(f"Could not deliver indexing completion to the UI: {e}")
+            self._indexing_in_flight = False
+
+    def _update_indexing_progress(self, update: Dict[str, Any]) -> None:
+        """Show real per-batch backfill counts in the indexing status row."""
+        try:
+            status_text = self.query_one("#indexing-status-text", Static)
+        except NoMatches:
+            return
+        status_text.update(
+            f"Indexing {update.get('item_type', '?')}: "
+            f"{update.get('indexed', 0)} indexed, "
+            f"{update.get('skipped', 0)} up-to-date, "
+            f"{update.get('failed', 0)} failed"
+        )
+
+    def _finish_indexing_run(self, summary: Dict[str, Any]) -> None:
+        """Report the backfill outcome honestly and refresh the real stats."""
+        self._indexing_in_flight = False
+        self._set_indexing_ui_running(False)
+
+        status = summary.get("status")
+        errors = summary.get("errors") or []
+        last_error = str(errors[-1]) if errors else None
+        if status == "unavailable":
+            self.app_instance.notify(
+                f"Indexing did not run: {last_error or INDEXING_UNAVAILABLE_MESSAGE}",
+                severity="warning",
+            )
+        elif status == "error" or summary.get("failed") or errors:
+            detail = f" Last error: {last_error}" if last_error else ""
+            self.app_instance.notify(
+                f"Indexing finished with problems: {summary.get('indexed', 0)} indexed, "
+                f"{summary.get('failed', 0)} failed.{detail}",
+                severity="error" if status == "error" else "warning",
+            )
+        else:
+            self.app_instance.notify(
+                f"Indexing complete: {summary.get('indexed', 0)} indexed, "
+                f"{summary.get('skipped', 0)} already up-to-date.",
+                severity="information",
+            )
+        self._refresh_index_stats()
+
     # Search implementation methods
     @staticmethod
     def _sources_from_config(config: Dict[str, Any]) -> Dict[str, bool]:
@@ -1016,12 +1256,27 @@ class SearchRAGWindow(SearchEventHandlersMixin, Container):
         self.query_one("#prev-page", Button).disabled = self.current_page <= 1
         self.query_one("#next-page", Button).disabled = self.current_page >= total_pages
     
-    def _load_recent_search_history(self, limit: int = 20):
+    def _selected_history_days_back(self) -> Optional[int]:
+        """Read the #history-range-select value as days-back (None = all time)."""
+        try:
+            raw = self.query_one("#history-range-select", Select).value
+        except NoMatches:
+            return None
+        try:
+            return int(raw)
+        except (TypeError, ValueError):
+            return None
+
+    def _refresh_history_view(self) -> None:
+        """Reload the history table for the selected time range (task-251)."""
+        self._load_recent_search_history(days_back=self._selected_history_days_back())
+
+    def _load_recent_search_history(self, limit: int = 20, days_back: Optional[int] = None):
         """Load recent search history into the table"""
         table = self.query_one("#search-history-table", DataTable)
         table.clear()
-        
-        history = self.search_history_db.get_search_history(limit=limit)
+
+        history = self.search_history_db.get_search_history(limit=limit, days_back=days_back)
         for item in history:
             table.add_row(
                 item['query'],

--- a/tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py
+++ b/tldw_chatbook/UI/Views/RAGSearch/search_rag_window.py
@@ -50,7 +50,9 @@ from ....RAG_Search.ingestion_indexing import (
     ITEM_TYPE_MEDIA,
     ITEM_TYPE_NOTE,
     backfill_semantic_index,
+    get_shared_rag_service,
     peek_shared_rag_service,
+    semantic_indexing_available,
 )
 from ....RAG_Search.semantic_availability import (
     SEMANTIC_DIAGNOSTICS_KEY,
@@ -853,7 +855,11 @@ class SearchRAGWindow(SearchEventHandlersMixin, Container):
         try:
             stats = get_stats()
         except Exception as e:
-            logger.error(f"Vector-store stats read failed: {e}")
+            logger.error(
+                f"Vector-store stats read failed "
+                f"(operation=vector_store.get_collection_stats, "
+                f"service={type(service).__name__}): {e}"
+            )
             return {"error": str(e)}
         if not isinstance(stats, dict):
             return {"error": "vector store returned malformed statistics"}
@@ -866,7 +872,10 @@ class SearchRAGWindow(SearchEventHandlersMixin, Container):
             stats = self._load_index_stats()
             self.app.call_from_thread(self._apply_index_stats, stats)
         except Exception as e:
-            logger.error(f"Error refreshing index stats: {e}")
+            logger.error(
+                f"Error refreshing index stats "
+                f"(operation=refresh_index_stats, worker_group=rag-index-stats): {e}"
+            )
 
     def _apply_index_stats(self, stats: Optional[Dict[str, Any]]) -> None:
         """Render index statistics honestly: real counts or the actual state.
@@ -974,24 +983,74 @@ class SearchRAGWindow(SearchEventHandlersMixin, Container):
         classes use thread-local sqlite connections, so cross-thread use is
         safe. Progress and completion are marshalled back with
         ``call_from_thread``.
+
+        The shared RAG service is pre-resolved here, OUTSIDE the transient
+        ``asyncio.run`` loop, so first-time service construction can never
+        happen inside a loop that closes when this run finishes (PR #700
+        review). Verified no current component binds a loop at construction
+        (plain ThreadPoolExecutor, threading.Lock circuit breaker, cache's
+        asyncio.Lock binds on first acquisition, local embeddings with no
+        HTTP client) -- pre-resolving keeps that true by construction.
         """
         def _progress(update: Dict[str, Any]) -> None:
             try:
                 self.app.call_from_thread(self._update_indexing_progress, dict(update))
             except Exception as e:
-                logger.debug(f"Indexing progress update failed: {e}")
+                logger.debug(
+                    f"Indexing progress update failed "
+                    f"(operation=update_indexing_progress, "
+                    f"item_type={update.get('item_type', '?')}): {e}"
+                )
+
+        rag_service = None
+        indexing_available = False
+        try:
+            indexing_available = semantic_indexing_available()
+            if indexing_available:
+                rag_service = get_shared_rag_service()
+        except Exception as e:
+            logger.error(
+                f"Shared RAG service pre-resolution failed "
+                f"(operation=get_shared_rag_service, item_types={item_types}): {e}"
+            )
+        if indexing_available and rag_service is None:
+            # Do not enter the transient loop at all: backfill would retry
+            # service construction inside it, which is exactly what
+            # pre-resolution exists to prevent. Same outcome/copy as
+            # backfill's own service-unavailable path.
+            unavailable_summary = {
+                "status": "unavailable",
+                "indexed": 0,
+                "skipped": 0,
+                "failed": 0,
+                "errors": ["RAG service could not be created"],
+            }
+            try:
+                self.app.call_from_thread(self._finish_indexing_run, unavailable_summary)
+            except Exception as e:
+                logger.error(
+                    f"Could not deliver indexing completion to the UI "
+                    f"(operation=finish_indexing_run, item_types={item_types}, "
+                    f"summary_status=unavailable): {e}"
+                )
+                self._indexing_in_flight = False
+            return
 
         try:
             summary = asyncio.run(
                 backfill_semantic_index(
                     media_db=media_db,
                     chachanotes_db=chachanotes_db,
+                    rag_service=rag_service,
                     item_types=item_types,
                     progress_callback=_progress,
                 )
             )
         except Exception as e:
-            logger.opt(exception=True).error(f"Semantic index backfill crashed: {e}")
+            logger.opt(exception=True).error(
+                f"Semantic index backfill crashed "
+                f"(operation=backfill_semantic_index, item_types={item_types}): {e}"
+            )
             summary = {
                 "status": "error",
                 "indexed": 0,
@@ -1002,7 +1061,11 @@ class SearchRAGWindow(SearchEventHandlersMixin, Container):
         try:
             self.app.call_from_thread(self._finish_indexing_run, summary)
         except Exception as e:
-            logger.error(f"Could not deliver indexing completion to the UI: {e}")
+            logger.error(
+                f"Could not deliver indexing completion to the UI "
+                f"(operation=finish_indexing_run, item_types={item_types}, "
+                f"summary_status={summary.get('status')}): {e}"
+            )
             self._indexing_in_flight = False
 
     def _update_indexing_progress(self, update: Dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary

Final rider of the local-RAG program (ADR-005, 2026-07-12 RAG audit): the standalone Search window rendered "Index New Content" controls whose `#start-indexing` button had **no event handler anywhere**, plus index-stats controls that never updated. Every control the window renders now routes to a real implementation or is gone (task-251, both ACs).

## Per-control disposition

**Wired**
- `#start-indexing` → task-247's `backfill_semantic_index` on a thread worker (`@work(thread=True, exclusive=True, group="rag-index-backfill", exit_on_error=False)`) running `asyncio.run` exactly like the CLI entry point; single-flight guard + button disabled during the run; all exceptions contained in the worker; honest completion notifies (unavailable → install copy, failures → last error, success → indexed/up-to-date counts).
- `#index-source-select` → read at press, mapped onto the backfill `item_types` contract (media/conversations/notes/all).
- `#index-stats-table` (previously hard-coded zeros behind an always-None `self.rag_service` early-return) → real `vector_store.get_collection_stats()` counts read **off-thread from an already-initialized runtime only** (`app._rag_service` or the new non-creating `peek_shared_rag_service()`); honest "not initialized" / error / untrustworthy-count rows; columns reduced to Collection/Chunks/Status (Documents/Size/Last-Updated had no real source).
- `#indexing-status` text → real per-batch indexed/up-to-date/failed counts via the backfill progress callback (`call_from_thread`).
- `#refresh-collections` (relabeled "Refresh") → collections list + stats refresh.
- `#export-results` → the existing Ctrl+E export action.
- `#prev-page` / `#next-page` → real pagination (pages beyond 1 were unreachable by mouse).
- `#refresh-history` + `#history-range-select` → history reload honoring `get_search_history(days_back=...)`.

**Removed (no cheap real backing)**
- `#create-collection` / `#delete-collection` — the simplified RAG service manages exactly one collection per profile.
- `#refresh-results` — re-running the query is exactly the Search button.
- `#indexing-progress` ProgressBar — backfill total is unknown up front; a percentage would be fake.

**Left as-is** (not activation no-ops; search-flow scope stabilized by #692): `#collection-select` / `#temperature-input` (feed saved-search config), `#search-progress` (passive indicator).

## Root-cause fixes surfaced by AC #1

- **None of `SearchEventHandlersMixin`'s `@on` handlers — including the Search button's `handle_search` — were ever dispatched.** `@on` registration happens in Textual's `_MessagePumpMeta` at class creation, and dispatch walks each MRO class's own `_decorated_handlers`; a plain mixin class never got either. The mixin now uses `metaclass=_MessagePumpMeta` (identical to `Container`'s, so no metaclass conflict; verified `type(Container) is _MessagePumpMeta` on textual 8.2.7).
- The collections-apply seam used `run_worker(exclusive=True)` with no `group=` (the task-228 lesson): it cancelled unrelated default-group workers (e.g. an in-flight search), observable as `WorkerCancelled`. Now in its own group.

## Deps gate

With `embeddings_rag` missing, `#start-indexing` and `#index-source-select` are disabled at mount with the same shared recovery tooltip as the Search button (install copy incl. `pip install "tldw_chatbook[embeddings_rag]"`); the press path re-checks and notifies honestly, and `backfill_semantic_index` re-gates internally via `semantic_indexing_available()`.

## Shared helpers

- `RAG_Search/ingestion_indexing.py`: new `peek_shared_rag_service()` — read-only accessor, never constructs the runtime.
- `RAG_Search/semantic_availability.py`: trustworthy-count rule factored into `trustworthy_collection_count()` (strict non-negative int, bool/float/str rejected), reused by `semantic_index_is_empty` (behavior unchanged) and the stats display.

## Tests (TDD: all 14 window tests written failing first)

- `Tests/UI/test_search_rag_window.py`: **37 passed** (23 baseline from #692 + 14 new: deps-disable+tooltip, backfill invoked via worker with selected types/DB handles, single-flight (gated fake + guard), failure/unavailable/crash → honest notify + button re-enabled, honest stats states incl. untrustworthy counts, removed-controls assertions, pagination/export/history/collections wiring).
- `Tests/RAG/test_ingestion_indexing.py` + `Tests/RAG/test_semantic_honest_states.py`: **73 passed** (incl. new `peek_shared_rag_service` and `trustworthy_collection_count` coverage).
- Combined post-rebase run on b784e68b: **110 passed**; `python -c "import tldw_chatbook.app"` OK; adjacent `test_search_handoffs.py` + `test_product_maturity_gate16_library_search_rag.py`: 32 passed.

CI is intentionally cancelled by another build — verified locally as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired the Search window’s indexing controls to the real backfill path and made index stats honest and cheap to render. Also pre-resolves the RAG service before running, removes dead controls, and addresses task-251 by ensuring all visible controls work and reflect real state.

- New Features
  - Start Indexing runs `backfill_semantic_index` on a thread worker with single-flight guard and per-batch progress; pre-resolves the shared RAG service before `asyncio.run` and short-circuits with an “unavailable” notice if it can’t be created.
  - Index Stats read `vector_store.get_collection_stats()` from an already-initialized runtime via `peek_shared_rag_service`, run off the UI thread in their own worker group, and show trustworthy counts or honest “not initialized”/error states; never constructs the runtime.
  - Wired chrome: Export uses the existing action, pagination works, history refresh honors the selected range, and collections refresh updates both list and stats.
  - Deps gate: when `embeddings_rag` is missing, indexing controls are disabled with recovery tooltip; presses re-check and notify. Removed dead controls: create/delete collection, refresh results, and the fake progress bar.

- Bug Fixes
  - `@on` handlers in the mixin were not dispatched; fixed by deriving its metaclass from `type(Container)` so Textual registrations fire, with a regression test guarding it.
  - `run_worker(exclusive=True)` paths now use dedicated groups to avoid cancelling unrelated default-group workers (e.g., an in-flight search).

<sup>Written for commit 797e2761ca8b8bb01a821ddfd8d1b04ca619a31f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

