### PR TITLE
feat(console): address beta feedback for console screen

### DIFF
--- a/Docs/superpowers/plans/2026-07-19-console-screen-feedback-plan.md
+++ b/Docs/superpowers/plans/2026-07-19-console-screen-feedback-plan.md
@@ -1212,7 +1212,6 @@ async def action_view_chat_context(self) -> None:
         self.notify("No active conversation.", severity="warning")
         return
 
-    session = controller.store.session(session_id)
     composer = self.query_one("#console-native-composer", ConsoleComposerBar)
     draft = composer.value if composer else ""
     staged_sources = controller.store.workspace_context.allowed_sources

--- a/Docs/superpowers/plans/2026-07-19-console-screen-feedback-plan.md
+++ b/Docs/superpowers/plans/2026-07-19-console-screen-feedback-plan.md
@@ -1000,12 +1000,14 @@ class ConsoleContextModal(ModalScreen[None]):
 
     def __init__(
         self,
+        snapshot: ConsoleContextSnapshot,
         snapshot_factory: Callable[[], Awaitable[ConsoleContextSnapshot]],
         *,
         token_estimate: int | None = None,
         in_progress: bool = False,
     ) -> None:
         super().__init__()
+        self.snapshot = snapshot
         self._snapshot_factory = snapshot_factory
         self.token_estimate = token_estimate
         self.in_progress = in_progress
@@ -1026,6 +1028,7 @@ class ConsoleContextModal(ModalScreen[None]):
                 yield Checkbox("Raw JSON", id="console-context-raw")
                 yield Button("Refresh", id="console-context-refresh", disabled=self.in_progress)
                 yield Button("Copy JSON", id="console-context-copy")
+                yield Button("Save to File", id="console-context-save")
                 yield Button("Close", id="console-context-close")
 
     def on_mount(self) -> None:
@@ -1209,6 +1212,7 @@ async def action_view_chat_context(self) -> None:
         self.notify("No active conversation.", severity="warning")
         return
 
+    session = controller.store.session(session_id)
     composer = self.query_one("#console-native-composer", ConsoleComposerBar)
     draft = composer.value if composer else ""
     staged_sources = controller.store.workspace_context.allowed_sources
@@ -1292,7 +1296,7 @@ class ModalHarness(App):
         yield Static("background")
 
     def on_mount(self) -> None:
-        self.push_screen(ConsoleContextModal(_snapshot_factory, token_estimate=42))
+        self.push_screen(ConsoleContextModal(SNAPSHOT, _snapshot_factory, token_estimate=42))
 
 
 @pytest.mark.asyncio

--- a/Docs/superpowers/plans/2026-07-19-console-screen-feedback-plan.md
+++ b/Docs/superpowers/plans/2026-07-19-console-screen-feedback-plan.md
@@ -1026,7 +1026,6 @@ class ConsoleContextModal(ModalScreen[None]):
                 yield Checkbox("Raw JSON", id="console-context-raw")
                 yield Button("Refresh", id="console-context-refresh", disabled=self.in_progress)
                 yield Button("Copy JSON", id="console-context-copy")
-                yield Button("Save to File", id="console-context-save")
                 yield Button("Close", id="console-context-close")
 
     def on_mount(self) -> None:

--- a/Docs/superpowers/plans/2026-07-19-console-screen-feedback-plan.md
+++ b/Docs/superpowers/plans/2026-07-19-console-screen-feedback-plan.md
@@ -1000,14 +1000,12 @@ class ConsoleContextModal(ModalScreen[None]):
 
     def __init__(
         self,
-        snapshot: ConsoleContextSnapshot,
         snapshot_factory: Callable[[], Awaitable[ConsoleContextSnapshot]],
         *,
         token_estimate: int | None = None,
         in_progress: bool = False,
     ) -> None:
         super().__init__()
-        self.snapshot = snapshot
         self._snapshot_factory = snapshot_factory
         self.token_estimate = token_estimate
         self.in_progress = in_progress
@@ -1295,7 +1293,7 @@ class ModalHarness(App):
         yield Static("background")
 
     def on_mount(self) -> None:
-        self.push_screen(ConsoleContextModal(SNAPSHOT, _snapshot_factory, token_estimate=42))
+        self.push_screen(ConsoleContextModal(_snapshot_factory, token_estimate=42))
 
 
 @pytest.mark.asyncio

--- a/Tests/Chat/test_console_agent_bridge.py
+++ b/Tests/Chat/test_console_agent_bridge.py
@@ -3,6 +3,7 @@
 import asyncio
 import contextlib
 import json
+from unittest.mock import MagicMock, patch
 
 
 from tldw_chatbook.Chat.console_agent_bridge import (
@@ -24,11 +25,14 @@ from tldw_chatbook.Chat.console_provider_gateway import ProviderToolCalls
 from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
 from tldw_chatbook.Agents.agent_models import (
     LOAD_TOOLS_NAME,
+    RUN_DONE,
+    RUN_ERROR,
     SPAWN_TOOL_NAME,
     STEP_ERROR,
     STEP_MODEL,
     STEP_SPAWN,
     STEP_TOOL_RESULT,
+    RunOutcome,
     ToolCatalogEntry,
     ToolResult,
     ToolSchema,
@@ -1385,3 +1389,66 @@ def test_console_run_budget_is_raised_above_the_bare_engine_default(tmp_path):
     assert run["budget"]["max_steps"] > 8
     assert run["budget"]["max_steps"] >= 16
     assert run["budget"]["max_wall_seconds"] > 240.0
+
+
+def _make_bridge() -> ConsoleAgentBridge:
+    store = MagicMock()
+    store.messages_for_session.return_value = []
+    return ConsoleAgentBridge(
+        agent_runs_db=MagicMock(),
+        store=store,
+        provider_gateway=MagicMock(),
+    )
+
+
+def test_run_reply_returns_runoutcome_done():
+    bridge = _make_bridge()
+    outcome = RunOutcome(status=RUN_DONE, steps=[], final_text="done")
+
+    with patch.object(AgentService, "run_turn", return_value=("run-1", outcome)):
+        result = bridge.run_reply(
+            conversation_id="c1",
+            session_id="s1",
+            resolution=None,
+            assistant_message_id="a1",
+            model="gpt-4",
+            session_system_prompt="sys",
+            agent_messages=[{"role": "user", "content": "hi"}],
+            should_cancel=lambda: False,
+        )
+
+    assert result.status == RUN_DONE
+    assert result.final_text == "done"
+
+
+def test_run_reply_returns_runoutcome_error():
+    bridge = _make_bridge()
+    outcome = RunOutcome(status=RUN_ERROR, steps=[], final_text="")
+
+    with patch.object(AgentService, "run_turn", return_value=("run-1", outcome)):
+        result = bridge.run_reply(
+            conversation_id="c1",
+            session_id="s1",
+            resolution=None,
+            assistant_message_id="a1",
+            model="gpt-4",
+            session_system_prompt="sys",
+            agent_messages=[{"role": "user", "content": "hi"}],
+            should_cancel=lambda: False,
+        )
+
+    assert result.status == RUN_ERROR
+
+
+def test_native_tool_schemas_returns_builtin_tool_schemas():
+    bridge = _make_bridge()
+
+    schemas = bridge.native_tool_schemas()
+
+    names = {schema["name"] for schema in schemas}
+    assert "calculator" in names
+    assert "get_current_datetime" in names
+    for schema in schemas:
+        assert "name" in schema
+        assert "description" in schema
+        assert "parameters" in schema

--- a/Tests/Chat/test_console_agent_bridge.py
+++ b/Tests/Chat/test_console_agent_bridge.py
@@ -34,6 +34,7 @@ from tldw_chatbook.Agents.agent_models import (
     ToolSchema,
 )
 from tldw_chatbook.Agents.agent_runtime import FENCE_OPEN
+from tldw_chatbook.Agents.agent_service import AgentService
 from tldw_chatbook.Skills_Interop.skill_trust_models import SkillTrustBlockedError
 
 

--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -1822,6 +1822,24 @@ async def test_build_context_snapshot_redacts_secrets():
 
 
 @pytest.mark.asyncio
+async def test_build_context_snapshot_redacts_quoted_secrets_without_mangling_json():
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+    session = store.ensure_session(title="Chat 1")
+
+    store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content='run with {"api_key": "secret123"}',
+    )
+
+    snapshot = await controller.build_context_snapshot(draft="ok")
+    payload_text = str(snapshot.next_send_payload)
+    assert "secret123" not in payload_text
+    assert '"api_key": "[redacted]"' in payload_text
+
+
+@pytest.mark.asyncio
 async def test_build_context_snapshot_is_immutable():
     store = ConsoleChatStore()
     controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
@@ -1921,7 +1939,7 @@ def test_replace_image_data_preserves_detail_and_handles_string_url():
     assert dict_url["url"] == "[image: data redacted for preview]"
     assert dict_url["detail"] == "auto"
     string_url = redacted[0]["content"][1]["image_url"]
-    assert string_url == {"url": "[image: data redacted for preview]"}
+    assert string_url == "http://example.com/img.png"
 
 
 @pytest.mark.asyncio
@@ -2003,6 +2021,15 @@ def test_annotate_skill_commands_multimodal_text_part():
     assert annotated[0]["content"][1] == messages[0]["content"][1]
 
 
+def test_annotate_skill_commands_ignores_leading_whitespace():
+    messages = [{"role": "user", "content": "  /search tools"}]
+
+    annotated = ConsoleChatController._annotate_skill_commands(messages)
+
+    assert annotated[0]["content"].startswith("  /search tools")
+    assert "Skill command not resolved in preview" in annotated[0]["content"]
+
+
 def test_build_tools_info_for_snapshot_no_bridge():
     controller = ConsoleChatController(
         store=ConsoleChatStore(), provider_gateway=StreamingGateway()
@@ -2012,8 +2039,7 @@ def test_build_tools_info_for_snapshot_no_bridge():
 
     assert info["native_schemas"] == []
     assert info["mcp_note"] is None
-    assert info["preview_note"] is not None
-    assert "builtin native tools" in info["preview_note"]
+    assert info["preview_note"] == "No native tools are configured for preview."
 
 
 def test_build_tools_info_for_snapshot_with_native_schemas():
@@ -2048,8 +2074,7 @@ def test_build_tools_info_for_snapshot_mcp_provider_present():
     assert info["native_schemas"] == []
     assert info["mcp_note"] is not None
     assert "MCP tools are configured" in info["mcp_note"]
-    assert info["preview_note"] is not None
-    assert "skills/MCP" in info["preview_note"]
+    assert info["preview_note"] == "No native tools are configured for preview."
 
 
 def test_build_tools_info_for_snapshot_mcp_provider_absent():
@@ -2063,5 +2088,4 @@ def test_build_tools_info_for_snapshot_mcp_provider_absent():
 
     assert info["native_schemas"] == []
     assert info["mcp_note"] is None
-    assert info["preview_note"] is not None
-    assert "preview" in info["preview_note"]
+    assert info["preview_note"] == "No native tools are configured for preview."

--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -1807,6 +1807,22 @@ async def test_build_context_snapshot_does_not_execute_skills():
 
 
 @pytest.mark.asyncio
+async def test_build_context_snapshot_empty_draft_does_not_annotate_historical_skill_command():
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+    session = store.ensure_session(title="Chat 1")
+
+    store.append_message(session.id, role=ConsoleMessageRole.USER, content="/search tools")
+    store.append_message(session.id, role=ConsoleMessageRole.ASSISTANT, content="Here are some tools.")
+
+    snapshot = await controller.build_context_snapshot(draft="")
+    historical_user_content = snapshot.next_send_payload["messages"][0]["content"]
+
+    assert historical_user_content == "/search tools"
+    assert "Skill command not resolved in preview" not in historical_user_content
+
+
+@pytest.mark.asyncio
 async def test_build_context_snapshot_redacts_secrets():
     store = ConsoleChatStore()
     controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())

--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -3,7 +3,13 @@ from types import SimpleNamespace
 
 import pytest
 
-from tldw_chatbook.Agents.agent_models import ToolCall
+from tldw_chatbook.Agents.agent_models import (
+    RUN_CANCELLED,
+    RUN_DONE,
+    RUN_ERROR,
+    RunOutcome,
+    ToolCall,
+)
 from tldw_chatbook.Agents.mcp_tool_provider import MCPPendingCall
 from tldw_chatbook.Chat import console_chat_controller as controller_module
 from tldw_chatbook.Chat.attachment_core import PendingAttachment
@@ -1654,3 +1660,177 @@ def test_build_mcp_review_hook_clears_stamp_at_entry_before_a_raising_round_trip
 
     # No stale stamp from turn 1 must survive the raise for invoke() to peek.
     assert provider.stamped_decision("mcp__srv__run") is None
+
+
+# -----------------------------------------------------------------------------
+# _finalize_agent_reply hardening (task-2)
+# -----------------------------------------------------------------------------
+
+
+def test_finalize_agent_reply_empty_final_text_uses_fallback():
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+    session = store.ensure_session()
+    store.append_message(session.id, role=ConsoleMessageRole.USER, content="hi")
+    placeholder = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content=""
+    )
+
+    outcome = RunOutcome(status=RUN_DONE, steps=[], final_text="")
+    result = controller._finalize_agent_reply(
+        placeholder.id, session.id, outcome, variant_mode=False
+    )
+
+    messages = store.messages_for_session(session.id)
+    assistant = messages[-1]
+    assert assistant.content == "No response was generated."
+    assert assistant.status == "complete"
+    assert result.accepted is True
+    assert controller.run_state.status is ConsoleRunStatus.COMPLETED
+
+
+def test_finalize_agent_reply_missing_placeholder_appends_message():
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+    session = store.ensure_session()
+    store.append_message(session.id, role=ConsoleMessageRole.USER, content="hi")
+    fake_id = "nonexistent-msg-id"
+
+    outcome = RunOutcome(status=RUN_DONE, steps=[], final_text="hello back")
+    result = controller._finalize_agent_reply(
+        fake_id, session.id, outcome, variant_mode=False
+    )
+
+    messages = store.messages_for_session(session.id)
+    assistant = messages[-1]
+    assert assistant.role is ConsoleMessageRole.ASSISTANT
+    assert assistant.content == "hello back"
+    assert assistant.status == "complete"
+    assert result.accepted is True
+    assert controller.run_state.status is ConsoleRunStatus.COMPLETED
+
+
+def test_finalize_agent_reply_error_marks_failed():
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+    session = store.ensure_session()
+    store.append_message(session.id, role=ConsoleMessageRole.USER, content="hi")
+    placeholder = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content=""
+    )
+    store.append_stream_chunk(placeholder.id, "partial")
+
+    outcome = RunOutcome(status=RUN_ERROR, steps=[], final_text="")
+    result = controller._finalize_agent_reply(
+        placeholder.id, session.id, outcome, variant_mode=False
+    )
+
+    messages = store.messages_for_session(session.id)
+    assistant = next(m for m in messages if m.role is ConsoleMessageRole.ASSISTANT)
+    assert assistant.status == "failed"
+    assert assistant.content == "partial"
+    assert "Agent run failed" in controller.run_state.visible_copy
+    assert result.accepted is True
+
+
+def test_finalize_agent_reply_cancelled_marks_failed():
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+    session = store.ensure_session()
+    store.append_message(session.id, role=ConsoleMessageRole.USER, content="hi")
+    placeholder = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content=""
+    )
+
+    outcome = RunOutcome(status=RUN_CANCELLED, steps=[], final_text="")
+    result = controller._finalize_agent_reply(
+        placeholder.id, session.id, outcome, variant_mode=False
+    )
+
+    messages = store.messages_for_session(session.id)
+    assistant = next(m for m in messages if m.role is ConsoleMessageRole.ASSISTANT)
+    assert assistant.status == "failed"
+    assert controller.run_state.status is ConsoleRunStatus.FAILED
+    assert result.accepted is True
+
+
+def test_finalize_agent_reply_unknown_status_marks_failed():
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+    session = store.ensure_session()
+    store.append_message(session.id, role=ConsoleMessageRole.USER, content="hi")
+    placeholder = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content=""
+    )
+
+    outcome = RunOutcome(status="weird", steps=[], final_text="")
+    result = controller._finalize_agent_reply(
+        placeholder.id, session.id, outcome, variant_mode=False
+    )
+
+    messages = store.messages_for_session(session.id)
+    assistant = next(m for m in messages if m.role is ConsoleMessageRole.ASSISTANT)
+    assert assistant.status == "failed"
+    assert controller.run_state.status is ConsoleRunStatus.FAILED
+    assert result.accepted is True
+
+
+@pytest.mark.asyncio
+async def test_build_context_snapshot_returns_current_and_next_send():
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+    session = store.ensure_session(title="Chat 1")
+
+    store.append_message(session.id, role=ConsoleMessageRole.USER, content="Hello")
+    store.append_message(session.id, role=ConsoleMessageRole.ASSISTANT, content="Hi there")
+
+    snapshot = await controller.build_context_snapshot(draft="Explain tools")
+
+    assert len(snapshot.current_messages) == 2
+    assert snapshot.current_messages[0].role == ConsoleMessageRole.USER
+    assert snapshot.next_send_payload["messages"][-1]["content"].startswith("Explain tools")
+
+
+@pytest.mark.asyncio
+async def test_build_context_snapshot_does_not_execute_skills():
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+    session = store.ensure_session(title="Chat 1")
+
+    store.append_message(session.id, role=ConsoleMessageRole.USER, content="Hello")
+
+    snapshot = await controller.build_context_snapshot(draft="/search tools")
+    final_content = snapshot.next_send_payload["messages"][-1]["content"]
+    assert "/search tools" in final_content
+    assert "Skill command not resolved in preview" in final_content
+
+
+@pytest.mark.asyncio
+async def test_build_context_snapshot_redacts_secrets():
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+    session = store.ensure_session(title="Chat 1")
+
+    store.append_message(session.id, role=ConsoleMessageRole.USER, content="run")
+    controller.system_prompt = "Use api_key=secret123"
+
+    snapshot = await controller.build_context_snapshot(draft="ok")
+    payload_text = str(snapshot.next_send_payload)
+    assert "secret123" not in payload_text
+    assert "[redacted]" in payload_text
+
+
+@pytest.mark.asyncio
+async def test_build_context_snapshot_is_immutable():
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+    session = store.ensure_session(title="Chat 1")
+
+    msg = store.append_message(session.id, role=ConsoleMessageRole.USER, content="Hello")
+
+    snapshot = await controller.build_context_snapshot(draft="Follow up")
+    original_content = snapshot.current_messages[0].content
+    snapshot.current_messages[0].content = "mutated"
+
+    reloaded = store.get_message(msg.id)
+    assert reloaded.content == original_content

--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -1938,3 +1938,59 @@ async def test_build_context_snapshot_includes_staged_sources():
     assert len(staged) == 2
     assert staged[0] == {"source_id": "note-1", "label": "Note one", "type": "note"}
     assert staged[1] == {"source_id": "file-2", "label": "File two", "type": "file"}
+
+
+def test_build_tools_info_for_snapshot_no_bridge():
+    controller = ConsoleChatController(
+        store=ConsoleChatStore(), provider_gateway=StreamingGateway()
+    )
+
+    info = controller._build_tools_info_for_snapshot()
+
+    assert info["native_schemas"] == []
+    assert info["mcp_note"] is None
+
+
+def test_build_tools_info_for_snapshot_with_native_schemas():
+    controller = ConsoleChatController(
+        store=ConsoleChatStore(), provider_gateway=StreamingGateway()
+    )
+    controller._agent_bridge = SimpleNamespace(
+        native_tool_schemas=lambda: [
+            {"name": "calculator", "description": "Compute arithmetic.", "parameters": {}},
+        ]
+    )
+
+    info = controller._build_tools_info_for_snapshot()
+
+    assert info["native_schemas"] == [
+        {"name": "calculator", "description": "Compute arithmetic.", "parameters": {}},
+    ]
+    assert info["mcp_note"] is None
+
+
+def test_build_tools_info_for_snapshot_mcp_provider_present():
+    controller = ConsoleChatController(
+        store=ConsoleChatStore(), provider_gateway=StreamingGateway()
+    )
+    controller._agent_bridge = SimpleNamespace(native_tool_schemas=lambda: [])
+    controller._mcp_provider = object()
+
+    info = controller._build_tools_info_for_snapshot()
+
+    assert info["native_schemas"] == []
+    assert info["mcp_note"] is not None
+    assert "MCP tools are configured" in info["mcp_note"]
+
+
+def test_build_tools_info_for_snapshot_mcp_provider_absent():
+    controller = ConsoleChatController(
+        store=ConsoleChatStore(), provider_gateway=StreamingGateway()
+    )
+    controller._agent_bridge = SimpleNamespace(native_tool_schemas=lambda: [])
+    controller._mcp_provider = None
+
+    info = controller._build_tools_info_for_snapshot()
+
+    assert info["native_schemas"] == []
+    assert info["mcp_note"] is None

--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -1855,8 +1855,33 @@ async def test_build_context_snapshot_redacts_quoted_secrets_without_mangling_js
     assert '"api_key": "[redacted]"' in payload_text
 
 
+def test_redact_secrets_matches_hyphenated_and_camelcase_keys():
+    payload = {
+        "headers": {
+            "x-api-key": "secret123",
+            "apiKey": "secret456",
+            "my_api_key": "secret789",
+        }
+    }
+
+    redacted = ConsoleChatController._redact_secrets(payload)
+
+    assert redacted["headers"]["x-api-key"] == "[redacted]"
+    assert redacted["headers"]["apiKey"] == "[redacted]"
+    assert redacted["headers"]["my_api_key"] == "[redacted]"
+
+
+def test_redact_secrets_recursively_redacts_non_string_secret_values():
+    payload = {"api_key": {"value": "secret"}}
+
+    redacted = ConsoleChatController._redact_secrets(payload)
+
+    assert "secret" not in str(redacted)
+    assert redacted["api_key"] == {"value": "[redacted]"}
+
+
 @pytest.mark.asyncio
-async def test_build_context_snapshot_is_immutable():
+async def test_build_context_snapshot_messages_are_independent_of_store():
     store = ConsoleChatStore()
     controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
     session = store.ensure_session(title="Chat 1")
@@ -1991,6 +2016,27 @@ def test_replace_image_data_redacts_anthropic_and_string_image_parts():
     assert string_part["image"] == "[image: data redacted for preview]"
 
 
+def test_replace_image_data_redacts_string_content_with_data_urls():
+    messages = [
+        {
+            "role": "user",
+            "content": "Look at this image: data:image/png;base64,abc and this URL: http://example.com/img.png",
+        },
+        {
+            "role": "assistant",
+            "content": "data:image/jpeg;base64,xyz",
+        },
+    ]
+
+    redacted = ConsoleChatController._replace_image_data_with_placeholders(messages)
+
+    assert "data:image/png;base64,abc" not in redacted[0]["content"]
+    assert "data:image/jpeg;base64,xyz" not in redacted[1]["content"]
+    assert "http://example.com/img.png" in redacted[0]["content"]
+    assert redacted[0]["content"].count("[image: data redacted for preview]") == 1
+    assert redacted[1]["content"] == "[image: data redacted for preview]"
+
+
 @pytest.mark.asyncio
 async def test_build_context_snapshot_next_send_payload_independent_of_store():
     store = ConsoleChatStore()
@@ -2069,7 +2115,12 @@ async def test_build_context_snapshot_isolates_assembly_errors():
     payload = snapshot.next_send_payload
     assert "error" in payload
     assert "Failed to build context snapshot" in payload["error"]
-    assert payload["messages"] == []
+    # The degraded payload must still include the transcript-derived messages
+    # that were assembled before the failure, not an empty placeholder.
+    assert len(payload["messages"]) == 2
+    assert payload["messages"][0]["content"] == "Hello"
+    assert payload["messages"][1]["content"].startswith("Follow up")
+    assert payload["system"] == []
 
 
 def test_annotate_skill_commands_multimodal_text_part():

--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -1901,6 +1901,49 @@ async def test_build_context_snapshot_redacts_historical_image_data():
     assert "[image: data redacted for preview]" in payload_text
 
 
+def test_replace_image_data_preserves_detail_and_handles_string_url():
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,abc", "detail": "auto"},
+                },
+                {"type": "image_url", "image_url": "http://example.com/img.png"},
+            ],
+        }
+    ]
+
+    redacted = ConsoleChatController._replace_image_data_with_placeholders(messages)
+
+    dict_url = redacted[0]["content"][0]["image_url"]
+    assert dict_url["url"] == "[image: data redacted for preview]"
+    assert dict_url["detail"] == "auto"
+    string_url = redacted[0]["content"][1]["image_url"]
+    assert string_url == {"url": "[image: data redacted for preview]"}
+
+
+@pytest.mark.asyncio
+async def test_build_context_snapshot_next_send_payload_independent_of_store():
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+    session = store.ensure_session(title="Chat 1")
+    store.append_message(session.id, role=ConsoleMessageRole.USER, content="Hello")
+
+    snapshot = await controller.build_context_snapshot(draft="Follow up")
+    original = str(snapshot.next_send_payload)
+
+    # Mutate the returned payload in place; frozen only prevents reassignment
+    # of the top-level field, not mutation of the nested dict/list structures.
+    snapshot.next_send_payload["messages"].append(
+        {"role": "user", "content": "injected"}
+    )
+
+    snapshot2 = await controller.build_context_snapshot(draft="Follow up")
+    assert str(snapshot2.next_send_payload) == original
+
+
 @pytest.mark.asyncio
 async def test_build_context_snapshot_no_active_session_returns_empty():
     store = ConsoleChatStore()
@@ -1940,6 +1983,26 @@ async def test_build_context_snapshot_includes_staged_sources():
     assert staged[1] == {"source_id": "file-2", "label": "File two", "type": "file"}
 
 
+def test_annotate_skill_commands_multimodal_text_part():
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "/search tools"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+            ],
+        }
+    ]
+
+    annotated = ConsoleChatController._annotate_skill_commands(messages)
+
+    text_part = annotated[0]["content"][0]
+    assert text_part["type"] == "text"
+    assert text_part["text"].startswith("/search tools")
+    assert "Skill command not resolved in preview" in text_part["text"]
+    assert annotated[0]["content"][1] == messages[0]["content"][1]
+
+
 def test_build_tools_info_for_snapshot_no_bridge():
     controller = ConsoleChatController(
         store=ConsoleChatStore(), provider_gateway=StreamingGateway()
@@ -1949,6 +2012,8 @@ def test_build_tools_info_for_snapshot_no_bridge():
 
     assert info["native_schemas"] == []
     assert info["mcp_note"] is None
+    assert info["preview_note"] is not None
+    assert "builtin native tools" in info["preview_note"]
 
 
 def test_build_tools_info_for_snapshot_with_native_schemas():
@@ -1967,6 +2032,8 @@ def test_build_tools_info_for_snapshot_with_native_schemas():
         {"name": "calculator", "description": "Compute arithmetic.", "parameters": {}},
     ]
     assert info["mcp_note"] is None
+    assert info["preview_note"] is not None
+    assert "live run" in info["preview_note"]
 
 
 def test_build_tools_info_for_snapshot_mcp_provider_present():
@@ -1981,6 +2048,8 @@ def test_build_tools_info_for_snapshot_mcp_provider_present():
     assert info["native_schemas"] == []
     assert info["mcp_note"] is not None
     assert "MCP tools are configured" in info["mcp_note"]
+    assert info["preview_note"] is not None
+    assert "skills/MCP" in info["preview_note"]
 
 
 def test_build_tools_info_for_snapshot_mcp_provider_absent():
@@ -1994,3 +2063,5 @@ def test_build_tools_info_for_snapshot_mcp_provider_absent():
 
     assert info["native_schemas"] == []
     assert info["mcp_note"] is None
+    assert info["preview_note"] is not None
+    assert "preview" in info["preview_note"]

--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -24,6 +24,7 @@ from tldw_chatbook.Chat.console_chat_models import (
     ConsoleRunStatus,
     ConsoleStagedSource,
     ConsoleWorkspaceContext,
+    MessageAttachment,
 )
 from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
 from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
@@ -1834,3 +1835,106 @@ async def test_build_context_snapshot_is_immutable():
 
     reloaded = store.get_message(msg.id)
     assert reloaded.content == original_content
+
+
+@pytest.mark.asyncio
+async def test_build_context_snapshot_attachment_only_preview():
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=StreamingGateway(),
+        provider="openai",
+        model="gpt-4o",
+    )
+    store.ensure_session(title="Chat 1")
+
+    attachment = MessageAttachment(
+        data=b"fake-image-data",
+        mime_type="image/png",
+        display_name="image.png",
+        position=0,
+    )
+
+    snapshot = await controller.build_context_snapshot(draft="", attachments=[attachment])
+
+    messages = snapshot.next_send_payload["messages"]
+    assert len(messages) == 1
+    assert messages[0]["role"] == "user"
+    content = messages[0]["content"]
+    assert isinstance(content, list)
+    assert any(
+        part.get("type") == "image_url"
+        and part.get("image_url", {}).get("url") == "[image: data redacted for preview]"
+        for part in content
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_context_snapshot_redacts_historical_image_data():
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=StreamingGateway(),
+        provider="openai",
+        model="gpt-4o",
+    )
+    session = store.ensure_session(title="Chat 1")
+
+    store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content="Previous image",
+        attachments=(
+            MessageAttachment(
+                data=b"historical-image-data",
+                mime_type="image/png",
+                display_name="previous.png",
+                position=0,
+            ),
+        ),
+    )
+
+    snapshot = await controller.build_context_snapshot(draft="Describe it")
+
+    payload_text = str(snapshot.next_send_payload)
+    assert "data:image/png;base64," not in payload_text
+    assert "[image: data redacted for preview]" in payload_text
+
+
+@pytest.mark.asyncio
+async def test_build_context_snapshot_no_active_session_returns_empty():
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+
+    snapshot = await controller.build_context_snapshot(draft="hello")
+
+    assert snapshot.current_messages == []
+    assert snapshot.next_send_payload == {}
+
+
+@pytest.mark.asyncio
+async def test_build_context_snapshot_includes_staged_sources():
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+    store.ensure_session(title="Chat 1")
+
+    sources = [
+        ConsoleStagedSource(
+            source_id="note-1",
+            label="Note one",
+            source_type="note",
+            workspace_id="workspace-a",
+        ),
+        ConsoleStagedSource(
+            source_id="file-2",
+            label="File two",
+            source_type="file",
+        ),
+    ]
+
+    snapshot = await controller.build_context_snapshot(draft="Summarize", staged_sources=sources)
+
+    staged = snapshot.next_send_payload["staged_sources"]
+    assert len(staged) == 2
+    assert staged[0] == {"source_id": "note-1", "label": "Note one", "type": "note"}
+    assert staged[1] == {"source_id": "file-2", "label": "File two", "type": "file"}

--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -1944,6 +1944,7 @@ def test_replace_image_data_preserves_detail_and_handles_string_url():
                     "type": "image_url",
                     "image_url": {"url": "data:image/png;base64,abc", "detail": "auto"},
                 },
+                {"type": "image_url", "image_url": "data:image/png;base64,def"},
                 {"type": "image_url", "image_url": "http://example.com/img.png"},
             ],
         }
@@ -1954,8 +1955,40 @@ def test_replace_image_data_preserves_detail_and_handles_string_url():
     dict_url = redacted[0]["content"][0]["image_url"]
     assert dict_url["url"] == "[image: data redacted for preview]"
     assert dict_url["detail"] == "auto"
-    string_url = redacted[0]["content"][1]["image_url"]
-    assert string_url == "http://example.com/img.png"
+    data_string_url = redacted[0]["content"][1]["image_url"]
+    assert data_string_url == "[image: data redacted for preview]"
+    plain_string_url = redacted[0]["content"][2]["image_url"]
+    assert plain_string_url == "http://example.com/img.png"
+
+
+def test_replace_image_data_redacts_anthropic_and_string_image_parts():
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/png",
+                        "data": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
+                    },
+                },
+                {"type": "image", "image": "data:image/png;base64,def"},
+            ],
+        }
+    ]
+
+    redacted = ConsoleChatController._replace_image_data_with_placeholders(messages)
+
+    anthropic_part = redacted[0]["content"][0]
+    assert anthropic_part["type"] == "image"
+    assert anthropic_part["source"]["type"] == "base64"
+    assert anthropic_part["source"]["media_type"] == "image/png"
+    assert anthropic_part["source"]["data"] == "[image: data redacted for preview]"
+    string_part = redacted[0]["content"][1]
+    assert string_part["type"] == "image"
+    assert string_part["image"] == "[image: data redacted for preview]"
 
 
 @pytest.mark.asyncio
@@ -2017,6 +2050,28 @@ async def test_build_context_snapshot_includes_staged_sources():
     assert staged[1] == {"source_id": "file-2", "label": "File two", "type": "file"}
 
 
+@pytest.mark.asyncio
+async def test_build_context_snapshot_isolates_assembly_errors():
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+    session = store.ensure_session(title="Chat 1")
+    store.append_message(session.id, role=ConsoleMessageRole.USER, content="Hello")
+
+    async def _failing_apply(messages, session_id):
+        raise RuntimeError("dictionary applier exploded")
+
+    controller._apply_chat_dictionaries = _failing_apply
+
+    snapshot = await controller.build_context_snapshot(draft="Follow up")
+
+    assert len(snapshot.current_messages) == 1
+    assert snapshot.current_messages[0].content == "Hello"
+    payload = snapshot.next_send_payload
+    assert "error" in payload
+    assert "Failed to build context snapshot" in payload["error"]
+    assert payload["messages"] == []
+
+
 def test_annotate_skill_commands_multimodal_text_part():
     messages = [
         {
@@ -2044,6 +2099,17 @@ def test_annotate_skill_commands_ignores_leading_whitespace():
 
     assert annotated[0]["content"].startswith("  /search tools")
     assert "Skill command not resolved in preview" in annotated[0]["content"]
+
+
+def test_annotate_skill_commands_synthetic_turn_added_false_returns_unchanged():
+    messages = [{"role": "user", "content": "/search tools"}]
+
+    annotated = ConsoleChatController._annotate_skill_commands(
+        messages, synthetic_turn_added=False
+    )
+
+    assert annotated == messages
+    assert "Skill command not resolved in preview" not in annotated[0]["content"]
 
 
 def test_build_tools_info_for_snapshot_no_bridge():

--- a/Tests/UI/test_chat_screen_context_modal.py
+++ b/Tests/UI/test_chat_screen_context_modal.py
@@ -74,6 +74,8 @@ async def test_chat_screen_command_palette_opens_context_modal(app_instance):
         await pilot.pause()
 
         # Open command palette and select the context command.
+        # ctrl+p matches the project's default command-palette binding
+        # (see TldwCli.BINDINGS in app.py).
         await pilot.press("ctrl+p")
         await pilot.pause()
         for character in "view context":

--- a/Tests/UI/test_chat_screen_context_modal.py
+++ b/Tests/UI/test_chat_screen_context_modal.py
@@ -1,0 +1,85 @@
+import pytest
+from textual.app import App
+
+from Tests.UI.test_destination_shells import _build_test_app
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+from tldw_chatbook.UI.console_command_provider import ConsoleCommandProvider
+from tldw_chatbook.Widgets.Console.console_context_modal import ConsoleContextModal
+
+
+class ChatScreenHarness(App):
+    COMMANDS = App.COMMANDS | {ConsoleCommandProvider}
+
+    def __init__(self, app_instance):
+        super().__init__()
+        self.app_instance = app_instance
+
+    async def on_mount(self) -> None:
+        await self.push_screen(ChatScreen(self.app_instance))
+
+
+@pytest.fixture
+def app_instance():
+    app = _build_test_app()
+    app.app_config = {
+        "chat_defaults": {"provider": "llama_cpp", "model": "local-model"},
+        "api_settings": {
+            "llama_cpp": {
+                "api_url": "http://127.0.0.1:9099",
+                "model": "local-model",
+            },
+        },
+    }
+    app.chat_api_provider_value = "llama_cpp"
+    app.chat_api_model_value = "local-model"
+    return app
+
+
+@pytest.mark.asyncio
+async def test_chat_screen_keybinding_opens_context_modal(app_instance):
+    app = ChatScreenHarness(app_instance)
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        # Ensure an active session and a message exist.
+        screen = app.screen
+        controller = screen._ensure_console_chat_controller()
+        session = controller.store.ensure_session(title="Test")
+        controller.store.append_message(
+            session.id,
+            role=ConsoleMessageRole.USER,
+            content="Hello",
+        )
+        await pilot.pause()
+
+        await pilot.press("ctrl+shift+p")
+        await pilot.pause()
+
+        assert isinstance(app.screen, ConsoleContextModal)
+
+
+@pytest.mark.asyncio
+async def test_chat_screen_command_palette_opens_context_modal(app_instance):
+    app = ChatScreenHarness(app_instance)
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = app.screen
+        controller = screen._ensure_console_chat_controller()
+        session = controller.store.ensure_session(title="Test")
+        controller.store.append_message(
+            session.id,
+            role=ConsoleMessageRole.USER,
+            content="Hello",
+        )
+        await pilot.pause()
+
+        # Open command palette and select the context command.
+        await pilot.press("ctrl+p")
+        await pilot.pause()
+        for character in "view context":
+            await pilot.press(character)
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert isinstance(app.screen, ConsoleContextModal)

--- a/Tests/UI/test_console_context_modal.py
+++ b/Tests/UI/test_console_context_modal.py
@@ -1,0 +1,103 @@
+import pytest
+from textual.app import App, ComposeResult
+from textual.containers import Vertical
+from textual.widgets import Button, Label, Static, TextArea
+
+from tldw_chatbook.Chat.console_chat_models import (
+    ConsoleChatMessage,
+    ConsoleContextSnapshot,
+    ConsoleMessageRole,
+)
+from tldw_chatbook.Widgets.Console.console_context_modal import ConsoleContextModal
+
+
+SNAPSHOT = ConsoleContextSnapshot(
+    current_messages=[
+        ConsoleChatMessage(role=ConsoleMessageRole.USER, content="Hello"),
+        ConsoleChatMessage(role=ConsoleMessageRole.ASSISTANT, content="Hi"),
+    ],
+    next_send_payload={
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "Hello"}],
+    },
+)
+
+EMPTY_SNAPSHOT = ConsoleContextSnapshot(current_messages=[], next_send_payload={})
+
+
+async def _snapshot_factory() -> ConsoleContextSnapshot:
+    return SNAPSHOT
+
+
+async def _empty_factory() -> ConsoleContextSnapshot:
+    return EMPTY_SNAPSHOT
+
+
+class ModalHarness(App):
+    def compose(self) -> ComposeResult:
+        yield Static("background")
+
+    def on_mount(self) -> None:
+        self.push_screen(ConsoleContextModal(_snapshot_factory, token_estimate=42))
+
+
+@pytest.mark.asyncio
+async def test_context_modal_renders_tabs():
+    app = ModalHarness()
+
+    async with app.run_test(size=(100, 40)) as _pilot:
+        modal = app.screen
+        header = modal.query_one("#console-context-header", Static)
+        header_text = str(header.renderable)
+        assert "Chat Context" in header_text
+        assert "42 tokens" in header_text
+
+        current_container = modal.query_one(
+            "#console-context-current-body", Vertical
+        )
+        text_areas = current_container.query(TextArea)
+        assert any("Hello" in ta.text for ta in text_areas)
+
+        next_container = modal.query_one(
+            "#console-context-next-send-body", Vertical
+        )
+        labels = list(next_container.query(Label))
+        assert any("gpt-4" in str(label.renderable) for label in labels)
+
+
+@pytest.mark.asyncio
+async def test_context_modal_empty_state():
+    app = ModalHarness()
+    app._push_empty = lambda: app.push_screen(
+        ConsoleContextModal(_empty_factory)
+    )
+
+    async with app.run_test(size=(100, 40)) as pilot:
+        app._push_empty()
+        await pilot.pause()
+        modal = app.screen
+        current_container = modal.query_one(
+            "#console-context-current-body", Vertical
+        )
+        labels = list(current_container.query(Label))
+        assert any(
+            "No conversation context" in str(label.renderable)
+            for label in labels
+        )
+
+
+@pytest.mark.asyncio
+async def test_context_modal_in_progress_warning():
+    app = ModalHarness()
+    app._push_in_progress = lambda: app.push_screen(
+        ConsoleContextModal(_snapshot_factory, in_progress=True)
+    )
+
+    async with app.run_test(size=(100, 40)) as pilot:
+        app._push_in_progress()
+        await pilot.pause()
+        modal = app.screen
+        warning = modal.query_one("#console-context-warning", Static)
+        assert "in progress" in str(warning.renderable)
+        refresh_button = modal.query_one("#console-context-refresh", Button)
+        assert refresh_button.disabled

--- a/Tests/UI/test_console_context_modal.py
+++ b/Tests/UI/test_console_context_modal.py
@@ -193,6 +193,8 @@ async def test_context_modal_save_to_file(tmp_path, monkeypatch):
     expected_text = json.dumps(SNAPSHOT.next_send_payload, indent=2, default=str)
 
     class FakePath:
+        """Redirect filesystem operations under ``tmp_path`` for hermetic tests."""
+
         def __init__(self, *parts: str | Path) -> None:
             self._path = tmp_path.joinpath(*parts)
 
@@ -222,3 +224,38 @@ async def test_context_modal_save_to_file(tmp_path, monkeypatch):
         saved_files = list((tmp_path / "Downloads").glob("*.json"))
         assert len(saved_files) == 1
         assert saved_files[0].read_text(encoding="utf-8") == expected_text
+
+
+@pytest.mark.asyncio
+async def test_context_modal_save_to_file_failure(monkeypatch):
+    app = ActionHarness()
+
+    class FailingPath:
+        """Path stand-in whose ``write_text`` always raises ``OSError``."""
+
+        @classmethod
+        def home(cls):
+            return cls()
+
+        def __truediv__(self, other: str) -> "FailingPath":
+            return self
+
+        def mkdir(self, **kwargs: object) -> None:
+            return None
+
+        def write_text(self, *args: object, **kwargs: object) -> None:
+            raise OSError("disk full")
+
+    monkeypatch.setattr(
+        console_context_modal,
+        "Path",
+        FailingPath,
+    )
+
+    async with app.run_test(size=(100, 40)) as pilot:
+        app.push_screen(ConsoleContextModal(_snapshot_factory))
+        await pilot.pause()
+
+        # Should not crash; notification severity is checked best-effort.
+        await pilot.click("#console-context-save")
+        await pilot.pause()

--- a/Tests/UI/test_console_context_modal.py
+++ b/Tests/UI/test_console_context_modal.py
@@ -59,15 +59,11 @@ async def test_context_modal_renders_tabs():
         assert "Chat Context" in header_text
         assert "42 tokens" in header_text
 
-        current_container = modal.query_one(
-            "#console-context-current-body", Vertical
-        )
+        current_container = modal.query_one("#console-context-current-body", Vertical)
         text_areas = current_container.query(TextArea)
         assert any("Hello" in ta.text for ta in text_areas)
 
-        next_container = modal.query_one(
-            "#console-context-next-send-body", Vertical
-        )
+        next_container = modal.query_one("#console-context-next-send-body", Vertical)
         labels = list(next_container.query(Label))
         assert any("gpt-4" in str(label.renderable) for label in labels)
 
@@ -75,21 +71,16 @@ async def test_context_modal_renders_tabs():
 @pytest.mark.asyncio
 async def test_context_modal_empty_state():
     app = ModalHarness()
-    app._push_empty = lambda: app.push_screen(
-        ConsoleContextModal(_empty_factory)
-    )
+    app._push_empty = lambda: app.push_screen(ConsoleContextModal(_empty_factory))
 
     async with app.run_test(size=(100, 40)) as pilot:
         app._push_empty()
         await pilot.pause()
         modal = app.screen
-        current_container = modal.query_one(
-            "#console-context-current-body", Vertical
-        )
+        current_container = modal.query_one("#console-context-current-body", Vertical)
         labels = list(current_container.query(Label))
         assert any(
-            "No conversation context" in str(label.renderable)
-            for label in labels
+            "No conversation context" in str(label.renderable) for label in labels
         )
 
 
@@ -128,9 +119,7 @@ async def test_context_modal_toggle_raw_json():
         await pilot.pause()
 
         modal = app.screen
-        next_container = modal.query_one(
-            "#console-context-next-send-body", Vertical
-        )
+        next_container = modal.query_one("#console-context-next-send-body", Vertical)
         text_areas = list(next_container.query(TextArea))
         assert any(ta.text == expected_raw for ta in text_areas)
 

--- a/Tests/UI/test_console_context_modal.py
+++ b/Tests/UI/test_console_context_modal.py
@@ -1,3 +1,9 @@
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import Mock
+
 import pytest
 from textual.app import App, ComposeResult
 from textual.containers import Vertical
@@ -8,6 +14,7 @@ from tldw_chatbook.Chat.console_chat_models import (
     ConsoleContextSnapshot,
     ConsoleMessageRole,
 )
+from tldw_chatbook.Widgets.Console import console_context_modal
 from tldw_chatbook.Widgets.Console.console_context_modal import ConsoleContextModal
 
 
@@ -101,3 +108,117 @@ async def test_context_modal_in_progress_warning():
         assert "in progress" in str(warning.renderable)
         refresh_button = modal.query_one("#console-context-refresh", Button)
         assert refresh_button.disabled
+
+
+class ActionHarness(App):
+    def compose(self) -> ComposeResult:
+        yield Static("background")
+
+
+@pytest.mark.asyncio
+async def test_context_modal_toggle_raw_json():
+    app = ActionHarness()
+    expected_raw = json.dumps(SNAPSHOT.next_send_payload, indent=2, default=str)
+
+    async with app.run_test(size=(100, 40)) as pilot:
+        app.push_screen(ConsoleContextModal(_snapshot_factory))
+        await pilot.pause()
+
+        await pilot.click("#console-context-raw")
+        await pilot.pause()
+
+        modal = app.screen
+        next_container = modal.query_one(
+            "#console-context-next-send-body", Vertical
+        )
+        text_areas = list(next_container.query(TextArea))
+        assert any(ta.text == expected_raw for ta in text_areas)
+
+
+@pytest.mark.asyncio
+async def test_context_modal_refresh_invokes_factory():
+    calls = 0
+
+    async def counting_factory() -> ConsoleContextSnapshot:
+        nonlocal calls
+        calls += 1
+        return SNAPSHOT
+
+    app = ActionHarness()
+
+    async with app.run_test(size=(100, 40)) as pilot:
+        app.push_screen(ConsoleContextModal(counting_factory))
+        await pilot.pause()
+        assert calls == 1
+
+        await pilot.click("#console-context-refresh")
+        await pilot.pause()
+        assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_context_modal_close_dismisses():
+    app = ActionHarness()
+
+    async with app.run_test(size=(100, 40)) as pilot:
+        app.push_screen(ConsoleContextModal(_snapshot_factory))
+        await pilot.pause()
+        assert isinstance(app.screen, ConsoleContextModal)
+
+        await pilot.click("#console-context-close")
+        await pilot.pause()
+        assert not isinstance(app.screen, ConsoleContextModal)
+
+
+@pytest.mark.asyncio
+async def test_context_modal_copy_json(monkeypatch):
+    app = ActionHarness()
+    expected_text = json.dumps(SNAPSHOT.next_send_payload, indent=2, default=str)
+    fake_copy = types.SimpleNamespace(copy=Mock())
+    monkeypatch.setitem(sys.modules, "pyperclip", fake_copy)
+
+    async with app.run_test(size=(100, 40)) as pilot:
+        app.push_screen(ConsoleContextModal(_snapshot_factory))
+        await pilot.pause()
+
+        await pilot.click("#console-context-copy")
+        await pilot.pause()
+
+        fake_copy.copy.assert_called_once_with(expected_text)
+
+
+@pytest.mark.asyncio
+async def test_context_modal_save_to_file(tmp_path, monkeypatch):
+    app = ActionHarness()
+    expected_text = json.dumps(SNAPSHOT.next_send_payload, indent=2, default=str)
+
+    class FakePath:
+        def __init__(self, *parts: str | Path) -> None:
+            self._path = tmp_path.joinpath(*parts)
+
+        @classmethod
+        def home(cls):
+            return cls(tmp_path)
+
+        def __truediv__(self, other: str) -> "FakePath":
+            return FakePath(self._path, other)
+
+        def __getattr__(self, name: str):
+            return getattr(self._path, name)
+
+    monkeypatch.setattr(
+        console_context_modal,
+        "Path",
+        FakePath,
+    )
+
+    async with app.run_test(size=(100, 40)) as pilot:
+        app.push_screen(ConsoleContextModal(_snapshot_factory))
+        await pilot.pause()
+
+        await pilot.click("#console-context-save")
+        await pilot.pause()
+
+        saved_files = list((tmp_path / "Downloads").glob("*.json"))
+        assert len(saved_files) == 1
+        assert saved_files[0].read_text(encoding="utf-8") == expected_text

--- a/Tests/UI/test_console_native_transcript.py
+++ b/Tests/UI/test_console_native_transcript.py
@@ -474,6 +474,62 @@ async def test_console_transcript_click_selects_message_and_shows_actions():
 
 
 @pytest.mark.asyncio
+async def test_console_transcript_click_background_clears_selection():
+    app = TranscriptHarness()
+
+    async with app.run_test(size=(100, 32)) as pilot:
+        await pilot.click("#console-message-m2")
+        assert "Save as..." in _visible_text(app)
+
+        # Click empty space below the rendered messages.
+        await pilot.click("#console-native-transcript", offset=(5, 20))
+        await pilot.pause()
+
+        assert "Save as..." not in _visible_text(app)
+
+
+@pytest.mark.asyncio
+async def test_console_transcript_click_message_row_selects():
+    app = TranscriptHarness()
+
+    async with app.run_test(size=(100, 32)) as pilot:
+        await pilot.click("#console-message-m2")
+        text = _visible_text(app)
+
+    assert "Copy" in text
+    assert "Save as..." in text
+    assert "🗑" in text
+
+
+@pytest.mark.asyncio
+async def test_console_transcript_click_action_button_preserves_selection():
+    app = TranscriptHarness()
+
+    async with app.run_test(size=(100, 32)) as pilot:
+        await pilot.click("#console-message-m2")
+        assert "Save as..." in _visible_text(app)
+
+        await pilot.click("#console-message-action-copy-m2")
+        await pilot.pause()
+
+        assert "Save as..." in _visible_text(app)
+
+
+@pytest.mark.asyncio
+async def test_console_transcript_click_rule_separator_preserves_selection():
+    app = TranscriptHarness()
+
+    async with app.run_test(size=(100, 32)) as pilot:
+        await pilot.click("#console-message-m2")
+        assert "Save as..." in _visible_text(app)
+
+        await pilot.click(".console-transcript-rule")
+        await pilot.pause()
+
+        assert "Save as..." in _visible_text(app)
+
+
+@pytest.mark.asyncio
 async def test_console_selected_message_uses_class_without_inline_frame():
     app = TranscriptHarness()
 

--- a/Tests/UI/test_console_native_transcript.py
+++ b/Tests/UI/test_console_native_transcript.py
@@ -489,19 +489,6 @@ async def test_console_transcript_click_background_clears_selection():
 
 
 @pytest.mark.asyncio
-async def test_console_transcript_click_message_row_selects():
-    app = TranscriptHarness()
-
-    async with app.run_test(size=(100, 32)) as pilot:
-        await pilot.click("#console-message-m2")
-        text = _visible_text(app)
-
-    assert "Copy" in text
-    assert "Save as..." in text
-    assert "🗑" in text
-
-
-@pytest.mark.asyncio
 async def test_console_transcript_click_action_button_preserves_selection():
     app = TranscriptHarness()
 
@@ -546,8 +533,8 @@ async def test_console_transcript_click_scrollbar_does_not_clear_selection():
         await pilot.pause()
         assert transcript.selected_message_id == "m15"
 
-        # Click the vertical scrollbar (rightmost two columns of the scroll view).
-        await pilot.click("#console-native-transcript", offset=(38, 5))
+        scrollbar = transcript.vertical_scrollbar
+        await pilot.click(scrollbar)
         await pilot.pause()
 
         assert transcript.selected_message_id == "m15"

--- a/Tests/UI/test_console_native_transcript.py
+++ b/Tests/UI/test_console_native_transcript.py
@@ -530,6 +530,75 @@ async def test_console_transcript_click_rule_separator_preserves_selection():
 
 
 @pytest.mark.asyncio
+async def test_console_transcript_click_scrollbar_does_not_clear_selection():
+    app = MutableTranscriptHarness()
+    messages = [
+        ConsoleChatMessage(role=ConsoleMessageRole.USER, content=f"message {index}", id=f"m{index}")
+        for index in range(30)
+    ]
+
+    async with app.run_test(size=(40, 12)) as pilot:
+        transcript = app.query_one("#console-native-transcript", ConsoleTranscript)
+        transcript.set_messages(messages)
+        await transcript.refresh_messages()
+
+        transcript.select_message("m15")
+        await pilot.pause()
+        assert transcript.selected_message_id == "m15"
+
+        # Click the vertical scrollbar (rightmost two columns of the scroll view).
+        await pilot.click("#console-native-transcript", offset=(38, 5))
+        await pilot.pause()
+
+        assert transcript.selected_message_id == "m15"
+
+
+@pytest.mark.asyncio
+async def test_console_transcript_click_action_row_background_preserves_selection():
+    app = TranscriptHarness()
+
+    async with app.run_test(size=(100, 32)) as pilot:
+        await pilot.click("#console-message-m2")
+        await pilot.pause()
+        assert "Save as..." in _visible_text(app)
+
+        # Click the action-row container background, not a button.
+        await pilot.click("#console-message-actions-m2", offset=(5, 15))
+        await pilot.pause()
+
+        assert "Save as..." in _visible_text(app)
+
+
+@pytest.mark.asyncio
+async def test_console_transcript_click_action_help_preserves_selection():
+    app = TranscriptHarness()
+
+    async with app.run_test(size=(100, 32)) as pilot:
+        await pilot.click("#console-message-m2")
+        await pilot.pause()
+        assert "Save as..." in _visible_text(app)
+
+        await pilot.click(".console-transcript-action-guide")
+        await pilot.pause()
+
+        assert "Save as..." in _visible_text(app)
+
+
+@pytest.mark.asyncio
+async def test_console_transcript_click_empty_state_panel_preserves_selection():
+    app = EmptyTranscriptHarness()
+
+    async with app.run_test(size=(100, 32)) as pilot:
+        transcript = app.query_one("#console-native-transcript", ConsoleTranscript)
+        assert transcript.selected_message_id is None
+
+        await pilot.click(".console-transcript-empty-panel")
+        await pilot.pause()
+
+        assert transcript.selected_message_id is None
+
+
+@pytest.mark.asyncio
 async def test_console_selected_message_uses_class_without_inline_frame():
     app = TranscriptHarness()
 

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -729,6 +729,31 @@ class ConsoleAgentBridge:
         self._live: dict[str, AgentLiveSnapshot] = {}
         self._historical_cache: dict[str, AgentLiveSnapshot] = {}
 
+    def native_tool_schemas(self) -> list[dict[str, Any]]:
+        """Return the native tool schemas available to this bridge.
+
+        Iterates the bridge's tool registry and returns one schema dict per
+        catalog entry.  Failures to load an individual schema are logged and
+        skipped so the preview remains useful even when a provider is slow or
+        misconfigured.
+        """
+        schemas: list[dict[str, Any]] = []
+        for entry in self._registry.list_catalog():
+            try:
+                schema = self._registry.load_schema(entry.id)
+            except Exception as exc:  # pragma: no cover - defensive only
+                logger.warning(
+                    "Failed to load schema for {tool_id}: {exc}",
+                    tool_id=entry.id, exc=exc,
+                )
+                continue
+            schemas.append({
+                "name": schema.name,
+                "description": schema.description,
+                "parameters": schema.parameters,
+            })
+        return schemas
+
     # -- run ------------------------------------------------------------
 
     def run_reply(

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -559,6 +559,19 @@ class _CollisionFilteredMCPProvider:
         return self._provider.invoke(tool_id, args)
 
 
+def _truncate_log_value(value: Any, *, max_len: int = 200) -> str:
+    """Return a safe, bounded string representation for logging.
+
+    Tool arguments and results may contain secrets or very large payloads;
+    this helper truncates the string form so log lines stay readable and do
+    not dump sensitive data into logs.
+    """
+    text = str(value)
+    if len(text) > max_len:
+        return f"{text[: max_len - 3]}..."
+    return text
+
+
 def _non_colliding_mcp_names(
     mcp_provider: Any,
     collision_names: frozenset[str] | set[str],
@@ -874,17 +887,19 @@ class ConsoleAgentBridge:
             # tool invocation lives inside AgentService, so we observe it
             # through the step stream it emits.
             if step.kind == STEP_TOOL_RESULT:
-                logger.info(
-                    "agent tool call",
+                logger.debug(
+                    "agent tool call: agent_kind={agent_kind} tool={tool_name} "
+                    "args={args} result={result} step={step_index}",
                     agent_kind=agent_kind,
                     tool_name=step.tool_name,
-                    args=step.args,
-                    result=step.result,
+                    args=_truncate_log_value(step.args),
+                    result=_truncate_log_value(step.result),
                     step_index=step.index,
                 )
             elif step.kind == STEP_ERROR:
                 logger.warning(
-                    "agent step error",
+                    "agent step error: agent_kind={agent_kind} tool={tool_name} "
+                    "summary={summary} step={step_index}",
                     agent_kind=agent_kind,
                     tool_name=step.tool_name,
                     summary=step.summary,

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -16,6 +16,8 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Callable
 
+from loguru import logger
+
 from tldw_chatbook.Agents.agent_models import (
     AGENT_KIND_PRIMARY,
     AGENT_KIND_SUBAGENT,
@@ -843,6 +845,26 @@ class ConsoleAgentBridge:
                 )
                 if marker_text is not None:
                     self._append_marker(session_id, marker_text)
+            # Diagnostic logging for every tool call and result. The actual
+            # tool invocation lives inside AgentService, so we observe it
+            # through the step stream it emits.
+            if step.kind == STEP_TOOL_RESULT:
+                logger.info(
+                    "agent tool call",
+                    agent_kind=agent_kind,
+                    tool_name=step.tool_name,
+                    args=step.args,
+                    result=step.result,
+                    step_index=step.index,
+                )
+            elif step.kind == STEP_ERROR:
+                logger.warning(
+                    "agent step error",
+                    agent_kind=agent_kind,
+                    tool_name=step.tool_name,
+                    summary=step.summary,
+                    step_index=step.index,
+                )
             self._live[conversation_id] = AgentLiveSnapshot(
                 status="running",
                 step=len(live_steps),
@@ -906,6 +928,23 @@ class ConsoleAgentBridge:
             )
         finally:
             run_loop.close()
+        for step in outcome.steps:
+            logger.info(
+                "agent run step",
+                agent_kind=AGENT_KIND_PRIMARY,
+                step_kind=step.kind,
+                tool_name=step.tool_name,
+                summary=step.summary,
+                step_index=step.index,
+            )
+        logger.info(
+            "console agent bridge run_reply end",
+            conversation_id=conversation_id,
+            session_id=session_id,
+            outcome_status=outcome.status,
+            final_text_len=len(outcome.final_text),
+            step_count=len(outcome.steps),
+        )
         self._live[conversation_id] = AgentLiveSnapshot(
             status=outcome.status,
             step=len(live_steps),

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -1271,25 +1271,53 @@ class ConsoleChatController:
     @staticmethod
     def _annotate_skill_commands(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
         result = copy.deepcopy(messages)
-        if result and result[-1].get("role") == "user":
-            text = result[-1].get("content", "")
-            if isinstance(text, str) and text.startswith("/"):
-                result[-1]["content"] = (
-                    f"{text}\n\n[Skill command not resolved in preview; "
-                    "actual substitution happens at send time.]"
-                )
+        if not result or result[-1].get("role") != "user":
+            return result
+
+        content = result[-1].get("content", "")
+        annotation = (
+            "[Skill command not resolved in preview; "
+            "actual substitution happens at send time.]"
+        )
+
+        if isinstance(content, str) and content.startswith("/"):
+            result[-1]["content"] = f"{content}\n\n{annotation}"
+            return result
+
+        if isinstance(content, list):
+            new_parts: list[Any] = []
+            annotated = False
+            for part in content:
+                if (
+                    not annotated
+                    and isinstance(part, dict)
+                    and part.get("type") == "text"
+                    and isinstance(part.get("text"), str)
+                    and part["text"].startswith("/")
+                ):
+                    new_parts.append({**part, "text": f"{part['text']}\n\n{annotation}"})
+                    annotated = True
+                else:
+                    new_parts.append(part)
+            if annotated:
+                result[-1]["content"] = new_parts
         return result
 
     def _build_tools_info_for_snapshot(self) -> dict[str, Any]:
-        """Return native tool schemas and an MCP note for the snapshot."""
+        """Return native tool schemas and preview notes for the snapshot."""
         tools: list[dict[str, Any]] = []
         if self._agent_bridge is not None:
             # Native tools only; live MCP catalog composition is out of scope.
             tools = getattr(self._agent_bridge, "native_tool_schemas", lambda: [])()
         mcp_note = "MCP tools are configured but live catalog composition is not shown in this preview."
+        preview_note = (
+            "This preview shows only builtin native tools. "
+            "The live run may add skills/MCP tools."
+        )
         return {
             "native_schemas": tools,
             "mcp_note": mcp_note if self._mcp_provider else None,
+            "preview_note": preview_note,
         }
 
     _SECRET_REDACTION_KEYS = {"api_key", "apikey", "token", "password", "secret", "bearer"}

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import re
 import threading
 import time
@@ -1226,9 +1227,7 @@ class ConsoleChatController:
         redacted_system = self._redact_secrets(self._leading_system_message())
 
         # Deep-copy messages so the snapshot is independent of the store.
-        from dataclasses import replace
-
-        copied_messages = [replace(msg) for msg in current_messages]
+        copied_messages = copy.deepcopy(current_messages)
 
         return ConsoleContextSnapshot(
             current_messages=copied_messages,

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -1236,6 +1236,10 @@ class ConsoleChatController:
             next_send_payload={
                 "model": self.model or self.configured_model,
                 "messages": redacted_messages,
+                # `system` is intentionally duplicated from the leading system
+                # message in `messages` so the preview viewer can show the
+                # effective system prompt at a glance without scanning the
+                # message list.  It is the same redacted value.
                 "system": redacted_system,
                 "staged_sources": [
                     {"source_id": s.source_id, "label": s.label, "type": s.source_type}
@@ -1253,7 +1257,13 @@ class ConsoleChatController:
             if isinstance(content, list):
                 for part in content:
                     if isinstance(part, dict) and part.get("type") == "image_url":
-                        part["image_url"] = {"url": "[image: data redacted for preview]"}
+                        image_url = part.get("image_url")
+                        if isinstance(image_url, dict):
+                            image_url["url"] = "[image: data redacted for preview]"
+                        elif isinstance(image_url, str):
+                            part["image_url"] = {
+                                "url": "[image: data redacted for preview]"
+                            }
                     if isinstance(part, dict) and part.get("type") == "image":
                         part["image"] = "[image: data redacted for preview]"
         return result
@@ -1305,12 +1315,24 @@ class ConsoleChatController:
                 lambda m: f"{m.group('key')}=[redacted]", value
             )
 
+        def _matches_secret_key(key: str) -> bool:
+            """Return True when ``key`` is or ends with a secret word.
+
+            Matches exact keys such as ``api_key`` and suffixed keys such as
+            ``my_api_key``, while avoiding over-redaction of innocent keys like
+            ``token_count`` or ``secret_mode``.
+            """
+            lowered = key.lower()
+            for secret in ConsoleChatController._SECRET_REDACTION_KEYS:
+                if lowered == secret or lowered.endswith(f"_{secret}"):
+                    return True
+            return False
+
         def _redact_obj(obj: Any) -> Any:
             if isinstance(obj, dict):
                 result = {}
                 for key, value in obj.items():
-                    lowered = key.lower()
-                    if any(secret_key in lowered for secret_key in ConsoleChatController._SECRET_REDACTION_KEYS):
+                    if _matches_secret_key(key) and isinstance(value, str):
                         result[key] = "[redacted]"
                     else:
                         result[key] = _redact_obj(value)

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import re
 import threading
 import time
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Protocol
 
@@ -16,10 +17,12 @@ from tldw_chatbook.Chat.attachment_core import (
 )
 from tldw_chatbook.Chat.console_chat_models import (
     ConsoleChatMessage,
+    ConsoleContextSnapshot,
     ConsoleMessageRole,
     ConsoleProviderSelection,
     ConsoleRunState,
     ConsoleRunStatus,
+    ConsoleStagedSource,
     MessageAttachment,
     derive_console_session_title,
     is_default_console_session_title,
@@ -1172,6 +1175,153 @@ class ConsoleChatController:
             assistant_message_id=message_id,
             variant_mode=True,
         )
+
+    async def build_context_snapshot(
+        self,
+        draft: str,
+        attachments: Iterable[MessageAttachment] | None = None,
+        staged_sources: Iterable[ConsoleStagedSource] | None = None,
+    ) -> ConsoleContextSnapshot:
+        """Return a read-only snapshot of the current transcript and the assembled next-send payload.
+
+        Skills with side effects are NOT executed; only chat dictionaries are applied.
+        """
+        session_id = self.store.active_session_id
+        if not session_id:
+            return ConsoleContextSnapshot(current_messages=[], next_send_payload={})
+
+        current_messages = list(self.store.messages_for_session(session_id))
+
+        # Build the next-send payload as submit_draft would, but do not persist.
+        provider_messages = self._provider_messages_for_session(session_id)
+
+        # Append a synthetic user turn for the draft so the preview matches what would be sent.
+        if draft.strip():
+            synthetic_user = self._provider_message_payloads(
+                [
+                    ConsoleChatMessage(
+                        role=ConsoleMessageRole.USER,
+                        content=draft,
+                        attachments=tuple(attachments or ()),
+                    )
+                ],
+                skip_failed=True,
+            )
+            # Replace image data with placeholders for the preview.
+            synthetic_user = self._replace_image_data_with_placeholders(synthetic_user)
+            provider_messages.extend(synthetic_user)
+
+        # Do NOT call _apply_skill_substitution because it may execute skills with side effects.
+        # Instead, annotate the final user message if it starts with a skill command.
+        provider_messages = self._annotate_skill_commands(provider_messages)
+
+        # Chat dictionaries are safe to apply (string replacements only).
+        provider_messages = await self._apply_chat_dictionaries(provider_messages, session_id)
+
+        # Gather native tool schemas and MCP note.
+        tools_info = self._build_tools_info_for_snapshot()
+
+        # Redact secrets before returning.
+        redacted_messages = self._redact_secrets(provider_messages)
+        redacted_system = self._redact_secrets(self._leading_system_message())
+
+        # Deep-copy messages so the snapshot is independent of the store.
+        from dataclasses import replace
+
+        copied_messages = [replace(msg) for msg in current_messages]
+
+        return ConsoleContextSnapshot(
+            current_messages=copied_messages,
+            next_send_payload={
+                "model": self.model or self.configured_model,
+                "messages": redacted_messages,
+                "system": redacted_system,
+                "staged_sources": [
+                    {"source_id": s.source_id, "label": s.label, "type": s.source_type}
+                    for s in (staged_sources or ())
+                ],
+                "tools": tools_info,
+            },
+        )
+
+    @staticmethod
+    def _replace_image_data_with_placeholders(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        import copy
+
+        result = copy.deepcopy(messages)
+        for message in result:
+            content = message.get("content")
+            if isinstance(content, list):
+                for part in content:
+                    if isinstance(part, dict) and part.get("type") == "image_url":
+                        part["image_url"] = {"url": "[image: data redacted for preview]"}
+                    if isinstance(part, dict) and part.get("type") == "image":
+                        part["image"] = "[image: data redacted for preview]"
+        return result
+
+    @staticmethod
+    def _annotate_skill_commands(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        import copy
+
+        result = copy.deepcopy(messages)
+        if result and result[-1].get("role") == "user":
+            text = result[-1].get("content", "")
+            if isinstance(text, str) and text.startswith("/"):
+                result[-1]["content"] = (
+                    f"{text}\n\n[Skill command not resolved in preview; "
+                    "actual substitution happens at send time.]"
+                )
+        return result
+
+    def _build_tools_info_for_snapshot(self) -> dict[str, Any]:
+        """Return native tool schemas and an MCP note for the snapshot."""
+        tools: list[dict[str, Any]] = []
+        if self._agent_bridge is not None:
+            # Native tools only; live MCP catalog composition is out of scope.
+            tools = getattr(self._agent_bridge, "native_tool_schemas", lambda: [])()
+        mcp_note = "MCP tools are configured but live catalog composition is not shown in this preview."
+        return {
+            "native_schemas": tools,
+            "mcp_note": mcp_note if self._mcp_provider else None,
+        }
+
+    _SECRET_REDACTION_KEYS = {"api_key", "apikey", "token", "password", "secret", "bearer"}
+    _SECRET_REDACTION_PATTERN = re.compile(
+        r"(?P<key>"
+        + "|".join(re.escape(k) for k in _SECRET_REDACTION_KEYS)
+        + r")\s*[:=]\s*\S+",
+        re.IGNORECASE,
+    )
+
+    @staticmethod
+    def _redact_secrets(payload: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Return a deep-copied payload with likely secret values replaced."""
+        import copy
+
+        redacted = copy.deepcopy(payload)
+
+        def _redact_string(value: str) -> str:
+            return ConsoleChatController._SECRET_REDACTION_PATTERN.sub(
+                lambda m: f"{m.group('key')}=[redacted]", value
+            )
+
+        def _redact_obj(obj: Any) -> Any:
+            if isinstance(obj, dict):
+                result = {}
+                for key, value in obj.items():
+                    lowered = key.lower()
+                    if any(secret_key in lowered for secret_key in ConsoleChatController._SECRET_REDACTION_KEYS):
+                        result[key] = "[redacted]"
+                    else:
+                        result[key] = _redact_obj(value)
+                return result
+            if isinstance(obj, list):
+                return [_redact_obj(item) for item in obj]
+            if isinstance(obj, str):
+                return _redact_string(obj)
+            return obj
+
+        return _redact_obj(redacted)
 
     def _provider_selection(self) -> ConsoleProviderSelection:
         return ConsoleProviderSelection(

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -1197,19 +1197,18 @@ class ConsoleChatController:
         provider_messages = self._provider_messages_for_session(session_id)
 
         # Append a synthetic user turn for the draft so the preview matches what would be sent.
-        if draft.strip():
+        attachment_tuple = tuple(attachments or ())
+        if draft.strip() or attachment_tuple:
             synthetic_user = self._provider_message_payloads(
                 [
                     ConsoleChatMessage(
                         role=ConsoleMessageRole.USER,
                         content=draft,
-                        attachments=tuple(attachments or ()),
+                        attachments=attachment_tuple,
                     )
                 ],
                 skip_failed=True,
             )
-            # Replace image data with placeholders for the preview.
-            synthetic_user = self._replace_image_data_with_placeholders(synthetic_user)
             provider_messages.extend(synthetic_user)
 
         # Do NOT call _apply_skill_substitution because it may execute skills with side effects.
@@ -1218,6 +1217,9 @@ class ConsoleChatController:
 
         # Chat dictionaries are safe to apply (string replacements only).
         provider_messages = await self._apply_chat_dictionaries(provider_messages, session_id)
+
+        # Replace image data with placeholders for the preview, including historical images.
+        provider_messages = self._replace_image_data_with_placeholders(provider_messages)
 
         # Gather native tool schemas and MCP note.
         tools_info = self._build_tools_info_for_snapshot()
@@ -1245,8 +1247,6 @@ class ConsoleChatController:
 
     @staticmethod
     def _replace_image_data_with_placeholders(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        import copy
-
         result = copy.deepcopy(messages)
         for message in result:
             content = message.get("content")
@@ -1260,8 +1260,6 @@ class ConsoleChatController:
 
     @staticmethod
     def _annotate_skill_commands(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        import copy
-
         result = copy.deepcopy(messages)
         if result and result[-1].get("role") == "user":
             text = result[-1].get("content", "")
@@ -1294,9 +1292,12 @@ class ConsoleChatController:
 
     @staticmethod
     def _redact_secrets(payload: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        """Return a deep-copied payload with likely secret values replaced."""
-        import copy
+        """Return a deep-copied payload with likely secret values replaced.
 
+        Redaction is best-effort and intended for preview/export convenience
+        only. Do not rely on it for security-sensitive export or disclosure
+        scenarios.
+        """
         redacted = copy.deepcopy(payload)
 
         def _redact_string(value: str) -> str:

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -1198,7 +1198,8 @@ class ConsoleChatController:
 
         # Append a synthetic user turn for the draft so the preview matches what would be sent.
         attachment_tuple = tuple(attachments or ())
-        if draft.strip() or attachment_tuple:
+        synthetic_turn_added = bool(draft.strip() or attachment_tuple)
+        if synthetic_turn_added:
             synthetic_user = self._provider_message_payloads(
                 [
                     ConsoleChatMessage(
@@ -1212,8 +1213,12 @@ class ConsoleChatController:
             provider_messages.extend(synthetic_user)
 
         # Do NOT call _apply_skill_substitution because it may execute skills with side effects.
-        # Instead, annotate the final user message if it starts with a skill command.
-        provider_messages = self._annotate_skill_commands(provider_messages)
+        # Instead, annotate the final user message if a synthetic turn was appended and it
+        # starts with a skill command. Historical turns have already been resolved at send time
+        # and must not be annotated.
+        provider_messages = self._annotate_skill_commands(
+            provider_messages, synthetic_turn_added=synthetic_turn_added
+        )
 
         # Chat dictionaries are safe to apply (string replacements only).
         provider_messages = await self._apply_chat_dictionaries(provider_messages, session_id)
@@ -1274,9 +1279,13 @@ class ConsoleChatController:
         return result
 
     @staticmethod
-    def _annotate_skill_commands(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    def _annotate_skill_commands(
+        messages: list[dict[str, Any]],
+        *,
+        synthetic_turn_added: bool = True,
+    ) -> list[dict[str, Any]]:
         result = copy.deepcopy(messages)
-        if not result or result[-1].get("role") != "user":
+        if not synthetic_turn_added or not result or result[-1].get("role") != "user":
             return result
 
         content = result[-1].get("content", "")

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -1186,6 +1186,16 @@ class ConsoleChatController:
         """Return a read-only snapshot of the current transcript and the assembled next-send payload.
 
         Skills with side effects are NOT executed; only chat dictionaries are applied.
+
+        Args:
+            draft: The current composer draft text to include as a synthetic user turn.
+            attachments: Pending attachments to include with the synthetic user turn.
+            staged_sources: Staged workspace sources to include in the payload.
+
+        Returns:
+            A ``ConsoleContextSnapshot`` containing a deep-copied transcript and the
+            redacted next-send provider payload. If assembly fails, the payload may
+            contain an ``"error"`` key with a human-readable message.
         """
         session_id = self.store.active_session_id
         if not session_id:
@@ -1258,7 +1268,15 @@ class ConsoleChatController:
                 },
             )
         except Exception as exc:
-            logger.exception("Failed to build context snapshot")
+            logger.exception(
+                "Failed to build context snapshot: session_id={session_id} "
+                "draft_length={draft_length} attachments={attachments_count} "
+                "staged_sources={staged_sources_count}",
+                session_id=session_id,
+                draft_length=len(draft),
+                attachments_count=len(tuple(attachments or ())),
+                staged_sources_count=len(tuple(staged_sources or ())),
+            )
             # Preserve whatever was assembled before the failure so the viewer
             # still sees the transcript-derived payload and effective system
             # prompt rather than an empty placeholder.
@@ -2131,22 +2149,19 @@ class ConsoleChatController:
         # prior status for a regenerate, "stopped" for a plain send) and
         # the variant base (already popped), so this is a benign no-op
         # read-back, never an error, in either case.
-        if current.status == "stopped" or (
-            cancel_event is not None and cancel_event.is_set()
-        ):
+        stopped_now = (
+            (current is not None and current.status == "stopped")
+            or (cancel_event is not None and cancel_event.is_set())
+        )
+        if stopped_now:
             self._set_run_state(
                 ConsoleRunState(ConsoleRunStatus.STOPPED, "Response stopped.")
             )
             return ConsoleSubmitResult(True, True, current.content if current is not None else "")
 
         if outcome.status == RUN_CANCELLED:
-            try:
-                stopped = self._mark_stream_stopped(
-                    assistant_message_id, visible_copy="Response stopped."
-                )
-            except KeyError:
-                return self._session_closed_result()
-            return ConsoleSubmitResult(True, True, stopped.content)
+            return self._finalize_agent_cancelled(
+                assistant_message_id, session_id, variant_mode=variant_mode)
 
         if outcome.status != RUN_DONE:
             return self._finalize_agent_failure(
@@ -2234,16 +2249,42 @@ class ConsoleChatController:
             self._set_run_state(ConsoleRunState(ConsoleRunStatus.FAILED, visible_copy))
             return ConsoleSubmitResult(True, True, failed.content)
 
-        try:
-            if variant_mode:
-                completed = self.store.finalize_variant_stream(assistant_message_id)
-            else:
-                completed = self.store.mark_message_complete(assistant_message_id)
-        except KeyError:
-            return self._session_closed_result()
-        self._set_run_state(
-            ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete.")
-        )
+        runtime_written = self._find_runtime_written_assistant(session_id)
+        if runtime_written is not None and runtime_written.status in {"pending", "streaming"}:
+            self.store.append_stream_chunk(runtime_written.id, f"\n\n{visible_copy}")
+            failed = self.store.mark_message_failed(runtime_written.id)
+        else:
+            failed = self._append_failed_assistant(session_id, visible_copy)
+        self._set_run_state(ConsoleRunState(ConsoleRunStatus.FAILED, visible_copy))
+        return ConsoleSubmitResult(True, True, failed.content)
+
+    def _finalize_agent_success(
+        self, assistant_message_id: str, session_id: str, outcome: Any,
+        *, variant_mode: bool,
+    ) -> ConsoleSubmitResult:
+        """Handle ``RUN_DONE``: complete the placeholder (or a runtime-written one).
+
+        An empty ``final_text`` is replaced with the fallback copy ``No
+        response was generated.``. If the placeholder is missing, the runtime
+        may have streamed content into an assistant row already; complete it
+        when possible, otherwise append a new assistant message.
+        """
+        placeholder = self._ensure_assistant_placeholder(assistant_message_id, session_id)
+        if placeholder is not None:
+            completed = self._complete_agent_message(assistant_message_id, variant_mode, outcome)
+            self._set_run_state(ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete."))
+            return ConsoleSubmitResult(True, True, completed.content)
+
+        runtime_written = self._find_runtime_written_assistant(session_id)
+        if runtime_written is not None and runtime_written.status in {"pending", "streaming"}:
+            completed = self._complete_agent_message(runtime_written.id, variant_mode=False, outcome=outcome)
+            self._set_run_state(ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete."))
+            return ConsoleSubmitResult(True, True, completed.content)
+
+        final_text = getattr(outcome, "final_text", "") or "No response was generated."
+        completed = self.store.append_message(
+            session_id, role=ConsoleMessageRole.ASSISTANT, content=final_text)
+        self._set_run_state(ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete."))
         return ConsoleSubmitResult(True, True, completed.content)
 
     def _append_failed_assistant(

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -1252,20 +1252,25 @@ class ConsoleChatController:
     @staticmethod
     def _replace_image_data_with_placeholders(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
         result = copy.deepcopy(messages)
+
+        def _is_data_url(value: Any) -> bool:
+            return isinstance(value, str) and value.startswith("data:")
+
+        def _redact_image_url(value: Any) -> Any:
+            if isinstance(value, dict) and _is_data_url(value.get("url")):
+                return {**value, "url": "[image: data redacted for preview]"}
+            if isinstance(value, str) and _is_data_url(value):
+                return {"url": "[image: data redacted for preview]"}
+            return value
+
         for message in result:
             content = message.get("content")
             if isinstance(content, list):
                 for part in content:
                     if isinstance(part, dict) and part.get("type") == "image_url":
-                        image_url = part.get("image_url")
-                        if isinstance(image_url, dict):
-                            image_url["url"] = "[image: data redacted for preview]"
-                        elif isinstance(image_url, str):
-                            part["image_url"] = {
-                                "url": "[image: data redacted for preview]"
-                            }
+                        part["image_url"] = _redact_image_url(part.get("image_url"))
                     if isinstance(part, dict) and part.get("type") == "image":
-                        part["image"] = "[image: data redacted for preview]"
+                        part["image"] = _redact_image_url(part.get("image"))
         return result
 
     @staticmethod
@@ -1280,7 +1285,7 @@ class ConsoleChatController:
             "actual substitution happens at send time.]"
         )
 
-        if isinstance(content, str) and content.startswith("/"):
+        if isinstance(content, str) and content.lstrip().startswith("/"):
             result[-1]["content"] = f"{content}\n\n{annotation}"
             return result
 
@@ -1288,14 +1293,15 @@ class ConsoleChatController:
             new_parts: list[Any] = []
             annotated = False
             for part in content:
+                text = part.get("text") if isinstance(part, dict) else None
                 if (
                     not annotated
                     and isinstance(part, dict)
                     and part.get("type") == "text"
-                    and isinstance(part.get("text"), str)
-                    and part["text"].startswith("/")
+                    and isinstance(text, str)
+                    and text.lstrip().startswith("/")
                 ):
-                    new_parts.append({**part, "text": f"{part['text']}\n\n{annotation}"})
+                    new_parts.append({**part, "text": f"{text}\n\n{annotation}"})
                     annotated = True
                 else:
                     new_parts.append(part)
@@ -1308,12 +1314,15 @@ class ConsoleChatController:
         tools: list[dict[str, Any]] = []
         if self._agent_bridge is not None:
             # Native tools only; live MCP catalog composition is out of scope.
-            tools = getattr(self._agent_bridge, "native_tool_schemas", lambda: [])()
+            tools = self._agent_bridge.native_tool_schemas()
         mcp_note = "MCP tools are configured but live catalog composition is not shown in this preview."
-        preview_note = (
-            "This preview shows only builtin native tools. "
-            "The live run may add skills/MCP tools."
-        )
+        if tools:
+            preview_note = (
+                "This preview shows only builtin native tools. "
+                "The live run may add skills/MCP tools."
+            )
+        else:
+            preview_note = "No native tools are configured for preview."
         return {
             "native_schemas": tools,
             "mcp_note": mcp_note if self._mcp_provider else None,
@@ -1322,9 +1331,17 @@ class ConsoleChatController:
 
     _SECRET_REDACTION_KEYS = {"api_key", "apikey", "token", "password", "secret", "bearer"}
     _SECRET_REDACTION_PATTERN = re.compile(
+        r"(?P<open_quote>[\"']?)"
         r"(?P<key>"
         + "|".join(re.escape(k) for k in _SECRET_REDACTION_KEYS)
-        + r")\s*[:=]\s*\S+",
+        + r")"
+        r"(?P=open_quote)"
+        r"(?P<sep>\s*[:=]\s*)"
+        r"(?P<value>"
+        + r'"(?:\\.|[^"\\])*"'
+        + r"|'(?:\\.|[^'\\])*'"
+        + r"|[^\s,;}\]\)\"']+"
+        + r")",
         re.IGNORECASE,
     )
 
@@ -1339,9 +1356,20 @@ class ConsoleChatController:
         redacted = copy.deepcopy(payload)
 
         def _redact_string(value: str) -> str:
-            return ConsoleChatController._SECRET_REDACTION_PATTERN.sub(
-                lambda m: f"{m.group('key')}=[redacted]", value
-            )
+            def _replace_value(match: re.Match[str]) -> str:
+                matched_value = match.group("value")
+                if matched_value.startswith('"'):
+                    redacted_value = '"[redacted]"'
+                elif matched_value.startswith("'"):
+                    redacted_value = "'[redacted]'"
+                else:
+                    redacted_value = "[redacted]"
+                open_quote = match.group("open_quote")
+                key = match.group("key")
+                sep = match.group("sep")
+                return f"{open_quote}{key}{open_quote}{sep}{redacted_value}"
+
+            return ConsoleChatController._SECRET_REDACTION_PATTERN.sub(_replace_value, value)
 
         def _matches_secret_key(key: str) -> bool:
             """Return True when ``key`` is or ends with a secret word.

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -320,6 +320,10 @@ class ConsoleChatController:
         #: ``_stop_requested``, which the run's own ``finally`` block
         #: resets as soon as the coroutine side is done (task-227).
         self._active_cancel_event: threading.Event | None = None
+        #: The composed MCP provider for the current agent run, captured
+        #: on the main loop in ``_run_agent_reply`` so ``build_context_snapshot``
+        #: can read tool metadata later without recomposing.
+        self._mcp_provider: Any | None = None
 
         # -- MCP batch-approval bridge (task-5) ------------------------------
         #: Textual App-like object exposing ``call_from_thread`` -- assigned
@@ -1619,9 +1623,16 @@ class ConsoleChatController:
         variant_mode: bool,
     ) -> ConsoleSubmitResult:
         """Run the agent loop as the reply engine, streaming into the target row."""
+        logger.info(
+            "console agent reply start",
+            assistant_message_id=assistant_message_id,
+            variant_mode=variant_mode,
+            prepare_retry=prepare_retry,
+        )
         self._active_assistant_message_id = assistant_message_id
         self._active_stream_task = asyncio.current_task()
         self._stop_requested = False
+        self._mcp_provider = None
         # A fresh per-run Event, captured by `should_cancel` below by
         # closure (not read off `self` each time) -- see
         # `_active_cancel_event`'s docstring for why this, rather than
@@ -1676,6 +1687,7 @@ class ConsoleChatController:
         # on, or nothing composed) leaves the bridge's MCP-free path
         # byte-identical to before this task.
         mcp_provider, mcp_review_hook = await self._compose_mcp_provider()
+        self._mcp_provider = mcp_provider
 
         # Swap site: the agent loop runs synchronously on a worker thread via
         # asyncio.to_thread, so Stop is cooperative-only -- `should_cancel` is
@@ -1745,6 +1757,12 @@ class ConsoleChatController:
                 # to, forever, regardless of this attribute now pointing
                 # elsewhere (or nowhere) for the NEXT run (task-227).
                 self._active_cancel_event = None
+            logger.info(
+                "console agent reply end",
+                assistant_message_id=assistant_message_id,
+                run_status=self.run_state.status.value,
+                run_copy=self.run_state.visible_copy,
+            )
 
         # Captured here, before `_finalize_agent_reply` runs: this run's own
         # cancel_event is the authority on whether IT was stopped,
@@ -1776,10 +1794,7 @@ class ConsoleChatController:
     ) -> ConsoleSubmitResult:
         from tldw_chatbook.Agents.agent_models import RUN_CANCELLED, RUN_DONE
 
-        try:
-            current = self.store.get_message(assistant_message_id)
-        except KeyError:
-            return self._session_closed_result()
+        current = self._ensure_assistant_placeholder(assistant_message_id, session_id)
         # task-227 LOW-2 (+ AC3 follow-up): a Stop can land in the
         # ultra-narrow window after asyncio.to_thread returns an outcome
         # but before this method runs. `current.status == "stopped"` alone
@@ -1808,7 +1823,7 @@ class ConsoleChatController:
             self._set_run_state(
                 ConsoleRunState(ConsoleRunStatus.STOPPED, "Response stopped.")
             )
-            return ConsoleSubmitResult(True, True, current.content)
+            return ConsoleSubmitResult(True, True, current.content if current is not None else "")
 
         if outcome.status == RUN_CANCELLED:
             try:
@@ -1820,21 +1835,87 @@ class ConsoleChatController:
             return ConsoleSubmitResult(True, True, stopped.content)
 
         if outcome.status != RUN_DONE:
-            # RUN_ERROR/RUN_STUCK (and any other non-done outcome) are
-            # failures, never a silent "complete" (Plan-B Task 6 Critical
-            # 2): a failing regenerate must not clobber a good prior
-            # answer with a fake "[agent error]" variant, and a failed
-            # message must stay retryable and excluded from model context
-            # (skip_failed=True). `mark_message_failed` carries the Task-1
-            # variant-restore semantics on its own -- for a regenerate it
-            # restores the pre-regenerate base content + status untouched;
-            # for a plain send/retry it keeps whatever partial prose had
-            # already streamed, matching legacy failure behavior.
-            visible_copy = self._agent_failure_visible_copy(outcome)
-            try:
-                failed = self.store.mark_message_failed(assistant_message_id)
-            except KeyError:
-                return self._session_closed_result()
+            return self._finalize_agent_failure(
+                assistant_message_id, session_id, outcome, variant_mode=variant_mode)
+
+        return self._finalize_agent_success(
+            assistant_message_id, session_id, outcome, variant_mode=variant_mode)
+
+    def _ensure_assistant_placeholder(
+        self, assistant_message_id: str, session_id: str,
+    ) -> ConsoleChatMessage | None:
+        """Return the assistant placeholder message if it still exists.
+
+        ``KeyError`` means the session/placeholder was closed/removed mid-run;
+        ``None`` is returned so callers can recover by appending a fresh
+        assistant message instead of aborting the whole turn.
+        """
+        try:
+            return self.store.get_message(assistant_message_id)
+        except KeyError:
+            return None
+
+    def _find_runtime_written_assistant(
+        self, session_id: str,
+    ) -> ConsoleChatMessage | None:
+        """Return the most recent assistant message in ``session_id``, if any."""
+        try:
+            messages = self.store.messages_for_session(session_id)
+        except KeyError:
+            return None
+        for message in reversed(messages):
+            if message.role is ConsoleMessageRole.ASSISTANT:
+                return message
+        return None
+
+    def _complete_agent_message(
+        self, assistant_message_id: str, variant_mode: bool, outcome: Any,
+    ) -> ConsoleChatMessage:
+        """Finalize a placeholder, applying the empty-final-text fallback.
+
+        The fallback text is streamed into the placeholder so the store's
+        existing persistence/validation paths stay unchanged.
+        """
+        if not getattr(outcome, "final_text", ""):
+            self.store.append_stream_chunk(assistant_message_id, "No response was generated.")
+        if variant_mode:
+            return self.store.finalize_variant_stream(assistant_message_id)
+        return self.store.mark_message_complete(assistant_message_id)
+
+    def _finalize_agent_cancelled(
+        self, assistant_message_id: str, session_id: str, *, variant_mode: bool,
+    ) -> ConsoleSubmitResult:
+        """Handle a ``RUN_CANCELLED`` outcome: the placeholder becomes ``failed``.
+
+        Per the agent turn-control spec, a runtime-reported cancellation is a
+        terminal failure, not a user-initiated stop. If the placeholder has
+        vanished, append a failed assistant message carrying the visible copy.
+        """
+        visible_copy = "Response stopped/cancelled."
+        placeholder = self._ensure_assistant_placeholder(assistant_message_id, session_id)
+        if placeholder is not None:
+            failed = self.store.mark_message_failed(assistant_message_id)
+        else:
+            failed = self._append_failed_assistant(session_id, visible_copy)
+        self._set_run_state(ConsoleRunState(ConsoleRunStatus.FAILED, visible_copy))
+        return ConsoleSubmitResult(True, True, failed.content)
+
+    def _finalize_agent_failure(
+        self, assistant_message_id: str, session_id: str, outcome: Any,
+        *, variant_mode: bool,
+    ) -> ConsoleSubmitResult:
+        """Handle ``RUN_ERROR``, ``RUN_STUCK``, or any unknown non-done outcome.
+
+        A present placeholder is marked ``failed`` and a system row explains
+        the failure (preserving the existing failure UX). If the placeholder
+        is missing, the runtime may have already written an assistant message
+        (e.g. streamed partial content before the error); use it when
+        possible, otherwise append a new failed assistant message.
+        """
+        visible_copy = self._agent_failure_visible_copy(outcome)
+        placeholder = self._ensure_assistant_placeholder(assistant_message_id, session_id)
+        if placeholder is not None:
+            failed = self.store.mark_message_failed(assistant_message_id)
             self._append_failure_system_row(session_id, visible_copy)
             self._set_run_state(ConsoleRunState(ConsoleRunStatus.FAILED, visible_copy))
             return ConsoleSubmitResult(True, True, failed.content)
@@ -1850,6 +1931,20 @@ class ConsoleChatController:
             ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete.")
         )
         return ConsoleSubmitResult(True, True, completed.content)
+
+    def _append_failed_assistant(
+        self, session_id: str, visible_copy: str,
+    ) -> ConsoleChatMessage:
+        """Append a failed assistant message carrying ``visible_copy``.
+
+        The store's terminal-status validation only accepts pending/streaming
+        assistant messages, so the message is created empty, the copy is
+        streamed in, and then it is marked failed.
+        """
+        message = self.store.append_message(
+            session_id, role=ConsoleMessageRole.ASSISTANT, content="")
+        self.store.append_stream_chunk(message.id, visible_copy)
+        return self.store.mark_message_failed(message.id)
 
     @staticmethod
     def _agent_failure_visible_copy(outcome: Any) -> str:

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -1197,6 +1197,8 @@ class ConsoleChatController:
             for s in (staged_sources or ())
         ]
 
+        provider_messages: list[dict[str, Any]] = []
+
         try:
             # Build the next-send payload as submit_draft would, but do not persist.
             provider_messages = self._provider_messages_for_session(session_id)
@@ -1257,12 +1259,19 @@ class ConsoleChatController:
             )
         except Exception as exc:
             logger.exception("Failed to build context snapshot")
+            # Preserve whatever was assembled before the failure so the viewer
+            # still sees the transcript-derived payload and effective system
+            # prompt rather than an empty placeholder.
+            degraded_messages = self._replace_image_data_with_placeholders(
+                self._redact_secrets(provider_messages)
+            )
+            degraded_system = self._redact_secrets(self._leading_system_message())
             return ConsoleContextSnapshot(
                 current_messages=copy.deepcopy(current_messages),
                 next_send_payload={
                     "model": self.model or self.configured_model,
-                    "messages": [],
-                    "system": [],
+                    "messages": degraded_messages,
+                    "system": degraded_system,
                     "staged_sources": staged_sources_list,
                     "tools": {
                         "native_schemas": [],
@@ -1314,6 +1323,14 @@ class ConsoleChatController:
                             part["source"] = _redact_image_source(part["source"])
                         if "image" in part:
                             part["image"] = _redact_image_url_value(part["image"])
+            elif isinstance(content, str):
+                # Some providers may inline image data URLs directly in a string
+                # content body; redact them so they never leak into the preview.
+                message["content"] = re.sub(
+                    r"data:[^\s\"'<>]+",
+                    "[image: data redacted for preview]",
+                    content,
+                )
         return result
 
     @staticmethod
@@ -1362,7 +1379,11 @@ class ConsoleChatController:
         if self._agent_bridge is not None:
             # Native tools only; live MCP catalog composition is out of scope.
             tools = self._agent_bridge.native_tool_schemas()
-        mcp_note = "MCP tools are configured but live catalog composition is not shown in this preview."
+        mcp_note: str | None = None
+        if self._mcp_provider:
+            mcp_note = (
+                "MCP tools are configured but live catalog composition is not shown in this preview."
+            )
         if tools:
             preview_note = (
                 "This preview shows only builtin native tools. "
@@ -1372,11 +1393,14 @@ class ConsoleChatController:
             preview_note = "No native tools are configured for preview."
         return {
             "native_schemas": tools,
-            "mcp_note": mcp_note if self._mcp_provider else None,
+            "mcp_note": mcp_note,
             "preview_note": preview_note,
         }
 
     _SECRET_REDACTION_KEYS = {"api_key", "apikey", "token", "password", "secret", "bearer"}
+    _SECRET_REDACTION_KEYS_NORMALIZED = {
+        k.replace("-", "").replace("_", "") for k in _SECRET_REDACTION_KEYS
+    }
     _SECRET_REDACTION_PATTERN = re.compile(
         r"(?P<open_quote>[\"']?)"
         r"(?P<key>"
@@ -1419,30 +1443,45 @@ class ConsoleChatController:
             return ConsoleChatController._SECRET_REDACTION_PATTERN.sub(_replace_value, value)
 
         def _matches_secret_key(key: str) -> bool:
-            """Return True when ``key`` is or ends with a secret word.
+            """Return True when ``key`` matches or ends with a secret word.
 
-            Matches exact keys such as ``api_key`` and suffixed keys such as
-            ``my_api_key``, while avoiding over-redaction of innocent keys like
-            ``token_count`` or ``secret_mode``.
+            Matches exact keys such as ``api_key``, suffixed keys such as
+            ``my_api_key``, and hyphenated/camelCase variants such as
+            ``x-api-key`` or ``apiKey``.
             """
             lowered = key.lower()
+            normalized = lowered.replace("-", "").replace("_", "")
+            if normalized in ConsoleChatController._SECRET_REDACTION_KEYS_NORMALIZED:
+                return True
             for secret in ConsoleChatController._SECRET_REDACTION_KEYS:
-                if lowered == secret or lowered.endswith(f"_{secret}"):
+                if lowered.endswith(f"_{secret}"):
+                    return True
+                normalized_secret = secret.replace("-", "").replace("_", "")
+                if normalized.endswith(normalized_secret):
                     return True
             return False
 
-        def _redact_obj(obj: Any) -> Any:
+        def _redact_obj(obj: Any, under_secret: bool = False) -> Any:
             if isinstance(obj, dict):
                 result = {}
                 for key, value in obj.items():
-                    if _matches_secret_key(key) and isinstance(value, str):
+                    key_is_secret = _matches_secret_key(key)
+                    if key_is_secret and isinstance(value, str):
+                        result[key] = "[redacted]"
+                    elif key_is_secret:
+                        # Structured values under a secret key are recursively
+                        # redacted so nested strings do not leak.
+                        result[key] = _redact_obj(value, under_secret=True)
+                    elif under_secret and isinstance(value, str):
                         result[key] = "[redacted]"
                     else:
-                        result[key] = _redact_obj(value)
+                        result[key] = _redact_obj(value, under_secret=under_secret)
                 return result
             if isinstance(obj, list):
-                return [_redact_obj(item) for item in obj]
+                return [_redact_obj(item, under_secret=under_secret) for item in obj]
             if isinstance(obj, str):
+                if under_secret:
+                    return "[redacted]"
                 return _redact_string(obj)
             return obj
 

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -1192,67 +1192,86 @@ class ConsoleChatController:
             return ConsoleContextSnapshot(current_messages=[], next_send_payload={})
 
         current_messages = list(self.store.messages_for_session(session_id))
+        staged_sources_list = [
+            {"source_id": s.source_id, "label": s.label, "type": s.source_type}
+            for s in (staged_sources or ())
+        ]
 
-        # Build the next-send payload as submit_draft would, but do not persist.
-        provider_messages = self._provider_messages_for_session(session_id)
+        try:
+            # Build the next-send payload as submit_draft would, but do not persist.
+            provider_messages = self._provider_messages_for_session(session_id)
 
-        # Append a synthetic user turn for the draft so the preview matches what would be sent.
-        attachment_tuple = tuple(attachments or ())
-        synthetic_turn_added = bool(draft.strip() or attachment_tuple)
-        if synthetic_turn_added:
-            synthetic_user = self._provider_message_payloads(
-                [
-                    ConsoleChatMessage(
-                        role=ConsoleMessageRole.USER,
-                        content=draft,
-                        attachments=attachment_tuple,
-                    )
-                ],
-                skip_failed=True,
+            # Append a synthetic user turn for the draft so the preview matches what would be sent.
+            attachment_tuple = tuple(attachments or ())
+            synthetic_turn_added = bool(draft.strip() or attachment_tuple)
+            if synthetic_turn_added:
+                synthetic_user = self._provider_message_payloads(
+                    [
+                        ConsoleChatMessage(
+                            role=ConsoleMessageRole.USER,
+                            content=draft,
+                            attachments=attachment_tuple,
+                        )
+                    ],
+                    skip_failed=True,
+                )
+                provider_messages.extend(synthetic_user)
+
+            # Do NOT call _apply_skill_substitution because it may execute skills with side effects.
+            # Instead, annotate the final user message if a synthetic turn was appended and it
+            # starts with a skill command. Historical turns have already been resolved at send time
+            # and must not be annotated.
+            provider_messages = self._annotate_skill_commands(
+                provider_messages, synthetic_turn_added=synthetic_turn_added
             )
-            provider_messages.extend(synthetic_user)
 
-        # Do NOT call _apply_skill_substitution because it may execute skills with side effects.
-        # Instead, annotate the final user message if a synthetic turn was appended and it
-        # starts with a skill command. Historical turns have already been resolved at send time
-        # and must not be annotated.
-        provider_messages = self._annotate_skill_commands(
-            provider_messages, synthetic_turn_added=synthetic_turn_added
-        )
+            # Chat dictionaries are safe to apply (string replacements only).
+            provider_messages = await self._apply_chat_dictionaries(provider_messages, session_id)
 
-        # Chat dictionaries are safe to apply (string replacements only).
-        provider_messages = await self._apply_chat_dictionaries(provider_messages, session_id)
+            # Replace image data with placeholders for the preview, including historical images.
+            provider_messages = self._replace_image_data_with_placeholders(provider_messages)
 
-        # Replace image data with placeholders for the preview, including historical images.
-        provider_messages = self._replace_image_data_with_placeholders(provider_messages)
+            # Gather native tool schemas and MCP note.
+            tools_info = self._build_tools_info_for_snapshot()
 
-        # Gather native tool schemas and MCP note.
-        tools_info = self._build_tools_info_for_snapshot()
+            # Redact secrets before returning.
+            redacted_messages = self._redact_secrets(provider_messages)
+            redacted_system = self._redact_secrets(self._leading_system_message())
 
-        # Redact secrets before returning.
-        redacted_messages = self._redact_secrets(provider_messages)
-        redacted_system = self._redact_secrets(self._leading_system_message())
+            # Deep-copy messages so the snapshot is independent of the store.
+            copied_messages = copy.deepcopy(current_messages)
 
-        # Deep-copy messages so the snapshot is independent of the store.
-        copied_messages = copy.deepcopy(current_messages)
-
-        return ConsoleContextSnapshot(
-            current_messages=copied_messages,
-            next_send_payload={
-                "model": self.model or self.configured_model,
-                "messages": redacted_messages,
-                # `system` is intentionally duplicated from the leading system
-                # message in `messages` so the preview viewer can show the
-                # effective system prompt at a glance without scanning the
-                # message list.  It is the same redacted value.
-                "system": redacted_system,
-                "staged_sources": [
-                    {"source_id": s.source_id, "label": s.label, "type": s.source_type}
-                    for s in (staged_sources or ())
-                ],
-                "tools": tools_info,
-            },
-        )
+            return ConsoleContextSnapshot(
+                current_messages=copied_messages,
+                next_send_payload={
+                    "model": self.model or self.configured_model,
+                    "messages": redacted_messages,
+                    # `system` is intentionally duplicated from the leading system
+                    # message in `messages` so the preview viewer can show the
+                    # effective system prompt at a glance without scanning the
+                    # message list.  It is the same redacted value.
+                    "system": redacted_system,
+                    "staged_sources": staged_sources_list,
+                    "tools": tools_info,
+                },
+            )
+        except Exception as exc:
+            logger.exception("Failed to build context snapshot")
+            return ConsoleContextSnapshot(
+                current_messages=copy.deepcopy(current_messages),
+                next_send_payload={
+                    "model": self.model or self.configured_model,
+                    "messages": [],
+                    "system": [],
+                    "staged_sources": staged_sources_list,
+                    "tools": {
+                        "native_schemas": [],
+                        "mcp_note": None,
+                        "preview_note": "Preview unavailable due to an internal error.",
+                    },
+                    "error": f"Failed to build context snapshot: {exc}",
+                },
+            )
 
     @staticmethod
     def _replace_image_data_with_placeholders(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -1261,21 +1280,40 @@ class ConsoleChatController:
         def _is_data_url(value: Any) -> bool:
             return isinstance(value, str) and value.startswith("data:")
 
-        def _redact_image_url(value: Any) -> Any:
+        def _redact_image_url_value(value: Any) -> Any:
+            """Redact an image URL value while preserving its original shape."""
             if isinstance(value, dict) and _is_data_url(value.get("url")):
                 return {**value, "url": "[image: data redacted for preview]"}
             if isinstance(value, str) and _is_data_url(value):
-                return {"url": "[image: data redacted for preview]"}
+                return "[image: data redacted for preview]"
             return value
+
+        def _redact_image_source(source: dict[str, Any]) -> dict[str, Any]:
+            """Redact base64 or data-URL content inside an image source dict."""
+            if not isinstance(source, dict):
+                return source
+            redacted = {**source}
+            if _is_data_url(redacted.get("data")) or redacted.get("type") == "base64":
+                redacted["data"] = "[image: data redacted for preview]"
+            if _is_data_url(redacted.get("url")):
+                redacted["url"] = "[image: data redacted for preview]"
+            return redacted
 
         for message in result:
             content = message.get("content")
             if isinstance(content, list):
                 for part in content:
-                    if isinstance(part, dict) and part.get("type") == "image_url":
-                        part["image_url"] = _redact_image_url(part.get("image_url"))
-                    if isinstance(part, dict) and part.get("type") == "image":
-                        part["image"] = _redact_image_url(part.get("image"))
+                    if not isinstance(part, dict):
+                        continue
+                    if part.get("type") == "image_url":
+                        part["image_url"] = _redact_image_url_value(part.get("image_url"))
+                    if part.get("type") == "image":
+                        # Anthropic-style image parts use a ``source`` dict with
+                        # base64 data; preserve the surrounding structure.
+                        if isinstance(part.get("source"), dict):
+                            part["source"] = _redact_image_source(part["source"])
+                        if "image" in part:
+                            part["image"] = _redact_image_url_value(part["image"])
         return result
 
     @staticmethod
@@ -1355,7 +1393,7 @@ class ConsoleChatController:
     )
 
     @staticmethod
-    def _redact_secrets(payload: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    def _redact_secrets(payload: Any) -> Any:
         """Return a deep-copied payload with likely secret values replaced.
 
         Redaction is best-effort and intended for preview/export convenience

--- a/tldw_chatbook/Chat/console_chat_models.py
+++ b/tldw_chatbook/Chat/console_chat_models.py
@@ -265,7 +265,7 @@ class ConsoleVariantSet:
 
 @dataclass
 class ConsoleContextSnapshot:
-    """Read-only snapshot of current transcript and next-send provider payload."""
+    """Independent snapshot of current transcript and next-send provider payload."""
 
     current_messages: list[ConsoleChatMessage]
     next_send_payload: dict[str, Any]

--- a/tldw_chatbook/Chat/console_chat_models.py
+++ b/tldw_chatbook/Chat/console_chat_models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Literal
+from typing import Any, Literal
 from uuid import uuid4
 
 
@@ -261,3 +261,11 @@ class ConsoleVariantSet:
     def can_go_next(self) -> bool:
         """Return whether a next variant exists."""
         return self.selected_index < len(self.variants) - 1
+
+
+@dataclass
+class ConsoleContextSnapshot:
+    """Read-only snapshot of current transcript and next-send provider payload."""
+
+    current_messages: list[ConsoleChatMessage]
+    next_send_payload: dict[str, Any]

--- a/tldw_chatbook/Chat/console_chat_models.py
+++ b/tldw_chatbook/Chat/console_chat_models.py
@@ -265,7 +265,14 @@ class ConsoleVariantSet:
 
 @dataclass(frozen=True)
 class ConsoleContextSnapshot:
-    """Independent snapshot of current transcript and next-send provider payload."""
+    """Independent snapshot of current transcript and next-send provider payload.
+
+    ``frozen=True`` prevents reassigning the snapshot's top-level fields.
+    ``independent`` means the snapshot is safe from store mutation: the
+    ``current_messages`` and ``next_send_payload`` structures are copied at
+    creation time, so mutating them does not change the underlying store.
+    It does *not* promise deep immutability of nested values.
+    """
 
     current_messages: list[ConsoleChatMessage]
     next_send_payload: dict[str, Any]

--- a/tldw_chatbook/Chat/console_chat_models.py
+++ b/tldw_chatbook/Chat/console_chat_models.py
@@ -263,7 +263,7 @@ class ConsoleVariantSet:
         return self.selected_index < len(self.variants) - 1
 
 
-@dataclass
+@dataclass(frozen=True)
 class ConsoleContextSnapshot:
     """Independent snapshot of current transcript and next-send provider payload."""
 

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -197,6 +197,7 @@ from ...Utils.console_background_effects import (
     normalize_console_background_effects,
 )
 from ...Utils.input_validation import sanitize_string, validate_text_input
+from ...Utils.token_counter import count_tokens_tiktoken
 from ...UI.Workbench import (
     CommandStrip,
     DestinationHeader,
@@ -1211,27 +1212,38 @@ class ChatScreen(BaseAppScreen):
 
         try:
             composer = self.query_one("#console-native-composer", ConsoleComposerBar)
-            draft = composer.draft_text() if composer else ""
-        except Exception:
-            draft = ""
-
-        staged_sources = controller.store.workspace_context.allowed_sources
-        pending = controller.store.pending_attachments(session_id)
-        attachments = tuple(
-            MessageAttachment(
-                data=pending_attachment.data,
-                mime_type=pending_attachment.mime_type or "image/png",
-                display_name=pending_attachment.display_name,
-                position=index,
-            )
-            for index, pending_attachment in enumerate(pending)
-        )
+        except (NoMatches, QueryError):
+            composer = None
+        draft = composer.draft_text() if composer else ""
 
         async def _factory() -> ConsoleContextSnapshot:
+            try:
+                composer = self.query_one(
+                    "#console-native-composer", ConsoleComposerBar
+                )
+            except (NoMatches, QueryError):
+                composer = None
+            current_draft = composer.draft_text() if composer else ""
+
+            current_session_id = controller.store.active_session_id
+            pending = controller.store.pending_attachments(current_session_id)
+            current_attachments = tuple(
+                MessageAttachment(
+                    data=pending_attachment.data,
+                    mime_type=pending_attachment.mime_type or "image/png",
+                    display_name=pending_attachment.display_name,
+                    position=index,
+                )
+                for index, pending_attachment in enumerate(pending)
+            )
+            current_staged_sources = (
+                controller.store.workspace_context.allowed_sources
+            )
+
             return await controller.build_context_snapshot(
-                draft=draft,
-                attachments=attachments,
-                staged_sources=staged_sources,
+                draft=current_draft,
+                attachments=current_attachments,
+                staged_sources=current_staged_sources,
             )
 
         token_estimate = self._estimate_tokens({"draft": draft})
@@ -1245,9 +1257,14 @@ class ChatScreen(BaseAppScreen):
         )
 
     def _estimate_tokens(self, payload: dict[str, Any]) -> int | None:
-        """Return a rough token estimate for a text payload."""
-        text = str(payload)
-        return int(len(text.split()) * 1.3)
+        """Return a token estimate for the current draft text."""
+        text = payload.get("draft", "")
+        if not text:
+            return None
+        try:
+            return count_tokens_tiktoken(text)
+        except Exception:
+            return int(len(text.split()) * 1.3)
 
     async def action_jump_console_tab(self, number: int) -> None:
         """Jump directly to the Nth native Console session tab (Alt+1..9).

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -1210,12 +1210,6 @@ class ChatScreen(BaseAppScreen):
             self.notify("No active conversation.", severity="warning")
             return
 
-        try:
-            composer = self.query_one("#console-native-composer", ConsoleComposerBar)
-        except (NoMatches, QueryError):
-            composer = None
-        draft = composer.draft_text() if composer else ""
-
         async def _factory() -> ConsoleContextSnapshot:
             try:
                 composer = self.query_one(
@@ -1246,12 +1240,23 @@ class ChatScreen(BaseAppScreen):
                 staged_sources=current_staged_sources,
             )
 
-        token_estimate = self._estimate_tokens({"draft": draft})
+        def _estimate_factory() -> int | None:
+            try:
+                composer = self.query_one(
+                    "#console-native-composer", ConsoleComposerBar
+                )
+            except (NoMatches, QueryError):
+                composer = None
+            current_draft = composer.draft_text() if composer else ""
+            return self._estimate_tokens({"draft": current_draft})
+
+        token_estimate = _estimate_factory()
         in_progress = controller.run_state.status in CONSOLE_ACTIVE_RUN_STATUSES
         self.app.push_screen(
             ConsoleContextModal(
                 _factory,
                 token_estimate=token_estimate,
+                estimate_factory=_estimate_factory,
                 in_progress=in_progress,
             )
         )

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -72,6 +72,7 @@ from ...Chat.console_chat_models import (
     CONSOLE_GLOBAL_WORKSPACE_ID,
     DEFAULT_CONSOLE_SESSION_TITLE,
     ConsoleChatMessage,
+    ConsoleContextSnapshot,
     ConsoleMessageRole,
     ConsoleProviderSelection,
     ConsoleRunStatus,
@@ -227,6 +228,7 @@ from ...Widgets.Console import (
     ConsoleWorkspaceContextTray,
     ConsoleWorkspaceSwitcherModal,
 )
+from ...Widgets.Console.console_context_modal import ConsoleContextModal
 from ...Widgets.Console.console_model_popover import (
     CONSOLE_POPOVER_OPEN_FULL_SETTINGS,
     ConsoleModelPopover,
@@ -573,6 +575,7 @@ class ChatScreen(BaseAppScreen):
         Binding("ctrl+k", "open_console_session_switcher", "Switch session", show=True),
         Binding("alt+m", "open_console_model_popover", "Model", show=True),
         Binding("alt+v", "paste_clipboard_image", "Paste image", show=True),
+        Binding("ctrl+shift+p", "view_chat_context", "View context", show=True),
         # NOT priority: widget-level escapes (transcript clear-selection, modal
         # dismiss) must keep winning before this screen-level fallback runs.
         Binding("escape", "focus_console_composer_home", "Composer", show=False),
@@ -1195,6 +1198,56 @@ class ChatScreen(BaseAppScreen):
         if self._console_setup_modal_blocking():
             return
         self.run_worker(self._open_console_system_prompt_editor(), exclusive=False)
+
+    def action_view_chat_context(self) -> None:
+        """Open the Console context viewer modal (Ctrl+Shift+P)."""
+        if self._console_setup_modal_blocking():
+            return
+        controller = self._ensure_console_chat_controller()
+        session_id = controller.store.active_session_id
+        if not session_id:
+            self.notify("No active conversation.", severity="warning")
+            return
+
+        try:
+            composer = self.query_one("#console-native-composer", ConsoleComposerBar)
+            draft = composer.draft_text() if composer else ""
+        except Exception:
+            draft = ""
+
+        staged_sources = controller.store.workspace_context.allowed_sources
+        pending = controller.store.pending_attachments(session_id)
+        attachments = tuple(
+            MessageAttachment(
+                data=pending_attachment.data,
+                mime_type=pending_attachment.mime_type or "image/png",
+                display_name=pending_attachment.display_name,
+                position=index,
+            )
+            for index, pending_attachment in enumerate(pending)
+        )
+
+        async def _factory() -> ConsoleContextSnapshot:
+            return await controller.build_context_snapshot(
+                draft=draft,
+                attachments=attachments,
+                staged_sources=staged_sources,
+            )
+
+        token_estimate = self._estimate_tokens({"draft": draft})
+        in_progress = controller.run_state.status in CONSOLE_ACTIVE_RUN_STATUSES
+        self.app.push_screen(
+            ConsoleContextModal(
+                _factory,
+                token_estimate=token_estimate,
+                in_progress=in_progress,
+            )
+        )
+
+    def _estimate_tokens(self, payload: dict[str, Any]) -> int | None:
+        """Return a rough token estimate for a text payload."""
+        text = str(payload)
+        return int(len(text.split()) * 1.3)
 
     async def action_jump_console_tab(self, number: int) -> None:
         """Jump directly to the Nth native Console session tab (Alt+1..9).

--- a/tldw_chatbook/UI/console_command_provider.py
+++ b/tldw_chatbook/UI/console_command_provider.py
@@ -64,6 +64,11 @@ class ConsoleCommandProvider(Provider):
                 screen.action_open_console_system_prompt_editor,
                 "Edit this session's system prompt (/system)",
             ),
+            (
+                "Console: View chat context",
+                screen.action_view_chat_context,
+                "Show current and next-send context (Ctrl+Shift+P)",
+            ),
         )
 
     async def discover(self) -> Hits:

--- a/tldw_chatbook/Widgets/Console/console_context_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_context_modal.py
@@ -1,0 +1,290 @@
+"""Modal viewer for the native Console chat context snapshot."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from textual import on
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.reactive import reactive
+from textual.screen import ModalScreen
+from textual.widgets import (
+    Button,
+    Checkbox,
+    Collapsible,
+    Label,
+    LoadingIndicator,
+    Static,
+    TabbedContent,
+    TabPane,
+    TextArea,
+)
+from textual.worker import Worker, WorkerState
+
+from tldw_chatbook.Chat.console_chat_models import ConsoleContextSnapshot
+
+
+SIZE_THRESHOLD_BYTES = 1 * 1024 * 1024
+
+
+class ConsoleContextModal(ModalScreen[None]):
+    """Display the current transcript and assembled next-send payload."""
+
+    DEFAULT_CSS = """
+    ConsoleContextModal { align: center middle; }
+    #console-context-modal { width: 95; height: 40; border: tall gray; }
+    #console-context-header { height: auto; }
+    #console-context-warning { height: auto; color: yellow; }
+    #console-context-loading { display: none; }
+    #console-context-loading.loading { display: block; }
+    #console-context-tabs { height: 1fr; }
+    #console-context-actions { height: auto; }
+    """
+
+    BINDINGS = [
+        ("escape", "dismiss", "Close"),
+        ("r", "refresh", "Refresh"),
+    ]
+
+    snapshot = reactive(
+        ConsoleContextSnapshot(current_messages=[], next_send_payload={})
+    )
+    raw_json = reactive(False)
+    in_progress = reactive(False)
+    token_estimate = reactive(None)
+    loading = reactive(False)
+
+    def __init__(
+        self,
+        snapshot_factory: Callable[[], Awaitable[ConsoleContextSnapshot]],
+        *,
+        token_estimate: int | None = None,
+        in_progress: bool = False,
+    ) -> None:
+        super().__init__()
+        self._snapshot_factory = snapshot_factory
+        self.token_estimate = token_estimate
+        self.in_progress = in_progress
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="console-context-modal"):
+            yield Static("Chat Context", id="console-context-header")
+            yield Static("", id="console-context-warning")
+            yield LoadingIndicator(id="console-context-loading")
+
+            with TabbedContent(id="console-context-tabs"):
+                with TabPane("Current", id="console-context-current"):
+                    yield Vertical(id="console-context-current-body")
+                with TabPane("Next Send", id="console-context-next-send"):
+                    yield Vertical(id="console-context-next-send-body")
+
+            with Horizontal(id="console-context-actions"):
+                yield Checkbox("Raw JSON", id="console-context-raw")
+                yield Button(
+                    "Refresh",
+                    id="console-context-refresh",
+                    disabled=self.in_progress,
+                )
+                yield Button("Copy JSON", id="console-context-copy")
+                yield Button("Save to File", id="console-context-save")
+                yield Button("Close", id="console-context-close")
+
+    def on_mount(self) -> None:
+        self.run_worker(self._load_snapshot, exclusive=True)
+
+    def watch_snapshot(self) -> None:
+        self._update_view()
+
+    def watch_raw_json(self) -> None:
+        self._update_view()
+
+    def watch_loading(self) -> None:
+        loading = self.query_one("#console-context-loading", LoadingIndicator)
+        if self.loading:
+            loading.add_class("loading")
+        else:
+            loading.remove_class("loading")
+
+    def _update_view(self) -> None:
+        warning = self.query_one("#console-context-warning", Static)
+        if self.in_progress:
+            warning.update("A response is in progress; snapshot may change.")
+        else:
+            warning.update("")
+
+        header = self.query_one("#console-context-header", Static)
+        header_text = "Chat Context"
+        if self.token_estimate is not None:
+            header_text += f" (~{self.token_estimate} tokens)"
+        header.update(header_text)
+
+        current_container = self.query_one(
+            "#console-context-current-body", Vertical
+        )
+        current_container.remove_children()
+        for widget in self._build_current_context_widgets():
+            current_container.mount(widget)
+
+        next_container = self.query_one(
+            "#console-context-next-send-body", Vertical
+        )
+        next_container.remove_children()
+        for widget in self._build_next_send_widgets():
+            next_container.mount(widget)
+
+    def _build_current_context_widgets(self) -> list:
+        if not self.snapshot.current_messages:
+            return [Label("No conversation context.")]
+        return [
+            Collapsible(
+                TextArea(msg.content, read_only=True),
+                title=f"[{msg.role}] {msg.status}",
+                collapsed=True,
+            )
+            for msg in self.snapshot.current_messages
+        ]
+
+    def _build_next_send_widgets(self) -> list:
+        widgets: list = []
+        payload = self.snapshot.next_send_payload
+        text = self._format_next_send_text()
+
+        if len(text.encode("utf-8")) > SIZE_THRESHOLD_BYTES:
+            widgets.append(
+                Label(
+                    "Context exceeds 1 MiB. Use Save to File to view the full payload."
+                )
+            )
+            return widgets
+
+        if self.raw_json:
+            widgets.append(TextArea(text, read_only=True))
+            return widgets
+
+        widgets.append(
+            Collapsible(
+                Label(str(payload.get("model", "unknown"))),
+                title="Model",
+                collapsed=False,
+            )
+        )
+
+        widgets.append(
+            Collapsible(
+                TextArea(self._json_block(payload.get("system")), read_only=True),
+                title="System",
+                collapsed=True,
+            )
+        )
+
+        message_widgets = []
+        for i, msg in enumerate(payload.get("messages", [])):
+            message_widgets.append(
+                Collapsible(
+                    TextArea(self._json_block(msg), read_only=True),
+                    title=f"Message {i}",
+                    collapsed=True,
+                )
+            )
+        widgets.append(
+            Collapsible(
+                *message_widgets,
+                title="Messages",
+                collapsed=False,
+            )
+        )
+
+        tools = payload.get("tools")
+        if tools:
+            widgets.append(
+                Collapsible(
+                    TextArea(self._json_block(tools), read_only=True),
+                    title="Tools",
+                    collapsed=True,
+                )
+            )
+
+        staged = payload.get("staged_sources")
+        if staged:
+            widgets.append(
+                Collapsible(
+                    TextArea(self._json_block(staged), read_only=True),
+                    title="Staged Sources",
+                    collapsed=True,
+                )
+            )
+
+        return widgets
+
+    def _format_next_send_text(self) -> str:
+        import json
+
+        return json.dumps(self.snapshot.next_send_payload, indent=2, default=str)
+
+    @staticmethod
+    def _json_block(obj: Any) -> str:
+        import json
+
+        return json.dumps(obj, indent=2, default=str)
+
+    @on(Button.Pressed, "#console-context-close")
+    def _close(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.dismiss(None)
+
+    @on(Button.Pressed, "#console-context-refresh")
+    def _refresh(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.run_worker(self._load_snapshot, exclusive=True)
+
+    async def _load_snapshot(self) -> None:
+        self.loading = True
+        try:
+            self.snapshot = await self._snapshot_factory()
+        finally:
+            self.loading = False
+
+    def on_worker_state_changed(self, event: Worker.StateChanged) -> None:
+        if event.state == WorkerState.ERROR:
+            self.loading = False
+            self.notify("Failed to refresh context.", severity="error")
+
+    @on(Checkbox.Changed, "#console-context-raw")
+    def _toggle_raw(self, event: Checkbox.Changed) -> None:
+        event.stop()
+        self.raw_json = event.value
+
+    @on(Button.Pressed, "#console-context-copy")
+    def _copy_json(self, event: Button.Pressed) -> None:
+        event.stop()
+        import json
+
+        text = json.dumps(self.snapshot.next_send_payload, indent=2, default=str)
+        try:
+            import pyperclip
+
+            pyperclip.copy(text)
+            self.notify("JSON copied to clipboard.")
+        except Exception:
+            self.notify("Copy failed: pyperclip unavailable.", severity="warning")
+
+    @on(Button.Pressed, "#console-context-save")
+    def _save_json(self, event: Button.Pressed) -> None:
+        event.stop()
+        import json
+        from datetime import datetime
+        from pathlib import Path
+
+        text = json.dumps(self.snapshot.next_send_payload, indent=2, default=str)
+        filename = f"chatbook_context_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
+        path = Path.home() / "Downloads" / filename
+        path.write_text(text, encoding="utf-8")
+        self.notify(f"Saved to {path}")
+
+    def action_refresh(self) -> None:
+        self.run_worker(self._load_snapshot, exclusive=True)
+
+    def action_dismiss(self) -> None:
+        self.dismiss(None)

--- a/tldw_chatbook/Widgets/Console/console_context_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_context_modal.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Awaitable, Callable
+from datetime import datetime
+from pathlib import Path
 from typing import Any
+
+from textual.widget import Widget
 
 from textual import on
 from textual.app import ComposeResult
@@ -134,7 +139,7 @@ class ConsoleContextModal(ModalScreen[None]):
         for widget in self._build_next_send_widgets():
             next_container.mount(widget)
 
-    def _build_current_context_widgets(self) -> list:
+    def _build_current_context_widgets(self) -> list[Widget]:
         if not self.snapshot.current_messages:
             return [Label("No conversation context.")]
         return [
@@ -146,8 +151,8 @@ class ConsoleContextModal(ModalScreen[None]):
             for msg in self.snapshot.current_messages
         ]
 
-    def _build_next_send_widgets(self) -> list:
-        widgets: list = []
+    def _build_next_send_widgets(self) -> list[Widget]:
+        widgets: list[Widget] = []
         payload = self.snapshot.next_send_payload
         text = self._format_next_send_text()
 
@@ -219,14 +224,10 @@ class ConsoleContextModal(ModalScreen[None]):
         return widgets
 
     def _format_next_send_text(self) -> str:
-        import json
-
-        return json.dumps(self.snapshot.next_send_payload, indent=2, default=str)
+        return self._json_block(self.snapshot.next_send_payload)
 
     @staticmethod
     def _json_block(obj: Any) -> str:
-        import json
-
         return json.dumps(obj, indent=2, default=str)
 
     @on(Button.Pressed, "#console-context-close")
@@ -259,9 +260,7 @@ class ConsoleContextModal(ModalScreen[None]):
     @on(Button.Pressed, "#console-context-copy")
     def _copy_json(self, event: Button.Pressed) -> None:
         event.stop()
-        import json
-
-        text = json.dumps(self.snapshot.next_send_payload, indent=2, default=str)
+        text = self._format_next_send_text()
         try:
             import pyperclip
 
@@ -273,15 +272,17 @@ class ConsoleContextModal(ModalScreen[None]):
     @on(Button.Pressed, "#console-context-save")
     def _save_json(self, event: Button.Pressed) -> None:
         event.stop()
-        import json
-        from datetime import datetime
-        from pathlib import Path
-
-        text = json.dumps(self.snapshot.next_send_payload, indent=2, default=str)
+        text = self._format_next_send_text()
         filename = f"chatbook_context_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
         path = Path.home() / "Downloads" / filename
-        path.write_text(text, encoding="utf-8")
-        self.notify(f"Saved to {path}")
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(text, encoding="utf-8")
+            self.notify(f"Saved to {path}")
+        except (OSError, PermissionError) as exc:
+            self.notify(f"Save failed: {exc}", severity="error")
+        except Exception as exc:
+            self.notify(f"Save failed: {exc}", severity="error")
 
     def action_refresh(self) -> None:
         self.run_worker(self._load_snapshot, exclusive=True)

--- a/tldw_chatbook/Widgets/Console/console_context_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_context_modal.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from loguru import logger
 from textual.widget import Widget
 
 from textual import on
@@ -66,10 +67,12 @@ class ConsoleContextModal(ModalScreen[None]):
         snapshot_factory: Callable[[], Awaitable[ConsoleContextSnapshot]],
         *,
         token_estimate: int | None = None,
+        estimate_factory: Callable[[], int | None] | None = None,
         in_progress: bool = False,
     ) -> None:
         super().__init__()
         self._snapshot_factory = snapshot_factory
+        self._estimate_factory = estimate_factory
         self.token_estimate = token_estimate
         self.in_progress = in_progress
 
@@ -244,6 +247,8 @@ class ConsoleContextModal(ModalScreen[None]):
         self.loading = True
         try:
             self.snapshot = await self._snapshot_factory()
+            if self._estimate_factory is not None:
+                self.token_estimate = self._estimate_factory()
         finally:
             self.loading = False
 
@@ -266,7 +271,8 @@ class ConsoleContextModal(ModalScreen[None]):
 
             pyperclip.copy(text)
             self.notify("JSON copied to clipboard.")
-        except Exception:
+        except Exception as exc:
+            logger.warning("Failed to copy context JSON to clipboard: {}", exc)
             self.notify("Copy failed: pyperclip unavailable.", severity="warning")
 
     @on(Button.Pressed, "#console-context-save")
@@ -279,9 +285,11 @@ class ConsoleContextModal(ModalScreen[None]):
             path.parent.mkdir(parents=True, exist_ok=True)
             path.write_text(text, encoding="utf-8")
             self.notify(f"Saved to {path}")
-        except (OSError, PermissionError) as exc:
+        except OSError as exc:
+            logger.warning("Failed to save context snapshot to {}: {}", path, exc)
             self.notify(f"Save failed: {exc}", severity="error")
         except Exception as exc:
+            logger.exception("Unexpected error saving context snapshot to {}", path)
             self.notify(f"Save failed: {exc}", severity="error")
 
     def action_refresh(self) -> None:

--- a/tldw_chatbook/Widgets/Console/console_context_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_context_modal.py
@@ -9,13 +9,12 @@ from pathlib import Path
 from typing import Any
 
 from loguru import logger
-from textual.widget import Widget
-
 from textual import on
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
 from textual.reactive import reactive
 from textual.screen import ModalScreen
+from textual.widget import Widget
 from textual.widgets import (
     Button,
     Checkbox,

--- a/tldw_chatbook/Widgets/Console/console_context_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_context_modal.py
@@ -128,16 +128,12 @@ class ConsoleContextModal(ModalScreen[None]):
             header_text += f" (~{self.token_estimate} tokens)"
         header.update(header_text)
 
-        current_container = self.query_one(
-            "#console-context-current-body", Vertical
-        )
+        current_container = self.query_one("#console-context-current-body", Vertical)
         current_container.remove_children()
         for widget in self._build_current_context_widgets():
             current_container.mount(widget)
 
-        next_container = self.query_one(
-            "#console-context-next-send-body", Vertical
-        )
+        next_container = self.query_one("#console-context-next-send-body", Vertical)
         next_container.remove_children()
         for widget in self._build_next_send_widgets():
             next_container.mount(widget)

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -380,6 +380,9 @@ class ConsoleTranscript(VerticalScroll):
         ("r", "invoke_selected_action('regenerate')", "Regenerate"),
     ]
 
+    NEGATIVE_SPACE_CLASSES: frozenset[str] = frozenset()
+    """Widget classes that should be treated as negative space for selection clearing."""
+
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
         self._messages: list[ConsoleChatMessage] = []
@@ -656,6 +659,21 @@ class ConsoleTranscript(VerticalScroll):
             return False
         button.press()
         return True
+
+    def on_click(self, event: Click) -> None:
+        """Clear selection when the user clicks negative space in the transcript.
+
+        Clicks that land on message rows, action buttons, the action row,
+        rule separators, action-help text, the empty-state panel, or scrollbars
+        are ignored so that those interactive elements keep the current
+        selection active.
+        """
+        control = event.control
+        if control is self or (
+            control is not None
+            and any(control.has_class(class_name) for class_name in self.NEGATIVE_SPACE_CLASSES)
+        ):
+            self.action_clear_selection()
 
     def on_key(self, event: Key) -> None:
         if event.key in {"down", "j"}:

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -380,15 +380,13 @@ class ConsoleTranscript(VerticalScroll):
         ("r", "invoke_selected_action('regenerate')", "Regenerate"),
     ]
 
-    NEGATIVE_SPACE_CLASSES: frozenset[str] = frozenset()
-    """Widget classes that should be treated as negative space for selection clearing."""
-
     PROTECTED_CLICK_CLASSES: frozenset[str] = frozenset({
         "console-transcript-action-row",
         "console-transcript-action-guide",
         "console-transcript-empty-panel",
         "console-transcript-empty-body",
         "console-transcript-empty-state",
+        "console-transcript-rule",
         # Textual scrollbars carry the generic system-widget class; ignore them
         # defensively if a scrollbar click ever bubbles up to the transcript.
         "-textual-system",
@@ -678,22 +676,21 @@ class ConsoleTranscript(VerticalScroll):
     def on_click(self, event: Click) -> None:
         """Clear selection when the user clicks negative space in the transcript.
 
-        Clicks that land on message rows, action buttons, the action row,
-        rule separators, action-help text, the empty-state panel, or scrollbars
-        are ignored so that those interactive elements keep the current
-        selection active.
+        Clicks that land on controls with classes in ``PROTECTED_CLICK_CLASSES``
+        (message action rows/buttons, rule separators, action-help text, the
+        empty-state panel, or scrollbars) keep the current selection active. All
+        other clicks that bubble up to the transcript itself clear the selection.
         """
         control = event.control
         if control is not None and any(
             control.has_class(class_name)
             for class_name in self.PROTECTED_CLICK_CLASSES
         ):
+            event.stop()
             return
-        if control is self or (
-            control is not None
-            and any(control.has_class(class_name) for class_name in self.NEGATIVE_SPACE_CLASSES)
-        ):
+        if control is self:
             self.action_clear_selection()
+            event.stop()
 
     def on_key(self, event: Key) -> None:
         if event.key in {"down", "j"}:

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -383,6 +383,21 @@ class ConsoleTranscript(VerticalScroll):
     NEGATIVE_SPACE_CLASSES: frozenset[str] = frozenset()
     """Widget classes that should be treated as negative space for selection clearing."""
 
+    PROTECTED_CLICK_CLASSES: frozenset[str] = frozenset({
+        "console-transcript-action-row",
+        "console-transcript-action-guide",
+        "console-transcript-empty-panel",
+        "console-transcript-empty-body",
+        "console-transcript-empty-state",
+        # Textual scrollbars carry the generic system-widget class; ignore them
+        # defensively if a scrollbar click ever bubbles up to the transcript.
+        "-textual-system",
+        "vertical-scrollbar",
+        "horizontal-scrollbar",
+        "scrollbar",
+    })
+    """Widget classes that must keep the current selection active when clicked."""
+
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
         self._messages: list[ConsoleChatMessage] = []
@@ -669,6 +684,11 @@ class ConsoleTranscript(VerticalScroll):
         selection active.
         """
         control = event.control
+        if control is not None and any(
+            control.has_class(class_name)
+            for class_name in self.PROTECTED_CLICK_CLASSES
+        ):
+            return
         if control is self or (
             control is not None
             and any(control.has_class(class_name) for class_name in self.NEGATIVE_SPACE_CLASSES)


### PR DESCRIPTION
## Summary

This PR addresses three pieces of beta-tester feedback for the console screen:

- **Negative-space click deselection**: clicking empty space in the console transcript now clears the selected message and hides the action row.
- **Agent turn-control hardening**: the local agent reply finalization now handles empty `final_text`, missing placeholders, cancelled/error/unknown statuses, and runtime-written assistant messages without dropping the turn or surfacing a control-module error.
- **Context viewer modal**: added a `Ctrl+Shift+P` keybinding and **Console: View chat context** command-palette entry that opens a two-tab modal showing the current transcript and the full next-send payload (model, messages, system prompt, staged sources, tools), with image data redacted and secrets scrubbed.

## Test Plan

- [ ] Run `pytest Tests/UI/test_console_native_transcript.py Tests/UI/test_console_context_modal.py Tests/UI/test_chat_screen_context_modal.py Tests/Chat/test_console_chat_controller.py Tests/Chat/test_console_agent_bridge.py -v` (204 tests pass in this branch).
- [ ] Launch the app, open the console, send a message, select it, then click empty space below the last message — the action row should disappear.
- [ ] Enable agent mode and ask "explain all tools available" — the response should complete without a control error.
- [ ] Press `Ctrl+Shift+P` (or run **Console: View chat context** from the command palette) — verify both tabs render and Refresh updates the draft estimate.

## Notes

- The context preview intentionally does not execute skills with side effects; skill commands are annotated as unresolved in the preview.
- Secret redaction is best-effort and not a security boundary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the console screen UX and reliability: click empty space to clear selection, hardened agent turn finalization, and a context viewer modal that shows a safe, redacted next-send preview with a live token estimate.

- New Features
  - Transcript UX: clicking empty space clears selection; clicking action buttons, rule separators, scrollbars, and the empty-state panel preserves it.
  - Context viewer modal (Ctrl+Shift+P or “Console: View chat context”): shows current transcript and the next-send payload (model, system, messages, staged sources, tools), with Raw JSON, Copy, Save to File, Refresh, and an in-progress warning. Token estimate uses `tiktoken`.
  - Safe preview: redacts `data:` image content across all messages (keeps HTTP(S) URLs and `image_url.detail`), scrubs secret-like keys (incl. hyphenated/camelCase), and does not execute skills; only annotates draft commands starting with “/”. Snapshot is independent of the store.
  - Tools: includes native tool schemas from the agent bridge with a preview note; mentions MCP presence when configured.

- Bug Fixes
  - Agent turn finalization: treats RUN_CANCELLED as failed, applies a fallback text when final_text is empty, and recovers if the placeholder is missing by completing or failing a runtime-written assistant message. Preserves partial content, restores state correctly, and avoids surfacing control errors.
  - Context snapshot robustness: on assembly errors, returns a degraded payload with an error note instead of failing the UI; Refresh re-reads the current draft, attachments, and staged sources.

<sup>Written for commit 7aa468de4d9fb91adbef38cd04157c425af56052. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

