### PR TITLE
fix(mcp): third-party server onboarding — env paths + Pydantic Optional schema forms

### DIFF
--- a/Tests/MCP/test_local_store.py
+++ b/Tests/MCP/test_local_store.py
@@ -482,3 +482,30 @@ def test_local_store_still_rejects_secret_shaped_env_literal_over_path_acceptanc
                 env_literals={"API_KEY": "/looks/like/a/path/but/secret/key"},
             )
         )
+
+
+def test_local_store_rejects_path_shaped_secret_under_neutral_key(tmp_path):
+    """Accepting filesystem paths must NOT let a token-shaped secret slip the
+    value guard by wearing a leading path anchor under a non-secret key name
+    (the leading '/'/'~' used to break the ^sk-…$ full-match)."""
+    store = LocalMCPStore(tmp_path / "local_mcp_store.json")
+    for key, value in [
+        ("HOME_WS", "~/sk-live-abcdef012345ghij"),
+        ("GENERIC", "/ghp_1234567890abcdefghijklmno"),
+        ("NESTED", "/opt/creds/xoxb-1234567890-abcdefghij"),
+    ]:
+        with pytest.raises(ValueError, match="[Ss]ecret"):
+            store.save_profile(
+                LocalExternalMCPProfile(
+                    profile_id="p", command="python", env_literals={key: value}
+                )
+            )
+    # A genuine multi-segment workspace path is still accepted.
+    saved = store.save_profile(
+        LocalExternalMCPProfile(
+            profile_id="p",
+            command="python",
+            env_literals={"ATHF_WORKSPACE": "/home/analyst/hunts/prod"},
+        )
+    )
+    assert saved.env_literals["ATHF_WORKSPACE"] == "/home/analyst/hunts/prod"

--- a/Tests/MCP/test_local_store.py
+++ b/Tests/MCP/test_local_store.py
@@ -490,9 +490,9 @@ def test_local_store_rejects_path_shaped_secret_under_neutral_key(tmp_path):
     (the leading '/'/'~' used to break the ^sk-…$ full-match)."""
     store = LocalMCPStore(tmp_path / "local_mcp_store.json")
     for key, value in [
-        ("HOME_WS", "~/sk-live-abcdef012345ghij"),
-        ("GENERIC", "/ghp_1234567890abcdefghijklmno"),
-        ("NESTED", "/opt/creds/xoxb-1234567890-abcdefghij"),
+        ("HOME_WS", "~/sk-NOTAREALSECRET0000"),
+        ("GENERIC", "/ghp_NOTAREALSECRET00000"),
+        ("NESTED", "/opt/creds/xoxb-NOTAREAL-SECRET0000"),
     ]:
         with pytest.raises(ValueError, match="[Ss]ecret"):
             store.save_profile(
@@ -509,3 +509,31 @@ def test_local_store_rejects_path_shaped_secret_under_neutral_key(tmp_path):
         )
     )
     assert saved.env_literals["ATHF_WORKSPACE"] == "/home/analyst/hunts/prod"
+
+
+def test_local_store_rejects_secret_smuggled_in_url_or_query_param(tmp_path):
+    """Accepting URL literals must not let a secret hide in a URL path segment
+    or query parameter — the segment split covers /?&=:@ delimiters."""
+    store = LocalMCPStore(tmp_path / "local_mcp_store.json")
+    for value in [
+        "https://host.example/api?token=sk-NOTAREALSECRET0000",
+        "https://host.example/ghp_NOTAREALSECRET00000/callback",
+        "https://user:xoxb-NOTAREAL-SECRET0000@host.example/",
+    ]:
+        with pytest.raises(ValueError, match="[Ss]ecret"):
+            store.save_profile(
+                LocalExternalMCPProfile(
+                    profile_id="p",
+                    command="python",
+                    env_literals={"ENDPOINT": value},
+                )
+            )
+    # A clean URL with no secret-shaped segment is still accepted.
+    saved = store.save_profile(
+        LocalExternalMCPProfile(
+            profile_id="p",
+            command="python",
+            env_literals={"ENDPOINT": "https://host.example/v1/hunts?limit=50"},
+        )
+    )
+    assert saved.env_literals["ENDPOINT"] == "https://host.example/v1/hunts?limit=50"

--- a/Tests/MCP/test_local_store.py
+++ b/Tests/MCP/test_local_store.py
@@ -446,3 +446,39 @@ def test_local_store_raises_on_corrupt_payload_instead_of_treating_it_as_empty_s
         )
 
     assert path.read_text(encoding="utf-8") == corrupt_payload
+
+
+def test_local_store_accepts_filesystem_path_as_env_literal(tmp_path):
+    """A non-secret filesystem path (workspace root, config/db path — the most
+    common stdio-MCP-server env value, e.g. ATHF's ATHF_WORKSPACE) is a safe
+    operational literal, matching what the legacy env path already accepts.
+    (ATHF third-party UAT finding, 2026-07-21.)"""
+    store = LocalMCPStore(tmp_path / "local_mcp_store.json")
+    saved = store.save_profile(
+        LocalExternalMCPProfile(
+            profile_id="athf",
+            command="/opt/athf/bin/athf-mcp",
+            env_literals={
+                "ATHF_WORKSPACE": "/private/tmp/athf/hunts",
+                "HOME_WS": "~/hunts",
+            },
+        )
+    )
+    assert saved.env_literals["ATHF_WORKSPACE"] == "/private/tmp/athf/hunts"
+    assert saved.env_literals["HOME_WS"] == "~/hunts"
+
+
+def test_local_store_still_rejects_secret_shaped_env_literal_over_path_acceptance(
+    tmp_path,
+):
+    """Widening literals to accept paths must NOT relax the secret guards:
+    a secret-bearing key or token-shaped value is still rejected."""
+    store = LocalMCPStore(tmp_path / "local_mcp_store.json")
+    with pytest.raises(ValueError, match="[Ss]ecret"):
+        store.save_profile(
+            LocalExternalMCPProfile(
+                profile_id="p",
+                command="python",
+                env_literals={"API_KEY": "/looks/like/a/path/but/secret/key"},
+            )
+        )

--- a/Tests/UI/test_mcp_schema_form.py
+++ b/Tests/UI/test_mcp_schema_form.py
@@ -294,3 +294,42 @@ async def test_collect_arguments_raises_for_integer_with_decimal_string():
         with pytest.raises(ValueError) as exc_info:
             form.collect_arguments()
         assert str(exc_info.value) == "count: must be a whole number."
+
+
+def test_parse_schema_unwraps_pydantic_optional_anyof_null():
+    """Pydantic v2 encodes Optional[T] as anyOf:[{type:T},{type:null}]; render
+    it as an optional field of the underlying type rather than falling the whole
+    schema back to raw JSON. (ATHF third-party UAT finding, 2026-07-21.)"""
+    schema = {
+        "type": "object",
+        "properties": {
+            "technique_id": {"type": "string"},
+            "limit": {"anyOf": [{"type": "integer"}, {"type": "null"}], "default": None},
+            "status": {"anyOf": [{"enum": ["open", "done"]}, {"type": "null"}]},
+        },
+    }
+    fields = parse_schema(schema)
+    assert fields is not None
+    by_name = {f.name: f for f in fields}
+    assert by_name["limit"].kind == "integer" and by_name["limit"].required is False
+    assert by_name["status"].kind == "enum" and by_name["status"].choices == ("open", "done")
+
+
+def test_parse_schema_unwraps_type_array_nullable():
+    """The type:[T,"null"] spelling of Optional is unwrapped the same way."""
+    schema = {
+        "type": "object",
+        "properties": {"note": {"type": ["string", "null"]}},
+    }
+    fields = parse_schema(schema)
+    assert fields is not None and fields[0].kind == "string" and fields[0].required is False
+
+
+def test_parse_schema_still_raw_for_genuine_multitype_union():
+    """A real multi-type union (string|integer, no null) can't render as one
+    field and must still trigger the honest raw fallback."""
+    schema = {
+        "type": "object",
+        "properties": {"val": {"anyOf": [{"type": "string"}, {"type": "integer"}]}},
+    }
+    assert parse_schema(schema) is None

--- a/Tests/UI/test_mcp_schema_form.py
+++ b/Tests/UI/test_mcp_schema_form.py
@@ -357,3 +357,33 @@ def test_parse_schema_type_array_multitype_union_stays_raw():
         "properties": {"val": {"type": ["string", "integer"]}},
     }
     assert parse_schema(schema) is None
+
+
+def test_parse_schema_enum_with_null_is_nullable_and_filters_null_choice():
+    """An enum listing null among its values is nullable, and the null is
+    dropped from the rendered choices (never a literal "null" option)."""
+    schema = {
+        "type": "object",
+        "properties": {"mode": {"enum": ["fast", "slow", None]}},
+    }
+    fields = parse_schema(schema)
+    assert fields is not None
+    assert fields[0].kind == "enum" and fields[0].nullable is True
+    assert fields[0].choices == ("fast", "slow")
+
+
+@pytest.mark.asyncio
+async def test_collect_arguments_sends_null_for_blank_required_nullable_field():
+    """A required-but-nullable field (Pydantic T|None, no default, in the
+    schema's required list) left blank sends explicit JSON null instead of
+    raising 'required.' — the honest way to satisfy a nullable requirement."""
+    schema = {
+        "type": "object",
+        "properties": {"note": {"anyOf": [{"type": "string"}, {"type": "null"}]}},
+        "required": ["note"],
+    }
+    app = SchemaFormApp(schema=schema)
+    async with app.run_test():
+        form = app.query_one(MCPSchemaForm)
+        args = form.collect_arguments()
+    assert args == {"note": None}

--- a/Tests/UI/test_mcp_schema_form.py
+++ b/Tests/UI/test_mcp_schema_form.py
@@ -333,3 +333,27 @@ def test_parse_schema_still_raw_for_genuine_multitype_union():
         "properties": {"val": {"anyOf": [{"type": "string"}, {"type": "integer"}]}},
     }
     assert parse_schema(schema) is None
+
+
+def test_parse_schema_required_nullable_field_stays_required():
+    """A `T | None` param with no default lands in the schema's `required`
+    list; unwrapping the nullable idiom must NOT silently make it optional,
+    or the user could omit a parameter the tool requires."""
+    schema = {
+        "type": "object",
+        "properties": {"note": {"anyOf": [{"type": "string"}, {"type": "null"}]}},
+        "required": ["note"],
+    }
+    fields = parse_schema(schema)
+    assert fields is not None
+    assert fields[0].name == "note" and fields[0].kind == "string"
+    assert fields[0].required is True
+
+
+def test_parse_schema_type_array_multitype_union_stays_raw():
+    """type:[string,integer] (no null) is a genuine union — still raw."""
+    schema = {
+        "type": "object",
+        "properties": {"val": {"type": ["string", "integer"]}},
+    }
+    assert parse_schema(schema) is None

--- a/tldw_chatbook/MCP/local_store.py
+++ b/tldw_chatbook/MCP/local_store.py
@@ -158,7 +158,20 @@ def _is_secret_bearing_env_key(key: str) -> bool:
 
 
 def _looks_like_raw_secret_value(value: str) -> bool:
-    return any(pattern.fullmatch(value) for pattern in _SECRET_VALUE_PATTERNS)
+    # Test the whole value AND — so a leading path anchor can't smuggle a
+    # secret past the full-match patterns now that filesystem paths are
+    # accepted literals (e.g. "~/sk-live-…", "/foo/ghp_…") — the
+    # anchor-stripped value and each path segment.
+    candidates = [value]
+    stripped = value.lstrip("~/")
+    if stripped != value:
+        candidates.append(stripped)
+        candidates.extend(segment for segment in stripped.split("/") if segment)
+    return any(
+        pattern.fullmatch(candidate)
+        for candidate in candidates
+        for pattern in _SECRET_VALUE_PATTERNS
+    )
 
 
 def _is_safe_literal_value(value: str) -> bool:

--- a/tldw_chatbook/MCP/local_store.py
+++ b/tldw_chatbook/MCP/local_store.py
@@ -54,6 +54,9 @@ _SAFE_URL_LITERAL_PATTERN = re.compile(
 # secret guards (_is_secret_bearing_env_key / _looks_like_raw_secret_value)
 # still run first, so a token that happens to be path-shaped is rejected.
 _SAFE_PATH_LITERAL_PATTERN = re.compile(r"^(?:~|/)[A-Za-z0-9._/@:+-]{1,255}$")
+# Token separators in paths / URLs / query strings — used to extract candidate
+# secret segments from an otherwise-safe-looking literal.
+_SECRET_SEGMENT_SPLIT = re.compile(r"[/?&=:@~]+")
 _LEGACY_SAFE_URL_LITERAL_PATTERN = re.compile(
     r"^[A-Za-z][A-Za-z0-9+.-]*://[^\s]{1,255}$"
 )
@@ -158,15 +161,12 @@ def _is_secret_bearing_env_key(key: str) -> bool:
 
 
 def _looks_like_raw_secret_value(value: str) -> bool:
-    # Test the whole value AND — so a leading path anchor can't smuggle a
-    # secret past the full-match patterns now that filesystem paths are
-    # accepted literals (e.g. "~/sk-live-…", "/foo/ghp_…") — the
-    # anchor-stripped value and each path segment.
-    candidates = [value]
-    stripped = value.lstrip("~/")
-    if stripped != value:
-        candidates.append(stripped)
-        candidates.extend(segment for segment in stripped.split("/") if segment)
+    # Full-match the whole value AND every token segment, so a secret can't be
+    # smuggled past the anchored patterns inside a path, URL, or query string
+    # (e.g. "~/sk-live-…", "/foo/ghp_…", "https://h/p?key=sk-live-…") now that
+    # paths and URLs are accepted literals. Split on the delimiters that
+    # separate tokens in those forms.
+    candidates = [value, *(seg for seg in _SECRET_SEGMENT_SPLIT.split(value) if seg)]
     return any(
         pattern.fullmatch(candidate)
         for candidate in candidates

--- a/tldw_chatbook/MCP/local_store.py
+++ b/tldw_chatbook/MCP/local_store.py
@@ -48,6 +48,12 @@ _SAFE_DECIMAL_PATTERN = re.compile(r"^[0-9]{1,4}\.[0-9]{1,2}$")
 _SAFE_URL_LITERAL_PATTERN = re.compile(
     r"^https?://[A-Za-z0-9.-]+(?::[0-9]{1,5})?(?:/[^\s]*)?$", re.IGNORECASE
 )
+# A non-secret filesystem path (workspace root, config/db path) is a safe
+# operational literal — the most common stdio-MCP-server env value. Mirrors
+# _LEGACY_SAFE_PATH_PATTERN so the strict and legacy env paths agree; the
+# secret guards (_is_secret_bearing_env_key / _looks_like_raw_secret_value)
+# still run first, so a token that happens to be path-shaped is rejected.
+_SAFE_PATH_LITERAL_PATTERN = re.compile(r"^(?:~|/)[A-Za-z0-9._/@:+-]{1,255}$")
 _LEGACY_SAFE_URL_LITERAL_PATTERN = re.compile(
     r"^[A-Za-z][A-Za-z0-9+.-]*://[^\s]{1,255}$"
 )
@@ -165,6 +171,8 @@ def _is_safe_literal_value(value: str) -> bool:
         return True
     if _SAFE_URL_LITERAL_PATTERN.fullmatch(value.strip()):
         return True
+    if _SAFE_PATH_LITERAL_PATTERN.fullmatch(value.strip()):
+        return True
     return False
 
 
@@ -251,7 +259,10 @@ def _sanitize_env_literals(env: Mapping[str, Any] | None) -> dict[str, str]:
             )
         if not _is_safe_literal_value(value):
             raise ValueError(
-                f"Literal env key '{key}' must use an explicit safe operational literal or an env placeholder"
+                f"Literal env key '{key}' must be a safe non-secret value "
+                f"(a filesystem path, boolean, number, log level, or URL). "
+                f"For anything else, set it as a $NAME env placeholder and "
+                f"export {key} in the environment that launches the app."
             )
         sanitized[key] = value
     return sanitized

--- a/tldw_chatbook/UI/MCP_Modules/mcp_schema_form.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_schema_form.py
@@ -39,17 +39,66 @@ class SchemaField:
     choices: tuple[str, ...] = field(default_factory=tuple)
 
 
+def _resolve_property(spec: dict) -> tuple[str, tuple[str, ...], bool] | None:
+    """Resolve a JSON-Schema property to `(kind, enum_choices, nullable)`.
+
+    Renders the simple/enum types and unwraps the Optional[T] idiom that
+    Pydantic v2 (the most common third-party MCP server framework) emits:
+    `anyOf: [{...}, {"type": "null"}]` and `type: [T, "null"]` become an
+    optional field of the underlying type. `nullable` is True when `null`
+    was one of the allowed options -- the caller marks such fields
+    not-required (blank == the accepted null).
+
+    Returns `None` for genuinely unrenderable shapes -- nested object/array,
+    a real multi-type union (e.g. `string|integer`), `oneOf`, or a missing
+    type -- preserving the honest raw-JSON fallback (a partial form that
+    silently drops a parameter the tool needs would lie to the user).
+    """
+    enum_values = spec.get("enum")
+    if isinstance(enum_values, list) and enum_values:
+        return ("enum", tuple(str(value) for value in enum_values), False)
+
+    prop_type = spec.get("type")
+    if prop_type in _SIMPLE_KINDS:
+        return (str(prop_type), (), False)
+    if isinstance(prop_type, list):
+        nullable = "null" in prop_type
+        non_null = [t for t in prop_type if t != "null"]
+        if len(non_null) == 1 and non_null[0] in _SIMPLE_KINDS:
+            return (str(non_null[0]), (), nullable)
+        return None
+
+    branches = spec.get("anyOf")
+    if isinstance(branches, list):
+        subs = [b for b in branches if isinstance(b, dict)]
+        nullable = any(b.get("type") == "null" for b in subs)
+        non_null = [b for b in subs if b.get("type") != "null"]
+        if len(non_null) == 1:
+            inner = _resolve_property(non_null[0])
+            if inner is None:
+                return None
+            kind, choices, inner_nullable = inner
+            return (kind, choices, nullable or inner_nullable)
+        return None
+
+    return None
+
+
 def parse_schema(schema: dict | None) -> list[SchemaField] | None:
     """Turn a JSON-Schema `object` schema into a list of `SchemaField`s.
 
     PURE -- no widget/Textual dependency.
 
+    Renders simple/enum properties and the Optional[T] idiom (Pydantic v2's
+    `anyOf: [T, null]` / `type: [T, "null"]`) via `_resolve_property`.
+
     Returns:
         `None` when `schema` is falsy/not a dict, its `type` isn't
         `"object"`, `properties` isn't a mapping, or ANY property is
-        unrenderable (nested object/array, `oneOf`/`anyOf`, missing/
-        unsupported `type`) -- the raw-JSON-fallback trigger. Otherwise the
-        parsed fields, in `properties` iteration order.
+        unrenderable (nested object/array, a real multi-type union,
+        `oneOf`, missing/unsupported `type`) -- the raw-JSON-fallback
+        trigger. Otherwise the parsed fields, in `properties` iteration
+        order.
     """
     if not schema or not isinstance(schema, dict):
         return None
@@ -71,38 +120,26 @@ def parse_schema(schema: dict | None) -> list[SchemaField] | None:
         description = str(spec.get("description") or "")
         default = spec.get("default")
         field_name = str(name)
-        required = field_name in required_names
 
-        enum_values = spec.get("enum")
-        if isinstance(enum_values, list) and enum_values:
-            fields.append(
-                SchemaField(
-                    name=field_name,
-                    kind="enum",
-                    required=required,
-                    description=description,
-                    default=default,
-                    choices=tuple(str(value) for value in enum_values),
-                )
+        resolved = _resolve_property(spec)
+        if resolved is None:
+            # Nested object/array, real multi-type union, oneOf, missing
+            # type, etc. -- one unrenderable property fails the WHOLE schema.
+            return None
+        kind, choices, nullable = resolved
+        # A nullable field accepts null/absence, so a blank is valid -- never
+        # force it required even if the schema's `required` list names it.
+        required = field_name in required_names and not nullable
+        fields.append(
+            SchemaField(
+                name=field_name,
+                kind=kind,
+                required=required,
+                description=description,
+                default=default,
+                choices=choices,
             )
-            continue
-
-        prop_type = spec.get("type")
-        if prop_type in _SIMPLE_KINDS:
-            fields.append(
-                SchemaField(
-                    name=field_name,
-                    kind=str(prop_type),
-                    required=required,
-                    description=description,
-                    default=default,
-                )
-            )
-            continue
-
-        # Nested object/array, oneOf/anyOf, missing/unsupported type, etc.
-        # -- one unrenderable property fails the WHOLE schema.
-        return None
+        )
 
     return fields
 

--- a/tldw_chatbook/UI/MCP_Modules/mcp_schema_form.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_schema_form.py
@@ -3,13 +3,15 @@
 raw-JSON fallback.
 
 `parse_schema()` is pure: it turns a JSON-Schema "object" schema into a list
-of `SchemaField`s the widget can render as real controls. If ANY declared
-property can't be rendered faithfully (a nested object/array, `oneOf`, a
-missing/unsupported `type`), the WHOLE parse fails (returns `None`) rather
-than silently dropping that property -- a form missing a parameter the tool
-actually requires would lie to the user. `MCPSchemaForm` falls back to a raw
-JSON `TextArea` in that case, so every tool call remains possible even when
-its schema can't be rendered.
+of `SchemaField`s the widget can render as real controls. Simple/enum types
+render directly, and the Optional[T] idiom (Pydantic v2's `anyOf: [T, null]`
+/ `type: [T, "null"]`) is unwrapped to the underlying type. If ANY declared
+property can't be rendered faithfully (a nested object/array, a real
+multi-type union, `oneOf`, a missing/unsupported `type`), the WHOLE parse
+fails (returns `None`) rather than silently dropping that property -- a form
+missing a parameter the tool actually requires would lie to the user.
+`MCPSchemaForm` falls back to a raw JSON `TextArea` in that case, so every
+tool call remains possible even when its schema can't be rendered.
 """
 
 from __future__ import annotations
@@ -126,10 +128,13 @@ def parse_schema(schema: dict | None) -> list[SchemaField] | None:
             # Nested object/array, real multi-type union, oneOf, missing
             # type, etc. -- one unrenderable property fails the WHOLE schema.
             return None
-        kind, choices, nullable = resolved
-        # A nullable field accepts null/absence, so a blank is valid -- never
-        # force it required even if the schema's `required` list names it.
-        required = field_name in required_names and not nullable
+        kind, choices, _nullable = resolved
+        # The schema's `required` list is authoritative: a nullable field
+        # WITH a default isn't in it (renders optional), but `T | None` with
+        # NO default IS in it and the tool wants it -- forcing it optional
+        # would let the user silently omit a required parameter (the exact
+        # "partial form lies" failure this module's raw fallback prevents).
+        required = field_name in required_names
         fields.append(
             SchemaField(
                 name=field_name,

--- a/tldw_chatbook/UI/MCP_Modules/mcp_schema_form.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_schema_form.py
@@ -39,6 +39,7 @@ class SchemaField:
     description: str
     default: object | None
     choices: tuple[str, ...] = field(default_factory=tuple)
+    nullable: bool = False  # accepts null (Pydantic Optional[T]) — blank sends null
 
 
 def _resolve_property(spec: dict) -> tuple[str, tuple[str, ...], bool] | None:
@@ -58,7 +59,15 @@ def _resolve_property(spec: dict) -> tuple[str, tuple[str, ...], bool] | None:
     """
     enum_values = spec.get("enum")
     if isinstance(enum_values, list) and enum_values:
-        return ("enum", tuple(str(value) for value in enum_values), False)
+        # An enum listing null/None among its values is nullable; drop those
+        # so they don't render as literal "null"/"None" choices.
+        nullable = None in enum_values or "null" in enum_values
+        choices = tuple(
+            str(value)
+            for value in enum_values
+            if value is not None and value != "null"
+        )
+        return ("enum", choices, nullable)
 
     prop_type = spec.get("type")
     if prop_type in _SIMPLE_KINDS:
@@ -94,6 +103,10 @@ def parse_schema(schema: dict | None) -> list[SchemaField] | None:
     Renders simple/enum properties and the Optional[T] idiom (Pydantic v2's
     `anyOf: [T, null]` / `type: [T, "null"]`) via `_resolve_property`.
 
+    Args:
+        schema: A JSON-Schema dict for one tool's parameters (a top-level
+            `"object"` schema with a `properties` mapping), or `None`.
+
     Returns:
         `None` when `schema` is falsy/not a dict, its `type` isn't
         `"object"`, `properties` isn't a mapping, or ANY property is
@@ -128,12 +141,12 @@ def parse_schema(schema: dict | None) -> list[SchemaField] | None:
             # Nested object/array, real multi-type union, oneOf, missing
             # type, etc. -- one unrenderable property fails the WHOLE schema.
             return None
-        kind, choices, _nullable = resolved
+        kind, choices, nullable = resolved
         # The schema's `required` list is authoritative: a nullable field
         # WITH a default isn't in it (renders optional), but `T | None` with
-        # NO default IS in it and the tool wants it -- forcing it optional
-        # would let the user silently omit a required parameter (the exact
-        # "partial form lies" failure this module's raw fallback prevents).
+        # NO default IS in it and the tool wants it. Rather than silently
+        # dropping such a param OR forcing a non-null value, `collect_arguments`
+        # sends explicit JSON null when a nullable field is left blank.
         required = field_name in required_names
         fields.append(
             SchemaField(
@@ -143,6 +156,7 @@ def parse_schema(schema: dict | None) -> list[SchemaField] | None:
                 description=description,
                 default=default,
                 choices=choices,
+                nullable=nullable,
             )
         )
 
@@ -237,9 +251,10 @@ class MCPSchemaForm(Vertical):
         Returns:
             Raw mode: the parsed JSON object from `#mcp-schema-raw`.
             Form mode: one entry per field, coerced per kind (number ->
-            float, integer -> int, boolean -> the Checkbox's value); empty
-            optional strings/numbers and unselected optional enums are
-            omitted entirely.
+            float, integer -> int, boolean -> the Checkbox's value); a blank
+            nullable field (Pydantic Optional[T]) sends explicit JSON null;
+            empty non-nullable optional strings/numbers and unselected
+            optional enums are omitted entirely.
 
         Raises:
             ValueError: Raw mode -- invalid JSON, or valid JSON that isn't
@@ -262,7 +277,9 @@ class MCPSchemaForm(Vertical):
             if schema_field.kind == "enum":
                 value = self.query_one(widget_id, Select).value
                 if value is Select.NULL:
-                    if schema_field.required:
+                    if schema_field.nullable:
+                        result[schema_field.name] = None
+                    elif schema_field.required:
                         raise ValueError(f"{schema_field.name}: required.")
                     continue
                 result[schema_field.name] = value
@@ -271,7 +288,9 @@ class MCPSchemaForm(Vertical):
             raw_value = self.query_one(widget_id, Input).value
             text_value = raw_value.strip()
             if not text_value:
-                if schema_field.required:
+                if schema_field.nullable:
+                    result[schema_field.name] = None
+                elif schema_field.required:
                     raise ValueError(f"{schema_field.name}: required.")
                 continue
             if schema_field.kind == "number":


### PR DESCRIPTION
## Summary

Two friction fixes found during the ATHF (Agentic Threat Hunting Framework) third-party MCP server UAT (`Docs/superpowers/qa/athf-uat-2026-07-21/`), both verified end-to-end against the real ATHF server (21 tools) — these smooth onboarding for *any* third-party stdio MCP server, not just ATHF.

### 1. Filesystem paths as env literals (task-398)

A local MCP server whose required env is a filesystem path — a workspace root, config file, or DB path (ATHF needs `ATHF_WORKSPACE=/path/to/hunts`) — couldn't be configured via the Add-server form: the strict `env_literals` whitelist accepted only booleans/ints/URLs/log-levels, rejecting a path the store's *legacy* env path already allowed. Now:
- Non-secret filesystem paths are accepted (mirroring `_LEGACY_SAFE_PATH_PATTERN`; the secret-key and secret-value guards still run first and were **hardened** — a `/`- or `~/`-prefixed token like `~/sk-live-…` can no longer slip the value guard, since it now tests the anchor-stripped value and each path segment).
- The rejection copy names the fix: use a `$NAME` placeholder and export it.

### 2. Pydantic v2 Optional[T] schemas render as forms (task-399)

`parse_schema` fell the whole schema back to raw JSON on any `anyOf`, so the ubiquitous `Optional[T]` idiom (`anyOf:[T, null]` / `type:[T,"null"]`) forced raw mode for most third-party tools — **~half of ATHF's 21**. It now unwraps the nullable idiom to an optional field of the underlying type, while genuine multi-type unions / `oneOf` / nested shapes still trigger the honest raw fallback (the Phase-3 "partial forms lie" guarantee). A required-but-nullable param (`T | None` with no default, in the schema's `required` list) correctly stays required — no silent parameter drop. **Result: all 21 ATHF tools now render real forms.**

### Verification

- RED-first tests for both fixes plus the two review-hardening gaps (neutral-key path-shaped secret still rejected; required-nullable stays required). Broader MCP gate: 602 passed.
- Independently reviewed (two rounds); both invariants — no-secrets-on-disk and honest-schema-fallback — confirmed preserved.
- Re-verified against the live ATHF server after every change: path saves, 21/21 tools form-render, `athf_hunt_get` keeps `hunt_id` required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves third‑party stdio MCP server onboarding by accepting filesystem paths in env literals, rendering Pydantic v2 Optional[T] as real form fields, and hardening secret detection (including URLs). Verified with the ATHF server; all 21 tools now render forms.

- **Bug Fixes**
  - Env literals: Accept non‑secret filesystem paths (e.g. `ATHF_WORKSPACE=/path`), keep rejecting secret‑bearing keys and token‑shaped values, and detect secrets hidden in URL paths/query/basic‑auth by splitting on `/?&=:@~`. Error copy now points to `$NAME` placeholders. (task-398)
  - Schema forms: Unwrap Optional[T] (`anyOf:[T,null]` / `type:[T,"null"]`) to optional fields; respect the schema’s required list for required‑nullable params and send JSON null when left blank; filter null from enum choices; real unions/`oneOf` still fall back to raw JSON. (task-399)

<sup>Written for commit 9425a24b6fe84cfcc8a316de94918d0f5ce99119. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

