### PR TITLE
fix: unbreak dev CI — croniter in requirements.txt + stale test patch targets

### DIFF
--- a/Tests/Event_Handlers/Chat_Events/test_chat_events.py
+++ b/Tests/Event_Handlers/Chat_Events/test_chat_events.py
@@ -35,6 +35,7 @@ from tldw_chatbook.Widgets.Chat_Widgets.chat_message import ChatMessage
 from tldw_chatbook.Widgets.Chat_Widgets.chat_message_enhanced import ChatMessageEnhanced
 
 # Import our comprehensive mock fixture
+from Tests.fixtures.event_handler_mocks import mock_app  # noqa: F401
 
 # Test marker for unit tests
 pytestmark = [pytest.mark.asyncio, pytest.mark.unit]

--- a/Tests/Subscriptions/test_subscriptions_smoke.py
+++ b/Tests/Subscriptions/test_subscriptions_smoke.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from tldw_chatbook.DB import Subscriptions_DB as subscriptions_module
+from tldw_chatbook.DB import base_db as base_db_module
 from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
 
 
@@ -38,14 +38,14 @@ def test_subscriptions_db_closes_schema_initialization_connection(
     tmp_path, monkeypatch
 ):
     connections = []
-    original_connect = subscriptions_module.sqlite3.connect
+    original_connect = base_db_module.sqlite3.connect
 
     def tracked_connect(*args, **kwargs):
         conn = _TrackedConnection(original_connect(*args, **kwargs))
         connections.append(conn)
         return conn
 
-    monkeypatch.setattr(subscriptions_module.sqlite3, "connect", tracked_connect)
+    monkeypatch.setattr(base_db_module.sqlite3, "connect", tracked_connect)
 
     db = SubscriptionsDB(tmp_path / "subscriptions.db")
     try:

--- a/Tests/test_model_capabilities.py
+++ b/Tests/test_model_capabilities.py
@@ -413,10 +413,10 @@ class TestCachingAndPerformance:
 class TestModuleFunctions:
     """Test module-level convenience functions."""
 
-    @patch("tldw_chatbook.model_capabilities.get_cli_setting")
-    def test_get_model_capabilities(self, mock_get_setting):
+    @patch("tldw_chatbook.config.load_cli_config_and_ensure_existence")
+    def test_get_model_capabilities(self, mock_load_config):
         """Test get_model_capabilities function."""
-        mock_get_setting.return_value = {}
+        mock_load_config.return_value = {}
 
         # Should return singleton instance
         caps1 = get_model_capabilities()
@@ -438,10 +438,10 @@ class TestModuleFunctions:
         # Should work
         assert is_vision_capable("AnyProvider", "test-model") is True
 
-    @patch("tldw_chatbook.model_capabilities.get_cli_setting")
-    def test_reload_capabilities(self, mock_get_setting):
+    @patch("tldw_chatbook.config.load_cli_config_and_ensure_existence")
+    def test_reload_capabilities(self, mock_load_config):
         """Test reloading capabilities."""
-        mock_get_setting.return_value = {}
+        mock_load_config.return_value = {}
 
         # Get initial instance
         caps1 = get_model_capabilities()

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,7 @@ prometheus_client
 aiofiles
 yt_dlp
 anytree
+croniter>=1.4.0
 #pytest  # In dev group
 
 # Optional Dependencies (install via pip install -e ".[group_name]")


### PR DESCRIPTION
## Summary

Unbreaks `dev`'s CI, in two parts:

1. **`croniter` missing from `requirements.txt`** — PR #707 added `croniter>=1.4.0` to `pyproject.toml` but not `requirements.txt`. CI workflows (`python-app.yml`, `test.yml`) install with `pip install -r requirements.txt`, so every unit-test job failed at collection with `ModuleNotFoundError: No module named 'croniter'` (Scheduling/Chat/Library test modules). One-line fix, same pin as pyproject.

2. **Stale test patch targets** (unmasked once collection worked again — 3 failures on the macOS jobs):
   - `Tests/test_model_capabilities.py`: patched `tldw_chatbook.model_capabilities.get_cli_setting`, which no longer exists — the module lazily imports `load_cli_config_and_ensure_existence` from `tldw_chatbook.config` at call time. Tests now patch that (matching the sibling test in the same class).
   - `Tests/Subscriptions/test_subscriptions_smoke.py`: patched `subscriptions_module.sqlite3`, but `Subscriptions_DB.py` no longer imports `sqlite3` at top level — connections come from `base_db` (`SubscriptionsDB(BaseDB)`). Test now patches `base_db_module.sqlite3.connect`.

No product-code bugs found — both were test-only staleness.

## Test Plan

- [x] `pytest Tests/Subscriptions/test_subscriptions_smoke.py Tests/test_model_capabilities.py -q` → 25 passed (3 previously failing now pass)
- [ ] CI unit-test jobs: collection succeeds (no `croniter` ModuleNotFoundError) and the 3 previously failing tests pass

3. **\`mock_app\` fixture import removed by #707** from \`Tests/Event_Handlers/Chat_Events/test_chat_events.py\` → 14 setup errors (\`fixture 'mock_app' not found\`). Restored the import from \`Tests/fixtures/event_handler_mocks.py\` (15/15 pass; full \`Tests/Event_Handlers/\` suite: 96 passed, 26 skipped).