### PR TITLE
Roleplay P2g-1 — native-Console world-info send

### DIFF
--- a/Docs/superpowers/plans/2026-07-21-roleplay-p2g-1-native-console-world-info.md
+++ b/Docs/superpowers/plans/2026-07-21-roleplay-p2g-1-native-console-world-info.md
@@ -1,0 +1,545 @@
+# Roleplay P2g-1 — native-Console world-info send — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Make conversation-attached world books take effect on the **native Console** send (they apply on the legacy Chat send today, never on native Console). Mirror the merged native-Console dictionary send.
+
+**Architecture:** A shared, never-raising lib helper `apply_world_info_to_message` (faithful to the legacy build→process→format→join) + a native applier `ConsoleChatController._apply_world_info` called at the 4 send sites after `_apply_chat_dictionaries`, wired conversation-only (`char_data=None`).
+
+**Tech Stack:** Python 3.11+, Textual, SQLite (`CharactersRAGDB`), pytest.
+
+**Spec:** `Docs/superpowers/specs/2026-07-21-roleplay-p2g-1-native-console-world-info-design.md`.
+
+## Global Constraints
+
+- **No schema migration** (v22). **No change to `chat_events.py` or `world_info_processor.py`** (legacy path + engine are P2g-3 / unchanged).
+- The helper **never raises** — no conversation/books/match/error → returns the text unchanged.
+- **World-info runs AFTER `_apply_chat_dictionaries`** at each of the **4 send sites** (submit / retry / continue / regenerate). The **preview** `_apply_chat_dictionaries` call inside `build_context_snapshot` is NOT a send site — do not add world-info there.
+- **Conversation-only wiring:** the bound native applier passes `char_data=None` (native Console has no character). The shared helper is general (takes `char_data`) for P2g-3's legacy reuse.
+- **Multimodal-safe:** the controller normalizes the message + history to plain text (text parts only) before scanning; injects into the text of the final user message, preserving image parts.
+- Legacy join order is exactly `at_start → before_char → message → after_char → at_end`, joined `"\n\n"`.
+- Leave `_apply_chat_dictionaries` and the dict lib untouched.
+- **Staging:** each task stages ONLY its files. Never `git add -A`; never stage `.superpowers/`.
+- **Test env** (venv in MAIN checkout; run from the worktree root; UI/integration tests slow):
+  ```
+  HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest <targets> \
+  -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+  ```
+
+---
+
+### Task 1: Shared helper `apply_world_info_to_message`
+
+**Files:**
+- Create: `tldw_chatbook/Character_Chat/world_info_resolver.py`
+- Test: `Tests/Character_Chat/test_apply_world_info_to_message.py`
+
+**Interfaces:**
+- Consumes: `WorldBookManager.get_world_books_for_conversation`, `resolve_character_world_books`, `WorldInfoProcessor` (all existing).
+- Produces: `apply_world_info_to_message(db, conversation_id: str | None, char_data: dict | None, message_text: str, history: list[dict]) -> str`; internal `_collect_active_world_books(db, conversation_id, char_data) -> tuple[list[dict], bool]` (for P2g-2 reuse).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/Character_Chat/test_apply_world_info_to_message.py`:
+```python
+import pytest
+
+from tldw_chatbook.Character_Chat.world_info_resolver import (
+    apply_world_info_to_message,
+)
+from tldw_chatbook.Character_Chat.world_book_manager import WorldBookManager
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+
+@pytest.fixture
+def wb_db(tmp_path):
+    db = CharactersRAGDB(tmp_path / "world_info_resolver.db", "test-client")
+    yield db
+    db.close_connection()
+
+
+def _attach_book(db, conv_id, key, content, title="Case"):
+    db.add_conversation({"id": conv_id, "title": title})
+    wb = WorldBookManager(db)
+    book_id = wb.create_world_book("Lore")
+    wb.create_world_book_entry(book_id, keys=[key], content=content)
+    wb.associate_world_book_with_conversation(conv_id, book_id)
+    return book_id
+
+
+def test_injects_matched_conversation_book(wb_db):
+    _attach_book(wb_db, "conv-1", "dragon", "Dragons breathe fire.")
+    out = apply_world_info_to_message(wb_db, "conv-1", None, "a dragon appears", [])
+    assert "Dragons breathe fire." in out
+    assert out.endswith("a dragon appears") or "a dragon appears" in out
+    assert out != "a dragon appears"
+
+
+def test_no_match_returns_unchanged(wb_db):
+    _attach_book(wb_db, "conv-2", "dragon", "Dragons breathe fire.")
+    assert apply_world_info_to_message(wb_db, "conv-2", None, "hello there", []) == "hello there"
+
+
+def test_no_conversation_returns_unchanged(wb_db):
+    assert apply_world_info_to_message(wb_db, None, None, "a dragon appears", []) == "a dragon appears"
+
+
+def test_no_books_returns_unchanged(wb_db):
+    wb_db.add_conversation({"id": "conv-3", "title": "Empty"})
+    assert apply_world_info_to_message(wb_db, "conv-3", None, "a dragon appears", []) == "a dragon appears"
+
+
+def test_db_error_returns_unchanged():
+    # A bogus db object: the helper must swallow the error and return the text.
+    assert apply_world_info_to_message(object(), "conv-x", None, "a dragon appears", []) == "a dragon appears"
+
+
+def test_non_string_message_returned_as_is(wb_db):
+    assert apply_world_info_to_message(wb_db, "conv-1", None, None, []) is None
+
+
+def test_character_only_book_not_injected_when_char_data_none(wb_db):
+    # A book attached to a CHARACTER (char_data=None here) must not inject.
+    char_id = wb_db.add_character_card({"name": "Hero"})
+    wb = WorldBookManager(wb_db)
+    book_id = wb.create_world_book("CharLore")
+    wb.create_world_book_entry(book_id, keys=["griffin"], content="Griffins soar.")
+    wb.attach_world_book_to_character(book_id, char_id)
+    wb_db.add_conversation({"id": "conv-4", "title": "NoConvBook"})
+    out = apply_world_info_to_message(wb_db, "conv-4", None, "a griffin flies", [])
+    assert out == "a griffin flies"  # char_data is None → character books never apply
+```
+
+- [ ] **Step 2: Run to verify they fail**
+```bash
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+Tests/Character_Chat/test_apply_world_info_to_message.py -q -p no:cacheprovider -o addopts="" --timeout=120 --timeout-method=thread
+```
+Expected: FAIL — `ModuleNotFoundError: ...world_info_resolver`.
+
+- [ ] **Step 3: Create the helper** (replicates the legacy `chat_events.py:868-925` build + the `:1470-1489` join)
+
+Create `tldw_chatbook/Character_Chat/world_info_resolver.py`:
+```python
+"""Shared world-info send-path resolver (Roleplay P2g).
+
+Builds the world-info-injected message text for a send, composing the same
+sources the legacy chat_events path does (conversation-attached books ∪
+character-attached snapshots ∪ a native character_book) — so the native Console
+(P2g-1) and, later, the legacy path (P2g-3) share one faithful implementation.
+Never raises: any problem returns the message text unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from loguru import logger
+
+
+def _collect_active_world_books(
+    db: Any, conversation_id: Optional[str], char_data: Optional[Dict[str, Any]]
+) -> Tuple[List[Dict[str, Any]], bool]:
+    """Collect the world books that apply to this send.
+
+    Args:
+        db: A ``CharactersRAGDB`` (or None).
+        conversation_id: The active conversation (string UUID) or None.
+        char_data: The active character record, or None (native Console).
+
+    Returns:
+        ``(world_books, has_character_book)`` — the conversation-attached books
+        unioned with character-attached snapshots (conversation wins on a name
+        collision), and whether ``char_data`` carries a native ``character_book``.
+        Never raises.
+    """
+    world_books: List[Dict[str, Any]] = []
+    if conversation_id and db is not None:
+        try:
+            from .world_book_manager import WorldBookManager
+
+            world_books = WorldBookManager(db).get_world_books_for_conversation(
+                str(conversation_id), enabled_only=True
+            )
+        except Exception:
+            logger.opt(exception=True).debug(
+                "world-info: could not load conversation world books"
+            )
+            world_books = []
+
+    has_character_book = False
+    extensions = char_data.get("extensions", {}) if isinstance(char_data, dict) else {}
+    if isinstance(extensions, dict) and extensions.get("character_book"):
+        has_character_book = True
+
+    try:
+        from .world_book_manager import resolve_character_world_books
+
+        character_books = resolve_character_world_books(
+            char_data, {str(b.get("name")) for b in world_books}
+        )
+    except Exception:
+        character_books = []
+    if character_books:
+        world_books = world_books + character_books
+
+    return world_books, has_character_book
+
+
+def apply_world_info_to_message(
+    db: Any,
+    conversation_id: Optional[str],
+    char_data: Optional[Dict[str, Any]],
+    message_text: str,
+    history: List[Dict[str, Any]],
+) -> str:
+    """Return ``message_text`` with matched world-info injected, or unchanged.
+
+    Args:
+        db: A ``CharactersRAGDB`` (or None).
+        conversation_id: The active conversation (string UUID) or None.
+        char_data: The active character record, or None (conversation-only).
+        message_text: The current user message text (already plain string).
+        history: Prior messages as ``{"role","content": str}`` (string content;
+            the caller normalizes multimodal content to text before calling).
+
+    Returns:
+        The message text wrapped with world-info injections in the order
+        ``at_start → before_char → message → after_char → at_end`` (``"\\n\\n"``
+        separated), or the original ``message_text`` when nothing matches / no
+        books / no conversation / any error. Never raises.
+    """
+    if not isinstance(message_text, str):
+        return message_text
+    try:
+        world_books, has_character_book = _collect_active_world_books(
+            db, conversation_id, char_data
+        )
+        if not (has_character_book or world_books):
+            return message_text
+        from .world_info_processor import WorldInfoProcessor
+
+        processor = WorldInfoProcessor(
+            character_data=char_data if has_character_book else None,
+            world_books=world_books or None,
+        )
+        result = processor.process_messages(message_text, history or [])
+        if not result.get("matched_entries"):
+            return message_text
+        formatted = processor.format_injections(result.get("injections", {}))
+        parts: List[str] = []
+        if formatted.get("at_start"):
+            parts.append(formatted["at_start"])
+        if formatted.get("before_char"):
+            parts.append(formatted["before_char"])
+        parts.append(message_text)
+        if formatted.get("after_char"):
+            parts.append(formatted["after_char"])
+        if formatted.get("at_end"):
+            parts.append(formatted["at_end"])
+        return "\n\n".join(parts)
+    except Exception:
+        logger.opt(exception=True).debug(
+            "world-info: apply failed; returning message text unchanged"
+        )
+        return message_text
+
+
+__all__ = ["apply_world_info_to_message"]
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run the Step-2 command. Expected: PASS (7 tests).
+
+- [ ] **Step 5: Commit**
+```bash
+git add tldw_chatbook/Character_Chat/world_info_resolver.py Tests/Character_Chat/test_apply_world_info_to_message.py
+git commit -m "feat(lore): apply_world_info_to_message shared send-path resolver"
+```
+
+---
+
+### Task 2: `ConsoleChatController._apply_world_info` + param + 4 send sites
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py`
+- Test: `Tests/Chat/test_console_world_info_application.py` (new)
+
+**Interfaces:**
+- Consumes: `self._world_info_applier` (new), `ConsoleMessageRole`, `COMMAND_PREFIX` (already imported/used by `_apply_chat_dictionaries`).
+- Produces: `ConsoleChatController.__init__` gains `world_info_applier: Callable[[str | None, str, list], str] | None = None`; `async _apply_world_info(provider_messages, session_id) -> provider_messages`; called after `_apply_chat_dictionaries` at the 4 send sites. The applier callback contract is `applier(conversation_id, message_text, history) -> str`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Read `Tests/Chat/test_console_chat_controller.py` / `Tests/Chat/test_console_dictionary_application.py` for how a `ConsoleChatController` is constructed with a stub applier in a unit test, and mirror that harness. Create `Tests/Chat/test_console_world_info_application.py` with tests that:
+- Build a controller with a **stub** `world_info_applier` that returns `f"[WI]\n\n{text}"` (so the test asserts the controller's splicing, not real world-info — the real resolver is covered by Task 1 and Task 3).
+- `test_apply_world_info_wraps_final_user_message`: a session pinned to a conversation id, `provider_messages` ending in a user string message → after `_apply_world_info`, the final user message content is `"[WI]\n\n<original>"`; earlier messages untouched.
+- `test_apply_world_info_noop_without_conversation`: session with no `persisted_conversation_id` → payload unchanged.
+- `test_apply_world_info_multimodal_history_and_message`: the final user message has list/multimodal content `[{"type":"text","text":"a dragon"},{"type":"image_url",...}]` and history contains a multimodal message → does not raise; the applier is called with a **string** message + string-content history (assert the stub captured string types); the text part is wrapped and the image part preserved.
+- `test_apply_world_info_command_message_skipped`: a final user message starting with `COMMAND_PREFIX` → unchanged.
+- `test_apply_world_info_applier_none`: controller with `world_info_applier=None` → unchanged.
+
+(Match the exact construction/session-seeding pattern from the existing controller tests; adapt fixture names to reality.)
+
+- [ ] **Step 2: Run to verify they fail**
+```bash
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+Tests/Chat/test_console_world_info_application.py -q -p no:cacheprovider -o addopts="" --timeout=180 --timeout-method=thread
+```
+Expected: FAIL (no `_apply_world_info` / no `world_info_applier` param).
+
+- [ ] **Step 3: Add the param**
+
+In `ConsoleChatController.__init__`, next to `chat_dictionary_applier` (param ~:281, assignment ~:308), add:
+```python
+        world_info_applier: "Callable[[str | None, str, list], str] | None" = None,
+```
+and in the body:
+```python
+        self._world_info_applier = world_info_applier
+```
+
+- [ ] **Step 4: Add `_apply_world_info` + a history normalizer**
+
+Add a module-level helper (near the top of `console_chat_controller.py`, after the imports):
+```python
+def _normalize_world_info_history(
+    messages: "list[dict[str, Any]]",
+) -> "list[dict[str, Any]]":
+    """Flatten messages to ``{"role","content": str}`` for world-info scanning.
+
+    ``WorldInfoProcessor.process_messages`` types content as ``str``; native
+    provider messages may carry multimodal list content, so extract the text
+    parts (joined) and drop images before scanning.
+    """
+    out: list[dict[str, Any]] = []
+    for message in messages:
+        content = message.get("content")
+        if isinstance(content, str):
+            text = content
+        elif isinstance(content, list):
+            text = "\n".join(
+                part["text"]
+                for part in content
+                if isinstance(part, dict)
+                and part.get("type") == "text"
+                and isinstance(part.get("text"), str)
+            )
+        else:
+            text = ""
+        out.append({"role": message.get("role", ""), "content": text})
+    return out
+```
+
+Add the applier method next to `_apply_chat_dictionaries` (mirror its structure; adapt for the `(conv_id, text, history)` callback + the wrap-not-substitute semantics):
+```python
+    async def _apply_world_info(
+        self, provider_messages: list[dict[str, Any]], session_id: str
+    ) -> list[dict[str, Any]]:
+        """Inject conversation world-info into the final user message of the
+        ephemeral provider payload (never the stored transcript).
+
+        Runs AFTER `_apply_chat_dictionaries` so world-info matches the
+        dict-substituted text the model will see. Conversation-only (the bound
+        applier passes `char_data=None`). Offloaded via `asyncio.to_thread`;
+        any failure returns the payload unchanged; `CancelledError` re-raised.
+        """
+        applier = self._world_info_applier
+        if applier is None:
+            return provider_messages
+
+        session = next((s for s in self.store.sessions() if s.id == session_id), None)
+        conversation_id = (
+            session.persisted_conversation_id if session is not None else None
+        )
+        if not conversation_id:
+            return provider_messages
+
+        final_index: int | None = None
+        for index in range(len(provider_messages) - 1, -1, -1):
+            if provider_messages[index].get("role") == ConsoleMessageRole.USER.value:
+                final_index = index
+                break
+        if final_index is None:
+            return provider_messages
+
+        message = provider_messages[final_index]
+        content = message.get("content")
+        if isinstance(content, str) and content.startswith(COMMAND_PREFIX):
+            return provider_messages
+
+        history = _normalize_world_info_history(provider_messages[:final_index])
+
+        try:
+            if isinstance(content, str):
+                injected: Any = await asyncio.to_thread(
+                    applier, conversation_id, content, history
+                )
+                if injected == content:
+                    return provider_messages
+                new_content = injected
+            elif isinstance(content, list):
+                combined = "\n".join(
+                    part["text"]
+                    for part in content
+                    if isinstance(part, dict)
+                    and part.get("type") == "text"
+                    and isinstance(part.get("text"), str)
+                )
+                if not combined:
+                    return provider_messages
+                injected = await asyncio.to_thread(
+                    applier, conversation_id, combined, history
+                )
+                if injected == combined:
+                    return provider_messages
+                new_parts: list[Any] = []
+                first_text_done = False
+                for part in content:
+                    if (
+                        isinstance(part, dict)
+                        and part.get("type") == "text"
+                        and isinstance(part.get("text"), str)
+                    ):
+                        if not first_text_done:
+                            new_parts.append({**part, "text": injected})
+                            first_text_done = True
+                        # subsequent text parts are folded into the injected block
+                        continue
+                    new_parts.append(part)
+                new_content = new_parts
+            else:
+                return provider_messages
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            return provider_messages
+
+        new_messages = list(provider_messages)
+        new_messages[final_index] = {**message, "content": new_content}
+        return new_messages
+```
+
+- [ ] **Step 5: Call it at the 4 send sites**
+
+After each of the FOUR two-line send-site calls `provider_messages = await self._apply_chat_dictionaries(provider_messages, session_id)` — at `submit_draft` (~:431), retry (~:1066), `continue_from_message` (~:1114), `regenerate_message` (~:1170) — add immediately after:
+```python
+        provider_messages = await self._apply_world_info(
+            provider_messages, session_id
+        )
+```
+**Do NOT** add it after the single-line `_apply_chat_dictionaries` call inside `build_context_snapshot` (~:1241) — that is a preview builder, not a send.
+
+- [ ] **Step 6: Run to verify + import check**
+
+Run the Step-2 command (PASS), then:
+```bash
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -c "import tldw_chatbook.Chat.console_chat_controller; print('OK')"
+```
+
+- [ ] **Step 7: Commit**
+```bash
+git add tldw_chatbook/Chat/console_chat_controller.py Tests/Chat/test_console_world_info_application.py
+git commit -m "feat(console): native-Console world-info applier at the 4 send sites"
+```
+
+---
+
+### Task 3: `chat_screen` wiring + end-to-end real-DB test
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`
+- Test: `Tests/UI/test_console_world_info_send_integration.py` (new)
+
+**Interfaces:**
+- Consumes: `apply_world_info_to_message` (Task 1), the `world_info_applier` param (Task 2).
+- Produces: `ChatScreen._console_world_info_applier(conversation_id, message_text, history) -> str`; passed to `ConsoleChatController(..., world_info_applier=...)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Read `Tests/UI/test_console_dictionary_send_integration.py` (the `_build_test_app` / `ConsoleHarness` / `_CapturingGateway` end-to-end harness) and mirror it for world books. Create `Tests/UI/test_console_world_info_send_integration.py` that: seeds a real `CharactersRAGDB` with a conversation-attached world book (`WorldBookManager.associate_world_book_with_conversation`, entry keyed to a word), pins a native session to that conversation, drives a native send with a message containing that word, and asserts the **captured outbound `provider_messages`** final user message contains the injected world-info content while the persisted transcript keeps the raw text. Skeleton (adapt to the real harness):
+```python
+# Mirror Tests/UI/test_console_dictionary_send_integration.py's harness exactly,
+# swapping the dictionary seam for the world-book seam:
+#   wb = WorldBookManager(db); book = wb.create_world_book("Lore")
+#   wb.create_world_book_entry(book, keys=["dragon"], content="Dragons breathe fire.")
+#   db.add_conversation({"id": conv_id, ...}); wb.associate_world_book_with_conversation(conv_id, book)
+#   ... pin the native session to conv_id, send "a dragon appears",
+#   assert "Dragons breathe fire." in _final_user_content(gateway.captured)
+#   assert the persisted transcript row still has the raw "a dragon appears"
+```
+
+- [ ] **Step 2: Run to verify it fails**
+```bash
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+Tests/UI/test_console_world_info_send_integration.py -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: FAIL — the outbound payload has no world-info (no wiring yet).
+
+- [ ] **Step 3: Add the bound applier** (mirror `_console_chat_dictionary_applier`, `chat_screen.py:5753-5775`)
+
+Add near `_console_chat_dictionary_applier`:
+```python
+    def _console_world_info_applier(
+        self, conversation_id: str | None, message_text: str, history: list
+    ) -> str:
+        """Bound applier handed to the native Console controller: inject the
+        active CONVERSATION world-info into a send's text (never raises).
+
+        Resolves the db lazily. Conversation-only: ``char_data`` is ``None``
+        (native sessions carry no character card).
+        """
+        db = getattr(self.app_instance, "chachanotes_db", None)
+        if db is None or not conversation_id or not isinstance(message_text, str):
+            return message_text
+        from ...Character_Chat.world_info_resolver import apply_world_info_to_message
+
+        return apply_world_info_to_message(
+            db, conversation_id, None, message_text, history or []
+        )
+```
+
+- [ ] **Step 4: Wire it into the controller construction**
+
+At the `ConsoleChatController(...)` construction (`chat_screen.py:2724`), next to `chat_dictionary_applier=self._console_chat_dictionary_applier,` (~:2749), add:
+```python
+                world_info_applier=self._console_world_info_applier,
+```
+
+- [ ] **Step 5: Run to verify + full gate + app import**
+
+Run the Step-2 command (PASS), then:
+```bash
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+Tests/Character_Chat/test_apply_world_info_to_message.py Tests/Chat/test_console_world_info_application.py \
+Tests/UI/test_console_world_info_send_integration.py Tests/UI/test_console_dictionary_send_integration.py \
+Tests/Character_Chat/test_world_book_manager.py \
+-q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -c "import tldw_chatbook.app; print('APP IMPORT OK')"
+```
+Expected: all pass (the dict send-integration test confirms no native-send regression); `APP IMPORT OK`.
+
+- [ ] **Step 6: Commit**
+```bash
+git add tldw_chatbook/UI/Screens/chat_screen.py Tests/UI/test_console_world_info_send_integration.py
+git commit -m "feat(console): wire native-Console world-info applier (conversation-only)"
+```
+
+---
+
+## Notes for reviewers
+
+- **No migration; no `chat_events.py` / `world_info_processor.py` change.** The only production files touched are `world_info_resolver.py` (new), `console_chat_controller.py`, and `chat_screen.py`.
+- **Ordering:** world-info is applied AFTER `_apply_chat_dictionaries` at the 4 send sites, and NOT in the `build_context_snapshot` preview.
+- **Conversation-only:** the bound applier passes `char_data=None`; a character-only attached book must not inject on native send (Task 1 test).
+- **Never-raises:** the helper returns text unchanged on any failure; the applier re-raises only `CancelledError`.
+- **Multimodal:** history + message normalized to text before scanning; image parts preserved.
+- Inspector "what's in play" → P2g-2 (reuses `_collect_active_world_books`); legacy gate fix + dead-code cleanup → P2g-3.

--- a/Docs/superpowers/specs/2026-07-21-roleplay-p2g-1-native-console-world-info-design.md
+++ b/Docs/superpowers/specs/2026-07-21-roleplay-p2g-1-native-console-world-info-design.md
@@ -1,0 +1,95 @@
+# Roleplay P2g-1 — shared world-info resolver + native-Console world-info send
+
+**Status:** Design.
+
+**Program:** Roleplay (Personas) redesign — P2 (Lore mode), **P2g cycle 1 of 3**. P2g mirrors the merged Dictionary Console work (P1g inspector + native-send #664). This cycle = native-Console send application. P2g-2 = Console "what's in play" world-book inspector. P2g-3 = legacy send gate-bug fix + dead-code cleanup. Follows P2a/P2c/P2d-1/2/regex/P2e/P2f (all merged); schema **v22**.
+
+## Why
+
+Conversation-attached world books (P2e) take effect on the **legacy** Chat send path but **never on the native Console** — `console_chat_controller.py` has zero world-info code. The native Console is a live shipping surface, so a user who attaches a world book to a conversation (via the Roleplay Lore Attachments tab) sees it apply in the legacy Chat window but silently do nothing in the native Console. This cycle closes that gap, mirroring the merged native-Console dictionary send (`_apply_chat_dictionaries`, #664).
+
+## What already exists (verified at dev tip)
+
+- **Dictionary native-send precedent (mirror target):** `ConsoleChatController._apply_chat_dictionaries(provider_messages, session_id)` (`console_chat_controller.py:1645-1719`), called at the **4 real send sites** — `submit_draft` (:431), retry (:1066), `continue_from_message` (:1114), `regenerate_message` (:1170) — each right after `_apply_skill_substitution`. Offloaded via `asyncio.to_thread`; handles string + list/multimodal content per-part (:1683-1711); `CancelledError` re-raised; any other failure returns the payload unchanged; resolves `conversation_id` from `session.persisted_conversation_id`. The `build_context_snapshot` call (:1241) is preview-only (NOT a send site). Wired via `chat_dictionary_applier` on `ConsoleChatController.__init__`; the bound `_console_chat_dictionary_applier(conversation_id, text) -> str` (`chat_screen.py:5753-5775`) hard-codes `char_data=None` ("native sessions carry no character card").
+- **World-info processing engine (unchanged):** `WorldInfoProcessor(character_data, world_books)` (`world_info_processor.py:64-97`); `process_messages(current_message: str, conversation_history: List[Dict[str,str]], scan_depth=None, apply_token_budget=True) -> {"injections": {pos:[str]}, "matched_entries":[...], "tokens_used": int}` (:262); `format_injections(injections) -> {pos: "joined\n\n"}` keyed `before_char/after_char/at_start/at_end` (:625).
+- **The legacy join (the exact target to replicate)** — `chat_events.py:1470-1489`:
+  ```
+  parts = []
+  if at_start:  parts.append(at_start)
+  if before_char: parts.append(before_char)
+  parts.append(message_text)
+  if after_char: parts.append(after_char)
+  if at_end:  parts.append(at_end)
+  message_text_with_world_info = "\n\n".join(parts)
+  ```
+- **Book sources:** `WorldBookManager.get_world_books_for_conversation(conversation_id, enabled_only=True)` (conversation-attached, entries populated); `resolve_character_world_books(char_data, exclude_names)` (character-attached snapshots, P2f); the processor also reads a character's native `character_book` via `character_data`.
+- **Native Console has no character** — `ConsoleSessionSettings.character_label` is a free-text display string, never a DB id (`chat_screen.py:5785-5791`).
+
+## Scope
+
+**In (this cycle):** a shared, testable send-path helper that builds the world-info-injected message text; a native applier `_apply_world_info` at the 4 send sites; the conversation-only wiring. **Purely additive to native Console** — a conversation with no attached books is byte-identical to today.
+
+**Deferred:** the Console "what's in play" inspector block → **P2g-2**; the legacy `chat_events.py` gate-bug fix (routing it through the shared helper) + deleting the dead legacy world-book UI → **P2g-3**. This cycle does NOT touch `chat_events.py` or `world_info_processor.py`.
+
+## Design decisions
+
+1. **World-info runs AFTER dictionaries on native Console** (`_apply_world_info` immediately after `_apply_chat_dictionaries` at each send site). Rationale — NOT a legacy-parity match (the legacy `chat_events.py` path applies no dictionaries at all): world-info should fire on **what the LLM actually sees**, i.e. the dict-substituted text. The injected world-info block itself is authored content and is not dict-substituted.
+2. **Conversation-only wiring.** The native bound applier passes `char_data=None`, so only conversation-attached books apply (native Console has no character). The shared helper itself is general (takes `char_data`) so P2g-3 can route the legacy path — which does have a character — through the same code.
+3. **Shared helper replicates the legacy pipeline faithfully**, so P2g-3's "route legacy through the helper" is a pure refactor (byte-parity), not a behavior change.
+4. **Multimodal-safe.** `process_messages` types content as `str`; the applier normalizes the current message + history to plain strings (text parts only) before scanning, and injects into the **text** of the final user message (string content → wrap it; list/multimodal content → wrap the text part(s), leave image parts intact), mirroring `_apply_chat_dictionaries`'s per-part handling.
+
+## Behavior-change framing
+
+Additive to the native Console send: a new applier at the 4 send sites + a new shared lib helper + one new `world_info_applier` constructor param. No change to the legacy path, `world_info_processor.py`, or the schema. No conversation attached ⇒ the native send is byte-identical to today.
+
+## Ground truths
+
+- `process_messages` returns `{}`-injections when `self.entries` is empty; `format_injections` returns only non-empty positions. The helper must no-op (return `message_text` unchanged) whenever nothing matches, there are no books, there is no conversation id, or the DB read fails — **never raise** (embedded/imported content is already hardened by P2f's `resolve_character_world_books`; the helper additionally wraps the processor build/scan in try/except).
+- `get_world_books_for_conversation` type-hints `conversation_id: int` but the real value is a string UUID (SQLite loose typing) — pass strings, matching P2e.
+- History content may be a multimodal list (`[{"type":"text","text":...}, {"type":"image_url",...}]`); `_build_scan_text` expects string content, so normalization is mandatory.
+
+## Architecture
+
+### 1. Shared send-path helper (new module `tldw_chatbook/Character_Chat/world_info_resolver.py`)
+`apply_world_info_to_message(db, conversation_id: str | None, char_data: dict | None, message_text: str, history: list[dict]) -> str` — parallels the dict lib's `apply_active_chatdicts_to_text`:
+- If no `conversation_id` and no `char_data` → return `message_text` unchanged.
+- Collect books exactly as the legacy path does: `world_books = get_world_books_for_conversation(conversation_id, enabled_only=True)` (when a conversation id is present) unioned with `resolve_character_world_books(char_data, {names of those books})`; detect `has_character_book`.
+- `processor = WorldInfoProcessor(character_data=char_data if has_character_book else None, world_books=world_books or None)`.
+- `result = processor.process_messages(message_text, history)`; if no `matched_entries` → return `message_text` unchanged.
+- `formatted = processor.format_injections(result["injections"])`; build the join (`at_start → before_char → message_text → after_char → at_end`, `"\n\n"`).
+- Wrap the whole thing in try/except → on any error return `message_text` unchanged (log at debug).
+- A small internal `_collect_active_world_books(db, conversation_id, char_data)` (the book-gathering half — conversation ∪ character, mirroring the dict `_resolve_active_dictionaries`) is factored so **P2g-2's summarize can reuse it** (the shared-core seam). The helper assumes string-content `history` (the native controller normalizes multimodal → text before calling; the legacy caller already passes string-content history).
+
+### 2. Native applier (`console_chat_controller.py`)
+`async def _apply_world_info(self, provider_messages, session_id) -> provider_messages` mirroring `_apply_chat_dictionaries`:
+- Resolve `conversation_id = session.persisted_conversation_id`; if falsy → return `provider_messages` unchanged.
+- Find the final `role=="user"` message. Build the **history** = the messages before it, and the **current text** = that message's text — both **normalized to strings** (extract `text` parts from multimodal content; skip image parts).
+- `injected = await asyncio.to_thread(self._world_info_applier, conversation_id, current_text, history)`.
+- Write `injected` back into the final user message: string content → replace; list/multimodal content → replace the text part(s), leave image parts.
+- `CancelledError` re-raised; any other exception → return `provider_messages` unchanged.
+- New constructor param `world_info_applier: Callable[[str | None, str, list], str] | None = None` (mirror `chat_dictionary_applier`).
+
+### 3. Call sites + ordering
+Call `_apply_world_info` at the same 4 send sites (submit / retry / continue / regenerate), immediately **after** `_apply_chat_dictionaries`. Leave `build_context_snapshot` (preview) untouched — matching how the dict applier treats it.
+
+### 4. Wiring (`chat_screen.py`)
+A bound `_console_world_info_applier(conversation_id: str | None, message_text: str, history: list) -> str` mirroring `_console_chat_dictionary_applier`, hard-coding `char_data=None` (conversation-only), delegating to `apply_world_info_to_message(self.app.chachanotes_db, conversation_id, None, message_text, history)`. Passed to `ConsoleChatController(..., world_info_applier=self._console_world_info_applier)` at construction (`chat_screen.py:2749` area).
+
+## Error handling
+- The helper never raises: no conversation/books/match → unchanged text; DB or processor error → unchanged text (debug log). The applier never raises except re-raising `CancelledError`.
+- Malformed embedded character content is already sanitized by `resolve_character_world_books` (P2f); with `char_data=None` on native it isn't even reached.
+
+## Testing (real-integration, no fakes)
+- **Helper:** a conversation with an attached book whose entry keys match the message → the returned text contains the injected content in the correct join order; no attached book / no match / no conversation id → text unchanged; a DB error (e.g. bad db) → text unchanged, no raise; multimodal history (list content) → does not raise and still matches on the text parts; `char_data=None` never pulls character books (attach a book to the character only and confirm it does NOT inject when `char_data=None`).
+- **Native applier:** with a session whose `persisted_conversation_id` has an attached matching book, `_apply_world_info` injects into the final user message (string content AND multimodal content shapes); no `persisted_conversation_id` → payload unchanged; ordering — runs after `_apply_chat_dictionaries`; `CancelledError` propagates. Mirror the merged `Tests/UI/test_console_dictionaries_*` harness.
+- **Full gate:** the new resolver tests + console-controller tests, `test_world_book_manager`, `import tldw_chatbook.app`.
+
+## Decomposition
+P2g-1 of 3. No migration. P2g-2 (inspector) reuses `_collect_active_world_books` for its summary; P2g-3 routes the legacy `chat_events.py` path through `apply_world_info_to_message` (fixing the character-gate bug) and deletes the dead legacy world-book UI.
+
+## Acceptance criteria
+- [ ] A shared `apply_world_info_to_message(db, conversation_id, char_data, message_text, history)` builds the world-info-injected message (legacy join order) or returns the text unchanged on no-match/no-books/no-conversation/error; never raises; multimodal-history-safe.
+- [ ] `ConsoleChatController._apply_world_info` applies it at the 4 send sites after `_apply_chat_dictionaries`, on the final user message (string + multimodal shapes), off-thread, `CancelledError`-safe, no-op without a `persisted_conversation_id`.
+- [ ] Native wiring is conversation-only (`char_data=None`) — a character-only attached book does NOT inject on native send.
+- [ ] No conversation attached ⇒ native send byte-identical to today; no change to `chat_events.py`, `world_info_processor.py`, or the schema.
+- [ ] Full gate green; `import tldw_chatbook.app` OK. Inspector → P2g-2; legacy fix + cleanup → P2g-3.

--- a/Tests/Character_Chat/test_apply_world_info_to_message.py
+++ b/Tests/Character_Chat/test_apply_world_info_to_message.py
@@ -1,0 +1,66 @@
+import pytest
+
+from tldw_chatbook.Character_Chat.world_info_resolver import (
+    apply_world_info_to_message,
+)
+from tldw_chatbook.Character_Chat.world_book_manager import WorldBookManager
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+
+@pytest.fixture
+def wb_db(tmp_path):
+    db = CharactersRAGDB(tmp_path / "world_info_resolver.db", "test-client")
+    yield db
+    db.close_connection()
+
+
+def _attach_book(db, conv_id, key, content, title="Case"):
+    db.add_conversation({"id": conv_id, "title": title})
+    wb = WorldBookManager(db)
+    book_id = wb.create_world_book("Lore")
+    wb.create_world_book_entry(book_id, keys=[key], content=content)
+    wb.associate_world_book_with_conversation(conv_id, book_id)
+    return book_id
+
+
+def test_injects_matched_conversation_book(wb_db):
+    _attach_book(wb_db, "conv-1", "dragon", "Dragons breathe fire.")
+    out = apply_world_info_to_message(wb_db, "conv-1", None, "a dragon appears", [])
+    assert "Dragons breathe fire." in out
+    assert out.endswith("a dragon appears") or "a dragon appears" in out
+    assert out != "a dragon appears"
+
+
+def test_no_match_returns_unchanged(wb_db):
+    _attach_book(wb_db, "conv-2", "dragon", "Dragons breathe fire.")
+    assert apply_world_info_to_message(wb_db, "conv-2", None, "hello there", []) == "hello there"
+
+
+def test_no_conversation_returns_unchanged(wb_db):
+    assert apply_world_info_to_message(wb_db, None, None, "a dragon appears", []) == "a dragon appears"
+
+
+def test_no_books_returns_unchanged(wb_db):
+    wb_db.add_conversation({"id": "conv-3", "title": "Empty"})
+    assert apply_world_info_to_message(wb_db, "conv-3", None, "a dragon appears", []) == "a dragon appears"
+
+
+def test_db_error_returns_unchanged():
+    # A bogus db object: the helper must swallow the error and return the text.
+    assert apply_world_info_to_message(object(), "conv-x", None, "a dragon appears", []) == "a dragon appears"
+
+
+def test_non_string_message_returned_as_is(wb_db):
+    assert apply_world_info_to_message(wb_db, "conv-1", None, None, []) is None
+
+
+def test_character_only_book_not_injected_when_char_data_none(wb_db):
+    # A book attached to a CHARACTER (char_data=None here) must not inject.
+    char_id = wb_db.add_character_card({"name": "Hero"})
+    wb = WorldBookManager(wb_db)
+    book_id = wb.create_world_book("CharLore")
+    wb.create_world_book_entry(book_id, keys=["griffin"], content="Griffins soar.")
+    wb.attach_world_book_to_character(book_id, char_id)
+    wb_db.add_conversation({"id": "conv-4", "title": "NoConvBook"})
+    out = apply_world_info_to_message(wb_db, "conv-4", None, "a griffin flies", [])
+    assert out == "a griffin flies"  # char_data is None → character books never apply

--- a/Tests/Chat/test_console_world_info_application.py
+++ b/Tests/Chat/test_console_world_info_application.py
@@ -131,3 +131,63 @@ async def test_apply_world_info_applier_none():
     messages = [{"role": ConsoleMessageRole.USER.value, "content": "a dragon appears"}]
     out = await controller._apply_world_info(messages, session.id)
     assert out[-1]["content"] == "a dragon appears"
+
+
+@pytest.mark.asyncio
+async def test_apply_world_info_history_excludes_system_message():
+    """Qodo finding: keywords in the system prompt must not spuriously
+    activate world-info entries -- the applier's `history` argument should
+    only ever contain user/assistant turns, never the leading system
+    message."""
+    captured = {}
+
+    def _recording_wi(conv_id, text, history):
+        captured["history"] = history
+        return f"[WI]\n\n{text}"
+
+    controller, store = _controller(_recording_wi)
+    session = _session_with_conv(store)
+    messages = [
+        {"role": "system", "content": "sys prompt mentioning dragon"},
+        {"role": "assistant", "content": "earlier reply"},
+        {"role": ConsoleMessageRole.USER.value, "content": "a dragon appears"},
+    ]
+    await controller._apply_world_info(messages, session.id)
+
+    history = captured["history"]
+    assert all(entry["role"] != "system" for entry in history)
+    assert any(entry["role"] == "assistant" for entry in history)
+
+
+@pytest.mark.asyncio
+async def test_apply_world_info_multimodal_preserves_interleaved_order():
+    """Gemini finding: folding all text parts into the first reorders
+    interleaved [Text1, Image1, Text2] content. The injection must instead
+    be partitioned so the prefix lands on the first text part, the suffix
+    lands on the last text part, and images/other parts stay in place."""
+
+    def _stub_wi_wrap(conv_id, text, history):
+        return f"[START]\n\n{text}\n\n[END]"
+
+    controller, store = _controller(_stub_wi_wrap)
+    session = _session_with_conv(store)
+    image_part = {
+        "type": "image_url",
+        "image_url": {"url": "data:image/png;base64,AAAA"},
+    }
+    messages = [
+        {
+            "role": ConsoleMessageRole.USER.value,
+            "content": [
+                {"type": "text", "text": "Text1"},
+                image_part,
+                {"type": "text", "text": "Text2"},
+            ],
+        }
+    ]
+    out = await controller._apply_world_info(messages, session.id)
+
+    parts = out[-1]["content"]
+    assert parts[0] == {"type": "text", "text": "[START]\n\nText1"}
+    assert parts[1] is image_part
+    assert parts[2] == {"type": "text", "text": "Text2\n\n[END]"}

--- a/Tests/Chat/test_console_world_info_application.py
+++ b/Tests/Chat/test_console_world_info_application.py
@@ -1,0 +1,133 @@
+import pytest
+
+from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+
+
+class _Gateway:
+    async def resolve_for_send(self, _selection):
+        class _R:
+            ready = True
+            visible_copy = ""
+
+        return _R()
+
+    async def stream_chat(self, _resolution, _messages):
+        if False:
+            yield ""
+
+
+def _controller(applier):
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=_Gateway(),
+        provider="llama_cpp",
+        model="test-model",
+        world_info_applier=applier,
+    )
+    return controller, store
+
+
+def _session_with_conv(store, conv_id="conv-1"):
+    session = store.create_session(title="t")
+    session.persisted_conversation_id = conv_id
+    return session
+
+
+def _stub_wi(conv_id, text, history):
+    return f"[WI]\n\n{text}"
+
+
+@pytest.mark.asyncio
+async def test_apply_world_info_wraps_final_user_message():
+    controller, store = _controller(_stub_wi)
+    session = _session_with_conv(store)
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "assistant", "content": "earlier reply"},
+        {"role": ConsoleMessageRole.USER.value, "content": "a dragon appears"},
+    ]
+    out = await controller._apply_world_info(messages, session.id)
+    assert out[-1]["content"] == "[WI]\n\na dragon appears"
+    # Earlier messages untouched.
+    assert out[0] == {"role": "system", "content": "sys"}
+    assert out[1] == {"role": "assistant", "content": "earlier reply"}
+    # Input list/dicts untouched (fresh copies only).
+    assert messages[-1]["content"] == "a dragon appears"
+
+
+@pytest.mark.asyncio
+async def test_apply_world_info_noop_without_conversation():
+    controller, store = _controller(_stub_wi)
+    session = store.create_session(title="t")  # persisted_conversation_id stays None
+    messages = [{"role": ConsoleMessageRole.USER.value, "content": "a dragon appears"}]
+    out = await controller._apply_world_info(messages, session.id)
+    assert out[-1]["content"] == "a dragon appears"
+
+
+@pytest.mark.asyncio
+async def test_apply_world_info_multimodal_history_and_message():
+    captured = {}
+
+    def _recording_wi(conv_id, text, history):
+        captured["message_text"] = text
+        captured["history"] = history
+        assert isinstance(text, str)
+        assert all(isinstance(h["content"], str) for h in history)
+        return f"[WI]\n\n{text}"
+
+    controller, store = _controller(_recording_wi)
+    session = _session_with_conv(store)
+    image_part = {
+        "type": "image_url",
+        "image_url": {"url": "data:image/png;base64,AAAA"},
+    }
+    history_image_part = {
+        "type": "image_url",
+        "image_url": {"url": "data:image/png;base64,BBBB"},
+    }
+    messages = [
+        {
+            "role": ConsoleMessageRole.USER.value,
+            "content": [
+                {"type": "text", "text": "earlier turn"},
+                history_image_part,
+            ],
+        },
+        {"role": "assistant", "content": "ok"},
+        {
+            "role": ConsoleMessageRole.USER.value,
+            "content": [{"type": "text", "text": "a dragon"}, image_part],
+        },
+    ]
+    out = await controller._apply_world_info(messages, session.id)
+
+    # Stub received string types, proving normalization happened.
+    assert captured["message_text"] == "a dragon"
+    assert captured["history"][0]["content"] == "earlier turn"
+
+    parts = out[-1]["content"]
+    assert parts[0] == {"type": "text", "text": "[WI]\n\na dragon"}
+    assert parts[1] is image_part
+
+
+@pytest.mark.asyncio
+async def test_apply_world_info_command_message_skipped():
+    controller, store = _controller(_stub_wi)
+    session = _session_with_conv(store)
+    messages = [
+        {"role": ConsoleMessageRole.USER.value, "content": "/do a thing"}
+    ]
+    out = await controller._apply_world_info(messages, session.id)
+    assert out[-1]["content"] == "/do a thing"
+
+
+@pytest.mark.asyncio
+async def test_apply_world_info_applier_none():
+    controller, store = _controller(None)
+    session = _session_with_conv(store)
+    messages = [{"role": ConsoleMessageRole.USER.value, "content": "a dragon appears"}]
+    out = await controller._apply_world_info(messages, session.id)
+    assert out[-1]["content"] == "a dragon appears"

--- a/Tests/UI/test_console_world_info_send_integration.py
+++ b/Tests/UI/test_console_world_info_send_integration.py
@@ -1,0 +1,164 @@
+"""Load-bearing integration test: the native Console send path applies the
+active CONVERSATION world-info to the model-bound payload while the
+persisted transcript keeps the raw text (Roleplay P2g-1 Task 3).
+
+Exercises the real ``ChatScreen`` -> ``_ensure_console_chat_controller``
+wiring (``world_info_applier=self._console_world_info_applier``) end to end:
+a real ``CharactersRAGDB`` seeded with a conversation-attached world book (the
+``WorldBookManager`` attach seam), a native session pinned to that
+conversation, and a capturing double standing in for the provider transport
+so the actual outbound payload can be inspected.
+
+Mirrors ``Tests/UI/test_console_dictionary_send_integration.py``'s harness,
+swapping the chat-dictionary seam for the world-book seam.
+"""
+
+import pytest
+
+from Tests.UI.test_console_dictionary_send_integration import (
+    _CapturingGateway,
+    _final_user_content,
+)
+from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+    ConsoleHarness,
+)
+from tldw_chatbook.Character_Chat.world_book_manager import WorldBookManager
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+
+@pytest.fixture
+def wb_db(tmp_path):
+    db = CharactersRAGDB(tmp_path / "console_world_info_send.db", "test-client")
+    yield db
+    db.close_connection()
+
+
+def _active_native_session(console):
+    store = console._ensure_console_chat_store()
+    return next(s for s in store.sessions() if s.id == store.active_session_id)
+
+
+@pytest.mark.asyncio
+async def test_native_send_applies_conversation_world_info_provider_branch(wb_db):
+    app = _build_test_app()
+    app.chachanotes_db = wb_db
+
+    conv_id = wb_db.add_conversation({"title": "World send"})
+    wb = WorldBookManager(wb_db)
+    book_id = wb.create_world_book("Lore")
+    wb.create_world_book_entry(
+        book_id, keys=["dragon"], content="Dragons breathe fire."
+    )
+    wb.associate_world_book_with_conversation(conv_id, book_id)
+
+    async with ConsoleHarness(app).run_test(size=(180, 48)) as pilot:
+        screen = pilot.app.screen_stack[-1]
+        await _wait_for_selector(screen, pilot, "#console-native-composer")
+        _active_native_session(screen).persisted_conversation_id = conv_id
+
+        controller = screen._ensure_console_chat_controller()
+        gateway = _CapturingGateway()
+        controller.provider_gateway = gateway
+        controller._agent_runtime_enabled = False  # force the provider branch
+
+        result = await controller.submit_draft("a dragon appears")
+        assert result.accepted
+
+        # Model received the world-info-INJECTED text...
+        final_content = _final_user_content(gateway.captured)
+        assert "Dragons breathe fire." in final_content
+        assert "a dragon appears" in final_content
+
+        # ...while the persisted transcript keeps the RAW text.
+        store = screen._ensure_console_chat_store()
+        stored = [
+            m
+            for m in store.messages_for_session(_active_native_session(screen).id)
+            if m.role is ConsoleMessageRole.USER
+        ]
+        assert stored[-1].content == "a dragon appears"
+
+
+@pytest.mark.asyncio
+async def test_native_send_world_info_disabled_by_config_not_injected(wb_db, monkeypatch):
+    app = _build_test_app()
+    app.chachanotes_db = wb_db
+
+    conv_id = wb_db.add_conversation({"title": "World send disabled"})
+    wb = WorldBookManager(wb_db)
+    book_id = wb.create_world_book("Lore")
+    wb.create_world_book_entry(
+        book_id, keys=["dragon"], content="Dragons breathe fire."
+    )
+    wb.associate_world_book_with_conversation(conv_id, book_id)
+
+    from tldw_chatbook.UI.Screens import chat_screen as chat_screen_module
+
+    def _fake_get_cli_setting(section, key, default=None):
+        if section == "character_chat" and key == "enable_world_info":
+            return False
+        return default
+
+    monkeypatch.setattr(
+        chat_screen_module, "get_cli_setting", _fake_get_cli_setting
+    )
+
+    async with ConsoleHarness(app).run_test(size=(180, 48)) as pilot:
+        screen = pilot.app.screen_stack[-1]
+        await _wait_for_selector(screen, pilot, "#console-native-composer")
+        _active_native_session(screen).persisted_conversation_id = conv_id
+
+        controller = screen._ensure_console_chat_controller()
+        gateway = _CapturingGateway()
+        controller.provider_gateway = gateway
+        controller._agent_runtime_enabled = False  # force the provider branch
+
+        result = await controller.submit_draft("a dragon appears")
+        assert result.accepted
+
+        final_content = _final_user_content(gateway.captured)
+        assert final_content == "a dragon appears"
+        assert "Dragons breathe fire." not in final_content
+
+
+def test_console_world_info_applier_honors_enable_world_info_setting(monkeypatch):
+    """Focused unit test of the gate itself (belt-and-braces alongside the
+    end-to-end disabled-config test above): the bound applier must return the
+    text unchanged, without ever reaching ``apply_world_info_to_message``,
+    when ``[character_chat] enable_world_info`` is falsy."""
+    from tldw_chatbook.Character_Chat import world_info_resolver
+    from tldw_chatbook.UI.Screens import chat_screen as chat_screen_module
+
+    def _fake_get_cli_setting(section, key, default=None):
+        if section == "character_chat" and key == "enable_world_info":
+            return False
+        return default
+
+    monkeypatch.setattr(
+        chat_screen_module, "get_cli_setting", _fake_get_cli_setting
+    )
+
+    def _fail_if_called(*args, **kwargs):
+        raise AssertionError(
+            "apply_world_info_to_message must not be called when "
+            "enable_world_info is disabled"
+        )
+
+    monkeypatch.setattr(
+        world_info_resolver, "apply_world_info_to_message", _fail_if_called
+    )
+
+    class _FakeApp:
+        chachanotes_db = object()  # non-None so the earlier guards pass
+
+    class _FakeScreen:
+        app_instance = _FakeApp()
+
+    # Bind the real method to a lightweight stand-in with just app_instance.
+    applier = chat_screen_module.ChatScreen._console_world_info_applier.__get__(
+        _FakeScreen()
+    )
+    result = applier("conv-1", "a dragon appears", [])
+    assert result == "a dragon appears"

--- a/backlog/tasks/task-401 - Test-char-world-book-write-preserves-other-extensions-keys.md
+++ b/backlog/tasks/task-401 - Test-char-world-book-write-preserves-other-extensions-keys.md
@@ -1,0 +1,23 @@
+---
+id: TASK-401
+title: 'Test: char world-book write preserves other extensions keys'
+status: To Do
+assignee: []
+created_date: '2026-07-21 03:42'
+labels:
+  - roleplay
+  - lore
+  - test-coverage
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+P2f (#728) char world-book attach/detach writes extensions['character_world_books'] via read-modify-write of the whole extensions dict. The opus final review flagged that no test asserts the load-bearing invariant that this preserves OTHER extensions keys (native 'character_book', 'chat_dictionaries'). Implementation was verified correct by review but is untested; a regression here would silently drop a character's native lore or embedded dictionaries on a world-book attach.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A test attaches then detaches a world book on a character whose extensions already contain both 'character_book' and 'chat_dictionaries', and asserts BOTH keys (and their values) survive unchanged through attach and through detach,WorldBookManager.get_world_books_for_character reflects the attach/detach,test lives in Tests/Character_Chat/test_world_book_manager.py and passes
+<!-- AC:END -->

--- a/backlog/tasks/task-402 - Remove-redundant-dict_panel.display-gate-in-_show_center-personas.md
+++ b/backlog/tasks/task-402 - Remove-redundant-dict_panel.display-gate-in-_show_center-personas.md
@@ -1,0 +1,22 @@
+---
+id: TASK-402
+title: Remove redundant dict_panel.display gate in _show_center (personas)
+status: To Do
+assignee: []
+created_date: '2026-07-21 03:42'
+labels:
+  - roleplay
+  - tech-debt
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+P2f (#728) moved PersonasCharacterDictionariesWidget into the #personas-character-attachments wrapper, whose display is now gated by _show_center on the character card/editor views. _show_center STILL sets dict_panel.display independently by the identical condition — redundant/dead-ish now that the wrapper controls both panels. Harmless (always consistent) but should be removed so the wrapper is the single source of truth for character-attachment panel visibility.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 _show_center no longer sets PersonasCharacterDictionariesWidget.display separately; the character-attachment panels' visibility is driven solely by the #personas-character-attachments wrapper gate,character-dictionary and world-book screen tests stay green (no visibility regression in card/editor/transcript views)
+<!-- AC:END -->

--- a/tldw_chatbook/Character_Chat/world_info_resolver.py
+++ b/tldw_chatbook/Character_Chat/world_info_resolver.py
@@ -1,0 +1,125 @@
+"""Shared world-info send-path resolver (Roleplay P2g).
+
+Builds the world-info-injected message text for a send, composing the same
+sources the legacy chat_events path does (conversation-attached books ∪
+character-attached snapshots ∪ a native character_book) — so the native Console
+(P2g-1) and, later, the legacy path (P2g-3) share one faithful implementation.
+Never raises: any problem returns the message text unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from loguru import logger
+
+
+def _collect_active_world_books(
+    db: Any, conversation_id: Optional[str], char_data: Optional[Dict[str, Any]]
+) -> Tuple[List[Dict[str, Any]], bool]:
+    """Collect the world books that apply to this send.
+
+    Args:
+        db: A ``CharactersRAGDB`` (or None).
+        conversation_id: The active conversation (string UUID) or None.
+        char_data: The active character record, or None (native Console).
+
+    Returns:
+        ``(world_books, has_character_book)`` — the conversation-attached books
+        unioned with character-attached snapshots (conversation wins on a name
+        collision), and whether ``char_data`` carries a native ``character_book``.
+        Never raises.
+    """
+    world_books: List[Dict[str, Any]] = []
+    if conversation_id and db is not None:
+        try:
+            from .world_book_manager import WorldBookManager
+
+            world_books = WorldBookManager(db).get_world_books_for_conversation(
+                str(conversation_id), enabled_only=True
+            )
+        except Exception:
+            logger.opt(exception=True).debug(
+                "world-info: could not load conversation world books"
+            )
+            world_books = []
+
+    has_character_book = False
+    extensions = char_data.get("extensions", {}) if isinstance(char_data, dict) else {}
+    if isinstance(extensions, dict) and extensions.get("character_book"):
+        has_character_book = True
+
+    try:
+        from .world_book_manager import resolve_character_world_books
+
+        character_books = resolve_character_world_books(
+            char_data, {str(b.get("name")) for b in world_books}
+        )
+    except Exception:
+        character_books = []
+    if character_books:
+        world_books = world_books + character_books
+
+    return world_books, has_character_book
+
+
+def apply_world_info_to_message(
+    db: Any,
+    conversation_id: Optional[str],
+    char_data: Optional[Dict[str, Any]],
+    message_text: str,
+    history: List[Dict[str, Any]],
+) -> str:
+    """Return ``message_text`` with matched world-info injected, or unchanged.
+
+    Args:
+        db: A ``CharactersRAGDB`` (or None).
+        conversation_id: The active conversation (string UUID) or None.
+        char_data: The active character record, or None (conversation-only).
+        message_text: The current user message text (already plain string).
+        history: Prior messages as ``{"role","content": str}`` (string content;
+            the caller normalizes multimodal content to text before calling).
+
+    Returns:
+        The message text wrapped with world-info injections in the order
+        ``at_start → before_char → message → after_char → at_end`` (``"\\n\\n"``
+        separated), or the original ``message_text`` when nothing matches / no
+        books / no conversation / any error. Never raises.
+    """
+    if not isinstance(message_text, str):
+        return message_text
+    try:
+        world_books, has_character_book = _collect_active_world_books(
+            db, conversation_id, char_data
+        )
+        if not (has_character_book or world_books):
+            return message_text
+        from .world_info_processor import WorldInfoProcessor
+
+        processor = WorldInfoProcessor(
+            character_data=char_data if has_character_book else None,
+            world_books=world_books or None,
+        )
+        result = processor.process_messages(message_text, history or [])
+        if not result.get("matched_entries"):
+            return message_text
+        formatted = processor.format_injections(result.get("injections", {}))
+        parts: List[str] = []
+        if formatted.get("at_start"):
+            parts.append(formatted["at_start"])
+        if formatted.get("before_char"):
+            parts.append(formatted["before_char"])
+        parts.append(message_text)
+        if formatted.get("after_char"):
+            parts.append(formatted["after_char"])
+        if formatted.get("at_end"):
+            parts.append(formatted["at_end"])
+        return "\n\n".join(parts)
+    except Exception:
+        logger.opt(exception=True).debug(
+            "world-info: apply failed; returning message text unchanged"
+        )
+        return message_text
+
+
+__all__ = ["apply_world_info_to_message"]

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -67,6 +67,34 @@ MAX_CONSOLE_DRAFT_LENGTH = 100_000
 CONSOLE_CONTINUE_INSTRUCTION = "Continue and extend the selected message."
 
 
+def _normalize_world_info_history(
+    messages: "list[dict[str, Any]]",
+) -> "list[dict[str, Any]]":
+    """Flatten messages to ``{"role","content": str}`` for world-info scanning.
+
+    ``WorldInfoProcessor.process_messages`` types content as ``str``; native
+    provider messages may carry multimodal list content, so extract the text
+    parts (joined) and drop images before scanning.
+    """
+    out: list[dict[str, Any]] = []
+    for message in messages:
+        content = message.get("content")
+        if isinstance(content, str):
+            text = content
+        elif isinstance(content, list):
+            text = "\n".join(
+                part["text"]
+                for part in content
+                if isinstance(part, dict)
+                and part.get("type") == "text"
+                and isinstance(part.get("text"), str)
+            )
+        else:
+            text = ""
+        out.append({"role": message.get("role", ""), "content": text})
+    return out
+
+
 def build_mcp_review_hook(
     provider: MCPToolProvider,
     request_mcp_approvals: Callable[[list["MCPPendingCall"]], dict[str, str]],
@@ -279,6 +307,7 @@ class ConsoleChatController:
         skills_service: Any | None = None,
         skill_substitution_enabled: bool = True,
         chat_dictionary_applier: "Callable[[str | None, str], str] | None" = None,
+        world_info_applier: "Callable[[str | None, str, list], str] | None" = None,
     ) -> None:
         self.store = store
         self.provider_gateway = provider_gateway
@@ -306,6 +335,7 @@ class ConsoleChatController:
         self._skills_service = skills_service
         self._skill_substitution_enabled = skill_substitution_enabled
         self._chat_dictionary_applier = chat_dictionary_applier
+        self._world_info_applier = world_info_applier
         self.run_state = ConsoleRunState()
         self.run_state_history: list[ConsoleRunStatus] = [self.run_state.status]
         #: Optional owner hook invoked once a submit is accepted (user message
@@ -429,6 +459,9 @@ class ConsoleChatController:
         if refuse is not None:
             return self._block(session.id, refuse)
         provider_messages = await self._apply_chat_dictionaries(
+            provider_messages, session.id
+        )
+        provider_messages = await self._apply_world_info(
             provider_messages, session.id
         )
         prefill, prefill_from_one_shot = self._resolve_submit_prefill(session.id)
@@ -1069,6 +1102,9 @@ class ConsoleChatController:
         provider_messages = await self._apply_chat_dictionaries(
             provider_messages, session_id
         )
+        provider_messages = await self._apply_world_info(
+            provider_messages, session_id
+        )
         prefill = self._pinned_prefill_for_session(session_id)
         return await self._stream_assistant_response(
             resolution=resolution,
@@ -1117,6 +1153,9 @@ class ConsoleChatController:
         if refuse is not None:
             return self._block(session_id, refuse)
         provider_messages = await self._apply_chat_dictionaries(
+            provider_messages, session_id
+        )
+        provider_messages = await self._apply_world_info(
             provider_messages, session_id
         )
         assistant = self.store.append_message(
@@ -1173,6 +1212,9 @@ class ConsoleChatController:
         if refuse is not None:
             return self._block(session_id, refuse)
         provider_messages = await self._apply_chat_dictionaries(
+            provider_messages, session_id
+        )
+        provider_messages = await self._apply_world_info(
             provider_messages, session_id
         )
         prefill = self._pinned_prefill_for_session(session_id)
@@ -1690,6 +1732,92 @@ class ConsoleChatController:
         new_messages = list(provider_messages)
         new_messages[final_index] = rendered_message
         return new_messages, None
+
+    async def _apply_world_info(
+        self, provider_messages: list[dict[str, Any]], session_id: str
+    ) -> list[dict[str, Any]]:
+        """Inject conversation world-info into the final user message of the
+        ephemeral provider payload (never the stored transcript).
+
+        Runs AFTER `_apply_chat_dictionaries` so world-info matches the
+        dict-substituted text the model will see. Conversation-only (the bound
+        applier passes `char_data=None`). Offloaded via `asyncio.to_thread`;
+        any failure returns the payload unchanged; `CancelledError` re-raised.
+        """
+        applier = self._world_info_applier
+        if applier is None:
+            return provider_messages
+
+        session = next((s for s in self.store.sessions() if s.id == session_id), None)
+        conversation_id = (
+            session.persisted_conversation_id if session is not None else None
+        )
+        if not conversation_id:
+            return provider_messages
+
+        final_index: int | None = None
+        for index in range(len(provider_messages) - 1, -1, -1):
+            if provider_messages[index].get("role") == ConsoleMessageRole.USER.value:
+                final_index = index
+                break
+        if final_index is None:
+            return provider_messages
+
+        message = provider_messages[final_index]
+        content = message.get("content")
+        if isinstance(content, str) and content.startswith(COMMAND_PREFIX):
+            return provider_messages
+
+        history = _normalize_world_info_history(provider_messages[:final_index])
+
+        try:
+            if isinstance(content, str):
+                injected: Any = await asyncio.to_thread(
+                    applier, conversation_id, content, history
+                )
+                if injected == content:
+                    return provider_messages
+                new_content = injected
+            elif isinstance(content, list):
+                combined = "\n".join(
+                    part["text"]
+                    for part in content
+                    if isinstance(part, dict)
+                    and part.get("type") == "text"
+                    and isinstance(part.get("text"), str)
+                )
+                if not combined:
+                    return provider_messages
+                injected = await asyncio.to_thread(
+                    applier, conversation_id, combined, history
+                )
+                if injected == combined:
+                    return provider_messages
+                new_parts: list[Any] = []
+                first_text_done = False
+                for part in content:
+                    if (
+                        isinstance(part, dict)
+                        and part.get("type") == "text"
+                        and isinstance(part.get("text"), str)
+                    ):
+                        if not first_text_done:
+                            new_parts.append({**part, "text": injected})
+                            first_text_done = True
+                        # subsequent text parts are folded into the injected block
+                        continue
+                    new_parts.append(part)
+                new_content = new_parts
+            else:
+                return provider_messages
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            return provider_messages
+
+        new_messages = list(provider_messages)
+        new_messages[final_index] = {**message, "content": new_content}
+        return new_messages
 
     async def _apply_chat_dictionaries(
         self, provider_messages: list[dict[str, Any]], session_id: str

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -74,10 +74,15 @@ def _normalize_world_info_history(
 
     ``WorldInfoProcessor.process_messages`` types content as ``str``; native
     provider messages may carry multimodal list content, so extract the text
-    parts (joined) and drop images before scanning.
+    parts (joined) and drop images before scanning. System messages are
+    skipped entirely -- world-info should scan only the user/assistant
+    conversation, matching the legacy path; keywords in the system prompt
+    must not spuriously activate entries.
     """
     out: list[dict[str, Any]] = []
     for message in messages:
+        if message.get("role") == ConsoleMessageRole.SYSTEM.value:
+            continue
         content = message.get("content")
         if isinstance(content, str):
             text = content
@@ -1793,20 +1798,27 @@ class ConsoleChatController:
                 )
                 if injected == combined:
                     return provider_messages
+                prefix, _, suffix = injected.partition(combined)
+                text_indices = [
+                    i
+                    for i, part in enumerate(content)
+                    if isinstance(part, dict)
+                    and part.get("type") == "text"
+                    and isinstance(part.get("text"), str)
+                ]
+                first_idx = text_indices[0]
+                last_idx = text_indices[-1]
                 new_parts: list[Any] = []
-                first_text_done = False
-                for part in content:
-                    if (
-                        isinstance(part, dict)
-                        and part.get("type") == "text"
-                        and isinstance(part.get("text"), str)
-                    ):
-                        if not first_text_done:
-                            new_parts.append({**part, "text": injected})
-                            first_text_done = True
-                        # subsequent text parts are folded into the injected block
-                        continue
-                    new_parts.append(part)
+                for i, part in enumerate(content):
+                    if i == first_idx or i == last_idx:
+                        new_text = part["text"]
+                        if i == first_idx:
+                            new_text = prefix + new_text
+                        if i == last_idx:
+                            new_text = new_text + suffix
+                        new_parts.append({**part, "text": new_text})
+                    else:
+                        new_parts.append(part)
                 new_content = new_parts
             else:
                 return provider_messages

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -2759,6 +2759,7 @@ class ChatScreen(BaseAppScreen):
                 agent_runtime_enabled=self._console_agent_runtime_enabled(),
                 skills_service=getattr(self.app_instance, "skills_scope_service", None),
                 chat_dictionary_applier=self._console_chat_dictionary_applier,
+                world_info_applier=self._console_world_info_applier,
             )
         self._console_chat_controller.on_submission_accepted = (
             self._on_console_submission_accepted
@@ -5789,6 +5790,31 @@ class ChatScreen(BaseAppScreen):
             text,
             max_tokens=_CHATDICT_MAX_TOKENS,
             strategy=_CHATDICT_STRATEGY,
+        )
+
+    def _console_world_info_applier(
+        self, conversation_id: str | None, message_text: str, history: list
+    ) -> str:
+        """Bound applier handed to the native Console controller: inject the
+        active CONVERSATION world-info into a send's text (never raises).
+
+        Resolves the db lazily. Conversation-only: ``char_data`` is ``None``
+        (native sessions carry no character card). Honors the same
+        ``[character_chat] enable_world_info`` gate as the legacy send path
+        (`Event_Handlers/Chat_Events/chat_events.py`).
+        """
+        db = getattr(self.app_instance, "chachanotes_db", None)
+        if (
+            db is None
+            or not conversation_id
+            or not isinstance(message_text, str)
+            or not get_cli_setting("character_chat", "enable_world_info", True)
+        ):
+            return message_text
+        from ...Character_Chat.world_info_resolver import apply_world_info_to_message
+
+        return apply_world_info_to_message(
+            db, conversation_id, None, message_text, history or []
         )
 
     def _active_console_dictionary_scope_ids(self) -> tuple[str | None, int | None]:


### PR DESCRIPTION
## Roleplay P2g-1 — native-Console world-info send

First of three P2g cycles. Makes conversation-attached world books actually take effect on the **native Console** send (they applied only on the legacy Chat send before — `console_chat_controller.py` had zero world-info code). Mirrors the merged native-Console dictionary send (`_apply_chat_dictionaries`, #664).

### What's in it
- **Shared resolver** (`Character_Chat/world_info_resolver.py`, new): `apply_world_info_to_message(db, conversation_id, char_data, message_text, history)` — composes the same sources the legacy path does (conversation books ∪ character snapshots ∪ native `character_book`), builds a `WorldInfoProcessor`, matches, and joins the injections around the message in the exact legacy order (`at_start → before_char → message → after_char → at_end`). **Never raises** (no conversation/books/match/error → text unchanged). Factors `_collect_active_world_books` — the shared core **P2g-2's inspector will reuse**.
- **Native applier** (`console_chat_controller.py`): `_apply_world_info` mirroring `_apply_chat_dictionaries` — called at the **4 send sites** (submit/retry/continue/regenerate) immediately **after** the dictionary applier (world-info fires on the LLM-visible, dict-substituted text), off-thread, `CancelledError`-safe, no-op without a `persisted_conversation_id`. A `_normalize_world_info_history` flattener makes it **multimodal-safe** (image parts preserved). The preview `build_context_snapshot` is left alone.
- **Wiring** (`chat_screen.py`): `_console_world_info_applier` bound applier — **conversation-only** (`char_data=None`; a character-only book cannot inject on native send), lazy db, honors `get_cli_setting("character_chat", "enable_world_info", True)` (parity with legacy) — passed to `ConsoleChatController(...)`.

### Constraints honored
- **No schema migration** (v22); **no change to `chat_events.py` or `world_info_processor.py`** (the legacy gate-bug fix + dead-code cleanup is the separate **P2g-3** cycle). Only `world_info_resolver.py` (new), `console_chat_controller.py`, `chat_screen.py` touched.
- No conversation attached ⇒ native send byte-identical to today. The native dictionary send is untouched (its integration test stays green).

### Deferred
Console "what's in play" world-book inspector → **P2g-2** (reuses `_collect_active_world_books`); legacy send character-gate bug fix + dead-code deletion → **P2g-3**.

### Testing
Real-integration throughout: resolver real-DB tests, controller stub-applier splicing tests, and an end-to-end **capturing-gateway** test (a real send through the real controller asserts the injected world-info reaches the outbound payload while the transcript keeps raw text). Full P2g-1 gate **49 passed**; `import tldw_chatbook.app` OK. Subagent-driven (implementer + reviewer per task, opus whole-branch review = READY TO MERGE).

(Also includes a small `chore(backlog)` commit adding two P2f follow-up tasks — unrelated to the code.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables world books on native Console send: conversation-attached lore is injected into the final user message sent to the model, while the stored transcript stays raw. Mirrors the dictionary send path and keeps behavior unchanged when no conversation is attached.

- **New Features**
  - Added shared resolver `apply_world_info_to_message` that composes conversation books ∪ character snapshots ∪ native `character_book`, matches, and joins injections in legacy order; never raises.
  - Implemented `_apply_world_info` in `ConsoleChatController` at submit/retry/continue/regenerate, immediately after `_apply_chat_dictionaries`; multimodal-safe, skips command messages, off-thread, no-op without a `persisted_conversation_id`.
  - Wired `_console_world_info_applier` in `chat_screen.py` (conversation-only, `char_data=None`), gated by `get_cli_setting("character_chat", "enable_world_info", True)`. No schema or legacy path changes.

- **Bug Fixes**
  - Excluded system messages from the scan history so prompt keywords don’t trigger world-info matches.
  - Preserved multimodal order by injecting around text while keeping images in place (prefix on first text part, suffix on last).

<sup>Written for commit 8484159de02f84ccda67f16d603ef780b48b27a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

