### PR TITLE
chore(console): follow-up review minors for rail row-wrap (#749)

### DIFF
--- a/Tests/UI/test_console_conversation_row_wrap.py
+++ b/Tests/UI/test_console_conversation_row_wrap.py
@@ -42,7 +42,9 @@ def test_unchanged_width_is_a_noop_after_first_measure() -> None:
 
 
 def test_multi_cell_resize_relabels_after_first_measure() -> None:
+    # Both boundary directions at exactly the threshold, plus larger jumps.
     assert _relabel_decision(25, current=23, measured_before=True) is True
+    assert _relabel_decision(21, current=23, measured_before=True) is True
     assert _relabel_decision(40, current=23, measured_before=True) is True
     assert _relabel_decision(10, current=23, measured_before=True) is True
 

--- a/tldw_chatbook/Widgets/Console/console_workspace_context.py
+++ b/tldw_chatbook/Widgets/Console/console_workspace_context.py
@@ -55,6 +55,10 @@ _CONVERSATION_BROWSER_EMPTY_COPY_HEIGHT = 1
 _TITLE_WRAP_MAX_LINES = 2
 _MIN_TITLE_WRAP_BUDGET = 10
 _ROW_ELLIPSIS = "…"
+# Shared fallback for a conversation with no usable title. Used by both the
+# wrap helper and ``ConsoleWorkspaceContextTray._conversation_title`` so the
+# two normalizations cannot drift.
+_UNTITLED_CONVERSATION = "Untitled conversation"
 
 
 def _cut_prefix_cells(text: str, budget: int) -> str:
@@ -99,8 +103,8 @@ def wrap_console_conversation_title(title: str, budget: int) -> tuple[str, ...]:
     longer than one line hard-break at the budget. When two lines are still
     insufficient the second line is ellipsized. The budget is clamped to
     ``_MIN_TITLE_WRAP_BUDGET`` to avoid degenerate wraps on absurdly narrow
-    rails. Blank titles normalize to "Untitled conversation" (keep in sync
-    with ``ConsoleWorkspaceContextTray._conversation_title``).
+    rails. Blank titles normalize to ``_UNTITLED_CONVERSATION`` (the shared
+    fallback ``ConsoleWorkspaceContextTray._conversation_title`` also uses).
 
     Args:
         title: Raw (unescaped) conversation title to wrap.
@@ -113,7 +117,7 @@ def wrap_console_conversation_title(title: str, budget: int) -> tuple[str, ...]:
         still overflows two lines.
     """
     budget = max(_MIN_TITLE_WRAP_BUDGET, int(budget))
-    remaining = str(title).strip() or "Untitled conversation"
+    remaining = str(title).strip() or _UNTITLED_CONVERSATION
     lines: list[str] = []
     while remaining:
         if len(lines) == _TITLE_WRAP_MAX_LINES - 1:
@@ -453,9 +457,15 @@ class ConsoleWorkspaceContextTray(Vertical):
         if region is None or region.width <= 0:
             return False
         measured = int(region.width)
-        if not self._should_relabel_at_width(measured):
-            return False
+        should_relabel = self._should_relabel_at_width(measured)
+        # Latch on the first *real* measurement regardless of whether it
+        # relabels: when the measured width coincides with the fallback the
+        # decision is a no-op, but the tray has still been measured, so a
+        # later one-cell change must be treated as a scrollbar flap (hysteresis
+        # branch), not as another first measurement.
         self._row_width_measured = True
+        if not should_relabel:
+            return False
         self._row_content_width = measured
         scroll_parent = self._nearest_scroll_parent()
         parent_scroll_y = getattr(scroll_parent, "scroll_y", None)
@@ -1150,7 +1160,7 @@ class ConsoleWorkspaceContextTray(Vertical):
     @staticmethod
     def _conversation_title(title: str) -> str:
         """Return a readable conversation label."""
-        return str(title).strip() or "Untitled conversation"
+        return str(title).strip() or _UNTITLED_CONVERSATION
 
     def _browser_title_budget(self) -> int:
         """Cells available to grouped-browser row text."""


### PR DESCRIPTION
## What

Small follow-up to #749 (merged), applying the three Minor items from that PR's post-merge code review. No behavior change to the shipped feature beyond closing one rare correctness corner.

## Changes

1. **Latch `_row_width_measured` on the first real measurement even when it coincides with the fallback width** (`console_workspace_context.py`). The width-relabel hysteresis guard added in #749 latches "we've been measured" only when a relabel actually fires. If the first measured `content_region.width` happens to equal `_FALLBACK_ROW_CONTENT_WIDTH` (20), no relabel fires and the flag never latches, so the *next* one-cell scrollbar-toggle flap is mis-treated as another first measurement (relabels on a 1-cell delta instead of being suppressed). Now the flag latches on any real measurement, so the hysteresis branch governs from then on. Rare corner, never an oscillation — but removes the edge.

2. **Extract `_UNTITLED_CONVERSATION`** so `wrap_console_conversation_title` and `_conversation_title` share one blank-title fallback instead of relying on a "keep in sync" comment.

3. **Add the negative-direction threshold boundary** (`21` vs `23`, a −2 delta) to the relabel decision-table tests, alongside the existing `+2` case.

## Testing

- `Tests/UI/test_console_conversation_row_wrap.py` + `test_console_workspace_context_rail.py`: 56 passed on this dev base.
- Full `Tests/UI/test_console_native_chat_flow.py`: 187/187 (run pre-merge on the same commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Follow-up to #749 that fixes a rare row-wrap edge: we now latch the first real width measurement even when it equals the fallback, preventing a mislabel on the next 1‑cell change. Also unifies the blank-title fallback and adds a missing threshold test.

- **Bug Fixes**
  - Latch `_row_width_measured` on the first real measurement (including fallback width) so 1‑cell scrollbar flaps don’t trigger relabels.
  - Add the negative-direction threshold case (21 vs 23) to the relabel decision tests.

- **Refactors**
  - Extract `_UNTITLED_CONVERSATION` so `wrap_console_conversation_title` and `_conversation_title` share the same fallback.

<sup>Written for commit 9bbec1bd5d23bce70e07fbd501bb4aeae6760c5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

