### PR TITLE
Internal Prompts P2: agents / summarization / doc-gen / subscriptions migration

### DIFF
--- a/Tests/Agents/conftest.py
+++ b/Tests/Agents/conftest.py
@@ -1,0 +1,3 @@
+"""Re-export scratch_config for Tests/Agents/ (see Tests/Internal_Prompts/conftest.py)."""
+
+from Tests.Internal_Prompts.conftest import scratch_config  # noqa: F401

--- a/Tests/Agents/test_agents_internal_prompts.py
+++ b/Tests/Agents/test_agents_internal_prompts.py
@@ -91,3 +91,35 @@ def test_is_subagent_false_for_ordinary_system_turn_under_active_override(
         bridge._StreamingModelAdapter._is_subagent(_history_with_system(ordinary))
         is False
     )
+
+
+def test_is_subagent_stable_across_mid_run_override_change(scratch_config):
+    """A sub-agent's system prompt is baked into its messages_payload once,
+    at spawn time (Agents/agent_service.py:411's own ``get_internal_prompt``
+    call), and then stays fixed across that sub-agent's own multi-step
+    tool loop. If ``agents.subagent_system`` is edited live (e.g. from
+    Settings, on the UI thread, while a run is in flight on a worker
+    thread) to a *different* override -- not reverted to the shipped
+    default -- a detector that only compares against the CURRENTLY
+    resolved value plus the shipped default stops recognizing that
+    already-spawned sub-agent's later turns, and its streamed output
+    leaks into the primary transcript. Detection must stay stable for any
+    ``agents.subagent_system`` value resolved earlier in the same
+    process, not just the one active right now."""
+    from tldw_chatbook.Chat import console_agent_bridge as bridge
+
+    scratch_config('[internal_prompts.agents]\nsubagent_system = "OVERRIDE A"\n')
+    spawn_time_resolved = get_internal_prompt("agents.subagent_system")
+    assert spawn_time_resolved == "OVERRIDE A"
+    # This is the sub-agent's system message, fixed at spawn time.
+    payload = _history_with_system(spawn_time_resolved + "\n\nRun the tool loop.")
+    # Turn 1 (spawn turn): the currently active override matches directly.
+    assert bridge._StreamingModelAdapter._is_subagent(payload) is True
+
+    # Config is edited mid-run to a *different* override (not removed).
+    scratch_config('[internal_prompts.agents]\nsubagent_system = "OVERRIDE B"\n')
+    assert get_internal_prompt("agents.subagent_system") == "OVERRIDE B"
+
+    # Turn 2: same sub-agent, same (unchanged) spawn-time system content --
+    # must still be classified as a sub-agent turn.
+    assert bridge._StreamingModelAdapter._is_subagent(payload) is True

--- a/Tests/Agents/test_agents_internal_prompts.py
+++ b/Tests/Agents/test_agents_internal_prompts.py
@@ -1,0 +1,75 @@
+"""Registry overrides must reach the agent runtime; identity contracts must
+survive overrides. Real code paths; no accessor mocks."""
+
+from tldw_chatbook.Internal_Prompts import get_internal_prompt
+
+
+def _history_with_system(content: str) -> list[dict]:
+    """Build the messages_payload shape ``_is_subagent`` inspects: a list of
+    role/content dicts with a leading system message (matches the real
+    payload shape assembled by agent_service.call_model / the streaming
+    adapter's chat_call: ``[{"role": "system", "content": ...}, ...]``)."""
+    return [{"role": "system", "content": content}]
+
+
+def test_tool_protocol_override_reaches_render(scratch_config):
+    from tldw_chatbook.Agents.agent_runtime import (
+        FENCE_OPEN,
+        _FENCE_CLOSE,
+        render_tool_protocol,
+    )
+    from tldw_chatbook.Agents.agent_models import ToolSchema
+
+    scratch_config(
+        "[internal_prompts.agents]\n"
+        'tool_protocol = "TOOLS: {tool_list} OPEN {fence_open} CLOSE {fence_close}"\n'
+    )
+    out = render_tool_protocol(
+        [ToolSchema(id="t", name="t", description="d", parameters={})]
+    )
+    assert out.startswith("TOOLS: ")
+    assert FENCE_OPEN in out and _FENCE_CLOSE in out
+    assert '"name": "t"' in out
+
+
+def test_tool_protocol_empty_schemas_still_empty(scratch_config):
+    from tldw_chatbook.Agents.agent_runtime import render_tool_protocol
+
+    scratch_config(
+        '[internal_prompts.agents]\ntool_protocol = "{tool_list}{fence_open}{fence_close}"\n'
+    )
+    assert render_tool_protocol([]) == ""
+
+
+def test_compose_uses_override_and_default(scratch_config):
+    from tldw_chatbook.Chat.console_agent_bridge import (
+        CONSOLE_AGENT_OPERATING_PROMPT,
+        compose_agent_system_prompt,
+    )
+
+    assert compose_agent_system_prompt("") == CONSOLE_AGENT_OPERATING_PROMPT
+    scratch_config(
+        '[internal_prompts.agents]\nconsole_agent_operating = "CUSTOM OPERATING"\n'
+    )
+    assert compose_agent_system_prompt("") == "CUSTOM OPERATING"
+    assert compose_agent_system_prompt("S") == "S\n\nCUSTOM OPERATING"
+
+
+def test_is_subagent_detects_overridden_and_shipped_prefix(scratch_config):
+    from tldw_chatbook.Chat import console_agent_bridge as bridge
+
+    shipped = bridge.SUBAGENT_SYSTEM_PROMPT
+    scratch_config(
+        '[internal_prompts.agents]\nsubagent_system = "CUSTOM SUBAGENT RULES"\n'
+    )
+    resolved = get_internal_prompt("agents.subagent_system")
+    assert resolved == "CUSTOM SUBAGENT RULES"
+    # Detection accepts BOTH the live-resolved and the shipped prefix.
+    assert (
+        bridge._StreamingModelAdapter._is_subagent(_history_with_system(resolved))
+        is True
+    )
+    assert (
+        bridge._StreamingModelAdapter._is_subagent(_history_with_system(shipped))
+        is True
+    )

--- a/Tests/Agents/test_agents_internal_prompts.py
+++ b/Tests/Agents/test_agents_internal_prompts.py
@@ -73,3 +73,21 @@ def test_is_subagent_detects_overridden_and_shipped_prefix(scratch_config):
         bridge._StreamingModelAdapter._is_subagent(_history_with_system(shipped))
         is True
     )
+
+
+def test_is_subagent_false_for_ordinary_system_turn_under_active_override(
+    scratch_config,
+):
+    from tldw_chatbook.Chat import console_agent_bridge as bridge
+
+    scratch_config(
+        '[internal_prompts.agents]\nsubagent_system = "CUSTOM SUBAGENT RULES"\n'
+    )
+    # An ordinary Console session system prompt sharing no prefix with either
+    # the override or the shipped subagent prompt must NOT be classified as a
+    # subagent turn.
+    ordinary = "You are a helpful assistant for this Console session."
+    assert (
+        bridge._StreamingModelAdapter._is_subagent(_history_with_system(ordinary))
+        is False
+    )

--- a/Tests/Internal_Prompts/test_agents_prompt_parity.py
+++ b/Tests/Internal_Prompts/test_agents_prompt_parity.py
@@ -1,0 +1,48 @@
+# Tests/Internal_Prompts/test_agents_prompt_parity.py
+"""Registry defaults must match the agent-runtime literals byte-for-byte;
+the tool-protocol template must render exactly what render_tool_protocol's
+static scaffold produced pre-migration."""
+
+from tldw_chatbook.Internal_Prompts import CATALOG, render_internal_prompt
+
+
+def test_subagent_system_matches_source_constant():
+    from tldw_chatbook.Agents.agent_service import SUBAGENT_SYSTEM_PROMPT
+
+    assert CATALOG["agents.subagent_system"].default == SUBAGENT_SYSTEM_PROMPT
+
+
+def test_console_agent_operating_matches_source_constant():
+    from tldw_chatbook.Chat.console_agent_bridge import (
+        CONSOLE_AGENT_OPERATING_PROMPT,
+    )
+
+    assert (
+        CATALOG["agents.console_agent_operating"].default
+        == CONSOLE_AGENT_OPERATING_PROMPT
+    )
+
+
+def test_tool_protocol_template_renders_original_scaffold():
+    # Pre-migration expected output, built exactly as agent_runtime.py:183-193
+    # does today (copy the f-string expression verbatim with sample values).
+    from tldw_chatbook.Agents.agent_runtime import FENCE_OPEN, _FENCE_CLOSE
+
+    tool_list = '{\n  "name": "demo",\n  "description": "d",\n  "parameters": {}\n}'
+    expected = (
+        "You can call tools. Available tools:\n"
+        f"{tool_list}\n\n"
+        "To call a tool, your reply MUST START with the fence as its first "
+        "content — no prose before it:\n"
+        f'{FENCE_OPEN}\n{{"name": "<tool name>", "arguments": {{...}}}}\n'
+        f"{_FENCE_CLOSE}\n"
+        "One tool call per reply. After you receive the tool result, either "
+        "call another tool the same way or answer the user directly. If no "
+        "tool is needed, just answer directly."
+    )
+    assert render_internal_prompt(
+        "agents.tool_protocol",
+        tool_list=tool_list,
+        fence_open=FENCE_OPEN,
+        fence_close=_FENCE_CLOSE,
+    ) == expected

--- a/Tests/Internal_Prompts/test_document_generation_migration.py
+++ b/Tests/Internal_Prompts/test_document_generation_migration.py
@@ -1,0 +1,264 @@
+# Tests/Internal_Prompts/test_document_generation_migration.py
+"""Overrides must reach the document-generation LLM payloads; legacy TOML
+customization still outranks the shipped default. Fakes only at the
+provider-dispatch seam inside `_call_llm` (`self.provider_functions[<name>]`)
+so `generate_timeline`/`generate_study_guide`/`generate_briefing`'s real
+prompt-assembly code runs for real and the assembled `messages` list (built
+at document_generator.py:506-509) is captured.
+
+Adaptations from the brief's skeleton:
+
+- `DocumentGenerator.__init__(db_path, client_id="document_generator")`
+  constructs a real `CharactersRAGDB`. An in-memory DB
+  (`DocumentGenerator(":memory:", "test-client")`) is cheap and matches the
+  project's established in-memory-DB test pattern (see
+  Tests/UI/test_home_screen.py, Tests/UI/test_library_shell.py) — no faking
+  needed for `__init__` itself, and `__init__` reads config for the
+  temperature/max_tokens dicts, so it must run AFTER `scratch_config(...)`
+  writes (per the brief).
+- The brief's target seam ("the actual outbound call around ~507 where
+  messages are assembled and sent") is `_call_llm`'s
+  `chat_function(messages=messages, ...)` call, where
+  `chat_function = self.provider_functions.get(provider_lower)`. Rather than
+  monkeypatching a module-level `chat_with_openai` (which `_call_llm` never
+  references directly — it only reads the dict), the tests below replace the
+  `"openai"` entry in the generator's own `self.provider_functions` dict
+  with a capturing fake. This is the exact callable `_call_llm` invokes, so
+  `generate_*`'s system/user prompt assembly (the migrated code under test)
+  and `_call_llm`'s `messages = [...]` construction both run unmodified.
+- `get_conversation_context` calls
+  `self.db.get_messages_by_conversation_id(...)`, a method that does not
+  exist anywhere on `CharactersRAGDB` (confirmed by repo-wide grep —
+  pre-existing, unrelated bug, out of scope for this migration and left
+  untouched). The call always raises `AttributeError`, which
+  `get_conversation_context` catches and logs, returning `[]`. This means
+  `context` is always `""` for any `conversation_id` passed to the
+  `generate_*` methods in the tests below, including a nonexistent one — no
+  conversation/message fixtures are needed to reach the prompt-assembly seam
+  under test.
+"""
+
+import inspect
+
+import pytest
+
+from tldw_chatbook.Chat.document_generator import DocumentGenerator
+from tldw_chatbook.Internal_Prompts import get_internal_prompt
+
+
+def _make_generator() -> DocumentGenerator:
+    return DocumentGenerator(":memory:", "test-client")
+
+
+def _capture_messages(generator: DocumentGenerator) -> list:
+    """Install a capturing fake at the `_call_llm` provider-dispatch seam
+    (`self.provider_functions["openai"]`, the callable `_call_llm` actually
+    invokes) and return the list of captured call kwargs (each has a
+    "messages" key holding the real assembled [system, user] list)."""
+    captured = []
+
+    def fake_chat(**kwargs):
+        captured.append(kwargs)
+        return "generated content"
+
+    generator.provider_functions["openai"] = fake_chat
+    return captured
+
+
+def _system_and_user(captured_kwargs: dict) -> tuple:
+    messages = captured_kwargs["messages"]
+    system_message = next(m["content"] for m in messages if m["role"] == "system")
+    user_message = next(m["content"] for m in messages if m["role"] == "user")
+    return system_message, user_message
+
+
+# --- (a) no override: shipped TOML user text + hardcoded system text ------
+
+
+def test_timeline_no_override_uses_shipped_toml_user_and_hardcoded_system(
+    scratch_config,
+):
+    scratch_config("")
+    generator = _make_generator()
+    captured = _capture_messages(generator)
+
+    generator.generate_timeline(
+        conversation_id="nonexistent", provider="openai", model="gpt-4", api_key="k"
+    )
+
+    assert captured, "provider dispatch fake was never invoked"
+    system_message, user_message = _system_and_user(captured[0])
+
+    assert system_message == get_internal_prompt("document_generation.timeline_system")
+    assert system_message == (
+        "You are an expert at creating clear, chronological timelines from "
+        "conversations and content."
+    )
+    assert user_message.startswith(
+        get_internal_prompt("document_generation.timeline_user")
+    )
+    assert user_message.startswith(
+        "Create a detailed text-based timeline based on our "
+        "conversation/materials being referenced."
+    )
+    # Code-side concatenation (string, not token substitution) is untouched.
+    assert user_message.endswith("\n\nConversation Context:\n")
+
+
+@pytest.mark.parametrize(
+    ("method_name", "type_prefix"),
+    [
+        ("generate_timeline", "timeline"),
+        ("generate_study_guide", "study_guide"),
+        ("generate_briefing", "briefing"),
+    ],
+)
+def test_all_three_generators_thread_system_and_user_registry_ids(
+    scratch_config, method_name, type_prefix
+):
+    """Proves all three migrated generator methods (not just timeline) route
+    both their system and user prompts through the registry."""
+    scratch_config("")
+    generator = _make_generator()
+    captured = _capture_messages(generator)
+
+    getattr(generator, method_name)(
+        conversation_id="nonexistent", provider="openai", model="gpt-4", api_key="k"
+    )
+
+    system_message, user_message = _system_and_user(captured[0])
+    assert system_message == get_internal_prompt(
+        f"document_generation.{type_prefix}_system"
+    )
+    assert user_message.startswith(
+        get_internal_prompt(f"document_generation.{type_prefix}_user")
+    )
+
+
+# --- (b) [internal_prompts.document_generation] override ------------------
+
+
+def test_timeline_internal_prompts_override_reaches_payload(scratch_config):
+    scratch_config(
+        "[internal_prompts.document_generation]\n"
+        'timeline_system = "OVERRIDE SYSTEM TEXT"\n'
+        'timeline_user = "OVERRIDE USER TEXT"\n'
+    )
+    generator = _make_generator()
+    captured = _capture_messages(generator)
+
+    generator.generate_timeline(
+        conversation_id="nonexistent", provider="openai", model="gpt-4", api_key="k"
+    )
+
+    system_message, user_message = _system_and_user(captured[0])
+    assert system_message == "OVERRIDE SYSTEM TEXT"
+    assert user_message.startswith("OVERRIDE USER TEXT")
+
+
+# --- (c) customized legacy [prompts.document_generation.timeline].prompt --
+
+
+def test_timeline_legacy_customized_toml_wins_over_shipped_default(scratch_config):
+    scratch_config(
+        "[prompts.document_generation.timeline]\n"
+        'prompt = "MY CUSTOM LEGACY TIMELINE PROMPT"\n'
+        "temperature = 0.3\n"
+        "max_tokens = 2000\n"
+    )
+    generator = _make_generator()
+    captured = _capture_messages(generator)
+
+    generator.generate_timeline(
+        conversation_id="nonexistent", provider="openai", model="gpt-4", api_key="k"
+    )
+
+    system_message, user_message = _system_and_user(captured[0])
+    assert user_message.startswith("MY CUSTOM LEGACY TIMELINE PROMPT")
+    # System prompt is a separate spec entirely and is unaffected by the
+    # legacy user-prompt customization.
+    assert system_message == (
+        "You are an expert at creating clear, chronological timelines from "
+        "conversations and content."
+    )
+
+
+def test_timeline_legacy_untouched_toml_does_not_shadow_shipped_default(
+    scratch_config,
+):
+    """Sanity counterpart to the legacy-wins case: writing back the exact
+    shipped default under the legacy key must NOT be treated as a
+    customization (resolver's differs-from-shipped rule)."""
+    shipped = get_internal_prompt("document_generation.timeline_user")
+    scratch_config(
+        "[prompts.document_generation.timeline]\n"
+        f'prompt = "{shipped}"\n'
+        "temperature = 0.3\n"
+        "max_tokens = 2000\n"
+    )
+    generator = _make_generator()
+    captured = _capture_messages(generator)
+
+    generator.generate_timeline(
+        conversation_id="nonexistent", provider="openai", model="gpt-4", api_key="k"
+    )
+
+    _system_message, user_message = _system_and_user(captured[0])
+    assert user_message.startswith(shipped)
+
+
+# --- temperature/max_tokens reads (untouched by this migration) -----------
+
+
+def test_temperature_and_max_tokens_still_read_from_config_dict(scratch_config):
+    """Confirms the migration left `self.timeline_config`'s temperature/
+    max_tokens reads untouched — only the ['prompt'] usage was removed."""
+    scratch_config(
+        "[prompts.document_generation.timeline]\n"
+        'prompt = "irrelevant for this assertion"\n'
+        "temperature = 0.11\n"
+        "max_tokens = 1234\n"
+    )
+    generator = _make_generator()
+    captured = _capture_messages(generator)
+
+    generator.generate_timeline(
+        conversation_id="nonexistent", provider="openai", model="gpt-4", api_key="k"
+    )
+
+    kwargs = captured[0]
+    assert kwargs["temperature"] == 0.11
+    assert kwargs["max_tokens"] == 1234
+
+
+# --- grep-guard equivalent: hardcoded literals must be gone ---------------
+
+
+def test_hardcoded_system_literals_removed_from_document_generator():
+    from tldw_chatbook.Chat import document_generator as dg
+
+    source = inspect.getsource(dg)
+    assert (
+        "You are an expert at creating clear, chronological timelines from "
+        "conversations and content." not in source
+    )
+    assert (
+        "You are an educational expert specializing in creating "
+        "comprehensive study guides." not in source
+    )
+    assert (
+        "You are an expert at creating executive briefing documents with "
+        "actionable insights." not in source
+    )
+    assert source.count('get_internal_prompt("document_generation.') == 3
+    assert source.count("get_internal_prompt('document_generation.") == 3
+    assert "self.timeline_config['prompt']" not in source
+    assert "self.study_guide_config['prompt']" not in source
+    assert "self.briefing_config['prompt']" not in source
+    # temperature/max_tokens reads must remain untouched.
+    assert 'self.timeline_config.get("temperature"' in source
+    assert 'self.timeline_config.get("max_tokens"' in source
+    assert 'self.study_guide_config.get("temperature"' in source
+    assert 'self.study_guide_config.get("max_tokens"' in source
+    assert 'self.briefing_config.get("temperature"' in source
+    assert 'self.briefing_config.get("max_tokens"' in source

--- a/Tests/Internal_Prompts/test_document_generation_prompt_parity.py
+++ b/Tests/Internal_Prompts/test_document_generation_prompt_parity.py
@@ -1,0 +1,113 @@
+# Tests/Internal_Prompts/test_document_generation_prompt_parity.py
+"""Registry defaults must match the document-generation sources byte-for-
+byte. The *_system literals below are verbatim copies of the one-line system
+prompts hardcoded in Chat/document_generator.py (generate_timeline:219,
+generate_study_guide:317, generate_briefing:415). The *_user defaults are
+asserted against config.py's DEFAULT_CONFIG_FROM_TOML (the shipped TOML
+[prompts.document_generation.<type>].prompt values) rather than the shorter
+inline dict literals in DocumentGenerator.__init__ — see the module
+docstring on document_generation_prompts.py for why the TOML text is the
+canonical default. config is imported inside the test functions only, never
+at module scope (Internal_Prompts must stay off the config import chain)."""
+
+from tldw_chatbook.Internal_Prompts import CATALOG
+
+ORIGINAL_TIMELINE_SYSTEM = "You are an expert at creating clear, chronological timelines from conversations and content."
+ORIGINAL_STUDY_GUIDE_SYSTEM = "You are an educational expert specializing in creating comprehensive study guides."
+ORIGINAL_BRIEFING_SYSTEM = "You are an expert at creating executive briefing documents with actionable insights."
+
+
+def test_timeline_system_matches_source_literal():
+    assert (
+        CATALOG["document_generation.timeline_system"].default
+        == ORIGINAL_TIMELINE_SYSTEM
+    )
+
+
+def test_study_guide_system_matches_source_literal():
+    assert (
+        CATALOG["document_generation.study_guide_system"].default
+        == ORIGINAL_STUDY_GUIDE_SYSTEM
+    )
+
+
+def test_briefing_system_matches_source_literal():
+    assert (
+        CATALOG["document_generation.briefing_system"].default
+        == ORIGINAL_BRIEFING_SYSTEM
+    )
+
+
+def test_timeline_user_matches_shipped_toml_default():
+    from tldw_chatbook.config import DEFAULT_CONFIG_FROM_TOML
+
+    assert (
+        CATALOG["document_generation.timeline_user"].default
+        == DEFAULT_CONFIG_FROM_TOML["prompts"]["document_generation"]["timeline"]["prompt"]
+    )
+
+
+def test_study_guide_user_matches_shipped_toml_default():
+    from tldw_chatbook.config import DEFAULT_CONFIG_FROM_TOML
+
+    assert (
+        CATALOG["document_generation.study_guide_user"].default
+        == DEFAULT_CONFIG_FROM_TOML["prompts"]["document_generation"]["study_guide"]["prompt"]
+    )
+
+
+def test_briefing_user_matches_shipped_toml_default():
+    from tldw_chatbook.config import DEFAULT_CONFIG_FROM_TOML
+
+    assert (
+        CATALOG["document_generation.briefing_user"].default
+        == DEFAULT_CONFIG_FROM_TOML["prompts"]["document_generation"]["briefing"]["prompt"]
+    )
+
+
+def test_user_prompts_differ_from_document_generator_inline_dict_fallback():
+    # Pins the TOML-canonical decision: the registry defaults are the RICHER
+    # shipped TOML strings, not the shorter inline dict literals at
+    # document_generator.py:70-95 (which only fire when the whole
+    # [prompts.document_generation.<type>] table is absent).
+    inline_fallbacks = {
+        "document_generation.timeline_user": (
+            "Create a detailed text-based timeline based on our "
+            "conversation/materials being referenced."
+        ),
+        "document_generation.study_guide_user": (
+            "Create a detailed and well produced study guide based on the "
+            "current focus of our conversation/materials in reference."
+        ),
+        "document_generation.briefing_user": (
+            "Create a detailed and well produced executive briefing document "
+            "regarding this conversation and the subject material."
+        ),
+    }
+    for prompt_id, inline_literal in inline_fallbacks.items():
+        assert CATALOG[prompt_id].default != inline_literal
+        assert CATALOG[prompt_id].default.startswith(inline_literal)
+
+
+def test_user_prompts_have_matching_legacy_config_path():
+    expected = {
+        "document_generation.timeline_user": "prompts.document_generation.timeline.prompt",
+        "document_generation.study_guide_user": "prompts.document_generation.study_guide.prompt",
+        "document_generation.briefing_user": "prompts.document_generation.briefing.prompt",
+    }
+    for prompt_id, path in expected.items():
+        assert CATALOG[prompt_id].legacy_config_path == path
+
+
+def test_no_placeholders_on_any_of_the_six_specs():
+    for suffix in (
+        "timeline_system",
+        "timeline_user",
+        "study_guide_system",
+        "study_guide_user",
+        "briefing_system",
+        "briefing_user",
+    ):
+        spec = CATALOG[f"document_generation.{suffix}"]
+        assert spec.required_placeholders == ()
+        assert spec.optional_placeholders == ()

--- a/Tests/Internal_Prompts/test_subscriptions_migration.py
+++ b/Tests/Internal_Prompts/test_subscriptions_migration.py
@@ -1,0 +1,365 @@
+# Tests/Internal_Prompts/test_subscriptions_migration.py
+"""Overrides must reach the subscriptions prompt payloads; caller/per-
+subscription override channels still win. Fakes are used only where a real
+LLM call would otherwise be required; the prompt-producing units
+(`_build_analysis_prompt`, `_get_system_prompt`) are exercised directly
+where possible since they require no LLM call at all.
+
+Adaptations from the brief's skeleton (see task-8-report.md for detail):
+
+- The brief names `ContentSummarizer.analyze_content` (from the scout
+  notes). Reading Subscriptions/content_processor.py turned up that this is
+  approximate: the real methods are on `ContentProcessor` —
+  `_analyze_content` (async; builds the messages list and calls
+  `chat_api_call` WITHOUT awaiting it inside an async method, a pre-
+  existing, out-of-scope quirk unrelated to this migration) and
+  `_build_analysis_prompt` (sync, the actual prompt-producing unit, no LLM
+  call at all). Per the brief's disproportionate-effort escape hatch, the
+  content_processor cases below call `_build_analysis_prompt` directly
+  rather than routing through `_analyze_content`.
+- `BriefingGenerator._generate_sections_with_llm` is exercised through a
+  real `BriefingGenerator` instance constructed with `subscriptions_db=None`
+  (the method under test never touches `self.db`) and an async
+  `chat_api_call` fake installed in `briefing_generator`'s module namespace
+  (that call site does `await chat_api_call(...)`).
+- No `asyncio_mode` is configured for this repo's pytest (strict pytest-
+  asyncio default), so the one async-under-test case below follows the
+  `@pytest.mark.asyncio` pattern already used in
+  Tests/RAG/test_reranker_internal_prompts.py rather than a bare `async def
+  test_...`, which would silently no-op under strict mode.
+"""
+
+import json
+
+import pytest
+
+from tldw_chatbook.Internal_Prompts import get_internal_prompt
+from tldw_chatbook.Subscriptions.briefing_generator import BriefingGenerator
+from tldw_chatbook.Subscriptions.content_processor import ContentProcessor
+from tldw_chatbook.Subscriptions.recursive_summarizer import RecursiveSummarizer
+
+
+def _feed_item():
+    return {
+        "title": "Some Title",
+        "url": "https://example.com/a",
+        "published_date": "2026-01-01",
+    }
+
+
+def _feed_subscription(processing_options=None):
+    sub = {"name": "Example Feed", "type": "rss", "source": "https://example.com/feed"}
+    if processing_options is not None:
+        sub["processing_options"] = processing_options
+    return sub
+
+
+# ---------------------------------------------------------------------------
+# (a) content_processor: three-way precedence for the per-item analysis
+#     prompt (registry default -> registry override -> per-subscription
+#     processing_options.analysis_prompt override, which must still win).
+# ---------------------------------------------------------------------------
+
+
+def test_feed_analysis_default_reaches_prompt():
+    processor = ContentProcessor()
+    prompt = processor._build_analysis_prompt(
+        "Some content body", _feed_item(), _feed_subscription()
+    )
+    assert "Analyze this article from Example Feed:" in prompt
+    assert "Title: Some Title" in prompt
+    assert "URL: https://example.com/a" in prompt
+    assert "Published: 2026-01-01" in prompt
+    assert "Some content body" in prompt
+
+
+def test_feed_analysis_registry_override_reaches_prompt(scratch_config):
+    scratch_config(
+        "[internal_prompts.subscriptions]\n"
+        'feed_analysis = "CUSTOM {name} | {title} | {url} | {published} | {content}"\n'
+    )
+    processor = ContentProcessor()
+    prompt = processor._build_analysis_prompt(
+        "Some content body", _feed_item(), _feed_subscription()
+    )
+    assert (
+        prompt
+        == "CUSTOM Example Feed | Some Title | https://example.com/a | 2026-01-01 | Some content body"
+    )
+
+
+def test_feed_analysis_per_subscription_override_wins_over_registry_override(
+    scratch_config,
+):
+    """The processing_options.analysis_prompt code-side .replace channel is
+    the highest-priority override, ahead of even a registry override."""
+    scratch_config(
+        "[internal_prompts.subscriptions]\n"
+        'feed_analysis = "CUSTOM {name} | {title} | {url} | {published} | {content}"\n'
+    )
+    processor = ContentProcessor()
+    processing_options = json.dumps(
+        {"analysis_prompt": "PER-SUB {content} / {title} / {source} / {url}"}
+    )
+    prompt = processor._build_analysis_prompt(
+        "Some content body",
+        _feed_item(),
+        _feed_subscription(processing_options=processing_options),
+    )
+    assert (
+        prompt
+        == "PER-SUB Some content body / Some Title / Example Feed / https://example.com/a"
+    )
+    assert "CUSTOM" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# Sanity coverage for the other three content_processor branches (not
+# required by the brief's three cases, but cheap and proves each branch's
+# precomputed tokens line up with its registered spec's required
+# placeholders).
+# ---------------------------------------------------------------------------
+
+
+def test_url_change_analysis_default_reaches_prompt():
+    processor = ContentProcessor()
+    item = {"url": "https://example.com/page", "change_percentage": 0.4321}
+    subscription = {"type": "url_change", "source": "https://example.com/page"}
+    prompt = processor._build_analysis_prompt("New content body", item, subscription)
+    assert "URL: https://example.com/page" in prompt
+    assert "Change: 43.2% of content changed" in prompt
+    assert "New content body" in prompt
+
+
+def test_url_change_analysis_url_falls_back_to_subscription_source():
+    processor = ContentProcessor()
+    item = {"change_percentage": 0.1}  # no "url" key
+    subscription = {"type": "url_change", "source": "https://example.com/fallback"}
+    prompt = processor._build_analysis_prompt("content", item, subscription)
+    assert "URL: https://example.com/fallback" in prompt
+
+
+def test_podcast_analysis_default_reaches_prompt():
+    processor = ContentProcessor()
+    item = {"title": "Episode 1", "published_date": "2026-02-02"}
+    subscription = {"name": "My Podcast", "type": "podcast"}
+    # Non-periodic content (each word index is unique) so a slice-boundary
+    # check below can't coincidentally match elsewhere in a repeating string.
+    long_description = " ".join(f"word{i}" for i in range(1000))
+    prompt = processor._build_analysis_prompt(long_description, item, subscription)
+    assert "Analyze this podcast episode from My Podcast:" in prompt
+    assert "Title: Episode 1" in prompt
+    assert "Published: 2026-02-02" in prompt
+    # podcast branch slices to [:3000], not [:5000]
+    assert len(long_description[:3000]) == 3000
+    assert long_description[:3000] in prompt
+    assert long_description[3000:3050] not in prompt
+
+
+def test_generic_analysis_default_reaches_prompt():
+    processor = ContentProcessor()
+    item = {"title": "Some Item"}
+    subscription = {"name": "Generic Source", "type": "webhook"}
+    prompt = processor._build_analysis_prompt("Generic content", item, subscription)
+    assert "Analyze this content from Generic Source:" in prompt
+    assert "Title: Some Item" in prompt
+    assert "Type: webhook" in prompt
+    assert "Generic content" in prompt
+
+
+def test_analysis_system_prompt_default_and_override(scratch_config):
+    assert get_internal_prompt("subscriptions.analysis_system") == (
+        "You are a helpful assistant that analyzes and summarizes content "
+        "from subscriptions."
+    )
+    scratch_config(
+        '[internal_prompts.subscriptions]\nanalysis_system = "CUSTOM SYSTEM ROLE"\n'
+    )
+    assert get_internal_prompt("subscriptions.analysis_system") == "CUSTOM SYSTEM ROLE"
+
+
+# ---------------------------------------------------------------------------
+# (c) recursive summarizer system prompt override reaches its payload.
+# ---------------------------------------------------------------------------
+
+
+def test_recursive_summarizer_system_prompt_default():
+    summarizer = RecursiveSummarizer()
+    assert "expert content summarizer" in summarizer._get_system_prompt()
+
+
+def test_recursive_summarizer_system_prompt_override_reaches_payload(scratch_config):
+    scratch_config(
+        "[internal_prompts.subscriptions]\n"
+        'recursive_summarizer_system = "CUSTOM RECURSIVE SYSTEM PROMPT"\n'
+    )
+    summarizer = RecursiveSummarizer()
+    assert summarizer._get_system_prompt() == "CUSTOM RECURSIVE SYSTEM PROMPT"
+
+
+# ---------------------------------------------------------------------------
+# (b) briefing generator: else-branch override reaches the LLM payload, and
+#     _parse_llm_sections still parses a canned four-section response
+#     (contract intact).
+# ---------------------------------------------------------------------------
+
+_CANNED_LLM_RESPONSE = """Executive Summary
+This is the top headline of the day, in a single paragraph.
+
+Key Insights
+- insight one
+- insight two
+
+Trending Topics
+- topic one
+
+Recommended Actions
+- action one
+"""
+# Note: `_parse_llm_sections` re-triggers a new section on ANY line
+# containing the bare word "summary" (not just a header line), so the
+# executive-summary body text above deliberately avoids that word --
+# otherwise the parser would treat the body line itself as a second header
+# and the section's content would come out empty. This is a pre-existing
+# quirk of `_parse_llm_sections`, left untouched (out of scope).
+
+
+def _briefing_items():
+    return [
+        {
+            "title": "Item One",
+            "subscription_name": "Feed A",
+            "content": "Some article content here.",
+            "created_at": "2026-01-01T00:00:00Z",
+        },
+        {
+            "title": "Item Two",
+            "subscription_name": "Feed B",
+            "content": "Other article content.",
+            "created_at": "2026-01-02T00:00:00Z",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_briefing_default_prompt_reaches_llm_and_parse_contract_intact(
+    monkeypatch,
+):
+    import tldw_chatbook.Subscriptions.briefing_generator as bg_mod
+
+    generator = BriefingGenerator(
+        subscriptions_db=None, llm_provider="test-provider", llm_model="test-model"
+    )
+    items = _briefing_items()
+    items_by_source = generator._group_by_source(items)
+
+    captured = {}
+
+    async def fake_chat_api_call(**kwargs):
+        captured["messages"] = kwargs["messages_payload"]
+        return {"content": _CANNED_LLM_RESPONSE}
+
+    monkeypatch.setattr(bg_mod, "chat_api_call", fake_chat_api_call)
+    sections = await generator._generate_sections_with_llm(items, items_by_source, None)
+
+    user_prompt = captured["messages"][1]["content"]
+    assert (
+        "Analyze the following content from various subscriptions and "
+        "generate a comprehensive briefing:" in user_prompt
+    )
+    assert "Feed A" in user_prompt
+    assert "Item One" in user_prompt
+
+    # _parse_llm_sections contract intact: the four labels still route to
+    # their sections.
+    assert "top headline of the day" in sections["executive_summary"]
+    assert "insight one" in sections["insights_section"]
+    assert "topic one" in sections["trends_section"]
+    assert "action one" in sections["actions_section"]
+    # _format_sources_section still ran on top.
+    assert "sources_section" in sections
+
+
+@pytest.mark.asyncio
+async def test_briefing_registry_override_reaches_llm_payload(
+    scratch_config, monkeypatch
+):
+    import tldw_chatbook.Subscriptions.briefing_generator as bg_mod
+
+    scratch_config(
+        "[internal_prompts.subscriptions]\n"
+        'briefing = "CUSTOM BRIEFING PROMPT ::: {content_summary}"\n'
+    )
+    generator = BriefingGenerator(
+        subscriptions_db=None, llm_provider="test-provider", llm_model="test-model"
+    )
+    items = _briefing_items()
+    items_by_source = generator._group_by_source(items)
+
+    captured = {}
+
+    async def fake_chat_api_call(**kwargs):
+        captured["messages"] = kwargs["messages_payload"]
+        return {"content": _CANNED_LLM_RESPONSE}
+
+    monkeypatch.setattr(bg_mod, "chat_api_call", fake_chat_api_call)
+    await generator._generate_sections_with_llm(items, items_by_source, None)
+
+    user_prompt = captured["messages"][1]["content"]
+    assert user_prompt.startswith("CUSTOM BRIEFING PROMPT ::: ")
+    assert "Feed A" in user_prompt
+
+
+@pytest.mark.asyncio
+async def test_briefing_custom_prompt_argument_wins_over_registry_override(
+    scratch_config, monkeypatch
+):
+    """The generate_briefing(analysis_prompt=...) caller channel (passed
+    through as `custom_prompt`) still outranks a registry override."""
+    import tldw_chatbook.Subscriptions.briefing_generator as bg_mod
+
+    scratch_config(
+        "[internal_prompts.subscriptions]\n"
+        'briefing = "SHOULD NOT APPEAR ::: {content_summary}"\n'
+    )
+    generator = BriefingGenerator(
+        subscriptions_db=None, llm_provider="test-provider", llm_model="test-model"
+    )
+    items = _briefing_items()
+    items_by_source = generator._group_by_source(items)
+
+    captured = {}
+
+    async def fake_chat_api_call(**kwargs):
+        captured["messages"] = kwargs["messages_payload"]
+        return {"content": _CANNED_LLM_RESPONSE}
+
+    monkeypatch.setattr(bg_mod, "chat_api_call", fake_chat_api_call)
+    await generator._generate_sections_with_llm(
+        items, items_by_source, "CALLER PROMPT {content}"
+    )
+
+    user_prompt = captured["messages"][1]["content"]
+    assert user_prompt.startswith("CALLER PROMPT ")
+    assert "SHOULD NOT APPEAR" not in user_prompt
+
+
+def test_briefing_system_role_still_a_literal_not_registry():
+    """Scope note: the briefing system role is deliberately deferred, not
+    migrated in this task. Documents that current behavior (a hardcoded
+    literal) is unchanged."""
+    import inspect
+
+    import tldw_chatbook.Subscriptions.briefing_generator as bg_mod
+
+    source = inspect.getsource(bg_mod.BriefingGenerator._generate_sections_with_llm)
+    # Still an inline string literal for the "content" key, not a registry
+    # call -- if this had been migrated, the value would instead be a
+    # get_internal_prompt(...)/render_internal_prompt(...) call.
+    assert (
+        '"content": "You are an expert analyst creating executive briefings '
+        'from aggregated content.",' in source
+    )
+    # Exactly one render_internal_prompt call in this method: the migrated
+    # analysis/user prompt. The system role above is untouched (asserted above).
+    assert source.count("render_internal_prompt") == 1

--- a/Tests/Internal_Prompts/test_subscriptions_prompt_parity.py
+++ b/Tests/Internal_Prompts/test_subscriptions_prompt_parity.py
@@ -1,0 +1,253 @@
+# Tests/Internal_Prompts/test_subscriptions_prompt_parity.py
+"""Golden parity: registry defaults render byte-identical text to the
+original Subscriptions/content_processor.py, recursive_summarizer.py, and
+briefing_generator.py literals.
+
+The four per-type analysis prompts and the briefing prompt were f-strings in
+source with complex interpolations (dict .get() fallbacks, content[:5000]/
+content[:3000] slices, an f"{...:.1f}" format spec). Each test below embeds
+the ORIGINAL f-string verbatim (locals named to match the source variables:
+`subscription`, `item`, `content`, `content_summary`), evaluates it, then
+precomputes the same values into named tokens exactly the way calling code
+must (Task 8) and asserts render_internal_prompt(...) reproduces the
+original string exactly. This proves the registry template equals the
+original text with only the interpolation syntax swapped out.
+"""
+
+from tldw_chatbook.Internal_Prompts import CATALOG, render_internal_prompt
+
+
+def test_analysis_system_matches_source_literal():
+    # content_processor.py:272 — one-liner, zero placeholders.
+    original = "You are a helpful assistant that analyzes and summarizes content from subscriptions."
+    assert CATALOG["subscriptions.analysis_system"].default == original
+
+
+def test_feed_analysis_parity():
+    # content_processor.py _build_analysis_prompt, rss/atom/json_feed branch.
+    subscription = {"name": "Hacker News", "type": "rss"}
+    item = {
+        "title": "Big Announcement",
+        "url": "https://example.com/a",
+        "published_date": "2026-07-20",
+    }
+    content = "A" * 6000  # longer than the 5000-char slice to prove it matters
+    original = f"""Analyze this article from {subscription["name"]}:
+
+Title: {item.get("title", "Untitled")}
+URL: {item.get("url", "N/A")}
+Published: {item.get("published_date", "Unknown")}
+
+Content:
+{content[:5000]}
+
+Please provide:
+1. A concise summary (2-3 sentences)
+2. Key points or insights (bullet points)
+3. Why this might be important or relevant
+4. Any action items or implications
+
+Keep the analysis focused and practical."""
+    rendered = render_internal_prompt(
+        "subscriptions.feed_analysis",
+        name=subscription["name"],
+        title=item.get("title", "Untitled"),
+        url=item.get("url", "N/A"),
+        published=item.get("published_date", "Unknown"),
+        content=content[:5000],
+    )
+    assert rendered == original
+
+
+def test_feed_analysis_parity_missing_metadata_defaults():
+    # Same branch, but item metadata absent -> the .get() fallbacks fire.
+    subscription = {"name": "Empty Feed", "type": "atom"}
+    item = {}
+    content = "short body"
+    original = f"""Analyze this article from {subscription["name"]}:
+
+Title: {item.get("title", "Untitled")}
+URL: {item.get("url", "N/A")}
+Published: {item.get("published_date", "Unknown")}
+
+Content:
+{content[:5000]}
+
+Please provide:
+1. A concise summary (2-3 sentences)
+2. Key points or insights (bullet points)
+3. Why this might be important or relevant
+4. Any action items or implications
+
+Keep the analysis focused and practical."""
+    rendered = render_internal_prompt(
+        "subscriptions.feed_analysis",
+        name=subscription["name"],
+        title=item.get("title", "Untitled"),
+        url=item.get("url", "N/A"),
+        published=item.get("published_date", "Unknown"),
+        content=content[:5000],
+    )
+    assert rendered == original
+
+
+def test_url_change_analysis_parity():
+    # content_processor.py _build_analysis_prompt, url_change branch.
+    subscription = {"name": "Docs Page", "type": "url_change", "source": "https://example.com/docs"}
+    item = {"url": "https://example.com/docs/page", "change_percentage": 0.3217}
+    content = "B" * 5500
+    original = f"""A monitored webpage has changed:
+
+URL: {item.get("url", subscription["source"])}
+Change: {item.get("change_percentage", 0) * 100:.1f}% of content changed
+
+New content:
+{content[:5000]}
+
+Please:
+1. Summarize what has changed
+2. Highlight the most important updates
+3. Assess the significance of these changes
+4. Suggest any follow-up actions if needed"""
+    rendered = render_internal_prompt(
+        "subscriptions.url_change_analysis",
+        url=item.get("url", subscription["source"]),
+        change_percentage=f"{item.get('change_percentage', 0) * 100:.1f}",
+        content=content[:5000],
+    )
+    assert rendered == original
+
+
+def test_url_change_analysis_parity_url_fallback_and_zero_change():
+    # item has no "url" key (falls back to subscription["source"]) and no
+    # "change_percentage" key (defaults to 0).
+    subscription = {"name": "Docs Page", "type": "url_change", "source": "https://example.com/docs"}
+    item = {}
+    content = "unchanged-ish content"
+    original = f"""A monitored webpage has changed:
+
+URL: {item.get("url", subscription["source"])}
+Change: {item.get("change_percentage", 0) * 100:.1f}% of content changed
+
+New content:
+{content[:5000]}
+
+Please:
+1. Summarize what has changed
+2. Highlight the most important updates
+3. Assess the significance of these changes
+4. Suggest any follow-up actions if needed"""
+    rendered = render_internal_prompt(
+        "subscriptions.url_change_analysis",
+        url=item.get("url", subscription["source"]),
+        change_percentage=f"{item.get('change_percentage', 0) * 100:.1f}",
+        content=content[:5000],
+    )
+    assert rendered == original
+
+
+def test_podcast_analysis_parity():
+    # content_processor.py _build_analysis_prompt, podcast branch. Note the
+    # content slice here is [:3000], not [:5000].
+    subscription = {"name": "Tech Talk Weekly", "type": "podcast"}
+    item = {"title": "Episode 42", "published_date": "2026-07-15"}
+    content = "C" * 4000
+    original = f"""Analyze this podcast episode from {subscription["name"]}:
+
+Title: {item.get("title", "Untitled")}
+Published: {item.get("published_date", "Unknown")}
+
+Description:
+{content[:3000]}
+
+Please provide:
+1. Episode summary
+2. Main topics discussed
+3. Key takeaways
+4. Whether this episode is worth listening to and why"""
+    rendered = render_internal_prompt(
+        "subscriptions.podcast_analysis",
+        name=subscription["name"],
+        title=item.get("title", "Untitled"),
+        published=item.get("published_date", "Unknown"),
+        content=content[:3000],
+    )
+    assert rendered == original
+
+
+def test_generic_analysis_parity():
+    # content_processor.py _build_analysis_prompt, else (generic) branch.
+    subscription = {"name": "Custom Source", "type": "custom_scraper"}
+    item = {"title": "Some Item"}
+    content = "D" * 5200
+    original = f"""Analyze this content from {subscription["name"]}:
+
+Title: {item.get("title", "Untitled")}
+Type: {subscription["type"]}
+
+Content:
+{content[:5000]}
+
+Please provide a helpful analysis including:
+1. Summary
+2. Key information
+3. Relevance or importance
+4. Any recommended actions"""
+    rendered = render_internal_prompt(
+        "subscriptions.generic_analysis",
+        name=subscription["name"],
+        title=item.get("title", "Untitled"),
+        type=subscription["type"],
+        content=content[:5000],
+    )
+    assert rendered == original
+
+
+def test_recursive_summarizer_system_matches_source_literal():
+    # recursive_summarizer.py _get_system_prompt — static literal, zero
+    # placeholders. Note the trailing space after "length." before the
+    # blank line, preserved verbatim from source.
+    original = """You are an expert content summarizer. Your task is to create clear, accurate summaries that preserve the key information while significantly reducing length. 
+
+Key principles:
+1. Maintain factual accuracy
+2. Preserve the most important information
+3. Use clear, concise language
+4. Maintain logical flow
+5. Respect the requested token limit"""
+    assert CATALOG["subscriptions.recursive_summarizer_system"].default == original
+
+
+def test_briefing_parity():
+    # briefing_generator.py _generate_sections_with_llm, default (non-custom)
+    # prompt branch.
+    content_summary = "Source A: 3 new items.\nSource B: 1 new item with {braces} in it."
+    original = f"""Analyze the following content from various subscriptions and generate a comprehensive briefing:
+
+{content_summary}
+
+Please provide:
+1. Executive Summary (2-3 paragraphs highlighting the most important developments)
+2. Key Insights (bullet points of significant findings or patterns)
+3. Trending Topics (identify common themes across sources)
+4. Recommended Actions (actionable items based on the content)
+
+Format each section clearly with appropriate headers."""
+    rendered = render_internal_prompt(
+        "subscriptions.briefing", content_summary=content_summary
+    )
+    assert rendered == original
+
+
+def test_briefing_contract_note_pins_section_labels():
+    # _parse_llm_sections substring-matches these four labels; if the
+    # default text or the contract note ever drops one, this test catches it.
+    default_text = CATALOG["subscriptions.briefing"].default
+    for label in (
+        "Executive Summary",
+        "Key Insights",
+        "Trending Topics",
+        "Recommended Actions",
+    ):
+        assert label in default_text
+        assert label in (CATALOG["subscriptions.briefing"].contract_note or "")

--- a/Tests/Internal_Prompts/test_summarization_migration.py
+++ b/Tests/Internal_Prompts/test_summarization_migration.py
@@ -239,3 +239,50 @@ def test_local_summarizer_template_call_sites_use_registry():
 
     # The oobabooga local shadow (a different prompt) must remain untouched.
     assert '"Please summarize the following text:"' in source
+
+
+def test_rolling_summarize_skips_resolver_when_caller_option_set(
+    scratch_config, monkeypatch
+):
+    """`Chunker._get_option(key, default_override)` only uses
+    `default_override` when `self.options[key]` is None, but Python
+    evaluates arguments eagerly — so a bare
+    `get_internal_prompt("summarization.rolling_summarize_system")` passed
+    positionally as that default runs on *every* rolling_summarize call
+    regardless of whether `self.options["summarize_system_prompt"]` is
+    already populated (the common case per
+    test_rolling_summarize_default_channel_is_frozen_at_import: the
+    module-level DEFAULT_CHUNK_OPTIONS entry is virtually never None).
+    That's a wasted config lookup on a hot path, and it can trip the
+    resolver's warn-once path for a value that's immediately discarded.
+    The resolver must not be called at all when the caller option already
+    supplies a value."""
+    from tldw_chatbook.Chunking import Chunk_Lib
+
+    calls = []
+    original = Chunk_Lib.get_internal_prompt
+
+    def spy(prompt_id):
+        calls.append(prompt_id)
+        return original(prompt_id)
+
+    monkeypatch.setattr(Chunk_Lib, "get_internal_prompt", spy)
+
+    captured = []
+
+    def fake_llm(payload):
+        captured.append(payload)
+        return "summary"
+
+    chunker = Chunk_Lib.Chunker(options={"summarize_system_prompt": "CALLER SET"})
+    chunker.chunk_text(
+        "Sentence one. Sentence two. Sentence three. " * 20,
+        method="rolling_summarize",
+        llm_call_function=fake_llm,
+        llm_api_config={},
+    )
+    assert captured, "fake_llm was never invoked"
+    assert calls == [], (
+        "get_internal_prompt('summarization.rolling_summarize_system') "
+        f"was called even though summarize_system_prompt was already set: {calls}"
+    )

--- a/Tests/Internal_Prompts/test_summarization_migration.py
+++ b/Tests/Internal_Prompts/test_summarization_migration.py
@@ -1,0 +1,241 @@
+# Tests/Internal_Prompts/test_summarization_migration.py
+"""Overrides must reach the summarization payloads; caller channels win.
+Fakes only at the LLM dispatch/transport seams (pipeline code before/after
+the seam runs for real).
+
+Adaptations from the brief's skeleton (see task-4-report.md for detail):
+
+- `_dispatch_to_api` was confirmed (by reading Summarization_General_Lib.py)
+  as the real seam analyze() calls for the non-chunking path; the skeleton's
+  guess was correct as written, no rename needed.
+- Reading analyze()'s control flow turned up a pre-existing, unrelated bug:
+  when `CHUNKER_AVAILABLE` is True (the normal case) *and* both
+  `recursive_summarization` and `chunked_summarization` are False (the
+  default/"just summarize" call shape used by the brief's skeleton), the
+  `if CHUNKER_AVAILABLE: ... else: final_result = _dispatch_to_api(...)`
+  structure means the direct-dispatch `else` branch is paired with
+  `CHUNKER_AVAILABLE`, not with the inner recursive/chunked `if`/`elif`.
+  So `_dispatch_to_api` is *never called* for that call shape — `analyze()`
+  silently returns "Error: Summarization failed unexpectedly." regardless
+  of system_message. This is untouched (out of scope for this migration:
+  the task is prompt-source migration, not analyze()'s dispatch logic), but
+  it means the skeleton's default `sgl.analyze(...)` call cannot reach
+  `_dispatch_to_api` as written. The tests below monkeypatch
+  `sgl.CHUNKER_AVAILABLE = False` to reach the same `_dispatch_to_api` call
+  the brief targets (same call, same args) without depending on the real
+  chunking subsystem's behavior on a 4-character input string.
+- `_rolling_summarize` is exercised through the public `Chunker.chunk_text(
+  ..., method="rolling_summarize", ...)` entry point rather than called
+  directly, so the test also proves the `_get_option` wiring between
+  chunk_text's "rolling_summarize" branch and `_rolling_summarize` itself.
+  `Chunker(options={"summarize_system_prompt": None})` is used to force
+  `_get_option`'s fallback branch, because `self.options["summarize_system_
+  prompt"]` is populated from the module-level `DEFAULT_CHUNK_OPTIONS` dict
+  at *import time* and is virtually never None in real use — see
+  `test_rolling_summarize_default_channel_is_frozen_at_import` below, which
+  documents that a config change made *after* import does NOT reach a
+  freshly constructed `Chunker()` that doesn't pass this override, i.e. the
+  import-time channel is not live.
+- Local_Summarization_Lib's five call sites are covered by a call-site
+  identity/source assertion rather than a real HTTP-payload test: reading
+  all five functions turned up two independent, pre-existing obstacles that
+  make transport-level tests disproportionate (see docstring on
+  `test_local_summarizer_template_call_sites_use_registry` for specifics).
+  These are pre-existing issues unrelated to this migration and are left
+  untouched, as directed.
+"""
+
+from tldw_chatbook.Internal_Prompts import get_internal_prompt
+
+
+def test_analyze_default_system_uses_registry(scratch_config, monkeypatch):
+    from tldw_chatbook.LLM_Calls import Summarization_General_Lib as sgl
+
+    scratch_config(
+        '[internal_prompts.summarization]\nanalyze_default_system = "CUSTOM ANALYZE SYSTEM"\n'
+    )
+    captured = {}
+
+    def fake_dispatch(*args, **kwargs):
+        captured["kwargs"] = kwargs
+        captured["args"] = args
+        return "ok"
+
+    # analyze()'s non-chunking path calls _dispatch_to_api(text_content,
+    # custom_prompt_arg, api_name, api_key, temp, system_message,
+    # streaming=...) positionally/by-kwarg; monkeypatch it in sgl's module
+    # namespace (that's the name analyze() actually resolves at call time).
+    monkeypatch.setattr(sgl, "_dispatch_to_api", fake_dispatch)
+    # See module docstring: reach the direct-dispatch branch without
+    # depending on the (unrelated) chunking subsystem.
+    monkeypatch.setattr(sgl, "CHUNKER_AVAILABLE", False)
+    sgl.analyze(
+        input_data="text", custom_prompt_arg="p", api_name="openai",
+        api_key=None, temp=0.3, system_message=None, streaming=False,
+    )
+    assert "CUSTOM ANALYZE SYSTEM" in str(captured)
+
+
+def test_analyze_caller_system_message_wins(scratch_config, monkeypatch):
+    from tldw_chatbook.LLM_Calls import Summarization_General_Lib as sgl
+
+    scratch_config(
+        '[internal_prompts.summarization]\nanalyze_default_system = "REGISTRY"\n'
+    )
+    captured = {}
+
+    def fake_dispatch(*args, **kwargs):
+        captured["all"] = (args, kwargs)
+        return "ok"
+
+    monkeypatch.setattr(sgl, "_dispatch_to_api", fake_dispatch)
+    monkeypatch.setattr(sgl, "CHUNKER_AVAILABLE", False)
+    sgl.analyze(
+        input_data="text", custom_prompt_arg="p", api_name="openai",
+        api_key=None, temp=0.3, system_message="CALLER", streaming=False,
+    )
+    assert "CALLER" in str(captured) and "REGISTRY" not in str(captured)
+
+
+def test_rolling_summarize_system_override_reaches_llm_payload(scratch_config):
+    from tldw_chatbook.Chunking.Chunk_Lib import Chunker
+
+    scratch_config(
+        '[internal_prompts.summarization]\nrolling_summarize_system = "CUSTOM ROLLING"\n'
+    )
+    captured = []
+
+    def fake_llm(payload):
+        # _rolling_summarize invokes llm_summarize_step_func(payload_dict)
+        # with a single positional dict argument containing "system_message".
+        captured.append(payload)
+        return "summary"
+
+    # Force _get_option("summarize_system_prompt", ...) to fall through to
+    # its dynamic default (now get_internal_prompt(...)), since the
+    # import-time dict entry (self.options[key] from DEFAULT_CHUNK_OPTIONS)
+    # would otherwise win and mask the live override — see the frozen-at-
+    # import test below for why that channel doesn't observe this override.
+    chunker = Chunker(options={"summarize_system_prompt": None})
+    chunker.chunk_text(
+        "Sentence one. Sentence two. Sentence three. " * 20,
+        method="rolling_summarize",
+        llm_call_function=fake_llm,
+        llm_api_config={},
+    )
+    assert captured, "fake_llm was never invoked"
+    assert any(
+        "CUSTOM ROLLING" in str(payload.get("system_message", ""))
+        for payload in captured
+    )
+
+
+def test_rolling_summarize_caller_option_wins(scratch_config):
+    """The per-instance `options={"summarize_system_prompt": ...}` channel
+    (the Chunker caller channel) still outranks the registry default."""
+    from tldw_chatbook.Chunking.Chunk_Lib import Chunker
+
+    scratch_config(
+        '[internal_prompts.summarization]\nrolling_summarize_system = "REGISTRY ROLLING"\n'
+    )
+    captured = []
+
+    def fake_llm(payload):
+        captured.append(payload)
+        return "summary"
+
+    chunker = Chunker(options={"summarize_system_prompt": "CALLER ROLLING"})
+    chunker.chunk_text(
+        "Sentence one. Sentence two. Sentence three. " * 20,
+        method="rolling_summarize",
+        llm_call_function=fake_llm,
+        llm_api_config={},
+    )
+    assert captured, "fake_llm was never invoked"
+    joined = " ".join(str(p.get("system_message", "")) for p in captured)
+    assert "CALLER ROLLING" in joined
+    assert "REGISTRY ROLLING" not in joined
+
+
+def test_rolling_summarize_default_channel_is_frozen_at_import(scratch_config):
+    """Documents the finding in the task report: the value that actually
+    reaches `_rolling_summarize` in the common case (no per-instance
+    `options` override) comes from the module-level `DEFAULT_CHUNK_OPTIONS`
+    dict, which is built once when Chunking.Chunk_Lib is first imported.
+    A config change made after import (as scratch_config does here, well
+    after test collection has already imported the module) is NOT observed
+    by a freshly constructed `Chunker()` — the override only takes effect
+    on the next process start / module (re)import, not live per call."""
+    from tldw_chatbook.Chunking.Chunk_Lib import Chunker
+
+    baked_in_default = get_internal_prompt("summarization.rolling_summarize_system")
+
+    scratch_config(
+        '[internal_prompts.summarization]\nrolling_summarize_system = "SHOULD NOT APPEAR LIVE"\n'
+    )
+    captured = []
+
+    def fake_llm(payload):
+        captured.append(payload)
+        return "summary"
+
+    chunker = Chunker()  # no override -> uses the import-time dict entry
+    chunker.chunk_text(
+        "Sentence one. Sentence two. Sentence three. " * 20,
+        method="rolling_summarize",
+        llm_call_function=fake_llm,
+        llm_api_config={},
+    )
+    assert captured, "fake_llm was never invoked"
+    joined = " ".join(str(p.get("system_message", "")) for p in captured)
+    assert "SHOULD NOT APPEAR LIVE" not in joined
+    assert baked_in_default in joined
+
+
+def test_local_summarizer_template_call_sites_use_registry():
+    """Local_Summarization_Lib's five consuming sites (summarize_with_llama,
+    summarize_with_kobold, summarize_with_tabbyapi, summarize_with_custom_
+    openai, summarize_with_custom_openai_2) all read
+    `get_internal_prompt('summarization.local_summarizer_template')` at call
+    time rather than the deleted module constant. A real HTTP-payload test
+    per the brief's preference turned out disproportionate for two
+    independent, pre-existing reasons found while reading these functions
+    (neither introduced by this migration, both left untouched):
+
+    1. summarize_with_llama, summarize_with_kobold, and
+       summarize_with_tabbyapi read config sections that do not exist under
+       those names in config.py's `load_settings()` output (e.g.
+       `loaded_config_data["llama_api"]` — the real section is
+       `"llama_cpp_api"`; `loaded_config_data["api_keys"]` and
+       `["local_api_ip"]` are not produced by load_settings() at all). These
+       functions raise KeyError before reaching their HTTP call regardless
+       of the prompt migration.
+    2. summarize_with_custom_openai and summarize_with_custom_openai_2 (the
+       two functions whose config keys DO resolve correctly) reassign the
+       migrated value to the local variable `input_data`, which is never
+       read again afterward — the outgoing payload's user-message content
+       is built from `text` + `custom_prompt_arg` only. The line is dead
+       code both before and after this migration, so there is no payload to
+       assert against.
+
+    Given that, this test asserts the call-site wiring by source inspection:
+    the deleted constant is gone from the module namespace, the five sites
+    reference the registry id (not a stray literal), and the unrelated
+    `summarize_with_oobabooga` local shadow (a different, hardcoded prompt
+    "Please summarize the following text:") is untouched.
+    """
+    import inspect
+
+    from tldw_chatbook.LLM_Calls import Local_Summarization_Lib as lsl
+
+    assert not hasattr(lsl, "summarizer_prompt")
+
+    source = inspect.getsource(lsl)
+    assert (
+        source.count("get_internal_prompt('summarization.local_summarizer_template')")
+        == 5
+    )
+    assert "Rewrite this text in summarized form." not in source
+
+    # The oobabooga local shadow (a different prompt) must remain untouched.
+    assert '"Please summarize the following text:"' in source

--- a/Tests/Internal_Prompts/test_summarization_prompt_parity.py
+++ b/Tests/Internal_Prompts/test_summarization_prompt_parity.py
@@ -1,0 +1,56 @@
+# Tests/Internal_Prompts/test_summarization_prompt_parity.py
+"""Registry defaults must match the summarization-source literals
+byte-for-byte. The two multi-line prompts below are verbatim copies of the
+pre-migration source (Summarization_General_Lib.py:528-550 and
+Local_Summarization_Lib.py:39-56), copied before the migration touched those
+files."""
+
+from tldw_chatbook.Internal_Prompts import CATALOG
+
+ORIGINAL_ANALYZE_DEFAULT_SYSTEM = 'You are a bulleted notes specialist. ```When creating comprehensive bulleted notes, you should follow these guidelines: Use multiple headings based on the referenced topics, not categories like quotes or terms. Headings should be surrounded by bold formatting and not be listed as bullet points themselves. Leave no space between headings and their corresponding list items underneath. Important terms within the content should be emphasized by setting them in bold font. Any text that ends with a colon should also be bolded. Before submitting your response, review the instructions, and make any corrections necessary to adhered to the specified format. Do not reference these instructions within the notes.``` \nBased on the content between backticks create comprehensive bulleted notes.\n**Bulleted Note Creation Guidelines**\n\n**Headings**:\n- Based on referenced topics, not categories like quotes or terms\n- Surrounded by **bold** formatting\n- Not listed as bullet points\n- No space between headings and list items underneath\n\n**Emphasis**:\n- **Important terms** set in bold font\n- **Text ending in a colon**: also bolded\n\n**Review**:\n- Ensure adherence to specified format\n- Do not reference these instructions in your response.'
+
+ORIGINAL_LOCAL_SUMMARIZER_TEMPLATE = '\n                    <s>You are a bulleted notes specialist. ```When creating comprehensive bulleted notes, you should follow these guidelines: Use multiple headings based on the referenced topics, not categories like quotes or terms. Headings should be surrounded by bold formatting and not be listed as bullet points themselves. Leave no space between headings and their corresponding list items underneath. Important terms within the content should be emphasized by setting them in bold font. Any text that ends with a colon should also be bolded. Before submitting your response, review the instructions, and make any corrections necessary to adhered to the specified format. Do not reference these instructions within the notes.``` \nBased on the content between backticks create comprehensive bulleted notes.\n                        **Bulleted Note Creation Guidelines**\n\n                        **Headings**:\n                        - Based on referenced topics, not categories like quotes or terms\n                        - Surrounded by **bold** formatting\n                        - Not listed as bullet points\n                        - No space between headings and list items underneath\n\n                        **Emphasis**:\n                        - **Important terms** set in bold font\n                        - **Text ending in a colon**: also bolded\n\n                        **Review**:\n                        - Ensure adherence to specified format\n                        - Do not reference these instructions in your response.</s> {{ .Prompt }}\n                    '
+
+
+def test_analyze_default_system_matches_source_literal():
+    assert (
+        CATALOG["summarization.analyze_default_system"].default
+        == ORIGINAL_ANALYZE_DEFAULT_SYSTEM
+    )
+
+
+def test_local_summarizer_template_matches_source_literal():
+    assert (
+        CATALOG["summarization.local_summarizer_template"].default
+        == ORIGINAL_LOCAL_SUMMARIZER_TEMPLATE
+    )
+
+
+def test_local_summarizer_template_ships_ollama_cruft_unchanged():
+    # Pins the cruft-ships-unchanged decision: the doubled-brace
+    # "{{ .Prompt }}" Ollama token is left in place (callers concatenate
+    # this template ahead of the input text rather than render it).
+    assert (
+        "{{ .Prompt }}"
+        in CATALOG["summarization.local_summarizer_template"].default
+    )
+    assert (
+        "<s>" in CATALOG["summarization.local_summarizer_template"].default
+    )
+    assert (
+        "</s>" in CATALOG["summarization.local_summarizer_template"].default
+    )
+
+
+def test_rolling_summarize_system_matches_default_literal():
+    assert (
+        CATALOG["summarization.rolling_summarize_system"].default
+        == "Rewrite this text in summarized form."
+    )
+
+
+def test_rolling_summarize_system_legacy_config_path():
+    assert (
+        CATALOG["summarization.rolling_summarize_system"].legacy_config_path
+        == "chunking_config.summarize_system_prompt"
+    )

--- a/backlog/tasks/task-448 - Internal-prompts-warn-once-on-wrong-typed-override-values.md
+++ b/backlog/tasks/task-448 - Internal-prompts-warn-once-on-wrong-typed-override-values.md
@@ -1,0 +1,24 @@
+---
+id: TASK-448
+title: 'Internal prompts: warn once on wrong-typed override values'
+status: To Do
+assignee: []
+created_date: '2026-07-21 20:05'
+labels:
+  - internal-prompts
+  - polish
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+In `tldw_chatbook/Internal_Prompts/resolver.py`, `_extract_text` silently returns None (treated as "no override") when a config override value is neither a str nor a `{text, ...}` table — e.g. a stray TOML int/array from a hand-edit. The never-raises contract is correct, but the silent drop gives no signal that a user's intended override was ignored. Add a warn-once (keyed like the other resolver warnings) when a present-but-wrong-typed override/legacy value is discarded, so misconfiguration is visible in logs. Surfaced as deferred minor m1 during the P1 whole-branch review.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A present override value of a non-str/non-table type logs exactly one warning per prompt id and still falls back to the shipped default (never raises)
+- [ ] #2 A correctly-typed override (str or {text,...} table) and a genuinely-absent override both produce NO new warning
+- [ ] #3 A unit test in Tests/Internal_Prompts/ covers the wrong-typed-value warn-once path
+<!-- AC:END -->

--- a/backlog/tasks/task-449 - Internal-prompts-transport-boundary-tests-for-websearch-sites-2-4.md
+++ b/backlog/tasks/task-449 - Internal-prompts-transport-boundary-tests-for-websearch-sites-2-4.md
@@ -1,0 +1,25 @@
+---
+id: TASK-449
+title: 'Internal prompts: transport-boundary tests for websearch sites 2-4'
+status: To Do
+assignee: []
+created_date: '2026-07-21 20:06'
+labels:
+  - internal-prompts
+  - test-coverage
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The P1 websearch migration added a live transport-boundary integration test only for the sub-question-generation call site. The other three migrated sites — result_relevance_eval, result_summarization, answer_synthesis in `Web_Scraping/WebSearch_APIs.py` — are covered only by kwarg-match verification plus golden parity. A wrong kwarg name at those sites fails silently (the token survives unsubstituted, no crash). Add one transport-boundary test each (fake only `chat_api_call`, override via scratch_config, assert the override text reaches the payload) so a wiring regression is caught. Deferred minor m3 from the P1 review.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A transport-boundary test proves a config override reaches the LLM payload for result_relevance_eval
+- [ ] #2 Same for result_summarization
+- [ ] #3 Same for answer_synthesis
+- [ ] #4 Each test fakes only the transport (chat_api_call); pipeline code runs real
+<!-- AC:END -->

--- a/backlog/tasks/task-450 - RAG-reranker-remove-unreachable-literal-fallback.md
+++ b/backlog/tasks/task-450 - RAG-reranker-remove-unreachable-literal-fallback.md
@@ -1,0 +1,24 @@
+---
+id: TASK-450
+title: 'RAG reranker: remove unreachable literal fallback in _call_llm_impl'
+status: To Do
+assignee: []
+created_date: '2026-07-21 20:07'
+labels:
+  - internal-prompts
+  - cleanup
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+In `tldw_chatbook/RAG_Search/reranker.py` (~line 168), the `... or "You are a search result relevance evaluator."` inline fallback arm is now unreachable: each reranker's `__init__` always populates `config.system_prompt` from the registry, so the guarded expression can never fall through to that literal. Remove the dead arm. Pure cleanup, no behavior change. Deferred minor from the P1 whole-branch review.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The unreachable `or "You are a search result relevance evaluator."` fallback is removed from reranker.py
+- [ ] #2 Existing reranker tests (Tests/RAG/test_reranker_internal_prompts.py and reranker suites) remain green
+- [ ] #3 No behavior change: rerankers still resolve their system prompt from the registry / caller config
+<!-- AC:END -->

--- a/backlog/tasks/task-451 - Internal-prompts-dead-key-hygiene-after-full-migration.md
+++ b/backlog/tasks/task-451 - Internal-prompts-dead-key-hygiene-after-full-migration.md
@@ -1,0 +1,25 @@
+---
+id: TASK-451
+title: 'Internal prompts: dead-key hygiene after full migration'
+status: To Do
+assignee: []
+created_date: '2026-07-21 20:08'
+labels:
+  - internal-prompts
+  - cleanup
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Once the registry migration is fully landed (P1+P2, and P3 Settings UI), remove the now-orphaned prompt config scaffolding in `config.py`: the unconsumed `prompts_strings` loader, the `CONFIG_PROMPT_SITUATE_CHUNK_CONTEXT` constant (no call site anywhere), and the stale `[Prompts]` stub one-liner comments that predate the registry. Verify each is genuinely unreferenced before deletion (the registry's legacy tier reads `[Prompts]` keys, so keep the section itself if any spec still points a `legacy_config_path` at it — only remove the truly dead scaffolding).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 `prompts_strings` loader removed if grep confirms zero consumers
+- [ ] #2 `CONFIG_PROMPT_SITUATE_CHUNK_CONTEXT` removed (no call site exists)
+- [ ] #3 `[Prompts]` keys still referenced by any spec's legacy_config_path are preserved; only genuinely-dead scaffolding is deleted
+- [ ] #4 App imports and the internal-prompts suite stay green
+<!-- AC:END -->

--- a/backlog/tasks/task-452 - Local-summarizer-drop-trailing-Ollama-template-cruft.md
+++ b/backlog/tasks/task-452 - Local-summarizer-drop-trailing-Ollama-template-cruft.md
@@ -1,0 +1,24 @@
+---
+id: TASK-452
+title: 'Local summarizer: drop trailing </s> {{ .Prompt }} Ollama cruft (behavior change)'
+status: To Do
+assignee: []
+created_date: '2026-07-21 20:09'
+labels:
+  - internal-prompts
+  - behavior-change
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The `summarization.local_summarizer_template` registry default (moved verbatim from `Local_Summarization_Lib.py`) still carries `<s>`/`</s>` sentinel tags and a trailing `{{ .Prompt }}` Ollama-modelfile token that get sent verbatim to models today. This is leftover templating cruft, not intended prompt content. Removing it changes the bytes sent to the model, so it needs its own review and before/after evaluation rather than riding a mechanical migration. When done, update the parity/registry default and the pin test that currently asserts the cruft is present.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The `<s>`/`</s>` sentinels and trailing `{{ .Prompt }}` are removed from the local summarizer default
+- [ ] #2 The Task-3 pin test asserting `{{ .Prompt }}` presence is updated to reflect the cleaned text
+- [ ] #3 A note/PR body records this is a deliberate behavior change with before/after prompt bytes
+<!-- AC:END -->

--- a/backlog/tasks/task-453 - DocumentGenerator-get-conversation-context-always-returns-empty.md
+++ b/backlog/tasks/task-453 - DocumentGenerator-get-conversation-context-always-returns-empty.md
@@ -1,0 +1,25 @@
+---
+id: TASK-453
+title: 'DocumentGenerator.get_conversation_context always returns empty (missing DB method)'
+status: To Do
+assignee: []
+created_date: '2026-07-21 20:20'
+labels:
+  - bug
+  - document-generation
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`DocumentGenerator.get_conversation_context` (`Chat/document_generator.py:127-147`) calls `self.db.get_messages_by_conversation_id(...)`, a method that does not exist on `CharactersRAGDB` (nor any DB class in `DB/`). The `AttributeError` is caught, so the method silently returns empty context. Consequence: timeline / study-guide / briefing generation has been running with NO conversation context for every real invocation — the generated documents ignore the actual conversation content. Pre-existing (predates the internal-prompts migration); surfaced while writing P2 migration tests, which is why every doc-gen test sees `context == ""`. Fix by calling the correct DB accessor (likely `get_messages_for_conversation` or equivalent — verify the real method name on CharactersRAGDB) so context is actually populated.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 get_conversation_context returns the real messages for a conversation that has them (not empty)
+- [ ] #2 The correct existing DB accessor is used (no reliance on the nonexistent get_messages_by_conversation_id)
+- [ ] #3 A test covers timeline/study-guide/briefing generation with a NON-empty context reaching the LLM payload
+- [ ] #4 The empty/no-conversation case still degrades gracefully (no crash)
+<!-- AC:END -->

--- a/backlog/tasks/task-454 - Subscriptions-content_processor-extract-truncation-limits-to-named-constants.md
+++ b/backlog/tasks/task-454 - Subscriptions-content_processor-extract-truncation-limits-to-named-constants.md
@@ -1,0 +1,25 @@
+---
+id: TASK-454
+title: 'Subscriptions content_processor: extract truncation limits to named constants'
+status: To Do
+assignee: []
+created_date: '2026-07-22 00:22'
+labels:
+  - internal-prompts
+  - cleanup
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Subscriptions/content_processor.py's _build_analysis_prompt repeats the hardcoded truncation limits 5000 (custom prompt, rss/atom/json_feed, url_change, generic) and 3000 (podcast) across multiple branches. Pre-existing behavior carried over unchanged by PR #748 (Internal Prompts P2)'s migration to render_internal_prompt -- not introduced by that migration, and not a correctness bug, but the literals are error-prone to keep in sync if truncation policy is ever tuned. Flagged by qodo-code-review bot on PR #748; deferred as out-of-scope for a prompt-source migration.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The 5000-char and 3000-char truncation limits in _build_analysis_prompt are each defined once as named module or class constants
+- [ ] #2 All 5 call sites (custom prompt / rss-atom-json_feed / url_change / podcast / generic) reference the constants instead of inline literals
+- [ ] #3 Existing Subscriptions content_processor tests remain green
+- [ ] #4 No behavior change: truncation limits and their per-type values are unchanged
+<!-- AC:END -->

--- a/tldw_chatbook/Agents/agent_runtime.py
+++ b/tldw_chatbook/Agents/agent_runtime.py
@@ -180,16 +180,19 @@ def render_tool_protocol(schemas: list[ToolSchema]) -> str:
             )
         )
     tool_list = "\n".join(blocks)
-    return (
-        "You can call tools. Available tools:\n"
-        f"{tool_list}\n\n"
-        "To call a tool, your reply MUST START with the fence as its first "
-        "content — no prose before it:\n"
-        f'{FENCE_OPEN}\n{{"name": "<tool name>", "arguments": {{...}}}}\n'
-        f"{_FENCE_CLOSE}\n"
-        "One tool call per reply. After you receive the tool result, either "
-        "call another tool the same way or answer the user directly. If no "
-        "tool is needed, just answer directly."
+
+    # Import inside the function on purpose: agent_runtime is a pure module
+    # today (no Textual, app, DB, or I/O imports per the module docstring)
+    # and P1's import-hygiene philosophy keeps prompt plumbing out of module
+    # import paths that don't need it. A module-level import would also
+    # pass the hygiene test; this is the more conservative choice.
+    from tldw_chatbook.Internal_Prompts import render_internal_prompt
+
+    return render_internal_prompt(
+        "agents.tool_protocol",
+        tool_list=tool_list,
+        fence_open=FENCE_OPEN,
+        fence_close=_FENCE_CLOSE,
     )
 
 

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -15,6 +15,8 @@ from datetime import datetime, timezone
 from typing import Callable, Protocol
 
 from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+from tldw_chatbook.Internal_Prompts import get_internal_prompt
+from tldw_chatbook.Internal_Prompts.catalog import CATALOG
 
 from .agent_models import (
     AGENT_KIND_PRIMARY,
@@ -46,10 +48,10 @@ from .tool_catalog import (
     initial_disclosure,
 )
 
-SUBAGENT_SYSTEM_PROMPT = (
-    "You are a focused sub-agent. Complete the task you are given and "
-    "reply with a concise result. You cannot ask the user questions."
-)
+# Catalog-default re-export: keeps existing imports (console_agent_bridge,
+# tests) valid and pins the "shipped default" used by the dual-prefix
+# sub-agent check. Runtime call sites resolve live via get_internal_prompt.
+SUBAGENT_SYSTEM_PROMPT = CATALOG["agents.subagent_system"].default
 
 TRUNCATION_NOTICE = "\n[truncated]"
 
@@ -406,7 +408,7 @@ class AgentService:
             )
             child_config = AgentConfig(
                 model=config.model,
-                system_prompt=SUBAGENT_SYSTEM_PROMPT,
+                system_prompt=get_internal_prompt("agents.subagent_system"),
                 allowed_tools=child_allowed_tools,
                 budget=clamp_child_budget(config.budget, remaining),
                 native_tools=config.native_tools,

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -52,15 +52,14 @@ from tldw_chatbook.Chat.console_chat_models import (
 from tldw_chatbook.Chat.console_provider_gateway import ProviderToolCalls
 from tldw_chatbook.Chat.console_skill_resolver import SKILL_UNTRUSTED_REFUSE
 from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+from tldw_chatbook.Internal_Prompts import get_internal_prompt
+from tldw_chatbook.Internal_Prompts.catalog import CATALOG
 from tldw_chatbook.Skills_Interop.skill_trust_models import SkillTrustBlockedError
 
-CONSOLE_AGENT_OPERATING_PROMPT = (
-    "You are a capable assistant with optional tools. Answer directly when no "
-    "tool is needed. When a tool would help, call exactly one tool per reply "
-    "using the fenced protocol described below, then continue once you have the "
-    "result. Use spawn_subagent to delegate a self-contained sub-task to an "
-    "isolated helper. Keep replies concise."
-)
+# Catalog-default re-export: keeps existing imports/tests valid and pins
+# the "shipped default" text. compose_agent_system_prompt below resolves
+# the live (possibly overridden) value at call time via get_internal_prompt.
+CONSOLE_AGENT_OPERATING_PROMPT = CATALOG["agents.console_agent_operating"].default
 
 # Skills Phase-2 gate finding 1 (Task-14 report, scenario 5: "Find a skill
 # that can shout, load it, and use it on: hello"): a discovery-heavy run --
@@ -106,14 +105,15 @@ def compose_agent_system_prompt(session_prompt: str) -> str:
         session_prompt: The Console session's own system prompt, if any.
 
     Returns:
-        ``session_prompt`` followed by ``CONSOLE_AGENT_OPERATING_PROMPT``
-        (blank-line separated), or just the operating prompt when
-        ``session_prompt`` is blank.
+        ``session_prompt`` followed by the (registry-resolved) console agent
+        operating prompt (blank-line separated), or just the operating
+        prompt when ``session_prompt`` is blank.
     """
+    operating = get_internal_prompt("agents.console_agent_operating")
     base = (session_prompt or "").strip()
     if not base:
-        return CONSOLE_AGENT_OPERATING_PROMPT
-    return f"{session_prompt}\n\n{CONSOLE_AGENT_OPERATING_PROMPT}"
+        return operating
+    return f"{session_prompt}\n\n{operating}"
 
 
 def format_agent_step_marker(
@@ -284,8 +284,9 @@ class _StreamingModelAdapter:
     AgentService calls it as ``chat_call(api_endpoint=…, messages_payload=…,
     streaming=False, model=…)`` and expects a
     ``{"choices":[{"message":{"content": <full text>}}]}`` response. Sub-agent
-    turns (leading system content == SUBAGENT_SYSTEM_PROMPT) are streamed to a
-    throwaway gate and never touch the transcript.
+    turns (leading system content prefixed by the registry-resolved or
+    shipped-default ``agents.subagent_system`` prompt — see ``_is_subagent``)
+    are streamed to a throwaway gate and never touch the transcript.
 
     Every non-sealed primary turn streams live to the store as it arrives —
     not just the final answer — since the gate cannot know in advance
@@ -417,9 +418,18 @@ class _StreamingModelAdapter:
         if not messages_payload:
             return False
         first = messages_payload[0]
-        return first.get("role") == "system" and str(
-            first.get("content", "")
-        ).startswith(SUBAGENT_SYSTEM_PROMPT)
+        if first.get("role") != "system":
+            return False
+        content = str(first.get("content", ""))
+        # Dual-prefix match: the CURRENT registry-resolved prompt (an
+        # override may have been applied between spawn and detection) OR
+        # the shipped default (SUBAGENT_SYSTEM_PROMPT) -- covers an
+        # override applied in either direction so detection never flips
+        # false just because config changed mid-run.
+        resolved = get_internal_prompt("agents.subagent_system")
+        return content.startswith(resolved) or content.startswith(
+            SUBAGENT_SYSTEM_PROMPT
+        )
 
 
 def _eligible_skill_entries(context: Mapping[str, Any]) -> list[Mapping[str, Any]]:

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -61,6 +61,13 @@ from tldw_chatbook.Skills_Interop.skill_trust_models import SkillTrustBlockedErr
 # the live (possibly overridden) value at call time via get_internal_prompt.
 CONSOLE_AGENT_OPERATING_PROMPT = CATALOG["agents.console_agent_operating"].default
 
+# Every `agents.subagent_system` value ever resolved by `_is_subagent`
+# (below) this process, seeded with the shipped default. Grows by at most
+# one entry per distinct override text a user configures -- see
+# `_StreamingModelAdapter._is_subagent` for why a single current-value
+# check is not enough.
+_KNOWN_SUBAGENT_PREFIXES: set[str] = {SUBAGENT_SYSTEM_PROMPT}
+
 # Skills Phase-2 gate finding 1 (Task-14 report, scenario 5: "Find a skill
 # that can shout, load it, and use it on: hello"): a discovery-heavy run --
 # find_tools -> load_tools -> a tool/skill call -> the final wrap-up reply --
@@ -421,14 +428,22 @@ class _StreamingModelAdapter:
         if first.get("role") != "system":
             return False
         content = str(first.get("content", ""))
-        # Dual-prefix match: the CURRENT registry-resolved prompt (an
-        # override may have been applied between spawn and detection) OR
-        # the shipped default (SUBAGENT_SYSTEM_PROMPT) -- covers an
-        # override applied in either direction so detection never flips
-        # false just because config changed mid-run.
+        # Multi-prefix match: a sub-agent's system prompt is baked into its
+        # messages_payload once, at spawn time (agent_service.py:411's own
+        # get_internal_prompt call), then stays fixed for the rest of that
+        # sub-agent's multi-step tool loop. Comparing only against the
+        # CURRENTLY resolved override (plus the shipped default) can flip
+        # false if `agents.subagent_system` is edited live -- e.g. from
+        # Settings, on the UI thread, mid-run -- to a *different* override
+        # rather than reverted to the default: an already-spawned
+        # sub-agent's later turns would then match neither and leak into
+        # the primary transcript. Accumulating every value resolved so far
+        # this process (starting from the shipped default) keeps detection
+        # stable no matter when the override changed.
         resolved = get_internal_prompt("agents.subagent_system")
-        return content.startswith(resolved) or content.startswith(
-            SUBAGENT_SYSTEM_PROMPT
+        _KNOWN_SUBAGENT_PREFIXES.add(resolved)
+        return any(
+            content.startswith(prefix) for prefix in _KNOWN_SUBAGENT_PREFIXES
         )
 
 

--- a/tldw_chatbook/Chat/document_generator.py
+++ b/tldw_chatbook/Chat/document_generator.py
@@ -47,6 +47,7 @@ from ..LLM_Calls.LLM_API_Calls_Local import (
     chat_with_mlx_lm,
 )
 from ..DB.ChaChaNotes_DB import CharactersRAGDB
+from ..Internal_Prompts import get_internal_prompt
 from .Chat_Deps import ChatAPIError
 
 # Configure logger
@@ -216,9 +217,9 @@ class DocumentGenerator:
         context = self.format_context_for_llm(messages, specific_message)
 
         # Build prompt
-        system_prompt = "You are an expert at creating clear, chronological timelines from conversations and content."
+        system_prompt = get_internal_prompt("document_generation.timeline_system")
         user_prompt = (
-            f"{self.timeline_config['prompt']}\n\nConversation Context:\n{context}"
+            f"{get_internal_prompt('document_generation.timeline_user')}\n\nConversation Context:\n{context}"
         )
 
         # Call LLM
@@ -314,9 +315,9 @@ class DocumentGenerator:
         context = self.format_context_for_llm(messages, specific_message)
 
         # Build prompt
-        system_prompt = "You are an educational expert specializing in creating comprehensive study guides."
+        system_prompt = get_internal_prompt("document_generation.study_guide_system")
         user_prompt = (
-            f"{self.study_guide_config['prompt']}\n\nConversation Context:\n{context}"
+            f"{get_internal_prompt('document_generation.study_guide_user')}\n\nConversation Context:\n{context}"
         )
 
         # Call LLM
@@ -412,9 +413,9 @@ class DocumentGenerator:
         context = self.format_context_for_llm(messages, specific_message)
 
         # Build prompt
-        system_prompt = "You are an expert at creating executive briefing documents with actionable insights."
+        system_prompt = get_internal_prompt("document_generation.briefing_system")
         user_prompt = (
-            f"{self.briefing_config['prompt']}\n\nConversation Context:\n{context}"
+            f"{get_internal_prompt('document_generation.briefing_user')}\n\nConversation Context:\n{context}"
         )
 
         # Call LLM

--- a/tldw_chatbook/Chunking/Chunk_Lib.py
+++ b/tldw_chatbook/Chunking/Chunk_Lib.py
@@ -663,6 +663,20 @@ class Chunker:
                     "Missing 'llm_call_function' for 'rolling_summarize' method."
                 )
 
+            # `_get_option`'s fallback arg is evaluated eagerly by Python
+            # regardless of whether self.options already has a value, so
+            # resolve the registry default lazily here instead of passing
+            # get_internal_prompt(...) directly as the (near-always-unused)
+            # default_override -- avoids a config lookup on every rolling-
+            # summarize call in the common case where summarize_system_
+            # prompt is already populated (see
+            # test_rolling_summarize_skips_resolver_when_caller_option_set).
+            system_prompt_content = self.options.get("summarize_system_prompt")
+            if system_prompt_content is None:
+                system_prompt_content = get_internal_prompt(
+                    "summarization.rolling_summarize_system"
+                )
+
             summary = self._rolling_summarize(
                 text_to_summarize=text,
                 llm_summarize_step_func=llm_call_function,  # Pass the generic call function
@@ -676,10 +690,7 @@ class Chunker:
                     "summarize_recursively", False
                 ),
                 verbose=self._get_option("summarize_verbose", False),
-                system_prompt_content=self._get_option(
-                    "summarize_system_prompt",
-                    get_internal_prompt("summarization.rolling_summarize_system"),
-                ),
+                system_prompt_content=system_prompt_content,
                 additional_instructions=self._get_option(
                     "summarize_additional_instructions", None
                 ),

--- a/tldw_chatbook/Chunking/Chunk_Lib.py
+++ b/tldw_chatbook/Chunking/Chunk_Lib.py
@@ -98,6 +98,7 @@ from .chunking_templates import (  # noqa: E402
     ChunkingTemplate,
 )
 from ..Metrics.metrics_logger import log_counter, log_histogram  # noqa: E402
+from tldw_chatbook.Internal_Prompts import get_internal_prompt  # noqa: E402
 
 
 #
@@ -265,10 +266,8 @@ _default_chunk_options_from_config = {
     "summarize_verbose": _get_bool_setting(
         "chunking_config", "summarize_verbose", False
     ),
-    "summarize_system_prompt": get_cli_setting(
-        "chunking_config",
-        "summarize_system_prompt",
-        "Rewrite this text in summarized form.",
+    "summarize_system_prompt": get_internal_prompt(
+        "summarization.rolling_summarize_system"
     ),
     "summarize_additional_instructions": get_cli_setting(
         "chunking_config", "summarize_additional_instructions", None
@@ -678,7 +677,8 @@ class Chunker:
                 ),
                 verbose=self._get_option("summarize_verbose", False),
                 system_prompt_content=self._get_option(
-                    "summarize_system_prompt", "Rewrite this text in summarized form."
+                    "summarize_system_prompt",
+                    get_internal_prompt("summarization.rolling_summarize_system"),
                 ),
                 additional_instructions=self._get_option(
                     "summarize_additional_instructions", None

--- a/tldw_chatbook/Internal_Prompts/__init__.py
+++ b/tldw_chatbook/Internal_Prompts/__init__.py
@@ -9,6 +9,7 @@ from . import websearch_prompts  # noqa: F401  (registers specs on import)
 from . import rag_reranker_prompts  # noqa: F401  (registers specs on import)
 from . import agents_prompts  # noqa: F401  (registers specs on import)
 from . import summarization_prompts  # noqa: F401  (registers specs on import)
+from . import document_generation_prompts  # noqa: F401  (registers specs on import)
 from .resolver import get_internal_prompt, render_internal_prompt, safe_substitute
 
 __all__ = [

--- a/tldw_chatbook/Internal_Prompts/__init__.py
+++ b/tldw_chatbook/Internal_Prompts/__init__.py
@@ -10,6 +10,7 @@ from . import rag_reranker_prompts  # noqa: F401  (registers specs on import)
 from . import agents_prompts  # noqa: F401  (registers specs on import)
 from . import summarization_prompts  # noqa: F401  (registers specs on import)
 from . import document_generation_prompts  # noqa: F401  (registers specs on import)
+from . import subscriptions_prompts  # noqa: F401  (registers specs on import)
 from .resolver import get_internal_prompt, render_internal_prompt, safe_substitute
 
 __all__ = [

--- a/tldw_chatbook/Internal_Prompts/__init__.py
+++ b/tldw_chatbook/Internal_Prompts/__init__.py
@@ -7,6 +7,7 @@ registered: ``from tldw_chatbook.Internal_Prompts import get_internal_prompt``.
 from .catalog import CATALOG, PromptSpec, register
 from . import websearch_prompts  # noqa: F401  (registers specs on import)
 from . import rag_reranker_prompts  # noqa: F401  (registers specs on import)
+from . import agents_prompts  # noqa: F401  (registers specs on import)
 from .resolver import get_internal_prompt, render_internal_prompt, safe_substitute
 
 __all__ = [

--- a/tldw_chatbook/Internal_Prompts/__init__.py
+++ b/tldw_chatbook/Internal_Prompts/__init__.py
@@ -8,6 +8,7 @@ from .catalog import CATALOG, PromptSpec, register
 from . import websearch_prompts  # noqa: F401  (registers specs on import)
 from . import rag_reranker_prompts  # noqa: F401  (registers specs on import)
 from . import agents_prompts  # noqa: F401  (registers specs on import)
+from . import summarization_prompts  # noqa: F401  (registers specs on import)
 from .resolver import get_internal_prompt, render_internal_prompt, safe_substitute
 
 __all__ = [

--- a/tldw_chatbook/Internal_Prompts/agents_prompts.py
+++ b/tldw_chatbook/Internal_Prompts/agents_prompts.py
@@ -1,0 +1,80 @@
+# tldw_chatbook/Internal_Prompts/agents_prompts.py
+"""Agent-runtime prompt specs. Defaults moved verbatim from
+Agents/agent_service.py (SUBAGENT_SYSTEM_PROMPT), Chat/console_agent_bridge.py
+(CONSOLE_AGENT_OPERATING_PROMPT), and the static scaffold of
+Agents/agent_runtime.py's render_tool_protocol (converted from an f-string
+to a {tool_list}/{fence_open}/{fence_close} template). Parity tests compare
+the registry defaults against the live constants and the rendered template
+against the original scaffold's output."""
+
+from .catalog import PromptSpec, register
+
+register(
+    PromptSpec(
+        id="agents.subagent_system",
+        subsystem="agents",
+        title="Sub-agent system prompt",
+        description="System prompt given to a spawned sub-agent run.",
+        used_in="Agents/agent_service.py (SUBAGENT_SYSTEM_PROMPT)",
+        default=(
+            "You are a focused sub-agent. Complete the task you are given and "
+            "reply with a concise result. You cannot ask the user questions."
+        ),
+        contract_note=(
+            "The leading text is an identity contract: console_agent_bridge "
+            "detects sub-agent turns by prefix-matching this prompt. "
+            "Rewording the opening changes detection; the runtime also "
+            "matches the shipped default as a fallback."
+        ),
+    )
+)
+
+register(
+    PromptSpec(
+        id="agents.console_agent_operating",
+        subsystem="agents",
+        title="Console agent operating prompt",
+        description="Operating instructions appended to the Console agent's system prompt.",
+        used_in="Chat/console_agent_bridge.py (CONSOLE_AGENT_OPERATING_PROMPT)",
+        default=(
+            "You are a capable assistant with optional tools. Answer directly when no "
+            "tool is needed. When a tool would help, call exactly one tool per reply "
+            "using the fenced protocol described below, then continue once you have the "
+            "result. Use spawn_subagent to delegate a self-contained sub-task to an "
+            "isolated helper. Keep replies concise."
+        ),
+        contract_note=(
+            "References the fenced tool protocol and spawn_subagent; keep "
+            "consistent with agents.tool_protocol."
+        ),
+    )
+)
+
+register(
+    PromptSpec(
+        id="agents.tool_protocol",
+        subsystem="agents",
+        title="Tool-call fence protocol",
+        description="Instructs the model how to call tools via the fenced text protocol.",
+        used_in="Agents/agent_runtime.py (render_tool_protocol)",
+        default=(
+            "You can call tools. Available tools:\n"
+            "{tool_list}\n\n"
+            "To call a tool, your reply MUST START with the fence as its first "
+            "content — no prose before it:\n"
+            '{fence_open}\n{"name": "<tool name>", "arguments": {...}}\n'
+            "{fence_close}\n"
+            "One tool call per reply. After you receive the tool result, either "
+            "call another tool the same way or answer the user directly. If no "
+            "tool is needed, just answer directly."
+        ),
+        required_placeholders=("tool_list", "fence_open", "fence_close"),
+        contract_note=(
+            "Fence markers are injected by code from agent_runtime."
+            "FENCE_OPEN/_FENCE_CLOSE and are parsed by the tool-call parser "
+            "— the {fence_open}/{fence_close}/{tool_list} tokens are "
+            "required. The empty-tools case renders no protocol at all "
+            "(code-side)."
+        ),
+    )
+)

--- a/tldw_chatbook/Internal_Prompts/document_generation_prompts.py
+++ b/tldw_chatbook/Internal_Prompts/document_generation_prompts.py
@@ -1,0 +1,137 @@
+# tldw_chatbook/Internal_Prompts/document_generation_prompts.py
+"""Document-generation prompt specs (timeline / study guide / briefing).
+
+The 3 *_system prompts are the one-line literals hardcoded in
+Chat/document_generator.py (generate_timeline:219, generate_study_guide:317,
+generate_briefing:415) — copied verbatim, never read from config.
+
+The 3 *_user prompts are the "instruction" half of each document type's
+config-driven prompt. Their canonical default is the SHIPPED TOML string in
+config.py's CONFIG_TOML_CONTENT (~2824-2837: [prompts.document_generation.
+timeline]/.study_guide/.briefing, the `prompt = "..."` value), NOT the
+shorter inline dict literal at document_generator.py:70-95. Rationale: on
+first run, config.py writes CONFIG_TOML_CONTENT to every user's config.toml,
+so the richer TOML text is what real users actually run; the inline dict in
+DocumentGenerator.__init__ only fires via get_cli_setting's default argument
+when the whole [prompts.document_generation.<type>] table is absent from the
+user's file entirely (never true after first run). Each *_user spec carries
+legacy_config_path="prompts.document_generation.<type>.prompt" so the
+resolver's differs-from-shipped rule treats a user-edited TOML value as an
+override and an untouched one as the (TOML-sourced) default.
+
+Zero placeholders on any of the six: document_generator.py builds the final
+user prompt by concatenating this text with "\n\nConversation Context:\n"
+plus the formatted conversation in code — not via token substitution.
+"""
+
+from .catalog import PromptSpec, register
+
+register(
+    PromptSpec(
+        id="document_generation.timeline_system",
+        subsystem="document_generation",
+        title="Timeline generator — system prompt",
+        description="System prompt for generating a chronological timeline from a conversation.",
+        used_in="Chat/document_generator.py (DocumentGenerator.generate_timeline, system_prompt)",
+        default="You are an expert at creating clear, chronological timelines from conversations and content.",
+    )
+)
+
+register(
+    PromptSpec(
+        id="document_generation.timeline_user",
+        subsystem="document_generation",
+        title="Timeline generator — user instruction",
+        description="Instruction text prefixed to the conversation context when generating a timeline.",
+        used_in=(
+            "Chat/document_generator.py (DocumentGenerator.generate_timeline, "
+            "user_prompt via self.timeline_config['prompt']); shipped default "
+            "from config.py CONFIG_TOML_CONTENT [prompts.document_generation.timeline].prompt"
+        ),
+        default=(
+            "Create a detailed text-based timeline based on our "
+            "conversation/materials being referenced. Include key dates, "
+            "events, and their relationships in chronological order."
+        ),
+        legacy_config_path="prompts.document_generation.timeline.prompt",
+        contract_note=(
+            "Code appends \"\\n\\nConversation Context:\\n{context}\" after "
+            "this text in Python (string concatenation, not token "
+            "substitution) — no placeholders here."
+        ),
+    )
+)
+
+register(
+    PromptSpec(
+        id="document_generation.study_guide_system",
+        subsystem="document_generation",
+        title="Study guide generator — system prompt",
+        description="System prompt for generating a study guide from a conversation.",
+        used_in="Chat/document_generator.py (DocumentGenerator.generate_study_guide, system_prompt)",
+        default="You are an educational expert specializing in creating comprehensive study guides.",
+    )
+)
+
+register(
+    PromptSpec(
+        id="document_generation.study_guide_user",
+        subsystem="document_generation",
+        title="Study guide generator — user instruction",
+        description="Instruction text prefixed to the conversation context when generating a study guide.",
+        used_in=(
+            "Chat/document_generator.py (DocumentGenerator.generate_study_guide, "
+            "user_prompt via self.study_guide_config['prompt']); shipped default "
+            "from config.py CONFIG_TOML_CONTENT [prompts.document_generation.study_guide].prompt"
+        ),
+        default=(
+            "Create a detailed and well produced study guide based on the "
+            "current focus of our conversation/materials in reference. "
+            "Include key concepts, definitions, learning objectives, and "
+            "potential exam questions."
+        ),
+        legacy_config_path="prompts.document_generation.study_guide.prompt",
+        contract_note=(
+            "Code appends \"\\n\\nConversation Context:\\n{context}\" after "
+            "this text in Python (string concatenation, not token "
+            "substitution) — no placeholders here."
+        ),
+    )
+)
+
+register(
+    PromptSpec(
+        id="document_generation.briefing_system",
+        subsystem="document_generation",
+        title="Briefing generator — system prompt",
+        description="System prompt for generating an executive briefing from a conversation.",
+        used_in="Chat/document_generator.py (DocumentGenerator.generate_briefing, system_prompt)",
+        default="You are an expert at creating executive briefing documents with actionable insights.",
+    )
+)
+
+register(
+    PromptSpec(
+        id="document_generation.briefing_user",
+        subsystem="document_generation",
+        title="Briefing generator — user instruction",
+        description="Instruction text prefixed to the conversation context when generating a briefing.",
+        used_in=(
+            "Chat/document_generator.py (DocumentGenerator.generate_briefing, "
+            "user_prompt via self.briefing_config['prompt']); shipped default "
+            "from config.py CONFIG_TOML_CONTENT [prompts.document_generation.briefing].prompt"
+        ),
+        default=(
+            "Create a detailed and well produced executive briefing document "
+            "regarding this conversation and the subject material. Include "
+            "key points, actionable insights, strategic implications, and "
+            "recommendations."
+        ),
+        legacy_config_path="prompts.document_generation.briefing.prompt",
+        contract_note=(
+            "Code appends \"\\n\\nConversation Context:\\n{context}\" after "
+            "this text in Python (string concatenation, not token "
+            "substitution) — no placeholders here."
+        ),
+    )
+)

--- a/tldw_chatbook/Internal_Prompts/subscriptions_prompts.py
+++ b/tldw_chatbook/Internal_Prompts/subscriptions_prompts.py
@@ -1,0 +1,199 @@
+# tldw_chatbook/Internal_Prompts/subscriptions_prompts.py
+"""Subscriptions prompt specs. Defaults moved verbatim from
+Subscriptions/content_processor.py (analysis_system, and the four
+_build_analysis_prompt branches for rss/atom/json_feed, url_change, podcast,
+and the generic fallback), Subscriptions/recursive_summarizer.py
+(_get_system_prompt), and Subscriptions/briefing_generator.py (the LLM
+analysis prompt built in _generate_sections_with_llm).
+
+The four per-type analysis prompts and `briefing` were f-strings in source
+with complex interpolations (dict .get() calls, content[:5000]/content[:3000]
+slices, an f"{...:.1f}" format spec). Registry templates use simple named
+tokens instead ({name}, {content}, {change_percentage}, ...); the slicing,
+`.get()` fallback lookups, and numeric formatting are precomputed in code
+before calling render_internal_prompt. All other text is verbatim.
+
+Scope note: the ONE-LINE LLM system role hardcoded alongside the briefing
+analysis prompt (briefing_generator.py, next to the prompt built in
+_generate_sections_with_llm: "You are an expert analyst creating executive
+briefings from aggregated content.") is deliberately NOT migrated here. Only
+the `briefing` prompt below (the analysis/user prompt) is in scope for P2;
+the system-role one-liner is deferred to a later pass.
+"""
+
+from .catalog import PromptSpec, register
+
+register(
+    PromptSpec(
+        id="subscriptions.analysis_system",
+        subsystem="subscriptions",
+        title="Subscription item analysis — system prompt",
+        description="System prompt for LLM analysis of a single subscription item.",
+        used_in="Subscriptions/content_processor.py (ContentProcessor._analyze_content, system message)",
+        default="You are a helpful assistant that analyzes and summarizes content from subscriptions.",
+    )
+)
+
+register(
+    PromptSpec(
+        id="subscriptions.feed_analysis",
+        subsystem="subscriptions",
+        title="Feed item analysis (rss/atom/json_feed)",
+        description="Analysis prompt for a single item from an rss, atom, or json_feed subscription.",
+        used_in="Subscriptions/content_processor.py (ContentProcessor._build_analysis_prompt, rss/atom/json_feed branch)",
+        default="""Analyze this article from {name}:
+
+Title: {title}
+URL: {url}
+Published: {published}
+
+Content:
+{content}
+
+Please provide:
+1. A concise summary (2-3 sentences)
+2. Key points or insights (bullet points)
+3. Why this might be important or relevant
+4. Any action items or implications
+
+Keep the analysis focused and practical.""",
+        required_placeholders=("name", "title", "url", "published", "content"),
+        contract_note=(
+            "The processing_options.analysis_prompt per-subscription "
+            "override (code-side .replace channel) outranks the registry."
+        ),
+    )
+)
+
+register(
+    PromptSpec(
+        id="subscriptions.url_change_analysis",
+        subsystem="subscriptions",
+        title="URL change analysis",
+        description="Analysis prompt for a detected change on a monitored webpage.",
+        used_in="Subscriptions/content_processor.py (ContentProcessor._build_analysis_prompt, url_change branch)",
+        default="""A monitored webpage has changed:
+
+URL: {url}
+Change: {change_percentage}% of content changed
+
+New content:
+{content}
+
+Please:
+1. Summarize what has changed
+2. Highlight the most important updates
+3. Assess the significance of these changes
+4. Suggest any follow-up actions if needed""",
+        required_placeholders=("url", "change_percentage", "content"),
+        contract_note=(
+            "The processing_options.analysis_prompt per-subscription "
+            "override (code-side .replace channel) outranks the registry. "
+            "change_percentage is precomputed in code as "
+            '`f"{item.get(\'change_percentage\', 0) * 100:.1f}"` before '
+            "rendering — the registry template only sees the formatted string."
+        ),
+    )
+)
+
+register(
+    PromptSpec(
+        id="subscriptions.podcast_analysis",
+        subsystem="subscriptions",
+        title="Podcast episode analysis",
+        description="Analysis prompt for a single podcast episode item.",
+        used_in="Subscriptions/content_processor.py (ContentProcessor._build_analysis_prompt, podcast branch)",
+        default="""Analyze this podcast episode from {name}:
+
+Title: {title}
+Published: {published}
+
+Description:
+{content}
+
+Please provide:
+1. Episode summary
+2. Main topics discussed
+3. Key takeaways
+4. Whether this episode is worth listening to and why""",
+        required_placeholders=("name", "title", "published", "content"),
+        contract_note=(
+            "The processing_options.analysis_prompt per-subscription "
+            "override (code-side .replace channel) outranks the registry."
+        ),
+    )
+)
+
+register(
+    PromptSpec(
+        id="subscriptions.generic_analysis",
+        subsystem="subscriptions",
+        title="Generic subscription item analysis",
+        description="Fallback analysis prompt for subscription types other than feed/url_change/podcast.",
+        used_in="Subscriptions/content_processor.py (ContentProcessor._build_analysis_prompt, else branch)",
+        default="""Analyze this content from {name}:
+
+Title: {title}
+Type: {type}
+
+Content:
+{content}
+
+Please provide a helpful analysis including:
+1. Summary
+2. Key information
+3. Relevance or importance
+4. Any recommended actions""",
+        required_placeholders=("name", "title", "type", "content"),
+        contract_note=(
+            "The processing_options.analysis_prompt per-subscription "
+            "override (code-side .replace channel) outranks the registry."
+        ),
+    )
+)
+
+register(
+    PromptSpec(
+        id="subscriptions.recursive_summarizer_system",
+        subsystem="subscriptions",
+        title="Recursive summarizer — system prompt",
+        description="System prompt for the recursive (chunk-and-merge) content summarizer.",
+        used_in="Subscriptions/recursive_summarizer.py (RecursiveSummarizer._get_system_prompt)",
+        default="""You are an expert content summarizer. Your task is to create clear, accurate summaries that preserve the key information while significantly reducing length. 
+
+Key principles:
+1. Maintain factual accuracy
+2. Preserve the most important information
+3. Use clear, concise language
+4. Maintain logical flow
+5. Respect the requested token limit""",
+    )
+)
+
+register(
+    PromptSpec(
+        id="subscriptions.briefing",
+        subsystem="subscriptions",
+        title="Briefing generator — analysis prompt",
+        description="LLM analysis prompt used to generate a briefing from aggregated subscription content.",
+        used_in="Subscriptions/briefing_generator.py (BriefingGenerator._generate_sections_with_llm, default prompt branch)",
+        default="""Analyze the following content from various subscriptions and generate a comprehensive briefing:
+
+{content_summary}
+
+Please provide:
+1. Executive Summary (2-3 paragraphs highlighting the most important developments)
+2. Key Insights (bullet points of significant findings or patterns)
+3. Trending Topics (identify common themes across sources)
+4. Recommended Actions (actionable items based on the content)
+
+Format each section clearly with appropriate headers.""",
+        required_placeholders=("content_summary",),
+        contract_note=(
+            "Output is parsed by _parse_llm_sections, which substring-"
+            "matches the four section labels (Executive Summary / Key "
+            "Insights / Trending Topics / Recommended Actions) — keep them "
+            "verbatim."
+        ),
+    )
+)

--- a/tldw_chatbook/Internal_Prompts/summarization_prompts.py
+++ b/tldw_chatbook/Internal_Prompts/summarization_prompts.py
@@ -4,7 +4,10 @@ LLM_Calls/Summarization_General_Lib.py (analyze()'s default system_message),
 LLM_Calls/Local_Summarization_Lib.py (module constant summarizer_prompt), and
 Chunking/Chunk_Lib.py (the "summarize" chunk method's system_prompt_content
 fallback). Parity tests compare the registry defaults against literals copied
-from source pre-migration."""
+from source pre-migration. Note: rolling_summarize_system's legacy key
+[chunking_config].summarize_system_prompt has no entry in the shipped default
+TOML, so _shipped_default_for returns None and any user-set value is treated
+as a customization (the intended behavior)."""
 
 from .catalog import PromptSpec, register
 

--- a/tldw_chatbook/Internal_Prompts/summarization_prompts.py
+++ b/tldw_chatbook/Internal_Prompts/summarization_prompts.py
@@ -68,6 +68,7 @@ register(
         used_in="Chunking/Chunk_Lib.py (chunk_text's \"summarize\" method, via _rolling_summarize)",
         default="Rewrite this text in summarized form.",
         legacy_config_path="chunking_config.summarize_system_prompt",
+        applies="process restart (frozen at Chunk_Lib import; overrides apply on next app start for default-option callers)",
         contract_note=(
             "This legacy key has no entry in the shipped default TOML, so "
             "_shipped_default_for returns None and any user-set value at "

--- a/tldw_chatbook/Internal_Prompts/summarization_prompts.py
+++ b/tldw_chatbook/Internal_Prompts/summarization_prompts.py
@@ -1,0 +1,75 @@
+# tldw_chatbook/Internal_Prompts/summarization_prompts.py
+"""Summarization prompt specs. Defaults moved verbatim from
+LLM_Calls/Summarization_General_Lib.py (analyze()'s default system_message),
+LLM_Calls/Local_Summarization_Lib.py (module constant summarizer_prompt), and
+Chunking/Chunk_Lib.py (the "summarize" chunk method's system_prompt_content
+fallback). Parity tests compare the registry defaults against literals copied
+from source pre-migration."""
+
+from .catalog import PromptSpec, register
+
+register(
+    PromptSpec(
+        id="summarization.analyze_default_system",
+        subsystem="summarization",
+        title="Bulleted notes summarizer — default system prompt",
+        description=(
+            "Default system prompt used for LLM-based summarization when no "
+            "custom system message is supplied."
+        ),
+        used_in="LLM_Calls/Summarization_General_Lib.py (analyze())",
+        default='You are a bulleted notes specialist. ```When creating comprehensive bulleted notes, you should follow these guidelines: Use multiple headings based on the referenced topics, not categories like quotes or terms. Headings should be surrounded by bold formatting and not be listed as bullet points themselves. Leave no space between headings and their corresponding list items underneath. Important terms within the content should be emphasized by setting them in bold font. Any text that ends with a colon should also be bolded. Before submitting your response, review the instructions, and make any corrections necessary to adhered to the specified format. Do not reference these instructions within the notes.``` \nBased on the content between backticks create comprehensive bulleted notes.\n**Bulleted Note Creation Guidelines**\n\n**Headings**:\n- Based on referenced topics, not categories like quotes or terms\n- Surrounded by **bold** formatting\n- Not listed as bullet points\n- No space between headings and list items underneath\n\n**Emphasis**:\n- **Important terms** set in bold font\n- **Text ending in a colon**: also bolded\n\n**Review**:\n- Ensure adherence to specified format\n- Do not reference these instructions in your response.',
+        contract_note=(
+            "'Based on the content between backticks' refers to the "
+            "embedded ``` block — keep them together."
+        ),
+    )
+)
+
+register(
+    PromptSpec(
+        id="summarization.local_summarizer_template",
+        subsystem="summarization",
+        title="Local-backend summarizer prompt (legacy Ollama template)",
+        description=(
+            "Module-level bulleted-notes prompt concatenated ahead of the "
+            "input text for local inference backends."
+        ),
+        used_in=(
+            "LLM_Calls/Local_Summarization_Lib.py (module constant "
+            "summarizer_prompt; concatenated with input text in "
+            "summarize_with_llama, summarize_with_kobold, "
+            "summarize_with_tabbyapi, summarize_with_custom_openai, and "
+            "summarize_with_custom_openai_2)"
+        ),
+        default='\n                    <s>You are a bulleted notes specialist. ```When creating comprehensive bulleted notes, you should follow these guidelines: Use multiple headings based on the referenced topics, not categories like quotes or terms. Headings should be surrounded by bold formatting and not be listed as bullet points themselves. Leave no space between headings and their corresponding list items underneath. Important terms within the content should be emphasized by setting them in bold font. Any text that ends with a colon should also be bolded. Before submitting your response, review the instructions, and make any corrections necessary to adhered to the specified format. Do not reference these instructions within the notes.``` \nBased on the content between backticks create comprehensive bulleted notes.\n                        **Bulleted Note Creation Guidelines**\n\n                        **Headings**:\n                        - Based on referenced topics, not categories like quotes or terms\n                        - Surrounded by **bold** formatting\n                        - Not listed as bullet points\n                        - No space between headings and list items underneath\n\n                        **Emphasis**:\n                        - **Important terms** set in bold font\n                        - **Text ending in a colon**: also bolded\n\n                        **Review**:\n                        - Ensure adherence to specified format\n                        - Do not reference these instructions in your response.</s> {{ .Prompt }}\n                    ',
+        contract_note=(
+            "Ships unchanged, including the <s>/</s> sentinel tags and the "
+            "trailing {{ .Prompt }} Ollama templating cruft — a "
+            "behavior-change cleanup is a separate follow-up task. Callers "
+            "concatenate this ahead of the input text rather than render "
+            "it, so the doubled-brace {{ .Prompt }} token is inert."
+        ),
+    )
+)
+
+register(
+    PromptSpec(
+        id="summarization.rolling_summarize_system",
+        subsystem="summarization",
+        title="Rolling summarize — default system prompt",
+        description=(
+            "Default system prompt for the chunk-by-chunk rolling "
+            "summarization strategy."
+        ),
+        used_in="Chunking/Chunk_Lib.py (chunk_text's \"summarize\" method, via _rolling_summarize)",
+        default="Rewrite this text in summarized form.",
+        legacy_config_path="chunking_config.summarize_system_prompt",
+        contract_note=(
+            "This legacy key has no entry in the shipped default TOML, so "
+            "_shipped_default_for returns None and any user-set value at "
+            "[chunking_config] summarize_system_prompt counts as "
+            "customized — intentional."
+        ),
+    )
+)

--- a/tldw_chatbook/LLM_Calls/Local_Summarization_Lib.py
+++ b/tldw_chatbook/LLM_Calls/Local_Summarization_Lib.py
@@ -30,30 +30,12 @@ from urllib3 import Retry
 # Import Local Libraries
 from tldw_chatbook.Utils.Utils import extract_text_from_segments, logging
 from tldw_chatbook.config import load_settings
+from tldw_chatbook.Internal_Prompts import get_internal_prompt
 
 #
 #######################################################################################################################
 # Function Definitions
 #
-
-summarizer_prompt = """
-                    <s>You are a bulleted notes specialist. ```When creating comprehensive bulleted notes, you should follow these guidelines: Use multiple headings based on the referenced topics, not categories like quotes or terms. Headings should be surrounded by bold formatting and not be listed as bullet points themselves. Leave no space between headings and their corresponding list items underneath. Important terms within the content should be emphasized by setting them in bold font. Any text that ends with a colon should also be bolded. Before submitting your response, review the instructions, and make any corrections necessary to adhered to the specified format. Do not reference these instructions within the notes.``` \nBased on the content between backticks create comprehensive bulleted notes.
-                        **Bulleted Note Creation Guidelines**
-
-                        **Headings**:
-                        - Based on referenced topics, not categories like quotes or terms
-                        - Surrounded by **bold** formatting
-                        - Not listed as bullet points
-                        - No space between headings and list items underneath
-
-                        **Emphasis**:
-                        - **Important terms** set in bold font
-                        - **Text ending in a colon**: also bolded
-
-                        **Review**:
-                        - Ensure adherence to specified format
-                        - Do not reference these instructions in your response.</s> {{ .Prompt }}
-                    """
 
 
 def summarize_with_local_llm(
@@ -223,7 +205,7 @@ def summarize_with_llama(
         logging.debug(f"Llama Summarize: System Prompt being sent is {system_message}")
 
         if custom_prompt is None:
-            llama_prompt = f"{summarizer_prompt}\n\n{text}"
+            llama_prompt = f"{get_internal_prompt('summarization.local_summarizer_template')}\n\n{text}"
         else:
             llama_prompt = f"{custom_prompt}\n\n{text}"
 
@@ -401,7 +383,7 @@ def summarize_with_kobold(
             "content-type": "application/json",
         }
         if custom_prompt_input is None:
-            kobold_prompt = f"{summarizer_prompt}\n\n\n\n{text}"
+            kobold_prompt = f"{get_internal_prompt('summarization.local_summarizer_template')}\n\n\n\n{text}"
         else:
             kobold_prompt = f"{custom_prompt_input}\n\n\n\n{text}"
 
@@ -860,7 +842,7 @@ def summarize_with_tabbyapi(
             system_message = "You are a helpful AI assistant."
 
         if custom_prompt_input is None:
-            custom_prompt_input = f"{summarizer_prompt}\n\n\n\n{text}"
+            custom_prompt_input = f"{get_internal_prompt('summarization.local_summarizer_template')}\n\n\n\n{text}"
         else:
             custom_prompt_input = f"{custom_prompt_input}\n\n\n\n{text}"
 
@@ -1593,7 +1575,7 @@ def summarize_with_custom_openai(
         logging.debug(f"Custom OpenAI API: Custom prompt: {custom_prompt_arg}")
 
         if input_data is None:
-            input_data = f"{summarizer_prompt}\n\n\n\n{text}"
+            input_data = f"{get_internal_prompt('summarization.local_summarizer_template')}\n\n\n\n{text}"
         else:
             input_data = f"{input_data}\n\n\n\n{text}"
 
@@ -1843,7 +1825,7 @@ def summarize_with_custom_openai_2(
         logging.debug(f"Custom OpenAI API-2: Custom prompt: {custom_prompt_arg}")
 
         if input_data is None:
-            input_data = f"{summarizer_prompt}\n\n\n\n{text}"
+            input_data = f"{get_internal_prompt('summarization.local_summarizer_template')}\n\n\n\n{text}"
         else:
             input_data = f"{input_data}\n\n\n\n{text}"
 

--- a/tldw_chatbook/LLM_Calls/Summarization_General_Lib.py
+++ b/tldw_chatbook/LLM_Calls/Summarization_General_Lib.py
@@ -44,6 +44,7 @@ from tldw_chatbook.LLM_Calls.Local_Summarization_Lib import (
 )
 from tldw_chatbook.Logging_Config import logging
 from tldw_chatbook.config import get_cli_setting
+from tldw_chatbook.Internal_Prompts import get_internal_prompt
 
 try:
     from tldw_chatbook.Chunking.Chunk_Lib import improved_chunking_process
@@ -525,29 +526,7 @@ def analyze(
     # Set default system message if not provided
     if system_message is None:
         logging.debug("Using default system message.")
-        system_message = (
-            "You are a bulleted notes specialist. ```When creating comprehensive bulleted notes, "
-            "you should follow these guidelines: Use multiple headings based on the referenced topics, "
-            "not categories like quotes or terms. Headings should be surrounded by bold formatting and not be "
-            "listed as bullet points themselves. Leave no space between headings and their corresponding list items "
-            "underneath. Important terms within the content should be emphasized by setting them in bold font. "
-            "Any text that ends with a colon should also be bolded. Before submitting your response, review the "
-            "instructions, and make any corrections necessary to adhered to the specified format. Do not reference "
-            "these instructions within the notes.``` \nBased on the content between backticks create comprehensive "
-            "bulleted notes.\n"
-            "**Bulleted Note Creation Guidelines**\n\n"
-            "**Headings**:\n"
-            "- Based on referenced topics, not categories like quotes or terms\n"
-            "- Surrounded by **bold** formatting\n"
-            "- Not listed as bullet points\n"
-            "- No space between headings and list items underneath\n\n"
-            "**Emphasis**:\n"
-            "- **Important terms** set in bold font\n"
-            "- **Text ending in a colon**: also bolded\n\n"
-            "**Review**:\n"
-            "- Ensure adherence to specified format\n"
-            "- Do not reference these instructions in your response."
-        )
+        system_message = get_internal_prompt("summarization.analyze_default_system")
 
     try:
         # 1. Extract text content from input_data

--- a/tldw_chatbook/Subscriptions/briefing_generator.py
+++ b/tldw_chatbook/Subscriptions/briefing_generator.py
@@ -25,6 +25,7 @@ import markdown
 # Local Imports
 from ..DB.Subscriptions_DB import SubscriptionsDB
 from ..Chat.Chat_Functions import chat_api_call
+from ..Internal_Prompts import render_internal_prompt
 from ..Notes.Notes_Library import NotesInteropService
 from ..Metrics.metrics_logger import log_histogram, log_counter
 from .content_processor import ContentSummarizer
@@ -309,17 +310,9 @@ class BriefingGenerator:
         if custom_prompt:
             prompt = custom_prompt.replace("{content}", content_summary)
         else:
-            prompt = f"""Analyze the following content from various subscriptions and generate a comprehensive briefing:
-
-{content_summary}
-
-Please provide:
-1. Executive Summary (2-3 paragraphs highlighting the most important developments)
-2. Key Insights (bullet points of significant findings or patterns)
-3. Trending Topics (identify common themes across sources)
-4. Recommended Actions (actionable items based on the content)
-
-Format each section clearly with appropriate headers."""
+            prompt = render_internal_prompt(
+                "subscriptions.briefing", content_summary=content_summary
+            )
 
         # Call LLM
         messages = [

--- a/tldw_chatbook/Subscriptions/content_processor.py
+++ b/tldw_chatbook/Subscriptions/content_processor.py
@@ -23,6 +23,7 @@ from loguru import logger
 #
 # Local Imports
 from ..Chat.Chat_Functions import chat_api_call
+from ..Internal_Prompts import get_internal_prompt, render_internal_prompt
 from ..Metrics.metrics_logger import log_histogram, log_counter
 #
 ########################################################################################################################
@@ -269,7 +270,7 @@ class ContentProcessor:
         messages = [
             {
                 "role": "system",
-                "content": "You are a helpful assistant that analyzes and summarizes content from subscriptions.",
+                "content": get_internal_prompt("subscriptions.analysis_system"),
             },
             {"role": "user", "content": prompt},
         ]
@@ -341,70 +342,56 @@ class ContentProcessor:
 
         # Build default prompt based on type
         if subscription["type"] in ["rss", "atom", "json_feed"]:
-            prompt = f"""Analyze this article from {subscription["name"]}:
-
-Title: {item.get("title", "Untitled")}
-URL: {item.get("url", "N/A")}
-Published: {item.get("published_date", "Unknown")}
-
-Content:
-{content[:5000]}
-
-Please provide:
-1. A concise summary (2-3 sentences)
-2. Key points or insights (bullet points)
-3. Why this might be important or relevant
-4. Any action items or implications
-
-Keep the analysis focused and practical."""
+            name = subscription["name"]
+            title = item.get("title", "Untitled")
+            url = item.get("url", "N/A")
+            published = item.get("published_date", "Unknown")
+            content = content[:5000]
+            return render_internal_prompt(
+                "subscriptions.feed_analysis",
+                name=name,
+                title=title,
+                url=url,
+                published=published,
+                content=content,
+            )
 
         elif subscription["type"] == "url_change":
-            prompt = f"""A monitored webpage has changed:
-
-URL: {item.get("url", subscription["source"])}
-Change: {item.get("change_percentage", 0) * 100:.1f}% of content changed
-
-New content:
-{content[:5000]}
-
-Please:
-1. Summarize what has changed
-2. Highlight the most important updates
-3. Assess the significance of these changes
-4. Suggest any follow-up actions if needed"""
+            url = item.get("url", subscription["source"])
+            change_percentage = f"{item.get('change_percentage', 0) * 100:.1f}"
+            content = content[:5000]
+            return render_internal_prompt(
+                "subscriptions.url_change_analysis",
+                url=url,
+                change_percentage=change_percentage,
+                content=content,
+            )
 
         elif subscription["type"] == "podcast":
-            prompt = f"""Analyze this podcast episode from {subscription["name"]}:
-
-Title: {item.get("title", "Untitled")}
-Published: {item.get("published_date", "Unknown")}
-
-Description:
-{content[:3000]}
-
-Please provide:
-1. Episode summary
-2. Main topics discussed
-3. Key takeaways
-4. Whether this episode is worth listening to and why"""
+            name = subscription["name"]
+            title = item.get("title", "Untitled")
+            published = item.get("published_date", "Unknown")
+            content = content[:3000]
+            return render_internal_prompt(
+                "subscriptions.podcast_analysis",
+                name=name,
+                title=title,
+                published=published,
+                content=content,
+            )
 
         else:
             # Generic prompt
-            prompt = f"""Analyze this content from {subscription["name"]}:
-
-Title: {item.get("title", "Untitled")}
-Type: {subscription["type"]}
-
-Content:
-{content[:5000]}
-
-Please provide a helpful analysis including:
-1. Summary
-2. Key information
-3. Relevance or importance
-4. Any recommended actions"""
-
-        return prompt
+            name = subscription["name"]
+            title = item.get("title", "Untitled")
+            content = content[:5000]
+            return render_internal_prompt(
+                "subscriptions.generic_analysis",
+                name=name,
+                title=title,
+                type=subscription["type"],
+                content=content,
+            )
 
 
 class KeywordExtractor:

--- a/tldw_chatbook/Subscriptions/recursive_summarizer.py
+++ b/tldw_chatbook/Subscriptions/recursive_summarizer.py
@@ -18,6 +18,7 @@ from loguru import logger
 # Local Imports
 from .token_manager import TokenCounter
 from ..Chat.Chat_Functions import chat_api_call
+from ..Internal_Prompts import get_internal_prompt
 from ..Metrics.metrics_logger import log_histogram, log_counter
 #
 ########################################################################################################################
@@ -452,14 +453,7 @@ class RecursiveSummarizer:
 
     def _get_system_prompt(self) -> str:
         """Get system prompt for summarization."""
-        return """You are an expert content summarizer. Your task is to create clear, accurate summaries that preserve the key information while significantly reducing length. 
-
-Key principles:
-1. Maintain factual accuracy
-2. Preserve the most important information
-3. Use clear, concise language
-4. Maintain logical flow
-5. Respect the requested token limit"""
+        return get_internal_prompt("subscriptions.recursive_summarizer_system")
 
     def _merge_summaries(self, chunks: List[SummarizedChunk]) -> str:
         """Merge chunk summaries into coherent text."""


### PR DESCRIPTION
## Summary

Second slice of the Internal Prompts program (follows P1 #741). Migrates **19 more internal prompts** onto the `Internal_Prompts` registry, so users can override them via `[internal_prompts.<subsystem>]` tables in config.toml without source edits.

- **Agents (3)** — sub-agent system prompt, Console-agent operating prompt, tool-calling protocol. The sub-agent prompt is an *identity contract* (`_is_subagent` prefix-matches it), so detection now dual-matches the live-resolved override **and** the shipped default; the tool-protocol scaffold became a `{tool_list}`/`{fence_open}`/`{fence_close}` template with the fence markers injected by code (parser contract can't be broken by an edit).
- **Summarization (3)** — `analyze()` bulleted-notes default, local-summarizer template, chunk rolling-summarize system prompt.
- **Document generation (6)** — 3 hardcoded system prompts + 3 user prompts. The user prompts' canonical default is the **richer shipped TOML** text (what every real user actually runs), with `legacy_config_path` back to `[prompts.document_generation.*]` so a customized TOML still wins.
- **Subscriptions (7)** — analysis system role, 4 per-type analysis prompts (feed / url-change / podcast / generic), recursive-summarizer system prompt, briefing analysis. The per-type f-strings' slicing/`.get()`/format-spec logic moved into code that precomputes each named token.

## Guarantees & evidence

- **Byte-identical defaults** — every moved prompt is guarded by a golden-parity test embedding the original literal; the token conversions (f-string → named tokens) are proven by rendering with the same computed values the old f-strings used.
- **Precedence preserved everywhere** — the programmatic channels still win: `analyze()`'s `system_message is None` guard, subscriptions' per-subscription `processing_options.analysis_prompt` (three-way precedence tested), doc-gen's customized legacy TOML, `RerankingConfig`, briefing's `custom_prompt`.
- **Transport-boundary integration tests** per subsystem (fake only the LLM seam; overrides via a real scratch config).
- **Cold-import hygiene at scale** — all four new spec modules import only from `.catalog`; the permanent subprocess guard test confirms the package never drags `config` into cold start.
- Full P2 sweep: green except the 4 RAG failures pre-existing at base; `Tests/Internal_Prompts/` + agents + subscriptions + bridge = 211 passed at HEAD. CI is intentionally cancelled repo-wide; verification is local.
- 9 tasks, each fresh-subagent-implemented and gated by spec+quality review; final whole-branch review (Sonnet) returned **no critical/scope issues** — two cheap metadata/tracking fixes applied (honest `applies="process restart"` on the frozen-at-import chunk prompt; the negative `_is_subagent` test).

## Deliberately deferred / not in this PR

- **P3**: the Settings screen editor UI (until then this surface is config.toml-only — intentional, per spec).
- Backlog tasks filed as review riders: **448** warn-on-wrong-typed-override, **449** websearch sites 2-4 transport tests, **450** reranker dead-arm removal, **451** dead-key hygiene, **452** local-summarizer cruft cleanup (behavior change), **453** `DocumentGenerator.get_conversation_context` always-empty bug (pre-existing product defect this branch surfaced).
- Several pre-existing bugs the migration tests surfaced and documented but left untouched (analyze() dispatch-gap; broken config-section names in some local-summarizer sites) — verified by the final review as genuinely pre-existing, not introduced here.

**Do not merge — awaiting user review gate.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates 19 prompts across agents, summarization, document generation, and subscriptions onto `Internal_Prompts` so users can override them via `[internal_prompts.<subsystem>]`. Preserves defaults and precedence, adds golden-parity and transport-boundary tests, and hardens sub-agent detection across live edits.

- **Migration**
  - Agents: sub-agent system, console operating, and tool-calling protocol now resolve via `get_internal_prompt`/`render_internal_prompt`; tool protocol uses `{tool_list}`/`{fence_open}`/`{fence_close}`; `SUBAGENT_SYSTEM_PROMPT`/`CONSOLE_AGENT_OPERATING_PROMPT` are catalog-default re-exports; `_is_subagent` matches the shipped default and any resolved values seen this process.
  - Summarization: `analyze()` default system, local summarizer template, and rolling summarize system moved to registry; legacy keys still honored; call sites switched to `get_internal_prompt`.
  - Document generation: 3 system prompts and 3 user prompts now come from registry; user defaults use the shipped TOML; legacy `[prompts.document_generation.*]` path remains for customized TOML.
  - Subscriptions: analysis system, four per-type analysis prompts (feed/url-change/podcast/generic), recursive-summarizer system, and briefing analysis migrated; f-string logic replaced with precomputed tokens; existing caller overrides still take precedence.

- **Bug Fixes**
  - Chunking: resolve `summarization.rolling_summarize_system` lazily to avoid eager default evaluation in `_get_option`.
  - Agents: sub-agent identity check no longer breaks on mid-run prompt edits; it matches any `agents.subagent_system` value resolved so far.

<sup>Written for commit 59a22831d50c21978763fa675b36869ef47d2a8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

