### PR TITLE
fix(llm): stop sending default temperature/top_p to OpenAI reasoning models (task-404)

### DIFF
--- a/Tests/Chat/test_openai_reasoning_sampling_params.py
+++ b/Tests/Chat/test_openai_reasoning_sampling_params.py
@@ -26,47 +26,46 @@ class _FakeResponse:
         return self._body
 
 
-class _FakeSession:
-    """Stands in for ``requests.Session`` in the non-streaming send path."""
-
-    captured: list[dict] = []
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *exc_info):
-        return False
-
-    def mount(self, *_args, **_kwargs) -> None:
-        return None
-
-    def post(self, url, headers=None, json=None, timeout=None, **_kwargs):
-        _FakeSession.captured.append({"url": url, "payload": json})
-        if url.rstrip("/").endswith("responses"):
-            return _FakeResponse(
-                {"id": "resp_1", "output_text": "ok", "output": [], "usage": {}}
-            )
-        return _FakeResponse(
-            {
-                "id": "chatcmpl_1",
-                "model": json.get("model", ""),
-                "choices": [
-                    {
-                        "index": 0,
-                        "message": {"role": "assistant", "content": "ok"},
-                        "finish_reason": "stop",
-                    }
-                ],
-                "usage": {},
-            }
-        )
-
-
 @pytest.fixture
 def captured_payloads(monkeypatch):
-    _FakeSession.captured = []
+    """Swap ``requests.Session`` for a fake that records posted payloads."""
+    payloads: list[dict] = []
+
+    class _FakeSession:
+        """Stands in for ``requests.Session`` in the non-streaming send path."""
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc_info):
+            return False
+
+        def mount(self, *_args, **_kwargs) -> None:
+            return None
+
+        def post(self, url, headers=None, json=None, timeout=None, **_kwargs):
+            payloads.append({"url": url, "payload": json})
+            if url.rstrip("/").endswith("responses"):
+                return _FakeResponse(
+                    {"id": "resp_1", "output_text": "ok", "output": [], "usage": {}}
+                )
+            return _FakeResponse(
+                {
+                    "id": "chatcmpl_1",
+                    "model": json.get("model", ""),
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {"role": "assistant", "content": "ok"},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "usage": {},
+                }
+            )
+
     monkeypatch.setattr(llm_calls.requests, "Session", _FakeSession)
-    return _FakeSession.captured
+    return payloads
 
 
 _MESSAGES = [{"role": "user", "content": "hi"}]

--- a/Tests/Chat/test_openai_reasoning_sampling_params.py
+++ b/Tests/Chat/test_openai_reasoning_sampling_params.py
@@ -1,0 +1,151 @@
+"""task-404: reasoning-model requests must omit unsupported sampling params.
+
+OpenAI reasoning models (o-series, gpt-5 family) reject `temperature` and
+`top_p` with HTTP 400 on both the Chat Completions and Responses APIs.
+`chat_with_openai` used to inject config-backed defaults for both on every
+request, so ANY call routed to a reasoning model failed. These tests pin the
+payload shape at the HTTP seam for both request branches.
+"""
+
+import pytest
+
+import tldw_chatbook.LLM_Calls.LLM_API_Calls as llm_calls
+from tldw_chatbook.LLM_Calls.LLM_API_Calls import chat_with_openai
+
+
+class _FakeResponse:
+    status_code = 200
+
+    def __init__(self, body: dict):
+        self._body = body
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return self._body
+
+
+class _FakeSession:
+    """Stands in for ``requests.Session`` in the non-streaming send path."""
+
+    captured: list[dict] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+    def mount(self, *_args, **_kwargs) -> None:
+        return None
+
+    def post(self, url, headers=None, json=None, timeout=None, **_kwargs):
+        _FakeSession.captured.append({"url": url, "payload": json})
+        if url.rstrip("/").endswith("responses"):
+            return _FakeResponse(
+                {"id": "resp_1", "output_text": "ok", "output": [], "usage": {}}
+            )
+        return _FakeResponse(
+            {
+                "id": "chatcmpl_1",
+                "model": json.get("model", ""),
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "ok"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {},
+            }
+        )
+
+
+@pytest.fixture
+def captured_payloads(monkeypatch):
+    _FakeSession.captured = []
+    monkeypatch.setattr(llm_calls.requests, "Session", _FakeSession)
+    return _FakeSession.captured
+
+
+_MESSAGES = [{"role": "user", "content": "hi"}]
+
+
+def test_responses_branch_omits_temperature_and_top_p(captured_payloads):
+    chat_with_openai(
+        input_data=_MESSAGES,
+        api_key="test-key",
+        model="gpt-5-mini",
+        streaming=False,
+        reasoning_effort="low",
+    )
+    payload = captured_payloads[-1]["payload"]
+    assert "temperature" not in payload
+    assert "top_p" not in payload
+    assert payload["input"] == _MESSAGES
+    assert payload["reasoning"] == {"effort": "low"}
+
+
+def test_reasoning_model_on_chat_completions_omits_sampling(captured_payloads):
+    chat_with_openai(
+        input_data=_MESSAGES,
+        api_key="test-key",
+        model="o3-mini",
+        streaming=False,
+    )
+    payload = captured_payloads[-1]["payload"]
+    assert "temperature" not in payload
+    assert "top_p" not in payload
+    assert payload["messages"] == _MESSAGES
+
+
+def test_explicit_sampling_on_reasoning_model_is_dropped(captured_payloads):
+    chat_with_openai(
+        input_data=_MESSAGES,
+        api_key="test-key",
+        model="gpt-5-mini",
+        streaming=False,
+        reasoning_effort="low",
+        temp=0.9,
+        maxp=0.5,
+    )
+    payload = captured_payloads[-1]["payload"]
+    assert "temperature" not in payload
+    assert "top_p" not in payload
+
+
+def test_non_reasoning_model_keeps_default_sampling(captured_payloads):
+    chat_with_openai(
+        input_data=_MESSAGES,
+        api_key="test-key",
+        model="gpt-4o-mini",
+        streaming=False,
+    )
+    payload = captured_payloads[-1]["payload"]
+    # Today's behavior preserved: config/hardcoded defaults still included.
+    assert payload["temperature"] == pytest.approx(0.7)
+    assert payload["top_p"] == pytest.approx(0.95)
+    assert payload["messages"] == _MESSAGES
+
+
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [
+        ("o1", True),
+        ("o1-mini", True),
+        ("o3", True),
+        ("o3-mini-2025-01-31", True),
+        ("o4-mini", True),
+        ("gpt-5", True),
+        ("gpt-5-mini", True),
+        ("gpt-5.1", True),
+        ("GPT-5-NANO", True),
+        ("gpt-4o-mini", False),
+        ("gpt-4.1", False),
+        ("olmo-7b", False),
+        ("o365-copilot", False),
+    ],
+)
+def test_is_openai_reasoning_model_boundaries(model, expected):
+    assert llm_calls._is_openai_reasoning_model(model) is expected

--- a/backlog/tasks/task-404 - Stop-sending-default-temperature-top_p-to-OpenAI-reasoning-models.md
+++ b/backlog/tasks/task-404 - Stop-sending-default-temperature-top_p-to-OpenAI-reasoning-models.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-404
 title: Stop sending default temperature/top_p to OpenAI reasoning models
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-21 07:12'
+updated_date: '2026-07-21 14:13'
 labels: []
 dependencies: []
 ---
@@ -16,5 +18,11 @@ chat_with_openai force-includes default temperature and top_p in the request; Op
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Reasoning-model requests omit unsupported sampling parameters,Non-reasoning models keep today's parameter behavior,Regression test covers both shapes
+- [x] #1 Reasoning-model requests omit unsupported sampling parameters,Non-reasoning models keep today's parameter behavior,Regression test covers both shapes
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+chat_with_openai no longer injects config-backed temperature/top_p for reasoning-family models: new _is_openai_reasoning_model predicate (o1/o3/o4/gpt-5 families, boundary-safe — o365-copilot and olmo never match) gates the sampling block, together with the Responses-API branch; explicit caller values on that path are dropped with a warning (the API rejects any value). Non-reasoning models keep byte-identical behavior. 17 new payload-seam tests (fake requests.Session capturing json) covering both branches + boundary matrix; live proof: the previously-400ing gpt-5-mini reasoning_effort call now succeeds end-to-end through chat_api_call against the real API.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
+++ b/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
@@ -198,6 +198,33 @@ def _openai_use_responses_api(
     )
 
 
+_OPENAI_REASONING_MODEL_FAMILIES = ("o1", "o3", "o4", "gpt-5")
+
+
+def _is_openai_reasoning_model(model: object) -> bool:
+    """Return True for OpenAI reasoning-family models (o-series, gpt-5).
+
+    These models reject classic sampling parameters (``temperature``,
+    ``top_p``) with HTTP 400 on both the Chat Completions and Responses
+    APIs, so the handler must not inject its config-backed defaults for
+    them (task-404). Family names match exactly or at a ``-``/``.``
+    boundary so e.g. ``o365-copilot`` or ``olmo-7b`` never match.
+
+    Args:
+        model: Model identifier as passed to the OpenAI handler.
+
+    Returns:
+        True when the model belongs to a reasoning family.
+    """
+    normalized = str(model or "").strip().lower()
+    return any(
+        normalized == family
+        or normalized.startswith(family + "-")
+        or normalized.startswith(family + ".")
+        for family in _OPENAI_REASONING_MODEL_FAMILIES
+    )
+
+
 def _extract_openai_responses_text(response_data: Dict[str, Any]) -> str:
     output_text = response_data.get("output_text")
     if isinstance(output_text, str) and output_text:
@@ -533,11 +560,22 @@ def chat_with_openai(
         payload["input"] = api_messages
     else:
         payload["messages"] = api_messages
-    # Add optional parameters if they have a value
-    if final_temp is not None:
-        payload["temperature"] = final_temp
-    if final_top_p is not None:
-        payload["top_p"] = final_top_p  # OpenAI uses top_p
+    # Add optional parameters if they have a value. Reasoning-family models
+    # (and therefore every Responses-API request, which this handler only
+    # builds for reasoning params) reject temperature/top_p with HTTP 400,
+    # so the config-backed defaults must not be injected there (task-404).
+    omit_sampling_params = use_responses_api or _is_openai_reasoning_model(final_model)
+    if omit_sampling_params:
+        if temp is not None or maxp is not None:
+            logger.warning(
+                "OpenAI: dropping explicit temperature/top_p for reasoning "
+                f"model '{final_model}' — the API rejects them."
+            )
+    else:
+        if final_temp is not None:
+            payload["temperature"] = final_temp
+        if final_top_p is not None:
+            payload["top_p"] = final_top_p  # OpenAI uses top_p
     if final_max_tokens is not None and use_responses_api:
         payload["max_output_tokens"] = final_max_tokens
     elif final_max_tokens is not None:


### PR DESCRIPTION
## What

`chat_with_openai` resolved `temperature`/`top_p` through config defaults (0.7/0.95) and sent them on **every** request — OpenAI reasoning models (o-series, gpt-5 family) reject both with HTTP 400 ("Unsupported parameter"), so any call routed to them through this handler failed, on both the Chat Completions and Responses-API branches. Found during the prefill provider verification (task-403).

## Fix

- New `_is_openai_reasoning_model` predicate: o1/o3/o4/gpt-5 families, matched exactly or at a `-`/`.` boundary (so `o365-copilot` and `olmo-7b` never match).
- The sampling block is skipped when the model is reasoning-family **or** the request takes the Responses-API branch; explicit caller-passed values on that path are dropped with a warning (the API rejects any value, so sending them would just 400).
- Non-reasoning models keep byte-identical behavior (config defaults still included).

## Tests

17 new tests at the HTTP seam (fake `requests.Session` capturing the JSON payload): both branches omit sampling, explicit-value drop, preserved non-reasoning behavior, and a 13-case predicate boundary matrix. Handler-adjacent suites at their documented pre-existing baseline (6 pytest-mock errors in untouched files).

**Live proof:** the exact previously-400ing repro (`gpt-5-mini`, `reasoning_effort='low'` through `chat_api_call`) now succeeds against the real API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop sending default `temperature`/`top_p` to OpenAI reasoning models to prevent 400s, keeping sampling for other models. Addresses task-404; `gpt-5-*` and `o*-*` requests (including via the Responses API) now succeed.

- **Bug Fixes**
  - Added `_is_openai_reasoning_model` (o1/o3/o4, gpt-5) with case-insensitive hyphen/dot boundary matching.
  - Omit `temperature`/`top_p` for reasoning models and all Responses API calls; drop caller-provided values with a warning.
  - Preserved defaults for non-reasoning models; added 17 HTTP-seam tests across both paths and boundary cases.

- **Refactors**
  - Tests now capture posted payloads via a fixture closure, removing shared class state.

<sup>Written for commit 932c22bccc76d4adf881b056a5774063d75150aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

