### PR TITLE
fix(console): persistence honesty — tab rename persists the conversation title, Save-as-default sampling round-trips (tasks 341, 342)

### DIFF
--- a/Tests/Chat/test_console_chat_store.py
+++ b/Tests/Chat/test_console_chat_store.py
@@ -304,9 +304,10 @@ def test_store_renames_session_with_trimmed_title():
     store = ConsoleChatStore()
     session = store.ensure_session(title="Chat 1")
 
-    renamed = store.rename_session(session.id, "  Planning tab  ")
+    renamed, persisted = store.rename_session(session.id, "  Planning tab  ")
 
     assert renamed is session
+    assert persisted is True
     assert store.sessions()[0].title == "Planning tab"
 
 
@@ -1682,3 +1683,64 @@ def test_one_shot_prefill_is_per_session():
     session_b = store.create_session(title="B")
     store.set_session_one_shot_prefill(session_a.id, "only A")
     assert store.session_one_shot_prefill(session_b.id) is None
+
+def test_rename_session_persists_conversation_title_when_saved():
+    """TASK-341: renaming a saved conversation's tab must rename the
+    persisted conversation, not just the ephemeral tab label."""
+
+    class TitleRecordingPersistence(FakePersistence):
+        def __init__(self):
+            super().__init__()
+            self.updated_titles = []
+
+        def update_conversation_title(self, *, conversation_id, title):
+            self.updated_titles.append(
+                {"conversation_id": conversation_id, "title": title}
+            )
+            return True
+
+    persistence = TitleRecordingPersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    session = store.restore_persisted_session(
+        title="Old title",
+        workspace_id=None,
+        persisted_conversation_id="conv-77",
+        messages=[],
+    )
+
+    renamed, persisted = store.rename_session(session.id, "New title")
+
+    assert renamed.title == "New title"
+    assert persisted is True
+    assert persistence.updated_titles == [
+        {"conversation_id": "conv-77", "title": "New title"}
+    ]
+
+
+def test_rename_session_keeps_memory_title_when_persistence_fails():
+    class ExplodingTitlePersistence(FakePersistence):
+        def update_conversation_title(self, *, conversation_id, title):
+            raise RuntimeError("db locked")
+
+    store = ConsoleChatStore(persistence=ExplodingTitlePersistence())
+    session = store.restore_persisted_session(
+        title="Old title",
+        workspace_id=None,
+        persisted_conversation_id="conv-88",
+        messages=[],
+    )
+
+    renamed, persisted = store.rename_session(session.id, "New title")
+
+    assert renamed.title == "New title"
+    assert persisted is False
+
+
+def test_rename_session_without_persisted_conversation_stays_in_memory():
+    store = ConsoleChatStore()
+    session = store.ensure_session(title="Chat 1")
+
+    renamed, persisted = store.rename_session(session.id, "Local only")
+
+    assert renamed.title == "Local only"
+    assert persisted is True

--- a/Tests/Chat/test_console_chat_store.py
+++ b/Tests/Chat/test_console_chat_store.py
@@ -1744,3 +1744,42 @@ def test_rename_session_without_persisted_conversation_stays_in_memory():
 
     assert renamed.title == "Local only"
     assert persisted is True
+
+
+def test_rename_session_reports_unpersisted_when_update_returns_false():
+    """Optimistic-lock/version-check failures surface as persisted=False."""
+
+    class RefusingTitlePersistence(FakePersistence):
+        def update_conversation_title(self, *, conversation_id, title):
+            return False
+
+    store = ConsoleChatStore(persistence=RefusingTitlePersistence())
+    session = store.restore_persisted_session(
+        title="Old title",
+        workspace_id=None,
+        persisted_conversation_id="conv-99",
+        messages=[],
+    )
+
+    renamed, persisted = store.rename_session(session.id, "New title")
+
+    assert renamed.title == "New title"
+    assert persisted is False
+
+
+def test_rename_session_reports_unpersisted_when_seam_is_missing():
+    """A saved conversation whose persistence lacks the title seam cannot
+    have persisted silently — the modal's warning depends on it."""
+    # FakePersistence predates update_conversation_title on purpose here.
+    store = ConsoleChatStore(persistence=FakePersistence())
+    session = store.restore_persisted_session(
+        title="Old title",
+        workspace_id=None,
+        persisted_conversation_id="conv-100",
+        messages=[],
+    )
+
+    renamed, persisted = store.rename_session(session.id, "New title")
+
+    assert renamed.title == "New title"
+    assert persisted is False

--- a/Tests/Chat/test_console_session_settings.py
+++ b/Tests/Chat/test_console_session_settings.py
@@ -904,3 +904,84 @@ def test_pinned_prefill_defaults_none_and_replaces():
     pinned = replace(settings, pinned_prefill="*She pauses*")
     assert pinned.pinned_prefill == "*She pauses*"
     assert settings.pinned_prefill is None
+
+def test_provider_scoped_defaults_beat_chat_defaults_for_sampling_fields():
+    """TASK-342: Save-as-default persists sampling values under
+    [console.provider_defaults.<provider>] — a section that only ever holds
+    Console-saved defaults, so the boot builder ranks it above chat_defaults
+    without letting factory api_settings scalars shadow user-tuned globals
+    (that protection is pinned by f14d22dc3's tests)."""
+    config = {
+        "chat_defaults": {
+            "provider": "llama_cpp",
+            "model": "chat-model",
+            "temperature": 0.6,
+            "top_p": 0.95,
+            "streaming": True,
+        },
+        "api_settings": {"llama_cpp": {"model": "saved-model"}},
+        "console": {
+            "provider_defaults": {
+                "llama_cpp": {
+                    "temperature": 0.88,
+                    "top_p": 0.5,
+                    "top_k": 17,
+                    "max_tokens": 1234,
+                    "seed": 42,
+                    "presence_penalty": 0.25,
+                    "frequency_penalty": 0.75,
+                    "reasoning_effort": "high",
+                    "reasoning_summary": "detailed",
+                    "verbosity": "low",
+                    "thinking_effort": "medium",
+                    "thinking_budget_tokens": 2048,
+                    "min_p": 0.07,
+                },
+            },
+        },
+    }
+
+    settings = build_default_console_session_settings(
+        app_config=config,
+        provider="llama_cpp",
+        model=None,
+    )
+
+    assert settings.temperature == 0.88
+    assert settings.top_p == 0.5
+    assert settings.min_p == 0.07
+    assert settings.top_k == 17
+    assert settings.max_tokens == 1234
+    assert settings.seed == 42
+    assert settings.presence_penalty == 0.25
+    assert settings.frequency_penalty == 0.75
+    assert settings.reasoning_effort == "high"
+    assert settings.reasoning_summary == "detailed"
+    assert settings.verbosity == "low"
+    assert settings.thinking_effort == "medium"
+    assert settings.thinking_budget_tokens == 2048
+
+
+def test_chat_defaults_still_apply_when_no_console_saved_defaults_exist():
+    # Factory api_settings sampling scalars must STILL lose to chat_defaults
+    # (f14d22dc3) — only Console-saved defaults outrank them.
+    config = {
+        "chat_defaults": {
+            "provider": "llama_cpp",
+            "model": "chat-model",
+            "temperature": 0.6,
+            "top_p": 0.9,
+        },
+        "api_settings": {
+            "llama_cpp": {"model": "saved-model", "temperature": 0.7, "top_p": 0.95}
+        },
+    }
+
+    settings = build_default_console_session_settings(
+        app_config=config,
+        provider="llama_cpp",
+        model=None,
+    )
+
+    assert settings.temperature == 0.6
+    assert settings.top_p == 0.9

--- a/Tests/UI/test_console_rename_persistence.py
+++ b/Tests/UI/test_console_rename_persistence.py
@@ -1,0 +1,66 @@
+"""TASK-341: the tab rename modal must persist a saved conversation's title.
+
+Renaming looked successful (tab + transcript header updated) but only
+mutated the in-memory session; on restart the rail showed the old title
+(UX review finding j2-rename-tab-only-silently-lost).
+"""
+
+import pytest
+
+from Tests.UI.test_console_native_chat_flow import _select_llamacpp_console
+from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+    ConsoleHarness,
+)
+from tldw_chatbook.Widgets.Console import ConsoleRenameSessionModal
+
+
+class _TitleRecorder:
+    def __init__(self):
+        self.updates = []
+
+    def update_conversation_title(self, *, conversation_id, title):
+        self.updates.append({"conversation_id": conversation_id, "title": title})
+        return True
+
+    def create_conversation(self, **kwargs):
+        return "conv-render"
+
+    def create_message(self, **kwargs):
+        return "msg-render"
+
+
+@pytest.mark.asyncio
+async def test_rename_modal_persists_saved_conversation_title():
+    app = _build_test_app()
+    app.chat_api_provider_value = "llama_cpp"
+    app.chat_api_model_value = "test-model"
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        _select_llamacpp_console(console)
+
+        store = console._ensure_console_chat_store()
+        recorder = _TitleRecorder()
+        store.persistence = recorder
+        session = store.restore_persisted_session(
+            title="Websocket reconnect strategy",
+            workspace_id=None,
+            persisted_conversation_id="conv-341",
+            messages=[],
+        )
+
+        console._open_console_session_rename_modal(session.id)
+        await pilot.pause()
+        modal = host.screen_stack[-1]
+        assert isinstance(modal, ConsoleRenameSessionModal)
+        modal.dismiss("Reconnect deep dive")
+        await pilot.pause()
+        await pilot.pause()
+
+        assert store.sessions()[-1].title == "Reconnect deep dive"
+        assert recorder.updates == [
+            {"conversation_id": "conv-341", "title": "Reconnect deep dive"}
+        ]

--- a/Tests/UI/test_console_session_settings.py
+++ b/Tests/UI/test_console_session_settings.py
@@ -4050,14 +4050,19 @@ async def test_console_settings_modal_save_as_default_writes_through_config(
     assert provider_section["model"] == "model-a"
     # llama_cpp already persists its endpoint under api_url in ModalHarness config.
     assert provider_section["api_url"] == "http://127.0.0.1:9099"
-    assert provider_section["temperature"] == 0.6
+    # TASK-342: sampling values land in the Console-saved-defaults section the
+    # boot builder ranks above chat_defaults; writing them into api_settings
+    # was inert (chat_defaults deliberately outranks it, f14d22dc3).
+    assert "temperature" not in provider_section
+    saved_section = sections["console.provider_defaults.llama_cpp"]
+    assert saved_section["temperature"] == 0.6
     # Streaming persists on the canonical chat_defaults key (bridged legacy key),
     # and the provider itself becomes the default (PR #606 review finding:
     # chat_defaults.provider is the ONLY source of the default provider).
     assert sections["chat_defaults"] == {"streaming": False, "provider": "llama_cpp"}
     # Never persist None-valued optionals.
-    assert "min_p" not in provider_section
-    assert "seed" not in provider_section
+    assert "min_p" not in saved_section
+    assert "seed" not in saved_section
 
 
 @pytest.mark.asyncio

--- a/backlog/tasks/task-341 - Fix-silent-loss-of-conversation-rename-made-via-the-tab-rename-modal.md
+++ b/backlog/tasks/task-341 - Fix-silent-loss-of-conversation-rename-made-via-the-tab-rename-modal.md
@@ -1,10 +1,14 @@
 ---
 id: TASK-341
 title: Fix silent loss of conversation rename made via the tab rename modal
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-20 14:21'
-labels: [console, ux]
+updated_date: '2026-07-21 03:34'
+labels:
+  - console
+  - ux
 dependencies: []
 priority: high
 ---
@@ -23,5 +27,34 @@ Resumed 'Websocket reconnect strategy', clicked its active tab to open 'Rename C
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Renaming the tab of a saved conversation should rename (or offer to rename) the conversation, or the modal must state that the change is tab-only and temporary
+- [x] #1 Renaming the tab of a saved conversation should rename (or offer to rename) the conversation, or the modal must state that the change is tab-only and temporary
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add update_conversation_title to ConsoleChatPersistence protocol + ChatPersistenceService (mirror update_conversation_system_prompt: version-checked db.update_conversation)
+2. rename_session persists when the session has a persisted_conversation_id, returns (session, persisted) like the system-prompt seam; in-memory title always applied
+3. _apply_rename warns when persistence fails
+4. TDD store-level (fake persistence recorder) + UI-level modal flow
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+Renaming now persists: `ConsoleChatStore.rename_session` returns
+`(session, persisted)` and, for sessions with a `persisted_conversation_id`,
+calls a new `update_conversation_title` persistence seam (protocol method +
+`ChatPersistenceService` implementation mirroring
+`update_conversation_system_prompt`: version-checked `db.update_conversation`).
+The in-memory rename is always applied; a persistence failure logs and
+returns `persisted=False`, and `_apply_rename` warns the user that the
+stored conversation kept its old name. Unsaved sessions are unchanged
+(title flows into `create_conversation` at first persist). The controller's
+auto-title path picks up persistence for free.
+
+Verified: 3 store-level tests (recorder/exploding/unsaved fakes) + a
+UI-level modal-flow test (`Tests/UI/test_console_rename_persistence.py`),
+reproduced RED first; live served-app check — renamed via the real tab
+modal, restarted the app, rail shows the new title. Files:
+`Chat/console_chat_store.py`, `Chat/chat_persistence_service.py`,
+`UI/Screens/chat_screen.py`.

--- a/backlog/tasks/task-342 - Fix-Save-as-default-writing-temperature-to-a-config-location-the-boot-path-never-reads.md
+++ b/backlog/tasks/task-342 - Fix-Save-as-default-writing-temperature-to-a-config-location-the-boot-path-never-reads.md
@@ -1,10 +1,16 @@
 ---
 id: TASK-342
-title: Fix Save-as-default writing temperature to a config location the boot path never reads
-status: To Do
-assignee: []
+title: >-
+  Fix Save-as-default writing temperature to a config location the boot path
+  never reads
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-20 14:21'
-labels: [console, ux]
+updated_date: '2026-07-21 03:34'
+labels:
+  - console
+  - ux
 dependencies: []
 priority: high
 ---
@@ -23,5 +29,38 @@ With temperature set to 0.88, clicking 'Save as default' closed the modal with n
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Save as default should either round-trip all shown values, or the dialog should state that sampling values are session-only and not write them to config at all. Silent acceptance followed by silent reversion after restart is the worst combination
+- [x] #1 Save as default should either round-trip all shown values, or the dialog should state that sampling values are session-only and not write them to config at all. Silent acceptance followed by silent reversion after restart is the worst combination
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Align build_default_console_session_settings source precedence with the documented Save-as-default contract: (model_profile, provider_settings, chat_defaults) — provider-scoped saves beat global defaults, matching how model already resolves
+2. TDD: precedence unit test + parametrized round-trip over PROVIDER_DEFAULT_PERSIST_FIELDS
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+Two deliberate-but-conflicting contracts existed: f14d22dc3 (review
+feedback, pinned by tests) ranks chat_defaults ABOVE [api_settings.*]
+scalars so factory provider templates can't shadow user-tuned globals —
+which made Save-as-default's sampling writes into [api_settings.<provider>]
+permanently inert (the docstring claimed it was the boot source).
+
+Fix honors both: Save-as-default now writes sampling values to
+**[console.provider_defaults.<provider>]** — a section that only ever
+contains Console-saved defaults — and the boot builder ranks it
+(model_profile, console_saved_defaults, chat_defaults, provider_settings).
+Model/endpoint writes stay in api_settings (model already resolves
+provider-first). The f14d22dc3 protection is untouched and its tests stay
+green; a first attempt that blanket-reordered provider_settings above
+chat_defaults was caught by exactly those tests and reverted.
+
+Verified: precedence unit tests over all PROVIDER_DEFAULT_PERSIST_FIELDS +
+factory-shadow control (RED first); write-path test updated to the new
+section; against a real config file, api_settings temperature=0.88 alone
+boots 0.6 (protection intact) while console.provider_defaults 0.88 boots
+0.88 (round-trip fixed; the review's j5-74 evidence showed this reverting).
+Note: defaults saved by the modal BEFORE this fix sit inert in
+api_settings and need one re-save to migrate. Files:
+`Chat/console_session_settings.py`, `Widgets/Console/console_settings_modal.py`.

--- a/tldw_chatbook/Chat/chat_persistence_service.py
+++ b/tldw_chatbook/Chat/chat_persistence_service.py
@@ -259,6 +259,36 @@ class ChatPersistenceService:
         )
         return True
 
+    def update_conversation_title(
+        self,
+        *,
+        conversation_id: str,
+        title: str,
+    ) -> bool:
+        """Update the persisted title for an existing conversation.
+
+        Args:
+            conversation_id: UUID of the conversation to update.
+            title: New conversation title (already validated non-blank).
+
+        Returns:
+            True if the update was applied.
+
+        Raises:
+            ValueError: If the conversation cannot be found.
+        """
+        current_conversation = self.db.get_conversation_by_id(conversation_id)
+        if not current_conversation:
+            raise ValueError(f"Conversation {conversation_id} not found")
+
+        return bool(
+            self.db.update_conversation(
+                conversation_id,
+                {"title": title},
+                expected_version=current_conversation["version"],
+            )
+        )
+
     def update_message_content(
         self,
         *,

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -486,7 +486,7 @@ class ConsoleChatController:
             return
         derived = derive_console_session_title(draft)
         if derived:
-            self.store.rename_session(session.id, derived)
+            self.store.rename_session(session.id, derived)  # (session, persisted) — auto-title best-effort
 
     def update_provider_selection(self, selection: ConsoleProviderSelection) -> None:
         """Sync controller provider settings from a Console selection."""

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -112,7 +112,16 @@ class ConsoleChatPersistence(Protocol):
         conversation_id: str,
         title: str,
     ) -> bool:
-        """Persist a changed title for an already-saved conversation."""
+        """Persist a changed title for an already-saved conversation.
+
+        Args:
+            conversation_id: Durable Chat conversation identifier.
+            title: New conversation title (already validated non-blank).
+
+        Returns:
+            True when the update was applied; False when refused (e.g. an
+            optimistic-lock version check failed).
+        """
 
     def get_attachments_for_messages(
         self, message_ids: Sequence[str]
@@ -276,10 +285,21 @@ class ConsoleChatStore:
         conversation — renaming only the in-memory session looked successful
         (tab + transcript header updated) but evaporated on restart.
 
+        Args:
+            session_id: Native Console session ID to rename.
+            title: New title; surrounding whitespace is trimmed.
+
         Returns:
-            ``(session, persisted)`` — ``persisted`` is ``False`` only when a
-            saved conversation's title update failed; the in-memory rename is
-            always applied (mirrors ``update_session_system_prompt``).
+            ``(session, persisted)`` — the in-memory rename is always
+            applied. ``persisted`` is ``False`` when the session has a saved
+            conversation whose durable title update did not happen: the
+            persistence call raised, returned falsy (e.g. an optimistic-lock
+            version check refused the write), or the persistence object has
+            no ``update_conversation_title`` seam at all.
+
+        Raises:
+            ValueError: If the trimmed title is blank.
+            KeyError: If no session with ``session_id`` exists.
         """
         normalized_title = title.strip()
         if not normalized_title:
@@ -292,11 +312,18 @@ class ConsoleChatStore:
             and self.persistence is not None
         ):
             update_title = getattr(self.persistence, "update_conversation_title", None)
-            if callable(update_title):
+            if not callable(update_title):
+                # A saved conversation with no durable rename seam: claiming
+                # persisted=True here would recreate the original silent-loss
+                # bug for exactly the sessions this fix targets.
+                persisted = False
+            else:
                 try:
-                    update_title(
-                        conversation_id=session.persisted_conversation_id,
-                        title=normalized_title,
+                    persisted = bool(
+                        update_title(
+                            conversation_id=session.persisted_conversation_id,
+                            title=normalized_title,
+                        )
                     )
                 except Exception:
                     persisted = False

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -106,6 +106,14 @@ class ConsoleChatPersistence(Protocol):
     ) -> bool:
         """Set or clear the pinned response prefill on a conversation."""
 
+    def update_conversation_title(
+        self,
+        *,
+        conversation_id: str,
+        title: str,
+    ) -> bool:
+        """Persist a changed title for an already-saved conversation."""
+
     def get_attachments_for_messages(
         self, message_ids: Sequence[str]
     ) -> dict[str, list[dict[str, Any]]]:
@@ -259,14 +267,47 @@ class ConsoleChatStore:
         self.active_session_id = session.id
         return session
 
-    def rename_session(self, session_id: str, title: str) -> ConsoleChatSession:
-        """Rename an existing native Console session."""
+    def rename_session(
+        self, session_id: str, title: str
+    ) -> tuple[ConsoleChatSession, bool]:
+        """Rename a native Console session, persisting a saved conversation's title.
+
+        TASK-341: the tab IS the conversation for a resumed saved
+        conversation — renaming only the in-memory session looked successful
+        (tab + transcript header updated) but evaporated on restart.
+
+        Returns:
+            ``(session, persisted)`` — ``persisted`` is ``False`` only when a
+            saved conversation's title update failed; the in-memory rename is
+            always applied (mirrors ``update_session_system_prompt``).
+        """
         normalized_title = title.strip()
         if not normalized_title:
             raise ValueError("Console chat session title cannot be blank.")
         session = self._session_or_raise(session_id)
         session.title = normalized_title
-        return session
+        persisted = True
+        if (
+            session.persisted_conversation_id is not None
+            and self.persistence is not None
+        ):
+            update_title = getattr(self.persistence, "update_conversation_title", None)
+            if callable(update_title):
+                try:
+                    update_title(
+                        conversation_id=session.persisted_conversation_id,
+                        title=normalized_title,
+                    )
+                except Exception:
+                    persisted = False
+                    logger.bind(
+                        session_id=session_id,
+                        conversation_id=session.persisted_conversation_id,
+                    ).exception(
+                        "Failed to persist Console session title; "
+                        "in-memory session keeps the applied value."
+                    )
+        return session, persisted
 
     def close_session(self, session_id: str) -> ConsoleChatSession | None:
         """Close a native Console session and activate a neighboring session.

--- a/tldw_chatbook/Chat/console_session_settings.py
+++ b/tldw_chatbook/Chat/console_session_settings.py
@@ -13,7 +13,7 @@ from tldw_chatbook.Chat.console_provider_support import (
     supported_console_provider_readiness_keys,
 )
 from tldw_chatbook.Chat.console_provider_endpoints import (
-    URL_BASED_PROVIDER_KEYS,
+    URL_BASED_PROVIDER_KEYS,  # noqa: F401  (re-exported; console_settings_modal imports it from here)
     first_configured_endpoint,
     generic_endpoint_differs,
     normalize_generic_endpoint_for_compare,
@@ -392,7 +392,18 @@ def build_default_console_session_settings(
         chat_defaults.get("model"),
     )
     model_profile = _model_default_profile(provider_settings, configured_model)
-    default_sources = (model_profile, chat_defaults, provider_settings)
+    # TASK-342: [console.provider_defaults.<provider>] holds ONLY values the
+    # Console's Save-as-default wrote, so it outranks everything except a
+    # model profile. chat_defaults stays ahead of raw [api_settings.*]
+    # scalars (f14d22dc3, review feedback): factory provider templates carry
+    # sampling values for every provider and must not shadow user-tuned
+    # global defaults — which is precisely why saved defaults need their own
+    # section instead of writing into api_settings.
+    saved_defaults = _mapping_value(
+        _mapping_value(_mapping_value(app_config, "console"), "provider_defaults"),
+        configured_provider,
+    )
+    default_sources = (model_profile, saved_defaults, chat_defaults, provider_settings)
 
     return ConsoleSessionSettings(
         provider=configured_provider,

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -1094,7 +1094,7 @@ class ChatScreen(BaseAppScreen):
             if result is None:
                 return
             try:
-                store.rename_session(session_id, result)
+                _renamed, persisted = store.rename_session(session_id, result)
             except ValueError as exc:
                 self.app_instance.notify(str(exc), severity="warning")
                 return
@@ -1103,6 +1103,12 @@ class ChatScreen(BaseAppScreen):
                     "Console tab is no longer available.", severity="error"
                 )
                 return
+            if not persisted:
+                self.app_instance.notify(
+                    "Renamed this tab, but saving the conversation title "
+                    "failed — the stored conversation keeps its old name.",
+                    severity="warning",
+                )
             # TASK-251: a renamed session's persisted conversation title
             # must appear in the browser on the very next sync.
             self._invalidate_console_persisted_rows_cache()

--- a/tldw_chatbook/Widgets/Console/console_settings_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_settings_modal.py
@@ -715,9 +715,15 @@ class ConsoleSettingsModal(ModalScreen[ConsoleSessionSettings | None]):
     ) -> dict[str, dict[str, object]]:
         """Build config sections written through by Save as default.
 
-        Provider-scoped values land in ``[api_settings.<provider>]`` (the source
-        ``build_default_console_session_settings`` reads on the next boot);
-        streaming lands on the canonical ``chat_defaults.streaming`` key (the
+        Model and endpoint land in ``[api_settings.<provider>]`` (the sources
+        ``build_default_console_session_settings`` resolves provider/model
+        from). Sampling values land in ``[console.provider_defaults.
+        <provider>]`` — a section that only ever contains Console-saved
+        defaults, so the boot builder can rank it above ``chat_defaults``
+        without letting factory ``api_settings`` template scalars shadow
+        user-tuned globals (TASK-342; writing sampling into api_settings was
+        inert because chat_defaults deliberately outranks it, f14d22dc3).
+        Streaming lands on the canonical ``chat_defaults.streaming`` key (the
         legacy ``enable_streaming`` bridge only applies when the canonical key
         is absent). ``chat_defaults.provider`` is written too — the default
         provider itself resolves ONLY from that key, so omitting it would make
@@ -733,12 +739,15 @@ class ConsoleSettingsModal(ModalScreen[ConsoleSessionSettings | None]):
         base_url = (draft.base_url or "").strip()
         if base_url and self._provider_uses_base_url(draft.provider):
             provider_values[self._endpoint_persist_key(provider_key)] = base_url
+        saved_defaults: dict[str, object] = {}
         for field_name in PROVIDER_DEFAULT_PERSIST_FIELDS:
             value = getattr(draft, field_name)
             if value is not None:
-                provider_values[field_name] = value
+                saved_defaults[field_name] = value
         if provider_key and provider_values:
             sections[f"api_settings.{provider_key}"] = provider_values
+        if provider_key and saved_defaults:
+            sections[f"console.provider_defaults.{provider_key}"] = saved_defaults
         chat_defaults: dict[str, object] = {"streaming": bool(draft.streaming)}
         if provider_key:
             chat_defaults["provider"] = provider_key


### PR DESCRIPTION
## Summary

Third batch from the Console UX review backlog (#720): the **persistence-honesty P1 pair** — two flows that accepted user intent, confirmed it visually, then silently dropped it.

### TASK-341 — tab rename silently lost (P1)
Renaming a resumed conversation via the tab modal updated the tab AND the transcript header (reading as a conversation-level rename) but only mutated the in-memory session; restart brought the old title back (finding `j2-rename-tab-only-silently-lost`).
- New `update_conversation_title` persistence seam (protocol + `ChatPersistenceService`, mirroring the system-prompt seam's version-checked `db.update_conversation`).
- `rename_session` returns `(session, persisted)`; the in-memory rename always applies, and the modal warns if the stored title couldn't be written. Unsaved sessions unchanged; the auto-title path inherits persistence for free.
- **Live-proven across a real restart**: renamed via the actual tab modal, fresh app process shows the new title in the rail.

### TASK-342 — Save-as-default sampling never came back (P1)
Save-as-default wrote sampling to `[api_settings.<provider>]` with a docstring claiming that's the boot source — but `f14d22dc3` (May 30, review feedback, pinned by tests) deliberately ranks `chat_defaults` above raw `api_settings` scalars so factory provider templates can't shadow user-tuned globals. Every sampling save was inert (finding `j5-save-as-default-temperature-lost`).

Both contracts now hold:
- Sampling saves land in **`[console.provider_defaults.<provider>]`** — a section that only ever contains Console-saved defaults — ranked `(model_profile, console_saved_defaults, chat_defaults, provider_settings)` at boot.
- Factory `api_settings` scalars still lose to `chat_defaults` (the f14d22dc3 tests are untouched and green). A first attempt that blanket-reordered precedence was caught by exactly those tests and reverted — the archaeology is in the task notes.
- Migration note: defaults saved before this fix sit inert in `api_settings`; one re-save migrates them.
- **Live-proven both ways against a real config**: `api_settings` temperature 0.88 alone boots 0.6 (protection intact); `console.provider_defaults` 0.88 boots 0.88 (round-trip fixed — the review's j5-74 evidence showed this reverting to 0.60).

## Verification
- RED-first tests: store-level rename (recorder / exploding / unsaved fakes), UI modal-flow rename, precedence across all `PROVIDER_DEFAULT_PERSIST_FIELDS`, factory-shadow control, updated write-path sections test.
- Console UI sweep: **1114 passed**; 15 failures = the 14 known dev-tip set (12 schedules-domain + 2 from the #725/#727-era merges, all reproduced on clean origin/dev) + one load-timing flake that passes 3/3 in isolation.
- `Tests/Chat`: 1055 passed; one pre-existing dev-tip failure (anthropic-tools passthrough, reproduces on clean origin/dev).

Both task files marked Done with implementation notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two persistence bugs: tab renames now update the saved conversation title, and “Save as default” sampling settings now round‑trip after restart.

- **Bug Fixes**
  - TASK-341: Renaming a tab for a saved conversation persists the title via `update_conversation_title`. `rename_session` returns `(session, persisted)` and honors the seam’s boolean result; it reports `False` on version-check refusal, exceptions, or if the seam is missing, and the UI warns on failure. Unsaved sessions unchanged; auto‑title uses the same path.
  - TASK-342: “Save as default” writes sampling fields to `console.provider_defaults.<provider>`. Boot order is `model_profile` → `console_saved_defaults` → `chat_defaults` → `provider_settings`. Model/endpoint still persist under `api_settings.<provider>`.

- **Migration**
  - Defaults saved before this change remain under `api_settings`; re-save once to migrate.

<sup>Written for commit b3b8c2845fee927ffcc29ac105f53332db6bfb35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

