### PR TITLE
fix(console): classify provider failures with response-body detail + image-poisoning recovery hint (task 335)

### DIFF
--- a/Tests/Chat/test_console_provider_failure_copy.py
+++ b/Tests/Chat/test_console_provider_failure_copy.py
@@ -1,0 +1,113 @@
+"""TASK-335: provider failures must surface the server's message, never MDN links.
+
+The agent-runtime send path rendered raw httpx text — `Server error '500
+...' For more information check: https://developer.mozilla.org/...` — while
+the response body's actionable hint ("you may need to provide the mmproj")
+was discarded, and the re-sent image poisoned every later send with the
+same undiagnosable 500 (UX review finding
+j3-provider-error-discards-detail-poisons-conversation, REGRESSION).
+"""
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from tldw_chatbook.Chat.console_agent_bridge import ConsoleAgentBridge
+from tldw_chatbook.Chat.console_chat_controller import (
+    ConsoleChatController,
+    describe_stream_failure,
+)
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+
+MMPROJ_BODY = (
+    '{"error": {"message": "image input is not supported - '
+    'hint: you may need to provide the mmproj", "code": 500}}'
+)
+
+
+def _http_500(body: str) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "http://127.0.0.1:9099/v1/chat/completions")
+    response = httpx.Response(500, request=request, text=body)
+    return httpx.HTTPStatusError(
+        "Server error '500 Internal Server Error' for url "
+        "'http://127.0.0.1:9099/v1/chat/completions'\n"
+        "For more information check: "
+        "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500",
+        request=request,
+        response=response,
+    )
+
+
+def test_describe_stream_failure_surfaces_json_error_body():
+    copy = describe_stream_failure(_http_500(MMPROJ_BODY))
+    assert "HTTP 500" in copy
+    assert "provide the mmproj" in copy
+    assert "developer.mozilla.org" not in copy
+
+
+def test_describe_stream_failure_surfaces_plain_text_body_truncated():
+    copy = describe_stream_failure(_http_500("plain provider explosion " * 40))
+    assert "HTTP 500" in copy
+    assert "plain provider explosion" in copy
+    assert len(copy) < 400
+    assert "developer.mozilla.org" not in copy
+
+
+def test_describe_stream_failure_never_emits_mdn_link_without_body():
+    copy = describe_stream_failure(_http_500(""))
+    assert "HTTP 500" in copy
+    assert "developer.mozilla.org" not in copy
+
+
+class _ExplodingGateway:
+    async def resolve_for_send(self, _selection):
+        return SimpleNamespace(ready=True, provider="llama_cpp", visible_copy="")
+
+    async def stream_chat(self, _resolution, _messages, **_kwargs):
+        raise _http_500(MMPROJ_BODY)
+        yield  # pragma: no cover — makes this an async generator
+
+
+@pytest.mark.asyncio
+async def test_agent_failure_row_carries_body_and_image_recovery_hint(tmp_path):
+    gateway = _ExplodingGateway()
+    store = ConsoleChatStore()
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    bridge = ConsoleAgentBridge(
+        agent_runs_db=db, store=store, provider_gateway=gateway
+    )
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=gateway,
+        provider="llama_cpp",
+        model="test-model",
+        agent_bridge=bridge,
+        agent_runtime_enabled=True,
+    )
+    session = store.ensure_session(title="Chat 1")
+    store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content="what is in this image?",
+        image_data=b"\x89PNG-fake",
+        image_mime_type="image/png",
+    )
+
+    result = await controller.submit_draft("and now this text send fails too")
+    assert result.accepted is True
+
+    messages = store.messages_for_session(session.id)
+    system_rows = [
+        m.content for m in messages if m.role is ConsoleMessageRole.SYSTEM
+    ]
+    assert system_rows, "no failure system row appended"
+    failure_row = system_rows[-1]
+    assert "provide the mmproj" in failure_row
+    assert "developer.mozilla.org" not in failure_row
+    # Recovery hint: the conversation carries an image the provider may be
+    # rejecting — point at it and at the existing remove/switch affordances.
+    assert "image" in failure_row.lower()
+    assert "remove" in failure_row.lower() or "vision" in failure_row.lower()

--- a/backlog/tasks/task-335 - Fix-Console-provider-failure-UX-raw-500-discards-server-detail-and-failed-image-poisons-the-conversation.md
+++ b/backlog/tasks/task-335 - Fix-Console-provider-failure-UX-raw-500-discards-server-detail-and-failed-image-poisons-the-conversation.md
@@ -1,10 +1,17 @@
 ---
 id: TASK-335
-title: Fix Console provider-failure UX - raw 500 discards server detail and failed image poisons the conversation
-status: To Do
-assignee: []
+title: >-
+  Fix Console provider-failure UX - raw 500 discards server detail and failed
+  image poisons the conversation
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-20 14:21'
-labels: [console, ux, regression]
+updated_date: '2026-07-21 14:20'
+labels:
+  - console
+  - ux
+  - regression
 dependencies: []
 priority: high
 ---
@@ -23,6 +30,50 @@ Sending an image to llama.cpp produced transcript rows: 'Assistant [failed]' + '
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Surface the provider's error body, translate it ('this model can't accept images'), point at the offending attachment, and offer recovery (retry without images / remove from context). Never emit MDN links in a chat transcript
-- [ ] #2 A regression test pins the restored behavior
+- [x] #1 Surface the provider's error body, translate it ('this model can't accept images'), point at the offending attachment, and offer recovery (retry without images / remove from context). Never emit MDN links in a chat transcript
+- [x] #2 A regression test pins the restored behavior
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Route agent-path failures through describe_stream_failure (kills raw httpx text + MDN links)
+2. Surface the provider's response body (the actionable hint, e.g. 'provide the mmproj') in the classified copy
+3. When the failed request carried image attachments, append a recovery hint naming the image as likely cause and pointing at existing remove/delete affordances
+4. Check the reload-renders-as-Tool claim; RED-first tests for copy + body + hint
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+The raw copy leaked through TWO paths: (a) `describe_stream_failure`'s
+`(detail)` parenthetical appended the full `str(exc)` — for httpx status
+errors that IS the status line + MDN boilerplate; (b) the agent service's
+catch-all (`agent_service.py` run_turn) stamped raw `str(exc)` into the
+STEP_ERROR summary that becomes `Agent run failed: {reason}` — the
+review's exact live path.
+
+Fixes: the classifier moved to a shared `Chat/provider_failures.py`
+(controller re-exports for existing importers); for status errors the
+detail is now the provider's RESPONSE BODY (best-effort JSON message
+extraction, whitespace-collapsed, truncated) — surfacing hints like
+"you may need to provide the mmproj" — and the MDN boilerplate is
+stripped from any detail. The agent service classifies at capture where
+the exception is live. Both failure sites (exception path and
+failed-outcome path) append a recovery hint when the session history
+carries an image and the failure is HTTP-status-shaped: names the image
+as likely cause and points at the existing Delete affordance /
+vision-capable-model switch (history re-sends the image every turn, so a
+rejecting provider fails ALL later sends — the poisoning half of the
+finding).
+
+Verified: 4 RED-first tests (JSON body, plain-text truncation, no-MDN,
+and a controller-level integration with a real httpx 500 carrying the
+review's exact body + an image message in history → classified row with
+body + recovery hint). Live E2E was attempted but headless-clipboard →
+xterm paste friction blocked attaching a real image through the served
+app (documented harness limitation class); the provider body itself was
+already live-proven by the review's curl evidence (j3-63). Reload-as-Tool
+rendering claim: rows persist as SYSTEM role; the Tool-render on reload
+belongs to task-350's sub-agent rendering cluster. Files:
+`Chat/provider_failures.py` (new), `Chat/console_chat_controller.py`,
+`Agents/agent_service.py`.

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -505,9 +505,20 @@ class AgentService:
         try:
             outcome = run_agent_loop(config, messages, active, deps)
         except Exception as exc:  # noqa: BLE001 — a run never raises out
+            from tldw_chatbook.Chat.provider_failures import describe_stream_failure
+
+            # TASK-335: raw str(exc) is httpx's status line + MDN boilerplate;
+            # the classified copy carries the provider's response-body message
+            # instead — this summary becomes user-facing failure copy.
             outcome = RunOutcome(
                 status=RUN_ERROR,
-                steps=[AgentStep(index=0, kind=STEP_ERROR, summary=str(exc)[:500])],
+                steps=[
+                    AgentStep(
+                        index=0,
+                        kind=STEP_ERROR,
+                        summary=describe_stream_failure(exc)[:500],
+                    )
+                ],
             )
         self._persist(run_id, outcome)
         return run_id, outcome

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -43,6 +43,9 @@ from tldw_chatbook.Agents.mcp_tool_provider import MCPToolProvider
 from tldw_chatbook.config import get_cli_setting
 from tldw_chatbook.Skills_Interop.skill_trust_models import SkillTrustBlockedError
 from tldw_chatbook.Utils.input_validation import sanitize_string, validate_text_input
+from tldw_chatbook.Chat.provider_failures import (  # noqa: F401  (re-export: tests and callers import describe_stream_failure from here)
+    describe_stream_failure,
+)
 from tldw_chatbook.model_capabilities import is_vision_capable
 
 if TYPE_CHECKING:
@@ -200,48 +203,6 @@ def build_mcp_review_hook(
         return {call.llm_name: "proceed" for call in pending}
 
     return review_tool_calls
-
-
-def describe_stream_failure(exc: BaseException) -> str:
-    """Return user-facing copy classifying a provider stream failure.
-
-    ``str(exc)`` alone can be empty (observed live as ``"Provider stream
-    failed: "`` rendering ``"[failed]"``), so the failure class is always
-    included in user terms: timeout vs connection vs HTTP status.
-
-    Args:
-        exc: The exception raised by the provider stream.
-
-    Returns:
-        A short, user-readable failure description that is never empty.
-    """
-    detail = str(exc).strip()
-    response = getattr(exc, "response", None)
-    status_code = getattr(response, "status_code", None) or getattr(
-        exc, "status_code", None
-    )
-    exc_name = type(exc).__name__
-    lowered_name = exc_name.lower()
-
-    if (
-        isinstance(exc, (asyncio.TimeoutError, TimeoutError))
-        or "timeout" in lowered_name
-    ):
-        summary = "request timed out waiting for the provider"
-    elif isinstance(
-        exc, ConnectionRefusedError
-    ) or "connectrefused" in lowered_name.replace("_", ""):
-        summary = "connection refused - is the provider server running?"
-    elif isinstance(exc, ConnectionError) or "connect" in lowered_name:
-        summary = "could not connect to the provider"
-    elif status_code is not None:
-        summary = f"provider returned HTTP {status_code}"
-    else:
-        summary = f"{exc_name} error"
-
-    if detail and detail.lower() != summary.lower():
-        return f"{summary} ({detail})"
-    return summary
 
 
 def _split_skill_command_word(text: str) -> tuple[str, str]:
@@ -2039,6 +2000,30 @@ class ConsoleChatController:
             # must never abort an already-accepted provider run.
             pass
 
+    _IMAGE_REJECTION_RECOVERY_HINT = (
+        " This conversation includes an image attachment; if the model can't "
+        "accept images, remove that message (select it and use Delete) or "
+        "switch to a vision-capable model."
+    )
+
+    def _session_history_carries_images(self, session_id: str) -> bool:
+        """Return whether any message in the session carries an image.
+
+        TASK-335: history re-sends attachments on every turn, so a provider
+        that rejects images fails ALL later sends in the conversation with
+        the same opaque status — the failure copy names the likely cause.
+        """
+        try:
+            messages = self.store.messages_for_session(session_id)
+        except KeyError:
+            return False
+        for message in messages:
+            if getattr(message, "attachments", None):
+                return True
+            if getattr(message, "image_data", None) is not None:
+                return True
+        return False
+
     def _append_failure_system_row(self, session_id: str, visible_copy: str) -> None:
         """Append a transcript-only system row describing a provider failure."""
         try:
@@ -2346,6 +2331,12 @@ class ConsoleChatController:
             # preserves whatever partial content already streamed
             # otherwise).
             visible_copy = f"Agent run failed: {describe_stream_failure(exc)}"
+            if (
+                getattr(getattr(exc, "response", None), "status_code", None)
+                is not None
+                and self._session_history_carries_images(session_id)
+            ):
+                visible_copy += self._IMAGE_REJECTION_RECOVERY_HINT
             try:
                 self.store.mark_message_failed(assistant_message_id)
             except KeyError:
@@ -2517,6 +2508,10 @@ class ConsoleChatController:
         possible, otherwise append a new failed assistant message.
         """
         visible_copy = self._agent_failure_visible_copy(outcome)
+        if "provider returned HTTP" in visible_copy and (
+            self._session_history_carries_images(session_id)
+        ):
+            visible_copy += self._IMAGE_REJECTION_RECOVERY_HINT
         placeholder = self._ensure_assistant_placeholder(assistant_message_id, session_id)
         if placeholder is not None:
             failed = self.store.mark_message_failed(assistant_message_id)

--- a/tldw_chatbook/Chat/provider_failures.py
+++ b/tldw_chatbook/Chat/provider_failures.py
@@ -1,0 +1,107 @@
+"""Provider-failure classification shared by chat and agent runtimes.
+
+TASK-335: the agent service captures provider exceptions on its own thread
+(`run_turn`'s catch-all) and previously stamped raw ``str(exc)`` — httpx's
+status line plus MDN boilerplate — into the STEP_ERROR summary that becomes
+user-facing failure copy, while the response body's actionable message was
+discarded. Both the Console controller and the agent service now classify
+through this module.
+"""
+
+import asyncio
+
+
+_MDN_BOILERPLATE_MARKER = "For more information check:"
+
+
+def _provider_error_body_detail(response: object) -> str:
+    """Best-effort human detail from a provider error response body.
+
+    Providers put the actionable message in the body (e.g. llama.cpp's
+    "image input is not supported - hint: you may need to provide the
+    mmproj"); httpx's ``str(exc)`` carries only the status line plus MDN
+    boilerplate. JSON bodies are probed for the common message keys; plain
+    text is used as-is. The result is whitespace-collapsed and truncated.
+    """
+    try:
+        text = (getattr(response, "text", "") or "").strip()
+    except Exception:
+        return ""
+    if not text:
+        return ""
+    detail = text
+    try:
+        import json as _json
+
+        payload = _json.loads(text)
+        if isinstance(payload, dict):
+            candidate = payload.get("error")
+            if isinstance(candidate, dict):
+                candidate = candidate.get("message") or candidate.get("detail")
+            candidate = (
+                candidate
+                or payload.get("message")
+                or payload.get("detail")
+            )
+            if isinstance(candidate, str) and candidate.strip():
+                detail = candidate
+    except (ValueError, TypeError):
+        pass
+    detail = " ".join(str(detail).split())
+    if len(detail) > 240:
+        detail = detail[:237] + "..."
+    return detail
+
+
+def describe_stream_failure(exc: BaseException) -> str:
+    """Return user-facing copy classifying a provider stream failure.
+
+    ``str(exc)`` alone can be empty (observed live as ``"Provider stream
+    failed: "`` rendering ``"[failed]"``), so the failure class is always
+    included in user terms: timeout vs connection vs HTTP status.
+
+    Args:
+        exc: The exception raised by the provider stream.
+
+    Returns:
+        A short, user-readable failure description that is never empty.
+    """
+    detail = str(exc).strip()
+    response = getattr(exc, "response", None)
+    status_code = getattr(response, "status_code", None) or getattr(
+        exc, "status_code", None
+    )
+    exc_name = type(exc).__name__
+    lowered_name = exc_name.lower()
+
+    if (
+        isinstance(exc, (asyncio.TimeoutError, TimeoutError))
+        or "timeout" in lowered_name
+    ):
+        summary = "request timed out waiting for the provider"
+    elif isinstance(
+        exc, ConnectionRefusedError
+    ) or "connectrefused" in lowered_name.replace("_", ""):
+        summary = "connection refused - is the provider server running?"
+    elif isinstance(exc, ConnectionError) or "connect" in lowered_name:
+        summary = "could not connect to the provider"
+    elif status_code is not None:
+        summary = f"provider returned HTTP {status_code}"
+        # TASK-335: the response BODY carries the provider's actionable
+        # message; str(exc) is just the status line + MDN boilerplate.
+        body_detail = _provider_error_body_detail(response)
+        if body_detail:
+            detail = body_detail
+    else:
+        summary = f"{exc_name} error"
+
+    if detail:
+        # Never emit httpx's MDN "For more information check: https://…"
+        # boilerplate into a chat transcript (TASK-335).
+        marker = detail.find(_MDN_BOILERPLATE_MARKER)
+        if marker != -1:
+            detail = detail[:marker].rstrip()
+        detail = " ".join(detail.split())
+    if detail and detail.lower() != summary.lower():
+        return f"{summary} ({detail})"
+    return summary


### PR DESCRIPTION
## Summary

Fifth batch from the Console UX review backlog (#720): the last P1 regression — `j3-provider-error-discards-detail-poisons-conversation`.

**Before:** an image send to a non-vision llama.cpp rendered `Agent run failed: Server error '500 …' For more information check: https://developer.mozilla.org/…` — the server's actual message (`image input is not supported - hint: you may need to provide the mmproj`, verified by curl during the review) was discarded, and because history re-sends the image every turn, every later plain-text send failed with the same opaque 500.

**After:** `Agent run failed: provider returned HTTP 500 (image input is not supported - hint: you may need to provide the mmproj). This conversation includes an image attachment; if the model can't accept images, remove that message (select it and use Delete) or switch to a vision-capable model.`

### The two leak paths
1. `describe_stream_failure`'s `(detail)` parenthetical appended the full `str(exc)` — for httpx status errors that IS the status line + MDN boilerplate. For status errors the detail is now the **response body** (best-effort JSON message extraction, truncated), and MDN boilerplate is stripped from any detail.
2. **The review's actual live path**: the agent service's `run_turn` catch-all stamped raw `str(exc)` into the STEP_ERROR summary that becomes user-facing `Agent run failed: {reason}` copy. It now classifies at capture, where the exception and its response body are still live. (Found by the integration test flowing through the outcome path, not the exception path my first fix covered.)

### Structure
- Classifier extracted to a shared `Chat/provider_failures.py` — the Agents layer must not import the Console controller; the controller re-exports `describe_stream_failure` for existing importers (top-of-file, E402-clean).
- The recovery hint fires on **both** failure sites via a session-level image probe.

## Verification
- 4 RED-first tests, including a controller-level integration with a real `httpx` 500 carrying the review's curl-proven body plus an image message in history → classified row with body detail + recovery hint, zero MDN.
- `Tests/Chat`: 1120 passed (one known pre-existing dev-tip failure). Console sweep: **1129 passed**, all 14 failures in the known dev-tip set.
- Honest caveat (in the task notes): live E2E of the *attach* step was blocked by headless-clipboard→xterm paste friction; the provider body behavior rests on the review's live curl evidence plus the real-httpx integration test.

Task file marked Done with implementation notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix provider error UX in Console by surfacing the server’s response message and adding an image-rejection recovery hint; prevents opaque `httpx` 500s and reduces image-poisoned conversations. Addresses TASK-335.

- **Bug Fixes**
  - Classify failures via shared `Chat/provider_failures.py` (controller re-exports `describe_stream_failure`).
  - For HTTP errors, show response-body message (JSON-aware), collapse/trim text, and strip MDN boilerplate.
  - Agent runtime now uses the classifier for `STEP_ERROR` summaries so `Agent run failed: …` includes the body detail.
  - If session history includes images and the error is HTTP, append a hint to remove the image or switch to a vision model; tests cover JSON/plain bodies, MDN stripping, and controller/agent paths.

<sup>Written for commit f735351d239f194b6a33b52b52a366b0d3a769bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

