### PR TITLE
fix(settings): stop Theme/Splash Screen categories crashing the app

### DIFF
--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -131,6 +131,62 @@ def test_theme_and_splash_not_in_guided_mutation_categories():
     assert SettingsCategoryId.SPLASH_SCREEN not in settings_screen_module.GUIDED_SETTINGS_MUTATION_CATEGORIES
 
 
+def test_inspector_guidance_covers_every_settings_category():
+    """Every non-domain sidebar category must have an explicit guidance entry.
+
+    Regression: THEME and SPLASH_SCREEN were added to the sidebar without
+    guidance entries, so selecting them raised KeyError inside compose and
+    crashed the whole app. The runtime now returns a generic fallback so a
+    missing entry can never crash, which means asserting a truthy return would
+    always pass. This test guards the stronger property instead -- that every
+    category outside DOMAIN_SETTINGS_CATEGORY_IDS is an explicit key in
+    _INSPECTOR_GUIDANCE -- so a new category without real guidance fails CI
+    rather than silently shipping the generic fallback to users.
+    """
+    screen = SettingsScreen(_build_test_app())
+    for category in SettingsCategoryId:
+        guidance = screen._inspector_guidance(category)
+        assert guidance, f"no inspector guidance for {category!r}"
+        if category in settings_screen_module.DOMAIN_SETTINGS_CATEGORY_IDS:
+            continue
+        assert category in settings_screen_module._INSPECTOR_GUIDANCE, (
+            f"{category!r} has no explicit guidance entry and would fall back "
+            f"to generic text; add it to _INSPECTOR_GUIDANCE"
+        )
+
+
+@pytest.mark.asyncio
+async def test_theme_category_opens_without_crashing():
+    """Selecting the Theme category mounts its editor without crashing compose.
+
+    The editor widget mounting is the regression signal: the original bug
+    raised KeyError inside compose, so a crash would leave the editor unmounted
+    and time this wait out. Editor content is verified in
+    test_settings_theme_editor.py.
+    """
+    app = _build_test_app()
+    host = DestinationHarness(app, "settings")
+    async with host.run_test(size=(190, 55)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-theme")
+        screen = _active_destination_screen(host)
+        # Poll rather than a fixed settle: selecting a category triggers a
+        # recompose whose mount lands at a load-dependent moment.
+        await _wait_for_selector(screen, pilot, "#settings-theme-editor", timeout=8.0)
+
+
+@pytest.mark.asyncio
+async def test_splash_screen_category_opens_without_crashing():
+    """Selecting the Splash Screen category mounts its viewer without crashing compose."""
+    app = _build_test_app()
+    host = DestinationHarness(app, "settings")
+    async with host.run_test(size=(190, 55)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-splash_screen")
+        screen = _active_destination_screen(host)
+        await _wait_for_selector(
+            screen, pilot, "#settings-splash-screen-viewer", timeout=8.0
+        )
+
+
 class FakeSettingsModelDiscoveryScope:
     def __init__(
         self,

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -598,6 +598,162 @@ DOMAIN_CONTRACT_BY_CATEGORY = _build_domain_contract_by_category(
 DOMAIN_SETTINGS_CATEGORY_IDS = frozenset(DOMAIN_CONTRACT_BY_CATEGORY)
 _WORKSPACE_RECORD_UNSET = object()
 
+# Impact-pane guidance rows keyed by non-domain Settings category. Domain
+# categories (DOMAIN_SETTINGS_CATEGORY_IDS) derive their guidance from their
+# ownership contract instead and are intentionally absent here. Every other
+# SettingsCategoryId MUST have an entry: this table is read inside compose, so
+# a missing key would otherwise take down the whole app (see PR #713 / #742).
+_INSPECTOR_GUIDANCE: dict[SettingsCategoryId, tuple[tuple[str, str], ...]] = {
+    SettingsCategoryId.OVERVIEW: (
+        ("Affected config", "all Settings categories summarized for readiness"),
+        ("Recovery", "open the specific category before changing values"),
+        (
+            "Boundary",
+            "runtime MCP, ACP, and tool control stay in their own destinations",
+        ),
+    ),
+    SettingsCategoryId.PROVIDERS_MODELS: (
+        (
+            "Affected config",
+            "provider, model, endpoint, and credential source defaults",
+        ),
+        (
+            "Recovery",
+            "test provider readiness before saving provider-backed Console defaults",
+        ),
+        (
+            "Boundary",
+            "Sampling and transport defaults are routed to Console Defaults",
+        ),
+    ),
+    SettingsCategoryId.APPEARANCE: (
+        ("Affected config", "theme, density, font size, and motion defaults"),
+        (
+            "Recovery",
+            "open Theme for full theme editing; use Settings for persisted defaults",
+        ),
+        ("Boundary", "visual preferences do not change runtime or data access"),
+    ),
+    SettingsCategoryId.STORAGE: (
+        (
+            "Affected config",
+            "config file path, local database paths, media storage roots",
+        ),
+        (
+            "Recovery",
+            "verify paths, reload config, then restart only if storage roots changed",
+        ),
+        (
+            "Boundary",
+            "server handoff does not move local source content unless explicitly requested",
+        ),
+    ),
+    SettingsCategoryId.PRIVACY_SECURITY: (
+        (
+            "Affected config",
+            "encryption posture, credential-source status, and redaction status",
+        ),
+        (
+            "Credential source",
+            "Environment variables are preferred for provider credentials.",
+        ),
+        (
+            "Recovery",
+            "open Providers & Models for provider defaults or Advanced Config for expert repair",
+        ),
+        (
+            "Boundary",
+            "raw secret values are never displayed; encryption mutation needs a password-gated flow",
+        ),
+    ),
+    SettingsCategoryId.CONSOLE_BEHAVIOR: (
+        (
+            "Affected config",
+            "chat_defaults fallbacks plus Console composer paste behavior",
+        ),
+        (
+            "Recovery",
+            "revert unsaved changes or disable paste collapse if composer flow is disrupted",
+        ),
+        (
+            "Boundary",
+            "active sessions and provider+model profiles override these global fallbacks",
+        ),
+    ),
+    SettingsCategoryId.LIBRARY_RAG: (
+        (
+            "Affected config",
+            "AppRAGSearchConfig.rag.search and AppRAGSearchConfig.rag.retriever defaults",
+        ),
+        (
+            "Recovery",
+            "revert unsaved defaults or open Library to validate retrieval behavior",
+        ),
+        (
+            "Boundary",
+            "Library owns indexing, query execution, source browse, Collections, and staging",
+        ),
+    ),
+    SettingsCategoryId.DIAGNOSTICS: (
+        (
+            "Affected config",
+            "read-only validation, reload status, and troubleshooting output",
+        ),
+        (
+            "Recovery",
+            "validate first, reload only after confirming the config source is correct",
+        ),
+        (
+            "Boundary",
+            "diagnostics redact secrets and should not mutate advanced config",
+        ),
+    ),
+    SettingsCategoryId.ADVANCED_CONFIG: (
+        ("Affected config", "raw TOML for every loaded configuration section"),
+        (
+            "Recovery",
+            "validate current text, save atomically, then restore from backup if needed",
+        ),
+        ("Boundary", "save is blocked until the exact current text validates"),
+    ),
+    SettingsCategoryId.THEME: (
+        (
+            "Affected config",
+            "custom theme files under ~/.config/tldw_cli/themes/",
+        ),
+        (
+            "Recovery",
+            "use the editor's Apply/Save/Reset buttons; delete a theme file to remove it",
+        ),
+        (
+            "Boundary",
+            "launch visual defaults stay in Appearance; theme edits never touch config.toml",
+        ),
+    ),
+    SettingsCategoryId.SPLASH_SCREEN: (
+        (
+            "Affected config",
+            "splash_screen section defaults and card selection",
+        ),
+        (
+            "Recovery",
+            "reset defaults from this category or edit splash_screen values in Advanced Config",
+        ),
+        ("Boundary", "changes are saved immediately; no shared Settings draft state"),
+    ),
+}
+# Generic guidance for a category with no explicit entry. Kept as a runtime
+# safety net only; test_inspector_guidance_covers_every_settings_category fails
+# CI before an uncovered category can reach a user.
+_INSPECTOR_GUIDANCE_FALLBACK: tuple[tuple[str, str], ...] = (
+    ("Affected config", "this category manages its own settings"),
+    ("Recovery", "use the controls in the category detail pane"),
+    ("Boundary", "no shared Settings draft state is affected"),
+)
+# Categories already warned about, so the fallback logs once per run per
+# category instead of on every compose pass.
+_WARNED_MISSING_GUIDANCE_CATEGORIES: set[SettingsCategoryId] = set()
+
 
 def _textual_web_safe_url_display(value: str) -> str:
     """Break URL schemes in rendered input text without changing the stored value."""
@@ -5805,120 +5961,6 @@ class SettingsScreen(BaseAppScreen):
     def _inspector_guidance(
         self, category: SettingsCategoryId
     ) -> tuple[tuple[str, str], ...]:
-        guidance: dict[SettingsCategoryId, tuple[tuple[str, str], ...]] = {
-            SettingsCategoryId.OVERVIEW: (
-                ("Affected config", "all Settings categories summarized for readiness"),
-                ("Recovery", "open the specific category before changing values"),
-                (
-                    "Boundary",
-                    "runtime MCP, ACP, and tool control stay in their own destinations",
-                ),
-            ),
-            SettingsCategoryId.PROVIDERS_MODELS: (
-                (
-                    "Affected config",
-                    "provider, model, endpoint, and credential source defaults",
-                ),
-                (
-                    "Recovery",
-                    "test provider readiness before saving provider-backed Console defaults",
-                ),
-                (
-                    "Boundary",
-                    "Sampling and transport defaults are routed to Console Defaults",
-                ),
-            ),
-            SettingsCategoryId.APPEARANCE: (
-                ("Affected config", "theme, density, font size, and motion defaults"),
-                (
-                    "Recovery",
-                    "open Theme for full theme editing; use Settings for persisted defaults",
-                ),
-                ("Boundary", "visual preferences do not change runtime or data access"),
-            ),
-            SettingsCategoryId.STORAGE: (
-                (
-                    "Affected config",
-                    "config file path, local database paths, media storage roots",
-                ),
-                (
-                    "Recovery",
-                    "verify paths, reload config, then restart only if storage roots changed",
-                ),
-                (
-                    "Boundary",
-                    "server handoff does not move local source content unless explicitly requested",
-                ),
-            ),
-            SettingsCategoryId.PRIVACY_SECURITY: (
-                (
-                    "Affected config",
-                    "encryption posture, credential-source status, and redaction status",
-                ),
-                (
-                    "Credential source",
-                    "Environment variables are preferred for provider credentials.",
-                ),
-                (
-                    "Recovery",
-                    "open Providers & Models for provider defaults or Advanced Config for expert repair",
-                ),
-                (
-                    "Boundary",
-                    "raw secret values are never displayed; encryption mutation needs a password-gated flow",
-                ),
-            ),
-            SettingsCategoryId.CONSOLE_BEHAVIOR: (
-                (
-                    "Affected config",
-                    "chat_defaults fallbacks plus Console composer paste behavior",
-                ),
-                (
-                    "Recovery",
-                    "revert unsaved changes or disable paste collapse if composer flow is disrupted",
-                ),
-                (
-                    "Boundary",
-                    "active sessions and provider+model profiles override these global fallbacks",
-                ),
-            ),
-            SettingsCategoryId.LIBRARY_RAG: (
-                (
-                    "Affected config",
-                    "AppRAGSearchConfig.rag.search and AppRAGSearchConfig.rag.retriever defaults",
-                ),
-                (
-                    "Recovery",
-                    "revert unsaved defaults or open Library to validate retrieval behavior",
-                ),
-                (
-                    "Boundary",
-                    "Library owns indexing, query execution, source browse, Collections, and staging",
-                ),
-            ),
-            SettingsCategoryId.DIAGNOSTICS: (
-                (
-                    "Affected config",
-                    "read-only validation, reload status, and troubleshooting output",
-                ),
-                (
-                    "Recovery",
-                    "validate first, reload only after confirming the config source is correct",
-                ),
-                (
-                    "Boundary",
-                    "diagnostics redact secrets and should not mutate advanced config",
-                ),
-            ),
-            SettingsCategoryId.ADVANCED_CONFIG: (
-                ("Affected config", "raw TOML for every loaded configuration section"),
-                (
-                    "Recovery",
-                    "validate current text, save atomically, then restore from backup if needed",
-                ),
-                ("Boundary", "save is blocked until the exact current text validates"),
-            ),
-        }
         if category in DOMAIN_SETTINGS_CATEGORY_IDS:
             contract = self._domain_category_contract(category)
             return (
@@ -5935,7 +5977,21 @@ class SettingsScreen(BaseAppScreen):
                     f"{contract.owner_destination} remains the runtime owner; Settings cannot mutate it yet",
                 ),
             )
-        return guidance[category]
+        guidance = _INSPECTOR_GUIDANCE.get(category)
+        if guidance is not None:
+            return guidance
+        # A missing entry must degrade gracefully: this runs inside compose,
+        # where an uncaught exception takes down the whole app. Warn once per
+        # category so the coverage gap is visible in logs without spamming
+        # every rebuild.
+        if category not in _WARNED_MISSING_GUIDANCE_CATEGORIES:
+            _WARNED_MISSING_GUIDANCE_CATEGORIES.add(category)
+            logger.warning(
+                "No inspector guidance entry for Settings category %r; using "
+                "generic fallback. Add an entry to _INSPECTOR_GUIDANCE.",
+                category,
+            )
+        return _INSPECTOR_GUIDANCE_FALLBACK
 
     def _render_category_buttons(self) -> ComposeResult:
         summaries_by_id = {


### PR DESCRIPTION
## Summary

Selecting **Theme** or **Splash Screen** in the Settings sidebar crashed the entire app (reported by an end user as "accessing the themes page causes the application to crash").

**Root cause:** PR #713 added `THEME` and `SPLASH_SCREEN` to the Settings sidebar without adding matching entries to the hardcoded guidance table in `SettingsScreen._inspector_guidance()`. The method ended in a bare `guidance[category]` lookup, so selecting either category raised `KeyError` — and because the lookup runs inside `compose_content` → `_render_impact_pane`, the uncaught exception inside compose took down the whole app. This hit every user on dev with completely default state.

Existing tests never caught it because they mounted `SettingsThemeEditor` / `SettingsSplashScreenViewer` directly, bypassing `SettingsScreen`'s category navigation.

## Fix

- Add proper `_inspector_guidance` entries for `THEME` and `SPLASH_SCREEN` (affected config / recovery / boundary rows, matching the existing entries' style).
- Replace the bare `guidance[category]` with `guidance.get(category, <generic fallback>)` so a future missing entry degrades to generic guidance instead of crashing the app from inside compose.

## Verification

TDD (RED confirmed with the exact `KeyError` before the fix, then GREEN):

- `test_inspector_guidance_covers_every_settings_category` — sweeps every `SettingsCategoryId` through `_inspector_guidance`, so any future sidebar addition without guidance fails a unit test instead of crashing users.
- `test_theme_category_opens_without_crashing` / `test_splash_screen_category_opens_without_crashing` — real navigation through `SettingsScreen` via `DestinationHarness`, asserting the editor/viewer actually mount.

Local results: `Tests/UI/test_settings_configuration_hub.py` → 245 passed; theme editor, splash viewer, and appearance test files green. (CI checks are intentionally cancelled in this repo — verified locally.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash when opening the Theme or Splash Screen categories in Settings by adding missing inspector guidance and a safe fallback to prevent KeyError inside compose. Adds regression tests to cover all categories and verify both views mount.

- **Bug Fixes**
  - Add guidance entries for THEME and SPLASH_SCREEN.
  - Hoist the guidance table to module-level `_INSPECTOR_GUIDANCE`, and fall back to generic guidance with a once-per-category warning instead of raising.
  - Tests: sweep asserts every non-domain category is an explicit key in `_INSPECTOR_GUIDANCE`; navigation tests confirm the Theme editor and Splash Screen viewer mount.

<sup>Written for commit ae08c2ab2fdb71495871fd2694a4d1783eb0d073. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

