### PR TITLE
fix(console): prefill follow-ups — snapshot preview, store-twin contract, provider verification (tasks 401-403)

### DIFF
--- a/Docs/superpowers/specs/2026-07-20-console-response-prefill-design.md
+++ b/Docs/superpowers/specs/2026-07-20-console-response-prefill-design.md
@@ -244,9 +244,16 @@ the prefill turn.
   could not be confirmed live; Anthropic documents prefill as supported).
 - **OpenAI (Chat Completions):** accepted the trailing-assistant payload via the app's
   handler; response was influenced-but-not-literal continuation, exactly as §5 documents.
-- **NOT verified (no key / not configured):** Gemini (`chat_with_google` role-remap) and the
-  OpenAI Responses-API branch. These remain open §5 verification items; no guard entries
-  were added for them.
+- **OpenAI Responses-API branch (verified 2026-07-21, task-403):** the Responses API
+  ACCEPTS a trailing-assistant `input` (raw call with the handler's exact input shape;
+  `gpt-5-mini` + `reasoning.effort`): influence-not-literal continuation, same as Chat
+  Completions. No guard needed. Note: verification through `chat_with_openai` itself is
+  currently blocked by an unrelated pre-existing bug — the handler force-sends default
+  `temperature`/`top_p`, which reasoning models reject with 400 (filed as task-404).
+- **Gemini: STILL NOT verified** — no Google API key available in this environment
+  (task-403 AC left open). No guard entry added; the skip+warn guard mechanism from §5
+  still does not exist and would need building if Gemini turns out to reject trailing
+  `model` turns.
 
 ## 9. Follow-up candidates (explicitly not v1)
 

--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -2507,3 +2507,56 @@ async def test_prefilled_send_bypasses_agent_loop():
     await controller.submit_draft("with prefill")
     assert len(bridge_calls) == 1  # unchanged
     assert gateway.messages_seen[-1] == {"role": "assistant", "content": "PRE"}
+
+
+@pytest.mark.asyncio
+async def test_build_context_snapshot_includes_armed_one_shot_prefill():
+    """task-401: an armed prefill must appear in the preview exactly as the
+    send would apply it -- trailing assistant turn + explicit indicator --
+    and the snapshot read must not consume the one-shot."""
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+    session = _arm_session(store)
+    store.set_session_one_shot_prefill(session.id, "Sure thing:")
+
+    snapshot = await controller.build_context_snapshot(draft="Explain tools")
+
+    assert snapshot.next_send_payload["messages"][-1] == {
+        "role": "assistant",
+        "content": "Sure thing:",
+    }
+    assert snapshot.next_send_payload["response_prefill"] == {
+        "source": "one-shot",
+        "text": "Sure thing:",
+        "agent_loop_bypassed": True,
+    }
+    # Read-only: the snapshot must not consume the armed one-shot.
+    assert store.session_one_shot_prefill(session.id) == "Sure thing:"
+
+
+@pytest.mark.asyncio
+async def test_build_context_snapshot_includes_pinned_prefill():
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+    session = _arm_session(store)
+    store.set_session_pinned_prefill(session.id, "Voice:")
+
+    snapshot = await controller.build_context_snapshot(draft="Explain tools")
+
+    assert snapshot.next_send_payload["messages"][-1] == {
+        "role": "assistant",
+        "content": "Voice:",
+    }
+    assert snapshot.next_send_payload["response_prefill"]["source"] == "pinned"
+
+
+@pytest.mark.asyncio
+async def test_build_context_snapshot_unchanged_when_no_prefill_armed():
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+    _arm_session(store)
+
+    snapshot = await controller.build_context_snapshot(draft="Explain tools")
+
+    assert "response_prefill" not in snapshot.next_send_payload
+    assert snapshot.next_send_payload["messages"][-1]["role"] == "user"

--- a/Tests/Chat/test_console_chat_store.py
+++ b/Tests/Chat/test_console_chat_store.py
@@ -1783,3 +1783,32 @@ def test_rename_session_reports_unpersisted_when_seam_is_missing():
 
     assert renamed.title == "New title"
     assert persisted is False
+
+
+def test_set_session_system_prompt_settings_none_reports_not_applied():
+    """task-402: a settings-less session cannot hold the update in memory --
+    the method must skip the durable write too and report False, not lie."""
+    persistence = FakePersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    session = store.create_session(title="Chat 1")
+    session.settings = None
+    session.persisted_conversation_id = "conv-1"
+
+    updated, persisted = store.set_session_system_prompt(session.id, "New prompt")
+    assert persisted is False
+    assert updated.settings is None
+    assert persistence.updated_system_prompts == []
+
+
+def test_set_session_pinned_prefill_settings_none_reports_not_applied():
+    """task-402: twin contract for the pinned prefill."""
+    persistence = FakePersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    session = store.create_session(title="Chat 1")
+    session.settings = None
+    session.persisted_conversation_id = "conv-1"
+
+    updated, persisted = store.set_session_pinned_prefill(session.id, "Voice:")
+    assert persisted is False
+    assert updated.settings is None
+    assert persistence.updated_pinned_prefills == []

--- a/Tests/UI/test_console_context_modal.py
+++ b/Tests/UI/test_console_context_modal.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock
 import pytest
 from textual.app import App, ComposeResult
 from textual.containers import Vertical
-from textual.widgets import Button, Label, Static, TextArea
+from textual.widgets import Button, Collapsible, Label, Static, TextArea
 
 from tldw_chatbook.Chat.console_chat_models import (
     ConsoleChatMessage,
@@ -248,3 +248,63 @@ async def test_context_modal_save_to_file_failure(monkeypatch):
         # Should not crash; notification severity is checked best-effort.
         await pilot.click("#console-context-save")
         await pilot.pause()
+
+
+PREFILL_SNAPSHOT = ConsoleContextSnapshot(
+    current_messages=[
+        ConsoleChatMessage(role=ConsoleMessageRole.USER, content="Hello"),
+    ],
+    next_send_payload={
+        "model": "gpt-4",
+        "messages": [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Sure thing:"},
+        ],
+        "response_prefill": {
+            "source": "one-shot",
+            "text": "Sure thing:",
+            "agent_loop_bypassed": True,
+        },
+    },
+)
+
+
+async def _prefill_factory() -> ConsoleContextSnapshot:
+    return PREFILL_SNAPSHOT
+
+
+class PrefillModalHarness(App):
+    def compose(self) -> ComposeResult:
+        yield Static("background")
+
+    def on_mount(self) -> None:
+        self.push_screen(ConsoleContextModal(_prefill_factory, token_estimate=7))
+
+
+@pytest.mark.asyncio
+async def test_context_modal_renders_response_prefill_section():
+    """task-401: an armed prefill renders as its own Next Send section with
+    the agent-loop-bypass note; absent entirely when the key is missing."""
+    app = PrefillModalHarness()
+
+    async with app.run_test(size=(100, 40)) as _pilot:
+        modal = app.screen
+        next_container = modal.query_one("#console-context-next-send-body", Vertical)
+        collapsibles = list(next_container.query(Collapsible))
+        titles = [c.title for c in collapsibles]
+        assert "Response Prefill" in titles
+        labels = [str(label.renderable) for label in next_container.query(Label)]
+        assert any("agent" in text and "skipped" in text for text in labels)
+        text_areas = [ta.text for ta in next_container.query(TextArea)]
+        assert any("one-shot" in text for text in text_areas)
+
+
+@pytest.mark.asyncio
+async def test_context_modal_no_prefill_section_without_key():
+    app = ModalHarness()
+
+    async with app.run_test(size=(100, 40)) as _pilot:
+        modal = app.screen
+        next_container = modal.query_one("#console-context-next-send-body", Vertical)
+        titles = [c.title for c in next_container.query(Collapsible)]
+        assert "Response Prefill" not in titles

--- a/backlog/tasks/task-401 - Show-armed-response-prefill-in-Console-context-snapshot-preview.md
+++ b/backlog/tasks/task-401 - Show-armed-response-prefill-in-Console-context-snapshot-preview.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-401
 title: Show armed response prefill in Console context snapshot preview
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-21 03:48'
+updated_date: '2026-07-21 07:09'
 labels: []
 dependencies: []
 ---
@@ -16,7 +18,13 @@ The Console context snapshot modal claims to show the assembled next-send payloa
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Context snapshot preview includes the trailing assistant prefill turn when one is armed
-- [ ] #2 Preview indicates the agent loop is bypassed for that send
-- [ ] #3 No change when no prefill is armed
+- [x] #1 Context snapshot preview includes the trailing assistant prefill turn when one is armed
+- [x] #2 Preview indicates the agent loop is bypassed for that send
+- [x] #3 No change when no prefill is armed
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+build_context_snapshot now mirrors the send path after the dictionaries step: resolves one-shot-over-pinned via _resolve_submit_prefill (read-only, never consumes), appends the trailing assistant turn through the same redaction pipeline, and adds a response_prefill payload key {source, text (redacted), agent_loop_bypassed: true}. No payload change when nothing armed. 3 new controller tests; suite 103 passed.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-401 - Show-armed-response-prefill-in-Console-context-snapshot-preview.md
+++ b/backlog/tasks/task-401 - Show-armed-response-prefill-in-Console-context-snapshot-preview.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@claude'
 created_date: '2026-07-21 03:48'
-updated_date: '2026-07-21 07:09'
+updated_date: '2026-07-21 07:30'
 labels: []
 dependencies: []
 ---
@@ -26,5 +26,5 @@ The Console context snapshot modal claims to show the assembled next-send payloa
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-build_context_snapshot now mirrors the send path after the dictionaries step: resolves one-shot-over-pinned via _resolve_submit_prefill (read-only, never consumes), appends the trailing assistant turn through the same redaction pipeline, and adds a response_prefill payload key {source, text (redacted), agent_loop_bypassed: true}. No payload change when nothing armed. 3 new controller tests; suite 103 passed.
+build_context_snapshot mirrors the send path after the dictionaries step: resolves one-shot-over-pinned via _resolve_submit_prefill (read-only, never consumes), appends the trailing assistant turn through the same redaction pipeline, and adds a response_prefill payload key {source, text (redacted), agent_loop_bypassed: true}. Closeout addition: ConsoleContextModal renders that key as its own 'Response Prefill' section (bypass note + JSON block) — the modal renders a fixed key set and would otherwise silently drop it (third instance of the widget-drops-unknown-keys trap). Live-verified in the running TUI. Tests: 3 controller + 2 modal; suites green.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-402 - Fix-silent-settings-None-no-op-in-set_session_system_prompt-and-set_session_pinned_prefill.md
+++ b/backlog/tasks/task-402 - Fix-silent-settings-None-no-op-in-set_session_system_prompt-and-set_session_pinned_prefill.md
@@ -3,9 +3,11 @@ id: TASK-402
 title: >-
   Fix silent settings-None no-op in set_session_system_prompt and
   set_session_pinned_prefill
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-21 03:48'
+updated_date: '2026-07-21 07:07'
 labels: []
 dependencies: []
 ---
@@ -18,6 +20,18 @@ Both store methods silently skip the in-memory settings update when session.sett
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Both methods either seed default settings or report the skipped update honestly
-- [ ] #2 Unit tests cover the settings-None path for both methods
+- [x] #1 Both methods either seed default settings or report the skipped update honestly
+- [x] #2 Unit tests cover the settings-None path for both methods
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. TDD: settings-None tests for both set_session_system_prompt and set_session_pinned_prefill asserting (session, False) honest flag\n2. Implement shared guard in both twins: durable write still runs (persistent truth), flag False + warning log when in-memory update skipped\n3. Docstring the contract; run store suite
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Both twins now early-return (session, False) with a warning log when session.settings is None — the durable write is skipped too (no split-brain between live session and saved conversation). Zero production blast radius: the /system caller ensures settings via _ensure_active_console_session_settings and /prefill seeds defaults since PR #729. Tests: 2 new settings-None contract tests; store suite 79 passed.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-403 - Verify-response-prefill-against-Gemini-and-OpenAI-Responses-API-branch.md
+++ b/backlog/tasks/task-403 - Verify-response-prefill-against-Gemini-and-OpenAI-Responses-API-branch.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-403
 title: Verify response prefill against Gemini and OpenAI Responses-API branch
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-07-21 03:48'
+updated_date: '2026-07-21 07:12'
 labels: []
 dependencies: []
 ---
@@ -17,6 +19,12 @@ Spec section 5/8 verification items left open (no key/config available at implem
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
 - [ ] #1 Gemini prefilled send verified accepted or guarded
-- [ ] #2 Responses-API branch verified accepted or guarded
-- [ ] #3 Spec section 8 updated with outcomes
+- [x] #2 Responses-API branch verified accepted or guarded
+- [x] #3 Spec section 8 updated with outcomes
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Responses-API leg VERIFIED ACCEPTED 2026-07-21: raw /v1/responses call with the handler's exact trailing-assistant input shape (gpt-5-mini, reasoning.effort=low) succeeds; influence-not-literal continuation like Chat Completions; no guard needed. Through-the-handler check blocked by pre-existing unrelated bug (handler force-sends temperature/top_p which reasoning models 400) — filed as task-404. Gemini leg remains BLOCKED: no Google API key in this environment; AC #1 left open, task stays In Progress until a key is available.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-404 - Stop-sending-default-temperature-top_p-to-OpenAI-reasoning-models.md
+++ b/backlog/tasks/task-404 - Stop-sending-default-temperature-top_p-to-OpenAI-reasoning-models.md
@@ -1,0 +1,20 @@
+---
+id: TASK-404
+title: Stop sending default temperature/top_p to OpenAI reasoning models
+status: To Do
+assignee: []
+created_date: '2026-07-21 07:12'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+chat_with_openai force-includes default temperature and top_p in the request; OpenAI reasoning models (o-series, gpt-5 family) reject these with HTTP 400 'Unsupported parameter', so ANY call routed to them through this handler fails — including the Responses-API branch. Found during task-403 verification.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Reasoning-model requests omit unsupported sampling parameters,Non-reasoning models keep today's parameter behavior,Regression test covers both shapes
+<!-- AC:END -->

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -1294,6 +1294,22 @@ class ConsoleChatController:
             # Chat dictionaries are safe to apply (string replacements only).
             provider_messages = await self._apply_chat_dictionaries(provider_messages, session_id)
 
+            # task-401: mirror the send path's response prefill exactly --
+            # same resolution (one-shot wins over pinned) and same trailing
+            # assistant turn -- WITHOUT consuming the one-shot (this is a
+            # read-only preview). Placed after dictionaries to match
+            # `_stream_assistant_response`'s ordering (dictionaries never
+            # rewrite prefill text).
+            prefill, prefill_from_one_shot = self._resolve_submit_prefill(session_id)
+            if prefill:
+                provider_messages = [
+                    *provider_messages,
+                    {
+                        "role": ConsoleMessageRole.ASSISTANT.value,
+                        "content": prefill,
+                    },
+                ]
+
             # Replace image data with placeholders for the preview, including historical images.
             provider_messages = self._replace_image_data_with_placeholders(provider_messages)
 
@@ -1307,19 +1323,30 @@ class ConsoleChatController:
             # Deep-copy messages so the snapshot is independent of the store.
             copied_messages = copy.deepcopy(current_messages)
 
+            next_send_payload: dict[str, Any] = {
+                "model": self.model or self.configured_model,
+                "messages": redacted_messages,
+                # `system` is intentionally duplicated from the leading system
+                # message in `messages` so the preview viewer can show the
+                # effective system prompt at a glance without scanning the
+                # message list.  It is the same redacted value.
+                "system": redacted_system,
+                "staged_sources": staged_sources_list,
+                "tools": tools_info,
+            }
+            if prefill:
+                # Text mirrors the redacted trailing assistant turn so the
+                # indicator can never leak what the messages list redacted.
+                next_send_payload["response_prefill"] = {
+                    "source": "one-shot" if prefill_from_one_shot else "pinned",
+                    "text": redacted_messages[-1]["content"]
+                    if redacted_messages
+                    else prefill,
+                    "agent_loop_bypassed": True,
+                }
             return ConsoleContextSnapshot(
                 current_messages=copied_messages,
-                next_send_payload={
-                    "model": self.model or self.configured_model,
-                    "messages": redacted_messages,
-                    # `system` is intentionally duplicated from the leading system
-                    # message in `messages` so the preview viewer can show the
-                    # effective system prompt at a glance without scanning the
-                    # message list.  It is the same redacted value.
-                    "system": redacted_system,
-                    "staged_sources": staged_sources_list,
-                    "tools": tools_info,
-                },
+                next_send_payload=next_send_payload,
             )
         except Exception as exc:
             logger.exception(

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -1024,11 +1024,6 @@ class ConsoleChatStore:
             update was skipped entirely (task-402 honest-contract guard).
         """
         session = self._session_or_raise(session_id)
-        normalized = (
-            system_prompt
-            if isinstance(system_prompt, str) and system_prompt.strip()
-            else None
-        )
         if session.settings is None:
             # task-402: without a settings snapshot the update cannot take
             # effect in memory; writing it durably anyway would split-brain
@@ -1038,6 +1033,11 @@ class ConsoleChatStore:
                 "set_session_system_prompt skipped: session has no settings."
             )
             return session, False
+        normalized = (
+            system_prompt
+            if isinstance(system_prompt, str) and system_prompt.strip()
+            else None
+        )
         session.settings = replace(session.settings, system_prompt=normalized)
         persisted = True
         if (
@@ -1078,9 +1078,19 @@ class ConsoleChatStore:
         the honest ``persisted`` flag is returned. A session with no
         settings snapshot skips the update entirely and returns ``False``
         (task-402 honest-contract guard).
+
+        Args:
+            session_id: Native Console session ID to update.
+            prefill: New pinned prefill text, or ``None``/blank to clear it.
+
+        Returns:
+            A ``(session, persisted)`` pair: the updated Console session,
+            and whether the requested state fully took effect — ``False``
+            when the durable write failed or the session has no settings
+            snapshot; ``True`` otherwise (including when no durable write
+            was needed).
         """
         session = self._session_or_raise(session_id)
-        normalized = prefill if isinstance(prefill, str) and prefill.strip() else None
         if session.settings is None:
             # task-402: mirror set_session_system_prompt -- no settings
             # snapshot means the update cannot apply in memory; skip the
@@ -1089,6 +1099,7 @@ class ConsoleChatStore:
                 "set_session_pinned_prefill skipped: session has no settings."
             )
             return session, False
+        normalized = prefill if isinstance(prefill, str) and prefill.strip() else None
         session.settings = replace(session.settings, pinned_prefill=normalized)
         persisted = True
         if (

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -1019,7 +1019,9 @@ class ConsoleChatStore:
             A ``(session, persisted)`` pair: the updated Console session,
             and whether the durable write (when one was attempted) actually
             succeeded. ``persisted`` is ``True`` when no durable write was
-            needed (session not yet saved, or no persistence configured).
+            needed (session not yet saved, or no persistence configured),
+            and ``False`` when the session has no settings snapshot — the
+            update was skipped entirely (task-402 honest-contract guard).
         """
         session = self._session_or_raise(session_id)
         normalized = (
@@ -1027,8 +1029,16 @@ class ConsoleChatStore:
             if isinstance(system_prompt, str) and system_prompt.strip()
             else None
         )
-        if session.settings is not None:
-            session.settings = replace(session.settings, system_prompt=normalized)
+        if session.settings is None:
+            # task-402: without a settings snapshot the update cannot take
+            # effect in memory; writing it durably anyway would split-brain
+            # the live session against the saved conversation. Report
+            # honestly instead of silently claiming success.
+            logger.bind(session_id=session_id).warning(
+                "set_session_system_prompt skipped: session has no settings."
+            )
+            return session, False
+        session.settings = replace(session.settings, system_prompt=normalized)
         persisted = True
         if (
             session.persisted_conversation_id is not None
@@ -1065,12 +1075,21 @@ class ConsoleChatStore:
         settings snapshot and, when the session already owns a persisted
         conversation, writes through to conversation metadata. A durable
         write failure is caught and logged; the in-memory value is kept and
-        the honest ``persisted`` flag is returned.
+        the honest ``persisted`` flag is returned. A session with no
+        settings snapshot skips the update entirely and returns ``False``
+        (task-402 honest-contract guard).
         """
         session = self._session_or_raise(session_id)
         normalized = prefill if isinstance(prefill, str) and prefill.strip() else None
-        if session.settings is not None:
-            session.settings = replace(session.settings, pinned_prefill=normalized)
+        if session.settings is None:
+            # task-402: mirror set_session_system_prompt -- no settings
+            # snapshot means the update cannot apply in memory; skip the
+            # durable write and report honestly.
+            logger.bind(session_id=session_id).warning(
+                "set_session_pinned_prefill skipped: session has no settings."
+            )
+            return session, False
+        session.settings = replace(session.settings, pinned_prefill=normalized)
         persisted = True
         if (
             session.persisted_conversation_id is not None

--- a/tldw_chatbook/Widgets/Console/console_context_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_context_modal.py
@@ -199,6 +199,20 @@ class ConsoleContextModal(ModalScreen[None]):
             )
         )
 
+        response_prefill = payload.get("response_prefill")
+        if response_prefill:
+            widgets.append(
+                Collapsible(
+                    Label(
+                        "The reply will continue from this prefill; the agent "
+                        "loop (tools/MCP) is skipped for this send."
+                    ),
+                    TextArea(self._json_block(response_prefill), read_only=True),
+                    title="Response Prefill",
+                    collapsed=False,
+                )
+            )
+
         tools = payload.get("tools")
         if tools:
             widgets.append(


### PR DESCRIPTION
## What

Addresses the three follow-ups filed from PR #729:

- **task-401 (Done):** `build_context_snapshot` now mirrors the send path's prefill exactly — trailing assistant turn through the same redaction pipeline, plus a `response_prefill` payload key (`source`, redacted `text`, `agent_loop_bypassed: true`). Read-only: never consumes the one-shot. No payload change when nothing is armed.
- **task-402 (Done):** both `set_session_system_prompt` and `set_session_pinned_prefill` now return `(session, False)` with a warning log when the session has no settings snapshot, skipping the durable write too (no split-brain). Zero production blast radius — both UI callers ensure settings first.
- **task-403 (partial):** OpenAI **Responses-API branch verified ACCEPTED** for trailing-assistant input (raw call with the handler's exact shape; influence-not-literal continuation, no guard needed) — recorded in spec §8. **Gemini leg remains blocked**: no Google API key in this environment; task stays In Progress.
- **task-404 (new, filed):** found during verification — `chat_with_openai` force-sends default `temperature`/`top_p`, which reasoning models reject with 400, breaking any o-series/gpt-5 call through the handler (independent of prefill).

## Tests

5 new tests (3 snapshot, 2 store-contract). Suites: controller 103, store 79, composer UI 26, inspector 7 — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefill preview now mirrors the send path (trailing assistant turn plus `response_prefill`) without consuming one-shot, and the context modal renders it with a clear bypass note. Store updates now honestly report and skip when a session has no settings; OpenAI Responses API accepted the prefill shape, Gemini is still blocked, and a follow-up is filed to stop sending default `temperature`/`top_p` to reasoning models. (Tasks 401–403)

- **New Features**
  - `build_context_snapshot` appends the redacted trailing assistant prefill and sets `response_prefill {source, text, agent_loop_bypassed: true}`; read-only.
  - Console context modal shows a “Response Prefill” section with the bypass note; hidden when missing.

- **Bug Fixes**
  - `set_session_system_prompt` and `set_session_pinned_prefill` return `(session, False)` and skip durable writes when `settings` is `None` to avoid split-brain.
  - Guard-first ordering; pinned-prefill contract clarified in docstrings.

<sup>Written for commit 14d1da945e4f623561411ee2e26bf37f45e8e113. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

