### PR TITLE
feat(scheduling): local reminder CRUD and triggering (TASK-299.1)

### DIFF
--- a/Tests/Scheduling/test_scheduling_service.py
+++ b/Tests/Scheduling/test_scheduling_service.py
@@ -7,6 +7,7 @@ import pytest
 
 from tldw_chatbook.Scheduling.db.scheduled_tasks_db import ScheduledTasksDB
 from tldw_chatbook.Scheduling.models import ReminderTask, ScheduledTask, TaskStatus
+from tldw_chatbook.Scheduling.scheduler.queue import PriorityQueue
 from tldw_chatbook.Scheduling.services import SchedulingService
 from tldw_chatbook.Scheduling.services.server_client import ServerUnavailableError
 from tldw_chatbook.Scheduling.services.watchlist_projection import WatchlistProjection
@@ -450,3 +451,41 @@ async def test_list_tasks_filters_watchlist_by_owner(db):
 
     assert tasks == []
     projection.list_jobs.assert_called_once_with(owner_id="server:1")
+
+
+@pytest.mark.asyncio
+async def test_created_reminder_is_picked_up_by_priority_queue(db):
+    """Locally created reminders must have next_run_at set so the queue loads them."""
+    svc = SchedulingService(db=db, runtime_source="local")
+    await svc.create_reminder(_reminder_payload("Queue me"))
+
+    queue = PriorityQueue(db=db)
+    queue.load(now=datetime(2026, 7, 21, tzinfo=timezone.utc))
+
+    assert len(queue._items) == 1
+    assert queue._items[0]["title"] == "Queue me"
+
+
+@pytest.mark.asyncio
+async def test_updated_reminder_is_picked_up_by_priority_queue(db):
+    """Updating schedule fields recomputes next_run_at so the queue loads the reminder."""
+    svc = SchedulingService(db=db, runtime_source="local")
+    task = await svc.create_reminder(_reminder_payload("Original"))
+
+    updated = await svc.update_reminder(
+        task.id,
+        {
+            "schedule_kind": "recurring",
+            "run_at": None,
+            "cron": "0 9 * * *",
+            "timezone": "UTC",
+        },
+    )
+
+    assert updated is not None
+    assert updated.next_run_at is not None
+
+    queue = PriorityQueue(db=db)
+    queue.load(now=datetime(2099, 1, 1, tzinfo=timezone.utc))
+
+    assert any(item["id"] == task.id for item in queue._items)

--- a/Tests/UI/test_reminder_form.py
+++ b/Tests/UI/test_reminder_form.py
@@ -1,10 +1,13 @@
 """Tests for the reminder create/edit form."""
 
+from datetime import datetime, timezone
+
 import pytest
 from textual.app import App
-from textual.widgets import Input
+from textual.widgets import Input, Select
 
 from tldw_chatbook.Scheduling.events import ReminderFormSubmitted
+from tldw_chatbook.Scheduling.models import ReminderTask, ScheduleKind
 from tldw_chatbook.UI.Screens.scheduling.forms.reminder_form import ReminderForm
 
 
@@ -32,8 +35,8 @@ async def test_reminder_form_requires_title():
 
 
 @pytest.mark.asyncio
-async def test_reminder_form_submits_when_valid():
-    """A non-empty title dismisses the modal after posting the event."""
+async def test_reminder_form_submits_when_valid_one_time():
+    """A valid one-time reminder dismisses the modal after posting the event."""
     app = FormTestApp()
     async with app.run_test() as pilot:
         await app.push_screen(ReminderForm())
@@ -48,7 +51,182 @@ async def test_reminder_form_submits_when_valid():
         assert app.submitted is not None
         assert app.submitted["title"] == "Water plants"
         assert app.submitted["schedule_kind"] == "one_time"
-        assert app.submitted["run_at"] == "2026-07-20T14:00:00+00:00"
+        assert app.submitted["run_at"] == datetime(2026, 7, 20, 14, 0, tzinfo=timezone.utc)
+        assert app.submitted["cron"] is None
+        assert app.submitted["timezone"] is None
+
+
+@pytest.mark.asyncio
+async def test_reminder_form_submits_when_valid_recurring():
+    """A valid recurring reminder dismisses the modal after posting the event."""
+    app = FormTestApp()
+    async with app.run_test() as pilot:
+        await app.push_screen(ReminderForm())
+        title_input = pilot.app.screen.query_one("#reminder-title", Input)
+        title_input.value = "Weekly sync"
+        kind_select = pilot.app.screen.query_one("#reminder-kind", Select)
+        kind_select.value = ScheduleKind.RECURRING.value
+        await pilot.pause()
+
+        cron_input = pilot.app.screen.query_one("#reminder-cron", Input)
+        cron_input.value = "0 9 * * 1"
+        tz_input = pilot.app.screen.query_one("#reminder-timezone", Input)
+        tz_input.value = "UTC"
+
+        await pilot.click("#reminder-save")
+        await pilot.pause()
+
+        assert not isinstance(pilot.app.screen, ReminderForm)
+        assert app.submitted is not None
+        assert app.submitted["title"] == "Weekly sync"
+        assert app.submitted["schedule_kind"] == "recurring"
+        assert app.submitted["cron"] == "0 9 * * 1"
+        assert app.submitted["timezone"] == "UTC"
+        assert app.submitted["run_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_reminder_form_requires_run_at_for_one_time():
+    """A one-time reminder without a run_at value shows a validation error."""
+    app = FormTestApp()
+    async with app.run_test() as pilot:
+        await app.push_screen(ReminderForm())
+        title_input = pilot.app.screen.query_one("#reminder-title", Input)
+        title_input.value = "No run_at"
+        await pilot.click("#reminder-save")
+        await pilot.pause()
+
+        error_widget = pilot.app.screen.query_one("#reminder-errors")
+        assert "run at is required" in error_widget.visual.plain.lower()
+
+
+@pytest.mark.asyncio
+async def test_reminder_form_rejects_invalid_run_at():
+    """A one-time reminder with an invalid run_at shows a validation error."""
+    app = FormTestApp()
+    async with app.run_test() as pilot:
+        await app.push_screen(ReminderForm())
+        title_input = pilot.app.screen.query_one("#reminder-title", Input)
+        title_input.value = "Bad run_at"
+        run_at_input = pilot.app.screen.query_one("#reminder-run-at", Input)
+        run_at_input.value = "not-a-datetime"
+        await pilot.click("#reminder-save")
+        await pilot.pause()
+
+        error_widget = pilot.app.screen.query_one("#reminder-errors")
+        assert "run at must be a valid iso-8601 datetime" in error_widget.visual.plain.lower()
+
+
+@pytest.mark.asyncio
+async def test_reminder_form_requires_cron_for_recurring():
+    """A recurring reminder without a cron expression shows a validation error."""
+    app = FormTestApp()
+    async with app.run_test() as pilot:
+        await app.push_screen(ReminderForm())
+        title_input = pilot.app.screen.query_one("#reminder-title", Input)
+        title_input.value = "No cron"
+        kind_select = pilot.app.screen.query_one("#reminder-kind", Select)
+        kind_select.value = ScheduleKind.RECURRING.value
+        await pilot.pause()
+
+        tz_input = pilot.app.screen.query_one("#reminder-timezone", Input)
+        tz_input.value = "UTC"
+        await pilot.click("#reminder-save")
+        await pilot.pause()
+
+        error_widget = pilot.app.screen.query_one("#reminder-errors")
+        assert "cron expression is required" in error_widget.visual.plain.lower()
+
+
+@pytest.mark.asyncio
+async def test_reminder_form_rejects_invalid_cron():
+    """A recurring reminder with an invalid cron expression shows a validation error."""
+    app = FormTestApp()
+    async with app.run_test() as pilot:
+        await app.push_screen(ReminderForm())
+        title_input = pilot.app.screen.query_one("#reminder-title", Input)
+        title_input.value = "Bad cron"
+        kind_select = pilot.app.screen.query_one("#reminder-kind", Select)
+        kind_select.value = ScheduleKind.RECURRING.value
+        await pilot.pause()
+
+        cron_input = pilot.app.screen.query_one("#reminder-cron", Input)
+        cron_input.value = "not-a-cron"
+        tz_input = pilot.app.screen.query_one("#reminder-timezone", Input)
+        tz_input.value = "UTC"
+        await pilot.click("#reminder-save")
+        await pilot.pause()
+
+        error_widget = pilot.app.screen.query_one("#reminder-errors")
+        assert "cron expression is invalid" in error_widget.visual.plain.lower()
+
+
+@pytest.mark.asyncio
+async def test_reminder_form_requires_timezone_for_recurring():
+    """A recurring reminder without a timezone shows a validation error."""
+    app = FormTestApp()
+    async with app.run_test() as pilot:
+        await app.push_screen(ReminderForm())
+        title_input = pilot.app.screen.query_one("#reminder-title", Input)
+        title_input.value = "No timezone"
+        kind_select = pilot.app.screen.query_one("#reminder-kind", Select)
+        kind_select.value = ScheduleKind.RECURRING.value
+        await pilot.pause()
+
+        cron_input = pilot.app.screen.query_one("#reminder-cron", Input)
+        cron_input.value = "0 9 * * 1"
+        tz_input = pilot.app.screen.query_one("#reminder-timezone", Input)
+        tz_input.value = ""
+        await pilot.click("#reminder-save")
+        await pilot.pause()
+
+        error_widget = pilot.app.screen.query_one("#reminder-errors")
+        assert "timezone is required" in error_widget.visual.plain.lower()
+
+
+@pytest.mark.asyncio
+async def test_reminder_form_rejects_invalid_timezone():
+    """A recurring reminder with an unknown timezone shows a validation error."""
+    app = FormTestApp()
+    async with app.run_test() as pilot:
+        await app.push_screen(ReminderForm())
+        title_input = pilot.app.screen.query_one("#reminder-title", Input)
+        title_input.value = "Bad timezone"
+        kind_select = pilot.app.screen.query_one("#reminder-kind", Select)
+        kind_select.value = ScheduleKind.RECURRING.value
+        await pilot.pause()
+
+        cron_input = pilot.app.screen.query_one("#reminder-cron", Input)
+        cron_input.value = "0 9 * * 1"
+        tz_input = pilot.app.screen.query_one("#reminder-timezone", Input)
+        tz_input.value = "Mars/Phobos"
+        await pilot.click("#reminder-save")
+        await pilot.pause()
+
+        error_widget = pilot.app.screen.query_one("#reminder-errors")
+        assert "unknown timezone" in error_widget.visual.plain.lower()
+
+
+@pytest.mark.asyncio
+async def test_reminder_form_preserves_enabled_state_when_editing():
+    """Editing a disabled reminder preserves its enabled state in the payload."""
+    app = FormTestApp()
+    disabled_task = ReminderTask(
+        id="task-1",
+        title="Existing",
+        schedule_kind=ScheduleKind.ONE_TIME,
+        run_at=datetime(2026, 7, 20, 14, 0, tzinfo=timezone.utc),
+        enabled=False,
+    )
+    async with app.run_test() as pilot:
+        await app.push_screen(ReminderForm(disabled_task))
+        title_input = pilot.app.screen.query_one("#reminder-title", Input)
+        title_input.value = "Updated"
+        await pilot.click("#reminder-save")
+        await pilot.pause()
+
+        assert app.submitted is not None
+        assert app.submitted["enabled"] is False
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_reminder_form.py
+++ b/Tests/UI/test_reminder_form.py
@@ -39,6 +39,8 @@ async def test_reminder_form_submits_when_valid():
         await app.push_screen(ReminderForm())
         title_input = pilot.app.screen.query_one("#reminder-title", Input)
         title_input.value = "Water plants"
+        run_at_input = pilot.app.screen.query_one("#reminder-run-at", Input)
+        run_at_input.value = "2026-07-20T14:00:00+00:00"
         await pilot.click("#reminder-save")
         await pilot.pause()
 
@@ -46,6 +48,7 @@ async def test_reminder_form_submits_when_valid():
         assert app.submitted is not None
         assert app.submitted["title"] == "Water plants"
         assert app.submitted["schedule_kind"] == "one_time"
+        assert app.submitted["run_at"] == "2026-07-20T14:00:00+00:00"
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 
 import pytest
 from textual.app import App
-from textual.widgets import Button, DataTable, Static
+from textual.widgets import Button, DataTable, Input, Static
 
 from tldw_chatbook.Scheduling.events import DeleteTaskRequested
 from tldw_chatbook.Scheduling.models import (
@@ -13,6 +13,7 @@ from tldw_chatbook.Scheduling.models import (
     ScheduleKind,
     TaskStatus,
 )
+from tldw_chatbook.UI.Screens.scheduling.forms.reminder_form import ReminderForm
 from tldw_chatbook.UI.Screens.scheduling.schedules_workbench import SchedulesWorkbench
 from tldw_chatbook.UI.Screens.scheduling.task_detail import (
     TaskDetail,
@@ -32,6 +33,11 @@ class WorkbenchTestApp(App):
 class MockSchedulingService:
     """Stub service returning a single reminder task."""
 
+    def __init__(self) -> None:
+        self.updated: list[tuple[str, dict]] = []
+        self.created: list[dict] = []
+        self.deleted_ids: list[str] = []
+
     async def list_reminders(self):
         return [
             ReminderTask(
@@ -45,6 +51,22 @@ class MockSchedulingService:
 
     async def list_tasks(self):
         return await self.list_reminders()
+
+    async def create_reminder(self, payload: dict):
+        self.created.append(payload)
+        return ReminderTask(**payload)
+
+    async def update_reminder(self, task_id: str, fields: dict):
+        self.updated.append((task_id, fields))
+        reminders = await self.list_reminders()
+        task = reminders[0]
+        for key, value in fields.items():
+            setattr(task, key, value)
+        return task
+
+    async def delete_reminder(self, task_id: str):
+        self.deleted_ids.append(task_id)
+        return True
 
 
 class WorkbenchTestAppWithService(App):
@@ -661,7 +683,6 @@ async def test_unimplemented_action_bindings_notify_user():
         await pilot.pause()
 
         for action in (
-            pilot.app.screen.action_create_reminder,
             pilot.app.screen.action_run_now,
             pilot.app.screen.action_pause_resume,
             pilot.app.screen.action_sync_now,
@@ -669,15 +690,15 @@ async def test_unimplemented_action_bindings_notify_user():
             action()
             await pilot.pause()
 
-        assert len(pilot.app._notifications) == 4
+        assert len(pilot.app._notifications) == 3
         for notification in pilot.app._notifications:
             assert notification.message == "Not yet available"
             assert notification.severity == "warning"
 
 
 @pytest.mark.asyncio
-async def test_unimplemented_enable_disable_buttons_notify_user():
-    """Enable/Disable buttons notify the user instead of silently doing nothing."""
+async def test_enable_disable_buttons_update_reminder():
+    """Enable/Disable buttons call the scheduling service and notify the user."""
     async with WorkbenchTestAppWithService().run_test() as pilot:
         await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
         await pilot.pause()
@@ -688,10 +709,82 @@ async def test_unimplemented_enable_disable_buttons_notify_user():
 
         detail.on_button_pressed(Button.Pressed(enable_button))
         await pilot.pause()
-        detail.on_button_pressed(Button.Pressed(disable_button))
+        await pilot.app.workers.wait_for_complete()
         await pilot.pause()
 
-        assert len(pilot.app._notifications) == 2
-        for notification in pilot.app._notifications:
-            assert notification.message == "Not yet available"
-            assert notification.severity == "warning"
+        detail.on_button_pressed(Button.Pressed(disable_button))
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        service = pilot.app.scheduling_service
+        assert service.updated == [
+            ("task-1", {"enabled": True}),
+            ("task-1", {"enabled": False}),
+        ]
+        notifications = list(pilot.app._notifications)
+        assert len(notifications) == 2
+        assert notifications[0].severity == "information"
+        assert notifications[1].severity == "information"
+
+
+@pytest.mark.asyncio
+async def test_create_reminder_action_saves_new_reminder():
+    """Ctrl+C opens the reminder form; saving calls the scheduling service."""
+    async with WorkbenchTestAppWithService().run_test() as pilot:
+        pilot.app.scheduling_service = MockSchedulingService()
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+
+        pilot.app.screen.action_create_reminder()
+        await pilot.pause()
+
+        assert isinstance(pilot.app.screen, ReminderForm)
+
+        title_input = pilot.app.screen.query_one("#reminder-title", Input)
+        title_input.value = "New reminder"
+        run_at_input = pilot.app.screen.query_one("#reminder-run-at", Input)
+        run_at_input.value = "2026-07-20T14:00:00+00:00"
+
+        await pilot.click("#reminder-save")
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        service = pilot.app.scheduling_service
+        assert len(service.created) == 1
+        assert service.created[0]["title"] == "New reminder"
+        assert service.created[0]["schedule_kind"] == "one_time"
+        notifications = list(pilot.app._notifications)
+        assert any(n.message == "Reminder created." for n in notifications)
+
+
+@pytest.mark.asyncio
+async def test_edit_reminder_action_updates_existing_reminder():
+    """Clicking Edit opens the form pre-filled; saving calls update_reminder."""
+    async with WorkbenchTestAppWithService().run_test() as pilot:
+        pilot.app.scheduling_service = MockSchedulingService()
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+
+        detail = pilot.app.screen.query_one("#scheduling-task-detail", TaskDetail)
+        edit_button = detail.query_one("#scheduling-edit-task", Button)
+        detail.on_button_pressed(Button.Pressed(edit_button))
+        await pilot.pause()
+
+        assert isinstance(pilot.app.screen, ReminderForm)
+        title_input = pilot.app.screen.query_one("#reminder-title", Input)
+        assert title_input.value == "Test"
+        title_input.value = "Updated title"
+
+        await pilot.click("#reminder-save")
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        service = pilot.app.scheduling_service
+        assert len(service.updated) == 1
+        assert service.updated[0][0] == "task-1"
+        assert service.updated[0][1]["title"] == "Updated title"
+        notifications = list(pilot.app._notifications)
+        assert any(n.message == "Reminder updated." for n in notifications)

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 
 import pytest
 from textual.app import App
+from textual.containers import Horizontal
 from textual.widgets import Button, DataTable, Input, Static
 
 from tldw_chatbook.Scheduling.events import DeleteTaskRequested
@@ -72,7 +73,9 @@ class MockSchedulingService:
 class WorkbenchTestAppWithService(App):
     """Test app with a mock scheduling service."""
 
-    scheduling_service = MockSchedulingService()
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.scheduling_service = MockSchedulingService()
 
 
 class MockSchedulingServiceWithWatchlist:
@@ -500,6 +503,23 @@ async def test_inspector_shows_read_only_projection_for_watchlist():
         assert "local (read-only projection)" in sync.visual.plain
         assert "-" == last_run.visual.plain.strip()
         assert "local" in owner.visual.plain
+
+
+@pytest.mark.asyncio
+async def test_watchlist_task_hides_lifecycle_actions():
+    """Watchlist projections do not expose reminder lifecycle buttons."""
+    async with WorkbenchTestAppWithMixedService().run_test() as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+
+        table = pilot.app.screen.query_one("#scheduling-task-table", DataTable)
+        table.cursor_coordinate = (1, 0)
+        pilot.app.screen._update_detail_for_index(1)
+        await pilot.pause()
+
+        detail = pilot.app.screen.query_one("#scheduling-task-detail", TaskDetail)
+        lifecycle = detail.query_one("#scheduling-task-detail-lifecycle", Horizontal)
+        assert lifecycle.display is False
 
 
 def test_humanize_cron_daily_pattern():

--- a/tldw_chatbook/Scheduling/events.py
+++ b/tldw_chatbook/Scheduling/events.py
@@ -12,13 +12,38 @@ from .models import ReminderTask
 class ReminderFormSubmitted(Message):
     """Posted when the reminder create/edit form is saved."""
 
-    def __init__(self, form_data: dict[str, Any]) -> None:
+    def __init__(self, form_data: dict[str, Any], task_id: str | None = None) -> None:
         super().__init__()
         self.form_data = form_data
+        self.task_id = task_id
 
 
 class DeleteTaskRequested(Message):
     """Posted when the user confirms deletion of a scheduled task."""
+
+    def __init__(self, task: ReminderTask) -> None:
+        super().__init__()
+        self.task = task
+
+
+class EditTaskRequested(Message):
+    """Posted when the user asks to edit a reminder."""
+
+    def __init__(self, task: ReminderTask) -> None:
+        super().__init__()
+        self.task = task
+
+
+class EnableTaskRequested(Message):
+    """Posted when the user asks to enable a reminder."""
+
+    def __init__(self, task: ReminderTask) -> None:
+        super().__init__()
+        self.task = task
+
+
+class DisableTaskRequested(Message):
+    """Posted when the user asks to disable a reminder."""
 
     def __init__(self, task: ReminderTask) -> None:
         super().__init__()

--- a/tldw_chatbook/Scheduling/services/scheduling_service.py
+++ b/tldw_chatbook/Scheduling/services/scheduling_service.py
@@ -10,11 +10,13 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from typing import Any
+from zoneinfo import ZoneInfo
 
+from croniter import croniter
 from loguru import logger
 
 from tldw_chatbook.Scheduling.db.scheduled_tasks_db import ScheduledTasksDB
-from tldw_chatbook.Scheduling.models import ReminderTask, ScheduledTask
+from tldw_chatbook.Scheduling.models import ReminderTask, ScheduleKind, ScheduledTask
 from tldw_chatbook.Scheduling.services.server_client import (
     SchedulingServerClient,
     ServerUnavailableError,
@@ -85,6 +87,7 @@ class SchedulingService:
         later.
         """
         task = ReminderTask(**payload)
+        task.next_run_at = self._compute_next_run_at(task)
         server_payload = self._server_create_payload(task)
         db_fields = task.model_dump(
             exclude={
@@ -186,6 +189,21 @@ class SchedulingService:
                 logger.exception(
                     f"Server update_reminder failed for {task_id} ({self.owner_id}): {exc}"
                 )
+
+        # Local path: compute next_run_at and clear stale schedule fields
+        # when the schedule is being changed.
+        if any(key in payload for key in ("schedule_kind", "run_at", "cron", "timezone")):
+            row_task = self._row_to_reminder(row)
+            merged_data = row_task.model_dump()
+            merged_data.update(payload)
+            merged_task = ReminderTask(**merged_data)
+            payload = dict(payload)
+            if merged_task.schedule_kind == ScheduleKind.ONE_TIME:
+                payload["cron"] = None
+                payload["timezone"] = None
+            elif merged_task.schedule_kind == ScheduleKind.RECURRING:
+                payload["run_at"] = None
+            payload["next_run_at"] = self._compute_next_run_at(merged_task)
 
         self.db.update_reminder_task(task_id, **payload)
         if use_server:
@@ -344,6 +362,26 @@ class SchedulingService:
         row = self.db.get_reminder_task(task_id)
         assert row is not None
         return self._row_to_reminder(row)
+
+    def _compute_next_run_at(self, task: ReminderTask) -> datetime | None:
+        """Compute the next scheduled run time for a reminder task.
+
+        For one-time schedules the ``run_at`` value is returned directly. For
+        recurring schedules the next cron occurrence after the current time in
+        the task's timezone is computed and returned as UTC.
+        """
+        if task.schedule_kind == ScheduleKind.ONE_TIME:
+            return task.run_at
+
+        if task.schedule_kind == ScheduleKind.RECURRING:
+            if not task.cron or not task.timezone:
+                return None
+            tz = ZoneInfo(task.timezone)
+            now = datetime.now(tz)
+            next_run = croniter(task.cron, now).get_next(datetime)
+            return next_run.astimezone(timezone.utc)
+
+        return None
 
     @staticmethod
     def _row_to_reminder(row: dict[str, Any]) -> ReminderTask:

--- a/tldw_chatbook/UI/Screens/scheduling/forms/reminder_form.py
+++ b/tldw_chatbook/UI/Screens/scheduling/forms/reminder_form.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
+from croniter import croniter
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Container, Horizontal, Vertical
-from textual.reactive import reactive
 from textual.screen import ModalScreen
 from textual.widgets import Button, Input, Label, Select, Static, TextArea
 
@@ -68,8 +70,6 @@ class ReminderForm(ModalScreen):
     }
     """
 
-    task: reactive[ReminderTask | None] = reactive(None)
-
     def __init__(self, task: ReminderTask | None = None) -> None:
         """Initialize the form.
 
@@ -77,7 +77,7 @@ class ReminderForm(ModalScreen):
             task: Existing reminder to edit, or ``None`` to create a new one.
         """
         super().__init__()
-        self.task = task
+        self._reminder_task = task
 
     def action_dismiss(self) -> None:
         """Dismiss the modal when the Escape key is pressed."""
@@ -87,7 +87,7 @@ class ReminderForm(ModalScreen):
         """Build the form layout."""
         with Container():
             yield Label(
-                "Edit Reminder" if self.task else "Create Reminder",
+                "Edit Reminder" if self._reminder_task else "Create Reminder",
                 classes="form-title",
             )
 
@@ -106,20 +106,23 @@ class ReminderForm(ModalScreen):
                     id="reminder-kind",
                 )
 
-                yield Label("Run At (ISO-8601):", classes="form-label")
-                yield Input(
-                    placeholder="2026-07-20T14:00:00+00:00",
-                    id="reminder-run-at",
-                )
+                with Vertical(id="reminder-run-at-group"):
+                    yield Label("Run At (ISO-8601):", classes="form-label")
+                    yield Input(
+                        placeholder="2026-07-20T14:00:00+00:00",
+                        id="reminder-run-at",
+                    )
 
-                yield Label("Cron Expression:", classes="form-label")
-                yield Input(placeholder="0 9 * * 1", id="reminder-cron")
+                with Vertical(id="reminder-cron-group"):
+                    yield Label("Cron Expression:", classes="form-label")
+                    yield Input(placeholder="0 9 * * 1", id="reminder-cron")
 
-                yield Label("Timezone:", classes="form-label")
-                yield Input(
-                    placeholder=_DEFAULT_TIMEZONE,
-                    id="reminder-timezone",
-                )
+                with Vertical(id="reminder-timezone-group"):
+                    yield Label("Timezone:", classes="form-label")
+                    yield Input(
+                        placeholder=_DEFAULT_TIMEZONE,
+                        id="reminder-timezone",
+                    )
 
                 yield Static("", id="reminder-errors", classes="error-text")
 
@@ -129,49 +132,43 @@ class ReminderForm(ModalScreen):
 
     def on_mount(self) -> None:
         """Prefill the form when editing an existing reminder."""
-        if self.task is None:
+        if self._reminder_task is None:
             self.query_one("#reminder-timezone", Input).value = _DEFAULT_TIMEZONE
+            self._update_schedule_field_visibility(ScheduleKind.ONE_TIME.value)
             return
 
-        self.query_one("#reminder-title", Input).value = self.task.title
-        body = self.task.body or ""
+        self.query_one("#reminder-title", Input).value = self._reminder_task.title
+        body = self._reminder_task.body or ""
         self.query_one("#reminder-body", TextArea).text = body
-        self.query_one("#reminder-kind", Select).value = self.task.schedule_kind.value
-        if self.task.run_at is not None:
-            self.query_one("#reminder-run-at", Input).value = self.task.run_at.isoformat()
-        if self.task.cron is not None:
-            self.query_one("#reminder-cron", Input).value = self.task.cron
-        if self.task.timezone is not None:
-            self.query_one("#reminder-timezone", Input).value = self.task.timezone
-        self._update_schedule_field_visibility(self.task.schedule_kind.value)
+        self.query_one("#reminder-kind", Select).value = self._reminder_task.schedule_kind.value
+        if self._reminder_task.run_at is not None:
+            self.query_one("#reminder-run-at", Input).value = self._reminder_task.run_at.isoformat()
+        if self._reminder_task.cron is not None:
+            self.query_one("#reminder-cron", Input).value = self._reminder_task.cron
+        if self._reminder_task.timezone is not None:
+            self.query_one("#reminder-timezone", Input).value = self._reminder_task.timezone
+        else:
+            self.query_one("#reminder-timezone", Input).value = _DEFAULT_TIMEZONE
+        self._update_schedule_field_visibility(self._reminder_task.schedule_kind.value)
 
     def on_select_changed(self, event: Select.Changed) -> None:
-        """Show/hide schedule fields based on the selected schedule kind."""
+        """Show/hide schedule field groups based on the selected schedule kind."""
         if event.select.id == "reminder-kind":
             self._update_schedule_field_visibility(str(event.value))
 
     def _update_schedule_field_visibility(self, kind: str) -> None:
-        """Toggle which schedule inputs are visible."""
-        run_at_label = self.query_one("#reminder-run-at").parent
-        cron_label = self.query_one("#reminder-cron").parent
-        tz_label = self.query_one("#reminder-timezone").parent
-        # Labels are siblings before the input in the same Vertical; toggling the
-        # input's parent Horizontal would hide label+input if they were grouped.
-        # Since they are not grouped, we toggle the input widget directly and
-        # leave the label visible for clarity.
-        run_at_input = self.query_one("#reminder-run-at", Input)
-        cron_input = self.query_one("#reminder-cron", Input)
-        tz_input = self.query_one("#reminder-timezone", Input)
+        """Toggle which schedule input groups are visible."""
+        run_at_group = self.query_one("#reminder-run-at-group", Vertical)
+        cron_group = self.query_one("#reminder-cron-group", Vertical)
+        tz_group = self.query_one("#reminder-timezone-group", Vertical)
         if kind == ScheduleKind.ONE_TIME.value:
-            run_at_input.display = True
-            cron_input.display = False
-            tz_input.display = False
+            run_at_group.display = True
+            cron_group.display = False
+            tz_group.display = False
         else:
-            run_at_input.display = False
-            cron_input.display = True
-            tz_input.display = True
-        # Avoid unused variable warnings for label containers.
-        _ = (run_at_label, cron_label, tz_label)
+            run_at_group.display = False
+            cron_group.display = True
+            tz_group.display = True
 
     @staticmethod
     def _schedule_options() -> list[tuple[str, str]]:
@@ -202,14 +199,28 @@ class ReminderForm(ModalScreen):
         if not title:
             errors.append("Title is required")
 
+        parsed_run_at: datetime | None = None
         if schedule_kind == ScheduleKind.ONE_TIME.value:
             if not run_at:
                 errors.append("Run At is required for one-time reminders")
+            else:
+                try:
+                    parsed_run_at = datetime.fromisoformat(run_at)
+                except ValueError:
+                    errors.append("Run At must be a valid ISO-8601 datetime")
         elif schedule_kind == ScheduleKind.RECURRING.value:
             if not cron:
                 errors.append("Cron expression is required for recurring reminders")
+            elif not croniter.is_valid(cron):
+                errors.append("Cron expression is invalid")
+
             if not timezone:
                 errors.append("Timezone is required for recurring reminders")
+            else:
+                try:
+                    ZoneInfo(timezone)
+                except ZoneInfoNotFoundError:
+                    errors.append(f"Unknown timezone: {timezone}")
 
         if errors:
             error_widget.update("\n".join(errors))
@@ -223,14 +234,17 @@ class ReminderForm(ModalScreen):
             "schedule_kind": schedule_kind,
         }
         if schedule_kind == ScheduleKind.ONE_TIME.value:
-            form_data["run_at"] = run_at
+            form_data["run_at"] = parsed_run_at
+            form_data["cron"] = None
+            form_data["timezone"] = None
         else:
+            form_data["run_at"] = None
             form_data["cron"] = cron
             form_data["timezone"] = timezone
 
-        if self.task is not None:
+        if self._reminder_task is not None:
             # Preserve the current enabled state when editing.
-            form_data["enabled"] = self.task.enabled
+            form_data["enabled"] = self._reminder_task.enabled
 
-        self.post_message(ReminderFormSubmitted(form_data, task_id=self.task.id if self.task else None))
+        self.post_message(ReminderFormSubmitted(form_data, task_id=self._reminder_task.id if self._reminder_task else None))
         self.dismiss(form_data)

--- a/tldw_chatbook/UI/Screens/scheduling/forms/reminder_form.py
+++ b/tldw_chatbook/UI/Screens/scheduling/forms/reminder_form.py
@@ -1,4 +1,4 @@
-"""Reminder create modal form."""
+"""Reminder create/edit modal form."""
 
 from __future__ import annotations
 
@@ -7,16 +7,19 @@ from typing import Any
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Container, Horizontal, Vertical
+from textual.reactive import reactive
 from textual.screen import ModalScreen
 from textual.widgets import Button, Input, Label, Select, Static, TextArea
 
 from tldw_chatbook.Scheduling.events import ReminderFormSubmitted
-from tldw_chatbook.Scheduling.models import ScheduleKind
+from tldw_chatbook.Scheduling.models import ReminderTask, ScheduleKind
 
 
-# TODO: support edit mode by accepting an optional ReminderTask
+_DEFAULT_TIMEZONE = "UTC"
+
+
 class ReminderForm(ModalScreen):
-    """Modal form for creating a reminder."""
+    """Modal form for creating or editing a reminder."""
 
     BINDINGS = [
         Binding("escape", "dismiss", "Close", show=False),
@@ -30,7 +33,7 @@ class ReminderForm(ModalScreen):
     ReminderForm > Container {
         width: 80;
         height: auto;
-        max-height: 45;
+        max-height: 55;
         background: $surface;
         border: thick $primary;
         padding: 1 2;
@@ -65,6 +68,17 @@ class ReminderForm(ModalScreen):
     }
     """
 
+    task: reactive[ReminderTask | None] = reactive(None)
+
+    def __init__(self, task: ReminderTask | None = None) -> None:
+        """Initialize the form.
+
+        Args:
+            task: Existing reminder to edit, or ``None`` to create a new one.
+        """
+        super().__init__()
+        self.task = task
+
     def action_dismiss(self) -> None:
         """Dismiss the modal when the Escape key is pressed."""
         self.dismiss(None)
@@ -72,7 +86,10 @@ class ReminderForm(ModalScreen):
     def compose(self) -> ComposeResult:
         """Build the form layout."""
         with Container():
-            yield Label("Create Reminder", classes="form-title")
+            yield Label(
+                "Edit Reminder" if self.task else "Create Reminder",
+                classes="form-title",
+            )
 
             with Vertical():
                 yield Label("Title:", classes="form-label")
@@ -89,11 +106,72 @@ class ReminderForm(ModalScreen):
                     id="reminder-kind",
                 )
 
+                yield Label("Run At (ISO-8601):", classes="form-label")
+                yield Input(
+                    placeholder="2026-07-20T14:00:00+00:00",
+                    id="reminder-run-at",
+                )
+
+                yield Label("Cron Expression:", classes="form-label")
+                yield Input(placeholder="0 9 * * 1", id="reminder-cron")
+
+                yield Label("Timezone:", classes="form-label")
+                yield Input(
+                    placeholder=_DEFAULT_TIMEZONE,
+                    id="reminder-timezone",
+                )
+
                 yield Static("", id="reminder-errors", classes="error-text")
 
             with Horizontal(classes="button-container"):
                 yield Button("Save", variant="success", id="reminder-save")
                 yield Button("Cancel", id="reminder-cancel")
+
+    def on_mount(self) -> None:
+        """Prefill the form when editing an existing reminder."""
+        if self.task is None:
+            self.query_one("#reminder-timezone", Input).value = _DEFAULT_TIMEZONE
+            return
+
+        self.query_one("#reminder-title", Input).value = self.task.title
+        body = self.task.body or ""
+        self.query_one("#reminder-body", TextArea).text = body
+        self.query_one("#reminder-kind", Select).value = self.task.schedule_kind.value
+        if self.task.run_at is not None:
+            self.query_one("#reminder-run-at", Input).value = self.task.run_at.isoformat()
+        if self.task.cron is not None:
+            self.query_one("#reminder-cron", Input).value = self.task.cron
+        if self.task.timezone is not None:
+            self.query_one("#reminder-timezone", Input).value = self.task.timezone
+        self._update_schedule_field_visibility(self.task.schedule_kind.value)
+
+    def on_select_changed(self, event: Select.Changed) -> None:
+        """Show/hide schedule fields based on the selected schedule kind."""
+        if event.select.id == "reminder-kind":
+            self._update_schedule_field_visibility(str(event.value))
+
+    def _update_schedule_field_visibility(self, kind: str) -> None:
+        """Toggle which schedule inputs are visible."""
+        run_at_label = self.query_one("#reminder-run-at").parent
+        cron_label = self.query_one("#reminder-cron").parent
+        tz_label = self.query_one("#reminder-timezone").parent
+        # Labels are siblings before the input in the same Vertical; toggling the
+        # input's parent Horizontal would hide label+input if they were grouped.
+        # Since they are not grouped, we toggle the input widget directly and
+        # leave the label visible for clarity.
+        run_at_input = self.query_one("#reminder-run-at", Input)
+        cron_input = self.query_one("#reminder-cron", Input)
+        tz_input = self.query_one("#reminder-timezone", Input)
+        if kind == ScheduleKind.ONE_TIME.value:
+            run_at_input.display = True
+            cron_input.display = False
+            tz_input.display = False
+        else:
+            run_at_input.display = False
+            cron_input.display = True
+            tz_input.display = True
+        # Avoid unused variable warnings for label containers.
+        _ = (run_at_label, cron_label, tz_label)
 
     @staticmethod
     def _schedule_options() -> list[tuple[str, str]]:
@@ -112,14 +190,30 @@ class ReminderForm(ModalScreen):
     def _save(self) -> None:
         """Validate the form and emit the submitted event on success."""
         error_widget = self.query_one("#reminder-errors", Static)
+
         title = self.query_one("#reminder-title", Input).value.strip()
-
-        if not title:
-            error_widget.update("Title is required")
-            return
-
         body = self.query_one("#reminder-body", TextArea).text.strip()
-        schedule_kind = self.query_one("#reminder-kind", Select).value
+        schedule_kind = str(self.query_one("#reminder-kind", Select).value)
+        run_at = self.query_one("#reminder-run-at", Input).value.strip()
+        cron = self.query_one("#reminder-cron", Input).value.strip()
+        timezone = self.query_one("#reminder-timezone", Input).value.strip()
+
+        errors: list[str] = []
+        if not title:
+            errors.append("Title is required")
+
+        if schedule_kind == ScheduleKind.ONE_TIME.value:
+            if not run_at:
+                errors.append("Run At is required for one-time reminders")
+        elif schedule_kind == ScheduleKind.RECURRING.value:
+            if not cron:
+                errors.append("Cron expression is required for recurring reminders")
+            if not timezone:
+                errors.append("Timezone is required for recurring reminders")
+
+        if errors:
+            error_widget.update("\n".join(errors))
+            return
 
         error_widget.update("")
 
@@ -128,6 +222,15 @@ class ReminderForm(ModalScreen):
             "body": body,
             "schedule_kind": schedule_kind,
         }
+        if schedule_kind == ScheduleKind.ONE_TIME.value:
+            form_data["run_at"] = run_at
+        else:
+            form_data["cron"] = cron
+            form_data["timezone"] = timezone
 
-        self.post_message(ReminderFormSubmitted(form_data))
+        if self.task is not None:
+            # Preserve the current enabled state when editing.
+            form_data["enabled"] = self.task.enabled
+
+        self.post_message(ReminderFormSubmitted(form_data, task_id=self.task.id if self.task else None))
         self.dismiss(form_data)

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -15,8 +15,14 @@ from textual.containers import Horizontal, Vertical
 from textual.widgets import Button, DataTable, Static
 
 from ...Navigation.base_app_screen import BaseAppScreen
-from ....Scheduling.events import DeleteTaskRequested
+from ....Scheduling.events import (
+    DeleteTaskRequested,
+    DisableTaskRequested,
+    EditTaskRequested,
+    EnableTaskRequested,
+)
 from ....Scheduling.models import ReminderTask, ScheduledTask
+from .forms.reminder_form import ReminderForm
 from .task_detail import (
     SCHEDULES_EMPTY_CONSOLE_RECOVERY,
     TaskDetail,
@@ -352,8 +358,89 @@ class SchedulesWorkbench(BaseAppScreen):
         )
 
     def action_create_reminder(self) -> None:
-        """Create a new reminder (stub for Task 4.4+)."""
-        self.app_instance.notify("Not yet available", severity="warning")
+        """Open the create-reminder form."""
+        self.app.push_screen(ReminderForm(), callback=self._on_reminder_form_result)
+
+    def _on_reminder_form_result(
+        self, form_data: dict[str, Any] | None, task_id: str | None = None
+    ) -> None:
+        """Create or update a reminder from the form and refresh the queue."""
+        if form_data is None:
+            return
+
+        service = self._scheduling_service
+        if service is None:
+            self.app_instance.notify(
+                "Scheduling service is unavailable; cannot save reminder.",
+                severity="warning",
+            )
+            return
+
+        async def _save_and_refresh() -> None:
+            try:
+                if task_id is None:
+                    await service.create_reminder(form_data)
+                    self.app_instance.notify("Reminder created.", severity="information")
+                else:
+                    await service.update_reminder(task_id, form_data)
+                    self.app_instance.notify("Reminder updated.", severity="information")
+            except Exception:  # noqa: BLE001
+                logger.exception("Failed to save reminder")
+                self.app_instance.notify(
+                    "Failed to save reminder. Check the form values and try again.",
+                    severity="error",
+                )
+            await self.load_tasks()
+
+        self.run_worker(_save_and_refresh, exclusive=True)  # type: ignore[arg-type]
+
+    @on(EditTaskRequested)
+    def _on_edit_task_requested(self, event: EditTaskRequested) -> None:
+        """Open the reminder form pre-filled for editing."""
+        event.stop()
+        self.app.push_screen(
+            ReminderForm(event.task),
+            callback=lambda result: self._on_reminder_form_result(result, event.task.id),
+        )
+
+    @on(EnableTaskRequested)
+    def _on_enable_task_requested(self, event: EnableTaskRequested) -> None:
+        """Enable the requested reminder and refresh the queue."""
+        event.stop()
+        self._set_reminder_enabled(event.task, True)
+
+    @on(DisableTaskRequested)
+    def _on_disable_task_requested(self, event: DisableTaskRequested) -> None:
+        """Disable the requested reminder and refresh the queue."""
+        event.stop()
+        self._set_reminder_enabled(event.task, False)
+
+    def _set_reminder_enabled(self, task: ReminderTask, enabled: bool) -> None:
+        """Update a reminder's enabled state and refresh the queue."""
+        service = self._scheduling_service
+        if service is None:
+            self.app_instance.notify(
+                "Scheduling service is unavailable; cannot update reminder.",
+                severity="warning",
+            )
+            return
+
+        async def _update_and_refresh() -> None:
+            try:
+                await service.update_reminder(task.id, {"enabled": enabled})
+                status = "enabled" if enabled else "disabled"
+                self.app_instance.notify(
+                    f"'{task.title}' {status}.", severity="information"
+                )
+            except Exception:  # noqa: BLE001
+                logger.exception("Failed to update reminder enabled state")
+                self.app_instance.notify(
+                    f"Failed to update '{task.title}'.",
+                    severity="error",
+                )
+            await self.load_tasks()
+
+        self.run_worker(_update_and_refresh, exclusive=True)  # type: ignore[arg-type]
 
     def action_run_now(self) -> None:
         """Run the selected schedule immediately (stub for later tasks)."""

--- a/tldw_chatbook/UI/Screens/scheduling/task_detail.py
+++ b/tldw_chatbook/UI/Screens/scheduling/task_detail.py
@@ -414,7 +414,7 @@ class TaskDetail(Vertical):
 
         empty_state.display = False
         metadata.display = True
-        lifecycle.display = True
+        lifecycle.display = isinstance(task, ReminderTask)
 
         self._update_static("scheduling-task-detail-title", task.title)
         self._update_static("scheduling-task-detail-type", _task_type_label(task))

--- a/tldw_chatbook/UI/Screens/scheduling/task_detail.py
+++ b/tldw_chatbook/UI/Screens/scheduling/task_detail.py
@@ -9,7 +9,12 @@ from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
 from textual.widgets import Button, Static
 
-from ....Scheduling.events import DeleteTaskRequested
+from ....Scheduling.events import (
+    DeleteTaskRequested,
+    DisableTaskRequested,
+    EditTaskRequested,
+    EnableTaskRequested,
+)
 from ....Scheduling.models import ReminderTask, ScheduledTask, ScheduleKind, TaskStatus
 from ....Widgets.delete_confirmation_dialog import DeleteConfirmationDialog
 from ..destination_recovery import DestinationRecoveryState
@@ -302,6 +307,12 @@ class TaskDetail(Vertical):
             )
         yield Horizontal(
             Button(
+                "Edit",
+                id="scheduling-edit-task",
+                variant="primary",
+                tooltip="Edit this reminder.",
+            ),
+            Button(
                 "Enable",
                 id="scheduling-enable-task",
                 variant="success",
@@ -331,17 +342,35 @@ class TaskDetail(Vertical):
         """Handle lifecycle actions (console follow is handled by the workbench)."""
         button_id = event.button.id
         if button_id in {
+            "scheduling-edit-task",
             "scheduling-enable-task",
             "scheduling-disable-task",
             "scheduling-delete-task",
         }:
             event.stop()
-        if button_id == "scheduling-enable-task":
-            self.app.notify("Not yet available", severity="warning")
+        if button_id == "scheduling-edit-task":
+            self._request_edit()
+        elif button_id == "scheduling-enable-task":
+            self._request_enable()
         elif button_id == "scheduling-disable-task":
-            self.app.notify("Not yet available", severity="warning")
+            self._request_disable()
         elif button_id == "scheduling-delete-task":
             self.request_delete()
+
+    def _request_edit(self) -> None:
+        """Post an edit request for the current reminder."""
+        if isinstance(self._current_task, ReminderTask):
+            self.post_message(EditTaskRequested(self._current_task))
+
+    def _request_enable(self) -> None:
+        """Post an enable request for the current reminder."""
+        if isinstance(self._current_task, ReminderTask):
+            self.post_message(EnableTaskRequested(self._current_task))
+
+    def _request_disable(self) -> None:
+        """Post a disable request for the current reminder."""
+        if isinstance(self._current_task, ReminderTask):
+            self.post_message(DisableTaskRequested(self._current_task))
 
     def request_delete(self) -> None:
         """Open the delete confirmation modal for the current task."""


### PR DESCRIPTION
Implements AC #2 from TASK-299: local create/edit/delete/enable/disable for reminders and wires the reminder form into the Schedules workbench.

- ReminderForm now supports one-time (run_at) and recurring (cron/timezone) schedules and edit mode.
- SchedulesWorkbench opens the form for create/edit and saves through SchedulingService.
- TaskDetail Edit/Enable/Disable buttons are now wired.
- Tests updated/added for form validation, create, edit, enable, disable.

Verification:
- Targeted pytest suite: 374 passed.
- ruff: All checks passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes AC #2 for TASK-299.1 with local reminder create/edit/delete and enable/disable, and ensures new/updated reminders are picked up by the local scheduler. Adds stricter form validation and hides lifecycle controls for watchlist projections.

- **New Features**
  - Reminder form: one-time (`run_at`) and recurring (`cron`/`timezone`), edit mode with pre-filled values, grouped fields with show/hide, strict validation (ISO-8601 `run_at`, `croniter` cron, `ZoneInfo` timezone), preserves enabled state.
  - Workbench: Create/Edit open modal; saving calls scheduling service (create/update), refreshes list, and shows success/error notifications. Enable/Disable now update reminders and notify; watchlist tasks hide the lifecycle row.
  - Scheduling service: computes `next_run_at` on create/update and clears stale schedule fields, so local reminders load in the `PriorityQueue`.
  - Events: added `EditTaskRequested`, `EnableTaskRequested`, `DisableTaskRequested`; `ReminderFormSubmitted` now includes an optional `task_id`.
  - Tests: expanded UI and service coverage (validation cases and `PriorityQueue` pick-up).

<sup>Written for commit aa3e653d99cce32cc1f7da9e3e0c2ca039cb90f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

