### PR TITLE
fix(console): reflect active generation in the status chip + Inspector instead of 'Ready' (task 347)

### DIFF
--- a/Tests/Chat/test_console_run_status_surfaces.py
+++ b/Tests/Chat/test_console_run_status_surfaces.py
@@ -1,0 +1,104 @@
+"""TASK-347: status surfaces must reflect an active run, not read 'Ready'.
+
+During a run (thinking gap and visible streaming) the header status chip
+read 'Ready' and the Inspector read 'Status: Ready' / 'Live work: No active
+work' — a direct contradiction of the streaming transcript (UX review
+finding j4-status-surfaces-say-ready-during-run). The truthful indicators
+(amber Stop, [streaming] suffix) existed, but the dedicated status surfaces
+lied.
+"""
+
+from tldw_chatbook.Chat.console_display_state import (
+    ConsoleControlState,
+    ConsoleInspectorState,
+)
+from tldw_chatbook.Widgets.Console.console_run_inspector import ConsoleRunInspector
+from tldw_chatbook.Widgets.Console.console_workbench_state import (
+    build_console_workbench_state,
+)
+
+
+def _ready_control_state() -> ConsoleControlState:
+    return ConsoleControlState(
+        provider_label="Provider: llama_cpp",
+        model_label="Model: local-gemma",
+        persona_label="Assistant: General",
+        rag_label="RAG: off",
+        sources_label="Sources: 0",
+        tools_label="Tools: 0",
+        approvals_label="Approvals: 0",
+    )
+
+
+def test_workbench_header_status_is_running_during_active_run():
+    running = build_console_workbench_state(
+        control_state=_ready_control_state(),
+        can_send=False,
+        can_stop=True,
+        run_active=True,
+    )
+    assert running.header.status == "running"
+
+    idle = build_console_workbench_state(
+        control_state=_ready_control_state(),
+        can_send=True,
+        can_stop=False,
+        run_active=False,
+    )
+    assert idle.header.status == "ready"
+
+
+def test_workbench_header_stays_blocked_over_running_when_not_active():
+    blocked = build_console_workbench_state(
+        control_state=_ready_control_state(),
+        provider_blocker_copy="Provider setup needed: choose a model",
+        run_active=False,
+    )
+    assert blocked.header.status == "blocked"
+
+
+def test_inspector_live_work_and_status_reflect_active_run():
+    running = ConsoleInspectorState.from_values(
+        provider_label="llama_cpp",
+        model_label="local-gemma",
+        provider_ready=True,
+        run_active=True,
+    )
+    rows = {row.label: row for row in running.rows}
+    assert "No active work" not in rows["Live work"].value
+    assert "Generating" in rows["Live work"].value
+
+    inspector_status = ConsoleRunInspector._status_summary(
+        ConsoleRunInspector, running
+    )
+    assert "Generating" in inspector_status
+    assert inspector_status != "Status: Ready"
+
+
+def test_inspector_returns_to_ready_when_run_inactive():
+    idle = ConsoleInspectorState.from_values(
+        provider_label="llama_cpp",
+        model_label="local-gemma",
+        provider_ready=True,
+        run_active=False,
+    )
+    rows = {row.label: row for row in idle.rows}
+    assert rows["Live work"].value == "No active work"
+    assert (
+        ConsoleRunInspector._status_summary(ConsoleRunInspector, idle)
+        == "Status: Ready"
+    )
+
+
+def test_inspector_blocked_still_wins_over_running():
+    """A mid-run provider block (or pending approval) is more important to
+    surface than the generic running state."""
+    blocked = ConsoleInspectorState.from_values(
+        provider_ready=False,
+        provider_recovery="Configure a provider before sending.",
+        run_active=True,
+    )
+    assert (
+        ConsoleRunInspector._status_summary(ConsoleRunInspector, blocked)
+        == "Status: Blocked"
+    )

--- a/Tests/UI/test_console_run_status_wiring.py
+++ b/Tests/UI/test_console_run_status_wiring.py
@@ -1,0 +1,83 @@
+"""TASK-347: end-to-end — the screen must feed run-active into the header
+and Inspector status surfaces during a real (harness) generation.
+
+Drives an actual run through the sync path with a held-open gateway and
+asserts the built workbench/inspector states reflect it, then return to
+Ready when the stream completes. Verifies the wiring the builder unit
+tests can't (the screen reading controller.run_state through _build_*).
+"""
+
+import asyncio
+
+import pytest
+
+from Tests.UI.test_console_native_chat_flow import _select_llamacpp_console
+from Tests.UI.test_console_regenerate_feedback import GatedGateway
+from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+    ConsoleHarness,
+)
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.Widgets.Console import ConsoleComposerBar
+
+
+@pytest.mark.asyncio
+async def test_status_surfaces_reflect_active_run_end_to_end():
+    app = _build_test_app()
+    app.chat_api_provider_value = "llama_cpp"
+    app.chat_api_model_value = "test-model"
+    gateway = GatedGateway()
+    app.console_provider_gateway_factory = lambda: gateway
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        _select_llamacpp_console(console)
+
+        # Idle: header ready, inspector not generating.
+        assert not console._console_run_active()
+        idle_wb = console._build_console_workbench_state(
+            console._build_console_control_state(None)
+        )
+        assert idle_wb.header.status == "ready"
+
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.load_draft("stream and hold")
+        console.query_one("#console-send-message").press()
+
+        store = console._ensure_console_chat_store()
+        for _ in range(60):
+            await pilot.pause(0.05)
+            if any(
+                m.content.startswith("first-chunk")
+                for m in store.messages_for_session(store.active_session_id)
+                if m.role is ConsoleMessageRole.ASSISTANT
+            ):
+                break
+
+        # Mid-stream (gateway held open): the status surfaces must reflect it.
+        assert console._console_run_active()
+        running_wb = console._build_console_workbench_state(
+            console._build_console_control_state(None)
+        )
+        assert running_wb.header.status == "running"
+        running_inspector = console._build_console_inspector_state(None)
+        rows = {r.label: r for r in running_inspector.rows}
+        assert "Generating" in rows["Live work"].value
+        assert running_inspector.run_active is True
+
+        # Release and let it finish — surfaces return to ready.
+        gateway.release.set()
+        for _ in range(60):
+            await pilot.pause(0.05)
+            if not console._console_run_active():
+                break
+        assert not console._console_run_active()
+        done_wb = console._build_console_workbench_state(
+            console._build_console_control_state(None)
+        )
+        assert done_wb.header.status == "ready"
+        done_inspector = console._build_console_inspector_state(None)
+        done_rows = {r.label: r for r in done_inspector.rows}
+        assert done_rows["Live work"].value == "No active work"

--- a/backlog/tasks/task-347 - Reflect-active-generation-in-Console-status-surfaces-instead-of-Ready-No-active-work.md
+++ b/backlog/tasks/task-347 - Reflect-active-generation-in-Console-status-surfaces-instead-of-Ready-No-active-work.md
@@ -1,10 +1,16 @@
 ---
 id: TASK-347
-title: Reflect active generation in Console status surfaces instead of Ready - No active work
-status: To Do
-assignee: []
+title: >-
+  Reflect active generation in Console status surfaces instead of Ready - No
+  active work
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-20 14:21'
-labels: [console, ux]
+updated_date: '2026-07-22 00:36'
+labels:
+  - console
+  - ux
 dependencies: []
 priority: medium
 ---
@@ -23,5 +29,34 @@ During an active run (both the silent thinking phase and while tokens were visib
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Status surfaces should agree with reality: the chip and Inspector 'Run/Live work' section should switch to a running state (e.g. 'Generating... 12s') for the duration of the run, and return to Ready on completion/stop
+- [x] #1 Status surfaces should agree with reality: the chip and Inspector 'Run/Live work' section should switch to a running state (e.g. 'Generating... 12s') for the duration of the run, and return to Ready on completion/stop
 <!-- AC:END -->
+
+## Implementation Notes
+
+The header status chip and the Inspector status/live-work rows were
+readiness surfaces by construction — they only knew Blocked/Ready and drew
+'Live work' from Library-RAG launch context, never chat runs — so both read
+'Ready'/'No active work' while a generation streamed.
+
+Fix threads run-active from the controller into both surfaces:
+`build_console_workbench_state(run_active=...)` sets the header status to
+`running` (the shared WorkbenchStatus already had it; a run only runs past
+the blocker gate, so running > blocked > ready);
+`ConsoleInspectorState.from_values(run_active=...)` makes the status summary
+read 'Status: Generating…' and the Live work row 'Generating…' during a run
+(a mid-run block/approval still takes precedence). The screen's
+`_console_run_active()` (run_state.status in CONSOLE_ACTIVE_RUN_STATUSES)
+feeds both via `_build_console_workbench_state` / `_build_console_inspector_state`.
+run_active is constant tick-to-tick during a run, so no new sync thrash
+(the states change once at run start and once at end).
+
+Verified: 5 builder unit tests (header running/blocked-precedence, inspector
+generating/ready/blocked-precedence) + an end-to-end pilot test driving a
+real held-open run through the sync path (header→running, inspector→
+Generating…, both return to ready on completion). A textual-serve visual
+capture was not possible this session (the llama-server on :9099 was down);
+the end-to-end pilot test exercises the same wiring the capture would.
+Files: `Widgets/Console/console_workbench_state.py`,
+`Chat/console_display_state.py`, `Widgets/Console/console_run_inspector.py`,
+`UI/Screens/chat_screen.py`.

--- a/tldw_chatbook/Chat/console_display_state.py
+++ b/tldw_chatbook/Chat/console_display_state.py
@@ -459,6 +459,10 @@ class ConsoleInspectorState:
     dictionary_actions: tuple[ConsoleInspectorAction, ...] = ()
     world_book_rows: tuple[ConsoleDisplayRow, ...] = ()
     world_book_actions: tuple[ConsoleInspectorAction, ...] = ()
+    #: TASK-347: whether a generation is actively running (thinking or
+    #: streaming) — the status-summary/Live-work surfaces read this so they
+    #: stop claiming "Ready" mid-run.
+    run_active: bool = False
 
     @classmethod
     def from_values(
@@ -481,6 +485,7 @@ class ConsoleInspectorState:
         mcp_not_connected_count: int = 0,
         can_save_chatbook: bool = False,
         scope_item_count: int | None = None,
+        run_active: bool = False,
     ) -> "ConsoleInspectorState":
         provider_status = "ready" if provider_ready else "blocked"
         normalized_tool_count = coerce_non_negative_int(tool_count)
@@ -501,7 +506,14 @@ class ConsoleInspectorState:
             run_recipe = f"{run_recipe} / scope {scope_item_count} items"
         rows = [
             ConsoleDisplayRow("Run recipe", run_recipe),
-            ConsoleDisplayRow("Live work", _clean(live_work_title, "No active work")),
+            ConsoleDisplayRow(
+                "Live work",
+                # TASK-347: a running generation shows "Generating…"; else
+                # the pending Library-RAG launch title, else no active work.
+                "Generating…"
+                if run_active
+                else _clean(live_work_title, "No active work"),
+            ),
             ConsoleDisplayRow(
                 "Provider",
                 provider_status,
@@ -568,6 +580,7 @@ class ConsoleInspectorState:
             actions=tuple(actions),
             has_pending_approval=normalized_approval_count > 0,
             can_save_chatbook=can_save_chatbook,
+            run_active=run_active,
         )
 
     def to_plain_text(self) -> str:

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -6149,6 +6149,7 @@ class ChatScreen(BaseAppScreen):
         evidence_state = build_console_evidence_display_state(pending_launch)
         inspector_state = ConsoleInspectorState.from_values(
             live_work_title=pending_launch.title if pending_launch else None,
+            run_active=self._console_run_active(),
             provider_label=provider_display,
             model_label=model,
             provider_ready=provider_ready,
@@ -6974,6 +6975,18 @@ class ChatScreen(BaseAppScreen):
             f" | Approvals {readiness_count(control_state.approvals_label)}"
         )
 
+    def _console_run_active(self) -> bool:
+        """Return whether a native Console generation is actively running.
+
+        TASK-347: the header chip and Inspector status/live-work surfaces
+        read this so they stop claiming "Ready"/"No active work" mid-run.
+        """
+        controller = self._console_chat_controller
+        return (
+            controller is not None
+            and controller.run_state.status in CONSOLE_ACTIVE_RUN_STATUSES
+        )
+
     def _build_console_workbench_state(self, control_state: ConsoleControlState):
         blocker_copy = self._console_provider_blocker_copy()
         action_label, _action_target, _action_tooltip = (
@@ -7000,6 +7013,7 @@ class ChatScreen(BaseAppScreen):
             can_stop=can_stop,
             can_save_chatbook=self._console_chatbook_action_available(),
             density=self._console_workbench_density(),
+            run_active=self._console_run_active(),
         )
 
     def _console_provider_blocker_copy(self) -> str:

--- a/tldw_chatbook/Widgets/Console/console_run_inspector.py
+++ b/tldw_chatbook/Widgets/Console/console_run_inspector.py
@@ -361,6 +361,10 @@ class ConsoleRunInspector(Vertical):
             return "Status: Needs approval"
         if rag_source is not None and rag_source.status == "blocked":
             return "Status: Source blocked"
+        # TASK-347: a live generation must not read "Ready" — but a mid-run
+        # block / pending approval above is still the more important signal.
+        if getattr(state or self.state, "run_active", False):
+            return "Status: Generating…"
         return "Status: Ready"
 
     def compose(self) -> ComposeResult:

--- a/tldw_chatbook/Widgets/Console/console_workbench_state.py
+++ b/tldw_chatbook/Widgets/Console/console_workbench_state.py
@@ -22,6 +22,7 @@ def build_console_workbench_state(
     can_stop: bool = False,
     can_save_chatbook: bool = False,
     density: str = "normal",
+    run_active: bool = False,
 ) -> WorkbenchState:
     """Return a shared Workbench state snapshot for Console.
 
@@ -125,7 +126,9 @@ def build_console_workbench_state(
         header=WorkbenchHeaderState(
             title="Console",
             subtitle="Chat, source handoffs, live runs, and control actions.",
-            status="blocked" if blocker else "ready",
+            # TASK-347: a live generation must not read "Ready". A run only
+            # runs once past the blocker gate, so running takes precedence.
+            status="running" if run_active else ("blocked" if blocker else "ready"),
             density=workbench_density,
         ),
         modes=modes,


### PR DESCRIPTION
## Summary

First of the P2 tier from the Console UX review backlog (#720): the status surfaces stop lying during a run.

During a generation (both the silent thinking gap and visible streaming), the header status chip read **Ready** and the Inspector read **Status: Ready / Live work: No active work / Provider: ready** — a direct contradiction of the `[streaming]` transcript in the same frame (finding `j4-status-surfaces-say-ready-during-run`). The truthful indicators (amber Stop, `[streaming]` suffix, tab dot) existed, but the dedicated status surfaces lied.

### Root cause
These were readiness surfaces by construction — the Inspector status line only knew Blocked/Needs-approval/Source-blocked/Ready, and `Live work` came from pending Library-RAG launch context, never chat runs. `ConsoleControlState` had no run field.

### Fix
Thread run-active from the controller into both:
- `build_console_workbench_state(run_active=...)` → header status `running` (the shared `WorkbenchStatus` already supported it; a run only proceeds past the blocker gate, so **running > blocked > ready**).
- `ConsoleInspectorState.from_values(run_active=...)` → status summary reads **Status: Generating…** and the Live-work row **Generating…** during a run (a mid-run block/approval still takes precedence).
- The screen's `_console_run_active()` (`run_state.status in CONSOLE_ACTIVE_RUN_STATUSES`) feeds both via `_build_console_workbench_state` / `_build_console_inspector_state`. `run_active` is constant tick-to-tick, so **no new sync thrash** — the states flip once at run start and once at end.

## Verification
- 5 builder unit tests: header running / blocked-precedence; inspector generating / ready / blocked-precedence.
- An **end-to-end pilot test** driving a real held-open run through the actual sync path — header → running, inspector → Generating…, both return to Ready on completion (proves the wiring, not just the isolated builders).
- Console sweep: **1150 passed**, all 15 failures within the known dev-tip baseline, none outside.
- A textual-serve visual capture wasn't possible this session (the llama-server on :9099 was down); the end-to-end pilot exercises the same controller→screen→builder wiring a capture would.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Console status surfaces to reflect an active generation: the header chip now shows "running" and the Inspector shows "Status: Generating…" and "Live work: Generating…" during a run, returning to "Ready" when finished. Addresses TASK-347 by removing the contradiction where status read "Ready" while streaming.

- **Bug Fixes**
  - Propagated run-active from the controller via `chat_screen._console_run_active()` into `build_console_workbench_state` and `ConsoleInspectorState.from_values`.
  - Header status switches to "running"; Inspector shows "Status: Generating…" and Live work "Generating…" during a run. Blocked/approval states still take precedence.
  - Added tests: 5 unit tests for states and precedence, plus one end-to-end test verifying the screen-to-builder wiring.

<sup>Written for commit 06750be9b456f9aba907dd443d3ccae63443f3bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

