### PR TITLE
feat(roleplay): preview provider/model readout + Configure deep-link (task-426)

### DIFF
--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -2986,6 +2986,130 @@ class TestPreviewIntegration:
                 "character: Edited opener from Detective Sam to User."
             )
 
+    async def _readout_text(self, screen):
+        from textual.widgets import Static as _Static
+
+        return str(
+            screen.query_one("#personas-preview-provider", _Static).renderable
+        )
+
+    async def test_provider_readout_shows_character_and_fallback(
+        self, mock_app_instance, stub_characters, stub_conversations
+    ):
+        """The readout names the character provider/model and fallback target
+        (task-426)."""
+        mock_app_instance.app_config = {
+            "character_defaults": {"provider": "anthropic", "model": "claude-3-haiku"},
+            "chat_defaults": {"provider": "llama_cpp", "model": "local.gguf"},
+        }
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await self._select_first_character(pilot)
+            text = await self._readout_text(screen)
+            assert "Anthropic" in text
+            assert "claude-3-haiku" in text
+            # The Console-default fallback target is named too.
+            assert "llama.cpp" in text
+
+    async def test_provider_readout_no_fallback_note_when_same_provider(
+        self, mock_app_instance, stub_characters, stub_conversations
+    ):
+        """No fallback note when chat_defaults matches character_defaults."""
+        mock_app_instance.app_config = {
+            "character_defaults": {"provider": "openai", "model": "gpt-4o"},
+            "chat_defaults": {"provider": "openai", "model": "gpt-4o"},
+        }
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await self._select_first_character(pilot)
+            text = await self._readout_text(screen)
+            assert "OpenAI" in text
+            assert "gpt-4o" in text
+            assert "Console default" not in text
+
+    async def test_provider_readout_falls_to_chat_when_no_character_provider(
+        self, mock_app_instance, stub_characters, stub_conversations
+    ):
+        """With no character provider, the chat default is what answers."""
+        mock_app_instance.app_config = {
+            "character_defaults": {},
+            "chat_defaults": {"provider": "llama_cpp", "model": "local.gguf"},
+        }
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await self._select_first_character(pilot)
+            text = await self._readout_text(screen)
+            assert "llama.cpp" in text
+            assert "local.gguf" in text
+            assert "Console default" in text
+
+    async def test_configure_button_navigates_to_settings_providers(
+        self, mock_app_instance, stub_characters, stub_conversations
+    ):
+        """The Configure affordance deep-links to Settings > Providers & Models
+        with the character provider preselected (task-426)."""
+        from textual.widgets import Button
+
+        from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
+        from tldw_chatbook.UI.Screens.settings_config_models import (
+            SettingsCategoryId,
+        )
+
+        mock_app_instance.app_config = {
+            "character_defaults": {"provider": "anthropic", "model": "claude-3-haiku"},
+            "chat_defaults": {"provider": "llama_cpp", "model": "local.gguf"},
+        }
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await self._select_first_character(pilot)
+            posted: list[NavigateToScreen] = []
+            original = screen.post_message
+
+            def _record(message):
+                if isinstance(message, NavigateToScreen):
+                    posted.append(message)
+                return original(message)
+
+            screen.post_message = _record
+            screen.query_one("#personas-preview-configure", Button).press()
+            await pilot.pause()
+            assert posted, "Configure should post a navigation message"
+            nav = posted[-1]
+            assert nav.screen_name == "settings"
+            category = nav.screen_context.get("category")
+            category_value = getattr(category, "value", category)
+            assert category_value == SettingsCategoryId.PROVIDERS_MODELS.value
+            assert nav.screen_context.get("provider") == "anthropic"
+
+    async def test_post_send_readout_reflects_resolved_fallback_provider(
+        self, mock_app_instance, stub_characters, stub_conversations
+    ):
+        """After a fallback reply, the readout reflects the provider that
+        actually answered (task-425/426)."""
+        from tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages import (
+            PreviewReplyRequested,
+        )
+
+        mock_app_instance.app_config = {
+            "character_defaults": {"provider": "anthropic", "model": "claude-3-haiku"},
+            "chat_defaults": {"provider": "llama_cpp", "model": "local.gguf"},
+        }
+        fake = _ReadinessMapPreviewGateway(ready_providers={"llama_cpp"})
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await self._select_first_character(pilot)
+            screen.preview.ensure_gateway = lambda: fake
+            screen.post_message(PreviewReplyRequested("Hi"))
+            await pilot.pause()
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+            text = await self._readout_text(screen)
+            assert "llama.cpp" in text
+            assert "Console default" in text
+            # Configure still targets the character-configured provider (the
+            # one to make ready), not the fallback that happened to answer.
+            assert screen.preview._readout_nav_provider == "anthropic"
+
     async def test_blocked_provider_shows_readable_status(
         self, mock_app_instance, stub_characters, stub_conversations
     ):

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -3043,10 +3043,48 @@ class TestPreviewIntegration:
             assert "local.gguf" in text
             assert "Console default" in text
 
+    async def test_provider_readout_uses_effective_provider_model(
+        self, mock_app_instance, stub_characters, stub_conversations
+    ):
+        """The readout and send share the model inherited from provider config."""
+        from tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages import (
+            PreviewReplyRequested,
+        )
+
+        mock_app_instance.app_config = {
+            "character_defaults": {"provider": "anthropic"},
+            "api_settings": {
+                "anthropic": {"model": "claude-3-5-haiku-latest"},
+            },
+        }
+        fake = ReadinessMapPreviewGateway(ready_providers={"anthropic"})
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await self._select_first_character(pilot)
+            screen.preview.ensure_gateway = lambda: fake
+            text = await self._readout_text(screen)
+            assert text == "Provider: Anthropic / claude-3-5-haiku-latest"
+
+            screen.post_message(PreviewReplyRequested("Hi"))
+            await pilot.pause()
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+
+            assert fake.selections[0].provider == "anthropic"
+            assert fake.selections[0].explicit_model is None
+            assert (
+                fake.selections[0].configured_model
+                == "claude-3-5-haiku-latest"
+            )
+
     async def test_provider_readout_normalizes_whitespace_defaults(
         self, mock_app_instance, stub_characters, stub_conversations
     ):
-        """Whitespace-only character defaults fall through to trimmed chat defaults."""
+        """Readout and send normalize whitespace before Console resolution."""
+        from tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages import (
+            PreviewReplyRequested,
+        )
+
         mock_app_instance.app_config = {
             "character_defaults": {"provider": "   ", "model": " ignored "},
             "chat_defaults": {
@@ -3054,12 +3092,27 @@ class TestPreviewIntegration:
                 "model": "  local.gguf  ",
             },
         }
+        fake = ReadinessMapPreviewGateway(ready_providers={"llama_cpp"})
         app = PersonasTestApp(mock_app_instance)
         async with app.run_test(size=(160, 50)) as pilot:
             screen = await self._select_first_character(pilot)
+            screen.preview.ensure_gateway = lambda: fake
             text = await self._readout_text(screen)
             assert text == "Provider: llama.cpp / local.gguf (Console default)"
             assert screen.preview._readout_nav_provider == "llama_cpp"
+
+            screen.post_message(PreviewReplyRequested("Hi"))
+            await pilot.pause()
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+
+            assert [selection.provider for selection in fake.selections] == [
+                "",
+                "llama_cpp",
+            ]
+            fallback = fake.selections[-1]
+            assert fallback.explicit_model == "local.gguf"
+            assert fake.requests, "Normalized fallback selection should answer"
 
     async def test_configure_button_navigates_to_settings_providers(
         self, mock_app_instance, stub_characters, stub_conversations

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -3043,6 +3043,24 @@ class TestPreviewIntegration:
             assert "local.gguf" in text
             assert "Console default" in text
 
+    async def test_provider_readout_normalizes_whitespace_defaults(
+        self, mock_app_instance, stub_characters, stub_conversations
+    ):
+        """Whitespace-only character defaults fall through to trimmed chat defaults."""
+        mock_app_instance.app_config = {
+            "character_defaults": {"provider": "   ", "model": " ignored "},
+            "chat_defaults": {
+                "provider": "  llama_cpp  ",
+                "model": "  local.gguf  ",
+            },
+        }
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await self._select_first_character(pilot)
+            text = await self._readout_text(screen)
+            assert text == "Provider: llama.cpp / local.gguf (Console default)"
+            assert screen.preview._readout_nav_provider == "llama_cpp"
+
     async def test_configure_button_navigates_to_settings_providers(
         self, mock_app_instance, stub_characters, stub_conversations
     ):
@@ -3094,7 +3112,7 @@ class TestPreviewIntegration:
             "character_defaults": {"provider": "anthropic", "model": "claude-3-haiku"},
             "chat_defaults": {"provider": "llama_cpp", "model": "local.gguf"},
         }
-        fake = _ReadinessMapPreviewGateway(ready_providers={"llama_cpp"})
+        fake = ReadinessMapPreviewGateway(ready_providers={"llama_cpp"})
         app = PersonasTestApp(mock_app_instance)
         async with app.run_test(size=(160, 50)) as pilot:
             screen = await self._select_first_character(pilot)

--- a/Tests/UI/test_personas_workbench_state.py
+++ b/Tests/UI/test_personas_workbench_state.py
@@ -184,6 +184,44 @@ class TestWorkbenchSelectionRestore:
 class TestPreviewRestore:
     """AC#2: the preview conversation (greeting + turns) survives the round-trip."""
 
+    async def test_restore_refreshes_provider_readout_without_character_load(
+        self, mock_app_instance, stub_characters
+    ):
+        """Restoring preview state also restores its provider affordances.
+
+        ``stub_characters`` deliberately makes ``load_character`` a no-op, so
+        this covers the valid navigation-restore path where no later
+        ``CharacterMessage.Loaded`` event repaints the readout.
+        """
+        from textual.widgets import Static
+
+        mock_app_instance.app_config = {
+            "character_defaults": {
+                "provider": "anthropic",
+                "model": "claude-3-haiku",
+            },
+            "chat_defaults": {"provider": "llama_cpp", "model": "local.gguf"},
+        }
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test() as pilot:
+            screen = await _mounted(pilot)
+            await screen._select_character("char-1", "Elara")
+            await pilot.pause()
+            saved = screen.save_state()
+
+        app2 = _RestoringPersonasTestApp(mock_app_instance, saved)
+        async with app2.run_test() as pilot2:
+            screen2 = await _mounted(pilot2)
+            readout = str(
+                screen2.query_one("#personas-preview-provider", Static).renderable
+            )
+
+            assert readout == (
+                "Provider: Anthropic / claude-3-haiku"
+                " - Console default if unavailable: llama.cpp"
+            )
+            assert screen2.preview._readout_nav_provider == "anthropic"
+
     async def test_save_restore_preserves_preview_greeting_and_turns(
         self, mock_app_instance, stub_characters
     ):

--- a/backlog/tasks/task-426 - Roleplay-preview-shows-provider-and-model-readout-with-a-Settings-deep-link.md
+++ b/backlog/tasks/task-426 - Roleplay-preview-shows-provider-and-model-readout-with-a-Settings-deep-link.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-426
 title: Roleplay preview shows provider and model readout with a Settings deep-link
-status: Done
+status: In Progress
 assignee:
   - '@claude'
 created_date: '2026-07-21 09:38'
-updated_date: '2026-07-21 21:18'
+updated_date: '2026-07-23 13:46'
 labels:
   - roleplay
   - ux
@@ -29,13 +29,17 @@ Filed from the RP/character-card UX review (Docs/superpowers/qa/rp-ux-review-202
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-Stacked on task-425 branch (needs _resolve_selection_with_fallback).
-1. TDD in Tests/UI/test_personas_workbench.py: (a) provider_readout() sync formatting — char+distinct-chat shows fallback note; char-only no note; no-char-provider falls to chat/none; (b) readout Static populated after selecting a character; (c) Configure button posts NavigateToScreen settings/providers-models with char provider; (d) post-send readout reflects resolved (fallback) provider.
-2. Pane (personas_preview_pane.py): add #personas-preview-provider Static at top of body; set_provider_readout(text); 'Configure' Button in toolbar posting PreviewConfigureProviderRequested.
-3. Message: add PreviewConfigureProviderRequested to personas_pane_messages.py.
-4. Controller: provider_readout()->(text,nav_provider) sync from config using PROVIDER_DISPLAY_NAMES; refresh_provider_readout() sets pane; call from handle_character_loaded/reset_for_character/reset; open_provider_settings() posts NavigateToScreen; in _run_reply update readout to resolution.provider/model (+Console default when fallback).
-5. Screen: @on(PreviewConfigureProviderRequested)->preview.open_provider_settings().
-6. Scoped pytest + live-verify readout + Configure nav in real TUI.
+ADR required: no
+ADR path: backlog/decisions/004-personas-destination-native-workbench.md; backlog/decisions/007-personas-workbench-route-consolidation.md; backlog/decisions/006-provider-aware-generation-settings.md; backlog/decisions/012-provider-credential-settings-boundary.md
+Reason: This is corrective normalization, documentation, and UI verification within the existing Personas preview, provider-default, and Settings navigation boundaries; it introduces no new storage, runtime, security, dependency, or long-lived UX decision.
+
+1. Replay only the task-426 commit onto current origin/dev, preserving the merged task-425 implementation and resolving conflicts against its reviewed final shape.
+2. Retarget PR #746 from the retired stacked base branch to dev and verify the diff contains only task-426 work plus review remediation.
+3. Add a focused failing regression proving whitespace-only character provider/model values are treated as unset and the readout plus Configure target match actual send-path normalization.
+4. Implement the smallest controller normalization fix and add the required Google-style Args section to set_provider_readout.
+5. Run focused Personas preview/workbench tests, lint, type checks, diff checks, and task/backlog validation.
+6. Commit and push the rebased remediation, reply to and resolve every review thread, then request an independent code review.
+7. Monitor final GitHub checks, compare any inherited failures with the exact dev baseline, verify mergeability and unresolved-thread state, then merge through the normal GitHub path.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes

--- a/backlog/tasks/task-426 - Roleplay-preview-shows-provider-and-model-readout-with-a-Settings-deep-link.md
+++ b/backlog/tasks/task-426 - Roleplay-preview-shows-provider-and-model-readout-with-a-Settings-deep-link.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@claude'
 created_date: '2026-07-21 09:38'
-updated_date: '2026-07-23 14:08'
+updated_date: '2026-07-23 15:57'
 labels:
   - roleplay
   - ux
@@ -45,13 +45,13 @@ Reason: This is corrective normalization, documentation, and UI verification wit
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Rebased the task-426 feature directly onto current dev after task-425 merged, so PR #746 contains only the provider/model preview readout, Settings deep-link, and review remediation. Preserved the final task-425 readiness gateway shape while resolving the stacked-branch conflict.
+Rebased the task-426 feature directly onto current dev after task-425 merged, so PR #746 contains only the provider/model preview readout, Settings deep-link, and review remediation. Replayed cleanly across the later TASK-433 endpoint and TASK-434 Personas preview-persistence merges, preserving their reviewed final behavior.
 
 Review remediation: added Google-style Args documentation to PersonasPreviewPane.set_provider_readout(). Provider and model normalization now happens in the shared _selection_from_defaults send path, and provider_readout derives both character and Console-default labels from those effective selections. This keeps display text, Settings navigation, logs, and actual sends aligned, including whitespace-only defaults and models inherited from api_settings.
 
 TDD evidence: the whitespace end-to-end and inherited-provider-model cases both failed before the shared-path fix, then passed after it. The tests submit real preview requests through ReadinessMapPreviewGateway and assert the normalized/effective ConsoleProviderSelection values, fallback behavior, rendered readout, and Configure target.
 
-Verification: Tests/UI/test_personas_workbench.py + Tests/UI/test_personas_preview.py = 197 passed; Ruff passed on all changed test/controller/widget files; mypy passed for personas_preview_controller.py; compileall and git diff --check passed; Backlog Guard found no duplicate IDs across 593 task files. Independent pre-merge review found no Critical issues; its two Important alignment findings were fixed and covered by the new end-to-end assertions.
+Verification on dev 0f5904e6: Tests/UI/test_personas_workbench.py + Tests/UI/test_personas_preview.py = 198 passed; Ruff passed on all changed test/controller/widget files; mypy passed for personas_preview_controller.py; compileall and git diff --check passed; Backlog Guard found no duplicate IDs across 595 task files. Independent pre-merge review and post-rebase integration review found no remaining Critical or Important issues.
 
 ADR required: no. Existing boundaries remain governed by backlog/decisions/004-personas-destination-native-workbench.md, 006-provider-aware-generation-settings.md, 007-personas-workbench-route-consolidation.md, and 012-provider-credential-settings-boundary.md.
 

--- a/backlog/tasks/task-426 - Roleplay-preview-shows-provider-and-model-readout-with-a-Settings-deep-link.md
+++ b/backlog/tasks/task-426 - Roleplay-preview-shows-provider-and-model-readout-with-a-Settings-deep-link.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-426
 title: Roleplay preview shows provider and model readout with a Settings deep-link
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-07-21 09:38'
-updated_date: '2026-07-23 13:46'
+updated_date: '2026-07-23 13:56'
 labels:
   - roleplay
   - ux
@@ -45,13 +45,13 @@ Reason: This is corrective normalization, documentation, and UI verification wit
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Stacked on task-425. Added a provider/model readout line at the top of the preview pane body (#personas-preview-provider) plus a Configure button in the toolbar.
+Rebased the task-426 feature directly onto current dev after task-425 merged, so PR #746 now contains only the provider/model preview readout, Settings deep-link, and review remediation. Preserved the final task-425 readiness gateway shape while resolving the stacked-branch conflict.
 
-Readout (PersonasPreviewController.provider_readout): computed synchronously from config — no readiness probe — mirroring 425's resolution order. Shows the character_defaults provider/model that replies try first and, when chat_defaults names a distinct provider, the Console-default fallback target ('- Console default if unavailable: <provider>'). With no character provider it shows the chat default as '(Console default)'. Recomputed on every seed (reset + handle_character_loaded), so config changes reflect on the next selection (AC #3). After a real reply resolves in _run_reply, the readout is repainted with the provider/model that actually answered (free — we already resolved), so it reflects the fallback rather than intent (AC #1). Provider keys → display names via PROVIDER_DISPLAY_NAMES.
+Review remediation: normalized provider and model values with strip() before resolution, so whitespace-only character defaults fall back to the Console defaults and the Settings deep-link carries the normalized provider key. Added Google-style Args documentation to PersonasPreviewPane.set_provider_readout(). Added a regression test that failed before the normalization fix and now verifies both the exact Console-default readout and navigation provider.
 
-Configure (AC #2): pane posts PreviewConfigureProviderRequested → screen → controller.open_provider_settings() posts NavigateToScreen('settings', {category: PROVIDERS_MODELS, provider: <char provider>}). Settings' own unsaved-changes guard may suppress the provider preselect (pre-existing), but navigation to Providers & Models is reliable.
+Verification: Tests/UI/test_personas_workbench.py + Tests/UI/test_personas_preview.py = 196 passed; Ruff passed on all changed test/controller/widget files; mypy passed for personas_preview_controller.py; compileall and git diff --check passed; Backlog Guard found no duplicate IDs across 593 task files.
 
-Tests: 5 new cases in test_personas_workbench.py (readout content for char+fallback / same-provider / no-char-provider; Configure navigation context; post-send resolved readout). Full test_personas_workbench + test_personas_preview = 195 passed. Live-verified in the real TUI: readout renders 'Provider: Anthropic / claude-3-haiku - Console default if unavailable: llama.cpp', flips post-send to 'Provider: llama.cpp / local-gemma.gguf (Console default)', and Configure lands on Settings > Providers & Models.
+ADR required: no. Existing boundaries remain governed by backlog/decisions/004-personas-destination-native-workbench.md, 006-provider-aware-generation-settings.md, 007-personas-workbench-route-consolidation.md, and 012-provider-credential-settings-boundary.md.
 
-Files: personas_preview_controller.py, personas_preview_pane.py, personas_pane_messages.py, personas_screen.py, Tests/UI/test_personas_workbench.py.
+Modified files: personas_preview_controller.py, personas_preview_pane.py, personas_pane_messages.py, personas_screen.py, Tests/UI/test_personas_workbench.py, and this task record.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-426 - Roleplay-preview-shows-provider-and-model-readout-with-a-Settings-deep-link.md
+++ b/backlog/tasks/task-426 - Roleplay-preview-shows-provider-and-model-readout-with-a-Settings-deep-link.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@claude'
 created_date: '2026-07-21 09:38'
-updated_date: '2026-07-23 15:57'
+updated_date: '2026-07-23 16:08'
 labels:
   - roleplay
   - ux
@@ -45,15 +45,5 @@ Reason: This is corrective normalization, documentation, and UI verification wit
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Rebased the task-426 feature directly onto current dev after task-425 merged, so PR #746 contains only the provider/model preview readout, Settings deep-link, and review remediation. Replayed cleanly across the later TASK-433 endpoint and TASK-434 Personas preview-persistence merges, preserving their reviewed final behavior.
-
-Review remediation: added Google-style Args documentation to PersonasPreviewPane.set_provider_readout(). Provider and model normalization now happens in the shared _selection_from_defaults send path, and provider_readout derives both character and Console-default labels from those effective selections. This keeps display text, Settings navigation, logs, and actual sends aligned, including whitespace-only defaults and models inherited from api_settings.
-
-TDD evidence: the whitespace end-to-end and inherited-provider-model cases both failed before the shared-path fix, then passed after it. The tests submit real preview requests through ReadinessMapPreviewGateway and assert the normalized/effective ConsoleProviderSelection values, fallback behavior, rendered readout, and Configure target.
-
-Verification on dev 0f5904e6: Tests/UI/test_personas_workbench.py + Tests/UI/test_personas_preview.py = 198 passed; Ruff passed on all changed test/controller/widget files; mypy passed for personas_preview_controller.py; compileall and git diff --check passed; Backlog Guard found no duplicate IDs across 595 task files. Independent pre-merge review and post-rebase integration review found no remaining Critical or Important issues.
-
-ADR required: no. Existing boundaries remain governed by backlog/decisions/004-personas-destination-native-workbench.md, 006-provider-aware-generation-settings.md, 007-personas-workbench-route-consolidation.md, and 012-provider-credential-settings-boundary.md.
-
-Modified files: personas_preview_controller.py, personas_preview_pane.py, personas_pane_messages.py, personas_screen.py, Tests/UI/test_personas_workbench.py, and this task record.
+Implemented the Personas preview provider/model readout and Configure deep-link within the existing provider-aware Settings boundary. Centralized provider/model normalization so display, send resolution, navigation targeting, and logs share effective selections; added fallback/resolved-provider copy; documented the pane API; and covered whitespace-only defaults plus inherited provider models. After rebasing onto dev 0f5904e6, final integration review found TASK-434 could restore preview state without a character-load event, so restore_conversation now refreshes the readout directly and a no-load navigation-restore regression verifies both visible text and the Configure provider. Verification: 206 focused Personas workbench/preview/persistence tests passed; Ruff passed on all task code (the sole full-screen F821 is inherited unchanged from dev at personas_screen.py:4215); mypy passed for the controller; production files compile; git diff --check passed; duplicate guard passed across 595 task files. Independent re-review found no Critical or Important issues. ADR required: no. Existing ADR-004, ADR-006, ADR-007, and ADR-012 govern this corrective slice. Modified files: Personas preview controller/pane/messages/screen, focused UI tests including restore coverage, and TASK-426.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-426 - Roleplay-preview-shows-provider-and-model-readout-with-a-Settings-deep-link.md
+++ b/backlog/tasks/task-426 - Roleplay-preview-shows-provider-and-model-readout-with-a-Settings-deep-link.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@claude'
 created_date: '2026-07-21 09:38'
-updated_date: '2026-07-23 13:56'
+updated_date: '2026-07-23 14:08'
 labels:
   - roleplay
   - ux
@@ -45,11 +45,13 @@ Reason: This is corrective normalization, documentation, and UI verification wit
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Rebased the task-426 feature directly onto current dev after task-425 merged, so PR #746 now contains only the provider/model preview readout, Settings deep-link, and review remediation. Preserved the final task-425 readiness gateway shape while resolving the stacked-branch conflict.
+Rebased the task-426 feature directly onto current dev after task-425 merged, so PR #746 contains only the provider/model preview readout, Settings deep-link, and review remediation. Preserved the final task-425 readiness gateway shape while resolving the stacked-branch conflict.
 
-Review remediation: normalized provider and model values with strip() before resolution, so whitespace-only character defaults fall back to the Console defaults and the Settings deep-link carries the normalized provider key. Added Google-style Args documentation to PersonasPreviewPane.set_provider_readout(). Added a regression test that failed before the normalization fix and now verifies both the exact Console-default readout and navigation provider.
+Review remediation: added Google-style Args documentation to PersonasPreviewPane.set_provider_readout(). Provider and model normalization now happens in the shared _selection_from_defaults send path, and provider_readout derives both character and Console-default labels from those effective selections. This keeps display text, Settings navigation, logs, and actual sends aligned, including whitespace-only defaults and models inherited from api_settings.
 
-Verification: Tests/UI/test_personas_workbench.py + Tests/UI/test_personas_preview.py = 196 passed; Ruff passed on all changed test/controller/widget files; mypy passed for personas_preview_controller.py; compileall and git diff --check passed; Backlog Guard found no duplicate IDs across 593 task files.
+TDD evidence: the whitespace end-to-end and inherited-provider-model cases both failed before the shared-path fix, then passed after it. The tests submit real preview requests through ReadinessMapPreviewGateway and assert the normalized/effective ConsoleProviderSelection values, fallback behavior, rendered readout, and Configure target.
+
+Verification: Tests/UI/test_personas_workbench.py + Tests/UI/test_personas_preview.py = 197 passed; Ruff passed on all changed test/controller/widget files; mypy passed for personas_preview_controller.py; compileall and git diff --check passed; Backlog Guard found no duplicate IDs across 593 task files. Independent pre-merge review found no Critical issues; its two Important alignment findings were fixed and covered by the new end-to-end assertions.
 
 ADR required: no. Existing boundaries remain governed by backlog/decisions/004-personas-destination-native-workbench.md, 006-provider-aware-generation-settings.md, 007-personas-workbench-route-consolidation.md, and 012-provider-credential-settings-boundary.md.
 

--- a/backlog/tasks/task-426 - Roleplay-preview-shows-provider-and-model-readout-with-a-Settings-deep-link.md
+++ b/backlog/tasks/task-426 - Roleplay-preview-shows-provider-and-model-readout-with-a-Settings-deep-link.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-426
 title: Roleplay preview shows provider and model readout with a Settings deep-link
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-21 09:38'
+updated_date: '2026-07-21 21:18'
 labels:
   - roleplay
   - ux
@@ -19,7 +21,33 @@ Filed from the RP/character-card UX review (Docs/superpowers/qa/rp-ux-review-202
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Preview pane displays the resolved provider and model that character replies will use
-- [ ] #2 A visible affordance navigates to the provider configuration surface
-- [ ] #3 Readout updates when the resolution changes (settings saved, config reloaded)
+- [x] #1 Preview pane displays the resolved provider and model that character replies will use
+- [x] #2 A visible affordance navigates to the provider configuration surface
+- [x] #3 Readout updates when the resolution changes (settings saved, config reloaded)
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Stacked on task-425 branch (needs _resolve_selection_with_fallback).
+1. TDD in Tests/UI/test_personas_workbench.py: (a) provider_readout() sync formatting — char+distinct-chat shows fallback note; char-only no note; no-char-provider falls to chat/none; (b) readout Static populated after selecting a character; (c) Configure button posts NavigateToScreen settings/providers-models with char provider; (d) post-send readout reflects resolved (fallback) provider.
+2. Pane (personas_preview_pane.py): add #personas-preview-provider Static at top of body; set_provider_readout(text); 'Configure' Button in toolbar posting PreviewConfigureProviderRequested.
+3. Message: add PreviewConfigureProviderRequested to personas_pane_messages.py.
+4. Controller: provider_readout()->(text,nav_provider) sync from config using PROVIDER_DISPLAY_NAMES; refresh_provider_readout() sets pane; call from handle_character_loaded/reset_for_character/reset; open_provider_settings() posts NavigateToScreen; in _run_reply update readout to resolution.provider/model (+Console default when fallback).
+5. Screen: @on(PreviewConfigureProviderRequested)->preview.open_provider_settings().
+6. Scoped pytest + live-verify readout + Configure nav in real TUI.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Stacked on task-425. Added a provider/model readout line at the top of the preview pane body (#personas-preview-provider) plus a Configure button in the toolbar.
+
+Readout (PersonasPreviewController.provider_readout): computed synchronously from config — no readiness probe — mirroring 425's resolution order. Shows the character_defaults provider/model that replies try first and, when chat_defaults names a distinct provider, the Console-default fallback target ('- Console default if unavailable: <provider>'). With no character provider it shows the chat default as '(Console default)'. Recomputed on every seed (reset + handle_character_loaded), so config changes reflect on the next selection (AC #3). After a real reply resolves in _run_reply, the readout is repainted with the provider/model that actually answered (free — we already resolved), so it reflects the fallback rather than intent (AC #1). Provider keys → display names via PROVIDER_DISPLAY_NAMES.
+
+Configure (AC #2): pane posts PreviewConfigureProviderRequested → screen → controller.open_provider_settings() posts NavigateToScreen('settings', {category: PROVIDERS_MODELS, provider: <char provider>}). Settings' own unsaved-changes guard may suppress the provider preselect (pre-existing), but navigation to Providers & Models is reliable.
+
+Tests: 5 new cases in test_personas_workbench.py (readout content for char+fallback / same-provider / no-char-provider; Configure navigation context; post-send resolved readout). Full test_personas_workbench + test_personas_preview = 195 passed. Live-verified in the real TUI: readout renders 'Provider: Anthropic / claude-3-haiku - Console default if unavailable: llama.cpp', flips post-send to 'Provider: llama.cpp / local-gemma.gguf (Console default)', and Configure lands on Settings > Providers & Models.
+
+Files: personas_preview_controller.py, personas_preview_pane.py, personas_pane_messages.py, personas_screen.py, Tests/UI/test_personas_workbench.py.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py
+++ b/tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py
@@ -170,13 +170,16 @@ class PersonasPreviewController:
             ``(readout_text, nav_provider)`` where ``nav_provider`` is the
             provider key the Configure deep-link should preselect.
         """
-        config = getattr(self.screen.app_instance, "app_config", {}) or {}
-        char = config.get("character_defaults", {}) or {}
-        chat = config.get("chat_defaults", {}) or {}
-        char_provider = str(char.get("provider") or "").strip()
-        char_model = str(char.get("model") or "").strip()
-        chat_provider = str(chat.get("provider") or "").strip()
-        chat_model = str(chat.get("model") or "").strip()
+        raw_config = getattr(self.screen.app_instance, "app_config", {}) or {}
+        config = raw_config if isinstance(raw_config, Mapping) else {}
+        char_selection = self._selection_from_defaults(
+            config, "character_defaults"
+        )
+        chat_selection = self._selection_from_defaults(config, "chat_defaults")
+        char_provider = char_selection.provider
+        char_model = self._selection_model(char_selection)
+        chat_provider = chat_selection.provider
+        chat_model = self._selection_model(chat_selection)
         if not char_provider:
             if chat_provider:
                 text = (
@@ -395,8 +398,8 @@ class PersonasPreviewController:
         """
         raw_defaults = config.get(defaults_key, {})
         defaults = raw_defaults if isinstance(raw_defaults, Mapping) else {}
-        provider = str(defaults.get("provider") or "")
-        explicit_model = str(defaults.get("model") or "") or None
+        provider = str(defaults.get("provider") or "").strip()
+        explicit_model = str(defaults.get("model") or "").strip() or None
 
         settings_config: Mapping[str, Any] = config
         if defaults_key != "chat_defaults":
@@ -413,7 +416,7 @@ class PersonasPreviewController:
             model=explicit_model,
         )
         return ConsoleProviderSelection(
-            provider=provider,
+            provider=settings.provider,
             base_url=settings.base_url,
             explicit_model=explicit_model,
             configured_model=None if explicit_model else settings.model,

--- a/tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py
+++ b/tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py
@@ -16,8 +16,8 @@ from textual.css.query import QueryError
 from ...Character_Chat.Character_Chat_Lib import replace_placeholders
 from ...Chat.console_chat_models import ConsoleProviderSelection
 from ...Chat.console_provider_gateway import ConsoleProviderGateway
-from ...Chat.provider_catalog import PROVIDER_DISPLAY_NAMES
 from ...Chat.console_session_settings import build_default_console_session_settings
+from ...Chat.provider_catalog import PROVIDER_DISPLAY_NAMES
 from ...Widgets.Persona_Widgets.personas_character_editor_widget import (
     PersonasCharacterEditorWidget,
 )
@@ -150,7 +150,7 @@ class PersonasPreviewController:
     @staticmethod
     def _provider_label(provider_key: str) -> str:
         """Human-readable display name for a provider config key."""
-        key = str(provider_key or "")
+        key = str(provider_key or "").strip()
         if not key:
             return ""
         return PROVIDER_DISPLAY_NAMES.get(
@@ -173,10 +173,10 @@ class PersonasPreviewController:
         config = getattr(self.screen.app_instance, "app_config", {}) or {}
         char = config.get("character_defaults", {}) or {}
         chat = config.get("chat_defaults", {}) or {}
-        char_provider = str(char.get("provider") or "")
-        char_model = str(char.get("model") or "")
-        chat_provider = str(chat.get("provider") or "")
-        chat_model = str(chat.get("model") or "")
+        char_provider = str(char.get("provider") or "").strip()
+        char_model = str(char.get("model") or "").strip()
+        chat_provider = str(chat.get("provider") or "").strip()
+        chat_model = str(chat.get("model") or "").strip()
         if not char_provider:
             if chat_provider:
                 text = (

--- a/tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py
+++ b/tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py
@@ -133,6 +133,7 @@ class PersonasPreviewController:
             elif role == "assistant":
                 pane.append_reply(content)
         self.history = [dict(m) for m in history]
+        self.refresh_provider_readout()
 
     async def close_gateway(self) -> None:
         """Release the preview gateway's HTTP client if it was created."""

--- a/tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py
+++ b/tldw_chatbook/UI/Persona_Modules/personas_preview_controller.py
@@ -16,11 +16,14 @@ from textual.css.query import QueryError
 from ...Character_Chat.Character_Chat_Lib import replace_placeholders
 from ...Chat.console_chat_models import ConsoleProviderSelection
 from ...Chat.console_provider_gateway import ConsoleProviderGateway
+from ...Chat.provider_catalog import PROVIDER_DISPLAY_NAMES
 from ...Chat.console_session_settings import build_default_console_session_settings
 from ...Widgets.Persona_Widgets.personas_character_editor_widget import (
     PersonasCharacterEditorWidget,
 )
 from ...Widgets.Persona_Widgets.personas_preview_pane import PersonasPreviewPane
+from ..Navigation.main_navigation import NavigateToScreen
+from ..Screens.settings_config_models import SettingsCategoryId
 
 if TYPE_CHECKING:
     from ..Screens.personas_screen import PersonasScreen
@@ -44,6 +47,12 @@ class PersonasPreviewController:
         # Character id whose greeting last seeded the preview.
         self.seeded_for: str | None = None
         self.gateway: ConsoleProviderGateway | None = None
+        # Provider key the Configure deep-link targets in Settings. This is
+        # deliberately the CHARACTER-configured provider (or the chat default
+        # when no character provider is set) - the provider a user would make
+        # ready so replies stop falling back - even after a fallback send has
+        # repainted the readout text with the provider that actually answered.
+        self._readout_nav_provider: str = ""
 
     def invalidate(self) -> None:
         """Clear history and cancel in-flight preview workers."""
@@ -66,6 +75,7 @@ class PersonasPreviewController:
             # Tolerate calls that race screen teardown.
             pass
         self.seeded_for = seeded_for
+        self.refresh_provider_readout()
 
     async def reset_for_character(
         self,
@@ -137,6 +147,75 @@ class PersonasPreviewController:
                 exception=True
             ).warning("Could not close the preview provider gateway.")
 
+    @staticmethod
+    def _provider_label(provider_key: str) -> str:
+        """Human-readable display name for a provider config key."""
+        key = str(provider_key or "")
+        if not key:
+            return ""
+        return PROVIDER_DISPLAY_NAMES.get(
+            key.lower(), key.replace("_", " ").replace("-", " ").title()
+        )
+
+    def provider_readout(self) -> tuple[str, str]:
+        """Compute the pre-send provider readout from current config.
+
+        The preview send path (``_run_reply``) tries ``character_defaults``
+        first and falls back to ``chat_defaults`` when that provider is not
+        ready (task-425). The readout mirrors that intent from config alone —
+        no readiness probe — and is recomputed on every seed so config changes
+        are reflected on the next selection.
+
+        Returns:
+            ``(readout_text, nav_provider)`` where ``nav_provider`` is the
+            provider key the Configure deep-link should preselect.
+        """
+        config = getattr(self.screen.app_instance, "app_config", {}) or {}
+        char = config.get("character_defaults", {}) or {}
+        chat = config.get("chat_defaults", {}) or {}
+        char_provider = str(char.get("provider") or "")
+        char_model = str(char.get("model") or "")
+        chat_provider = str(chat.get("provider") or "")
+        chat_model = str(chat.get("model") or "")
+        if not char_provider:
+            if chat_provider:
+                text = (
+                    f"Provider: {self._provider_label(chat_provider)} / "
+                    f"{chat_model or 'default model'} (Console default)"
+                )
+                return text, chat_provider
+            return "Provider: none configured - use Configure", ""
+        text = (
+            f"Provider: {self._provider_label(char_provider)} / "
+            f"{char_model or 'default model'}"
+        )
+        # Note the fallback target only when it is a distinct provider. A
+        # same-provider/different-model chat default is an approximation gap we
+        # accept: this readout is config-only (no readiness probe), and after a
+        # real send the readout is repainted with what actually resolved.
+        if chat_provider and chat_provider.lower() != char_provider.lower():
+            text += (
+                " - Console default if unavailable: "
+                f"{self._provider_label(chat_provider)}"
+            )
+        return text, char_provider
+
+    def refresh_provider_readout(self) -> None:
+        """Repaint the preview provider readout from current config."""
+        text, nav_provider = self.provider_readout()
+        self._readout_nav_provider = nav_provider
+        try:
+            self.screen.query_one(PersonasPreviewPane).set_provider_readout(text)
+        except QueryError:
+            pass
+
+    def open_provider_settings(self) -> None:
+        """Deep-link to Settings > Providers & Models for the readout provider."""
+        context: dict[str, Any] = {"category": SettingsCategoryId.PROVIDERS_MODELS}
+        if self._readout_nav_provider:
+            context["provider"] = self._readout_nav_provider
+        self.screen.post_message(NavigateToScreen("settings", context))
+
     async def handle_character_loaded(
         self, *, character_id: str, card_data: dict[str, Any] | None
     ) -> None:
@@ -167,10 +246,12 @@ class PersonasPreviewController:
         # not erase an in-progress preview conversation.
         if self.seeded_for == character_id and pane.transcript_text():
             pane.refresh_greeting_seed(greeting)
+            self.refresh_provider_readout()
             return
         self.invalidate()
         await pane.seed_greeting(greeting)
         self.seeded_for = character_id
+        self.refresh_provider_readout()
 
     def ensure_gateway(self) -> ConsoleProviderGateway:
         """Return the lazily-created Console provider gateway.
@@ -475,6 +556,15 @@ class PersonasPreviewController:
             pane.set_status(f"Running via Console default: {fallback_provider}")
         else:
             pane.set_status("Running")
+        # Repaint the readout with the provider/model that actually resolved,
+        # so it reflects reality (incl. a fallback) rather than config intent.
+        resolved_readout = (
+            f"Provider: {self._provider_label(resolution.provider)} / "
+            f"{resolution.model or 'default model'}"
+        )
+        if fallback_provider:
+            resolved_readout += " (Console default)"
+        pane.set_provider_readout(resolved_readout)
         await pane.discard_partial_reply()
         history: list[dict[str, str]] = []
         for entry in self.history:

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -93,6 +93,7 @@ from ...Widgets.Persona_Widgets.personas_pane_messages import (
     EditPersonaRequested,
     PersonaProfileEditCancelled,
     PersonaProfileSaveRequested,
+    PreviewConfigureProviderRequested,
     PreviewOpenInConsoleRequested,
     PreviewReplyRequested,
     PreviewResetRequested,
@@ -3574,6 +3575,13 @@ class PersonasScreen(BaseAppScreen):
     ) -> None:
         message.stop()
         self.preview.open_in_console()
+
+    @on(PreviewConfigureProviderRequested)
+    def _handle_preview_configure(
+        self, message: PreviewConfigureProviderRequested
+    ) -> None:
+        message.stop()
+        self.preview.open_provider_settings()
 
     # ===== Create / edit =====
 

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py
@@ -122,3 +122,7 @@ class PreviewResetRequested(Message):
 
 class PreviewOpenInConsoleRequested(Message):
     """Open the preview-conversation transcript in Console."""
+
+
+class PreviewConfigureProviderRequested(Message):
+    """Open Settings > Providers & Models from the preview provider readout."""

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_preview_pane.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_preview_pane.py
@@ -15,6 +15,7 @@ from textual.widgets import Button, Input, Static
 
 from ...Utils.input_validation import validate_text_input
 from .personas_pane_messages import (
+    PreviewConfigureProviderRequested,
     PreviewOpenInConsoleRequested,
     PreviewReplyRequested,
     PreviewResetRequested,
@@ -50,6 +51,12 @@ class PersonasPreviewPane(Vertical):
     PersonasPreviewPane #personas-preview-status {
         height: 1;
         min-height: 1;
+    }
+
+    PersonasPreviewPane #personas-preview-provider {
+        height: auto;
+        min-height: 1;
+        color: $text-muted;
     }
 
     PersonasPreviewPane #personas-preview-transcript {
@@ -94,6 +101,10 @@ class PersonasPreviewPane(Vertical):
             classes="console-action-subdued",
         )
         with Vertical(id="personas-preview-body"):
+            # Provider/model readout: which provider will answer a test reply.
+            # Kept at the top of the body so it is the first thing seen when
+            # the preview expands.
+            yield Static("", id="personas-preview-provider")
             yield VerticalScroll(id="personas-preview-transcript")
             # The status line is a status region adjacent to the input, kept
             # BELOW the transcript so provider/error messages never render
@@ -115,6 +126,13 @@ class PersonasPreviewPane(Vertical):
                     "Open in Console",
                     id="personas-preview-open-console",
                     classes="console-action-subdued",
+                )
+                yield Button(
+                    "Configure",
+                    id="personas-preview-configure",
+                    classes="console-action-subdued",
+                    tooltip="Open Settings > Providers & Models to change which "
+                    "provider answers character chats.",
                 )
 
     def on_mount(self) -> None:
@@ -218,6 +236,10 @@ class PersonasPreviewPane(Vertical):
         """Update the readable status line."""
         self.query_one("#personas-preview-status", Static).update(str(text or ""))
 
+    def set_provider_readout(self, text: str) -> None:
+        """Update the provider/model readout line above the transcript."""
+        self.query_one("#personas-preview-provider", Static).update(str(text or ""))
+
     def transcript_text(self) -> str:
         """The visible transcript as plain text, one line per message."""
         return "\n".join(self._lines)
@@ -311,6 +333,11 @@ class PersonasPreviewPane(Vertical):
     def _handle_open_console(self, event: Button.Pressed) -> None:
         event.stop()
         self.post_message(PreviewOpenInConsoleRequested())
+
+    @on(Button.Pressed, "#personas-preview-configure")
+    def _handle_configure(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.post_message(PreviewConfigureProviderRequested())
 
 
 __all__ = ["PersonasPreviewPane"]

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_preview_pane.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_preview_pane.py
@@ -237,7 +237,11 @@ class PersonasPreviewPane(Vertical):
         self.query_one("#personas-preview-status", Static).update(str(text or ""))
 
     def set_provider_readout(self, text: str) -> None:
-        """Update the provider/model readout line above the transcript."""
+        """Update the provider/model readout line above the transcript.
+
+        Args:
+            text: Provider/model status text to display.
+        """
         self.query_one("#personas-preview-provider", Static).update(str(text or ""))
 
     def transcript_text(self) -> str:


### PR DESCRIPTION
## What & why

The Roleplay preview chat gave no indication of which provider/model would answer (TASK-426, from the RP UX review). This adds a provider/model readout at the top of the preview body and a Configure button that deep-links to Settings > Providers & Models.

PR #744 / TASK-425 has merged. This branch is rebased directly onto `dev`; the diff contains only TASK-426 and its review remediation.

## Behavior

- **Readout** — derives provider/model labels from the same normalized effective `ConsoleProviderSelection` used by sends, including models inherited from provider settings. It shows the character target plus a distinct Console-default fallback, refreshes on each seed/config reload, and repaints with the provider/model that actually answered after a reply.
- **Configure** — opens Settings > Providers & Models with the character-configured provider preselected; after a fallback reply it still targets the provider the user should make ready.
- **Normalization** — whitespace-only providers/models are normalized before both display and gateway resolution, so the readout, Settings target, logs, and actual send cannot drift.

## Review remediation

- Added the requested Google-style `Args:` documentation to `set_provider_readout`.
- Fixed whitespace-only provider/model handling in the shared send path.
- Fixed effective-model display when the model is inherited from `api_settings`.
- Replied to and resolved both Qodo review threads. Independent re-review found no remaining Critical or Important issues and returned **Ready to merge: Yes**.

## Verification

- `Tests/UI/test_personas_workbench.py` + `Tests/UI/test_personas_preview.py`: **197 passed**
- Ruff on all changed test/controller/widget files: passed
- mypy on `personas_preview_controller.py`: passed
- compileall, `git diff --check`, and Backlog duplicate-ID guard: passed

ADR required: no; this remains within ADR-004, ADR-006, ADR-007, and ADR-012.