### PR TITLE
docs(spec): Gemini prefill verified accepted — task-403 complete

### DIFF
--- a/Docs/superpowers/specs/2026-07-20-console-response-prefill-design.md
+++ b/Docs/superpowers/specs/2026-07-20-console-response-prefill-design.md
@@ -250,10 +250,14 @@ the prefill turn.
   Completions. No guard needed. Note: verification through `chat_with_openai` itself is
   currently blocked by an unrelated pre-existing bug — the handler force-sends default
   `temperature`/`top_p`, which reasoning models reject with 400 (filed as task-404).
-- **Gemini: STILL NOT verified** — no Google API key available in this environment
-  (task-403 AC left open). No guard entry added; the skip+warn guard mechanism from §5
-  still does not exist and would need building if Gemini turns out to reject trailing
-  `model` turns.
+- **Gemini (verified 2026-07-21, task-403): ACCEPTED, with LITERAL continuation.** Both
+  raw `generateContent` (trailing `model`-role turn) and the app's own
+  `chat_with_google` handler (assistant→`model` remap + alternation) accept the prefilled
+  payload; the model continues directly from the prefill text ("The answer is" →
+  " 7, because…") — stronger continuation semantics than OpenAI's restart behavior.
+  Verified on `gemini-flash-lite-latest`; free-tier per-minute quota produces transient
+  429s (retry/backoff handles them). No guard needed for any verified provider; the §5
+  skip+warn guard mechanism was never built and no known provider requires it.
 
 ## 9. Follow-up candidates (explicitly not v1)
 

--- a/backlog/tasks/task-403 - Verify-response-prefill-against-Gemini-and-OpenAI-Responses-API-branch.md
+++ b/backlog/tasks/task-403 - Verify-response-prefill-against-Gemini-and-OpenAI-Responses-API-branch.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-403
 title: Verify response prefill against Gemini and OpenAI Responses-API branch
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-07-21 03:48'
-updated_date: '2026-07-21 07:12'
+updated_date: '2026-07-21 14:03'
 labels: []
 dependencies: []
 ---
@@ -18,7 +18,7 @@ Spec section 5/8 verification items left open (no key/config available at implem
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Gemini prefilled send verified accepted or guarded
+- [x] #1 Gemini prefilled send verified accepted or guarded
 - [x] #2 Responses-API branch verified accepted or guarded
 - [x] #3 Spec section 8 updated with outcomes
 <!-- AC:END -->
@@ -26,5 +26,5 @@ Spec section 5/8 verification items left open (no key/config available at implem
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Responses-API leg VERIFIED ACCEPTED 2026-07-21: raw /v1/responses call with the handler's exact trailing-assistant input shape (gpt-5-mini, reasoning.effort=low) succeeds; influence-not-literal continuation like Chat Completions; no guard needed. Through-the-handler check blocked by pre-existing unrelated bug (handler force-sends temperature/top_p which reasoning models 400) — filed as task-404. Gemini leg remains BLOCKED: no Google API key in this environment; AC #1 left open, task stays In Progress until a key is available.
+COMPLETE 2026-07-21. Gemini leg: ACCEPTED with literal continuation, verified both raw (generateContent, trailing model turn) and through chat_with_google's remap/alternation path on gemini-flash-lite-latest (free-tier 429s are quota noise; gemini-2.5-flash-lite 404s as retired-for-new-users — use -latest aliases). Responses-API leg: verified accepted earlier (see notes below). No provider requires the skip+warn guard; it remains unbuilt by design. Spec §8 records all outcomes.
 <!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## What

Closes the last open leg of task-403 using the newly provided Google API key:

- **Gemini: ACCEPTED, with literal continuation.** Verified both raw (`generateContent` with a trailing `model`-role turn) and through the app's `chat_with_google` handler (assistant→model remap + alternation) on `gemini-flash-lite-latest` — the model continues directly from the prefill text ("The answer is" → " 7, because…"), stronger continuation semantics than OpenAI's restart behavior.
- Spec §8 updated with the outcome; task-403 marked Done (all three ACs).
- Environment notes recorded: free-tier per-minute quota throws transient 429s; `gemini-2.5-flash-lite` 404s as retired-for-new-users (use the `-latest` aliases).

With this, every provider checked (llama.cpp, OpenAI Chat Completions, OpenAI Responses API, Gemini; Anthropic handler-side) accepts prefill — the spec §5 skip+warn guard remains unbuilt because no provider needs it.

Docs + task file only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Verified Gemini accepts response prefill with literal continuation on `gemini-flash-lite-latest` (via raw `generateContent` and the app’s `chat_with_google` path), and updated spec §8. This satisfies task-403: marked Done, noted free-tier 429s and that `gemini-2.5-flash-lite` is retired; no guard needed for any provider.

<sup>Written for commit 1d91c4cc18a782b867fa9b3289ea417f1d2efd2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

