### PR TITLE
Roleplay P2g-2 — Console world-book inspector + attach/detach

### DIFF
--- a/Docs/superpowers/plans/2026-07-21-roleplay-p2g-2-console-worldbook-inspector.md
+++ b/Docs/superpowers/plans/2026-07-21-roleplay-p2g-2-console-worldbook-inspector.md
@@ -1,0 +1,569 @@
+# Roleplay P2g-2 — Console world-book inspector + attach/detach — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Add a "World Books" block to the Console run inspector showing the conversation's attached world books, with Attach/Detach actions — mirroring the merged dict inspector (P1g).
+
+**Architecture:** A `summarize_active_world_books` resolver; `world_book_rows`/`world_book_actions` on `ConsoleInspectorState` rendered as a trailing block; a cached scope-guarded off-thread refresh; and two `console-io` workers driving `WorldBookPicker` + `associate/disassociate_world_book_with_conversation`.
+
+**Tech Stack:** Python 3.11+, Textual, SQLite (`CharactersRAGDB`), pytest.
+
+**Spec:** `Docs/superpowers/specs/2026-07-21-roleplay-p2g-2-console-worldbook-inspector-design.md`.
+
+## Global Constraints
+
+- **No schema migration** (v22). **No send-path change** (P2g-1 already applies attached books on native send). Legacy `chat_events.py` gate-fix + dead-code deletion is P2g-3 — not this cycle.
+- The summary shows **ALL attached books** (enabled + disabled, marked) via `get_world_books_for_conversation(conv_id, enabled_only=False)` — NOT the send-path `_collect_active_world_books` (enabled-only).
+- The world-book block is a **trailing custom block** (like the dict block), threaded through **all three** `ConsoleRunInspector` spots: `compose()`, `_rendered_row_entries()`, `_structural_key()`. **No `_ROW_ID_BY_LABEL`/`_ROW_GROUPS` change.**
+- Row/action projection + the action-list method read **ONLY the cache + the conversation id — never the DB**. The DB read happens only in the scope-guarded off-thread `refresh_active_world_books_summary()`.
+- Conversation-only on native (`char_data=None`). Reuse `WorldBookPicker` (P2f) for both Attach and Detach. Leave the dict inspector, its refresh, and its actions untouched.
+- Action workers: off-thread, every await individually guarded (uncaught worker exception kills the app under `run_worker(exit_on_error=True)`), `finally`-reset the dialog flag.
+- **Subagents:** first verify `git rev-parse --show-toplevel` == the worktree + branch `claude/roleplay-p2g-2-inspector` (Agent-tool subagents can start in the MAIN checkout). Run tests **foreground, scoped** — NO background jobs, NO broad sweeps. Stage ONLY the task's files; never `git add -A`; never stage `.superpowers/`.
+- **Test env** (venv in MAIN checkout; run from the worktree root):
+  ```
+  HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest <targets> \
+  -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+  ```
+
+---
+
+### Task 1: `summarize_active_world_books` resolver
+
+**Files:**
+- Modify: `tldw_chatbook/Character_Chat/world_info_resolver.py`
+- Test: `Tests/Character_Chat/test_summarize_active_world_books.py` (new)
+
+**Interfaces:**
+- Produces: `summarize_active_world_books(db, conversation_id: str | None, char_data: dict | None) -> dict` → `{"world_books": [{"name": str, "enabled": bool, "entry_count": int}], "source": "local"}`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/Character_Chat/test_summarize_active_world_books.py`:
+```python
+import pytest
+
+from tldw_chatbook.Character_Chat.world_info_resolver import (
+    summarize_active_world_books,
+)
+from tldw_chatbook.Character_Chat.world_book_manager import WorldBookManager
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+
+@pytest.fixture
+def wb_db(tmp_path):
+    db = CharactersRAGDB(tmp_path / "summarize_wb.db", "test-client")
+    yield db
+    db.close_connection()
+
+
+def test_lists_attached_books_with_counts(wb_db):
+    wb_db.add_conversation({"id": "c1", "title": "C"})
+    wb = WorldBookManager(wb_db)
+    b1 = wb.create_world_book("Alpha")
+    wb.create_world_book_entry(b1, keys=["a"], content="x")
+    wb.create_world_book_entry(b1, keys=["b"], content="y")
+    wb.associate_world_book_with_conversation("c1", b1)
+    out = summarize_active_world_books(wb_db, "c1", None)
+    assert out["world_books"] == [{"name": "Alpha", "enabled": True, "entry_count": 2}]
+
+
+def test_includes_disabled_attached_book(wb_db):
+    wb_db.add_conversation({"id": "c2", "title": "C"})
+    wb = WorldBookManager(wb_db)
+    b = wb.create_world_book("Off", enabled=False)
+    wb.create_world_book_entry(b, keys=["k"], content="x")
+    wb.associate_world_book_with_conversation("c2", b)
+    out = summarize_active_world_books(wb_db, "c2", None)
+    assert out["world_books"] == [{"name": "Off", "enabled": False, "entry_count": 1}]
+
+
+def test_empty_when_none_attached(wb_db):
+    wb_db.add_conversation({"id": "c3", "title": "C"})
+    assert summarize_active_world_books(wb_db, "c3", None) == {"world_books": [], "source": "local"}
+
+
+def test_no_conversation_returns_empty(wb_db):
+    assert summarize_active_world_books(wb_db, None, None) == {"world_books": [], "source": "local"}
+
+
+def test_db_error_returns_empty():
+    assert summarize_active_world_books(object(), "cX", None) == {"world_books": [], "source": "local"}
+```
+(If `get_conversation_by_id` doesn't exist, drop the helper's guard — just call `add_conversation` once per test as the other tests do.)
+
+- [ ] **Step 2: Run to verify they fail**
+```bash
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+Tests/Character_Chat/test_summarize_active_world_books.py -q -p no:cacheprovider -o addopts="" --timeout=120 --timeout-method=thread
+```
+Expected: FAIL — `ImportError: cannot import name 'summarize_active_world_books'`.
+
+- [ ] **Step 3: Add the function**
+
+In `world_info_resolver.py`, add after `apply_world_info_to_message` (and add `summarize_active_world_books` to `__all__`):
+```python
+def summarize_active_world_books(
+    db: Any,
+    conversation_id: Optional[str],
+    char_data: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """World-book "what's in play" summary for the Console inspector (never raises).
+
+    Shows ALL attached books (enabled + disabled) — the *attachment picture* —
+    via ``get_world_books_for_conversation(enabled_only=False)``, NOT the
+    send-path ``_collect_active_world_books`` (which is enabled-only). ``char_data``
+    is accepted for signature parity but P2g-2 is conversation-only (native
+    ``char_data=None``).
+
+    Args:
+        db: A ``CharactersRAGDB`` (or None).
+        conversation_id: The active conversation (string UUID) or None.
+        char_data: Unused on native Console (accepted for parity).
+
+    Returns:
+        ``{"world_books": [{"name": str, "enabled": bool, "entry_count": int}],
+        "source": "local"}``. ``{"world_books": [], "source": "local"}`` on no
+        conversation / no books / any error.
+    """
+    if not conversation_id or db is None:
+        return {"world_books": [], "source": "local"}
+    try:
+        from .world_book_manager import WorldBookManager
+
+        books = WorldBookManager(db).get_world_books_for_conversation(
+            str(conversation_id), enabled_only=False
+        )
+    except Exception:
+        logger.opt(exception=True).debug(
+            "world-info: could not summarize conversation world books"
+        )
+        return {"world_books": [], "source": "local"}
+    world_books = []
+    for book in books:
+        if not isinstance(book, dict):
+            continue
+        entries = book.get("entries")
+        world_books.append(
+            {
+                "name": str(book.get("name") or "Unnamed"),
+                "enabled": bool(book.get("enabled", True)),
+                "entry_count": len(entries) if isinstance(entries, list) else 0,
+            }
+        )
+    return {"world_books": world_books, "source": "local"}
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run the Step-2 command. Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+```bash
+git add tldw_chatbook/Character_Chat/world_info_resolver.py Tests/Character_Chat/test_summarize_active_world_books.py
+git commit -m "feat(lore): summarize_active_world_books for the Console inspector"
+```
+
+---
+
+### Task 2: Inspector state field + trailing render block
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_display_state.py` (add two fields to `ConsoleInspectorState`)
+- Modify: `tldw_chatbook/Widgets/Console/console_run_inspector.py` (render block in 3 spots)
+- Test: `Tests/UI/test_console_run_inspector_worldbooks.py` (new)
+
+**Interfaces:**
+- Consumes: `ConsoleDisplayRow(label, value)`, `ConsoleInspectorAction(widget_id, label, enabled, disabled_reason)`.
+- Produces: `ConsoleInspectorState.world_book_rows` / `.world_book_actions`; a "World Books" block with row ids `console-inspector-worldbooks-row-{index}` and heading id `console-inspector-worldbooks-heading`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/UI/test_console_run_inspector_worldbooks.py`. Read `Tests/UI/` for how `ConsoleRunInspector` is mounted with a `ConsoleInspectorState` in existing inspector tests (search for `ConsoleRunInspector(` / `dictionary_rows` in Tests/) and mirror. The test builds a `ConsoleInspectorState` with `world_book_rows=(ConsoleDisplayRow("Alpha", "2 entries"),)` and `world_book_actions=(ConsoleInspectorAction("console-inspector-worldbooks-attach","Attach world book…",enabled=True),)`, mounts the inspector, and asserts: the "World Books" heading Static exists; a `#console-inspector-worldbooks-row-0` Static with text `"Alpha: 2 entries"`; the attach button `#console-inspector-worldbooks-attach` exists; and with empty tuples the block is absent. Also assert the dict block still renders when `dictionary_rows` is set (no regression).
+
+- [ ] **Step 2: Run to verify it fails**
+```bash
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+Tests/UI/test_console_run_inspector_worldbooks.py -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+Expected: FAIL (no world_book_rows field / no rendered block).
+
+- [ ] **Step 3: Add the state fields**
+
+In `console_display_state.py`, in `ConsoleInspectorState`, after `dictionary_rows`/`dictionary_actions`:
+```python
+    world_book_rows: tuple[ConsoleDisplayRow, ...] = ()
+    world_book_actions: tuple[ConsoleInspectorAction, ...] = ()
+```
+
+- [ ] **Step 4: Render the block (all three spots) in `console_run_inspector.py`**
+
+(a) In `compose()`, immediately after the `dict_rows`/`dict_actions` block, add:
+```python
+        world_book_rows = getattr(self.state, "world_book_rows", ())
+        world_book_actions = getattr(self.state, "world_book_actions", ())
+        if world_book_rows or world_book_actions:
+            yield Static(
+                "World Books",
+                id="console-inspector-worldbooks-heading",
+                classes="console-inspector-group-heading destination-section",
+            )
+            for index, row in enumerate(world_book_rows):
+                yield Static(
+                    row.text,
+                    id=f"console-inspector-worldbooks-row-{index}",
+                    classes=f"console-inspector-row console-inspector-row-{row.status}",
+                    markup=False,
+                )
+            for action in world_book_actions:
+                yield from self._compose_action(action)
+```
+(b) In `_rendered_row_entries()`, after the `dictionary_rows` loop:
+```python
+        for index, row in enumerate(getattr(state, "world_book_rows", ()) or ()):
+            entries.append(
+                (f"console-inspector-worldbooks-row-{index}", row.text, row.status)
+            )
+```
+(c) In `_structural_key()`, add a third tuple to the returned tuple (after the `dictionary_actions` one):
+```python
+            tuple(
+                _action_key(action)
+                for action in getattr(state, "world_book_actions", ()) or ()
+            ),
+```
+
+- [ ] **Step 5: Run to verify + no regression**
+
+Run the Step-2 command (PASS). Then run the existing inspector tests to confirm no regression:
+```bash
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+Tests/UI/ -k "run_inspector" -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+```
+
+- [ ] **Step 6: Commit**
+```bash
+git add tldw_chatbook/Chat/console_display_state.py tldw_chatbook/Widgets/Console/console_run_inspector.py Tests/UI/test_console_run_inspector_worldbooks.py
+git commit -m "feat(console): World Books inspector block (trailing render, 3 spots)"
+```
+
+---
+
+### Task 3: Screen read wiring (cache, scope-guarded refresh, row projection)
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`
+- Test: `Tests/UI/test_console_worldbook_inspector.py` (new)
+
+**Interfaces:**
+- Consumes: `summarize_active_world_books` (Task 1); `world_book_rows` (Task 2).
+- Produces: `_active_world_books_summary` cache; `refresh_active_world_books_summary()`; `_refresh_active_world_books_summary_if_scope_changed()`; `_active_console_world_book_scope_ids()`; `_console_world_book_inspector_rows()`; `world_book_rows=…` wired into `_build_console_inspector_state`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/UI/test_console_worldbook_inspector.py`. Read the existing dict-inspector screen test (search Tests/ for `_console_dictionary_inspector_rows` / `refresh_active_dictionaries_summary` / `_active_dictionaries_summary`) and mirror its harness. The test: builds the ChatScreen with a real `CharactersRAGDB`; pins a native session to a conversation with two attached world books (`WorldBookManager.associate_world_book_with_conversation`); calls `await screen.refresh_active_world_books_summary()`; asserts `screen._console_world_book_inspector_rows()` yields rows for both books (`.text` contains each name); and `_build_console_inspector_state()` carries them in `world_book_rows`. Also: with no conversation → a single "No active chat" row; conversation but no books → "No world books in play".
+
+- [ ] **Step 2: Run to verify it fails**
+
+Same command shape as Task 2 Step 2 for the new file. Expected: FAIL (methods missing).
+
+- [ ] **Step 3: Add the cache + scope-ids + refresh + scope-guard**
+
+In `chat_screen.py.__init__`, next to the dict cache init (`self._active_dictionaries_summary` / `self._last_console_dictionary_scope_ids`):
+```python
+        self._active_world_books_summary: dict | None = None
+        # Sentinel distinct from any real `(conversation_id,)` tuple so the
+        # first scope check always refreshes.
+        self._last_console_world_book_scope_ids: tuple | None = None
+```
+Add these methods near the dict ones (`_active_console_dictionary_scope_ids` / `refresh_active_dictionaries_summary` / `_refresh_active_dictionaries_summary_if_scope_changed`):
+```python
+    def _active_console_world_book_scope_ids(self) -> tuple[str | None]:
+        """(conversation_id,) for the active native Console world-book scope.
+
+        Conversation-only: native Console has no character (see
+        `_active_console_dictionary_scope_ids`).
+        """
+        return (self._current_console_rail_conversation_id(),)
+
+    async def refresh_active_world_books_summary(self) -> None:
+        """The ONLY place that performs the DB-backed world-book summarize.
+
+        `_build_console_inspector_state` reads only the cache set here. The
+        sync summarize is marshalled onto a worker thread via `asyncio.to_thread`
+        so it never blocks the UI loop.
+        """
+        conversation_id = self._current_console_rail_conversation_id()
+        db = getattr(self.app_instance, "chachanotes_db", None)
+        if not conversation_id or db is None:
+            self._active_world_books_summary = {"world_books": []}
+            self._sync_console_control_bar()
+            return
+        try:
+            from ...Character_Chat.world_info_resolver import (
+                summarize_active_world_books,
+            )
+
+            summary = await asyncio.to_thread(
+                summarize_active_world_books, db, conversation_id, None
+            )
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Could not summarize active world books for the Console inspector."
+            )
+            summary = {"world_books": []}
+        self._active_world_books_summary = (
+            summary if isinstance(summary, dict) else {"world_books": []}
+        )
+        self._sync_console_control_bar()
+
+    async def _refresh_active_world_books_summary_if_scope_changed(self) -> None:
+        """Recompute the world-book summary only when the scope changed."""
+        scope_ids = self._active_console_world_book_scope_ids()
+        if scope_ids == self._last_console_world_book_scope_ids:
+            return
+        self._last_console_world_book_scope_ids = scope_ids
+        await self.refresh_active_world_books_summary()
+
+    def _console_world_book_inspector_rows(self) -> tuple[ConsoleDisplayRow, ...]:
+        """Project the cached world-book summary into inspector rows (no DB)."""
+        conversation_id = self._current_console_rail_conversation_id()
+        if conversation_id is None:
+            return (ConsoleDisplayRow("No active chat", ""),)
+        summary = self._active_world_books_summary or {}
+        books = summary.get("world_books") or []
+        if not books:
+            return (ConsoleDisplayRow("No world books in play", ""),)
+        rows = []
+        for entry in books:
+            if not isinstance(entry, dict):
+                continue
+            name = str(entry.get("name") or "Unnamed")
+            count = entry.get("entry_count")
+            value = f"{count} entries" if isinstance(count, int) else "0 entries"
+            if not entry.get("enabled", True):
+                value += " (disabled)"
+            rows.append(ConsoleDisplayRow(name, value))
+        return tuple(rows)
+```
+(Confirm `_sync_console_control_bar` is the method the dict refresh calls at its end; match whatever the dict refresh does.)
+
+- [ ] **Step 4: Wire the rows into `_build_console_inspector_state` + the scope-guard into `_sync_native_console_chat_ui`**
+
+In `_build_console_inspector_state()`, in the `replace(inspector_state, dictionary_rows=…, dictionary_actions=…)` call, add:
+```python
+            world_book_rows=self._console_world_book_inspector_rows(),
+```
+In `_sync_native_console_chat_ui()`, immediately after `await self._refresh_active_dictionaries_summary_if_scope_changed()`, add:
+```python
+            await self._refresh_active_world_books_summary_if_scope_changed()
+```
+
+- [ ] **Step 5: Run to verify + no regression**
+
+Run the new test (PASS), then the dict-inspector screen test(s) to confirm no regression (find them via the search in Step 1).
+
+- [ ] **Step 6: Commit**
+```bash
+git add tldw_chatbook/UI/Screens/chat_screen.py Tests/UI/test_console_worldbook_inspector.py
+git commit -m "feat(console): populate World Books inspector rows (cached, scope-guarded)"
+```
+
+---
+
+### Task 4: Attach/Detach actions + workers
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`
+- Test: `Tests/UI/test_console_worldbook_inspector.py` (extend Task 3's file)
+
+**Interfaces:**
+- Consumes: `world_book_actions` (Task 2); `refresh_active_world_books_summary` (Task 3); `WorldBookPicker` (P2f); `WorldBookManager.get_world_books_for_conversation`/`associate_world_book_with_conversation`/`disassociate_world_book_from_conversation`/`list_world_books`.
+- Produces: `_console_world_book_inspector_actions()`; `_console_worldbook_dialog_active`; two `Button.Pressed` handlers; `_console_worldbook_attach_worker`/`_console_worldbook_detach_worker`; `world_book_actions=…` wired into `_build_console_inspector_state`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Extend `Tests/UI/test_console_worldbook_inspector.py` (mirror the dict Console attach/detach test — search Tests/ for `_console_dictionary_attach_worker` / `console-inspector-dictionaries-attach`): with a native session pinned to a conversation and a standalone world book seeded, monkeypatch `app_instance.push_screen_wait` to return the book id for a `WorldBookPicker`, click/post the attach action → `WorldBookManager(db).get_world_books_for_conversation(conv_id)` shows it + the inspector rows update; then detach → removed. Also assert `_console_world_book_inspector_actions()` gates Attach on a conversation id and Detach on ≥1 attached book.
+
+- [ ] **Step 2: Run to verify it fails** (methods/handlers missing).
+
+- [ ] **Step 3: Add the actions projection + dialog flag + handlers + workers**
+
+Add the dialog-flag init in `__init__` (next to `_console_dictionary_dialog_active`):
+```python
+        self._console_worldbook_dialog_active = False
+```
+Add the actions method (near `_console_dictionary_inspector_actions`):
+```python
+    def _console_world_book_inspector_actions(
+        self,
+    ) -> tuple[ConsoleInspectorAction, ...]:
+        """Attach/Detach actions for the Console world-book block (cache + conv id only)."""
+        conversation_id = self._current_console_rail_conversation_id()
+        summary = self._active_world_books_summary or {}
+        has_attached = bool(summary.get("world_books"))
+        return (
+            ConsoleInspectorAction(
+                "console-inspector-worldbooks-attach",
+                "Attach world book…",
+                enabled=bool(conversation_id),
+                disabled_reason="Start or load a conversation first",
+            ),
+            ConsoleInspectorAction(
+                "console-inspector-worldbooks-detach",
+                "Detach world book…",
+                enabled=has_attached,
+            ),
+        )
+```
+Wire it into `_build_console_inspector_state`'s `replace(...)` alongside `world_book_rows`:
+```python
+            world_book_actions=self._console_world_book_inspector_actions(),
+```
+Add the two `Button.Pressed` handlers (next to the dict inspector ones at `on_console_inspector_dictionaries_attach`/`_detach`):
+```python
+    @on(Button.Pressed, "#console-inspector-worldbooks-attach")
+    def on_console_inspector_worldbooks_attach(self, event: Button.Pressed) -> None:
+        event.stop()
+        if self._console_worldbook_dialog_active:
+            return
+        self._console_worldbook_dialog_active = True
+        self.run_worker(self._console_worldbook_attach_worker(), group="console-io")
+
+    @on(Button.Pressed, "#console-inspector-worldbooks-detach")
+    def on_console_inspector_worldbooks_detach(self, event: Button.Pressed) -> None:
+        event.stop()
+        if self._console_worldbook_dialog_active:
+            return
+        self._console_worldbook_dialog_active = True
+        self.run_worker(self._console_worldbook_detach_worker(), group="console-io")
+```
+Add the workers (mirror `_console_dictionary_attach_worker`/`_detach_worker`; import `WorldBookPicker` + `WorldBookManager` lazily inside the workers):
+```python
+    async def _console_worldbook_attach_worker(self) -> None:
+        try:
+            conversation_id = self._current_console_rail_conversation_id()
+            if not conversation_id:
+                self.app_instance.notify("Start or load a conversation first.", severity="warning")
+                return
+            db = getattr(self.app_instance, "chachanotes_db", None)
+            if db is None:
+                return
+            from ...Character_Chat.world_book_manager import WorldBookManager
+            from ...Widgets.Persona_Widgets.world_book_picker import WorldBookPicker
+
+            def _attachable() -> list[dict]:
+                mgr = WorldBookManager(db)
+                attached_ids = {b.get("id") for b in mgr.get_world_books_for_conversation(str(conversation_id), enabled_only=False)}
+                return [
+                    {"world_book_id": int(b.get("id")), "name": str(b.get("name"))}
+                    for b in (mgr.list_world_books(include_disabled=False) or [])
+                    if b.get("id") not in attached_ids
+                ]
+            try:
+                rows = await asyncio.to_thread(_attachable)
+            except Exception:
+                logger.opt(exception=True).warning("Could not load world books for the Console attach picker.")
+                return
+            if not rows:
+                self.app_instance.notify("No more world books to attach.", severity="information")
+                return
+            try:
+                picked = await self.app_instance.push_screen_wait(WorldBookPicker(rows))
+            except Exception:
+                logger.opt(exception=True).warning("Could not show the Console world-book picker.")
+                return
+            if not picked:
+                return
+            try:
+                await asyncio.to_thread(
+                    WorldBookManager(db).associate_world_book_with_conversation,
+                    str(conversation_id), int(picked),
+                )
+            except Exception as exc:
+                logger.opt(exception=True).warning("Could not attach the world book.")
+                self.app_instance.notify(f"Attach failed: {exc}", severity="error")
+                return
+            await self.refresh_active_world_books_summary()
+        finally:
+            self._console_worldbook_dialog_active = False
+
+    async def _console_worldbook_detach_worker(self) -> None:
+        try:
+            conversation_id = self._current_console_rail_conversation_id()
+            if not conversation_id:
+                self.app_instance.notify("Start or load a conversation first.", severity="warning")
+                return
+            db = getattr(self.app_instance, "chachanotes_db", None)
+            if db is None:
+                return
+            from ...Character_Chat.world_book_manager import WorldBookManager
+            from ...Widgets.Persona_Widgets.world_book_picker import WorldBookPicker
+
+            def _attached() -> list[dict]:
+                mgr = WorldBookManager(db)
+                return [
+                    {"world_book_id": int(b.get("id")), "name": str(b.get("name"))}
+                    for b in mgr.get_world_books_for_conversation(str(conversation_id), enabled_only=False)
+                ]
+            try:
+                rows = await asyncio.to_thread(_attached)
+            except Exception:
+                logger.opt(exception=True).warning("Could not load world books for the Console detach picker.")
+                return
+            if not rows:
+                self.app_instance.notify("No world books attached to this conversation.", severity="information")
+                return
+            try:
+                picked = await self.app_instance.push_screen_wait(
+                    WorldBookPicker(rows, title="Detach world book", confirm_label="Detach")
+                )
+            except Exception:
+                logger.opt(exception=True).warning("Could not show the Console world-book picker.")
+                return
+            if not picked:
+                return
+            try:
+                await asyncio.to_thread(
+                    WorldBookManager(db).disassociate_world_book_from_conversation,
+                    str(conversation_id), int(picked),
+                )
+            except Exception as exc:
+                logger.opt(exception=True).warning("Could not detach the world book.")
+                self.app_instance.notify(f"Detach failed: {exc}", severity="error")
+                return
+            await self.refresh_active_world_books_summary()
+        finally:
+            self._console_worldbook_dialog_active = False
+```
+Confirm `Button` and `@on` are imported in `chat_screen.py` (the dict handlers use them). `disassociate_world_book_from_conversation(conversation_id, world_book_id)` — verify arg order against `world_book_manager.py` (P2e: `(conversation_id, world_book_id)`).
+
+- [ ] **Step 4: Run to verify + full P2g-2 gate + app import**
+```bash
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+Tests/Character_Chat/test_summarize_active_world_books.py Tests/UI/test_console_run_inspector_worldbooks.py \
+Tests/UI/test_console_worldbook_inspector.py \
+-q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -c "import tldw_chatbook.app; print('APP IMPORT OK')"
+```
+
+- [ ] **Step 5: Commit**
+```bash
+git add tldw_chatbook/UI/Screens/chat_screen.py Tests/UI/test_console_worldbook_inspector.py
+git commit -m "feat(console): World Books inspector Attach/Detach actions + workers"
+```
+
+---
+
+## Notes for reviewers
+
+- **No migration; no send-path change.** Legacy `chat_events.py` gate-fix + dead-code deletion is P2g-3.
+- The summary uses `enabled_only=False` (attachment picture, shows disabled marked) — NOT the send-path `_collect_active_world_books`.
+- The world-book block is a **trailing custom block** threaded through `compose`/`_rendered_row_entries`/`_structural_key` — no `_ROW_ID_BY_LABEL` change; the dict block is untouched.
+- Projection/action methods read ONLY the cache + conversation id; the DB read is only in the scope-guarded off-thread refresh.
+- Action workers guard every await + `finally`-reset `_console_worldbook_dialog_active`; conversation-only; `WorldBookPicker` reused for Attach and Detach.

--- a/Docs/superpowers/specs/2026-07-21-roleplay-p2g-2-console-worldbook-inspector-design.md
+++ b/Docs/superpowers/specs/2026-07-21-roleplay-p2g-2-console-worldbook-inspector-design.md
@@ -1,0 +1,88 @@
+# Roleplay P2g-2 — Console "what's in play" world-book inspector + attach/detach
+
+**Status:** Design.
+
+**Program:** Roleplay (Personas) redesign — P2 (Lore mode), **P2g cycle 2 of 3**. Mirrors the merged Dictionary Console inspector (P1g). P2g-1 (native-Console world-info send) merged; P2g-3 = legacy send gate-bug fix + dead-code cleanup. Schema **v22**.
+
+## Why
+
+The native Console applies conversation-attached world books on send (P2g-1), but the Console run inspector shows nothing about them — a user can't see which world books are in play, and (unlike dictionaries, which have a Console "Chat Dictionaries" block with Attach/Detach) can't manage them without leaving the Console. This adds the world-book equivalent: a "World Books" inspector block that shows what's active and lets the user attach/detach a conversation world book in place.
+
+## What already exists (verified at dev tip)
+
+- **The dict "Chat Dictionaries" inspector block (mirror target):** a **trailing custom block** on `ConsoleRunInspector` — NOT routed through `_ROW_GROUPS`/`_ROW_ID_BY_LABEL` (those drive the main grouped rows). It is threaded through THREE spots: `compose()` (`console_run_inspector.py:415-422`, reads `state.dictionary_rows`/`dictionary_actions`), `_rendered_row_entries()` (`:227`, for in-place row updates), and `_structural_key()` (`:263`, for structural-recompose detection). Missing any of the three breaks updates.
+- **State carrier:** `ConsoleInspectorState` (`console_display_state.py`) has extra `dictionary_rows: tuple[ConsoleDisplayRow, ...]` / `dictionary_actions: tuple[ConsoleInspectorAction, ...]` fields. `ConsoleInspectorAction(widget_id, label, enabled, disabled_reason="", classes=...)` — a button spec; `ConsoleDisplayRow(text, status?)`.
+- **Row/action projection:** `ChatScreen._console_dictionary_inspector_rows()` and `_console_dictionary_inspector_actions()` (`chat_screen.py:5847`, `:5930`) read ONLY the cache + the active conversation id (never the DB), and are wired into `_build_console_inspector_state()` (`:5769`).
+- **Zero-DB-on-recompose:** a cached `self._active_dictionaries_summary` (`:1622`); `refresh_active_dictionaries_summary()` (`:5795`, the ONLY DB summarize call, off-thread via `asyncio.to_thread` + a private `asyncio.run` loop, `:535`); `_refresh_active_dictionaries_summary_if_scope_changed()` (`:5829`, compares `_active_console_dictionary_scope_ids()` vs `_last_console_dictionary_scope_ids`), invoked from `_sync_native_console_chat_ui()` (also on the 0.2s transcript poll while streaming).
+- **Action click routing:** `@on(Button.Pressed, "#console-inspector-dictionaries-attach")` / `"#…-detach"` handlers (`chat_screen.py:829`, `:847`) guard a `_console_dictionary_dialog_active` flag and `run_worker(worker, group="console-io")`. The **detach uses a picker** too (pick which attached dictionary to remove).
+- **Conversation id:** `ChatScreen._current_console_rail_conversation_id()` (`:3088`, sources from the native session's `persisted_conversation_id`).
+- **Reusable pieces:** `summarize`-style resolver seam via P2g-1's `_collect_active_world_books(db, conversation_id, char_data)` (`world_info_resolver.py:17`); `WorldBookPicker(world_books, *, title, confirm_label)` returning an int id (P2f); `WorldBookManager.get_world_books_for_conversation` / `associate_world_book_with_conversation` / `disassociate_world_book_from_conversation` / `list_world_books` (P2a/P2e).
+
+## Scope
+
+**In:** a "World Books" inspector block (read) + Attach/Detach actions (Console-side, conversation world books). **Deferred → P2g-3:** the legacy `chat_events.py` character-gate bug fix + deleting the dead legacy world-book UI. No migration; no send-path change (P2g-1 already applies attached books on native send).
+
+## Design decisions
+
+1. **Full parity with the dict inspector** (read block + Attach/Detach actions) — the user chose Read + Attach/Detach.
+2. **Trailing custom block, not routed rows.** The world-book block mirrors the dict block's trailing pattern (`world_book_rows`/`world_book_actions`), threaded through **all three** render spots. It needs **no** `_ROW_ID_BY_LABEL`/`_ROW_GROUPS` registration.
+3. **Detach via picker** (mirror dict): a picker of the currently-attached books → `disassociate`. `WorldBookPicker` is reused for both Attach and Detach via its `title`/`confirm_label` params — no new picker.
+4. **Conversation-only on native.** The summary uses `_collect_active_world_books(db, conversation_id, char_data)` with `char_data=None` on native Console (no character), so it shows conversation-attached books — matching the send path.
+5. **No scope service.** Dictionaries route through `ChatDictionaryScopeService` (local/server split); world books have no such split — `summarize_active_world_books` is a plain function in `world_info_resolver.py`, called off-thread directly.
+
+## Behavior-change framing
+
+Additive: a new inspector block + a summarize function + a cached scope-guarded refresh + two action workers. The dictionary inspector block, its refresh, and its actions are untouched. With no conversation / no attached books, the world-book block is empty (renders nothing), so the inspector is visually unchanged for that case.
+
+## Ground truths
+
+- `_collect_active_world_books` returns `(world_books: list[dict], has_character_book: bool)`; each book dict has `name`, `entries` (list), `enabled`. On native (`char_data=None`) it returns conversation books only.
+- `get_world_books_for_conversation` returns book dicts with `id`, `name`, `entries`, `enabled`; map to `{"world_book_id": id, "name": name}` for the picker.
+- The inspector projection methods and the action-list method read ONLY the cache + the conversation id — never the DB (the DB read happens only in the scope-guarded off-thread refresh).
+
+## Architecture
+
+### 1. Summarize resolver (`world_info_resolver.py`)
+`summarize_active_world_books(db, conversation_id: str | None, char_data: dict | None) -> dict` — reuse `_collect_active_world_books`, return `{"world_books": [{"name": str, "enabled": bool, "entry_count": int}], "source": "local"}` (names normalized to str, `entry_count = len(entries) if list else 0`). **No dedup-by-name** — conversation books are keyed by id (two distinct books may share a name), and the inspector rows are index-keyed (`…-row-{index}`), not name-keyed, so there is no `DuplicateKey` risk (unlike the P2f widget). Never raises (returns `{"world_books": [], "source": "local"}` on any error). Mirrors `summarize_active_dictionaries`.
+
+### 2. Inspector state (`console_display_state.py`)
+Add `world_book_rows: tuple[ConsoleDisplayRow, ...] = ()` and `world_book_actions: tuple[ConsoleInspectorAction, ...] = ()` to `ConsoleInspectorState`.
+
+### 3. Zero-DB-on-recompose refresh (`chat_screen.py`)
+- Cache `self._active_world_books_summary: dict | None = None`; `self._last_console_world_book_scope_ids`.
+- `refresh_active_world_books_summary()` — the ONLY DB call: off-thread `asyncio.to_thread(summarize_active_world_books, db, conversation_id, char_data=None)`, stores the result in the cache.
+- `_refresh_active_world_books_summary_if_scope_changed()` — compare `_active_console_world_book_scope_ids()` (`(conversation_id,)` on native) to `_last_…`; refresh only on change. Invoke it from `_sync_native_console_chat_ui()` alongside the dict guard.
+
+### 4. Row/action projection (`chat_screen.py`)
+- `_console_world_book_inspector_rows() -> tuple[ConsoleDisplayRow, ...]` — from the cache only: one row per book, `text = name`, value = entry count + a "(disabled)" suffix when not enabled (mirror `_console_dictionary_inspector_rows`).
+- `_console_world_book_inspector_actions() -> tuple[ConsoleInspectorAction, ...]` — Attach (`#console-inspector-worldbooks-attach`, enabled when a conversation id is present, `disabled_reason="Start or load a conversation first"`) + Detach (`#console-inspector-worldbooks-detach`, enabled when ≥1 book is attached). Reads cache + conversation id only.
+- Wire both into `_build_console_inspector_state()` (`world_book_rows=…, world_book_actions=…`).
+
+### 5. Inspector block render (`console_run_inspector.py`)
+Add a "World Books" heading block mirroring the dict block, threaded through **all three**: `compose()` (heading + `state.world_book_rows` + `state.world_book_actions` via `_compose_action`), `_rendered_row_entries()` (append the world-book rows), `_structural_key()` (include `world_book_rows`/`world_book_actions`). No `_ROW_ID_BY_LABEL` change.
+
+### 6. Attach/Detach handlers + workers (`chat_screen.py`)
+- `@on(Button.Pressed, "#console-inspector-worldbooks-attach")` / `"#…-detach"` — guard a new `_console_worldbook_dialog_active` flag; `run_worker(worker, group="console-io")`.
+- **Attach worker:** `conv_id = _current_console_rail_conversation_id()`; off-thread list standalone books not already attached (`list_world_books` minus `get_world_books_for_conversation`); `WorldBookPicker(books, title="Attach world book", confirm_label="Attach")`; on pick, off-thread `associate_world_book_with_conversation(conv_id, picked)`; then `refresh_active_world_books_summary()` + rebuild the inspector + notify; `finally` reset the flag.
+- **Detach worker:** attached books via `get_world_books_for_conversation(conv_id)` → `WorldBookPicker(attached, title="Detach world book", confirm_label="Detach")`; on pick, off-thread `disassociate_world_book_from_conversation(conv_id, picked)`; refresh + rebuild + notify.
+- All DB I/O off-thread, wrapped → notify, never crash; re-entrancy guarded; the picker is shown via `push_screen_wait`.
+
+## Error handling
+- The summarize function never raises. The refresh swallows errors (cache stays as-is / empties). The action workers wrap DB/picker calls → notify on failure, `finally`-reset the dialog flag; a missing conversation id → no-op.
+
+## Testing (real-integration, no fakes)
+- **Summarize:** attach two books to a conversation → `summarize_active_world_books` lists both with entry counts; a disabled book reports its state; none → empty; malformed → empty, no raise.
+- **Inspector render (widget):** a `ConsoleInspectorState` carrying `world_book_rows`/`world_book_actions` renders the "World Books" heading + rows + Attach/Detach buttons; empty tuples → nothing rendered; the dict block still renders (no regression).
+- **Scope-guard:** `refresh_active_world_books_summary` runs the DB read only when the scope id changes (mirror the dict scope-guard test).
+- **Console attach/detach (real-DB):** with a native session pinned to a conversation, the Attach action (picker monkeypatched to return a book id) persists the junction + the block shows it; Detach removes it; re-entrancy guard holds.
+- **Full gate:** the new resolver/inspector/screen tests + the dict inspector tests (no regression) + `import tldw_chatbook.app`.
+
+## Decomposition
+P2g-2 of 3. No migration. P2g-3 = legacy `chat_events.py` character-gate fix + dead-code deletion.
+
+## Acceptance criteria
+- [ ] `summarize_active_world_books` returns the conversation's active world books (`name`/`enabled`/`entry_count`) reusing `_collect_active_world_books`; never raises; conversation-only when `char_data=None`.
+- [ ] `ConsoleInspectorState` gains `world_book_rows`/`world_book_actions`; the "World Books" block renders via `compose()`/`_rendered_row_entries()`/`_structural_key()` (all three) with no `_ROW_ID_BY_LABEL` change; the dict block is unaffected.
+- [ ] The world-book summary is cached and refreshed ONLY by a scope-guarded off-thread `refresh_active_world_books_summary()`; the projection/action methods never touch the DB.
+- [ ] Attach/Detach actions (gated on conversation presence / attached-book presence) open a `WorldBookPicker` and `associate`/`disassociate` a conversation world book off-thread, guarded by `_console_worldbook_dialog_active`, then refresh; never crash.
+- [ ] Full gate green; `import tldw_chatbook.app` OK. Legacy fix + cleanup → P2g-3.

--- a/Docs/superpowers/specs/2026-07-21-roleplay-p2g-2-console-worldbook-inspector-design.md
+++ b/Docs/superpowers/specs/2026-07-21-roleplay-p2g-2-console-worldbook-inspector-design.md
@@ -16,7 +16,7 @@ The native Console applies conversation-attached world books on send (P2g-1), bu
 - **Zero-DB-on-recompose:** a cached `self._active_dictionaries_summary` (`:1622`); `refresh_active_dictionaries_summary()` (`:5795`, the ONLY DB summarize call, off-thread via `asyncio.to_thread` + a private `asyncio.run` loop, `:535`); `_refresh_active_dictionaries_summary_if_scope_changed()` (`:5829`, compares `_active_console_dictionary_scope_ids()` vs `_last_console_dictionary_scope_ids`), invoked from `_sync_native_console_chat_ui()` (also on the 0.2s transcript poll while streaming).
 - **Action click routing:** `@on(Button.Pressed, "#console-inspector-dictionaries-attach")` / `"#…-detach"` handlers (`chat_screen.py:829`, `:847`) guard a `_console_dictionary_dialog_active` flag and `run_worker(worker, group="console-io")`. The **detach uses a picker** too (pick which attached dictionary to remove).
 - **Conversation id:** `ChatScreen._current_console_rail_conversation_id()` (`:3088`, sources from the native session's `persisted_conversation_id`).
-- **Reusable pieces:** `summarize`-style resolver seam via P2g-1's `_collect_active_world_books(db, conversation_id, char_data)` (`world_info_resolver.py:17`); `WorldBookPicker(world_books, *, title, confirm_label)` returning an int id (P2f); `WorldBookManager.get_world_books_for_conversation` / `associate_world_book_with_conversation` / `disassociate_world_book_from_conversation` / `list_world_books` (P2a/P2e).
+- **Reusable pieces:** `WorldBookManager.get_world_books_for_conversation(conversation_id, enabled_only=…)` (the summary uses `enabled_only=False` to show the full attachment picture; P2a/P2e) / `associate_world_book_with_conversation` / `disassociate_world_book_from_conversation` / `list_world_books`; `WorldBookPicker(world_books, *, title, confirm_label)` returning an int id (P2f). (P2g-1's `_collect_active_world_books` is the *send-path* collector — enabled-only + character union — so the inspector does NOT reuse it; see §1.)
 
 ## Scope
 
@@ -27,7 +27,7 @@ The native Console applies conversation-attached world books on send (P2g-1), bu
 1. **Full parity with the dict inspector** (read block + Attach/Detach actions) — the user chose Read + Attach/Detach.
 2. **Trailing custom block, not routed rows.** The world-book block mirrors the dict block's trailing pattern (`world_book_rows`/`world_book_actions`), threaded through **all three** render spots. It needs **no** `_ROW_ID_BY_LABEL`/`_ROW_GROUPS` registration.
 3. **Detach via picker** (mirror dict): a picker of the currently-attached books → `disassociate`. `WorldBookPicker` is reused for both Attach and Detach via its `title`/`confirm_label` params — no new picker.
-4. **Conversation-only on native.** The summary uses `_collect_active_world_books(db, conversation_id, char_data)` with `char_data=None` on native Console (no character), so it shows conversation-attached books — matching the send path.
+4. **Conversation-only on native.** On native Console there is no character (`char_data=None`), so the summary shows conversation-attached books only (it queries `get_world_books_for_conversation` directly — see §1).
 5. **No scope service.** Dictionaries route through `ChatDictionaryScopeService` (local/server split); world books have no such split — `summarize_active_world_books` is a plain function in `world_info_resolver.py`, called off-thread directly.
 
 ## Behavior-change framing
@@ -36,14 +36,13 @@ Additive: a new inspector block + a summarize function + a cached scope-guarded 
 
 ## Ground truths
 
-- `_collect_active_world_books` returns `(world_books: list[dict], has_character_book: bool)`; each book dict has `name`, `entries` (list), `enabled`. On native (`char_data=None`) it returns conversation books only.
-- `get_world_books_for_conversation` returns book dicts with `id`, `name`, `entries`, `enabled`; map to `{"world_book_id": id, "name": name}` for the picker.
+- `get_world_books_for_conversation(conv_id, enabled_only=False)` returns book dicts with `id`, `name`, `entries` (list), `enabled` for ALL attached books; the summary reads those directly; for the pickers, map to `{"world_book_id": id, "name": name}`.
 - The inspector projection methods and the action-list method read ONLY the cache + the conversation id — never the DB (the DB read happens only in the scope-guarded off-thread refresh).
 
 ## Architecture
 
 ### 1. Summarize resolver (`world_info_resolver.py`)
-`summarize_active_world_books(db, conversation_id: str | None, char_data: dict | None) -> dict` — reuse `_collect_active_world_books`, return `{"world_books": [{"name": str, "enabled": bool, "entry_count": int}], "source": "local"}` (names normalized to str, `entry_count = len(entries) if list else 0`). **No dedup-by-name** — conversation books are keyed by id (two distinct books may share a name), and the inspector rows are index-keyed (`…-row-{index}`), not name-keyed, so there is no `DuplicateKey` risk (unlike the P2f widget). Never raises (returns `{"world_books": [], "source": "local"}` on any error). Mirrors `summarize_active_dictionaries`.
+`summarize_active_world_books(db, conversation_id: str | None, char_data: dict | None) -> dict` — return `{"world_books": [{"name": str, "enabled": bool, "entry_count": int}], "source": "local"}` (names normalized to str, `entry_count = len(entries) if list else 0`). **Shows ALL attached books, not just enabled ones** — it calls `WorldBookManager.get_world_books_for_conversation(conversation_id, enabled_only=False)` directly (NOT the send-path `_collect_active_world_books`, which is correctly `enabled_only=True`): the inspector reflects the *attachment picture* (disabled books are shown and marked), whereas the send path reflects what *applies*. This matches the dict inspector, which shows disabled dictionaries marked "(disabled)". `char_data` is accepted for signature parity with `summarize_active_dictionaries` but P2g-2 is conversation-only (native `char_data=None`). **No dedup-by-name** — conversation books are keyed by id (two distinct books may share a name), and the inspector rows are index-keyed (`…-row-{index}`), not name-keyed, so there is no `DuplicateKey` risk (unlike the P2f widget). Never raises (returns `{"world_books": [], "source": "local"}` on any error).
 
 ### 2. Inspector state (`console_display_state.py`)
 Add `world_book_rows: tuple[ConsoleDisplayRow, ...] = ()` and `world_book_actions: tuple[ConsoleInspectorAction, ...] = ()` to `ConsoleInspectorState`.
@@ -64,7 +63,7 @@ Add a "World Books" heading block mirroring the dict block, threaded through **a
 ### 6. Attach/Detach handlers + workers (`chat_screen.py`)
 - `@on(Button.Pressed, "#console-inspector-worldbooks-attach")` / `"#…-detach"` — guard a new `_console_worldbook_dialog_active` flag; `run_worker(worker, group="console-io")`.
 - **Attach worker:** `conv_id = _current_console_rail_conversation_id()`; off-thread list standalone books not already attached (`list_world_books` minus `get_world_books_for_conversation`); `WorldBookPicker(books, title="Attach world book", confirm_label="Attach")`; on pick, off-thread `associate_world_book_with_conversation(conv_id, picked)`; then `refresh_active_world_books_summary()` + rebuild the inspector + notify; `finally` reset the flag.
-- **Detach worker:** attached books via `get_world_books_for_conversation(conv_id)` → `WorldBookPicker(attached, title="Detach world book", confirm_label="Detach")`; on pick, off-thread `disassociate_world_book_from_conversation(conv_id, picked)`; refresh + rebuild + notify.
+- **Detach worker:** attached books via `get_world_books_for_conversation(conv_id, enabled_only=False)` (so a disabled-but-attached book can still be detached) → `WorldBookPicker(attached, title="Detach world book", confirm_label="Detach")`; on pick, off-thread `disassociate_world_book_from_conversation(conv_id, picked)`; refresh + rebuild + notify.
 - All DB I/O off-thread, wrapped → notify, never crash; re-entrancy guarded; the picker is shown via `push_screen_wait`.
 
 ## Error handling
@@ -81,7 +80,7 @@ Add a "World Books" heading block mirroring the dict block, threaded through **a
 P2g-2 of 3. No migration. P2g-3 = legacy `chat_events.py` character-gate fix + dead-code deletion.
 
 ## Acceptance criteria
-- [ ] `summarize_active_world_books` returns the conversation's active world books (`name`/`enabled`/`entry_count`) reusing `_collect_active_world_books`; never raises; conversation-only when `char_data=None`.
+- [ ] `summarize_active_world_books` returns the conversation's attached world books (`name`/`enabled`/`entry_count`) via `get_world_books_for_conversation(enabled_only=False)` — including disabled-but-attached books; never raises; conversation-only when `char_data=None`.
 - [ ] `ConsoleInspectorState` gains `world_book_rows`/`world_book_actions`; the "World Books" block renders via `compose()`/`_rendered_row_entries()`/`_structural_key()` (all three) with no `_ROW_ID_BY_LABEL` change; the dict block is unaffected.
 - [ ] The world-book summary is cached and refreshed ONLY by a scope-guarded off-thread `refresh_active_world_books_summary()`; the projection/action methods never touch the DB.
 - [ ] Attach/Detach actions (gated on conversation presence / attached-book presence) open a `WorldBookPicker` and `associate`/`disassociate` a conversation world book off-thread, guarded by `_console_worldbook_dialog_active`, then refresh; never crash.

--- a/Tests/Character_Chat/test_summarize_active_world_books.py
+++ b/Tests/Character_Chat/test_summarize_active_world_books.py
@@ -1,0 +1,48 @@
+import pytest
+
+from tldw_chatbook.Character_Chat.world_info_resolver import (
+    summarize_active_world_books,
+)
+from tldw_chatbook.Character_Chat.world_book_manager import WorldBookManager
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+
+@pytest.fixture
+def wb_db(tmp_path):
+    db = CharactersRAGDB(tmp_path / "summarize_wb.db", "test-client")
+    yield db
+    db.close_connection()
+
+
+def test_lists_attached_books_with_counts(wb_db):
+    wb_db.add_conversation({"id": "c1", "title": "C"})
+    wb = WorldBookManager(wb_db)
+    b1 = wb.create_world_book("Alpha")
+    wb.create_world_book_entry(b1, keys=["a"], content="x")
+    wb.create_world_book_entry(b1, keys=["b"], content="y")
+    wb.associate_world_book_with_conversation("c1", b1)
+    out = summarize_active_world_books(wb_db, "c1", None)
+    assert out["world_books"] == [{"name": "Alpha", "enabled": True, "entry_count": 2}]
+
+
+def test_includes_disabled_attached_book(wb_db):
+    wb_db.add_conversation({"id": "c2", "title": "C"})
+    wb = WorldBookManager(wb_db)
+    b = wb.create_world_book("Off", enabled=False)
+    wb.create_world_book_entry(b, keys=["k"], content="x")
+    wb.associate_world_book_with_conversation("c2", b)
+    out = summarize_active_world_books(wb_db, "c2", None)
+    assert out["world_books"] == [{"name": "Off", "enabled": False, "entry_count": 1}]
+
+
+def test_empty_when_none_attached(wb_db):
+    wb_db.add_conversation({"id": "c3", "title": "C"})
+    assert summarize_active_world_books(wb_db, "c3", None) == {"world_books": [], "source": "local"}
+
+
+def test_no_conversation_returns_empty(wb_db):
+    assert summarize_active_world_books(wb_db, None, None) == {"world_books": [], "source": "local"}
+
+
+def test_db_error_returns_empty():
+    assert summarize_active_world_books(object(), "cX", None) == {"world_books": [], "source": "local"}

--- a/Tests/UI/test_console_run_inspector_worldbooks.py
+++ b/Tests/UI/test_console_run_inspector_worldbooks.py
@@ -1,0 +1,73 @@
+"""Roleplay P2g-2: the inspector renders a World Books block from state (no I/O)."""
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Static, Button
+
+from tldw_chatbook.Chat.console_display_state import (
+    ConsoleInspectorState,
+    ConsoleDisplayRow,
+    ConsoleInspectorAction,
+)
+from tldw_chatbook.Widgets.Console.console_run_inspector import ConsoleRunInspector
+
+pytestmark = pytest.mark.asyncio
+
+
+def _state(**kw):
+    return ConsoleInspectorState.from_values(**kw)
+
+
+class _Host(App):
+    def __init__(self, state):
+        super().__init__()
+        self._state = state
+
+    def compose(self) -> ComposeResult:
+        yield ConsoleRunInspector(self._state)
+
+
+async def test_worldbooks_block_renders_rows_and_actions():
+    from dataclasses import replace
+
+    state = replace(
+        _state(),
+        world_book_rows=(ConsoleDisplayRow("Alpha", "2 entries"),),
+        world_book_actions=(
+            ConsoleInspectorAction(
+                "console-inspector-worldbooks-attach", "Attach world book…", True
+            ),
+        ),
+    )
+    async with _Host(state).run_test(size=(120, 50)) as pilot:
+        texts = [str(s.renderable) for s in pilot.app.query(Static)]
+        assert any("World Books" in t for t in texts)
+        row = pilot.app.query_one("#console-inspector-worldbooks-row-0", Static)
+        assert str(row.renderable) == "Alpha: 2 entries"
+        assert pilot.app.query_one("#console-inspector-worldbooks-attach", Button)
+
+
+async def test_worldbooks_block_absent_when_empty():
+    async with _Host(_state()).run_test(size=(120, 50)) as pilot:
+        texts = [str(s.renderable) for s in pilot.app.query(Static)]
+        assert not any("World Books" in t for t in texts)
+
+
+async def test_dictionaries_block_still_renders_no_regression():
+    from dataclasses import replace
+
+    state = replace(
+        _state(),
+        dictionary_rows=(ConsoleDisplayRow("Slang", "from conversation"),),
+        dictionary_actions=(
+            ConsoleInspectorAction(
+                "console-inspector-dictionaries-attach", "Attach dictionary…", True
+            ),
+        ),
+    )
+    async with _Host(state).run_test(size=(120, 50)) as pilot:
+        texts = [str(s.renderable) for s in pilot.app.query(Static)]
+        assert any("Chat Dictionaries" in t for t in texts)
+        assert any("Slang" in t for t in texts)
+        assert pilot.app.query_one("#console-inspector-dictionaries-attach", Button)
+        assert not any("World Books" in t for t in texts)

--- a/Tests/UI/test_console_worldbook_inspector.py
+++ b/Tests/UI/test_console_worldbook_inspector.py
@@ -1,0 +1,171 @@
+"""P2g-2 Task 3: `ChatScreen` caches the "what's in play" world-book summary
+on native Console session change and feeds it into the Console inspector
+build with ZERO DB I/O on recompose.
+
+Mirrors `Tests/UI/test_console_dictionaries_screen.py` (the chat-dictionary
+inspector read wiring), but drives a REAL `CharactersRAGDB` +
+`WorldBookManager` instead of a fake scope service -- world-book
+summarization (`summarize_active_world_books`, P2g-2 Task 1) always reads the
+DB directly rather than going through an app-level scope service.
+
+`refresh_active_world_books_summary()` is the ONLY place allowed to call
+`summarize_active_world_books`; a bare `_build_console_inspector_state()`
+call (the same path every Console recompose/refresh goes through) must read
+only the cached `self._active_world_books_summary` set by the last refresh.
+"""
+
+import pytest
+
+from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+    ConsoleHarness,
+)
+from tldw_chatbook.Chat.console_display_state import ConsoleDisplayRow
+from tldw_chatbook.Character_Chat.world_book_manager import WorldBookManager
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+
+def _active_native_session(console: ChatScreen):
+    store = console._ensure_console_chat_store()
+    return next(s for s in store.sessions() if s.id == store.active_session_id)
+
+
+@pytest.fixture
+def wb_db(tmp_path):
+    db = CharactersRAGDB(tmp_path / "console_worldbook_inspector.db", "test-client")
+    yield db
+    db.close_connection()
+
+
+@pytest.mark.asyncio
+async def test_refresh_caches_summary_and_build_projects_world_book_rows(wb_db):
+    wb_db.add_conversation({"id": "conv-wb", "title": "C"})
+    manager = WorldBookManager(wb_db)
+    book_a = manager.create_world_book("Alpha")
+    manager.create_world_book_entry(book_a, keys=["a"], content="x")
+    manager.create_world_book_entry(book_a, keys=["b"], content="y")
+    book_b = manager.create_world_book("Beta")
+    manager.create_world_book_entry(book_b, keys=["c"], content="z")
+    manager.associate_world_book_with_conversation("conv-wb", book_a)
+    manager.associate_world_book_with_conversation("conv-wb", book_b)
+
+    app = _build_test_app()
+    app.chachanotes_db = wb_db
+
+    async with ConsoleHarness(app).run_test(size=(180, 48)) as pilot:
+        screen = pilot.app.screen_stack[-1]
+        await _wait_for_selector(screen, pilot, "#console-native-composer")
+        _active_native_session(screen).persisted_conversation_id = "conv-wb"
+
+        await screen.refresh_active_world_books_summary()
+
+        rows = screen._console_world_book_inspector_rows()
+        row_texts = [row.text for row in rows]
+        assert any("Alpha" in text for text in row_texts)
+        assert any("Beta" in text for text in row_texts)
+
+        inspector_state = screen._build_console_inspector_state(None)
+        assert inspector_state.world_book_rows == rows
+        inspector_row_texts = [row.text for row in inspector_state.world_book_rows]
+        assert any("Alpha" in text for text in inspector_row_texts)
+        assert any("Beta" in text for text in inspector_row_texts)
+
+
+@pytest.mark.asyncio
+async def test_build_console_inspector_state_never_re_queries_the_db(wb_db, monkeypatch):
+    wb_db.add_conversation({"id": "conv-wb", "title": "C"})
+    manager = WorldBookManager(wb_db)
+    book_a = manager.create_world_book("Alpha")
+    manager.create_world_book_entry(book_a, keys=["a"], content="x")
+    manager.associate_world_book_with_conversation("conv-wb", book_a)
+
+    app = _build_test_app()
+    app.chachanotes_db = wb_db
+
+    calls: list[tuple] = []
+    from tldw_chatbook.Character_Chat import world_info_resolver as wir
+
+    real_summarize = wir.summarize_active_world_books
+
+    def _tracking_summarize(db, conversation_id, char_data):
+        calls.append((conversation_id, char_data))
+        return real_summarize(db, conversation_id, char_data)
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Character_Chat.world_info_resolver.summarize_active_world_books",
+        _tracking_summarize,
+    )
+
+    async with ConsoleHarness(app).run_test(size=(180, 48)) as pilot:
+        screen = pilot.app.screen_stack[-1]
+        await _wait_for_selector(screen, pilot, "#console-native-composer")
+        _active_native_session(screen).persisted_conversation_id = "conv-wb"
+
+        await screen.refresh_active_world_books_summary()
+        assert len(calls) == 1
+
+        # A bare, recompose-equivalent build must read only the cache -- no
+        # re-invocation of the DB-backed summarize call.
+        screen._build_console_inspector_state(None)
+        screen._build_console_inspector_state(None)
+        screen._build_console_inspector_state(None)
+
+        assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_no_active_chat_renders_no_active_chat_row(wb_db):
+    app = _build_test_app()
+    app.chachanotes_db = wb_db
+
+    async with ConsoleHarness(app).run_test(size=(180, 48)) as pilot:
+        screen = pilot.app.screen_stack[-1]
+        await _wait_for_selector(screen, pilot, "#console-native-composer")
+        # Fresh default native session has no persisted conversation yet.
+        assert _active_native_session(screen).persisted_conversation_id is None
+
+        await screen.refresh_active_world_books_summary()
+
+        rows = screen._console_world_book_inspector_rows()
+        assert rows == (ConsoleDisplayRow("No active chat", ""),)
+
+
+@pytest.mark.asyncio
+async def test_conversation_with_no_books_renders_no_world_books_in_play_row(wb_db):
+    wb_db.add_conversation({"id": "conv-empty", "title": "C"})
+
+    app = _build_test_app()
+    app.chachanotes_db = wb_db
+
+    async with ConsoleHarness(app).run_test(size=(180, 48)) as pilot:
+        screen = pilot.app.screen_stack[-1]
+        await _wait_for_selector(screen, pilot, "#console-native-composer")
+        _active_native_session(screen).persisted_conversation_id = "conv-empty"
+
+        await screen.refresh_active_world_books_summary()
+
+        rows = screen._console_world_book_inspector_rows()
+        assert rows == (ConsoleDisplayRow("No world books in play", ""),)
+
+
+@pytest.mark.asyncio
+async def test_sync_native_console_chat_ui_refreshes_world_books_on_scope_change(wb_db):
+    wb_db.add_conversation({"id": "conv-wb", "title": "C"})
+    manager = WorldBookManager(wb_db)
+    book_a = manager.create_world_book("Alpha")
+    manager.create_world_book_entry(book_a, keys=["a"], content="x")
+    manager.associate_world_book_with_conversation("conv-wb", book_a)
+
+    app = _build_test_app()
+    app.chachanotes_db = wb_db
+
+    async with ConsoleHarness(app).run_test(size=(180, 48)) as pilot:
+        screen = pilot.app.screen_stack[-1]
+        await _wait_for_selector(screen, pilot, "#console-native-composer")
+        _active_native_session(screen).persisted_conversation_id = "conv-wb"
+
+        await screen._sync_native_console_chat_ui()
+
+        rows = screen._console_world_book_inspector_rows()
+        assert any("Alpha" in row.text for row in rows)

--- a/Tests/UI/test_console_worldbook_inspector.py
+++ b/Tests/UI/test_console_worldbook_inspector.py
@@ -12,6 +12,12 @@ DB directly rather than going through an app-level scope service.
 `summarize_active_world_books`; a bare `_build_console_inspector_state()`
 call (the same path every Console recompose/refresh goes through) must read
 only the cached `self._active_world_books_summary` set by the last refresh.
+
+P2g-2 Task 4 (below): the World Books inspector block's Attach/Detach
+actions + workers -- a real-DB round trip mirroring
+`Tests/UI/test_console_dictionaries_attach.py` (the chat-dictionary Console
+attach/detach test), driving the REAL `WorldBookManager` over the REAL db
+rather than a fake.
 """
 
 import pytest
@@ -24,6 +30,7 @@ from tldw_chatbook.Chat.console_display_state import ConsoleDisplayRow
 from tldw_chatbook.Character_Chat.world_book_manager import WorldBookManager
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
 from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+from tldw_chatbook.Widgets.Persona_Widgets.world_book_picker import WorldBookPicker
 
 
 def _active_native_session(console: ChatScreen):
@@ -169,3 +176,156 @@ async def test_sync_native_console_chat_ui_refreshes_world_books_on_scope_change
 
         rows = screen._console_world_book_inspector_rows()
         assert any("Alpha" in row.text for row in rows)
+
+
+# --- P2g-2 Task 4: Attach/Detach actions + workers --------------------------
+
+
+@pytest.mark.asyncio
+async def test_console_worldbook_attach_then_detach_round_trips_through_real_db(
+    wb_db, monkeypatch
+):
+    """A real-DB round trip: the attach worker persists a genuine
+    ``conversation_world_books`` junction row (not a stub), the inspector
+    cache reflects it, and the detach worker removes it again.
+    """
+    conv_id = wb_db.add_conversation({"title": "Attach flow"})
+    manager = WorldBookManager(wb_db)
+    book_id = manager.create_world_book("Standalone Lore")
+    manager.create_world_book_entry(book_id, keys=["a"], content="x")
+
+    app = _build_test_app()
+    app.chachanotes_db = wb_db
+
+    async with ConsoleHarness(app).run_test(size=(180, 48)) as pilot:
+        screen = pilot.app.screen_stack[-1]
+        await _wait_for_selector(screen, pilot, "#console-native-composer")
+        _active_native_session(screen).persisted_conversation_id = conv_id
+
+        async def _fake_push_screen_wait(picker):
+            return book_id if isinstance(picker, WorldBookPicker) else None
+
+        monkeypatch.setattr(
+            screen.app_instance,
+            "push_screen_wait",
+            _fake_push_screen_wait,
+            raising=False,
+        )
+
+        await screen.refresh_active_world_books_summary()
+        assert manager.get_world_books_for_conversation(conv_id, enabled_only=False) == []
+
+        # --- Attach ---
+        await screen._console_worldbook_attach_worker()
+        await pilot.pause()
+
+        attached = manager.get_world_books_for_conversation(conv_id, enabled_only=False)
+        assert [b["id"] for b in attached] == [book_id]
+        rows = screen._console_world_book_inspector_rows()
+        assert any("Standalone Lore" in row.text for row in rows)
+        assert screen._console_worldbook_dialog_active is False
+
+        # --- Detach (same monkeypatched picker returns the same id) ---
+        await screen._console_worldbook_detach_worker()
+        await pilot.pause()
+
+        assert manager.get_world_books_for_conversation(conv_id, enabled_only=False) == []
+        rows_after = screen._console_world_book_inspector_rows()
+        assert rows_after == (ConsoleDisplayRow("No world books in play", ""),)
+        assert screen._console_worldbook_dialog_active is False
+
+
+@pytest.mark.asyncio
+async def test_console_worldbook_attach_notifies_and_noops_without_a_conversation(
+    wb_db, monkeypatch
+):
+    """No active native-session conversation -> the attach worker must not
+    touch the DB. The attach action is *disabled* with no conversation (see
+    the gating test below), so this drives the worker directly -- exercising
+    the same production guard the button-press handler defers to.
+    """
+    app = _build_test_app()
+    app.chachanotes_db = wb_db
+
+    calls: list = []
+    monkeypatch.setattr(app, "notify", lambda *a, **k: calls.append((a, k)))
+
+    push_calls: list = []
+
+    async def _fake_push_screen_wait(picker):
+        push_calls.append(picker)
+        return None
+
+    async with ConsoleHarness(app).run_test(size=(180, 48)) as pilot:
+        screen = pilot.app.screen_stack[-1]
+        await _wait_for_selector(screen, pilot, "#console-native-composer")
+        assert _active_native_session(screen).persisted_conversation_id is None
+
+        monkeypatch.setattr(
+            screen.app_instance,
+            "push_screen_wait",
+            _fake_push_screen_wait,
+            raising=False,
+        )
+
+        await screen._console_worldbook_attach_worker()
+        await pilot.pause()
+
+        assert push_calls == []  # never even opened the picker
+        assert any("conversation" in str(a).lower() for a, _k in calls)
+        assert screen._console_worldbook_dialog_active is False
+
+
+@pytest.mark.asyncio
+async def test_console_world_book_inspector_actions_gate_on_conversation_and_attached(
+    wb_db,
+):
+    """``_console_world_book_inspector_actions`` gates Attach on a
+    conversation id being active and Detach on >=1 currently-attached book --
+    read purely from the cache + conversation id, never the DB.
+    """
+    conv_id = wb_db.add_conversation({"title": "Gate flow"})
+    manager = WorldBookManager(wb_db)
+    book_id = manager.create_world_book("Gate Lore")
+    manager.create_world_book_entry(book_id, keys=["a"], content="x")
+
+    app = _build_test_app()
+    app.chachanotes_db = wb_db
+
+    async with ConsoleHarness(app).run_test(size=(180, 48)) as pilot:
+        screen = pilot.app.screen_stack[-1]
+        await _wait_for_selector(screen, pilot, "#console-native-composer")
+
+        # No conversation yet: Attach disabled, Detach disabled (no summary).
+        actions = screen._console_world_book_inspector_actions()
+        attach = next(
+            a for a in actions if a.widget_id == "console-inspector-worldbooks-attach"
+        )
+        detach = next(
+            a for a in actions if a.widget_id == "console-inspector-worldbooks-detach"
+        )
+        assert attach.enabled is False
+        assert detach.enabled is False
+
+        # Conversation active, but nothing attached yet: Attach enabled,
+        # Detach still disabled.
+        _active_native_session(screen).persisted_conversation_id = conv_id
+        await screen.refresh_active_world_books_summary()
+        actions = screen._console_world_book_inspector_actions()
+        attach = next(
+            a for a in actions if a.widget_id == "console-inspector-worldbooks-attach"
+        )
+        detach = next(
+            a for a in actions if a.widget_id == "console-inspector-worldbooks-detach"
+        )
+        assert attach.enabled is True
+        assert detach.enabled is False
+
+        # After attaching: Detach becomes enabled too.
+        manager.associate_world_book_with_conversation(conv_id, book_id)
+        await screen.refresh_active_world_books_summary()
+        actions = screen._console_world_book_inspector_actions()
+        detach = next(
+            a for a in actions if a.widget_id == "console-inspector-worldbooks-detach"
+        )
+        assert detach.enabled is True

--- a/backlog/tasks/task-404 - Fix-misleading-conversation_id-int-type-hints-in-WorldBookManager.md
+++ b/backlog/tasks/task-404 - Fix-misleading-conversation_id-int-type-hints-in-WorldBookManager.md
@@ -1,0 +1,22 @@
+---
+id: TASK-404
+title: 'Fix misleading conversation_id: int type hints in WorldBookManager'
+status: To Do
+assignee: []
+created_date: '2026-07-21 15:06'
+labels:
+  - lore
+  - tech-debt
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+WorldBookManager's conversation-facing methods (associate_world_book_with_conversation, disassociate_world_book_from_conversation, get_world_books_for_conversation, get_conversations_for_world_book) annotate conversation_id: int, but the runtime value is always a string UUID and the conversation_world_books.conversation_id column is TEXT. SQLite's dynamic typing makes current calls (which pass str(...)) correct, so this is cosmetic, but the hints mislead callers. Gemini flagged the associate/disassociate pair on PR #738 (P2g-2); fixing them piecemeal would be inconsistent with the sibling getters, so do all of them together.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 All conversation_id parameters on WorldBookManager conversation-facing methods are annotated conversation_id: str (not int),No runtime behavior change; existing world-book conversation-attach tests stay green,Docstrings/annotations consistent across associate/disassociate/get_world_books_for_conversation/get_conversations_for_world_book
+<!-- AC:END -->

--- a/tldw_chatbook/Character_Chat/world_info_resolver.py
+++ b/tldw_chatbook/Character_Chat/world_info_resolver.py
@@ -122,4 +122,55 @@ def apply_world_info_to_message(
         return message_text
 
 
-__all__ = ["apply_world_info_to_message"]
+def summarize_active_world_books(
+    db: Any,
+    conversation_id: Optional[str],
+    char_data: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """World-book "what's in play" summary for the Console inspector (never raises).
+
+    Shows ALL attached books (enabled + disabled) — the *attachment picture* —
+    via ``get_world_books_for_conversation(enabled_only=False)``, NOT the
+    send-path ``_collect_active_world_books`` (which is enabled-only). ``char_data``
+    is accepted for signature parity but P2g-2 is conversation-only (native
+    ``char_data=None``).
+
+    Args:
+        db: A ``CharactersRAGDB`` (or None).
+        conversation_id: The active conversation (string UUID) or None.
+        char_data: Unused on native Console (accepted for parity).
+
+    Returns:
+        ``{"world_books": [{"name": str, "enabled": bool, "entry_count": int}],
+        "source": "local"}``. ``{"world_books": [], "source": "local"}`` on no
+        conversation / no books / any error.
+    """
+    if not conversation_id or db is None:
+        return {"world_books": [], "source": "local"}
+    try:
+        from .world_book_manager import WorldBookManager
+
+        books = WorldBookManager(db).get_world_books_for_conversation(
+            str(conversation_id), enabled_only=False
+        )
+    except Exception:
+        logger.opt(exception=True).debug(
+            "world-info: could not summarize conversation world books"
+        )
+        return {"world_books": [], "source": "local"}
+    world_books = []
+    for book in books:
+        if not isinstance(book, dict):
+            continue
+        entries = book.get("entries")
+        world_books.append(
+            {
+                "name": str(book.get("name") or "Unnamed"),
+                "enabled": bool(book.get("enabled", True)),
+                "entry_count": len(entries) if isinstance(entries, list) else 0,
+            }
+        )
+    return {"world_books": world_books, "source": "local"}
+
+
+__all__ = ["apply_world_info_to_message", "summarize_active_world_books"]

--- a/tldw_chatbook/Chat/console_display_state.py
+++ b/tldw_chatbook/Chat/console_display_state.py
@@ -402,6 +402,8 @@ class ConsoleInspectorState:
     can_save_chatbook: bool = False
     dictionary_rows: tuple[ConsoleDisplayRow, ...] = ()
     dictionary_actions: tuple[ConsoleInspectorAction, ...] = ()
+    world_book_rows: tuple[ConsoleDisplayRow, ...] = ()
+    world_book_actions: tuple[ConsoleInspectorAction, ...] = ()
 
     @classmethod
     def from_values(

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -853,6 +853,24 @@ class ChatScreen(BaseAppScreen):
         self._console_dictionary_dialog_active = True
         self.run_worker(self._console_dictionary_detach_worker(), group="console-io")
 
+    @on(Button.Pressed, "#console-inspector-worldbooks-attach")
+    def on_console_inspector_worldbooks_attach(self, event: Button.Pressed) -> None:
+        """Open the attach-world-book picker for the active Console conversation."""
+        event.stop()
+        if self._console_worldbook_dialog_active:
+            return
+        self._console_worldbook_dialog_active = True
+        self.run_worker(self._console_worldbook_attach_worker(), group="console-io")
+
+    @on(Button.Pressed, "#console-inspector-worldbooks-detach")
+    def on_console_inspector_worldbooks_detach(self, event: Button.Pressed) -> None:
+        """Open the detach-world-book picker for the active Console conversation."""
+        event.stop()
+        if self._console_worldbook_dialog_active:
+            return
+        self._console_worldbook_dialog_active = True
+        self.run_worker(self._console_worldbook_detach_worker(), group="console-io")
+
     async def _open_console_settings(self, *, focus_model: bool = False) -> None:
         """Open Console session settings for the active native session."""
         settings = self._ensure_active_console_session_settings()
@@ -1652,6 +1670,9 @@ class ChatScreen(BaseAppScreen):
         # flow against a double-open (mirrors P1f's `_io_dialog_active`),
         # reset in a `finally` in both attach/detach workers.
         self._console_dictionary_dialog_active = False
+        # P2g-2 Task 4: same double-open guard, for the World Books
+        # inspector block's Attach/Detach picker flow.
+        self._console_worldbook_dialog_active = False
         self.ui_state = UIState()
         self._load_sidebar_state()
 
@@ -5788,6 +5809,7 @@ class ChatScreen(BaseAppScreen):
             dictionary_rows=self._console_dictionary_inspector_rows(),
             dictionary_actions=self._console_dictionary_inspector_actions(),
             world_book_rows=self._console_world_book_inspector_rows(),
+            world_book_actions=self._console_world_book_inspector_actions(),
         )
         return inspector_state
 
@@ -6097,6 +6119,162 @@ class ChatScreen(BaseAppScreen):
             await self.refresh_active_dictionaries_summary()
         finally:
             self._console_dictionary_dialog_active = False
+
+    def _console_world_book_inspector_actions(
+        self,
+    ) -> tuple[ConsoleInspectorAction, ...]:
+        """Attach/Detach actions for the Console world-book block (cache + conv id only)."""
+        conversation_id = self._current_console_rail_conversation_id()
+        summary = self._active_world_books_summary or {}
+        has_attached = bool(summary.get("world_books"))
+        return (
+            ConsoleInspectorAction(
+                "console-inspector-worldbooks-attach",
+                "Attach world book…",
+                enabled=bool(conversation_id),
+                disabled_reason="Start or load a conversation first",
+            ),
+            ConsoleInspectorAction(
+                "console-inspector-worldbooks-detach",
+                "Detach world book…",
+                enabled=has_attached,
+            ),
+        )
+
+    async def _console_worldbook_attach_worker(self) -> None:
+        """Pick and attach a world book to the active Console conversation.
+
+        Mirrors :meth:`_console_dictionary_attach_worker`: every await is
+        individually guarded so no exception escapes the worker boundary --
+        an uncaught worker exception kills the whole app under
+        ``run_worker(exit_on_error=True)``.
+        """
+        try:
+            conversation_id = self._current_console_rail_conversation_id()
+            if not conversation_id:
+                self.app_instance.notify(
+                    "Start or load a conversation first.", severity="warning"
+                )
+                return
+            db = getattr(self.app_instance, "chachanotes_db", None)
+            if db is None:
+                return
+            from ...Character_Chat.world_book_manager import WorldBookManager
+            from ...Widgets.Persona_Widgets.world_book_picker import WorldBookPicker
+
+            def _attachable() -> list[dict]:
+                mgr = WorldBookManager(db)
+                attached_ids = {
+                    b.get("id")
+                    for b in mgr.get_world_books_for_conversation(
+                        str(conversation_id), enabled_only=False
+                    )
+                }
+                return [
+                    {"world_book_id": int(b.get("id")), "name": str(b.get("name"))}
+                    for b in (mgr.list_world_books(include_disabled=False) or [])
+                    if b.get("id") not in attached_ids
+                ]
+
+            try:
+                rows = await asyncio.to_thread(_attachable)
+            except Exception:
+                logger.opt(exception=True).warning(
+                    "Could not load world books for the Console attach picker."
+                )
+                return
+            if not rows:
+                self.app_instance.notify(
+                    "No more world books to attach.", severity="information"
+                )
+                return
+            try:
+                picked = await self.app_instance.push_screen_wait(WorldBookPicker(rows))
+            except Exception:
+                logger.opt(exception=True).warning(
+                    "Could not show the Console world-book picker."
+                )
+                return
+            if not picked:
+                return
+            try:
+                await asyncio.to_thread(
+                    WorldBookManager(db).associate_world_book_with_conversation,
+                    str(conversation_id),
+                    int(picked),
+                )
+            except Exception as exc:
+                logger.opt(exception=True).warning("Could not attach the world book.")
+                self.app_instance.notify(f"Attach failed: {exc}", severity="error")
+                return
+            await self.refresh_active_world_books_summary()
+        finally:
+            self._console_worldbook_dialog_active = False
+
+    async def _console_worldbook_detach_worker(self) -> None:
+        """Pick and detach a world book from the active Console conversation.
+
+        Analogous to :meth:`_console_worldbook_attach_worker`.
+        """
+        try:
+            conversation_id = self._current_console_rail_conversation_id()
+            if not conversation_id:
+                self.app_instance.notify(
+                    "Start or load a conversation first.", severity="warning"
+                )
+                return
+            db = getattr(self.app_instance, "chachanotes_db", None)
+            if db is None:
+                return
+            from ...Character_Chat.world_book_manager import WorldBookManager
+            from ...Widgets.Persona_Widgets.world_book_picker import WorldBookPicker
+
+            def _attached() -> list[dict]:
+                mgr = WorldBookManager(db)
+                return [
+                    {"world_book_id": int(b.get("id")), "name": str(b.get("name"))}
+                    for b in mgr.get_world_books_for_conversation(
+                        str(conversation_id), enabled_only=False
+                    )
+                ]
+
+            try:
+                rows = await asyncio.to_thread(_attached)
+            except Exception:
+                logger.opt(exception=True).warning(
+                    "Could not load world books for the Console detach picker."
+                )
+                return
+            if not rows:
+                self.app_instance.notify(
+                    "No world books attached to this conversation.",
+                    severity="information",
+                )
+                return
+            try:
+                picked = await self.app_instance.push_screen_wait(
+                    WorldBookPicker(rows, title="Detach world book", confirm_label="Detach")
+                )
+            except Exception:
+                logger.opt(exception=True).warning(
+                    "Could not show the Console world-book picker."
+                )
+                return
+            if not picked:
+                return
+            try:
+                await asyncio.to_thread(
+                    WorldBookManager(db).disassociate_world_book_from_conversation,
+                    str(conversation_id),
+                    int(picked),
+                )
+            except Exception as exc:
+                logger.opt(exception=True).warning("Could not detach the world book.")
+                self.app_instance.notify(f"Detach failed: {exc}", severity="error")
+                return
+            await self.refresh_active_world_books_summary()
+        finally:
+            self._console_worldbook_dialog_active = False
 
     async def _console_dictionary_detach_worker(self) -> None:
         """Pick and detach a chat dictionary from the active Console conversation.

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -1639,6 +1639,15 @@ class ChatScreen(BaseAppScreen):
         self._last_console_dictionary_scope_ids: (
             tuple[str | None, int | None] | None
         ) = None
+        # P2g-2: cached "what's in play" world-book summary for the active
+        # native Console session's conversation scope, recomputed only by
+        # `refresh_active_world_books_summary()`. Mirrors the dictionary
+        # cache above -- `_build_console_inspector_state` reads only this
+        # cache, never a DB query on recompose.
+        self._active_world_books_summary: dict | None = None
+        # Sentinel distinct from any real `(conversation_id,)` tuple so the
+        # first scope check always refreshes.
+        self._last_console_world_book_scope_ids: tuple | None = None
         # P1g Task 5: guards the Console dictionary attach/detach picker
         # flow against a double-open (mirrors P1f's `_io_dialog_active`),
         # reset in a `finally` in both attach/detach workers.
@@ -5778,6 +5787,7 @@ class ChatScreen(BaseAppScreen):
             inspector_state,
             dictionary_rows=self._console_dictionary_inspector_rows(),
             dictionary_actions=self._console_dictionary_inspector_actions(),
+            world_book_rows=self._console_world_book_inspector_rows(),
         )
         return inspector_state
 
@@ -5933,6 +5943,74 @@ class ChatScreen(BaseAppScreen):
             )
             if entry.get("shadowed"):
                 value += " (shadowed)"
+            if not entry.get("enabled", True):
+                value += " (disabled)"
+            rows.append(ConsoleDisplayRow(name, value))
+        return tuple(rows)
+
+    def _active_console_world_book_scope_ids(self) -> tuple[str | None]:
+        """(conversation_id,) for the active native Console world-book scope.
+
+        Conversation-only: native Console has no character (see
+        `_active_console_dictionary_scope_ids`).
+        """
+        return (self._current_console_rail_conversation_id(),)
+
+    async def refresh_active_world_books_summary(self) -> None:
+        """The ONLY place that performs the DB-backed world-book summarize.
+
+        `_build_console_inspector_state` reads only the cache set here. The
+        sync summarize is marshalled onto a worker thread via `asyncio.to_thread`
+        so it never blocks the UI loop.
+        """
+        conversation_id = self._current_console_rail_conversation_id()
+        db = getattr(self.app_instance, "chachanotes_db", None)
+        if not conversation_id or db is None:
+            self._active_world_books_summary = {"world_books": []}
+            self._sync_console_control_bar()
+            return
+        try:
+            from ...Character_Chat.world_info_resolver import (
+                summarize_active_world_books,
+            )
+
+            summary = await asyncio.to_thread(
+                summarize_active_world_books, db, conversation_id, None
+            )
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Could not summarize active world books for the Console inspector."
+            )
+            summary = {"world_books": []}
+        self._active_world_books_summary = (
+            summary if isinstance(summary, dict) else {"world_books": []}
+        )
+        self._sync_console_control_bar()
+
+    async def _refresh_active_world_books_summary_if_scope_changed(self) -> None:
+        """Recompute the world-book summary only when the scope changed."""
+        scope_ids = self._active_console_world_book_scope_ids()
+        if scope_ids == self._last_console_world_book_scope_ids:
+            return
+        self._last_console_world_book_scope_ids = scope_ids
+        await self.refresh_active_world_books_summary()
+
+    def _console_world_book_inspector_rows(self) -> tuple[ConsoleDisplayRow, ...]:
+        """Project the cached world-book summary into inspector rows (no DB)."""
+        conversation_id = self._current_console_rail_conversation_id()
+        if conversation_id is None:
+            return (ConsoleDisplayRow("No active chat", ""),)
+        summary = self._active_world_books_summary or {}
+        books = summary.get("world_books") or []
+        if not books:
+            return (ConsoleDisplayRow("No world books in play", ""),)
+        rows = []
+        for entry in books:
+            if not isinstance(entry, dict):
+                continue
+            name = str(entry.get("name") or "Unnamed")
+            count = entry.get("entry_count")
+            value = f"{count} entries" if isinstance(count, int) else "0 entries"
             if not entry.get("enabled", True):
                 value += " (disabled)"
             rows.append(ConsoleDisplayRow(name, value))
@@ -8806,6 +8884,7 @@ class ChatScreen(BaseAppScreen):
             # build already sees the freshly recomputed cache instead of one
             # stale frame behind.
             await self._refresh_active_dictionaries_summary_if_scope_changed()
+            await self._refresh_active_world_books_summary_if_scope_changed()
             # task-280: hand the control bar a pre-await snapshot (its own
             # pre-existing timing). The rail-VISIBILITY call below must NOT
             # reuse this snapshot: `_sync_console_native_session_tabs` can

--- a/tldw_chatbook/Widgets/Console/console_run_inspector.py
+++ b/tldw_chatbook/Widgets/Console/console_run_inspector.py
@@ -228,6 +228,10 @@ class ConsoleRunInspector(Vertical):
             entries.append(
                 (f"console-inspector-dictionaries-row-{index}", row.text, row.status)
             )
+        for index, row in enumerate(getattr(state, "world_book_rows", ()) or ()):
+            entries.append(
+                (f"console-inspector-worldbooks-row-{index}", row.text, row.status)
+            )
         return entries
 
     @classmethod
@@ -261,6 +265,10 @@ class ConsoleRunInspector(Vertical):
             tuple(
                 _action_key(action)
                 for action in getattr(state, "dictionary_actions", ()) or ()
+            ),
+            tuple(
+                _action_key(action)
+                for action in getattr(state, "world_book_actions", ()) or ()
             ),
         )
 
@@ -428,4 +436,22 @@ class ConsoleRunInspector(Vertical):
                     markup=False,
                 )
             for action in dict_actions:
+                yield from self._compose_action(action)
+
+        world_book_rows = getattr(self.state, "world_book_rows", ())
+        world_book_actions = getattr(self.state, "world_book_actions", ())
+        if world_book_rows or world_book_actions:
+            yield Static(
+                "World Books",
+                id="console-inspector-worldbooks-heading",
+                classes="console-inspector-group-heading destination-section",
+            )
+            for index, row in enumerate(world_book_rows):
+                yield Static(
+                    row.text,
+                    id=f"console-inspector-worldbooks-row-{index}",
+                    classes=f"console-inspector-row console-inspector-row-{row.status}",
+                    markup=False,
+                )
+            for action in world_book_actions:
                 yield from self._compose_action(action)


### PR DESCRIPTION
## Roleplay P2g-2 — Console world-book inspector + attach/detach

Second of three P2g cycles. Adds a "World Books" block to the Console run inspector — showing which world books are attached to the current conversation, with **Attach/Detach** actions — mirroring the merged dictionary inspector (P1g). Follows P2g-1 (native-Console world-info send).

### What's in it
- **Summarize resolver** (`world_info_resolver.py`): `summarize_active_world_books` — the *attachment picture* via `get_world_books_for_conversation(enabled_only=False)` (shows disabled-but-attached books, marked), distinct from the send-path enabled-only collector; never raises.
- **Inspector block** (`console_display_state.py` + `console_run_inspector.py`): `world_book_rows`/`world_book_actions` on `ConsoleInspectorState`, rendered as a **trailing custom block** threaded through all three spots (`compose`/`_rendered_row_entries`/`_structural_key`) — no `_ROW_ID_BY_LABEL` change; the dict block is untouched.
- **Screen read wiring** (`chat_screen.py`): a cached `_active_world_books_summary` refreshed by a scope-guarded off-thread `refresh_active_world_books_summary()` (the only DB read) invoked from `_sync_native_console_chat_ui` — the "zero-DB-on-recompose" pattern; the projection/action methods read only the cache.
- **Attach/Detach** (`chat_screen.py`): two `ConsoleInspectorAction`s (gated on a conversation / on ≥1 attached book) + `Button.Pressed` handlers → `console-io` workers reusing `WorldBookPicker` (Attach = unattached books, Detach = attached books) + `associate/disassociate_world_book_with_conversation`, off-thread, guarded, `finally`-reset.

### Constraints honored
- **No schema migration** (v22); **no send-path change** (P2g-1 already applies attached books on native send). Only four production files touched; the dictionary inspector is left untouched (its regression test stays green).
- Conversation-only on native (`char_data=None`). The world-book block is a faithful parity mirror of the dict block.

### Deferred → P2g-3
The legacy `chat_events.py` character-gate bug fix + deleting the confirmed-dead legacy world-book UI.

### Testing
Real-integration throughout: resolver real-DB tests, an inspector widget-render test, and a real-DB Console test (a native session pinned to a conversation → attach persists the junction and the block updates; detach removes it). Full P2g-2 gate **16 passed** + the dict inspector regression **9 passed**; `import tldw_chatbook.app` OK. Subagent-driven (implementer + reviewer per task, opus whole-branch review = READY TO MERGE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “World Books” block to the Console run inspector that lists the conversation’s attached world books and supports Attach/Detach. Mirrors the Chat Dictionaries block; no schema or send-path changes.

- New Features
  - Added summarize_active_world_books to return all attached books (enabled and disabled) with entry counts; never raises.
  - Added world_book_rows/world_book_actions to ConsoleInspectorState and render them as a trailing block via compose, _rendered_row_entries, and _structural_key (no _ROW_ID_BY_LABEL change).
  - Cached _active_world_books_summary with refresh_active_world_books_summary(); rows/actions read only the cache. Scope-guarded refresh runs off-thread and is invoked from _sync_native_console_chat_ui.
  - Attach/Detach reuse WorldBookPicker; attach from unattached, detach from attached via associate_world_book_with_conversation/disassociate_world_book_from_conversation (enabled_only=False for detach). Guarded by _console_worldbook_dialog_active; DB I/O off-thread.
  - Added real-DB tests for summarizing, inspector rendering, and attach/detach; included plan/spec docs. Backlog: task to change WorldBookManager conversation_id type hints from int to str (no runtime change).

<sup>Written for commit f7d9a4f873deec0752c60a7001ba0e2c58de876d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

