### PR TITLE
Roleplay P2d-2: world-book (Lore) import/export UI

### DIFF
--- a/Docs/superpowers/plans/2026-07-17-roleplay-p2d2-import-export.md
+++ b/Docs/superpowers/plans/2026-07-17-roleplay-p2d2-import-export.md
@@ -1,0 +1,853 @@
+# Roleplay P2d-2 — world-book import/export UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a user import a world book from a `.json` file and export the selected world book to a file in the Roleplay Lore mode, wired to the existing `WorldBookManager.export_world_book`/`import_world_book`.
+
+**Architecture:** A new pure module `world_book_import.py` maps any supported input shape (tldw export, character-book array, SillyTavern World Info object-form) to tldw's field names and validates the whole file up front (so `import_world_book`'s non-atomic loop never gets bad data → no partial book). The screen adds an import path-handler + a file-picker worker (mirroring the dictionary import flow) and an export worker (mirroring the character `EnhancedFileSave` flow); the lore detail widget gains an Export button + typed message.
+
+**Tech Stack:** Python ≥3.11, Textual, pytest + pytest-asyncio, SQLite (`CharactersRAGDB`), `WorldBookManager`.
+
+## Global Constraints
+
+- NO change to `world_book_manager.py` (manager) or `ChaChaNotes_DB.py` (schema stays `_CURRENT_SCHEMA_VERSION = 21`).
+- `normalize_world_book_import` validates the ENTIRE file before any DB write — a bad file yields NO partial book.
+- Import and export must NEVER crash the UI: all I/O and parsing wrapped, errors surfaced via `self._notify(msg, level)`.
+- I/O workers run via `self.run_worker(..., group="personas-io")` guarded by `self._io_dialog_active` (set True before, reset in `finally`).
+- After an import/export worker finishes, if `self.state.active_mode != "lore"` the user navigated away — do NOT yank them back (mirror the dictionary/character import guards).
+- JSON only (no Markdown export).
+- Implementers stage ONLY their task's files (`git add <explicit paths>`; never `git add -A`; never `.superpowers/`).
+- **Test environment (run from the worktree root):**
+  ```bash
+  HOME=/private/tmp/tldw-chatbook-test-home \
+  XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest <targets> \
+  -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+  ```
+  The venv is in the MAIN checkout; `import tldw_chatbook` resolves to the worktree source (cwd on `sys.path`).
+
+## File Structure
+
+- **Create** `tldw_chatbook/Character_Chat/world_book_import.py` — pure, DB-free normalization/validation. One responsibility: turn imported JSON into a validated tldw-shaped dict or raise `ValueError`.
+- **Modify** `tldw_chatbook/Widgets/Persona_Widgets/personas_lore_detail.py` — add `LoreBookExportRequested` message + Export button + handler + `__all__`.
+- **Modify** `tldw_chatbook/Widgets/Persona_Widgets/personas_library_pane.py` — un-gate the Import button for `lore` in `set_mode`.
+- **Modify** `tldw_chatbook/UI/Screens/personas_screen.py` — import branch + import dialog/worker/path-handler; export handler/worker; the `WORLDBOOK` size constant; the `normalize_world_book_import` import.
+- **Create** `Tests/Character_Chat/test_world_book_import.py` — pure adapter unit tests.
+- **Modify** `Tests/UI/test_personas_lore.py` — real-DB import/export + round-trip tests.
+
+---
+
+### Task 1: `world_book_import.py` normalization adapter
+
+**Files:**
+- Create: `tldw_chatbook/Character_Chat/world_book_import.py`
+- Test: `Tests/Character_Chat/test_world_book_import.py`
+
+**Interfaces:**
+- Produces: `normalize_world_book_import(data: Any) -> dict` — returns `{**data, "entries": [<normalized entry dict>...]}` where each entry has exactly `{keys, secondary_keys, content, insertion_order, position, selective, case_sensitive, enabled, priority, extensions}`; raises `ValueError` (user-facing message) on any invalid shape / empty-keys / empty-content entry.
+
+- [ ] **Step 1: Write the failing unit tests**
+
+Create `Tests/Character_Chat/test_world_book_import.py`:
+
+```python
+import pytest
+
+from tldw_chatbook.Character_Chat.world_book_import import normalize_world_book_import
+
+
+def _tldw_entry(**kw):
+    base = {"keys": ["Warden"], "content": "grim jailer", "position": "before_char",
+            "insertion_order": 0, "selective": False, "secondary_keys": [],
+            "case_sensitive": False, "enabled": True, "priority": 0}
+    base.update(kw)
+    return base
+
+
+def test_tldw_export_passthrough():
+    data = {"name": "B", "description": "d", "scan_depth": 3, "token_budget": 500,
+            "recursive_scanning": False, "entries": [_tldw_entry(priority=42)]}
+    out = normalize_world_book_import(data)
+    assert out["name"] == "B" and out["scan_depth"] == 3
+    e = out["entries"][0]
+    assert e["keys"] == ["Warden"] and e["content"] == "grim jailer"
+    assert e["priority"] == 42 and e["position"] == "before_char"
+
+
+def test_character_book_array_passthrough():
+    data = {"entries": [{"keys": ["a", "b"], "content": "c", "secondary_keys": ["s"],
+                         "insertion_order": 2, "selective": True, "case_sensitive": True}]}
+    e = normalize_world_book_import(data)["entries"][0]
+    assert e["keys"] == ["a", "b"] and e["secondary_keys"] == ["s"]
+    assert e["insertion_order"] == 2 and e["selective"] is True and e["case_sensitive"] is True
+
+
+def test_sillytavern_world_info_object_form_remaps():
+    data = {"entries": {"0": {"key": ["Warden"], "keysecondary": ["jail"], "content": "x",
+                              "order": 5, "position": 1, "disable": True,
+                              "caseSensitive": True, "selective": True}}}
+    e = normalize_world_book_import(data)["entries"][0]
+    assert e["keys"] == ["Warden"] and e["secondary_keys"] == ["jail"]
+    assert e["insertion_order"] == 5 and e["position"] == "after_char"
+    assert e["enabled"] is False and e["case_sensitive"] is True and e["selective"] is True
+
+
+def test_missing_entries_yields_empty_list():
+    assert normalize_world_book_import({"name": "B"})["entries"] == []
+
+
+def test_priority_and_extensions_preserved_and_defaulted():
+    data = {"entries": [{"keys": ["k"], "content": "c", "extensions": {"x": 1}},
+                        {"keys": ["k2"], "content": "c2"}]}
+    out = normalize_world_book_import(data)["entries"]
+    assert out[0]["extensions"] == {"x": 1} and out[0]["priority"] == 0
+    assert out[1]["extensions"] == {} and out[1]["insertion_order"] == 1
+
+
+def test_non_dict_top_level_raises():
+    with pytest.raises(ValueError, match="must be a JSON object"):
+        normalize_world_book_import([1, 2, 3])
+
+
+def test_entries_not_list_or_dict_raises():
+    with pytest.raises(ValueError, match="must be a list or an object"):
+        normalize_world_book_import({"entries": 42})
+
+
+def test_empty_keys_entry_raises():
+    with pytest.raises(ValueError, match="Entry 1 has no keys"):
+        normalize_world_book_import({"entries": [{"keys": [], "content": "c"}]})
+
+
+def test_empty_content_entry_raises():
+    with pytest.raises(ValueError, match="Entry 1 has no content"):
+        normalize_world_book_import({"entries": [{"keys": ["k"], "content": "   "}]})
+
+
+def test_non_dict_entry_raises():
+    with pytest.raises(ValueError, match="Entry 1 is not an object"):
+        normalize_world_book_import({"entries": ["not a dict"]})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+```bash
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+Tests/Character_Chat/test_world_book_import.py -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: FAIL — `ModuleNotFoundError: No module named 'tldw_chatbook.Character_Chat.world_book_import'`.
+
+- [ ] **Step 3: Write the module**
+
+Create `tldw_chatbook/Character_Chat/world_book_import.py`:
+
+```python
+"""Pure normalization/validation for world-book (Lore) import files.
+
+Maps the supported input shapes — tldw's own export, the character-book array
+form, and SillyTavern 'World Info' object-form — to tldw's ``world_book_entries``
+field names, and validates the whole file up front so the import screen can
+reject a bad file before any DB write (``WorldBookManager.import_world_book`` is
+not atomic). Pure and DB-free; raises ``ValueError`` with a user-facing message.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+_VALID_POSITIONS = {"before_char", "after_char", "at_start", "at_end"}
+_INT_POSITION_MAP = {0: "before_char", 1: "after_char"}
+
+
+def _coerce_int(value: Any, default: int) -> int:
+    """Best-effort int coercion; ``default`` on None/non-numeric."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_str_list(value: Any) -> List[str]:
+    """Coerce a keys-like field to a list of non-blank strings."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value] if value.strip() else []
+    if isinstance(value, list):
+        return [str(v) for v in value if str(v).strip()]
+    return []
+
+
+def _normalize_position(pos: Any) -> str:
+    """Map a position (tldw string or SillyTavern int) to a tldw position."""
+    if isinstance(pos, str) and pos in _VALID_POSITIONS:
+        return pos
+    if isinstance(pos, bool):
+        return "before_char"
+    if isinstance(pos, int):
+        return _INT_POSITION_MAP.get(pos, "before_char")
+    return "before_char"
+
+
+def _normalize_entry(entry: Any, index: int) -> Dict[str, Any]:
+    """Map one entry to tldw fields; raise ValueError (1-based index) if invalid."""
+    if not isinstance(entry, dict):
+        raise ValueError(f"Entry {index + 1} is not an object.")
+    raw_keys = entry.get("keys")
+    if raw_keys is None:
+        raw_keys = entry.get("key")
+    keys = _as_str_list(raw_keys)
+    if not keys:
+        raise ValueError(f"Entry {index + 1} has no keys.")
+    content = str(entry.get("content", ""))
+    if not content.strip():
+        raise ValueError(f"Entry {index + 1} has no content.")
+    raw_secondary = entry.get("secondary_keys")
+    if raw_secondary is None:
+        raw_secondary = entry.get("keysecondary")
+    extensions = entry.get("extensions")
+    return {
+        "keys": keys,
+        "secondary_keys": _as_str_list(raw_secondary),
+        "content": content,
+        "insertion_order": _coerce_int(
+            entry.get("insertion_order", entry.get("order", index)), index
+        ),
+        "position": _normalize_position(entry.get("position")),
+        "selective": bool(entry.get("selective", False)),
+        "case_sensitive": bool(entry.get("case_sensitive", entry.get("caseSensitive", False))),
+        "enabled": bool(entry.get("enabled", not entry.get("disable", False))),
+        "priority": _coerce_int(entry.get("priority", 0), 0),
+        "extensions": extensions if isinstance(extensions, dict) else {},
+    }
+
+
+def normalize_world_book_import(data: Any) -> Dict[str, Any]:
+    """Normalize + validate an imported world-book payload.
+
+    Args:
+        data: The parsed JSON from an import file.
+
+    Returns:
+        A dict with tldw metadata keys preserved and ``entries`` mapped to
+        tldw's field names as a list, ready for ``import_world_book``.
+
+    Raises:
+        ValueError: If the payload is not a dict, ``entries`` is neither a list
+            nor an object, or any entry is not a dict / has no keys / no content.
+    """
+    if not isinstance(data, dict):
+        raise ValueError("World book file must be a JSON object.")
+    raw_entries = data.get("entries")
+    if raw_entries is None:
+        entries_list: List[Any] = []
+    elif isinstance(raw_entries, dict):
+        entries_list = list(raw_entries.values())
+    elif isinstance(raw_entries, list):
+        entries_list = raw_entries
+    else:
+        raise ValueError("'entries' must be a list or an object.")
+    normalized = [_normalize_entry(entry, i) for i, entry in enumerate(entries_list)]
+    return {**data, "entries": normalized}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run the same command as Step 2. Expected: PASS (11 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Character_Chat/world_book_import.py Tests/Character_Chat/test_world_book_import.py
+git commit -m "feat(lore): pure world-book import normalizer (tldw/character-book/SillyTavern)"
+```
+
+---
+
+### Task 2: Export flow
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/Persona_Widgets/personas_lore_detail.py` (message class near `:63`; Export button after `:151`; handler near `:456`; `__all__` at `:477`)
+- Modify: `tldw_chatbook/UI/Screens/personas_screen.py` (import block `:90-98`; new handler + worker near `_handle_lore_settings_save` `:2037`)
+- Test: `Tests/UI/test_personas_lore.py`
+
+**Interfaces:**
+- Consumes: `WorldBookManager.export_world_book(id) -> dict` (already exists); `EnhancedFileSave`/`Filters` from `Widgets/enhanced_file_picker.py`.
+- Produces: message class `LoreBookExportRequested` (no payload); screen handler `_handle_lore_export`; worker `_lore_export_worker`; button id `#personas-lore-export`.
+
+- [ ] **Step 1: Write the failing export test**
+
+Append to `Tests/UI/test_personas_lore.py` (after the last real-DB test). It monkeypatches the save-picker to return a temp path. `Switch` etc. are already imported; add `import json` at the top of the file if not present (check first).
+
+```python
+@pytest.mark.asyncio
+async def test_export_selected_lore_book_writes_json_file(
+    mock_app_instance, stub_characters_lore, lore_db, seeded_lore_book, tmp_path, monkeypatch
+):
+    """Exporting the selected lore book writes a JSON file that parses back to the
+    book's export payload (name + entries)."""
+    import json as _json
+    mock_app_instance.chachanotes_db = lore_db
+    app = LorePersonasTestApp(mock_app_instance)
+    async with app.run_test(size=(200, 60)) as pilot:
+        screen = await _enter_lore(pilot)
+        await _select_first_lore(pilot, screen)
+        target = tmp_path / "exported.json"
+
+        async def _fake_save(picker):
+            return target
+
+        monkeypatch.setattr(app, "push_screen_wait", _fake_save)
+        screen.post_message(LoreBookExportRequested())
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        assert target.exists()
+        payload = _json.loads(target.read_text("utf-8"))
+        assert payload["name"] == "Blackreach"
+        assert any(e["keys"] == ["Warden"] for e in payload["entries"])
+```
+
+Add `LoreBookExportRequested` to the test file's import from `personas_lore_detail` (the block that already imports `LoreBookEnableToggled`, `LoreBookSettingsSaveRequested`, `LoreEntryAddRequested`).
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run:
+```bash
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+Tests/UI/test_personas_lore.py -k "export_selected_lore" -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: FAIL — `ImportError` (`LoreBookExportRequested` does not exist).
+
+- [ ] **Step 3: Add the message class + Export button + handler to the detail widget**
+
+In `personas_lore_detail.py`, add the message class next to `LoreBookSettingsSaveRequested` (after its definition, around `:66`):
+
+```python
+class LoreBookExportRequested(Message):
+    """Intent: export the currently selected world book to a file (JSON)."""
+```
+
+In compose, add the Export button right after the "Save settings" button (`:151`):
+
+```python
+                yield Button("Save settings", id="personas-lore-settings-save", classes="console-action-secondary")
+                yield Button("Export", id="personas-lore-export", classes="console-action-secondary")
+```
+
+Add the button handler next to the existing settings-save handler (`:456-459`):
+
+```python
+    @on(Button.Pressed, "#personas-lore-export")
+    def _export_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.post_message(LoreBookExportRequested())
+```
+
+Add `"LoreBookExportRequested",` to `__all__` (`:477`, keep it alpha-ish next to `LoreBookEnableToggled`):
+
+```python
+__all__ = [
+    "LoreBookEnableToggled",
+    "LoreBookExportRequested",
+    "LoreBookSettingsSaveRequested",
+    ...
+]
+```
+
+- [ ] **Step 4: Wire the screen handler + worker**
+
+In `personas_screen.py`, add `LoreBookExportRequested` to the import block (`:90-98`):
+
+```python
+from ...Widgets.Persona_Widgets.personas_lore_detail import (
+    LoreBookEnableToggled,
+    LoreBookExportRequested,
+    LoreBookSettingsSaveRequested,
+    ...
+)
+```
+
+Add the handler + worker right after `_handle_lore_settings_save` (`:2037` region). `asyncio`, `json` are already imported at the top:
+
+```python
+    @on(LoreBookExportRequested)
+    async def _handle_lore_export(self, message: LoreBookExportRequested) -> None:
+        message.stop()
+        if self.state.selected_entity_kind != "lore" or not self.state.selected_entity_id:
+            return
+        if self._io_dialog_active:
+            return
+        self._io_dialog_active = True
+        self.run_worker(self._lore_export_worker(), group="personas-io")
+
+    async def _lore_export_worker(self) -> None:
+        """Save the selected world book to a user-chosen JSON path."""
+        from ...Widgets.enhanced_file_picker import EnhancedFileSave, Filters
+
+        try:
+            manager = self._lore_manager()
+            entity_id = self.state.selected_entity_id
+            if manager is None or not entity_id:
+                return
+            try:
+                data = await asyncio.to_thread(manager.export_world_book, int(entity_id))
+            except Exception as exc:
+                logger.opt(exception=True).warning(f"Could not export world book {entity_id}.")
+                self._notify(f"Export failed: {exc}", "error")
+                return
+            raw_name = str(data.get("name") or "world_book")
+            safe_name = "".join(c for c in raw_name if c.isalnum() or c in " -_").rstrip()
+            default_filename = f"{safe_name or 'world_book'}.json"
+            picker = EnhancedFileSave(
+                title="Export World Book",
+                default_filename=default_filename,
+                filters=Filters(
+                    ("JSON Files", lambda p: p.suffix.lower() == ".json"),
+                    ("All Files", lambda p: True),
+                ),
+                context="lore_export",
+            )
+            try:
+                target = await self.app.push_screen_wait(picker)
+            except Exception:
+                logger.opt(exception=True).warning("Could not show the export file dialog.")
+                return
+            if not target:
+                return
+            body = json.dumps(data, indent=2, ensure_ascii=False)
+            try:
+                await asyncio.to_thread(target.write_text, body, "utf-8")
+            except OSError as exc:
+                logger.opt(exception=True).warning("Could not write the world-book export file.")
+                self._notify(f"Export failed: {exc}", "error")
+                return
+            self._notify(f"Exported to {target}", "information")
+        except Exception as exc:
+            logger.opt(exception=True).error("Unexpected error exporting the world book.")
+            self._notify(f"Export failed: {exc}", "error")
+        finally:
+            self._io_dialog_active = False
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run the Step-2 command. Expected: PASS. Then run the whole test file to catch regressions:
+```bash
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+Tests/UI/test_personas_lore.py -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/Widgets/Persona_Widgets/personas_lore_detail.py tldw_chatbook/UI/Screens/personas_screen.py Tests/UI/test_personas_lore.py
+git commit -m "feat(lore): export the selected world book to a JSON file"
+```
+
+---
+
+### Task 3: Import flow
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/Persona_Widgets/personas_library_pane.py` (`set_mode` `:148-155`)
+- Modify: `tldw_chatbook/UI/Screens/personas_screen.py` (size constant near `:156`; `normalize_world_book_import` import; import branch `:2415-2419`; new `_open_lore_import_dialog` + `_lore_import_dialog_worker` + `_import_world_book_from_path` near the dictionary import methods `:2969`)
+- Test: `Tests/UI/test_personas_lore.py`
+
+**Interfaces:**
+- Consumes: `normalize_world_book_import` (Task 1); `WorldBookManager.import_world_book(data, name_override) -> int`; `self._unique_lore_name(base)`; `self._render_lore_rows(query="")`; `self._select_lore_entry(id, name)`; `self._lore_manager()`; `validate_path_simple`; `ConflictError`.
+- Produces: `_import_world_book_from_path(path: str)` (directly testable); import wired via the library Import button in lore mode.
+
+- [ ] **Step 1: Write the failing import tests**
+
+Append to `Tests/UI/test_personas_lore.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_import_world_book_from_file_creates_book_and_entries(
+    mock_app_instance, stub_characters_lore, lore_db, seeded_lore_book, tmp_path
+):
+    """_import_world_book_from_path imports a tldw-shaped file, preserving priority
+    and matching fields."""
+    import json as _json
+    mock_app_instance.chachanotes_db = lore_db
+    app = LorePersonasTestApp(mock_app_instance)
+    payload = {"name": "Imported Realm", "description": "", "scan_depth": 3,
+               "token_budget": 500, "recursive_scanning": False,
+               "entries": [{"keys": ["Sword"], "content": "a blade", "priority": 55,
+                            "selective": True, "secondary_keys": ["hilt"],
+                            "case_sensitive": True, "insertion_order": 0,
+                            "position": "before_char", "enabled": True}]}
+    f = tmp_path / "realm.json"
+    f.write_text(_json.dumps(payload), "utf-8")
+    async with app.run_test(size=(200, 60)) as pilot:
+        screen = await _enter_lore(pilot)
+        await _select_first_lore(pilot, screen)
+        await screen._import_world_book_from_path(str(f))
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        manager = WorldBookManager(lore_db)
+        books = manager.list_world_books(True)
+        realm = next(b for b in books if b["name"] == "Imported Realm")
+        entries = manager.get_world_book_entries(realm["id"])
+        assert len(entries) == 1
+        e = entries[0]
+        assert e["keys"] == ["Sword"] and e["priority"] == 55
+        assert e["selective"] is True and e["secondary_keys"] == ["hilt"] and e["case_sensitive"] is True
+
+
+@pytest.mark.asyncio
+async def test_import_sillytavern_world_info_object_form(
+    mock_app_instance, stub_characters_lore, lore_db, seeded_lore_book, tmp_path
+):
+    """A SillyTavern World Info object-form file imports with fields remapped."""
+    import json as _json
+    mock_app_instance.chachanotes_db = lore_db
+    app = LorePersonasTestApp(mock_app_instance)
+    payload = {"name": "ST Book",
+               "entries": {"0": {"key": ["Dragon"], "keysecondary": [], "content": "a wyrm",
+                                 "order": 3, "position": 0, "disable": False}}}
+    f = tmp_path / "st.json"
+    f.write_text(_json.dumps(payload), "utf-8")
+    async with app.run_test(size=(200, 60)) as pilot:
+        screen = await _enter_lore(pilot)
+        await _select_first_lore(pilot, screen)
+        await screen._import_world_book_from_path(str(f))
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        manager = WorldBookManager(lore_db)
+        book = next(b for b in manager.list_world_books(True) if b["name"] == "ST Book")
+        e = manager.get_world_book_entries(book["id"])[0]
+        assert e["keys"] == ["Dragon"] and e["content"] == "a wyrm" and e["insertion_order"] == 3
+
+
+@pytest.mark.asyncio
+async def test_import_malformed_world_book_creates_no_book(
+    mock_app_instance, stub_characters_lore, lore_db, seeded_lore_book, tmp_path
+):
+    """A file whose entry has no keys is rejected up front — no partial book."""
+    import json as _json
+    mock_app_instance.chachanotes_db = lore_db
+    app = LorePersonasTestApp(mock_app_instance)
+    payload = {"name": "Bad Book", "entries": [{"keys": [], "content": "x"}]}
+    f = tmp_path / "bad.json"
+    f.write_text(_json.dumps(payload), "utf-8")
+    async with app.run_test(size=(200, 60)) as pilot:
+        screen = await _enter_lore(pilot)
+        await _select_first_lore(pilot, screen)
+        await screen._import_world_book_from_path(str(f))
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        manager = WorldBookManager(lore_db)
+        assert all(b["name"] != "Bad Book" for b in manager.list_world_books(True))
+
+
+@pytest.mark.asyncio
+async def test_import_name_collision_renames(
+    mock_app_instance, stub_characters_lore, lore_db, seeded_lore_book, tmp_path
+):
+    """Importing a book whose name clashes with an existing one imports under a
+    unique name."""
+    import json as _json
+    mock_app_instance.chachanotes_db = lore_db
+    app = LorePersonasTestApp(mock_app_instance)
+    payload = {"name": "Blackreach",  # same as the seeded book
+               "entries": [{"keys": ["Echo"], "content": "a sound"}]}
+    f = tmp_path / "dup.json"
+    f.write_text(_json.dumps(payload), "utf-8")
+    async with app.run_test(size=(200, 60)) as pilot:
+        screen = await _enter_lore(pilot)
+        await _select_first_lore(pilot, screen)
+        await screen._import_world_book_from_path(str(f))
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        manager = WorldBookManager(lore_db)
+        names = [b["name"] for b in manager.list_world_books(True)]
+        assert "Blackreach" in names
+        assert any(n != "Blackreach" and n.startswith("Blackreach") for n in names)
+
+
+@pytest.mark.asyncio
+async def test_library_import_button_visible_in_lore_mode(
+    mock_app_instance, stub_characters_lore, lore_db, seeded_lore_book
+):
+    """The library Import button is displayed in lore mode (un-gated)."""
+    mock_app_instance.chachanotes_db = lore_db
+    app = LorePersonasTestApp(mock_app_instance)
+    async with app.run_test(size=(200, 60)) as pilot:
+        screen = await _enter_lore(pilot)
+        assert screen.query_one("#personas-library-import", Button).display is True
+```
+
+(`Button` is already imported at the top of the test file.) The four async import tests plus this button test are the load-bearing coverage — before Task 3 the button test goes RED because `set_mode` gates Import to characters/dictionaries.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run:
+```bash
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+Tests/UI/test_personas_lore.py -k "import_world_book or sillytavern_world_info or malformed_world_book or name_collision_renames or library_import_button" \
+-q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: FAIL — the four import tests error with `AttributeError: 'PersonasScreen' object has no attribute '_import_world_book_from_path'`, and `test_library_import_button_visible_in_lore_mode` fails its `display is True` assertion (Import is still gated to characters/dictionaries).
+
+- [ ] **Step 3: Un-gate the Import button for lore**
+
+In `personas_library_pane.py::set_mode` (`:148`), add `"lore"` and a lore tooltip:
+
+```python
+        self._import_visible = mode in ("characters", "dictionaries", "lore")
+        import_button = self.query_one("#personas-library-import", Button)
+        import_button.display = self._import_visible
+        if mode == "dictionaries":
+            import_button.tooltip = "Import a dictionary (JSON or Markdown)."
+        elif mode == "lore":
+            import_button.tooltip = "Import a world book (JSON)."
+        else:
+            import_button.tooltip = "Import a character card (PNG or JSON)."
+```
+
+(Replace the existing `import_button.tooltip = (...)` ternary with this if/elif/else.)
+
+- [ ] **Step 4: Add the constant, import, action branch, and import methods to the screen**
+
+In `personas_screen.py`, add the size constant beside `PERSONAS_DICTIONARY_IMPORT_MAX_BYTES` (`:156`):
+
+```python
+PERSONAS_WORLDBOOK_IMPORT_MAX_BYTES = 10 * 1024 * 1024
+```
+
+Add the normalizer import near the other `Character_Chat` imports (top of file):
+
+```python
+from ...Character_Chat.world_book_import import normalize_world_book_import
+```
+
+In `_handle_action_requested`, add a `lore` branch under `message.action == "import"` (after the dictionaries branch at `:2418`):
+
+```python
+        elif message.action == "import":
+            if self.state.active_mode == "characters":
+                await self._run_guarded(self._open_import_dialog)
+            elif self.state.active_mode == "dictionaries":
+                await self._run_guarded(self._open_dictionary_import_dialog)
+            elif self.state.active_mode == "lore":
+                await self._run_guarded(self._open_lore_import_dialog)
+```
+
+Add the three import methods near `_open_dictionary_import_dialog` (`:2969`):
+
+```python
+    async def _open_lore_import_dialog(self) -> None:
+        """Continuation for the guarded lore-import action."""
+        if self._io_dialog_active:
+            logger.debug("Import/export dialog already active; ignoring import request.")
+            return
+        self._io_dialog_active = True
+        self.run_worker(self._lore_import_dialog_worker(), group="personas-io")
+
+    async def _lore_import_dialog_worker(self) -> None:
+        """Show the import file picker and hand the chosen path off to import."""
+        from ...Widgets.enhanced_file_picker import EnhancedFileOpen, Filters
+
+        try:
+            picker = EnhancedFileOpen(
+                title="Import World Book",
+                filters=Filters(
+                    ("World books (JSON)", lambda p: p.suffix.lower() == ".json"),
+                    ("All Files", lambda p: True),
+                ),
+                context="lore_import",
+            )
+            try:
+                file_path = await self.app.push_screen_wait(picker)
+            except Exception:
+                logger.opt(exception=True).warning("Could not show the world-book import dialog.")
+                return
+            if file_path:
+                await self._import_world_book_from_path(str(file_path))
+        except Exception as exc:
+            logger.opt(exception=True).error("Unexpected error in the world-book import worker.")
+            self._notify(f"Import failed: {exc}", "error")
+        finally:
+            self._io_dialog_active = False
+
+    async def _import_world_book_from_path(self, path: str) -> None:
+        """Validate + normalize a world-book file and import it; rename on clash.
+
+        Args:
+            path: Filesystem path to the ``.json`` file chosen via the picker.
+        """
+        manager = self._lore_manager()
+        if manager is None:
+            self._notify("Lore is not configured: the database is unavailable.", "error")
+            return
+        try:
+            source = validate_path_simple(path, require_exists=True)
+        except (ValueError, OSError) as exc:
+            logger.opt(exception=True).warning(f"Rejected world-book import path {path}.")
+            self._notify(f"Import failed: {exc}", "error")
+            return
+        try:
+            if source.stat().st_size > PERSONAS_WORLDBOOK_IMPORT_MAX_BYTES:
+                self._notify(
+                    f"Import failed: file is larger than "
+                    f"{PERSONAS_WORLDBOOK_IMPORT_MAX_BYTES // (1024 * 1024)} MB.",
+                    "error",
+                )
+                return
+        except OSError as exc:
+            self._notify(f"Import failed: {exc}", "error")
+            return
+        try:
+            text = await asyncio.to_thread(source.read_text, "utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            logger.opt(exception=True).warning(f"Could not read world-book file {path}.")
+            self._notify(f"Import failed: {exc}", "error")
+            return
+        try:
+            parsed = json.loads(text)
+        except (json.JSONDecodeError, RecursionError, ValueError) as exc:
+            self._notify(f"Import failed: not valid JSON ({exc})", "error")
+            return
+        try:
+            data = normalize_world_book_import(parsed)
+        except ValueError as exc:
+            self._notify(f"Import failed: {exc}", "error")
+            return
+        base = str(data.get("name") or "Imported world book")
+        name = self._unique_lore_name(base)
+        try:
+            new_id = await asyncio.to_thread(manager.import_world_book, data, name_override=name)
+        except ConflictError:
+            self._notify("A lore book with that name already exists.", "error")
+            return
+        except Exception as exc:
+            logger.opt(exception=True).warning(f"World-book import failed for {path}.")
+            self._notify(f"Import failed: {exc}", "error")
+            return
+        if self.state.active_mode != "lore":
+            self._notify(f"Imported '{name}' — open Lore to see it.", "information")
+            return
+        await self._render_lore_rows(query="")
+        await self._select_lore_entry(str(new_id), name)
+        suffix = " Renamed to avoid a name clash." if name != base else ""
+        self._notify(f"Imported '{name}'.{suffix}", "information")
+```
+
+- [ ] **Step 5: Run to verify they pass**
+
+Run the Step-2 command. Expected: PASS (5 tests, including the button test).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/Widgets/Persona_Widgets/personas_library_pane.py tldw_chatbook/UI/Screens/personas_screen.py Tests/UI/test_personas_lore.py
+git commit -m "feat(lore): import a world book from a JSON file (with SillyTavern World Info support)"
+```
+
+---
+
+### Task 4: Round-trip integration + full gate
+
+**Files:**
+- Test: `Tests/UI/test_personas_lore.py`
+
+**Interfaces:**
+- Consumes: `_lore_export_worker`/`export_world_book` (Task 2) + `_import_world_book_from_path` (Task 3).
+
+- [ ] **Step 1: Write the round-trip test**
+
+Append to `Tests/UI/test_personas_lore.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_export_then_import_round_trip_preserves_entries(
+    mock_app_instance, stub_characters_lore, lore_db, seeded_lore_book, tmp_path, monkeypatch
+):
+    """Export the seeded book to a file, then import that file — the new book's
+    entry matches the original (keys/content preserved through export→import)."""
+    mock_app_instance.chachanotes_db = lore_db
+    app = LorePersonasTestApp(mock_app_instance)
+    manager = WorldBookManager(lore_db)
+    # Give the seeded entry non-default matching fields to prove they survive.
+    entry = manager.get_world_book_entries(seeded_lore_book["book_id"])[0]
+    manager.update_world_book_entry(entry["id"], priority=70, selective=True,
+                                    secondary_keys=["oath"], case_sensitive=True)
+    target = tmp_path / "roundtrip.json"
+    async with app.run_test(size=(200, 60)) as pilot:
+        screen = await _enter_lore(pilot)
+        await _select_first_lore(pilot, screen)
+
+        async def _fake_save(picker):
+            return target
+
+        monkeypatch.setattr(app, "push_screen_wait", _fake_save)
+        screen.post_message(LoreBookExportRequested())
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        assert target.exists()
+        await screen._import_world_book_from_path(str(target))
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+    books = manager.list_world_books(True)
+    imported = next(b for b in books if b["name"] != "Blackreach" and b["name"].startswith("Blackreach"))
+    e = manager.get_world_book_entries(imported["id"])[0]
+    assert e["keys"] == ["Warden"] and e["priority"] == 70
+    assert e["selective"] is True and e["secondary_keys"] == ["oath"] and e["case_sensitive"] is True
+```
+
+- [ ] **Step 2: Run to verify it passes**
+
+Run:
+```bash
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+Tests/UI/test_personas_lore.py::test_export_then_import_round_trip_preserves_entries \
+-q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: PASS (Tasks 2 + 3 make it green).
+
+- [ ] **Step 3: Run the full gate**
+
+```bash
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+Tests/Character_Chat/test_world_book_import.py Tests/UI/test_personas_lore.py \
+Tests/Character_Chat/test_world_book_manager.py Tests/Character_Chat/test_world_info.py \
+-q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: all pass. Then the import smoke:
+```bash
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -c "import tldw_chatbook.app; print('APP IMPORT OK')"
+```
+Expected: `APP IMPORT OK`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Tests/UI/test_personas_lore.py
+git commit -m "test(lore): export→import round-trip preserves entries + matching fields"
+```
+
+---
+
+## Notes for the reviewer
+
+- **No manager/schema change.** Any edit to `world_book_manager.py` or `ChaChaNotes_DB.py` is out of scope — reject it.
+- **Validation is up front.** `normalize_world_book_import` must validate the whole file before `import_world_book` runs, so a malformed file leaves NO partial book (Task 3's `test_import_malformed_world_book_creates_no_book` pins this).
+- **Never-crash.** Every import/export failure path must `self._notify(...)` and return, not raise.
+- **`_import_world_book_from_path` is directly testable** (no picker) — that's deliberate; the picker workers are thin wrappers.
+- The export/round-trip tests monkeypatch `app.push_screen_wait` to stand in for the save dialog — this is the seam for driving `EnhancedFileSave` in tests.

--- a/Docs/superpowers/specs/2026-07-17-roleplay-p2d2-import-export-design.md
+++ b/Docs/superpowers/specs/2026-07-17-roleplay-p2d2-import-export-design.md
@@ -1,0 +1,127 @@
+# Roleplay P2d-2 — world-book (Lore) import/export UI
+
+**Status:** Design.
+
+**Program:** Roleplay (Personas) redesign — P2 (Lore mode). Second half of P2d, after P2d-1 (matching-controls editor, merged #694). Schema stays v21.
+
+## Why
+
+A user can create, edit, duplicate, and delete world books in the Roleplay Lore mode, but cannot import a world book from a file or export the selected one. `WorldBookManager` already has `export_world_book`/`import_world_book` (a full SillyTavern-character-book-compatible round-trip, carrying priority + selective/secondary_keys/case_sensitive), and the internal Duplicate already uses them — but there is no file I/O UI. P2d-2 adds import-from-file and export-to-file, plus an adapter so real SillyTavern *World Info* exports (a different field shape) import correctly.
+
+## Scope
+
+**In scope:** import a world book from a `.json` file (with a normalization adapter covering tldw exports, character-book array form, and SillyTavern World Info object-form); export the selected world book to a `.json` file; a pure, unit-tested normalization/validation function.
+
+**Explicitly NOT in scope (deferred):**
+- Retiring the legacy `ccp_dictionary_handler.py` "Import Dictionary/World Book" TODO stub → P2g.
+- Extracting an embedded `character_book` from a full character-card JSON → later (overlaps Characters-mode card import).
+- Markdown export (world books have no Markdown equivalent — JSON only).
+- Any change to `world_book_manager.py` (manager) or the schema (stays v21).
+
+## Behavior-change framing
+
+Pure additive UI + one new pure helper module. No schema migration, no manager change, no matcher change. Existing flows (create/edit/duplicate/delete/Try-it) are untouched.
+
+## Ground truths (verified at dev tip, post-#694)
+
+- **Manager:** `export_world_book(id) -> dict` emits `{name, description, scan_depth, token_budget, recursive_scanning, entries: [ {keys, content, enabled, position, insertion_order, selective, secondary_keys, case_sensitive, extensions, priority} ]}`. `import_world_book(data, name_override=None) -> int` calls `create_world_book(name)` then, for each `entry` in `data.get('entries', [])` (a **list**), `create_world_book_entry(keys=entry.get('keys',[]), content=entry.get('content',''), ...)`.
+  - `import_world_book` is **NOT atomic** (book insert, then per-entry inserts in separate transactions) and iterates `entries` as a **list**; feeding a dict (`enumerate` yields string keys) or an entry with empty `keys`/`content` (`create_world_book_entry` raises `InputError`) crashes mid-loop and leaves a **partial book**. → The UI must fully validate/normalize before calling it.
+  - `world_books.name` is `UNIQUE NOT NULL`; `create_world_book` raises `ConflictError` on a duplicate name; `import_world_book` accepts `name_override` for exactly this.
+- **Screen (`personas_screen.py`) — reusable pieces already present:**
+  - `_unique_lore_name(base)` (`:2547`) disambiguates against `self._lore_books_cache`.
+  - `_render_lore_rows(query="")` (`:993`) reloads the lore library list.
+  - `_select_lore_entry(entity_id, name)` (`:1286`) selects a book.
+  - `_duplicate_selected_lore` (`:2581`) is already an `export_world_book` → `import_world_book(name_override=unique)` → `_render_lore_rows("")` template (the exact collision + refresh pattern).
+  - `_io_dialog_active` (`:397`) re-entrancy guard; I/O workers run in `group="personas-io"`; user feedback via `self._notify(msg, level)`.
+  - `_run_guarded(continuation)` (`:3727`) wraps guarded actions.
+  - `validate_path_simple` imported (`:29`); `PERSONAS_DICTIONARY_IMPORT_MAX_BYTES = 10*1024*1024` (`:154`).
+  - Dictionary import template: `_open_dictionary_import_dialog`/`_dictionary_import_dialog_worker` (`:2953`/`:2961`) + `_import_dictionary_from_path` (`:2989`); export template: `_handle_dictionary_export` (`:1405`) + `_dictionary_export_worker` (`:1431`) using `EnhancedFileSave`.
+  - `_handle_action_requested` (`:2387`) `import` branch handles characters/dictionaries — **no `lore` branch** yet.
+- **Library pane (`personas_library_pane.py`):** `set_mode` gates the Import button visible for `("characters", "dictionaries")` (`:148`) — needs `"lore"` added; the Import button posts `PersonaActionRequested(action="import")` (`:323`). `PersonaAction` literal already includes `"import"`/`"export"`.
+- **Lore detail (`personas_lore_detail.py`):** Settings tab composes name/description/scan-depth/token-budget/recursive/enabled + a "Save settings" button (`:131-142`); it already defines typed messages (e.g. `LoreBookSettingsSaveRequested`) that the screen handles — the pattern a new `LoreBookExportRequested` follows.
+- **File dialogs:** `EnhancedFileOpen`/`EnhancedFileSave` + `Filters` from `Widgets/enhanced_file_picker.py`, via `await self.app.push_screen_wait(picker)` → `Path | None`. `Filters` entries are `(label, callable)`.
+- **SillyTavern World Info format** (object-form export) differs from tldw/character-book: entries is an **object** `{"0": {...}}`, and fields are `key` (not `keys`), `keysecondary` (not `secondary_keys`), `order` (not `insertion_order`), integer `position` (0/1/…), `disable` (inverted `enabled`), `comment` (a label, no tldw equivalent). The character-book array form (and tldw's own export) already use tldw's field names.
+
+## Architecture
+
+### 1. Normalization adapter — new pure module `tldw_chatbook/Character_Chat/world_book_import.py`
+
+A pure, DB-free, unit-tested function that maps *any* supported input shape to tldw's field names **and** validates every entry, so the screen can reject a bad file before any DB write (no partial import).
+
+```
+def normalize_world_book_import(data: dict) -> dict:
+    # raise ValueError(<user message>) on any invalid shape
+```
+
+- If `data` is not a dict → `ValueError("World book file must be a JSON object.")`
+- Resolve entries container: `entries = data.get('entries')`; `None` → `[]`; a dict → `list(entries.values())` (World Info object-form); a list → as-is; anything else → `ValueError("'entries' must be a list or object.")`
+- Map + validate each entry via `_normalize_entry(entry, index)`; return `{**data, 'entries': [<normalized>]}` (metadata keys — name/description/scan_depth/token_budget/recursive_scanning — pass through untouched for `import_world_book`).
+
+`_normalize_entry(entry, index) -> dict` (raises `ValueError` with the 1-based index on invalid data):
+- Not a dict → `ValueError(f"Entry {index+1} is not an object.")`
+- `keys = _as_str_list(entry.get('keys') if entry.get('keys') is not None else entry.get('key'))`; if no non-blank key → `ValueError(f"Entry {index+1} has no keys.")`
+- `content = str(entry.get('content', ''))`; if blank → `ValueError(f"Entry {index+1} has no content.")`
+- `secondary_keys = _as_str_list(entry.get('secondary_keys') if entry.get('secondary_keys') is not None else entry.get('keysecondary'))`
+- `insertion_order = _coerce_int(entry.get('insertion_order', entry.get('order', index)), index)`
+- `position = _normalize_position(entry.get('position'))`
+- `selective = bool(entry.get('selective', False))`
+- `case_sensitive = bool(entry.get('case_sensitive', entry.get('caseSensitive', False)))`
+- `enabled = bool(entry.get('enabled', not entry.get('disable', False)))`
+- `priority = _coerce_int(entry.get('priority', 0), 0)`
+- `extensions = entry.get('extensions') if isinstance(entry.get('extensions'), dict) else {}` (pass-through for round-trip fidelity; `import_world_book` reads it)
+- returns exactly the field set `import_world_book` consumes: `{keys, secondary_keys, content, insertion_order, position, selective, case_sensitive, enabled, priority, extensions}`
+
+Helpers (same module):
+- `_as_str_list(v)`: `None`→`[]`; `str`→`[v]` (if non-blank); `list`→`[str(x) for x in v if str(x).strip()]`; else `[]`.
+- `_coerce_int(v, default)`: `try: int(v) except (TypeError, ValueError): default` (mirrors the P2c/P2d-0 helper).
+- `_normalize_position(pos)`: string in `{before_char, after_char, at_start, at_end}` → itself; `int` → `{0:"before_char", 1:"after_char"}.get(pos, "before_char")`; else `"before_char"`.
+
+### 2. Import flow (`personas_screen.py` + `personas_library_pane.py`)
+
+- **`personas_library_pane.py::set_mode`** (`:148`): add `"lore"` → `self._import_visible = mode in ("characters", "dictionaries", "lore")`.
+- **`_handle_action_requested`** (`:2399` import branch): add `elif self.state.active_mode == "lore": await self._run_guarded(self._open_lore_import_dialog)`.
+- **`_open_lore_import_dialog`** (mirror `_open_dictionary_import_dialog`): re-entrancy guard on `_io_dialog_active`; `self.run_worker(self._lore_import_dialog_worker(), group="personas-io")`.
+- **`_lore_import_dialog_worker`** (mirror the dictionary worker): `EnhancedFileOpen(title="Import World Book", filters=Filters(("World books (JSON)", lambda p: p.suffix.lower()==".json"), ("All Files", lambda p: True)), context="lore_import")` → `push_screen_wait` → `_import_world_book_from_path(str(path))`; `finally: self._io_dialog_active = False`.
+- **`_import_world_book_from_path(path)`**:
+  1. `manager = self._lore_manager()`; if None → notify + return.
+  2. `validate_path_simple(path, require_exists=True)` (reject `ValueError`/`OSError` → notify).
+  3. Size cap: `source.stat().st_size > PERSONAS_WORLDBOOK_IMPORT_MAX_BYTES` (a new `10*1024*1024` constant beside the dictionary one) → notify + return.
+  4. `text = await asyncio.to_thread(source.read_text, "utf-8")` (reject `OSError`/`UnicodeDecodeError`).
+  5. `parsed = json.loads(text)` (reject `JSONDecodeError`/`ValueError`/`RecursionError` → "not valid JSON").
+  6. `try: data = normalize_world_book_import(parsed) except ValueError as exc: self._notify(f"Import failed: {exc}", "error"); return` — **all validation up front; no partial import.**
+  7. Collision + import (mirror `_duplicate_selected_lore`): `base = str(data.get("name") or "Imported world book")`; `name = self._unique_lore_name(base)`; `new_id = await asyncio.to_thread(manager.import_world_book, data, name_override=name)`; on `ConflictError` (race) notify + return; other `Exception` → notify + return.
+  8. On success: `await self._render_lore_rows(query="")`; `await self._select_lore_entry(str(new_id), name)`; `self._notify(f"Imported '{name}'." + (" Renamed to avoid a name clash." if name != base else ""), "information")`.
+
+### 3. Export flow (`personas_lore_detail.py` + `personas_screen.py`)
+
+- **`personas_lore_detail.py`:** add a new typed message `class LoreBookExportRequested(Message)` (no payload — JSON only) and an "Export" `Button(id="personas-lore-export")` in the **Settings tab** next to "Save settings"; a `@on(Button.Pressed, "#personas-lore-export")` handler posts `LoreBookExportRequested()`.
+- **`_handle_lore_export`** (`@on(LoreBookExportRequested)`, mirror `_handle_dictionary_export`): `message.stop()`; return unless `self.state.selected_entity_kind == "lore" and self.state.selected_entity_id`; re-entrancy guard; `self.run_worker(self._lore_export_worker(), group="personas-io")`.
+- **`_lore_export_worker`**: read `book_id = int(self.state.selected_entity_id)`; `data = await asyncio.to_thread(manager.export_world_book, book_id)`; default filename = `_safe_filename(data.get("name") or "world_book") + ".json"`; `EnhancedFileSave(title="Export World Book", filters=Filters(("JSON Files", lambda p: p.suffix.lower()==".json"), ("All Files", lambda p: True)), default_filename=..., context="lore_export")` → `push_screen_wait` → if a path: `await asyncio.to_thread(target.write_text, json.dumps(data, indent=2, ensure_ascii=False), "utf-8")`; notify success; wrap write in try/except → notify on `OSError`; `finally: self._io_dialog_active = False`. (`_safe_filename` strips path separators/control chars — reuse the character-export sanitizer if one exists, else a small local `re.sub(r'[^\w.\- ]', "_", name).strip()`.)
+
+## Data flow
+
+Import: file → `push_screen_wait` path → validate path/size → read → `json.loads` → `normalize_world_book_import` (map + validate, or `ValueError`) → `_unique_lore_name` → `import_world_book(data, name_override)` → `_render_lore_rows("")` + `_select_lore_entry` + notify.
+
+Export: selected book → `export_world_book(id)` → `EnhancedFileSave` path → `json.dumps` → write → notify.
+
+## Error handling
+
+- Import never crashes the UI: path, size, decode, JSON, and shape/field errors are each caught and surfaced via `_notify`; `normalize_world_book_import` validates the entire file before any DB write, so a bad file yields **no partial book**. A late `ConflictError` (name race) is caught.
+- Export: `export_world_book` and the file write are wrapped; write failures notify and don't crash.
+- Both paths run inside `group="personas-io"` workers with the `_io_dialog_active` re-entrancy guard.
+
+## Testing
+
+- **Adapter (pure unit tests, `Tests/Character_Chat/test_world_book_import.py`):** tldw export passes through unchanged; character-book array form passes through; a SillyTavern World Info object-form (`entries` as `{"0": {...}}` with `key`/`keysecondary`/`order`/int-`position`/`disable`) maps to tldw fields (keys, secondary_keys, insertion_order, string position, `enabled = not disable`); non-dict top-level → `ValueError`; `entries` neither list nor dict → `ValueError`; an entry with empty keys → `ValueError` naming the entry; an entry with empty content → `ValueError`; a non-dict entry → `ValueError`; `caseSensitive`→`case_sensitive`; priority preserved / defaulted.
+- **Import (real-DB, `Tests/UI/test_personas_lore.py` with `LorePersonasTestApp` + `lore_db`):** exporting a seeded book to a temp file then importing it recreates the book + entries (priority + selective/secondary_keys/case_sensitive preserved) = round-trip; importing a World Info object-form file creates a book with correctly-mapped entries; importing a malformed file (bad entry) notifies an error and creates **no** book; a name collision imports under a `_unique_lore_name` and the imported book is selected.
+- **Export (real-DB):** the Export button on a selected book writes a JSON file whose parsed content re-imports to an equivalent book.
+- Full gate: `Tests/Character_Chat/test_world_book_import.py`, `Tests/UI/test_personas_lore.py`, `Tests/Character_Chat/test_world_book_manager.py`, `Tests/Character_Chat/test_world_info.py`, plus `import tldw_chatbook.app`.
+
+## Acceptance criteria
+
+- [ ] `normalize_world_book_import` maps tldw / character-book / SillyTavern World Info shapes to tldw's field set and raises `ValueError` (with a user-facing message) on any invalid shape or empty-keys/empty-content entry — validating the whole file before import (no partial book).
+- [ ] The library Import button is visible in Lore mode and imports a `.json` world book from a file picker; a name clash imports under a unique name; the imported book is selected and the list refreshes.
+- [ ] Import rejects oversized files, non-JSON, and malformed shapes gracefully (a notification, no crash, no partial book).
+- [ ] The Lore detail Settings tab has an Export button that writes the selected book to a chosen `.json` path; export→import is a faithful round-trip (priority + matching fields preserved).
+- [ ] No manager change, no schema migration (stays v21); no Markdown export; no legacy-stub retirement; no character-card `character_book` extraction.
+- [ ] Full gate green; `import tldw_chatbook.app` OK.

--- a/Tests/Character_Chat/test_world_book_import.py
+++ b/Tests/Character_Chat/test_world_book_import.py
@@ -74,3 +74,53 @@ def test_empty_content_entry_raises():
 def test_non_dict_entry_raises():
     with pytest.raises(ValueError, match="Entry 1 is not an object"):
         normalize_world_book_import({"entries": ["not a dict"]})
+
+
+# --- whole-branch-review Minor coverage (M1 null-in-keys, M2 branch guards) ---
+
+def test_null_in_keys_list_is_dropped_not_stringified():
+    """A null inside a keys array is dropped, not turned into the literal "None"."""
+    e = normalize_world_book_import({"entries": [{"keys": ["Warden", None], "content": "c"}]})["entries"][0]
+    assert e["keys"] == ["Warden"]
+
+
+def test_keys_of_only_nulls_is_rejected():
+    """A keys list of only nulls has no real keys → rejected (not ["None"])."""
+    with pytest.raises(ValueError, match="Entry 1 has no keys"):
+        normalize_world_book_import({"entries": [{"keys": [None], "content": "c"}]})
+
+
+def test_bool_position_does_not_alias_to_int_position():
+    """bool is an int subclass; the isinstance(pos, bool) guard must keep
+    position True/False from aliasing to the int-position map (1/0)."""
+    e_true = normalize_world_book_import({"entries": [{"keys": ["k"], "content": "c", "position": True}]})["entries"][0]
+    e_false = normalize_world_book_import({"entries": [{"keys": ["k"], "content": "c", "position": False}]})["entries"][0]
+    assert e_true["position"] == "before_char" and e_false["position"] == "before_char"
+
+
+def test_unknown_int_position_defaults_before_char():
+    e = normalize_world_book_import({"entries": [{"keys": ["k"], "content": "c", "position": 7}]})["entries"][0]
+    assert e["position"] == "before_char"
+
+
+def test_bare_string_key_becomes_single_item_list():
+    e = normalize_world_book_import({"entries": [{"key": "Warden", "content": "c"}]})["entries"][0]
+    assert e["keys"] == ["Warden"]
+
+
+def test_non_dict_extensions_defaults_empty():
+    e = normalize_world_book_import({"entries": [{"keys": ["k"], "content": "c", "extensions": "oops"}]})["entries"][0]
+    assert e["extensions"] == {}
+
+
+def test_non_numeric_order_falls_back_to_index():
+    entries = normalize_world_book_import({"entries": [
+        {"keys": ["a"], "content": "c"},
+        {"keys": ["b"], "content": "c", "order": "abc"},
+    ]})["entries"]
+    assert entries[1]["insertion_order"] == 1
+
+
+def test_explicit_enabled_false_preserved():
+    e = normalize_world_book_import({"entries": [{"keys": ["k"], "content": "c", "enabled": False}]})["entries"][0]
+    assert e["enabled"] is False

--- a/Tests/Character_Chat/test_world_book_import.py
+++ b/Tests/Character_Chat/test_world_book_import.py
@@ -131,3 +131,33 @@ def test_null_content_is_rejected_not_stringified():
     #701 high-severity finding, parallel to the null-in-keys trap."""
     with pytest.raises(ValueError, match="Entry 1 has no content"):
         normalize_world_book_import({"entries": [{"keys": ["k"], "content": None}]})
+
+
+# --- Qodo #701 finding 4: robust boolean coercion for loosely-typed files ---
+
+def _b(**kw):
+    return normalize_world_book_import({"entries": [{"keys": ["k"], "content": "c", **kw}]})["entries"][0]
+
+
+def test_string_false_booleans_are_not_truthy():
+    """bool("false") is True in Python — the coercer must map string booleans."""
+    e = _b(selective="false", case_sensitive="false", enabled="false")
+    assert e["selective"] is False and e["case_sensitive"] is False and e["enabled"] is False
+
+
+def test_string_true_booleans_map_true():
+    e = _b(selective="true", caseSensitive="TRUE")
+    assert e["selective"] is True and e["case_sensitive"] is True
+
+
+def test_null_enabled_defaults_true():
+    assert _b(enabled=None)["enabled"] is True
+
+
+def test_string_disable_false_means_enabled():
+    """SillyTavern `disable: "false"` (string) must mean enabled=True."""
+    assert _b(disable="false")["enabled"] is True
+
+
+def test_disable_true_flag_disables_when_no_enabled():
+    assert _b(disable=True)["enabled"] is False

--- a/Tests/Character_Chat/test_world_book_import.py
+++ b/Tests/Character_Chat/test_world_book_import.py
@@ -1,0 +1,76 @@
+import pytest
+
+from tldw_chatbook.Character_Chat.world_book_import import normalize_world_book_import
+
+
+def _tldw_entry(**kw):
+    base = {"keys": ["Warden"], "content": "grim jailer", "position": "before_char",
+            "insertion_order": 0, "selective": False, "secondary_keys": [],
+            "case_sensitive": False, "enabled": True, "priority": 0}
+    base.update(kw)
+    return base
+
+
+def test_tldw_export_passthrough():
+    data = {"name": "B", "description": "d", "scan_depth": 3, "token_budget": 500,
+            "recursive_scanning": False, "entries": [_tldw_entry(priority=42)]}
+    out = normalize_world_book_import(data)
+    assert out["name"] == "B" and out["scan_depth"] == 3
+    e = out["entries"][0]
+    assert e["keys"] == ["Warden"] and e["content"] == "grim jailer"
+    assert e["priority"] == 42 and e["position"] == "before_char"
+
+
+def test_character_book_array_passthrough():
+    data = {"entries": [{"keys": ["a", "b"], "content": "c", "secondary_keys": ["s"],
+                         "insertion_order": 2, "selective": True, "case_sensitive": True}]}
+    e = normalize_world_book_import(data)["entries"][0]
+    assert e["keys"] == ["a", "b"] and e["secondary_keys"] == ["s"]
+    assert e["insertion_order"] == 2 and e["selective"] is True and e["case_sensitive"] is True
+
+
+def test_sillytavern_world_info_object_form_remaps():
+    data = {"entries": {"0": {"key": ["Warden"], "keysecondary": ["jail"], "content": "x",
+                              "order": 5, "position": 1, "disable": True,
+                              "caseSensitive": True, "selective": True}}}
+    e = normalize_world_book_import(data)["entries"][0]
+    assert e["keys"] == ["Warden"] and e["secondary_keys"] == ["jail"]
+    assert e["insertion_order"] == 5 and e["position"] == "after_char"
+    assert e["enabled"] is False and e["case_sensitive"] is True and e["selective"] is True
+
+
+def test_missing_entries_yields_empty_list():
+    assert normalize_world_book_import({"name": "B"})["entries"] == []
+
+
+def test_priority_and_extensions_preserved_and_defaulted():
+    data = {"entries": [{"keys": ["k"], "content": "c", "extensions": {"x": 1}},
+                        {"keys": ["k2"], "content": "c2"}]}
+    out = normalize_world_book_import(data)["entries"]
+    assert out[0]["extensions"] == {"x": 1} and out[0]["priority"] == 0
+    assert out[1]["extensions"] == {} and out[1]["insertion_order"] == 1
+
+
+def test_non_dict_top_level_raises():
+    with pytest.raises(ValueError, match="must be a JSON object"):
+        normalize_world_book_import([1, 2, 3])
+
+
+def test_entries_not_list_or_dict_raises():
+    with pytest.raises(ValueError, match="must be a list or an object"):
+        normalize_world_book_import({"entries": 42})
+
+
+def test_empty_keys_entry_raises():
+    with pytest.raises(ValueError, match="Entry 1 has no keys"):
+        normalize_world_book_import({"entries": [{"keys": [], "content": "c"}]})
+
+
+def test_empty_content_entry_raises():
+    with pytest.raises(ValueError, match="Entry 1 has no content"):
+        normalize_world_book_import({"entries": [{"keys": ["k"], "content": "   "}]})
+
+
+def test_non_dict_entry_raises():
+    with pytest.raises(ValueError, match="Entry 1 is not an object"):
+        normalize_world_book_import({"entries": ["not a dict"]})

--- a/Tests/Character_Chat/test_world_book_import.py
+++ b/Tests/Character_Chat/test_world_book_import.py
@@ -124,3 +124,10 @@ def test_non_numeric_order_falls_back_to_index():
 def test_explicit_enabled_false_preserved():
     e = normalize_world_book_import({"entries": [{"keys": ["k"], "content": "c", "enabled": False}]})["entries"][0]
     assert e["enabled"] is False
+
+
+def test_null_content_is_rejected_not_stringified():
+    """Explicit null content must raise (not become the literal "None") — Gemini
+    #701 high-severity finding, parallel to the null-in-keys trap."""
+    with pytest.raises(ValueError, match="Entry 1 has no content"):
+        normalize_world_book_import({"entries": [{"keys": ["k"], "content": None}]})

--- a/Tests/UI/test_personas_lore.py
+++ b/Tests/UI/test_personas_lore.py
@@ -4,6 +4,8 @@ Also (Task 6): PersonasScreen wiring — mounted integration against a REAL
 CharactersRAGDB seeded through WorldBookManager (mirrors
 test_personas_dictionaries.py's PersonasTestApp harness)."""
 
+import json
+
 import pytest
 from textual.app import App, ComposeResult
 from textual.coordinate import Coordinate
@@ -12,6 +14,7 @@ from textual.widgets import Button, DataTable, Input, ListView, Static, Switch, 
 from tldw_chatbook.Widgets.Persona_Widgets.personas_lore_detail import (
     PersonasLoreDetailWidget,
     LoreBookEnableToggled,
+    LoreBookExportRequested,
     LoreBookSettingsSaveRequested,
     LoreEntryAddRequested,
 )
@@ -728,3 +731,31 @@ async def test_selective_entry_created_via_editor_gates_matching(
     # primary + secondary present → fires
     r2 = proc.process_messages("the hero draws a sword", [])
     assert any("brave hero" in c for c in r2["injections"]["before_char"])
+
+
+@pytest.mark.asyncio
+async def test_export_selected_lore_book_writes_json_file(
+    mock_app_instance, stub_characters_lore, lore_db, seeded_lore_book, tmp_path, monkeypatch
+):
+    """Exporting the selected lore book writes a JSON file that parses back to the
+    book's export payload (name + entries)."""
+    import json as _json
+    mock_app_instance.chachanotes_db = lore_db
+    app = LorePersonasTestApp(mock_app_instance)
+    async with app.run_test(size=(200, 60)) as pilot:
+        screen = await _enter_lore(pilot)
+        await _select_first_lore(pilot, screen)
+        target = tmp_path / "exported.json"
+
+        async def _fake_save(picker):
+            return target
+
+        monkeypatch.setattr(app, "push_screen_wait", _fake_save)
+        screen.post_message(LoreBookExportRequested())
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        assert target.exists()
+        payload = _json.loads(target.read_text("utf-8"))
+        assert payload["name"] == "Blackreach"
+        assert any(e["keys"] == ["Warden"] for e in payload["entries"])

--- a/Tests/UI/test_personas_lore.py
+++ b/Tests/UI/test_personas_lore.py
@@ -759,3 +759,123 @@ async def test_export_selected_lore_book_writes_json_file(
         payload = _json.loads(target.read_text("utf-8"))
         assert payload["name"] == "Blackreach"
         assert any(e["keys"] == ["Warden"] for e in payload["entries"])
+
+
+@pytest.mark.asyncio
+async def test_import_world_book_from_file_creates_book_and_entries(
+    mock_app_instance, stub_characters_lore, lore_db, seeded_lore_book, tmp_path
+):
+    """_import_world_book_from_path imports a tldw-shaped file, preserving priority
+    and matching fields."""
+    import json as _json
+    mock_app_instance.chachanotes_db = lore_db
+    app = LorePersonasTestApp(mock_app_instance)
+    payload = {"name": "Imported Realm", "description": "", "scan_depth": 3,
+               "token_budget": 500, "recursive_scanning": False,
+               "entries": [{"keys": ["Sword"], "content": "a blade", "priority": 55,
+                            "selective": True, "secondary_keys": ["hilt"],
+                            "case_sensitive": True, "insertion_order": 0,
+                            "position": "before_char", "enabled": True}]}
+    f = tmp_path / "realm.json"
+    f.write_text(_json.dumps(payload), "utf-8")
+    async with app.run_test(size=(200, 60)) as pilot:
+        screen = await _enter_lore(pilot)
+        await _select_first_lore(pilot, screen)
+        await screen._import_world_book_from_path(str(f))
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        manager = WorldBookManager(lore_db)
+        books = manager.list_world_books(True)
+        realm = next(b for b in books if b["name"] == "Imported Realm")
+        entries = manager.get_world_book_entries(realm["id"])
+        assert len(entries) == 1
+        e = entries[0]
+        assert e["keys"] == ["Sword"] and e["priority"] == 55
+        assert e["selective"] is True and e["secondary_keys"] == ["hilt"] and e["case_sensitive"] is True
+
+
+@pytest.mark.asyncio
+async def test_import_sillytavern_world_info_object_form(
+    mock_app_instance, stub_characters_lore, lore_db, seeded_lore_book, tmp_path
+):
+    """A SillyTavern World Info object-form file imports with fields remapped."""
+    import json as _json
+    mock_app_instance.chachanotes_db = lore_db
+    app = LorePersonasTestApp(mock_app_instance)
+    payload = {"name": "ST Book",
+               "entries": {"0": {"key": ["Dragon"], "keysecondary": [], "content": "a wyrm",
+                                 "order": 3, "position": 0, "disable": False}}}
+    f = tmp_path / "st.json"
+    f.write_text(_json.dumps(payload), "utf-8")
+    async with app.run_test(size=(200, 60)) as pilot:
+        screen = await _enter_lore(pilot)
+        await _select_first_lore(pilot, screen)
+        await screen._import_world_book_from_path(str(f))
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        manager = WorldBookManager(lore_db)
+        book = next(b for b in manager.list_world_books(True) if b["name"] == "ST Book")
+        e = manager.get_world_book_entries(book["id"])[0]
+        assert e["keys"] == ["Dragon"] and e["content"] == "a wyrm" and e["insertion_order"] == 3
+
+
+@pytest.mark.asyncio
+async def test_import_malformed_world_book_creates_no_book(
+    mock_app_instance, stub_characters_lore, lore_db, seeded_lore_book, tmp_path
+):
+    """A file whose entry has no keys is rejected up front — no partial book."""
+    import json as _json
+    mock_app_instance.chachanotes_db = lore_db
+    app = LorePersonasTestApp(mock_app_instance)
+    payload = {"name": "Bad Book", "entries": [{"keys": [], "content": "x"}]}
+    f = tmp_path / "bad.json"
+    f.write_text(_json.dumps(payload), "utf-8")
+    async with app.run_test(size=(200, 60)) as pilot:
+        screen = await _enter_lore(pilot)
+        await _select_first_lore(pilot, screen)
+        await screen._import_world_book_from_path(str(f))
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        manager = WorldBookManager(lore_db)
+        assert all(b["name"] != "Bad Book" for b in manager.list_world_books(True))
+
+
+@pytest.mark.asyncio
+async def test_import_name_collision_renames(
+    mock_app_instance, stub_characters_lore, lore_db, seeded_lore_book, tmp_path
+):
+    """Importing a book whose name clashes with an existing one imports under a
+    unique name."""
+    import json as _json
+    mock_app_instance.chachanotes_db = lore_db
+    app = LorePersonasTestApp(mock_app_instance)
+    payload = {"name": "Blackreach",  # same as the seeded book
+               "entries": [{"keys": ["Echo"], "content": "a sound"}]}
+    f = tmp_path / "dup.json"
+    f.write_text(_json.dumps(payload), "utf-8")
+    async with app.run_test(size=(200, 60)) as pilot:
+        screen = await _enter_lore(pilot)
+        await _select_first_lore(pilot, screen)
+        await screen._import_world_book_from_path(str(f))
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        manager = WorldBookManager(lore_db)
+        names = [b["name"] for b in manager.list_world_books(True)]
+        assert "Blackreach" in names
+        assert any(n != "Blackreach" and n.startswith("Blackreach") for n in names)
+
+
+@pytest.mark.asyncio
+async def test_library_import_button_visible_in_lore_mode(
+    mock_app_instance, stub_characters_lore, lore_db, seeded_lore_book
+):
+    """The library Import button is displayed in lore mode (un-gated)."""
+    mock_app_instance.chachanotes_db = lore_db
+    app = LorePersonasTestApp(mock_app_instance)
+    async with app.run_test(size=(200, 60)) as pilot:
+        screen = await _enter_lore(pilot)
+        assert screen.query_one("#personas-library-import", Button).display is True

--- a/Tests/UI/test_personas_lore.py
+++ b/Tests/UI/test_personas_lore.py
@@ -879,3 +879,41 @@ async def test_library_import_button_visible_in_lore_mode(
     async with app.run_test(size=(200, 60)) as pilot:
         screen = await _enter_lore(pilot)
         assert screen.query_one("#personas-library-import", Button).display is True
+
+
+@pytest.mark.asyncio
+async def test_export_then_import_round_trip_preserves_entries(
+    mock_app_instance, stub_characters_lore, lore_db, seeded_lore_book, tmp_path, monkeypatch
+):
+    """Export the seeded book to a file, then import that file — the new book's
+    entry matches the original (keys/content preserved through export→import)."""
+    mock_app_instance.chachanotes_db = lore_db
+    app = LorePersonasTestApp(mock_app_instance)
+    manager = WorldBookManager(lore_db)
+    # Give the seeded entry non-default matching fields to prove they survive.
+    entry = manager.get_world_book_entries(seeded_lore_book["book_id"])[0]
+    manager.update_world_book_entry(entry["id"], priority=70, selective=True,
+                                    secondary_keys=["oath"], case_sensitive=True)
+    target = tmp_path / "roundtrip.json"
+    async with app.run_test(size=(200, 60)) as pilot:
+        screen = await _enter_lore(pilot)
+        await _select_first_lore(pilot, screen)
+
+        async def _fake_save(picker):
+            return target
+
+        monkeypatch.setattr(app, "push_screen_wait", _fake_save)
+        screen.post_message(LoreBookExportRequested())
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        assert target.exists()
+        await screen._import_world_book_from_path(str(target))
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+    books = manager.list_world_books(True)
+    imported = next(b for b in books if b["name"] != "Blackreach" and b["name"].startswith("Blackreach"))
+    e = manager.get_world_book_entries(imported["id"])[0]
+    assert e["keys"] == ["Warden"] and e["priority"] == 70
+    assert e["selective"] is True and e["secondary_keys"] == ["oath"] and e["case_sensitive"] is True

--- a/tldw_chatbook/Character_Chat/world_book_import.py
+++ b/tldw_chatbook/Character_Chat/world_book_import.py
@@ -1,0 +1,106 @@
+"""Pure normalization/validation for world-book (Lore) import files.
+
+Maps the supported input shapes — tldw's own export, the character-book array
+form, and SillyTavern 'World Info' object-form — to tldw's ``world_book_entries``
+field names, and validates the whole file up front so the import screen can
+reject a bad file before any DB write (``WorldBookManager.import_world_book`` is
+not atomic). Pure and DB-free; raises ``ValueError`` with a user-facing message.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+_VALID_POSITIONS = {"before_char", "after_char", "at_start", "at_end"}
+_INT_POSITION_MAP = {0: "before_char", 1: "after_char"}
+
+
+def _coerce_int(value: Any, default: int) -> int:
+    """Best-effort int coercion; ``default`` on None/non-numeric."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_str_list(value: Any) -> List[str]:
+    """Coerce a keys-like field to a list of non-blank strings."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value] if value.strip() else []
+    if isinstance(value, list):
+        return [str(v) for v in value if str(v).strip()]
+    return []
+
+
+def _normalize_position(pos: Any) -> str:
+    """Map a position (tldw string or SillyTavern int) to a tldw position."""
+    if isinstance(pos, str) and pos in _VALID_POSITIONS:
+        return pos
+    if isinstance(pos, bool):
+        return "before_char"
+    if isinstance(pos, int):
+        return _INT_POSITION_MAP.get(pos, "before_char")
+    return "before_char"
+
+
+def _normalize_entry(entry: Any, index: int) -> Dict[str, Any]:
+    """Map one entry to tldw fields; raise ValueError (1-based index) if invalid."""
+    if not isinstance(entry, dict):
+        raise ValueError(f"Entry {index + 1} is not an object.")
+    raw_keys = entry.get("keys")
+    if raw_keys is None:
+        raw_keys = entry.get("key")
+    keys = _as_str_list(raw_keys)
+    if not keys:
+        raise ValueError(f"Entry {index + 1} has no keys.")
+    content = str(entry.get("content", ""))
+    if not content.strip():
+        raise ValueError(f"Entry {index + 1} has no content.")
+    raw_secondary = entry.get("secondary_keys")
+    if raw_secondary is None:
+        raw_secondary = entry.get("keysecondary")
+    extensions = entry.get("extensions")
+    return {
+        "keys": keys,
+        "secondary_keys": _as_str_list(raw_secondary),
+        "content": content,
+        "insertion_order": _coerce_int(
+            entry.get("insertion_order", entry.get("order", index)), index
+        ),
+        "position": _normalize_position(entry.get("position")),
+        "selective": bool(entry.get("selective", False)),
+        "case_sensitive": bool(entry.get("case_sensitive", entry.get("caseSensitive", False))),
+        "enabled": bool(entry.get("enabled", not entry.get("disable", False))),
+        "priority": _coerce_int(entry.get("priority", 0), 0),
+        "extensions": extensions if isinstance(extensions, dict) else {},
+    }
+
+
+def normalize_world_book_import(data: Any) -> Dict[str, Any]:
+    """Normalize + validate an imported world-book payload.
+
+    Args:
+        data: The parsed JSON from an import file.
+
+    Returns:
+        A dict with tldw metadata keys preserved and ``entries`` mapped to
+        tldw's field names as a list, ready for ``import_world_book``.
+
+    Raises:
+        ValueError: If the payload is not a dict, ``entries`` is neither a list
+            nor an object, or any entry is not a dict / has no keys / no content.
+    """
+    if not isinstance(data, dict):
+        raise ValueError("World book file must be a JSON object.")
+    raw_entries = data.get("entries")
+    if raw_entries is None:
+        entries_list: List[Any] = []
+    elif isinstance(raw_entries, dict):
+        entries_list = list(raw_entries.values())
+    elif isinstance(raw_entries, list):
+        entries_list = raw_entries
+    else:
+        raise ValueError("'entries' must be a list or an object.")
+    normalized = [_normalize_entry(entry, i) for i, entry in enumerate(entries_list)]
+    return {**data, "entries": normalized}

--- a/tldw_chatbook/Character_Chat/world_book_import.py
+++ b/tldw_chatbook/Character_Chat/world_book_import.py
@@ -22,6 +22,34 @@ def _coerce_int(value: Any, default: int) -> int:
         return default
 
 
+_TRUE_STRINGS = {"true", "1", "yes", "on"}
+_FALSE_STRINGS = {"false", "0", "no", "off"}
+
+
+def _coerce_bool(value: Any, default: bool) -> bool:
+    """Best-effort bool coercion for loosely-typed/hand-edited import files.
+
+    Plain ``bool(value)`` is wrong here: ``bool("false")`` is ``True`` and
+    ``bool(None)`` is ``False``, so a string boolean or an explicit null would
+    silently change an entry's matching behavior. ``None`` returns ``default``;
+    recognized string booleans map by value; unknown strings return ``default``.
+    """
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        token = value.strip().lower()
+        if token in _TRUE_STRINGS:
+            return True
+        if token in _FALSE_STRINGS:
+            return False
+        return default
+    return default
+
+
 def _as_str_list(value: Any) -> List[str]:
     """Coerce a keys-like field to a list of non-blank strings."""
     if value is None:
@@ -66,6 +94,16 @@ def _normalize_entry(entry: Any, index: int) -> Dict[str, Any]:
     raw_secondary = entry.get("secondary_keys")
     if raw_secondary is None:
         raw_secondary = entry.get("keysecondary")
+    raw_case = entry.get("case_sensitive")
+    if raw_case is None:
+        raw_case = entry.get("caseSensitive")
+    # enabled: an explicit value wins (null → default enabled); otherwise fall
+    # back to the (inverted) SillyTavern ``disable`` flag.
+    raw_enabled = entry.get("enabled")
+    if raw_enabled is not None:
+        enabled = _coerce_bool(raw_enabled, True)
+    else:
+        enabled = not _coerce_bool(entry.get("disable"), False)
     extensions = entry.get("extensions")
     return {
         "keys": keys,
@@ -75,9 +113,9 @@ def _normalize_entry(entry: Any, index: int) -> Dict[str, Any]:
             entry.get("insertion_order", entry.get("order", index)), index
         ),
         "position": _normalize_position(entry.get("position")),
-        "selective": bool(entry.get("selective", False)),
-        "case_sensitive": bool(entry.get("case_sensitive", entry.get("caseSensitive", False))),
-        "enabled": bool(entry.get("enabled", not entry.get("disable", False))),
+        "selective": _coerce_bool(entry.get("selective"), False),
+        "case_sensitive": _coerce_bool(raw_case, False),
+        "enabled": enabled,
         "priority": _coerce_int(entry.get("priority", 0), 0),
         "extensions": extensions if isinstance(extensions, dict) else {},
     }

--- a/tldw_chatbook/Character_Chat/world_book_import.py
+++ b/tldw_chatbook/Character_Chat/world_book_import.py
@@ -29,7 +29,10 @@ def _as_str_list(value: Any) -> List[str]:
     if isinstance(value, str):
         return [value] if value.strip() else []
     if isinstance(value, list):
-        return [str(v) for v in value if str(v).strip()]
+        # Drop None (and blank) items BEFORE stringifying — otherwise a null in a
+        # keys array becomes the literal "None" (a phantom keyword), and a list of
+        # only nulls would slip past the empty-keys validation as ["None"].
+        return [str(v) for v in value if v is not None and str(v).strip()]
     return []
 
 

--- a/tldw_chatbook/Character_Chat/world_book_import.py
+++ b/tldw_chatbook/Character_Chat/world_book_import.py
@@ -57,7 +57,10 @@ def _normalize_entry(entry: Any, index: int) -> Dict[str, Any]:
     keys = _as_str_list(raw_keys)
     if not keys:
         raise ValueError(f"Entry {index + 1} has no keys.")
-    content = str(entry.get("content", ""))
+    # Explicit null content must be treated as empty (→ ValueError), not
+    # stringified to the literal "None" (the same null-stringify trap as keys).
+    raw_content = entry.get("content")
+    content = str(raw_content) if raw_content is not None else ""
     if not content.strip():
         raise ValueError(f"Entry {index + 1} has no content.")
     raw_secondary = entry.get("secondary_keys")

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -23,6 +23,7 @@ from ...Character_Chat.Character_Chat_Lib import (
     export_character_card_to_png,
     validate_character_book,
 )
+from ...Character_Chat.world_book_import import normalize_world_book_import
 from ...Chat.chat_handoff_models import ChatHandoffPayload
 from ...DB.ChaChaNotes_DB import ConflictError
 from ...tldw_api import PersonaProfileCreate, PersonaProfileUpdate
@@ -155,6 +156,7 @@ PERSONAS_AVATAR_IMAGE_SUFFIX_COPY = "PNG, JPG, JPEG, WEBP, or GIF"
 PERSONAS_AVATAR_MAX_BYTES = 5 * 1024 * 1024
 PERSONAS_AVATAR_MAX_SIZE_COPY = "5 MB"
 PERSONAS_DICTIONARY_IMPORT_MAX_BYTES = 10 * 1024 * 1024
+PERSONAS_WORLDBOOK_IMPORT_MAX_BYTES = 10 * 1024 * 1024
 
 # 80-column terminals need a tighter three-pane split than the default
 # 2:4:2 workbench minimums. Keep this screen-owned so a later rail-collapse
@@ -2476,6 +2478,8 @@ class PersonasScreen(BaseAppScreen):
                 await self._run_guarded(self._open_import_dialog)
             elif self.state.active_mode == "dictionaries":
                 await self._run_guarded(self._open_dictionary_import_dialog)
+            elif self.state.active_mode == "lore":
+                await self._run_guarded(self._open_lore_import_dialog)
         elif message.action == "duplicate":
             if self.state.active_mode == "dictionaries":
                 await self._run_guarded(self._duplicate_selected_dictionary)
@@ -3024,6 +3028,102 @@ class PersonasScreen(BaseAppScreen):
             self._notify("Character already existed; selected it.", "information")
         else:
             self._notify("Character imported.", "information")
+
+    async def _open_lore_import_dialog(self) -> None:
+        """Continuation for the guarded lore-import action."""
+        if self._io_dialog_active:
+            logger.debug("Import/export dialog already active; ignoring import request.")
+            return
+        self._io_dialog_active = True
+        self.run_worker(self._lore_import_dialog_worker(), group="personas-io")
+
+    async def _lore_import_dialog_worker(self) -> None:
+        """Show the import file picker and hand the chosen path off to import."""
+        from ...Widgets.enhanced_file_picker import EnhancedFileOpen, Filters
+
+        try:
+            picker = EnhancedFileOpen(
+                title="Import World Book",
+                filters=Filters(
+                    ("World books (JSON)", lambda p: p.suffix.lower() == ".json"),
+                    ("All Files", lambda p: True),
+                ),
+                context="lore_import",
+            )
+            try:
+                file_path = await self.app.push_screen_wait(picker)
+            except Exception:
+                logger.opt(exception=True).warning("Could not show the world-book import dialog.")
+                return
+            if file_path:
+                await self._import_world_book_from_path(str(file_path))
+        except Exception as exc:
+            logger.opt(exception=True).error("Unexpected error in the world-book import worker.")
+            self._notify(f"Import failed: {exc}", "error")
+        finally:
+            self._io_dialog_active = False
+
+    async def _import_world_book_from_path(self, path: str) -> None:
+        """Validate + normalize a world-book file and import it; rename on clash.
+
+        Args:
+            path: Filesystem path to the ``.json`` file chosen via the picker.
+        """
+        manager = self._lore_manager()
+        if manager is None:
+            self._notify("Lore is not configured: the database is unavailable.", "error")
+            return
+        try:
+            source = validate_path_simple(path, require_exists=True)
+        except (ValueError, OSError) as exc:
+            logger.opt(exception=True).warning(f"Rejected world-book import path {path}.")
+            self._notify(f"Import failed: {exc}", "error")
+            return
+        try:
+            if source.stat().st_size > PERSONAS_WORLDBOOK_IMPORT_MAX_BYTES:
+                self._notify(
+                    f"Import failed: file is larger than "
+                    f"{PERSONAS_WORLDBOOK_IMPORT_MAX_BYTES // (1024 * 1024)} MB.",
+                    "error",
+                )
+                return
+        except OSError as exc:
+            self._notify(f"Import failed: {exc}", "error")
+            return
+        try:
+            text = await asyncio.to_thread(source.read_text, "utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            logger.opt(exception=True).warning(f"Could not read world-book file {path}.")
+            self._notify(f"Import failed: {exc}", "error")
+            return
+        try:
+            parsed = json.loads(text)
+        except (json.JSONDecodeError, RecursionError, ValueError) as exc:
+            self._notify(f"Import failed: not valid JSON ({exc})", "error")
+            return
+        try:
+            data = normalize_world_book_import(parsed)
+        except ValueError as exc:
+            self._notify(f"Import failed: {exc}", "error")
+            return
+        base = str(data.get("name") or "Imported world book")
+        name = self._unique_lore_name(base)
+        try:
+            new_id = await asyncio.to_thread(manager.import_world_book, data, name_override=name)
+        except ConflictError:
+            self._notify("A lore book with that name already exists.", "error")
+            return
+        except Exception as exc:
+            logger.opt(exception=True).warning(f"World-book import failed for {path}.")
+            self._notify(f"Import failed: {exc}", "error")
+            return
+        if self.state.active_mode != "lore":
+            self._notify(f"Imported '{name}' — open Lore to see it.", "information")
+            return
+        await self._render_lore_rows(query="")
+        await self._select_lore_entry(str(new_id), name)
+        suffix = " Renamed to avoid a name clash." if name != base else ""
+        self._notify(f"Imported '{name}'.{suffix}", "information")
 
     async def _open_dictionary_import_dialog(self) -> None:
         """Continuation for the guarded dictionaries-import action."""

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -89,6 +89,7 @@ from ...Widgets.Persona_Widgets.personas_dictionary_tryit import (
 )
 from ...Widgets.Persona_Widgets.personas_lore_detail import (
     LoreBookEnableToggled,
+    LoreBookExportRequested,
     LoreBookSettingsSaveRequested,
     LoreEntriesReorderRequested,
     LoreEntryAddRequested,
@@ -2095,6 +2096,64 @@ class PersonasScreen(BaseAppScreen):
         await self._render_lore_rows(query=self.state.search_query)
         self.query_one(PersonasLibraryPane).mark_active_row("lore", entity_id)
         self._sync_inspector_console_actions()
+
+    @on(LoreBookExportRequested)
+    async def _handle_lore_export(self, message: LoreBookExportRequested) -> None:
+        message.stop()
+        if self.state.selected_entity_kind != "lore" or not self.state.selected_entity_id:
+            return
+        if self._io_dialog_active:
+            return
+        self._io_dialog_active = True
+        self.run_worker(self._lore_export_worker(), group="personas-io")
+
+    async def _lore_export_worker(self) -> None:
+        """Save the selected world book to a user-chosen JSON path."""
+        from ...Widgets.enhanced_file_picker import EnhancedFileSave, Filters
+
+        try:
+            manager = self._lore_manager()
+            entity_id = self.state.selected_entity_id
+            if manager is None or not entity_id:
+                return
+            try:
+                data = await asyncio.to_thread(manager.export_world_book, int(entity_id))
+            except Exception as exc:
+                logger.opt(exception=True).warning(f"Could not export world book {entity_id}.")
+                self._notify(f"Export failed: {exc}", "error")
+                return
+            raw_name = str(data.get("name") or "world_book")
+            safe_name = "".join(c for c in raw_name if c.isalnum() or c in " -_").rstrip()
+            default_filename = f"{safe_name or 'world_book'}.json"
+            picker = EnhancedFileSave(
+                title="Export World Book",
+                default_filename=default_filename,
+                filters=Filters(
+                    ("JSON Files", lambda p: p.suffix.lower() == ".json"),
+                    ("All Files", lambda p: True),
+                ),
+                context="lore_export",
+            )
+            try:
+                target = await self.app.push_screen_wait(picker)
+            except Exception:
+                logger.opt(exception=True).warning("Could not show the export file dialog.")
+                return
+            if not target:
+                return
+            body = json.dumps(data, indent=2, ensure_ascii=False)
+            try:
+                await asyncio.to_thread(target.write_text, body, "utf-8")
+            except OSError as exc:
+                logger.opt(exception=True).warning("Could not write the world-book export file.")
+                self._notify(f"Export failed: {exc}", "error")
+                return
+            self._notify(f"Exported to {target}", "information")
+        except Exception as exc:
+            logger.opt(exception=True).error("Unexpected error exporting the world book.")
+            self._notify(f"Export failed: {exc}", "error")
+        finally:
+            self._io_dialog_active = False
 
     @on(LoreBookEnableToggled)
     async def _handle_lore_enable_toggled(self, message: LoreBookEnableToggled) -> None:

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -2145,14 +2145,30 @@ class PersonasScreen(BaseAppScreen):
                 return
             body = json.dumps(data, indent=2, ensure_ascii=False)
             try:
-                await asyncio.to_thread(target.write_text, body, "utf-8")
-            except OSError as exc:
-                logger.opt(exception=True).warning("Could not write the world-book export file.")
+                validated = validate_path_simple(str(target))
+            except (ValueError, OSError) as exc:
+                logger.opt(exception=True).warning(f"Rejected world-book export path {target}.")
                 self._notify(f"Export failed: {exc}", "error")
                 return
-            self._notify(f"Exported to {target}", "information")
+            # Atomic write: temp file + replace, so an interruption can't leave a
+            # truncated/corrupt export (mirrors the dictionary export flow).
+            temp = validated.parent / f".{validated.name}.tmp"
+            try:
+                await asyncio.to_thread(temp.write_text, body, "utf-8")
+                await asyncio.to_thread(temp.replace, validated)
+            except OSError as exc:
+                logger.opt(exception=True).warning(f"Could not write world-book export to {validated}.")
+                try:
+                    temp.unlink(missing_ok=True)
+                except OSError:
+                    pass
+                self._notify(f"Export failed: {exc}", "error")
+                return
+            self._notify(f"Exported to {validated}", "information")
         except Exception as exc:
-            logger.opt(exception=True).error("Unexpected error exporting the world book.")
+            logger.opt(exception=True).error(
+                f"Unexpected error exporting world book {self.state.selected_entity_id}."
+            )
             self._notify(f"Export failed: {exc}", "error")
         finally:
             self._io_dialog_active = False

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_library_pane.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_library_pane.py
@@ -144,15 +144,16 @@ class PersonasLibraryPane(Vertical):
         yield Static("", id="personas-library-count", classes="destination-purpose")
 
     def set_mode(self, mode: str) -> None:
-        """Gate the toolbar per mode: Import for characters+dictionaries, Duplicate for dictionaries+lore."""
-        self._import_visible = mode in ("characters", "dictionaries")
+        """Gate the toolbar per mode: Import for characters+dictionaries+lore, Duplicate for dictionaries+lore."""
+        self._import_visible = mode in ("characters", "dictionaries", "lore")
         import_button = self.query_one("#personas-library-import", Button)
         import_button.display = self._import_visible
-        import_button.tooltip = (
-            "Import a dictionary (JSON or Markdown)."
-            if mode == "dictionaries"
-            else "Import a character card (PNG or JSON)."
-        )
+        if mode == "dictionaries":
+            import_button.tooltip = "Import a dictionary (JSON or Markdown)."
+        elif mode == "lore":
+            import_button.tooltip = "Import a world book (JSON)."
+        else:
+            import_button.tooltip = "Import a character card (PNG or JSON)."
         self.query_one("#personas-library-duplicate", Button).display = mode in ("dictionaries", "lore")
 
     async def update_rows(

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_lore_detail.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_lore_detail.py
@@ -66,6 +66,10 @@ class LoreBookSettingsSaveRequested(Message):
         self.payload = payload
 
 
+class LoreBookExportRequested(Message):
+    """Intent: export the currently selected world book to a file (JSON)."""
+
+
 class PersonasLoreDetailWidget(Vertical):
     """Entries + Settings tabs for one lore/world book. Emits intents; owns no I/O."""
 
@@ -149,6 +153,7 @@ class PersonasLoreDetailWidget(Vertical):
                     yield Static("Enabled", markup=False)
                     yield Switch(value=True, id="personas-lore-enabled")
                 yield Button("Save settings", id="personas-lore-settings-save", classes="console-action-secondary")
+                yield Button("Export", id="personas-lore-export", classes="console-action-secondary")
         yield Static("", id="personas-lore-status", markup=False)
 
     def on_mount(self) -> None:
@@ -458,6 +463,11 @@ class PersonasLoreDetailWidget(Vertical):
         event.stop()
         self.post_message(LoreBookSettingsSaveRequested(self.settings_payload()))
 
+    @on(Button.Pressed, "#personas-lore-export")
+    def _export_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.post_message(LoreBookExportRequested())
+
     @on(Switch.Changed, "#personas-lore-enabled")
     def _enabled_changed(self, event: Switch.Changed) -> None:
         event.stop()
@@ -476,6 +486,7 @@ class PersonasLoreDetailWidget(Vertical):
 
 __all__ = [
     "LoreBookEnableToggled",
+    "LoreBookExportRequested",
     "LoreBookSettingsSaveRequested",
     "LoreEntriesReorderRequested",
     "LoreEntryAddRequested",


### PR DESCRIPTION
## Roleplay P2d-2 — world-book import/export UI

Second half of **P2d**, after P2d-1 (matching-controls editor, #694). Adds import-from-file and export-to-file for Lore world books. **Pure additive UI + one new pure module — no manager change, no schema change (stays v21).**

### What changed
- **New `Character_Chat/world_book_import.py`** — `normalize_world_book_import(data)`, a pure/DB-free adapter that maps tldw exports, character-book array form, and **SillyTavern World Info** object-form (`key`→`keys`, `keysecondary`→`secondary_keys`, `order`→`insertion_order`, int-`position`→string, `disable`→`enabled`, `caseSensitive`→`case_sensitive`) to tldw's field names, and validates the **whole file** up front (raising `ValueError`) so a malformed file creates **no partial book**.
- **Export** — an Export button + `LoreBookExportRequested` message in the lore detail widget; the screen saves the selected book to a user-chosen `.json` via `EnhancedFileSave`.
- **Import** — the library Import button is un-gated for lore mode; `_import_world_book_from_path` validates path/size, parses JSON, normalizes via the adapter, imports via `WorldBookManager.import_world_book`, and renames on a name clash (`_unique_lore_name`). Never crashes; navigated-away guard.

### Testing
- Adapter unit tests (18): shape passthrough, SillyTavern remap, all `ValueError` rejections, plus branch coverage for the bool-position guard, unknown int positions, bare-string keys, non-dict extensions, non-numeric order, null-in-keys, and explicit `enabled=false`.
- Real-DB import tests: tldw file, SillyTavern object-form, malformed→no-book, name-collision→rename, Import-button-visible.
- Real-DB export + export→import round-trip (priority + selective/secondary_keys/case_sensitive preserved).
- Full gate: **90 passed**; `import tldw_chatbook.app` OK.

### Review
Subagent-driven (implementer + reviewer per task). Opus whole-branch review = **Ready to merge**, no Critical/Important. Two Minors (null-in-keys phantom-keyword gap + untested adapter branches) were **fixed** before this PR (`dd24889c`) with load-bearing regression tests.

**Deferred:** legacy `ccp_dictionary_handler` stub retirement (P2g), embedded `character_book` extraction, Markdown export.

Spec: `Docs/superpowers/specs/2026-07-17-roleplay-p2d2-import-export-design.md`
Plan: `Docs/superpowers/plans/2026-07-17-roleplay-p2d2-import-export.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds import and export for Lore world books. Users can export the selected book to JSON and import JSON files (tldw, character-book array, or SillyTavern World Info), with upfront validation and no schema or manager changes.

- New Features
  - New pure normalizer `normalize_world_book_import` in `tldw_chatbook/Character_Chat/world_book_import.py` to map/validate inputs before DB writes.
  - Lore detail adds an Export button; screen saves the selected book to `.json` via `EnhancedFileSave`.
  - Lore library Import is enabled; dialog + worker validate path/size (10 MB), parse JSON, normalize, and import via `WorldBookManager.import_world_book`.
  - Name collisions auto-rename via `_unique_lore_name`; never crashes, errors shown via notifications.
  - Supports SillyTavern World Info fields (`key`, `keysecondary`, `order`, int `position`, `disable`) and preserves matching fields (`priority`, `secondary_keys`, `case_sensitive`, `selective`, `extensions`).

- Bug Fixes
  - Normalizer hardening: drops nulls in `keys`, rejects null/blank `content`, guards bool `position`, defaults unknown int positions, preserves `enabled=false`, ignores non-dict `extensions`, and robustly coerces string/number booleans for `selective`, `case_sensitive`, and `enabled` (including inverted `disable`).
  - Export hardening: validates the chosen save path and writes JSON atomically (temp file + replace) to prevent partial/corrupt files; errors are notified.

<sup>Written for commit 25261eee933e3a0720e2f50d9ba7770c475725ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

