### PR TITLE
fix(splash): resolve animation content keys for all animated cards

### DIFF
--- a/Tests/Utils/test_startup_polish_regressions.py
+++ b/Tests/Utils/test_startup_polish_regressions.py
@@ -9,6 +9,10 @@ from types import SimpleNamespace
 
 import pytest
 from loguru import logger
+from textual.app import App, ComposeResult
+
+from tldw_chatbook.Utils.Splash_Screens.card_definitions import get_all_card_definitions
+from tldw_chatbook.Widgets.splash_screen import SplashScreen
 
 
 def test_splash_effect_modules_import_without_annotation_name_errors() -> None:
@@ -183,6 +187,55 @@ def test_random_splash_selection_skips_missing_active_card_definitions(
 
     assert screen.card_name == "default"
     assert choices == [["default"]]
+
+
+class _SplashHost(App):
+    """Minimal app host that mounts a single SplashScreen for testing."""
+
+    def __init__(self, card_name: str) -> None:
+        super().__init__()
+        self.card_name = card_name
+        self.screen_under_test: SplashScreen | None = None
+
+    def compose(self) -> ComposeResult:
+        self.screen_under_test = SplashScreen(card_name=self.card_name, duration=10.0)
+        yield self.screen_under_test
+
+
+@pytest.fixture(autouse=True)
+def _isolate_splash_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep splash screen config loading away from the developer's config file."""
+    from tldw_chatbook.Widgets import splash_screen
+
+    monkeypatch.setattr(splash_screen, "get_cli_setting", lambda _setting, default=None, *_args, **_kwargs: default)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "card_name",
+    [
+        name
+        for name, data in get_all_card_definitions().items()
+        if data.get("type") == "animated"
+    ],
+)
+async def test_animated_splash_card_starts_animation(card_name: str) -> None:
+    """Every animated card must instantiate its effect and start its timer.
+
+    Regression: several card definitions passed art-name keys that did not
+    match the effect constructors (e.g. ``background_art_name`` instead of
+    ``background_content``), causing ``SplashScreen`` to fall back to a static
+    image and silently skip the animation.
+    """
+    app = _SplashHost(card_name)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        screen = app.screen_under_test
+        assert screen is not None
+        assert screen.effect_handler is not None, f"{card_name}: effect handler was not created"
+        assert screen.animation_timer is not None, f"{card_name}: animation timer was not started"
+        screen.close()
 
 
 def test_nltk_download_false_is_not_logged_as_success(

--- a/tldw_chatbook/Utils/Splash_Screens/card_definitions.py
+++ b/tldw_chatbook/Utils/Splash_Screens/card_definitions.py
@@ -115,7 +115,7 @@ def get_all_card_definitions():
         "loading_bar": {
             "type": "animated",
             "effect": "loading_bar",
-            "content": get_ascii_art("loading_bar_frame"),
+            "bar_frame_content": get_ascii_art("loading_bar_frame"),
             "style": "white on black",
             "animation_speed": 0.1,
             "fill_char": "█",
@@ -213,8 +213,8 @@ def get_all_card_definitions():
             "style": "bold white on black",
             "animation_speed": 0.05,
             "duration": 3.0,
-            "start_art_name": "morph_art_start",
-            "end_art_name": "morph_art_end",
+            "start_content": get_ascii_art("morph_art_start"),
+            "end_content": get_ascii_art("morph_art_end"),
             "morph_style": "dissolve",
         },
         "game_of_life": {
@@ -260,7 +260,7 @@ def get_all_card_definitions():
         "spotlight_reveal": {
             "type": "animated",
             "effect": "spotlight",
-            "background_art_name": "spotlight_background",
+            "background_content": get_ascii_art("spotlight_background"),
             "style": "dim black on black",
             "animation_speed": 0.05,
             "spotlight_radius": 7,
@@ -307,7 +307,7 @@ def get_all_card_definitions():
         "pixel_zoom": {
             "type": "animated",
             "effect": "pixel_zoom",
-            "target_art_name": "pixel_art_target",
+            "target_content": get_ascii_art("pixel_art_target"),
             "style": "bold white on black",
             "animation_speed": 0.05,
             "duration": 3.0,
@@ -328,7 +328,7 @@ def get_all_card_definitions():
         "old_film": {
             "type": "animated",
             "effect": "old_film",
-            "frames_art_names": ["film_generic_frame"],
+            "frames_content": [get_ascii_art(name) for name in ["film_generic_frame"]],
             "style": "white on black",
             "animation_speed": 0.1,
             "frame_duration": 0.8,


### PR DESCRIPTION
## Summary
Five animated splash cards were passing art-name keys that did not match their effect constructors, so "SplashScreen" fell back to a static image and skipped the animation.

## Changes
- Updated "tldw_chatbook/Utils/Splash_Screens/card_definitions.py" to resolve the correct content keys:
  - loading_bar: content → bar_frame_content
  - ascii_morph: start_art_name/end_art_name → start_content/end_content
  - spotlight_reveal: background_art_name → background_content
  - pixel_zoom: target_art_name → target_content
  - old_film: frames_art_names → frames_content
- Added parametric regression test in "Tests/Utils/test_startup_polish_regressions.py" that mounts every animated card and asserts both "effect_handler" and "animation_timer" are set.
- Marked TASK-299 as Done with implementation notes.

## Verification
```bash
pytest Tests/Utils/test_startup_polish_regressions.py
```
Result: 94 passed (76/76 animated cards now start animation).

Closes TASK-299.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes splash screen animations by correcting content keys in five animated card definitions so all cards animate instead of falling back to static images. Adds a regression test and closes TASK-299.

- **Bug Fixes**
  - Updated `tldw_chatbook/Utils/Splash_Screens/card_definitions.py` to pass the correct content keys: loading_bar → `bar_frame_content`, ascii_morph → `start_content`/`end_content`, spotlight_reveal → `background_content`, pixel_zoom → `target_content`, old_film → `frames_content`.
  - Added a parametric test in `Tests/Utils/test_startup_polish_regressions.py` that mounts each animated card in a minimal `App`, isolates splash config, and asserts `effect_handler` and `animation_timer` are set.

<sup>Written for commit f2a919b52f229dfbbcdd398b26d004a0d54e37bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

