### PR TITLE
fix: restore console_session_settings re-export and UI conftest fixtures broken by #707

### DIFF
--- a/Tests/UI/conftest.py
+++ b/Tests/UI/conftest.py
@@ -33,6 +33,13 @@ from textual.app import App  # noqa: E402
 from textual.widget import Widget  # noqa: E402
 
 # Import test utilities
+from Tests.textual_test_utils import app_pilot, widget_pilot  # noqa: E402
+from Tests.textual_test_harness import (  # noqa: E402
+    IsolatedWidgetTestApp,
+    TestApp,
+    enhanced_app_pilot,
+    isolated_widget_pilot,
+)
 
 # Type variables
 W = TypeVar("W", bound=Widget)

--- a/tldw_chatbook/Chat/console_session_settings.py
+++ b/tldw_chatbook/Chat/console_session_settings.py
@@ -13,6 +13,7 @@ from tldw_chatbook.Chat.console_provider_support import (
     supported_console_provider_readiness_keys,
 )
 from tldw_chatbook.Chat.console_provider_endpoints import (
+    URL_BASED_PROVIDER_KEYS,
     first_configured_endpoint,
     generic_endpoint_differs,
     normalize_generic_endpoint_for_compare,


### PR DESCRIPTION
## Summary

PR #707 (`8a9ce5cf9`, merged today) broke two things on `dev` HEAD; this PR restores both with the minimal pre-#707 state:

1. **`URL_BASED_PROVIDER_KEYS` re-export removed from `console_session_settings.py`** while `console_settings_modal.py:29` still imports it from there → `ImportError` on any import of `tldw_chatbook.Widgets.Console` (e.g. via `Widgets/Console/__init__.py` → `console_settings_modal`). Restored the removed import-list line (re-export from `console_provider_endpoints`, where the symbol now lives).
2. **`widget_pilot`/`app_pilot` (+ harness) fixture imports removed from `Tests/UI/conftest.py`** → 19 collection/setup errors in `Tests/UI/test_ui_example_best_practices.py` (`fixture 'widget_pilot' not found`). Restored both import blocks.

## Test Plan

- [x] `pytest Tests/UI/test_ui_example_best_practices.py -q` → 19 passed
- [x] `python -c "from tldw_chatbook.Chat.console_session_settings import URL_BASED_PROVIDER_KEYS"` → OK

Note: these same fixes also ride along in #709 (which needed them to test green after rebasing onto broken dev); whichever lands first is fine — the changes are identical and conflict-free.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the missing `URL_BASED_PROVIDER_KEYS` re-export and UI test fixtures removed in #707, fixing Console import errors and UI test collection failures.

- **Bug Fixes**
  - Re-export `URL_BASED_PROVIDER_KEYS` in `tldw_chatbook.Chat.console_session_settings` from `tldw_chatbook.Chat.console_provider_endpoints` to unblock `console_settings_modal` imports.
  - Re-add `widget_pilot`/`app_pilot` and harness imports in `Tests/UI/conftest.py` to restore UI fixtures and eliminate 19 collection errors.

<sup>Written for commit a5a7de651e9d1b672b83bd09caba4d8df4da7a1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

