### PR TITLE
fix(filepicker): refactor picker layout, flatten eval wrappers, wire search/bookmarks

### DIFF
--- a/Docs/Development/Filepicker/Enhanced-Filepicker-Guide.md
+++ b/Docs/Development/Filepicker/Enhanced-Filepicker-Guide.md
@@ -40,7 +40,25 @@ The enhanced file picker in tldw_chatbook provides a feature-rich file selection
 - Icons for different file types and bookmarks
 - Clear visual indicators for attached files
 - Highlighted search results
+- Dedicated inline error line instead of easy-to-miss border subtitles
+- Column headers in the file list (Name, Size, Modified)
 - Better spacing and organization
+
+### 6. **Type-Ahead File Jumping** ⌨️
+- When the file list is focused, type letters to jump to the next file whose name starts with the typed prefix
+- The prefix resets after a short period of inactivity
+- Digits are reserved for the `1-9` bookmark jumps unless you are already typing a prefix
+
+### 7. **Optional Multi-Select** ☑️
+- `EnhancedFileOpen` supports `multi_select=True`
+- Use `Space` to toggle the highlighted file
+- Selected files show a check-mark in the list and a count above the button bar
+- The main button returns a `List[Path]` instead of a single `Path`
+- `EnhancedFileSave` does not support multi-select
+
+### 8. **Collapsible Shortcut Hints** ❓
+- Footer shows the full shortcut cheat-sheet by default
+- Press `?` to collapse it to a compact "? Show shortcuts" reminder
 
 ## Keyboard Shortcuts
 
@@ -54,7 +72,11 @@ The enhanced file picker in tldw_chatbook provides a feature-rich file selection
 | `F5` | Refresh | Refresh current directory listing |
 | `Ctrl+F` | Search | Focus search box |
 | `1-9` | Quick Jump | Jump to bookmark 1-9 (only when an input is not focused) |
+| `Space` | Toggle Select | Toggle the highlighted file in multi-select mode |
+| `?` | Toggle Hints | Expand/collapse the shortcut-hint footer |
 | `Escape` | Cancel | Close file picker |
+
+*When the file list is focused, typing printable letters jumps to the next matching file name.*
 
 ## Usage Examples
 
@@ -98,6 +120,18 @@ save_dialog = EnhancedFileSave(
     title="Save Document",
     default_filename="document.txt",
     context="document_save"
+)
+```
+
+### Multi-Select File Open
+```python
+from tldw_chatbook.Widgets.enhanced_file_picker import EnhancedFileOpen
+
+# Select multiple files; dismiss returns a list of Path objects
+multi_dialog = EnhancedFileOpen(
+    title="Select Files",
+    context="batch_import",
+    multi_select=True,
 )
 ```
 
@@ -154,7 +188,13 @@ The following contexts are pre-configured with the migration:
 Users can add their own bookmarks by navigating to a directory and pressing `Ctrl+D`. Custom bookmarks are marked with `custom: true` in the config.
 
 ### Search Functionality
-Press `Ctrl+F` to focus the search box. The directory list filters in real-time as you type, matching partial filenames case-insensitively. Press the **Clear** button or `Ctrl+F` again to reset the filter.
+Press `Ctrl+F` to focus the search box. The directory list filters in real-time as you type, matching partial filenames case-insensitively. A result count is shown next to the search box and a "no matches" message appears when the filter matches nothing. Press the **Clear** button or `Ctrl+F` again to reset the filter.
+
+### Type-Ahead Jumping
+With the file list focused, type any printable letter to jump to the next entry whose name starts with that prefix. The prefix is cleared after a short idle timeout, so successive keystrokes refine the jump. Digits are reserved for bookmark jumps unless you have already started a prefix.
+
+### Multi-Select Mode
+Enable `multi_select=True` on `EnhancedFileOpen`. Use `Space` (or Enter) on a file to add it to the selection; a check-mark appears beside selected files and the status label shows the count. Click the main button to return a `list[Path]`. If no files are selected, the button shows an inline error.
 
 ### Multiple Contexts
 Different features of the app use different contexts, so your character import directory won't interfere with your document directory, etc.
@@ -187,7 +227,6 @@ All existing code has been automatically migrated to use the enhanced file picke
 
 Planned improvements include:
 - Drag and drop support
-- Multi-file selection
 - File preview pane
 - Grid view for images
 - Favorites filters

--- a/Docs/Development/Filepicker/Enhanced-Filepicker-Guide.md
+++ b/Docs/Development/Filepicker/Enhanced-Filepicker-Guide.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The enhanced file picker in tldw_chatbook provides a modern, feature-rich file selection experience with persistent settings, bookmarks, recent files, and context-aware defaults. This guide covers the new features and how to use them effectively.
+The enhanced file picker in tldw_chatbook provides a feature-rich file selection experience with persistent settings, bookmarks, recent files, and context-aware defaults. It subclasses the vendored `textual_fspicker` base dialog and adds persistence and search without forking the third-party code. This guide covers the implemented features and how to use them effectively.
 
 ## Key Features
 
@@ -53,7 +53,7 @@ The enhanced file picker in tldw_chatbook provides a modern, feature-rich file s
 | `Ctrl+D` | Bookmark Current | Add/remove current directory bookmark |
 | `F5` | Refresh | Refresh current directory listing |
 | `Ctrl+F` | Search | Focus search box |
-| `1-9` | Quick Jump | Jump to bookmark 1-9 |
+| `1-9` | Quick Jump | Jump to bookmark 1-9 (only when an input is not focused) |
 | `Escape` | Cancel | Close file picker |
 
 ## Usage Examples
@@ -143,6 +143,10 @@ The following contexts are pre-configured with the migration:
 - `mlx_models` - MLX model files
 - `file_open` - Generic file open (default)
 - `file_save` - Generic file save (default)
+- `eval_file` - Generic evaluation file selection
+- `eval_task` - Evaluation task file selection
+- `eval_dataset` - Evaluation dataset file selection
+- `eval_export` - Evaluation result export destination
 
 ## Advanced Features
 
@@ -150,7 +154,7 @@ The following contexts are pre-configured with the migration:
 Users can add their own bookmarks by navigating to a directory and pressing `Ctrl+D`. Custom bookmarks are marked with `custom: true` in the config.
 
 ### Search Functionality
-The search box filters files in real-time as you type. The search is case-insensitive and matches partial filenames.
+Press `Ctrl+F` to focus the search box. The directory list filters in real-time as you type, matching partial filenames case-insensitively. Press the **Clear** button or `Ctrl+F` again to reset the filter.
 
 ### Multiple Contexts
 Different features of the app use different contexts, so your character import directory won't interfere with your document directory, etc.
@@ -192,9 +196,13 @@ Planned improvements include:
 
 ## Testing
 
-Run the test script to verify the enhanced file picker:
+Run the focused test suite to verify the enhanced file picker:
+
 ```bash
-python test_enhanced_filepicker.py
+python3 -m pytest Tests/UI/test_file_picker_filters_callable.py \
+    Tests/UI/test_file_picker_bookmarks_lazy.py \
+    Tests/UI/test_file_picker_action_tooltips.py \
+    Tests/UI/test_enhanced_file_dialog_mount.py -q
 ```
 
-This will open a test application where you can try all the features.
+For interactive exploration, you can still run `Tests/test_enhanced_filepicker.py` as a standalone Textual app.

--- a/Docs/superpowers/plans/2026-07-18-watchlists-tui-screen.md
+++ b/Docs/superpowers/plans/2026-07-18-watchlists-tui-screen.md
@@ -1,0 +1,1474 @@
+# Watchlists TUI Screen Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the placeholder `watchlists_collections` destination shell with a full three-pane TUI management screen supporting local and server backends, with Overview, Sources, Items, Runs, and Alert Rules sections.
+
+**Architecture:** Reuse the existing `WatchlistScopeService` for backend routing; extend `SubscriptionsDB` and `LocalWatchlistsService` for local scraped-items, source-level filters, and content alerts; decompose the UI into a thin shell plus focused pane/controller modules under `tldw_chatbook/UI/Watchlists_Modules`.
+
+**Tech Stack:** Python 3.11+, Textual, SQLite, pydantic, httpx, pytest.
+
+**Spec:** [docs/superpowers/specs/2026-07-18-watchlists-tui-screen-design.md](../specs/2026-07-18-watchlists-tui-screen-design.md)  
+**ADR:** [backlog/decisions/018-watchlists-tui-screen.md](../../../backlog/decisions/018-watchlists-tui-screen.md)
+
+---
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `tldw_chatbook/DB/Subscriptions_DB.py` | Idempotent schema migration for new columns/indexes and widened `subscription_filters` CHECK constraint. |
+| `tldw_chatbook/Subscriptions/watchlist_filter_service.py` | Evaluate source-level `include`/`exclude`/`flag` filters against candidate items. |
+| `tldw_chatbook/Subscriptions/watchlist_content_alert_service.py` | Evaluate keyword/regex content-alert rules per item and build notification payloads. |
+| `tldw_chatbook/Subscriptions/watchlist_preview_service.py` | Dry-run fetch for a source without persistence (local backend). |
+| `tldw_chatbook/Subscriptions/watchlist_opml_service.py` | Parse and serialize OPML for local bulk import/export. |
+| `tldw_chatbook/Subscriptions/local_watchlists_service.py` | Extended to honor `active` on create, apply filters/content alerts, upsert items. |
+| `tldw_chatbook/UI/Watchlists_Modules/__init__.py` | Package marker. |
+| `tldw_chatbook/UI/Watchlists_Modules/watchlists_backend_controller.py` | Backend authority switching, policy enforcement, operation routing, error handling. |
+| `tldw_chatbook/UI/Watchlists_Modules/watchlists_navigator.py` | Left-rail section list widget. |
+| `tldw_chatbook/UI/Watchlists_Modules/overview_pane.py` | Dashboard cards and recent-failed-runs list. |
+| `tldw_chatbook/UI/Watchlists_Modules/sources_pane.py` | Source list, create/edit form, filter editor, OPML, preview/check-now. |
+| `tldw_chatbook/UI/Watchlists_Modules/runs_pane.py` | Run list and full run inspector. |
+| `tldw_chatbook/UI/Watchlists_Modules/items_pane.py` | Item reader with smart counts and batch actions. |
+| `tldw_chatbook/UI/Watchlists_Modules/alert_rules_pane.py` | Health + content alert rule editor and inbox. |
+| `tldw_chatbook/UI/Screens/watchlists_collections_screen.py` | Thin shell composing rail + workbench + inspector; message routing. |
+| `tldw_chatbook/UI/Screens/subscription_screen.py` | Deleted. |
+| `tldw_chatbook/app.py` | Remove subscription-specific handlers; update handoff staging. |
+| `tldw_chatbook/Constants.py` | Review/remove `TAB_SUBSCRIPTIONS` usage. |
+| `tldw_chatbook/UI/Navigation/screen_registry.py` | Remove `subscriptions` route. |
+| `tldw_chatbook/UI/Navigation/shell_destinations.py` | Keep `subscriptions` as alias for `watchlists_collections`. |
+| `tldw_chatbook/UI/Workbench/route_inventory.py` | Update owner mapping. |
+
+---
+
+## Phase 1: Foundation (local schema + services + controller)
+
+### Task 1: Add Watchlists schema migration to SubscriptionsDB
+
+**Files:**
+- Modify: `tldw_chatbook/DB/Subscriptions_DB.py`
+- Test: `Tests/DB/test_subscriptions_db.py` (create if missing; otherwise extend)
+
+**Goal:** Idempotently add `queued_for_briefing`, `run_id`, `alert_matches` to `subscription_items`; add `priority`, `is_include_required` to `subscription_filters`; widen the `action` CHECK constraint; add indexes.
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# Tests/DB/test_subscriptions_db.py
+import pytest
+from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
+
+@pytest.fixture
+def db(tmp_path):
+    return SubscriptionsDB(str(tmp_path / "subs.db"), client_id="test")
+
+
+def test_watchlists_columns_exist(db):
+    cursor = db.conn.cursor()
+    cols = {row[1] for row in cursor.execute("PRAGMA table_info(subscription_items)")}
+    assert "queued_for_briefing" in cols
+    assert "run_id" in cols
+    assert "alert_matches" in cols
+
+    cols = {row[1] for row in cursor.execute("PRAGMA table_info(subscription_filters)")}
+    assert "priority" in cols
+    assert "is_include_required" in cols
+
+
+def test_subscription_filters_action_constraint_allows_include(db):
+    cursor = db.conn.cursor()
+    cursor.execute(
+        "INSERT INTO subscription_filters (subscription_id, name, conditions, action) VALUES (?, ?, ?, ?)",
+        (1, "include ai", "{}", "include"),
+    )
+    db.conn.commit()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pytest Tests/DB/test_subscriptions_db.py::test_watchlists_columns_exist -v
+```
+Expected: FAIL — columns missing.
+
+- [ ] **Step 3: Implement `_ensure_watchlists_schema`**
+
+Add near the end of `_initialize_schema` in `tldw_chatbook/DB/Subscriptions_DB.py`:
+
+```python
+    def _ensure_watchlists_schema(self):
+        """Idempotent migration for watchlists screen schema additions."""
+        with closing(self._get_connection()) as conn:
+            cursor = conn.cursor()
+
+            # Add columns to subscription_items
+            items_cols = {row[1] for row in cursor.execute("PRAGMA table_info(subscription_items)")}
+            if "queued_for_briefing" not in items_cols:
+                cursor.execute("ALTER TABLE subscription_items ADD COLUMN queued_for_briefing BOOLEAN DEFAULT 0")
+            if "run_id" not in items_cols:
+                cursor.execute("ALTER TABLE subscription_items ADD COLUMN run_id INTEGER")
+            if "alert_matches" not in items_cols:
+                cursor.execute("ALTER TABLE subscription_items ADD COLUMN alert_matches TEXT")
+
+            # Add columns to subscription_filters
+            filters_cols = {row[1] for row in cursor.execute("PRAGMA table_info(subscription_filters)")}
+            if "priority" not in filters_cols:
+                cursor.execute("ALTER TABLE subscription_filters ADD COLUMN priority INTEGER DEFAULT 0")
+            if "is_include_required" not in filters_cols:
+                cursor.execute("ALTER TABLE subscription_filters ADD COLUMN is_include_required BOOLEAN DEFAULT 0")
+
+            # Widen CHECK constraint on subscription_filters.action
+            existing_check = None
+            for row in cursor.execute("SELECT sql FROM sqlite_master WHERE type='table' AND name='subscription_filters'"):
+                existing_check = row[0]
+            if existing_check and "include" not in existing_check:
+                cursor.execute("""
+                    CREATE TABLE subscription_filters_new (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        subscription_id INTEGER,
+                        name TEXT NOT NULL,
+                        is_active BOOLEAN DEFAULT 1,
+                        conditions TEXT NOT NULL,
+                        action TEXT NOT NULL CHECK(action IN ('auto_ingest','auto_ignore','tag','priority','notify','include','exclude','flag')),
+                        action_params TEXT,
+                        priority INTEGER DEFAULT 0,
+                        is_include_required BOOLEAN DEFAULT 0,
+                        created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                        updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                        FOREIGN KEY (subscription_id) REFERENCES subscriptions(id) ON DELETE CASCADE
+                    )
+                """)
+                cursor.execute("""
+                    INSERT INTO subscription_filters_new
+                        (id, subscription_id, name, is_active, conditions, action, action_params, priority, is_include_required, created_at, updated_at)
+                    SELECT id, subscription_id, name, is_active, conditions, action, action_params, priority, is_include_required, created_at, updated_at
+                    FROM subscription_filters
+                """)
+                cursor.execute("DROP TABLE subscription_filters")
+                cursor.execute("ALTER TABLE subscription_filters_new RENAME TO subscription_filters")
+                cursor.execute("""
+                    CREATE TRIGGER IF NOT EXISTS update_subscription_filters_timestamp
+                    AFTER UPDATE ON subscription_filters
+                    BEGIN
+                        UPDATE subscription_filters SET updated_at = CURRENT_TIMESTAMP WHERE id = NEW.id;
+                    END
+                """)
+
+            # Indexes
+            cursor.execute("CREATE INDEX IF NOT EXISTS idx_subscription_items_run_id ON subscription_items(run_id)")
+            cursor.execute("CREATE INDEX IF NOT EXISTS idx_subscription_items_queued ON subscription_items(queued_for_briefing, status)")
+            conn.commit()
+```
+
+Call `_ensure_watchlists_schema()` at the end of `_initialize_schema`.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pytest Tests/DB/test_subscriptions_db.py -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/DB/Subscriptions_DB.py Tests/DB/test_subscriptions_db.py
+git commit -m "feat(watchlists): extend SubscriptionsDB schema for items, filters, and content alerts"
+```
+
+---
+
+### Task 2: Add local filter evaluation service
+
+**Files:**
+- Create: `tldw_chatbook/Subscriptions/watchlist_filter_service.py`
+- Test: `Tests/Subscriptions/test_watchlist_filter_service.py`
+
+**Goal:** Given a list of candidate items and filter rows, return each item with a decision (`include`, `exclude`, `flag`) and matched filter.
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# Tests/Subscriptions/test_watchlist_filter_service.py
+import pytest
+from tldw_chatbook.Subscriptions.watchlist_filter_service import WatchlistFilterService
+
+@pytest.fixture
+def service():
+    return WatchlistFilterService()
+
+
+def test_keyword_include(service):
+    items = [{"title": "AI news", "summary": "", "content": ""}]
+    filters = [
+        {"id": 1, "priority": 1, "action": "include", "conditions": {"type": "keyword", "mode": "contains", "pattern": "AI"}, "is_include_required": False}
+    ]
+    result = service.evaluate(items, filters)
+    assert result[0]["filter_decision"] == "include"
+
+
+def test_exclude_wins_over_include(service):
+    items = [{"title": "AI news", "summary": "", "content": ""}]
+    filters = [
+        {"id": 1, "priority": 1, "action": "include", "conditions": {"type": "keyword", "pattern": "AI"}, "is_include_required": False},
+        {"id": 2, "priority": 0, "action": "exclude", "conditions": {"type": "keyword", "pattern": "AI"}, "is_include_required": False},
+    ]
+    result = service.evaluate(items, filters)
+    # Lower priority number evaluated first; exclude wins.
+    assert result[0]["filter_decision"] == "exclude"
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+pytest Tests/Subscriptions/test_watchlist_filter_service.py -v
+```
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement service**
+
+```python
+# tldw_chatbook/Subscriptions/watchlist_filter_service.py
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping
+
+
+class WatchlistFilterService:
+    """Evaluate source-level include/exclude/flag filters against candidate items."""
+
+    VALID_ACTIONS = frozenset({"include", "exclude", "flag"})
+
+    def evaluate(
+        self,
+        items: list[dict[str, Any]],
+        filters: list[Mapping[str, Any]],
+    ) -> list[dict[str, Any]]:
+        active_filters = [
+            f for f in filters
+            if f.get("action") in self.VALID_ACTIONS and f.get("is_active", True)
+        ]
+        active_filters.sort(key=lambda f: int(f.get("priority") or 0))
+
+        require_include = any(f.get("is_include_required") for f in active_filters)
+
+        results: list[dict[str, Any]] = []
+        for item in items:
+            decision: str | None = None
+            matched_filter_id: int | None = None
+            for rule in active_filters:
+                if self._matches(item, rule):
+                    decision = str(rule["action"])
+                    matched_filter_id = rule.get("id")
+                    break
+            if decision is None and require_include:
+                decision = "exclude"
+            enriched = dict(item)
+            enriched["filter_decision"] = decision or "include"
+            enriched["matched_filter_id"] = matched_filter_id
+            results.append(enriched)
+        return results
+
+    @staticmethod
+    def _matches(item: Mapping[str, Any], rule: Mapping[str, Any]) -> bool:
+        conditions = dict(rule.get("conditions") or {})
+        rule_type = str(conditions.get("type") or "keyword").lower()
+        mode = str(conditions.get("mode") or "contains").lower()
+        pattern = str(conditions.get("pattern") or "")
+        if not pattern:
+            return False
+
+        haystack = " ".join(
+            str(item.get(key) or "") for key in ("title", "summary", "content", "author")
+        ).lower()
+
+        if rule_type == "keyword":
+            needle = pattern.lower()
+            if mode == "contains":
+                return needle in haystack
+            if mode == "starts_with":
+                return haystack.startswith(needle)
+            if mode == "ends_with":
+                return haystack.endswith(needle)
+            return needle in haystack
+
+        if rule_type == "regex":
+            try:
+                return bool(re.search(pattern, haystack, re.IGNORECASE))
+            except re.error:
+                return False
+
+        return False
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pytest Tests/Subscriptions/test_watchlist_filter_service.py -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Subscriptions/watchlist_filter_service.py Tests/Subscriptions/test_watchlist_filter_service.py
+git commit -m "feat(watchlists): add local filter evaluation service"
+```
+
+---
+
+### Task 3: Add local content-alert evaluation service
+
+**Files:**
+- Create: `tldw_chatbook/Subscriptions/watchlist_content_alert_service.py`
+- Test: `Tests/Subscriptions/test_watchlist_content_alert_service.py`
+
+**Goal:** Given an item and content-alert rules, return matched rule IDs and notification payloads.
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# Tests/Subscriptions/test_watchlist_content_alert_service.py
+import pytest
+from tldw_chatbook.Subscriptions.watchlist_content_alert_service import WatchlistContentAlertService
+
+@pytest.fixture
+def service():
+    return WatchlistContentAlertService()
+
+
+def test_keyword_match(service):
+    rules = [
+        {"id": 1, "name": "AI alert", "severity": "warning", "conditions": {"type": "keyword", "pattern": "AI"}}
+    ]
+    matches = service.evaluate({"title": "AI news", "summary": "", "content": ""}, rules)
+    assert len(matches) == 1
+    assert matches[0]["rule_id"] == 1
+    assert matches[0]["severity"] == "warning"
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+pytest Tests/Subscriptions/test_watchlist_content_alert_service.py -v
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Implement service**
+
+Reuse the matching logic from `watchlist_filter_service`. Provide a method that returns matched rules with message + payload.
+
+```python
+# tldw_chatbook/Subscriptions/watchlist_content_alert_service.py
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping
+
+
+class WatchlistContentAlertService:
+    """Evaluate per-item content-alert rules."""
+
+    def evaluate(
+        self,
+        item: Mapping[str, Any],
+        rules: list[Mapping[str, Any]],
+    ) -> list[dict[str, Any]]:
+        matched: list[dict[str, Any]] = []
+        haystack = " ".join(
+            str(item.get(key) or "") for key in ("title", "summary", "content", "author")
+        ).lower()
+        for rule in rules:
+            conditions = dict(rule.get("conditions") or {})
+            pattern = str(conditions.get("pattern") or "")
+            if not pattern:
+                continue
+            rule_type = str(conditions.get("type") or "keyword").lower()
+            is_match = False
+            if rule_type == "keyword":
+                is_match = pattern.lower() in haystack
+            elif rule_type == "regex":
+                try:
+                    is_match = bool(re.search(pattern, haystack, re.IGNORECASE))
+                except re.error:
+                    is_match = False
+            if is_match:
+                matched.append({
+                    "rule_id": rule.get("id"),
+                    "rule_name": rule.get("name"),
+                    "severity": rule.get("severity", "warning"),
+                    "message": f"Alert '{rule.get('name')}' matched item: {item.get('title') or item.get('url')}",
+                    "notification_payload": {
+                        "kind": "watchlist_content_alert",
+                        "source_domain": "watchlists",
+                        "source_entity_kind": "watchlist_item",
+                        "source_entity_id": str(item.get("id") or ""),
+                        "rule_id": str(rule.get("id")),
+                        "dedupe_key": f"watchlist-content-alert:{rule.get('id')}:{item.get('id')}",
+                    },
+                })
+        return matched
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pytest Tests/Subscriptions/test_watchlist_content_alert_service.py -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Subscriptions/watchlist_content_alert_service.py Tests/Subscriptions/test_watchlist_content_alert_service.py
+git commit -m "feat(watchlists): add local content-alert evaluation service"
+```
+
+---
+
+### Task 4: Extend LocalWatchlistsService
+
+**Files:**
+- Modify: `tldw_chatbook/Subscriptions/local_watchlists_service.py`
+- Test: `Tests/Subscriptions/test_local_watchlists_service.py` (extend)
+
+**Goal:** Honor `active` on create, evaluate filters/content alerts during `execute_run`, upsert items into `subscription_items`, and return run stats.
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `Tests/Subscriptions/test_local_watchlists_service.py`:
+
+```python
+import pytest
+from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
+from tldw_chatbook.Subscriptions.local_watchlists_service import LocalWatchlistsService
+
+
+@pytest.fixture
+def local_service(tmp_path):
+    db = SubscriptionsDB(str(tmp_path / "subs.db"), client_id="test")
+    return LocalWatchlistsService(db_factory=lambda: db)
+
+
+@pytest.mark.asyncio
+async def test_create_source_honors_inactive(local_service):
+    result = await local_service.create_source({"name": "Inactive", "source_type": "rss", "url": "http://example.com/feed", "active": False})
+    assert result["active"] is False
+
+
+@pytest.mark.asyncio
+async def test_execute_run_persists_items_and_evaluates_filters(local_service):
+    source = await local_service.create_source({"name": "Test", "source_type": "rss", "url": "http://example.com/feed"})
+    run = await local_service.launch_run(source_id=source["source_id"])
+    # Stub executor injection omitted for brevity; see implementation notes.
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+pytest Tests/Subscriptions/test_local_watchlists_service.py -v
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Implement changes**
+
+1. In `create_source`, accept `active` from payload:
+   ```python
+   source_id = db.add_subscription(
+       ...
+       is_active=bool(payload.get("active", True)),
+       ...
+   )
+   ```
+2. Inject `filter_service` and `content_alert_service` via constructor defaults.
+3. In `execute_run`, after fetching items:
+   - Apply filters.
+   - Evaluate content-alert rules for the source (`subscription_filters` where `action='notify'`).
+   - Upsert items using `INSERT ... ON CONFLICT(subscription_id, url, content_hash) DO UPDATE`.
+   - Store `run_id` and `alert_matches` JSON.
+4. Keep existing health-alert evaluation.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pytest Tests/Subscriptions/test_local_watchlists_service.py -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Subscriptions/local_watchlists_service.py Tests/Subscriptions/test_local_watchlists_service.py
+git commit -m "feat(watchlists): extend local watchlist service with filters, content alerts, and item upsert"
+```
+
+---
+
+### Task 5: Add local preview service
+
+**Files:**
+- Create: `tldw_chatbook/Subscriptions/watchlist_preview_service.py`
+- Test: `Tests/Subscriptions/test_watchlist_preview_service.py`
+
+**Goal:** Fetch a source once without persistence and return candidate items.
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# Tests/Subscriptions/test_watchlist_preview_service.py
+import pytest
+from tldw_chatbook.Subscriptions.watchlist_preview_service import WatchlistPreviewService
+
+@pytest.mark.asyncio
+async def test_preview_returns_items_or_empty():
+    svc = WatchlistPreviewService()
+    result = await svc.preview({"type": "rss", "source": "http://example.com/feed"})
+    assert "items" in result
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+pytest Tests/Subscriptions/test_watchlist_preview_service.py -v
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```python
+# tldw_chatbook/Subscriptions/watchlist_preview_service.py
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from .local_watchlists_service import LocalWatchlistsService
+
+
+class WatchlistPreviewService:
+    """Dry-run fetch a source without persisting anything."""
+
+    async def preview(self, source_config: Mapping[str, Any]) -> dict[str, Any]:
+        # Re-use the existing fetchers from LocalWatchlistsService via a temporary executor.
+        service = LocalWatchlistsService(db_factory=lambda: None, run_executor=self._no_op_executor)
+        items = await service._default_run_executor(source_config, db=None)
+        return {"items": items.get("items", []), "log_text": "Preview completed."}
+
+    async def _no_op_executor(self, subscription: Mapping[str, Any]) -> dict[str, Any]:
+        return {"items": []}
+```
+
+Use the actual `FeedMonitor` / `URLMonitor` imports from `local_watchlists_service` instead of the no-op.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pytest Tests/Subscriptions/test_watchlist_preview_service.py -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Subscriptions/watchlist_preview_service.py Tests/Subscriptions/test_watchlist_preview_service.py
+git commit -m "feat(watchlists): add local source preview service"
+```
+
+---
+
+### Task 6: Add local OPML import/export service
+
+**Files:**
+- Create: `tldw_chatbook/Subscriptions/watchlist_opml_service.py`
+- Test: `Tests/Subscriptions/test_watchlist_opml_service.py`
+- Fixture: `Tests/fixtures/watchlists/sample.opml`
+
+**Goal:** Parse OPML outlines into source create payloads and serialize sources back to OPML.
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# Tests/Subscriptions/test_watchlist_opml_service.py
+import pytest
+from tldw_chatbook.Subscriptions.watchlist_opml_service import WatchlistOpmlService
+
+
+def test_parse_opml():
+    xml = '''<?xml version="1.0"?><opml version="2.0"><body><outline text="Tech" title="Tech"><outline text="AI" title="AI" type="rss" xmlUrl="http://example.com/ai"/></outline></body></opml>'''
+    svc = WatchlistOpmlService()
+    items = svc.parse(xml)
+    assert len(items) == 1
+    assert items[0]["url"] == "http://example.com/ai"
+    assert items[0]["source_type"] == "rss"
+
+
+def test_export_opml():
+    svc = WatchlistOpmlService()
+    xml = svc.export([
+        {"name": "AI", "url": "http://example.com/ai", "source_type": "rss"}
+    ])
+    assert "http://example.com/ai" in xml
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+pytest Tests/Subscriptions/test_watchlist_opml_service.py -v
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+Use Python stdlib `xml.etree.ElementTree`.
+
+```python
+# tldw_chatbook/Subscriptions/watchlist_opml_service.py
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from typing import Any
+
+
+class WatchlistOpmlService:
+    """Minimal OPML import/export for watchlist sources."""
+
+    def parse(self, xml_text: str) -> list[dict[str, Any]]:
+        root = ET.fromstring(xml_text)
+        items: list[dict[str, Any]] = []
+        for outline in root.iter("outline"):
+            url = outline.get("xmlUrl") or outline.get("htmlUrl")
+            if not url:
+                continue
+            source_type = outline.get("type", "rss").lower()
+            if source_type not in {"rss", "site", "forum"}:
+                source_type = "rss"
+            items.append({
+                "name": outline.get("text") or outline.get("title") or "Untitled",
+                "url": url,
+                "source_type": source_type,
+            })
+        return items
+
+    def export(self, sources: list[dict[str, Any]]) -> str:
+        root = ET.Element("opml", {"version": "2.0"})
+        body = ET.SubElement(root, "body")
+        for source in sources:
+            outline = ET.SubElement(body, "outline", {
+                "text": str(source.get("name") or "Untitled"),
+                "title": str(source.get("name") or "Untitled"),
+                "type": str(source.get("source_type") or "rss"),
+                "xmlUrl": str(source.get("url") or ""),
+            })
+        return ET.tostring(root, encoding="unicode")
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pytest Tests/Subscriptions/test_watchlist_opml_service.py -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Subscriptions/watchlist_opml_service.py Tests/Subscriptions/test_watchlist_opml_service.py Tests/fixtures/watchlists/sample.opml
+git commit -m "feat(watchlists): add local OPML import/export service"
+```
+
+---
+
+### Task 7: Create WatchlistsBackendController
+
+**Files:**
+- Create: `tldw_chatbook/UI/Watchlists_Modules/watchlists_backend_controller.py`
+- Test: `Tests/Watchlists/test_watchlists_backend_controller.py`
+
+**Goal:** Encapsulate backend switching, policy enforcement, operation routing, and error-to-recovery conversion.
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# Tests/Watchlists/test_watchlists_backend_controller.py
+import pytest
+from tldw_chatbook.UI.Watchlists_Modules.watchlists_backend_controller import WatchlistsBackendController
+
+
+class FakeScopeService:
+    async def list_watch_items(self, *, runtime_backend, **kwargs):
+        return [{"id": 1, "title": "Source"}]
+
+
+def test_controller_normalizes_backend():
+    ctrl = WatchlistsBackendController(app_instance=None, scope_service=FakeScopeService(), server_service=None)
+    assert ctrl._normalize_backend("server") == "server"
+    assert ctrl._normalize_backend(None) == "local"
+
+
+@pytest.mark.asyncio
+async def test_list_sources_routes_to_scope_service():
+    ctrl = WatchlistsBackendController(app_instance=None, scope_service=FakeScopeService(), server_service=None)
+    items = await ctrl.list_sources(runtime_backend="local")
+    assert len(items) == 1
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+pytest Tests/Watchlists/test_watchlists_backend_controller.py -v
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```python
+# tldw_chatbook/UI/Watchlists_Modules/watchlists_backend_controller.py
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+
+class WatchlistsBackendController:
+    """Route watchlist operations to the active local/server authority."""
+
+    def __init__(
+        self,
+        *,
+        app_instance: Any,
+        scope_service: Any,
+        server_service: Any,
+        notification_dispatch_service: Any = None,
+    ) -> None:
+        self.app_instance = app_instance
+        self.scope_service = scope_service
+        self.server_service = server_service
+        self.notification_dispatch_service = notification_dispatch_service
+
+    @staticmethod
+    def _normalize_backend(runtime_backend: Any) -> str:
+        return str(runtime_backend or "local").strip().lower() or "local"
+
+    async def _maybe_await(self, value: Any) -> Any:
+        if inspect.isawaitable(value):
+            return await value
+        return value
+
+    async def list_sources(self, *, runtime_backend: str | None = None, **kwargs: Any) -> list[dict[str, Any]]:
+        backend = self._normalize_backend(runtime_backend)
+        result = await self._maybe_await(
+            self.scope_service.list_watch_items(runtime_backend=backend, **kwargs)
+        )
+        return [dict(item) for item in list(result or [])]
+
+    async def create_source(self, *, runtime_backend: str | None = None, payload: dict[str, Any]) -> dict[str, Any]:
+        backend = self._normalize_backend(runtime_backend)
+        result = await self._maybe_await(
+            self.scope_service.create_watch_item(runtime_backend=backend, payload=payload)
+        )
+        return dict(result)
+
+    async def update_source(self, *, runtime_backend: str | None = None, item_id: Any, payload: dict[str, Any]) -> dict[str, Any]:
+        backend = self._normalize_backend(runtime_backend)
+        result = await self._maybe_await(
+            self.scope_service.update_watch_item(runtime_backend=backend, item_id=item_id, payload=payload)
+        )
+        return dict(result)
+
+    async def delete_source(self, *, runtime_backend: str | None = None, item_id: Any) -> dict[str, Any]:
+        backend = self._normalize_backend(runtime_backend)
+        result = await self._maybe_await(
+            self.scope_service.delete_watch_item(runtime_backend=backend, item_id=item_id)
+        )
+        return dict(result)
+
+    async def list_runs(self, *, runtime_backend: str | None = None, **kwargs: Any) -> list[dict[str, Any]]:
+        backend = self._normalize_backend(runtime_backend)
+        result = await self._maybe_await(
+            self.scope_service.list_runs(runtime_backend=backend, **kwargs)
+        )
+        return [dict(item) for item in list(result or [])]
+
+    async def get_run(self, *, runtime_backend: str | None = None, run_id: Any) -> dict[str, Any]:
+        backend = self._normalize_backend(runtime_backend)
+        result = await self._maybe_await(
+            self.scope_service.get_run(runtime_backend=backend, run_id=run_id)
+        )
+        return dict(result)
+
+    async def observe_run(self, *, runtime_backend: str | None = None, run_id: Any) -> dict[str, Any]:
+        backend = self._normalize_backend(runtime_backend)
+        result = await self._maybe_await(
+            self.scope_service.observe_run(runtime_backend=backend, run_id=run_id)
+        )
+        return dict(result)
+
+    async def cancel_run(self, *, runtime_backend: str | None = None, run_id: Any) -> dict[str, Any]:
+        backend = self._normalize_backend(runtime_backend)
+        result = await self._maybe_await(
+            self.scope_service.cancel_run(runtime_backend=backend, run_id=run_id)
+        )
+        return dict(result)
+
+    async def launch_run(self, *, runtime_backend: str | None = None, source_id: Any = None) -> dict[str, Any]:
+        backend = self._normalize_backend(runtime_backend)
+        result = await self._maybe_await(
+            self.scope_service.launch_run(runtime_backend=backend, source_id=source_id)
+        )
+        return dict(result)
+
+    async def list_alert_rules(self, *, runtime_backend: str | None = None, **kwargs: Any) -> list[dict[str, Any]]:
+        backend = self._normalize_backend(runtime_backend)
+        result = await self._maybe_await(
+            self.scope_service.list_alert_rules(runtime_backend=backend, **kwargs)
+        )
+        return [dict(item) for item in list(result or [])]
+
+    async def save_alert_rule(self, *, runtime_backend: str | None = None, payload: dict[str, Any]) -> dict[str, Any]:
+        backend = self._normalize_backend(runtime_backend)
+        result = await self._maybe_await(
+            self.scope_service.save_alert_rule(runtime_backend=backend, payload=payload)
+        )
+        return dict(result)
+
+    async def delete_alert_rule(self, *, runtime_backend: str | None = None, rule_id: Any) -> dict[str, Any]:
+        backend = self._normalize_backend(runtime_backend)
+        result = await self._maybe_await(
+            self.scope_service.delete_alert_rule(runtime_backend=backend, rule_id=rule_id)
+        )
+        return dict(result)
+
+    def list_unsupported_capabilities(self, *, runtime_backend: str | None = None) -> list[dict[str, Any]]:
+        backend = self._normalize_backend(runtime_backend)
+        method = getattr(self.scope_service, "list_unsupported_capabilities", None)
+        if callable(method):
+            return list(method(runtime_backend=backend))
+        return []
+```
+
+Extend with preview/check-now/OPML routing once the service helpers exist.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pytest Tests/Watchlists/test_watchlists_backend_controller.py -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/UI/Watchlists_Modules/watchlists_backend_controller.py Tests/Watchlists/test_watchlists_backend_controller.py
+git commit -m "feat(watchlists): add backend controller for watchlists screen"
+```
+
+---
+
+## Phase 2: Slice 1A UI — Overview, Sources, Runs
+
+### Task 8: Create `Watchlists_Modules` package and shared navigator widget
+
+**Files:**
+- Create: `tldw_chatbook/UI/Watchlists_Modules/__init__.py`
+- Create: `tldw_chatbook/UI/Watchlists_Modules/watchlists_navigator.py`
+
+**Goal:** Left-rail widget with Overview, Sources, Items, Runs, Rules buttons.
+
+- [ ] **Step 1: Implement**
+
+```python
+# tldw_chatbook/UI/Watchlists_Modules/watchlists_navigator.py
+from __future__ import annotations
+
+from textual.containers import Vertical
+from textual.message import Message
+from textual.widgets import Button
+
+
+class SectionSelected(Message):
+    def __init__(self, section_id: str) -> None:
+        self.section_id = section_id
+        super().__init__()
+
+
+class WatchlistsNavigator(Vertical):
+    SECTIONS = [
+        ("overview", "Overview"),
+        ("sources", "Sources"),
+        ("items", "Items"),
+        ("runs", "Runs"),
+        ("rules", "Rules"),
+    ]
+
+    def compose(self):
+        for section_id, label in self.SECTIONS:
+            yield Button(label, id=f"nav-{section-id}", classes="watchlists-nav-button")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        section_id = str(event.button.id).replace("nav-", "")
+        self.post_message(SectionSelected(section_id))
+```
+
+- [ ] **Step 2: Basic test**
+
+```bash
+pytest Tests/Watchlists/test_watchlists_navigator.py -v
+```
+
+Create a minimal pilot test that asserts all five buttons exist.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tldw_chatbook/UI/Watchlists_Modules/__init__.py tldw_chatbook/UI/Watchlists_Modules/watchlists_navigator.py Tests/Watchlists/test_watchlists_navigator.py
+git commit -m "feat(watchlists): add watchlists navigator widget"
+```
+
+---
+
+### Task 9: Rewrite the Watchlists screen shell
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/watchlists_collections_screen.py`
+- Test: `Tests/UI/test_watchlists_destination_shell.py` (rewrite from existing tests if needed)
+
+**Goal:** Keep public contract (route, class name, stable selectors) but replace internals with shell + panes + controller.
+
+- [ ] **Step 1: Implement shell**
+
+Rewrite `watchlists_collections_screen.py` to:
+- Keep `class WatchlistsCollectionsScreen(BaseAppScreen)`.
+- Add reactive state: `active_section`, `runtime_backend`, `selected_source`, `selected_run`, `recovery_state`.
+- Compose: header bar with backend `Select`, left `WatchlistsNavigator`, middle `WatchlistsWorkbench` container, right `WatchlistsInspector` container.
+- Instantiate controller in `__init__` from `app.watchlist_scope_service` etc.
+- Handle `SectionSelected`, load pane into middle container.
+- Preserve existing stable selectors (`watchlists-collections-title`, `wc-attach-to-console`, etc.) for backward compatibility where possible.
+
+- [ ] **Step 2: Run destination tests**
+
+```bash
+pytest Tests/UI/test_watchlists_destination_shell.py -v
+```
+Expected: PASS after updating tests to the new layout.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tldw_chatbook/UI/Screens/watchlists_collections_screen.py Tests/UI/test_watchlists_destination_shell.py
+git commit -m "feat(watchlists): rewrite watchlists screen shell with navigator and panes"
+```
+
+---
+
+### Task 10: Implement Overview pane
+
+**Files:**
+- Create: `tldw_chatbook/UI/Watchlists_Modules/overview_pane.py`
+- Test: `Tests/Watchlists/test_watchlists_overview_pane.py`
+
+**Goal:** Show summary cards, health alerts, and recent failed runs.
+
+- [ ] **Step 1: Implement**
+
+A Textual `Vertical`/`Grid` of `Static` widgets and a `DataTable` for recent failed runs. Reactive data drives updates.
+
+```python
+# tldw_chatbook/UI/Watchlists_Modules/overview_pane.py
+from textual.containers import Grid, Vertical
+from textual.reactive import reactive
+from textual.widgets import DataTable, Static
+
+
+class OverviewPane(Vertical):
+    data = reactive({}, recompose=True)
+
+    def compose(self):
+        with Grid(id="watchlists-overview-grid"):
+            yield Static("Feeds: -", id="overview-feeds")
+            yield Static("Updates: -", id="overview-updates")
+            yield Static("Activity: -", id="overview-activity")
+        yield Static("Recent failed runs", classes="pane-title")
+        yield DataTable(id="overview-failed-runs")
+
+    def watch_data(self):
+        table = self.query_one("#overview-failed-runs", DataTable)
+        table.clear()
+        for run in self.data.get("failed_runs", []):
+            table.add_row(run.get("source_title"), run.get("status"), run.get("error_msg"))
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+pytest Tests/Watchlists/test_watchlists_overview_pane.py -v
+```
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tldw_chatbook/UI/Watchlists_Modules/overview_pane.py Tests/Watchlists/test_watchlists_overview_pane.py
+git commit -m "feat(watchlists): add overview dashboard pane"
+```
+
+---
+
+### Task 11: Implement Sources pane
+
+**Files:**
+- Create: `tldw_chatbook/UI/Watchlists_Modules/sources_pane.py`
+- Test: `Tests/Watchlists/test_watchlists_sources_pane.py`
+
+**Goal:** Source list with search/type filter, DataTable, create/edit form, actions.
+
+- [ ] **Step 1: Implement**
+
+Build a pane with:
+- Top bar: `Input` for search, `Select` for type, `Button` New Source.
+- `DataTable` for source list columns: Name, Type, Status, Last scraped, Active, Actions.
+- Selection updates `selected_source` reactive and posts a message to the shell.
+- Create/edit uses a modal or inline form with fields: name, URL, source_type, active, tags, extraction rules.
+- Actions wired through the controller.
+
+- [ ] **Step 2: Run tests**
+
+```bash
+pytest Tests/Watchlists/test_watchlists_sources_pane.py -v
+```
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tldw_chatbook/UI/Watchlists_Modules/sources_pane.py Tests/Watchlists/test_watchlists_sources_pane.py
+git commit -m "feat(watchlists): add sources management pane"
+```
+
+---
+
+### Task 12: Implement Runs pane
+
+**Files:**
+- Create: `tldw_chatbook/UI/Watchlists_Modules/runs_pane.py`
+- Test: `Tests/Watchlists/test_watchlists_runs_pane.py`
+
+**Goal:** Run list and run inspector (stats, items, logs).
+
+- [ ] **Step 1: Implement**
+
+Build a pane with:
+- `DataTable` for runs: Source/Job, Status, Started, Duration, Found, Processed, Filtered, Errors, Actions.
+- Selection shows run detail in the right inspector:
+  - `Static` for stats.
+  - `DataTable` for items.
+  - `Static` for log text.
+- Polling worker refreshes run detail while status is `running`.
+- Cancel and Re-run actions call controller.
+
+- [ ] **Step 2: Run tests**
+
+```bash
+pytest Tests/Watchlists/test_watchlists_runs_pane.py -v
+```
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tldw_chatbook/UI/Watchlists_Modules/runs_pane.py Tests/Watchlists/test_watchlists_runs_pane.py
+git commit -m "feat(watchlists): add runs list and inspector pane"
+```
+
+---
+
+### Task 13: Wire screen messages and inspector pane
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/watchlists_collections_screen.py`
+- Create: `tldw_chatbook/UI/Watchlists_Modules/inspector_pane.py`
+- Test: `Tests/UI/test_watchlists_inspector.py`
+
+**Goal:** Selecting an entity updates the right inspector with context-aware actions.
+
+- [ ] **Step 1: Implement inspector pane**
+
+A dynamic `Vertical` that inspects `selected_entity` and renders action buttons: Preview, Check now, Stage in Console, Delete.
+
+- [ ] **Step 2: Handle messages in shell**
+
+The shell listens for messages from panes (e.g., `SourceSelected`, `RunSelected`) and updates reactive state, which re-composes the inspector.
+
+- [ ] **Step 3: Run tests**
+
+```bash
+pytest Tests/UI/test_watchlists_inspector.py -v
+```
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tldw_chatbook/UI/Watchlists_Modules/inspector_pane.py tldw_chatbook/UI/Screens/watchlists_collections_screen.py Tests/UI/test_watchlists_inspector.py
+git commit -m "feat(watchlists): wire pane selection to inspector actions"
+```
+
+---
+
+### Task 14: App wiring and route cleanup
+
+**Files:**
+- Modify: `tldw_chatbook/Constants.py`
+- Modify: `tldw_chatbook/UI/Navigation/screen_registry.py`
+- Modify: `tldw_chatbook/UI/Workbench/route_inventory.py`
+- Modify: `tldw_chatbook/app.py`
+- Delete: `tldw_chatbook/UI/SubscriptionWindow.py`
+- Test: `Tests/UI/test_screen_navigation.py`, `Tests/UI/test_shell_destinations.py`
+
+**Goal:** Retire `SubscriptionWindow`, fold `subscriptions` route into the new screen.
+
+- [ ] **Step 1: Update Constants**
+
+Remove `TAB_SUBSCRIPTIONS` from `ALL_TABS` and `TAB_DISPLAY_LABELS`, or repurpose the tab label to point to Watchlists. Keep the constant itself if other code references it, but update `ALL_TABS` so the tab bar does not show a separate Subscriptions tab.
+
+- [ ] **Step 2: Update screen_registry**
+
+Remove the `subscriptions` route entry; keep the alias in `screen_registry._SCREEN_ALIASES` mapping `subscriptions -> watchlists_collections`.
+
+- [ ] **Step 3: Update shell_destinations**
+
+Already maps `subscriptions` to `watchlists_collections`; no change needed.
+
+- [ ] **Step 4: Update route_inventory**
+
+Ensure `subscriptions` and `subscription` owners map to `watchlists_collections`.
+
+- [ ] **Step 5: Update app.py**
+
+- Remove the `TAB_SUBSCRIPTIONS` event handler map entry around line 4347.
+- Update `_stage_subscription_watchlist_run_context` to set pending state on the new screen (e.g., `pending_watchlists_section = "runs"`, `pending_watchlists_run_id`).
+- Remove import of `SubscriptionWindow`.
+
+- [ ] **Step 6: Delete SubscriptionWindow**
+
+```bash
+rm tldw_chatbook/UI/SubscriptionWindow.py
+```
+
+- [ ] **Step 7: Run navigation tests**
+
+```bash
+pytest Tests/UI/test_screen_navigation.py Tests/UI/test_shell_destinations.py -v
+```
+Expected: PASS after test updates.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tldw_chatbook/Constants.py tldw_chatbook/UI/Navigation/screen_registry.py tldw_chatbook/UI/Workbench/route_inventory.py tldw_chatbook/app.py
+git rm tldw_chatbook/UI/SubscriptionWindow.py
+git commit -m "feat(watchlists): retire SubscriptionWindow and fold subscriptions route into Watchlists"
+```
+
+---
+
+### Task 15: Slice 1A integration regression
+
+**Files:** all Slice 1A files.
+
+**Goal:** Verify the screen works end-to-end locally.
+
+- [ ] **Step 1: Run focused test suite**
+
+```bash
+pytest Tests/Watchlists Tests/UI/test_watchlists_destination_shell.py Tests/UI/test_watchlists_sources.py Tests/UI/test_watchlists_runs.py Tests/UI/test_watchlists_inspector.py -v
+```
+Expected: PASS.
+
+- [ ] **Step 2: Manual smoke**
+
+```bash
+python3 -m tldw_chatbook.app
+```
+Navigate to Watchlists, confirm Overview/Sources/Runs render and backend toggle works.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -m "feat(watchlists): complete Slice 1A integration"
+```
+
+---
+
+## Phase 3: Slice 1B UI — Items, Rules, filters, OPML, preview, Check now
+
+### Task 16: Extend controller with preview/check-now/OPML
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Watchlists_Modules/watchlists_backend_controller.py`
+- Test: `Tests/Watchlists/test_watchlists_backend_controller.py` (extend)
+
+**Goal:** Route preview, check-now, OPML, and item/rule operations.
+
+- [ ] **Step 1: Add methods**
+
+```python
+async def preview_source(self, *, runtime_backend, source_config):
+    backend = self._normalize_backend(runtime_backend)
+    if backend == "local":
+        from ...Subscriptions.watchlist_preview_service import WatchlistPreviewService
+        return await WatchlistPreviewService().preview(source_config)
+    # server
+    client = self.server_service._require_client()
+    return await client.test_watchlist_source(source_config)
+
+async def check_now_source(self, *, runtime_backend, source_id):
+    backend = self._normalize_backend(runtime_backend)
+    if backend == "local":
+        return await self.launch_run(runtime_backend=backend, source_id=source_id)
+    client = self.server_service._require_client()
+    return await client.check_watchlist_sources_now([int(source_id)])
+
+async def import_opml(self, *, runtime_backend, xml_text):
+    backend = self._normalize_backend(runtime_backend)
+    if backend == "local":
+        from ...Subscriptions.watchlist_opml_service import WatchlistOpmlService
+        items = WatchlistOpmlService().parse(xml_text)
+        created = []
+        for item in items:
+            created.append(await self.create_source(runtime_backend=backend, payload=item))
+        return {"items": created, "total": len(items), "created": len(created)}
+    client = self.server_service._require_client()
+    return await client.import_watchlist_sources(xml_text)
+
+async def export_opml(self, *, runtime_backend):
+    backend = self._normalize_backend(runtime_backend)
+    if backend == "local":
+        sources = await self.list_sources(runtime_backend=backend)
+        from ...Subscriptions.watchlist_opml_service import WatchlistOpmlService
+        return WatchlistOpmlService().export(sources)
+    client = self.server_service._require_client()
+    return await client.export_watchlist_sources()
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+pytest Tests/Watchlists/test_watchlists_backend_controller.py -v
+```
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tldw_chatbook/UI/Watchlists_Modules/watchlists_backend_controller.py Tests/Watchlists/test_watchlists_backend_controller.py
+git commit -m "feat(watchlists): extend backend controller with preview, check-now, and OPML"
+```
+
+---
+
+### Task 17: Add filter editor to Sources pane
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Watchlists_Modules/sources_pane.py`
+- Test: `Tests/Watchlists/test_watchlists_sources_pane.py` (extend)
+
+**Goal:** Edit `include`/`exclude`/`flag` filters in priority order.
+
+- [ ] **Step 1: Implement filter editor**
+
+Add a collapsible section or modal with a `DataTable` of filters and a form: type (keyword/regex), pattern, action, priority.
+On save, insert/update a `subscription_filters` row via `SubscriptionsDB` directly or through a new controller method.
+
+- [ ] **Step 2: Run tests**
+
+```bash
+pytest Tests/Watchlists/test_watchlists_sources_pane.py -v
+```
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tldw_chatbook/UI/Watchlists_Modules/sources_pane.py Tests/Watchlists/test_watchlists_sources_pane.py
+git commit -m "feat(watchlists): add source-level filter editor"
+```
+
+---
+
+### Task 18: Add preview and Check now actions to Sources pane
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Watchlists_Modules/sources_pane.py`
+- Modify: `tldw_chatbook/UI/Watchlists_Modules/inspector_pane.py`
+- Test: `Tests/Watchlists/test_watchlists_sources_pane.py`
+
+**Goal:** User can dry-run a source and trigger a real run.
+
+- [ ] **Step 1: Wire actions**
+
+- "Preview" calls `controller.preview_source(source_config)` and shows candidate items in a modal/Static.
+- "Check now" calls `controller.check_now_source(source_id)` and switches to Runs section.
+
+- [ ] **Step 2: Run tests**
+
+```bash
+pytest Tests/Watchlists/test_watchlists_sources_pane.py::test_preview_action Tests/Watchlists/test_watchlists_sources_pane.py::test_check_now_action -v
+```
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tldw_chatbook/UI/Watchlists_Modules/sources_pane.py tldw_chatbook/UI/Watchlists_Modules/inspector_pane.py Tests/Watchlists/test_watchlists_sources_pane.py
+git commit -m "feat(watchlists): add source preview and check-now actions"
+```
+
+---
+
+### Task 19: Add OPML import/export UI
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Watchlists_Modules/sources_pane.py`
+- Test: `Tests/Watchlists/test_watchlists_sources_pane.py`
+
+**Goal:** Buttons to import OPML from clipboard/file and export to clipboard.
+
+- [ ] **Step 1: Implement**
+
+Use Textual `Input` (paste XML) or a file picker if available. Call controller `import_opml` / `export_opml`.
+
+- [ ] **Step 2: Run tests**
+
+```bash
+pytest Tests/Watchlists/test_watchlists_sources_pane.py -k opml -v
+```
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tldw_chatbook/UI/Watchlists_Modules/sources_pane.py Tests/Watchlists/test_watchlists_sources_pane.py
+git commit -m "feat(watchlists): add OPML import/export actions"
+```
+
+---
+
+### Task 20: Implement Items pane
+
+**Files:**
+- Create: `tldw_chatbook/UI/Watchlists_Modules/items_pane.py`
+- Test: `Tests/Watchlists/test_watchlists_items_pane.py`
+
+**Goal:** Global item reader with smart counts, batch review, queue for briefing.
+
+- [ ] **Step 1: Implement**
+
+Build a three-column pane:
+- Left: source list filter.
+- Middle: `DataTable` of items with smart filters (All/Today/Unread/Queued/Alert matches) and counts.
+- Right inspector: item preview, mark reviewed, queue toggle, open external, discuss in Console.
+Batch controls appear on selection.
+Use `subscription_items` queries via controller.
+
+- [ ] **Step 2: Run tests**
+
+```bash
+pytest Tests/Watchlists/test_watchlists_items_pane.py -v
+```
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tldw_chatbook/UI/Watchlists_Modules/items_pane.py Tests/Watchlists/test_watchlists_items_pane.py
+git commit -m "feat(watchlists): add items reader pane"
+```
+
+---
+
+### Task 21: Implement Alert Rules pane
+
+**Files:**
+- Create: `tldw_chatbook/UI/Watchlists_Modules/alert_rules_pane.py`
+- Test: `Tests/Watchlists/test_watchlists_alert_rules_pane.py`
+
+**Goal:** Health + content alert rule editor and alert inbox.
+
+- [ ] **Step 1: Implement**
+
+- Top: capability banner when server backend is active (content rules local-only).
+- Rule list with toggle, edit, delete.
+- Inline form: name, kind (health/content), condition type/pattern, severity, source scope.
+- Health rules use `WatchlistScopeService.save_alert_rule`.
+- Content rules write to `subscription_filters` with `action='notify'` via a small DB helper or controller method.
+- Alert inbox: list of recent alert notifications filtered to `source_domain='watchlists'`.
+
+- [ ] **Step 2: Run tests**
+
+```bash
+pytest Tests/Watchlists/test_watchlists_alert_rules_pane.py -v
+```
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tldw_chatbook/UI/Watchlists_Modules/alert_rules_pane.py Tests/Watchlists/test_watchlists_alert_rules_pane.py
+git commit -m "feat(watchlists): add alert rules and inbox pane"
+```
+
+---
+
+### Task 22: Final integration and full regression
+
+**Files:** all changed files.
+
+**Goal:** All tests pass and the screen is usable.
+
+- [ ] **Step 1: Run full watchlists test suite**
+
+```bash
+pytest Tests/Watchlists Tests/UI/test_watchlists_*.py -v
+```
+Expected: PASS.
+
+- [ ] **Step 2: Run related tests**
+
+```bash
+pytest Tests/Subscriptions/test_local_watchlists_service.py Tests/Subscriptions/test_watchlist_filter_service.py Tests/Subscriptions/test_watchlist_content_alert_service.py Tests/DB/test_subscriptions_db.py -v
+```
+Expected: PASS.
+
+- [ ] **Step 3: Manual smoke**
+
+```bash
+python3 -m tldw_chatbook.app
+```
+Walk through all five sections, toggle backend, create a source, check now, view run, view items, create a rule.
+
+- [ ] **Step 4: Update ADR / spec if needed**
+
+If any deviations occurred during implementation, update the spec and ADR.
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git commit -m "feat(watchlists): complete Slice 1B and full Watchlists screen"
+```
+
+---
+
+## Plan review
+
+After completing this plan, run a final review:
+
+```bash
+# Verify every new file is imported and lint-clean
+python -m compileall tldw_chatbook/UI/Watchlists_Modules tldw_chatbook/Subscriptions/watchlist_*.py
+pytest Tests/Watchlists Tests/UI/test_watchlists_*.py -q
+```
+
+**Note:** The spec review subagent hit an API quota before final approval. This plan should be reviewed by a human or a fresh subagent before execution. Pay special attention to:
+- Schema migration idempotency on existing user databases.
+- The `subscription_filters` action CHECK constraint migration.
+- Server backend content-alert rule gap (local-only in first slice).

--- a/Docs/superpowers/specs/2026-07-18-watchlists-tui-screen-design.md
+++ b/Docs/superpowers/specs/2026-07-18-watchlists-tui-screen-design.md
@@ -1,0 +1,316 @@
+# Watchlists TUI Screen Design
+
+Date: 2026-07-18  
+Status: Draft (pending spec review)  
+ADR: [backlog/decisions/018-watchlists-tui-screen.md](../../../backlog/decisions/018-watchlists-tui-screen.md)  
+Reference: `rmusser01/tldw_server` — `apps/packages/ui/src/components/Option/Watchlists` and `tldw_Server_API/app/core/Watchlists`
+
+## Summary
+
+Replace the placeholder `watchlists_collections` destination shell with a full Watchlists management screen. The new screen uses a three-pane destination workbench, supports both local and server backends, and provides Overview, Sources, Items, Runs, and Alert Rules sections. Jobs, Outputs, and Templates are deferred to later slices.
+
+## Goals
+
+- Manage watchlist sources (RSS, site, forum) with create/edit/delete, active toggle, and groups/tags.
+- View and consume scraped items with smart counts, batch review, and "queue for briefing".
+- Inspect runs: status, stats, filter tallies, fetched items, logs, and cancel/retry actions.
+- Create and manage both run-health and content alert rules, with alert notifications surfacing in the app inbox and Home dashboard.
+- Support source preview / dry-run and "Check now" actions.
+- Support OPML import/export for sources.
+- Work offline against local `SubscriptionsDB` and online against a connected `tldw_server` API.
+- Retire `SubscriptionWindow.py` and fold the `subscriptions` route into the new screen.
+
+## Non-goals
+
+- Jobs / scheduling UI (parallel Scheduling module migration).
+- Briefing output generation and template authoring (deferred).
+- Advanced source group editing (groups/tags remain read-only in the first slice).
+- Forum sources if disabled by server policy or local capability flags.
+- WebSocket live log streaming (poll run detail instead).
+
+## Architecture
+
+### Web UI → TUI mapping
+
+The `tldw_server` web UI uses a top tab bar with primary views. The TUI maps those views into a left-rail section navigator plus a three-pane workbench.
+
+```
+┌─ Watchlists ─ [Local ▼] ─ [New Source] ─ [Refresh] ─────────────┐
+│                                                                  │
+│ ┌────────┐ ┌────────────────────────────────┐ ┌──────────────┐ │
+│ │Overview│ │  Middle: Workbench             │ │ Right:       │ │
+│ │Sources │ │                                │ │ Inspector /  │ │
+│ │ Items  │ │  • Source list / form          │ │ Actions      │ │
+│ │ Runs   │ │  • Item reader                 │ │              │ │
+│ │ Rules  │ │  • Run inspector               │ │ Context-aware│ │
+│ │        │ │  • Alert editor / inbox        │ │ buttons:     │ │
+│ │        │ │                                │ │ Preview,     │ │
+│ └────────┘ └────────────────────────────────┘ │ Check now,   │ │
+│                                               │ Stage,       │ │
+│                                               │ Mark read,   │ │
+│                                               │ Delete, …    │ │
+└───────────────────────────────────────────────┴──────────────┘
+```
+
+| Web UI tab | TUI section | First-slice scope |
+|---|---|---|
+| Overview | **Overview** | Summary cards, health alerts, recent failed runs, latest briefing placeholder |
+| Feeds | **Sources** | Source CRUD, groups/tags read-only, OPML import/export, simple source-level filters, preview, Check now |
+| Updates | **Items** | Global item reader with smart counts, batch review, queue for briefing |
+| Activity | **Runs** | Run history, full run inspector (stats, items, tallies, logs), cancel/retry |
+| Alerts | **Rules** | Health + content alert rule editor; alert inbox |
+| Monitors | *deferred* | Jobs / scheduling |
+| Reports | *deferred* | Outputs and templates |
+
+### Module layout
+
+| Path | Role |
+|---|---|
+| `tldw_chatbook/UI/Screens/watchlists_collections_screen.py` | Thin shell; left rail, three panes, backend toggle, recovery state |
+| `tldw_chatbook/UI/Watchlists_Modules/__init__.py` | Package marker |
+| `tldw_chatbook/UI/Watchlists_Modules/watchlists_backend_controller.py` | Local/server authority switching, policy enforcement, unsupported-capability reporting |
+| `tldw_chatbook/UI/Watchlists_Modules/overview_pane.py` | Dashboard cards, health summary, recent failed runs |
+| `tldw_chatbook/UI/Watchlists_Modules/sources_pane.py` | Source list, create/edit form, filter editor, preview, OPML import/export |
+| `tldw_chatbook/UI/Watchlists_Modules/items_pane.py` | Item reader, smart counts, batch actions |
+| `tldw_chatbook/UI/Watchlists_Modules/runs_pane.py` | Run list, full run inspector |
+| `tldw_chatbook/UI/Watchlists_Modules/alert_rules_pane.py` | Rule editor + alert inbox |
+| `tldw_chatbook/Subscriptions/watchlist_filter_service.py` | Local source-level filter evaluation |
+| `tldw_chatbook/Subscriptions/watchlist_content_alert_service.py` | Local content-alert evaluation |
+| `tldw_chatbook/Subscriptions/local_watchlists_service.py` | Extended for content alerts, filters, scraped-item persistence, OPML import |
+
+### Backend split
+
+```
+WatchlistsBackendController
+├── local backend
+│   └── LocalWatchlistsService (extended)
+│       └── SubscriptionsDB
+└── server backend
+    └── ServerWatchlistsService
+        └── TLDWAPIClient
+```
+
+- Source CRUD, runs, and alert rules go through `WatchlistScopeService` (`app.watchlist_scope_service`).
+- Server-only operations (OPML server endpoints, group/tag read-only listing) call `app.server_watchlists_service` directly when server backend is active.
+- Local-only operations (content-alert evaluation, filter evaluation, OPML parsing) live in new local helper services.
+
+## Data flow
+
+1. Shell mounts → controller checks backend availability → panes load initial data via background workers.
+2. User selects a left-rail section → shell updates `active_section` reactive → workbench swaps pane.
+3. User selects an entity (source/run/item/rule) → shell updates `selected_entity` reactive → inspector pane updates.
+4. Mutations (create/update/delete/preview/check now) → pane calls controller method → controller routes to local/server service → worker executes → reactive state updates → UI refreshes.
+5. Run inspector opens a running run → starts a polling worker that refreshes run detail every 3–5 s until terminal.
+6. Alert rules trigger notifications via the existing `NotificationDispatchService`; payloads use `source_domain="watchlists"` so Home and the notifications inbox can route them.
+
+### Controller routing for backend-specific operations
+
+| Operation | Local backend | Server backend |
+|---|---|---|
+| List sources | `LocalWatchlistsService.list_sources` | `ServerWatchlistsService.list_sources` |
+| Source CRUD | `WatchlistScopeService.{create/update/delete}_watch_item` | `WatchlistScopeService.{create/update/delete}_watch_item` |
+| Preview source | Local fetchers without persistence (new helper) | `TLDWAPIClient.test_watchlist_source` / `test_watchlist_source_draft` |
+| Check now | `LocalWatchlistsService.launch_run` + `execute_run` | `TLDWAPIClient.check_watchlist_sources_now` |
+| List runs | `WatchlistScopeService.list_runs` | `WatchlistScopeService.list_runs` |
+| Run detail | `WatchlistScopeService.get_run` / `observe_run` | `WatchlistScopeService.get_run` / `observe_run` |
+| Run cancel | `LocalWatchlistsService.cancel_run` | `TLDWAPIClient.cancel_watchlist_run` |
+| Re-run | `LocalWatchlistsService.launch_run` + `execute_run` | `TLDWAPIClient.trigger_watchlist_run` (job-scoped; source-level via check-now) |
+| Health alert rules | `WatchlistScopeService.{list/create/update/delete}_alert_rule` | `WatchlistScopeService.{list/create/update/delete}_alert_rule` |
+| Content alert rules | `subscription_filters` with `action='notify'` | **Deferred** — server API content-alert endpoints are not yet wired in the Chatbook client |
+| OPML import | Local OPML parser + bulk create sources | `TLDWAPIClient.import_watchlist_sources` |
+| OPML export | Serialize sources to OPML | `TLDWAPIClient.export_watchlist_sources` |
+| List groups/tags | Read-only; not stored locally | `TLDWAPIClient.list_watchlist_groups` / `list_watchlist_tags` |
+
+Content alert rules are local-only in the first slice. The Rules pane shows a capability banner when the server backend is active, disabling content-rule creation with an explanation.
+
+> **Note:** The referenced `TLDWAPIClient` methods (`test_watchlist_source`, `check_watchlist_sources_now`, `import_watchlist_sources`, `export_watchlist_sources`, etc.) already exist in `tldw_chatbook/tldw_api/client.py`.
+
+### Local storage additions
+
+Reuse existing `SubscriptionsDB` tables where possible and extend them with the minimal columns needed for the new screen.
+
+**Schema migration plan**
+
+`SubscriptionsDB` currently initializes tables with `CREATE TABLE IF NOT EXISTS` and has no versioned migration runner. A new `_ensure_watchlists_schema` startup helper performs idempotent migrations:
+
+1. **Add missing columns** by inspecting `PRAGMA table_info` and running `ALTER TABLE ADD COLUMN` for any column not present.
+2. **Widen `subscription_filters.action` CHECK constraint.** SQLite cannot drop a CHECK constraint directly, so the helper:
+   - Creates a new `subscription_filters_new` table with the same columns but a widened CHECK constraint allowing `('auto_ingest','auto_ignore','tag','priority','notify','include','exclude','flag')`.
+   - Copies all rows from `subscription_filters`.
+   - Drops `subscription_filters` and renames `subscription_filters_new`.
+   - Recreates indexes/triggers.
+3. **Add indexes** for the new columns used in list queries:
+   - `CREATE INDEX IF NOT EXISTS idx_subscription_items_run_id ON subscription_items(run_id)`
+   - `CREATE INDEX IF NOT EXISTS idx_subscription_items_queued ON subscription_items(queued_for_briefing, status)`
+
+| Table | Column | Type | Purpose |
+|---|---|---|---|
+| `subscription_items` | `queued_for_briefing` | `BOOLEAN DEFAULT 0` | Queue item for future briefing output |
+| `subscription_items` | `run_id` | `INTEGER` | Link item to the run that produced it (no FK, because `local_watchlist_runs` is created lazily) |
+| `subscription_items` | `alert_matches` | `TEXT` | JSON array of matched local content-alert rule IDs |
+| `subscription_filters` | `priority` | `INTEGER DEFAULT 0` | Filter ordering |
+| `subscription_filters` | `is_include_required` | `BOOLEAN DEFAULT 0` | Include-only gating |
+
+**Filter and content-alert rule storage**
+
+After the migration, `subscription_filters.action` allows:
+
+- Legacy automatic-processing actions: `auto_ingest`, `auto_ignore`, `tag`, `priority`, `notify`.
+- New source-level filter actions: `include`, `exclude`, `flag`.
+
+Source-level filters use `include`/`exclude`/`flag` directly. Content-alert rules are stored as filters with `action = 'notify'` and a `severity` value in `action_params`; `severity` acts as the discriminator between legacy notification filters and new content-alert rules.
+
+Filter type/mode/pattern (keyword/regex/author/date_range) is stored in `conditions` JSON. Example `conditions` rows:
+
+- `{"type": "keyword", "mode": "contains", "pattern": "AI"}`
+- `{"type": "regex", "pattern": "^Breaking:"}`
+
+**Run-health rules**
+
+Keep `local_watchlist_alert_rules` for run-health alert rules only (no schema change).
+
+**Execution flow in `LocalWatchlistsService.execute_run`**
+
+1. Fetch items.
+2. Apply source-level filters (`subscription_filters` with `action IN ('include','exclude','flag')`) in priority order.
+3. Evaluate local content-alert rules (`subscription_filters` with `action = 'notify'`) per item; store matched rule IDs in `alert_matches`.
+4. Persist items to `subscription_items` using `INSERT … ON CONFLICT(subscription_id, url, content_hash) DO UPDATE`:
+   - Update `run_id` to the current run.
+   - Update `alert_matches` to the newly evaluated matches.
+   - Preserve existing `status` if it is already `reviewed` or `ignored`; otherwise set to `new`.
+5. Evaluate run-health rules (`local_watchlist_alert_rules`) and dispatch notifications.
+
+**Source active toggle on create**
+
+Extend `LocalWatchlistsService.create_source` to honor an `active` boolean in the payload (default `True`), matching the server `SourceCreateRequest` shape.
+
+**Local re-run action**
+
+The UI calls `WatchlistScopeService.launch_run(source_id=…)`. For the local backend, `WatchlistScopeService.launch_run` already calls `LocalWatchlistsService.launch_run` and then `execute_run` in the same flow, so the UI does not need to invoke `execute_run` separately.
+
+## UI Layout Details
+
+### Overview section
+
+```
+┌─ Latest Briefing ─┐ ┌─ Health ──────┐ ┌─ Attention Needed ────────┐
+│ Run #123 running  │ │ System healthy│ │ 2 feeds need review       │
+│ Next: 14:00       │ │               │ │ 1 failed run              │
+└───────────────────┘ └───────────────┘ └───────────────────────────┘
+┌─ Feeds ─┐ ┌─ Updates ─┐ ┌─ Activity ───────────────┐
+│ 12 total│ │ 7 unread  │ │ 1 running / 0 pending    │
+└─────────┘ └───────────┘ └──────────────────────────┘
+Recent Failed Runs
+• Monitor #4  FAILED  2m ago  Connection timeout  [View run]
+```
+
+### Sources section
+
+- Left part of workbench: search, type filter, group tree, tag filter.
+- Main area: sources `DataTable` with columns Name, Type, Status, Last scraped, Active toggle, Actions.
+- Actions per row: Edit, Health/Seen drawer, Clone, Delete, Check now.
+- Bulk action bar when rows selected.
+- Form modal/inline for create/edit.
+- Filter editor: include/exclude/flag rules with keyword/regex matcher, priority order.
+
+### Items section
+
+- Smart filters with counts: All / Today / Today unread / Unread / Reviewed / Queued / Alert matches.
+  - `Alert matches` is derived from `subscription_items.alert_matches` JSON, populated during local run execution.
+- Source list (left) and item list (middle) with item detail/preview (right inspector).
+- Batch controls: mark selected/page/all filtered as reviewed; queue/dequeue for briefing.
+- Item actions: open external link, discuss in Console, mark reviewed, queue.
+
+### Runs section
+
+- Runs `DataTable`: Source/Job, Status, Started, Duration, Found, Processed, Filtered, Errors, Actions.
+- Attention alert for failed/stalled runs.
+- Run detail inspector (right pane):
+  - Statistics: status, duration, counts, failure remediation.
+  - Items tab: paginated items from this run.
+  - Log tab: `log_text` from run detail, with poll indicator.
+  - Actions: **Re-run** (re-launch the same source/job via existing `launch_run`), cancel, export tallies. True "retry" that preserves the exact run configuration is deferred.
+
+### Rules section
+
+- Info boundary explaining health vs content alerts.
+- Rule list with severity/kind tags, enable toggle, edit/delete.
+- Inline rule form: name, kind, match mode, pattern, severity, source scope.
+- Alert inbox: filters by status/severity/rule/source; cards with mark read/unread/dismiss.
+
+## Error Handling
+
+- Use a **screen-level recovery state** (consistent with the current placeholder) for backend/service-level errors.
+- Policy denials use the existing `DestinationRecoveryState` / `policy_denied_recovery_state` pattern.
+- Background workers use `@work(exclusive=True)` per pane to prevent duplicate fetches.
+- Pass a backend token into each worker; ignore results if the user switched backends while the worker was in flight.
+- Service exceptions are caught in the controller and converted to user-facing messages.
+- Form validation errors appear inline next to fields.
+- Polling workers stop when a run reaches a terminal status or the user leaves the Runs section.
+
+## Testing Plan
+
+### Unit tests
+
+| Test file | Coverage |
+|---|---|
+| `Tests/Watchlists/test_watchlists_backend_controller.py` | Backend switching, policy enforcement, unsupported capabilities, error conversion |
+| `Tests/Watchlists/test_watchlists_sources_pane.py` | List filtering, form validation, preview/check-now wiring, OPML parsing |
+| `Tests/Watchlists/test_watchlists_runs_pane.py` | Run list refresh, inspector binding, cancel/retry guards |
+| `Tests/Watchlists/test_watchlists_items_pane.py` | Smart-count filtering, batch review, item row actions |
+| `Tests/Watchlists/test_watchlists_alert_rules_pane.py` | Health/content rule forms, rule toggle, inbox filters |
+
+### Service/DB tests
+
+| Test file | Coverage |
+|---|---|
+| `Tests/Subscriptions/test_local_watchlists_service.py` (extended) | Content-alert evaluation, filter evaluation, scraped-item persistence, run stats |
+| `Tests/Subscriptions/test_watchlist_filter_service.py` | Include/exclude/flag matching |
+| `Tests/Subscriptions/test_watchlist_content_alert_service.py` | Pattern matching, severity, notification payload |
+
+### UI integration tests
+
+| Test file | Coverage |
+|---|---|
+| `Tests/UI/test_watchlists_destination_shell.py` | Empty/error/recovery states, backend toggle, section switching, Console handoff |
+| `Tests/UI/test_watchlists_sources.py` | CRUD, OPML import, preview |
+| `Tests/UI/test_watchlists_runs.py` | List refresh, inspector, cancel |
+| `Tests/UI/test_watchlists_items.py` | Filters, mark reviewed, queue |
+| `Tests/UI/test_watchlists_alert_rules.py` | Create rules, inbox surfacing |
+
+### Fixtures
+
+- Reuse existing Textual `pilot` fixtures.
+- Add `Tests/fixtures/watchlists/sample.opml` for import tests.
+- Use an in-memory `SubscriptionsDB` factory for service tests.
+
+## Migration / Cleanup
+
+- Delete `tldw_chatbook/UI/SubscriptionWindow.py`.
+- Remove `subscriptions` route from `screen_registry.py`; keep it as a shell alias in `shell_destinations.py` pointing to `watchlists_collections`.
+- Update `route_inventory.py` owner mapping if needed.
+- Review `tldw_chatbook/Constants.py` (`TAB_SUBSCRIPTIONS`, `ALL_TABS`, `TAB_DISPLAY_LABELS`) and remove or repurpose as appropriate.
+- Update `tldw_chatbook/app.py` references:
+  - `TAB_SUBSCRIPTIONS` binding/tooltip.
+  - `pending_subscription_initial_tab` and `_stage_subscription_watchlist_run_context` staging logic should target the new Watchlists screen route.
+  - Subscription button event-handler map around line 4347 should be removed or migrated to the new screen's pane actions.
+- Remove or rewrite focused subscription UI tests.
+
+## Decisions / Resolved Questions
+
+1. **Sub-slice split** — Yes, the first slice is split into two reviewable sub-slices:
+   - **Slice 1A**: Overview, Sources, Runs (core management and run inspection).
+   - **Slice 1B**: Items reader, Alert Rules, source-level filters, OPML import/export, Preview, and Check now.
+2. **Content-alert rule storage** — Reuse `subscription_filters` with `action = 'notify'` and store severity in `action_params`. Run-health rules remain in `local_watchlist_alert_rules`.
+3. **Scraped-item storage** — Reuse `subscription_items`; add `queued_for_briefing` and `run_id` columns.
+4. **Server content-alert rules** — Deferred. The Chatbook client does not yet expose the server's content-alert endpoints, so content rules are local-only in Slice 1B with a backend-capability banner.
+
+## Related Files
+
+- `tldw_chatbook/UI/Screens/watchlists_collections_screen.py`
+- `tldw_chatbook/Subscriptions/local_watchlists_service.py`
+- `tldw_chatbook/Subscriptions/server_watchlists_service.py`
+- `tldw_chatbook/Subscriptions/watchlist_scope_service.py`
+- `tldw_chatbook/UI/Navigation/shell_destinations.py`
+- `tldw_chatbook/UI/Navigation/screen_registry.py`
+- `tldw_chatbook/UI/Workbench/route_inventory.py`

--- a/Tests/Scheduling/test_server_client.py
+++ b/Tests/Scheduling/test_server_client.py
@@ -1,0 +1,56 @@
+import pytest
+
+from tldw_chatbook.Scheduling.services.server_client import (
+    SchedulingServerClient,
+    ServerUnavailableError,
+)
+
+
+class FakeNotificationsService:
+    def __init__(self):
+        self.client = object()
+        self.calls = []
+
+    async def create_reminder(self, **payload):
+        self.calls.append(("create_reminder", payload))
+        return {"id": "task-1", "title": payload.get("title")}
+
+    async def update_reminder(self, task_id, **payload):
+        self.calls.append(("update_reminder", task_id, payload))
+        return {"id": task_id, **payload}
+
+    async def delete_reminder(self, task_id):
+        self.calls.append(("delete_reminder", task_id))
+        return {"deleted": True}
+
+    async def list_reminders(self):
+        self.calls.append(("list_reminders",))
+        return {"items": [{"id": "task-1"}], "total": 1}
+
+    async def get_reminder(self, task_id):
+        self.calls.append(("get_reminder", task_id))
+        return {"id": task_id}
+
+
+@pytest.mark.asyncio
+async def test_create_reminder_delegates_to_notifications_service():
+    service = FakeNotificationsService()
+    client = SchedulingServerClient(notifications_service=service)
+
+    result = await client.create_reminder(title="Test", schedule_kind="one_time", run_at="2026-04-24T12:00:00Z")
+
+    assert result == {"id": "task-1", "title": "Test"}
+    assert service.calls == [
+        (
+            "create_reminder",
+            {"title": "Test", "schedule_kind": "one_time", "run_at": "2026-04-24T12:00:00Z"},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_unavailable_client_raises_server_unavailable_error():
+    client = SchedulingServerClient(notifications_service=None)
+
+    with pytest.raises(ServerUnavailableError, match="server not available"):
+        await client.create_reminder(title="Test", schedule_kind="one_time")

--- a/Tests/Scheduling/test_server_client.py
+++ b/Tests/Scheduling/test_server_client.py
@@ -1,14 +1,10 @@
 import pytest
 
-from tldw_chatbook.Scheduling.services.server_client import (
-    SchedulingServerClient,
-    ServerUnavailableError,
-)
+from tldw_chatbook.Scheduling.services import SchedulingServerClient, ServerUnavailableError
 
 
 class FakeNotificationsService:
     def __init__(self):
-        self.client = object()
         self.calls = []
 
     async def create_reminder(self, **payload):
@@ -32,11 +28,18 @@ class FakeNotificationsService:
         return {"id": task_id}
 
 
-@pytest.mark.asyncio
-async def test_create_reminder_delegates_to_notifications_service():
-    service = FakeNotificationsService()
-    client = SchedulingServerClient(notifications_service=service)
+@pytest.fixture
+def service():
+    return FakeNotificationsService()
 
+
+@pytest.fixture
+def client(service):
+    return SchedulingServerClient(notifications_service=service)
+
+
+@pytest.mark.asyncio
+async def test_create_reminder_delegates_to_notifications_service(client, service):
     result = await client.create_reminder(title="Test", schedule_kind="one_time", run_at="2026-04-24T12:00:00Z")
 
     assert result == {"id": "task-1", "title": "Test"}
@@ -49,8 +52,51 @@ async def test_create_reminder_delegates_to_notifications_service():
 
 
 @pytest.mark.asyncio
-async def test_unavailable_client_raises_server_unavailable_error():
+async def test_update_reminder_delegates_to_notifications_service(client, service):
+    result = await client.update_reminder("task-1", title="Updated")
+
+    assert result == {"id": "task-1", "title": "Updated"}
+    assert service.calls == [("update_reminder", "task-1", {"title": "Updated"})]
+
+
+@pytest.mark.asyncio
+async def test_delete_reminder_delegates_to_notifications_service(client, service):
+    result = await client.delete_reminder("task-1")
+
+    assert result == {"deleted": True}
+    assert service.calls == [("delete_reminder", "task-1")]
+
+
+@pytest.mark.asyncio
+async def test_list_reminders_delegates_to_notifications_service(client, service):
+    result = await client.list_reminders()
+
+    assert result == {"items": [{"id": "task-1"}], "total": 1}
+    assert service.calls == [("list_reminders",)]
+
+
+@pytest.mark.asyncio
+async def test_get_reminder_delegates_to_notifications_service(client, service):
+    result = await client.get_reminder("task-1")
+
+    assert result == {"id": "task-1"}
+    assert service.calls == [("get_reminder", "task-1")]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "method_name,args,kwargs",
+    [
+        ("create_reminder", [], {"title": "Test", "schedule_kind": "one_time"}),
+        ("update_reminder", ["task-1"], {"title": "Updated"}),
+        ("delete_reminder", ["task-1"], {}),
+        ("list_reminders", [], {}),
+        ("get_reminder", ["task-1"], {}),
+    ],
+)
+async def test_unavailable_client_raises_server_unavailable_error(method_name, args, kwargs):
     client = SchedulingServerClient(notifications_service=None)
 
+    method = getattr(client, method_name)
     with pytest.raises(ServerUnavailableError, match="server not available"):
-        await client.create_reminder(title="Test", schedule_kind="one_time")
+        await method(*args, **kwargs)

--- a/Tests/UI/test_enhanced_file_dialog_mount.py
+++ b/Tests/UI/test_enhanced_file_dialog_mount.py
@@ -467,6 +467,24 @@ async def test_directory_change_updates_breadcrumbs_and_bookmark_button(tmp_path
 
 
 @pytest.mark.asyncio
+async def test_legacy_list_filters_are_normalized(tmp_path):
+    """A list of glob strings can be passed as ``filters`` without crashing."""
+    dialog = EnhancedFileOpen(
+        location=str(tmp_path),
+        title="Test Legacy Filters",
+        filters=["*.zip"],
+        context="test_legacy_filters",
+    )
+    app = _DialogHost(dialog)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        # The dialog should mount and expose the filter Select.
+        select = dialog.query_one("#file-filter")
+        assert select is not None
+
+
+@pytest.mark.asyncio
 async def test_open_must_exist_rejects_missing_file(tmp_path):
     """EnhancedFileOpen with must_exist=True refuses a non-existent filename."""
     dialog = EnhancedFileOpen(

--- a/Tests/UI/test_enhanced_file_dialog_mount.py
+++ b/Tests/UI/test_enhanced_file_dialog_mount.py
@@ -19,6 +19,7 @@ from tldw_chatbook.Third_Party.textual_fspicker.base_dialog import Dialog
 from tldw_chatbook.Widgets.enhanced_file_picker import (
     EnhancedFileOpen,
     EnhancedFileSave,
+    MultiSelectDirectoryEntry,
     SearchableDirectoryNavigation,
 )
 
@@ -317,6 +318,112 @@ async def test_cancel_dismisses_with_none(tmp_path):
         result.append(app._result)
 
     assert result[0] is None
+
+
+@pytest.mark.asyncio
+async def test_multi_select_hides_filename_input(tmp_path):
+    """Multi-select mode does not render the single-filename input."""
+    dialog = EnhancedFileOpen(
+        location=str(tmp_path),
+        title="Test Multi Select UI",
+        multi_select=True,
+        context="test_multi_select_ui",
+    )
+    app = _DialogHost(dialog)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        with pytest.raises(Exception):
+            dialog.query_one("#filename-input", Input)
+
+
+@pytest.mark.asyncio
+async def test_multi_select_toggles_and_returns_list(tmp_path):
+    """Multi-select mode returns a list of selected files."""
+    file_a = tmp_path / "alpha.txt"
+    file_b = tmp_path / "beta.txt"
+    file_a.write_text("a")
+    file_b.write_text("b")
+
+    dialog = EnhancedFileOpen(
+        location=str(tmp_path),
+        title="Test Multi Select",
+        multi_select=True,
+        context="test_multi_select",
+    )
+    app = _DialogHost(dialog)
+    result = []
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        dir_nav = dialog.query_one(SearchableDirectoryNavigation)
+        for _ in range(20):
+            if dir_nav.option_count > 0:
+                break
+            await pilot.pause()
+
+        # Find the two files in the option list.
+        indices = {}
+        for index in range(dir_nav.option_count):
+            option = dir_nav.get_option_at_index(index)
+            if option.location == file_a:
+                indices["alpha"] = index
+            elif option.location == file_b:
+                indices["beta"] = index
+        assert "alpha" in indices and "beta" in indices
+
+        # Toggle both files via Space/action_toggle_selection.
+        for key in ("alpha", "beta"):
+            dir_nav.highlighted = indices[key]
+            await pilot.pause()
+            dialog.action_toggle_selection()
+            await pilot.pause()
+            option = dir_nav.get_option_at_index(indices[key])
+            assert isinstance(option, MultiSelectDirectoryEntry)
+            assert option.selected is True
+
+        dialog.query_one("#select").press()
+        await pilot.pause()
+        result.append(app._result)
+
+    assert isinstance(result[0], list)
+    assert set(result[0]) == {file_a, file_b}
+
+
+@pytest.mark.asyncio
+async def test_type_ahead_jumps_to_file_prefix(tmp_path):
+    """Typing a letter in the directory list jumps to the matching file."""
+    alpha = tmp_path / "alpha.txt"
+    beta = tmp_path / "beta.txt"
+    alpha.write_text("a")
+    beta.write_text("b")
+
+    dialog = EnhancedFileOpen(
+        location=str(tmp_path),
+        title="Test Type Ahead",
+        context="test_type_ahead",
+    )
+    app = _DialogHost(dialog)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        dir_nav = dialog.query_one(SearchableDirectoryNavigation)
+        for _ in range(20):
+            if dir_nav.option_count > 0:
+                break
+            await pilot.pause()
+
+        dir_nav.focus()
+        await pilot.pause()
+        # Jump to the file whose name starts with "b".
+        await pilot.press("b")
+        await pilot.pause()
+
+        assert dir_nav.highlighted is not None
+        option = dir_nav.get_option_at_index(dir_nav.highlighted)
+        assert option.location.name.startswith("b")
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_enhanced_file_dialog_mount.py
+++ b/Tests/UI/test_enhanced_file_dialog_mount.py
@@ -427,6 +427,46 @@ async def test_type_ahead_jumps_to_file_prefix(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_directory_change_updates_breadcrumbs_and_bookmark_button(tmp_path):
+    """Changing directory refreshes breadcrumbs and the bookmark button state."""
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+
+    dialog = EnhancedFileOpen(
+        location=str(tmp_path),
+        title="Test Directory Change",
+        context="test_dir_change",
+    )
+    app = _DialogHost(dialog)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        dir_nav = dialog.query_one(SearchableDirectoryNavigation)
+        for _ in range(20):
+            if dir_nav.option_count > 0:
+                break
+            await pilot.pause()
+
+        # Sanity check: initial breadcrumbs show the starting directory.
+        initial_breadcrumbs = [str(btn.label) for btn in dialog.query("#path-breadcrumbs Button")]
+        assert tmp_path.name in initial_breadcrumbs or "🏠" in initial_breadcrumbs
+
+        # Navigate into the subdirectory.
+        dir_nav.location = subdir
+        await pilot.pause()
+        await pilot.pause()
+
+        # Breadcrumbs should now include the subdirectory name.
+        breadcrumbs = [str(btn.label) for btn in dialog.query("#path-breadcrumbs Button")]
+        assert "subdir" in breadcrumbs, f"Expected 'subdir' in breadcrumbs, got {breadcrumbs}"
+
+        # The bookmark button tooltip should reflect the new path (even if not bookmarked).
+        add_bookmark = dialog.query_one("#add-bookmark")
+        assert add_bookmark.tooltip is not None
+
+
+@pytest.mark.asyncio
 async def test_open_must_exist_rejects_missing_file(tmp_path):
     """EnhancedFileOpen with must_exist=True refuses a non-existent filename."""
     dialog = EnhancedFileOpen(

--- a/Tests/UI/test_enhanced_file_dialog_mount.py
+++ b/Tests/UI/test_enhanced_file_dialog_mount.py
@@ -1,0 +1,346 @@
+"""Mount/smoke tests for the refactored enhanced file picker.
+
+These tests push ``EnhancedFileOpen`` and ``EnhancedFileSave`` through a
+Textual pilot and verify that:
+
+* the dialogs mount without ``MountError``/``QueryError``,
+* the base layout IDs the hooks rely on are present,
+* the recent/bookmarks panels and search input can be toggled without crashing.
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Input
+
+from tldw_chatbook.Third_Party.textual_fspicker import Filters
+from tldw_chatbook.Third_Party.textual_fspicker.base_dialog import Dialog
+from tldw_chatbook.Widgets.enhanced_file_picker import (
+    EnhancedFileOpen,
+    EnhancedFileSave,
+    SearchableDirectoryNavigation,
+)
+
+
+def _make_filters() -> Filters:
+    return Filters(
+        ("All Files", lambda _path: True),
+    )
+
+
+class _DialogHost(App[None]):
+    """Minimal host that immediately pushes the dialog under test."""
+
+    def __init__(self, dialog):
+        super().__init__()
+        self._dialog = dialog
+        self._result: object = None
+
+    def compose(self) -> ComposeResult:
+        yield from ()
+
+    async def on_mount(self) -> None:
+        def _capture(result):
+            self._result = result
+            self.exit()
+
+        await self.push_screen(self._dialog, callback=_capture)
+
+
+@pytest.mark.asyncio
+async def test_enhanced_file_open_mounts_and_widgets_exist():
+    dialog = EnhancedFileOpen(
+        location=".",
+        title="Test Open",
+        filters=_make_filters(),
+        context="test_open",
+    )
+    app = _DialogHost(dialog)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        # Base layout IDs required by the hooks must exist.
+        assert dialog.query_one("#path-breadcrumbs") is not None
+        assert dialog.query_one("#recent-list") is not None
+        assert dialog.query_one("#bookmarks-panel") is not None
+        assert dialog.query_one("#bookmarks-list") is not None
+        assert dialog.query_one("#search-input") is not None
+        assert dialog.query_one(SearchableDirectoryNavigation) is not None
+        assert dialog.query_one("#select") is not None
+        assert dialog.query_one("#cancel") is not None
+
+        # Panels and search should toggle without error.
+        dialog.action_show_recent()
+        await pilot.pause()
+        dialog.action_toggle_bookmarks()
+        await pilot.pause()
+        dialog.action_focus_search()
+        await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_enhanced_file_save_mounts_and_widgets_exist():
+    dialog = EnhancedFileSave(
+        location=".",
+        title="Test Save",
+        filters=_make_filters(),
+        default_filename="test.txt",
+        context="test_save",
+    )
+    app = _DialogHost(dialog)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        assert dialog.query_one("#path-breadcrumbs") is not None
+        assert dialog.query_one("#recent-list") is not None
+        assert dialog.query_one("#bookmarks-panel") is not None
+        assert dialog.query_one("#bookmarks-list") is not None
+        assert dialog.query_one("#search-input") is not None
+        assert dialog.query_one(SearchableDirectoryNavigation) is not None
+        assert dialog.query_one("#select") is not None
+        assert dialog.query_one("#cancel") is not None
+
+        dialog.action_show_recent()
+        await pilot.pause()
+        dialog.action_toggle_bookmarks()
+        await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_search_filter_filters_directory_entries():
+    """Search input updates ``SearchableDirectoryNavigation.search_filter``."""
+    dialog = EnhancedFileOpen(
+        location=".",
+        title="Test Search",
+        context="test_search",
+    )
+    app = _DialogHost(dialog)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        dir_nav = dialog.query_one(SearchableDirectoryNavigation)
+        search_input = dialog.query_one("#search-input")
+
+        # Typing a query that almost certainly does not match every entry.
+        search_input.value = "__unlikely_name__"
+        await pilot.pause()
+        assert dir_nav.search_filter == "__unlikely_name__"
+
+        # Clearing the search resets the filter.
+        dialog.query_one("#clear-search").press()
+        await pilot.pause()
+        assert dir_nav.search_filter == ""
+
+
+@pytest.mark.asyncio
+async def test_selecting_file_populates_filename_input(tmp_path):
+    """Selecting a file in the directory list fills the filename input.
+
+    Regression guard for the filename-input ambiguity bug: the dialog
+    contains ``#path-input``, ``#search-input``, and the filename input, so
+    ``query_one(Input)`` is ambiguous. Selecting a file must populate the
+    filename input, not one of the other inputs.
+    """
+    test_file = tmp_path / "sample_file.txt"
+    test_file.write_text("hello")
+
+    dialog = EnhancedFileOpen(
+        location=str(tmp_path),
+        title="Test Select File",
+        context="test_select_file",
+    )
+    app = _DialogHost(dialog)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        dir_nav = dialog.query_one(SearchableDirectoryNavigation)
+        # Wait for the directory navigation worker to populate the list.
+        for _ in range(20):
+            if dir_nav.option_count > 0:
+                break
+            await pilot.pause()
+
+        # Find the option that corresponds to our test file.
+        file_index = None
+        for index in range(dir_nav.option_count):
+            option = dir_nav.get_option_at_index(index)
+            if option.location == test_file:
+                file_index = index
+                break
+
+        assert file_index is not None, "test file should appear in the directory list"
+
+        dir_nav.highlighted = file_index
+        dir_nav.action_select()
+        await pilot.pause()
+
+        filename_input = dialog.query_one("#filename-input", Input)
+        assert filename_input.value == "sample_file.txt"
+
+
+@pytest.mark.asyncio
+async def test_selecting_file_does_not_populate_hidden_path_input(tmp_path):
+    """Selecting a file must not touch the hidden ``#path-input``.
+
+    Regression guard for the MRO handler shadowing bug: the base
+    ``BaseFileDialog._select_file`` runs ``query_one(Input)`` and would
+    populate whichever input is found first. With the hidden ``#path-input``
+    present, selecting a file must leave it empty.
+    """
+    test_file = tmp_path / "sample_file.txt"
+    test_file.write_text("hello")
+
+    dialog = EnhancedFileOpen(
+        location=str(tmp_path),
+        title="Test Hidden Path Input",
+        context="test_hidden_path_input",
+    )
+    app = _DialogHost(dialog)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        dir_nav = dialog.query_one(SearchableDirectoryNavigation)
+        for _ in range(20):
+            if dir_nav.option_count > 0:
+                break
+            await pilot.pause()
+
+        file_index = None
+        for index in range(dir_nav.option_count):
+            option = dir_nav.get_option_at_index(index)
+            if option.location == test_file:
+                file_index = index
+                break
+
+        assert file_index is not None, "test file should appear in the directory list"
+
+        dir_nav.highlighted = file_index
+        dir_nav.action_select()
+        await pilot.pause()
+
+        path_input = dialog.query_one("#path-input", Input)
+        assert path_input.value == ""
+
+
+
+@pytest.mark.asyncio
+async def test_open_dialog_confirms_selected_file(tmp_path):
+    """Pushing EnhancedFileOpen and clicking Select returns the chosen file."""
+    test_file = tmp_path / "confirm_me.txt"
+    test_file.write_text("hello")
+
+    dialog = EnhancedFileOpen(
+        location=str(tmp_path),
+        title="Test Confirm Open",
+        context="test_confirm_open",
+    )
+    app = _DialogHost(dialog)
+    result = []
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        dir_nav = dialog.query_one(SearchableDirectoryNavigation)
+        for _ in range(20):
+            if dir_nav.option_count > 0:
+                break
+            await pilot.pause()
+
+        file_index = None
+        for index in range(dir_nav.option_count):
+            option = dir_nav.get_option_at_index(index)
+            if option.location == test_file:
+                file_index = index
+                break
+        assert file_index is not None
+
+        dir_nav.highlighted = file_index
+        dir_nav.action_select()
+        await pilot.pause()
+
+        dialog.query_one("#select").press()
+        await pilot.pause()
+
+        # The host app exits once the screen is dismissed.
+        result.append(app._result)
+
+    assert result[0] == test_file
+
+
+@pytest.mark.asyncio
+async def test_save_dialog_confirms_new_file(tmp_path):
+    """Pushing EnhancedFileSave and clicking Select returns the entered path."""
+    dialog = EnhancedFileSave(
+        location=str(tmp_path),
+        title="Test Confirm Save",
+        default_filename="new_file.txt",
+        context="test_confirm_save",
+    )
+    app = _DialogHost(dialog)
+    result = []
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        filename_input = dialog.query_one("#filename-input", Input)
+        assert filename_input.value == "new_file.txt"
+
+        dialog.query_one("#select").press()
+        await pilot.pause()
+
+        result.append(app._result)
+
+    assert result[0] == tmp_path / "new_file.txt"
+
+
+@pytest.mark.asyncio
+async def test_cancel_dismisses_with_none(tmp_path):
+    """Pushing EnhancedFileOpen and clicking Cancel dismisses with None."""
+    dialog = EnhancedFileOpen(
+        location=str(tmp_path),
+        title="Test Cancel",
+        context="test_cancel",
+    )
+    app = _DialogHost(dialog)
+    result = []
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        dialog.query_one("#cancel").press()
+        await pilot.pause()
+        result.append(app._result)
+
+    assert result[0] is None
+
+
+@pytest.mark.asyncio
+async def test_open_must_exist_rejects_missing_file(tmp_path):
+    """EnhancedFileOpen with must_exist=True refuses a non-existent filename."""
+    dialog = EnhancedFileOpen(
+        location=str(tmp_path),
+        title="Test Must Exist",
+        must_exist=True,
+        context="test_must_exist",
+    )
+    app = _DialogHost(dialog)
+    result = []
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        filename_input = dialog.query_one("#filename-input", Input)
+        filename_input.value = "does_not_exist.txt"
+        await pilot.pause()
+
+        dialog.query_one("#select").press()
+        await pilot.pause()
+
+        result.append(app._result)
+
+    assert result[0] is None

--- a/Tests/UI/test_eval_file_picker_dialog.py
+++ b/Tests/UI/test_eval_file_picker_dialog.py
@@ -1,0 +1,230 @@
+"""Integration tests for the flattened evaluation file picker wrappers.
+
+These tests push each eval-specific dialog through a Textual pilot and verify
+open/cancel flows and callback delivery.
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual.app import App, ComposeResult
+
+from tldw_chatbook.Widgets.enhanced_file_picker import SearchableDirectoryNavigation
+from tldw_chatbook.Widgets.file_picker_dialog import (
+    DatasetFilePickerDialog,
+    EvalFilePickerDialog,
+    ExportFilePickerDialog,
+    QuickPickerWidget,
+    TaskFilePickerDialog,
+)
+
+
+class _DialogHost(App[None]):
+    """Minimal host that immediately pushes the dialog under test."""
+
+    def __init__(self, dialog):
+        super().__init__()
+        self._dialog = dialog
+        self._result: object = None
+
+    def compose(self) -> ComposeResult:
+        yield from ()
+
+    async def on_mount(self) -> None:
+        def _capture(result):
+            self._result = result
+            self.exit()
+
+        await self.push_screen(self._dialog, callback=_capture)
+
+
+class _WidgetHost(App[None]):
+    """Host for inline QuickPickerWidget tests."""
+
+    def __init__(self, widget):
+        super().__init__()
+        self._widget = widget
+
+    def compose(self) -> ComposeResult:
+        yield self._widget
+
+
+async def _wait_for_options(dir_nav, pilot, attempts=20):
+    for _ in range(attempts):
+        if dir_nav.option_count > 0:
+            break
+        await pilot.pause()
+
+
+def _index_of(dir_nav, target):
+    for index in range(dir_nav.option_count):
+        option = dir_nav.get_option_at_index(index)
+        if option.location == target:
+            return index
+    return None
+
+
+@pytest.mark.asyncio
+async def test_eval_file_picker_selects_file(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    test_file = tmp_path / "eval.yaml"
+    test_file.write_text("test: true")
+
+    picked = []
+    dialog = EvalFilePickerDialog(callback=lambda p: picked.append(p))
+    app = _DialogHost(dialog)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        dir_nav = dialog.query_one(SearchableDirectoryNavigation)
+        await _wait_for_options(dir_nav, pilot)
+
+        index = _index_of(dir_nav, test_file)
+        assert index is not None, "eval file should appear in the filtered list"
+
+        dir_nav.highlighted = index
+        dir_nav.action_select()
+        await pilot.pause()
+        dialog.query_one("#select").press()
+        await pilot.pause()
+
+    assert picked and picked[0] == str(test_file)
+
+
+@pytest.mark.asyncio
+async def test_eval_file_picker_cancel_returns_none(tmp_path):
+    picked = ["not-called"]
+    dialog = EvalFilePickerDialog(callback=lambda p: picked.append(p))
+    app = _DialogHost(dialog)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        dialog.query_one("#cancel").press()
+        await pilot.pause()
+
+    assert picked[-1] is None
+
+
+@pytest.mark.asyncio
+async def test_task_file_picker_selects_yaml(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    test_file = tmp_path / "task.yaml"
+    test_file.write_text("task: test")
+
+    picked = []
+    dialog = TaskFilePickerDialog(callback=lambda p: picked.append(p))
+    app = _DialogHost(dialog)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        dir_nav = dialog.query_one(SearchableDirectoryNavigation)
+        await _wait_for_options(dir_nav, pilot)
+
+        index = _index_of(dir_nav, test_file)
+        assert index is not None, "YAML task file should appear"
+
+        dir_nav.highlighted = index
+        dir_nav.action_select()
+        await pilot.pause()
+        dialog.query_one("#select").press()
+        await pilot.pause()
+
+    assert picked and picked[0] == str(test_file)
+
+
+@pytest.mark.asyncio
+async def test_dataset_file_picker_selects_csv(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    test_file = tmp_path / "data.csv"
+    test_file.write_text("a,b\n1,2\n")
+
+    picked = []
+    dialog = DatasetFilePickerDialog(callback=lambda p: picked.append(p))
+    app = _DialogHost(dialog)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        dir_nav = dialog.query_one(SearchableDirectoryNavigation)
+        await _wait_for_options(dir_nav, pilot)
+
+        index = _index_of(dir_nav, test_file)
+        assert index is not None, "CSV dataset file should appear"
+
+        dir_nav.highlighted = index
+        dir_nav.action_select()
+        await pilot.pause()
+        dialog.query_one("#select").press()
+        await pilot.pause()
+
+    assert picked and picked[0] == str(test_file)
+
+
+@pytest.mark.asyncio
+async def test_export_file_picker_returns_new_file(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    picked = []
+    dialog = ExportFilePickerDialog(callback=lambda p: picked.append(p))
+    app = _DialogHost(dialog)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        from textual.widgets import Input
+
+        filename_input = dialog.query_one("#filename-input", Input)
+        filename_input.value = "results.json"
+        await pilot.pause()
+        dialog.query_one("#select").press()
+        await pilot.pause()
+
+    assert picked and picked[0] == str(tmp_path / "results.json")
+
+
+@pytest.mark.asyncio
+async def test_quick_picker_widget_browse_selects_file(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    test_file = tmp_path / "task.yaml"
+    test_file.write_text("task: test")
+
+    picked = []
+    widget = QuickPickerWidget(
+        file_types="task files", callback=lambda p: picked.append(p), context="test_quick"
+    )
+    app = _WidgetHost(widget)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        widget.query_one("#browse-button").press()
+        await pilot.pause()
+
+        dialog = app.screen
+        dir_nav = dialog.query_one(SearchableDirectoryNavigation)
+        await _wait_for_options(dir_nav, pilot)
+
+        index = _index_of(dir_nav, test_file)
+        assert index is not None, "task file should appear for QuickPickerWidget"
+
+        dir_nav.highlighted = index
+        dir_nav.action_select()
+        await pilot.pause()
+        dialog.query_one("#select").press()
+        await pilot.pause()
+
+        assert picked and picked[0] == str(test_file)
+        display = widget.query_one("#selected-file-display")
+        assert "task.yaml" in str(display.renderable)
+
+
+@pytest.mark.asyncio
+async def test_quick_picker_widget_clear_selection(tmp_path):
+    widget = QuickPickerWidget(file_types="evaluation files", context="test_quick_clear")
+    widget.selected_file = str(tmp_path / "old.txt")
+    app = _WidgetHost(widget)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        widget.clear_selection()
+        await pilot.pause()
+
+        assert widget.get_selected_file() is None
+        display = widget.query_one("#selected-file-display")
+        assert "No file selected" in str(display.renderable)

--- a/Tests/UI/test_file_picker_filters_callable.py
+++ b/Tests/UI/test_file_picker_filters_callable.py
@@ -30,7 +30,7 @@ def test_eval_default_filters_are_callable():
     from tldw_chatbook.Widgets.file_picker_dialog import EvalFilePickerDialog
 
     dialog = EvalFilePickerDialog()
-    _assert_filters_callable(dialog._get_default_filters())
+    _assert_filters_callable(dialog._default_filters())
 
 
 def test_create_filter_helper_is_callable_and_matches():
@@ -39,7 +39,7 @@ def test_create_filter_helper_is_callable_and_matches():
     f = create_filter("*.yaml;*.yml;*.json")
     assert callable(f)
     assert f(Path("x.json")) is True
-    assert f(Path("x.YAML")) is False  # case-sensitive fnmatch on name
+    assert f(Path("x.YAML")) is True  # create_filter is case-insensitive
     assert f(Path("x.txt")) is False
 
 

--- a/backlog/decisions/018-watchlists-tui-screen.md
+++ b/backlog/decisions/018-watchlists-tui-screen.md
@@ -1,0 +1,46 @@
+# ADR-018: Watchlists TUI Screen
+
+Status: Proposed
+Date: 2026-07-18
+Related Task: Watchlists module+screen redesign
+Supersedes: N/A
+
+## Decision
+
+Replace the placeholder `watchlists_collections` destination shell with a full, three-pane Watchlists management screen that reuses the existing `WatchlistScopeService` local/server split, adds local scraped-item and content-alert storage, and adapts the layout and information architecture from `tldw_server`'s web UI Watchlists page.
+
+## Context
+
+The Chatbook currently has:
+
+- A placeholder `watchlists_collections_screen.py` destination shell that only stages a local snapshot for Console.
+- A legacy `SubscriptionWindow.py` with tabbed watchlist management that we want to retire.
+- A mature backend seam: `LocalWatchlistsService`, `ServerWatchlistsService`, and `WatchlistScopeService` already support source/run/health-alert CRUD.
+- A rich reference implementation in `tldw_server` (`apps/packages/ui/src/components/Option/Watchlists`) with Overview, Sources, Items, Runs, Alerts, Jobs, Outputs, and Templates tabs.
+
+The goal is to give users a single screen where they can monitor sources, view/consume items, inspect runs, and manage alert rules. The screen must work both offline (local `SubscriptionsDB`) and against a connected `tldw_server` API.
+
+## Alternatives Considered
+
+| Option | Why rejected |
+| --- | --- |
+| Build a single monolithic screen class | Would become a very large file, hard to test, and would entangle list/detail/form logic for four entity types. |
+| Adopt the web UI's top tab bar directly in Textual | The Chatbook shell already uses a destination-workbench pattern with a left rail; mixing top tabs inside a destination would be inconsistent. |
+| Server-only implementation | Would not work offline and would waste the existing local service seam. |
+| Keep `SubscriptionWindow` and add a new screen side-by-side | Per user direction, the old window is being retired and its route folded into the new screen. |
+
+## Consequences
+
+- Extend existing `SubscriptionsDB` tables rather than create parallel ones:
+  - `subscription_items` gains `queued_for_briefing` and `run_id` columns for the item reader.
+  - `subscription_filters` is reused for source-level filters and local-only content-alert rules (`action='notify'`).
+  - `local_watchlist_alert_rules` remains dedicated to run-health alert rules.
+- New cross-module UI package: `tldw_chatbook/UI/Watchlists_Modules/` with focused pane/controller modules.
+- The `subscriptions` legacy route becomes an alias for `watchlists_collections`.
+- `SubscriptionWindow.py` is removed after the new screen is wired and tested.
+- Jobs, Outputs, and Templates are intentionally deferred to keep the first slice bounded; the design preserves space for them.
+
+## Links
+
+- Design spec: `docs/superpowers/specs/2026-07-18-watchlists-tui-screen-design.md`
+- Reference module: `rmusser01/tldw_server` (`apps/packages/ui/src/components/Option/Watchlists`, `tldw_Server_API/app/core/Watchlists`)

--- a/backlog/decisions/README.md
+++ b/backlog/decisions/README.md
@@ -19,6 +19,7 @@ ADRs explain why significant architectural decisions were made. Backlog tasks, S
 | [ADR-011](011-chatbook-workbench-ui-system.md) | Accepted | Adopt a shared Textual-native Workbench UI System with stable composition, explicit state, visible workflow controls, responsiveness gates, and route-owner migration policy. |
 | [ADR-013](013-media-search-plain-text-fts-boundary.md) | Accepted | Keep raw media search text separate from optional preformatted FTS MATCH expressions across the local media-reading boundary. |
 | [ADR-016](016-palette-liveness-and-hotkey-layer.md) | Accepted | Palette commands must be live (notify-only commands deleted or wired); Ctrl+N destination hotkey layer zipped from `SHELL_DESTINATION_ORDER`; generic BINDINGS-driven F1 help. |
+| [ADR-018](018-watchlists-tui-screen.md) | Proposed | Replace the placeholder Watchlists destination shell with a full three-pane TUI screen reusing the local/server scope service and mirroring `tldw_server` Watchlists IA. |
 
 ## Historical Decision Material
 

--- a/tldw_chatbook/Scheduling/services/__init__.py
+++ b/tldw_chatbook/Scheduling/services/__init__.py
@@ -1,0 +1,3 @@
+from .server_client import SchedulingServerClient, ServerUnavailableError
+
+__all__ = ["SchedulingServerClient", "ServerUnavailableError"]

--- a/tldw_chatbook/Scheduling/services/server_client.py
+++ b/tldw_chatbook/Scheduling/services/server_client.py
@@ -2,40 +2,41 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 
 class ServerUnavailableError(Exception):
     """Raised when the server client is invoked while no server is connected."""
 
 
 class SchedulingServerClient:
-    def __init__(self, notifications_service=None, api_client=None):
+    def __init__(self, notifications_service: Any | None = None) -> None:
         self.notifications_service = notifications_service
-        self.api_client = api_client
 
     def _is_available(self) -> bool:
-        return self.notifications_service is not None and getattr(self.notifications_service, "client", None) is not None
+        return self.notifications_service is not None
 
-    async def create_reminder(self, **payload):
+    async def create_reminder(self, **payload: Any) -> dict[str, Any]:
         if not self._is_available():
             raise ServerUnavailableError("server not available")
         return await self.notifications_service.create_reminder(**payload)
 
-    async def update_reminder(self, task_id, **payload):
+    async def update_reminder(self, task_id: str, **payload: Any) -> dict[str, Any]:
         if not self._is_available():
             raise ServerUnavailableError("server not available")
         return await self.notifications_service.update_reminder(task_id, **payload)
 
-    async def delete_reminder(self, task_id):
+    async def delete_reminder(self, task_id: str) -> dict[str, Any]:
         if not self._is_available():
             raise ServerUnavailableError("server not available")
         return await self.notifications_service.delete_reminder(task_id)
 
-    async def list_reminders(self):
+    async def list_reminders(self) -> dict[str, Any]:
         if not self._is_available():
             raise ServerUnavailableError("server not available")
         return await self.notifications_service.list_reminders()
 
-    async def get_reminder(self, task_id):
+    async def get_reminder(self, task_id: str) -> dict[str, Any]:
         if not self._is_available():
             raise ServerUnavailableError("server not available")
         return await self.notifications_service.get_reminder(task_id)

--- a/tldw_chatbook/Scheduling/services/server_client.py
+++ b/tldw_chatbook/Scheduling/services/server_client.py
@@ -1,0 +1,41 @@
+"""Server client for scheduling reminders."""
+
+from __future__ import annotations
+
+
+class ServerUnavailableError(Exception):
+    """Raised when the server client is invoked while no server is connected."""
+
+
+class SchedulingServerClient:
+    def __init__(self, notifications_service=None, api_client=None):
+        self.notifications_service = notifications_service
+        self.api_client = api_client
+
+    def _is_available(self) -> bool:
+        return self.notifications_service is not None and getattr(self.notifications_service, "client", None) is not None
+
+    async def create_reminder(self, **payload):
+        if not self._is_available():
+            raise ServerUnavailableError("server not available")
+        return await self.notifications_service.create_reminder(**payload)
+
+    async def update_reminder(self, task_id, **payload):
+        if not self._is_available():
+            raise ServerUnavailableError("server not available")
+        return await self.notifications_service.update_reminder(task_id, **payload)
+
+    async def delete_reminder(self, task_id):
+        if not self._is_available():
+            raise ServerUnavailableError("server not available")
+        return await self.notifications_service.delete_reminder(task_id)
+
+    async def list_reminders(self):
+        if not self._is_available():
+            raise ServerUnavailableError("server not available")
+        return await self.notifications_service.list_reminders()
+
+    async def get_reminder(self, task_id):
+        if not self._is_available():
+            raise ServerUnavailableError("server not available")
+        return await self.notifications_service.get_reminder(task_id)

--- a/tldw_chatbook/Scheduling/services/server_client.py
+++ b/tldw_chatbook/Scheduling/services/server_client.py
@@ -10,33 +10,101 @@ class ServerUnavailableError(Exception):
 
 
 class SchedulingServerClient:
+    """Async client that delegates scheduling operations to a notifications service.
+
+    The client is a thin wrapper around an injected notifications service. All
+    methods raise :class:`ServerUnavailableError` when no service has been
+    configured, so callers can distinguish "server missing" from actual request
+    failures.
+    """
+
     def __init__(self, notifications_service: Any | None = None) -> None:
+        """Initialize the client.
+
+        Args:
+            notifications_service: Service that implements the reminder CRUD
+                contract, or ``None`` if no scheduling server is connected.
+        """
         self.notifications_service = notifications_service
 
     def _is_available(self) -> bool:
+        """Return whether a notifications service is available."""
         return self.notifications_service is not None
 
     async def create_reminder(self, **payload: Any) -> dict[str, Any]:
+        """Create a new reminder.
+
+        Args:
+            **payload: Reminder fields to pass to the notifications service.
+
+        Returns:
+            The created reminder as returned by the service.
+
+        Raises:
+            ServerUnavailableError: If no scheduling server is connected.
+        """
         if not self._is_available():
             raise ServerUnavailableError("server not available")
         return await self.notifications_service.create_reminder(**payload)
 
     async def update_reminder(self, task_id: str, **payload: Any) -> dict[str, Any]:
+        """Update an existing reminder.
+
+        Args:
+            task_id: Identifier of the reminder to update.
+            **payload: Reminder fields to update.
+
+        Returns:
+            The updated reminder as returned by the service.
+
+        Raises:
+            ServerUnavailableError: If no scheduling server is connected.
+        """
         if not self._is_available():
             raise ServerUnavailableError("server not available")
         return await self.notifications_service.update_reminder(task_id, **payload)
 
     async def delete_reminder(self, task_id: str) -> dict[str, Any]:
+        """Delete a reminder.
+
+        Args:
+            task_id: Identifier of the reminder to delete.
+
+        Returns:
+            The service response after deletion.
+
+        Raises:
+            ServerUnavailableError: If no scheduling server is connected.
+        """
         if not self._is_available():
             raise ServerUnavailableError("server not available")
         return await self.notifications_service.delete_reminder(task_id)
 
     async def list_reminders(self) -> dict[str, Any]:
+        """List all reminders.
+
+        Returns:
+            The service response containing the reminder list.
+
+        Raises:
+            ServerUnavailableError: If no scheduling server is connected.
+        """
         if not self._is_available():
             raise ServerUnavailableError("server not available")
         return await self.notifications_service.list_reminders()
 
     async def get_reminder(self, task_id: str) -> dict[str, Any]:
+        """Fetch a single reminder.
+
+        Args:
+            task_id: Identifier of the reminder to retrieve.
+
+        Returns:
+            The requested reminder as returned by the service.
+
+        Raises:
+            ServerUnavailableError: If no scheduling server is connected.
+        """
         if not self._is_available():
             raise ServerUnavailableError("server not available")
         return await self.notifications_service.get_reminder(task_id)

--- a/tldw_chatbook/Widgets/enhanced_file_picker.py
+++ b/tldw_chatbook/Widgets/enhanced_file_picker.py
@@ -1,36 +1,39 @@
 # enhanced_file_picker.py
-# Enhanced file picker with keyboard shortcuts, recent files, breadcrumbs, and search
+# Enhanced file picker with keyboard shortcuts, recent files, breadcrumbs, bookmarks, and search
 
+import sys
 from pathlib import Path
-from typing import List, Optional, Callable, Set, Dict, Any, Tuple, Union
+from typing import List, Optional, Callable, Dict, Any, Union
 from datetime import datetime
-import json
 import os
-from textual import on, work
+from textual import on
 from textual.app import ComposeResult
 from textual.binding import Binding
-from textual.containers import Container, Vertical, Horizontal, VerticalScroll
-from textual.screen import ModalScreen
-from textual.widgets import Button, Label, Static, ListView, ListItem, Input, Select
+from textual.containers import Horizontal, VerticalScroll
+
+from textual.widgets import Button, Label, ListView, ListItem, Input
 from textual.reactive import reactive
-from textual.worker import Worker, get_current_worker
+from textual.message import Message
 from loguru import logger
 
-from ..Third_Party.textual_fspicker import FileOpen, FileSave, Filters
+from ..Third_Party.textual_fspicker import Filters
 from ..Third_Party.textual_fspicker.file_dialog import BaseFileDialog
+from ..Third_Party.textual_fspicker.base_dialog import FileSystemPickerScreen
 from ..Third_Party.textual_fspicker.parts import DirectoryNavigation
+from ..Third_Party.textual_fspicker.parts.directory_navigation import DirectoryEntry
+from ..Third_Party.textual_fspicker.path_maker import MakePath
 from ..config import get_cli_setting, save_setting_to_cli_config
 
 
 class RecentLocations:
     """Manages recently accessed file locations with persistent storage"""
-    
+
     def __init__(self, max_items: int = 20, context: str = "default"):
         self.max_items = max_items
         self.context = context  # Context for different file picker uses
         self._recent: List[Dict[str, Any]] = []
         self.load_from_config()
-    
+
     def load_from_config(self):
         """Load recent locations from config"""
         try:
@@ -42,21 +45,21 @@ class RecentLocations:
         except Exception as e:
             logger.error(f"Failed to load recent locations: {e}")
             self._recent = []
-    
+
     def save_to_config(self):
         """Save recent locations to config"""
         try:
             save_setting_to_cli_config("filepicker", f"recent_{self.context}", self._recent)
         except Exception as e:
             logger.error(f"Failed to save recent locations: {e}")
-    
+
     def add(self, path: Path, file_type: str = "file"):
         """Add a path to recent locations"""
         path_str = str(path.resolve())
-        
+
         # Remove if already exists
         self._recent = [item for item in self._recent if item.get("path") != path_str]
-        
+
         # Add to front
         self._recent.insert(0, {
             "path": path_str,
@@ -64,15 +67,15 @@ class RecentLocations:
             "type": file_type,
             "timestamp": datetime.now().isoformat()
         })
-        
+
         # Trim to max
         self._recent = self._recent[:self.max_items]
         self.save_to_config()
-    
+
     def get_recent(self) -> List[Dict[str, Any]]:
         """Get recent locations"""
         return self._recent
-    
+
     def clear(self):
         """Clear all recent locations"""
         self._recent = []
@@ -228,8 +231,13 @@ class BookmarksManager:
 
 
 class PathBreadcrumbs(Horizontal):
-    """Clickable breadcrumb navigation for paths"""
-    
+    """Clickable breadcrumb navigation for paths.
+
+    NOTE: ``EnhancedFileDialog`` now uses the base ``#path-breadcrumbs``
+    container directly. This widget is kept for compatibility and may be used
+    by other consumers.
+    """
+
     DEFAULT_CSS = """
     /* Local fallbacks so DEFAULT_CSS parses without the app bundle. */
     $ds-focus-bg: $surface;
@@ -242,7 +250,7 @@ class PathBreadcrumbs(Horizontal):
         border-bottom: tall $primary-lighten-1;
         overflow: hidden;
     }
-    
+
     PathBreadcrumbs .breadcrumb-button {
         min-width: 0;
         padding: 0 1;
@@ -253,60 +261,66 @@ class PathBreadcrumbs(Horizontal):
         color: $text;
         text-style: none;
     }
-    
+
     PathBreadcrumbs .breadcrumb-button:hover {
         background: $primary 20%;
         text-style: underline;
     }
-    
+
     PathBreadcrumbs .breadcrumb-button:focus {
         background: $ds-focus-bg;
         color: $ds-focus-fg;
         text-style: bold underline;
     }
-    
+
     PathBreadcrumbs .breadcrumb-separator {
         margin: 0;
         padding: 0 1;
         color: $text-muted;
     }
     """
-    
+
     from textual.message import Message
-    
+
     class PathChanged(Message):
         """Emitted when a breadcrumb is clicked"""
         def __init__(self, path: Path) -> None:
             self.path = path
             super().__init__()
-    
+
     def __init__(self, initial_path: Optional[Path] = None):
         super().__init__()
         self.current_path = initial_path or Path.cwd()
-    
+
     def update_path(self, path: Path):
         """Update the breadcrumb display with a new path"""
         self.current_path = path
         self.refresh_breadcrumbs()
-    
-    @work(exclusive=True)
-    async def refresh_breadcrumbs(self):
-        """Refresh the breadcrumb display"""
-        await self.remove_children()
-        
+
+    def refresh_breadcrumbs(self):
+        """Refresh the breadcrumb display synchronously.
+
+        This previously ran inside a worker and awaited ``mount()``, which
+        raised ``MountError`` when called before the widget was attached.
+        """
+        if not self.is_attached:
+            return
+
+        self.remove_children()
+
         parts = self.current_path.parts
         for i, part in enumerate(parts):
             partial_path = Path(*parts[:i+1])
-            
+
             # Create button for each part
             btn = Button(part, variant="default", classes="breadcrumb-button")
             btn.data = partial_path  # Store the path in the button
-            await self.mount(btn)
-            
+            self.mount(btn)
+
             # Add separator if not last
             if i < len(parts) - 1:
-                await self.mount(Label("/", classes="breadcrumb-separator"))
-    
+                self.mount(Label("/", classes="breadcrumb-separator"))
+
     @on(Button.Pressed)
     def handle_breadcrumb_click(self, event: Button.Pressed):
         """Handle clicks on breadcrumb buttons"""
@@ -315,8 +329,13 @@ class PathBreadcrumbs(Horizontal):
 
 
 class DirectorySearch(Horizontal):
-    """Search widget for filtering directory contents"""
-    
+    """Search widget for filtering directory contents.
+
+    NOTE: ``EnhancedFileDialog`` uses the base ``#search-container`` input
+    and a subclassed ``DirectoryNavigation`` for live filtering. This widget
+    is kept for compatibility and may be used by other consumers.
+    """
+
     DEFAULT_CSS = """
     DirectorySearch {
         height: 3;
@@ -324,34 +343,34 @@ class DirectorySearch(Horizontal):
         background: $surface;
         border-bottom: tall $primary-lighten-1;
     }
-    
+
     DirectorySearch Input {
         width: 1fr;
         margin-right: 1;
     }
-    
+
     DirectorySearch Button {
         min-width: 7;
     }
     """
-    
+
     from textual.message import Message
-    
+
     class SearchChanged(Message):
         """Emitted when search text changes"""
         def __init__(self, query: str) -> None:
             self.query = query
             super().__init__()
-    
+
     def compose(self) -> ComposeResult:
         yield Input(placeholder="Search files...", id="search-input")
         yield Button("Clear", id="clear-search", variant="default")
-    
+
     @on(Input.Changed, "#search-input")
     def handle_search_change(self, event: Input.Changed):
         """Handle search input changes"""
         self.post_message(self.SearchChanged(event.value))
-    
+
     @on(Button.Pressed, "#clear-search")
     def handle_clear(self):
         """Clear the search"""
@@ -360,46 +379,72 @@ class DirectorySearch(Horizontal):
         self.post_message(self.SearchChanged(""))
 
 
+class SearchableDirectoryNavigation(DirectoryNavigation):
+    """Directory navigation that also filters by a free-text search term.
+
+    The base ``DirectoryNavigation`` references ``search_filter`` in its watch
+    method but does not declare the reactive variable, and its
+    ``_repopulate_display`` does not apply the term. This subclass adds the
+    missing reactive and applies it without editing third-party code.
+    """
+
+    search_filter = reactive("")
+    """Free-text filter applied to entry names."""
+
+    def _repopulate_display(self) -> None:
+        """Repopulate the display, honouring file, hidden, and search filters."""
+        styles = self._styles
+        query = self.search_filter.strip().lower()
+        with self.app.batch_update():
+            self.clear_options()
+            if not self.is_root:
+                self.add_option(DirectoryEntry(self._location / "..", styles))
+            self.add_options(
+                self._sort(
+                    entry
+                    for entry in self._entries
+                    if not self.hide(entry.location)
+                    and (not query or query in entry.location.name.lower())
+                )
+            )
+        self._settle_highlight()
+
+
 class EnhancedFileDialog(BaseFileDialog):
-    """Enhanced file picker with keyboard shortcuts, recent files, breadcrumbs, and search"""
-    
+    """Enhanced file picker with keyboard shortcuts, recent files, breadcrumbs, bookmarks, and search"""
+
     DEFAULT_CSS = BaseFileDialog.DEFAULT_CSS + """
     BaseFileDialog {
+        .hidden {
+            display: none;
+        }
+
         Dialog {
             height: 90%;
             width: 90%;
         }
-        
-        #top-panels {
-            height: auto;
-            display: none;
-        }
-        
-        #top-panels.has-content {
-            display: block;
-        }
-        
+
         #recent-locations, #bookmarks-panel {
             height: 10;
             border: solid $primary;
             background: $surface;
             margin-bottom: 1;
-            display: none;  /* Hidden by default */
+            display: none;
         }
-        
+
         #recent-locations.visible, #bookmarks-panel.visible {
             display: block;
         }
-        
+
         #recent-list, #bookmarks-list {
             height: 8;
             background: $surface;
         }
-        
+
         .recent-item, .bookmark-item {
             padding: 0 1;
         }
-        
+
         #bookmarks-list {
             layout: grid;
             grid-size: 2;
@@ -408,28 +453,28 @@ class EnhancedFileDialog(BaseFileDialog):
             height: 8;
             overflow-y: auto;
         }
-        
+
         #bookmarks-list ListItem {
             height: 3;
             margin: 0;
             padding: 0 1;
         }
-        
+
         .bookmark-item {
             padding: 0 1;
             height: 3;
             overflow: hidden;
         }
-        
+
         .bookmark-item-icon {
             margin-right: 1;
         }
-        
+
         .bookmarks-header {
             height: 2;
             padding: 0 1;
         }
-        
+
         .bookmark-button, #add-bookmark {
             min-width: 1;
             width: 3;
@@ -438,71 +483,117 @@ class EnhancedFileDialog(BaseFileDialog):
             padding: 0;
             text-align: center;
         }
-        
+
         .bookmark-container {
             width: 100%;
             height: 100%;
             align: left middle;
         }
-        
-        #navigation-section {
-            height: auto;
-            margin-bottom: 1;
+
+        #path-breadcrumbs {
+            height: 3;
+            padding: 0 1;
+            background: $surface;
+            border-bottom: tall $primary-lighten-1;
+            overflow: hidden;
         }
-        
-        #browser-section {
-            height: 1fr;
+
+        #path-breadcrumbs .breadcrumb-btn {
+            min-width: 0;
+            padding: 0 1;
+            margin: 0;
+            height: 1;
+            background: transparent;
+            border: none;
+            color: $text;
+            text-style: none;
         }
-        
-        #browser-section Horizontal {
-            height: 100%;
+
+        #path-breadcrumbs .breadcrumb-btn:hover {
+            background: $primary 20%;
+            text-style: underline;
         }
-        
-        DirectoryNavigation {
-            width: 1fr;
-            height: 100%;
+
+        #path-breadcrumbs .breadcrumb-separator {
+            margin: 0;
+            padding: 0 1;
+            color: $text-muted;
         }
-        
+
         .search-active {
             border-title-style: bold;
             border-title-color: $warning;
         }
-        
+
         .section-title {
             width: 1fr;
             text-style: bold;
         }
-        
-        .hidden {
-            display: none;
-        }
     }
     """
-    
+
     BINDINGS = [
-        Binding("ctrl+h", "toggle_hidden", "Toggle hidden files"),
-        Binding("ctrl+l", "focus_path_input", "Edit path directly"),
-        Binding("ctrl+r", "toggle_recent", "Show recent files"),
         Binding("ctrl+b", "toggle_bookmarks", "Show bookmarks"),
-        Binding("ctrl+d", "bookmark_current", "Bookmark current directory"),
-        Binding("f5", "refresh", "Refresh directory"),
-        Binding("ctrl+f", "focus_search", "Search files"),
-        Binding("ctrl+1", "quick_access", "Quick access", key_display="1-9"),
-        Binding("escape", "dismiss(None)", "Cancel"),
+        *[Binding(str(n), f"jump_bookmark_{n}", f"Bookmark {n}", show=False) for n in range(1, 10)],
     ]
-    
-    show_recent = reactive(False)
+
     show_bookmarks = reactive(False)
-    search_query = reactive("")
-    
-    def __init__(self, *args, context: str = "default", **kwargs):
-        super().__init__(*args, **kwargs)
+
+    # Base class handlers that this subclass replaces. Textual dispatches
+    # decorated handlers from the whole MRO, so simply renaming the subclass
+    # methods and adding no-op overrides is not enough to stop the base
+    # implementations from firing. ``_get_dispatch_methods`` filters them out.
+    _SUPPRESSED_BASE_HANDLERS = {
+        BaseFileDialog._select_file,
+        BaseFileDialog._confirm_file,
+        FileSystemPickerScreen._on_clear_search,
+        FileSystemPickerScreen._on_directory_changed,
+    }
+
+    def _get_dispatch_methods(self, method_name: str, message: Message):
+        """Yield dispatch methods, skipping base handlers we replace."""
+        for cls, method in super()._get_dispatch_methods(method_name, message):
+            if method.__func__ in self._SUPPRESSED_BASE_HANDLERS:
+                continue
+            yield cls, method
+
+    def __init__(
+        self,
+        location: Union[str, Path] = ".",
+        title: str = "",
+        select_button: str = "",
+        cancel_button: str = "",
+        *,
+        filters: Optional[Filters] = None,
+        default_file: Optional[Union[str, Path]] = None,
+        context: str = "default",
+        id: Optional[str] = None,
+        classes: Optional[str] = None,
+        name: Optional[str] = None,
+    ):
+        # ``BaseFileDialog`` does not accept Textual screen kwargs such as
+        # ``id`` or ``classes``; apply them manually after the base init.
+        super().__init__(
+            location,
+            title,
+            select_button,
+            cancel_button,
+            filters=filters,
+            default_file=default_file,
+        )
+        if id is not None:
+            self.id = id
+        if classes is not None:
+            self.classes = classes
+        if name is not None:
+            self.name = name
         self.context = context
         self.recent_locations = RecentLocations(context=context)
         self.bookmarks_manager = BookmarksManager(context=context)
-        self._original_entries = []  # Store original entries for search filtering
         self._last_directory = self._get_last_directory()
-    
+        if self._last_directory is not None:
+            self._location = self._last_directory
+
     def _get_last_directory(self) -> Optional[Path]:
         """Get the last used directory for this context"""
         try:
@@ -512,7 +603,7 @@ class EnhancedFileDialog(BaseFileDialog):
         except Exception:
             pass
         return None
-    
+
     def _save_last_directory(self, path: Path):
         """Save the last used directory for this context"""
         try:
@@ -520,150 +611,246 @@ class EnhancedFileDialog(BaseFileDialog):
             save_setting_to_cli_config("filepicker", f"last_dir_{self.context}", str(dir_path))
         except Exception as e:
             logger.error(f"Failed to save last directory: {e}")
-    
+
     def compose(self) -> ComposeResult:
-        """Compose the enhanced file picker UI"""
-        from ..Third_Party.textual_fspicker.parts import DriveNavigation
+        """Compose the enhanced file picker UI.
+
+        The base ``FileSystemPickerScreen`` (defined in
+        ``Third_Party/textual_fspicker/base_dialog.py``) does not expose any
+        compositional hooks for adding a bookmarks panel or for replacing its
+        ``DirectoryNavigation`` with a search-aware subclass. To keep the
+        enhancement isolated in this file, we deliberately mirror the base
+        layout here and inject the extra widgets at the documented IDs.
+        """
         from ..Third_Party.textual_fspicker.base_dialog import Dialog, InputBar
-        import sys
-        
-        # Use last directory if available, otherwise use provided location
-        initial_location = self._last_directory or Path(self._location)
-        
+        from ..Third_Party.textual_fspicker.parts import DriveNavigation
+
         with Dialog() as dialog:
             dialog.border_title = self._title
-            
-            # Hidden element required by parent class
-            yield Label("", id="current_path_display", classes="hidden")
-            
-            # Top section with panels
-            with Container(id="top-panels"):
-                # Recent locations panel (hidden by default)
-                with Container(id="recent-locations"):
-                    yield Label("📋 Recent Locations", classes="section-title")
-                    yield ListView(id="recent-list")
-                
-                # Bookmarks panel (hidden by default)
-                with Container(id="bookmarks-panel"):
-                    with Horizontal(classes="bookmarks-header"):
-                        yield Label("⭐ Bookmarks", classes="section-title")
-                        yield Button("➕", id="add-bookmark", classes="bookmark-button")
-                    yield ListView(id="bookmarks-list")
-            
-            # Navigation section
-            with Container(id="navigation-section"):
-                # Breadcrumb navigation
-                yield PathBreadcrumbs(initial_location)
-                
-                # Search bar
-                yield DirectorySearch()
-            
-            # Main file browser section
-            with Container(id="browser-section"):
-                with Horizontal():
-                    if sys.platform == "win32":
-                        yield DriveNavigation(str(initial_location))
-                    yield DirectoryNavigation(str(initial_location))
-            
-            # Bottom section with input and buttons
+
+            # Recent locations panel (hidden by default)
+            with VerticalScroll(id="recent-locations"):
+                yield Label("📋 Recent Locations", classes="section-title")
+                yield ListView(id="recent-list")
+
+            # Bookmarks panel (hidden by default)
+            with VerticalScroll(id="bookmarks-panel"):
+                with Horizontal(classes="bookmarks-header"):
+                    yield Label("⭐ Bookmarks", classes="section-title")
+                    yield Button("➕", id="add-bookmark", classes="bookmark-button")
+                yield ListView(id="bookmarks-list")
+
+            # Path display and breadcrumbs
+            yield Label(id="current_path_display")
+            with Horizontal(id="path-breadcrumbs"):
+                pass
+
+            # Path input field (hidden by default, shown with Ctrl+L)
+            with Horizontal(id="path-input-container", classes="hidden"):
+                yield Input(placeholder="Enter path...", id="path-input")
+                yield Button("Go", id="go-to-path", variant="primary")
+                yield Button("Cancel", id="cancel-path-input", variant="default")
+
+            # Search container (hidden by default)
+            with Horizontal(id="search-container"):
+                yield Input(placeholder="Search files...", id="search-input")
+                yield Button("Clear", id="clear-search", variant="default")
+
+            # Main directory navigation
+            with Horizontal():
+                if sys.platform == "win32":
+                    yield DriveNavigation(self._location)
+                yield SearchableDirectoryNavigation(self._location)
+
+            # Input bar with buttons
             with InputBar():
                 yield from self._input_bar()
                 yield Button(self._label(self._select_button, "Select"), id="select")
                 yield Button(self._label(self._cancel_button, "Cancel"), id="cancel")
-    
+
     def on_mount(self) -> None:
-        """Initialize the dialog on mount"""
+        """Initialize the dialog on mount.
+
+        The base ``on_mount`` expects ``#path-breadcrumbs`` and
+        ``#recent-list`` to exist; our compose provides them, so calling
+        ``super().on_mount()`` is safe.
+        """
         super().on_mount()
-        self._update_recent_list()
         self._update_bookmarks_list()
-        
-        # Update breadcrumbs with initial location
-        dir_nav = self.query_one(DirectoryNavigation)
-        breadcrumbs = self.query_one(PathBreadcrumbs)
-        breadcrumbs.update_path(dir_nav.location)
-        
-        # Update bookmark button state
-        self._update_bookmark_button_state(dir_nav.location)
-    
+        self._update_bookmark_button_state(
+            self.query_one(SearchableDirectoryNavigation).location
+        )
+
     def watch_show_recent(self, show: bool) -> None:
-        """Toggle recent locations visibility"""
+        """Toggle recent locations visibility."""
         try:
             recent_panel = self.query_one("#recent-locations")
             recent_panel.set_class(show, "visible")
-            # Hide bookmarks if showing recent
             if show:
                 self.show_bookmarks = False
-            # Update top panels visibility
-            self._update_top_panels_visibility()
         except Exception:
             pass
-    
+
+    def action_show_recent(self) -> None:
+        """Toggle the recent locations panel (explicit override)."""
+        self.show_recent = not self.show_recent
+
     def watch_show_bookmarks(self, show: bool) -> None:
-        """Toggle bookmarks panel visibility"""
+        """Toggle bookmarks panel visibility."""
         try:
             bookmarks_panel = self.query_one("#bookmarks-panel")
             bookmarks_panel.set_class(show, "visible")
-            # Hide recent if showing bookmarks
             if show:
                 self.show_recent = False
-            # Update top panels visibility
-            self._update_top_panels_visibility()
         except Exception:
             pass
-    
-    def _update_top_panels_visibility(self):
-        """Update top-panels container visibility based on content"""
+
+    def _select_file(self, event: DirectoryNavigation.Selected) -> None:
+        """No-op override of ``BaseFileDialog._select_file``.
+
+        The real selection handling happens in ``_on_select_file``. The base
+        decorated handler is suppressed via ``_get_dispatch_methods`` because
+        Textual dispatches decorated handlers from the whole MRO; a simple
+        name-shadowing override is not sufficient to stop it from firing.
+        """
+        pass
+
+    @on(DirectoryNavigation.Selected)
+    def _on_select_file(self, event: DirectoryNavigation.Selected) -> None:
+        """Handle a file being selected in the picker.
+
+        Mirrors ``BaseFileDialog._select_file`` but targets the dedicated
+        ``#filename-input`` so the hidden ``#path-input`` and
+        ``#search-input`` are not selected by ``query_one(Input)``.
+        """
         try:
-            top_panels = self.query_one("#top-panels")
-            has_content = self.show_recent or self.show_bookmarks
-            top_panels.set_class(has_content, "has-content")
+            file_name = self.query_one("#filename-input", Input)
+        except Exception:
+            return
+        file_name.value = str(event.path.name)
+        file_name.focus()
+
+    def _confirm_file(self, event: Input.Submitted | Button.Pressed) -> None:
+        """No-op override of ``BaseFileDialog._confirm_file``.
+
+        The real confirmation handling happens in ``_on_confirm_file``. The
+        base decorated handler is suppressed via ``_get_dispatch_methods``.
+        """
+        pass
+
+    @on(Input.Submitted, "#filename-input")
+    @on(Button.Pressed, "#select")
+    def _on_confirm_file(self, event: Input.Submitted | Button.Pressed) -> None:
+        """Confirm the selection of the file in the input box.
+
+        Mirrors ``BaseFileDialog._confirm_file`` but targets the dedicated
+        ``#filename-input`` so the hidden ``#path-input`` and
+        ``#search-input`` are not selected by ``query_one(Input)``.
+        """
+        event.stop()
+        file_name = self.query_one("#filename-input", Input)
+
+        # Only even try and process this if there's some input.
+        if not file_name.value:
+            self._set_error(self.ERROR_A_FILE_MUST_BE_CHOSEN)
+            return
+
+        # If it looks like the user is typing in some sort of home
+        # directory path...
+        if file_name.value.startswith("~"):
+            # ...let's simply expand and go with that.
+            try:
+                chosen = MakePath.of(file_name.value).expanduser()
+            except RuntimeError as error:
+                self._set_error(str(error))
+                return
+        else:
+            # It's not a home directory path, so let's combine with the
+            # location of the directory navigator widget.
+            chosen = (
+                self.query_one(DirectoryNavigation).location / file_name.value
+            ).resolve()
+
+        # If it's a directory, approach it like it's the user simply
+        # doing a "cd".
+        try:
+            if chosen.is_dir():
+                if sys.platform == "win32":
+                    if drive_letter := MakePath.of(chosen).drive:
+                        # Ensure DriveNavigation is present before querying
+                        try:
+                            from ..Third_Party.textual_fspicker.parts import DriveNavigation
+                            drive_nav = self.query_one(DriveNavigation)
+                            drive_nav.drive = drive_letter
+                        except Exception:  # QueryError if not present
+                            pass  # Silently ignore if DriveNavigation isn't there
+                self.query_one(DirectoryNavigation).location = chosen
+                self.query_one(DirectoryNavigation).focus()
+                file_name.value = ""
+                return
+        except PermissionError:
+            self._set_error(self.ERROR_PERMISSION_ERROR)
+            return
+
+        # If the chosen file passes the final tests...
+        if self._should_return(chosen):
+            # ...return it.
+            self.dismiss(result=chosen)
+
+    def _update_breadcrumbs(self, path: Path) -> None:
+        """Update breadcrumb navigation using the base container."""
+        try:
+            breadcrumb_container = self.query_one("#path-breadcrumbs", Horizontal)
+            breadcrumb_container.remove_children()
+
+            parts = path.parts
+            for i, part in enumerate(parts):
+                partial_path = Path(*parts[:i+1])
+
+                btn = Button(part, variant="default", classes="breadcrumb-btn")
+                btn.tooltip = str(partial_path)
+                breadcrumb_container.mount(btn)
+
+                if i < len(parts) - 1:
+                    breadcrumb_container.mount(Label("/", classes="breadcrumb-separator"))
         except Exception:
             pass
-    
-    def watch_search_query(self, query: str) -> None:
-        """Filter directory entries based on search query"""
-        try:
-            dir_nav = self.query_one(DirectoryNavigation)
-            from ..Third_Party.textual_fspicker.base_dialog import Dialog
-            dialog = self.query_one(Dialog)
-            
-            if query:
-                dialog.add_class("search-active")
-                # Implement filtering logic here
-                # This would require modifying DirectoryNavigation or creating a wrapper
-            else:
-                dialog.remove_class("search-active")
-        except Exception as e:
-            logger.error(f"Error filtering entries: {e}")
-    
-    def _update_recent_list(self):
-        """Update the recent locations list"""
+
+    def _load_recent_locations(self) -> None:
+        """Populate the recent locations list from persistent storage."""
         try:
             recent_list = self.query_one("#recent-list", ListView)
             recent_list.clear()
-            
+
             for item in self.recent_locations.get_recent():
-                path = item["path"]
+                path_str = item["path"]
                 name = item["name"]
                 file_type = item.get("type", "file")
                 icon = "📁" if file_type == "directory" else "📄"
-                list_item = ListItem(Label(f"{icon} {name} - {path}", classes="recent-item"))
-                list_item.data = path
+                list_item = ListItem(
+                    Label(f"{icon} {name} - {path_str}", classes="recent-item")
+                )
+                list_item.data = path_str
                 recent_list.append(list_item)
-        except Exception as e:
-            logger.error(f"Error updating recent list: {e}")
-    
+        except Exception:
+            pass
+
+    def _add_to_recent(self, path: Path, file_type: str) -> None:
+        """Persist a recent location and refresh the list."""
+        self.recent_locations.add(path, file_type)
+        self._save_last_directory(path)
+        self._load_recent_locations()
+
     def _update_bookmarks_list(self):
-        """Update the bookmarks list"""
+        """Update the bookmarks list."""
         try:
             bookmarks_list = self.query_one("#bookmarks-list", ListView)
             bookmarks_list.clear()
-            
+
             for bookmark in self.bookmarks_manager.get_bookmarks():
                 path = bookmark["path"]
                 name = bookmark["name"]
                 icon = bookmark.get("icon", "📁")
-                # Truncate name if too long for grid layout
                 if len(name) > 15:
                     name = name[:12] + "..."
                 list_item = ListItem(
@@ -677,181 +864,178 @@ class EnhancedFileDialog(BaseFileDialog):
                 bookmarks_list.append(list_item)
         except Exception as e:
             logger.error(f"Error updating bookmarks list: {e}")
-    
+
     def _update_bookmark_button_state(self, path: Path):
-        """Update the bookmark button based on current directory"""
+        """Update the bookmark button based on current directory."""
         try:
             btn = self.query_one("#add-bookmark", Button)
             if self.bookmarks_manager.is_bookmarked(path):
-                btn.label = "⭐"  # Already bookmarked
+                btn.label = "⭐"
                 btn.tooltip = "Remove bookmark"
             else:
                 btn.label = "➕"
                 btn.tooltip = "Add bookmark"
         except Exception:
             pass
-    
-    def action_toggle_hidden(self) -> None:
-        """Toggle showing hidden files"""
-        self.query_one(DirectoryNavigation).toggle_hidden()
-        self.notify("Hidden files toggled", timeout=2)
-    
-    def action_focus_path_input(self) -> None:
-        """Focus the path input field"""
-        try:
-            from textual.widgets import Input
-            input_widget = self.query_one(Input)
-            input_widget.focus()
-            input_widget.action_select_all()
-        except Exception:
-            pass
-    
-    def action_toggle_recent(self) -> None:
-        """Toggle recent locations panel"""
-        self.show_recent = not self.show_recent
-    
+
     def action_toggle_bookmarks(self) -> None:
-        """Toggle bookmarks panel"""
+        """Toggle bookmarks panel."""
         self.show_bookmarks = not self.show_bookmarks
-    
+
+    def action_toggle_recent(self) -> None:
+        """Toggle recent locations panel (compatibility alias)."""
+        self.show_recent = not self.show_recent
+
+    def action_toggle_hidden(self) -> None:
+        """Toggle showing hidden files (compatibility alias)."""
+        self.query_one(SearchableDirectoryNavigation).toggle_hidden()
+        self.notify("Hidden files toggled", timeout=2)
+
+    def _action_hidden(self) -> None:
+        """Override the base ``hidden`` action to use the notifying toggle."""
+        self.action_toggle_hidden()
+
     def action_bookmark_current(self) -> None:
-        """Add or remove current directory from bookmarks"""
-        dir_nav = self.query_one(DirectoryNavigation)
+        """Add or remove current directory from bookmarks."""
+        dir_nav = self.query_one(SearchableDirectoryNavigation)
         current_path = dir_nav.location
-        
+
         if self.bookmarks_manager.is_bookmarked(current_path):
             self.bookmarks_manager.remove(current_path)
             self.notify(f"Removed bookmark: {current_path.name}", timeout=2)
         else:
             self.bookmarks_manager.add(current_path)
             self.notify(f"Added bookmark: {current_path.name}", timeout=2)
-        
+
         self._update_bookmarks_list()
         self._update_bookmark_button_state(current_path)
-    
-    def action_refresh(self) -> None:
-        """Refresh the current directory"""
-        dir_nav = self.query_one(DirectoryNavigation)
-        # Trigger a refresh by resetting the location
-        current = dir_nav.location
-        dir_nav.location = current
-        self.notify("Directory refreshed", timeout=2)
-    
-    def action_focus_search(self) -> None:
-        """Focus the search input"""
+
+    def _jump_to_bookmark(self, index: int) -> None:
+        """Jump to the bookmark at ``index`` if one exists.
+
+        Does nothing when an input field is focused so typing filenames or
+        search queries is not hijacked.
+        """
+        focused = self.screen.focused if self.screen else None
+        if isinstance(focused, Input):
+            return
+
+        bookmarks = self.bookmarks_manager.get_bookmarks()
+        if 0 <= index < len(bookmarks):
+            path = Path(bookmarks[index]["path"])
+            if path.exists():
+                dir_nav = self.query_one(SearchableDirectoryNavigation)
+                dir_nav.location = path
+                self._update_bookmark_button_state(path)
+                self.notify(f"Jumped to: {bookmarks[index]['name']}", timeout=1)
+            else:
+                self.notify(f"Path no longer exists: {path}", severity="warning")
+
+    def action_jump_bookmark_1(self) -> None:
+        self._jump_to_bookmark(0)
+
+    def action_jump_bookmark_2(self) -> None:
+        self._jump_to_bookmark(1)
+
+    def action_jump_bookmark_3(self) -> None:
+        self._jump_to_bookmark(2)
+
+    def action_jump_bookmark_4(self) -> None:
+        self._jump_to_bookmark(3)
+
+    def action_jump_bookmark_5(self) -> None:
+        self._jump_to_bookmark(4)
+
+    def action_jump_bookmark_6(self) -> None:
+        self._jump_to_bookmark(5)
+
+    def action_jump_bookmark_7(self) -> None:
+        self._jump_to_bookmark(6)
+
+    def action_jump_bookmark_8(self) -> None:
+        self._jump_to_bookmark(7)
+
+    def action_jump_bookmark_9(self) -> None:
+        self._jump_to_bookmark(8)
+
+    @on(DirectoryNavigation.Changed)
+    def _on_directory_changed(self, event: DirectoryNavigation.Changed) -> None:
+        """React to directory navigation.
+
+        Mirrors the base handler but deliberately skips ``_add_to_recent`` so
+        the config is not rewritten on every directory change. Persistence
+        happens in ``dismiss`` instead.
+        """
+        self._set_error()
         try:
-            search_input = self.query_one("#search-input", Input)
-            search_input.focus()
+            current_path_label = self.query_one("#current_path_display", Label)
+            current_path_label.update(str(event.control.location))
         except Exception:
             pass
-    
-    def action_quick_access(self) -> None:
-        """Quick access to bookmarks via number keys"""
-        # This is handled by key bindings 1-9
-        pass
-    
-    def on_key(self, event):
-        """Handle key presses for quick bookmark access"""
-        if event.key in "123456789" and not event.ctrl:
-            index = int(event.key) - 1
-            bookmarks = self.bookmarks_manager.get_bookmarks()
-            
-            if 0 <= index < len(bookmarks):
-                path = Path(bookmarks[index]["path"])
-                if path.exists():
-                    dir_nav = self.query_one(DirectoryNavigation)
-                    dir_nav.location = path
-                    self._update_bookmark_button_state(path)
-                    self.notify(f"Jumped to: {bookmarks[index]['name']}", timeout=1)
-                else:
-                    self.notify(f"Path no longer exists: {path}", severity="warning")
-                
-                event.prevent_default()
-                event.stop()
-    
-    @on(DirectoryNavigation.Changed)
-    def handle_directory_changed(self, event: DirectoryNavigation.Changed):
-        """Handle directory changes to update UI"""
-        try:
-            # Get the new location from the navigation widget
-            dir_nav = event.navigation
-            new_path = dir_nav.location
-            # Update breadcrumbs
-            breadcrumbs = self.query_one(PathBreadcrumbs)
-            breadcrumbs.update_path(new_path)
-            # Update bookmark button
-            self._update_bookmark_button_state(new_path)
-        except Exception as e:
-            logger.debug(f"Error handling directory change: {e}")
-    
-    @on(ListView.Selected, "#recent-list")
-    def handle_recent_selection(self, event: ListView.Selected):
-        """Handle selection from recent list"""
-        if hasattr(event.item, 'data'):
-            path = Path(event.item.data)
-            if path.exists():
-                dir_nav = self.query_one(DirectoryNavigation)
-                
-                if path.is_dir():
-                    dir_nav.location = path
-                else:
-                    dir_nav.location = path.parent
-                    # TODO: Select the file in the list
-                
-                self.show_recent = False
-                self._update_bookmark_button_state(dir_nav.location)
-    
+        self._update_breadcrumbs(event.control.location)
+        self._update_bookmark_button_state(event.control.location)
+
     @on(ListView.Selected, "#bookmarks-list")
     def handle_bookmark_selection(self, event: ListView.Selected):
-        """Handle selection from bookmarks list"""
+        """Handle selection from bookmarks list."""
         if hasattr(event.item, 'data'):
             path = Path(event.item.data)
             if path.exists():
-                dir_nav = self.query_one(DirectoryNavigation)
+                dir_nav = self.query_one(SearchableDirectoryNavigation)
                 dir_nav.location = path
                 self.show_bookmarks = False
                 self._update_bookmark_button_state(path)
             else:
                 self.notify(f"Path no longer exists: {path}", severity="warning")
-    
+
     @on(Button.Pressed, "#add-bookmark")
     def handle_bookmark_button(self, event: Button.Pressed):
-        """Handle bookmark button press"""
+        """Handle bookmark button press."""
         self.action_bookmark_current()
-    
-    @on(PathBreadcrumbs.PathChanged)
-    def handle_breadcrumb_navigation(self, event: PathBreadcrumbs.PathChanged):
-        """Handle breadcrumb navigation"""
-        dir_nav = self.query_one(DirectoryNavigation)
-        dir_nav.location = event.path
-        self._update_bookmark_button_state(event.path)
-    
-    @on(DirectorySearch.SearchChanged)
-    def handle_search_change(self, event: DirectorySearch.SearchChanged):
-        """Handle search query changes"""
-        self.search_query = event.query
-    
-    def dismiss(self, result: Optional[Path]) -> None:
-        """Override dismiss to save recent location and last directory"""
-        if result:
-            # Save to recent locations
-            self.recent_locations.add(result, "file" if result.is_file() else "directory")
-            # Save last directory
-            self._save_last_directory(result)
-        
-        # Always save current directory even if cancelled
+
+    def _on_clear_search(self, event: Button.Pressed) -> None:
+        """No-op override of ``FileSystemPickerScreen._on_clear_search``.
+
+        The real clear handling happens in ``_on_clear_search_enhanced``. The
+        base decorated handler is suppressed via ``_get_dispatch_methods``.
+        """
+        pass
+
+    @on(Button.Pressed, "#clear-search")
+    def _on_clear_search_enhanced(self, event: Button.Pressed) -> None:
+        """Clear the search input and reset the directory filter."""
+        event.stop()
         try:
-            dir_nav = self.query_one(DirectoryNavigation)
+            search_input = self.query_one("#search-input", Input)
+            search_input.value = ""
+        except Exception:
+            pass
+        self.search_active = False
+        try:
+            self.query_one(SearchableDirectoryNavigation).search_filter = ""
+        except Exception:
+            pass
+
+    def dismiss(self, result: Optional[Path]) -> None:
+        """Override dismiss to save recent location and last directory."""
+        if result:
+            self.recent_locations.add(result, "file" if result.is_file() else "directory")
+            self._save_last_directory(result)
+
+        try:
+            dir_nav = self.query_one(SearchableDirectoryNavigation)
             self._save_last_directory(dir_nav.location)
         except Exception:
             pass
-        
+
         super().dismiss(result)
 
 
 class EnhancedFileOpen(EnhancedFileDialog):
     """Enhanced file open dialog with bookmarks and recent files"""
-    
+
+    ERROR_FILE_MUST_EXIST = "The file must exist"
+
     def __init__(
         self,
         location: Union[str, Path] = ".",
@@ -862,7 +1046,9 @@ class EnhancedFileOpen(EnhancedFileDialog):
         context: str = "file_open",
         select_button: str = "Open",
         cancel_button: str = "Cancel",
-        **kwargs
+        id: Optional[str] = None,
+        classes: Optional[str] = None,
+        name: Optional[str] = None,
     ):
         super().__init__(
             location=location,
@@ -871,16 +1057,25 @@ class EnhancedFileOpen(EnhancedFileDialog):
             cancel_button=cancel_button,
             filters=filters,
             context=context,
-            **kwargs
+            id=id,
+            classes=classes,
+            name=name,
         )
         self.filters = filters
         self.must_exist = must_exist
-    
+
+    def _should_return(self, candidate: Path) -> bool:
+        """Final check on a picked file before returning it."""
+        if self.must_exist and not candidate.exists():
+            self._set_error(self.ERROR_FILE_MUST_EXIST)
+            return False
+        return True
+
     def _input_bar(self) -> ComposeResult:
         """Provide input widgets for file selection"""
         from textual.widgets import Input, Select
-        
-        yield Input(placeholder="File name...")
+
+        yield Input(placeholder="File name...", id="filename-input")
         if self.filters:
             yield Select(
                 self.filters.selections,
@@ -892,7 +1087,7 @@ class EnhancedFileOpen(EnhancedFileDialog):
 
 class EnhancedFileSave(EnhancedFileDialog):
     """Enhanced file save dialog with bookmarks and recent files"""
-    
+
     def __init__(
         self,
         location: Union[str, Path] = ".",
@@ -903,7 +1098,9 @@ class EnhancedFileSave(EnhancedFileDialog):
         context: str = "file_save",
         select_button: str = "Save",
         cancel_button: str = "Cancel",
-        **kwargs
+        id: Optional[str] = None,
+        classes: Optional[str] = None,
+        name: Optional[str] = None,
     ):
         super().__init__(
             location=location,
@@ -913,16 +1110,18 @@ class EnhancedFileSave(EnhancedFileDialog):
             filters=filters,
             default_file=default_filename,
             context=context,
-            **kwargs
+            id=id,
+            classes=classes,
+            name=name,
         )
         self.filters = filters
         self.default_filename = default_filename
-    
+
     def _input_bar(self) -> ComposeResult:
         """Provide input widgets for file saving"""
         from textual.widgets import Input, Select
-        
-        yield Input(value=self.default_filename, placeholder="File name...")
+
+        yield Input(value=self.default_filename, placeholder="File name...", id="filename-input")
         if self.filters:
             yield Select(
                 self.filters.selections,

--- a/tldw_chatbook/Widgets/enhanced_file_picker.py
+++ b/tldw_chatbook/Widgets/enhanced_file_picker.py
@@ -3,15 +3,15 @@
 
 import sys
 from pathlib import Path
-from typing import List, Optional, Callable, Dict, Any, Union
+from typing import List, Optional, Dict, Any, Union
 from datetime import datetime
 import os
 from textual import on
 from textual.app import ComposeResult
 from textual.binding import Binding
-from textual.containers import Horizontal, VerticalScroll
+from textual.containers import Horizontal, Vertical, VerticalScroll
 
-from textual.widgets import Button, Label, ListView, ListItem, Input
+from textual.widgets import Button, Label, ListView, ListItem, Input, Static
 from textual.reactive import reactive
 from textual.message import Message
 from loguru import logger
@@ -414,121 +414,166 @@ class EnhancedFileDialog(BaseFileDialog):
     """Enhanced file picker with keyboard shortcuts, recent files, breadcrumbs, bookmarks, and search"""
 
     DEFAULT_CSS = BaseFileDialog.DEFAULT_CSS + """
-    BaseFileDialog {
-        .hidden {
-            display: none;
-        }
+    .hidden {
+        display: none;
+    }
 
-        Dialog {
-            height: 90%;
-            width: 90%;
-        }
+    EnhancedFileDialog Dialog {
+        height: 95%;
+        width: 95%;
+        border-title-align: center;
+        border-title-style: bold;
+    }
 
-        #recent-locations, #bookmarks-panel {
-            height: 10;
-            border: solid $primary;
-            background: $surface;
-            margin-bottom: 1;
-            display: none;
-        }
+    #dialog-body {
+        height: 1fr;
+        width: 1fr;
+    }
 
-        #recent-locations.visible, #bookmarks-panel.visible {
-            display: block;
-        }
+    #filepicker-sidebar {
+        width: 28;
+        height: 1fr;
+        border-right: tall $primary-lighten-1;
+        background: $surface;
+        display: none;
+    }
 
-        #recent-list, #bookmarks-list {
-            height: 8;
-            background: $surface;
-        }
+    #filepicker-main {
+        width: 1fr;
+        height: 1fr;
+    }
 
-        .recent-item, .bookmark-item {
-            padding: 0 1;
-        }
+    #recent-locations, #bookmarks-panel {
+        height: auto;
+        border: none;
+        background: $surface;
+        padding: 0 1;
+    }
 
-        #bookmarks-list {
-            layout: grid;
-            grid-size: 2;
-            grid-columns: 1fr 1fr;
-            grid-gutter: 1;
-            height: 8;
-            overflow-y: auto;
-        }
+    #recent-list, #bookmarks-list {
+        height: auto;
+        background: $surface;
+    }
 
-        #bookmarks-list ListItem {
-            height: 3;
-            margin: 0;
-            padding: 0 1;
-        }
+    .recent-item, .bookmark-item {
+        padding: 0 1;
+    }
 
-        .bookmark-item {
-            padding: 0 1;
-            height: 3;
-            overflow: hidden;
-        }
+    EnhancedFileDialog #bookmarks-list {
+        height: auto;
+        max-height: 1fr;
+        overflow-y: auto;
+    }
 
-        .bookmark-item-icon {
-            margin-right: 1;
-        }
+    EnhancedFileDialog #bookmarks-list ListItem {
+        height: 3;
+        margin: 0;
+        padding: 0 1;
+    }
 
-        .bookmarks-header {
-            height: 2;
-            padding: 0 1;
-        }
+    .bookmark-item {
+        padding: 0 1;
+        height: 3;
+        overflow: hidden;
+    }
 
-        .bookmark-button, #add-bookmark {
-            min-width: 1;
-            width: 3;
-            height: 1;
-            margin: 0;
-            padding: 0;
-            text-align: center;
-        }
+    .bookmark-item-icon {
+        margin-right: 1;
+    }
 
-        .bookmark-container {
-            width: 100%;
-            height: 100%;
-            align: left middle;
-        }
+    .bookmarks-header {
+        height: 2;
+        padding: 0 1;
+    }
 
-        #path-breadcrumbs {
-            height: 3;
-            padding: 0 1;
-            background: $surface;
-            border-bottom: tall $primary-lighten-1;
-            overflow: hidden;
-        }
+    .bookmark-button, #add-bookmark {
+        min-width: 1;
+        width: 3;
+        height: 1;
+        margin: 0;
+        padding: 0;
+        text-align: center;
+    }
 
-        #path-breadcrumbs .breadcrumb-btn {
-            min-width: 0;
-            padding: 0 1;
-            margin: 0;
-            height: 1;
-            background: transparent;
-            border: none;
-            color: $text;
-            text-style: none;
-        }
+    .bookmark-container {
+        width: 100%;
+        height: 100%;
+        align: left middle;
+    }
 
-        #path-breadcrumbs .breadcrumb-btn:hover {
-            background: $primary 20%;
-            text-style: underline;
-        }
+    #current_path_display {
+        display: none;
+    }
 
-        #path-breadcrumbs .breadcrumb-separator {
-            margin: 0;
-            padding: 0 1;
-            color: $text-muted;
-        }
+    EnhancedFileDialog #path-breadcrumbs {
+        height: 3;
+        min-height: 3;
+        padding: 0 1;
+        margin-bottom: 1;
+        background: $surface;
+        border-bottom: tall $primary-lighten-1;
+        align: center middle;
+    }
 
-        .search-active {
-            border-title-style: bold;
-            border-title-color: $warning;
-        }
+    EnhancedFileDialog #path-breadcrumbs .breadcrumb-btn {
+        min-width: 0;
+        padding: 0 1;
+        margin: 0;
+        height: 1;
+        background: transparent;
+        border: none;
+        color: $text;
+        text-style: none;
+    }
 
-        .section-title {
-            width: 1fr;
-            text-style: bold;
-        }
+    EnhancedFileDialog #path-breadcrumbs .breadcrumb-btn:hover {
+        background: $primary 20%;
+        text-style: underline;
+    }
+
+    EnhancedFileDialog #path-breadcrumbs .breadcrumb-separator {
+        margin: 0;
+        padding: 0 1;
+        color: $text-muted;
+    }
+
+    EnhancedFileDialog #path-input-container {
+        height: 3;
+        padding: 0 1;
+    }
+
+    EnhancedFileDialog #path-input {
+        width: 1fr;
+    }
+
+    EnhancedFileDialog #go-to-path,
+    EnhancedFileDialog #cancel-path-input {
+        min-width: 7;
+    }
+
+    .search-active {
+        border-title-style: bold;
+        border-title-color: $warning;
+    }
+
+    .section-title {
+        width: 1fr;
+        text-style: bold;
+    }
+
+    .shortcut-hints {
+        height: 1;
+        padding: 0 1;
+        color: $text-muted;
+        background: $surface-darken-1;
+        text-align: center;
+        text-style: italic;
+    }
+
+    #select {
+        background: $primary;
+        color: $text;
+        text-style: bold;
     }
     """
 
@@ -628,45 +673,63 @@ class EnhancedFileDialog(BaseFileDialog):
         with Dialog() as dialog:
             dialog.border_title = self._title
 
-            # Recent locations panel (hidden by default)
-            with VerticalScroll(id="recent-locations"):
-                yield Label("📋 Recent Locations", classes="section-title")
-                yield ListView(id="recent-list")
+            with Horizontal(id="dialog-body"):
+                # Sidebar for bookmarks/recent (hidden by default)
+                with VerticalScroll(id="filepicker-sidebar"):
+                    with VerticalScroll(id="recent-locations"):
+                        yield Label("📋 Recent", classes="section-title")
+                        yield ListView(id="recent-list")
 
-            # Bookmarks panel (hidden by default)
-            with VerticalScroll(id="bookmarks-panel"):
-                with Horizontal(classes="bookmarks-header"):
-                    yield Label("⭐ Bookmarks", classes="section-title")
-                    yield Button("➕", id="add-bookmark", classes="bookmark-button")
-                yield ListView(id="bookmarks-list")
+                    with VerticalScroll(id="bookmarks-panel"):
+                        with Horizontal(classes="bookmarks-header"):
+                            yield Label("⭐ Bookmarks", classes="section-title")
+                            yield Button("➕", id="add-bookmark", classes="bookmark-button")
+                        yield ListView(id="bookmarks-list")
 
-            # Path display and breadcrumbs
-            yield Label(id="current_path_display")
-            with Horizontal(id="path-breadcrumbs"):
-                pass
+                with Vertical(id="filepicker-main"):
+                    # Path display (kept for base on_mount, hidden visually)
+                    yield Label(id="current_path_display")
+                    with Horizontal(id="path-breadcrumbs"):
+                        pass
 
-            # Path input field (hidden by default, shown with Ctrl+L)
-            with Horizontal(id="path-input-container", classes="hidden"):
-                yield Input(placeholder="Enter path...", id="path-input")
-                yield Button("Go", id="go-to-path", variant="primary")
-                yield Button("Cancel", id="cancel-path-input", variant="default")
+                    # Path input field (hidden by default, shown with Ctrl+L)
+                    with Horizontal(id="path-input-container", classes="hidden"):
+                        yield Input(placeholder="Enter path...", id="path-input")
+                        yield Button("Go", id="go-to-path", variant="primary")
+                        yield Button("Cancel", id="cancel-path-input", variant="default")
 
-            # Search container (hidden by default)
-            with Horizontal(id="search-container"):
-                yield Input(placeholder="Search files...", id="search-input")
-                yield Button("Clear", id="clear-search", variant="default")
+                    # Search container (hidden by default)
+                    with Horizontal(id="search-container"):
+                        yield Input(placeholder="Search files...", id="search-input")
+                        yield Button("Clear", id="clear-search", variant="default")
 
-            # Main directory navigation
-            with Horizontal():
-                if sys.platform == "win32":
-                    yield DriveNavigation(self._location)
-                yield SearchableDirectoryNavigation(self._location)
+                    # Main directory navigation
+                    with Horizontal():
+                        if sys.platform == "win32":
+                            yield DriveNavigation(self._location)
+                        yield SearchableDirectoryNavigation(self._location)
 
-            # Input bar with buttons
-            with InputBar():
-                yield from self._input_bar()
-                yield Button(self._label(self._select_button, "Select"), id="select")
-                yield Button(self._label(self._cancel_button, "Cancel"), id="cancel")
+                    select_hint = self._label(self._select_button, "Select")
+                    yield Static(
+                        f"Ctrl+B Bookmarks  Ctrl+R Recent  Ctrl+F Search  Ctrl+L Path  "
+                        f"1-9 Jump  Enter {select_hint}  Esc Cancel",
+                        id="shortcut-hints",
+                        classes="shortcut-hints",
+                    )
+
+                    # Input bar with buttons
+                    with InputBar():
+                        yield from self._input_bar()
+                        yield Button(
+                            self._label(self._select_button, "Select"),
+                            id="select",
+                            variant="primary",
+                        )
+                        yield Button(
+                            self._label(self._cancel_button, "Cancel"),
+                            id="cancel",
+                            variant="default",
+                        )
 
     def on_mount(self) -> None:
         """Initialize the dialog on mount.
@@ -674,20 +737,47 @@ class EnhancedFileDialog(BaseFileDialog):
         The base ``on_mount`` expects ``#path-breadcrumbs`` and
         ``#recent-list`` to exist; our compose provides them, so calling
         ``super().on_mount()`` is safe.
+
+        Hidden panels rely on inline ``styles.display`` rather than CSS
+        ``display: none`` rules because the vendored base selectors do not
+        reliably override container defaults in this subclass.
         """
         super().on_mount()
         self._update_bookmarks_list()
         self._update_bookmark_button_state(
             self.query_one(SearchableDirectoryNavigation).location
         )
+        try:
+            self.query_one("#path-input-container").styles.display = "none"
+            self.query_one("#search-container").styles.display = "none"
+            self.query_one("#recent-locations").styles.display = "none"
+            self.query_one("#bookmarks-panel").styles.display = "none"
+            self.query_one("#filepicker-sidebar").styles.display = "none"
+            # Breadcrumbs already show the path; the label is redundant and
+            # often truncated.
+            self.query_one("#current_path_display").styles.display = "none"
+        except Exception:
+            pass
+
+    def _sync_sidebar(self) -> None:
+        """Show the sidebar if either panel is open, otherwise hide it."""
+        try:
+            sidebar = self.query_one("#filepicker-sidebar")
+            sidebar.styles.display = (
+                "block" if self.show_recent or self.show_bookmarks else "none"
+            )
+        except Exception:
+            pass
 
     def watch_show_recent(self, show: bool) -> None:
         """Toggle recent locations visibility."""
         try:
-            recent_panel = self.query_one("#recent-locations")
-            recent_panel.set_class(show, "visible")
+            self.query_one("#recent-locations").styles.display = (
+                "block" if show else "none"
+            )
             if show:
                 self.show_bookmarks = False
+            self._sync_sidebar()
         except Exception:
             pass
 
@@ -698,12 +788,43 @@ class EnhancedFileDialog(BaseFileDialog):
     def watch_show_bookmarks(self, show: bool) -> None:
         """Toggle bookmarks panel visibility."""
         try:
-            bookmarks_panel = self.query_one("#bookmarks-panel")
-            bookmarks_panel.set_class(show, "visible")
+            self.query_one("#bookmarks-panel").styles.display = (
+                "block" if show else "none"
+            )
             if show:
                 self.show_recent = False
+            self._sync_sidebar()
         except Exception:
             pass
+
+    def watch_search_active(self, active: bool) -> None:
+        """Toggle search container visibility."""
+        try:
+            self.query_one("#search-container").styles.display = (
+                "block" if active else "none"
+            )
+            if active:
+                self.query_one("#search-input", Input).focus()
+        except Exception:
+            pass
+
+    def action_focus_path_input(self) -> None:
+        """Toggle and focus the path input field."""
+        try:
+            path_container = self.query_one("#path-input-container")
+            path_input = self.query_one("#path-input", Input)
+            if path_container.styles.display == "none":
+                path_container.styles.display = "block"
+                path_input.value = str(
+                    self.query_one(SearchableDirectoryNavigation).location
+                )
+                path_input.focus()
+                path_input.selection = (0, len(path_input.value))
+            else:
+                path_container.styles.display = "none"
+                self.query_one(SearchableDirectoryNavigation).focus()
+        except Exception as e:
+            self.notify(f"Error toggling path input: {e}", severity="error", timeout=2)
 
     def _select_file(self, event: DirectoryNavigation.Selected) -> None:
         """No-op override of ``BaseFileDialog._select_file``.
@@ -797,22 +918,46 @@ class EnhancedFileDialog(BaseFileDialog):
             # ...return it.
             self.dismiss(result=chosen)
 
+    _MAX_VISIBLE_BREADCRUMBS = 5
+
     def _update_breadcrumbs(self, path: Path) -> None:
-        """Update breadcrumb navigation using the base container."""
+        """Update breadcrumb navigation using the base container.
+
+        Very deep paths are collapsed in the middle so the current directory
+        always remains readable.
+        """
         try:
             breadcrumb_container = self.query_one("#path-breadcrumbs", Horizontal)
             breadcrumb_container.remove_children()
 
             parts = path.parts
-            for i, part in enumerate(parts):
-                partial_path = Path(*parts[:i+1])
+            max_visible = self._MAX_VISIBLE_BREADCRUMBS
+            if len(parts) > max_visible:
+                # Root + ellipsis + tail so the current directory is visible.
+                visible_indices = [0] + list(range(len(parts) - max_visible + 2, len(parts)))
+            else:
+                visible_indices = list(range(len(parts)))
 
-                btn = Button(part, variant="default", classes="breadcrumb-btn")
+            for position, i in enumerate(visible_indices):
+                part = parts[i]
+                # Show the root as a home-ish icon rather than a raw "/" that
+                # would collide with the separator.
+                label = "🏠" if part == "/" else part
+                partial_path = Path(*parts[: i + 1])
+
+                if i > 0 and i != visible_indices[position - 1] + 1:
+                    breadcrumb_container.mount(
+                        Label("…", classes="breadcrumb-separator")
+                    )
+
+                btn = Button(label, variant="default", classes="breadcrumb-btn")
                 btn.tooltip = str(partial_path)
                 breadcrumb_container.mount(btn)
 
-                if i < len(parts) - 1:
-                    breadcrumb_container.mount(Label("/", classes="breadcrumb-separator"))
+                if position < len(visible_indices) - 1:
+                    breadcrumb_container.mount(
+                        Label("›", classes="breadcrumb-separator")
+                    )
         except Exception:
             pass
 
@@ -877,6 +1022,12 @@ class EnhancedFileDialog(BaseFileDialog):
                 btn.tooltip = "Add bookmark"
         except Exception:
             pass
+
+    def _filename_placeholder(self) -> str:
+        """Placeholder text for the filename input."""
+        if getattr(self, "filters", None):
+            return "File name (filtered by selected type)"
+        return "File name"
 
     def action_toggle_bookmarks(self) -> None:
         """Toggle bookmarks panel."""
@@ -1075,7 +1226,7 @@ class EnhancedFileOpen(EnhancedFileDialog):
         """Provide input widgets for file selection"""
         from textual.widgets import Input, Select
 
-        yield Input(placeholder="File name...", id="filename-input")
+        yield Input(placeholder=self._filename_placeholder(), id="filename-input")
         if self.filters:
             yield Select(
                 self.filters.selections,
@@ -1121,7 +1272,11 @@ class EnhancedFileSave(EnhancedFileDialog):
         """Provide input widgets for file saving"""
         from textual.widgets import Input, Select
 
-        yield Input(value=self.default_filename, placeholder="File name...", id="filename-input")
+        yield Input(
+            value=self.default_filename,
+            placeholder=self._filename_placeholder(),
+            id="filename-input",
+        )
         if self.filters:
             yield Select(
                 self.filters.selections,

--- a/tldw_chatbook/Widgets/enhanced_file_picker.py
+++ b/tldw_chatbook/Widgets/enhanced_file_picker.py
@@ -1,12 +1,13 @@
 # enhanced_file_picker.py
 # Enhanced file picker with keyboard shortcuts, recent files, breadcrumbs, bookmarks, and search
 
+import asyncio
 import sys
 from pathlib import Path
 from typing import List, Optional, Dict, Any, Union
 from datetime import datetime
 import os
-from textual import on
+from textual import events, on
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
@@ -15,12 +16,15 @@ from textual.widgets import Button, Label, ListView, ListItem, Input, Static
 from textual.reactive import reactive
 from textual.message import Message
 from loguru import logger
+from rich.table import Table
+from rich.console import RenderableType
 
 from ..Third_Party.textual_fspicker import Filters
 from ..Third_Party.textual_fspicker.file_dialog import BaseFileDialog
 from ..Third_Party.textual_fspicker.base_dialog import FileSystemPickerScreen
 from ..Third_Party.textual_fspicker.parts import DirectoryNavigation
 from ..Third_Party.textual_fspicker.parts.directory_navigation import DirectoryEntry
+from ..Third_Party.textual_fspicker.safe_tests import is_dir, is_file, is_symlink
 from ..Third_Party.textual_fspicker.path_maker import MakePath
 from ..config import get_cli_setting, save_setting_to_cli_config
 
@@ -379,6 +383,88 @@ class DirectorySearch(Horizontal):
         self.post_message(self.SearchChanged(""))
 
 
+def _human_readable_size(size: int) -> str:
+    """Return a concise, human-readable byte size."""
+    if size < 1024:
+        return f"{size} B"
+    units = ["KB", "MB", "GB", "TB", "PB"]
+    value = size
+    unit = units[-1]
+    for u in units:
+        value /= 1024
+        if value < 1024:
+            unit = u
+            break
+    formatted = f"{value:.1f}"
+    # Drop trailing zeros and the decimal point when not needed.
+    if "." in formatted:
+        formatted = formatted.rstrip("0").rstrip(".")
+    return f"{formatted} {unit}"
+
+
+class FormattedDirectoryEntry(DirectoryEntry):
+    """Directory entry with human-readable sizes and no size for directories."""
+
+    @staticmethod
+    def _size(location: Path) -> str:
+        if is_dir(location):
+            return ""
+        try:
+            entry_size = location.stat().st_size
+        except (FileNotFoundError, OSError):
+            entry_size = 0
+        return _human_readable_size(entry_size)
+
+
+class MultiSelectDirectoryEntry(FormattedDirectoryEntry):
+    """A directory entry that renders a selection marker for multi-select."""
+
+    def __init__(self, location: Path, styles: Any, selected: bool = False) -> None:
+        self.selected = selected
+        super().__init__(location, styles)
+
+    def _as_renderable(self, location: Path) -> RenderableType:
+        """Render with an extra leading check-mark column."""
+        prompt = Table.grid(expand=True)
+        prompt.add_column(no_wrap=True, width=1)
+        prompt.add_column(
+            no_wrap=True,
+            width=1,
+            style=self._style(self._styles.name, location),
+        )
+        prompt.add_column(no_wrap=True, width=3)
+        prompt.add_column(
+            no_wrap=True,
+            justify="left",
+            ratio=1,
+            style=self._style(self._styles.name, location),
+        )
+        prompt.add_column(
+            no_wrap=True,
+            justify="right",
+            width=10,
+            style=self._style(self._styles.size, location),
+        )
+        prompt.add_column(
+            no_wrap=True,
+            justify="right",
+            width=20,
+            style=self._style(self._styles.time, location),
+        )
+        prompt.add_column(no_wrap=True, width=1)
+        marker = "✓" if self.selected else " "
+        prompt.add_row(
+            "",
+            marker,
+            self.FOLDER_ICON if is_dir(location) else self.FILE_ICON,
+            self._name(location),
+            self._size(location),
+            self._mtime(location),
+            "",
+        )
+        return prompt
+
+
 class SearchableDirectoryNavigation(DirectoryNavigation):
     """Directory navigation that also filters by a free-text search term.
 
@@ -386,28 +472,164 @@ class SearchableDirectoryNavigation(DirectoryNavigation):
     method but does not declare the reactive variable, and its
     ``_repopulate_display`` does not apply the term. This subclass adds the
     missing reactive and applies it without editing third-party code.
+
+    Additional enhancements:
+    - Type-ahead jumping to the next entry whose name starts with the typed
+      prefix.
+    - Optional multi-select rendering via :class:`MultiSelectDirectoryEntry`.
     """
 
     search_filter = reactive("")
     """Free-text filter applied to entry names."""
 
+    class SearchCountChanged(Message):
+        """Posted when the number of visible options changes."""
+        def __init__(self, navigation: DirectoryNavigation, count: int, query: str) -> None:
+            self.navigation = navigation
+            self.count = count
+            self.query = query
+            super().__init__()
+
+    class ToggleSelection(Message):
+        """Posted when the user asks to toggle the highlighted entry."""
+        def __init__(self, navigation: DirectoryNavigation) -> None:
+            self.navigation = navigation
+            super().__init__()
+
+    def __init__(self, location: Path | str = ".") -> None:
+        super().__init__(location)
+        self._type_ahead_buffer = ""
+        self._type_ahead_timer: Optional[asyncio.TimerHandle] = None
+
+    def _restart_type_ahead_timer(self) -> None:
+        """Reset the inactivity timeout that clears the type-ahead buffer."""
+        if self._type_ahead_timer is not None:
+            self._type_ahead_timer.cancel()
+        self._type_ahead_timer = asyncio.get_event_loop().call_later(
+            0.8, self._reset_type_ahead
+        )
+
+    def _reset_type_ahead(self) -> None:
+        """Clear the type-ahead buffer after a period of inactivity."""
+        self._type_ahead_buffer = ""
+        self._type_ahead_timer = None
+
+    def _jump_to_prefix(self, prefix: str) -> None:
+        """Move the highlight to the next entry whose name starts with prefix."""
+        prefix = prefix.lower()
+        start = (self.highlighted or -1) + 1
+        options = self.options
+
+        def match_at(index: int) -> bool:
+            option = options[index]
+            if not isinstance(option, DirectoryEntry):
+                return False
+            name = option.location.name.lower()
+            return name.startswith(prefix)
+
+        # Search from the item after the current highlight, wrapping around.
+        for idx in range(start, len(options)):
+            if match_at(idx):
+                self.highlighted = idx
+                return
+        for idx in range(0, start):
+            if match_at(idx):
+                self.highlighted = idx
+                return
+
+    def _on_key(self, event: events.Key) -> None:
+        """Handle type-ahead jumping and multi-select toggling.
+
+        Navigation keys (arrows, page, home, end, enter, backspace) are left
+        for the default OptionList bindings.  The space bar toggles selection
+        in multi-select mode.  Printable letters drive type-ahead jumping;
+        digits are reserved for the screen's bookmark-jump bindings unless a
+        type-ahead prefix is already active.
+        """
+        if event.key in ("up", "down", "pageup", "pagedown", "home", "end", "enter", "backspace"):
+            return
+
+        if event.key == "space":
+            if getattr(self.screen, "multi_select", False):
+                event.stop()
+                event.prevent_default()
+                self.post_message(self.ToggleSelection(self))
+            return
+
+        if not event.is_printable or not event.character or len(event.character) != 1:
+            return
+
+        char = event.character
+        if char.isspace():
+            return
+
+        # Digits jump bookmarks when no prefix is active; otherwise extend it.
+        if char.isdigit():
+            if self._type_ahead_buffer:
+                event.stop()
+                event.prevent_default()
+                self._type_ahead_buffer += char
+                self._jump_to_prefix(self._type_ahead_buffer)
+                self._restart_type_ahead_timer()
+            return
+
+        # Printable characters start or extend the type-ahead prefix.
+        event.stop()
+        event.prevent_default()
+        self._type_ahead_buffer += char.lower()
+        self._jump_to_prefix(self._type_ahead_buffer)
+        self._restart_type_ahead_timer()
+
     def _repopulate_display(self) -> None:
         """Repopulate the display, honouring file, hidden, and search filters."""
         styles = self._styles
         query = self.search_filter.strip().lower()
+
+        # Remember the currently highlighted path so we can restore it after
+        # rebuilding the option list.
+        previous_path: Optional[Path] = None
+        try:
+            if self.highlighted is not None:
+                highlighted_option = self.get_option_at_index(self.highlighted)
+                if isinstance(highlighted_option, DirectoryEntry):
+                    previous_path = highlighted_option.location
+        except Exception:
+            pass
+
+        # Determine whether the hosting dialog is in multi-select mode.
+        screen = self.screen
+        multi_select = getattr(screen, "multi_select", False)
+        selected = getattr(screen, "_selected_paths", set()) if multi_select else set()
+
         with self.app.batch_update():
             self.clear_options()
             if not self.is_root:
-                self.add_option(DirectoryEntry(self._location / "..", styles))
+                if multi_select:
+                    self.add_option(MultiSelectDirectoryEntry(self._location / "..", styles, False))
+                else:
+                    self.add_option(FormattedDirectoryEntry(self._location / "..", styles))
             self.add_options(
                 self._sort(
-                    entry
+                    (
+                        MultiSelectDirectoryEntry(entry.location, styles, entry.location in selected)
+                        if multi_select
+                        else FormattedDirectoryEntry(entry.location, styles)
+                    )
                     for entry in self._entries
                     if not self.hide(entry.location)
                     and (not query or query in entry.location.name.lower())
                 )
             )
         self._settle_highlight()
+
+        # Restore the previous highlight if the entry still exists.
+        if previous_path is not None:
+            for idx, option in enumerate(self.options):
+                if isinstance(option, DirectoryEntry) and option.location == previous_path:
+                    self.highlighted = idx
+                    break
+
+        self.post_message(self.SearchCountChanged(self, self.option_count, query))
 
 
 class EnhancedFileDialog(BaseFileDialog):
@@ -433,7 +655,7 @@ class EnhancedFileDialog(BaseFileDialog):
     #filepicker-sidebar {
         width: 28;
         height: 1fr;
-        border-right: tall $primary-lighten-1;
+        border-right: solid $surface-lighten-2;
         background: $surface;
         display: none;
     }
@@ -443,15 +665,35 @@ class EnhancedFileDialog(BaseFileDialog):
         height: 1fr;
     }
 
-    #recent-locations, #bookmarks-panel {
+    #file-list-container {
+        width: 1fr;
+        height: 1fr;
+    }
+
+    #file-list-pane {
+        width: 1fr;
+        height: 1fr;
+    }
+
+    EnhancedFileDialog #file-list-header {
         height: auto;
+        min-height: 1;
+        padding: 0 1 0 2;
+        color: $text-muted;
+        text-style: bold;
+        background: $surface;
+        border-bottom: solid $surface-lighten-2;
+    }
+
+    #recent-locations, #bookmarks-panel {
+        height: 1fr;
         border: none;
         background: $surface;
         padding: 0 1;
     }
 
     #recent-list, #bookmarks-list {
-        height: auto;
+        height: 1fr;
         background: $surface;
     }
 
@@ -459,9 +701,13 @@ class EnhancedFileDialog(BaseFileDialog):
         padding: 0 1;
     }
 
+    .empty-state {
+        color: $text-muted;
+        text-style: italic;
+    }
+
     EnhancedFileDialog #bookmarks-list {
-        height: auto;
-        max-height: 1fr;
+        height: 1fr;
         overflow-y: auto;
     }
 
@@ -497,7 +743,7 @@ class EnhancedFileDialog(BaseFileDialog):
 
     .bookmark-container {
         width: 100%;
-        height: 100%;
+        height: 3;
         align: left middle;
     }
 
@@ -537,6 +783,11 @@ class EnhancedFileDialog(BaseFileDialog):
         color: $text-muted;
     }
 
+    EnhancedFileDialog #path-breadcrumbs .breadcrumb-ellipsis {
+        color: $text-disabled;
+        padding: 0;
+    }
+
     EnhancedFileDialog #path-input-container {
         height: 3;
         padding: 0 1;
@@ -562,7 +813,8 @@ class EnhancedFileDialog(BaseFileDialog):
     }
 
     .shortcut-hints {
-        height: 1;
+        height: auto;
+        min-height: 1;
         padding: 0 1;
         color: $text-muted;
         background: $surface-darken-1;
@@ -570,19 +822,73 @@ class EnhancedFileDialog(BaseFileDialog):
         text-style: italic;
     }
 
+    .shortcut-hints.collapsed {
+        text-align: right;
+        text-style: none;
+    }
+
     #select {
         background: $primary;
         color: $text;
         text-style: bold;
     }
+
+    EnhancedFileDialog #error-line {
+        height: auto;
+        min-height: 1;
+        padding: 0 1;
+        color: $error;
+        text-style: bold;
+        display: none;
+    }
+
+    EnhancedFileDialog SearchableDirectoryNavigation > .option-list--option-highlighted {
+        background: $primary 30%;
+        color: $text;
+        text-style: bold;
+    }
+
+    EnhancedFileDialog SearchableDirectoryNavigation:focus > .option-list--option-highlighted {
+        background: $primary 50%;
+        color: $text;
+        text-style: bold;
+    }
+
+    EnhancedFileDialog #search-status {
+        width: auto;
+        min-width: 10;
+        padding: 0 1;
+        color: $text-muted;
+        text-align: right;
+        content-align: center middle;
+    }
+
+    EnhancedFileDialog #search-no-match {
+        height: auto;
+        padding: 1;
+        color: $text-muted;
+        text-style: italic;
+        text-align: center;
+    }
+
+    EnhancedFileDialog #multi-select-info {
+        height: auto;
+        min-height: 1;
+        padding: 0 1;
+        color: $text-muted;
+        text-align: right;
+        display: none;
+    }
     """
 
     BINDINGS = [
         Binding("ctrl+b", "toggle_bookmarks", "Show bookmarks"),
+        Binding("question_mark", "toggle_hints", "Toggle shortcuts"),
         *[Binding(str(n), f"jump_bookmark_{n}", f"Bookmark {n}", show=False) for n in range(1, 10)],
     ]
 
     show_bookmarks = reactive(False)
+    show_hints = reactive(True)
 
     # Base class handlers that this subclass replaces. Textual dispatches
     # decorated handlers from the whole MRO, so simply renaming the subclass
@@ -612,6 +918,7 @@ class EnhancedFileDialog(BaseFileDialog):
         filters: Optional[Filters] = None,
         default_file: Optional[Union[str, Path]] = None,
         context: str = "default",
+        multi_select: bool = False,
         id: Optional[str] = None,
         classes: Optional[str] = None,
         name: Optional[str] = None,
@@ -633,6 +940,8 @@ class EnhancedFileDialog(BaseFileDialog):
         if name is not None:
             self.name = name
         self.context = context
+        self.multi_select = multi_select
+        self._selected_paths: set[Path] = set()
         self.recent_locations = RecentLocations(context=context)
         self.bookmarks_manager = BookmarksManager(context=context)
         self._last_directory = self._get_last_directory()
@@ -702,20 +1011,30 @@ class EnhancedFileDialog(BaseFileDialog):
                     with Horizontal(id="search-container"):
                         yield Input(placeholder="Search files...", id="search-input")
                         yield Button("Clear", id="clear-search", variant="default")
+                        yield Label("", id="search-status")
+
+                    # Shown when a search returns no results.
+                    yield Static("", id="search-no-match", classes="hidden")
+
+                    # Multi-select status (visible only in multi-select mode).
+                    yield Static("", id="multi-select-info")
 
                     # Main directory navigation
-                    with Horizontal():
+                    with Horizontal(id="file-list-container"):
                         if sys.platform == "win32":
                             yield DriveNavigation(self._location)
-                        yield SearchableDirectoryNavigation(self._location)
+                        with Vertical(id="file-list-pane"):
+                            yield Static(self._file_list_header(), id="file-list-header")
+                            yield SearchableDirectoryNavigation(self._location)
 
-                    select_hint = self._label(self._select_button, "Select")
                     yield Static(
-                        f"Ctrl+B Bookmarks  Ctrl+R Recent  Ctrl+F Search  Ctrl+L Path  "
-                        f"1-9 Jump  Enter {select_hint}  Esc Cancel",
+                        "",
                         id="shortcut-hints",
                         classes="shortcut-hints",
                     )
+
+                    # Dedicated error line above the input bar.
+                    yield Static("", id="error-line")
 
                     # Input bar with buttons
                     with InputBar():
@@ -756,6 +1075,10 @@ class EnhancedFileDialog(BaseFileDialog):
             # Breadcrumbs already show the path; the label is redundant and
             # often truncated.
             self.query_one("#current_path_display").styles.display = "none"
+            self.watch_show_hints(self.show_hints)
+            if self.multi_select:
+                self.query_one("#multi-select-info").styles.display = "block"
+                self._update_multi_select_ui()
         except Exception:
             pass
 
@@ -808,6 +1131,38 @@ class EnhancedFileDialog(BaseFileDialog):
         except Exception:
             pass
 
+    def _shortcut_hint_text(self) -> str:
+        """Full shortcut-hint text shown when the footer is expanded."""
+        select_hint = self._label(self._select_button, "Select")
+        hints = [
+            "Ctrl+B Bookmarks",
+            "Ctrl+R Recent",
+            "Ctrl+F Search",
+            "Ctrl+L Path",
+            "1-9 Jump",
+        ]
+        if self.multi_select:
+            hints.append("Space Toggle")
+        hints.extend([f"Enter {select_hint}", "Esc Cancel", "? Hide"])
+        return "  ".join(hints)
+
+    def watch_show_hints(self, show: bool) -> None:
+        """Expand or collapse the shortcut-hints footer."""
+        try:
+            hints = self.query_one("#shortcut-hints", Static)
+            if show:
+                hints.update(self._shortcut_hint_text())
+                hints.remove_class("collapsed")
+            else:
+                hints.update("? Show shortcuts")
+                hints.add_class("collapsed")
+        except Exception:
+            pass
+
+    def action_toggle_hints(self) -> None:
+        """Toggle the shortcut-hints footer."""
+        self.show_hints = not self.show_hints
+
     def action_focus_path_input(self) -> None:
         """Toggle and focus the path input field."""
         try:
@@ -840,10 +1195,14 @@ class EnhancedFileDialog(BaseFileDialog):
     def _on_select_file(self, event: DirectoryNavigation.Selected) -> None:
         """Handle a file being selected in the picker.
 
-        Mirrors ``BaseFileDialog._select_file`` but targets the dedicated
-        ``#filename-input`` so the hidden ``#path-input`` and
-        ``#search-input`` are not selected by ``query_one(Input)``.
+        In multi-select mode the list selection toggles the file in the
+        selected set.  In single-select mode the file name is copied into the
+        filename input for editing/confirmation.
         """
+        if self.multi_select:
+            self._toggle_path_selection(event.path)
+            return
+
         try:
             file_name = self.query_one("#filename-input", Input)
         except Exception:
@@ -854,21 +1213,14 @@ class EnhancedFileDialog(BaseFileDialog):
     def _confirm_file(self, event: Input.Submitted | Button.Pressed) -> None:
         """No-op override of ``BaseFileDialog._confirm_file``.
 
-        The real confirmation handling happens in ``_on_confirm_file``. The
-        base decorated handler is suppressed via ``_get_dispatch_methods``.
+        The real confirmation handling happens in ``_on_confirm_file`` and
+        ``_on_select_button``. The base decorated handler is suppressed via
+        ``_get_dispatch_methods``.
         """
         pass
 
-    @on(Input.Submitted, "#filename-input")
-    @on(Button.Pressed, "#select")
-    def _on_confirm_file(self, event: Input.Submitted | Button.Pressed) -> None:
-        """Confirm the selection of the file in the input box.
-
-        Mirrors ``BaseFileDialog._confirm_file`` but targets the dedicated
-        ``#filename-input`` so the hidden ``#path-input`` and
-        ``#search-input`` are not selected by ``query_one(Input)``.
-        """
-        event.stop()
+    def _confirm_single(self) -> None:
+        """Confirm the single filename currently in the input box."""
         file_name = self.query_one("#filename-input", Input)
 
         # Only even try and process this if there's some input.
@@ -918,6 +1270,109 @@ class EnhancedFileDialog(BaseFileDialog):
             # ...return it.
             self.dismiss(result=chosen)
 
+    def _confirm_multi_select(self) -> None:
+        """Confirm a multi-select pick and return the selected files."""
+        if not self._selected_paths:
+            self._set_error("Select at least one file")
+            return
+        self.dismiss(result=list(self._selected_paths))
+
+    @on(Input.Submitted, "#filename-input")
+    def _on_confirm_file(self, event: Input.Submitted) -> None:
+        """Handle Enter in the filename input.
+
+        In single-select mode this confirms the file.  In multi-select mode a
+        non-empty value adds the file to the selection and an empty value
+        confirms the current selection.
+        """
+        event.stop()
+
+        if not self.multi_select:
+            self._confirm_single()
+            return
+
+        try:
+            file_name = self.query_one("#filename-input", Input)
+        except Exception:
+            self._confirm_multi_select()
+            return
+
+        if not file_name.value:
+            self._confirm_multi_select()
+            return
+
+        if file_name.value.startswith("~"):
+            try:
+                chosen = MakePath.of(file_name.value).expanduser().resolve()
+            except RuntimeError as error:
+                self._set_error(str(error))
+                return
+        else:
+            chosen = (
+                self.query_one(DirectoryNavigation).location / file_name.value
+            ).resolve()
+
+        if self._should_return(chosen):
+            self._toggle_path_selection(chosen)
+            file_name.value = ""
+
+    @on(Button.Pressed, "#select")
+    def _on_select_button(self, event: Button.Pressed) -> None:
+        """Handle the main select/save/open button."""
+        event.stop()
+        if self.multi_select:
+            self._confirm_multi_select()
+        else:
+            self._confirm_single()
+
+    def _toggle_path_selection(self, path: Path) -> None:
+        """Add or remove a file from the multi-select set."""
+        if not path.is_file():
+            self.notify("Only files can be selected", severity="warning", timeout=2)
+            return
+        if path in self._selected_paths:
+            self._selected_paths.discard(path)
+        else:
+            self._selected_paths.add(path)
+        self._update_multi_select_ui()
+        try:
+            self.query_one(SearchableDirectoryNavigation)._repopulate_display()
+        except Exception:
+            pass
+
+    def action_toggle_selection(self) -> None:
+        """Toggle selection for the currently highlighted file."""
+        if not self.multi_select:
+            return
+        nav = self.query_one(SearchableDirectoryNavigation)
+        highlighted = nav.highlighted
+        if highlighted is None:
+            return
+        option = nav.get_option_at_index(highlighted)
+        self._toggle_path_selection(option.location)
+
+    def _update_multi_select_ui(self) -> None:
+        """Refresh the multi-select status label and select button."""
+        if not self.multi_select:
+            return
+        count = len(self._selected_paths)
+        try:
+            info = self.query_one("#multi-select-info", Static)
+            if count == 0:
+                info.update("No files selected")
+            elif count == 1:
+                info.update("1 file selected")
+            else:
+                info.update(f"{count} files selected")
+        except Exception:
+            pass
+        try:
+            btn = self.query_one("#select", Button)
+            base = self._label(self._select_button, "Select")
+            btn.label = f"{base} ({count})" if count else base
+        except Exception:
+            pass
+
     _MAX_VISIBLE_BREADCRUMBS = 5
 
     def _update_breadcrumbs(self, path: Path) -> None:
@@ -947,7 +1402,7 @@ class EnhancedFileDialog(BaseFileDialog):
 
                 if i > 0 and i != visible_indices[position - 1] + 1:
                     breadcrumb_container.mount(
-                        Label("…", classes="breadcrumb-separator")
+                        Label("…", classes="breadcrumb-separator breadcrumb-ellipsis")
                     )
 
                 btn = Button(label, variant="default", classes="breadcrumb-btn")
@@ -967,7 +1422,16 @@ class EnhancedFileDialog(BaseFileDialog):
             recent_list = self.query_one("#recent-list", ListView)
             recent_list.clear()
 
-            for item in self.recent_locations.get_recent():
+            recent = self.recent_locations.get_recent()
+            if not recent:
+                empty_item = ListItem(
+                    Label("No recent files yet. Open a file to see it here.", classes="recent-item empty-state")
+                )
+                empty_item.data = None
+                recent_list.append(empty_item)
+                return
+
+            for item in recent:
                 path_str = item["path"]
                 name = item["name"]
                 file_type = item.get("type", "file")
@@ -992,7 +1456,19 @@ class EnhancedFileDialog(BaseFileDialog):
             bookmarks_list = self.query_one("#bookmarks-list", ListView)
             bookmarks_list.clear()
 
-            for bookmark in self.bookmarks_manager.get_bookmarks():
+            bookmarks = self.bookmarks_manager.get_bookmarks()
+            if not bookmarks:
+                empty_item = ListItem(
+                    Label(
+                        "No bookmarks. Press Ctrl+D to bookmark the current directory.",
+                        classes="bookmark-item empty-state"
+                    )
+                )
+                empty_item.data = None
+                bookmarks_list.append(empty_item)
+                return
+
+            for bookmark in bookmarks:
                 path = bookmark["path"]
                 name = bookmark["name"]
                 icon = bookmark.get("icon", "📁")
@@ -1028,6 +1504,26 @@ class EnhancedFileDialog(BaseFileDialog):
         if getattr(self, "filters", None):
             return "File name (filtered by selected type)"
         return "File name"
+
+    def _file_list_header(self) -> RenderableType:
+        """Return a column header matching DirectoryEntry's layout."""
+        grid = Table.grid(expand=True)
+        # Optional multi-select marker column.
+        if getattr(self, "multi_select", False):
+            grid.add_column(no_wrap=True, width=1)
+            grid.add_column(no_wrap=True, width=1)
+        else:
+            grid.add_column(no_wrap=True, width=1)
+        grid.add_column(no_wrap=True, width=3)
+        grid.add_column(no_wrap=True, ratio=1)
+        grid.add_column(no_wrap=True, justify="right", width=10)
+        grid.add_column(no_wrap=True, justify="right", width=20)
+        grid.add_column(no_wrap=True, width=1)
+        if self.multi_select:
+            grid.add_row("", "", "", "Name", "Size", "Modified", "")
+        else:
+            grid.add_row("", "", "Name", "Size", "Modified", "")
+        return grid
 
     def action_toggle_bookmarks(self) -> None:
         """Toggle bookmarks panel."""
@@ -1109,7 +1605,27 @@ class EnhancedFileDialog(BaseFileDialog):
     def action_jump_bookmark_9(self) -> None:
         self._jump_to_bookmark(8)
 
-    @on(DirectoryNavigation.Changed)
+    def _set_error(self, message: str = "") -> None:
+        """Show or clear the dedicated error line.
+
+        Overrides the base implementation that paints errors into the dialog's
+        border subtitle, which is too easy to miss.
+        """
+        try:
+            error_line = self.query_one("#error-line", Static)
+        except Exception:
+            # Fall back to the base border-subtitle behavior if the dedicated
+            # line is not in the DOM.
+            super()._set_error(message)
+            return
+
+        if message:
+            error_line.update(message)
+            error_line.styles.display = "block"
+        else:
+            error_line.update("")
+            error_line.styles.display = "none"
+
     def _on_directory_changed(self, event: DirectoryNavigation.Changed) -> None:
         """React to directory navigation.
 
@@ -1129,7 +1645,7 @@ class EnhancedFileDialog(BaseFileDialog):
     @on(ListView.Selected, "#bookmarks-list")
     def handle_bookmark_selection(self, event: ListView.Selected):
         """Handle selection from bookmarks list."""
-        if hasattr(event.item, 'data'):
+        if hasattr(event.item, 'data') and event.item.data is not None:
             path = Path(event.item.data)
             if path.exists():
                 dir_nav = self.query_one(SearchableDirectoryNavigation)
@@ -1167,10 +1683,41 @@ class EnhancedFileDialog(BaseFileDialog):
         except Exception:
             pass
 
-    def dismiss(self, result: Optional[Path]) -> None:
-        """Override dismiss to save recent location and last directory."""
-        if result:
-            self.recent_locations.add(result, "file" if result.is_file() else "directory")
+    @on(SearchableDirectoryNavigation.SearchCountChanged)
+    def _on_search_count_changed(self, event: SearchableDirectoryNavigation.SearchCountChanged) -> None:
+        """Update the search status label and no-match notice."""
+        try:
+            status = self.query_one("#search-status", Label)
+            no_match = self.query_one("#search-no-match", Static)
+            if event.query:
+                status.update(f"{event.count} result{'s' if event.count != 1 else ''}")
+                if event.count == 0:
+                    no_match.update(f"No files match '{event.query}'")
+                    no_match.styles.display = "block"
+                else:
+                    no_match.styles.display = "none"
+            else:
+                status.update("")
+                no_match.styles.display = "none"
+        except Exception:
+            pass
+
+    @on(SearchableDirectoryNavigation.ToggleSelection)
+    def _on_toggle_selection(self, event: SearchableDirectoryNavigation.ToggleSelection) -> None:
+        """Toggle selection for the currently highlighted file."""
+        self.action_toggle_selection()
+
+    def dismiss(self, result: Optional[Union[Path, List[Path]]]) -> None:
+        """Override dismiss to save recent location(s) and last directory."""
+        if isinstance(result, list):
+            for path in result:
+                self.recent_locations.add(
+                    path, "file" if path.is_file() else "directory"
+                )
+        elif result:
+            self.recent_locations.add(
+                result, "file" if result.is_file() else "directory"
+            )
             self._save_last_directory(result)
 
         try:
@@ -1194,6 +1741,7 @@ class EnhancedFileOpen(EnhancedFileDialog):
         *,
         filters: Optional[Filters] = None,
         must_exist: bool = True,
+        multi_select: bool = False,
         context: str = "file_open",
         select_button: str = "Open",
         cancel_button: str = "Cancel",
@@ -1208,12 +1756,14 @@ class EnhancedFileOpen(EnhancedFileDialog):
             cancel_button=cancel_button,
             filters=filters,
             context=context,
+            multi_select=multi_select,
             id=id,
             classes=classes,
             name=name,
         )
         self.filters = filters
         self.must_exist = must_exist
+        self.multi_select = multi_select
 
     def _should_return(self, candidate: Path) -> bool:
         """Final check on a picked file before returning it."""
@@ -1226,7 +1776,8 @@ class EnhancedFileOpen(EnhancedFileDialog):
         """Provide input widgets for file selection"""
         from textual.widgets import Input, Select
 
-        yield Input(placeholder=self._filename_placeholder(), id="filename-input")
+        if not self.multi_select:
+            yield Input(placeholder=self._filename_placeholder(), id="filename-input")
         if self.filters:
             yield Select(
                 self.filters.selections,

--- a/tldw_chatbook/Widgets/enhanced_file_picker.py
+++ b/tldw_chatbook/Widgets/enhanced_file_picker.py
@@ -1,31 +1,33 @@
 # enhanced_file_picker.py
 # Enhanced file picker with keyboard shortcuts, recent files, breadcrumbs, bookmarks, and search
 
-import sys
-from pathlib import Path
-from typing import List, Optional, Dict, Any, Union
-from datetime import datetime
 import os
+import sys
+from datetime import datetime
+from fnmatch import fnmatch
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+from loguru import logger
+from rich.console import RenderableType
+from rich.table import Table
 from textual import events, on
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
-from textual.timer import Timer
-
-from textual.widgets import Button, Label, ListView, ListItem, Input, Static
-from textual.reactive import reactive
 from textual.message import Message
-from loguru import logger
-from rich.table import Table
-from rich.console import RenderableType
+from textual.reactive import reactive
+from textual.timer import Timer
+from textual.widgets import Button, Input, Label, ListItem, ListView, Static
 
 from ..Third_Party.textual_fspicker import Filters
-from ..Third_Party.textual_fspicker.file_dialog import BaseFileDialog
 from ..Third_Party.textual_fspicker.base_dialog import FileSystemPickerScreen
+from ..Third_Party.textual_fspicker.file_dialog import BaseFileDialog
 from ..Third_Party.textual_fspicker.parts import DirectoryNavigation
 from ..Third_Party.textual_fspicker.parts.directory_navigation import DirectoryEntry
-from ..Third_Party.textual_fspicker.safe_tests import is_dir, is_file, is_symlink
 from ..Third_Party.textual_fspicker.path_maker import MakePath
+from ..Third_Party.textual_fspicker.safe_tests import is_dir, is_file, is_symlink
+from ..Utils.path_validation import validate_path_simple
 from ..config import get_cli_setting, save_setting_to_cli_config
 
 
@@ -381,6 +383,28 @@ class DirectorySearch(Horizontal):
         search_input = self.query_one("#search-input", Input)
         search_input.value = ""
         self.post_message(self.SearchChanged(""))
+
+
+def _make_glob_filter(patterns: Union[str, List[str], Tuple[str, ...]]) -> Callable[[Path], bool]:
+    """Build a case-insensitive path filter from glob patterns.
+
+    Args:
+        patterns: One or more glob patterns. A semicolon-separated string or an
+            iterable of strings is accepted.
+
+    Returns:
+        A callable that returns ``True`` when a path matches any pattern.
+    """
+    if isinstance(patterns, str):
+        pattern_list = [p.strip().lower() for p in patterns.split(";") if p.strip()]
+    else:
+        pattern_list = [p.strip().lower() for p in patterns if p and isinstance(p, str)]
+
+    def filter_func(path: Path) -> bool:
+        name = path.name.lower()
+        return any(fnmatch(name, pattern) for pattern in pattern_list)
+
+    return filter_func
 
 
 def _human_readable_size(size: int) -> str:
@@ -882,7 +906,7 @@ class EnhancedFileDialog(BaseFileDialog):
     BINDINGS = [
         Binding("ctrl+b", "toggle_bookmarks", "Show bookmarks"),
         Binding("question_mark", "toggle_hints", "Toggle shortcuts"),
-        *[Binding(str(n), f"jump_bookmark_{n}", f"Bookmark {n}", show=False) for n in range(1, 10)],
+        *[Binding(str(n), f"jump_bookmark('{n}')", f"Bookmark {n}", show=False) for n in range(1, 10)],
     ]
 
     show_bookmarks = reactive(False)
@@ -913,7 +937,7 @@ class EnhancedFileDialog(BaseFileDialog):
         select_button: str = "",
         cancel_button: str = "",
         *,
-        filters: Optional[Filters] = None,
+        filters: Optional[Union[Filters, List[str], Tuple[str, ...]]] = None,
         default_file: Optional[Union[str, Path]] = None,
         context: str = "default",
         multi_select: bool = False,
@@ -923,6 +947,9 @@ class EnhancedFileDialog(BaseFileDialog):
     ):
         # ``BaseFileDialog`` does not accept Textual screen kwargs such as
         # ``id`` or ``classes``; apply them manually after the base init.
+        # Normalize legacy list/tuple filters to a Filters instance so the
+        # dialog can safely read ``self.filters.selections`` during compose.
+        filters = self._normalize_filters(filters)
         super().__init__(
             location,
             title,
@@ -931,6 +958,9 @@ class EnhancedFileDialog(BaseFileDialog):
             filters=filters,
             default_file=default_file,
         )
+        # The base class stores filters internally as ``_filters``; expose the
+        # normalized value as ``self.filters`` for the input bar and callers.
+        self.filters = filters
         if id is not None:
             self.id = id
         if classes is not None:
@@ -945,6 +975,26 @@ class EnhancedFileDialog(BaseFileDialog):
         self._last_directory = self._get_last_directory()
         if self._last_directory is not None:
             self._location = self._last_directory
+
+    @staticmethod
+    def _normalize_filters(
+        filters: Optional[Union[Filters, List[str], Tuple[str, ...]]]
+    ) -> Optional[Filters]:
+        """Convert legacy list/tuple filters into a ``Filters`` instance.
+
+        Args:
+            filters: A ``Filters`` collection, an iterable of glob strings, or
+                ``None``.
+
+        Returns:
+            A ``Filters`` instance or ``None``.
+        """
+        if filters is None or isinstance(filters, Filters):
+            return filters
+        patterns = list(filters)
+        if not patterns:
+            return None
+        return Filters(("Filtered files", _make_glob_filter(patterns)))
 
     def _get_last_directory(self) -> Optional[Path]:
         """Get the last used directory for this context"""
@@ -1232,19 +1282,19 @@ class EnhancedFileDialog(BaseFileDialog):
 
         # If it looks like the user is typing in some sort of home
         # directory path...
-        if file_name.value.startswith("~"):
-            # ...let's simply expand and go with that.
-            try:
+        try:
+            if file_name.value.startswith("~"):
+                # ...let's simply expand and go with that.
                 chosen = MakePath.of(file_name.value).expanduser().resolve()
-            except RuntimeError as error:
-                self._set_error(str(error))
-                return
-        else:
-            # It's not a home directory path, so let's combine with the
-            # location of the directory navigator widget.
-            chosen = (
-                self.query_one(DirectoryNavigation).location / file_name.value
-            ).resolve()
+            else:
+                # It's not a home directory path, so let's combine with the
+                # location of the directory navigator widget.
+                chosen = (
+                    self.query_one(DirectoryNavigation).location / file_name.value
+                ).resolve()
+        except (RuntimeError, OSError) as error:
+            self._set_error(str(error))
+            return
 
         # If it's a directory, approach it like it's the user simply
         # doing a "cd".
@@ -1303,16 +1353,16 @@ class EnhancedFileDialog(BaseFileDialog):
             self._confirm_multi_select()
             return
 
-        if file_name.value.startswith("~"):
-            try:
+        try:
+            if file_name.value.startswith("~"):
                 chosen = MakePath.of(file_name.value).expanduser().resolve()
-            except RuntimeError as error:
-                self._set_error(str(error))
-                return
-        else:
-            chosen = (
-                self.query_one(DirectoryNavigation).location / file_name.value
-            ).resolve()
+            else:
+                chosen = (
+                    self.query_one(DirectoryNavigation).location / file_name.value
+                ).resolve()
+        except (RuntimeError, OSError) as error:
+            self._set_error(str(error))
+            return
 
         if self._should_return(chosen):
             self._toggle_path_selection(chosen)
@@ -1409,6 +1459,7 @@ class EnhancedFileDialog(BaseFileDialog):
 
                 btn = Button(label, variant="default", classes="breadcrumb-btn")
                 btn.tooltip = str(partial_path)
+                btn.data = partial_path
                 breadcrumb_container.mount(btn)
 
                 if position < len(visible_indices) - 1:
@@ -1417,6 +1468,16 @@ class EnhancedFileDialog(BaseFileDialog):
                     )
         except Exception:
             pass
+
+    @on(Button.Pressed, ".breadcrumb-btn")
+    def _on_breadcrumb_click(self, event: Button.Pressed) -> None:
+        """Navigate to the directory represented by a breadcrumb button."""
+        path = getattr(event.button, "data", None)
+        if isinstance(path, Path) and path.exists():
+            try:
+                self.query_one(SearchableDirectoryNavigation).location = path
+            except Exception:
+                pass
 
     def _load_recent_locations(self) -> None:
         """Populate the recent locations list from persistent storage."""
@@ -1571,41 +1632,24 @@ class EnhancedFileDialog(BaseFileDialog):
 
         bookmarks = self.bookmarks_manager.get_bookmarks()
         if 0 <= index < len(bookmarks):
-            path = Path(bookmarks[index]["path"])
-            if path.exists():
-                dir_nav = self.query_one(SearchableDirectoryNavigation)
-                dir_nav.location = path
-                self._update_bookmark_button_state(path)
-                self.notify(f"Jumped to: {bookmarks[index]['name']}", timeout=1)
-            else:
-                self.notify(f"Path no longer exists: {path}", severity="warning")
+            raw_path = bookmarks[index]["path"]
+            try:
+                path = validate_path_simple(raw_path, require_exists=True)
+            except ValueError as exc:
+                self.notify(f"Invalid bookmark path: {exc}", severity="warning")
+                return
+            dir_nav = self.query_one(SearchableDirectoryNavigation)
+            dir_nav.location = path
+            self._update_bookmark_button_state(path)
+            self.notify(f"Jumped to: {bookmarks[index]['name']}", timeout=1)
 
-    def action_jump_bookmark_1(self) -> None:
-        self._jump_to_bookmark(0)
-
-    def action_jump_bookmark_2(self) -> None:
-        self._jump_to_bookmark(1)
-
-    def action_jump_bookmark_3(self) -> None:
-        self._jump_to_bookmark(2)
-
-    def action_jump_bookmark_4(self) -> None:
-        self._jump_to_bookmark(3)
-
-    def action_jump_bookmark_5(self) -> None:
-        self._jump_to_bookmark(4)
-
-    def action_jump_bookmark_6(self) -> None:
-        self._jump_to_bookmark(5)
-
-    def action_jump_bookmark_7(self) -> None:
-        self._jump_to_bookmark(6)
-
-    def action_jump_bookmark_8(self) -> None:
-        self._jump_to_bookmark(7)
-
-    def action_jump_bookmark_9(self) -> None:
-        self._jump_to_bookmark(8)
+    def action_jump_bookmark(self, index: str) -> None:
+        """Jump to the bookmark at the 1-based index supplied by the binding."""
+        try:
+            idx = int(index) - 1
+        except ValueError:
+            return
+        self._jump_to_bookmark(idx)
 
     def _set_error(self, message: str = "") -> None:
         """Show or clear the dedicated error line.
@@ -1742,7 +1786,7 @@ class EnhancedFileOpen(EnhancedFileDialog):
         location: Union[str, Path] = ".",
         title: str = "Open File",
         *,
-        filters: Optional[Filters] = None,
+        filters: Optional[Union[Filters, List[str], Tuple[str, ...]]] = None,
         must_exist: bool = True,
         multi_select: bool = False,
         context: str = "file_open",
@@ -1764,7 +1808,6 @@ class EnhancedFileOpen(EnhancedFileDialog):
             classes=classes,
             name=name,
         )
-        self.filters = filters
         self.must_exist = must_exist
         self.multi_select = multi_select
 
@@ -1798,7 +1841,7 @@ class EnhancedFileSave(EnhancedFileDialog):
         location: Union[str, Path] = ".",
         title: str = "Save File",
         *,
-        filters: Optional[Filters] = None,
+        filters: Optional[Union[Filters, List[str], Tuple[str, ...]]] = None,
         default_filename: str = "",
         context: str = "file_save",
         select_button: str = "Save",
@@ -1819,7 +1862,6 @@ class EnhancedFileSave(EnhancedFileDialog):
             classes=classes,
             name=name,
         )
-        self.filters = filters
         self.default_filename = default_filename
 
     def _input_bar(self) -> ComposeResult:

--- a/tldw_chatbook/Widgets/enhanced_file_picker.py
+++ b/tldw_chatbook/Widgets/enhanced_file_picker.py
@@ -1,7 +1,6 @@
 # enhanced_file_picker.py
 # Enhanced file picker with keyboard shortcuts, recent files, breadcrumbs, bookmarks, and search
 
-import asyncio
 import sys
 from pathlib import Path
 from typing import List, Optional, Dict, Any, Union
@@ -11,6 +10,7 @@ from textual import events, on
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.timer import Timer
 
 from textual.widgets import Button, Label, ListView, ListItem, Input, Static
 from textual.reactive import reactive
@@ -387,7 +387,7 @@ def _human_readable_size(size: int) -> str:
     """Return a concise, human-readable byte size."""
     if size < 1024:
         return f"{size} B"
-    units = ["KB", "MB", "GB", "TB", "PB"]
+    units = ["KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"]
     value = size
     unit = units[-1]
     for u in units:
@@ -499,15 +499,13 @@ class SearchableDirectoryNavigation(DirectoryNavigation):
     def __init__(self, location: Path | str = ".") -> None:
         super().__init__(location)
         self._type_ahead_buffer = ""
-        self._type_ahead_timer: Optional[asyncio.TimerHandle] = None
+        self._type_ahead_timer: Optional[Timer] = None
 
     def _restart_type_ahead_timer(self) -> None:
         """Reset the inactivity timeout that clears the type-ahead buffer."""
         if self._type_ahead_timer is not None:
-            self._type_ahead_timer.cancel()
-        self._type_ahead_timer = asyncio.get_event_loop().call_later(
-            0.8, self._reset_type_ahead
-        )
+            self._type_ahead_timer.stop()
+        self._type_ahead_timer = self.app.set_timer(0.8, self._reset_type_ahead)
 
     def _reset_type_ahead(self) -> None:
         """Clear the type-ahead buffer after a period of inactivity."""
@@ -1221,6 +1219,10 @@ class EnhancedFileDialog(BaseFileDialog):
 
     def _confirm_single(self) -> None:
         """Confirm the single filename currently in the input box."""
+        if self.multi_select:
+            # Multi-select uses _confirm_multi_select; this path has no filename input.
+            return
+
         file_name = self.query_one("#filename-input", Input)
 
         # Only even try and process this if there's some input.
@@ -1233,7 +1235,7 @@ class EnhancedFileDialog(BaseFileDialog):
         if file_name.value.startswith("~"):
             # ...let's simply expand and go with that.
             try:
-                chosen = MakePath.of(file_name.value).expanduser()
+                chosen = MakePath.of(file_name.value).expanduser().resolve()
             except RuntimeError as error:
                 self._set_error(str(error))
                 return
@@ -1626,6 +1628,7 @@ class EnhancedFileDialog(BaseFileDialog):
             error_line.update("")
             error_line.styles.display = "none"
 
+    @on(DirectoryNavigation.Changed)
     def _on_directory_changed(self, event: DirectoryNavigation.Changed) -> None:
         """React to directory navigation.
 

--- a/tldw_chatbook/Widgets/file_picker_dialog.py
+++ b/tldw_chatbook/Widgets/file_picker_dialog.py
@@ -18,21 +18,29 @@ subclass of ``EnhancedFileOpen`` or ``EnhancedFileSave`` so there is only one
 screen on the stack and no duplicated Cancel/Select buttons.
 """
 
-from pathlib import Path
-from typing import Optional, Callable
 from fnmatch import fnmatch
+from pathlib import Path
+from typing import Callable, Optional
+
+from loguru import logger
 from textual import on
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal
 from textual.widgets import Button, Label, Static
-from loguru import logger
 
 from ..Third_Party.textual_fspicker import Filters
 from .enhanced_file_picker import EnhancedFileOpen, EnhancedFileSave
 
 
 def create_filter(patterns: str) -> Callable[[Path], bool]:
-    """Create a case-insensitive filter function from semicolon-separated globs."""
+    """Create a case-insensitive filter function from semicolon-separated globs.
+
+    Args:
+        patterns: Semicolon-separated glob patterns (e.g. ``"*.yaml;*.json"``).
+
+    Returns:
+        A callable that returns ``True`` when a file name matches any pattern.
+    """
     pattern_list = [p.strip().lower() for p in patterns.split(";") if p.strip()]
 
     def filter_func(path: Path) -> bool:

--- a/tldw_chatbook/Widgets/file_picker_dialog.py
+++ b/tldw_chatbook/Widgets/file_picker_dialog.py
@@ -1,257 +1,228 @@
 # file_picker_dialog.py
-# Description: File picker dialog for evaluation tasks and datasets
+# Description: File picker dialogs for evaluation tasks and datasets
 #
 """
-File Picker Dialog for Evaluations
-----------------------------------
+File Picker Dialogs for Evaluations
+-----------------------------------
 
-Provides file selection functionality for:
-- Task upload (YAML, JSON files)
-- Dataset import (CSV, TSV, JSON files)
-- Result export destination
+Provides thin, evaluation-specific wrappers around the enhanced file picker:
 
-Uses the existing fspicker component with evaluation-specific filters.
+- ``EvalFilePickerDialog``: generic eval file open dialog
+- ``TaskFilePickerDialog``: task file selection (YAML/JSON)
+- ``DatasetFilePickerDialog``: dataset file selection (JSON/CSV/TSV)
+- ``ExportFilePickerDialog``: result export destination
+- ``QuickPickerWidget``: inline file selection widget
+
+These are no longer nested ``ModalScreen`` wrappers; each dialog is a direct
+subclass of ``EnhancedFileOpen`` or ``EnhancedFileSave`` so there is only one
+screen on the stack and no duplicated Cancel/Select buttons.
 """
 
 from pathlib import Path
-from typing import List, Optional, Callable, Any
+from typing import Optional, Callable
 from fnmatch import fnmatch
 from textual import on
 from textual.app import ComposeResult
-from textual.containers import Container, Vertical, Horizontal
-from textual.screen import ModalScreen
-from textual.widgets import Button, Label, Static, ListView, ListItem
-from textual.binding import Binding
+from textual.containers import Container, Horizontal
+from textual.widgets import Button, Label, Static
 from loguru import logger
 
-from ..Third_Party.textual_fspicker import FileOpen, FileSave, Filters
-from .enhanced_file_picker import EnhancedFileOpen, EnhancedFileSave, RecentLocations
+from ..Third_Party.textual_fspicker import Filters
+from .enhanced_file_picker import EnhancedFileOpen, EnhancedFileSave
 
-def create_filter(patterns: str):
-    """Create a filter function from semicolon-separated patterns."""
-    pattern_list = patterns.split(';')
+
+def create_filter(patterns: str) -> Callable[[Path], bool]:
+    """Create a case-insensitive filter function from semicolon-separated globs."""
+    pattern_list = [p.strip().lower() for p in patterns.split(";") if p.strip()]
+
     def filter_func(path: Path) -> bool:
-        return any(fnmatch(path.name, pattern) for pattern in pattern_list)
+        name = path.name.lower()
+        return any(fnmatch(name, pattern) for pattern in pattern_list)
+
     return filter_func
 
-class EvalFilePickerDialog(ModalScreen):
-    """Modal dialog for file selection in evaluation context."""
-    
-    BINDINGS = [
-        Binding("ctrl+h", "toggle_hidden", "Toggle hidden files"),
-        Binding("ctrl+r", "toggle_recent", "Show recent files"),
-        Binding("ctrl+f", "focus_search", "Search files"),
-        Binding("f5", "refresh", "Refresh directory"),
-        Binding("escape", "dismiss(None)", "Cancel"),
-    ]
-    
-    def __init__(self, 
-                 title: str = "Select File",
-                 filters: Optional[Filters] = None,
-                 callback: Optional[Callable[[Optional[str]], None]] = None,
-                 save_mode: bool = False,
-                 use_enhanced: bool = True,
-                 **kwargs):
-        super().__init__(**kwargs)
-        self.title = title
-        self.filters = filters or self._get_default_filters()
-        self.callback = callback
-        self.save_mode = save_mode
-        self.use_enhanced = use_enhanced
-        self.selected_file: Optional[str] = None
-        self.recent_locations = RecentLocations() if use_enhanced else None
-    
-    def _get_default_filters(self) -> Filters:
-        """Get default file filters for evaluation files."""
-        # Filters require callable testers; glob strings here crash the picker
-        # (TypeError: 'str' object is not callable). Use the create_filter helper.
+
+class EvalFilePickerDialog(EnhancedFileOpen):
+    """Generic evaluation file open dialog.
+
+    This is a direct ``EnhancedFileOpen`` subclass rather than a wrapper screen,
+    so callers can push it with ``app.push_screen`` exactly as before.
+    """
+
+    def __init__(
+        self,
+        title: str = "Select File",
+        filters: Optional[Filters] = None,
+        callback: Optional[Callable[[Optional[str]], None]] = None,
+        context: str = "eval_file",
+        id: Optional[str] = None,
+        classes: Optional[str] = None,
+        name: Optional[str] = None,
+    ):
+        self._callback = callback
+        super().__init__(
+            location=".",
+            title=title,
+            filters=filters or self._default_filters(),
+            must_exist=True,
+            context=context,
+            id=id,
+            classes=classes,
+            name=name,
+        )
+
+    @staticmethod
+    def _default_filters() -> Filters:
+        """Default filters for evaluation files."""
         return Filters(
             ("All Evaluation Files", create_filter("*.yaml;*.yml;*.json;*.csv;*.tsv")),
             ("YAML Files", create_filter("*.yaml;*.yml")),
             ("JSON Files", create_filter("*.json")),
             ("CSV Files", create_filter("*.csv;*.tsv")),
-            ("All Files", lambda path: True),
+            ("All Files", lambda _path: True),
         )
-    
-    def compose(self) -> ComposeResult:
-        with Container(classes="file-picker-dialog"):
-            yield Label(self.title, classes="dialog-title")
-            
-            if self.use_enhanced:
-                # Use enhanced file picker with new features
-                if self.save_mode:
-                    yield EnhancedFileSave(
-                        location=".",
-                        filters=self.filters,
-                        id="file-picker"
-                    )
-                else:
-                    yield EnhancedFileOpen(
-                        location=".",
-                        filters=self.filters,
-                        id="file-picker"
-                    )
-            else:
-                # Fallback to original file picker
-                if self.save_mode:
-                    yield FileSave(
-                        location=".",
-                        filters=self.filters,
-                        id="file-picker"
-                    )
-                else:
-                    yield FileOpen(
-                        location=".",
-                        filters=self.filters,
-                        id="file-picker"
-                    )
-            
-            with Horizontal(classes="dialog-buttons"):
-                yield Button("Cancel", id="cancel-button", variant="error")
-                yield Button("Select", id="select-button", variant="primary")
-    
-    def on_dismiss(self, result):
-        """Handle dialog dismissal with selected file."""
-        if result:
-            self.selected_file = str(result)
-            logger.info(f"File selected: {self.selected_file}")
-            
-            # Add to recent locations if using enhanced picker
-            if self.use_enhanced and self.recent_locations:
-                from pathlib import Path
-                self.recent_locations.add(Path(result))
-            
-            # Call callback if provided
-            if self.callback:
-                self.callback(self.selected_file)
-    
-    @on(Button.Pressed, "#select-button")
-    def handle_select(self):
-        """Handle select button press."""
-        if self.selected_file and self.callback:
-            self.callback(self.selected_file)
-        self.dismiss(self.selected_file)
-    
-    def action_toggle_hidden(self) -> None:
-        """Forward toggle hidden action to file picker"""
-        try:
-            picker = self.query_one("#file-picker")
-            if hasattr(picker, 'action_toggle_hidden'):
-                picker.action_toggle_hidden()
-        except Exception:
-            pass
-    
-    def action_toggle_recent(self) -> None:
-        """Forward toggle recent action to file picker"""
-        try:
-            picker = self.query_one("#file-picker")
-            if hasattr(picker, 'action_toggle_recent'):
-                picker.action_toggle_recent()
-        except Exception:
-            pass
-    
-    def action_focus_search(self) -> None:
-        """Forward focus search action to file picker"""
-        try:
-            picker = self.query_one("#file-picker")
-            if hasattr(picker, 'action_focus_search'):
-                picker.action_focus_search()
-        except Exception:
-            pass
-    
-    def action_refresh(self) -> None:
-        """Forward refresh action to file picker"""
-        try:
-            picker = self.query_one("#file-picker")
-            if hasattr(picker, 'action_refresh'):
-                picker.action_refresh()
-        except Exception:
-            pass
-    
-    @on(Button.Pressed, "#cancel-button")
-    def handle_cancel(self):
-        """Handle cancel button press."""
-        self.dismiss(None)
+
+    def dismiss(self, result: Optional[Path]) -> None:
+        """Dismiss and notify the caller's callback."""
+        if self._callback:
+            try:
+                self._callback(str(result) if result else None)
+            except Exception:
+                logger.exception("Eval file picker callback failed")
+        super().dismiss(result)
+
 
 class TaskFilePickerDialog(EvalFilePickerDialog):
-    """Specialized file picker for evaluation task files."""
-    
-    def __init__(self, callback: Optional[Callable[[Optional[str]], None]] = None, **kwargs):
+    """File open dialog for evaluation task files."""
+
+    def __init__(
+        self,
+        callback: Optional[Callable[[Optional[str]], None]] = None,
+        context: str = "eval_task",
+        id: Optional[str] = None,
+        classes: Optional[str] = None,
+        name: Optional[str] = None,
+    ):
         filters = Filters(
             ("Task Files", create_filter("*.yaml;*.yml;*.json")),
             ("YAML Files", create_filter("*.yaml;*.yml")),
             ("JSON Files", create_filter("*.json")),
-            ("All Files", lambda path: True)
+            ("All Files", lambda _path: True),
         )
         super().__init__(
             title="Select Evaluation Task File",
             filters=filters,
             callback=callback,
-            **kwargs
+            context=context,
+            id=id,
+            classes=classes,
+            name=name,
         )
 
+
 class DatasetFilePickerDialog(EvalFilePickerDialog):
-    """Specialized file picker for dataset files."""
-    
-    def __init__(self, callback: Optional[Callable[[Optional[str]], None]] = None, **kwargs):
+    """File open dialog for dataset files."""
+
+    def __init__(
+        self,
+        callback: Optional[Callable[[Optional[str]], None]] = None,
+        context: str = "eval_dataset",
+        id: Optional[str] = None,
+        classes: Optional[str] = None,
+        name: Optional[str] = None,
+    ):
         filters = Filters(
             ("Dataset Files", create_filter("*.json;*.csv;*.tsv")),
             ("JSON Files", create_filter("*.json")),
             ("CSV Files", create_filter("*.csv;*.tsv")),
-            ("All Files", lambda path: True)
+            ("All Files", lambda _path: True),
         )
         super().__init__(
             title="Select Dataset File",
             filters=filters,
             callback=callback,
-            **kwargs
+            context=context,
+            id=id,
+            classes=classes,
+            name=name,
         )
 
-class ExportFilePickerDialog(EvalFilePickerDialog):
-    """Specialized file picker for result export."""
-    
-    def __init__(self, callback: Optional[Callable[[Optional[str]], None]] = None, **kwargs):
+
+class ExportFilePickerDialog(EnhancedFileSave):
+    """File save dialog for exporting evaluation results."""
+
+    def __init__(
+        self,
+        callback: Optional[Callable[[Optional[str]], None]] = None,
+        id: Optional[str] = None,
+        classes: Optional[str] = None,
+        name: Optional[str] = None,
+    ):
+        self._callback = callback
         filters = Filters(
             ("JSON Files", create_filter("*.json")),
             ("CSV Files", create_filter("*.csv")),
-            ("All Files", lambda path: True)
+            ("All Files", lambda _path: True),
         )
         super().__init__(
+            location=".",
             title="Export Results To",
             filters=filters,
-            callback=callback,
-            save_mode=True,
-            **kwargs
+            context="eval_export",
+            id=id,
+            classes=classes,
+            name=name,
         )
+
+    def dismiss(self, result: Optional[Path]) -> None:
+        """Dismiss and notify the caller's callback."""
+        if self._callback:
+            try:
+                self._callback(str(result) if result else None)
+            except Exception:
+                logger.exception("Export file picker callback failed")
+        super().dismiss(result)
+
 
 class QuickPickerWidget(Container):
     """Quick file picker widget for inline use."""
-    
-    def __init__(self, 
-                 label: str = "Selected File",
-                 file_types: str = "evaluation files",
-                 callback: Optional[Callable[[str], None]] = None,
-                 **kwargs):
-        super().__init__(**kwargs)
+
+    def __init__(
+        self,
+        label: str = "Selected File",
+        file_types: str = "evaluation files",
+        callback: Optional[Callable[[str], None]] = None,
+        context: str = "eval_file",
+        id: Optional[str] = None,
+        classes: Optional[str] = None,
+        name: Optional[str] = None,
+    ):
+        super().__init__(id=id, classes=classes, name=name)
         self.label = label
         self.file_types = file_types
         self.callback = callback
+        self.context = context
         self.selected_file: Optional[str] = None
-    
+
     def compose(self) -> ComposeResult:
         with Horizontal(classes="quick-picker"):
             yield Label(self.label, classes="picker-label")
-            yield Static("No file selected", id="selected-file-display", classes="file-display")
+            yield Static(
+                "No file selected",
+                id="selected-file-display",
+                classes="file-display",
+            )
             yield Button(
                 "Browse...",
                 id="browse-button",
                 classes="browse-button",
                 tooltip=f"Choose {self.file_types} from disk.",
             )
-    
+
     @on(Button.Pressed, "#browse-button")
     def handle_browse(self):
-        """Open file picker dialog."""
+        """Open the appropriate file picker dialog."""
+
         def on_file_selected(file_path: Optional[str]):
             if file_path:
                 self.selected_file = file_path
@@ -260,26 +231,32 @@ class QuickPickerWidget(Container):
                     display = self.query_one("#selected-file-display")
                     display.update(file_name)
                     display.set_class(True, "file-selected")
-                except:
+                except Exception:
                     pass
-                
+
                 if self.callback:
                     self.callback(file_path)
-        
-        # Determine dialog type based on file types
-        if "task" in self.file_types.lower():
-            dialog = TaskFilePickerDialog(callback=on_file_selected)
-        elif "dataset" in self.file_types.lower():
-            dialog = DatasetFilePickerDialog(callback=on_file_selected)
+
+        file_types = self.file_types.lower()
+        if "task" in file_types:
+            dialog: EnhancedFileOpen = TaskFilePickerDialog(
+                callback=on_file_selected, context=self.context
+            )
+        elif "dataset" in file_types:
+            dialog = DatasetFilePickerDialog(
+                callback=on_file_selected, context=self.context
+            )
         else:
-            dialog = EvalFilePickerDialog(callback=on_file_selected)
-        
+            dialog = EvalFilePickerDialog(
+                callback=on_file_selected, context=self.context
+            )
+
         self.app.push_screen(dialog)
-    
+
     def get_selected_file(self) -> Optional[str]:
         """Get the currently selected file path."""
         return self.selected_file
-    
+
     def clear_selection(self):
         """Clear the current file selection."""
         self.selected_file = None
@@ -287,5 +264,5 @@ class QuickPickerWidget(Container):
             display = self.query_one("#selected-file-display")
             display.update("No file selected")
             display.set_class(False, "file-selected")
-        except:
+        except Exception:
             pass


### PR DESCRIPTION
## Summary

This PR addresses the filepicker crash/UX review by implementing the immediate fixes and the actionable medium-term improvements:

- Removes the `@work` worker from `PathBreadcrumbs` and builds breadcrumbs synchronously after mount.
- Replaces arbitrary `**kwargs` forwarding in `EnhancedFileOpen`/`EnhancedFileSave` and the eval wrappers with explicit `id`/`classes`/`name` (and `context`) parameters.
- Makes `EnhancedFileDialog.on_mount` safe by preserving every base compose ID that `super().on_mount()` queries.
- Flattens `EvalFilePickerDialog`/`TaskFilePickerDialog`/`DatasetFilePickerDialog`/`ExportFilePickerDialog` into direct `EnhancedFileOpen`/`EnhancedFileSave` subclasses, eliminating nested screens and duplicated buttons.
- Fixes the double callback / double recent-save bug in the eval wrappers.
- Wires search to `DirectoryNavigation.search_filter` via a new `SearchableDirectoryNavigation` subclass and updates `Enhanced-Filepicker-Guide.md` accordingly.
- Replaces the global `on_key` digit handler with explicit `Binding('1'..'9')` actions that guard focus so typing filenames/search queries still works.
- Propagates `context` through `EvalFilePickerDialog` and `QuickPickerWidget`.
- Avoids rewriting the config file on every directory change; recent locations and last directory are now persisted only on dialog dismiss.

## Test Plan

- [x] `python3 -m pytest Tests/UI/test_enhanced_file_dialog_mount.py Tests/UI/test_file_picker_filters_callable.py Tests/UI/test_file_picker_bookmarks_lazy.py Tests/UI/test_file_picker_action_tooltips.py Tests/UI/test_eval_file_picker_dialog.py -q` → 35 passed
- [x] `python3 -m pytest Tests/UI/ -k "file_picker or picker" -q --timeout=60` → 68 passed, 1 skipped
- [x] `python3 -m py_compile` on changed Python files succeeds

## Notes for reviewers

- `EnhancedFileDialog` still mirrors the base `FileSystemPickerScreen` compose tree because the vendored base does not expose hooks for injecting the bookmarks panel or search-aware `DirectoryNavigation`. A future refactor could replace this with base-class hook usage if the upstream layout becomes extensible.
- The base handler suppression uses Textual's private `_get_dispatch_methods`; this is documented in the code and is the minimal fix for the MRO handler-shadowing problem.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the enhanced file picker to simplify the layout, remove nested eval wrappers, and wire search/bookmarks to fix crashes and double callbacks. Adds inline errors, type-ahead, optional multi-select, human-readable sizes, and UI tweaks for breadcrumbs, bookmarks, and the path input.

- **Bug Fixes and Refactors**
  - Build breadcrumbs synchronously with clickable buttons; restore navigation-change handling and validate bookmark paths.
  - Flatten eval dialogs into direct `EnhancedFileOpen`/`EnhancedFileSave`; use explicit `id`/`classes`/`name`/`context`; fix double-callback and double recent-save.
  - Normalize legacy list/tuple filters to a `Filters` instance; make `create_filter` case-insensitive; add regression tests (incl. list-filters and breadcrumb/bookmark updates).
  - Keys: replace global digit handler with `Binding('1'..'9')` and a parameterized bookmark-jump action; use app timer for type-ahead reset.
  - Path handling: catch `OSError` during filename/path resolution; resolve `~` consistently; guard single-confirm in multi-select.
  - Persist recents/last-dir only on dialog dismiss; CSS specificity fixes (nest under `EnhancedFileDialog`), correct sidebar heights, render breadcrumbs/bookmarks/path input, and size dialog to 95%.

- **New Features**
  - Wire search via `SearchableDirectoryNavigation.search_filter`; type-ahead file jumping; collapsible shortcut hint via `?`.
  - Optional multi-select in open dialogs (Space/Enter toggle, checkmarks, count).
  - Human-readable file sizes (omit directories; extended units).
  - Docs/Plans: update the guide; add Watchlists TUI plan/spec and ADR. Scheduling: add `SchedulingServerClient` for reminders with tests.

<sup>Written for commit 213d166b7a58c3e84683e6b84f8786f4e93b6a7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

