### PR TITLE
chore(backlog): RAG-program closeout follow-ups (tasks 299-301)

### DIFF
--- a/backlog/tasks/task-299 - Unify-hybrid-retrieval-leg-key-namespaces-so-RRF-fusion-can-merge-overlapping-documents.md
+++ b/backlog/tasks/task-299 - Unify-hybrid-retrieval-leg-key-namespaces-so-RRF-fusion-can-merge-overlapping-documents.md
@@ -1,0 +1,27 @@
+---
+id: TASK-299
+title: >-
+  Unify hybrid retrieval leg key namespaces so RRF fusion can merge overlapping
+  documents
+status: To Do
+assignee: []
+created_date: '2026-07-19 04:23'
+labels:
+  - rag
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The RRF fusion shipped in task-256 (PR 681) blends FTS and vector legs by document identity, but the legs emit different result-key namespaces: search_semantic produces source='unknown' plus chunk-level ids while the FTS5 legs key by source document, so the same underlying document is never recognized as present in both legs. Consequences: cross-leg RRF score blending effectively never fires (each doc scores from one leg only), and the overlap citation-merge path added in the 681 review round is unreachable in practice. Flagged as a follow-up in PR 681's review discussion (comment 3604960547 reply) and the task-256 Implementation Notes. Unify the identity scheme (e.g. carry source_type plus source_id through search_semantic's result metadata into the leg key, falling back to chunk id only when no doc identity exists) so fusion sees true overlap.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A document returned by both the FTS leg and the vector leg is fused into one result with blended RRF contributions from both legs
+- [ ] #2 Fusion unit tests cover cross-leg overlap with the real key shapes emitted by search_semantic and the FTS5 leg functions (not hand-built keys)
+- [ ] #3 Semantic-leg citations survive on the fused result when the FTS item is primary (existing 681 test extended to the real-overlap path)
+- [ ] #4 No change to single-leg ranking behavior (alpha semantics and RRF math unchanged)
+<!-- AC:END -->

--- a/backlog/tasks/task-300 - Decide-RAG-admin-surface-rebuild-reachable-Console-parity-screen-or-delete-the-services.md
+++ b/backlog/tasks/task-300 - Decide-RAG-admin-surface-rebuild-reachable-Console-parity-screen-or-delete-the-services.md
@@ -1,0 +1,27 @@
+---
+id: TASK-300
+title: >-
+  Decide RAG admin surface: rebuild reachable Console-parity screen or delete
+  the services
+status: To Do
+assignee: []
+created_date: '2026-07-19 04:23'
+labels:
+  - rag
+  - product-decision
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The three RAG admin services (server_rag_admin_service, local_rag_admin_service, rag_admin_scope_service) have zero production consumers: their legacy UI was deleted in PR 669, task-248 (PR 677) repointed the local service at the shared vector store, and task-254 (PR 689) made construction lazy — explicitly deferring the keep-vs-delete decision as a product call. Resolve it: either (a) rebuild a reachable Console-parity admin surface (collection inspection, index stats, backfill trigger, chunking templates scope routing — note task-251 already shipped user-facing indexing controls in the Search window, so define what admin adds beyond that) or (b) delete the services, their scope-policy wiring, and Tests/RAG_Admin. This is a product decision task: the deliverable starts with a short written recommendation for owner sign-off before implementation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A written recommendation (rebuild vs delete, with scope and rationale) exists and has owner sign-off recorded in this task
+- [ ] #2 The chosen option is implemented: either an admin surface reachable through shell navigation consuming the services, or the services plus their tests and wiring are removed
+- [ ] #3 No unreachable-but-constructed admin code remains either way
+<!-- AC:END -->

--- a/backlog/tasks/task-301 - Audit-and-remove-remaining-zero-importer-orphan-widgets.md
+++ b/backlog/tasks/task-301 - Audit-and-remove-remaining-zero-importer-orphan-widgets.md
@@ -1,0 +1,26 @@
+---
+id: TASK-301
+title: Audit and remove remaining zero-importer orphan widgets
+status: To Do
+assignee: []
+created_date: '2026-07-19 04:23'
+labels:
+  - cleanup
+  - ui
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The task-253 SearchWindow deletion (PR 669) verified importers for everything it removed and explicitly left a set of pre-existing zero-importer orphans for a separate audit because they were not reachable through the SearchWindow stack: at minimum Widgets/toast.py-style notification widgets, a detailed-progress widget, and an embedding-template-selector (exact filenames in PR 669's report and worth re-verifying). Sweep Widgets/ (and UI/ leaf modules) for zero-importer files, verify each with git grep across production code and tests, and delete confirmed orphans following the repo precedent (commit 628b1b8b, tasks 252/253). Note the codebase moves fast: re-verify every candidate on the current tree at implementation time rather than trusting this list.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Every Widgets/ and UI/ module with zero production importers is either deleted or recorded with a documented reason to keep
+- [ ] #2 Importer evidence (git grep) is captured per removed file in the task or PR description
+- [ ] #3 Exclusive tests and CSS for removed widgets are cleaned up and the CSS bundle rebuilt if inputs changed
+- [ ] #4 Full test suite shows zero regressions vs the pre-change baseline
+<!-- AC:END -->


### PR DESCRIPTION
Files the three remaining follow-ups deferred with evidence during the ADR-005 RAG program, so the program's loose ends live in the backlog rather than PR threads:

- **task-299** (medium) — unify hybrid leg result-key namespaces so RRF fusion can actually merge overlapping documents; today `search_semantic`'s chunk-keyed/`source='unknown'` results never match the FTS legs' doc keys, so cross-leg blending and the #681 overlap-citation path are unreachable in practice.
- **task-300** (low, product-decision) — resolve the deliberately-deferred RAG_Admin keep-vs-delete call (#689 left the services as a lazy zero-consumer seam); starts with a written recommendation for owner sign-off.
- **task-301** (low) — the orphan-widget audit #669 explicitly left behind (toast/detailed-progress/embedding-template-selector class of zero-importer files), with re-verification required at implementation time.

IDs 299–301 chosen manually past every open branch's claims per the collision lesson; duplicate-ID guard passes locally on both namespaces.

Backlog-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three backlog tasks to close out ADR-005 RAG program follow-ups. Backlog-only; no code changes or runtime impact.

- **New Tasks**
  - 299 — Unify hybrid retrieval key namespaces so RRF can fuse overlapping documents and keep citations.
  - 300 — Product decision: rebuild a reachable RAG admin surface or remove unused admin services.
  - 301 — Audit and remove zero-importer orphan widgets, with evidence and related cleanup.

<sup>Written for commit d05ae4fd0245dc95c30e86f546d81f6d5ef573dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

