### PR TITLE
feat(console): Start Chat opens a real character conversation in native Console (task-427)

### DIFF
--- a/Docs/superpowers/plans/2026-07-21-start-chat-character-conversation.md
+++ b/Docs/superpowers/plans/2026-07-21-start-chat-character-conversation.md
@@ -1,0 +1,590 @@
+# Start Chat → Real Character Conversation (TASK-427) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Roleplay workbench's "Start Chat" open a real character conversation in the native Console — greeting as the first assistant message, character identity persisted, card system prompt applied on send, and the plain provider path (not the agent harness).
+
+**Architecture:** Wire character identity through the existing native-Console session/persistence machinery (no schema change — `conversations.character_id` already exists). A new character branch in the handoff consumer fetches the card, builds the effective system prompt like the Personas preview, creates a dedicated global-workspace session, seeds the greeting as a persisted assistant message, and directly syncs the Console UI. The greeting is excluded from provider payloads (display-only, like the preview) so strict providers accept the first send. The plain-provider gate keys on `character_id`.
+
+**Tech Stack:** Python 3.11+, Textual, pytest / pytest-asyncio, SQLite (ChaChaNotes_DB).
+
+## Global Constraints
+
+- **Run tests via the repo venv, from the worktree root:** `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest ...` (system python lacks deps).
+- **No ChaChaNotes migration.** Schema stays v22; `conversations.character_id` already exists.
+- **Design source of truth:** `Docs/superpowers/specs/2026-07-21-start-chat-character-conversation-design.md` (rev 2).
+- **Commit message trailer:** end each commit body with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- **`character_id` is the single "this is a character session" signal** — it drives persistence, the plain-provider gate, and restart behavior. No separate agent-override field.
+- Preview parity: effective system prompt = newline-join of non-empty `[system_prompt, personality, description, scenario]` card fields, fallback `"Stay in character."`; `replace_placeholders` applies ONLY to the greeting (`first_message`), with user name `"User"`.
+
+---
+
+## Task 1: Character identity on the session + character-aware persist
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_chat_store.py` (dataclass `ConsoleChatSession` ~148-160; `persist_session_if_needed` ~948-984)
+- Test: `Tests/Chat/test_console_chat_store.py`
+
+**Interfaces:**
+- Produces: `ConsoleChatSession.character_id: int | None`, `ConsoleChatSession.character_name: str | None`. When `character_id` is set on a session, `persist_session_if_needed` calls `create_conversation(character_id=..., character_name=..., assistant_kind="character", assistant_id=str(character_id), ...)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `Tests/Chat/test_console_chat_store.py` (near the existing `test_persist_session_if_needed_passes_system_prompt`). `FakePersistence.create_conversation(**kwargs)` already records calls in `self.created` / returns an id — inspect its recorded kwargs (match the existing fixture's attribute; the existing system-prompt test shows how it captures kwargs).
+
+```python
+def test_persist_session_if_needed_passes_character_identity(self):
+    store, fake = self._store_with_fake_persistence()  # mirror the existing helper
+    session = store.create_session(title="Chat with Elara")
+    session.character_id = 7
+    session.character_name = "Elara"
+    conv_id = store.persist_session_if_needed(session.id)
+    assert conv_id is not None
+    kwargs = fake.last_create_kwargs  # same accessor the system-prompt test uses
+    assert kwargs["character_id"] == 7
+    assert kwargs["character_name"] == "Elara"
+    assert kwargs["assistant_kind"] == "character"
+    assert kwargs["assistant_id"] == "7"
+
+def test_persist_session_if_needed_non_character_stays_generic(self):
+    store, fake = self._store_with_fake_persistence()
+    session = store.create_session(title="Chat 1")
+    store.persist_session_if_needed(session.id)
+    kwargs = fake.last_create_kwargs
+    assert kwargs["assistant_kind"] == "generic"
+    assert kwargs["assistant_id"] == "console"
+    assert kwargs.get("character_id") is None
+```
+
+If `FakePersistence` does not already expose `last_create_kwargs`, add it: in its `create_conversation(self, **kwargs)` set `self.last_create_kwargs = kwargs` before returning the id. If the existing helper to build a store+fake has a different name, reuse it verbatim (grep `def _store_with_fake` / how `test_persist_session_if_needed_passes_system_prompt` builds its store).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Chat/test_console_chat_store.py -k character_identity -v`
+Expected: FAIL — `ConsoleChatSession` has no `character_id` attribute (AttributeError) or the kwargs assertions fail.
+
+- [ ] **Step 3: Add the dataclass fields**
+
+In `console_chat_store.py`, in `ConsoleChatSession` (after `one_shot_prefill: str | None = None`):
+
+```python
+    one_shot_prefill: str | None = None
+    #: When set, this is a character-bound session: it persists with the
+    #: character's id, forces the plain-provider path, and restores as a
+    #: character session (task-427). ``None`` = a normal Console session.
+    character_id: int | None = None
+    character_name: str | None = None
+```
+
+- [ ] **Step 4: Pass identity through `persist_session_if_needed`**
+
+In `persist_session_if_needed`, replace the `create_conversation(...)` call (currently hardcoding `assistant_kind="generic", assistant_id="console"`) with identity-aware kwargs:
+
+```python
+        scope_type, persisted_workspace_id = self._persistence_scope(session)
+        if session.character_id is not None:
+            identity_kwargs = {
+                "assistant_kind": "character",
+                "assistant_id": str(session.character_id),
+                "character_id": session.character_id,
+                "character_name": session.character_name,
+            }
+        else:
+            identity_kwargs = {
+                "assistant_kind": "generic",
+                "assistant_id": "console",
+            }
+        session.persisted_conversation_id = self.persistence.create_conversation(
+            conversation_title=session.title,
+            workspace_id=persisted_workspace_id,
+            scope_type=scope_type,
+            system_prompt=session.settings.system_prompt
+            if session.settings is not None
+            else None,
+            **identity_kwargs,
+        )
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Chat/test_console_chat_store.py -v`
+Expected: PASS (new tests + all existing store tests green).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_chat_store.py Tests/Chat/test_console_chat_store.py
+git commit -m "feat(console): character identity on session + character-aware persist (task-427)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Greeting is display-only to the provider + regenerate/continue guard
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py` (`_provider_message_payloads` ~2645; `regenerate_message` ~1161; `continue_from_message` ~1105)
+- Test: `Tests/Chat/test_console_chat_controller.py`
+
+**Interfaces:**
+- Produces: `_provider_message_payloads` drops assistant messages that precede the first payload-eligible user message. `regenerate_message`/`continue_from_message` return a blocked `ConsoleSubmitResult` when the resulting payload has no user turn.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `Tests/Chat/test_console_chat_controller.py` (reuse `CapturingGateway` and the existing controller-build helper — grep how `test_submit_draft_prepends_system_prompt_message` builds its controller + store and drives a send). The greeting is a persisted ASSISTANT message seeded before any user turn.
+
+```python
+async def test_leading_greeting_excluded_from_provider_payload(self):
+    controller, store, gateway = self._build_controller(CapturingGateway())
+    session = store.create_session(title="Chat with Elara")
+    controller.switch_session(session.id)
+    store.append_message(session.id, role=ConsoleMessageRole.ASSISTANT,
+                         content="Greetings, traveler.", persist=False)
+    store.set_session_draft(session.id, "Hi")
+    await controller.submit_draft(session.id)
+    sent = gateway.captured_messages  # list[dict] of the outbound payload
+    roles = [m["role"] for m in sent]
+    # No leading assistant: first non-system role is user.
+    assert "assistant" not in roles[: roles.index("user")] if "user" in roles else True
+    assert roles[0] in ("system", "user")
+    # The greeting text is not in the outbound payload.
+    assert all("Greetings, traveler." not in (m.get("content") or "") for m in sent)
+
+async def test_regenerate_on_leading_greeting_is_blocked(self):
+    controller, store, gateway = self._build_controller(CapturingGateway())
+    session = store.create_session(title="Chat with Elara")
+    controller.switch_session(session.id)
+    greeting = store.append_message(session.id, role=ConsoleMessageRole.ASSISTANT,
+                                    content="Greetings.", persist=False)
+    result = await controller.regenerate_message(greeting.id)
+    assert result.ok is False
+    assert not gateway.captured_messages  # nothing sent
+```
+
+Match the real `ConsoleSubmitResult` success attribute name (grep its definition — it may be `.ok`, `.success`, or positional). Match `CapturingGateway`'s captured-messages attribute name exactly.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Chat/test_console_chat_controller.py -k "leading_greeting or regenerate_on_leading" -v`
+Expected: FAIL — greeting text appears in the payload / regenerate is not blocked.
+
+- [ ] **Step 3: Drop leading assistant messages in the payload builder**
+
+In `_provider_message_payloads`, in the `for message in session_messages:` loop (~2678), add a leading-assistant skip. Introduce `seen_user = False` before the loop and skip pre-user assistants:
+
+```python
+        payloads: list[dict[str, Any]] = []
+        seen_user = False
+        for message in session_messages:
+            if message.role not in {
+                ConsoleMessageRole.USER,
+                ConsoleMessageRole.ASSISTANT,
+            }:
+                continue
+            if skip_failed and message.status == "failed":
+                continue
+            # A seeded character greeting is a display-only assistant turn:
+            # keep it out of the provider payload so strict providers (Anthropic,
+            # Gemini) never see an assistant-first message array (task-427).
+            if not seen_user and message.role is ConsoleMessageRole.ASSISTANT:
+                continue
+            if message.role is ConsoleMessageRole.USER:
+                seen_user = True
+```
+(The existing body — text extraction / image budgeting / payload append — stays after this, unchanged.)
+
+- [ ] **Step 4: Add the no-user-turn guard to regenerate and continue**
+
+Add a helper near `_ensure_user_continuation_instruction`:
+
+```python
+    @staticmethod
+    def _has_user_turn(provider_messages: list[dict[str, Any]]) -> bool:
+        return any(
+            m.get("role") == ConsoleMessageRole.USER.value for m in provider_messages
+        )
+```
+
+In `regenerate_message`, right after `self._ensure_user_continuation_instruction(provider_messages)` (~1196):
+
+```python
+        self._ensure_user_continuation_instruction(provider_messages)
+        if not self._has_user_turn(provider_messages):
+            return self._block(
+                session_id,
+                "Nothing to regenerate before the character's opening line.",
+            )
+```
+
+In `continue_from_message`, right after its `self._ensure_user_continuation_instruction(provider_messages)` (~1137):
+
+```python
+        self._ensure_user_continuation_instruction(provider_messages)
+        if not self._has_user_turn(provider_messages):
+            return self._block(
+                session_id,
+                "Nothing to continue before the character's opening line.",
+            )
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Chat/test_console_chat_controller.py -v`
+Expected: PASS (new tests + all existing controller tests green — the leading-drop must be a no-op for normal user-first sessions).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_chat_controller.py Tests/Chat/test_console_chat_controller.py
+git commit -m "feat(console): greeting display-only in provider payload + regen/continue guard (task-427)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Plain-provider gate keyed on the message-owning character session
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py` (`_stream_assistant_response` gate ~2051)
+- Test: `Tests/Chat/test_console_chat_controller.py`
+
+**Interfaces:**
+- Consumes: `ConsoleChatSession.character_id` (Task 1).
+- Produces: character sessions (`character_id` set) always take the plain-provider branch, even when the global agent runtime is enabled and an agent bridge is present.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `Tests/Chat/test_console_chat_controller.py`. Build the controller **with** an agent bridge and global agent-runtime enabled, then assert a character session does NOT invoke the bridge. Define a minimal spy bridge:
+
+```python
+class _SpyAgentBridge:
+    def __init__(self):
+        self.calls = 0
+    async def run_reply(self, *args, **kwargs):
+        self.calls += 1
+        raise AssertionError("agent bridge should not be called for a character session")
+
+async def test_character_session_forces_plain_provider(self):
+    bridge = _SpyAgentBridge()
+    controller, store, gateway = self._build_controller(
+        CapturingGateway(), agent_bridge=bridge, agent_runtime_enabled=True
+    )
+    session = store.create_session(title="Chat with Elara")
+    session.character_id = 7
+    controller.switch_session(session.id)
+    store.set_session_draft(session.id, "Hi")
+    result = await controller.submit_draft(session.id)
+    assert bridge.calls == 0
+    assert gateway.captured_messages  # plain provider path ran
+
+async def test_normal_session_still_uses_agent_when_enabled(self):
+    bridge = _RecordingAgentBridge()  # returns a benign reply, records the call
+    controller, store, gateway = self._build_controller(
+        CapturingGateway(), agent_bridge=bridge, agent_runtime_enabled=True
+    )
+    session = store.create_session(title="Chat 1")
+    controller.switch_session(session.id)
+    store.set_session_draft(session.id, "Hi")
+    await controller.submit_draft(session.id)
+    assert bridge.calls == 1
+```
+
+If `self._build_controller` does not accept `agent_bridge`/`agent_runtime_enabled`, extend it to pass them into the controller constructor / the `set_agent_runtime(enabled, bridge)` setter (grep the controller's constructor + `console_chat_controller.py:570` for how the owner wires them). Define `_RecordingAgentBridge` with an async `run_reply` that returns whatever the real `_run_agent_reply` expects the bridge to return (grep `_run_agent_reply` ~2240 for the outcome shape) — or, if that is heavy, assert the split differently: keep `_SpyAgentBridge` for the character case and, for the normal case, assert that with `character_id=None` the gate condition `self._agent_runtime_enabled and self._agent_bridge is not None and not prefill` is True by unit-testing a small extracted predicate (see Step 3).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Chat/test_console_chat_controller.py -k "character_session_forces_plain" -v`
+Expected: FAIL — the agent bridge IS called (AssertionError from the spy) because the gate ignores `character_id`.
+
+- [ ] **Step 3: Key the gate on the message-owning session**
+
+In `_stream_assistant_response`, replace the gate (~2051):
+
+```python
+        owner_id = self.store.session_id_for_message(assistant_message_id)
+        owner = next(
+            (s for s in self.store.sessions() if s.id == owner_id), None
+        )
+        force_plain = owner is not None and owner.character_id is not None
+        if (
+            self._agent_runtime_enabled
+            and self._agent_bridge is not None
+            and not prefill
+            and not force_plain
+        ):
+            return await self._run_agent_reply(
+                resolution=resolution,
+                provider_messages=provider_messages,
+                assistant_message_id=assistant_message_id,
+                prepare_retry=prepare_retry,
+                variant_mode=variant_mode,
+            )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Chat/test_console_chat_controller.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_chat_controller.py Tests/Chat/test_console_chat_controller.py
+git commit -m "feat(console): plain-provider gate for character sessions (task-427)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Native character branch in the handoff consumer
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py` (`_consume_pending_chat_handoff` ~8741; add helper `_start_character_console_session`)
+- Test: `Tests/UI/test_chat_first_handoffs.py`
+
+**Interfaces:**
+- Consumes: Task 1 (`session.character_id`/`character_name`), Task 2 (greeting exclusion), Task 3 (plain gate). Existing: `_character_session_identity_from_handoff` (`chat_screen.py:442`); `store.create_session`, `store.append_message`; `self._sync_native_console_chat_ui`, `self._focus_console_composer_if_needed`.
+- Produces: a dedicated character-bound Console session with the greeting seeded, on the native handoff branch, with a guarded fallback to `_stage_handoff_as_console_live_work`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `Tests/UI/test_chat_first_handoffs.py` (reuse its `ChatScreen` harness + a fake character DB that returns a card for `get_character_card_by_id`; mirror `stub_characters` from `Tests/UI/test_personas_character_attach.py`). Assert on the native branch (no legacy tab container):
+
+```python
+async def test_native_start_chat_builds_character_session_with_greeting(self, ...):
+    # app_instance.chachanotes_db.get_character_card_by_id(7) -> card dict with
+    # name/first_message/system_prompt/personality/description/scenario.
+    screen = ...  # mounted native Console ChatScreen (no legacy tab container)
+    screen.app_instance.pending_chat_handoff = _character_start_chat_payload(
+        character_id=7, name="Elara",
+        first_message="Greetings, {{user}}.",
+    )
+    await screen._consume_pending_chat_handoff()
+    store = screen._ensure_console_chat_store()
+    session = store._sessions[store.active_session_id]
+    assert session.character_id == 7
+    assert session.character_name == "Elara"
+    assert session.title == "Chat with Elara"
+    assert session.workspace_id == CONSOLE_GLOBAL_WORKSPACE_ID
+    msgs = store.messages_for_session(session.id)
+    assert msgs[0].role is ConsoleMessageRole.ASSISTANT
+    assert msgs[0].content == "Greetings, User."   # {{user}} substituted
+    assert "Stay in character." not in (session.settings.system_prompt or "")  # real prompt used
+    assert screen.app_instance.pending_chat_handoff is None
+
+async def test_native_start_chat_falls_back_when_card_fetch_fails(self, ...):
+    screen = ...
+    screen.app_instance.chachanotes_db.get_character_card_by_id = \
+        lambda *_a, **_k: (_ for _ in ()).throw(RuntimeError("boom"))
+    screen.app_instance.pending_chat_handoff = _character_start_chat_payload(
+        character_id=7, name="Elara", first_message="Hi")
+    await screen._consume_pending_chat_handoff()  # must not raise
+    # Fell back to staged context; no character session created.
+    store = screen._ensure_console_chat_store()
+    active = store._sessions.get(store.active_session_id) if store.active_session_id else None
+    assert active is None or active.character_id is None
+    assert screen.app_instance.pending_chat_handoff is None
+```
+
+`_character_start_chat_payload(...)` builds a dict shaped like a `ChatHandoffPayload` with `metadata={"intent": "start_chat", "selected_kind": "character", "selected_record_id": str(character_id), "selected_name": name}` and `source="personas"`. Model it on the payloads used by the existing `test_chat_screen_start_chat_handoff_binds_character_session_identity` (`:236`).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_chat_first_handoffs.py -k native_start_chat -v`
+Expected: FAIL — the native branch stages context instead of creating a character session (no `character_id`, no greeting).
+
+- [ ] **Step 3: Add the character-session builder helper**
+
+In `chat_screen.py`, add imports if missing near the top-of-file imports: `import asyncio` (check it is already imported) and `from ...Character_Chat.Character_Chat_Lib import replace_placeholders` (grep — add only if absent). Add the method to `ChatScreen`:
+
+```python
+    async def _start_character_console_session(self, payload) -> bool:
+        """Build a dedicated character conversation from a Start-Chat handoff.
+
+        Returns True when a character session was created; False to let the
+        caller fall back to the staged-context path (task-427).
+        """
+        identity = _character_session_identity_from_handoff(payload)
+        if identity is None:
+            return False
+        character_id, _name_hint, _assistant_id = identity
+        db = getattr(self.app_instance, "chachanotes_db", None)
+        if db is None:
+            return False
+        try:
+            card = await asyncio.to_thread(db.get_character_card_by_id, character_id)
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Start Chat: character card fetch failed; staging context instead."
+            )
+            return False
+        if not card:
+            return False
+
+        name = str(card.get("name") or _name_hint or "").strip() or "Character"
+        parts = [
+            str(card.get(key) or "").strip()
+            for key in ("system_prompt", "personality", "description", "scenario")
+        ]
+        system_prompt = "\n".join(p for p in parts if p) or "Stay in character."
+        greeting = replace_placeholders(str(card.get("first_message") or ""), name, "User")
+
+        store = self._ensure_console_chat_store()
+        settings = replace(
+            self._default_console_session_settings(),
+            system_prompt=system_prompt,
+            character_label=name,
+        )
+        session = store.create_session(
+            title=f"Chat with {name}",
+            workspace_id=CONSOLE_GLOBAL_WORKSPACE_ID,
+            settings=settings,
+        )
+        session.character_id = int(character_id)
+        session.character_name = name
+        if greeting:
+            try:
+                store.append_message(
+                    session.id,
+                    role=ConsoleMessageRole.ASSISTANT,
+                    content=greeting,
+                    persist=True,
+                )
+            except Exception:
+                logger.opt(exception=True).warning(
+                    "Start Chat: greeting seed/persist failed; continuing."
+                )
+        await self._sync_native_console_chat_ui()
+        self._focus_console_composer_if_needed(force=True)
+        return True
+```
+
+Verify `replace` (from `dataclasses`) and `_default_console_session_settings` exist in this module (grep — both are used elsewhere in `chat_screen.py`). `ConsoleMessageRole` and `CONSOLE_GLOBAL_WORKSPACE_ID` are already imported (`chat_screen.py:96` and workspace const import).
+
+- [ ] **Step 4: Call the helper from the native branch**
+
+In `_consume_pending_chat_handoff`, inside the `if tab_container is None:` block (~8756), try the character path first:
+
+```python
+            tab_container = self._get_tab_container()
+            if tab_container is None:
+                if await self._start_character_console_session(payload):
+                    self.app_instance.pending_chat_handoff = None
+                    return
+                # Not a character Start-Chat (or fetch failed): stage context.
+                self._stage_handoff_as_console_live_work(payload)
+                self.app_instance.pending_chat_handoff = None
+                return
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_chat_first_handoffs.py -v`
+Expected: PASS (new native-branch tests + existing legacy-path handoff tests green).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/UI/Screens/chat_screen.py Tests/UI/test_chat_first_handoffs.py
+git commit -m "feat(console): Start Chat builds a real character session on the native handoff branch (task-427)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Restore character identity on resume
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py` (`_resume_console_workspace_conversation` ~3466-3472)
+- Test: `Tests/UI/test_chat_first_handoffs.py` or the existing resume-path test module (grep for `_resume_console_workspace_conversation` in `Tests/`)
+
+**Interfaces:**
+- Consumes: the persisted `conversations.character_id` (round-trips via `normalize_conversation_row`).
+- Produces: a resumed session with `session.character_id` set, so its sends stay on the plain path (Task 3) after restart.
+
+- [ ] **Step 1: Write the failing test**
+
+Add a test that resumes a conversation whose row carries `character_id=7` and asserts the restored session is character-bound. Reuse the resume-path harness (grep an existing `_resume_console_workspace_conversation` test; if none, drive it via a fake `conversation` dict that includes `"character_id": 7`).
+
+```python
+async def test_resume_restores_character_identity(self, ...):
+    screen = ...
+    # conversation row / tree fake with character_id=7 and title "Chat with Elara"
+    await screen._resume_console_workspace_conversation(target=..., conversation={..., "character_id": 7, "title": "Chat with Elara"}, tree=...)
+    store = screen._ensure_console_chat_store()
+    session = store._sessions[store.active_session_id]
+    assert session.character_id == 7
+```
+
+Match the real signature/args of `_resume_console_workspace_conversation` (read ~3387-3410 for its parameters; adapt the call).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_chat_first_handoffs.py -k resume_restores_character -v`
+Expected: FAIL — `session.character_id` is `None`.
+
+- [ ] **Step 3: Set `character_id` on the restored session**
+
+In `_resume_console_workspace_conversation`, right after `session = store.restore_persisted_session(...)` (~3472):
+
+```python
+        raw_character_id = conversation.get("character_id")
+        if raw_character_id is not None:
+            try:
+                session.character_id = int(raw_character_id)
+            except (TypeError, ValueError):
+                session.character_id = None
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_chat_first_handoffs.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/UI/Screens/chat_screen.py Tests/UI/test_chat_first_handoffs.py
+git commit -m "feat(console): restore character identity on resume so sends stay plain (task-427)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Full-suite regression + live verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the affected suites**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Chat/test_console_chat_store.py Tests/Chat/test_console_chat_controller.py Tests/UI/test_chat_first_handoffs.py -q`
+Expected: all green.
+
+- [ ] **Step 2: Live-verify in the real TUI**
+
+Using the `verify` recipe: scratch `TLDW_CONFIG_PATH` profile with a reachable provider (local OpenAI-compat mock on :9099 if no real server), import a character card, click inspector **Start Chat**. Confirm:
+- the greeting renders as the first assistant message in the Console transcript;
+- the session/tab is titled "Chat with {name}";
+- sending a message returns an **in-character** reply (not the agent sub-agent "please provide the character details" dead-end);
+- quitting and relaunching the app shows the conversation still titled/identified with the character, and a further send still replies in character on the plain path.
+
+- [ ] **Step 3: Mark ACs + notes on the task**
+
+```bash
+backlog task edit 427 --check-ac 1 --check-ac 2 --check-ac 3 --check-ac 4
+backlog task edit 427 --notes "<implementation summary>"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** §1 identity→Task 1; §2 persist→Task 1; §3 native branch→Task 4; §4 UI sync for first-send system prompt→Task 4 (`_sync_native_console_chat_ui`); §5 plain gate→Task 3; §6 restart→Task 5; §7 greeting display-only + regen/continue guard→Task 2. All covered.
+- **Placeholder scan:** test bodies note where to match existing fixture accessor names (`last_create_kwargs`, `captured_messages`, `ConsoleSubmitResult.ok`) — these are "match the real name" instructions, not TBDs; the executing agent greps the one true name. No functional placeholders.
+- **Type consistency:** `character_id: int|None` and `character_name: str|None` are used identically across Tasks 1/3/4/5; `_start_character_console_session(payload) -> bool` and the `force_plain` gate reference only fields defined in Task 1.
+- **Ordering:** 1 (fields+persist) → 2 (payload) → 3 (gate) → 4 (integration) → 5 (restart) → 6 (verify). Task 4 depends on 1/2/3; Task 5 depends on 1.

--- a/Docs/superpowers/specs/2026-07-21-start-chat-character-conversation-design.md
+++ b/Docs/superpowers/specs/2026-07-21-start-chat-character-conversation-design.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-07-21
 - **Task:** TASK-427 (P0, from the RP/character-card UX review `Docs/superpowers/qa/rp-ux-review-2026-07-21/report.md`)
 - **Branch base:** origin/dev (schema v22)
+- **Revision:** 2 — incorporates an adversarial design review (greeting-must-be-display-only-to-provider; message-owning agent gate; explicit UI-sync step for AC#3; workspace scoping; inline card fetch).
 
 ## Problem
 
@@ -17,11 +18,13 @@
 
 ## Scope
 
-**In scope:** the inspector **Start Chat** button (`#personas-start-chat`) and the **Attach** button when it carries `intent="start_chat"` — the path that carries character identity in handoff metadata.
+**In scope:** the inspector **Start Chat** button (`#personas-start-chat`) and the **Attach** button when it carries `intent="start_chat"` — the path that carries character identity in handoff metadata (`_character_session_identity_from_handoff` fires only for `intent=="start_chat"` + `selected_kind=="character"`).
 
-**Out of scope (deferred to existing follow-up work):**
-- Character-scoped **dictionaries and world-info** on the native send path (the `_active_console_dictionary_scope_ids` / applier `char_data=None` seam — explicitly deferred in PR #664 / P2g). Only the card **system prompt** applies here.
-- The preview pane's **"Open in Console"** (continue-an-existing-transcript) flow — genuinely different "continue this transcript" semantics.
+**Out of scope (deferred):**
+- Character-scoped **dictionaries and world-info** on the native send path (deferred in PR #664 / P2g). Only the card **system prompt** applies here.
+- The preview pane's **"Open in Console"** transcript-continuation flow.
+- A **per-session "use the agent with this character" opt-in** UI. None exists today; character sessions are plain-provider. A future opt-in can layer on the gate described in §5.
+- Persona (user-profile) Start Chat (`selected_kind=="persona_profile"`): falls through to the existing staged-context behavior, unchanged.
 
 **No ChaChaNotes migration.** The `conversations` table already has `character_id INTEGER REFERENCES character_cards(id)` (`ChaChaNotes_DB.py:263-280`, schema v22), and `ChatPersistenceService.create_conversation` already accepts `character_id`/`character_name`/`assistant_kind`/`conversation_title`/`system_prompt` (`chat_persistence_service.py:44-98`). The native session-creation path simply never passes them.
 
@@ -32,44 +35,69 @@
 Add to `ConsoleChatSession` (`console_chat_store.py:148-160`):
 - `character_id: int | None = None`
 - `character_name: str | None = None`
-- `agent_runtime_enabled: bool | None = None` — per-session override of the global agent-runtime default (`None` = inherit global; `False` = force plain provider).
 
-The card system prompt is carried by the existing `ConsoleSessionSettings.system_prompt` (`console_session_settings.py:172`); `character_label` (`:166`) carries the display name.
+`character_id` is the single source of truth for "this is a character session": it drives persistence (§2), the plain-provider gate (§5), and greeting handling (§7). The card system prompt rides the existing `ConsoleSessionSettings.system_prompt`; `character_label` (`:166`) carries the display name for the rail.
+
+No `agent_runtime_enabled` field is added — the plain-provider decision keys on `character_id` (§5), which already persists, so it survives restart for free (this is why the review's I2 "agent override lost on restart" cannot occur here).
 
 ### 2. Persist identity
 
-In `persist_session_if_needed` (`console_chat_store.py:948-984`): when `session.character_id is not None`, call `create_conversation` with `character_id=session.character_id`, `character_name=session.character_name`, `assistant_kind="character"`, `assistant_id=str(session.character_id)` (instead of the hardcoded `assistant_kind="generic", assistant_id="console"`). The adapter derives a "Chat with {name}" title and writes `conversations.character_id`. `system_prompt` is already passed from settings.
+In `persist_session_if_needed` (`console_chat_store.py:948-984`): when `session.character_id is not None`, call `create_conversation` with `character_id=session.character_id`, `character_name=session.character_name`, `assistant_kind="character"`, `assistant_id=str(session.character_id)` (instead of the hardcoded `assistant_kind="generic", assistant_id="console"`). `system_prompt` is already passed from settings. The adapter derives a "Chat with {name}" title (preserved on resume — see §6). A non-character session keeps `generic`/`console` unchanged.
+
+`session.character_id` is set **before** the first `persist=True` message (§3 orders create → set identity → seed), and `persist_session_if_needed` guards on `persisted_conversation_id`, so `create_conversation` runs exactly once, with character fields present.
 
 ### 3. Native character branch (handoff consumer)
 
-In `ChatScreen._consume_pending_chat_handoff` (`chat_screen.py:8741-8779`), before the native staged-context degradation (`tab_container is None` → `_stage_handoff_as_console_live_work`), branch when the payload is a character Start-Chat:
+In `ChatScreen._consume_pending_chat_handoff` (`chat_screen.py:8741-8779`), before the native staged-context degradation (`tab_container is None` → `_stage_handoff_as_console_live_work`), add a character branch. **All work happens inline within the existing guarded (`_handoff_consumption_in_progress`) `try/finally` body** — no detached worker — so the re-entrancy guard and the `pending_chat_handoff` clear stay correct and a failure can still fall back:
 
-- Detect via `_character_session_identity_from_handoff(payload)` (`chat_screen.py:442-475`) returning a non-`None` `(character_id, character_name, assistant_id)` (it already reads `metadata["intent"]=="start_chat"` + `metadata["selected_kind"]=="character"` and extracts the numeric id).
-- **Re-fetch the card by id off-thread** (`run_worker(..., exit_on_error=False)`; recurring app-crash guard for off-thread reads) via `Character_Chat_Lib.load_character_and_image` / `db.get_character_card_by_id` (`ChaChaNotes_DB.py:4326`) to obtain `first_message` and the system-prompt/definition fields.
-- **Build the effective system prompt** from the card (`system_prompt` plus definition fields), mirroring the Personas preview's `system_prompt()` construction so the Console character behaves like the preview.
-- **Create a dedicated new session** (`store.create_session`, NOT `ensure_session` — a character chat must not pollute the active conversation), title `Chat with {name}`, set `settings.system_prompt` from the card, `character_label = name`, `character_id`/`character_name` on the session, and `agent_runtime_enabled = False`.
-- **Seed the greeting** as the first message: `store.append_message(session_id, role=ConsoleMessageRole.ASSISTANT, content=<placeholder-substituted first_message>, persist=True)`. Placeholder substitution via `replace_placeholders(first_message, name, user_name)` (same helper the preview uses).
-- Switch the Console to that session and focus the composer.
-- Clear `app_instance.pending_chat_handoff`.
+1. Detect via `_character_session_identity_from_handoff(payload)` (`chat_screen.py:442-475`) returning non-`None` `(character_id, character_name, assistant_id)`.
+2. **Fetch the card by id off the event loop**: `card = await asyncio.to_thread(db.get_character_card_by_id, character_id)` (`ChaChaNotes_DB.py:4326`; the DB uses `threading.local` connections with `check_same_thread=False`, so a threaded read is safe). Wrap in `try/except`. Use `get_character_card_by_id`, **not** `load_character_and_image` (the latter decodes a PIL image the caller must `.close()` and runs placeholder substitution over the system-prompt fields — both unwanted here).
+3. **On any failure** (identity `None`, card missing, exception): fall through to `_stage_handoff_as_console_live_work(payload)` unchanged, then clear `pending_chat_handoff`. No regression.
+4. **Build the effective system prompt** exactly like the preview (`personas_preview_controller.py:189-194`): `"\n".join` of the non-empty `[system_prompt, personality, description, scenario]` card fields, fallback `"Stay in character."`. Apply `replace_placeholders` **only** to the greeting (`first_message`), not to the system prompt (matches the preview).
+5. **Display name** comes from the fetched `card["name"]` (metadata `selected_name` can be blank → "Chat with " / empty label). Use the metadata id only for routing.
+6. **Create a dedicated new session** via `store.create_session(...)` (NOT `ensure_session` — a character chat must not pollute the active conversation), with `workspace_id=CONSOLE_GLOBAL_WORKSPACE_ID` (character chats are global `ccp_character` discovery, never workspace work — this avoids the `create_conversation` `ValueError` path for workspace scopes and keeps the conversation visible in the character's conversation browser, which excludes `scope_type=="workspace"`). Set `title="Chat with {name}"`, `settings.system_prompt` = built prompt, `character_label=name`, `character_id`/`character_name` on the session.
+7. **Seed the greeting** as the first message: `store.append_message(session_id, role=ConsoleMessageRole.ASSISTANT, content=<substituted first_message>, persist=True)`, wrapped in `try/except` (a persist failure must not crash the consumer). Substitution: `replace_placeholders(first_message, name, "User")`.
+8. **Make it the visible, synced session (see §4)**, then clear `pending_chat_handoff`.
 
-**Fallback (no regression):** if `_character_session_identity_from_handoff` returns `None`, or the card fetch fails / has no id, fall through to the existing `_stage_handoff_as_console_live_work(payload)` path unchanged.
+### 4. Make the session visible AND apply the card prompt on the first send (AC#3)
 
-### 4. Card system prompt on send (AC #3)
+This is the step the first design version got wrong. The send path emits `self.system_prompt` (the **controller** attribute), not `session.settings.system_prompt` (`_leading_system_message`, `console_chat_controller.py:2611`). `self.system_prompt` is only refreshed from the active session when `update_provider_selection` runs, which happens inside `_sync_native_console_chat_ui()` → `_sync_console_chat_core_state()`.
 
-No new send-path code: the controller already emits `session.settings.system_prompt` as the leading system message via `_leading_system_message` / `_provider_messages_for_session` (`console_chat_controller.py:2598-2629`) on every send. Setting `settings.system_prompt` at session creation (step 3) satisfies AC #3.
+Because `store.create_session` **pre-activates** the new session (`console_chat_store.py:234`), the shared `_activate_native_console_session` (`chat_screen.py:1354-1367`) early-outs on `if active_session_id != session_id:` and **skips the sync**. So the handoff consumer must, after create + seed, call **`await self._sync_native_console_chat_ui()` directly** (renders the transcript incl. the greeting, refreshes the session list, and runs `update_provider_selection` so `controller.system_prompt` = the card prompt for the first send), then `self._focus_console_composer_if_needed(force=True)`.
 
-### 5. Plain provider path (AC #4)
+No other send-path change is needed for AC#3: with `controller.system_prompt` set, `_leading_system_message` prepends the card prompt on submit/retry/regenerate/continue.
 
-The agent-vs-plain decision is at `console_chat_controller.py:2040-2062`:
+### 5. Plain provider path (AC#4)
+
+The agent-vs-plain gate is `console_chat_controller.py:2051`:
 ```
 if self._agent_runtime_enabled and self._agent_bridge is not None and not prefill:
     return await self._run_agent_reply(...)
 ```
-Change the gate to consult a **per-session** override: the effective agent-runtime is `session.agent_runtime_enabled` when set, else the global `self._agent_runtime_enabled`. Character sessions set the override to `False`, so they always take the plain-provider branch (`provider_gateway.stream_chat`) regardless of the global default. A user who explicitly enables the agent for that session flips the override — satisfying "unless the user has explicitly enabled an agent profile."
+Change it to consult the **session that owns the message being streamed**, derived race-free from the message id (reading `self.store.active_session_id` at the gate is racy — a session switch is not blocked during a run's async setup):
+```
+owner_id = self.store.session_id_for_message(assistant_message_id)
+owner = next((s for s in self.store.sessions() if s.id == owner_id), None)
+force_plain = owner is not None and owner.character_id is not None
+if self._agent_runtime_enabled and self._agent_bridge is not None and not prefill and not force_plain:
+    ... agent ...
+```
+(`session_id_for_message` at `console_chat_store.py:690`; the `next(... sessions())` lookup mirrors the established pattern at `console_chat_controller.py:1766/1862`.) A character session (`character_id` set) therefore always takes the plain-provider branch (`provider_gateway.stream_chat`), regardless of the global `[console] agent_runtime` default, and **across restarts** (character_id persists and is restored in §6). A future per-session "use agent" opt-in would relax `force_plain`.
 
-### 6. Restart identity (AC #2)
+### 6. Restart identity (AC#2)
 
-`_resume_console_workspace_conversation` (`chat_screen.py:3387-3481`) currently restores title/workspace/messages/settings but not `character_id`. Extend it to read `conversation.get("character_id")` (and character name) back onto the restored `ConsoleChatSession` so the identity survives restart. The title and the seeded greeting message already persist via the conversation row + messages.
+`_resume_console_workspace_conversation` (`chat_screen.py:3387-3481`) restores title/workspace/messages/settings but not `character_id`. Extend it to set `session.character_id = conversation.get("character_id")` on the restored `ConsoleChatSession` (the value round-trips via `normalize_conversation_row`, `chat_conversation_service.py:223`). This restores both identity **and** the plain-provider behavior (§5 keys on `character_id`). The title ("Chat with {name}") and the seeded greeting message already persist and restore; `system_prompt` restores via `_console_session_settings_for_resume` (`chat_screen.py:3370-3384`), so AC#3 also holds across restart. `character_name` is not stored as a column; the rail label after restart derives from the persisted title (acceptable — no name-dependent send logic).
+
+### 7. Greeting is display-only to the provider
+
+Seeding the greeting as a normal ASSISTANT message makes it eligible for the provider payload (`_provider_message_payloads` includes USER and ASSISTANT, `console_chat_controller.py:2645+`), producing `[system, assistant(greeting), user]`. **Anthropic rejects a leading assistant turn (400)** — `LLM_API_Calls.py:1093` only checks that *some* user message exists and never reorders — and strict Gemini alternation likewise. The preview avoids this by keeping the greeting pane-only (`self.history` empty; sends `[system]+[user]`).
+
+Fix: in `_provider_message_payloads`, **skip assistant messages that precede the first payload-eligible user message**. This:
+- makes the first character send `[system, user]` (valid for all providers);
+- is a **no-op** for normal user-first sessions;
+- matches the preview (greeting not in model context — decided deliberately over a synthetic-user-prepend, for preview parity; the tradeoff is the model does not see its own opening line on turn 1, mitigated by the card system prompt).
+
+**Edge — regenerate/continue on the seeded greeting:** the greeting is a `complete` assistant message, so `regenerate_message`/continue would target it and (with the drop) build a `[system]`-only payload → provider error. Guard both paths: when the target assistant message has **no preceding payload-eligible user turn**, deny the action with a gentle status ("Nothing to regenerate before the character's opening line.") rather than send an invalid payload.
 
 ## Data flow
 
@@ -77,37 +105,46 @@ Change the gate to consult a **per-session** override: the effective agent-runti
 Start Chat (inspector)
   → _attach_selection_to_console(intent="start_chat")
   → _stage_handoff(payload{metadata: selected_kind=character, selected_record_id=<id>, selected_name, intent})
-  → app.open_chat_with_handoff(payload)  [gated on chat_defaults.enable_tabs — pre-existing, unchanged]
+  → app.open_chat_with_handoff(payload)   [gated on chat_defaults.enable_tabs=true by default — unchanged]
   → NavigateToScreen(Console)
-  → _consume_pending_chat_handoff
-      → [character branch] resolve id → fetch card (worker) → build system prompt
-      → store.create_session(identity, system_prompt, agent_off)
-      → store.append_message(ASSISTANT, greeting, persist)
-      → switch session, focus composer
+  → _consume_pending_chat_handoff  [guarded body]
+      → [character branch] resolve id → await to_thread(get_character_card_by_id) → build 4-part system prompt
+      → store.create_session(global workspace, title "Chat with {name}", system_prompt, character_id/name)
+      → store.append_message(ASSISTANT, substituted greeting, persist=True)   [try/except]
+      → await _sync_native_console_chat_ui()   → update_provider_selection → controller.system_prompt = card prompt
+      → focus composer; clear pending_chat_handoff
+      → [on any failure] _stage_handoff_as_console_live_work(payload)  (unchanged fallback)
 First user send
-  → plain provider path (agent override off) with card system prompt as leading system message
+  → gate keys on owner.character_id → plain provider path
+  → _provider_message_payloads drops the leading greeting → [system(card prompt), user]
   → in-character reply
 Restart
-  → _resume_console_workspace_conversation reads character_id back → identity restored; title + greeting persisted
+  → _resume_console_workspace_conversation sets session.character_id from the row
+  → identity + plain-provider behavior restored; title + greeting + system_prompt persisted
 ```
 
 ## Testing
 
-- **Store** (`Tests/Chat/test_console_chat_store.py`, `FakePersistence`): `persist_session_if_needed` on a character-bound session passes `character_id`/`character_name`/`assistant_kind="character"` to `create_conversation`; a non-character session still passes `generic`/`console` (no regression).
-- **Controller** (`Tests/Chat/test_console_chat_controller.py`, `CapturingGateway`): a character session (agent override `False`) with an agent bridge present still takes the **plain provider** path (agent bridge not invoked) and prepends the card system prompt as the leading system message; a normal session with the global agent default unchanged still routes to the agent path.
-- **Handoff / screen** (`Tests/UI/test_chat_first_handoffs.py` or a new native-branch test): a native-Console handoff with `intent=start_chat` + character metadata creates a **dedicated** character-bound session, seeds the greeting as the **first ASSISTANT message**, and titles it "Chat with {name}"; an unresolvable/id-less payload **falls back** to the staged-context path.
-- **Live-verify** (real TUI, scratch profile + local OpenAI-compat mock on :9099): Start Chat → greeting renders as first assistant message → send → in-character reply via plain provider → restart the app → conversation still titled/identified with the character.
+- **Store** (`Tests/Chat/test_console_chat_store.py`, `FakePersistence`): `persist_session_if_needed` on a character-bound session passes `character_id`/`character_name`/`assistant_kind="character"`/`assistant_id` to `create_conversation`; a non-character session still passes `generic`/`console`.
+- **Controller — agent gate** (`Tests/Chat/test_console_chat_controller.py`): with an agent bridge present and global `agent_runtime` enabled, a send in a **character** session (character_id set) takes the **plain** path (agent bridge not invoked); a normal session still routes to the agent. Assert via the message-owning session, not the active session.
+- **Controller — greeting exclusion** (`CapturingGateway`): a session whose first message is a seeded ASSISTANT greeting sends `[system, user]` on the first user turn (no leading assistant); the card system prompt is the leading system message. Regenerate/continue targeting the greeting is denied (no invalid payload).
+- **Handoff / screen** (`Tests/UI/test_chat_first_handoffs.py` or a new native-branch test): a native-Console handoff with `intent=start_chat` + character metadata creates a **dedicated** character session in the **global** workspace, seeds the greeting as the **first ASSISTANT message**, titles it "Chat with {name}", and calls `_sync_native_console_chat_ui`; an unresolvable/id-less or fetch-failing payload **falls back** to the staged-context path with no exception.
+- **Restart** (resume path test or store): a resumed conversation row carrying `character_id` restores `session.character_id`, so its sends stay on the plain path.
+- **Live-verify** (real TUI, scratch profile + local OpenAI-compat mock on :9099): Start Chat → greeting renders as first assistant message → send → in-character reply via plain provider → restart the app → conversation still titled/identified with the character and still plain-path.
 
 ## Risks / mitigations
 
-- **Off-thread card fetch** → `run_worker(exit_on_error=False)` (uncaught worker exceptions kill the app — recurring lesson).
-- **Regression risk on the handoff path** → the character branch is additive and guarded; any failure to resolve identity falls through to the exact current staged-context behavior.
-- **`enable_tabs` gate** (`app.py:3476`): Start Chat already no-ops today when a user disabled tabs. Pre-existing, out of scope; noted, not changed.
-- **Agent bridge is `None` for in-memory DBs** — the per-session override must be consulted *in addition to* the existing `_agent_bridge is not None` check; character sessions force plain regardless.
+- **Assistant-first provider 400** → §7 drops the leading greeting from the payload (verified against the Anthropic handler).
+- **AC#3 silent failure on first send** → §4 calls `_sync_native_console_chat_ui()` directly (the pre-activation early-out would otherwise skip the prompt sync).
+- **Wrong workspace / crash on seed** → §3/§6 force `CONSOLE_GLOBAL_WORKSPACE_ID`; the greeting-seed persist is `try/except`.
+- **Racy agent gate** → §5 keys on the message-owning session, not the active session.
+- **Re-entrancy / lost fallback** → §3 keeps the card fetch inline (`asyncio.to_thread`) within the guarded body; failure falls through to the staged-context path.
+- **Regression on the handoff path** → the character branch is additive and guarded; every failure falls through to today's exact behavior.
+- **`enable_tabs` gate** (`app.py:3476`, default `true`): Start Chat already no-ops when a user disabled tabs. Pre-existing, out of scope; noted, not changed.
 
 ## Non-goals
 
 - Character dictionaries / world-info on native send (deferred follow-up).
 - Preview "Open in Console" transcript continuation.
-- Changing the `enable_tabs` gate.
-- Any schema change.
+- Per-session "use the agent with this character" opt-in UI.
+- Changing the `enable_tabs` gate or any schema.

--- a/Docs/superpowers/specs/2026-07-21-start-chat-character-conversation-design.md
+++ b/Docs/superpowers/specs/2026-07-21-start-chat-character-conversation-design.md
@@ -1,0 +1,113 @@
+# TASK-427 — Start Chat opens a real character conversation in native Console
+
+- **Date:** 2026-07-21
+- **Task:** TASK-427 (P0, from the RP/character-card UX review `Docs/superpowers/qa/rp-ux-review-2026-07-21/report.md`)
+- **Branch base:** origin/dev (schema v22)
+
+## Problem
+
+"Start Chat" / "Open in Console" from the Roleplay workbench does not open a live character conversation in the native Console. The handoff degrades to invisible "staged context" (`chat_screen.py:_stage_handoff_as_console_live_work`): blank transcript, no greeting, no character identity, composer prefilled with a meta-instruction (`Respond as {name}.`). Observed live: sending that prefilled text routes through the agent/sub-agent harness, which replies *"Please provide the previous conversation and the character details you'd like me to use."* — the staged context never reaches the model. The RP core loop is a dead end.
+
+## Goal (acceptance criteria)
+
+1. Start Chat on a character opens Console with the character greeting visible as the **first assistant message**.
+2. The created conversation is **titled/labelled with the character name** and retains that identity **across app restarts**.
+3. The first user send **replies in character** (card system prompt + definition applied) without the user re-describing the character.
+4. Character sends **do not route through the agent/sub-agent harness** unless the user has explicitly enabled an agent profile.
+
+## Scope
+
+**In scope:** the inspector **Start Chat** button (`#personas-start-chat`) and the **Attach** button when it carries `intent="start_chat"` — the path that carries character identity in handoff metadata.
+
+**Out of scope (deferred to existing follow-up work):**
+- Character-scoped **dictionaries and world-info** on the native send path (the `_active_console_dictionary_scope_ids` / applier `char_data=None` seam — explicitly deferred in PR #664 / P2g). Only the card **system prompt** applies here.
+- The preview pane's **"Open in Console"** (continue-an-existing-transcript) flow — genuinely different "continue this transcript" semantics.
+
+**No ChaChaNotes migration.** The `conversations` table already has `character_id INTEGER REFERENCES character_cards(id)` (`ChaChaNotes_DB.py:263-280`, schema v22), and `ChatPersistenceService.create_conversation` already accepts `character_id`/`character_name`/`assistant_kind`/`conversation_title`/`system_prompt` (`chat_persistence_service.py:44-98`). The native session-creation path simply never passes them.
+
+## Design
+
+### 1. Session identity (in-memory)
+
+Add to `ConsoleChatSession` (`console_chat_store.py:148-160`):
+- `character_id: int | None = None`
+- `character_name: str | None = None`
+- `agent_runtime_enabled: bool | None = None` — per-session override of the global agent-runtime default (`None` = inherit global; `False` = force plain provider).
+
+The card system prompt is carried by the existing `ConsoleSessionSettings.system_prompt` (`console_session_settings.py:172`); `character_label` (`:166`) carries the display name.
+
+### 2. Persist identity
+
+In `persist_session_if_needed` (`console_chat_store.py:948-984`): when `session.character_id is not None`, call `create_conversation` with `character_id=session.character_id`, `character_name=session.character_name`, `assistant_kind="character"`, `assistant_id=str(session.character_id)` (instead of the hardcoded `assistant_kind="generic", assistant_id="console"`). The adapter derives a "Chat with {name}" title and writes `conversations.character_id`. `system_prompt` is already passed from settings.
+
+### 3. Native character branch (handoff consumer)
+
+In `ChatScreen._consume_pending_chat_handoff` (`chat_screen.py:8741-8779`), before the native staged-context degradation (`tab_container is None` → `_stage_handoff_as_console_live_work`), branch when the payload is a character Start-Chat:
+
+- Detect via `_character_session_identity_from_handoff(payload)` (`chat_screen.py:442-475`) returning a non-`None` `(character_id, character_name, assistant_id)` (it already reads `metadata["intent"]=="start_chat"` + `metadata["selected_kind"]=="character"` and extracts the numeric id).
+- **Re-fetch the card by id off-thread** (`run_worker(..., exit_on_error=False)`; recurring app-crash guard for off-thread reads) via `Character_Chat_Lib.load_character_and_image` / `db.get_character_card_by_id` (`ChaChaNotes_DB.py:4326`) to obtain `first_message` and the system-prompt/definition fields.
+- **Build the effective system prompt** from the card (`system_prompt` plus definition fields), mirroring the Personas preview's `system_prompt()` construction so the Console character behaves like the preview.
+- **Create a dedicated new session** (`store.create_session`, NOT `ensure_session` — a character chat must not pollute the active conversation), title `Chat with {name}`, set `settings.system_prompt` from the card, `character_label = name`, `character_id`/`character_name` on the session, and `agent_runtime_enabled = False`.
+- **Seed the greeting** as the first message: `store.append_message(session_id, role=ConsoleMessageRole.ASSISTANT, content=<placeholder-substituted first_message>, persist=True)`. Placeholder substitution via `replace_placeholders(first_message, name, user_name)` (same helper the preview uses).
+- Switch the Console to that session and focus the composer.
+- Clear `app_instance.pending_chat_handoff`.
+
+**Fallback (no regression):** if `_character_session_identity_from_handoff` returns `None`, or the card fetch fails / has no id, fall through to the existing `_stage_handoff_as_console_live_work(payload)` path unchanged.
+
+### 4. Card system prompt on send (AC #3)
+
+No new send-path code: the controller already emits `session.settings.system_prompt` as the leading system message via `_leading_system_message` / `_provider_messages_for_session` (`console_chat_controller.py:2598-2629`) on every send. Setting `settings.system_prompt` at session creation (step 3) satisfies AC #3.
+
+### 5. Plain provider path (AC #4)
+
+The agent-vs-plain decision is at `console_chat_controller.py:2040-2062`:
+```
+if self._agent_runtime_enabled and self._agent_bridge is not None and not prefill:
+    return await self._run_agent_reply(...)
+```
+Change the gate to consult a **per-session** override: the effective agent-runtime is `session.agent_runtime_enabled` when set, else the global `self._agent_runtime_enabled`. Character sessions set the override to `False`, so they always take the plain-provider branch (`provider_gateway.stream_chat`) regardless of the global default. A user who explicitly enables the agent for that session flips the override — satisfying "unless the user has explicitly enabled an agent profile."
+
+### 6. Restart identity (AC #2)
+
+`_resume_console_workspace_conversation` (`chat_screen.py:3387-3481`) currently restores title/workspace/messages/settings but not `character_id`. Extend it to read `conversation.get("character_id")` (and character name) back onto the restored `ConsoleChatSession` so the identity survives restart. The title and the seeded greeting message already persist via the conversation row + messages.
+
+## Data flow
+
+```
+Start Chat (inspector)
+  → _attach_selection_to_console(intent="start_chat")
+  → _stage_handoff(payload{metadata: selected_kind=character, selected_record_id=<id>, selected_name, intent})
+  → app.open_chat_with_handoff(payload)  [gated on chat_defaults.enable_tabs — pre-existing, unchanged]
+  → NavigateToScreen(Console)
+  → _consume_pending_chat_handoff
+      → [character branch] resolve id → fetch card (worker) → build system prompt
+      → store.create_session(identity, system_prompt, agent_off)
+      → store.append_message(ASSISTANT, greeting, persist)
+      → switch session, focus composer
+First user send
+  → plain provider path (agent override off) with card system prompt as leading system message
+  → in-character reply
+Restart
+  → _resume_console_workspace_conversation reads character_id back → identity restored; title + greeting persisted
+```
+
+## Testing
+
+- **Store** (`Tests/Chat/test_console_chat_store.py`, `FakePersistence`): `persist_session_if_needed` on a character-bound session passes `character_id`/`character_name`/`assistant_kind="character"` to `create_conversation`; a non-character session still passes `generic`/`console` (no regression).
+- **Controller** (`Tests/Chat/test_console_chat_controller.py`, `CapturingGateway`): a character session (agent override `False`) with an agent bridge present still takes the **plain provider** path (agent bridge not invoked) and prepends the card system prompt as the leading system message; a normal session with the global agent default unchanged still routes to the agent path.
+- **Handoff / screen** (`Tests/UI/test_chat_first_handoffs.py` or a new native-branch test): a native-Console handoff with `intent=start_chat` + character metadata creates a **dedicated** character-bound session, seeds the greeting as the **first ASSISTANT message**, and titles it "Chat with {name}"; an unresolvable/id-less payload **falls back** to the staged-context path.
+- **Live-verify** (real TUI, scratch profile + local OpenAI-compat mock on :9099): Start Chat → greeting renders as first assistant message → send → in-character reply via plain provider → restart the app → conversation still titled/identified with the character.
+
+## Risks / mitigations
+
+- **Off-thread card fetch** → `run_worker(exit_on_error=False)` (uncaught worker exceptions kill the app — recurring lesson).
+- **Regression risk on the handoff path** → the character branch is additive and guarded; any failure to resolve identity falls through to the exact current staged-context behavior.
+- **`enable_tabs` gate** (`app.py:3476`): Start Chat already no-ops today when a user disabled tabs. Pre-existing, out of scope; noted, not changed.
+- **Agent bridge is `None` for in-memory DBs** — the per-session override must be consulted *in addition to* the existing `_agent_bridge is not None` check; character sessions force plain regardless.
+
+## Non-goals
+
+- Character dictionaries / world-info on native send (deferred follow-up).
+- Preview "Open in Console" transcript continuation.
+- Changing the `enable_tabs` gate.
+- Any schema change.

--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -2657,6 +2657,53 @@ async def test_normal_session_still_uses_agent_when_enabled():
 
 
 @pytest.mark.asyncio
+async def test_stream_assistant_response_owner_lookup_survives_closed_session():
+    """task-427 review fix: the force_plain owner-lookup added at the top of
+    ``_stream_assistant_response`` calls ``store.session_id_for_message``,
+    which raises ``KeyError`` for an unknown message id. ``retry_message`` /
+    ``continue_from_message`` / ``regenerate_message`` resolve the message id
+    and then ``await`` several times (resolve_for_send / skill substitution /
+    chat dictionaries / world info) before reaching this method -- a
+    ``close_session`` racing one of those awaits purges
+    ``_message_session_index`` for that message, so the id is unknown by the
+    time the gate runs. This must be treated exactly like every other
+    "session vanished mid-flight" race in this method: swallowed and turned
+    into the session-closed result, not an uncaught KeyError."""
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+    session = _arm_session(store)
+    assistant = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content=""
+    )
+
+    # Simulate the session closing while a caller (e.g. retry_message) was
+    # still awaiting earlier stages of the pipeline: this purges
+    # `_message_session_index` for `assistant.id` before the gate runs.
+    controller.close_session(session.id)
+
+    resolution = type(
+        "Resolution",
+        (),
+        {
+            "ready": True,
+            "provider": "llama_cpp",
+            "model": "test-model",
+            "base_url": "http://127.0.0.1:9099",
+            "visible_copy": "",
+        },
+    )()
+
+    result = await controller._stream_assistant_response(
+        resolution=resolution,
+        provider_messages=[],
+        assistant_message_id=assistant.id,
+    )
+
+    assert result.accepted is True
+    assert result.visible_copy == "Session closed."
+
+
+@pytest.mark.asyncio
 async def test_build_context_snapshot_includes_armed_one_shot_prefill():
     """task-401: an armed prefill must appear in the preview exactly as the
     send would apply it -- trailing assistant turn + explicit indicator --

--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -1017,6 +1017,11 @@ async def test_continue_from_message_streams_new_assistant_turn_after_selected_m
     store = ConsoleChatStore()
     controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
     session = store.ensure_session()
+    store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content="Hi",
+    )
     source = store.append_message(
         session.id,
         role=ConsoleMessageRole.ASSISTANT,
@@ -1087,6 +1092,11 @@ async def test_regenerate_message_streams_new_selected_variant():
     store = ConsoleChatStore()
     controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
     session = store.ensure_session()
+    store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content="Hi",
+    )
     source = store.append_message(
         session.id,
         role=ConsoleMessageRole.ASSISTANT,
@@ -1136,6 +1146,75 @@ async def test_regenerate_continuation_message_ends_provider_payload_with_user_i
         {"role": "assistant", "content": "Seed"},
         {"role": "user", "content": "Continue and extend the selected message."},
     ]
+
+
+@pytest.mark.asyncio
+async def test_leading_greeting_excluded_from_provider_payload():
+    """A seeded character greeting (persisted ASSISTANT message before any
+    user turn) must never reach the provider payload -- strict providers
+    (Anthropic, Gemini) reject an assistant-first message array (task-427)."""
+    store = ConsoleChatStore()
+    gateway = RecordingStreamingGateway()
+    controller = ConsoleChatController(store=store, provider_gateway=gateway)
+    session = store.create_session(title="Chat with Elara")
+    store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="Greetings, traveler.",
+        persist=False,
+    )
+
+    result = await controller.submit_draft("Hi")
+
+    assert result.accepted is True
+    sent = gateway.messages_seen
+    roles = [m["role"] for m in sent]
+    # No leading assistant: the first role sent is the user's turn.
+    assert roles[0] == "user"
+    # The greeting text is not in the outbound payload at all.
+    assert all("Greetings, traveler." not in (m.get("content") or "") for m in sent)
+
+
+@pytest.mark.asyncio
+async def test_regenerate_on_leading_greeting_is_blocked():
+    """Regenerating the seeded greeting before any user turn exists must be
+    blocked rather than sending a payload with no user message."""
+    store = ConsoleChatStore()
+    gateway = RecordingStreamingGateway()
+    controller = ConsoleChatController(store=store, provider_gateway=gateway)
+    session = store.create_session(title="Chat with Elara")
+    greeting = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="Greetings.",
+        persist=False,
+    )
+
+    result = await controller.regenerate_message(greeting.id)
+
+    assert result.accepted is False
+    assert gateway.messages_seen is None
+
+
+@pytest.mark.asyncio
+async def test_continue_from_leading_greeting_is_blocked():
+    """Continuing from the seeded greeting before any user turn exists must
+    be blocked rather than sending a payload with no user message."""
+    store = ConsoleChatStore()
+    gateway = RecordingStreamingGateway()
+    controller = ConsoleChatController(store=store, provider_gateway=gateway)
+    session = store.create_session(title="Chat with Elara")
+    greeting = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="Greetings.",
+        persist=False,
+    )
+
+    result = await controller.continue_from_message(greeting.id)
+
+    assert result.accepted is False
+    assert gateway.messages_seen is None
 
 
 class _AutoTitleReadyGateway:

--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -2597,6 +2597,65 @@ async def test_prefilled_send_bypasses_agent_loop():
     assert gateway.messages_seen[-1] == {"role": "assistant", "content": "PRE"}
 
 
+class _SpyAgentBridge:
+    """Records calls and refuses to be used -- for asserting the agent
+    bridge is never invoked on a character session's send (task-427)."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def run_reply(self, **kwargs):
+        self.calls += 1
+        raise AssertionError("agent bridge should not be called for a character session")
+
+
+@pytest.mark.asyncio
+async def test_character_session_forces_plain_provider():
+    """task-427: a session with character_id set always takes the plain
+    provider branch, even with the global agent runtime enabled and a
+    bridge present."""
+    store = ConsoleChatStore()
+    gateway = RecordingStreamingGateway()
+    controller = ConsoleChatController(
+        store=store, provider_gateway=gateway, agent_runtime_enabled=True
+    )
+    bridge = _SpyAgentBridge()
+    controller._agent_bridge = bridge
+    session = _arm_session(store)
+    session.character_id = 7
+
+    result = await controller.submit_draft("Hi")
+
+    assert bridge.calls == 0
+    assert result.accepted
+    assert gateway.messages_seen is not None  # plain provider path ran
+
+
+@pytest.mark.asyncio
+async def test_normal_session_still_uses_agent_when_enabled():
+    """Control for test_character_session_forces_plain_provider: a session
+    with no character_id keeps using the agent bridge as before."""
+    store = ConsoleChatStore()
+    gateway = RecordingStreamingGateway()
+    controller = ConsoleChatController(
+        store=store, provider_gateway=gateway, agent_runtime_enabled=True
+    )
+    bridge_calls = []
+
+    def run_reply(**kwargs):
+        bridge_calls.append(kwargs)
+        return RunOutcome(status=RUN_DONE, steps=[], final_text="agent says")
+
+    controller._agent_bridge = SimpleNamespace(run_reply=run_reply)
+    session = _arm_session(store)
+    assert session.character_id is None
+
+    await controller.submit_draft("Hi")
+
+    assert len(bridge_calls) == 1
+    assert gateway.messages_seen is None  # agent path handled it, not the gateway
+
+
 @pytest.mark.asyncio
 async def test_build_context_snapshot_includes_armed_one_shot_prefill():
     """task-401: an armed prefill must appear in the preview exactly as the

--- a/Tests/Chat/test_console_chat_store.py
+++ b/Tests/Chat/test_console_chat_store.py
@@ -450,9 +450,11 @@ class FakePersistence:
         self.updated_messages = []
         self.updated_system_prompts = []
         self.updated_pinned_prefills = []
+        self.last_create_kwargs = None
 
     def create_conversation(self, **kwargs):
         self.created_conversations.append(kwargs)
+        self.last_create_kwargs = kwargs
         return "conv-1"
 
     def update_conversation_system_prompt(self, *, conversation_id, system_prompt):
@@ -580,6 +582,36 @@ def test_persist_session_if_needed_passes_none_system_prompt_without_settings():
     store.persist_session_if_needed(session.id)
 
     assert persistence.created_conversations[0]["system_prompt"] is None
+
+
+def test_persist_session_if_needed_passes_character_identity():
+    persistence = FakePersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    session = store.create_session(title="Chat with Elara")
+    session.character_id = 7
+    session.character_name = "Elara"
+
+    conv_id = store.persist_session_if_needed(session.id)
+
+    assert conv_id is not None
+    kwargs = persistence.last_create_kwargs
+    assert kwargs["character_id"] == 7
+    assert kwargs["character_name"] == "Elara"
+    assert kwargs["assistant_kind"] == "character"
+    assert kwargs["assistant_id"] == "7"
+
+
+def test_persist_session_if_needed_non_character_stays_generic():
+    persistence = FakePersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    session = store.create_session(title="Chat 1")
+
+    store.persist_session_if_needed(session.id)
+
+    kwargs = persistence.last_create_kwargs
+    assert kwargs["assistant_kind"] == "generic"
+    assert kwargs["assistant_id"] == "console"
+    assert kwargs.get("character_id") is None
 
 
 def test_set_session_system_prompt_updates_settings_without_persisting_when_unsaved():

--- a/Tests/UI/test_chat_first_handoffs.py
+++ b/Tests/UI/test_chat_first_handoffs.py
@@ -289,6 +289,129 @@ def test_chat_screen_start_chat_handoff_preserves_numeric_zero_character_id():
     assert session_data.discovery_owner == "ccp_character"
 
 
+def _character_start_chat_payload(
+    *, character_id: int, name: str, first_message: str
+) -> ChatHandoffPayload:
+    """Build a Personas Start-Chat handoff payload for a character (task-427)."""
+    return ChatHandoffPayload(
+        source="personas",
+        item_type="character-card",
+        title=f"{name} (character)",
+        body=f"Name: {name}",
+        source_id=str(character_id),
+        metadata={
+            "intent": "start_chat",
+            "selected_kind": "character",
+            "selected_record_id": str(character_id),
+            "selected_name": name,
+        },
+    )
+
+
+class _StubCharacterCardDB:
+    """Minimal ``chachanotes_db`` double exposing only the character-card read
+    the native handoff consumer needs (task-427). Deliberately narrow: it has
+    no ``add_conversation``/``client_id`` surface, so any attempted
+    persistence during the seeded-greeting write fails and is swallowed by
+    the consumer's own try/except -- the in-memory session/message state is
+    what these tests assert on.
+    """
+
+    def __init__(self, card: dict) -> None:
+        self._card = card
+
+    def get_character_card_by_id(self, character_id):
+        return self._card
+
+
+@pytest.mark.asyncio
+async def test_native_start_chat_builds_character_session_with_greeting():
+    """Start Chat on the native Console handoff branch should create a
+    dedicated character-bound session with the greeting seeded (task-427)."""
+    from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+        ConsoleHarness,
+    )
+    from Tests.UI.test_screen_navigation import _build_test_app
+    from tldw_chatbook.Chat.console_chat_models import (
+        CONSOLE_GLOBAL_WORKSPACE_ID,
+        ConsoleMessageRole,
+    )
+
+    app = _build_test_app()
+    app.chachanotes_db = _StubCharacterCardDB(
+        {
+            "name": "Elara",
+            "first_message": "Greetings, {{user}}.",
+            "system_prompt": "You are Elara, a forest guide.",
+            "personality": "Warm and curious",
+            "description": "An elven ranger",
+            "scenario": "A quiet forest clearing",
+        }
+    )
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        await pilot.pause()
+        screen = host.screen_stack[-1]
+
+        app.pending_chat_handoff = _character_start_chat_payload(
+            character_id=7, name="Elara", first_message="Greetings, {{user}}."
+        )
+
+        await screen._consume_pending_chat_handoff()
+        await pilot.pause()
+
+        store = screen._ensure_console_chat_store()
+        session = store._sessions[store.active_session_id]
+        assert session.character_id == 7
+        assert session.character_name == "Elara"
+        assert session.title == "Chat with Elara"
+        assert session.workspace_id == CONSOLE_GLOBAL_WORKSPACE_ID
+        msgs = store.messages_for_session(session.id)
+        assert msgs[0].role is ConsoleMessageRole.ASSISTANT
+        assert msgs[0].content == "Greetings, User."  # {{user}} substituted
+        assert "Stay in character." not in (session.settings.system_prompt or "")
+        assert app.pending_chat_handoff is None
+
+
+@pytest.mark.asyncio
+async def test_native_start_chat_falls_back_when_card_fetch_fails():
+    """A character-card fetch failure must not raise; the handoff should
+    fall back to the staged-context lane with no character session
+    created (task-427)."""
+    from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+        ConsoleHarness,
+    )
+    from Tests.UI.test_screen_navigation import _build_test_app
+
+    app = _build_test_app()
+    app.chachanotes_db = _StubCharacterCardDB({"name": "Elara"})
+    app.chachanotes_db.get_character_card_by_id = lambda *_a, **_k: (
+        _ for _ in ()
+    ).throw(RuntimeError("boom"))
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        await pilot.pause()
+        screen = host.screen_stack[-1]
+
+        app.pending_chat_handoff = _character_start_chat_payload(
+            character_id=7, name="Elara", first_message="Hi"
+        )
+
+        await screen._consume_pending_chat_handoff()  # must not raise
+        await pilot.pause()
+
+        store = screen._ensure_console_chat_store()
+        active = (
+            store._sessions.get(store.active_session_id)
+            if store.active_session_id
+            else None
+        )
+        assert active is None or active.character_id is None
+        assert app.pending_chat_handoff is None
+
+
 @pytest.mark.asyncio
 async def test_chat_screen_pending_handoff_consumer_is_reentrant_safe():
     payload = ChatHandoffPayload(

--- a/Tests/UI/test_chat_first_handoffs.py
+++ b/Tests/UI/test_chat_first_handoffs.py
@@ -413,6 +413,51 @@ async def test_native_start_chat_falls_back_when_card_fetch_fails():
 
 
 @pytest.mark.asyncio
+async def test_resume_restores_character_identity():
+    """Resuming a saved character conversation after an app restart must
+    restore ``session.character_id`` so the plain-provider gate (task-3)
+    keeps routing the resumed conversation's sends off the agent loop
+    (task-427, task-5)."""
+    from Tests.UI.test_console_native_chat_flow import StaticConversationTreeService
+    from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+        ConsoleHarness,
+    )
+    from Tests.UI.test_screen_navigation import _build_test_app
+
+    tree = {
+        "conversation": {
+            "conversation_id": "conv-elara-1",
+            "title": "Chat with Elara",
+            "character_id": 7,
+            "workspace_id": None,
+            "system_prompt": None,
+            "metadata": None,
+        },
+        "root_threads": [],
+        "pagination": {"total_root_threads": 0},
+    }
+    app = _build_test_app()
+    app.chat_conversation_scope_service = StaticConversationTreeService(
+        {"conv-elara-1": tree}
+    )
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        await pilot.pause()
+        screen = host.screen_stack[-1]
+
+        resumed = await screen._resume_console_workspace_conversation(
+            "conv-elara-1"
+        )
+        await pilot.pause()
+
+        assert resumed is True
+        store = screen._ensure_console_chat_store()
+        session = store._sessions[store.active_session_id]
+        assert session.character_id == 7
+
+
+@pytest.mark.asyncio
 async def test_chat_screen_pending_handoff_consumer_is_reentrant_safe():
     payload = ChatHandoffPayload(
         source="notes",

--- a/Tests/UI/test_chat_first_handoffs.py
+++ b/Tests/UI/test_chat_first_handoffs.py
@@ -413,6 +413,54 @@ async def test_native_start_chat_falls_back_when_card_fetch_fails():
 
 
 @pytest.mark.asyncio
+async def test_native_start_chat_survives_post_seed_sync_failure():
+    """A post-seed UI sync/focus failure must not leave the handoff
+    unconsumed. The character session (and its greeting) is already
+    durably created by the time ``_sync_native_console_chat_ui`` runs, so a
+    raise there must not propagate out of
+    ``_start_character_console_session`` -- otherwise the caller would
+    never clear ``pending_chat_handoff`` and a later re-consume (e.g. a
+    screen re-mount timer) would build a SECOND durable character session
+    (task-427 polish finding 1)."""
+    from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+        ConsoleHarness,
+    )
+    from Tests.UI.test_screen_navigation import _build_test_app
+
+    app = _build_test_app()
+    app.chachanotes_db = _StubCharacterCardDB(
+        {
+            "name": "Elara",
+            "first_message": "Greetings, {{user}}.",
+            "system_prompt": "You are Elara, a forest guide.",
+        }
+    )
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        await pilot.pause()
+        screen = host.screen_stack[-1]
+
+        async def _boom():
+            raise RuntimeError("sync boom")
+
+        screen._sync_native_console_chat_ui = _boom
+
+        payload = _character_start_chat_payload(
+            character_id=7, name="Elara", first_message="Greetings, {{user}}."
+        )
+
+        result = await screen._start_character_console_session(payload)
+
+        assert result is True
+        store = screen._ensure_console_chat_store()
+        character_sessions = [
+            s for s in store._sessions.values() if s.character_id == 7
+        ]
+        assert len(character_sessions) == 1
+
+
+@pytest.mark.asyncio
 async def test_resume_restores_character_identity():
     """Resuming a saved character conversation after an app restart must
     restore ``session.character_id`` so the plain-provider gate (task-3)

--- a/Tests/UI/test_chat_first_handoffs.py
+++ b/Tests/UI/test_chat_first_handoffs.py
@@ -506,6 +506,113 @@ async def test_resume_restores_character_identity():
 
 
 @pytest.mark.asyncio
+async def test_resume_restores_character_label_for_identity_row():
+    """Resuming a character conversation must rehydrate the character name and
+    ``settings.character_label`` from the card so the settings identity row
+    reads "Character: <name>" instead of the Persona fallback (task-427).
+
+    The persisted conversation row carries only ``character_id``; the label is
+    resolved best-effort from the character card.
+    """
+    from Tests.UI.test_console_native_chat_flow import StaticConversationTreeService
+    from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+        ConsoleHarness,
+    )
+    from Tests.UI.test_screen_navigation import _build_test_app
+
+    tree = {
+        "conversation": {
+            "conversation_id": "conv-elara-1",
+            "title": "Chat with Elara",
+            "character_id": 7,
+            "workspace_id": None,
+            "system_prompt": None,
+            "metadata": None,
+        },
+        "root_threads": [],
+        "pagination": {"total_root_threads": 0},
+    }
+    app = _build_test_app()
+    app.chat_conversation_scope_service = StaticConversationTreeService(
+        {"conv-elara-1": tree}
+    )
+    app.chachanotes_db = _StubCharacterCardDB({"name": "Elara"})
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        await pilot.pause()
+        screen = host.screen_stack[-1]
+
+        resumed = await screen._resume_console_workspace_conversation("conv-elara-1")
+        await pilot.pause()
+
+        assert resumed is True
+        store = screen._ensure_console_chat_store()
+        session = store._sessions[store.active_session_id]
+        assert session.character_id == 7
+        assert session.character_name == "Elara"
+        assert session.settings is not None
+        assert session.settings.character_label == "Elara"
+
+
+@pytest.mark.asyncio
+async def test_resume_clears_inherited_label_when_card_unresolved():
+    """A character resume whose card cannot be resolved must clear any
+    inherited ``character_label`` rather than display a *different* active
+    character's name (settings are inherited from the active session)."""
+    from dataclasses import replace
+
+    from Tests.UI.test_console_native_chat_flow import StaticConversationTreeService
+    from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+        ConsoleHarness,
+    )
+    from Tests.UI.test_screen_navigation import _build_test_app
+    from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
+
+    tree = {
+        "conversation": {
+            "conversation_id": "conv-missing-card",
+            "title": "Chat with Ghost",
+            "character_id": 99,
+            "workspace_id": None,
+            "system_prompt": None,
+            "metadata": None,
+        },
+        "root_threads": [],
+        "pagination": {"total_root_threads": 0},
+    }
+    app = _build_test_app()
+    app.chat_conversation_scope_service = StaticConversationTreeService(
+        {"conv-missing-card": tree}
+    )
+    # Card 99 does not exist -> name resolves to "".
+    app.chachanotes_db = _StubCharacterCardDB(None)
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        await pilot.pause()
+        screen = host.screen_stack[-1]
+        store = screen._ensure_console_chat_store()
+        # Simulate a *different* character session being active first, whose
+        # label would otherwise be inherited by the resumed session.
+        active = store.ensure_session()
+        if active.settings is not None:
+            active.settings = replace(active.settings, character_label="Someone Else")
+        else:
+            active.settings = ConsoleSessionSettings(character_label="Someone Else")
+
+        resumed = await screen._resume_console_workspace_conversation(
+            "conv-missing-card"
+        )
+        await pilot.pause()
+
+        assert resumed is True
+        session = store._sessions[store.active_session_id]
+        assert session.character_id == 99
+        assert (session.settings.character_label or "") == ""
+
+
+@pytest.mark.asyncio
 async def test_chat_screen_pending_handoff_consumer_is_reentrant_safe():
     payload = ChatHandoffPayload(
         source="notes",

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -6654,6 +6654,43 @@ def test_native_console_state_round_trip_preserves_session_system_prompt():
     assert restored_session.settings.system_prompt == "Be terse and cite sources."
 
 
+def test_native_console_state_round_trip_preserves_character_identity():
+    """A character-bound session must keep ``character_id``/``character_name``
+    across a native Console screen-state save/restore (task-427).
+
+    Without round-tripping these fields, a screen-state restore silently
+    flips a character session back to a generic one (``character_id=None``),
+    disabling the plain-provider gate and losing the character identity that
+    ``_serialize_native_console_state`` is supposed to preserve.
+    """
+    store = ConsoleChatStore()
+    session = ConsoleChatSession(
+        id="session-a",
+        title="Chat with Elara",
+        character_id=7,
+        character_name="Elara",
+    )
+    store.restore_state(
+        sessions=[session],
+        messages_by_session={session.id: []},
+        active_session_id=session.id,
+    )
+    screen = _bare_console_screen(store)
+
+    payload = screen._serialize_native_console_state()
+    assert payload is not None
+    assert payload["sessions"][0]["character_id"] == 7
+    assert payload["sessions"][0]["character_name"] == "Elara"
+
+    restored_store = ConsoleChatStore()
+    restored_screen = _bare_console_screen(restored_store)
+    restored_screen._restore_native_console_state(payload)
+
+    restored_session = restored_store.sessions()[0]
+    assert restored_session.character_id == 7
+    assert restored_session.character_name == "Elara"
+
+
 def test_native_console_state_restore_tolerates_legacy_payload_without_updated_at():
     """Verify legacy saved states (no ``updated_at`` key) still restore.
 

--- a/backlog/tasks/task-427 - Start-Chat-creates-a-real-character-conversation-in-native-Console.md
+++ b/backlog/tasks/task-427 - Start-Chat-creates-a-real-character-conversation-in-native-Console.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-427
 title: Start Chat creates a real character conversation in native Console
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-21 09:38'
+updated_date: '2026-07-22 02:14'
 labels:
   - roleplay
   - console
@@ -20,8 +21,29 @@ Filed from the RP/character-card UX review (Docs/superpowers/qa/rp-ux-review-202
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Start Chat on a character opens Console with the character greeting visible as the first assistant message
-- [ ] #2 The created conversation is titled/labelled with the character name and retains that identity across app restarts
-- [ ] #3 The first user send replies in character (card system prompt and definition applied) without the user re-describing the character
-- [ ] #4 Character sends do not route through the agent/sub-agent harness unless the user has explicitly enabled an agent profile
+- [x] #1 Start Chat on a character opens Console with the character greeting visible as the first assistant message
+- [x] #2 The created conversation is titled/labelled with the character name and retains that identity across app restarts
+- [x] #3 The first user send replies in character (card system prompt and definition applied) without the user re-describing the character
+- [x] #4 Character sends do not route through the agent/sub-agent harness unless the user has explicitly enabled an agent profile
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Start Chat from the Roleplay workbench now opens a REAL character conversation in the native Console (was: invisible staged-context dead-end where the agent sub-agent asked the user to re-describe the character). No ChaChaNotes migration (conversations.character_id already existed at schema v22).
+
+Delivered across 5 TDD tasks + review fixes:
+1. character_id/character_name on ConsoleChatSession; persist_session_if_needed passes assistant_kind='character'+character_id when bound (console_chat_store.py).
+2. Greeting is display-only to the provider: _provider_message_payloads drops leading pre-first-user assistant turns (avoids Anthropic/Gemini assistant-first 400), matching the preview; regenerate/continue guarded against a lone-greeting payload (console_chat_controller.py).
+3. Plain-provider gate keyed on the message-OWNING session's character_id (race-free via session_id_for_message), so character sends never hit the agent harness; closed-session KeyError guard added (console_chat_controller.py).
+4. Native handoff branch _start_character_console_session: inline asyncio.to_thread card fetch (get_character_card_by_id) with guarded fallback to staged-context, builds the effective system prompt like the preview (system_prompt+personality+description+scenario), creates a dedicated GLOBAL-workspace session titled 'Chat with {name}', seeds the greeting as the first ASSISTANT message, then _sync_native_console_chat_ui() so the card prompt reaches the FIRST send; post-seed sync guarded so a failure can't duplicate the conversation (chat_screen.py).
+5. Restore character_id on resume so a resumed character conversation stays on the plain path (chat_screen.py).
+
+Deferred (out of scope, per design §Scope): character-scoped dictionaries/world-info on native send; preview 'Open in Console' transcript continuation; per-session agent opt-in UI.
+
+Design: Docs/superpowers/specs/2026-07-21-start-chat-character-conversation-design.md (rev 2, adversarial-reviewed). Plan: Docs/superpowers/plans/2026-07-21-start-chat-character-conversation.md.
+
+Tests: store/controller/handoff suites green (227 in the 3 affected files); whole-branch opus review = ready to merge, no Critical/Important. LIVE-VERIFIED in the real TUI (all 4 ACs incl. across an app RESTART): greeting as first assistant message, 'Chat with {name}' title persisted, in-character reply with system prompt applied ([sys:on]), plain provider path with no sub-agent dead-end.
+
+Files: tldw_chatbook/Chat/console_chat_store.py, tldw_chatbook/Chat/console_chat_controller.py, tldw_chatbook/UI/Screens/chat_screen.py + their tests.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -2064,7 +2064,10 @@ class ConsoleChatController:
         prefill: str | None = None,
         prefill_from_one_shot: bool = False,
     ) -> ConsoleSubmitResult:
-        owner_id = self.store.session_id_for_message(assistant_message_id)
+        try:
+            owner_id = self.store.session_id_for_message(assistant_message_id)
+        except KeyError:
+            return self._session_closed_result()
         owner = next(
             (s for s in self.store.sessions() if s.id == owner_id), None
         )

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -1135,6 +1135,11 @@ class ConsoleChatController:
             session_id, message_id
         )
         self._ensure_user_continuation_instruction(provider_messages)
+        if not self._has_user_turn(provider_messages):
+            return self._block(
+                session_id,
+                "Nothing to continue before the character's opening line.",
+            )
         provider_messages, refuse = await self._apply_skill_substitution(
             provider_messages
         )
@@ -1194,6 +1199,11 @@ class ConsoleChatController:
             before_message_id=message_id,
         )
         self._ensure_user_continuation_instruction(provider_messages)
+        if not self._has_user_turn(provider_messages):
+            return self._block(
+                session_id,
+                "Nothing to regenerate before the character's opening line.",
+            )
         provider_messages, refuse = await self._apply_skill_substitution(
             provider_messages
         )
@@ -1607,6 +1617,12 @@ class ConsoleChatController:
                     "content": CONSOLE_CONTINUE_INSTRUCTION,
                 }
             )
+
+    @staticmethod
+    def _has_user_turn(provider_messages: list[dict[str, Any]]) -> bool:
+        return any(
+            m.get("role") == ConsoleMessageRole.USER.value for m in provider_messages
+        )
 
     def _pinned_prefill_for_session(self, session_id: str) -> str | None:
         """Return the session's pinned response prefill, if any."""
@@ -2675,6 +2691,7 @@ class ConsoleChatController:
             budget -= take
 
         payloads: list[dict[str, Any]] = []
+        seen_user = False
         for message in session_messages:
             if message.role not in {
                 ConsoleMessageRole.USER,
@@ -2683,6 +2700,13 @@ class ConsoleChatController:
                 continue
             if skip_failed and message.status == "failed":
                 continue
+            # A seeded character greeting is a display-only assistant turn:
+            # keep it out of the provider payload so strict providers (Anthropic,
+            # Gemini) never see an assistant-first message array (task-427).
+            if not seen_user and message.role is ConsoleMessageRole.ASSISTANT:
+                continue
+            if message.role is ConsoleMessageRole.USER:
+                seen_user = True
             text = (
                 message.variants.current.content
                 if use_variant_content and message.variants is not None

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -1138,7 +1138,7 @@ class ConsoleChatController:
         if not self._has_user_turn(provider_messages):
             return self._block(
                 session_id,
-                "Nothing to continue before the character's opening line.",
+                "Nothing to continue before the first message.",
             )
         provider_messages, refuse = await self._apply_skill_substitution(
             provider_messages
@@ -1202,7 +1202,7 @@ class ConsoleChatController:
         if not self._has_user_turn(provider_messages):
             return self._block(
                 session_id,
-                "Nothing to regenerate before the character's opening line.",
+                "Nothing to regenerate before the first message.",
             )
         provider_messages, refuse = await self._apply_skill_substitution(
             provider_messages

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -2064,10 +2064,21 @@ class ConsoleChatController:
         prefill: str | None = None,
         prefill_from_one_shot: bool = False,
     ) -> ConsoleSubmitResult:
+        owner_id = self.store.session_id_for_message(assistant_message_id)
+        owner = next(
+            (s for s in self.store.sessions() if s.id == owner_id), None
+        )
+        # task-427: a character session always takes the plain-provider
+        # path, even with the global agent runtime enabled and a bridge
+        # present. Keyed on the message's OWNING session (looked up here,
+        # not the controller's active session) so a session switch racing
+        # this send can't flip which branch a still-in-flight message uses.
+        force_plain = owner is not None and owner.character_id is not None
         if (
             self._agent_runtime_enabled
             and self._agent_bridge is not None
             and not prefill
+            and not force_plain
         ):
             return await self._run_agent_reply(
                 resolution=resolution,

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -175,6 +175,11 @@ class ConsoleChatSession:
     #: ``SessionScopeHolder``. ``persist_session_if_needed`` flushes it
     #: through to durable storage exactly once, at first persistence.
     rag_scope_holder: SessionScopeHolder = field(default_factory=SessionScopeHolder)
+    #: When set, this is a character-bound session: it persists with the
+    #: character's id, forces the plain-provider path, and restores as a
+    #: character session (task-427). ``None`` = a normal Console session.
+    character_id: int | None = None
+    character_name: str | None = None
 
 
 class ConsoleChatStore:
@@ -986,15 +991,26 @@ class ConsoleChatStore:
         if self.persistence is None:
             return None
         scope_type, persisted_workspace_id = self._persistence_scope(session)
+        if session.character_id is not None:
+            identity_kwargs = {
+                "assistant_kind": "character",
+                "assistant_id": str(session.character_id),
+                "character_id": session.character_id,
+                "character_name": session.character_name,
+            }
+        else:
+            identity_kwargs = {
+                "assistant_kind": "generic",
+                "assistant_id": "console",
+            }
         session.persisted_conversation_id = self.persistence.create_conversation(
-            assistant_kind="generic",
-            assistant_id="console",
             conversation_title=session.title,
             workspace_id=persisted_workspace_id,
             scope_type=scope_type,
             system_prompt=session.settings.system_prompt
             if session.settings is not None
             else None,
+            **identity_kwargs,
         )
         pinned_prefill = (
             session.settings.pinned_prefill if session.settings is not None else None

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -4069,6 +4069,31 @@ class ChatScreen(BaseAppScreen):
             settings, system_prompt=system_prompt, pinned_prefill=pinned_prefill
         )
 
+    async def _resolve_resumed_character_name(self, character_id: int) -> str:
+        """Return a resumed character's display name from its card, or ``""``.
+
+        Args:
+            character_id: The persisted conversation's character id.
+
+        Returns:
+            The character card's name, or an empty string when the DB is
+            unavailable, the card is missing, or the fetch fails (best-effort:
+            the caller keeps ``character_id`` set regardless).
+        """
+        db = getattr(self.app_instance, "chachanotes_db", None)
+        if db is None:
+            return ""
+        try:
+            card = await asyncio.to_thread(db.get_character_card_by_id, character_id)
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Resume: character card fetch failed; identity row falls back."
+            )
+            return ""
+        if not card:
+            return ""
+        return str(card.get("name") or "").strip()
+
     async def _resume_console_workspace_conversation(
         self,
         conversation_id: str,
@@ -4162,9 +4187,31 @@ class ChatScreen(BaseAppScreen):
         raw_character_id = conversation.get("character_id")
         if raw_character_id is not None:
             try:
-                session.character_id = int(raw_character_id)
+                character_id = int(raw_character_id)
             except (TypeError, ValueError):
-                session.character_id = None
+                character_id = None
+            session.character_id = character_id
+            if character_id is not None:
+                # The persisted conversation row carries only the id, so
+                # rehydrate the character name/label from the card. This keeps
+                # the settings identity row reading "Character: <name>" after
+                # resume instead of the Persona fallback. Best-effort: a
+                # missing/failed card leaves ``character_id`` (and the routing
+                # gate) intact.
+                character_name = await self._resolve_resumed_character_name(
+                    character_id
+                )
+                if character_name:
+                    session.character_name = character_name
+                # Always (re)set the label on a character resume -- to the
+                # resolved name, or clear it when unresolved. ``settings`` are
+                # otherwise inherited from the currently active session, so
+                # leaving an inherited ``character_label`` in place would make
+                # a card-less resume show a *different* character's name.
+                if session.settings is not None:
+                    session.settings = replace(
+                        session.settings, character_label=character_name
+                    )
         self._set_active_workspace_for_console_session(session.id)
         # task-9/task-13: warm the EFFECTIVE (conversation ∩ workspace)
         # scope cache for this session now (off-loop) so the Inspector row
@@ -9075,6 +9122,11 @@ class ChatScreen(BaseAppScreen):
                     "draft": session.draft,
                     "settings": self._serialize_console_settings(session.settings),
                     "updated_at": session.updated_at,
+                    # task-427: round-trip the character binding so a screen-
+                    # state restore keeps a character session on the plain-
+                    # provider gate instead of reverting it to a generic one.
+                    "character_id": session.character_id,
+                    "character_name": session.character_name,
                 }
                 for session in store.sessions()
             ],
@@ -9129,6 +9181,18 @@ class ChatScreen(BaseAppScreen):
             raw_updated_at = raw_session.get("updated_at")
             if raw_updated_at:
                 session_kwargs["updated_at"] = str(raw_updated_at)
+            # task-427: restore the character binding when present. Legacy
+            # payloads (saved before these keys existed) simply omit them and
+            # keep the ConsoleChatSession ``None`` defaults.
+            raw_character_id = raw_session.get("character_id")
+            if raw_character_id is not None:
+                try:
+                    session_kwargs["character_id"] = int(raw_character_id)
+                except (TypeError, ValueError):
+                    pass
+            raw_character_name = raw_session.get("character_name")
+            if raw_character_name is not None:
+                session_kwargs["character_name"] = str(raw_character_name)
             session = ConsoleChatSession(**session_kwargs)
             restored_sessions.append(session)
             restored_messages_by_session[session.id] = []
@@ -9587,8 +9651,14 @@ class ChatScreen(BaseAppScreen):
     async def _start_character_console_session(self, payload: ChatHandoffPayload) -> bool:
         """Build a dedicated character conversation from a Start-Chat handoff.
 
-        Returns True when a character session was created; False to let the
-        caller fall back to the staged-context path (task-427).
+        Args:
+            payload: The Personas Start-Chat handoff staged into the native
+                Console (its metadata carries the character identity).
+
+        Returns:
+            ``True`` when a character session was created (the caller then
+            marks the handoff consumed); ``False`` to let the caller fall back
+            to the staged-context path (task-427).
         """
         identity = _character_session_identity_from_handoff(payload)
         if identity is None:

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -4155,6 +4155,16 @@ class ChatScreen(BaseAppScreen):
             messages=messages,
             settings=self._console_session_settings_for_resume(conversation),
         )
+        # TASK-427: the plain-provider gate (task-3) keys off the active
+        # session's ``character_id`` -- restore it from the persisted
+        # conversation row so a character conversation resumed after an
+        # app restart keeps routing sends off the agent loop.
+        raw_character_id = conversation.get("character_id")
+        if raw_character_id is not None:
+            try:
+                session.character_id = int(raw_character_id)
+            except (TypeError, ValueError):
+                session.character_id = None
         self._set_active_workspace_for_console_session(session.id)
         # task-9/task-13: warm the EFFECTIVE (conversation ∩ workspace)
         # scope cache for this session now (off-loop) so the Inspector row

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -9631,7 +9631,7 @@ class ChatScreen(BaseAppScreen):
             workspace_id=CONSOLE_GLOBAL_WORKSPACE_ID,
             settings=settings,
         )
-        session.character_id = int(character_id)
+        session.character_id = character_id
         session.character_name = name
         if greeting:
             try:
@@ -9645,8 +9645,21 @@ class ChatScreen(BaseAppScreen):
                 logger.opt(exception=True).warning(
                     "Start Chat: greeting seed/persist failed; continuing."
                 )
-        await self._sync_native_console_chat_ui()
-        self._focus_console_composer_if_needed(force=True)
+        try:
+            await self._sync_native_console_chat_ui()
+            self._focus_console_composer_if_needed(force=True)
+        except Exception:
+            # The character session (and its greeting) is already durably
+            # created above -- a UI-sync/focus failure here must not
+            # propagate, or the caller would never clear
+            # ``pending_chat_handoff`` and a later re-consume (e.g. a
+            # screen re-mount timer) would build a SECOND durable
+            # character session.
+            logger.opt(exception=True).warning(
+                "Start Chat: post-seed console sync/focus failed; character "
+                "session was already created and the handoff is still "
+                "considered consumed."
+            )
         return True
 
     async def _consume_pending_chat_handoff(self) -> None:

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -9574,6 +9574,71 @@ class ChatScreen(BaseAppScreen):
             handoff_payload=payload,
         )
 
+    async def _start_character_console_session(self, payload: ChatHandoffPayload) -> bool:
+        """Build a dedicated character conversation from a Start-Chat handoff.
+
+        Returns True when a character session was created; False to let the
+        caller fall back to the staged-context path (task-427).
+        """
+        identity = _character_session_identity_from_handoff(payload)
+        if identity is None:
+            return False
+        character_id, _name_hint, _assistant_id = identity
+        db = getattr(self.app_instance, "chachanotes_db", None)
+        if db is None:
+            return False
+        try:
+            card = await asyncio.to_thread(db.get_character_card_by_id, character_id)
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Start Chat: character card fetch failed; staging context instead."
+            )
+            return False
+        if not card:
+            return False
+
+        # Local import matches this module's existing convention of
+        # deferring Character_Chat submodule imports (they pull in Pillow
+        # and CharactersRAGDB) rather than importing them at module scope.
+        from ...Character_Chat.Character_Chat_Lib import replace_placeholders
+
+        name = str(card.get("name") or _name_hint or "").strip() or "Character"
+        parts = [
+            str(card.get(key) or "").strip()
+            for key in ("system_prompt", "personality", "description", "scenario")
+        ]
+        system_prompt = "\n".join(p for p in parts if p) or "Stay in character."
+        greeting = replace_placeholders(str(card.get("first_message") or ""), name, "User")
+
+        store = self._ensure_console_chat_store()
+        settings = replace(
+            self._default_console_session_settings(),
+            system_prompt=system_prompt,
+            character_label=name,
+        )
+        session = store.create_session(
+            title=f"Chat with {name}",
+            workspace_id=CONSOLE_GLOBAL_WORKSPACE_ID,
+            settings=settings,
+        )
+        session.character_id = int(character_id)
+        session.character_name = name
+        if greeting:
+            try:
+                store.append_message(
+                    session.id,
+                    role=ConsoleMessageRole.ASSISTANT,
+                    content=greeting,
+                    persist=True,
+                )
+            except Exception:
+                logger.opt(exception=True).warning(
+                    "Start Chat: greeting seed/persist failed; continuing."
+                )
+        await self._sync_native_console_chat_ui()
+        self._focus_console_composer_if_needed(force=True)
+        return True
+
     async def _consume_pending_chat_handoff(self) -> None:
         payload = getattr(self.app_instance, "pending_chat_handoff", None)
         if payload is None:
@@ -9590,9 +9655,16 @@ class ChatScreen(BaseAppScreen):
 
             tab_container = self._get_tab_container()
             if tab_container is None:
-                # The native Console composes no legacy tab surface; stage the
-                # handoff into the Console live-work lane so the context lands
-                # in Staged Context instead of being dropped with a warning.
+                # The native Console composes no legacy tab surface. A
+                # Personas Start-Chat character handoff gets a dedicated
+                # character-bound session with its greeting seeded
+                # (task-427); anything else -- or a character session that
+                # failed to build -- stages into the Console live-work lane
+                # so the context lands in Staged Context instead of being
+                # dropped with a warning.
+                if await self._start_character_console_session(payload):
+                    self.app_instance.pending_chat_handoff = None
+                    return
                 self._stage_handoff_as_console_live_work(payload)
                 self.app_instance.pending_chat_handoff = None
                 return


### PR DESCRIPTION
## What & why (P0 from the RP UX review)

"Start Chat" / "Open in Console" from the Roleplay workbench did **not** open a live character conversation. The handoff degraded to invisible "staged context": blank transcript, no greeting, no character identity, composer prefilled with a meta-instruction — and sending it routed through the agent harness, whose sub-agent replied *"Please provide the previous conversation and the character details you'd like me to use."* The RP core loop was a dead end (TASK-427).

Now **Start Chat opens a real, character-identified Console conversation**: the greeting is the first assistant message, the card system prompt is applied on send, replies come from the plain provider (no agent), and the identity persists across restarts.

**No ChaChaNotes migration** — `conversations.character_id` already existed (schema v22); the native session path just never passed it.

## How (5 TDD tasks + review fixes)

1. **Session identity + persist** — `character_id`/`character_name` on `ConsoleChatSession`; `persist_session_if_needed` writes `assistant_kind="character"` + `character_id` when bound.
2. **Greeting display-only to the provider** — `_provider_message_payloads` drops leading pre-first-user assistant turns, so the first send is `[system, user]` (avoids the **Anthropic/Gemini assistant-first 400**), matching the Personas preview; regenerate/continue guarded against a lone-greeting payload.
3. **Plain-provider gate** — keyed on the **message-owning** session's `character_id` (race-free via `session_id_for_message`), so character sends never hit the agent harness; closed-session `KeyError` guard added.
4. **Native handoff branch** — `_start_character_console_session`: inline `asyncio.to_thread` card fetch with a guarded **fallback to staged-context**, effective system prompt built like the preview, a dedicated **global-workspace** session titled "Chat with {name}", greeting seeded as the first assistant message, then `_sync_native_console_chat_ui()` so the card prompt reaches the **first** send (the controller-`system_prompt`-vs-session-settings seam the design flagged); post-seed sync guarded so a failure can't duplicate the conversation.
5. **Restart restore** — `character_id` restored on resume so a resumed character conversation stays on the plain path.

Deferred (per design scope): character-scoped dictionaries/world-info on native send; preview "Open in Console" continuation; per-session agent opt-in UI.

## AC coverage
1. Greeting visible as the first assistant message ✅
2. Titled/labelled with the character, persists across restart ✅
3. First send replies in character (card system prompt applied) ✅
4. Character sends do not route through the agent harness ✅

## Verification
- Store / controller / handoff suites green (227 in the 3 affected files); `test_console_live_work_handoffs.py`'s 11 failures are pre-existing (schedules/subscriptions), **identical at merge-base and head**.
- **Whole-branch review (opus): ready to merge, no Critical/Important** — traced every cross-task seam (first-send system prompt bridge, `character_id`-before-persist, greeting-drop across persist/restore/retry/continue, global-workspace reuse).
- **Live-verified in the real TUI, all 4 ACs including across an app restart:** Start Chat → "Chat with {name}" with the greeting as the first assistant message → in-character reply with the system prompt applied (`[sys:on]`), plain provider, no sub-agent → restart → conversation still titled/identified, further send still plain.

Design: `Docs/superpowers/specs/2026-07-21-start-chat-character-conversation-design.md` (rev 2). Plan: `Docs/superpowers/plans/2026-07-21-start-chat-character-conversation.md`.

Independent of the 425/426 preview PRs (touches console/chat_screen, not the preview). CI expected cancelled per repo convention; verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Start Chat from the Roleplay workbench now opens a real character conversation in the native Console. It seeds the greeting, applies the card prompt on first send, uses the plain provider (not the agent harness), and the character identity persists across restarts and screen-state restores (TASK-427).

- **New Features**
  - Start Chat creates a character-bound session in the global workspace titled “Chat with {name}”.
  - Greeting is the first assistant message and excluded from provider payloads to avoid assistant-first errors.
  - Card system prompt is applied on the first send via native UI sync.
  - Character sessions always use the plain provider path; the agent bridge is bypassed. Identity restores on resume.

- **Bug Fixes**
  - Block regenerate/continue before the first user message.
  - Guard session-close races in message-owner lookup and return “Session closed.” cleanly.
  - Native handoff falls back to staged context if the card fetch fails; post-seed UI sync/focus is guarded to prevent duplicate sessions.
  - Native Console screen-state save/restore now round-trips `character_id`/`character_name`. Resume rehydrates the character label from the card and clears inherited labels when unresolved, so identity is preserved end-to-end.

<sup>Written for commit fe27ba49ff11071b1dad0677e500010bb32d8ef3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

