### PR TITLE
fix(console): unify saved-chat vocabulary + recency across rail and Ctrl+K switcher (task 356)

### DIFF
--- a/Tests/Chat/test_console_switcher_state.py
+++ b/Tests/Chat/test_console_switcher_state.py
@@ -95,9 +95,10 @@ def test_limit_zero_returns_no_entries():
 
 def test_subtitle_joins_available_parts():
     entry = build_console_switcher_entries([_row()])[0]
-    assert entry.subtitle == "Workspace 1 - workspace-thread - 2m"
+    # TASK-356: the switcher shows the shared friendly vocabulary, not raw status.
+    assert entry.subtitle == "Workspace 1 - saved chat - 2m"
     bare = build_console_switcher_entries(
-        [_row(row_key="x", workspace_label="", status="", updated_label="")]
+        [_row(row_key="x", workspace_label="", status="", updated_label="", updated_sort="")]
     )[0]
     assert bare.subtitle == ""
 
@@ -114,3 +115,41 @@ def test_matcher_tolerates_none_fields_without_raising():
     )
     assert _matches(none_row, []) is True
     assert _matches(none_row, ["anything"]) is False
+
+
+def test_switcher_status_uses_saved_chat_vocabulary_not_in_progress():
+    """TASK-356: the switcher must not label idle saved conversations
+    'in-progress' (raw status) — it must use the same friendly vocabulary
+    the rail shows ('saved chat'), so the two surfaces don't contradict."""
+    entries = build_console_switcher_entries(
+        [_row(status="in-progress", updated_label="")]
+    )
+    subtitle = entries[0].subtitle
+    assert "in-progress" not in subtitle
+    assert "saved chat" in subtitle
+
+
+def test_switcher_status_maps_membership_and_session_states():
+    saved = build_console_switcher_entries(
+        [_row(row_key="a", status="workspace-thread", updated_label="")]
+    )[0].subtitle
+    active = build_console_switcher_entries(
+        [_row(row_key="b", status="active", updated_label="")]
+    )[0].subtitle
+    assert "saved chat" in saved
+    assert "active session" in active
+
+
+def test_switcher_shows_recency_when_updated_label_absent():
+    """TASK-356: the rail carries age labels; the switcher must too. When a
+    row lacks a precomputed updated_label, derive it from updated_sort so
+    recognition works where it matters most."""
+    from datetime import datetime, timezone
+
+    now = datetime(2026, 7, 4, 12, 0, 0, tzinfo=timezone.utc)
+    entries = build_console_switcher_entries(
+        [_row(updated_label="", updated_sort="2026-07-04T11:58:00+00:00")],
+        now=now,
+    )
+    # 2 minutes before `now`.
+    assert "2m" in entries[0].subtitle

--- a/Tests/Chat/test_console_switcher_state.py
+++ b/Tests/Chat/test_console_switcher_state.py
@@ -153,3 +153,18 @@ def test_switcher_shows_recency_when_updated_label_absent():
     )
     # 2 minutes before `now`.
     assert "2m" in entries[0].subtitle
+
+
+def test_search_matches_the_friendly_status_label_now_shown():
+    """TASK-356 follow-up (Qodo #4): the subtitle now shows the friendly status
+    ('saved chat'), so a query for the VISIBLE word must match — searching the
+    raw 'in-progress' string would silently return nothing for the exact states
+    this change made user-facing. The raw status stays searchable too."""
+    rows = [_row(row_key="a", conversation_id="a", status="in-progress")]
+    assert [e.row_key for e in build_console_switcher_entries(rows, query="saved")] == [
+        "a"
+    ]
+    # Back-compat: the underlying status token still matches.
+    assert [
+        e.row_key for e in build_console_switcher_entries(rows, query="in-progress")
+    ] == ["a"]

--- a/Tests/UI/test_console_rail_sections.py
+++ b/Tests/UI/test_console_rail_sections.py
@@ -843,3 +843,33 @@ async def test_popover_model_search_inserts_transient_option():
         option_values = [value for _, value in model_select._options]
         assert "anthropic/claude-x" in option_values
         assert model_select.value == "anthropic/claude-x"
+
+
+@pytest.mark.asyncio
+async def test_switcher_result_shows_saved_chat_vocabulary_not_in_progress():
+    """TASK-356 end-to-end: a saved conversation with a membership role
+    renders in the switcher as 'saved chat' (the rail's vocabulary), never
+    the raw 'in-progress', with a recency label derived from updated_sort."""
+
+    class _App(App):
+        async def on_mount(self) -> None:
+            row = ConsoleConversationBrowserInputRow(
+                row_key="conv-9",
+                conversation_id="conv-9",
+                native_session_id=None,
+                title="Websocket reconnect strategy",
+                scope_type="workspace",
+                workspace_id="ws-1",
+                workspace_label="Chats",
+                status="in-progress",
+                updated_sort="2026-07-04T10:00:00+00:00",
+            )
+            await self.push_screen(ConsoleSessionSwitcherModal(rows=(row,)))
+
+    app = _App()
+    async with app.run_test(size=(90, 30)) as pilot:
+        await pilot.pause()
+        result = app.screen.query_one("#console-switcher-result-0", Button)
+        label = str(result.label)
+        assert "saved chat" in label
+        assert "in-progress" not in label

--- a/backlog/tasks/task-356 - Fix-CtrlK-switcher-labeling-idle-saved-conversations-as-in-progress.md
+++ b/backlog/tasks/task-356 - Fix-CtrlK-switcher-labeling-idle-saved-conversations-as-in-progress.md
@@ -1,10 +1,13 @@
 ---
 id: TASK-356
 title: Fix Ctrl+K switcher labeling idle saved conversations as in-progress
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-20 14:21'
-labels: [console, ux]
+updated_date: '2026-07-22 01:42'
+labels:
+  - console
+  - ux
 dependencies: []
 priority: medium
 ---
@@ -23,5 +26,33 @@ In the unfiltered Ctrl+K list, all saved conversations (nothing running, no open
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 One consistent state vocabulary (saved chat / open session / active session) plus recency shown in both surfaces
+- [x] #1 One consistent state vocabulary (saved chat / open session / active session) plus recency shown in both surfaces
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+The rail mapped raw row status ("in-progress"/"workspace-thread") to a
+friendly label ("saved chat") via a private table, but the Ctrl+K switcher
+built its subtitle from the RAW status — so identical saved conversations
+read 'in-progress' in the switcher and 'saved chat' in the rail. The
+switcher also omitted the age label (its input rows carry no precomputed
+updated_label).
+
+Fix: a shared `console_conversation_status_detail()` in the neutral
+`Workspaces/conversation_browser_state` module owns the one vocabulary
+(saved chat / active session / open session); the rail's
+`_conversation_detail_status` now delegates to it (behavior identical) and
+`build_console_switcher_entries` maps through it too. The switcher also
+derives recency from `updated_sort` (via `format_console_relative_age`,
+new `now` param) when a row lacks a precomputed age label, so both surfaces
+show recency.
+
+Verified: 4 new switcher-builder unit tests (saved-chat vocab, membership/
+session mapping, recency-from-updated_sort) + an end-to-end pilot test
+opening the real switcher modal (renders 'saved chat', not 'in-progress');
+rail suites unchanged (84 passed). Pure display logic — no live capture
+needed. Files: `Workspaces/conversation_browser_state.py`,
+`Chat/console_switcher_state.py`,
+`Widgets/Console/console_workspace_context.py`.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_switcher_state.py
+++ b/tldw_chatbook/Chat/console_switcher_state.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable
-
 from datetime import datetime, timezone
+from typing import Iterable
 
 from tldw_chatbook.Workspaces.conversation_browser_state import (
     ConsoleConversationBrowserInputRow,
@@ -78,6 +77,9 @@ def build_console_switcher_entries(
         query: Whitespace-separated tokens; every token must match the row's
             title, workspace label, or status (case-insensitive substring).
         limit: Maximum number of entries returned.
+        now: Reference time used to derive a recency label from ``updated_sort``
+            when a row carries no precomputed ``updated_label``; defaults to the
+            current UTC time.
 
     Returns:
         Up to ``limit`` entries, active row first, then most recent.

--- a/tldw_chatbook/Chat/console_switcher_state.py
+++ b/tldw_chatbook/Chat/console_switcher_state.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Iterable
 
+from datetime import datetime, timezone
+
 from tldw_chatbook.Workspaces.conversation_browser_state import (
     ConsoleConversationBrowserInputRow,
     ReverseKey,
+    console_conversation_status_detail,
+    format_console_relative_age,
 )
 
 CONSOLE_SWITCHER_RESULT_LIMIT = 20
@@ -53,6 +57,7 @@ def build_console_switcher_entries(
     *,
     query: str = "",
     limit: int = CONSOLE_SWITCHER_RESULT_LIMIT,
+    now: datetime | None = None,
 ) -> tuple[ConsoleSwitcherEntry, ...]:
     """Build deduped, recent-first switcher results for a query.
 
@@ -85,11 +90,20 @@ def build_console_switcher_entries(
             row.row_key,
         )
     )
+    reference_now = now or datetime.now(timezone.utc)
     entries = []
     for row in deduped[: max(0, int(limit))]:
+        # TASK-356: one state vocabulary across surfaces ("saved chat", not
+        # the raw "in-progress"), and always show recency — deriving it from
+        # updated_sort when the row carries no precomputed age label (the
+        # switcher's input rows usually don't, unlike the rail's).
+        status_detail = console_conversation_status_detail(row.status)
+        recency = str(row.updated_label or "").strip() or format_console_relative_age(
+            str(row.updated_sort or ""), now=reference_now
+        )
         subtitle = " - ".join(
             part
-            for part in (row.workspace_label, row.status, row.updated_label)
+            for part in (row.workspace_label, status_detail, recency)
             if str(part or "").strip()
         )
         entries.append(

--- a/tldw_chatbook/Chat/console_switcher_state.py
+++ b/tldw_chatbook/Chat/console_switcher_state.py
@@ -39,6 +39,12 @@ def _matches(row: ConsoleConversationBrowserInputRow, tokens: list[str]) -> bool
     ``workspace_label``, and ``status`` are coerced through ``str(... or "")``
     before joining -- a ``None`` in any field must not raise ``TypeError``.
 
+    The haystack includes BOTH the raw ``status`` and its friendly detail
+    (``console_conversation_status_detail``): TASK-356 made that friendly label
+    the one shown in the subtitle, so a query for the visible word ("saved")
+    must match even though the persisted status is still "in-progress"; the raw
+    token stays searchable for back-compat.
+
     Args:
         row: Candidate browser input row.
         tokens: Lowercased query tokens that must all match.
@@ -47,7 +53,13 @@ def _matches(row: ConsoleConversationBrowserInputRow, tokens: list[str]) -> bool
         True if every token is a substring of the row's joined text.
     """
     haystack = " ".join(
-        str(part or "") for part in (row.title, row.workspace_label, row.status)
+        str(part or "")
+        for part in (
+            row.title,
+            row.workspace_label,
+            row.status,
+            console_conversation_status_detail(row.status),
+        )
     ).lower()
     return all(token in haystack for token in tokens)
 

--- a/tldw_chatbook/Widgets/Console/console_workspace_context.py
+++ b/tldw_chatbook/Widgets/Console/console_workspace_context.py
@@ -17,6 +17,7 @@ from tldw_chatbook.Chat.console_glyphs import (
     GLYPH_EXPANDED,
 )
 from tldw_chatbook.Workspaces.conversation_browser_state import (
+    console_conversation_status_detail,
     ConsoleConversationBrowserGroup,
     ConsoleConversationBrowserRow,
     ConsoleConversationBrowserSection,
@@ -1186,8 +1187,9 @@ class ConsoleWorkspaceContextTray(Vertical):
 
     @staticmethod
     def _conversation_detail_status(status: str) -> str:
-        """Return second-line row metadata for row disambiguation."""
-        normalized = str(status or "").strip().lower()
-        if not normalized:
-            return ""
-        return _STATUS_DETAIL_LABELS.get(normalized, normalized.replace("-", " "))
+        """Return second-line row metadata for row disambiguation.
+
+        TASK-356: delegates to the shared vocabulary so the rail and the
+        Ctrl+K switcher never disagree on the same conversation's state.
+        """
+        return console_conversation_status_detail(status)

--- a/tldw_chatbook/Widgets/Console/console_workspace_context.py
+++ b/tldw_chatbook/Widgets/Console/console_workspace_context.py
@@ -43,13 +43,10 @@ _STATUS_LABELS = {
     "active": "active",
     "open": "open",
 }
-_STATUS_DETAIL_LABELS = {
-    "workspace-thread": "saved chat",
-    "workspace": "saved chat",
-    "in-progress": "saved chat",
-    "active": "active session",
-    "open": "open session",
-}
+# TASK-356: the "saved chat"/"active session"/"open session" detail vocabulary
+# now lives once in conversation_browser_state.console_conversation_status_detail
+# (which `_conversation_detail_status` below delegates to); the former local
+# `_STATUS_DETAIL_LABELS` copy was removed to keep a single source of truth.
 _CONVERSATION_BROWSER_HEADER_HEIGHT = 1
 _CONVERSATION_BROWSER_EMPTY_COPY_HEIGHT = 1
 

--- a/tldw_chatbook/Workspaces/conversation_browser_state.py
+++ b/tldw_chatbook/Workspaces/conversation_browser_state.py
@@ -43,7 +43,20 @@ _CONSOLE_CONVERSATION_STATUS_DETAIL = {
 
 
 def console_conversation_status_detail(status: str) -> str:
-    """Return the shared friendly state label for a conversation row status."""
+    """Return the shared friendly state label for a conversation row status.
+
+    The one vocabulary used by both the rail conversation browser and the
+    Ctrl+K switcher (TASK-356) so the two surfaces never contradict each other:
+    ``saved chat`` / ``active session`` / ``open session``.
+
+    Args:
+        status: Raw persisted/internal status (e.g. ``in-progress``,
+            ``workspace-thread``, ``active``); ``None`` is tolerated.
+
+    Returns:
+        The friendly label, an empty string for a blank status, or the status
+        with dashes spaced out when it is not a known state.
+    """
     normalized = str(status or "").strip().lower()
     if not normalized:
         return ""

--- a/tldw_chatbook/Workspaces/conversation_browser_state.py
+++ b/tldw_chatbook/Workspaces/conversation_browser_state.py
@@ -27,6 +27,31 @@ def _parse_browser_timestamp(value: str) -> datetime | None:
     return parsed
 
 
+# TASK-356: ONE state vocabulary for persisted-but-not-archived chats across
+# the rail AND the Ctrl+K switcher. Rows reach here with a workspace-
+# membership role ("workspace-thread"/"workspace") or the "in-progress"
+# state normalize_conversation_row assigns — all meaning "a chat saved
+# locally, not open in a tab". The switcher used the raw status
+# ("in-progress"), contradicting the rail's "saved chat"; both now call this.
+_CONSOLE_CONVERSATION_STATUS_DETAIL = {
+    "workspace-thread": "saved chat",
+    "workspace": "saved chat",
+    "in-progress": "saved chat",
+    "active": "active session",
+    "open": "open session",
+}
+
+
+def console_conversation_status_detail(status: str) -> str:
+    """Return the shared friendly state label for a conversation row status."""
+    normalized = str(status or "").strip().lower()
+    if not normalized:
+        return ""
+    return _CONSOLE_CONVERSATION_STATUS_DETAIL.get(
+        normalized, normalized.replace("-", " ")
+    )
+
+
 def format_console_relative_age(value: str, *, now: datetime) -> str:
     """Return a compact age label such as ``2m``, ``1h``, ``3d`` for a timestamp.
 


### PR DESCRIPTION
## Summary

Console UX review task **356** (P2, verdict NEW): in the unfiltered Ctrl+K switcher, idle saved conversations (nothing running, no open tab) showed the subtitle **"Chats - in-progress"**, while the rail simultaneously described the *same* conversation as **"Chats - saved chat - 21m"**. "In-progress" falsely implies activity, the two surfaces used different vocabulary for identical objects, and the switcher omitted the age labels the rail has — weakening recognition exactly where it matters most.

**Root cause:** the `"in-progress" → "saved chat"` humanization map lived only in `console_workspace_context.py`; the switcher joined the raw `row.status` directly (persisted rows carry the internal lifecycle value `in-progress`). Builders set `updated_sort` but never `updated_label`, so switcher rows also showed no ages. The task-179 rail/Library unification never touched the switcher — hence NEW, not a regression.

## Change

- New shared **`console_conversation_status_detail()`** in the neutral `Workspaces/conversation_browser_state` module owns the single vocabulary: **saved chat / active session / open session**.
- The rail's `_conversation_detail_status` now **delegates** to it (behavior identical — verified by unchanged rail suites).
- `build_console_switcher_entries` maps through the same helper, and **derives recency** from `updated_sort` via the new `format_console_relative_age(now=...)` when a row lacks a precomputed age label — so both surfaces now show consistent state + recency.

## Verification

- 4 new switcher-builder unit tests (saved-chat vocab, membership/session mapping, recency-from-`updated_sort`).
- End-to-end pilot test opening the **real** `ConsoleSessionSwitcherModal` — renders "saved chat", not "in-progress".
- Rail suites unchanged (84 passed); 140 Chat/Workspaces tests green.
- Full Console UI sweep: all failures within the known dev-tip baseline (one starred-section contention flake, passes 4/4 in isolation). Pure display logic — no live capture needed.

## Files

- `tldw_chatbook/Workspaces/conversation_browser_state.py`
- `tldw_chatbook/Chat/console_switcher_state.py`
- `tldw_chatbook/Widgets/Console/console_workspace_context.py`
- `Tests/Chat/test_console_switcher_state.py`, `Tests/UI/test_console_rail_sections.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies conversation state labels and recency between the rail and Ctrl+K switcher so saved chats no longer show "in-progress". Both surfaces now show "saved chat" with an age label (e.g., "2m"), and the switcher search matches the visible label. Satisfies task 356 acceptance criteria.

- **Bug Fixes**
  - Added shared `console_conversation_status_detail()` in `tldw_chatbook/Workspaces/conversation_browser_state.py`; both rail and switcher use the same vocabulary.
  - Switcher derives recency from `updated_sort` via `format_console_relative_age(now=...)` when `updated_label` is missing.
  - Search indexes the friendly status label alongside the raw status, so queries like "saved" match while keeping back-compat.

- **Refactors**
  - Removed the duplicated `_STATUS_DETAIL_LABELS` in `tldw_chatbook/Widgets/Console/console_workspace_context.py` and delegated to the shared helper; improved docstrings and tidied imports. No behavior change.

<sup>Written for commit 40779df15ee2b8667578fed8a0814f3635b020e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

