### PR TITLE
Internal Prompts P1: registry + web-search & RAG-reranker migration

### DIFF
--- a/Tests/Internal_Prompts/conftest.py
+++ b/Tests/Internal_Prompts/conftest.py
@@ -1,0 +1,36 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _loguru_to_caplog(caplog):
+    import logging
+    from loguru import logger as loguru_logger
+
+    class PropagateHandler(logging.Handler):
+        def emit(self, record):
+            logging.getLogger(record.name).handle(record)
+
+    handler_id = loguru_logger.add(PropagateHandler(), format="{message}")
+    yield
+    loguru_logger.remove(handler_id)
+
+
+@pytest.fixture
+def scratch_config(tmp_path, monkeypatch):
+    """Point the app at a throwaway config file. Yields write(toml_text)."""
+    from tldw_chatbook import config
+    from tldw_chatbook.Internal_Prompts import resolver
+
+    config_file = tmp_path / "config.toml"
+
+    def write(toml_text: str) -> None:
+        config_file.write_text(toml_text, encoding="utf-8")
+        monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_file))
+        config.load_settings(force_reload=True)
+
+    resolver._warned_ids.clear()
+    write("")
+    yield write
+    monkeypatch.delenv("TLDW_CONFIG_PATH", raising=False)
+    resolver._warned_ids.clear()
+    config.load_settings(force_reload=True)

--- a/Tests/Internal_Prompts/conftest.py
+++ b/Tests/Internal_Prompts/conftest.py
@@ -32,6 +32,4 @@ def scratch_config(tmp_path, monkeypatch):
     resolver._warned_ids.clear()
     write("")
     yield write
-    monkeypatch.delenv("TLDW_CONFIG_PATH", raising=False)
     resolver._warned_ids.clear()
-    config.load_settings(force_reload=True)

--- a/Tests/Internal_Prompts/conftest.py
+++ b/Tests/Internal_Prompts/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 
 
+# Automatically applies to every test module in Tests/Internal_Prompts/ so caplog captures loguru output.
 @pytest.fixture(autouse=True)
 def _loguru_to_caplog(caplog):
     import logging

--- a/Tests/Internal_Prompts/test_catalog.py
+++ b/Tests/Internal_Prompts/test_catalog.py
@@ -1,0 +1,55 @@
+import pytest
+
+from tldw_chatbook.Internal_Prompts.catalog import CATALOG, PromptSpec, register
+
+
+def _spec(**overrides):
+    base = dict(
+        id="demo.example",
+        subsystem="demo",
+        title="Example",
+        description="An example prompt.",
+        used_in="tests",
+        default="Hello {name}",
+        required_placeholders=("name",),
+    )
+    base.update(overrides)
+    return PromptSpec(**base)
+
+
+def test_register_adds_to_catalog():
+    spec = _spec()
+    try:
+        assert register(spec) is spec
+        assert CATALOG["demo.example"] is spec
+    finally:
+        CATALOG.pop("demo.example", None)
+
+
+def test_register_rejects_duplicate_id():
+    spec = _spec()
+    try:
+        register(spec)
+        with pytest.raises(ValueError, match="Duplicate"):
+            register(_spec())
+    finally:
+        CATALOG.pop("demo.example", None)
+
+
+def test_register_rejects_id_subsystem_mismatch():
+    with pytest.raises(ValueError, match="subsystem"):
+        register(_spec(id="other.example"))
+
+
+def test_spec_is_frozen():
+    spec = _spec()
+    with pytest.raises(Exception):
+        spec.default = "changed"
+
+
+def test_spec_defaults():
+    spec = _spec()
+    assert spec.optional_placeholders == ()
+    assert spec.contract_note is None
+    assert spec.legacy_config_path is None
+    assert spec.applies == "live"

--- a/Tests/Internal_Prompts/test_import_hygiene.py
+++ b/Tests/Internal_Prompts/test_import_hygiene.py
@@ -1,0 +1,24 @@
+# Tests/Internal_Prompts/test_import_hygiene.py
+"""The Internal_Prompts package must stay off the config import chain.
+
+P2 adds more prompt modules to this package; a careless top-level config
+import would silently drag config.py into cold start. Runs in a subprocess
+because in-process sys.modules is polluted by other tests' imports.
+"""
+
+import subprocess
+import sys
+
+
+def test_package_import_does_not_import_config():
+    code = (
+        "import sys; import tldw_chatbook.Internal_Prompts; "
+        "sys.exit(1 if 'tldw_chatbook.config' in sys.modules else 0)"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True
+    )
+    assert result.returncode == 0, (
+        "tldw_chatbook.Internal_Prompts imported tldw_chatbook.config at "
+        f"module import time. stderr: {result.stderr}"
+    )

--- a/Tests/Internal_Prompts/test_reranker_prompt_parity.py
+++ b/Tests/Internal_Prompts/test_reranker_prompt_parity.py
@@ -1,0 +1,118 @@
+# Tests/Internal_Prompts/test_reranker_prompt_parity.py
+"""Old .format() rendering vs new safe_substitute rendering must be
+byte-identical. The double-braced templates below are verbatim copies of the
+pre-migration reranker.py literals."""
+
+from tldw_chatbook.Internal_Prompts import CATALOG, safe_substitute
+
+ORIGINAL_POINTWISE_TEMPLATE = """Query: {query}
+
+Search Result:
+Title: {title}
+Content: {content}
+
+How relevant is this search result to the query? Consider:
+1. Direct answer to the query
+2. Topical relevance
+3. Information quality
+4. Completeness
+
+Return JSON: {{"score": 0.0-1.0{reasoning}}}"""
+
+ORIGINAL_PAIRWISE_TEMPLATE = """Query: {query}
+
+Result 1:
+Title: {title1}
+Content: {content1}
+
+Result 2:
+Title: {title2}
+Content: {content2}
+
+Which result better answers the query? Consider relevance, accuracy, and completeness.
+
+Return JSON: {{"choice": 1 or 2{reasoning}}}"""
+
+ORIGINAL_LISTWISE_TEMPLATE = """Query: {query}
+
+Search Results:
+{results_list}
+
+Reorder these results by relevance to the query (most relevant first).
+Return the indices in order.
+
+Return JSON: {{"ranking": [indices in order]{reasoning}}}"""
+
+
+def test_pointwise_template_parity():
+    # content deliberately contains a brace sequence ("{with braces}"). Both
+    # old .format() and new safe_substitute() are single-pass over the
+    # template string only — neither re-parses braces that arrive inside a
+    # substituted value — so this does not raise and both must render it
+    # through unchanged and identically.
+    values = dict(
+        query="what is rust",
+        title="Rust book",
+        content="Rust is a systems language {with braces}",
+        reasoning=', "reasoning": "explanation"',
+    )
+    assert safe_substitute(
+        CATALOG["rag_reranker.pointwise_template"].default, **values
+    ) == ORIGINAL_POINTWISE_TEMPLATE.format(**values)
+
+
+def test_pointwise_template_parity_without_reasoning():
+    values = dict(query="q", title="t", content="c", reasoning="")
+    assert safe_substitute(
+        CATALOG["rag_reranker.pointwise_template"].default, **values
+    ) == ORIGINAL_POINTWISE_TEMPLATE.format(**values)
+
+
+def test_pairwise_template_parity():
+    values = dict(
+        query="best db",
+        title1="Postgres",
+        content1="c1",
+        title2="SQLite",
+        content2="c2",
+        reasoning="",
+    )
+    assert safe_substitute(
+        CATALOG["rag_reranker.pairwise_template"].default, **values
+    ) == ORIGINAL_PAIRWISE_TEMPLATE.format(**values)
+
+
+def test_listwise_template_parity():
+    values = dict(
+        query="q",
+        results_list="0. Title: A\n   Content: a...",
+        reasoning=', "reasoning": "explanation"',
+    )
+    assert safe_substitute(
+        CATALOG["rag_reranker.listwise_template"].default, **values
+    ) == ORIGINAL_LISTWISE_TEMPLATE.format(**values)
+
+
+def test_substitute_tolerates_braces_in_values():
+    # safe_substitute is single-pass over the declared {name} tokens only
+    # (see test_pointwise_template_parity), so arbitrary braces inside a
+    # substituted value pass through untouched — this is the whole point of
+    # the new resolver, and worth pinning down directly rather than only via
+    # the parity comparison above.
+    out = safe_substitute(
+        CATALOG["rag_reranker.pointwise_template"].default,
+        query="q",
+        title="t",
+        content="has {curly} text",
+        reasoning="",
+    )
+    assert "has {curly} text" in out
+
+
+def test_system_prompts_match_source():
+    # System prompts are verbatim moves; spot-check load-bearing lines.
+    assert CATALOG["rag_reranker.pointwise_system"].default.startswith(
+        "You are a search result relevance evaluator."
+    )
+    assert "'choice' (1 or 2)" in CATALOG["rag_reranker.pairwise_system"].default
+    assert "'ranking' as an array" in CATALOG["rag_reranker.listwise_system"].default

--- a/Tests/Internal_Prompts/test_resolver.py
+++ b/Tests/Internal_Prompts/test_resolver.py
@@ -42,6 +42,13 @@ def test_substitute_never_raises_on_stray_braces():
     assert safe_substitute("{unclosed {weird}} {q}", q="ok") == "{unclosed {weird}} ok"
 
 
+def test_substitute_value_containing_token_not_reexpanded():
+    # Single-pass: a value that looks like another token must survive as-is,
+    # regardless of kwarg order.
+    assert safe_substitute("{a} {b}", b="{a}", a="X") == "X {a}"
+    assert safe_substitute("{a} {b}", a="X", b="{a}") == "X {a}"
+
+
 # --- precedence ------------------------------------------------------------
 
 def test_default_when_no_config(demo_spec, scratch_config):

--- a/Tests/Internal_Prompts/test_resolver.py
+++ b/Tests/Internal_Prompts/test_resolver.py
@@ -1,0 +1,122 @@
+import pytest
+
+from tldw_chatbook.Internal_Prompts.catalog import CATALOG, PromptSpec, register
+from tldw_chatbook.Internal_Prompts.resolver import (
+    get_internal_prompt,
+    render_internal_prompt,
+    safe_substitute,
+)
+
+
+@pytest.fixture
+def demo_spec():
+    spec = register(
+        PromptSpec(
+            id="demo.greeting",
+            subsystem="demo",
+            title="Greeting",
+            description="Test prompt.",
+            used_in="tests",
+            default="Hello {name}, JSON stays: {\"k\": 1}",
+            required_placeholders=("name",),
+            legacy_config_path="Prompts.demo_legacy",
+        )
+    )
+    yield spec
+    CATALOG.pop("demo.greeting", None)
+
+
+# --- safe_substitute -------------------------------------------------------
+
+def test_substitute_replaces_declared_tokens_only():
+    out = safe_substitute("A {x} B {y} C {z}", x=1, y="two")
+    assert out == "A 1 B two C {z}"
+
+
+def test_substitute_leaves_json_and_ollama_braces_alone():
+    text = 'Return {"score": 0.5} and {{ .Prompt }} end {q}'
+    assert safe_substitute(text, q="Q") == 'Return {"score": 0.5} and {{ .Prompt }} end Q'
+
+
+def test_substitute_never_raises_on_stray_braces():
+    assert safe_substitute("{unclosed {weird}} {q}", q="ok") == "{unclosed {weird}} ok"
+
+
+# --- precedence ------------------------------------------------------------
+
+def test_default_when_no_config(demo_spec, scratch_config):
+    assert get_internal_prompt("demo.greeting") == demo_spec.default
+
+
+def test_override_table_wins(demo_spec, scratch_config):
+    scratch_config(
+        '[internal_prompts.demo.greeting]\ntext = "Hi {name}!"\nbaseline = "abc"\n'
+    )
+    assert get_internal_prompt("demo.greeting") == "Hi {name}!"
+
+
+def test_override_plain_string_accepted(demo_spec, scratch_config):
+    scratch_config('[internal_prompts.demo]\ngreeting = "Yo {name}"\n')
+    assert get_internal_prompt("demo.greeting") == "Yo {name}"
+
+
+def test_empty_override_means_no_override(demo_spec, scratch_config):
+    scratch_config('[internal_prompts.demo]\ngreeting = ""\n')
+    assert get_internal_prompt("demo.greeting") == demo_spec.default
+
+
+def test_invalid_override_falls_back_to_default(demo_spec, scratch_config):
+    scratch_config('[internal_prompts.demo]\ngreeting = "no placeholder here"\n')
+    assert get_internal_prompt("demo.greeting") == demo_spec.default
+
+
+def test_override_beats_legacy(demo_spec, scratch_config):
+    scratch_config(
+        '[internal_prompts.demo]\ngreeting = "Override {name}"\n'
+        '[Prompts]\ndemo_legacy = "Legacy {name}"\n'
+    )
+    assert get_internal_prompt("demo.greeting") == "Override {name}"
+
+
+# --- legacy tier -----------------------------------------------------------
+
+def test_customized_legacy_honored(demo_spec, scratch_config):
+    scratch_config('[Prompts]\ndemo_legacy = "Legacy {name}"\n')
+    assert get_internal_prompt("demo.greeting") == "Legacy {name}"
+
+
+def test_legacy_equal_to_shipped_stub_ignored(demo_spec, scratch_config, monkeypatch):
+    from tldw_chatbook import config as config_mod
+
+    monkeypatch.setitem(
+        config_mod.DEFAULT_CONFIG_FROM_TOML.setdefault("Prompts", {}),
+        "demo_legacy",
+        "the shipped stub {name}",
+    )
+    scratch_config('[Prompts]\ndemo_legacy = "the shipped stub {name}"\n')
+    assert get_internal_prompt("demo.greeting") == demo_spec.default
+
+
+def test_invalid_legacy_falls_back(demo_spec, scratch_config):
+    scratch_config('[Prompts]\ndemo_legacy = "customized but tokenless"\n')
+    assert get_internal_prompt("demo.greeting") == demo_spec.default
+
+
+# --- misc ------------------------------------------------------------------
+
+def test_unknown_id_raises_keyerror(scratch_config):
+    with pytest.raises(KeyError):
+        get_internal_prompt("nope.nothing")
+
+
+def test_render(demo_spec, scratch_config):
+    out = render_internal_prompt("demo.greeting", name="Ada")
+    assert out == 'Hello Ada, JSON stays: {"k": 1}'
+
+
+def test_warn_once(demo_spec, scratch_config, caplog):
+    scratch_config('[internal_prompts.demo]\ngreeting = "tokenless"\n')
+    get_internal_prompt("demo.greeting")
+    get_internal_prompt("demo.greeting")
+    warnings = [r for r in caplog.records if "demo.greeting" in r.getMessage()]
+    assert len(warnings) == 1

--- a/Tests/Internal_Prompts/test_resolver.py
+++ b/Tests/Internal_Prompts/test_resolver.py
@@ -49,6 +49,17 @@ def test_substitute_value_containing_token_not_reexpanded():
     assert safe_substitute("{a} {b}", a="X", b="{a}") == "X {a}"
 
 
+def test_substitute_handles_overlapping_key_names():
+    # A full token includes its closing brace, so a name that is a prefix of
+    # another name cannot corrupt it, regardless of kwarg order.
+    assert safe_substitute("{a} {ab}", a="X", ab="Y") == "X Y"
+    assert safe_substitute("{ab} {a}", ab="Y", a="X") == "Y X"
+    assert (
+        safe_substitute("{query} vs {query_list}", query="Q", query_list="QL")
+        == "Q vs QL"
+    )
+
+
 # --- precedence ------------------------------------------------------------
 
 def test_default_when_no_config(demo_spec, scratch_config):
@@ -95,8 +106,11 @@ def test_customized_legacy_honored(demo_spec, scratch_config):
 def test_legacy_equal_to_shipped_stub_ignored(demo_spec, scratch_config, monkeypatch):
     from tldw_chatbook import config as config_mod
 
+    # Direct indexing on purpose: [Prompts] always exists in shipped defaults;
+    # if that ever changes this fails loud (KeyError) instead of setdefault
+    # silently leaking an empty section past monkeypatch's undo.
     monkeypatch.setitem(
-        config_mod.DEFAULT_CONFIG_FROM_TOML.setdefault("Prompts", {}),
+        config_mod.DEFAULT_CONFIG_FROM_TOML["Prompts"],
         "demo_legacy",
         "the shipped stub {name}",
     )
@@ -126,4 +140,21 @@ def test_warn_once(demo_spec, scratch_config, caplog):
     get_internal_prompt("demo.greeting")
     get_internal_prompt("demo.greeting")
     warnings = [r for r in caplog.records if "demo.greeting" in r.getMessage()]
+    assert len(warnings) == 1
+
+
+def test_render_missing_required_value_warns_once_never_raises(
+    demo_spec, scratch_config, caplog
+):
+    # Caller forgot name= entirely: token survives in output (never raises),
+    # and a once-per-prompt warning fires so the bug is visible in logs.
+    out = render_internal_prompt("demo.greeting")
+    assert "{name}" in out
+    render_internal_prompt("demo.greeting")
+    warnings = [
+        r
+        for r in caplog.records
+        if "without required placeholder value" in r.getMessage()
+        and "demo.greeting" in r.getMessage()
+    ]
     assert len(warnings) == 1

--- a/Tests/Internal_Prompts/test_websearch_prompt_parity.py
+++ b/Tests/Internal_Prompts/test_websearch_prompt_parity.py
@@ -1,0 +1,187 @@
+"""Golden parity: registry defaults render byte-identical text to the
+original WebSearch_APIs.py literals. The f-strings below are verbatim copies
+of the pre-migration source."""
+
+from tldw_chatbook.Internal_Prompts import render_internal_prompt
+
+
+def test_sub_question_generation_parity():
+    original_query = "How does climate change affect biodiversity?"
+    expected = f"""
+            You are an AI assistant that helps generate search queries. Given an original query, suggest alternative search queries that could help find relevant information. Your goal is to generate queries that are diverse, specific, and highly relevant to the original query, ensuring comprehensive coverage of the topic.
+
+            Important instructions:
+            1. Generate between 2 and 6 queries unless a fixed count is specified. Generate more queries for complex or multifaceted topics and fewer for simple or straightforward ones.
+            2. Ensure the queries are diverse, covering different aspects or perspectives of the original query, while remaining highly relevant to its core intent.
+            3. Prefer specific queries over general ones, as they are more likely to yield targeted and useful results.
+            4. If the query involves comparing two topics, generate separate queries for each topic.
+            5. If previous queries and an answer are provided, generate new queries that address the shortcomings of the previous answer and avoid repeating the previous queries.
+            6. If the original query is broad or ambiguous, generate queries that explore specific subtopics or clarify the intent.
+            7. If the query is too specific or unclear, generate queries that explore related or broader topics to ensure useful results.
+            8. Return the queries as a JSON array in the format ["query_1", "query_2", ...].
+
+            Examples:
+            1. For the query "What are the benefits of exercise?", generate queries like:
+               ["health benefits of physical activity", "mental health benefits of exercise", "long-term effects of regular exercise", "how exercise improves cardiovascular health", "role of exercise in weight management"]
+
+            2. For the query "Compare Python and JavaScript", generate queries like:
+               ["key features of Python programming language", "advantages of JavaScript for web development", "use cases for Python vs JavaScript", "performance comparison of Python and JavaScript", "ease of learning Python vs JavaScript"]
+
+            3. For the query "How does climate change affect biodiversity?", generate queries like:
+               ["impact of climate change on species extinction", "effects of global warming on ecosystems", "role of climate change in habitat loss", "how rising temperatures affect marine biodiversity", "climate change and its impact on migratory patterns"]
+
+            4. For the query "Best practices for remote work", generate queries like:
+               ["tips for staying productive while working from home", "how to maintain work-life balance in remote work", "tools for effective remote team collaboration", "managing communication in remote teams", "ergonomic setup for home offices"]
+
+            5. For the query "What is quantum computing?", generate queries like:
+               ["basic principles of quantum computing", "applications of quantum computing in real-world problems", "difference between classical and quantum computing", "key challenges in developing quantum computers", "future prospects of quantum computing"]
+
+            Original query: {original_query}
+            """
+    assert render_internal_prompt(
+        "websearch.sub_question_generation", original_query=original_query
+    ) == expected
+
+
+def test_result_relevance_eval_parity():
+    original_question = "What is quantum computing?"
+    sub_questions = ["basics of quantum computing", "qubits explained"]
+    content = 'Snippet with {braces} and "quotes" to prove safety.'
+    expected = f"""
+                Given the following search results for the user's question: "{original_question}" and the generated sub-questions: {sub_questions}, evaluate the relevance of the search result to the user's question.
+                Explain your reasoning for selection.
+
+                Search Results:
+                {content}
+
+                Instructions:
+                1. You MUST only answer TRUE or False while providing your reasoning for your answer.
+                2. A result is relevant if the result most likely contains comprehensive and relevant information to answer the user's question.
+                3. Provide a brief reason for selection.
+
+                You MUST respond using EXACTLY this format and nothing else:
+
+                Selected Answer: [True or False]
+                Reasoning: [Your reasoning for the selections]
+                """
+    assert render_internal_prompt(
+        "websearch.result_relevance_eval",
+        original_question=original_question,
+        sub_questions=sub_questions,
+        content=content,
+    ) == expected
+
+
+def test_result_summarization_parity():
+    question = "What is quantum computing?"
+    content = "Long scraped text with a stray { brace."
+    original_template = """
+    Summarize the following text in a concise way that captures the key information relevant to this question: "{question}"
+    
+    Text to summarize:
+    {content}
+    
+    Instructions:
+    1. Focus on information relevant to the question
+    2. Keep the summary under 2000 characters
+    3. Maintain factual accuracy
+    4. Include key details and statistics if present
+    """
+    expected = original_template.format(question=question, content=content)
+    assert render_internal_prompt(
+        "websearch.result_summarization", question=question, content=content
+    ) == expected
+
+
+def test_answer_synthesis_parity():
+    concatenated_texts = "1. Source one summary\n2. Source two summary"
+    current_date = "2026-07-21"
+    question = "Compare Python and JavaScript"
+    expected = rf"""INITIAL_QUERY: Here are some sources {concatenated_texts}. Read these carefully, as you will be asked a Query about them.
+        # General Instructions
+        
+        Write an accurate, detailed, and comprehensive response to the user's query located at INITIAL_QUERY. Additional context is provided as "USER_INPUT" after specific questions. Your answer should be informed by the provided "Search results". Your answer must be precise, of high-quality, and written by an expert using an unbiased and journalistic tone. Your answer must be written in the same language as the query, even if language preference is different.
+        
+        You MUST cite the most relevant search results that answer the query. Do not mention any irrelevant results. You MUST ADHERE to the following instructions for citing search results:
+        - to cite a search result, enclose its index located above the summary with brackets at the end of the corresponding sentence, for example "Ice is less dense than water[1][2]." or "Paris is the capital of France[1][4][5]."
+        - NO SPACE between the last word and the citation, and ALWAYS use brackets. Only use this format to cite search results. NEVER include a References section at the end of your answer.
+        - If you don't know the answer or the premise is incorrect, explain why.
+        If the search results are empty or unhelpful, answer the query as well as you can with existing knowledge.
+        
+        You MUST NEVER use moralization or hedging language. AVOID using the following phrases:
+        - "It is important to ..."
+        - "It is inappropriate ..."
+        - "It is subjective ..."
+        
+        You MUST ADHERE to the following formatting instructions:
+        - Use markdown to format paragraphs, lists, tables, and quotes whenever possible.
+        - Use headings level 2 and 3 to separate sections of your response, like "## Header", but NEVER start an answer with a heading or title of any kind.
+        - Use single new lines for lists and double new lines for paragraphs.
+        - Use markdown to render images given in the search results.
+        - NEVER write URLs or links.
+        
+        # Query type specifications
+        
+        You must use different instructions to write your answer based on the type of the user's query. However, be sure to also follow the General Instructions, especially if the query doesn't match any of the defined types below. Here are the supported types.
+        
+        ## Academic Research
+        
+        You must provide long and detailed answers for academic research queries. Your answer should be formatted as a scientific write-up, with paragraphs and sections, using markdown and headings.
+        
+        ## Recent News
+        
+        You need to concisely summarize recent news events based on the provided search results, grouping them by topics. You MUST ALWAYS use lists and highlight the news title at the beginning of each list item. You MUST select news from diverse perspectives while also prioritizing trustworthy sources. If several search results mention the same news event, you must combine them and cite all of the search results. Prioritize more recent events, ensuring to compare timestamps. You MUST NEVER start your answer with a heading of any kind.
+        
+        ## Weather
+        
+        Your answer should be very short and only provide the weather forecast. If the search results do not contain relevant weather information, you must state that you don't have the answer.
+        
+        ## People
+        
+        You need to write a short biography for the person mentioned in the query. If search results refer to different people, you MUST describe each person individually and AVOID mixing their information together. NEVER start your answer with the person's name as a header.
+        
+        ## Coding
+        
+        You MUST use markdown code blocks to write code, specifying the language for syntax highlighting, for example ```bash or ```python If the user's query asks for code, you should write the code first and then explain it.
+        
+        ## Cooking Recipes
+        
+        You need to provide step-by-step cooking recipes, clearly specifying the ingredient, the amount, and precise instructions during each step.
+        
+        ## Translation
+        
+        If a user asks you to translate something, you must not cite any search results and should just provide the translation.
+        
+        ## Creative Writing
+        
+        If the query requires creative writing, you DO NOT need to use or cite search results, and you may ignore General Instructions pertaining only to search. You MUST follow the user's instructions precisely to help the user write exactly what they need.
+        
+        ## Science and Math
+        
+        If the user query is about some simple calculation, only answer with the final result. Follow these rules for writing formulas:
+        - Always use \( and\) for inline formulas and\[ and\] for blocks, for example\(x^4 = x - 3 \)
+        - To cite a formula add citations to the end, for example\[ \sin(x) \] [1][2] or \(x^2-2\) [4].
+        - Never use $ or $$ to render LaTeX, even if it is present in the user query.
+        - Never use unicode to render math expressions, ALWAYS use LaTeX.
+        - Never use the \label instruction for LaTeX.
+        
+        ## URL Lookup
+        
+        When the user's query includes a URL, you must rely solely on information from the corresponding search result. DO NOT cite other search results, ALWAYS cite the first result, e.g. you need to end with [1]. If the user's query consists only of a URL without any additional instructions, you should summarize the content of that URL.
+        
+        ## Shopping
+        
+        If the user query is about shopping for a product, you MUST follow these rules:
+        - Organize the products into distinct sectors. For example, you could group shoes by style (boots, sneakers, etc.)
+        - Cite at most 9 search results using the format provided in General Instructions to avoid overwhelming the user with too many options.
+        
+        The current date is: {current_date}
+
+        The user's query is: {question}
+        """
+    assert render_internal_prompt(
+        "websearch.answer_synthesis",
+        concatenated_texts=concatenated_texts,
+        current_date=current_date,
+        question=question,
+    ) == expected

--- a/Tests/RAG/conftest.py
+++ b/Tests/RAG/conftest.py
@@ -1,0 +1,12 @@
+# Re-export the canonical scratch_config fixture from Tests/Internal_Prompts.conftest.
+#
+# We use a plain import (not pytest_plugins) because declaring pytest_plugins =
+# ["Tests.Internal_Prompts.conftest"] — either in the test module or here —
+# collides with pytest's implicit auto-load of Tests/Internal_Prompts/conftest.py
+# under --import-mode=importlib when both test directories are collected in the
+# same session: "ValueError: Plugin already registered under a different name".
+# See Tests/Web_Scraping/test_websearch_internal_prompts.py.
+#
+# pytest discovers fixtures present in a conftest's namespace, so a plain import
+# sidesteps this collision and gives us exactly ONE canonical definition.
+from Tests.Internal_Prompts.conftest import scratch_config  # noqa: F401

--- a/Tests/RAG/test_reranker_internal_prompts.py
+++ b/Tests/RAG/test_reranker_internal_prompts.py
@@ -1,0 +1,62 @@
+# Tests/RAG/test_reranker_internal_prompts.py
+"""Registry overrides must reach the reranker's LLM boundary; caller-supplied
+config must still win. Fake lives ONLY at _call_llm.
+
+The `scratch_config` fixture comes from Tests/RAG/conftest.py, which
+re-exports the canonical definition in Tests/Internal_Prompts/conftest.py
+(plain import, not `pytest_plugins` — see the comment in Tests/RAG/conftest.py
+and Tests/Web_Scraping/conftest.py for why)."""
+
+import pytest
+
+from tldw_chatbook.RAG_Search.reranker import PointwiseReranker, RerankingConfig
+from tldw_chatbook.RAG_Search.simplified.vector_store import SearchResult
+
+
+def _result(i):
+    return SearchResult(
+        id=str(i), document=f"doc {i}", metadata={"doc_title": f"t{i}"}, score=0.5
+    )
+
+
+@pytest.mark.asyncio
+async def test_override_reaches_llm_boundary(scratch_config, monkeypatch):
+    scratch_config(
+        "[internal_prompts.rag_reranker]\n"
+        'pointwise_template = "RATE {query} | {title} | {content} | end{reasoning}"\n'
+        'pointwise_system = "CUSTOM SYSTEM"\n'
+    )
+    reranker = PointwiseReranker(RerankingConfig())
+    assert reranker.config.system_prompt == "CUSTOM SYSTEM"
+
+    captured = []
+
+    async def fake_call_llm(prompt, system_prompt=None):
+        captured.append(prompt)
+        return '{"score": 0.9}'
+
+    monkeypatch.setattr(reranker, "_call_llm", fake_call_llm)
+    await reranker.rerank("my query", [_result(0), _result(1)])
+
+    assert captured, "reranker never called the LLM"
+    assert captured[0].startswith("RATE my query | t0 | doc 0 | end")
+
+
+@pytest.mark.asyncio
+async def test_caller_supplied_config_beats_registry(scratch_config, monkeypatch):
+    scratch_config(
+        '[internal_prompts.rag_reranker]\npointwise_system = "REGISTRY SYSTEM"\n'
+    )
+    config = RerankingConfig(system_prompt="CALLER SYSTEM")
+    reranker = PointwiseReranker(config)
+    assert reranker.config.system_prompt == "CALLER SYSTEM"
+
+
+def test_default_when_no_config(scratch_config):
+    reranker = PointwiseReranker(RerankingConfig())
+    assert reranker.config.system_prompt.startswith(
+        "You are a search result relevance evaluator."
+    )
+    assert 'Return JSON: {"score": 0.0-1.0{reasoning}}' in (
+        reranker.config.scoring_prompt_template
+    )

--- a/Tests/Web_Scraping/conftest.py
+++ b/Tests/Web_Scraping/conftest.py
@@ -1,29 +1,12 @@
-import pytest
-
-
-# Copied from Tests/Internal_Prompts/conftest.py (not imported via
-# pytest_plugins) because declaring pytest_plugins = ["Tests.Internal_Prompts.
-# conftest"] — either in the test module or here — collides with pytest's
-# implicit auto-load of Tests/Internal_Prompts/conftest.py under
-# --import-mode=importlib when both test directories are collected in the
-# same session: "ValueError: Plugin already registered under a different
-# name". See Tests/Web_Scraping/test_websearch_internal_prompts.py.
-@pytest.fixture
-def scratch_config(tmp_path, monkeypatch):
-    """Point the app at a throwaway config file. Yields write(toml_text)."""
-    from tldw_chatbook import config
-    from tldw_chatbook.Internal_Prompts import resolver
-
-    config_file = tmp_path / "config.toml"
-
-    def write(toml_text: str) -> None:
-        config_file.write_text(toml_text, encoding="utf-8")
-        monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_file))
-        config.load_settings(force_reload=True)
-
-    resolver._warned_ids.clear()
-    write("")
-    yield write
-    monkeypatch.delenv("TLDW_CONFIG_PATH", raising=False)
-    resolver._warned_ids.clear()
-    config.load_settings(force_reload=True)
+# Re-export the canonical scratch_config fixture from Tests/Internal_Prompts.conftest.
+#
+# We use a plain import (not pytest_plugins) because declaring pytest_plugins =
+# ["Tests.Internal_Prompts.conftest"] — either in the test module or here —
+# collides with pytest's implicit auto-load of Tests/Internal_Prompts/conftest.py
+# under --import-mode=importlib when both test directories are collected in the
+# same session: "ValueError: Plugin already registered under a different name".
+# See Tests/Web_Scraping/test_websearch_internal_prompts.py.
+#
+# pytest discovers fixtures present in a conftest's namespace, so a plain import
+# sidesteps this collision and gives us exactly ONE canonical definition.
+from Tests.Internal_Prompts.conftest import scratch_config  # noqa: F401

--- a/Tests/Web_Scraping/conftest.py
+++ b/Tests/Web_Scraping/conftest.py
@@ -1,0 +1,29 @@
+import pytest
+
+
+# Copied from Tests/Internal_Prompts/conftest.py (not imported via
+# pytest_plugins) because declaring pytest_plugins = ["Tests.Internal_Prompts.
+# conftest"] — either in the test module or here — collides with pytest's
+# implicit auto-load of Tests/Internal_Prompts/conftest.py under
+# --import-mode=importlib when both test directories are collected in the
+# same session: "ValueError: Plugin already registered under a different
+# name". See Tests/Web_Scraping/test_websearch_internal_prompts.py.
+@pytest.fixture
+def scratch_config(tmp_path, monkeypatch):
+    """Point the app at a throwaway config file. Yields write(toml_text)."""
+    from tldw_chatbook import config
+    from tldw_chatbook.Internal_Prompts import resolver
+
+    config_file = tmp_path / "config.toml"
+
+    def write(toml_text: str) -> None:
+        config_file.write_text(toml_text, encoding="utf-8")
+        monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_file))
+        config.load_settings(force_reload=True)
+
+    resolver._warned_ids.clear()
+    write("")
+    yield write
+    monkeypatch.delenv("TLDW_CONFIG_PATH", raising=False)
+    resolver._warned_ids.clear()
+    config.load_settings(force_reload=True)

--- a/Tests/Web_Scraping/test_websearch_internal_prompts.py
+++ b/Tests/Web_Scraping/test_websearch_internal_prompts.py
@@ -2,10 +2,10 @@
 """Overrides in config.toml must change the text handed to the LLM transport.
 Fakes live ONLY at chat_api_call — the pipeline code runs real.
 
-The `scratch_config` fixture is defined in Tests/Web_Scraping/conftest.py (a
-copy of the one in Tests/Internal_Prompts/conftest.py) rather than pulled in
-via `pytest_plugins`, because declaring `pytest_plugins =
-["Tests.Internal_Prompts.conftest"]` — in this test module or in a
+The `scratch_config` fixture comes from Tests/Web_Scraping/conftest.py, which
+re-exports the canonical definition in Tests/Internal_Prompts/conftest.py
+(plain import, not `pytest_plugins`), because declaring `pytest_plugins =
+["Tests.Internal_Prompts.conftest"]` — in this test module or in
 Tests/Web_Scraping/conftest.py — collides with pytest's implicit auto-load
 of Tests/Internal_Prompts/conftest.py under --import-mode=importlib when
 both test directories are collected in the same session (ValueError: Plugin

--- a/Tests/Web_Scraping/test_websearch_internal_prompts.py
+++ b/Tests/Web_Scraping/test_websearch_internal_prompts.py
@@ -1,0 +1,53 @@
+# Tests/Web_Scraping/test_websearch_internal_prompts.py
+"""Overrides in config.toml must change the text handed to the LLM transport.
+Fakes live ONLY at chat_api_call — the pipeline code runs real.
+
+The `scratch_config` fixture is defined in Tests/Web_Scraping/conftest.py (a
+copy of the one in Tests/Internal_Prompts/conftest.py) rather than pulled in
+via `pytest_plugins`, because declaring `pytest_plugins =
+["Tests.Internal_Prompts.conftest"]` — in this test module or in a
+Tests/Web_Scraping/conftest.py — collides with pytest's implicit auto-load
+of Tests/Internal_Prompts/conftest.py under --import-mode=importlib when
+both test directories are collected in the same session (ValueError: Plugin
+already registered under a different name)."""
+
+
+def test_sub_question_prompt_override_reaches_transport(scratch_config, monkeypatch):
+    from tldw_chatbook.Web_Scraping import WebSearch_APIs
+
+    scratch_config(
+        "[internal_prompts.websearch]\n"
+        'sub_question_generation = "CUSTOM SUBQ PROMPT for: {original_query}"\n'
+    )
+
+    captured = {}
+
+    def fake_chat_api_call(*args, **kwargs):
+        captured["payload"] = kwargs.get("messages_payload") or args[1]
+        return '{"sub_questions": ["a", "b"]}'
+
+    monkeypatch.setattr(WebSearch_APIs, "chat_api_call", fake_chat_api_call)
+
+    result = WebSearch_APIs.analyze_question("what is love", api_endpoint="openai")
+
+    content = captured["payload"][0]["content"]
+    assert "CUSTOM SUBQ PROMPT for: what is love" in content
+    assert result["sub_questions"] == ["a", "b"]
+
+
+def test_default_used_when_no_override(scratch_config, monkeypatch):
+    from tldw_chatbook.Web_Scraping import WebSearch_APIs
+
+    captured = {}
+
+    def fake_chat_api_call(*args, **kwargs):
+        captured["payload"] = kwargs.get("messages_payload") or args[1]
+        return '{"sub_questions": ["a"]}'
+
+    monkeypatch.setattr(WebSearch_APIs, "chat_api_call", fake_chat_api_call)
+
+    WebSearch_APIs.analyze_question("what is love", api_endpoint="openai")
+
+    content = captured["payload"][0]["content"]
+    assert "You are an AI assistant that helps generate search queries" in content
+    assert "Original query: what is love" in content

--- a/tldw_chatbook/Internal_Prompts/__init__.py
+++ b/tldw_chatbook/Internal_Prompts/__init__.py
@@ -1,0 +1,9 @@
+"""Internal/system prompt registry.
+
+Import from this package (not submodules) so subsystem prompt modules are
+registered: ``from tldw_chatbook.Internal_Prompts import get_internal_prompt``.
+"""
+
+from .catalog import CATALOG, PromptSpec, register
+
+__all__ = ["CATALOG", "PromptSpec", "register"]

--- a/tldw_chatbook/Internal_Prompts/__init__.py
+++ b/tldw_chatbook/Internal_Prompts/__init__.py
@@ -5,6 +5,7 @@ registered: ``from tldw_chatbook.Internal_Prompts import get_internal_prompt``.
 """
 
 from .catalog import CATALOG, PromptSpec, register
+from . import websearch_prompts  # noqa: F401  (registers specs on import)
 from .resolver import get_internal_prompt, render_internal_prompt, safe_substitute
 
 __all__ = [

--- a/tldw_chatbook/Internal_Prompts/__init__.py
+++ b/tldw_chatbook/Internal_Prompts/__init__.py
@@ -6,6 +6,7 @@ registered: ``from tldw_chatbook.Internal_Prompts import get_internal_prompt``.
 
 from .catalog import CATALOG, PromptSpec, register
 from . import websearch_prompts  # noqa: F401  (registers specs on import)
+from . import rag_reranker_prompts  # noqa: F401  (registers specs on import)
 from .resolver import get_internal_prompt, render_internal_prompt, safe_substitute
 
 __all__ = [

--- a/tldw_chatbook/Internal_Prompts/__init__.py
+++ b/tldw_chatbook/Internal_Prompts/__init__.py
@@ -5,5 +5,13 @@ registered: ``from tldw_chatbook.Internal_Prompts import get_internal_prompt``.
 """
 
 from .catalog import CATALOG, PromptSpec, register
+from .resolver import get_internal_prompt, render_internal_prompt, safe_substitute
 
-__all__ = ["CATALOG", "PromptSpec", "register"]
+__all__ = [
+    "CATALOG",
+    "PromptSpec",
+    "register",
+    "get_internal_prompt",
+    "render_internal_prompt",
+    "safe_substitute",
+]

--- a/tldw_chatbook/Internal_Prompts/catalog.py
+++ b/tldw_chatbook/Internal_Prompts/catalog.py
@@ -1,0 +1,42 @@
+"""Declarative catalog of internal/system prompts.
+
+Pure data. This module (and the per-subsystem prompt modules that call
+``register``) must not import ``tldw_chatbook.config`` directly or
+transitively — the resolver does config lookups lazily. Prompt ids are
+public config API and frozen once shipped.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PromptSpec:
+    """One internal prompt: identity, shipped default, and edit contract."""
+
+    id: str
+    subsystem: str
+    title: str
+    description: str
+    used_in: str
+    default: str
+    required_placeholders: tuple[str, ...] = ()
+    optional_placeholders: tuple[str, ...] = ()
+    contract_note: str | None = None
+    legacy_config_path: str | None = None
+    applies: str = "live"
+
+
+CATALOG: dict[str, PromptSpec] = {}
+
+
+def register(spec: PromptSpec) -> PromptSpec:
+    if spec.id in CATALOG:
+        raise ValueError(f"Duplicate internal prompt id: {spec.id!r}")
+    if not spec.id.startswith(spec.subsystem + "."):
+        raise ValueError(
+            f"Prompt id {spec.id!r} must start with its subsystem {spec.subsystem!r} + '.'"
+        )
+    CATALOG[spec.id] = spec
+    return spec

--- a/tldw_chatbook/Internal_Prompts/catalog.py
+++ b/tldw_chatbook/Internal_Prompts/catalog.py
@@ -32,6 +32,19 @@ CATALOG: dict[str, PromptSpec] = {}
 
 
 def register(spec: PromptSpec) -> PromptSpec:
+    """Add a prompt spec to the global ``CATALOG``.
+
+    Args:
+        spec: The spec to register. Its ``id`` must be globally unique and
+            must start with ``spec.subsystem + "."``.
+
+    Returns:
+        The registered spec, unchanged (convenient for module-level use).
+
+    Raises:
+        ValueError: If the id is already registered or does not match the
+            spec's subsystem prefix.
+    """
     if spec.id in CATALOG:
         raise ValueError(f"Duplicate internal prompt id: {spec.id!r}")
     if not spec.id.startswith(spec.subsystem + "."):

--- a/tldw_chatbook/Internal_Prompts/rag_reranker_prompts.py
+++ b/tldw_chatbook/Internal_Prompts/rag_reranker_prompts.py
@@ -1,0 +1,140 @@
+# tldw_chatbook/Internal_Prompts/rag_reranker_prompts.py
+"""LLM-reranker prompt specs. Defaults moved from RAG_Search/reranker.py
+__init__ fallbacks; templates converted from .format ({{) to final
+single-brace form. Parity tests compare rendered output against the
+original .format results. Rerankers snapshot config at construction, so
+overrides apply on the next search (applies="next search")."""
+
+from .catalog import PromptSpec, register
+
+_APPLIES = "next search"
+
+register(
+    PromptSpec(
+        id="rag_reranker.pointwise_system",
+        subsystem="rag_reranker",
+        title="Pointwise reranker — system",
+        description="System prompt for scoring one search result at a time.",
+        used_in="RAG search LLM reranking (PointwiseReranker)",
+        default="""You are a search result relevance evaluator. 
+Your task is to score how relevant a search result is to a given query.
+Return only a JSON object with a 'score' field (0.0 to 1.0) and optionally a 'reasoning' field.
+Higher scores indicate better relevance.""",
+        contract_note="Model must return JSON with a numeric 'score' field.",
+        applies=_APPLIES,
+    )
+)
+
+register(
+    PromptSpec(
+        id="rag_reranker.pointwise_template",
+        subsystem="rag_reranker",
+        title="Pointwise reranker — scoring template",
+        description="Per-result scoring prompt.",
+        used_in="RAG search LLM reranking (PointwiseReranker)",
+        default="""Query: {query}
+
+Search Result:
+Title: {title}
+Content: {content}
+
+How relevant is this search result to the query? Consider:
+1. Direct answer to the query
+2. Topical relevance
+3. Information quality
+4. Completeness
+
+Return JSON: {"score": 0.0-1.0{reasoning}}""",
+        required_placeholders=("query", "title", "content", "reasoning"),
+        contract_note=(
+            "Output is parsed as JSON with a numeric 'score'; {reasoning} "
+            "expands to the optional reasoning JSON fragment."
+        ),
+        applies=_APPLIES,
+    )
+)
+
+register(
+    PromptSpec(
+        id="rag_reranker.pairwise_system",
+        subsystem="rag_reranker",
+        title="Pairwise reranker — system",
+        description="System prompt for choosing the better of two results.",
+        used_in="RAG search LLM reranking (PairwiseReranker)",
+        default="""You are a search result comparator.
+Given a query and two search results, determine which one is more relevant.
+Return only a JSON object with 'choice' (1 or 2) and optionally 'reasoning'.""",
+        contract_note="Model must return JSON with 'choice' of 1 or 2.",
+        applies=_APPLIES,
+    )
+)
+
+register(
+    PromptSpec(
+        id="rag_reranker.pairwise_template",
+        subsystem="rag_reranker",
+        title="Pairwise reranker — comparison template",
+        description="Two-result comparison prompt.",
+        used_in="RAG search LLM reranking (PairwiseReranker)",
+        default="""Query: {query}
+
+Result 1:
+Title: {title1}
+Content: {content1}
+
+Result 2:
+Title: {title2}
+Content: {content2}
+
+Which result better answers the query? Consider relevance, accuracy, and completeness.
+
+Return JSON: {"choice": 1 or 2{reasoning}}""",
+        required_placeholders=(
+            "query",
+            "title1",
+            "content1",
+            "title2",
+            "content2",
+            "reasoning",
+        ),
+        contract_note="Output is parsed as JSON with 'choice' of 1 or 2.",
+        applies=_APPLIES,
+    )
+)
+
+register(
+    PromptSpec(
+        id="rag_reranker.listwise_system",
+        subsystem="rag_reranker",
+        title="Listwise reranker — system",
+        description="System prompt for reordering a result list.",
+        used_in="RAG search LLM reranking (ListwiseReranker)",
+        default="""You are a search result ranker.
+Given a query and a list of search results, reorder them by relevance.
+Return a JSON object with 'ranking' as an array of result indices in order of relevance.""",
+        contract_note="Model must return JSON with a 'ranking' index array.",
+        applies=_APPLIES,
+    )
+)
+
+register(
+    PromptSpec(
+        id="rag_reranker.listwise_template",
+        subsystem="rag_reranker",
+        title="Listwise reranker — ranking template",
+        description="Whole-list reordering prompt.",
+        used_in="RAG search LLM reranking (ListwiseReranker)",
+        default="""Query: {query}
+
+Search Results:
+{results_list}
+
+Reorder these results by relevance to the query (most relevant first).
+Return the indices in order.
+
+Return JSON: {"ranking": [indices in order]{reasoning}}""",
+        required_placeholders=("query", "results_list", "reasoning"),
+        contract_note="Output is parsed as JSON with a 'ranking' index array.",
+        applies=_APPLIES,
+    )
+)

--- a/tldw_chatbook/Internal_Prompts/resolver.py
+++ b/tldw_chatbook/Internal_Prompts/resolver.py
@@ -1,0 +1,101 @@
+"""Resolution + rendering for internal prompts.
+
+Precedence: user override table -> customized legacy config key -> shipped
+default. Never raises for user-caused problems (bad override text falls back
+to the default with a once-per-prompt warning). Unknown prompt ids raise
+KeyError — that is a programmer error the test suite catches.
+
+Config helpers are imported lazily to keep this package off the cold-start
+import chain and out of config.py import cycles.
+"""
+
+from __future__ import annotations
+
+from loguru import logger
+
+from .catalog import CATALOG, PromptSpec
+
+_warned_ids: set[str] = set()
+
+
+def safe_substitute(text: str, **values: object) -> str:
+    """Replace only the exact ``{name}`` tokens named in ``values``.
+
+    All other braces (JSON examples, Ollama ``{{ .Prompt }}`` cruft, stray
+    user typos) pass through untouched. Cannot raise.
+    """
+    for name, value in values.items():
+        text = text.replace("{" + name + "}", str(value))
+    return text
+
+
+def get_internal_prompt(prompt_id: str) -> str:
+    spec = CATALOG[prompt_id]
+
+    override = _extract_text(_config_value("internal_prompts." + prompt_id))
+    if override is not None:
+        if _has_required_placeholders(override, spec):
+            return override
+        _warn_once(prompt_id, "override is missing a required placeholder")
+
+    if spec.legacy_config_path:
+        legacy = _extract_text(_config_value(spec.legacy_config_path))
+        if legacy is not None and legacy != _shipped_default_for(
+            spec.legacy_config_path
+        ):
+            if _has_required_placeholders(legacy, spec):
+                return legacy
+            _warn_once(
+                prompt_id,
+                f"legacy value at [{spec.legacy_config_path}] is missing a "
+                "required placeholder",
+            )
+
+    return spec.default
+
+
+def render_internal_prompt(prompt_id: str, **values: object) -> str:
+    return safe_substitute(get_internal_prompt(prompt_id), **values)
+
+
+def _has_required_placeholders(text: str, spec: PromptSpec) -> bool:
+    return all("{" + name + "}" in text for name in spec.required_placeholders)
+
+
+def _extract_text(raw: object) -> str | None:
+    """Normalize a config value: {text, baseline} table or plain string."""
+    if isinstance(raw, dict):
+        raw = raw.get("text")
+    if isinstance(raw, str) and raw.strip():
+        return raw
+    return None
+
+
+def _config_value(dotted_path: str) -> object:
+    from tldw_chatbook.config import get_cli_setting  # lazy on purpose
+
+    section, _, key = dotted_path.rpartition(".")
+    if not section:
+        return None
+    return get_cli_setting(section, key, None)
+
+
+def _shipped_default_for(dotted_path: str) -> object:
+    from tldw_chatbook.config import DEFAULT_CONFIG_FROM_TOML  # lazy on purpose
+
+    node: object = DEFAULT_CONFIG_FROM_TOML
+    for part in dotted_path.split("."):
+        if not isinstance(node, dict) or part not in node:
+            return None
+        node = node[part]
+    return node
+
+
+def _warn_once(prompt_id: str, message: str) -> None:
+    if prompt_id in _warned_ids:
+        return
+    _warned_ids.add(prompt_id)
+    logger.warning(
+        f"internal_prompts: {message} (prompt id: {prompt_id}); "
+        "using shipped default"
+    )

--- a/tldw_chatbook/Internal_Prompts/resolver.py
+++ b/tldw_chatbook/Internal_Prompts/resolver.py
@@ -11,6 +11,8 @@ import chain and out of config.py import cycles.
 
 from __future__ import annotations
 
+import re
+
 from loguru import logger
 
 from .catalog import CATALOG, PromptSpec
@@ -21,15 +23,33 @@ _warned_ids: set[str] = set()
 def safe_substitute(text: str, **values: object) -> str:
     """Replace only the exact ``{name}`` tokens named in ``values``.
 
-    All other braces (JSON examples, Ollama ``{{ .Prompt }}`` cruft, stray
-    user typos) pass through untouched. Cannot raise.
+    Single-pass: tokens introduced by substituted values are NOT re-expanded,
+    and all other braces (JSON examples, Ollama ``{{ .Prompt }}`` cruft,
+    stray user typos) pass through untouched. Cannot raise.
     """
-    for name, value in values.items():
-        text = text.replace("{" + name + "}", str(value))
-    return text
+    if not values:
+        return text
+    pattern = re.compile(
+        "|".join(re.escape("{" + name + "}") for name in values)
+    )
+    return pattern.sub(lambda m: str(values[m.group(0)[1:-1]]), text)
 
 
 def get_internal_prompt(prompt_id: str) -> str:
+    """Resolve the internal prompt, prioritizing override → legacy → default.
+
+    Never raises for user-caused problems (bad override text falls back to
+    default with a once-per-prompt warning).
+
+    Args:
+        prompt_id: Prompt identifier (e.g., "chat.system_prompt").
+
+    Returns:
+        Resolved prompt text with placeholders intact.
+
+    Raises:
+        KeyError: If prompt_id is not registered in CATALOG.
+    """
     spec = CATALOG[prompt_id]
 
     override = _extract_text(_config_value("internal_prompts." + prompt_id))
@@ -55,6 +75,18 @@ def get_internal_prompt(prompt_id: str) -> str:
 
 
 def render_internal_prompt(prompt_id: str, **values: object) -> str:
+    """Resolve and substitute placeholders in an internal prompt.
+
+    Args:
+        prompt_id: Prompt identifier (e.g., "chat.system_prompt").
+        **values: Placeholder values, e.g., name="Ada", context="...".
+
+    Returns:
+        Prompt text with placeholders replaced.
+
+    Raises:
+        KeyError: If prompt_id is not registered in CATALOG.
+    """
     return safe_substitute(get_internal_prompt(prompt_id), **values)
 
 

--- a/tldw_chatbook/Internal_Prompts/resolver.py
+++ b/tldw_chatbook/Internal_Prompts/resolver.py
@@ -26,6 +26,16 @@ def safe_substitute(text: str, **values: object) -> str:
     Single-pass: tokens introduced by substituted values are NOT re-expanded,
     and all other braces (JSON examples, Ollama ``{{ .Prompt }}`` cruft,
     stray user typos) pass through untouched. Cannot raise.
+
+    Args:
+        text: Template text containing ``{name}`` tokens.
+        **values: Token values; each is substituted as ``str(value)``. Tokens
+            not named here are left untouched (a full token includes its
+            closing brace, so overlapping names like ``query``/``query_list``
+            cannot corrupt each other).
+
+    Returns:
+        The text with the named tokens substituted.
     """
     if not values:
         return text
@@ -56,7 +66,11 @@ def get_internal_prompt(prompt_id: str) -> str:
     if override is not None:
         if _has_required_placeholders(override, spec):
             return override
-        _warn_once(prompt_id, "override is missing a required placeholder")
+        _warn_once(
+            prompt_id,
+            f"override for {prompt_id} is missing a required placeholder; "
+            "falling back",
+        )
 
     if spec.legacy_config_path:
         legacy = _extract_text(_config_value(spec.legacy_config_path))
@@ -67,8 +81,8 @@ def get_internal_prompt(prompt_id: str) -> str:
                 return legacy
             _warn_once(
                 prompt_id,
-                f"legacy value at [{spec.legacy_config_path}] is missing a "
-                "required placeholder",
+                f"legacy value at [{spec.legacy_config_path}] for {prompt_id} "
+                "is missing a required placeholder; falling back",
             )
 
     return spec.default
@@ -87,7 +101,20 @@ def render_internal_prompt(prompt_id: str, **values: object) -> str:
     Raises:
         KeyError: If prompt_id is not registered in CATALOG.
     """
-    return safe_substitute(get_internal_prompt(prompt_id), **values)
+    spec = CATALOG[prompt_id]
+    rendered = safe_substitute(get_internal_prompt(prompt_id), **values)
+    missing = [
+        name
+        for name in spec.required_placeholders
+        if name not in values and "{" + name + "}" in rendered
+    ]
+    if missing:
+        _warn_once(
+            prompt_id + ":render",
+            f"render_internal_prompt({prompt_id!r}) called without required "
+            f"placeholder value(s) {missing}; tokens left unsubstituted",
+        )
+    return rendered
 
 
 def _has_required_placeholders(text: str, spec: PromptSpec) -> bool:
@@ -123,11 +150,9 @@ def _shipped_default_for(dotted_path: str) -> object:
     return node
 
 
-def _warn_once(prompt_id: str, message: str) -> None:
-    if prompt_id in _warned_ids:
+def _warn_once(key: str, message: str) -> None:
+    """Log ``message`` once per ``key`` (typically a prompt id) per process."""
+    if key in _warned_ids:
         return
-    _warned_ids.add(prompt_id)
-    logger.warning(
-        f"internal_prompts: {message} (prompt id: {prompt_id}); "
-        "falling back"
-    )
+    _warned_ids.add(key)
+    logger.warning(f"internal_prompts: {message}")

--- a/tldw_chatbook/Internal_Prompts/resolver.py
+++ b/tldw_chatbook/Internal_Prompts/resolver.py
@@ -129,5 +129,5 @@ def _warn_once(prompt_id: str, message: str) -> None:
     _warned_ids.add(prompt_id)
     logger.warning(
         f"internal_prompts: {message} (prompt id: {prompt_id}); "
-        "using shipped default"
+        "falling back"
     )

--- a/tldw_chatbook/Internal_Prompts/websearch_prompts.py
+++ b/tldw_chatbook/Internal_Prompts/websearch_prompts.py
@@ -1,0 +1,213 @@
+"""Web-search pipeline prompt specs. Defaults moved verbatim from
+Web_Scraping/WebSearch_APIs.py — do not edit prompt text here without a
+behavior-change review; parity tests compare against the original literals."""
+
+from .catalog import PromptSpec, register
+
+register(
+    PromptSpec(
+        id="websearch.sub_question_generation",
+        subsystem="websearch",
+        title="Sub-question generation",
+        description=(
+            "Generates alternative/expanded search queries for the user's "
+            "question before hitting search engines."
+        ),
+        used_in="Web search pipeline (analyze_question in WebSearch_APIs.py)",
+        default="""
+            You are an AI assistant that helps generate search queries. Given an original query, suggest alternative search queries that could help find relevant information. Your goal is to generate queries that are diverse, specific, and highly relevant to the original query, ensuring comprehensive coverage of the topic.
+
+            Important instructions:
+            1. Generate between 2 and 6 queries unless a fixed count is specified. Generate more queries for complex or multifaceted topics and fewer for simple or straightforward ones.
+            2. Ensure the queries are diverse, covering different aspects or perspectives of the original query, while remaining highly relevant to its core intent.
+            3. Prefer specific queries over general ones, as they are more likely to yield targeted and useful results.
+            4. If the query involves comparing two topics, generate separate queries for each topic.
+            5. If previous queries and an answer are provided, generate new queries that address the shortcomings of the previous answer and avoid repeating the previous queries.
+            6. If the original query is broad or ambiguous, generate queries that explore specific subtopics or clarify the intent.
+            7. If the query is too specific or unclear, generate queries that explore related or broader topics to ensure useful results.
+            8. Return the queries as a JSON array in the format ["query_1", "query_2", ...].
+
+            Examples:
+            1. For the query "What are the benefits of exercise?", generate queries like:
+               ["health benefits of physical activity", "mental health benefits of exercise", "long-term effects of regular exercise", "how exercise improves cardiovascular health", "role of exercise in weight management"]
+
+            2. For the query "Compare Python and JavaScript", generate queries like:
+               ["key features of Python programming language", "advantages of JavaScript for web development", "use cases for Python vs JavaScript", "performance comparison of Python and JavaScript", "ease of learning Python vs JavaScript"]
+
+            3. For the query "How does climate change affect biodiversity?", generate queries like:
+               ["impact of climate change on species extinction", "effects of global warming on ecosystems", "role of climate change in habitat loss", "how rising temperatures affect marine biodiversity", "climate change and its impact on migratory patterns"]
+
+            4. For the query "Best practices for remote work", generate queries like:
+               ["tips for staying productive while working from home", "how to maintain work-life balance in remote work", "tools for effective remote team collaboration", "managing communication in remote teams", "ergonomic setup for home offices"]
+
+            5. For the query "What is quantum computing?", generate queries like:
+               ["basic principles of quantum computing", "applications of quantum computing in real-world problems", "difference between classical and quantum computing", "key challenges in developing quantum computers", "future prospects of quantum computing"]
+
+            Original query: {original_query}
+            """,
+        required_placeholders=("original_query",),
+        contract_note=(
+            "The model must return a JSON array of query strings (a "
+            '{"sub_questions": [...]} object also parses); quoted strings '
+            "are regex-extracted as a fallback."
+        ),
+        legacy_config_path="Prompts.sub_question_generation_prompt",
+    )
+)
+
+register(
+    PromptSpec(
+        id="websearch.result_relevance_eval",
+        subsystem="websearch",
+        title="Result relevance evaluation",
+        description="Judges whether one search result is relevant to the question.",
+        used_in="Web search pipeline (search_result_relevance in WebSearch_APIs.py)",
+        default="""
+                Given the following search results for the user's question: "{original_question}" and the generated sub-questions: {sub_questions}, evaluate the relevance of the search result to the user's question.
+                Explain your reasoning for selection.
+
+                Search Results:
+                {content}
+
+                Instructions:
+                1. You MUST only answer TRUE or False while providing your reasoning for your answer.
+                2. A result is relevant if the result most likely contains comprehensive and relevant information to answer the user's question.
+                3. Provide a brief reason for selection.
+
+                You MUST respond using EXACTLY this format and nothing else:
+
+                Selected Answer: [True or False]
+                Reasoning: [Your reasoning for the selections]
+                """,
+        required_placeholders=("original_question", "sub_questions", "content"),
+        contract_note=(
+            "Downstream regex requires the exact lines 'Selected Answer: "
+            "True|False' and 'Reasoning: ...' in the model output."
+        ),
+        legacy_config_path="Prompts.search_result_relevance_eval_prompt",
+    )
+)
+
+register(
+    PromptSpec(
+        id="websearch.result_summarization",
+        subsystem="websearch",
+        title="Result summarization",
+        description="Summarizes a scraped page relative to the user's question.",
+        used_in="Web search pipeline (search_result_relevance in WebSearch_APIs.py)",
+        default="""
+    Summarize the following text in a concise way that captures the key information relevant to this question: "{question}"
+    
+    Text to summarize:
+    {content}
+    
+    Instructions:
+    1. Focus on information relevant to the question
+    2. Keep the summary under 2000 characters
+    3. Maintain factual accuracy
+    4. Include key details and statistics if present
+    """,
+        required_placeholders=("question", "content"),
+    )
+)
+
+register(
+    PromptSpec(
+        id="websearch.answer_synthesis",
+        subsystem="websearch",
+        title="Answer synthesis",
+        description=(
+            "Perplexity-style cited answer synthesis over the collected "
+            "search-result summaries."
+        ),
+        used_in="Web search pipeline (aggregate_results in WebSearch_APIs.py)",
+        default=r"""INITIAL_QUERY: Here are some sources {concatenated_texts}. Read these carefully, as you will be asked a Query about them.
+        # General Instructions
+        
+        Write an accurate, detailed, and comprehensive response to the user's query located at INITIAL_QUERY. Additional context is provided as "USER_INPUT" after specific questions. Your answer should be informed by the provided "Search results". Your answer must be precise, of high-quality, and written by an expert using an unbiased and journalistic tone. Your answer must be written in the same language as the query, even if language preference is different.
+        
+        You MUST cite the most relevant search results that answer the query. Do not mention any irrelevant results. You MUST ADHERE to the following instructions for citing search results:
+        - to cite a search result, enclose its index located above the summary with brackets at the end of the corresponding sentence, for example "Ice is less dense than water[1][2]." or "Paris is the capital of France[1][4][5]."
+        - NO SPACE between the last word and the citation, and ALWAYS use brackets. Only use this format to cite search results. NEVER include a References section at the end of your answer.
+        - If you don't know the answer or the premise is incorrect, explain why.
+        If the search results are empty or unhelpful, answer the query as well as you can with existing knowledge.
+        
+        You MUST NEVER use moralization or hedging language. AVOID using the following phrases:
+        - "It is important to ..."
+        - "It is inappropriate ..."
+        - "It is subjective ..."
+        
+        You MUST ADHERE to the following formatting instructions:
+        - Use markdown to format paragraphs, lists, tables, and quotes whenever possible.
+        - Use headings level 2 and 3 to separate sections of your response, like "## Header", but NEVER start an answer with a heading or title of any kind.
+        - Use single new lines for lists and double new lines for paragraphs.
+        - Use markdown to render images given in the search results.
+        - NEVER write URLs or links.
+        
+        # Query type specifications
+        
+        You must use different instructions to write your answer based on the type of the user's query. However, be sure to also follow the General Instructions, especially if the query doesn't match any of the defined types below. Here are the supported types.
+        
+        ## Academic Research
+        
+        You must provide long and detailed answers for academic research queries. Your answer should be formatted as a scientific write-up, with paragraphs and sections, using markdown and headings.
+        
+        ## Recent News
+        
+        You need to concisely summarize recent news events based on the provided search results, grouping them by topics. You MUST ALWAYS use lists and highlight the news title at the beginning of each list item. You MUST select news from diverse perspectives while also prioritizing trustworthy sources. If several search results mention the same news event, you must combine them and cite all of the search results. Prioritize more recent events, ensuring to compare timestamps. You MUST NEVER start your answer with a heading of any kind.
+        
+        ## Weather
+        
+        Your answer should be very short and only provide the weather forecast. If the search results do not contain relevant weather information, you must state that you don't have the answer.
+        
+        ## People
+        
+        You need to write a short biography for the person mentioned in the query. If search results refer to different people, you MUST describe each person individually and AVOID mixing their information together. NEVER start your answer with the person's name as a header.
+        
+        ## Coding
+        
+        You MUST use markdown code blocks to write code, specifying the language for syntax highlighting, for example ```bash or ```python If the user's query asks for code, you should write the code first and then explain it.
+        
+        ## Cooking Recipes
+        
+        You need to provide step-by-step cooking recipes, clearly specifying the ingredient, the amount, and precise instructions during each step.
+        
+        ## Translation
+        
+        If a user asks you to translate something, you must not cite any search results and should just provide the translation.
+        
+        ## Creative Writing
+        
+        If the query requires creative writing, you DO NOT need to use or cite search results, and you may ignore General Instructions pertaining only to search. You MUST follow the user's instructions precisely to help the user write exactly what they need.
+        
+        ## Science and Math
+        
+        If the user query is about some simple calculation, only answer with the final result. Follow these rules for writing formulas:
+        - Always use \( and\) for inline formulas and\[ and\] for blocks, for example\(x^4 = x - 3 \)
+        - To cite a formula add citations to the end, for example\[ \sin(x) \] [1][2] or \(x^2-2\) [4].
+        - Never use $ or $$ to render LaTeX, even if it is present in the user query.
+        - Never use unicode to render math expressions, ALWAYS use LaTeX.
+        - Never use the \label instruction for LaTeX.
+        
+        ## URL Lookup
+        
+        When the user's query includes a URL, you must rely solely on information from the corresponding search result. DO NOT cite other search results, ALWAYS cite the first result, e.g. you need to end with [1]. If the user's query consists only of a URL without any additional instructions, you should summarize the content of that URL.
+        
+        ## Shopping
+        
+        If the user query is about shopping for a product, you MUST follow these rules:
+        - Organize the products into distinct sectors. For example, you could group shoes by style (boots, sneakers, etc.)
+        - Cite at most 9 search results using the format provided in General Instructions to avoid overwhelming the user with too many options.
+        
+        The current date is: {current_date}
+
+        The user's query is: {question}
+        """,
+        required_placeholders=("concatenated_texts", "current_date", "question"),
+        contract_note=(
+            "Citation format [n], markdown/LaTeX formatting rules, and "
+            "query-type sections are load-bearing instructions."
+        ),
+        legacy_config_path="Prompts.analyze_search_results_prompt",
+    )
+)

--- a/tldw_chatbook/RAG_Search/reranker.py
+++ b/tldw_chatbook/RAG_Search/reranker.py
@@ -24,6 +24,7 @@ except ImportError:
 from ..Chat.Chat_Functions import chat_api_call
 from ..config import load_settings
 from ..Metrics.metrics_logger import log_counter, log_histogram, timeit
+from tldw_chatbook.Internal_Prompts import get_internal_prompt, safe_substitute
 from .simplified.vector_store import SearchResult, SearchResultWithCitations
 
 
@@ -213,28 +214,15 @@ class PointwiseReranker(BaseReranker):
     def __init__(self, config: RerankingConfig):
         super().__init__(config)
 
-        # Default system prompt for pointwise reranking
+        # Registry defaults only when the caller supplied none (caller wins).
         if not config.system_prompt:
-            self.config.system_prompt = """You are a search result relevance evaluator. 
-Your task is to score how relevant a search result is to a given query.
-Return only a JSON object with a 'score' field (0.0 to 1.0) and optionally a 'reasoning' field.
-Higher scores indicate better relevance."""
-
-        # Default scoring template
+            self.config.system_prompt = get_internal_prompt(
+                "rag_reranker.pointwise_system"
+            )
         if not config.scoring_prompt_template:
-            self.config.scoring_prompt_template = """Query: {query}
-
-Search Result:
-Title: {title}
-Content: {content}
-
-How relevant is this search result to the query? Consider:
-1. Direct answer to the query
-2. Topical relevance
-3. Information quality
-4. Completeness
-
-Return JSON: {{"score": 0.0-1.0{reasoning}}}"""
+            self.config.scoring_prompt_template = get_internal_prompt(
+                "rag_reranker.pointwise_template"
+            )
 
     @timeit("reranker_pointwise")
     async def rerank(
@@ -322,8 +310,9 @@ Return JSON: {{"score": 0.0-1.0{reasoning}}}"""
         reasoning_part = (
             ', "reasoning": "explanation"' if self.config.include_reasoning else ""
         )
-        prompt = self.config.scoring_prompt_template.format(
-            query=query, title=title, content=content, reasoning=reasoning_part
+        prompt = safe_substitute(
+            self.config.scoring_prompt_template,
+            query=query, title=title, content=content, reasoning=reasoning_part,
         )
 
         try:
@@ -439,25 +428,15 @@ class PairwiseReranker(BaseReranker):
     def __init__(self, config: RerankingConfig):
         super().__init__(config)
 
+        # Registry defaults only when the caller supplied none (caller wins).
         if not config.system_prompt:
-            self.config.system_prompt = """You are a search result comparator.
-Given a query and two search results, determine which one is more relevant.
-Return only a JSON object with 'choice' (1 or 2) and optionally 'reasoning'."""
-
+            self.config.system_prompt = get_internal_prompt(
+                "rag_reranker.pairwise_system"
+            )
         if not config.scoring_prompt_template:
-            self.config.scoring_prompt_template = """Query: {query}
-
-Result 1:
-Title: {title1}
-Content: {content1}
-
-Result 2:
-Title: {title2}
-Content: {content2}
-
-Which result better answers the query? Consider relevance, accuracy, and completeness.
-
-Return JSON: {{"choice": 1 or 2{reasoning}}}"""
+            self.config.scoring_prompt_template = get_internal_prompt(
+                "rag_reranker.pairwise_template"
+            )
 
     @timeit("reranker_pairwise")
     async def rerank(
@@ -537,7 +516,8 @@ Return JSON: {{"choice": 1 or 2{reasoning}}}"""
         reasoning_part = (
             ', "reasoning": "explanation"' if self.config.include_reasoning else ""
         )
-        prompt = self.config.scoring_prompt_template.format(
+        prompt = safe_substitute(
+            self.config.scoring_prompt_template,
             query=query,
             title1=result1.metadata.get("doc_title", "Untitled"),
             content1=result1.document[:300],
@@ -567,21 +547,15 @@ class ListwiseReranker(BaseReranker):
     def __init__(self, config: RerankingConfig):
         super().__init__(config)
 
+        # Registry defaults only when the caller supplied none (caller wins).
         if not config.system_prompt:
-            self.config.system_prompt = """You are a search result ranker.
-Given a query and a list of search results, reorder them by relevance.
-Return a JSON object with 'ranking' as an array of result indices in order of relevance."""
-
+            self.config.system_prompt = get_internal_prompt(
+                "rag_reranker.listwise_system"
+            )
         if not config.scoring_prompt_template:
-            self.config.scoring_prompt_template = """Query: {query}
-
-Search Results:
-{results_list}
-
-Reorder these results by relevance to the query (most relevant first).
-Return the indices in order.
-
-Return JSON: {{"ranking": [indices in order]{reasoning}}}"""
+            self.config.scoring_prompt_template = get_internal_prompt(
+                "rag_reranker.listwise_template"
+            )
 
     @timeit("reranker_listwise")
     async def rerank(
@@ -613,8 +587,9 @@ Return JSON: {{"ranking": [indices in order]{reasoning}}}"""
         reasoning_part = (
             ', "reasoning": "explanation"' if self.config.include_reasoning else ""
         )
-        prompt = self.config.scoring_prompt_template.format(
-            query=query, results_list=results_list, reasoning=reasoning_part
+        prompt = safe_substitute(
+            self.config.scoring_prompt_template,
+            query=query, results_list=results_list, reasoning=reasoning_part,
         )
 
         try:

--- a/tldw_chatbook/Web_Scraping/WebSearch_APIs.py
+++ b/tldw_chatbook/Web_Scraping/WebSearch_APIs.py
@@ -69,6 +69,7 @@ except ImportError:
 # Local Imports
 from tldw_chatbook.Web_Scraping.Article_Extractor_Lib import scrape_article
 from tldw_chatbook.Chat.Chat_Functions import chat_api_call
+from tldw_chatbook.Internal_Prompts import render_internal_prompt
 
 # `analyze` (LLM_Calls.Summarization_General_Lib) pulls in the summarization
 # stack (nltk/scipy/sklearn/pandas via Chunking/Chunk_Lib). It is imported
@@ -642,37 +643,9 @@ def analyze_question(question: str, api_endpoint) -> Dict:
         - analysis_prompt: str
     """
     original_query = question
-    sub_question_generation_prompt = f"""
-            You are an AI assistant that helps generate search queries. Given an original query, suggest alternative search queries that could help find relevant information. Your goal is to generate queries that are diverse, specific, and highly relevant to the original query, ensuring comprehensive coverage of the topic.
-
-            Important instructions:
-            1. Generate between 2 and 6 queries unless a fixed count is specified. Generate more queries for complex or multifaceted topics and fewer for simple or straightforward ones.
-            2. Ensure the queries are diverse, covering different aspects or perspectives of the original query, while remaining highly relevant to its core intent.
-            3. Prefer specific queries over general ones, as they are more likely to yield targeted and useful results.
-            4. If the query involves comparing two topics, generate separate queries for each topic.
-            5. If previous queries and an answer are provided, generate new queries that address the shortcomings of the previous answer and avoid repeating the previous queries.
-            6. If the original query is broad or ambiguous, generate queries that explore specific subtopics or clarify the intent.
-            7. If the query is too specific or unclear, generate queries that explore related or broader topics to ensure useful results.
-            8. Return the queries as a JSON array in the format ["query_1", "query_2", ...].
-
-            Examples:
-            1. For the query "What are the benefits of exercise?", generate queries like:
-               ["health benefits of physical activity", "mental health benefits of exercise", "long-term effects of regular exercise", "how exercise improves cardiovascular health", "role of exercise in weight management"]
-
-            2. For the query "Compare Python and JavaScript", generate queries like:
-               ["key features of Python programming language", "advantages of JavaScript for web development", "use cases for Python vs JavaScript", "performance comparison of Python and JavaScript", "ease of learning Python vs JavaScript"]
-
-            3. For the query "How does climate change affect biodiversity?", generate queries like:
-               ["impact of climate change on species extinction", "effects of global warming on ecosystems", "role of climate change in habitat loss", "how rising temperatures affect marine biodiversity", "climate change and its impact on migratory patterns"]
-
-            4. For the query "Best practices for remote work", generate queries like:
-               ["tips for staying productive while working from home", "how to maintain work-life balance in remote work", "tools for effective remote team collaboration", "managing communication in remote teams", "ergonomic setup for home offices"]
-
-            5. For the query "What is quantum computing?", generate queries like:
-               ["basic principles of quantum computing", "applications of quantum computing in real-world problems", "difference between classical and quantum computing", "key challenges in developing quantum computers", "future prospects of quantum computing"]
-
-            Original query: {original_query}
-            """
+    sub_question_generation_prompt = render_internal_prompt(
+        "websearch.sub_question_generation", original_query=original_query
+    )
 
     input_data = "Follow the above instructions."
 
@@ -785,20 +758,6 @@ async def search_result_relevance(
 
     relevant_results = {}
 
-    # Summarization prompt template
-    summarization_prompt = """
-    Summarize the following text in a concise way that captures the key information relevant to this question: "{question}"
-    
-    Text to summarize:
-    {content}
-    
-    Instructions:
-    1. Focus on information relevant to the question
-    2. Keep the summary under 2000 characters
-    3. Maintain factual accuracy
-    4. Include key details and statistics if present
-    """
-
     for idx, result in enumerate(search_results):
         content = result.get("content", "")
         if not content:
@@ -806,23 +765,12 @@ async def search_result_relevance(
             continue
 
         # First, evaluate relevance
-        eval_prompt = f"""
-                Given the following search results for the user's question: "{original_question}" and the generated sub-questions: {sub_questions}, evaluate the relevance of the search result to the user's question.
-                Explain your reasoning for selection.
-
-                Search Results:
-                {content}
-
-                Instructions:
-                1. You MUST only answer TRUE or False while providing your reasoning for your answer.
-                2. A result is relevant if the result most likely contains comprehensive and relevant information to answer the user's question.
-                3. Provide a brief reason for selection.
-
-                You MUST respond using EXACTLY this format and nothing else:
-
-                Selected Answer: [True or False]
-                Reasoning: [Your reasoning for the selections]
-                """
+        eval_prompt = render_internal_prompt(
+            "websearch.result_relevance_eval",
+            original_question=original_question,
+            sub_questions=sub_questions,
+            content=content,
+        )
         input_data = "Evaluate the relevance of the search result."
 
         try:
@@ -880,7 +828,8 @@ async def search_result_relevance(
                         logger.debug(
                             f"Creating Summarization Prompt for result idx={idx}"
                         )
-                        summary_prompt = summarization_prompt.format(
+                        summary_prompt = render_internal_prompt(
+                            "websearch.result_summarization",
                             question=original_question,
                             content=scraped_content["content"],
                         )
@@ -998,88 +947,12 @@ def aggregate_results(
     # Aggregation Prompt #1
 
     # Aggregation Prompt #2
-    analyze_search_results_prompt_2 = rf"""INITIAL_QUERY: Here are some sources {concatenated_texts}. Read these carefully, as you will be asked a Query about them.
-        # General Instructions
-        
-        Write an accurate, detailed, and comprehensive response to the user's query located at INITIAL_QUERY. Additional context is provided as "USER_INPUT" after specific questions. Your answer should be informed by the provided "Search results". Your answer must be precise, of high-quality, and written by an expert using an unbiased and journalistic tone. Your answer must be written in the same language as the query, even if language preference is different.
-        
-        You MUST cite the most relevant search results that answer the query. Do not mention any irrelevant results. You MUST ADHERE to the following instructions for citing search results:
-        - to cite a search result, enclose its index located above the summary with brackets at the end of the corresponding sentence, for example "Ice is less dense than water[1][2]." or "Paris is the capital of France[1][4][5]."
-        - NO SPACE between the last word and the citation, and ALWAYS use brackets. Only use this format to cite search results. NEVER include a References section at the end of your answer.
-        - If you don't know the answer or the premise is incorrect, explain why.
-        If the search results are empty or unhelpful, answer the query as well as you can with existing knowledge.
-        
-        You MUST NEVER use moralization or hedging language. AVOID using the following phrases:
-        - "It is important to ..."
-        - "It is inappropriate ..."
-        - "It is subjective ..."
-        
-        You MUST ADHERE to the following formatting instructions:
-        - Use markdown to format paragraphs, lists, tables, and quotes whenever possible.
-        - Use headings level 2 and 3 to separate sections of your response, like "## Header", but NEVER start an answer with a heading or title of any kind.
-        - Use single new lines for lists and double new lines for paragraphs.
-        - Use markdown to render images given in the search results.
-        - NEVER write URLs or links.
-        
-        # Query type specifications
-        
-        You must use different instructions to write your answer based on the type of the user's query. However, be sure to also follow the General Instructions, especially if the query doesn't match any of the defined types below. Here are the supported types.
-        
-        ## Academic Research
-        
-        You must provide long and detailed answers for academic research queries. Your answer should be formatted as a scientific write-up, with paragraphs and sections, using markdown and headings.
-        
-        ## Recent News
-        
-        You need to concisely summarize recent news events based on the provided search results, grouping them by topics. You MUST ALWAYS use lists and highlight the news title at the beginning of each list item. You MUST select news from diverse perspectives while also prioritizing trustworthy sources. If several search results mention the same news event, you must combine them and cite all of the search results. Prioritize more recent events, ensuring to compare timestamps. You MUST NEVER start your answer with a heading of any kind.
-        
-        ## Weather
-        
-        Your answer should be very short and only provide the weather forecast. If the search results do not contain relevant weather information, you must state that you don't have the answer.
-        
-        ## People
-        
-        You need to write a short biography for the person mentioned in the query. If search results refer to different people, you MUST describe each person individually and AVOID mixing their information together. NEVER start your answer with the person's name as a header.
-        
-        ## Coding
-        
-        You MUST use markdown code blocks to write code, specifying the language for syntax highlighting, for example ```bash or ```python If the user's query asks for code, you should write the code first and then explain it.
-        
-        ## Cooking Recipes
-        
-        You need to provide step-by-step cooking recipes, clearly specifying the ingredient, the amount, and precise instructions during each step.
-        
-        ## Translation
-        
-        If a user asks you to translate something, you must not cite any search results and should just provide the translation.
-        
-        ## Creative Writing
-        
-        If the query requires creative writing, you DO NOT need to use or cite search results, and you may ignore General Instructions pertaining only to search. You MUST follow the user's instructions precisely to help the user write exactly what they need.
-        
-        ## Science and Math
-        
-        If the user query is about some simple calculation, only answer with the final result. Follow these rules for writing formulas:
-        - Always use \( and\) for inline formulas and\[ and\] for blocks, for example\(x^4 = x - 3 \)
-        - To cite a formula add citations to the end, for example\[ \sin(x) \] [1][2] or \(x^2-2\) [4].
-        - Never use $ or $$ to render LaTeX, even if it is present in the user query.
-        - Never use unicode to render math expressions, ALWAYS use LaTeX.
-        - Never use the \label instruction for LaTeX.
-        
-        ## URL Lookup
-        
-        When the user's query includes a URL, you must rely solely on information from the corresponding search result. DO NOT cite other search results, ALWAYS cite the first result, e.g. you need to end with [1]. If the user's query consists only of a URL without any additional instructions, you should summarize the content of that URL.
-        
-        ## Shopping
-        
-        If the user query is about shopping for a product, you MUST follow these rules:
-        - Organize the products into distinct sectors. For example, you could group shoes by style (boots, sneakers, etc.)
-        - Cite at most 9 search results using the format provided in General Instructions to avoid overwhelming the user with too many options.
-        
-        The current date is: {current_date}
-
-        The user's query is: {question}
-        """
+    analyze_search_results_prompt_2 = render_internal_prompt(
+        "websearch.answer_synthesis",
+        concatenated_texts=concatenated_texts,
+        current_date=current_date,
+        question=question,
+    )
 
     input_data = "Follow the above instructions."
 


### PR DESCRIPTION
## Summary

First slice of the Internal Prompts program (spec: `Docs/superpowers/specs/2026-07-21-internal-prompts-settings-page-design.md`): users can now override 10 internal system prompts via `[internal_prompts.*]` tables in config.toml, without source modifications.

- **New `tldw_chatbook/Internal_Prompts/` package**: pure-data `PromptSpec` catalog + never-raises resolver. Precedence: user override → customized legacy key (honored only if it differs from the shipped default — prevents the materialized `[Prompts]` stub one-liners from hijacking real prompts) → shipped default. Single-pass declared-token-only substitution (JSON braces, `{{ .Prompt }}` cruft, and stray braces are inert; values containing token-like text are never re-expanded).
- **Web-search pipeline migrated** (4 prompts: sub-question generation, relevance eval, result summarization, answer synthesis). This *fixes the dead `[Prompts]` config keys* — loaded since forever, consumed never. Removes a raw `summarization_prompt.format()` crash vector.
- **RAG LLM rerankers migrated** (6 prompts: system + scoring template × pointwise/pairwise/listwise). Templates converted from `.format()` doubled-brace form to final single-brace form; the three raw `.format()` render sites replaced with `safe_substitute` (a caller-supplied template with stray braces used to crash — now renders). Caller-supplied `RerankingConfig` values still win; overrides apply on next reranker construction.

## Guarantees & evidence

- **Byte-identical defaults**: golden-parity tests embed the original literals verbatim and assert the new render path produces identical bytes (verified independently with `od`/AST extraction during review).
- **Transport-boundary integration tests**: overrides set via a real config file provably reach the LLM payload (only `chat_api_call` / instance `_call_llm` faked).
- **Cold-start hygiene**: importing the package never imports `config.py` — enforced by a permanent subprocess test (`Tests/Internal_Prompts/test_import_hygiene.py`).
- Suites at HEAD: `Tests/Internal_Prompts/` 32 passed, `Tests/Web_Scraping/` 71 passed, `Tests/RAG/` green except the 4 failures pre-existing at base `dc196563f`; `Tests/Chat/` and `-k config` sweeps match dev-tip baseline (details in the SDD ledger). CI is intentionally cancelled repo-wide; verification is local.
- 7 tasks, each implemented by a fresh subagent and gated by spec+quality review; final whole-branch review (2 Importants fixed: sandbox-safe test fixture teardown, permanent import-hygiene test).

## Not in this PR (planned follow-ups)

- **P2**: agents / summarization / doc-gen / subscriptions prompt migration. **P3**: the Settings screen editor UI (until then this config surface is documented only in the spec — intentional).
- To file as backlog tasks: warn-once on wrong-typed override values; transport tests for web-search sites 2-4; dead literal fallback arm at `reranker.py:168`; `[Prompts]`/`prompts_strings` dead-key removal once fully migrated.

**Do not merge — awaiting user review gate.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an internal prompt registry with config-based overrides for 10 system prompts, and migrates web-search and RAG rerankers to use it. Defaults are unchanged; overrides from `config.toml` now reach the LLM payload safely.

- New Features
  - Introduced `tldw_chatbook/Internal_Prompts` registry (`PromptSpec` + resolver) with id/subsystem guards; override via `config.toml` under `[internal_prompts.websearch]` and `[internal_prompts.rag_reranker]`.
  - Resolution order: user override → legacy `[Prompts]` (only if customized) → shipped default.
  - Web-search now renders 4 prompts from the registry; RAG rerankers load 6 prompts from the registry; caller `RerankingConfig` still takes precedence.

- Bug Fixes
  - Legacy `[Prompts]` keys are honored as a fallback tier; invalid overrides fall back with a warn-once.
  - Added warn-once when required placeholders are missing at render time (never raises).
  - Replaced `.format()` with single-pass `safe_substitute` to prevent crashes on stray braces and stop re-expansion; removed a summarization `.format()` crash path and kept config off the cold-start import chain.

<sup>Written for commit 419f44f3df9db09ad673b6b02307a3e482067eb9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

