### PR TITLE
Roleplay P2e — conversation-attach for Lore (Attachments tab)

### DIFF
--- a/Docs/superpowers/plans/2026-07-20-roleplay-p2e-conversation-attach.md
+++ b/Docs/superpowers/plans/2026-07-20-roleplay-p2e-conversation-attach.md
@@ -1,0 +1,747 @@
+# Roleplay P2e — Lore conversation-attach Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Roleplay-mode Attachments tab so a user can attach/detach a world book to/from a conversation (its entries then participate in that conversation's world-info injection).
+
+**Architecture:** A read-only reverse-query manager method + an I/O-free Attachments tab in the Lore detail widget + a generic conversation picker + screen handlers that call the existing `WorldBookManager` associate/disassociate methods off-thread. Mirrors the merged Dictionaries P1e. The junction and the legacy send-path application already exist.
+
+**Tech Stack:** Python ≥3.11, Textual (Modal/DataTable/TabPane), pytest + pytest-asyncio, SQLite (`CharactersRAGDB` / `WorldBookManager`).
+
+## Global Constraints
+
+- NO migration — the `conversation_world_books` junction already exists.
+- NO send-path change — `chat_events.py` already loads attached books into `WorldInfoProcessor`; attaching takes effect immediately on the legacy send.
+- `associate_world_book_with_conversation(conversation_id, world_book_id, priority=0)` is an `INSERT OR REPLACE` **upsert** — it never raises `ConflictError`; re-attach is a harmless no-op.
+- Conversation ids are **strings** (UUIDs) throughout — the `conversation_id: int` annotation on the manager methods is misleading; always pass `str(...)`.
+- The Lore detail widget stays **I/O-free**: `load_attachments(rows)` takes rows; no DB in the widget. All screen DB reads/writes run off-thread via `asyncio.to_thread`, wrapped → `self._notify` on failure, re-entrancy-guarded with `self._io_dialog_active` + `group="personas-io"`.
+- **Reuse** the existing generic `_list_attachable_conversations` (personas_screen); do NOT duplicate it. **Leave the merged `DictionaryAttachPicker` untouched.**
+- OUT of scope (→ P2g): Console "what's in play" world-book block, native-Console send application, retiring the legacy Chat-sidebar attach UI.
+- Implementers stage ONLY their task's files (`git add <paths>`; never `git add -A`; never `.superpowers/`).
+- **Test environment (from the worktree root; UI tests are slow ~60s — allow generous timeouts):**
+  ```bash
+  HOME=/private/tmp/tldw-chatbook-test-home \
+  XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest <targets> \
+  -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+  ```
+  The venv is in the MAIN checkout; `import tldw_chatbook` resolves to the worktree source (cwd on `sys.path`).
+
+## File Structure
+
+- **Modify** `tldw_chatbook/Character_Chat/world_book_manager.py` — add `get_conversations_for_world_book`.
+- **Create** `tldw_chatbook/Widgets/Persona_Widgets/conversation_attach_picker.py` — generic `ConversationAttachPicker`.
+- **Modify** `tldw_chatbook/Widgets/Persona_Widgets/personas_lore_detail.py` — Attachments tab + messages + `load_attachments`.
+- **Modify** `tldw_chatbook/UI/Screens/personas_screen.py` — refresh + attach + detach handlers.
+- Tests: `Tests/Character_Chat/test_world_book_manager.py`, `Tests/UI/test_personas_lore.py`.
+
+---
+
+### Task 1: Reverse query `get_conversations_for_world_book`
+
+**Files:**
+- Modify: `tldw_chatbook/Character_Chat/world_book_manager.py` (add a method after `get_world_books_for_conversation`)
+- Test: `Tests/Character_Chat/test_world_book_manager.py`
+
+**Interfaces:**
+- Consumes: existing `associate_world_book_with_conversation(conversation_id, world_book_id, priority=0)` (upsert).
+- Produces: `get_conversations_for_world_book(world_book_id: int) -> List[Dict[str, Any]]` returning `[{"conversation_id": str, "title": str}]`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `Tests/Character_Chat/test_world_book_manager.py`:
+```python
+def test_get_conversations_for_world_book_round_trips(wb_manager):
+    db = wb_manager.db
+    db.add_conversation({"id": "conv-1", "title": "First case"})
+    db.add_conversation({"id": "conv-2", "title": None})  # NULL title
+    book_id = wb_manager.create_world_book("B")
+    wb_manager.associate_world_book_with_conversation("conv-1", book_id)
+    wb_manager.associate_world_book_with_conversation("conv-2", book_id)
+    rows = wb_manager.get_conversations_for_world_book(book_id)
+    by_id = {r["conversation_id"]: r["title"] for r in rows}
+    assert by_id == {"conv-1": "First case", "conv-2": "(untitled)"}
+    assert all(isinstance(r["conversation_id"], str) for r in rows)
+
+
+def test_get_conversations_for_world_book_empty_when_unattached(wb_manager):
+    book_id = wb_manager.create_world_book("B")
+    assert wb_manager.get_conversations_for_world_book(book_id) == []
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run:
+```bash
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+Tests/Character_Chat/test_world_book_manager.py -k "get_conversations_for_world_book" \
+-q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: FAIL — `AttributeError: 'WorldBookManager' object has no attribute 'get_conversations_for_world_book'`.
+
+- [ ] **Step 3: Add the method**
+
+In `world_book_manager.py`, add right after `get_world_books_for_conversation`:
+```python
+    def get_conversations_for_world_book(
+        self, world_book_id: int
+    ) -> List[Dict[str, Any]]:
+        """Conversations this world book is attached to (reverse of
+        get_world_books_for_conversation).
+
+        Args:
+            world_book_id: The world book to find attachments for.
+
+        Returns:
+            ``[{"conversation_id": str, "title": str}]`` (NULL title → "(untitled)").
+        """
+        query = """
+        SELECT cwb.conversation_id, c.title
+        FROM conversation_world_books cwb
+        JOIN conversations c ON c.id = cwb.conversation_id
+        WHERE cwb.world_book_id = ? AND c.deleted = 0
+        ORDER BY c.last_modified DESC
+        """
+        with self.db.transaction() as cursor:
+            cursor.execute(query, (world_book_id,))
+            return [
+                {"conversation_id": str(row[0]), "title": row[1] or "(untitled)"}
+                for row in cursor.fetchall()
+            ]
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run the Step-2 command. Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Character_Chat/world_book_manager.py Tests/Character_Chat/test_world_book_manager.py
+git commit -m "feat(lore): WorldBookManager.get_conversations_for_world_book (reverse attach query)"
+```
+
+---
+
+### Task 2: Generic `ConversationAttachPicker`
+
+**Files:**
+- Create: `tldw_chatbook/Widgets/Persona_Widgets/conversation_attach_picker.py`
+- Test: `Tests/UI/test_conversation_attach_picker.py`
+
+**Interfaces:**
+- Produces: `ConversationAttachPicker(conversations: list[dict[str, Any]])` — a `ModalScreen[str | None]` that dismisses with the picked conversation id (str) or `None`. Ids kept as strings.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/UI/test_conversation_attach_picker.py`:
+```python
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Input, ListView
+
+from tldw_chatbook.Widgets.Persona_Widgets.conversation_attach_picker import (
+    ConversationAttachPicker,
+)
+
+
+class _PickerHost(App):
+    def __init__(self, convs):
+        super().__init__()
+        self._convs = convs
+        self.result = "unset"
+
+    def compose(self) -> ComposeResult:
+        yield from ()
+
+    async def on_mount(self) -> None:
+        self.result = await self.push_screen_wait(ConversationAttachPicker(self._convs))
+
+
+@pytest.mark.asyncio
+async def test_picker_select_returns_string_id():
+    convs = [{"conversation_id": "c1", "title": "Alpha"},
+             {"conversation_id": "c2", "title": "Beta"}]
+    app = _PickerHost(convs)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        app.query_one("#conversation-attach-list", ListView).index = 1
+        await pilot.pause()
+        await pilot.click("#conversation-attach-confirm")
+        await pilot.pause()
+    assert app.result == "c2"
+
+
+@pytest.mark.asyncio
+async def test_picker_filter_narrows_then_selects():
+    # After filtering to "beta", index 0 must be Beta (c2) — proving the filter
+    # rebuilt the row-id list. If the filter did nothing, index 0 would be c1.
+    convs = [{"conversation_id": "c1", "title": "Alpha"},
+             {"conversation_id": "c2", "title": "Beta"}]
+    app = _PickerHost(convs)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        app.query_one("#conversation-attach-search", Input).value = "beta"
+        await pilot.pause()
+        app.query_one("#conversation-attach-list", ListView).index = 0
+        await pilot.pause()
+        await pilot.click("#conversation-attach-confirm")
+        await pilot.pause()
+    assert app.result == "c2"
+
+
+@pytest.mark.asyncio
+async def test_picker_cancel_returns_none():
+    convs = [{"conversation_id": "c1", "title": "Alpha"}]
+    app = _PickerHost(convs)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        await pilot.click("#conversation-attach-cancel")
+        await pilot.pause()
+    assert app.result is None
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run:
+```bash
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+Tests/UI/test_conversation_attach_picker.py -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: FAIL — `ModuleNotFoundError: ...conversation_attach_picker`.
+
+- [ ] **Step 3: Create the picker**
+
+Create `tldw_chatbook/Widgets/Persona_Widgets/conversation_attach_picker.py` (generic clone of the merged `DictionaryAttachPicker`, generic name + ids):
+```python
+"""A small modal for picking a conversation (by string id) to attach the
+current entity to. Generic — used by the Roleplay Lore Attachments flow (P2e);
+the dictionary flow keeps its own DictionaryAttachPicker.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from textual import on
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Input, Label, ListItem, ListView, Static
+
+
+class ConversationAttachPicker(ModalScreen[str | None]):
+    """Pick one conversation (by string id) to attach the current entity to.
+
+    Args:
+        conversations: ``{"conversation_id": str, "title": str}`` rows to choose from.
+    """
+
+    DEFAULT_CSS = """
+    ConversationAttachPicker { align: center middle; }
+    ConversationAttachPicker > Vertical {
+        width: 60%; max-width: 80; height: auto; max-height: 80%;
+        padding: 1 2; border: round $panel;
+    }
+    ConversationAttachPicker #conversation-attach-list { height: auto; max-height: 16; }
+    """
+
+    def __init__(self, conversations: list[dict[str, Any]], **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._conversations = list(conversations)
+        self._row_ids: list[str] = []
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            yield Label("Attach to conversation", markup=False)
+            yield Input(placeholder="Search conversations…", id="conversation-attach-search")
+            yield ListView(id="conversation-attach-list")
+            with Vertical(id="conversation-attach-actions"):
+                yield Button("Attach", id="conversation-attach-confirm", classes="console-action-secondary")
+                yield Button("Cancel", id="conversation-attach-cancel", classes="console-action-secondary")
+
+    def on_mount(self) -> None:
+        self._populate(self._conversations)
+
+    def _populate(self, rows: list[dict[str, Any]]) -> None:
+        listing = self.query_one("#conversation-attach-list", ListView)
+        listing.clear()
+        self._row_ids = []
+        for row in rows:
+            item = ListItem(Static(str(row.get("title") or "(untitled)"), markup=False))
+            listing.append(item)
+            self._row_ids.append(str(row.get("conversation_id")))
+        # A filter change must require an explicit re-select.
+        listing.index = None
+
+    @on(Input.Changed, "#conversation-attach-search")
+    def _filter(self, event: Input.Changed) -> None:
+        event.stop()
+        needle = event.value.strip().lower()
+        rows = (
+            [c for c in self._conversations if needle in str(c.get("title") or "").lower()]
+            if needle
+            else self._conversations
+        )
+        self._populate(rows)
+
+    def _selected_id(self) -> str | None:
+        listing = self.query_one("#conversation-attach-list", ListView)
+        index = listing.index
+        if index is None or not 0 <= index < len(self._row_ids):
+            return None
+        return self._row_ids[index]
+
+    @on(Button.Pressed, "#conversation-attach-confirm")
+    def _confirm(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.dismiss(self._selected_id())
+
+    @on(Button.Pressed, "#conversation-attach-cancel")
+    def _cancel(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.dismiss(None)
+
+
+__all__ = ["ConversationAttachPicker"]
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run the Step-2 command. Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Widgets/Persona_Widgets/conversation_attach_picker.py Tests/UI/test_conversation_attach_picker.py
+git commit -m "feat(personas): generic ConversationAttachPicker modal"
+```
+
+---
+
+### Task 3: Lore Attachments tab (widget)
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/Persona_Widgets/personas_lore_detail.py` (messages after `:71`; Attachments TabPane after `:210`; `on_mount` `:213-221`; `clear` `:302`; `__all__` `:601`; new `load_attachments` + `_selected_attachment_id` + button handlers)
+- Test: `Tests/UI/test_personas_lore.py`
+
+**Interfaces:**
+- Consumes: nothing new (`Static`, `DataTable`, `Button`, `TabPane`, `Text`, `Message`, `on` already imported).
+- Produces: message classes `LoreAttachRequested` (bare) and `LoreDetachRequested(conversation_id: str)`; `load_attachments(rows: list[dict]) -> None`; ids `#personas-lore-tab-attachments`, `#personas-lore-attachments-empty`, `#personas-lore-attachments-table`, `#personas-lore-attach-add`, `#personas-lore-attach-detach`.
+
+- [ ] **Step 1: Write the failing tests**
+
+The `_DetailHost` harness in `Tests/UI/test_personas_lore.py` only captures `LoreEntryAddRequested` today. Add capture for the new messages: in `_DetailHost.__init__` add `self.attach_posts = []` and `self.detach_posts = []`, and add two handlers to the class:
+```python
+    def on_lore_attach_requested(self, message) -> None:
+        self.attach_posts.append(message)
+
+    def on_lore_detach_requested(self, message) -> None:
+        self.detach_posts.append(message.conversation_id)
+```
+Add the import to the test file's `personas_lore_detail` import block: `LoreAttachRequested, LoreDetachRequested`. Then append these tests:
+```python
+@pytest.mark.asyncio
+async def test_attachments_empty_state_and_render():
+    app = _DetailHost()
+    async with app.run_test(size=(140, 40)) as pilot:
+        widget = app.query_one(PersonasLoreDetailWidget)
+        widget.load_book({"id": 1, "name": "B", "description": "", "scan_depth": 3,
+                          "token_budget": 500, "recursive_scanning": False, "enabled": True})
+        widget.load_attachments([])
+        await pilot.pause()
+        empty = app.query_one("#personas-lore-attachments-empty", Static)
+        table = app.query_one("#personas-lore-attachments-table", DataTable)
+        assert empty.display is True and table.row_count == 0
+        widget.load_attachments([{"conversation_id": "c1", "title": "Noir case"}])
+        await pilot.pause()
+        assert empty.display is False and table.row_count == 1
+
+
+@pytest.mark.asyncio
+async def test_attach_button_posts_request():
+    app = _DetailHost()
+    async with app.run_test(size=(140, 40)) as pilot:
+        widget = app.query_one(PersonasLoreDetailWidget)
+        widget.load_book({"id": 1, "name": "B", "description": "", "scan_depth": 3,
+                          "token_budget": 500, "recursive_scanning": False, "enabled": True})
+        app.query_one("#personas-lore-tabs", TabbedContent).active = "personas-lore-tab-attachments"
+        await pilot.pause()
+        await pilot.click("#personas-lore-attach-add")
+        await pilot.pause()
+        assert len(app.attach_posts) == 1
+
+
+@pytest.mark.asyncio
+async def test_detach_button_posts_selected_conversation():
+    app = _DetailHost()
+    async with app.run_test(size=(140, 40)) as pilot:
+        widget = app.query_one(PersonasLoreDetailWidget)
+        widget.load_book({"id": 1, "name": "B", "description": "", "scan_depth": 3,
+                          "token_budget": 500, "recursive_scanning": False, "enabled": True})
+        widget.load_attachments([{"conversation_id": "c1", "title": "Noir case"}])
+        app.query_one("#personas-lore-tabs", TabbedContent).active = "personas-lore-tab-attachments"
+        await pilot.pause()
+        app.query_one("#personas-lore-attachments-table", DataTable).move_cursor(row=0)
+        await pilot.pause()
+        await pilot.click("#personas-lore-attach-detach")
+        await pilot.pause()
+        assert app.detach_posts == ["c1"]
+```
+Add `TabbedContent` to the test file's `from textual.widgets import ...` line (it is not currently imported there).
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run:
+```bash
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+Tests/UI/test_personas_lore.py -k "attachments or attach_button or detach_button" \
+-q -p no:cacheprovider -o addopts="" --timeout=120 --timeout-method=thread
+```
+Expected: FAIL — `ImportError` (`LoreAttachRequested` not defined) / `#personas-lore-attachments-empty` not found.
+
+- [ ] **Step 3: Add the message classes**
+
+In `personas_lore_detail.py`, after `LoreBookExportRequested` (`:71`):
+```python
+class LoreAttachRequested(Message):
+    """Intent: attach the selected world book to a conversation (opens a picker)."""
+
+
+class LoreDetachRequested(Message):
+    """Intent: detach the selected world book from a conversation."""
+
+    def __init__(self, conversation_id: str) -> None:
+        super().__init__()
+        self.conversation_id = conversation_id
+```
+
+- [ ] **Step 4: Add the Attachments TabPane**
+
+In `compose`, after the Settings TabPane's Export button block (`:210`) and before `yield Static("", id="personas-lore-status", markup=False)` (`:211`), at the TabPane indentation level:
+```python
+            with TabPane("Attachments", id="personas-lore-tab-attachments"):
+                yield Static(
+                    "Not attached to any conversation yet.",
+                    id="personas-lore-attachments-empty",
+                    markup=False,
+                )
+                yield DataTable(id="personas-lore-attachments-table", cursor_type="row")
+                with Horizontal(classes="personas-lore-form-row"):
+                    yield Button(
+                        "Attach to conversation…",
+                        id="personas-lore-attach-add",
+                        classes="console-action-secondary",
+                    )
+                    yield Button(
+                        "Detach",
+                        id="personas-lore-attach-detach",
+                        classes="console-action-secondary",
+                    )
+```
+
+- [ ] **Step 5: Register the table columns + clear on reset**
+
+In `on_mount` (`:219-220`), after the entries `add_columns`:
+```python
+        self.query_one("#personas-lore-attachments-table", DataTable).add_columns(
+            "conversation", "id"
+        )
+```
+In `clear` (`:302`), add a line resetting attachments (place it with the other clears):
+```python
+        self.load_attachments([])
+```
+
+- [ ] **Step 6: Add `load_attachments` + `_selected_attachment_id` + button handlers**
+
+Add these methods (place `load_attachments` near the other public render methods; the handlers near the other `@on(Button.Pressed, ...)` handlers):
+```python
+    def load_attachments(self, rows: list[dict]) -> None:
+        """Render the conversations this world book is attached to (I/O-free).
+
+        Args:
+            rows: ``{"conversation_id": str, "title": str}`` entries.
+        """
+        self._attachment_rows = list(rows)
+        table = self.query_one("#personas-lore-attachments-table", DataTable)
+        table.clear()
+        for row in self._attachment_rows:
+            table.add_row(
+                Text(str(row.get("title") or "(untitled)")),
+                Text(str(row.get("conversation_id") or "")),
+                key=str(row.get("conversation_id")),
+            )
+        empty = self.query_one("#personas-lore-attachments-empty", Static)
+        empty.display = not self._attachment_rows
+        table.display = bool(self._attachment_rows)
+
+    def _selected_attachment_id(self) -> str | None:
+        table = self.query_one("#personas-lore-attachments-table", DataTable)
+        if table.row_count == 0 or table.cursor_row is None or table.cursor_row < 0:
+            return None
+        try:
+            return str(table.coordinate_to_cell_key((table.cursor_row, 0)).row_key.value)
+        except Exception:
+            return None
+
+    @on(Button.Pressed, "#personas-lore-attach-add")
+    def _attach_add(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.post_message(LoreAttachRequested())
+
+    @on(Button.Pressed, "#personas-lore-attach-detach")
+    def _attach_detach(self, event: Button.Pressed) -> None:
+        event.stop()
+        conversation_id = self._selected_attachment_id()
+        if conversation_id is None:
+            self.set_status("Select an attached conversation first.")
+            return
+        self.post_message(LoreDetachRequested(conversation_id))
+```
+
+- [ ] **Step 7: Update `__all__`**
+
+In `__all__` (`:601`), add `"LoreAttachRequested",` and `"LoreDetachRequested",`.
+
+- [ ] **Step 8: Run to verify they pass + no regressions**
+
+Run the Step-2 command (PASS), then the whole file:
+```bash
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+Tests/UI/test_personas_lore.py -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: all pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add tldw_chatbook/Widgets/Persona_Widgets/personas_lore_detail.py Tests/UI/test_personas_lore.py
+git commit -m "feat(lore): Attachments tab in the Lore detail widget (I/O-free)"
+```
+
+---
+
+### Task 4: Screen handlers + real-DB integration
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/personas_screen.py` (import the messages + picker; add `_refresh_lore_attachments`; call it from `_select_lore_entry`; add attach/detach handlers)
+- Test: `Tests/UI/test_personas_lore.py`
+
+**Interfaces:**
+- Consumes: `get_conversations_for_world_book` (Task 1); `ConversationAttachPicker` (Task 2); `LoreAttachRequested`/`LoreDetachRequested` (Task 3); existing `_lore_manager()`, `_list_attachable_conversations`, `associate_world_book_with_conversation`, `disassociate_world_book_from_conversation`, `self.state.selected_entity_id`, `self._io_dialog_active`, `self._notify`.
+
+- [ ] **Step 1: Write the failing real-DB tests**
+
+Append to `Tests/UI/test_personas_lore.py` (uses `LorePersonasTestApp` + `lore_db` + `seeded_lore_book`):
+```python
+@pytest.mark.asyncio
+async def test_attach_via_picker_then_detach_real_db(
+    mock_app_instance, stub_characters_lore, lore_db, seeded_lore_book, monkeypatch
+):
+    from textual.widgets import TabbedContent
+    from tldw_chatbook.Widgets.Persona_Widgets.conversation_attach_picker import (
+        ConversationAttachPicker,
+    )
+    lore_db.add_conversation({"id": "conv-x", "title": "Noir case"})
+    mock_app_instance.chachanotes_db = lore_db
+    app = LorePersonasTestApp(mock_app_instance)
+    async with app.run_test(size=(200, 60)) as pilot:
+        screen = await _enter_lore(pilot)
+        await _select_first_lore(pilot, screen)
+        screen.query_one("#personas-lore-tabs", TabbedContent).active = "personas-lore-tab-attachments"
+        await pilot.pause()
+
+        async def _fake_push(screen_obj):
+            return "conv-x" if isinstance(screen_obj, ConversationAttachPicker) else None
+
+        monkeypatch.setattr(screen.app, "push_screen_wait", _fake_push, raising=False)
+        monkeypatch.setattr(
+            screen, "_list_attachable_conversations",
+            lambda: [{"conversation_id": "conv-x", "title": "Noir case"}],
+        )
+        screen.post_message(LoreAttachRequested())
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        manager = WorldBookManager(lore_db)
+        attached = manager.get_conversations_for_world_book(seeded_lore_book["book_id"])
+        assert [r["conversation_id"] for r in attached] == ["conv-x"]
+        table = screen.query_one("#personas-lore-attachments-table", DataTable)
+        assert table.row_count == 1
+        # detach
+        screen.post_message(LoreDetachRequested("conv-x"))
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        assert manager.get_conversations_for_world_book(seeded_lore_book["book_id"]) == []
+
+
+@pytest.mark.asyncio
+async def test_attached_book_reaches_send_path_query(
+    mock_app_instance, stub_characters_lore, lore_db, seeded_lore_book
+):
+    # Proves the (already-live) send path would inject an attached book:
+    # get_world_books_for_conversation returns it after attach.
+    lore_db.add_conversation({"id": "conv-y", "title": "Case Y"})
+    manager = WorldBookManager(lore_db)
+    manager.associate_world_book_with_conversation("conv-y", seeded_lore_book["book_id"])
+    books = manager.get_world_books_for_conversation("conv-y", enabled_only=False)
+    assert any(b["id"] == seeded_lore_book["book_id"] for b in books)
+```
+Add `LoreAttachRequested, LoreDetachRequested` to the test file's `personas_lore_detail` import (already added in Task 3).
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run:
+```bash
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+Tests/UI/test_personas_lore.py -k "attach_via_picker_then_detach or reaches_send_path" \
+-q -p no:cacheprovider -o addopts="" --timeout=120 --timeout-method=thread
+```
+Expected: FAIL — the attach test errors (no `@on(LoreAttachRequested)` handler → the message is unhandled, nothing persists). (`test_attached_book_reaches_send_path_query` may already PASS — it only uses the manager; that's fine, it's a live-path pin.)
+
+- [ ] **Step 3: Import the messages + picker in the screen**
+
+In `personas_screen.py`, add `LoreAttachRequested`, `LoreDetachRequested` to the existing `from ...Widgets.Persona_Widgets.personas_lore_detail import (...)` block, and add:
+```python
+from ...Widgets.Persona_Widgets.conversation_attach_picker import ConversationAttachPicker
+```
+
+- [ ] **Step 4: Add `_refresh_lore_attachments` + call it from `_select_lore_entry`**
+
+Add the refresh method near the other lore handlers:
+```python
+    async def _refresh_lore_attachments(self) -> None:
+        """Reload the Attachments tab for the selected lore book."""
+        entity_id = self.state.selected_entity_id
+        if self.state.selected_entity_kind != "lore" or not entity_id:
+            return
+        manager = self._lore_manager()
+        if manager is None:
+            return
+        try:
+            rows = await asyncio.to_thread(
+                manager.get_conversations_for_world_book, int(entity_id)
+            )
+        except Exception as exc:
+            logger.opt(exception=True).warning("Could not load lore attachments.")
+            self._notify(f"Could not load attachments: {exc}", "error")
+            return
+        try:
+            self.query_one(PersonasLoreDetailWidget).load_attachments(rows)
+        except QueryError:
+            pass
+```
+In `_select_lore_entry`, after the book + entries are loaded into the detail widget (mirroring where the dictionary path calls `_refresh_dictionary_attachments`), add:
+```python
+        await self._refresh_lore_attachments()
+```
+
+- [ ] **Step 5: Add the attach + detach handlers**
+
+Add near the other `@on(Lore...)` handlers:
+```python
+    @on(LoreAttachRequested)
+    async def _handle_lore_attach(self, message: LoreAttachRequested) -> None:
+        message.stop()
+        if self.state.selected_entity_kind != "lore" or not self.state.selected_entity_id:
+            return
+        if self._io_dialog_active:
+            return
+        self._io_dialog_active = True
+        self.run_worker(self._lore_attach_worker(), group="personas-io")
+
+    async def _lore_attach_worker(self) -> None:
+        try:
+            entity_id = self.state.selected_entity_id
+            manager = self._lore_manager()
+            if manager is None or not entity_id:
+                return
+            convs = await asyncio.to_thread(self._list_attachable_conversations)
+            try:
+                picked = await self.app.push_screen_wait(ConversationAttachPicker(convs))
+            except Exception:
+                logger.opt(exception=True).warning("Could not show the attach picker.")
+                return
+            if not picked:
+                return
+            try:
+                await asyncio.to_thread(
+                    manager.associate_world_book_with_conversation,
+                    str(picked),
+                    int(entity_id),
+                )
+            except Exception as exc:
+                logger.opt(exception=True).warning("Could not attach the world book.")
+                self._notify(f"Attach failed: {exc}", "error")
+                return
+            await self._refresh_lore_attachments()
+            self._notify("Attached to conversation.", "information")
+        finally:
+            self._io_dialog_active = False
+
+    @on(LoreDetachRequested)
+    async def _handle_lore_detach(self, message: LoreDetachRequested) -> None:
+        message.stop()
+        entity_id = self.state.selected_entity_id
+        if self.state.selected_entity_kind != "lore" or not entity_id:
+            return
+        manager = self._lore_manager()
+        if manager is None:
+            return
+        try:
+            await asyncio.to_thread(
+                manager.disassociate_world_book_from_conversation,
+                str(message.conversation_id),
+                int(entity_id),
+            )
+        except Exception as exc:
+            logger.opt(exception=True).warning("Could not detach the world book.")
+            self._notify(f"Detach failed: {exc}", "error")
+            return
+        await self._refresh_lore_attachments()
+        self._notify("Detached from conversation.", "information")
+```
+
+- [ ] **Step 6: Run to verify they pass + full file**
+
+Run the Step-2 command (PASS), then the whole file:
+```bash
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+Tests/UI/test_personas_lore.py -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: all pass.
+
+- [ ] **Step 7: Full gate + commit**
+
+```bash
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+Tests/Character_Chat/test_world_book_manager.py Tests/UI/test_conversation_attach_picker.py Tests/UI/test_personas_lore.py \
+-q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -c "import tldw_chatbook.app; print('APP IMPORT OK')"
+```
+Expected: all pass; `APP IMPORT OK`. Then:
+```bash
+git add tldw_chatbook/UI/Screens/personas_screen.py Tests/UI/test_personas_lore.py
+git commit -m "feat(lore): wire Attachments tab attach/detach to WorldBookManager"
+```
+
+---
+
+## Notes for the reviewer
+
+- **No migration, no send-path change:** the junction and `chat_events.py` application already exist. Any change to `chat_events.py` or a new migration is out of scope.
+- **Attach is an upsert:** `associate_world_book_with_conversation` never raises `ConflictError`; there must be no conflict-handling branch (re-attach just updates priority).
+- **String conversation ids:** every attach/detach/refresh path must pass `str(...)` conversation ids (the junction is `TEXT`).
+- **I/O-free widget:** `load_attachments` takes rows; the widget does no DB. All DB access is in the screen, off-thread.
+- **Reuse, don't duplicate:** the attach worker reuses `_list_attachable_conversations`; `DictionaryAttachPicker` is untouched.
+- The `test_attached_book_reaches_send_path_query` test pins that an attached book is returned by `get_world_books_for_conversation` — the query the live legacy send path already uses.

--- a/Docs/superpowers/specs/2026-07-20-roleplay-p2e-conversation-attach-design.md
+++ b/Docs/superpowers/specs/2026-07-20-roleplay-p2e-conversation-attach-design.md
@@ -1,0 +1,98 @@
+# Roleplay P2e — conversation-attach for Lore (Roleplay Attachments tab)
+
+**Status:** Design.
+
+**Program:** Roleplay (Personas) redesign — P2 (Lore mode), fifth sub-project. Mirrors the merged Dictionaries conversation-attach (P1e). Follows P2a/P2c/P2d-1/P2d-2/P2d-regex (all merged); schema v22.
+
+## Why
+
+A user can create, edit, import/export, and regex-match world books in the Roleplay Lore mode, but there is no Roleplay-mode way to **attach a world book to a conversation** so its entries participate in that conversation's world-info injection. The backend and the live send path already exist; only the Roleplay UI is missing.
+
+## What already exists (verified at dev tip)
+
+- **Junction + backend:** `conversation_world_books(conversation_id TEXT, world_book_id INTEGER, priority INTEGER DEFAULT 0, PK(conversation_id, world_book_id))`. `WorldBookManager.associate_world_book_with_conversation(conversation_id, world_book_id, priority=0)` (an `INSERT OR REPLACE` **upsert** — always returns True, never raises `ConflictError`), `disassociate_world_book_from_conversation(conversation_id, world_book_id)` (DELETE, returns rowcount>0), and `get_world_books_for_conversation(conversation_id, enabled_only=True)` (conversation→books, used on send).
+- **Live send application (legacy):** `chat_events.py` already calls `get_world_books_for_conversation(active_conversation_id)` and passes the result to `WorldInfoProcessor`, so an attached book takes effect immediately on the legacy send path.
+- **Legacy attach UI:** a "World Books" collapsible in the legacy Chat right sidebar (`chat_events_worldbooks.py`). This is the UI the redesign supersedes; its retirement is P2g.
+
+## Scope
+
+**In scope (mirrors dict P1e):** a Lore **Attachments** tab in `PersonasLoreDetailWidget`; a generic conversation picker; `personas_screen` attach/detach/refresh handlers wired to the existing manager methods; and one small backend method — the reverse query `get_conversations_for_world_book`.
+
+**Explicitly deferred → P2g:** the Console inspector "what's in play" world-book block and native-Console send-path application (Console never applies attached world books yet — only the legacy path does). Retiring the legacy Chat-sidebar attach UI → P2g. No migration (the junction exists).
+
+## Behavior-change framing
+
+Purely additive UI + one read-only backend query. No schema change, no send-path change (legacy already applies attached books), no change to existing lore flows. Only new: a Roleplay surface to attach/detach.
+
+## Ground truths (verified post-#707 reformat, v22)
+
+- `conversation_world_books.conversation_id` is `TEXT`; `conversations.id` is a UUID `TEXT` and `conversations.title` is nullable. `associate_world_book_with_conversation`'s `conversation_id: int` annotation is **misleading** — the runtime value is a string UUID (the P1e string-conv-id / int-book-id lesson). Pass conversation ids as **strings** everywhere.
+- **Dictionaries precedent to mirror:** `personas_dictionary_detail.py` has an Attachments `TabPane` (empty-state `Static`, a `#personas-dict-attachments-table` DataTable of conversation/id, `Attach to conversation…` + `Detach` buttons; an I/O-free `load_attachments(rows)`); message classes `DictionaryAttachRequested` / `DictionaryDetachRequested(conversation_id)`; `personas_screen` handlers `_refresh_dictionary_attachments` (on selection), `@on(DictionaryAttachRequested)` (lists conversations, shows a picker, attaches), `@on(DictionaryDetachRequested)`; the picker `dictionary_attach_picker.py::DictionaryAttachPicker(ModalScreen[str|None])` (takes `[{conversation_id, title}]`, returns the picked string id — fully generic apart from its name/CSS).
+- **Lore detail today:** `PersonasLoreDetailWidget` has exactly two tabs — `Entries` (`#personas-lore-tab-entries`) and `Settings` (`#personas-lore-tab-settings`); no Attachments tab, no attach messages. Lore CRUD in `personas_screen` uses `self._lore_manager()` (a `WorldBookManager`) directly, off-thread via `asyncio.to_thread` — NOT a scope service (unlike dicts).
+- Attachable-conversation source: `ChaChaNotes_DB.search_conversations_page` (used by the dict `_list_attachable_conversations`).
+
+## Architecture
+
+### 1. Backend — reverse query (`world_book_manager.py`)
+
+Add `get_conversations_for_world_book(world_book_id: int) -> List[Dict[str, Any]]`:
+```
+SELECT cwb.conversation_id, c.title
+FROM conversation_world_books cwb
+JOIN conversations c ON c.id = cwb.conversation_id
+WHERE cwb.world_book_id = ? AND c.deleted = 0
+ORDER BY c.last_modified DESC
+```
+Return `[{"conversation_id": str(row[0]), "title": row[1] or "(untitled)"}]` — conversation_id coerced to `str`, NULL title → `"(untitled)"` (matching the existing `_list_attachable_conversations` convention). (Mirrors the dict `list_dictionary_conversations`; no migration.) Verified: `conversations` has `deleted`, `last_modified`, and `title` columns.
+
+### 2. UI — Lore Attachments tab (`personas_lore_detail.py`)
+
+Add a third `TabPane("Attachments", id="personas-lore-tab-attachments")` to `#personas-lore-tabs`, mirroring the dict Attachments tab:
+- An empty-state `Static(id="personas-lore-attachments-empty")` ("Not attached to any conversation yet.").
+- A `DataTable(id="personas-lore-attachments-table")` with columns `conversation`, `id` (registered in `on_mount`).
+- Buttons `Attach to conversation…` (`#personas-lore-attach-add`) and `Detach` (`#personas-lore-attach-detach`).
+- **I/O-free:** `load_attachments(rows: list[dict])` renders `{conversation_id, title}` rows (title in the `conversation` cell, id in the `id` cell); shows the empty-state Static when no rows, the table otherwise.
+- New message classes: `LoreAttachRequested` (bare intent) and `LoreDetachRequested(conversation_id: str)`. The `#personas-lore-attach-add` handler posts `LoreAttachRequested()`; the `#personas-lore-attach-detach` handler reads the selected attachment row's conversation id (a `_selected_attachment_id` helper mirroring the dict) and posts `LoreDetachRequested(conversation_id)`. Add both to `__all__`.
+
+### 3. Conversation picker — new generic `ConversationAttachPicker` (`Widgets/Persona_Widgets/conversation_attach_picker.py`)
+
+A `ConversationAttachPicker(ModalScreen[str | None])` — a search-filterable conversation `ListView` that takes `conversations: list[{conversation_id: str, title: str}]` and returns the picked **string** conversation id (or `None` on cancel). Generic name + generic ids (no dict/lore-specific content), so it's reusable. The merged `DictionaryAttachPicker` is left untouched (dict may migrate to this later — out of scope).
+
+### 4. Screen handlers (`personas_screen.py`)
+
+Mirror the dict handlers, using `self._lore_manager()` (WorldBookManager) via `asyncio.to_thread`, guarded (never crash → `self._notify`):
+- `_refresh_lore_attachments()` — when a lore book is selected, `get_conversations_for_world_book(book_id)` off-thread → `detail.load_attachments(rows)`. Called from `_select_lore_entry` (the lore-selection hook, mirroring the dict's `_refresh_dictionary_attachments()` call in the dictionary-selection path).
+- `@on(LoreAttachRequested) _handle_lore_attach` — guard a selected lore book + `_io_dialog_active`; worker: list conversations by **reusing the existing `_list_attachable_conversations`** (it is generic — returns `[{conversation_id: str, title: str}]` from `search_conversations_page`, not dict-specific), show `ConversationAttachPicker` via `push_screen_wait` → if a conversation is picked, `associate_world_book_with_conversation(str(picked), book_id)` off-thread (no ConflictError — it's an upsert), then `_refresh_lore_attachments` + notify. Re-entrancy guarded (`group="personas-io"`).
+- `@on(LoreDetachRequested) _handle_lore_detach` — `disassociate_world_book_from_conversation(str(message.conversation_id), book_id)` off-thread → `_refresh_lore_attachments` + notify.
+
+### 5. Send path — no change
+
+`chat_events.py` already injects conversation-attached world books into `WorldInfoProcessor` on the legacy send, so an attached book takes effect immediately. Console "what's in play" + native-Console send application are P2g.
+
+## Error handling
+
+- Attach is idempotent (upsert) — no conflict path. Detach on a non-attached pair is a harmless no-op (rowcount 0).
+- All DB I/O off-thread, wrapped → `_notify` on failure; the widget is I/O-free. Re-entrancy guarded via `_io_dialog_active` / `group="personas-io"`. A missing/unsaved selected book → the handlers no-op gracefully.
+
+## Testing
+
+- **Backend:** `get_conversations_for_world_book` round-trip — associate a book to two conversations, assert both returned with titles (and a NULL-title conversation → "Untitled"); a book attached to none → `[]`.
+- **Widget (I/O-free):** `load_attachments([])` shows the empty-state and hides the table; `load_attachments([{conversation_id, title}])` renders the row; the Attach button posts `LoreAttachRequested`; selecting a row + Detach posts `LoreDetachRequested` with the row's conversation id.
+- **Screen (real-DB, `LorePersonasTestApp` + `lore_db`):** posting `LoreAttachRequested` with the picker monkeypatched to return a conversation id persists the association (junction row present) and the Attachments table shows it; `LoreDetachRequested` removes it; `_refresh_lore_attachments` reflects the current state.
+- **Integration:** an attached book appears in `get_world_books_for_conversation(conv_id)` — proving the (already-live) send path would inject it.
+- **Picker:** `ConversationAttachPicker` filters by search and returns the picked string id / `None` on cancel.
+- Full gate: `test_world_book_manager`, `test_personas_lore`, plus `import tldw_chatbook.app`.
+
+## Decomposition
+
+Single small plan (mirrors dict P1e). No migration. Console side (what's-in-play + native-send) and legacy-UI retirement → P2g.
+
+## Acceptance criteria
+
+- [ ] `get_conversations_for_world_book(id)` returns each attached conversation's `{conversation_id (str), title (NULL→"Untitled")}`; `[]` when none.
+- [ ] The Lore detail widget has an Attachments tab (empty-state + table + Attach/Detach) that is I/O-free and posts `LoreAttachRequested`/`LoreDetachRequested`.
+- [ ] A generic `ConversationAttachPicker` returns the picked string conversation id; the merged dict picker is untouched.
+- [ ] Attaching the selected book to a picked conversation persists to `conversation_world_books` (idempotent upsert, no ConflictError); detaching removes it; the Attachments table refreshes to reflect state.
+- [ ] Conversation ids are handled as strings throughout; no crash on missing selection or empty conversation list.
+- [ ] No schema change; no send-path change (legacy already applies); Console what's-in-play + native-send deferred to P2g.
+- [ ] Full gate green; `import tldw_chatbook.app` OK.

--- a/Tests/Character_Chat/test_world_book_manager.py
+++ b/Tests/Character_Chat/test_world_book_manager.py
@@ -581,3 +581,21 @@ def test_export_import_preserves_regex(wb_manager):
     assert data["entries"][0]["regex"] is True
     new_id = wb_manager.import_world_book(data, name_override="B copy")
     assert wb_manager.get_world_book_entries(new_id)[0]["regex"] is True
+
+
+def test_get_conversations_for_world_book_round_trips(wb_manager):
+    db = wb_manager.db
+    db.add_conversation({"id": "conv-1", "title": "First case"})
+    db.add_conversation({"id": "conv-2", "title": None})  # NULL title
+    book_id = wb_manager.create_world_book("B")
+    wb_manager.associate_world_book_with_conversation("conv-1", book_id)
+    wb_manager.associate_world_book_with_conversation("conv-2", book_id)
+    rows = wb_manager.get_conversations_for_world_book(book_id)
+    by_id = {r["conversation_id"]: r["title"] for r in rows}
+    assert by_id == {"conv-1": "First case", "conv-2": "(untitled)"}
+    assert all(isinstance(r["conversation_id"], str) for r in rows)
+
+
+def test_get_conversations_for_world_book_empty_when_unattached(wb_manager):
+    book_id = wb_manager.create_world_book("B")
+    assert wb_manager.get_conversations_for_world_book(book_id) == []

--- a/Tests/UI/test_conversation_attach_picker.py
+++ b/Tests/UI/test_conversation_attach_picker.py
@@ -1,0 +1,69 @@
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Input, ListView
+
+from tldw_chatbook.Widgets.Persona_Widgets.conversation_attach_picker import (
+    ConversationAttachPicker,
+)
+
+
+class _PickerHost(App):
+    def __init__(self, convs):
+        super().__init__()
+        self._convs = convs
+        self.result = "unset"
+
+    def compose(self) -> ComposeResult:
+        yield from ()
+
+    def on_mount(self) -> None:
+        # push_screen_wait requires an active worker (NoActiveWorker otherwise);
+        # mirrors the pattern used by the merged sibling test
+        # (Tests/UI/test_dictionary_attach_picker.py).
+        self.run_worker(self._drive)
+
+    async def _drive(self) -> None:
+        self.result = await self.push_screen_wait(ConversationAttachPicker(self._convs))
+
+
+@pytest.mark.asyncio
+async def test_picker_select_returns_string_id():
+    convs = [{"conversation_id": "c1", "title": "Alpha"},
+             {"conversation_id": "c2", "title": "Beta"}]
+    app = _PickerHost(convs)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        app.screen.query_one("#conversation-attach-list", ListView).index = 1
+        await pilot.pause()
+        await pilot.click("#conversation-attach-confirm")
+        await pilot.pause()
+    assert app.result == "c2"
+
+
+@pytest.mark.asyncio
+async def test_picker_filter_narrows_then_selects():
+    # After filtering to "beta", index 0 must be Beta (c2) — proving the filter
+    # rebuilt the row-id list. If the filter did nothing, index 0 would be c1.
+    convs = [{"conversation_id": "c1", "title": "Alpha"},
+             {"conversation_id": "c2", "title": "Beta"}]
+    app = _PickerHost(convs)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        app.screen.query_one("#conversation-attach-search", Input).value = "beta"
+        await pilot.pause()
+        app.screen.query_one("#conversation-attach-list", ListView).index = 0
+        await pilot.pause()
+        await pilot.click("#conversation-attach-confirm")
+        await pilot.pause()
+    assert app.result == "c2"
+
+
+@pytest.mark.asyncio
+async def test_picker_cancel_returns_none():
+    convs = [{"conversation_id": "c1", "title": "Alpha"}]
+    app = _PickerHost(convs)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        await pilot.click("#conversation-attach-cancel")
+        await pilot.pause()
+    assert app.result is None

--- a/Tests/UI/test_personas_lore.py
+++ b/Tests/UI/test_personas_lore.py
@@ -1462,3 +1462,63 @@ async def test_attached_book_reaches_send_path_query(
     manager.associate_world_book_with_conversation("conv-y", seeded_lore_book["book_id"])
     books = manager.get_world_books_for_conversation("conv-y", enabled_only=False)
     assert any(b["id"] == seeded_lore_book["book_id"] for b in books)
+
+
+@pytest.mark.asyncio
+async def test_refresh_clears_stale_rows_on_query_failure(
+    mock_app_instance, stub_characters_lore, lore_db, seeded_lore_book, monkeypatch
+):
+    # On a refresh DB failure, the Attachments tab must not keep showing the
+    # previously-rendered rows (which would misrepresent what is attached).
+    mock_app_instance.chachanotes_db = lore_db
+    app = LorePersonasTestApp(mock_app_instance)
+    async with app.run_test(size=(200, 60)) as pilot:
+        screen = await _enter_lore(pilot)
+        await _select_first_lore(pilot, screen)
+        widget = screen.query_one(PersonasLoreDetailWidget)
+        widget.load_attachments([{"conversation_id": "conv-x", "title": "Noir case"}])
+        await pilot.pause()
+        table = screen.query_one("#personas-lore-attachments-table", DataTable)
+        assert table.row_count == 1
+
+        def _boom(self, _wb_id):
+            raise RuntimeError("db unavailable")
+
+        monkeypatch.setattr(
+            WorldBookManager, "get_conversations_for_world_book", _boom
+        )
+        await screen._refresh_lore_attachments()
+        await pilot.pause()
+        assert table.row_count == 0
+        empty = screen.query_one("#personas-lore-attachments-empty", Static)
+        assert empty.display is True
+
+
+@pytest.mark.asyncio
+async def test_refresh_skips_write_when_selection_changed_mid_query(
+    mock_app_instance, stub_characters_lore, lore_db, seeded_lore_book, monkeypatch
+):
+    # If the user switches books while the attachment query is in flight, the
+    # slower (stale) result must not overwrite the newly-selected book's table.
+    mock_app_instance.chachanotes_db = lore_db
+    app = LorePersonasTestApp(mock_app_instance)
+    async with app.run_test(size=(200, 60)) as pilot:
+        screen = await _enter_lore(pilot)
+        await _select_first_lore(pilot, screen)
+        widget = screen.query_one(PersonasLoreDetailWidget)
+        widget.load_attachments([])
+        await pilot.pause()
+        table = screen.query_one("#personas-lore-attachments-table", DataTable)
+
+        def _switch_then_return(self, _wb_id):
+            # Simulate the user selecting a different book mid-query.
+            screen.state.selected_entity_id = "999999"
+            return [{"conversation_id": "conv-stale", "title": "Stale"}]
+
+        monkeypatch.setattr(
+            WorldBookManager, "get_conversations_for_world_book", _switch_then_return
+        )
+        await screen._refresh_lore_attachments()
+        await pilot.pause()
+        # The stale book's rows must not have landed on the current table.
+        assert table.row_count == 0

--- a/Tests/UI/test_personas_lore.py
+++ b/Tests/UI/test_personas_lore.py
@@ -7,13 +7,24 @@ test_personas_dictionaries.py's PersonasTestApp harness)."""
 import pytest
 from textual.app import App, ComposeResult
 from textual.coordinate import Coordinate
-from textual.widgets import Button, DataTable, Input, ListView, Static, Switch, TextArea
+from textual.widgets import (
+    Button,
+    DataTable,
+    Input,
+    ListView,
+    Static,
+    Switch,
+    TabbedContent,
+    TextArea,
+)
 
 from tldw_chatbook.Widgets.Persona_Widgets.personas_lore_detail import (
     PersonasLoreDetailWidget,
+    LoreAttachRequested,
     LoreBookEnableToggled,
     LoreBookExportRequested,
     LoreBookSettingsSaveRequested,
+    LoreDetachRequested,
     LoreEntryAddRequested,
 )
 from tldw_chatbook.Widgets.Persona_Widgets.personas_lore_tryit import (
@@ -25,12 +36,20 @@ class _DetailHost(App):
     def __init__(self):
         super().__init__()
         self.posted = []
+        self.attach_posts = []
+        self.detach_posts = []
 
     def compose(self) -> ComposeResult:
         yield PersonasLoreDetailWidget(id="personas-lore-detail")
 
     def on_lore_entry_add_requested(self, message: LoreEntryAddRequested) -> None:
         self.posted.append(message.payload)
+
+    def on_lore_attach_requested(self, message) -> None:
+        self.attach_posts.append(message)
+
+    def on_lore_detach_requested(self, message) -> None:
+        self.detach_posts.append(message.conversation_id)
 
 
 @pytest.mark.asyncio
@@ -402,6 +421,54 @@ async def test_secondary_keys_disabled_hint_tracks_selective():
         await pilot.pause()
         assert sec.disabled is True  # selective off → disabled again
         assert sec.value == "kept"  # value survives the toggle (fidelity)
+
+
+@pytest.mark.asyncio
+async def test_attachments_empty_state_and_render():
+    app = _DetailHost()
+    async with app.run_test(size=(140, 40)) as pilot:
+        widget = app.query_one(PersonasLoreDetailWidget)
+        widget.load_book({"id": 1, "name": "B", "description": "", "scan_depth": 3,
+                          "token_budget": 500, "recursive_scanning": False, "enabled": True})
+        widget.load_attachments([])
+        await pilot.pause()
+        empty = app.query_one("#personas-lore-attachments-empty", Static)
+        table = app.query_one("#personas-lore-attachments-table", DataTable)
+        assert empty.display is True and table.row_count == 0
+        widget.load_attachments([{"conversation_id": "c1", "title": "Noir case"}])
+        await pilot.pause()
+        assert empty.display is False and table.row_count == 1
+
+
+@pytest.mark.asyncio
+async def test_attach_button_posts_request():
+    app = _DetailHost()
+    async with app.run_test(size=(140, 40)) as pilot:
+        widget = app.query_one(PersonasLoreDetailWidget)
+        widget.load_book({"id": 1, "name": "B", "description": "", "scan_depth": 3,
+                          "token_budget": 500, "recursive_scanning": False, "enabled": True})
+        app.query_one("#personas-lore-tabs", TabbedContent).active = "personas-lore-tab-attachments"
+        await pilot.pause()
+        await pilot.click("#personas-lore-attach-add")
+        await pilot.pause()
+        assert len(app.attach_posts) == 1
+
+
+@pytest.mark.asyncio
+async def test_detach_button_posts_selected_conversation():
+    app = _DetailHost()
+    async with app.run_test(size=(140, 40)) as pilot:
+        widget = app.query_one(PersonasLoreDetailWidget)
+        widget.load_book({"id": 1, "name": "B", "description": "", "scan_depth": 3,
+                          "token_budget": 500, "recursive_scanning": False, "enabled": True})
+        widget.load_attachments([{"conversation_id": "c1", "title": "Noir case"}])
+        app.query_one("#personas-lore-tabs", TabbedContent).active = "personas-lore-tab-attachments"
+        await pilot.pause()
+        app.query_one("#personas-lore-attachments-table", DataTable).move_cursor(row=0)
+        await pilot.pause()
+        await pilot.click("#personas-lore-attach-detach")
+        await pilot.pause()
+        assert app.detach_posts == ["c1"]
 
 
 class _TryItHost(App):

--- a/Tests/UI/test_personas_lore.py
+++ b/Tests/UI/test_personas_lore.py
@@ -1344,3 +1344,66 @@ async def test_export_then_import_round_trip_preserves_entries(
         and e["secondary_keys"] == ["oath"]
         and e["case_sensitive"] is True
     )
+
+
+# ===================================================================
+# Task 4: Attachments tab wired to WorldBookManager (real DB)
+# ===================================================================
+
+
+@pytest.mark.asyncio
+async def test_attach_via_picker_then_detach_real_db(
+    mock_app_instance, stub_characters_lore, lore_db, seeded_lore_book, monkeypatch
+):
+    from tldw_chatbook.Widgets.Persona_Widgets.conversation_attach_picker import (
+        ConversationAttachPicker,
+    )
+
+    lore_db.add_conversation({"id": "conv-x", "title": "Noir case"})
+    mock_app_instance.chachanotes_db = lore_db
+    app = LorePersonasTestApp(mock_app_instance)
+    async with app.run_test(size=(200, 60)) as pilot:
+        screen = await _enter_lore(pilot)
+        await _select_first_lore(pilot, screen)
+        screen.query_one("#personas-lore-tabs", TabbedContent).active = (
+            "personas-lore-tab-attachments"
+        )
+        await pilot.pause()
+
+        async def _fake_push(screen_obj):
+            return "conv-x" if isinstance(screen_obj, ConversationAttachPicker) else None
+
+        monkeypatch.setattr(screen.app, "push_screen_wait", _fake_push, raising=False)
+        monkeypatch.setattr(
+            screen,
+            "_list_attachable_conversations",
+            lambda: [{"conversation_id": "conv-x", "title": "Noir case"}],
+        )
+        screen.post_message(LoreAttachRequested())
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        manager = WorldBookManager(lore_db)
+        attached = manager.get_conversations_for_world_book(seeded_lore_book["book_id"])
+        assert [r["conversation_id"] for r in attached] == ["conv-x"]
+        table = screen.query_one("#personas-lore-attachments-table", DataTable)
+        assert table.row_count == 1
+        # detach
+        screen.post_message(LoreDetachRequested("conv-x"))
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        assert manager.get_conversations_for_world_book(seeded_lore_book["book_id"]) == []
+
+
+@pytest.mark.asyncio
+async def test_attached_book_reaches_send_path_query(
+    mock_app_instance, stub_characters_lore, lore_db, seeded_lore_book
+):
+    # Proves the (already-live) send path would inject an attached book:
+    # get_world_books_for_conversation returns it after attach.
+    lore_db.add_conversation({"id": "conv-y", "title": "Case Y"})
+    manager = WorldBookManager(lore_db)
+    manager.associate_world_book_with_conversation("conv-y", seeded_lore_book["book_id"])
+    books = manager.get_world_books_for_conversation("conv-y", enabled_only=False)
+    assert any(b["id"] == seeded_lore_book["book_id"] for b in books)

--- a/Tests/UI/test_personas_lore.py
+++ b/Tests/UI/test_personas_lore.py
@@ -471,6 +471,26 @@ async def test_detach_button_posts_selected_conversation():
         assert app.detach_posts == ["c1"]
 
 
+@pytest.mark.asyncio
+async def test_detach_with_no_selection_does_not_post():
+    """Clicking Detach with no attachment row selected must not post
+    LoreDetachRequested (which would raise on a None conversation id downstream)
+    — it should short-circuit with a status message instead."""
+    app = _DetailHost()
+    async with app.run_test(size=(140, 40)) as pilot:
+        widget = app.query_one(PersonasLoreDetailWidget)
+        widget.load_book({"id": 1, "name": "B", "description": "", "scan_depth": 3,
+                          "token_budget": 500, "recursive_scanning": False, "enabled": True})
+        widget.load_attachments([])  # no rows → nothing selectable
+        app.query_one("#personas-lore-tabs", TabbedContent).active = "personas-lore-tab-attachments"
+        await pilot.pause()
+        await pilot.click("#personas-lore-attach-detach")
+        await pilot.pause()
+        assert app.detach_posts == []
+        status = str(app.query_one("#personas-lore-status", Static).renderable)
+        assert "Select an attached conversation first." in status
+
+
 class _TryItHost(App):
     def compose(self) -> ComposeResult:
         yield PersonasLoreTryItWidget(id="personas-lore-tryit")
@@ -1394,6 +1414,41 @@ async def test_attach_via_picker_then_detach_real_db(
         await pilot.app.workers.wait_for_complete()
         await pilot.pause()
         assert manager.get_conversations_for_world_book(seeded_lore_book["book_id"]) == []
+
+
+@pytest.mark.asyncio
+async def test_attach_survives_list_conversations_failure(
+    mock_app_instance, stub_characters_lore, lore_db, seeded_lore_book, monkeypatch
+):
+    """A real DB error inside _list_attachable_conversations (e.g.
+    search_conversations_page raising) must be caught inside the attach
+    worker -- the app keeps running and no association is created. Regression
+    for the final-review Important finding: the worker runs via
+    run_worker(..., group="personas-io") with the default exit_on_error=True,
+    so an unguarded raise there would tear down the whole app."""
+    mock_app_instance.chachanotes_db = lore_db
+    app = LorePersonasTestApp(mock_app_instance)
+    async with app.run_test(size=(200, 60)) as pilot:
+        screen = await _enter_lore(pilot)
+        await _select_first_lore(pilot, screen)
+        screen.query_one("#personas-lore-tabs", TabbedContent).active = (
+            "personas-lore-tab-attachments"
+        )
+        await pilot.pause()
+
+        def _boom():
+            raise RuntimeError("db unavailable")
+
+        monkeypatch.setattr(screen, "_list_attachable_conversations", _boom)
+        screen.post_message(LoreAttachRequested())
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        assert pilot.app.is_running, "a conversation-list failure must not crash the app"
+        manager = WorldBookManager(lore_db)
+        assert (
+            manager.get_conversations_for_world_book(seeded_lore_book["book_id"]) == []
+        )
 
 
 @pytest.mark.asyncio

--- a/tldw_chatbook/Character_Chat/world_book_manager.py
+++ b/tldw_chatbook/Character_Chat/world_book_manager.py
@@ -659,6 +659,32 @@ class WorldBookManager:
 
             return world_books
 
+    def get_conversations_for_world_book(
+        self, world_book_id: int
+    ) -> List[Dict[str, Any]]:
+        """Conversations this world book is attached to (reverse of
+        get_world_books_for_conversation).
+
+        Args:
+            world_book_id: The world book to find attachments for.
+
+        Returns:
+            ``[{"conversation_id": str, "title": str}]`` (NULL title → "(untitled)").
+        """
+        query = """
+        SELECT cwb.conversation_id, c.title
+        FROM conversation_world_books cwb
+        JOIN conversations c ON c.id = cwb.conversation_id
+        WHERE cwb.world_book_id = ? AND c.deleted = 0
+        ORDER BY c.last_modified DESC
+        """
+        with self.db.transaction() as cursor:
+            cursor.execute(query, (world_book_id,))
+            return [
+                {"conversation_id": str(row[0]), "title": row[1] or "(untitled)"}
+                for row in cursor.fetchall()
+            ]
+
     # --- Import/Export Functions ---
 
     def export_world_book(self, world_book_id: int) -> Dict[str, Any]:

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -95,10 +95,15 @@ from ...Widgets.Persona_Widgets.personas_dictionary_tryit import (
     DictionaryTryItRunRequested,
     PersonasDictionaryTryItWidget,
 )
+from ...Widgets.Persona_Widgets.conversation_attach_picker import (
+    ConversationAttachPicker,
+)
 from ...Widgets.Persona_Widgets.personas_lore_detail import (
+    LoreAttachRequested,
     LoreBookEnableToggled,
     LoreBookExportRequested,
     LoreBookSettingsSaveRequested,
+    LoreDetachRequested,
     LoreEntriesReorderRequested,
     LoreEntryAddRequested,
     LoreEntryDeleteRequested,
@@ -1465,6 +1470,28 @@ class PersonasScreen(BaseAppScreen):
         self._sync_inspector_console_actions()
         self._update_title()
         self._update_status_row()
+        await self._refresh_lore_attachments()
+
+    async def _refresh_lore_attachments(self) -> None:
+        """Reload the Attachments tab for the selected lore book."""
+        entity_id = self.state.selected_entity_id
+        if self.state.selected_entity_kind != "lore" or not entity_id:
+            return
+        manager = self._lore_manager()
+        if manager is None:
+            return
+        try:
+            rows = await asyncio.to_thread(
+                manager.get_conversations_for_world_book, int(entity_id)
+            )
+        except Exception as exc:
+            logger.opt(exception=True).warning("Could not load lore attachments.")
+            self._notify(f"Could not load attachments: {exc}", "error")
+            return
+        try:
+            self.query_one(PersonasLoreDetailWidget).load_attachments(rows)
+        except QueryError:
+            pass
 
     async def _refresh_dictionary_statistics(self, record: dict) -> None:
         """Re-feed the Stats tab for the given loaded record (best-effort).
@@ -2572,6 +2599,76 @@ class PersonasScreen(BaseAppScreen):
             self._selected_lore_book["enabled"] = bool(message.enabled)
         await self._render_lore_rows(query=self.state.search_query)
         self.query_one(PersonasLibraryPane).mark_active_row("lore", entity_id)
+
+    @on(LoreAttachRequested)
+    async def _handle_lore_attach(self, message: LoreAttachRequested) -> None:
+        message.stop()
+        if (
+            self.state.selected_entity_kind != "lore"
+            or not self.state.selected_entity_id
+        ):
+            return
+        if self._io_dialog_active:
+            return
+        self._io_dialog_active = True
+        self.run_worker(self._lore_attach_worker(), group="personas-io")
+
+    async def _lore_attach_worker(self) -> None:
+        try:
+            entity_id = self.state.selected_entity_id
+            manager = self._lore_manager()
+            if manager is None or not entity_id:
+                return
+            convs = await asyncio.to_thread(self._list_attachable_conversations)
+            try:
+                picked = await self.app.push_screen_wait(
+                    ConversationAttachPicker(convs)
+                )
+            except Exception:
+                logger.opt(exception=True).warning(
+                    "Could not show the attach picker."
+                )
+                return
+            if not picked:
+                return
+            try:
+                await asyncio.to_thread(
+                    manager.associate_world_book_with_conversation,
+                    str(picked),
+                    int(entity_id),
+                )
+            except Exception as exc:
+                logger.opt(exception=True).warning(
+                    "Could not attach the world book."
+                )
+                self._notify(f"Attach failed: {exc}", "error")
+                return
+            await self._refresh_lore_attachments()
+            self._notify("Attached to conversation.", "information")
+        finally:
+            self._io_dialog_active = False
+
+    @on(LoreDetachRequested)
+    async def _handle_lore_detach(self, message: LoreDetachRequested) -> None:
+        message.stop()
+        entity_id = self.state.selected_entity_id
+        if self.state.selected_entity_kind != "lore" or not entity_id:
+            return
+        manager = self._lore_manager()
+        if manager is None:
+            return
+        try:
+            await asyncio.to_thread(
+                manager.disassociate_world_book_from_conversation,
+                str(message.conversation_id),
+                int(entity_id),
+            )
+        except Exception as exc:
+            logger.opt(exception=True).warning("Could not detach the world book.")
+            self._notify(f"Detach failed: {exc}", "error")
+            return
+        await self._refresh_lore_attachments()
+        self._notify("Detached from conversation.", "information")
 
     @on(LoreTryItRunRequested)
     async def _handle_lore_tryit_run(self, message: LoreTryItRunRequested) -> None:

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -2619,7 +2619,14 @@ class PersonasScreen(BaseAppScreen):
             manager = self._lore_manager()
             if manager is None or not entity_id:
                 return
-            convs = await asyncio.to_thread(self._list_attachable_conversations)
+            try:
+                convs = await asyncio.to_thread(self._list_attachable_conversations)
+            except Exception as exc:
+                logger.opt(exception=True).warning(
+                    "Could not list conversations for attach."
+                )
+                self._notify(f"Attach failed: {exc}", "error")
+                return
             try:
                 picked = await self.app.push_screen_wait(
                     ConversationAttachPicker(convs)

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -1487,6 +1487,13 @@ class PersonasScreen(BaseAppScreen):
         except Exception as exc:
             logger.opt(exception=True).warning("Could not load lore attachments.")
             self._notify(f"Could not load attachments: {exc}", "error")
+            rows = []  # clear stale rows on failure rather than leave a lying table
+        # Guard against a stale write: if the user switched books while the query
+        # was in flight, a newer refresh now owns the table — don't clobber it.
+        if (
+            self.state.selected_entity_id != entity_id
+            or self.state.selected_entity_kind != "lore"
+        ):
             return
         try:
             self.query_one(PersonasLoreDetailWidget).load_attachments(rows)

--- a/tldw_chatbook/Widgets/Persona_Widgets/conversation_attach_picker.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/conversation_attach_picker.py
@@ -1,0 +1,104 @@
+"""A small modal for picking a conversation (by string id) to attach the
+current entity to. Generic — used by the Roleplay Lore Attachments flow (P2e);
+the dictionary flow keeps its own DictionaryAttachPicker.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from textual import on
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Input, Label, ListItem, ListView, Static
+
+
+class ConversationAttachPicker(ModalScreen[str | None]):
+    """Pick one conversation (by string id) to attach the current entity to.
+
+    Args:
+        conversations: ``{"conversation_id": str, "title": str}`` rows to choose from.
+    """
+
+    DEFAULT_CSS = """
+    ConversationAttachPicker { align: center middle; }
+    ConversationAttachPicker > Vertical {
+        width: 60%; max-width: 80; height: auto; max-height: 80%;
+        padding: 1 2; border: round $panel;
+    }
+    ConversationAttachPicker #conversation-attach-list { height: auto; max-height: 16; }
+    """
+
+    def __init__(self, conversations: list[dict[str, Any]], **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._conversations = list(conversations)
+        self._row_ids: list[str] = []
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            yield Label("Attach to conversation", markup=False)
+            yield Input(placeholder="Search conversations…", id="conversation-attach-search")
+            yield ListView(id="conversation-attach-list")
+            with Vertical(id="conversation-attach-actions"):
+                yield Button(
+                    "Attach",
+                    id="conversation-attach-confirm",
+                    classes="console-action-secondary",
+                )
+                yield Button(
+                    "Cancel",
+                    id="conversation-attach-cancel",
+                    classes="console-action-secondary",
+                )
+
+    def on_mount(self) -> None:
+        self._populate(self._conversations)
+
+    def _populate(self, rows: list[dict[str, Any]]) -> None:
+        listing = self.query_one("#conversation-attach-list", ListView)
+        listing.clear()
+        self._row_ids = []
+        for row in rows:
+            item = ListItem(Static(str(row.get("title") or "(untitled)"), markup=False))
+            listing.append(item)
+            self._row_ids.append(str(row.get("conversation_id")))
+        # A filter change must require an explicit re-select: don't let a
+        # previously-highlighted index silently carry over onto a rebuilt,
+        # differently-ordered row set.
+        listing.index = None
+
+    @on(Input.Changed, "#conversation-attach-search")
+    def _filter(self, event: Input.Changed) -> None:
+        event.stop()
+        needle = event.value.strip().lower()
+        rows = (
+            [
+                c
+                for c in self._conversations
+                if needle in str(c.get("title") or "").lower()
+            ]
+            if needle
+            else self._conversations
+        )
+        self._populate(rows)
+
+    def _selected_id(self) -> str | None:
+        listing = self.query_one("#conversation-attach-list", ListView)
+        index = listing.index
+        if index is None or not 0 <= index < len(self._row_ids):
+            return None
+        return self._row_ids[index]
+
+    @on(Button.Pressed, "#conversation-attach-confirm")
+    def _confirm(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.dismiss(self._selected_id())
+
+    @on(Button.Pressed, "#conversation-attach-cancel")
+    def _cancel(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.dismiss(None)
+
+
+__all__ = ["ConversationAttachPicker"]

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_lore_detail.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_lore_detail.py
@@ -109,6 +109,10 @@ class PersonasLoreDetailWidget(Vertical):
     PersonasLoreDetailWidget #personas-lore-status {
         height: 1;
     }
+    PersonasLoreDetailWidget #personas-lore-attachments-table {
+        height: auto;
+        max-height: 8;
+    }
     """
 
     def __init__(self, **kwargs: Any) -> None:

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_lore_detail.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_lore_detail.py
@@ -72,6 +72,18 @@ class LoreBookExportRequested(Message):
     """Intent: export the currently selected world book to a file (JSON)."""
 
 
+class LoreAttachRequested(Message):
+    """Intent: attach the selected world book to a conversation (opens a picker)."""
+
+
+class LoreDetachRequested(Message):
+    """Intent: detach the selected world book from a conversation."""
+
+    def __init__(self, conversation_id: str) -> None:
+        super().__init__()
+        self.conversation_id = conversation_id
+
+
 class PersonasLoreDetailWidget(Vertical):
     """Entries + Settings tabs for one lore/world book. Emits intents; owns no I/O."""
 
@@ -102,6 +114,7 @@ class PersonasLoreDetailWidget(Vertical):
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self._entries: list[dict] = []
+        self._attachment_rows: list[dict] = []
         self._suppress_enabled_toggle: bool = (
             False  # True while we set the Switch programmatically
         )
@@ -208,6 +221,24 @@ class PersonasLoreDetailWidget(Vertical):
                     id="personas-lore-export",
                     classes="console-action-secondary",
                 )
+            with TabPane("Attachments", id="personas-lore-tab-attachments"):
+                yield Static(
+                    "Not attached to any conversation yet.",
+                    id="personas-lore-attachments-empty",
+                    markup=False,
+                )
+                yield DataTable(id="personas-lore-attachments-table", cursor_type="row")
+                with Horizontal(classes="personas-lore-form-row"):
+                    yield Button(
+                        "Attach to conversation…",
+                        id="personas-lore-attach-add",
+                        classes="console-action-secondary",
+                    )
+                    yield Button(
+                        "Detach",
+                        id="personas-lore-attach-detach",
+                        classes="console-action-secondary",
+                    )
         yield Static("", id="personas-lore-status", markup=False)
 
     def on_mount(self) -> None:
@@ -218,6 +249,9 @@ class PersonasLoreDetailWidget(Vertical):
         """
         table = self.query_one("#personas-lore-entries-table", DataTable)
         table.add_columns("keys", "content", "position", "priority", "enabled")
+        self.query_one("#personas-lore-attachments-table", DataTable).add_columns(
+            "conversation", "id"
+        )
         self._sync_secondary_keys_disabled()
 
     def _sync_secondary_keys_disabled(self) -> None:
@@ -295,6 +329,34 @@ class PersonasLoreDetailWidget(Vertical):
                 key=str(entry.get("id")),
             )
 
+    def load_attachments(self, rows: list[dict]) -> None:
+        """Render the conversations this world book is attached to (I/O-free).
+
+        Args:
+            rows: ``{"conversation_id": str, "title": str}`` entries.
+        """
+        self._attachment_rows = list(rows)
+        table = self.query_one("#personas-lore-attachments-table", DataTable)
+        table.clear()
+        for row in self._attachment_rows:
+            table.add_row(
+                Text(str(row.get("title") or "(untitled)")),
+                Text(str(row.get("conversation_id") or "")),
+                key=str(row.get("conversation_id")),
+            )
+        empty = self.query_one("#personas-lore-attachments-empty", Static)
+        empty.display = not self._attachment_rows
+        table.display = bool(self._attachment_rows)
+
+    def _selected_attachment_id(self) -> str | None:
+        table = self.query_one("#personas-lore-attachments-table", DataTable)
+        if table.row_count == 0 or table.cursor_row is None or table.cursor_row < 0:
+            return None
+        try:
+            return str(table.coordinate_to_cell_key((table.cursor_row, 0)).row_key.value)
+        except Exception:
+            return None
+
     def apply_enabled(self, enabled: bool) -> None:
         """Reflect an externally-toggled enabled flag without touching other fields."""
         self._set_enabled_switch(bool(enabled))
@@ -313,6 +375,7 @@ class PersonasLoreDetailWidget(Vertical):
         self.query_one("#personas-lore-token-budget", Input).value = "500"
         self.query_one("#personas-lore-recursive", Switch).value = False
         self._set_enabled_switch(True)
+        self.load_attachments([])
         self.query_one("#personas-lore-status", Static).update("")
 
     def _set_enabled_switch(self, value: bool) -> None:
@@ -582,6 +645,20 @@ class PersonasLoreDetailWidget(Vertical):
         event.stop()
         self.post_message(LoreBookExportRequested())
 
+    @on(Button.Pressed, "#personas-lore-attach-add")
+    def _attach_add(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.post_message(LoreAttachRequested())
+
+    @on(Button.Pressed, "#personas-lore-attach-detach")
+    def _attach_detach(self, event: Button.Pressed) -> None:
+        event.stop()
+        conversation_id = self._selected_attachment_id()
+        if conversation_id is None:
+            self.set_status("Select an attached conversation first.")
+            return
+        self.post_message(LoreDetachRequested(conversation_id))
+
     @on(Switch.Changed, "#personas-lore-enabled")
     def _enabled_changed(self, event: Switch.Changed) -> None:
         event.stop()
@@ -599,9 +676,11 @@ class PersonasLoreDetailWidget(Vertical):
 
 
 __all__ = [
+    "LoreAttachRequested",
     "LoreBookEnableToggled",
     "LoreBookExportRequested",
     "LoreBookSettingsSaveRequested",
+    "LoreDetachRequested",
     "LoreEntriesReorderRequested",
     "LoreEntryAddRequested",
     "LoreEntryDeleteRequested",


### PR DESCRIPTION
## Roleplay P2e — conversation-attach for Lore/world-books

Fifth P2 (Lore mode) sub-project. Mirrors the merged Dictionaries conversation-attach (P1e). Adds a Roleplay-mode way to **attach a world book to a conversation** so its entries participate in that conversation's world-info injection — and detach it. The backend junction and the live legacy send path already existed; this fills in the missing Roleplay UI + one read-only backend query.

### What's in it
- **Backend (read-only):** `WorldBookManager.get_conversations_for_world_book(world_book_id)` — the reverse of `get_world_books_for_conversation`; returns `[{conversation_id: str, title: str}]` (NULL title → `"(untitled)"`), `deleted=0`, ordered by `last_modified DESC`.
- **Generic picker:** new `ConversationAttachPicker(ModalScreen[str | None])` — a search-filterable conversation list that returns the picked **string** conversation id. The merged `DictionaryAttachPicker` is left untouched (a later cleanup may migrate dict onto this).
- **Lore Attachments tab:** a third `TabPane` in `PersonasLoreDetailWidget` (empty-state + table + Attach/Detach), **I/O-free** (`load_attachments(rows)` renders given rows); new messages `LoreAttachRequested` / `LoreDetachRequested(conversation_id)`.
- **Screen wiring:** `_refresh_lore_attachments` (hooked into `_select_lore_entry`), `@on(LoreAttachRequested)` (worker → picker → `associate_world_book_with_conversation`, off-thread, `_io_dialog_active` guard + `group="personas-io"`), `@on(LoreDetachRequested)` (`disassociate_...`). Reuses the existing generic `_list_attachable_conversations`.

### Constraints honored
- **No schema migration** — the `conversation_world_books` junction already exists; schema stays **v22**.
- **No send-path change** — `chat_events.py` already injects conversation-attached books into `WorldInfoProcessor` on the legacy send; the included integration test pins that `get_world_books_for_conversation` returns an attached book.
- Attach is an idempotent **upsert** (no `ConflictError` branch). Conversation ids are **strings** throughout; book ids ints. Widget is I/O-free; all DB work is off-thread in the screen, wrapped → notify.

### Explicitly deferred → P2g
Console inspector "what's in play" world-book block; native-Console send-path application (native Console does not yet apply attached world books); retiring the legacy Chat-sidebar attach UI.

### Testing
Real-DB / real-integration throughout (no mocks masking persistence). Full gate green: `test_world_book_manager` + `test_conversation_attach_picker` + `test_personas_lore` = **75 passed**; `import tldw_chatbook.app` OK.

Built via subagent-driven development (implementer + reviewer per task, opus whole-branch review). The final review caught one **Important** app-crash gap — the attach worker's conversation-list read was unguarded, so a DB error would tear down the app via `run_worker(exit_on_error=True)` — now wrapped → notify, with a revert-verified regression test. Also folded in a table `max-height` cap (dict parity) and a detach-no-selection test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Roleplay Lore Attachments tab so users can attach or detach a world book to conversations. Completes the missing UI with one read-only backend query; the existing send path already applies attached books.

- **New Features**
  - Backend: `WorldBookManager.get_conversations_for_world_book(world_book_id)` → `[{'conversation_id': str, 'title': str}]` (NULL title → "(untitled)"), ordered by `last_modified DESC`.
  - UI: `ConversationAttachPicker` modal that filters and returns a picked conversation id (string).
  - UI: Lore Attachments tab (empty state, table, Attach/Detach). Widget stays I/O-free via `load_attachments(rows)`. New messages: `LoreAttachRequested`, `LoreDetachRequested(conversation_id)`.
  - Screen: Refresh attachments on lore selection; attach/detach run off-thread, reuse `_list_attachable_conversations`, show notifications. Conversation ids are strings; attach is an idempotent upsert.

- **Bug Fixes**
  - Guarded the attach worker’s conversation-list read to prevent app crashes; errors now notify instead of tearing down the app.
  - Attachments refresh now avoids stale writes if selection changes mid-query and clears rows on query errors (no stale table).
  - Capped attachments table max-height and added a detach-with-no-selection check.

<sup>Written for commit 4e3e66341524cfc78a2c1d62c63dfaa439c933a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

