### PR TITLE
feat(console): /prefill — assistant response prefill (one-shot + pinned)

### DIFF
--- a/Docs/superpowers/plans/2026-07-20-console-response-prefill.md
+++ b/Docs/superpowers/plans/2026-07-20-console-response-prefill.md
@@ -1,0 +1,1475 @@
+# Console Response Prefill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `/prefill` in the native Console lets the user supply the opening of the assistant's reply; it is sent as a trailing `{"role": "assistant"}` provider message and the model continues from it.
+
+**Architecture:** A pure parsing/validation module (`console_prefill.py`) + a `/prefill` slash command feed per-session state (one-shot on `ConsoleChatSession`, pinned on `ConsoleSessionSettings`). `_stream_assistant_response` gains a `prefill` parameter that bypasses the agent-runtime gate, appends the trailing assistant payload message, and seeds the display by pushing the prefill as the first stream chunk. Pinned persists in `conversations.metadata` via a merge-safe key write.
+
+**Tech Stack:** Python ≥3.11, Textual, pytest (venv-only — activate `.venv`), SQLite (ChaChaNotes).
+
+**Spec:** `Docs/superpowers/specs/2026-07-20-console-response-prefill-design.md` — read it before starting. Commit it with Task 1.
+
+## Global Constraints
+
+- Native Console only. Do NOT touch the legacy Chat window (`Chat_Window_Enhanced.py`, `chat_events.py`).
+- No schema migration. `conversations.metadata` (JSON TEXT, v20) is shared with `active_dictionaries` — every metadata write must preserve sibling keys.
+- Prefill text is stripped (`.strip()`) at arm time; empty-after-strip is an inline error; max 4,000 chars.
+- Metadata key: `pinned_response_prefill`. Command name: `prefill`. Handler id: `prefill`.
+- One-shot applies to `submit_draft` only and wins over pinned; consumed only on `complete`/`stopped` terminal outcomes; retained on blocked/failed. Pinned applies to submit/retry/regenerate; `continue_from_message` NEVER gets prefill.
+- A prefilled send bypasses the agent-runtime gate (direct provider stream; tools/MCP skipped that turn).
+- The display seed must never set the `emitted_content` flag in `_stream_assistant_response` (zero provider tokens must still fail with "Provider stream ended without content").
+- User-visible text containing prefill content must be markup-escaped (`rich.markup.escape` via the codebase's existing `escape_markup` usage in chat_screen).
+- Work in a git worktree off `origin/dev` (see `superpowers:using-git-worktrees`); this repo's checkout is shared by concurrent sessions.
+- Run tests with the project venv: `source .venv/bin/activate && python -m pytest ...` from the worktree root.
+
+---
+
+### Task 1: Pure prefill module (`console_prefill.py`)
+
+**Files:**
+- Create: `tldw_chatbook/Chat/console_prefill.py`
+- Test: `Tests/Chat/test_console_prefill.py`
+- Also: `git add Docs/superpowers/specs/2026-07-20-console-response-prefill-design.md Docs/superpowers/plans/2026-07-20-console-response-prefill.md` in this task's commit.
+
+**Interfaces:**
+- Consumes: nothing (stdlib only — `dataclasses`, `json`, `typing`).
+- Produces (used by Tasks 4, 6):
+  - `PREFILL_MAX_CHARS: int = 4000`
+  - `PINNED_PREFILL_METADATA_KEY: str = "pinned_response_prefill"`
+  - `ACTION_STATUS/ACTION_CLEAR/ACTION_PIN/ACTION_ONE_SHOT/ACTION_ERROR: str` constants
+  - `PrefillCommandAction(kind: str, text: str = "", error: str = "")` frozen dataclass
+  - `parse_prefill_args(args: str) -> PrefillCommandAction`
+  - `describe_prefill_preview(text: str, max_chars: int = 60) -> str`
+  - `pinned_prefill_from_conversation_metadata(raw_metadata: object) -> str | None`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/Chat/test_console_prefill.py`:
+
+```python
+"""Tests for the pure /prefill command parsing + metadata helpers."""
+
+import json
+
+from tldw_chatbook.Chat.console_prefill import (
+    ACTION_CLEAR,
+    ACTION_ERROR,
+    ACTION_ONE_SHOT,
+    ACTION_PIN,
+    ACTION_STATUS,
+    PINNED_PREFILL_METADATA_KEY,
+    PREFILL_MAX_CHARS,
+    PrefillCommandAction,
+    describe_prefill_preview,
+    parse_prefill_args,
+    pinned_prefill_from_conversation_metadata,
+)
+
+
+class TestParsePrefillArgs:
+    def test_bare_args_is_status(self):
+        assert parse_prefill_args("") == PrefillCommandAction(kind=ACTION_STATUS)
+        assert parse_prefill_args("   ") == PrefillCommandAction(kind=ACTION_STATUS)
+
+    def test_clear_matches_only_as_entire_args(self):
+        assert parse_prefill_args("clear").kind == ACTION_CLEAR
+        assert parse_prefill_args("  CLEAR  ").kind == ACTION_CLEAR
+        # 'clear' with trailing text is a one-shot whose text starts with 'clear'
+        result = parse_prefill_args("clear the table, then")
+        assert result == PrefillCommandAction(
+            kind=ACTION_ONE_SHOT, text="clear the table, then"
+        )
+
+    def test_pin_requires_trailing_text(self):
+        result = parse_prefill_args("pin *She pauses*")
+        assert result == PrefillCommandAction(kind=ACTION_PIN, text="*She pauses*")
+        bare_pin = parse_prefill_args("pin")
+        assert bare_pin.kind == ACTION_ERROR
+        assert "pin" in bare_pin.error
+
+    def test_pin_word_prefix_is_one_shot(self):
+        result = parse_prefill_args("pinch of salt")
+        assert result == PrefillCommandAction(kind=ACTION_ONE_SHOT, text="pinch of salt")
+
+    def test_plain_text_is_one_shot_stripped(self):
+        result = parse_prefill_args("  {\"answer\":  ")
+        assert result == PrefillCommandAction(kind=ACTION_ONE_SHOT, text="{\"answer\":")
+
+    def test_over_length_is_error(self):
+        result = parse_prefill_args("x" * (PREFILL_MAX_CHARS + 1))
+        assert result.kind == ACTION_ERROR
+        assert str(PREFILL_MAX_CHARS) in result.error
+
+    def test_pin_over_length_is_error(self):
+        result = parse_prefill_args("pin " + "x" * (PREFILL_MAX_CHARS + 1))
+        assert result.kind == ACTION_ERROR
+
+    def test_max_length_exactly_is_accepted(self):
+        result = parse_prefill_args("x" * PREFILL_MAX_CHARS)
+        assert result.kind == ACTION_ONE_SHOT
+        assert len(result.text) == PREFILL_MAX_CHARS
+
+
+class TestDescribePrefillPreview:
+    def test_short_text_verbatim(self):
+        assert describe_prefill_preview("Sure thing:") == "Sure thing:"
+
+    def test_long_text_truncated_with_ellipsis(self):
+        text = "a" * 100
+        preview = describe_prefill_preview(text)
+        assert len(preview) == 60
+        assert preview.endswith("…")
+
+    def test_newlines_flattened_to_spaces(self):
+        assert describe_prefill_preview("line one\nline two") == "line one line two"
+
+
+class TestPinnedPrefillFromConversationMetadata:
+    def test_reads_key_from_json(self):
+        raw = json.dumps({PINNED_PREFILL_METADATA_KEY: "*She pauses*"})
+        assert pinned_prefill_from_conversation_metadata(raw) == "*She pauses*"
+
+    def test_none_metadata_returns_none(self):
+        assert pinned_prefill_from_conversation_metadata(None) is None
+
+    def test_invalid_json_returns_none(self):
+        assert pinned_prefill_from_conversation_metadata("{not json") is None
+
+    def test_non_dict_json_returns_none(self):
+        assert pinned_prefill_from_conversation_metadata("[1, 2]") is None
+
+    def test_missing_key_returns_none(self):
+        assert pinned_prefill_from_conversation_metadata("{}") is None
+
+    def test_non_string_value_returns_none(self):
+        raw = json.dumps({PINNED_PREFILL_METADATA_KEY: 42})
+        assert pinned_prefill_from_conversation_metadata(raw) is None
+
+    def test_blank_string_value_returns_none(self):
+        raw = json.dumps({PINNED_PREFILL_METADATA_KEY: "   "})
+        assert pinned_prefill_from_conversation_metadata(raw) is None
+
+    def test_sibling_keys_ignored(self):
+        raw = json.dumps(
+            {"active_dictionaries": [1, 2], PINNED_PREFILL_METADATA_KEY: "Voice:"}
+        )
+        assert pinned_prefill_from_conversation_metadata(raw) == "Voice:"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest Tests/Chat/test_console_prefill.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'tldw_chatbook.Chat.console_prefill'`
+
+- [ ] **Step 3: Write the module**
+
+Create `tldw_chatbook/Chat/console_prefill.py`:
+
+```python
+"""Pure parsing/validation for the native Console ``/prefill`` command.
+
+No dependency on Textual, the running app, or any I/O — mirrors
+``console_command_grammar.py``. The screen layer owns all UI wiring; the
+controller/store layers own arming state and payload assembly. This module
+only classifies the ``/prefill`` args string and reads the pinned-prefill
+key out of a raw conversation ``metadata`` JSON string.
+
+Normalization: prefill text is ``.strip()``-ed at parse time. The spec
+requires right-trimming (Anthropic rejects a trailing-whitespace assistant
+turn); leading whitespace is stripped too for predictability, matching how
+``/system`` name args are treated.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+PREFILL_MAX_CHARS = 4000
+"""Maximum accepted prefill length; longer input is rejected at arm time."""
+
+PINNED_PREFILL_METADATA_KEY = "pinned_response_prefill"
+"""Key inside ``conversations.metadata`` JSON holding the pinned prefill."""
+
+ACTION_STATUS = "status"
+ACTION_CLEAR = "clear"
+ACTION_PIN = "pin"
+ACTION_ONE_SHOT = "one-shot"
+ACTION_ERROR = "error"
+
+_PIN_SUBCOMMAND = "pin"
+_CLEAR_SUBCOMMAND = "clear"
+_PREVIEW_MAX_CHARS = 60
+
+
+@dataclass(frozen=True)
+class PrefillCommandAction:
+    """One classified ``/prefill`` invocation.
+
+    Args:
+        kind: One of the ``ACTION_*`` constants.
+        text: Normalized prefill text for ``pin``/``one-shot`` kinds.
+        error: Human-readable message for the ``error`` kind.
+    """
+
+    kind: str
+    text: str = ""
+    error: str = ""
+
+
+def _validated(kind: str, text: str) -> PrefillCommandAction:
+    if not text:
+        return PrefillCommandAction(
+            kind=ACTION_ERROR, error="Prefill text is empty."
+        )
+    if len(text) > PREFILL_MAX_CHARS:
+        return PrefillCommandAction(
+            kind=ACTION_ERROR,
+            error=f"Prefill is too long ({len(text)} chars; max {PREFILL_MAX_CHARS}).",
+        )
+    return PrefillCommandAction(kind=kind, text=text)
+
+
+def parse_prefill_args(args: str) -> PrefillCommandAction:
+    """Classify the args string of one ``/prefill`` invocation.
+
+    ``clear`` matches only as the entire (stripped) args; ``pin`` matches
+    only as the first token with trailing text. A one-shot whose text
+    literally starts with ``pin `` or equals ``clear`` therefore cannot be
+    expressed — documented spec limitation.
+    """
+    stripped = args.strip()
+    if not stripped:
+        return PrefillCommandAction(kind=ACTION_STATUS)
+    if stripped.lower() == _CLEAR_SUBCOMMAND:
+        return PrefillCommandAction(kind=ACTION_CLEAR)
+    first, _, remainder = stripped.partition(" ")
+    if first.lower() == _PIN_SUBCOMMAND:
+        pin_text = remainder.strip()
+        if not pin_text:
+            return PrefillCommandAction(
+                kind=ACTION_ERROR, error="Usage: /prefill pin <text>."
+            )
+        return _validated(ACTION_PIN, pin_text)
+    return _validated(ACTION_ONE_SHOT, stripped)
+
+
+def describe_prefill_preview(text: str, max_chars: int = _PREVIEW_MAX_CHARS) -> str:
+    """Return a single-line preview of ``text``, truncated with an ellipsis."""
+    flattened = " ".join(text.split())
+    if len(flattened) <= max_chars:
+        return flattened
+    return flattened[: max_chars - 1] + "…"
+
+
+def pinned_prefill_from_conversation_metadata(raw_metadata: object) -> str | None:
+    """Read the pinned prefill out of a raw conversation ``metadata`` value.
+
+    Mirrors ``local_chat_dictionary_service._active_dictionaries``'s guarded
+    parse (the ``json.loads(None)`` crash class): any missing/invalid shape
+    yields ``None`` rather than raising.
+    """
+    try:
+        meta = json.loads(raw_metadata or "{}")
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(meta, dict):
+        return None
+    value = meta.get(PINNED_PREFILL_METADATA_KEY)
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return value
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest Tests/Chat/test_console_prefill.py -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_prefill.py Tests/Chat/test_console_prefill.py \
+  Docs/superpowers/specs/2026-07-20-console-response-prefill-design.md \
+  Docs/superpowers/plans/2026-07-20-console-response-prefill.md
+git commit -m "feat(console): add pure /prefill parsing + metadata helpers"
+```
+
+---
+
+### Task 2: Register `/prefill` in the command grammar
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_command_grammar.py` (constants near line 36-44; `default_console_registry()` near line 162)
+- Modify: `Tests/UI/test_console_command_composer.py:50-57` (the `UNKNOWN_NOPE_HINT` / `UNKNOWN_NADA_HINT` constants hardcode the available-command list — they break when `/prefill` registers)
+- Test: `Tests/Chat/test_console_command_grammar.py`
+
+**Interfaces:**
+- Consumes: existing `ConsoleCommand`, `ConsoleCommandRegistry`.
+- Produces (used by Task 6): `PREFILL_COMMAND_NAME = "prefill"`, `PREFILL_COMMAND_ARGUMENT_HINT = "[pin|clear] [text]"`, `PREFILL_COMMAND_HANDLER_ID = "prefill"`; `/prefill` registered in `default_console_registry()`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `Tests/Chat/test_console_command_grammar.py` (mirror the existing `/skills` test style; import `default_console_registry`, `CommandParse` as the file already does):
+
+```python
+def test_default_console_registry_includes_prefill():
+    registry = default_console_registry()
+    assert "prefill" in registry.available_names()
+
+
+def test_prefill_parses_with_args():
+    registry = default_console_registry()
+    assert registry.parse("/prefill pin *She pauses*") == CommandParse(
+        "command", "prefill", "pin *She pauses*"
+    )
+    assert registry.parse("/prefill") == CommandParse("command", "prefill", "")
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python -m pytest Tests/Chat/test_console_command_grammar.py -v -k prefill`
+Expected: FAIL — `'prefill' not in available_names()` (and the parse returns `unknown`).
+
+- [ ] **Step 3: Implement registration**
+
+In `tldw_chatbook/Chat/console_command_grammar.py`, after the `SKILLS_COMMAND_*` constants:
+
+```python
+PREFILL_COMMAND_NAME = "prefill"
+PREFILL_COMMAND_ARGUMENT_HINT = "[pin|clear] [text]"
+PREFILL_COMMAND_HANDLER_ID = "prefill"
+```
+
+In `default_console_registry()`, after the skills `registry.register(...)` block:
+
+```python
+    registry.register(
+        ConsoleCommand(
+            name=PREFILL_COMMAND_NAME,
+            argument_hint=PREFILL_COMMAND_ARGUMENT_HINT,
+            handler_id=PREFILL_COMMAND_HANDLER_ID,
+        )
+    )
+```
+
+Update the module docstring's command list if it enumerates commands, and the `default_console_registry` docstring ("built-in ``/prompt`` and ``/system``…") to mention `/prefill`.
+
+- [ ] **Step 4: Fix the unknown-command hint constants**
+
+In `Tests/UI/test_console_command_composer.py`, update both constants (the hint is derived from `available_names()`, so it now includes `/prefill`):
+
+```python
+UNKNOWN_NOPE_HINT = (
+    "Unknown command /nope — available: /prompt, /system, /skills, /prefill. "
+    "Press Enter again to send as text."
+)
+UNKNOWN_NADA_HINT = (
+    "Unknown command /nada — available: /prompt, /system, /skills, /prefill. "
+    "Press Enter again to send as text."
+)
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `python -m pytest Tests/Chat/test_console_command_grammar.py -v && python -m pytest Tests/UI/test_console_command_composer.py -v`
+Expected: grammar tests all PASS. Composer tests pass at their pre-existing baseline (this repo has known pre-existing UI-test failures; the requirement is: no NEW failures vs. running them before this change — if unsure, `git stash && pytest ... && git stash pop` to compare).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_command_grammar.py \
+  Tests/Chat/test_console_command_grammar.py Tests/UI/test_console_command_composer.py
+git commit -m "feat(console): register /prefill slash command"
+```
+
+---
+
+### Task 3: State homes — settings field, session field, store accessors
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_session_settings.py` (`ConsoleSessionSettings` fields end near line 176)
+- Modify: `tldw_chatbook/Chat/console_chat_store.py` (`ConsoleChatSession` dataclass ~line 123-134; accessors near `session_draft` ~line 315-323)
+- Test: `Tests/Chat/test_console_session_settings.py`, `Tests/Chat/test_console_chat_store.py`
+
+**Interfaces:**
+- Consumes: existing dataclasses.
+- Produces (used by Tasks 4, 5, 6):
+  - `ConsoleSessionSettings.pinned_prefill: str | None = None`
+  - `ConsoleChatSession.one_shot_prefill: str | None = None`
+  - `ConsoleChatStore.session_one_shot_prefill(session_id: str) -> str | None`
+  - `ConsoleChatStore.set_session_one_shot_prefill(session_id: str, prefill: str | None) -> ConsoleChatSession`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `Tests/Chat/test_console_session_settings.py` add (match the file's existing import of `ConsoleSessionSettings`; construct with the same minimal args existing tests use — `provider` is the only required field):
+
+```python
+def test_pinned_prefill_defaults_none_and_replaces():
+    from dataclasses import replace
+
+    settings = ConsoleSessionSettings(provider="llama_cpp")
+    assert settings.pinned_prefill is None
+    pinned = replace(settings, pinned_prefill="*She pauses*")
+    assert pinned.pinned_prefill == "*She pauses*"
+    assert settings.pinned_prefill is None
+```
+
+In `Tests/Chat/test_console_chat_store.py` add:
+
+```python
+def test_one_shot_prefill_accessors_round_trip():
+    store = ConsoleChatStore()
+    session = store.create_session(title="Chat 1")
+    assert store.session_one_shot_prefill(session.id) is None
+    store.set_session_one_shot_prefill(session.id, "Sure thing:")
+    assert store.session_one_shot_prefill(session.id) == "Sure thing:"
+    store.set_session_one_shot_prefill(session.id, None)
+    assert store.session_one_shot_prefill(session.id) is None
+
+
+def test_one_shot_prefill_is_per_session():
+    store = ConsoleChatStore()
+    session_a = store.create_session(title="A")
+    session_b = store.create_session(title="B")
+    store.set_session_one_shot_prefill(session_a.id, "only A")
+    assert store.session_one_shot_prefill(session_b.id) is None
+```
+
+(Note: check how existing store tests call `create_session` — if it requires `workspace_id` or activation, copy the file's existing minimal-session construction exactly.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python -m pytest Tests/Chat/test_console_session_settings.py Tests/Chat/test_console_chat_store.py -v -k prefill`
+Expected: FAIL — `TypeError`/`AttributeError` (unknown field / missing methods).
+
+- [ ] **Step 3: Implement**
+
+In `console_session_settings.py`, add as the LAST field of `ConsoleSessionSettings` (after `source: str = "derived"`):
+
+```python
+    pinned_prefill: str | None = None
+```
+
+In `console_chat_store.py`, add to `ConsoleChatSession` after `pending_attachments`:
+
+```python
+    one_shot_prefill: str | None = None
+```
+
+Add accessors right after `set_session_draft` (mirroring the draft accessors):
+
+```python
+    def session_one_shot_prefill(self, session_id: str) -> str | None:
+        """Return the armed one-shot response prefill for a session, if any."""
+        return self._session_or_raise(session_id).one_shot_prefill
+
+    def set_session_one_shot_prefill(
+        self, session_id: str, prefill: str | None
+    ) -> ConsoleChatSession:
+        """Arm (or clear, with ``None``) the one-shot response prefill."""
+        session = self._session_or_raise(session_id)
+        session.one_shot_prefill = prefill
+        return session
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `python -m pytest Tests/Chat/test_console_session_settings.py Tests/Chat/test_console_chat_store.py -v`
+Expected: all PASS (new and pre-existing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_session_settings.py tldw_chatbook/Chat/console_chat_store.py \
+  Tests/Chat/test_console_session_settings.py Tests/Chat/test_console_chat_store.py
+git commit -m "feat(console): add prefill state homes (session settings + store)"
+```
+
+---
+
+### Task 4: Pinned persistence — merge-safe metadata write + store write-through
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/chat_persistence_service.py` (new method after `update_conversation_system_prompt`, ~line 222)
+- Modify: `tldw_chatbook/Chat/console_chat_store.py` (Protocol `ConsoleChatPersistence` ~line 45-109; new `set_session_pinned_prefill` after `set_session_system_prompt` ~line 950; flush in `persist_session_if_needed` ~line 859-877)
+- Test: `Tests/Chat/test_console_chat_store.py`
+
+**Interfaces:**
+- Consumes: `PINNED_PREFILL_METADATA_KEY` from Task 1; `ConsoleSessionSettings.pinned_prefill` from Task 3.
+- Produces (used by Tasks 5, 6):
+  - `ChatPersistenceService.update_conversation_pinned_prefill(*, conversation_id: str, pinned_prefill: str | None) -> bool`
+  - `ConsoleChatStore.set_session_pinned_prefill(session_id: str, prefill: str | None) -> tuple[ConsoleChatSession, bool]` (returns `(session, persisted)` exactly like `set_session_system_prompt`)
+  - `persist_session_if_needed` flushes a pinned prefill when it first creates the conversation.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `Tests/Chat/test_console_chat_store.py`:
+
+(a) Extend the file's existing `FakePersistence` class (~line 444-510) with a recorder, following its `update_conversation_system_prompt` → `updated_system_prompts` pattern:
+
+```python
+    # inside FakePersistence.__init__:
+    self.updated_pinned_prefills = []
+
+    # new method on FakePersistence:
+    def update_conversation_pinned_prefill(self, *, conversation_id, pinned_prefill):
+        self.updated_pinned_prefills.append((conversation_id, pinned_prefill))
+        return True
+```
+
+(b) New tests (copy session/persistence construction from the file's existing `set_session_system_prompt` tests; `ConsoleSessionSettings` import already exists in the file or add it):
+
+```python
+def test_set_session_pinned_prefill_updates_memory_and_writes_through():
+    persistence = FakePersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    session = store.create_session(title="Chat 1")
+    session.settings = ConsoleSessionSettings(provider="llama_cpp")
+    session.persisted_conversation_id = "conv-1"
+
+    updated, persisted = store.set_session_pinned_prefill(session.id, "Voice:")
+    assert persisted is True
+    assert updated.settings.pinned_prefill == "Voice:"
+    assert persistence.updated_pinned_prefills == [("conv-1", "Voice:")]
+
+    updated, persisted = store.set_session_pinned_prefill(session.id, None)
+    assert updated.settings.pinned_prefill is None
+    assert persistence.updated_pinned_prefills[-1] == ("conv-1", None)
+
+
+def test_set_session_pinned_prefill_blank_normalizes_to_none():
+    store = ConsoleChatStore()
+    session = store.create_session(title="Chat 1")
+    session.settings = ConsoleSessionSettings(provider="llama_cpp")
+    updated, persisted = store.set_session_pinned_prefill(session.id, "   ")
+    assert updated.settings.pinned_prefill is None
+    assert persisted is True  # no durable write needed
+
+
+def test_set_session_pinned_prefill_persistence_failure_keeps_memory():
+    class ExplodingPersistence(FakePersistence):
+        def update_conversation_pinned_prefill(self, **kwargs):
+            raise RuntimeError("db locked")
+
+    persistence = ExplodingPersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    session = store.create_session(title="Chat 1")
+    session.settings = ConsoleSessionSettings(provider="llama_cpp")
+    session.persisted_conversation_id = "conv-1"
+    updated, persisted = store.set_session_pinned_prefill(session.id, "Voice:")
+    assert persisted is False
+    assert updated.settings.pinned_prefill == "Voice:"
+
+
+def test_persist_session_if_needed_flushes_pinned_prefill():
+    persistence = FakePersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    session = store.create_session(title="Chat 1")
+    session.settings = ConsoleSessionSettings(
+        provider="llama_cpp", pinned_prefill="Voice:"
+    )
+    store.persist_session_if_needed(session.id)
+    assert persistence.updated_pinned_prefills == [("conv-1", "Voice:")]
+```
+
+(c) Real-DB merge-safety test — append to the file's real-DB section (mirror the existing `CharactersRAGDB` construction at ~line 947-977 for imports and setup):
+
+```python
+def test_update_conversation_pinned_prefill_preserves_sibling_metadata(tmp_path):
+    import json
+
+    db = CharactersRAGDB(str(tmp_path / "chachanotes.sqlite"), "test_client")
+    service = ChatPersistenceService(db)
+    conversation_id = service.create_conversation(
+        assistant_kind="generic", assistant_id="console", conversation_title="T"
+    )
+    # Pre-seed a sibling key the dictionary-attach feature owns.
+    record = db.get_conversation_by_id(conversation_id)
+    db.update_conversation(
+        conversation_id,
+        {"metadata": json.dumps({"active_dictionaries": [1, 2]})},
+        expected_version=record["version"],
+    )
+
+    assert service.update_conversation_pinned_prefill(
+        conversation_id=conversation_id, pinned_prefill="Voice:"
+    )
+    meta = json.loads(db.get_conversation_by_id(conversation_id)["metadata"])
+    assert meta["active_dictionaries"] == [1, 2]
+    assert meta["pinned_response_prefill"] == "Voice:"
+
+    assert service.update_conversation_pinned_prefill(
+        conversation_id=conversation_id, pinned_prefill=None
+    )
+    meta = json.loads(db.get_conversation_by_id(conversation_id)["metadata"])
+    assert meta["active_dictionaries"] == [1, 2]
+    assert "pinned_response_prefill" not in meta
+
+    assert not service.update_conversation_pinned_prefill(
+        conversation_id="missing-conv", pinned_prefill="x"
+    )
+```
+
+(If the real-DB tests in the file also build the workspace registry, copy that setup verbatim; `create_conversation` may require `workspace_id`/`scope_type` — match the neighboring test exactly.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python -m pytest Tests/Chat/test_console_chat_store.py -v -k "pinned_prefill or prefill"`
+Expected: FAIL — missing methods.
+
+- [ ] **Step 3: Implement `ChatPersistenceService.update_conversation_pinned_prefill`**
+
+In `chat_persistence_service.py`, after `update_conversation_system_prompt` (add `import json` and the key import at the top: `from tldw_chatbook.Chat.console_prefill import PINNED_PREFILL_METADATA_KEY`):
+
+```python
+    def update_conversation_pinned_prefill(
+        self,
+        *,
+        conversation_id: str,
+        pinned_prefill: str | None,
+    ) -> bool:
+        """Set or clear the pinned response prefill in conversation metadata.
+
+        Merge-safe: re-parses the current ``metadata`` JSON and rewrites only
+        its own key, preserving siblings such as ``active_dictionaries``
+        (mirrors ``LocalChatDictionaryService._write_active_dictionaries``).
+        Optimistic-lock conflicts (``ConflictError``) propagate to the caller.
+
+        Returns:
+            True when the write happened; False when the conversation does
+            not exist.
+        """
+        record = self.db.get_conversation_by_id(str(conversation_id))
+        if record is None:
+            return False
+        try:
+            meta = json.loads(record.get("metadata") or "{}")
+        except (TypeError, ValueError):
+            meta = {}
+        if not isinstance(meta, dict):
+            meta = {}
+        if pinned_prefill:
+            meta[PINNED_PREFILL_METADATA_KEY] = pinned_prefill
+        else:
+            meta.pop(PINNED_PREFILL_METADATA_KEY, None)
+        self.db.update_conversation(
+            str(conversation_id),
+            {"metadata": json.dumps(meta)},
+            expected_version=record["version"],
+        )
+        return True
+```
+
+- [ ] **Step 4: Implement the store side**
+
+In `console_chat_store.py`:
+
+(a) Add to the `ConsoleChatPersistence` Protocol (after the `update_conversation_system_prompt` entry, matching its style):
+
+```python
+    def update_conversation_pinned_prefill(
+        self,
+        *,
+        conversation_id: str,
+        pinned_prefill: str | None,
+    ) -> bool:
+        """Set or clear the pinned response prefill on a conversation."""
+        ...
+```
+
+(b) Add `set_session_pinned_prefill` right after `set_session_system_prompt` — copy its structure exactly (in-memory `replace(...)`, getattr-guarded write-through, catch-log-flag; the getattr guard keeps old fakes/persistence objects without the new method working):
+
+```python
+    def set_session_pinned_prefill(
+        self, session_id: str, prefill: str | None
+    ) -> tuple[ConsoleChatSession, bool]:
+        """Set or clear a session's pinned response prefill.
+
+        Mirrors ``set_session_system_prompt``: updates the in-memory
+        settings snapshot and, when the session already owns a persisted
+        conversation, writes through to conversation metadata. A durable
+        write failure is caught and logged; the in-memory value is kept and
+        the honest ``persisted`` flag is returned.
+        """
+        session = self._session_or_raise(session_id)
+        normalized = prefill if isinstance(prefill, str) and prefill.strip() else None
+        if session.settings is not None:
+            session.settings = replace(session.settings, pinned_prefill=normalized)
+        persisted = True
+        if (
+            session.persisted_conversation_id is not None
+            and self.persistence is not None
+        ):
+            update_pinned = getattr(
+                self.persistence, "update_conversation_pinned_prefill", None
+            )
+            if callable(update_pinned):
+                try:
+                    update_pinned(
+                        conversation_id=session.persisted_conversation_id,
+                        pinned_prefill=normalized,
+                    )
+                except Exception:
+                    persisted = False
+                    logger.bind(
+                        session_id=session_id,
+                        conversation_id=session.persisted_conversation_id,
+                    ).exception(
+                        "Failed to persist Console pinned prefill; "
+                        "in-memory session keeps the applied value."
+                    )
+        return session, persisted
+```
+
+(c) In `persist_session_if_needed`, after `session.persisted_conversation_id = self.persistence.create_conversation(...)` and before `return`:
+
+```python
+        pinned_prefill = (
+            session.settings.pinned_prefill if session.settings is not None else None
+        )
+        if pinned_prefill:
+            update_pinned = getattr(
+                self.persistence, "update_conversation_pinned_prefill", None
+            )
+            if callable(update_pinned):
+                try:
+                    update_pinned(
+                        conversation_id=session.persisted_conversation_id,
+                        pinned_prefill=pinned_prefill,
+                    )
+                except Exception:
+                    logger.bind(
+                        session_id=session_id,
+                        conversation_id=session.persisted_conversation_id,
+                    ).exception("Failed to flush pinned prefill on first persist.")
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `python -m pytest Tests/Chat/test_console_chat_store.py -v`
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/Chat/chat_persistence_service.py tldw_chatbook/Chat/console_chat_store.py \
+  Tests/Chat/test_console_chat_store.py
+git commit -m "feat(console): merge-safe pinned-prefill persistence in conversation metadata"
+```
+
+---
+
+### Task 5: Controller send path — resolve, bypass, payload, seed, consume
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py`:
+  - `submit_draft` (prefill resolution after `_apply_chat_dictionaries`, ~line 431)
+  - `retry_message` / `regenerate_message` (pinned resolution before their `_stream_assistant_response` calls, ~lines 1069-1074 / 1170-1178)
+  - `_stream_assistant_response` (~line 1817): new params, gate condition, payload append, mode-specific seeding, one-shot consumption
+  - new private helpers `_pinned_prefill_for_session`, `_resolve_submit_prefill`, `_consume_one_shot_prefill`
+- Test: `Tests/Chat/test_console_chat_controller.py`
+
+**Interfaces:**
+- Consumes: `session_one_shot_prefill` / `set_session_one_shot_prefill` / `session_settings` (Task 3); `ConsoleSessionSettings.pinned_prefill` (Task 3).
+- Produces (used by Task 6): fully wired send behavior; no new public API beyond the two store-driven states — the screen arms state, the controller consumes it.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `Tests/Chat/test_console_chat_controller.py` (reuse the file's existing `StreamingGateway`, `RecordingStreamingGateway`, `BlockedGateway`, `FailingBeforeChunkGateway`, `EmptyStreamingGateway` fakes and its `ConsoleChatStore`/`ConsoleChatController` construction style; `ConsoleSessionSettings` import exists in the file):
+
+```python
+def _arm_session(store):
+    """Create+activate a session with settings; return it."""
+    session = store.ensure_session(
+        workspace_id=store.workspace_context.active_workspace_id
+    )
+    if session.settings is None:
+        session.settings = ConsoleSessionSettings(provider="llama_cpp")
+    return session
+
+
+@pytest.mark.asyncio
+async def test_submit_with_one_shot_prefill_appends_trailing_assistant_and_seeds():
+    store = ConsoleChatStore()
+    gateway = RecordingStreamingGateway()
+    controller = ConsoleChatController(store=store, provider_gateway=gateway)
+    session = _arm_session(store)
+    store.set_session_one_shot_prefill(session.id, "Sure thing:")
+
+    result = await controller.submit_draft("hello")
+    assert result.submitted
+    assert gateway.messages_seen[-1] == {
+        "role": "assistant",
+        "content": "Sure thing:",
+    }
+    assert gateway.messages_seen[-2]["role"] == "user"
+    messages = store.messages_for_session(session.id)
+    assert messages[-1].content == "Sure thing:ok"  # seed + RecordingStreamingGateway's "ok"
+    assert messages[-1].status == "complete"
+    # one-shot consumed on complete
+    assert store.session_one_shot_prefill(session.id) is None
+
+
+@pytest.mark.asyncio
+async def test_submit_with_pinned_prefill_applies_and_survives():
+    store = ConsoleChatStore()
+    gateway = RecordingStreamingGateway()
+    controller = ConsoleChatController(store=store, provider_gateway=gateway)
+    session = _arm_session(store)
+    store.set_session_pinned_prefill(session.id, "Voice:")
+
+    await controller.submit_draft("hello")
+    assert gateway.messages_seen[-1] == {"role": "assistant", "content": "Voice:"}
+    # pinned survives the send
+    assert store.session_settings(session.id).pinned_prefill == "Voice:"
+
+
+@pytest.mark.asyncio
+async def test_one_shot_wins_over_pinned_then_pinned_resumes():
+    store = ConsoleChatStore()
+    gateway = RecordingStreamingGateway()
+    controller = ConsoleChatController(store=store, provider_gateway=gateway)
+    session = _arm_session(store)
+    store.set_session_pinned_prefill(session.id, "PINNED")
+    store.set_session_one_shot_prefill(session.id, "ONESHOT")
+
+    await controller.submit_draft("first")
+    assert gateway.messages_seen[-1]["content"] == "ONESHOT"
+    await controller.submit_draft("second")
+    assert gateway.messages_seen[-1]["content"] == "PINNED"
+
+
+@pytest.mark.asyncio
+async def test_blocked_send_retains_one_shot():
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=BlockedGateway())
+    session = _arm_session(store)
+    store.set_session_one_shot_prefill(session.id, "KEEP")
+    await controller.submit_draft("hello")
+    assert store.session_one_shot_prefill(session.id) == "KEEP"
+
+
+@pytest.mark.asyncio
+async def test_failed_send_retains_one_shot_and_shows_prefill():
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(
+        store=store, provider_gateway=FailingBeforeChunkGateway()
+    )
+    session = _arm_session(store)
+    store.set_session_one_shot_prefill(session.id, "KEEP")
+    await controller.submit_draft("hello")
+    assert store.session_one_shot_prefill(session.id) == "KEEP"
+    messages = store.messages_for_session(session.id)
+    assert messages[-1].status == "failed"
+    assert messages[-1].content == "KEEP"  # seed materialized, no provider tokens
+
+
+@pytest.mark.asyncio
+async def test_zero_token_stream_fails_with_prefill_only_content():
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(
+        store=store, provider_gateway=EmptyStreamingGateway()
+    )
+    session = _arm_session(store)
+    store.set_session_one_shot_prefill(session.id, "PRE")
+    await controller.submit_draft("hello")
+    messages = store.messages_for_session(session.id)
+    assert messages[-1].status == "failed"
+    assert messages[-1].content == "PRE"
+    assert store.session_one_shot_prefill(session.id) == "PRE"
+
+
+@pytest.mark.asyncio
+async def test_stop_mid_stream_consumes_one_shot():
+    store = ConsoleChatStore()
+
+    class StopAfterFirstChunkGateway(StreamingGateway):
+        def __init__(self):
+            self.controller = None
+
+        async def stream_chat(self, resolution, messages):
+            yield "partial"
+            self.controller._stop_requested = True
+            yield "never-shown"
+
+    gateway = StopAfterFirstChunkGateway()
+    controller = ConsoleChatController(store=store, provider_gateway=gateway)
+    gateway.controller = controller
+    session = _arm_session(store)
+    store.set_session_one_shot_prefill(session.id, "PRE")
+    await controller.submit_draft("hello")
+    messages = store.messages_for_session(session.id)
+    assert messages[-1].status == "stopped"
+    assert messages[-1].content.startswith("PRE")
+    assert store.session_one_shot_prefill(session.id) is None
+
+
+@pytest.mark.asyncio
+async def test_retry_zero_tokens_leaves_failed_content_untouched():
+    """A pinned-prefill retry that yields no tokens must not seed: the lazy
+    prepare_message_retry never runs, so the original failed content (the
+    seed from the first attempt) stays exactly as it was."""
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(
+        store=store, provider_gateway=FailingBeforeChunkGateway()
+    )
+    session = _arm_session(store)
+    store.set_session_pinned_prefill(session.id, "PINNED")
+    await controller.submit_draft("hello")
+    failed = store.messages_for_session(session.id)[-1]
+    assert failed.status == "failed"
+    assert failed.content == "PINNED"  # seed from the failed first attempt
+
+    controller.provider_gateway = EmptyStreamingGateway()
+    await controller.retry_message(failed.id)
+    after = store.get_message(failed.id)
+    assert after.status == "failed"
+    assert after.content == "PINNED"  # untouched — no double-seed, no wipe
+
+
+@pytest.mark.asyncio
+async def test_retry_applies_pinned_but_not_one_shot():
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(
+        store=store, provider_gateway=FailingBeforeChunkGateway()
+    )
+    session = _arm_session(store)
+    store.set_session_pinned_prefill(session.id, "PINNED")
+    await controller.submit_draft("hello")
+    failed = store.messages_for_session(session.id)[-1]
+    assert failed.status == "failed"
+
+    gateway = RecordingStreamingGateway()
+    controller.provider_gateway = gateway
+    result = await controller.retry_message(failed.id)
+    assert result.submitted
+    assert gateway.messages_seen[-1] == {"role": "assistant", "content": "PINNED"}
+    retried = store.get_message(failed.id)
+    assert retried.status == "complete"
+    assert retried.content == "PINNEDok"
+
+
+@pytest.mark.asyncio
+async def test_regenerate_applies_pinned_into_variant():
+    store = ConsoleChatStore()
+    gateway = RecordingStreamingGateway()
+    controller = ConsoleChatController(store=store, provider_gateway=gateway)
+    session = _arm_session(store)
+    await controller.submit_draft("hello")
+    original = store.messages_for_session(session.id)[-1]
+    store.set_session_pinned_prefill(session.id, "PINNED")
+
+    await controller.regenerate_message(original.id)
+    assert gateway.messages_seen[-1] == {"role": "assistant", "content": "PINNED"}
+    regenerated = store.get_message(original.id)
+    assert regenerated.content == "PINNEDok"
+
+
+@pytest.mark.asyncio
+async def test_continue_never_gets_prefill():
+    store = ConsoleChatStore()
+    gateway = RecordingStreamingGateway()
+    controller = ConsoleChatController(store=store, provider_gateway=gateway)
+    session = _arm_session(store)
+    await controller.submit_draft("hello")
+    assistant = store.messages_for_session(session.id)[-1]
+    store.set_session_pinned_prefill(session.id, "PINNED")
+    store.set_session_one_shot_prefill(session.id, "ONESHOT")
+
+    await controller.continue_from_message(assistant.id)
+    # continue keeps its synthetic USER instruction; nothing assistant-trailing
+    assert gateway.messages_seen[-1]["role"] == "user"
+    # one-shot untouched (continue is not a normal send)
+    assert store.session_one_shot_prefill(session.id) == "ONESHOT"
+
+
+@pytest.mark.asyncio
+async def test_prefilled_send_bypasses_agent_loop():
+    from types import SimpleNamespace
+
+    from tldw_chatbook.Agents.agent_models import RUN_DONE, RunOutcome
+
+    store = ConsoleChatStore()
+    gateway = RecordingStreamingGateway()
+    controller = ConsoleChatController(
+        store=store, provider_gateway=gateway, agent_runtime_enabled=True
+    )
+    bridge_calls = []
+
+    def run_reply(**kwargs):
+        bridge_calls.append(kwargs)
+        return RunOutcome(status=RUN_DONE, steps=[], final_text="agent says")
+
+    controller._agent_bridge = SimpleNamespace(run_reply=run_reply)
+    session = _arm_session(store)
+
+    # Control: without prefill the agent path handles the send.
+    await controller.submit_draft("no prefill")
+    assert len(bridge_calls) == 1
+    assert gateway.messages_seen is None
+
+    # With prefill armed the direct provider path handles it.
+    store.set_session_one_shot_prefill(session.id, "PRE")
+    await controller.submit_draft("with prefill")
+    assert len(bridge_calls) == 1  # unchanged
+    assert gateway.messages_seen[-1] == {"role": "assistant", "content": "PRE"}
+```
+
+Adjust the control-test expectations to the real agent-path plumbing if `_run_agent_reply` requires more bridge surface than `run_reply` (e.g. `_agent_conversation_id` needs a persisted store, or `RunOutcome` needs more fields) — the file's existing agent-path tests around lines 1671-1776 and 2182-2218 show the working patterns; mirror them. The assertion that matters is: **prefill ⇒ `gateway.messages_seen` is populated and the bridge is NOT called; no prefill ⇒ bridge called.** If making the no-prefill control leg work requires disproportionate fake-bridge scaffolding, keep only the prefill leg plus a direct unit assertion that the gate condition includes `prefill is None`.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python -m pytest Tests/Chat/test_console_chat_controller.py -v -k prefill`
+Expected: FAIL — payloads lack the trailing assistant message; contents lack the seed; one-shot never consumed.
+
+- [ ] **Step 3: Implement controller helpers**
+
+In `console_chat_controller.py`, near the other small private helpers (e.g. after `_ensure_user_continuation_instruction`):
+
+```python
+    def _pinned_prefill_for_session(self, session_id: str) -> str | None:
+        """Return the session's pinned response prefill, if any."""
+        settings = self.store.session_settings(session_id)
+        pinned = getattr(settings, "pinned_prefill", None) if settings else None
+        return pinned or None
+
+    def _resolve_submit_prefill(self, session_id: str) -> tuple[str | None, bool]:
+        """Return ``(prefill, from_one_shot)`` for a normal send.
+
+        One-shot wins over pinned for the send it is armed for; pinned
+        resumes afterward (the one-shot is only cleared on a complete or
+        stopped outcome — see ``_consume_one_shot_prefill``).
+        """
+        one_shot = self.store.session_one_shot_prefill(session_id)
+        if one_shot:
+            return one_shot, True
+        return self._pinned_prefill_for_session(session_id), False
+
+    def _consume_one_shot_prefill(
+        self, assistant_message_id: str, used_one_shot: bool
+    ) -> None:
+        """Clear the armed one-shot after a send that used it terminated
+        ``complete`` or ``stopped``. Blocked and failed sends never call
+        this, so retry reproduces the original intent (spec §2)."""
+        if not used_one_shot:
+            return
+        try:
+            session_id = self.store.session_id_for_message(assistant_message_id)
+        except KeyError:
+            return
+        self.store.set_session_one_shot_prefill(session_id, None)
+```
+
+- [ ] **Step 4: Thread `prefill` through `_stream_assistant_response`**
+
+Modify the signature (line ~1817):
+
+```python
+    async def _stream_assistant_response(
+        self,
+        *,
+        resolution: Any,
+        provider_messages: list[dict[str, str]],
+        assistant_message_id: str,
+        prepare_retry: bool = False,
+        variant_mode: bool = False,
+        prefill: str | None = None,
+        prefill_from_one_shot: bool = False,
+    ) -> ConsoleSubmitResult:
+```
+
+Change the agent gate (first statement) to bypass when a prefill applies (spec §2: a prefilled send is a raw model continuation — the agent loop is skipped for that turn):
+
+```python
+        if (
+            self._agent_runtime_enabled
+            and self._agent_bridge is not None
+            and prefill is None
+        ):
+            return await self._run_agent_reply(...)  # unchanged call
+```
+
+After the gate, append the trailing assistant payload message (a copy, so callers' lists are not mutated) — insert right after the gate, before `self._active_assistant_message_id = assistant_message_id`:
+
+```python
+        if prefill:
+            provider_messages = [
+                *provider_messages,
+                {
+                    "role": ConsoleMessageRole.ASSISTANT.value,
+                    "content": prefill,
+                },
+            ]
+```
+
+Seed the display for normal/variant modes — insert right after the existing `if variant_mode: self.store.begin_variant_stream(assistant_message_id)` block and before `self._set_run_state(... STREAMING ...)`. Retry mode must NOT seed here (a failed message rejects chunks until `prepare_message_retry` runs, and the lazy prepare preserves original content on a zero-token retry):
+
+```python
+        if prefill and not prepare_retry:
+            try:
+                self.store.append_stream_chunk(assistant_message_id, prefill)
+            except KeyError:
+                return self._session_closed_result()
+```
+
+Seed retry mode at the lazy-prepare point — the existing block inside the chunk loop becomes:
+
+```python
+                if prepare_retry and not retry_prepared:
+                    self.store.prepare_message_retry(assistant_message_id)
+                    retry_prepared = True
+                    if prefill:
+                        try:
+                            self.store.append_stream_chunk(
+                                assistant_message_id, prefill
+                            )
+                        except KeyError:
+                            return self._session_closed_result()
+```
+
+(Do NOT touch `emitted_content` in any seed path — it must keep reflecting provider chunks only.)
+
+Consume the one-shot at the terminal outcomes that used it. Add `self._consume_one_shot_prefill(assistant_message_id, prefill_from_one_shot)` immediately BEFORE each of these four `return` statements in the direct path (all in the current function body):
+1. the mid-loop stop: `return ConsoleSubmitResult(True, True, stopped.content)` (after the first `_mark_stream_stopped` inside the chunk loop)
+2. the post-loop stop: same pattern after the loop
+3. the completion return: `return ConsoleSubmitResult(True, True, completed.content)`
+4. the `asyncio.CancelledError` stop: the `return ConsoleSubmitResult(True, True, stopped.content)` inside that handler
+
+Do NOT add it to the failed/blocked/exception exits.
+
+- [ ] **Step 5: Wire the three send sites**
+
+`submit_draft` — after `provider_messages = await self._apply_chat_dictionaries(provider_messages, session.id)` and before `self._notify_submission_accepted()`:
+
+```python
+        prefill, prefill_from_one_shot = self._resolve_submit_prefill(session.id)
+```
+
+…and extend its `_stream_assistant_response` call:
+
+```python
+        return await self._stream_assistant_response(
+            resolution=resolution,
+            provider_messages=provider_messages,
+            assistant_message_id=assistant.id,
+            prefill=prefill,
+            prefill_from_one_shot=prefill_from_one_shot,
+        )
+```
+
+`retry_message` — before its `_stream_assistant_response` call add `prefill = self._pinned_prefill_for_session(session_id)` and pass `prefill=prefill` (no `prefill_from_one_shot`):
+
+```python
+        prefill = self._pinned_prefill_for_session(session_id)
+        return await self._stream_assistant_response(
+            resolution=resolution,
+            provider_messages=provider_messages,
+            assistant_message_id=message_id,
+            prepare_retry=True,
+            prefill=prefill,
+        )
+```
+
+`regenerate_message` — same pattern:
+
+```python
+        prefill = self._pinned_prefill_for_session(session_id)
+        return await self._stream_assistant_response(
+            resolution=resolution,
+            provider_messages=provider_messages,
+            assistant_message_id=message_id,
+            variant_mode=True,
+            prefill=prefill,
+        )
+```
+
+`continue_from_message` — unchanged (no prefill argument).
+
+- [ ] **Step 6: Run the new tests, then the full controller + store suites**
+
+Run: `python -m pytest Tests/Chat/test_console_chat_controller.py -v -k prefill`
+Expected: all new tests PASS.
+Run: `python -m pytest Tests/Chat/test_console_chat_controller.py Tests/Chat/test_console_chat_store.py -v`
+Expected: no regressions (every pre-existing test still passes — these suites are green at baseline).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_chat_controller.py Tests/Chat/test_console_chat_controller.py
+git commit -m "feat(console): apply response prefill on the direct send path with agent-loop bypass"
+```
+
+---
+
+### Task 6: Screen wiring — `/prefill` handler, resume load, inspector rows
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`:
+  - imports (grammar constants + console_prefill helpers)
+  - `_CONSOLE_COMMAND_NAME_TO_HANDLER_ID` (~line 8975) and the `dispatch_map` in `_dispatch_console_command` (~line 9007)
+  - new handler `_console_command_prefill` (place after `_console_command_apply_system`, ~line 9276)
+  - `_console_session_settings_for_resume` (~line 3225)
+  - `_selected_console_conversation_inspector_rows` (~line 5950)
+- Test: `Tests/UI/test_console_command_composer.py`
+
+**Interfaces:**
+- Consumes: Task 1 (`parse_prefill_args`, `describe_prefill_preview`, `pinned_prefill_from_conversation_metadata`, `ACTION_*`), Task 2 (`PREFILL_COMMAND_NAME`, `PREFILL_COMMAND_HANDLER_ID`), Task 3/4 store accessors (`session_one_shot_prefill`, `set_session_one_shot_prefill`, `set_session_pinned_prefill`, `session_settings`).
+- Produces: complete user-facing feature.
+
+- [ ] **Step 1: Write the failing screen test**
+
+Add to `Tests/UI/test_console_command_composer.py`, using the file's exact harness pattern (`_build_test_app` + `_configure_native_ready_console` + `ConsoleHarness`, drive via `composer.load_draft(...)` + `#console-send-message` press, assert via `_system_message_contents(console)` — same as `test_console_unknown_command_first_enter_renders_hint_and_does_not_send` at line ~80):
+
+```python
+@pytest.mark.asyncio
+async def test_console_prefill_command_arms_one_shot_and_confirms():
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.load_draft("/prefill Sure thing:")
+
+        console.query_one("#console-send-message", Button).press()
+        await _wait_for_text(console, pilot, "Prefill armed for next send")
+
+        store = console._ensure_console_chat_store()
+        session_id = store.active_session_id
+        assert store.session_one_shot_prefill(session_id) == "Sure thing:"
+        assert composer.draft_text() == ""  # handled command clears its draft
+
+
+@pytest.mark.asyncio
+async def test_console_prefill_pin_and_clear_round_trip():
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        send_button = console.query_one("#console-send-message", Button)
+        store = console._ensure_console_chat_store()
+
+        composer.load_draft("/prefill pin Voice:")
+        send_button.press()
+        await _wait_for_text(console, pilot, "Prefill pinned")
+        session_id = store.active_session_id
+        assert store.session_settings(session_id).pinned_prefill == "Voice:"
+
+        composer.load_draft("/prefill clear")
+        send_button.press()
+        await _wait_for_text(console, pilot, "Prefill cleared")
+        assert store.session_settings(session_id).pinned_prefill is None
+        assert store.session_one_shot_prefill(session_id) is None
+        assert composer.draft_text() == ""
+```
+
+(If `store.active_session_id` is `None` before the first command lands, the handler's `ensure_session` creates it — read `session_id` AFTER the first send, as written above.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python -m pytest Tests/UI/test_console_command_composer.py -v -k prefill`
+Expected: FAIL — `/prefill` dispatches to no handler (nothing armed, no system message).
+
+- [ ] **Step 3: Implement dispatch wiring + handler**
+
+In `chat_screen.py`:
+
+(a) Extend the grammar import (the file already imports `PROMPT_COMMAND_NAME` etc. from `console_command_grammar`) with `PREFILL_COMMAND_NAME, PREFILL_COMMAND_HANDLER_ID`, and add a new import:
+
+```python
+from tldw_chatbook.Chat.console_prefill import (
+    ACTION_CLEAR,
+    ACTION_ERROR,
+    ACTION_ONE_SHOT,
+    ACTION_PIN,
+    ACTION_STATUS,
+    describe_prefill_preview,
+    parse_prefill_args,
+    pinned_prefill_from_conversation_metadata,
+)
+```
+
+(b) `_CONSOLE_COMMAND_NAME_TO_HANDLER_ID` — add `PREFILL_COMMAND_NAME: PREFILL_COMMAND_HANDLER_ID,`.
+
+(c) `dispatch_map` in `_dispatch_console_command` — add `PREFILL_COMMAND_HANDLER_ID: self._console_command_prefill,`.
+
+(d) The handler (after `_console_command_apply_system`; use the codebase's existing markup-escape import in this file — check how existing system messages escape user text and reuse that exact call, referred to below as `escape_markup`):
+
+```python
+    async def _console_command_prefill(self, parse: CommandParse) -> None:
+        """Arm, pin, clear, or report the Console response prefill (`/prefill`).
+
+        One-shot (`/prefill <text>`) applies to the next normal send only
+        and wins over pinned; `/prefill pin <text>` applies to every
+        submit/retry/regenerate until cleared and write-throughs to
+        conversation metadata when the session is persisted. Errors leave
+        the draft in place for correction (mirrors `/system`'s
+        no-system-part behavior); handled outcomes clear it.
+        """
+        action = parse_prefill_args(parse.args)
+        store = self._ensure_console_chat_store()
+        session = store.ensure_session(
+            workspace_id=store.workspace_context.active_workspace_id
+        )
+        if action.kind == ACTION_ERROR:
+            await self._append_native_console_system_message(
+                escape_markup(action.error)
+            )
+            return
+        if action.kind == ACTION_STATUS:
+            one_shot = store.session_one_shot_prefill(session.id)
+            settings = store.session_settings(session.id)
+            pinned = getattr(settings, "pinned_prefill", None) if settings else None
+            lines = []
+            if one_shot:
+                lines.append(
+                    "Prefill (next send only): "
+                    f"'{escape_markup(describe_prefill_preview(one_shot))}'"
+                )
+            if pinned:
+                lines.append(
+                    f"Prefill (pinned): '{escape_markup(describe_prefill_preview(pinned))}'"
+                )
+            if not lines:
+                lines.append("No prefill armed.")
+            await self._append_native_console_system_message("\n".join(lines))
+            self._clear_console_composer_draft()
+            return
+        if action.kind == ACTION_CLEAR:
+            store.set_session_one_shot_prefill(session.id, None)
+            _session, persisted = store.set_session_pinned_prefill(session.id, None)
+            copy = "Prefill cleared."
+            if not persisted:
+                copy += " (Warning: saved conversation not updated.)"
+            await self._append_native_console_system_message(copy)
+            self._clear_console_composer_draft()
+            return
+        preview = escape_markup(describe_prefill_preview(action.text))
+        if action.kind == ACTION_PIN:
+            _session, persisted = store.set_session_pinned_prefill(
+                session.id, action.text
+            )
+            copy = (
+                f"Prefill pinned: '{preview}'. Applies to every send, retry, and "
+                "regenerate until /prefill clear. The reply continues directly "
+                "from the last character; tool calling is skipped on prefilled sends."
+            )
+            if not persisted:
+                copy += " (Warning: saved conversation not updated.)"
+            await self._append_native_console_system_message(copy)
+            self._clear_console_composer_draft()
+            return
+        # ACTION_ONE_SHOT
+        store.set_session_one_shot_prefill(session.id, action.text)
+        await self._append_native_console_system_message(
+            f"Prefill armed for next send: '{preview}'. The reply continues "
+            "directly from the last character; tool calling is skipped on "
+            "prefilled sends."
+        )
+        self._clear_console_composer_draft()
+```
+
+After writing it, read `_apply_console_session_system_prompt` (`chat_screen.py:9326`) and append the same inspector/session-state refresh tail it uses after mutating settings (whatever call it makes to re-render the inspector — reuse it verbatim after the pin/clear/one-shot mutations). If it makes no such call (the inspector refreshes on its own cadence), add nothing.
+
+- [ ] **Step 4: Resume load + inspector rows**
+
+(a) `_console_session_settings_for_resume` — change the return to also restore the pinned prefill:
+
+```python
+        pinned_prefill = pinned_prefill_from_conversation_metadata(
+            conversation.get("metadata")
+        )
+        return replace(
+            settings, system_prompt=system_prompt, pinned_prefill=pinned_prefill
+        )
+```
+
+(b) `_selected_console_conversation_inspector_rows` — before the final `return (...)`, build optional prefill rows from the in-memory session (NO DB I/O — this function already holds `active_session`) and include them in the returned tuple:
+
+```python
+        prefill_rows: list[ConsoleDisplayRow] = []
+        one_shot = active_session.one_shot_prefill
+        if one_shot:
+            prefill_rows.append(
+                ConsoleDisplayRow(
+                    "Prefill (next send only)", describe_prefill_preview(one_shot)
+                )
+            )
+        session_settings = active_session.settings
+        pinned = (
+            session_settings.pinned_prefill if session_settings is not None else None
+        )
+        if pinned:
+            prefill_rows.append(
+                ConsoleDisplayRow("Prefill (pinned)", describe_prefill_preview(pinned))
+            )
+```
+
+…and append `*prefill_rows` to the returned tuple of rows.
+
+- [ ] **Step 5: Run tests**
+
+Run: `python -m pytest Tests/UI/test_console_command_composer.py -v -k prefill`
+Expected: new tests PASS.
+Run: `python -m pytest Tests/UI/test_console_command_composer.py Tests/Chat/ -v`
+Expected: no NEW failures vs. baseline (see Task 2 Step 5 note about the pre-existing UI-failure baseline).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/UI/Screens/chat_screen.py Tests/UI/test_console_command_composer.py
+git commit -m "feat(console): /prefill command, resume restore, and what's-in-play rows"
+```
+
+---
+
+### Task 7: Full verification + live smoke
+
+**Files:**
+- Modify (only if fixes needed): files from Tasks 1-6.
+- Modify: `Docs/superpowers/specs/2026-07-20-console-response-prefill-design.md` — record the §5 verification-item outcomes (Gemini / Responses-API) in a short "Verification results" appendix.
+
+**Interfaces:** none new — this is the spec's §5/§7 verification pass.
+
+- [ ] **Step 1: Full test suites**
+
+Run: `python -m pytest Tests/Chat/ -v` — expected: all pass.
+Run: `python -m pytest Tests/UI/test_console_command_composer.py Tests/UI/test_console_native_chat_flow.py -v` — expected: no new failures vs. baseline.
+
+- [ ] **Step 2: Live smoke against the local llama-server**
+
+Launch the app (`python3 -m tldw_chatbook.app` — run from the worktree root; note the `python -m` cwd trap: make sure the worktree, not the main checkout, is on `sys.path`) with the local llama-server running on `:9099`. In the Console:
+1. `/prefill Sure thing, here is the JSON: {` then send "give me a 2-key sample object" → reply must visibly start with the prefill text; inspector shows nothing armed afterward (one-shot consumed).
+2. `/prefill pin *speaking as the ship's AI*` → send twice → both replies start with the pin; "What's in play" shows the pinned row; regenerate the last reply → variant also starts with the pin.
+3. `/prefill clear` → next send has no prefill.
+4. `/prefill` bare → status line correct at each stage.
+5. Save/persist the conversation (send while persistence is on), quit, relaunch, resume the conversation → pinned prefill still applies (metadata round-trip).
+6. Stop a prefilled response mid-stream → message keeps prefill + partial, status stopped.
+
+- [ ] **Step 3: Spec §5 verification items (provider compatibility)**
+
+With whatever providers are configured locally (skip gracefully if no key, but record which were checked):
+- Anthropic: prefilled send → confirm literal continuation and no API error (right-trim guard).
+- Gemini (`chat_with_google`): prefilled send → confirm the trailing `model`-role turn is accepted. If the handler/API rejects it, implement the spec §5 incompatible-provider guard IN THIS BRANCH before finishing: in `_stream_assistant_response`, when `resolution.provider` is in the rejecting set, drop the prefill from BOTH the payload and the display seed and post an inline system row ("Prefill skipped: <provider> does not accept a prefilled response.") — the transcript must never show text the provider did not receive. Add a controller test for the guard. Do not silently ship a provider that errors.
+- OpenAI with Responses API enabled (`use_responses_api`): same check for the `input`-shaped branch.
+Record all three outcomes in the spec appendix.
+
+- [ ] **Step 4: Run the repo verify flow**
+
+Use the `verify` skill (drive the real app flow, not just tests) if not already covered by Step 2. Self-review the full diff (`git diff dev...HEAD`).
+
+- [ ] **Step 5: Commit + finish**
+
+```bash
+git add -A && git commit -m "test(console): prefill verification results + spec appendix"
+```
+
+Then follow `superpowers:finishing-a-development-branch` (PR against `dev`; CI is intentionally cancelled by another build in this repo — verify locally, don't block on CI).

--- a/Docs/superpowers/qa/console-prefill-uat-2026-07-20/README.md
+++ b/Docs/superpowers/qa/console-prefill-uat-2026-07-20/README.md
@@ -1,0 +1,45 @@
+# Console `/prefill` UAT — 2026-07-20
+
+Fresh-profile user-acceptance drive of the response-prefill feature (PR #729) in the real
+TUI (tmux 235x52, scratch `TLDW_CONFIG_PATH` profile `verify_prefill`, llama-server :9099,
+model gemma-4-26B heretic quant). Distinct from the engineering smoke: run as a new user,
+UI affordances only.
+
+## Results
+
+| # | Leg | Result |
+|---|-----|--------|
+| 1 | Discoverability: unknown-command hint lists `/prefill` | PASS |
+| 2 | Bare `/prefill` with nothing armed → "No prefill armed." | PASS |
+| 3 | Bracket-containing one-shot arm → confirmation renders literally, **no `\[` artifact** (validates the escape-drop) | PASS |
+| 4 | Prefilled send → literal continuation (`Sure! Here you go: ["alpha",` → `"beta"]`) | PASS |
+| 5 | One-shot consumed after completed send | PASS |
+| 6 | `/prefill pin` → subsequent send starts in voice | PASS |
+| 7 | Inspector "What's in play" shows pinned row | **FINDING → FIXED** (below) |
+| 8 | Pin restored across full app restart + rail resume (conversation metadata) | PASS |
+| 9 | UI regenerate (select message, `r`) → variant starts with the *current* pin | PASS |
+| 10 | `/prefill pin` with no text → usage error, draft kept | PASS (prior session) |
+| 11 | `/prefill clear` → metadata key removed merge-safely in SQLite | PASS (prior session) |
+
+## Finding (fixed in-branch, commit 0b596d067)
+
+The prefill inspector rows rendered as **unrouted rows at the very bottom** of the
+inspector (below "Selected Message", above "Chat Dictionaries") instead of inside the
+"Selected Conversation" section — `ConsoleRunInspector` routes rows through hardcoded
+label tables (`_ROW_ID_BY_LABEL`, `_ROW_GROUPS`) that the feature never registered its
+labels in. In a 52-row terminal the rows sat below the fold, i.e. effectively invisible.
+Fix: registered both labels with stable ids in the Selected Conversation group + widget
+test (`test_prefill_rows_route_into_selected_conversation_group`). Verified live
+post-fix: `Prefill (pinned)` renders directly under "Resume state".
+
+## Observations (non-blocking)
+
+- The test model (heretic Gemma quant) leaks `<|channel>thought` tokens into prefilled
+  continuations — model-template noise, present in raw curl too, not feature-related.
+- The message-action "Guide" line (`♻ Regenerate ---> Continue …`) is a legend, not
+  buttons; the actual affordance is keyboard (`r` etc.) with a message selected. Fine
+  once known, but a first-time user may click the legend expecting buttons (pre-existing
+  UX, not prefill-specific).
+- The two `_sync_console_*` calls in the `/prefill` handler's refresh tail do not rebuild
+  the inspector; the inspector catches up on the next UI-sync tick (message append
+  triggers one, so in practice the row appears immediately after the confirmation row).

--- a/Docs/superpowers/specs/2026-07-20-console-response-prefill-design.md
+++ b/Docs/superpowers/specs/2026-07-20-console-response-prefill-design.md
@@ -1,0 +1,229 @@
+# Console Response Prefill — Design
+
+**Date:** 2026-07-20
+**Status:** Approved design, pending implementation plan
+**Surface:** Native Console chat only. The legacy Chat window is deprecated and gets nothing.
+
+## 1. Overview
+
+Let the user supply the opening of the assistant's reply. The prefill text is sent to the
+provider as a trailing `{"role": "assistant", "content": <prefill>}` message (Anthropic-style
+prefill; OpenAI-compatible endpoints accept the same shape), and the model continues from it.
+In the transcript, the reply visibly grows out of the prefill; the saved message is one
+ordinary assistant message containing prefill + continuation, which is exactly what later
+turns should see as history.
+
+**Use cases:** steering format/structure (one-shot), keeping roleplay/character voice
+(pinned), and steering past hedging/preamble.
+
+### Non-goals (v1)
+
+- Legacy Chat window support (deprecated).
+- Multi-line prefill editor (real-world prefills are short; single-line command is enough).
+- SillyTavern-style "start the assistant message in the transcript and complete it".
+- Prefill threaded through the agent runtime/tool loop — a prefilled send bypasses the agent
+  loop for that turn instead (§2); engine-level support is a possible follow-up.
+- Reworking `continue_from_message` semantics (it keeps its synthetic user instruction).
+- Engine-native continuation flags (vLLM `continue_final_message`, DeepSeek `prefix: true`
+  beta) — candidate follow-up, not v1.
+- Recording "this response was prefilled with X" per message (no message-metadata column
+  exists; overloading `feedback` is a hack we refuse).
+
+## 2. User-facing behavior
+
+### Command grammar
+
+Registered as `prefill` in `default_console_registry()`
+(`tldw_chatbook/Chat/console_command_grammar.py:162`), handled in `chat_screen.py` following
+the `_console_command_apply_system` pattern (including clearing the composer draft on any
+handled outcome).
+
+| Input | Effect |
+|---|---|
+| `/prefill <text>` | Arm one-shot prefill for the next normal send. |
+| `/prefill pin <text>` | Pin prefill for every submit/retry/regenerate this session until cleared. |
+| `/prefill clear` | Clear both one-shot and pinned. |
+| `/prefill` | Inline status line: current one-shot and pinned values (or "none"). |
+
+Parse rules: `clear` matches only when it is the **entire** args string; `pin` matches only as
+the **first token with trailing text**. A one-shot whose text literally starts with `pin ` or
+equals `clear` therefore cannot be expressed — documented limitation, not guarded against.
+
+Validation at arm time: text is right-trimmed (Anthropic rejects trailing whitespace in a
+trailing assistant turn; applied uniformly so display and payload never diverge), empty after
+trim is an inline error, length capped at 4,000 characters with an inline error.
+
+### Lifecycle
+
+- **One-shot** applies to the next `submit_draft` send only. Precedence: if both one-shot and
+  pinned are set, one-shot wins for that send; pinned resumes afterward.
+- **Consumption rule:** a one-shot is consumed only when a send that used it terminates
+  `complete` or `stopped`. It stays armed through `_block()` outcomes (provider not ready,
+  skill refusal, policy) and through `failed` sends — so a retry of the failed send
+  reproduces the original intent.
+- **Pinned** applies to `submit_draft`, `retry_message`, and `regenerate_message`.
+  `continue_from_message` never gets prefill (it keeps today's synthetic user-instruction
+  semantics). A one-shot never applies to retry/regenerate.
+- Both states are **per-session**. Pinned additionally persists per-conversation (§4) and is
+  loaded when a conversation binds to the session. Switching sessions or conversations never
+  leaks armed state across.
+- **Agent loop bypass:** there are no "agent sessions" — the agent runtime is a
+  controller-wide gate (`[console].agent_runtime`, default on) checked at the top of
+  `_stream_assistant_response`, and under default config it handles every Console send. A
+  send where prefill applies takes the **direct provider stream for that turn**, skipping
+  the agent loop: true prefill semantics, but native tool-calling/MCP do not run on that
+  turn. Skill substitution and chat dictionaries are unaffected (they run before this
+  split). Sends without an applicable prefill route exactly as today. The arm confirmation
+  copy states that tool calling is disabled on prefilled sends.
+
+### Feedback
+
+- Inline transcript system messages via `_append_native_console_system_message`, with user
+  text markup-escaped: "Prefill armed for next send: '<preview>'" / "Prefill pinned:
+  '<preview>'" / "Prefill cleared." Confirmation copy notes that the continuation glues
+  directly to the last character (consequence of right-trimming).
+- The **"What's in play"** inspector block shows both states, labeled "next send only" vs
+  "pinned", alongside dictionaries.
+- No new composer chrome in v1.
+
+## 3. Architecture and data flow
+
+### State
+
+Following where existing per-session state lives:
+
+- **Pinned** → a new field on `ConsoleSessionSettings` (`console_session_settings.py:145`,
+  frozen dataclass, updated via `replace(...)` + `replace_session_settings`) — the same home
+  as the per-session system prompt. This means it rides the existing settings flows for
+  free: screen-state serialization across app restarts, and the conversation-resume seam
+  (§4).
+- **One-shot** → transient per-session state on `ConsoleChatSession`
+  (`console_chat_store.py:124`), like `draft` and `pending_attachments`, with store
+  accessors keyed by session id. Never serialized.
+
+### Single seam: `_stream_assistant_response`
+
+`_stream_assistant_response` (`tldw_chatbook/Chat/console_chat_controller.py:1817`) gains a
+`prefill: str | None` parameter and owns both halves of the feature. When `prefill` is set,
+the agent-runtime gate at the top of the function is skipped for that turn (§2 bypass) and
+the send proceeds down the direct provider-stream path unconditionally.
+
+1. **Payload:** appends `{"role": "assistant", "content": prefill}` as the final element of
+   `provider_messages`. The payload always ends in a user turn when it arrives here —
+   `submit_draft` builds it ending in the fresh user message, and retry/regenerate run
+   `_ensure_user_continuation_instruction` — so appending yields exactly one trailing
+   assistant turn and alternation stays valid.
+2. **Display seed:** pushes the prefill as the *first stream chunk* via
+   `append_stream_chunk`. The store's existing buffer machinery
+   (`console_chat_store.py:607-630`) then treats it as ordinary streamed content — zero store
+   changes. The seed is injected outside the provider-chunk loop and must not set the
+   `emitted_content` flag — a provider that streams nothing still terminates in today's
+   "Provider stream ended without content" failed state (§6). The injection point is
+   mode-specific:
+   - **Normal send:** immediately after streaming starts on the empty placeholder.
+   - **Regenerate:** immediately after `begin_variant_stream` (which wipes content/buffer).
+     Stop-during-regenerate then discards the prefill along with the partial variant and
+     restores the base — correct behavior for free.
+   - **Retry:** at the existing lazy `prepare_message_retry` point, before the first real
+     chunk. This preserves the current guarantee that a retry producing zero tokens leaves
+     the original failed content untouched. (A failed message rejects chunks until prepare
+     runs, so eager seeding is not an option.)
+
+Call sites (`submit_draft`, `retry_message`, `regenerate_message`) only compute which prefill
+applies — one-shot-or-pinned for submit, pinned-only for retry/regenerate — and pass it.
+`continue_from_message` passes `None`.
+
+### Ordering relative to existing transforms
+
+Prefill is resolved and appended **after** `_apply_skill_substitution` and
+`_apply_chat_dictionaries` — neither transform ever rewrites prefill text — and after
+`_ensure_user_continuation_instruction`, so the synthetic user-continue can never land after
+the prefill turn.
+
+## 4. Persistence
+
+- **Pinned:** stored in the existing `conversations.metadata` JSON column (schema v20 — **no
+  migration**) under key `pinned_response_prefill` (string). No generic metadata helper
+  exists — the dictionary-attach helpers are key-specific — so this adds a small analogous
+  helper following the `_write_active_dictionaries` pattern
+  (`local_chat_dictionary_service.py:794-808`): read-modify-write that re-parses the current
+  metadata, sets only its own key, and writes the whole dict back via
+  `db.update_conversation` under optimistic lock (that column is shared with
+  `active_dictionaries` — sibling keys must be preserved; `ConflictError` propagates). Reads
+  are guarded like `_active_dictionaries` (`json.loads(record.get("metadata") or "{}")` in
+  try/except with dict coercion — the known `json.loads(None)` crash class). Write-through
+  on pin/clear when a persisted conversation exists; if a session with a pinned prefill is
+  persisted later (`persist_session_if_needed`), the pinned value is flushed then. Ephemeral
+  sessions keep it in memory only.
+- **Load seam:** when a saved conversation is resumed,
+  `_console_session_settings_for_resume` (`chat_screen.py:3225`) already receives the full
+  conversation record (`SELECT *` includes `metadata`) and today reads only
+  `system_prompt`; it additionally parses `pinned_response_prefill` into the session
+  settings there. App-start restore needs nothing new — settings already ride screen-state
+  serialization.
+- **One-shot:** memory only, never persisted.
+- **The final message:** a plain assistant message (prefill + continuation), persisted by the
+  existing `mark_message_complete` / `finalize_variant_stream` flush. No marker of the
+  prefill's extent is recorded (non-goal).
+
+## 5. Provider compatibility
+
+- **Anthropic** (`LLM_API_Calls.py:874`): trailing assistant text passes through verbatim;
+  the API guarantees literal continuation. Trailing-whitespace rejection handled by
+  right-trimming at arm time.
+- **OpenAI-compatible** (OpenAI, Groq, Mistral, OpenRouter, Moonshot, local llama.cpp /
+  Ollama / vLLM / etc.): trailing assistant message passes through unmodified
+  (`LLM_API_Calls.py:521`). The API model is a *new* assistant message, so the model usually
+  continues but may restart or repeat — user docs state this honestly rather than pretending
+  prefill is uniform across providers.
+- **Verification items** (during implementation, not design unknowns to resolve here):
+  - Gemini (`chat_with_google`, role remap to `model` + alternation enforcement) — confirm a
+    trailing model turn is accepted.
+  - OpenAI Responses-API branch (`use_responses_api`, `payload["input"]`) — confirm shape.
+- **Incompatible-provider guard:** if a provider is verified to reject a trailing assistant
+  turn, the send skips the prefill in **both** the payload and the display seed and posts an
+  inline warning — the transcript must never show text the provider did not receive. v1
+  ships the guard mechanism with an empty (or verification-determined) provider list.
+
+## 6. Error handling and edge cases
+
+| Case | Behavior |
+|---|---|
+| Provider streams zero tokens | Existing "Provider stream ended without content" semantics: message marked `failed`, showing the prefill text; one-shot retained; retry available. |
+| Stream fails before any chunk (normal send) | Message shows prefill, status `failed`; one-shot not consumed; retry re-applies. |
+| Stop mid-stream (normal send) | Existing stopped semantics: partial content including prefill kept; one-shot consumed. |
+| Stop mid-regenerate | Existing base-restore semantics: prefill discarded with the partial variant. |
+| Retry produces zero tokens | Original failed content untouched (lazy-prepare preserved). |
+| Tool-call turns | Cannot occur on a prefilled send: the agent-loop bypass (§2) means the direct stream handles it, and only the agent bridge ever calls `reset_stream_content`. |
+| Empty/whitespace-only prefill text | Inline error; nothing armed. |
+| > 4,000 chars | Inline error; nothing armed. |
+
+## 7. Testing
+
+- **Grammar unit tests:** `pin`/`clear`/bare/plain-text parse forms, including the
+  `clear`-exact-match and `pin`-requires-trailing-text rules.
+- **Controller unit tests:** one-shot consumed on complete/stopped, retained on
+  blocked/failed; one-shot precedence over pinned; site matrix (submit/retry/regenerate get
+  pinned, continue never, retry/regenerate never get one-shot); payload ends in exactly one
+  assistant turn even when the continuation-instruction logic ran; skill/dictionary
+  transforms leave prefill untouched; right-trim and length-cap validation; **agent-loop
+  bypass**: with a (fake) bridge present and agent runtime enabled, a prefilled send takes
+  the direct provider path while an unprefilled send still routes to the bridge. (Note: the
+  in-memory test harness gets `bridge=None` from `_ensure_console_agent_bridge`, so bypass
+  tests must inject a fake bridge explicitly — the default harness only ever exercises the
+  direct path.)
+- **Real-store integration tests** (unmocked, in-memory SQLite, real `ConsoleChatStore`, fake
+  provider gateway capturing the outbound payload — per the project rule that new protocol
+  params get real-implementation integration tests): seeded placeholder streams to
+  prefill+continuation and persists; regenerate variant = prefill+continuation with correct
+  base restore on stop; retry zero-token leaves failed content; pinned metadata round-trips
+  across a conversation reload and preserves sibling metadata keys.
+- **Live smoke during verification:** Anthropic (native prefill honored) and local
+  llama-server; Gemini/Responses-API as the §5 verification items.
+
+## 8. Follow-up candidates (explicitly not v1)
+
+- Engine-native continuation flags (vLLM `continue_final_message`, DeepSeek `prefix: true`).
+- Multi-line prefill editor modal.
+- Per-message record of prefill extent (needs a message-metadata column).
+- Composer chrome (chip/toggle) if slash-command discoverability proves insufficient.

--- a/Docs/superpowers/specs/2026-07-20-console-response-prefill-design.md
+++ b/Docs/superpowers/specs/2026-07-20-console-response-prefill-design.md
@@ -221,7 +221,34 @@ the prefill turn.
 - **Live smoke during verification:** Anthropic (native prefill honored) and local
   llama-server; Gemini/Responses-API as the §5 verification items.
 
-## 8. Follow-up candidates (explicitly not v1)
+## 8. Verification results (2026-07-20, live smoke on llama-server :9099 + remote API checks)
+
+- **llama.cpp: SUPPORTED, with a verification-determined fix.** llama-server returns HTTP 400
+  ("Assistant response prefill is incompatible with enable_thinking.") when the loaded
+  template's thinking mode is on. Fix shipped in this branch: `build_llamacpp_chat_payload`
+  adds `chat_template_kwargs: {"enable_thinking": false}` whenever the payload ends in an
+  assistant turn (the wire-level signature of a prefilled send). Verified live: the model
+  literally continues the prefill. This replaces §5's skip+warn guard for llama.cpp — the
+  provider is compatible, not incompatible. Rationale: thinking-first generation is
+  incoherent with a forced response opening (same logic as the agent-loop bypass).
+- **Resume-path bug found and fixed:** `normalize_conversation_row` whitelisted away the
+  `metadata` column, so pinned prefill never restored on conversation resume. Fixed with a
+  raw passthrough; verified live across a full app restart + rail resume.
+- **All lifecycle legs verified live in the running TUI:** one-shot arm → literal
+  continuation → consumed on complete; retained through blocked sends (unreachable-provider)
+  and failed sends (HTTP 400), with the seed visible on the failed message; pin → voice on
+  subsequent sends; merge-safe metadata write AND clear confirmed in SQLite; `/prefill pin`
+  (no text) usage error; status lines correct at every stage.
+- **Anthropic:** the trailing-assistant payload passes the app's handler unmodified and was
+  POSTed to api.anthropic.com (401 — the configured key is invalid, so literal continuation
+  could not be confirmed live; Anthropic documents prefill as supported).
+- **OpenAI (Chat Completions):** accepted the trailing-assistant payload via the app's
+  handler; response was influenced-but-not-literal continuation, exactly as §5 documents.
+- **NOT verified (no key / not configured):** Gemini (`chat_with_google` role-remap) and the
+  OpenAI Responses-API branch. These remain open §5 verification items; no guard entries
+  were added for them.
+
+## 9. Follow-up candidates (explicitly not v1)
 
 - Engine-native continuation flags (vLLM `continue_final_message`, DeepSeek `prefix: true`).
 - Multi-line prefill editor modal.

--- a/Tests/Chat/test_chat_conversation_service.py
+++ b/Tests/Chat/test_chat_conversation_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -801,6 +802,57 @@ def test_get_conversation_tree_carries_system_prompt_through_real_db(tmp_path):
         tree = service.get_conversation_tree(conversation_id)
 
         assert tree["conversation"]["system_prompt"] == "Answer only in French."
+    finally:
+        db.close_connection()
+
+
+def test_get_conversation_tree_carries_metadata_through_real_db(tmp_path):
+    """Full production path: real DB row -> get_conversation_tree()["conversation"].
+
+    Console's pinned-response-prefill feature stores
+    ``{"pinned_response_prefill": "..."}`` in the ``conversations.metadata``
+    JSON column and reads it back via
+    ``ChatScreen._console_session_settings_for_resume`` ->
+    ``pinned_prefill_from_conversation_metadata(conversation.get("metadata"))``.
+    A whitelist projection in ``normalize_conversation_row`` that omits
+    ``metadata`` would silently break resume, so this exercises the real
+    ``CharactersRAGDB`` + ``ChatConversationService`` stack end to end and
+    asserts the raw JSON string round-trips unchanged.
+    """
+    db = CharactersRAGDB(str(tmp_path / "chachanotes.sqlite"), "test-client")
+    try:
+        conversation_id = db.add_conversation({"title": "Saved chat"})
+        record = db.get_conversation_by_id(conversation_id)
+        metadata_json = json.dumps({"pinned_response_prefill": "Understood:"})
+        db.update_conversation(
+            conversation_id,
+            {"metadata": metadata_json},
+            expected_version=record["version"],
+        )
+        service = ChatConversationService(db)
+
+        tree = service.get_conversation_tree(conversation_id)
+
+        assert tree["conversation"]["metadata"] == metadata_json
+    finally:
+        db.close_connection()
+
+
+def test_get_conversation_tree_metadata_is_none_for_new_conversation(tmp_path):
+    """A conversation with no metadata written yields an explicit ``None``.
+
+    Consumers use ``.get("metadata")``, but the key must still be present on
+    the normalized dict so the contract is explicit rather than accidental.
+    """
+    db = CharactersRAGDB(str(tmp_path / "chachanotes.sqlite"), "test-client")
+    try:
+        conversation_id = db.add_conversation({"title": "Fresh chat"})
+        service = ChatConversationService(db)
+
+        tree = service.get_conversation_tree(conversation_id)
+
+        assert "metadata" in tree["conversation"]
+        assert tree["conversation"]["metadata"] is None
     finally:
         db.close_connection()
 

--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -2359,6 +2359,42 @@ async def test_stop_mid_stream_consumes_one_shot():
 
 
 @pytest.mark.asyncio
+async def test_re_armed_one_shot_survives_in_flight_send_completion():
+    """A ``/prefill`` issued mid-stream (re-arming the one-shot to a new
+    value) must survive the in-flight send's completion: the send should
+    only compare-and-clear the one-shot text it actually used, not
+    whatever happens to be armed by the time it finishes."""
+    store = ConsoleChatStore()
+
+    class ReArmMidStreamGateway(StreamingGateway):
+        def __init__(self):
+            self.store = None
+            self.session_id = None
+
+        async def stream_chat(self, resolution, messages):
+            yield "chunk-one"
+            # Simulate a `/prefill SECOND` issued while this send is
+            # still streaming.
+            self.store.set_session_one_shot_prefill(self.session_id, "SECOND")
+            yield "chunk-two"
+
+    gateway = ReArmMidStreamGateway()
+    controller = ConsoleChatController(store=store, provider_gateway=gateway)
+    session = _arm_session(store)
+    gateway.store = store
+    gateway.session_id = session.id
+    store.set_session_one_shot_prefill(session.id, "FIRST")
+
+    result = await controller.submit_draft("hello")
+    assert result.accepted
+    messages = store.messages_for_session(session.id)
+    assert messages[-1].status == "complete"
+    assert messages[-1].content.startswith("FIRST")
+    # SECOND survived — the send only consumed the FIRST it actually used.
+    assert store.session_one_shot_prefill(session.id) == "SECOND"
+
+
+@pytest.mark.asyncio
 async def test_retry_zero_tokens_leaves_failed_content_untouched():
     """A pinned-prefill retry that yields no tokens must not seed: the lazy
     prepare_message_retry never runs, so the original failed content (the

--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -2222,3 +2222,252 @@ def test_build_tools_info_for_snapshot_mcp_provider_absent():
     assert info["native_schemas"] == []
     assert info["mcp_note"] is None
     assert info["preview_note"] == "No native tools are configured for preview."
+
+
+# -----------------------------------------------------------------------------
+# Response prefill (SDD Task 5) — resolve, bypass, payload, seed, consume
+# -----------------------------------------------------------------------------
+
+
+def _arm_session(store):
+    """Create+activate a session with settings; return it."""
+    session = store.ensure_session(
+        workspace_id=store.workspace_context.active_workspace_id
+    )
+    if session.settings is None:
+        session.settings = ConsoleSessionSettings(provider="llama_cpp")
+    return session
+
+
+@pytest.mark.asyncio
+async def test_submit_with_one_shot_prefill_appends_trailing_assistant_and_seeds():
+    store = ConsoleChatStore()
+    gateway = RecordingStreamingGateway()
+    controller = ConsoleChatController(store=store, provider_gateway=gateway)
+    session = _arm_session(store)
+    store.set_session_one_shot_prefill(session.id, "Sure thing:")
+
+    result = await controller.submit_draft("hello")
+    assert result.accepted
+    assert gateway.messages_seen[-1] == {
+        "role": "assistant",
+        "content": "Sure thing:",
+    }
+    assert gateway.messages_seen[-2]["role"] == "user"
+    messages = store.messages_for_session(session.id)
+    assert messages[-1].content == "Sure thing:ok"  # seed + RecordingStreamingGateway's "ok"
+    assert messages[-1].status == "complete"
+    # one-shot consumed on complete
+    assert store.session_one_shot_prefill(session.id) is None
+
+
+@pytest.mark.asyncio
+async def test_submit_with_pinned_prefill_applies_and_survives():
+    store = ConsoleChatStore()
+    gateway = RecordingStreamingGateway()
+    controller = ConsoleChatController(store=store, provider_gateway=gateway)
+    session = _arm_session(store)
+    store.set_session_pinned_prefill(session.id, "Voice:")
+
+    await controller.submit_draft("hello")
+    assert gateway.messages_seen[-1] == {"role": "assistant", "content": "Voice:"}
+    # pinned survives the send
+    assert store.session_settings(session.id).pinned_prefill == "Voice:"
+
+
+@pytest.mark.asyncio
+async def test_one_shot_wins_over_pinned_then_pinned_resumes():
+    store = ConsoleChatStore()
+    gateway = RecordingStreamingGateway()
+    controller = ConsoleChatController(store=store, provider_gateway=gateway)
+    session = _arm_session(store)
+    store.set_session_pinned_prefill(session.id, "PINNED")
+    store.set_session_one_shot_prefill(session.id, "ONESHOT")
+
+    await controller.submit_draft("first")
+    assert gateway.messages_seen[-1]["content"] == "ONESHOT"
+    await controller.submit_draft("second")
+    assert gateway.messages_seen[-1]["content"] == "PINNED"
+
+
+@pytest.mark.asyncio
+async def test_blocked_send_retains_one_shot():
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=BlockedGateway())
+    session = _arm_session(store)
+    store.set_session_one_shot_prefill(session.id, "KEEP")
+    await controller.submit_draft("hello")
+    assert store.session_one_shot_prefill(session.id) == "KEEP"
+
+
+@pytest.mark.asyncio
+async def test_failed_send_retains_one_shot_and_shows_prefill():
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(
+        store=store, provider_gateway=FailingBeforeChunkGateway()
+    )
+    session = _arm_session(store)
+    store.set_session_one_shot_prefill(session.id, "KEEP")
+    await controller.submit_draft("hello")
+    assert store.session_one_shot_prefill(session.id) == "KEEP"
+    # FailingBeforeChunkGateway raises, so a failure system row is appended
+    # after the assistant message; _last_failed_assistant skips it (the
+    # file's own convention for this exact shape, see line ~118).
+    failed = _last_failed_assistant(store, session.id)
+    assert failed.status == "failed"
+    assert failed.content == "KEEP"  # seed materialized, no provider tokens
+
+
+@pytest.mark.asyncio
+async def test_zero_token_stream_fails_with_prefill_only_content():
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(
+        store=store, provider_gateway=EmptyStreamingGateway()
+    )
+    session = _arm_session(store)
+    store.set_session_one_shot_prefill(session.id, "PRE")
+    await controller.submit_draft("hello")
+    messages = store.messages_for_session(session.id)
+    assert messages[-1].status == "failed"
+    assert messages[-1].content == "PRE"
+    assert store.session_one_shot_prefill(session.id) == "PRE"
+
+
+@pytest.mark.asyncio
+async def test_stop_mid_stream_consumes_one_shot():
+    store = ConsoleChatStore()
+
+    class StopAfterFirstChunkGateway(StreamingGateway):
+        def __init__(self):
+            self.controller = None
+
+        async def stream_chat(self, resolution, messages):
+            yield "partial"
+            self.controller._stop_requested = True
+            yield "never-shown"
+
+    gateway = StopAfterFirstChunkGateway()
+    controller = ConsoleChatController(store=store, provider_gateway=gateway)
+    gateway.controller = controller
+    session = _arm_session(store)
+    store.set_session_one_shot_prefill(session.id, "PRE")
+    await controller.submit_draft("hello")
+    messages = store.messages_for_session(session.id)
+    assert messages[-1].status == "stopped"
+    assert messages[-1].content.startswith("PRE")
+    assert store.session_one_shot_prefill(session.id) is None
+
+
+@pytest.mark.asyncio
+async def test_retry_zero_tokens_leaves_failed_content_untouched():
+    """A pinned-prefill retry that yields no tokens must not seed: the lazy
+    prepare_message_retry never runs, so the original failed content (the
+    seed from the first attempt) stays exactly as it was."""
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(
+        store=store, provider_gateway=FailingBeforeChunkGateway()
+    )
+    session = _arm_session(store)
+    store.set_session_pinned_prefill(session.id, "PINNED")
+    await controller.submit_draft("hello")
+    # FailingBeforeChunkGateway raises, so a failure system row follows the
+    # assistant message; _last_failed_assistant skips it.
+    failed = _last_failed_assistant(store, session.id)
+    assert failed.status == "failed"
+    assert failed.content == "PINNED"  # seed from the failed first attempt
+
+    controller.provider_gateway = EmptyStreamingGateway()
+    await controller.retry_message(failed.id)
+    after = store.get_message(failed.id)
+    assert after.status == "failed"
+    assert after.content == "PINNED"  # untouched — no double-seed, no wipe
+
+
+@pytest.mark.asyncio
+async def test_retry_applies_pinned_but_not_one_shot():
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(
+        store=store, provider_gateway=FailingBeforeChunkGateway()
+    )
+    session = _arm_session(store)
+    store.set_session_pinned_prefill(session.id, "PINNED")
+    await controller.submit_draft("hello")
+    # FailingBeforeChunkGateway raises, so a failure system row follows the
+    # assistant message; _last_failed_assistant skips it.
+    failed = _last_failed_assistant(store, session.id)
+    assert failed.status == "failed"
+
+    gateway = RecordingStreamingGateway()
+    controller.provider_gateway = gateway
+    result = await controller.retry_message(failed.id)
+    assert result.accepted
+    assert gateway.messages_seen[-1] == {"role": "assistant", "content": "PINNED"}
+    retried = store.get_message(failed.id)
+    assert retried.status == "complete"
+    assert retried.content == "PINNEDok"
+
+
+@pytest.mark.asyncio
+async def test_regenerate_applies_pinned_into_variant():
+    store = ConsoleChatStore()
+    gateway = RecordingStreamingGateway()
+    controller = ConsoleChatController(store=store, provider_gateway=gateway)
+    session = _arm_session(store)
+    await controller.submit_draft("hello")
+    original = store.messages_for_session(session.id)[-1]
+    store.set_session_pinned_prefill(session.id, "PINNED")
+
+    await controller.regenerate_message(original.id)
+    assert gateway.messages_seen[-1] == {"role": "assistant", "content": "PINNED"}
+    regenerated = store.get_message(original.id)
+    assert regenerated.content == "PINNEDok"
+
+
+@pytest.mark.asyncio
+async def test_continue_never_gets_prefill():
+    store = ConsoleChatStore()
+    gateway = RecordingStreamingGateway()
+    controller = ConsoleChatController(store=store, provider_gateway=gateway)
+    session = _arm_session(store)
+    await controller.submit_draft("hello")
+    assistant = store.messages_for_session(session.id)[-1]
+    store.set_session_pinned_prefill(session.id, "PINNED")
+    store.set_session_one_shot_prefill(session.id, "ONESHOT")
+
+    await controller.continue_from_message(assistant.id)
+    # continue keeps its synthetic USER instruction; nothing assistant-trailing
+    assert gateway.messages_seen[-1]["role"] == "user"
+    # one-shot untouched (continue is not a normal send)
+    assert store.session_one_shot_prefill(session.id) == "ONESHOT"
+
+
+@pytest.mark.asyncio
+async def test_prefilled_send_bypasses_agent_loop():
+    from types import SimpleNamespace
+
+    from tldw_chatbook.Agents.agent_models import RUN_DONE, RunOutcome
+
+    store = ConsoleChatStore()
+    gateway = RecordingStreamingGateway()
+    controller = ConsoleChatController(
+        store=store, provider_gateway=gateway, agent_runtime_enabled=True
+    )
+    bridge_calls = []
+
+    def run_reply(**kwargs):
+        bridge_calls.append(kwargs)
+        return RunOutcome(status=RUN_DONE, steps=[], final_text="agent says")
+
+    controller._agent_bridge = SimpleNamespace(run_reply=run_reply)
+    session = _arm_session(store)
+
+    # Control: without prefill the agent path handles the send.
+    await controller.submit_draft("no prefill")
+    assert len(bridge_calls) == 1
+    assert gateway.messages_seen is None
+
+    # With prefill armed the direct provider path handles it.
+    store.set_session_one_shot_prefill(session.id, "PRE")
+    await controller.submit_draft("with prefill")
+    assert len(bridge_calls) == 1  # unchanged
+    assert gateway.messages_seen[-1] == {"role": "assistant", "content": "PRE"}

--- a/Tests/Chat/test_console_chat_store.py
+++ b/Tests/Chat/test_console_chat_store.py
@@ -447,6 +447,7 @@ class FakePersistence:
         self.created_messages = []
         self.updated_messages = []
         self.updated_system_prompts = []
+        self.updated_pinned_prefills = []
 
     def create_conversation(self, **kwargs):
         self.created_conversations.append(kwargs)
@@ -456,6 +457,10 @@ class FakePersistence:
         self.updated_system_prompts.append(
             {"conversation_id": conversation_id, "system_prompt": system_prompt}
         )
+        return True
+
+    def update_conversation_pinned_prefill(self, *, conversation_id, pinned_prefill):
+        self.updated_pinned_prefills.append((conversation_id, pinned_prefill))
         return True
 
     def create_message(
@@ -682,6 +687,58 @@ def test_set_session_system_prompt_survives_persistence_failure():
     assert persisted is False
     assert updated.settings.system_prompt == "New prompt"
     assert store.session_settings(session.id).system_prompt == "New prompt"
+
+
+def test_set_session_pinned_prefill_updates_memory_and_writes_through():
+    persistence = FakePersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    session = store.create_session(title="Chat 1")
+    session.settings = ConsoleSessionSettings(provider="llama_cpp")
+    session.persisted_conversation_id = "conv-1"
+
+    updated, persisted = store.set_session_pinned_prefill(session.id, "Voice:")
+    assert persisted is True
+    assert updated.settings.pinned_prefill == "Voice:"
+    assert persistence.updated_pinned_prefills == [("conv-1", "Voice:")]
+
+    updated, persisted = store.set_session_pinned_prefill(session.id, None)
+    assert updated.settings.pinned_prefill is None
+    assert persistence.updated_pinned_prefills[-1] == ("conv-1", None)
+
+
+def test_set_session_pinned_prefill_blank_normalizes_to_none():
+    store = ConsoleChatStore()
+    session = store.create_session(title="Chat 1")
+    session.settings = ConsoleSessionSettings(provider="llama_cpp")
+    updated, persisted = store.set_session_pinned_prefill(session.id, "   ")
+    assert updated.settings.pinned_prefill is None
+    assert persisted is True  # no durable write needed
+
+
+def test_set_session_pinned_prefill_persistence_failure_keeps_memory():
+    class ExplodingPersistence(FakePersistence):
+        def update_conversation_pinned_prefill(self, **kwargs):
+            raise RuntimeError("db locked")
+
+    persistence = ExplodingPersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    session = store.create_session(title="Chat 1")
+    session.settings = ConsoleSessionSettings(provider="llama_cpp")
+    session.persisted_conversation_id = "conv-1"
+    updated, persisted = store.set_session_pinned_prefill(session.id, "Voice:")
+    assert persisted is False
+    assert updated.settings.pinned_prefill == "Voice:"
+
+
+def test_persist_session_if_needed_flushes_pinned_prefill():
+    persistence = FakePersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    session = store.create_session(title="Chat 1")
+    session.settings = ConsoleSessionSettings(
+        provider="llama_cpp", pinned_prefill="Voice:"
+    )
+    store.persist_session_if_needed(session.id)
+    assert persistence.updated_pinned_prefills == [("conv-1", "Voice:")]
 
 
 def test_store_enqueues_chat_sync_after_user_message_is_durable():
@@ -1052,6 +1109,41 @@ def test_store_system_prompt_round_trips_through_real_chat_persistence_service(
         )
     finally:
         db.close()
+
+
+def test_update_conversation_pinned_prefill_preserves_sibling_metadata(tmp_path):
+    import json
+
+    db = CharactersRAGDB(str(tmp_path / "chachanotes.sqlite"), "test_client")
+    service = ChatPersistenceService(db)
+    conversation_id = service.create_conversation(
+        assistant_kind="generic", assistant_id="console", conversation_title="T"
+    )
+    # Pre-seed a sibling key the dictionary-attach feature owns.
+    record = db.get_conversation_by_id(conversation_id)
+    db.update_conversation(
+        conversation_id,
+        {"metadata": json.dumps({"active_dictionaries": [1, 2]})},
+        expected_version=record["version"],
+    )
+
+    assert service.update_conversation_pinned_prefill(
+        conversation_id=conversation_id, pinned_prefill="Voice:"
+    )
+    meta = json.loads(db.get_conversation_by_id(conversation_id)["metadata"])
+    assert meta["active_dictionaries"] == [1, 2]
+    assert meta["pinned_response_prefill"] == "Voice:"
+
+    assert service.update_conversation_pinned_prefill(
+        conversation_id=conversation_id, pinned_prefill=None
+    )
+    meta = json.loads(db.get_conversation_by_id(conversation_id)["metadata"])
+    assert meta["active_dictionaries"] == [1, 2]
+    assert "pinned_response_prefill" not in meta
+
+    assert not service.update_conversation_pinned_prefill(
+        conversation_id="missing-conv", pinned_prefill="x"
+    )
 
 
 def test_store_delays_empty_assistant_persistence_until_terminal_content_with_real_service(

--- a/Tests/Chat/test_console_chat_store.py
+++ b/Tests/Chat/test_console_chat_store.py
@@ -1572,3 +1572,21 @@ def test_collapsed_buffer_variant_stream_finalizes_full_content():
         "original",
         "regenerated",
     ]
+
+
+def test_one_shot_prefill_accessors_round_trip():
+    store = ConsoleChatStore()
+    session = store.create_session(title="Chat 1")
+    assert store.session_one_shot_prefill(session.id) is None
+    store.set_session_one_shot_prefill(session.id, "Sure thing:")
+    assert store.session_one_shot_prefill(session.id) == "Sure thing:"
+    store.set_session_one_shot_prefill(session.id, None)
+    assert store.session_one_shot_prefill(session.id) is None
+
+
+def test_one_shot_prefill_is_per_session():
+    store = ConsoleChatStore()
+    session_a = store.create_session(title="A")
+    session_b = store.create_session(title="B")
+    store.set_session_one_shot_prefill(session_a.id, "only A")
+    assert store.session_one_shot_prefill(session_b.id) is None

--- a/Tests/Chat/test_console_command_grammar.py
+++ b/Tests/Chat/test_console_command_grammar.py
@@ -89,7 +89,7 @@ def test_second_fallback_resolver_is_consulted_after_first_declines():
 def test_default_console_registry_registers_prompt_system_and_skills_with_stable_ids():
     registry = default_console_registry()
 
-    assert registry.available_names() == ("prompt", "system", "skills")
+    assert registry.available_names() == ("prompt", "system", "skills", "prefill")
     assert registry.parse("/prompt") == CommandParse("command", "prompt", "")
     assert registry.parse("/system") == CommandParse("command", "system", "")
     assert registry.parse("/skills") == CommandParse("command", "skills", "")
@@ -135,3 +135,16 @@ def test_empty_registry_has_no_available_names_and_unknown_falls_through():
 
     assert registry.available_names() == ()
     assert registry.parse("/anything") == CommandParse("unknown", "anything", "")
+
+
+def test_default_console_registry_includes_prefill():
+    registry = default_console_registry()
+    assert "prefill" in registry.available_names()
+
+
+def test_prefill_parses_with_args():
+    registry = default_console_registry()
+    assert registry.parse("/prefill pin *She pauses*") == CommandParse(
+        "command", "prefill", "pin *She pauses*"
+    )
+    assert registry.parse("/prefill") == CommandParse("command", "prefill", "")

--- a/Tests/Chat/test_console_command_grammar.py
+++ b/Tests/Chat/test_console_command_grammar.py
@@ -86,7 +86,7 @@ def test_second_fallback_resolver_is_consulted_after_first_declines():
     assert registry.parse("/found here") == CommandParse("fallback", "found", "here")
 
 
-def test_default_console_registry_registers_prompt_system_and_skills_with_stable_ids():
+def test_default_console_registry_registers_prompt_system_skills_and_prefill_with_stable_ids():
     registry = default_console_registry()
 
     assert registry.available_names() == ("prompt", "system", "skills", "prefill")
@@ -135,11 +135,6 @@ def test_empty_registry_has_no_available_names_and_unknown_falls_through():
 
     assert registry.available_names() == ()
     assert registry.parse("/anything") == CommandParse("unknown", "anything", "")
-
-
-def test_default_console_registry_includes_prefill():
-    registry = default_console_registry()
-    assert "prefill" in registry.available_names()
 
 
 def test_prefill_parses_with_args():

--- a/Tests/Chat/test_console_prefill.py
+++ b/Tests/Chat/test_console_prefill.py
@@ -1,0 +1,107 @@
+"""Tests for the pure /prefill command parsing + metadata helpers."""
+
+import json
+
+from tldw_chatbook.Chat.console_prefill import (
+    ACTION_CLEAR,
+    ACTION_ERROR,
+    ACTION_ONE_SHOT,
+    ACTION_PIN,
+    ACTION_STATUS,
+    PINNED_PREFILL_METADATA_KEY,
+    PREFILL_MAX_CHARS,
+    PrefillCommandAction,
+    describe_prefill_preview,
+    parse_prefill_args,
+    pinned_prefill_from_conversation_metadata,
+)
+
+
+class TestParsePrefillArgs:
+    def test_bare_args_is_status(self):
+        assert parse_prefill_args("") == PrefillCommandAction(kind=ACTION_STATUS)
+        assert parse_prefill_args("   ") == PrefillCommandAction(kind=ACTION_STATUS)
+
+    def test_clear_matches_only_as_entire_args(self):
+        assert parse_prefill_args("clear").kind == ACTION_CLEAR
+        assert parse_prefill_args("  CLEAR  ").kind == ACTION_CLEAR
+        # 'clear' with trailing text is a one-shot whose text starts with 'clear'
+        result = parse_prefill_args("clear the table, then")
+        assert result == PrefillCommandAction(
+            kind=ACTION_ONE_SHOT, text="clear the table, then"
+        )
+
+    def test_pin_requires_trailing_text(self):
+        result = parse_prefill_args("pin *She pauses*")
+        assert result == PrefillCommandAction(kind=ACTION_PIN, text="*She pauses*")
+        bare_pin = parse_prefill_args("pin")
+        assert bare_pin.kind == ACTION_ERROR
+        assert "pin" in bare_pin.error
+
+    def test_pin_word_prefix_is_one_shot(self):
+        result = parse_prefill_args("pinch of salt")
+        assert result == PrefillCommandAction(kind=ACTION_ONE_SHOT, text="pinch of salt")
+
+    def test_plain_text_is_one_shot_stripped(self):
+        result = parse_prefill_args("  {\"answer\":  ")
+        assert result == PrefillCommandAction(kind=ACTION_ONE_SHOT, text="{\"answer\":")
+
+    def test_over_length_is_error(self):
+        result = parse_prefill_args("x" * (PREFILL_MAX_CHARS + 1))
+        assert result.kind == ACTION_ERROR
+        assert str(PREFILL_MAX_CHARS) in result.error
+
+    def test_pin_over_length_is_error(self):
+        result = parse_prefill_args("pin " + "x" * (PREFILL_MAX_CHARS + 1))
+        assert result.kind == ACTION_ERROR
+
+    def test_max_length_exactly_is_accepted(self):
+        result = parse_prefill_args("x" * PREFILL_MAX_CHARS)
+        assert result.kind == ACTION_ONE_SHOT
+        assert len(result.text) == PREFILL_MAX_CHARS
+
+
+class TestDescribePrefillPreview:
+    def test_short_text_verbatim(self):
+        assert describe_prefill_preview("Sure thing:") == "Sure thing:"
+
+    def test_long_text_truncated_with_ellipsis(self):
+        text = "a" * 100
+        preview = describe_prefill_preview(text)
+        assert len(preview) == 60
+        assert preview.endswith("…")
+
+    def test_newlines_flattened_to_spaces(self):
+        assert describe_prefill_preview("line one\nline two") == "line one line two"
+
+
+class TestPinnedPrefillFromConversationMetadata:
+    def test_reads_key_from_json(self):
+        raw = json.dumps({PINNED_PREFILL_METADATA_KEY: "*She pauses*"})
+        assert pinned_prefill_from_conversation_metadata(raw) == "*She pauses*"
+
+    def test_none_metadata_returns_none(self):
+        assert pinned_prefill_from_conversation_metadata(None) is None
+
+    def test_invalid_json_returns_none(self):
+        assert pinned_prefill_from_conversation_metadata("{not json") is None
+
+    def test_non_dict_json_returns_none(self):
+        assert pinned_prefill_from_conversation_metadata("[1, 2]") is None
+
+    def test_missing_key_returns_none(self):
+        assert pinned_prefill_from_conversation_metadata("{}") is None
+
+    def test_non_string_value_returns_none(self):
+        raw = json.dumps({PINNED_PREFILL_METADATA_KEY: 42})
+        assert pinned_prefill_from_conversation_metadata(raw) is None
+
+    def test_blank_string_value_returns_none(self):
+        raw = json.dumps({PINNED_PREFILL_METADATA_KEY: "   "})
+        assert pinned_prefill_from_conversation_metadata(raw) is None
+
+    def test_sibling_keys_ignored(self):
+        raw = json.dumps(
+            {"active_dictionaries": [1, 2], PINNED_PREFILL_METADATA_KEY: "Voice:"}
+        )
+        assert pinned_prefill_from_conversation_metadata(raw) == "Voice:"

--- a/Tests/Chat/test_console_provider_gateway.py
+++ b/Tests/Chat/test_console_provider_gateway.py
@@ -82,6 +82,45 @@ def test_llamacpp_payload_includes_explicit_top_k_zero() -> None:
     assert payload == {"model": "m", "messages": [], "stream": False, "top_k": 0}
 
 
+def test_llamacpp_payload_disables_thinking_for_trailing_assistant_message() -> None:
+    """A trailing assistant message is a response prefill; llama.cpp rejects
+    prefills when the chat template's thinking mode is enabled, so the
+    payload must ask the server to disable it."""
+    payload = build_llamacpp_chat_payload(
+        model="m",
+        messages=[
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "Sure, here is"},
+        ],
+        stream=True,
+    )
+
+    assert payload["chat_template_kwargs"] == {"enable_thinking": False}
+
+
+def test_llamacpp_payload_omits_thinking_kwarg_for_trailing_user_message() -> None:
+    payload = build_llamacpp_chat_payload(
+        model="m",
+        messages=[
+            {"role": "assistant", "content": "Hi there"},
+            {"role": "user", "content": "hello"},
+        ],
+        stream=True,
+    )
+
+    assert "chat_template_kwargs" not in payload
+
+
+def test_llamacpp_payload_omits_thinking_kwarg_for_empty_messages() -> None:
+    payload = build_llamacpp_chat_payload(
+        model="m",
+        messages=[],
+        stream=False,
+    )
+
+    assert "chat_template_kwargs" not in payload
+
+
 @pytest.mark.asyncio
 async def test_llamacpp_prefers_explicit_model_but_still_probes_reachability():
     seen_paths = []

--- a/Tests/Chat/test_console_session_settings.py
+++ b/Tests/Chat/test_console_session_settings.py
@@ -894,3 +894,13 @@ def test_rail_system_line_collapses_multiline_and_truncates_long_prompts():
     assert line.endswith("…")
     preview = line.removeprefix("System: ")
     assert len(preview) <= CONSOLE_RAIL_SYSTEM_PREVIEW_MAX_CHARS
+
+
+def test_pinned_prefill_defaults_none_and_replaces():
+    from dataclasses import replace
+
+    settings = ConsoleSessionSettings(provider="llama_cpp")
+    assert settings.pinned_prefill is None
+    pinned = replace(settings, pinned_prefill="*She pauses*")
+    assert pinned.pinned_prefill == "*She pauses*"
+    assert settings.pinned_prefill is None

--- a/Tests/UI/test_console_command_composer.py
+++ b/Tests/UI/test_console_command_composer.py
@@ -891,3 +891,32 @@ async def test_console_prefill_pin_and_clear_round_trip():
         assert store.session_settings(session_id).pinned_prefill is None
         assert store.session_one_shot_prefill(session_id) is None
         assert composer.draft_text() == ""
+
+
+@pytest.mark.asyncio
+async def test_console_prefill_pin_seeds_settings_on_settings_less_session():
+    """PR #729 Qodo finding 3: a session created without settings (e.g. by a
+    bare system-message append before any send) must not make `/prefill pin`
+    a silent no-op — the handler seeds default settings first."""
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        store = console._ensure_console_chat_store()
+        session = store.ensure_session(
+            workspace_id=store.workspace_context.active_workspace_id
+        )
+        store.replace_session_settings(session.id, None)
+        assert store.session_settings(session.id) is None
+
+        composer.load_draft("/prefill pin Voice:")
+        console.query_one("#console-send-message", Button).press()
+        await _wait_for_text(console, pilot, "Prefill pinned")
+
+        settings = store.session_settings(session.id)
+        assert settings is not None
+        assert settings.pinned_prefill == "Voice:"

--- a/Tests/UI/test_console_command_composer.py
+++ b/Tests/UI/test_console_command_composer.py
@@ -843,3 +843,51 @@ async def test_console_consumes_pending_prompt_insert_noop_when_nothing_pending(
 
         assert composer.draft_text() == "abc"
         notify_spy.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_console_prefill_command_arms_one_shot_and_confirms():
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.load_draft("/prefill Sure thing:")
+
+        console.query_one("#console-send-message", Button).press()
+        await _wait_for_text(console, pilot, "Prefill armed for next send")
+
+        store = console._ensure_console_chat_store()
+        session_id = store.active_session_id
+        assert store.session_one_shot_prefill(session_id) == "Sure thing:"
+        assert composer.draft_text() == ""  # handled command clears its draft
+
+
+@pytest.mark.asyncio
+async def test_console_prefill_pin_and_clear_round_trip():
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        send_button = console.query_one("#console-send-message", Button)
+        store = console._ensure_console_chat_store()
+
+        composer.load_draft("/prefill pin Voice:")
+        send_button.press()
+        await _wait_for_text(console, pilot, "Prefill pinned")
+        session_id = store.active_session_id
+        assert store.session_settings(session_id).pinned_prefill == "Voice:"
+
+        composer.load_draft("/prefill clear")
+        send_button.press()
+        await _wait_for_text(console, pilot, "Prefill cleared")
+        assert store.session_settings(session_id).pinned_prefill is None
+        assert store.session_one_shot_prefill(session_id) is None
+        assert composer.draft_text() == ""

--- a/Tests/UI/test_console_command_composer.py
+++ b/Tests/UI/test_console_command_composer.py
@@ -47,11 +47,11 @@ async def _wait_for_picker_search(pilot) -> None:
 
 
 UNKNOWN_NOPE_HINT = (
-    "Unknown command /nope — available: /prompt, /system, /skills. "
+    "Unknown command /nope — available: /prompt, /system, /skills, /prefill. "
     "Press Enter again to send as text."
 )
 UNKNOWN_NADA_HINT = (
-    "Unknown command /nada — available: /prompt, /system, /skills. "
+    "Unknown command /nada — available: /prompt, /system, /skills, /prefill. "
     "Press Enter again to send as text."
 )
 

--- a/Tests/UI/test_console_run_inspector.py
+++ b/Tests/UI/test_console_run_inspector.py
@@ -200,3 +200,34 @@ async def test_inspector_equal_state_sync_is_noop():
             inspector.query_one("#console-inspector-provider", Static)
             is provider_row_before
         )
+
+
+def test_prefill_rows_route_into_selected_conversation_group():
+    """Prefill rows must render inside the Selected Conversation group with
+    stable ids -- not fall through to the unrouted tail after Selected
+    Message (which also leaves them below the fold in a collapsed rail)."""
+    state = _base_state(
+        rows=(
+            ConsoleDisplayRow("Selected conversation", "Chat 1"),
+            ConsoleDisplayRow("Conversation source", "native Console session"),
+            ConsoleDisplayRow("Workspace", "Default"),
+            ConsoleDisplayRow("Resume state", "local session, not persisted yet"),
+            ConsoleDisplayRow("Prefill (next send only)", "Sure thing:"),
+            ConsoleDisplayRow("Prefill (pinned)", "*Ship AI:*"),
+            ConsoleDisplayRow("Selected message", "None selected"),
+        ),
+    )
+    entries = ConsoleRunInspector._rendered_row_entries(state)
+    ids = [entry_id for entry_id, _text, _status in entries]
+    assert "console-inspector-prefill-one-shot" in ids
+    assert "console-inspector-prefill-pinned" in ids
+    # Grouped BEFORE the Selected Message group's rows, not after them.
+    assert ids.index("console-inspector-prefill-pinned") < ids.index(
+        "console-inspector-selected-message"
+    )
+    # No prefill row left in the unrouted fallback tail (generic row-N ids).
+    assert not [
+        entry_id
+        for entry_id, text, _status in entries
+        if "Prefill" in text and entry_id.startswith("console-inspector-row-")
+    ]

--- a/backlog/tasks/task-401 - Show-armed-response-prefill-in-Console-context-snapshot-preview.md
+++ b/backlog/tasks/task-401 - Show-armed-response-prefill-in-Console-context-snapshot-preview.md
@@ -16,5 +16,7 @@ The Console context snapshot modal claims to show the assembled next-send payloa
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Context snapshot preview includes the trailing assistant prefill turn when one is armed,Preview indicates the agent loop is bypassed for that send,No change when no prefill is armed
+- [ ] #1 Context snapshot preview includes the trailing assistant prefill turn when one is armed
+- [ ] #2 Preview indicates the agent loop is bypassed for that send
+- [ ] #3 No change when no prefill is armed
 <!-- AC:END -->

--- a/backlog/tasks/task-401 - Show-armed-response-prefill-in-Console-context-snapshot-preview.md
+++ b/backlog/tasks/task-401 - Show-armed-response-prefill-in-Console-context-snapshot-preview.md
@@ -1,0 +1,20 @@
+---
+id: TASK-401
+title: Show armed response prefill in Console context snapshot preview
+status: To Do
+assignee: []
+created_date: '2026-07-21 03:48'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The Console context snapshot modal claims to show the assembled next-send payload, but an armed /prefill (one-shot or pinned) adds a trailing assistant turn and bypasses the agent loop for that send, neither of which the preview reflects. Surfaced by the response-prefill final review (spec Docs/superpowers/specs/2026-07-20-console-response-prefill-design.md).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Context snapshot preview includes the trailing assistant prefill turn when one is armed,Preview indicates the agent loop is bypassed for that send,No change when no prefill is armed
+<!-- AC:END -->

--- a/backlog/tasks/task-402 - Fix-silent-settings-None-no-op-in-set_session_system_prompt-and-set_session_pinned_prefill.md
+++ b/backlog/tasks/task-402 - Fix-silent-settings-None-no-op-in-set_session_system_prompt-and-set_session_pinned_prefill.md
@@ -1,0 +1,22 @@
+---
+id: TASK-402
+title: >-
+  Fix silent settings-None no-op in set_session_system_prompt and
+  set_session_pinned_prefill
+status: To Do
+assignee: []
+created_date: '2026-07-21 03:48'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Both store methods silently skip the in-memory settings update when session.settings is None yet still report persisted=True. Currently unreachable via UI handlers (they ensure settings), but the contract is dishonest for direct callers. Fix both twins together.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Both methods either seed default settings or report the skipped update honestly,Unit tests cover the settings-None path for both methods
+<!-- AC:END -->

--- a/backlog/tasks/task-402 - Fix-silent-settings-None-no-op-in-set_session_system_prompt-and-set_session_pinned_prefill.md
+++ b/backlog/tasks/task-402 - Fix-silent-settings-None-no-op-in-set_session_system_prompt-and-set_session_pinned_prefill.md
@@ -18,5 +18,6 @@ Both store methods silently skip the in-memory settings update when session.sett
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Both methods either seed default settings or report the skipped update honestly,Unit tests cover the settings-None path for both methods
+- [ ] #1 Both methods either seed default settings or report the skipped update honestly
+- [ ] #2 Unit tests cover the settings-None path for both methods
 <!-- AC:END -->

--- a/backlog/tasks/task-403 - Verify-response-prefill-against-Gemini-and-OpenAI-Responses-API-branch.md
+++ b/backlog/tasks/task-403 - Verify-response-prefill-against-Gemini-and-OpenAI-Responses-API-branch.md
@@ -16,5 +16,7 @@ Spec section 5/8 verification items left open (no key/config available at implem
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Gemini prefilled send verified accepted or guarded,Responses-API branch verified accepted or guarded,Spec section 8 updated with outcomes
+- [ ] #1 Gemini prefilled send verified accepted or guarded
+- [ ] #2 Responses-API branch verified accepted or guarded
+- [ ] #3 Spec section 8 updated with outcomes
 <!-- AC:END -->

--- a/backlog/tasks/task-403 - Verify-response-prefill-against-Gemini-and-OpenAI-Responses-API-branch.md
+++ b/backlog/tasks/task-403 - Verify-response-prefill-against-Gemini-and-OpenAI-Responses-API-branch.md
@@ -1,0 +1,20 @@
+---
+id: TASK-403
+title: Verify response prefill against Gemini and OpenAI Responses-API branch
+status: To Do
+assignee: []
+created_date: '2026-07-21 03:48'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Spec section 5/8 verification items left open (no key/config available at implementation time): Gemini role-remap with trailing model turn, and the OpenAI use_responses_api input-shape branch. If either rejects trailing-assistant payloads, build the skip+warn incompatible-provider guard (payload AND display seed dropped, inline warning) — note the guard mechanism was superseded for llama.cpp and does not exist yet.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Gemini prefilled send verified accepted or guarded,Responses-API branch verified accepted or guarded,Spec section 8 updated with outcomes
+<!-- AC:END -->

--- a/tldw_chatbook/Chat/chat_conversation_service.py
+++ b/tldw_chatbook/Chat/chat_conversation_service.py
@@ -253,6 +253,7 @@ def normalize_conversation_row(
         "source": _clean_text(conversation_row.get("source")),
         "external_ref": _clean_text(conversation_row.get("external_ref")),
         "system_prompt": _clean_text(conversation_row.get("system_prompt")),
+        "metadata": conversation_row.get("metadata"),
         "version": conversation_row.get("version"),
     }
 

--- a/tldw_chatbook/Chat/chat_persistence_service.py
+++ b/tldw_chatbook/Chat/chat_persistence_service.py
@@ -1,8 +1,10 @@
 import base64
+import json
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 
 from loguru import logger as _logger
 
+from tldw_chatbook.Chat.console_prefill import PINNED_PREFILL_METADATA_KEY
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
 
 logger = _logger.bind(module="ChatPersistenceService")
@@ -219,6 +221,43 @@ class ChatPersistenceService:
                 expected_version=current_conversation["version"],
             )
         )
+
+    def update_conversation_pinned_prefill(
+        self,
+        *,
+        conversation_id: str,
+        pinned_prefill: str | None,
+    ) -> bool:
+        """Set or clear the pinned response prefill in conversation metadata.
+
+        Merge-safe: re-parses the current ``metadata`` JSON and rewrites only
+        its own key, preserving siblings such as ``active_dictionaries``
+        (mirrors ``LocalChatDictionaryService._write_active_dictionaries``).
+        Optimistic-lock conflicts (``ConflictError``) propagate to the caller.
+
+        Returns:
+            True when the write happened; False when the conversation does
+            not exist.
+        """
+        record = self.db.get_conversation_by_id(str(conversation_id))
+        if record is None:
+            return False
+        try:
+            meta = json.loads(record.get("metadata") or "{}")
+        except (TypeError, ValueError):
+            meta = {}
+        if not isinstance(meta, dict):
+            meta = {}
+        if pinned_prefill:
+            meta[PINNED_PREFILL_METADATA_KEY] = pinned_prefill
+        else:
+            meta.pop(PINNED_PREFILL_METADATA_KEY, None)
+        self.db.update_conversation(
+            str(conversation_id),
+            {"metadata": json.dumps(meta)},
+            expected_version=record["version"],
+        )
+        return True
 
     def update_message_content(
         self,

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -1570,18 +1570,28 @@ class ConsoleChatController:
         return self._pinned_prefill_for_session(session_id), False
 
     def _consume_one_shot_prefill(
-        self, assistant_message_id: str, used_one_shot: bool
+        self, assistant_message_id: str, used_prefill: str | None
     ) -> None:
         """Clear the armed one-shot after a send that used it terminated
         ``complete`` or ``stopped``. Blocked and failed sends never call
-        this, so retry reproduces the original intent (spec §2)."""
-        if not used_one_shot:
+        this, so retry reproduces the original intent (spec §2).
+
+        Compare-and-clear: ``used_prefill`` is the exact one-shot text this
+        send consumed (or ``None`` if this send did not use a one-shot at
+        all, in which case this is a no-op). The session's armed one-shot
+        slot is only cleared when it still holds that same text. If a
+        ``/prefill`` re-armed a *different* one-shot while this send was
+        streaming, that newer one-shot must survive the in-flight send's
+        completion untouched.
+        """
+        if used_prefill is None:
             return
         try:
             session_id = self.store.session_id_for_message(assistant_message_id)
         except KeyError:
             return
-        self.store.set_session_one_shot_prefill(session_id, None)
+        if self.store.session_one_shot_prefill(session_id) == used_prefill:
+            self.store.set_session_one_shot_prefill(session_id, None)
 
     async def _apply_skill_substitution(
         self, provider_messages: list[dict[str, Any]]
@@ -1867,7 +1877,7 @@ class ConsoleChatController:
         if (
             self._agent_runtime_enabled
             and self._agent_bridge is not None
-            and prefill is None
+            and not prefill
         ):
             return await self._run_agent_reply(
                 resolution=resolution,
@@ -1876,6 +1886,7 @@ class ConsoleChatController:
                 prepare_retry=prepare_retry,
                 variant_mode=variant_mode,
             )
+        one_shot_used = prefill if prefill_from_one_shot else None
         if prefill:
             provider_messages = [
                 *provider_messages,
@@ -1916,7 +1927,7 @@ class ConsoleChatController:
                     except KeyError:
                         return self._session_closed_result()
                     self._consume_one_shot_prefill(
-                        assistant_message_id, prefill_from_one_shot
+                        assistant_message_id, one_shot_used
                     )
                     return ConsoleSubmitResult(True, True, stopped.content)
                 if prepare_retry and not retry_prepared:
@@ -1946,7 +1957,7 @@ class ConsoleChatController:
                 except KeyError:
                     return self._session_closed_result()
                 self._consume_one_shot_prefill(
-                    assistant_message_id, prefill_from_one_shot
+                    assistant_message_id, one_shot_used
                 )
                 return ConsoleSubmitResult(True, True, stopped.content)
             if not emitted_content:
@@ -1976,7 +1987,7 @@ class ConsoleChatController:
             self._set_run_state(
                 ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete.")
             )
-            self._consume_one_shot_prefill(assistant_message_id, prefill_from_one_shot)
+            self._consume_one_shot_prefill(assistant_message_id, one_shot_used)
             return ConsoleSubmitResult(True, True, completed.content)
         except asyncio.CancelledError:
             if self._stop_requested:
@@ -1990,7 +2001,7 @@ class ConsoleChatController:
                 except KeyError:
                     return self._session_closed_result()
                 self._consume_one_shot_prefill(
-                    assistant_message_id, prefill_from_one_shot
+                    assistant_message_id, one_shot_used
                 )
                 return ConsoleSubmitResult(True, True, stopped.content)
             raise

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -431,6 +431,7 @@ class ConsoleChatController:
         provider_messages = await self._apply_chat_dictionaries(
             provider_messages, session.id
         )
+        prefill, prefill_from_one_shot = self._resolve_submit_prefill(session.id)
         # The accepted-hook fires only once the turn is confirmed to
         # actually proceed (Qodo finding 3, PR #636 bot review): it used to
         # fire right after the USER row was appended, BEFORE this skill
@@ -456,6 +457,8 @@ class ConsoleChatController:
             resolution=resolution,
             provider_messages=provider_messages,
             assistant_message_id=assistant.id,
+            prefill=prefill,
+            prefill_from_one_shot=prefill_from_one_shot,
         )
 
     def new_session(
@@ -1066,11 +1069,13 @@ class ConsoleChatController:
         provider_messages = await self._apply_chat_dictionaries(
             provider_messages, session_id
         )
+        prefill = self._pinned_prefill_for_session(session_id)
         return await self._stream_assistant_response(
             resolution=resolution,
             provider_messages=provider_messages,
             assistant_message_id=message_id,
             prepare_retry=True,
+            prefill=prefill,
         )
 
     async def continue_from_message(self, message_id: str) -> ConsoleSubmitResult:
@@ -1170,11 +1175,13 @@ class ConsoleChatController:
         provider_messages = await self._apply_chat_dictionaries(
             provider_messages, session_id
         )
+        prefill = self._pinned_prefill_for_session(session_id)
         return await self._stream_assistant_response(
             resolution=resolution,
             provider_messages=provider_messages,
             assistant_message_id=message_id,
             variant_mode=True,
+            prefill=prefill,
         )
 
     async def build_context_snapshot(
@@ -1544,6 +1551,38 @@ class ConsoleChatController:
                 }
             )
 
+    def _pinned_prefill_for_session(self, session_id: str) -> str | None:
+        """Return the session's pinned response prefill, if any."""
+        settings = self.store.session_settings(session_id)
+        pinned = getattr(settings, "pinned_prefill", None) if settings else None
+        return pinned or None
+
+    def _resolve_submit_prefill(self, session_id: str) -> tuple[str | None, bool]:
+        """Return ``(prefill, from_one_shot)`` for a normal send.
+
+        One-shot wins over pinned for the send it is armed for; pinned
+        resumes afterward (the one-shot is only cleared on a complete or
+        stopped outcome — see ``_consume_one_shot_prefill``).
+        """
+        one_shot = self.store.session_one_shot_prefill(session_id)
+        if one_shot:
+            return one_shot, True
+        return self._pinned_prefill_for_session(session_id), False
+
+    def _consume_one_shot_prefill(
+        self, assistant_message_id: str, used_one_shot: bool
+    ) -> None:
+        """Clear the armed one-shot after a send that used it terminated
+        ``complete`` or ``stopped``. Blocked and failed sends never call
+        this, so retry reproduces the original intent (spec §2)."""
+        if not used_one_shot:
+            return
+        try:
+            session_id = self.store.session_id_for_message(assistant_message_id)
+        except KeyError:
+            return
+        self.store.set_session_one_shot_prefill(session_id, None)
+
     async def _apply_skill_substitution(
         self, provider_messages: list[dict[str, Any]]
     ) -> tuple[list[dict[str, Any]], str | None]:
@@ -1822,8 +1861,14 @@ class ConsoleChatController:
         assistant_message_id: str,
         prepare_retry: bool = False,
         variant_mode: bool = False,
+        prefill: str | None = None,
+        prefill_from_one_shot: bool = False,
     ) -> ConsoleSubmitResult:
-        if self._agent_runtime_enabled and self._agent_bridge is not None:
+        if (
+            self._agent_runtime_enabled
+            and self._agent_bridge is not None
+            and prefill is None
+        ):
             return await self._run_agent_reply(
                 resolution=resolution,
                 provider_messages=provider_messages,
@@ -1831,11 +1876,24 @@ class ConsoleChatController:
                 prepare_retry=prepare_retry,
                 variant_mode=variant_mode,
             )
+        if prefill:
+            provider_messages = [
+                *provider_messages,
+                {
+                    "role": ConsoleMessageRole.ASSISTANT.value,
+                    "content": prefill,
+                },
+            ]
         self._active_assistant_message_id = assistant_message_id
         self._active_stream_task = asyncio.current_task()
         self._stop_requested = False
         if variant_mode:
             self.store.begin_variant_stream(assistant_message_id)
+        if prefill and not prepare_retry:
+            try:
+                self.store.append_stream_chunk(assistant_message_id, prefill)
+            except KeyError:
+                return self._session_closed_result()
         self._set_run_state(
             ConsoleRunState(ConsoleRunStatus.STREAMING, "Streaming response.")
         )
@@ -1857,10 +1915,20 @@ class ConsoleChatController:
                         )
                     except KeyError:
                         return self._session_closed_result()
+                    self._consume_one_shot_prefill(
+                        assistant_message_id, prefill_from_one_shot
+                    )
                     return ConsoleSubmitResult(True, True, stopped.content)
                 if prepare_retry and not retry_prepared:
                     self.store.prepare_message_retry(assistant_message_id)
                     retry_prepared = True
+                    if prefill:
+                        try:
+                            self.store.append_stream_chunk(
+                                assistant_message_id, prefill
+                            )
+                        except KeyError:
+                            return self._session_closed_result()
                 try:
                     self.store.append_stream_chunk(assistant_message_id, chunk)
                 except KeyError:
@@ -1877,6 +1945,9 @@ class ConsoleChatController:
                     )
                 except KeyError:
                     return self._session_closed_result()
+                self._consume_one_shot_prefill(
+                    assistant_message_id, prefill_from_one_shot
+                )
                 return ConsoleSubmitResult(True, True, stopped.content)
             if not emitted_content:
                 try:
@@ -1905,6 +1976,7 @@ class ConsoleChatController:
             self._set_run_state(
                 ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete.")
             )
+            self._consume_one_shot_prefill(assistant_message_id, prefill_from_one_shot)
             return ConsoleSubmitResult(True, True, completed.content)
         except asyncio.CancelledError:
             if self._stop_requested:
@@ -1917,6 +1989,9 @@ class ConsoleChatController:
                     )
                 except KeyError:
                     return self._session_closed_result()
+                self._consume_one_shot_prefill(
+                    assistant_message_id, prefill_from_one_shot
+                )
                 return ConsoleSubmitResult(True, True, stopped.content)
             raise
         except Exception as exc:

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -132,6 +132,7 @@ class ConsoleChatSession:
     draft: str = ""
     updated_at: str = field(default_factory=_utc_now_iso)
     pending_attachments: list[PendingAttachment] = field(default_factory=list)
+    one_shot_prefill: str | None = None
 
 
 class ConsoleChatStore:
@@ -322,6 +323,18 @@ class ConsoleChatStore:
         session.draft = draft
         return session
 
+
+    def session_one_shot_prefill(self, session_id: str) -> str | None:
+        """Return the armed one-shot response prefill for a session, if any."""
+        return self._session_or_raise(session_id).one_shot_prefill
+
+    def set_session_one_shot_prefill(
+        self, session_id: str, prefill: str | None
+    ) -> ConsoleChatSession:
+        """Arm (or clear, with ``None``) the one-shot response prefill."""
+        session = self._session_or_raise(session_id)
+        session.one_shot_prefill = prefill
+        return session
     def pending_attachments(self, session_id: str) -> list[PendingAttachment]:
         """Return the staged attachments for a session (stage order).
 

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -331,7 +331,6 @@ class ConsoleChatStore:
         session.draft = draft
         return session
 
-
     def session_one_shot_prefill(self, session_id: str) -> str | None:
         """Return the armed one-shot response prefill for a session, if any."""
         return self._session_or_raise(session_id).one_shot_prefill
@@ -343,6 +342,7 @@ class ConsoleChatStore:
         session = self._session_or_raise(session_id)
         session.one_shot_prefill = prefill
         return session
+
     def pending_attachments(self, session_id: str) -> list[PendingAttachment]:
         """Return the staged attachments for a session (stage order).
 

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -98,6 +98,14 @@ class ConsoleChatPersistence(Protocol):
     ) -> bool:
         """Persist a changed system prompt for an already-saved conversation."""
 
+    def update_conversation_pinned_prefill(
+        self,
+        *,
+        conversation_id: str,
+        pinned_prefill: str | None,
+    ) -> bool:
+        """Set or clear the pinned response prefill on a conversation."""
+
     def get_attachments_for_messages(
         self, message_ids: Sequence[str]
     ) -> dict[str, list[dict[str, Any]]]:
@@ -887,6 +895,24 @@ class ConsoleChatStore:
             if session.settings is not None
             else None,
         )
+        pinned_prefill = (
+            session.settings.pinned_prefill if session.settings is not None else None
+        )
+        if pinned_prefill:
+            update_pinned = getattr(
+                self.persistence, "update_conversation_pinned_prefill", None
+            )
+            if callable(update_pinned):
+                try:
+                    update_pinned(
+                        conversation_id=session.persisted_conversation_id,
+                        pinned_prefill=pinned_prefill,
+                    )
+                except Exception:
+                    logger.bind(
+                        session_id=session_id,
+                        conversation_id=session.persisted_conversation_id,
+                    ).exception("Failed to flush pinned prefill on first persist.")
         return session.persisted_conversation_id
 
     def set_session_system_prompt(
@@ -958,6 +984,46 @@ class ConsoleChatStore:
                         conversation_id=session.persisted_conversation_id,
                     ).exception(
                         "Failed to persist Console session system prompt; "
+                        "in-memory session keeps the applied value."
+                    )
+        return session, persisted
+
+    def set_session_pinned_prefill(
+        self, session_id: str, prefill: str | None
+    ) -> tuple[ConsoleChatSession, bool]:
+        """Set or clear a session's pinned response prefill.
+
+        Mirrors ``set_session_system_prompt``: updates the in-memory
+        settings snapshot and, when the session already owns a persisted
+        conversation, writes through to conversation metadata. A durable
+        write failure is caught and logged; the in-memory value is kept and
+        the honest ``persisted`` flag is returned.
+        """
+        session = self._session_or_raise(session_id)
+        normalized = prefill if isinstance(prefill, str) and prefill.strip() else None
+        if session.settings is not None:
+            session.settings = replace(session.settings, pinned_prefill=normalized)
+        persisted = True
+        if (
+            session.persisted_conversation_id is not None
+            and self.persistence is not None
+        ):
+            update_pinned = getattr(
+                self.persistence, "update_conversation_pinned_prefill", None
+            )
+            if callable(update_pinned):
+                try:
+                    update_pinned(
+                        conversation_id=session.persisted_conversation_id,
+                        pinned_prefill=normalized,
+                    )
+                except Exception:
+                    persisted = False
+                    logger.bind(
+                        session_id=session_id,
+                        conversation_id=session.persisted_conversation_id,
+                    ).exception(
+                        "Failed to persist Console pinned prefill; "
                         "in-memory session keeps the applied value."
                     )
         return session, persisted

--- a/tldw_chatbook/Chat/console_command_grammar.py
+++ b/tldw_chatbook/Chat/console_command_grammar.py
@@ -42,6 +42,10 @@ SKILLS_COMMAND_NAME = "skills"
 SKILLS_COMMAND_ARGUMENT_HINT = "[name] [args]"
 SKILLS_COMMAND_HANDLER_ID = "skills"
 
+PREFILL_COMMAND_NAME = "prefill"
+PREFILL_COMMAND_ARGUMENT_HINT = "[pin|clear] [text]"
+PREFILL_COMMAND_HANDLER_ID = "prefill"
+
 
 @dataclass(frozen=True)
 class ConsoleCommand:
@@ -160,11 +164,11 @@ class ConsoleCommandRegistry:
 
 
 def default_console_registry() -> ConsoleCommandRegistry:
-    """Build the default registry with the built-in ``/prompt`` and ``/system`` commands.
+    """Build the default registry with built-in ``/prompt``, ``/system``, ``/skills``, and ``/prefill`` commands.
 
     Returns:
-        A new `ConsoleCommandRegistry` with `PROMPT_COMMAND_NAME` and
-        `SYSTEM_COMMAND_NAME` registered and no fallback resolvers.
+        A new `ConsoleCommandRegistry` with `PROMPT_COMMAND_NAME`, `SYSTEM_COMMAND_NAME`,
+        `SKILLS_COMMAND_NAME`, and `PREFILL_COMMAND_NAME` registered and no fallback resolvers.
     """
     registry = ConsoleCommandRegistry()
     registry.register(
@@ -186,6 +190,13 @@ def default_console_registry() -> ConsoleCommandRegistry:
             name=SKILLS_COMMAND_NAME,
             argument_hint=SKILLS_COMMAND_ARGUMENT_HINT,
             handler_id=SKILLS_COMMAND_HANDLER_ID,
+        )
+    )
+    registry.register(
+        ConsoleCommand(
+            name=PREFILL_COMMAND_NAME,
+            argument_hint=PREFILL_COMMAND_ARGUMENT_HINT,
+            handler_id=PREFILL_COMMAND_HANDLER_ID,
         )
     )
     return registry

--- a/tldw_chatbook/Chat/console_prefill.py
+++ b/tldw_chatbook/Chat/console_prefill.py
@@ -69,6 +69,14 @@ def parse_prefill_args(args: str) -> PrefillCommandAction:
     only as the first token with trailing text. A one-shot whose text
     literally starts with ``pin `` or equals ``clear`` therefore cannot be
     expressed — documented spec limitation.
+
+    Args:
+        args: Raw text after the ``/prefill`` command word.
+
+    Returns:
+        A `PrefillCommandAction` whose ``kind`` is one of the ``ACTION_*``
+        constants; ``text`` carries the normalized prefill for
+        ``pin``/``one-shot`` kinds, ``error`` the message for ``error``.
     """
     stripped = args.strip()
     if not stripped:
@@ -87,7 +95,16 @@ def parse_prefill_args(args: str) -> PrefillCommandAction:
 
 
 def describe_prefill_preview(text: str, max_chars: int = _PREVIEW_MAX_CHARS) -> str:
-    """Return a single-line preview of ``text``, truncated with an ellipsis."""
+    """Return a single-line preview of ``text``, truncated with an ellipsis.
+
+    Args:
+        text: Full prefill text to summarize.
+        max_chars: Maximum preview length, including the ellipsis.
+
+    Returns:
+        ``text`` with whitespace runs collapsed to single spaces, cut to
+        ``max_chars`` with a trailing ``…`` when longer.
+    """
     flattened = " ".join(text.split())
     if len(flattened) <= max_chars:
         return flattened
@@ -100,6 +117,15 @@ def pinned_prefill_from_conversation_metadata(raw_metadata: object) -> str | Non
     Mirrors ``local_chat_dictionary_service._active_dictionaries``'s guarded
     parse (the ``json.loads(None)`` crash class): any missing/invalid shape
     yields ``None`` rather than raising.
+
+    Args:
+        raw_metadata: The conversation record's ``metadata`` column value —
+            a JSON string, ``None``, or any invalid shape.
+
+    Returns:
+        The stored non-blank pinned prefill string, or ``None`` when the
+        metadata is missing, malformed, or has no usable value under
+        `PINNED_PREFILL_METADATA_KEY`.
     """
     try:
         meta = json.loads(raw_metadata or "{}")

--- a/tldw_chatbook/Chat/console_prefill.py
+++ b/tldw_chatbook/Chat/console_prefill.py
@@ -1,0 +1,113 @@
+"""Pure parsing/validation for the native Console ``/prefill`` command.
+
+No dependency on Textual, the running app, or any I/O — mirrors
+``console_command_grammar.py``. The screen layer owns all UI wiring; the
+controller/store layers own arming state and payload assembly. This module
+only classifies the ``/prefill`` args string and reads the pinned-prefill
+key out of a raw conversation ``metadata`` JSON string.
+
+Normalization: prefill text is ``.strip()``-ed at parse time. The spec
+requires right-trimming (Anthropic rejects a trailing-whitespace assistant
+turn); leading whitespace is stripped too for predictability, matching how
+``/system`` name args are treated.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+PREFILL_MAX_CHARS = 4000
+"""Maximum accepted prefill length; longer input is rejected at arm time."""
+
+PINNED_PREFILL_METADATA_KEY = "pinned_response_prefill"
+"""Key inside ``conversations.metadata`` JSON holding the pinned prefill."""
+
+ACTION_STATUS = "status"
+ACTION_CLEAR = "clear"
+ACTION_PIN = "pin"
+ACTION_ONE_SHOT = "one-shot"
+ACTION_ERROR = "error"
+
+_PIN_SUBCOMMAND = "pin"
+_CLEAR_SUBCOMMAND = "clear"
+_PREVIEW_MAX_CHARS = 60
+
+
+@dataclass(frozen=True)
+class PrefillCommandAction:
+    """One classified ``/prefill`` invocation.
+
+    Args:
+        kind: One of the ``ACTION_*`` constants.
+        text: Normalized prefill text for ``pin``/``one-shot`` kinds.
+        error: Human-readable message for the ``error`` kind.
+    """
+
+    kind: str
+    text: str = ""
+    error: str = ""
+
+
+def _validated(kind: str, text: str) -> PrefillCommandAction:
+    if not text:
+        return PrefillCommandAction(
+            kind=ACTION_ERROR, error="Prefill text is empty."
+        )
+    if len(text) > PREFILL_MAX_CHARS:
+        return PrefillCommandAction(
+            kind=ACTION_ERROR,
+            error=f"Prefill is too long ({len(text)} chars; max {PREFILL_MAX_CHARS}).",
+        )
+    return PrefillCommandAction(kind=kind, text=text)
+
+
+def parse_prefill_args(args: str) -> PrefillCommandAction:
+    """Classify the args string of one ``/prefill`` invocation.
+
+    ``clear`` matches only as the entire (stripped) args; ``pin`` matches
+    only as the first token with trailing text. A one-shot whose text
+    literally starts with ``pin `` or equals ``clear`` therefore cannot be
+    expressed — documented spec limitation.
+    """
+    stripped = args.strip()
+    if not stripped:
+        return PrefillCommandAction(kind=ACTION_STATUS)
+    if stripped.lower() == _CLEAR_SUBCOMMAND:
+        return PrefillCommandAction(kind=ACTION_CLEAR)
+    first, _, remainder = stripped.partition(" ")
+    if first.lower() == _PIN_SUBCOMMAND:
+        pin_text = remainder.strip()
+        if not pin_text:
+            return PrefillCommandAction(
+                kind=ACTION_ERROR, error="Usage: /prefill pin <text>."
+            )
+        return _validated(ACTION_PIN, pin_text)
+    return _validated(ACTION_ONE_SHOT, stripped)
+
+
+def describe_prefill_preview(text: str, max_chars: int = _PREVIEW_MAX_CHARS) -> str:
+    """Return a single-line preview of ``text``, truncated with an ellipsis."""
+    flattened = " ".join(text.split())
+    if len(flattened) <= max_chars:
+        return flattened
+    return flattened[: max_chars - 1] + "…"
+
+
+def pinned_prefill_from_conversation_metadata(raw_metadata: object) -> str | None:
+    """Read the pinned prefill out of a raw conversation ``metadata`` value.
+
+    Mirrors ``local_chat_dictionary_service._active_dictionaries``'s guarded
+    parse (the ``json.loads(None)`` crash class): any missing/invalid shape
+    yields ``None`` rather than raising.
+    """
+    try:
+        meta = json.loads(raw_metadata or "{}")
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(meta, dict):
+        return None
+    value = meta.get(PINNED_PREFILL_METADATA_KEY)
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return value

--- a/tldw_chatbook/Chat/console_provider_gateway.py
+++ b/tldw_chatbook/Chat/console_provider_gateway.py
@@ -402,6 +402,17 @@ def build_llamacpp_chat_payload(
 
     Returns:
         Request payload for the llama.cpp chat completions endpoint.
+
+    A trailing ``assistant`` message in ``messages`` is a response prefill:
+    the Console's "continue from here" send path appends the model's
+    in-progress reply as the last message so llama.cpp continues generating
+    from it. llama.cpp rejects prefilled requests when the chat template's
+    thinking mode is enabled (``Assistant response prefill is incompatible
+    with enable_thinking``), and forcing the response's opening text is
+    incoherent with a thinking-first template regardless. Prefilled
+    requests therefore disable thinking mode via ``chat_template_kwargs``,
+    which templates that lack the kwarg -- and older servers that drop
+    unknown fields -- simply ignore.
     """
     payload: dict[str, Any] = {
         "model": model,
@@ -418,6 +429,8 @@ def build_llamacpp_chat_payload(
         payload["top_k"] = top_k
     if max_tokens is not None:
         payload["max_tokens"] = max_tokens
+    if messages and messages[-1].get("role") == "assistant":
+        payload["chat_template_kwargs"] = {"enable_thinking": False}
     return payload
 
 

--- a/tldw_chatbook/Chat/console_provider_gateway.py
+++ b/tldw_chatbook/Chat/console_provider_gateway.py
@@ -404,11 +404,15 @@ def build_llamacpp_chat_payload(
         Request payload for the llama.cpp chat completions endpoint.
 
     A trailing ``assistant`` message in ``messages`` is a response prefill:
-    the Console's "continue from here" send path appends the model's
-    in-progress reply as the last message so llama.cpp continues generating
-    from it. llama.cpp rejects prefilled requests when the chat template's
-    thinking mode is enabled (``Assistant response prefill is incompatible
-    with enable_thinking``), and forcing the response's opening text is
+    the Console's response-prefill send path (a one-shot ``/prefill`` or a
+    pinned prefill applied to submit/retry/regenerate) appends the pending
+    prefill text as the last message so llama.cpp continues generating from
+    it. This is distinct from "continue from here", which never sends a
+    trailing-assistant message -- it instead appends a synthetic user
+    instruction asking the model to continue its prior reply. llama.cpp
+    rejects prefilled requests when the chat template's thinking mode is
+    enabled (``Assistant response prefill is incompatible with
+    enable_thinking``), and forcing the response's opening text is
     incoherent with a thinking-first template regardless. Prefilled
     requests therefore disable thinking mode via ``chat_template_kwargs``,
     which templates that lack the kwarg -- and older servers that drop

--- a/tldw_chatbook/Chat/console_session_settings.py
+++ b/tldw_chatbook/Chat/console_session_settings.py
@@ -174,6 +174,9 @@ class ConsoleSessionSettings:
     #: (refreshable when config changes while the session is unused) vs
     #: ``"user"`` for explicit user selections (never auto-replaced).
     source: str = "derived"
+    #: Pinned response prefill applied to every submit/retry/regenerate;
+    #: persisted per-conversation in conversations.metadata (one-shot
+    #: prefill is transient store state, not settings).
     pinned_prefill: str | None = None
 
 

--- a/tldw_chatbook/Chat/console_session_settings.py
+++ b/tldw_chatbook/Chat/console_session_settings.py
@@ -174,6 +174,7 @@ class ConsoleSessionSettings:
     #: (refreshable when config changes while the session is unused) vs
     #: ``"user"`` for explicit user selections (never auto-replaced).
     source: str = "derived"
+    pinned_prefill: str | None = None
 
 
 @dataclass(frozen=True)

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -50,6 +50,8 @@ from ...Chat.console_command_grammar import (
     KIND_FALLBACK,
     KIND_NOT_COMMAND,
     KIND_UNKNOWN,
+    PREFILL_COMMAND_HANDLER_ID,
+    PREFILL_COMMAND_NAME,
     PROMPT_COMMAND_HANDLER_ID,
     PROMPT_COMMAND_NAME,
     SKILLS_COMMAND_HANDLER_ID,
@@ -59,6 +61,16 @@ from ...Chat.console_command_grammar import (
     CommandParse,
     ConsoleCommandRegistry,
     default_console_registry,
+)
+from ...Chat.console_prefill import (
+    ACTION_CLEAR,
+    ACTION_ERROR,
+    ACTION_ONE_SHOT,
+    ACTION_PIN,
+    ACTION_STATUS,
+    describe_prefill_preview,
+    parse_prefill_args,
+    pinned_prefill_from_conversation_metadata,
 )
 from ...Chat.console_skill_resolver import (
     SKILL_UNTRUSTED_REFUSE,
@@ -3309,7 +3321,12 @@ class ChatScreen(BaseAppScreen):
             if isinstance(raw_system_prompt, str) and raw_system_prompt.strip()
             else None
         )
-        return replace(settings, system_prompt=system_prompt)
+        pinned_prefill = pinned_prefill_from_conversation_metadata(
+            conversation.get("metadata")
+        )
+        return replace(
+            settings, system_prompt=system_prompt, pinned_prefill=pinned_prefill
+        )
 
     async def _resume_console_workspace_conversation(
         self,
@@ -6044,11 +6061,28 @@ class ChatScreen(BaseAppScreen):
             if persisted_id
             else "local session, not persisted yet"
         )
+        prefill_rows: list[ConsoleDisplayRow] = []
+        one_shot = active_session.one_shot_prefill
+        if one_shot:
+            prefill_rows.append(
+                ConsoleDisplayRow(
+                    "Prefill (next send only)", describe_prefill_preview(one_shot)
+                )
+            )
+        session_settings = active_session.settings
+        pinned = (
+            session_settings.pinned_prefill if session_settings is not None else None
+        )
+        if pinned:
+            prefill_rows.append(
+                ConsoleDisplayRow("Prefill (pinned)", describe_prefill_preview(pinned))
+            )
         return (
             ConsoleDisplayRow("Selected conversation", active_session.title),
             ConsoleDisplayRow("Conversation source", source),
             ConsoleDisplayRow("Workspace", workspace_label),
             ConsoleDisplayRow("Resume state", resume_state),
+            *prefill_rows,
         )
 
     def _selected_console_message_inspector_rows(self) -> tuple[ConsoleDisplayRow, ...]:
@@ -9116,6 +9150,7 @@ class ChatScreen(BaseAppScreen):
         PROMPT_COMMAND_NAME: PROMPT_COMMAND_HANDLER_ID,
         SYSTEM_COMMAND_NAME: SYSTEM_COMMAND_HANDLER_ID,
         SKILLS_COMMAND_NAME: SKILLS_COMMAND_HANDLER_ID,
+        PREFILL_COMMAND_NAME: PREFILL_COMMAND_HANDLER_ID,
     }
 
     def _console_unknown_command_hint(self, name: str) -> str:
@@ -9148,6 +9183,7 @@ class ChatScreen(BaseAppScreen):
             "insert-prompt": self._console_command_insert_prompt,
             "apply-system": self._console_command_apply_system,
             SKILLS_COMMAND_HANDLER_ID: self._console_command_skills,
+            PREFILL_COMMAND_HANDLER_ID: self._console_command_prefill,
         }
         handler = dispatch_map.get(handler_id)
         if handler is None:
@@ -9413,6 +9449,89 @@ class ChatScreen(BaseAppScreen):
             self._clear_console_composer_draft()
             return
         await self._open_console_prompt_picker_for_apply_system(args)
+
+    async def _console_command_prefill(self, parse: CommandParse) -> None:
+        """Arm, pin, clear, or report the Console response prefill (`/prefill`).
+
+        One-shot (`/prefill <text>`) applies to the next normal send only
+        and wins over pinned; `/prefill pin <text>` applies to every
+        submit/retry/regenerate until cleared and write-throughs to
+        conversation metadata when the session is persisted. Errors leave
+        the draft in place for correction (mirrors `/system`'s
+        no-system-part behavior); handled outcomes clear it.
+        """
+        action = parse_prefill_args(parse.args)
+        store = self._ensure_console_chat_store()
+        session = store.ensure_session(
+            workspace_id=store.workspace_context.active_workspace_id
+        )
+        if action.kind == ACTION_ERROR:
+            await self._append_native_console_system_message(
+                escape_markup(action.error)
+            )
+            return
+        if action.kind == ACTION_STATUS:
+            one_shot = store.session_one_shot_prefill(session.id)
+            settings = store.session_settings(session.id)
+            pinned = getattr(settings, "pinned_prefill", None) if settings else None
+            lines = []
+            if one_shot:
+                lines.append(
+                    "Prefill (next send only): "
+                    f"'{escape_markup(describe_prefill_preview(one_shot))}'"
+                )
+            if pinned:
+                lines.append(
+                    f"Prefill (pinned): '{escape_markup(describe_prefill_preview(pinned))}'"
+                )
+            if not lines:
+                lines.append("No prefill armed.")
+            # Clear before the message-append await: `_append_native_console_
+            # system_message` triggers nested syncs (transcript render among
+            # them) that make the confirmation visible to a polling caller
+            # before this coroutine resumes past the `await` -- clearing
+            # first closes that window instead of racing it.
+            self._clear_console_composer_draft()
+            await self._append_native_console_system_message("\n".join(lines))
+            return
+        if action.kind == ACTION_CLEAR:
+            store.set_session_one_shot_prefill(session.id, None)
+            _session, persisted = store.set_session_pinned_prefill(session.id, None)
+            self._sync_console_chat_core_state()
+            self._sync_console_settings_summary()
+            copy = "Prefill cleared."
+            if not persisted:
+                copy += " (Warning: saved conversation not updated.)"
+            self._clear_console_composer_draft()
+            await self._append_native_console_system_message(copy)
+            return
+        preview = escape_markup(describe_prefill_preview(action.text))
+        if action.kind == ACTION_PIN:
+            _session, persisted = store.set_session_pinned_prefill(
+                session.id, action.text
+            )
+            self._sync_console_chat_core_state()
+            self._sync_console_settings_summary()
+            copy = (
+                f"Prefill pinned: '{preview}'. Applies to every send, retry, and "
+                "regenerate until /prefill clear. The reply continues directly "
+                "from the last character; tool calling is skipped on prefilled sends."
+            )
+            if not persisted:
+                copy += " (Warning: saved conversation not updated.)"
+            self._clear_console_composer_draft()
+            await self._append_native_console_system_message(copy)
+            return
+        # ACTION_ONE_SHOT
+        store.set_session_one_shot_prefill(session.id, action.text)
+        self._sync_console_chat_core_state()
+        self._sync_console_settings_summary()
+        self._clear_console_composer_draft()
+        await self._append_native_console_system_message(
+            f"Prefill armed for next send: '{preview}'. The reply continues "
+            "directly from the last character; tool calling is skipped on "
+            "prefilled sends."
+        )
 
     def _clear_console_composer_draft(self) -> None:
         """Clear the native Console composer's draft text, if mounted.

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -9466,6 +9466,15 @@ class ChatScreen(BaseAppScreen):
             workspace_id=store.workspace_context.active_workspace_id,
             settings=self._default_console_session_settings(),
         )
+        if session.settings is None:
+            # `ensure_session` only applies `settings=` when it CREATES the
+            # session; one created earlier without settings (e.g. by a bare
+            # system-message append) would make the pinned-prefill update a
+            # silent no-op in `set_session_pinned_prefill` (PR #729 Qodo
+            # finding 3), so seed defaults before any pin/clear below.
+            session = store.replace_session_settings(
+                session.id, self._default_console_session_settings()
+            )
         if action.kind == ACTION_ERROR:
             await self._append_native_console_system_message(action.error)
             return

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -9467,9 +9467,7 @@ class ChatScreen(BaseAppScreen):
             settings=self._default_console_session_settings(),
         )
         if action.kind == ACTION_ERROR:
-            await self._append_native_console_system_message(
-                escape_markup(action.error)
-            )
+            await self._append_native_console_system_message(action.error)
             return
         if action.kind == ACTION_STATUS:
             one_shot = store.session_one_shot_prefill(session.id)
@@ -9479,11 +9477,11 @@ class ChatScreen(BaseAppScreen):
             if one_shot:
                 lines.append(
                     "Prefill (next send only): "
-                    f"'{escape_markup(describe_prefill_preview(one_shot))}'"
+                    f"'{describe_prefill_preview(one_shot)}'"
                 )
             if pinned:
                 lines.append(
-                    f"Prefill (pinned): '{escape_markup(describe_prefill_preview(pinned))}'"
+                    f"Prefill (pinned): '{describe_prefill_preview(pinned)}'"
                 )
             if not lines:
                 lines.append("No prefill armed.")
@@ -9506,7 +9504,11 @@ class ChatScreen(BaseAppScreen):
             self._clear_console_composer_draft()
             await self._append_native_console_system_message(copy)
             return
-        preview = escape_markup(describe_prefill_preview(action.text))
+        # Deliberately NOT markup-escaped: native Console transcript rows
+        # render as literal Content (never parsed as Rich markup), so an
+        # escape here would surface as a visible backslash in previews
+        # containing '[' — matching every neighboring system-row handler.
+        preview = describe_prefill_preview(action.text)
         if action.kind == ACTION_PIN:
             _session, persisted = store.set_session_pinned_prefill(
                 session.id, action.text

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -9463,7 +9463,8 @@ class ChatScreen(BaseAppScreen):
         action = parse_prefill_args(parse.args)
         store = self._ensure_console_chat_store()
         session = store.ensure_session(
-            workspace_id=store.workspace_context.active_workspace_id
+            workspace_id=store.workspace_context.active_workspace_id,
+            settings=self._default_console_session_settings(),
         )
         if action.kind == ACTION_ERROR:
             await self._append_native_console_system_message(
@@ -9522,16 +9523,17 @@ class ChatScreen(BaseAppScreen):
             self._clear_console_composer_draft()
             await self._append_native_console_system_message(copy)
             return
-        # ACTION_ONE_SHOT
-        store.set_session_one_shot_prefill(session.id, action.text)
-        self._sync_console_chat_core_state()
-        self._sync_console_settings_summary()
-        self._clear_console_composer_draft()
-        await self._append_native_console_system_message(
-            f"Prefill armed for next send: '{preview}'. The reply continues "
-            "directly from the last character; tool calling is skipped on "
-            "prefilled sends."
-        )
+        if action.kind == ACTION_ONE_SHOT:
+            store.set_session_one_shot_prefill(session.id, action.text)
+            self._sync_console_chat_core_state()
+            self._sync_console_settings_summary()
+            self._clear_console_composer_draft()
+            await self._append_native_console_system_message(
+                f"Prefill armed for next send: '{preview}'. The reply continues "
+                "directly from the last character; tool calling is skipped on "
+                "prefilled sends."
+            )
+        return
 
     def _clear_console_composer_draft(self) -> None:
         """Clear the native Console composer's draft text, if mounted.

--- a/tldw_chatbook/Widgets/Console/console_run_inspector.py
+++ b/tldw_chatbook/Widgets/Console/console_run_inspector.py
@@ -41,6 +41,8 @@ _ROW_IDS = {
     "Conversation source": "console-inspector-conversation-source",
     "Workspace": "console-inspector-workspace",
     "Resume state": "console-inspector-resume-state",
+    "Prefill (next send only)": "console-inspector-prefill-one-shot",
+    "Prefill (pinned)": "console-inspector-prefill-pinned",
     "Session provider": "console-inspector-session-provider",
     "Session model": "console-inspector-session-model",
     "Session endpoint": "console-inspector-session-endpoint",
@@ -89,7 +91,14 @@ _ROW_GROUPS = (
     (
         "Selected Conversation",
         "console-inspector-selected-conversation-heading",
-        ("Selected conversation", "Conversation source", "Workspace", "Resume state"),
+        (
+            "Selected conversation",
+            "Conversation source",
+            "Workspace",
+            "Resume state",
+            "Prefill (next send only)",
+            "Prefill (pinned)",
+        ),
     ),
     (
         "Session Defaults",


### PR DESCRIPTION
## What

Adds a `/prefill` slash command to the native Console chat: the user supplies the opening of the assistant's reply, it is sent to the provider as a trailing `{"role": "assistant"}` message, and the model continues from it. Covers format steering (one-shot), roleplay/character voice (pinned), and anti-hedging.

- `/prefill <text>` — arms for the next send only (consumed on complete/stopped via compare-and-clear, so a one-shot re-armed mid-stream survives; retained through blocked/failed sends so retry reproduces intent)
- `/prefill pin <text>` — applies to every submit/retry/regenerate until cleared; persists per-conversation in the shared `conversations.metadata` JSON (merge-safe alongside `active_dictionaries`; **no schema migration**)
- `/prefill clear` / bare `/prefill` (status); armed state shown in the "What's in play" inspector
- **Prefilled sends bypass the agent loop for that turn** (a forced response opening is incoherent with tool loops/thinking) — skills substitution and chat dictionaries still apply; unprefilled sends route exactly as before
- Display: the reply visibly grows out of the prefill (seeded as the first stream chunk; zero store changes); `continue` keeps its existing semantics untouched

## Verification (live, llama-server :9099 + real TUI via tmux)

All lifecycle legs driven in the running app: literal continuation, consumption/retention matrix, pin voice across sends, merge-safe metadata write+clear confirmed in SQLite, restart + rail-resume restore, error paths. Two real bugs found live and fixed in-branch:
- llama.cpp rejects prefill when template thinking is on → `chat_template_kwargs: {"enable_thinking": false}` on trailing-assistant payloads (verified: model literally continues)
- `normalize_conversation_row` whitelisted away `metadata`, breaking pinned restore on resume → raw passthrough + regression tests

Remote checks: OpenAI accepts trailing-assistant (influence-not-literal continuation, documented in spec); Anthropic handler pass-through confirmed (configured key is invalid — full continuation unverified); Gemini + Responses-API deferred to task-403. Spec §8 records all outcomes: `Docs/superpowers/specs/2026-07-20-console-response-prefill-design.md`.

## Tests

31 new tests across grammar/pure-module/store/persistence/controller/gateway/conversation-service/UI-composer suites; final gate 382 passed on the touched files (the one intermittent failure, `test_active_http_client_concurrent_swap...`, was proven pre-existing — fails 2/3 on the base commit's own gateway code). Full `Tests/Chat` at the documented pre-existing baseline. Multi-round review: per-task gates + whole-branch final review (verdict: Yes) incl. an adversarial pass on the consumption-exit matrix.

## Follow-ups filed

- task-401 — context-snapshot preview should show the armed prefill
- task-402 — settings-None silent no-op shared by both `set_session_*` store twins
- task-403 — Gemini / Responses-API prefill verification (skip+warn guard does not exist yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `/prefill` command to Console chat so users can seed the opening of the assistant’s reply; the model continues from it. Supports one-shot and pinned modes, persists per conversation, bypasses the agent loop for that turn, and the reply visibly grows from the prefill.

- New Features
  - `/prefill <text>` one-shot for the next send; survives blocked/failed sends.
  - `/prefill pin <text>` applies to submit/retry/regenerate until cleared; stored merge-safely in `conversations.metadata` and restored on resume (no schema change).
  - Registered in the Console command set; UI shows armed state in “What’s in play” and the inspector; previews render literally; 4000‑char limit.
  - Prefilled turns append a trailing `{"role":"assistant"}` message and skip the agent loop; skills and dictionaries still apply; unprefilled flow unchanged.

- Bug Fixes
  - `llama.cpp` payloads disable thinking when a trailing assistant message is present so prefills are accepted.
  - Conversation `metadata` now passes through normalization and pinned updates write merge-safely, so pinned prefills persist across restarts.
  - One-shot clearing compares against the consumed value to avoid wiping a re-armed prefill.

<sup>Written for commit bccf9558494018630eb169dbefd28f637b226f17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

