### PR TITLE
Roleplay P3a — Characters/Personas library: pagination + sort + tag filter

### DIFF
--- a/Docs/superpowers/plans/2026-07-21-roleplay-p3a-library-scale-find.md
+++ b/Docs/superpowers/plans/2026-07-21-roleplay-p3a-library-scale-find.md
@@ -1,0 +1,1200 @@
+# Roleplay P3a — Library Pagination + Sort + Tag Filter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the shared Roleplay library list scale (page-at-a-time instead of mounting every row) and add a sort control + a characters-only tag filter, across the SQL-backed Characters mode and the file-backed Personas mode.
+
+**Architecture:** Add three new read-only DB methods (paged list + count + distinct-tags) that compose search (FTS-join) + tag (`json_each`, json-valid-guarded) + a whitelisted `ORDER BY` + `LIMIT/OFFSET`; thin `Character_Chat_Lib` wrappers shape them for the UI. Personas filter/sort/page in a pure helper over the ≤100 returned profiles (no backend edit, no tags). The shared `PersonasLibraryPane` gains a sort button, a tag button, and a page bar (all gated by mode); the screen owns the paging state, a `(search,tag)`-keyed count cache, and the five `self._characters` cache-assumption fixes.
+
+**Tech Stack:** Python 3.11+, Textual, SQLite (FTS5 + JSON1), pytest.
+
+**Spec:** `Docs/superpowers/specs/2026-07-21-roleplay-p3a-library-scale-find-design.md` (committed `290249b1e`).
+
+## Global Constraints
+
+- **NO schema migration** — reads existing `character_cards` columns only; ChaChaNotes stays **v22** (`_CURRENT_SCHEMA_VERSION = 22`, ChaChaNotes_DB.py:154). Do not touch the DDL or `migration_steps`.
+- **Parameterized SQL only.** The ONLY dynamic SQL fragment is the `ORDER BY` clause, taken from the fixed `_CHARACTER_SORT_CLAUSES` whitelist keyed by an enum string; `search_term` and `tag` are always bound `?` parameters. Never interpolate user input into SQL.
+- **`json_each` MUST be json-valid-guarded:** `json_each(CASE WHEN json_valid(<col>) THEN <col> ELSE '[]' END)` everywhere — bare `json_each` raises on NULL/invalid, and rows can hold NULL or non-JSON tags.
+- **`PERSONAS_LIBRARY_PAGE_SIZE = 50`** (one constant).
+- **Tag filter is characters-only** — persona profiles have no tags. Sort + page apply to characters and personas; **dict/lore modes are unchanged** (new controls gated off; `update_rows` stays backward-compatible when page kwargs are omitted).
+- **All screen DB I/O off-thread** via `asyncio.to_thread`, wrapped so a backend error notifies (never crashes the worker); reuse the existing exclusive `personas-library-search` worker group; extend the stale-snapshot guard to include `(mode, search, sort, tag, offset)`; **reset offset to 0 on any filter change**; clamp offset into range.
+- **Count is cached keyed by `(search_term, tag)`** — a prev/next page click or sort change reuses it and issues only the page query.
+- **Selection is by id** (`character_handler.load_character`) — never resolve a selected character by scanning `self._characters`.
+- **Real-DB tests** (fakes mask bugs). Character DB tests seed >2 pages (≥120 rows) with varied tags/timestamps **plus one NULL-tags row and one non-JSON-tags row** and assert the list/count/distinct queries never raise.
+- **Implementers stage ONLY their task's files** — never `git add -A`, never stage `.superpowers/`.
+- **No background/broad test sweeps; never broad-`pkill` pytest** (multi-session env) — scope commands to this worktree.
+- **Branch:** `claude/roleplay-p3a-library-scale-find` off `origin/dev` (`8f1d2cae8`). **Test command** (prefix every pytest run):
+  ```bash
+  HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest <targets> \
+  -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+  ```
+  (venv lives in the MAIN checkout; imports resolve to worktree source via cwd. UI tests are slow — the 300s timeout is deliberate.)
+
+---
+
+## File Structure
+
+**Modified:**
+- `tldw_chatbook/DB/ChaChaNotes_DB.py` — add `_CHARACTER_SORT_CLAUSES`, `list_character_cards_page`, `count_character_cards`, `list_distinct_character_tags` (Task 1). `list_character_cards` / `search_character_cards` left intact.
+- `tldw_chatbook/Character_Chat/Character_Chat_Lib.py` — add `get_character_page_for_ui`, `count_character_page`, `list_character_tags` (Task 1).
+- `tldw_chatbook/Widgets/Persona_Widgets/personas_messages.py` — add `PersonaSortCycleRequested`, `PersonaTagFilterRequested`, `PersonaPageChanged` (Task 3).
+- `tldw_chatbook/Widgets/Persona_Widgets/personas_library_pane.py` — sort button, tag button, page bar, `update_rows` page kwargs, `set_sort_label`/`set_tag_label`, `set_mode` gating (Task 3).
+- `tldw_chatbook/Widgets/Persona_Widgets/personas_state.py` — add `sort_key`, `tag_filter`, `page_offset` fields (Task 4).
+- `tldw_chatbook/UI/Screens/personas_screen.py` — paged character/persona render, count cache, sort/tag/page handlers, cache-assumption fixes, `_apply_mode` gating (Task 4).
+
+**Created:**
+- `tldw_chatbook/Character_Chat/persona_list_paging.py` — pure `page_persona_profiles(...)` (Task 2).
+- `tldw_chatbook/Widgets/Persona_Widgets/tag_filter_picker.py` — `TagFilterPicker(ModalScreen[str | None])` (Task 3).
+- Tests: `Tests/DB/test_character_cards_paging.py` (Task 1), `Tests/Character_Chat/test_persona_list_paging.py` (Task 2), `Tests/UI/test_personas_library_pane_paging.py` (Task 3), extend `Tests/UI/test_personas_screen_*` or a new `Tests/UI/test_personas_library_scale.py` (Task 4). Confirm exact existing test paths/fixtures at plan time by grepping `Tests/` for `character_cards`, `PersonasLibraryPane`, and personas-screen host apps.
+
+---
+
+## Task 1: Characters query + count + tags DB seam
+
+**Files:**
+- Modify: `tldw_chatbook/DB/ChaChaNotes_DB.py` (add methods near `list_character_cards`, ~:4460, and `search_character_cards`, ~:5113)
+- Modify: `tldw_chatbook/Character_Chat/Character_Chat_Lib.py` (add wrappers near `get_character_list_for_ui`, ~:490)
+- Test: `Tests/DB/test_character_cards_paging.py`
+
+**Interfaces:**
+- Produces (DB, on `CharactersRAGDB`):
+  - `_CHARACTER_SORT_CLAUSES: dict[str, str]` — class constant.
+  - `list_character_cards_page(self, *, limit: int, offset: int, order_by: str = "name_asc", search_term: str | None = None, tag: str | None = None) -> list[dict]` (full deserialized rows).
+  - `count_character_cards(self, *, search_term: str | None = None, tag: str | None = None) -> int`.
+  - `list_distinct_character_tags(self) -> list[str]`.
+- Produces (lib):
+  - `get_character_page_for_ui(db, *, limit, offset, order_by="name_asc", search_term=None, tag=None) -> list[dict]` → each `{"id","name","last_modified","created_at","tags"}`.
+  - `count_character_page(db, *, search_term=None, tag=None) -> int`.
+  - `list_character_tags(db) -> list[str]`.
+
+**Verified facts to build on:**
+- `character_cards.id INTEGER PRIMARY KEY AUTOINCREMENT` (rowid alias); `character_cards_fts` is FTS5 external-content (`content='character_cards', content_rowid='id'`); triggers exclude soft-deleted so FTS holds only non-deleted rows.
+- Existing search SQL to mirror (~:5136): `SELECT cc.* FROM character_cards_fts fts JOIN character_cards cc ON fts.rowid = cc.id WHERE fts.character_cards_fts MATCH ? AND cc.deleted = 0 ORDER BY rank LIMIT ?`.
+- The `"term"*` FTS prefix wrap lives in the handler (`ccp_character_handler.py:56-57`: `escaped = term.replace('"','""'); match_query = f'"{escaped}"*'`). Reuse this exact wrapping in the DB layer's search branch.
+- `_deserialize_row_fields(row, self._CHARACTER_CARD_JSON_FIELDS)` (~:4094) deserializes `tags`/`alternate_greetings`/`extensions`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/DB/test_character_cards_paging.py`. Grep an existing DB test (e.g. `Tests/DB/test_chachanotes_db*.py`) for the in-memory `CharactersRAGDB` fixture and mirror it; if none, construct `CharactersRAGDB(db_path=":memory:", client_id="test")` (confirm the constructor signature at plan time).
+
+```python
+import pytest
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    return CharactersRAGDB(tmp_path / "p3a.db", client_id="test")
+
+
+def _add(db, name, tags, desc=""):
+    return db.add_character_card({"name": name, "description": desc, "tags": tags})
+
+
+def test_page_returns_window_and_disjoint_pages(db):
+    for i in range(120):
+        _add(db, f"char{i:03d}", ["even"] if i % 2 == 0 else ["odd"])
+    page1 = db.list_character_cards_page(limit=50, offset=0, order_by="name_asc")
+    page2 = db.list_character_cards_page(limit=50, offset=50, order_by="name_asc")
+    assert len(page1) == 50 and len(page2) == 50
+    ids1 = {c["id"] for c in page1}
+    ids2 = {c["id"] for c in page2}
+    assert ids1.isdisjoint(ids2)
+    # name_asc order
+    assert [c["name"] for c in page1] == sorted(c["name"] for c in page1)
+
+
+def test_count_matches_full_set(db):
+    for i in range(120):
+        _add(db, f"c{i:03d}", [])
+    # +1 for the pre-seeded Default Assistant (id=1) — assert relative, not absolute:
+    assert db.count_character_cards() == len(
+        db.list_character_cards_page(limit=1000, offset=0)
+    )
+
+
+def test_tag_filter_narrows_list_and_count(db):
+    for i in range(10):
+        _add(db, f"t{i}", ["hero"] if i < 3 else ["villain"])
+    heroes = db.list_character_cards_page(limit=100, offset=0, tag="hero")
+    assert {c["name"] for c in heroes} == {"t0", "t1", "t2"}
+    assert db.count_character_cards(tag="hero") == 3
+
+
+def test_search_composes_with_tag_and_sort(db):
+    _add(db, "Dragon Knight", ["hero"])
+    _add(db, "Dragon Fiend", ["villain"])
+    _add(db, "Wolf", ["hero"])
+    hits = db.list_character_cards_page(
+        limit=100, offset=0, search_term='"Dragon"*', tag="hero", order_by="name_asc"
+    )
+    assert [c["name"] for c in hits] == ["Dragon Knight"]
+    assert db.count_character_cards(search_term='"Dragon"*', tag="hero") == 1
+
+
+def test_sort_by_modified_desc(db):
+    a = _add(db, "alpha", [])
+    b = _add(db, "beta", [])
+    # bump beta's last_modified by updating it
+    rec = db.get_character_card_by_id(b)
+    db.update_character_card(b, {"description": "x"}, int(rec["version"]))
+    rows = db.list_character_cards_page(limit=100, offset=0, order_by="modified_desc")
+    names = [c["name"] for c in rows]
+    assert names.index("beta") < names.index("alpha")
+
+
+def test_distinct_tags_sorted_unique(db):
+    _add(db, "a", ["Zed", "amber"])
+    _add(db, "b", ["amber"])
+    tags = db.list_distinct_character_tags()
+    assert tags == sorted(set(tags), key=str.lower)
+    assert "amber" in tags and "Zed" in tags
+    assert tags.count("amber") == 1
+
+
+def test_malformed_and_null_tags_never_raise(db):
+    good = _add(db, "good", ["ok"])
+    # Force a NULL tags row and a non-JSON tags row directly.
+    conn = db.get_connection()
+    conn.execute("UPDATE character_cards SET tags = NULL WHERE id = ?", (good,))
+    bad = _add(db, "bad", [])
+    conn.execute("UPDATE character_cards SET tags = 'not,json' WHERE id = ?", (bad,))
+    conn.commit()
+    # None of these may raise:
+    assert isinstance(db.list_character_cards_page(limit=100, offset=0), list)
+    assert isinstance(db.count_character_cards(), int)
+    assert isinstance(db.list_distinct_character_tags(), list)
+    assert isinstance(db.count_character_cards(tag="ok"), int)
+
+
+def test_unknown_order_by_falls_back_to_name(db):
+    _add(db, "b", [])
+    _add(db, "a", [])
+    rows = db.list_character_cards_page(limit=10, offset=0, order_by="bogus")
+    assert [c["name"] for c in rows][:2] == ["a", "b"]
+```
+
+- [ ] **Step 2: Run the tests — verify they fail**
+
+Run (from Global Constraints test command) `Tests/DB/test_character_cards_paging.py`.
+Expected: FAIL — `AttributeError: 'CharactersRAGDB' object has no attribute 'list_character_cards_page'`.
+
+- [ ] **Step 3: Add the sort whitelist + the three DB methods**
+
+In `ChaChaNotes_DB.py`, add the class constant near `_CHARACTER_CARD_JSON_FIELDS` (~:4130):
+
+```python
+    # P3a: whitelist of UI sort keys → exact ORDER BY clauses. The ONLY dynamic
+    # SQL fragment; search_term/tag are always bound parameters. "relevance"
+    # is valid only in the search (FTS) branch.
+    _CHARACTER_SORT_CLAUSES = {
+        "name_asc": "ORDER BY name COLLATE NOCASE ASC",
+        "modified_desc": "ORDER BY last_modified DESC, name COLLATE NOCASE ASC",
+        "created_desc": "ORDER BY created_at DESC, name COLLATE NOCASE ASC",
+        "relevance": "ORDER BY rank",
+    }
+```
+
+Add the methods after `list_character_cards` (after ~:4527). Note the shared `json_each` guard and the FTS-join branch mirroring `search_character_cards`:
+
+```python
+    # P3a: json-valid guard so json_each never sees NULL / non-JSON tags.
+    _TAGS_JSON_EACH = "json_each(CASE WHEN json_valid({t}.tags) THEN {t}.tags ELSE '[]' END)"
+
+    def _resolve_sort_clause(self, order_by: str, *, searching: bool) -> str:
+        clause = self._CHARACTER_SORT_CLAUSES.get(order_by)
+        if clause is None or (order_by == "relevance" and not searching):
+            clause = self._CHARACTER_SORT_CLAUSES["name_asc"]
+        return clause
+
+    def list_character_cards_page(
+        self,
+        *,
+        limit: int,
+        offset: int,
+        order_by: str = "name_asc",
+        search_term: str | None = None,
+        tag: str | None = None,
+    ) -> List[Dict[str, Any]]:
+        """Paged, sortable, tag- and search-filterable character list.
+
+        Args:
+            limit: Page size.
+            offset: Rows to skip.
+            order_by: A key of ``_CHARACTER_SORT_CLAUSES``; unknown keys (and
+                "relevance" without a search term) fall back to "name_asc".
+            search_term: FTS5 MATCH query (already prefix-wrapped by the caller,
+                e.g. ``'"dragon"*'``) or None for a browse query.
+            tag: Exact tag membership filter, or None.
+
+        Returns:
+            Deserialized character-card dicts for the page. Never raises on
+            NULL/invalid tags (json_each is json-valid-guarded).
+        """
+        searching = bool(search_term)
+        sort_clause = self._resolve_sort_clause(order_by, searching=searching)
+        params: list[Any] = []
+        where = ["cc.deleted = 0"] if searching else ["deleted = 0"]
+        alias = "cc" if searching else "character_cards"
+        if searching:
+            head = (
+                "SELECT cc.* FROM character_cards_fts fts "
+                "JOIN character_cards cc ON fts.rowid = cc.id"
+            )
+            where.insert(0, "fts.character_cards_fts MATCH ?")
+            params.append(search_term)
+        else:
+            head = "SELECT * FROM character_cards"
+        if tag is not None:
+            where.append(
+                f"EXISTS (SELECT 1 FROM {self._TAGS_JSON_EACH.format(t=alias)} WHERE value = ?)"
+            )
+            params.append(tag)
+        query = f"{head} WHERE {' AND '.join(where)} {sort_clause} LIMIT ? OFFSET ?"
+        params.extend([limit, offset])
+        cursor = self.execute_query(query, tuple(params))
+        return [
+            self._deserialize_row_fields(row, self._CHARACTER_CARD_JSON_FIELDS)
+            for row in cursor.fetchall()
+            if row
+        ]
+
+    def count_character_cards(
+        self, *, search_term: str | None = None, tag: str | None = None
+    ) -> int:
+        """Count non-deleted character cards matching the same search+tag filter."""
+        searching = bool(search_term)
+        params: list[Any] = []
+        alias = "cc" if searching else "character_cards"
+        where = ["cc.deleted = 0"] if searching else ["deleted = 0"]
+        if searching:
+            head = (
+                "SELECT COUNT(*) FROM character_cards_fts fts "
+                "JOIN character_cards cc ON fts.rowid = cc.id"
+            )
+            where.insert(0, "fts.character_cards_fts MATCH ?")
+            params.append(search_term)
+        else:
+            head = "SELECT COUNT(*) FROM character_cards"
+        if tag is not None:
+            where.append(
+                f"EXISTS (SELECT 1 FROM {self._TAGS_JSON_EACH.format(t=alias)} WHERE value = ?)"
+            )
+            params.append(tag)
+        query = f"{head} WHERE {' AND '.join(where)}"
+        cursor = self.execute_query(query, tuple(params))
+        row = cursor.fetchone()
+        return int(row[0]) if row else 0
+
+    def list_distinct_character_tags(self) -> List[str]:
+        """Distinct tag values across non-deleted cards, case-insensitively sorted."""
+        query = (
+            "SELECT DISTINCT je.value "
+            "FROM character_cards cc, "
+            + self._TAGS_JSON_EACH.format(t="cc")
+            + " je WHERE cc.deleted = 0 ORDER BY je.value COLLATE NOCASE"
+        )
+        cursor = self.execute_query(query, ())
+        return [str(r[0]) for r in cursor.fetchall() if r and r[0] is not None]
+```
+
+(Confirm `self.execute_query` / `self.get_connection` are the right accessors by matching `list_character_cards` and `search_character_cards` in the same file.)
+
+- [ ] **Step 4: Run the DB tests — verify they pass**
+
+Run `Tests/DB/test_character_cards_paging.py`. Expected: PASS (all 8).
+If `execute_query` isn't the right helper, mirror whatever `list_character_cards` uses.
+
+- [ ] **Step 5: Add the lib wrappers**
+
+In `Character_Chat_Lib.py`, after `get_character_list_for_ui` (~:525), add:
+
+```python
+def get_character_page_for_ui(
+    db: CharactersRAGDB,
+    *,
+    limit: int,
+    offset: int,
+    order_by: str = "name_asc",
+    search_term: str | None = None,
+    tag: str | None = None,
+) -> List[Dict[str, Any]]:
+    """UI-shaped page of characters: id/name/last_modified/created_at/tags."""
+    try:
+        rows = db.list_character_cards_page(
+            limit=limit, offset=offset, order_by=order_by,
+            search_term=search_term, tag=tag,
+        )
+    except Exception as exc:
+        logger.opt(exception=True).error(f"Character page fetch failed: {exc}")
+        return []
+    return [
+        {
+            "id": c.get("id"),
+            "name": c.get("name"),
+            "last_modified": c.get("last_modified"),
+            "created_at": c.get("created_at"),
+            "tags": c.get("tags") if isinstance(c.get("tags"), list) else [],
+        }
+        for c in rows
+        if c.get("id") is not None
+    ]
+
+
+def count_character_page(
+    db: CharactersRAGDB, *, search_term: str | None = None, tag: str | None = None
+) -> int:
+    try:
+        return db.count_character_cards(search_term=search_term, tag=tag)
+    except Exception as exc:
+        logger.opt(exception=True).error(f"Character count failed: {exc}")
+        return 0
+
+
+def list_character_tags(db: CharactersRAGDB) -> List[str]:
+    try:
+        return db.list_distinct_character_tags()
+    except Exception as exc:
+        logger.opt(exception=True).error(f"Character tag list failed: {exc}")
+        return []
+```
+
+- [ ] **Step 6: Add a lib wrapper test + run it**
+
+Append to `Tests/DB/test_character_cards_paging.py` (or a lib test file if that's the local convention):
+
+```python
+def test_lib_wrapper_shapes_rows(db):
+    from tldw_chatbook.Character_Chat.Character_Chat_Lib import (
+        get_character_page_for_ui, count_character_page, list_character_tags,
+    )
+    _add(db, "Zeta", ["x"])
+    rows = get_character_page_for_ui(db, limit=10, offset=0)
+    assert rows and set(rows[0]) == {"id", "name", "last_modified", "created_at", "tags"}
+    assert count_character_page(db) == len(get_character_page_for_ui(db, limit=1000, offset=0))
+    assert "x" in list_character_tags(db)
+```
+
+Run the whole `Tests/DB/test_character_cards_paging.py`. Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tldw_chatbook/DB/ChaChaNotes_DB.py tldw_chatbook/Character_Chat/Character_Chat_Lib.py Tests/DB/test_character_cards_paging.py
+git commit -m "feat(personas): P3a Task 1 — paged/sorted/tagged character query + count + distinct tags"
+```
+
+---
+
+## Task 2: Personas in-screen filter/sort/page helper
+
+**Files:**
+- Create: `tldw_chatbook/Character_Chat/persona_list_paging.py`
+- Test: `Tests/Character_Chat/test_persona_list_paging.py`
+
+**Interfaces:**
+- Produces: `page_persona_profiles(profiles: list[dict], *, search_term: str | None, sort_key: str, offset: int, page_size: int) -> tuple[list[dict], int]` — returns `(page_rows, filtered_total)`. `sort_key` ∈ `{"name_asc","modified_desc","created_desc"}` (NO "relevance" — personas have no FTS). Search = case-insensitive substring over `name` + `description`. No tag path (persona profiles have no tags).
+
+**Verified facts:** persona profiles carry `name` + `description` + `created_at` (+ a modified timestamp — confirm the exact key: check `_persona_profile_view`, ~:197, and the create payload, ~:512-534; likely `updated_at`/`last_modified`/`modified_at`). Use `created_at` for `created_desc`; use the modified key for `modified_desc`, falling back to `created_at` if absent.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+from tldw_chatbook.Character_Chat.persona_list_paging import page_persona_profiles
+
+PROFILES = [
+    {"id": "1", "name": "Alice", "description": "hero", "created_at": "2026-01-01", "updated_at": "2026-01-03"},
+    {"id": "2", "name": "bob", "description": "villain", "created_at": "2026-01-02", "updated_at": "2026-01-02"},
+    {"id": "3", "name": "Carol", "description": "hero mage", "created_at": "2026-01-03", "updated_at": "2026-01-01"},
+]
+
+
+def test_search_matches_name_and_description_case_insensitive():
+    rows, total = page_persona_profiles(PROFILES, search_term="HERO", sort_key="name_asc", offset=0, page_size=50)
+    assert {r["name"] for r in rows} == {"Alice", "Carol"}
+    assert total == 2
+
+
+def test_sort_name_asc_case_insensitive():
+    rows, total = page_persona_profiles(PROFILES, search_term=None, sort_key="name_asc", offset=0, page_size=50)
+    assert [r["name"] for r in rows] == ["Alice", "bob", "Carol"]
+    assert total == 3
+
+
+def test_sort_created_desc():
+    rows, _ = page_persona_profiles(PROFILES, search_term=None, sort_key="created_desc", offset=0, page_size=50)
+    assert [r["name"] for r in rows] == ["Carol", "bob", "Alice"]
+
+
+def test_sort_modified_desc():
+    rows, _ = page_persona_profiles(PROFILES, search_term=None, sort_key="modified_desc", offset=0, page_size=50)
+    assert [r["name"] for r in rows] == ["Alice", "bob", "Carol"]
+
+
+def test_pagination_window_and_total():
+    profiles = [{"id": str(i), "name": f"p{i:03d}", "description": "", "created_at": "x", "updated_at": "x"} for i in range(120)]
+    page2, total = page_persona_profiles(profiles, search_term=None, sort_key="name_asc", offset=50, page_size=50)
+    assert total == 120 and len(page2) == 50 and page2[0]["name"] == "p050"
+
+
+def test_unknown_sort_key_falls_back_to_name():
+    rows, _ = page_persona_profiles(PROFILES, search_term=None, sort_key="relevance", offset=0, page_size=50)
+    assert [r["name"] for r in rows] == ["Alice", "bob", "Carol"]
+```
+
+- [ ] **Step 2: Run — verify it fails**
+
+Run `Tests/Character_Chat/test_persona_list_paging.py`. Expected: FAIL — `ModuleNotFoundError`.
+
+- [ ] **Step 3: Implement the pure helper**
+
+Create `tldw_chatbook/Character_Chat/persona_list_paging.py`:
+
+```python
+"""Pure filter/sort/paginate helper for the file-backed persona profile list (P3a).
+
+Personas have no FTS and no tags, so this is a straight in-memory pass over the
+(≤100) profiles the scope service returns — no DB, no backend edit.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _modified_key(p: dict[str, Any]) -> str:
+    for key in ("updated_at", "last_modified", "modified_at"):
+        if p.get(key):
+            return str(p[key])
+    return str(p.get("created_at") or "")
+
+
+_SORTS = {
+    "name_asc": (lambda p: str(p.get("name") or "").lower(), False),
+    "created_desc": (lambda p: str(p.get("created_at") or ""), True),
+    "modified_desc": (_modified_key, True),
+}
+
+
+def page_persona_profiles(
+    profiles: list[dict[str, Any]],
+    *,
+    search_term: str | None,
+    sort_key: str,
+    offset: int,
+    page_size: int,
+) -> tuple[list[dict[str, Any]], int]:
+    """Return ``(page_rows, filtered_total)`` for the persona list.
+
+    Search is a case-insensitive substring over name + description. ``sort_key``
+    outside ``_SORTS`` (e.g. "relevance") falls back to "name_asc".
+    """
+    rows = list(profiles or [])
+    term = (search_term or "").strip().lower()
+    if term:
+        rows = [
+            p for p in rows
+            if term in str(p.get("name") or "").lower()
+            or term in str(p.get("description") or "").lower()
+        ]
+    filtered_total = len(rows)
+    key, reverse = _SORTS.get(sort_key, _SORTS["name_asc"])
+    rows = sorted(rows, key=key, reverse=reverse)
+    start = max(0, offset)
+    return rows[start:start + page_size], filtered_total
+```
+
+- [ ] **Step 4: Run — verify it passes**
+
+Run `Tests/Character_Chat/test_persona_list_paging.py`. Expected: PASS (6). If the persona modified-timestamp key differs from `updated_at`/`last_modified`/`modified_at`, add it to `_modified_key` and the test payload.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Character_Chat/persona_list_paging.py Tests/Character_Chat/test_persona_list_paging.py
+git commit -m "feat(personas): P3a Task 2 — pure persona list filter/sort/paginate helper"
+```
+
+---
+
+## Task 3: Pane controls (sort, tag, page bar) + messages + tag picker
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/Persona_Widgets/personas_messages.py`
+- Modify: `tldw_chatbook/Widgets/Persona_Widgets/personas_library_pane.py`
+- Create: `tldw_chatbook/Widgets/Persona_Widgets/tag_filter_picker.py`
+- Test: `Tests/UI/test_personas_library_pane_paging.py`
+
+**Interfaces:**
+- Consumes: `LibraryRow` (existing).
+- Produces (messages): `PersonaSortCycleRequested()` (bare intent), `PersonaTagFilterRequested()` (bare intent), `PersonaPageChanged(delta: int)` (−1 / +1).
+- Produces (pane methods): `set_sort_label(text: str)`, `set_tag_label(text: str)`; `update_rows(...)` gains `page_offset: int | None = None, page_size: int | None = None`; `set_mode` gates the sort button (characters+personas), tag button (characters only), and the page bar is auto-managed by `update_rows`.
+- Produces: `TagFilterPicker(ModalScreen[str | None])` — `__init__(self, tags: list[str], current: str | None)`; dismisses with the chosen tag string, `None` for "All (clear)", and does not dismiss with a sentinel on cancel/escape (Escape dismisses with a distinct `_CANCEL` sentinel — see below).
+
+**Design note (refinement over the spec's message names):** the pane posts *bare intents*; the screen owns all search-awareness, the tag list, and the sort cycle/labels (it has the DB). This keeps the pane a dumb view, matching the existing `PersonaActionRequested` pattern.
+
+- [ ] **Step 1: Add the messages**
+
+In `personas_messages.py`, mirror the existing `PersonaSearchChanged`/`PersonaActionRequested` `Message` subclasses and add:
+
+```python
+class PersonaSortCycleRequested(Message):
+    """The user asked to advance the library sort (screen decides the next key)."""
+
+
+class PersonaTagFilterRequested(Message):
+    """The user asked to open the tag filter (characters only)."""
+
+
+class PersonaPageChanged(Message):
+    """The user asked to move the library page window."""
+
+    def __init__(self, delta: int) -> None:
+        super().__init__()
+        self.delta = delta
+```
+
+Export them in that module's `__all__` if it has one.
+
+- [ ] **Step 2: Write the failing pane tests**
+
+Create `Tests/UI/test_personas_library_pane_paging.py`. Mirror any existing `PersonasLibraryPane` host-app test (grep `Tests/UI` for `PersonasLibraryPane`); if none, use this harness:
+
+```python
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Button, Static
+from tldw_chatbook.Widgets.Persona_Widgets.personas_library_pane import (
+    PersonasLibraryPane, LibraryRow,
+)
+from tldw_chatbook.Widgets.Persona_Widgets.personas_messages import (
+    PersonaSortCycleRequested, PersonaTagFilterRequested, PersonaPageChanged,
+)
+
+
+class _Host(App):
+    def __init__(self):
+        super().__init__()
+        self.events = []
+
+    def compose(self) -> ComposeResult:
+        yield PersonasLibraryPane(id="pane")
+
+    def on_persona_sort_cycle_requested(self, m): self.events.append(("sort", None))
+    def on_persona_tag_filter_requested(self, m): self.events.append(("tag", None))
+    def on_persona_page_changed(self, m): self.events.append(("page", m.delta))
+
+
+def _rows(n):
+    return tuple(LibraryRow(item_id=str(i), kind="character", name=f"c{i:03d}") for i in range(n))
+
+
+@pytest.mark.asyncio
+async def test_page_bar_shows_when_total_exceeds_page_size():
+    app = _Host()
+    async with app.run_test() as pilot:
+        pane = app.query_one(PersonasLibraryPane)
+        await pane.update_rows(_rows(50), total=130, noun="characters", page_offset=0, page_size=50)
+        info = app.query_one("#personas-library-page-info", Static)
+        assert "1-50 of 130" in str(info.render())
+        assert app.query_one("#personas-library-prev", Button).disabled is True
+        assert app.query_one("#personas-library-next", Button).disabled is False
+        assert app.query_one("#personas-library-pagebar").display is True
+
+
+@pytest.mark.asyncio
+async def test_page_bar_hidden_when_fits_one_page():
+    app = _Host()
+    async with app.run_test() as pilot:
+        pane = app.query_one(PersonasLibraryPane)
+        await pane.update_rows(_rows(5), total=5, noun="characters", page_offset=0, page_size=50)
+        assert app.query_one("#personas-library-pagebar").display is False
+
+
+@pytest.mark.asyncio
+async def test_next_prev_post_page_changed():
+    app = _Host()
+    async with app.run_test() as pilot:
+        pane = app.query_one(PersonasLibraryPane)
+        await pane.update_rows(_rows(50), total=130, noun="characters", page_offset=50, page_size=50)
+        await pilot.click("#personas-library-next")
+        await pilot.click("#personas-library-prev")
+        assert ("page", 1) in app.events and ("page", -1) in app.events
+
+
+@pytest.mark.asyncio
+async def test_sort_and_tag_buttons_post_intents():
+    app = _Host()
+    async with app.run_test() as pilot:
+        app.query_one(PersonasLibraryPane).set_mode("characters")
+        await pilot.click("#personas-library-sort")
+        await pilot.click("#personas-library-tag")
+        assert ("sort", None) in app.events and ("tag", None) in app.events
+
+
+@pytest.mark.asyncio
+async def test_tag_button_hidden_for_personas_visible_for_characters():
+    app = _Host()
+    async with app.run_test() as pilot:
+        pane = app.query_one(PersonasLibraryPane)
+        pane.set_mode("personas")
+        assert app.query_one("#personas-library-tag", Button).display is False
+        assert app.query_one("#personas-library-sort", Button).display is True
+        pane.set_mode("characters")
+        assert app.query_one("#personas-library-tag", Button).display is True
+
+
+@pytest.mark.asyncio
+async def test_sort_page_hidden_for_lore():
+    app = _Host()
+    async with app.run_test() as pilot:
+        pane = app.query_one(PersonasLibraryPane)
+        pane.set_mode("lore")
+        assert app.query_one("#personas-library-sort", Button).display is False
+        assert app.query_one("#personas-library-tag", Button).display is False
+        # dict/lore call update_rows WITHOUT page kwargs → no page bar, plain count
+        await pane.update_rows((), total=0, noun="world books")
+        assert app.query_one("#personas-library-pagebar").display is False
+```
+
+- [ ] **Step 3: Run — verify it fails**
+
+Run `Tests/UI/test_personas_library_pane_paging.py`. Expected: FAIL — no `#personas-library-sort` / `page-info` widgets.
+
+- [ ] **Step 4: Add the controls to the pane**
+
+In `personas_library_pane.py` `compose` (after the `#personas-library-toolbar` Horizontal, ~:142, before `yield ListView(...)`), add a filter bar:
+
+```python
+        with Horizontal(id="personas-library-filterbar", classes="ds-toolbar"):
+            yield Button(
+                "Sort: Name", id="personas-library-sort",
+                tooltip="Cycle the list sort order.",
+                classes="console-action-secondary",
+            )
+            yield Button(
+                "Tag: All", id="personas-library-tag",
+                tooltip="Filter characters by tag.",
+                classes="console-action-secondary",
+            )
+```
+
+After `yield ListView(id="personas-library-rows")` and before the count Static, add the page bar (hidden by default):
+
+```python
+        with Horizontal(id="personas-library-pagebar", classes="ds-toolbar"):
+            yield Button("<", id="personas-library-prev", compact=True,
+                         classes="console-action-secondary")
+            yield Static("", id="personas-library-page-info",
+                         classes="destination-purpose")
+            yield Button(">", id="personas-library-next", compact=True,
+                         classes="console-action-secondary")
+```
+
+In `on_mount`, hide the page bar initially and default sort/tag button visibility for characters mode:
+
+```python
+    def on_mount(self) -> None:
+        """Initialize control visibility for default characters mode."""
+        self.query_one("#personas-library-duplicate", Button).display = False
+        self.query_one("#personas-library-pagebar").display = False
+```
+
+Add label setters + intent handlers (near the other `@on(Button.Pressed, ...)` handlers):
+
+```python
+    def set_sort_label(self, text: str) -> None:
+        self.query_one("#personas-library-sort", Button).label = text
+
+    def set_tag_label(self, text: str) -> None:
+        self.query_one("#personas-library-tag", Button).label = text
+
+    @on(Button.Pressed, "#personas-library-sort")
+    def _sort_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.post_message(PersonaSortCycleRequested())
+
+    @on(Button.Pressed, "#personas-library-tag")
+    def _tag_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.post_message(PersonaTagFilterRequested())
+
+    @on(Button.Pressed, "#personas-library-prev")
+    def _prev_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.post_message(PersonaPageChanged(-1))
+
+    @on(Button.Pressed, "#personas-library-next")
+    def _next_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.post_message(PersonaPageChanged(1))
+```
+
+Import the three messages at the top (`from .personas_messages import (... PersonaSortCycleRequested, PersonaTagFilterRequested, PersonaPageChanged)`).
+
+- [ ] **Step 5: Gate the new controls in `set_mode`**
+
+Extend `set_mode` (~:146) — sort + page apply to characters+personas, tag characters-only:
+
+```python
+        sort_visible = mode in ("characters", "personas")
+        self.query_one("#personas-library-sort", Button).display = sort_visible
+        self.query_one("#personas-library-tag", Button).display = mode == "characters"
+        if not sort_visible:
+            # dict/lore never paginate — keep the page bar hidden.
+            self.query_one("#personas-library-pagebar").display = False
+```
+
+- [ ] **Step 6: Extend `update_rows` with the page window**
+
+Add the kwargs to the signature (after `recovery_id`):
+
+```python
+        page_offset: int | None = None,
+        page_size: int | None = None,
+```
+
+Replace the trailing count block (the `if recovery_copy: ... else: ...` at ~:252-262) with page-aware logic:
+
+```python
+        pagebar = self.query_one("#personas-library-pagebar")
+        count_static = self.query_one("#personas-library-count", Static)
+        paginated = page_offset is not None and page_size is not None
+        if recovery_copy:
+            pagebar.display = False
+            count_static.update(f"{noun.capitalize()} unavailable")
+        elif paginated and total > page_size:
+            start = page_offset + 1 if total else 0
+            end = page_offset + len(rows)
+            self.query_one("#personas-library-page-info", Static).update(
+                f"{start}-{end} of {total} {noun}"
+            )
+            self.query_one("#personas-library-prev", Button).disabled = page_offset <= 0
+            self.query_one("#personas-library-next", Button).disabled = (
+                page_offset + page_size >= total
+            )
+            pagebar.display = True
+            count_static.update("")
+        else:
+            pagebar.display = False
+            if filtered and filtered_total_unbounded:
+                match_word = "match" if len(rows) == 1 else "matches"
+                count_static.update(
+                    f"Showing {len(rows)} {_singular_noun(noun)} {match_word} from full library"
+                )
+            elif filtered:
+                count_static.update(f"{len(rows)} of {total} {noun}")
+            else:
+                count_static.update(f"{total} {noun}")
+```
+
+- [ ] **Step 7: Create the tag picker**
+
+Create `tldw_chatbook/Widgets/Persona_Widgets/tag_filter_picker.py`. Read the existing `ConversationAttachPicker` (`tldw_chatbook/Widgets/Persona_Widgets/conversation_attach_picker.py`, from P2e) and mirror its structure — a `ModalScreen[str | None]` with a search `Input` + a filterable `ListView`. First row is "All (clear filter)" → dismiss `None`; each tag row dismisses that tag string; Escape dismisses the sentinel `TagFilterPicker.CANCEL`. Keep ids generic (`#tag-filter-list`, `#tag-filter-search`).
+
+```python
+"""Modal tag picker for the characters library tag filter (P3a)."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Input, Label, ListItem, ListView, Static
+
+
+class TagFilterPicker(ModalScreen[str | None]):
+    CANCEL = object()  # distinct from None ("All") so cancel != clear-filter
+
+    def __init__(self, tags: list[str], current: str | None) -> None:
+        super().__init__()
+        self._tags = list(tags)
+        self._current = current
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="tag-filter-dialog"):
+            yield Label("Filter by tag")
+            yield Input(placeholder="Filter tags...", id="tag-filter-search")
+            yield ListView(id="tag-filter-list")
+            yield Static("Enter to pick · Esc to cancel", classes="destination-purpose")
+
+    def on_mount(self) -> None:
+        self._populate(self._tags)
+
+    def _populate(self, tags: list[str]) -> None:
+        lv = self.query_one("#tag-filter-list", ListView)
+        lv.clear()
+        lv.append(ListItem(Static("All (clear filter)", markup=False), id="tag-all"))
+        for t in tags:
+            safe = t.replace(" ", "-")
+            lv.append(ListItem(Static(t, markup=False), id=f"tag-{safe}"))
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        q = event.value.strip().lower()
+        self._populate([t for t in self._tags if q in t.lower()] if q else self._tags)
+
+    def on_list_view_selected(self, event: ListView.Selected) -> None:
+        item_id = event.item.id or ""
+        if item_id == "tag-all":
+            self.dismiss(None)
+            return
+        # Recover the exact tag from the visible label (ids are lossy).
+        label = str(event.item.query_one(Static).renderable)
+        self.dismiss(label)
+
+    def on_key(self, event) -> None:
+        if event.key == "escape":
+            event.stop()
+            self.dismiss(self.CANCEL)
+```
+
+(If `ConversationAttachPicker` uses a different dismiss/label-recovery idiom, follow it instead — the goal is a working picker consistent with the codebase.)
+
+- [ ] **Step 8: Run the pane tests — verify they pass**
+
+Run `Tests/UI/test_personas_library_pane_paging.py`. Expected: PASS (6). Fix any DEFAULT_CSS needed so the filter bar / page bar don't collapse (mirror `.ds-toolbar` usage already in the pane).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add tldw_chatbook/Widgets/Persona_Widgets/personas_messages.py tldw_chatbook/Widgets/Persona_Widgets/personas_library_pane.py tldw_chatbook/Widgets/Persona_Widgets/tag_filter_picker.py Tests/UI/test_personas_library_pane_paging.py
+git commit -m "feat(personas): P3a Task 3 — library sort/tag/page controls + tag picker"
+```
+
+---
+
+## Task 4: Screen wiring + cache-assumption fixes + integration
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/Persona_Widgets/personas_state.py` (add `sort_key`, `tag_filter`, `page_offset`)
+- Modify: `tldw_chatbook/UI/Screens/personas_screen.py`
+- Test: `Tests/UI/test_personas_library_scale.py` (new; also confirm/extend the existing personas-screen test module — grep `Tests/UI` for `PersonasScreen` host apps and mirror the fixture)
+
+**Interfaces:**
+- Consumes: Task 1 (`get_character_page_for_ui`, `count_character_page`, `list_character_tags`), Task 2 (`page_persona_profiles`), Task 3 (pane page kwargs, `set_sort_label`/`set_tag_label`, `PersonaSortCycleRequested`/`PersonaTagFilterRequested`/`PersonaPageChanged`, `TagFilterPicker`).
+
+**Verified facts / fix sites (re-verify line numbers fresh):**
+- `PersonasWorkbenchState` (personas_state.py:36) has `active_mode`, `search_query`, `selected_entity_kind`, `selected_entity_id`.
+- `_render_library_rows` (personas_screen.py:763) — replace the `total=len(self._characters)` + in-memory/FTS branch (~:778-802) with the paged query.
+- `_render_profile_rows` (~:885) — replace its `total=len` + in-memory filter (~:900-909) with `page_persona_profiles`.
+- `_build_library_rows` (~:733) — add a `meta` line for characters.
+- `refresh_character_library_list` (~:717) — `self._characters` is now the CURRENT PAGE only.
+- `_handle_search_changed` (~:942) — resets and re-renders; must reset `page_offset` and re-fetch count.
+- `_character_record` cache-scan (~:829) → callers at import (~:3797) and save (~:4565): switch name resolution to `_full_character_record`/by-id.
+- Status string (~:1329) `len(self._characters)` → use the cached total.
+- `pre_import_ids` (~:3766 → used ~:3803) — replace page-cache membership with a by-id existence check.
+- `PERSONAS_LIBRARY_PAGE_SIZE` — add near `PERSONAS_SEARCH_DEBOUNCE_SECONDS` (~:178).
+- Sort cycle order + labels: `[("name_asc","Name"), ("modified_desc","Recent edit"), ("created_desc","Recent add")]`; when a **character** search is active, prepend `("relevance","Relevance")` and make it the default the first time a search begins.
+
+- [ ] **Step 1: Add state fields**
+
+In `personas_state.py` (dataclass at :36), add fields (with the module's existing default style):
+
+```python
+    sort_key: str = "name_asc"
+    tag_filter: str | None = None
+    page_offset: int = 0
+```
+
+If `switch_mode`/`clear_selection` reset search, also reset `page_offset = 0` and `tag_filter = None` there (read the methods first).
+
+- [ ] **Step 2: Write the failing integration tests**
+
+Create `Tests/UI/test_personas_library_scale.py`. Mirror the existing personas-screen host-app fixture (it wires a real `CharactersRAGDB` + the scope service; find it by grepping `Tests/UI` for `PersonasScreen`). Sketch (adapt names to the real fixture):
+
+```python
+import pytest
+
+# Uses the project's PersonasScreen host-app fixture: `personas_app` yields a
+# running app whose screen has a real chachanotes_db. Seed >2 pages, drive the
+# library, assert paging/sort/tag.
+
+@pytest.mark.asyncio
+async def test_first_page_and_next(personas_app):
+    app, screen, db = personas_app
+    for i in range(130):
+        db.add_character_card({"name": f"c{i:03d}", "tags": []})
+    await screen._reload_character_page()          # helper added in Step 4
+    pane = screen.query_one_pane()                 # PersonasLibraryPane
+    assert screen.state.page_offset == 0
+    # page bar visible, 50 rows
+    assert len(pane_visible_rows(pane)) == 50
+    screen.state.page_offset = 0
+    await screen._on_page_changed_delta(1)         # simulate next
+    assert screen.state.page_offset == 50
+
+
+@pytest.mark.asyncio
+async def test_tag_filter_narrows_count(personas_app):
+    app, screen, db = personas_app
+    for i in range(10):
+        db.add_character_card({"name": f"h{i}", "tags": ["hero"] if i < 3 else ["v"]})
+    await screen._apply_tag_filter("hero")
+    assert screen._character_total == 3
+    assert screen.state.page_offset == 0
+
+
+@pytest.mark.asyncio
+async def test_sort_change_resets_offset(personas_app):
+    app, screen, db = personas_app
+    for i in range(130):
+        db.add_character_card({"name": f"c{i:03d}", "tags": []})
+    await screen._reload_character_page()
+    screen.state.page_offset = 50
+    await screen._cycle_sort()
+    assert screen.state.page_offset == 0
+
+
+@pytest.mark.asyncio
+async def test_import_offpage_name_conflict_message(personas_app, tmp_path):
+    # Seed a name-conflict character that will NOT be on page 1, import a card
+    # with the same name, assert the notification says "already exists"/updated,
+    # not "imported new". (Drives the pre_import_ids fix.)
+    ...
+```
+
+Because the exact host-app fixture and helper names depend on the existing test module, **the implementer's first action is to read the current personas-screen tests and shape these to match** — keep the assertions (page window, offset reset on filter change, tag count, import-conflict wording).
+
+- [ ] **Step 3: Run — verify it fails**
+
+Run `Tests/UI/test_personas_library_scale.py`. Expected: FAIL (missing helpers/behaviour).
+
+- [ ] **Step 4: Rewire the character render path**
+
+Add the constant near `PERSONAS_SEARCH_DEBOUNCE_SECONDS`:
+
+```python
+PERSONAS_LIBRARY_PAGE_SIZE = 50
+```
+
+Add instance state in `__init__` (near where `self._characters` is initialized, ~:475): `self._character_total = 0`, `self._count_cache_key: tuple | None = None`, `self._character_tags: list[str] = []`.
+
+Add a paged loader (new method) that the screen uses instead of the len/FTS branch. The DB reads go off-thread; count is cached by `(search, tag)`:
+
+```python
+    def _character_sort_cycle(self) -> list[tuple[str, str]]:
+        base = [("name_asc", "Name"), ("modified_desc", "Recent edit"), ("created_desc", "Recent add")]
+        if self.state.search_query:
+            return [("relevance", "Relevance"), *base]
+        return base
+
+    def _fts_match_query(self) -> str | None:
+        term = (self.state.search_query or "").strip()
+        if not term:
+            return None
+        escaped = term.replace('"', '""')
+        return f'"{escaped}"*'
+
+    async def _reload_character_page(self, *, reset_offset: bool = False) -> None:
+        if reset_offset:
+            self.state.page_offset = 0
+        mode, query = self.state.active_mode, self.state.search_query
+        sort_key, tag = self.state.sort_key, self.state.tag_filter
+        offset = self.state.page_offset
+        search = self._fts_match_query()
+        db = self.app.chachanotes_db  # confirm the accessor used elsewhere in this screen
+        cache_key = (search, tag)
+        try:
+            if self._count_cache_key != cache_key:
+                self._character_total = await asyncio.to_thread(
+                    ccl.count_character_page, db, search_term=search, tag=tag
+                )
+                self._count_cache_key = cache_key
+            # clamp offset into range
+            if offset > 0 and offset >= self._character_total:
+                offset = max(0, ((self._character_total - 1) // PERSONAS_LIBRARY_PAGE_SIZE)
+                             * PERSONAS_LIBRARY_PAGE_SIZE)
+                self.state.page_offset = offset
+            records = await asyncio.to_thread(
+                ccl.get_character_page_for_ui, db,
+                limit=PERSONAS_LIBRARY_PAGE_SIZE, offset=offset,
+                order_by=sort_key, search_term=search, tag=tag,
+            )
+        except Exception as exc:
+            logger.opt(exception=True).warning("Character page load failed.")
+            self._notify(f"Could not load characters: {exc}", "error")
+            return
+        # freshness guard: state may have moved while off-thread
+        if not self.is_mounted or self.state.active_mode != mode \
+           or self.state.search_query != query or self.state.sort_key != sort_key \
+           or self.state.tag_filter != tag or self.state.page_offset != offset:
+            return
+        self._characters = records
+        rows = self._build_library_rows(records, "character")
+        library = self.query_one(PersonasLibraryPane)
+        async with self._render_lock:
+            await library.update_rows(
+                rows, total=self._character_total, noun="characters",
+                page_offset=offset, page_size=PERSONAS_LIBRARY_PAGE_SIZE,
+            )
+            library.set_sort_label(f"Sort: {dict(self._character_sort_cycle())[sort_key]}"
+                                   if sort_key in dict(self._character_sort_cycle())
+                                   else "Sort: Name")
+            library.set_tag_label(f"Tag: {tag}" if tag else "Tag: All")
+            if self.state.selected_entity_kind == "character" and self.state.selected_entity_id:
+                library.mark_active_row("character", self.state.selected_entity_id)
+```
+
+(`ccl` = the `Character_Chat_Lib` import alias already used in the screen; confirm it, else import the three functions.) Replace `_render_library_rows`'s body so `refresh_character_library_list` and the debounced search path call `_reload_character_page`. Keep `_render_library_rows` as a thin `await self._reload_character_page()` (so existing callers/args still resolve) OR redirect callers — read the call sites first and pick the lower-churn option; the freshness guard here replaces `_library_render_snapshot_is_current` for the character path.
+
+Enrich `_build_library_rows` to add a meta line for characters (last-modified date). Since it's shared with personas, branch on kind:
+
+```python
+    @staticmethod
+    def _build_library_rows(records: list[dict], kind: str) -> tuple[LibraryRow, ...]:
+        rows = []
+        for record in records:
+            if record.get("id") is None:
+                continue
+            meta = None
+            if kind == "character":
+                lm = str(record.get("last_modified") or "")
+                meta = lm[:10] if lm else None  # YYYY-MM-DD
+            rows.append(LibraryRow(
+                item_id=str(record.get("id")), kind=kind,
+                name=str(record.get("name") or "Unnamed"), meta=meta,
+            ))
+        return tuple(rows)
+```
+
+- [ ] **Step 5: Rewire the persona render path**
+
+In `_render_profile_rows` (~:885), replace the `total=len` + substring filter with the Task 2 helper + page window (personas paginate, no tag, relevance N/A):
+
+```python
+        from tldw_chatbook.Character_Chat.persona_list_paging import page_persona_profiles
+        sort_key = self.state.sort_key if self.state.sort_key != "relevance" else "name_asc"
+        page_rows, total = page_persona_profiles(
+            self._profiles, search_term=self.state.search_query,
+            sort_key=sort_key, offset=self.state.page_offset,
+            page_size=PERSONAS_LIBRARY_PAGE_SIZE,
+        )
+        rows = self._build_library_rows(page_rows, "persona_profile")
+        # ... update_rows with page_offset=self.state.page_offset,
+        #     page_size=PERSONAS_LIBRARY_PAGE_SIZE, noun="persona profiles",
+        #     plus the existing recovery_copy handling.
+```
+
+Keep the existing recovery-copy path and `mark_active_row`. (Personas load ≤100 into `self._profiles` already, so no off-thread change is needed — filtering is in-memory.)
+
+- [ ] **Step 6: Add the sort / tag / page handlers**
+
+Add `@on` handlers for the three new messages:
+
+```python
+    @on(PersonaSortCycleRequested)
+    async def _handle_sort_cycle(self, message) -> None:
+        message.stop()
+        await self._cycle_sort()
+
+    async def _cycle_sort(self) -> None:
+        cycle = [k for k, _ in self._character_sort_cycle()]
+        cur = self.state.sort_key if self.state.sort_key in cycle else cycle[0]
+        self.state.sort_key = cycle[(cycle.index(cur) + 1) % len(cycle)]
+        self.state.page_offset = 0
+        await self._reload_active_library()
+
+    @on(PersonaTagFilterRequested)
+    async def _handle_tag_filter(self, message) -> None:
+        message.stop()
+        if self.state.active_mode != "characters" or self._io_dialog_active:
+            return
+        self._io_dialog_active = True
+        self.run_worker(self._tag_filter_worker(), group="personas-io", exit_on_error=False)
+
+    async def _tag_filter_worker(self) -> None:
+        try:
+            db = self.app.chachanotes_db
+            tags = await asyncio.to_thread(ccl.list_character_tags, db)
+            picked = await self.app.push_screen_wait(
+                TagFilterPicker(tags, self.state.tag_filter)
+            )
+            if picked is TagFilterPicker.CANCEL:
+                return
+            await self._apply_tag_filter(picked)  # None clears
+        except Exception as exc:
+            logger.opt(exception=True).warning("Tag filter failed.")
+            self._notify(f"Tag filter failed: {exc}", "error")
+        finally:
+            self._io_dialog_active = False
+
+    async def _apply_tag_filter(self, tag: str | None) -> None:
+        self.state.tag_filter = tag
+        self.state.page_offset = 0
+        self._count_cache_key = None  # (search,tag) changed → recount
+        await self._reload_character_page()
+
+    @on(PersonaPageChanged)
+    async def _handle_page_changed(self, message) -> None:
+        message.stop()
+        await self._on_page_changed_delta(message.delta)
+
+    async def _on_page_changed_delta(self, delta: int) -> None:
+        new_offset = self.state.page_offset + delta * PERSONAS_LIBRARY_PAGE_SIZE
+        total = self._character_total if self.state.active_mode == "characters" else len(self._profiles)
+        if new_offset < 0 or new_offset >= max(1, total):
+            return
+        self.state.page_offset = new_offset
+        await self._reload_active_library()
+
+    async def _reload_active_library(self) -> None:
+        if self.state.active_mode == "characters":
+            await self._reload_character_page()
+        elif self.state.active_mode == "personas":
+            await self._render_profile_rows()
+```
+
+In `_handle_search_changed` (~:942) and the debounced render path: whenever the search query changes, set `self.state.page_offset = 0` and `self._count_cache_key = None` before re-rendering so the count is recomputed and paging restarts. (Read the debounce flow first — the reset belongs where `state.search_query` is assigned.)
+
+- [ ] **Step 7: Fix the five cache-assumption sites**
+
+1. **Status string (~:1329):** replace `len(self._characters)` with `self._character_total`:
+   ```python
+   return f"Characters: {self._character_total} | Source: Local | Attachments: Console"
+   ```
+2. **`_character_record` callers (import ~:3797, save ~:4565):** resolve the name by id instead of scanning the page cache. Use the handler's loaded record after selection, or fetch by id:
+   ```python
+   # after load/select, the handler holds the record:
+   loaded = self._full_character_record(imported_id)
+   name = str((loaded or {}).get("name") or "Imported character")
+   ```
+   (For the save site, mirror with `saved_id`.) You may keep `_character_record` for any remaining page-local use, but these two must not depend on the full library being cached.
+3. **`pre_import_ids` (~:3766 / used ~:3803):** replace the page-cache id snapshot with a by-id existence check. Read the importer to see if it already signals "conflict" (it returns the EXISTING id on a name clash). Simplest correct form — snapshot existence of the *result* id before deciding the message:
+   ```python
+   existed_before = bool(await asyncio.to_thread(ccp_character_handler.fetch_character_by_id, imported_id))
+   # ... run import ...
+   # message: "Updated existing" if existed_before else "Imported"
+   ```
+   Confirm ordering (the snapshot must be taken BEFORE the import so a genuine new id reads as not-existing). If the importer already returns a conflict flag, prefer that over an extra query.
+4. **`_apply_mode` control gating + page-0 load:** on entering characters, call `library.set_mode("characters")` (already happens), reset `state.page_offset = 0`, `self._count_cache_key = None`, and `await self._reload_character_page()`. On entering personas, reset offset and `await self._render_profile_rows()`. Read `_apply_mode` (~:1064) and add these to the character/persona branches.
+
+- [ ] **Step 8: Run the integration tests — verify they pass**
+
+Run `Tests/UI/test_personas_library_scale.py` and the Task 3 pane tests together. Expected: PASS. Iterate on helper/fixture names to match the real personas-screen test harness.
+
+- [ ] **Step 9: Run the focused suite (no broad sweep)**
+
+Run exactly these (scoped to this feature):
+```
+Tests/DB/test_character_cards_paging.py
+Tests/Character_Chat/test_persona_list_paging.py
+Tests/UI/test_personas_library_pane_paging.py
+Tests/UI/test_personas_library_scale.py
+```
+Plus the existing personas-screen + library-pane test modules you mirrored (name them explicitly). Expected: PASS. Also run `python -c "import tldw_chatbook.app"` (with the test-env prefix) to confirm the app imports.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add tldw_chatbook/Widgets/Persona_Widgets/personas_state.py tldw_chatbook/UI/Screens/personas_screen.py Tests/UI/test_personas_library_scale.py
+git commit -m "feat(personas): P3a Task 4 — paged library wiring, sort/tag/page handlers, cache-assumption fixes"
+```
+
+---
+
+## Self-Review Notes (author)
+
+- **Spec coverage:** pagination (Tasks 1/4), sort whitelist (1/3/4), tag filter chars-only (1/3/4), FTS-preserve search (1/4), count caching (4), personas in-screen (2/4), dict-lore gated off (3), 5 cache-assumption fixes (4), no-migration/parameterized-SQL/off-thread/json-guard constraints — all mapped.
+- **Type consistency:** `list_character_cards_page`/`count_character_cards`/`list_distinct_character_tags` (DB) → `get_character_page_for_ui`/`count_character_page`/`list_character_tags` (lib) → `_reload_character_page` (screen); `page_persona_profiles` (Task 2) consumed in Step 5; `PersonaSortCycleRequested`/`PersonaTagFilterRequested`/`PersonaPageChanged(delta)` + `set_sort_label`/`set_tag_label` + `update_rows(page_offset,page_size)` (Task 3) consumed in Task 4; `TagFilterPicker.CANCEL` sentinel handled. Sort keys identical across DB whitelist, persona `_SORTS` (minus relevance), and the screen cycle.
+- **Known plan-time confirmations (read fresh):** the `CharactersRAGDB` constructor + `execute_query` accessor; the persona modified-timestamp key; the screen's DB accessor (`self.app.chachanotes_db` vs a handler); the existing personas-screen test host-app fixture; whether `_render_library_rows` is better replaced or redirected; the importer's conflict-return contract.

--- a/Docs/superpowers/specs/2026-07-21-roleplay-p3a-library-scale-find-design.md
+++ b/Docs/superpowers/specs/2026-07-21-roleplay-p3a-library-scale-find-design.md
@@ -1,0 +1,192 @@
+# Roleplay P3a — Characters/Personas Library: pagination + sort + tag filter
+
+**Program:** Personas → "Roleplay" workbench redesign. Sub-project **P3a** — the first of the **P3 (Characters/Personas flow polish)** cycle, which is the final phase of `P0 → P1 → P2 → P3`. P1 (Dictionaries) and P2 (Lore) are complete and merged. See the northstar `Docs/superpowers/specs/2026-07-13-roleplay-p0-reframe-northstar-design.md`.
+
+**Date:** 2026-07-21
+**Status:** Design (awaiting user review before writing-plans)
+**Schema:** ChaChaNotes v22 — **P3a adds NO migration** (no new columns; reads existing `character_cards`).
+
+---
+
+## Goal
+
+Make the shared Roleplay library list usable at scale and easier to search. Today the character list mounts every row at once (no virtualization), caps at 1,000 rows, has a hardcoded `ORDER BY name`, a denominator-less count, and a tag-blind capped-50 search. P3a introduces **page-at-a-time pagination**, a **sort control**, and a **tag filter** across the two list backends behind the shared `PersonasLibraryPane`.
+
+## Non-goals (explicitly out of scope)
+
+- **No architectural convergence** — the Characters mode keeps its card-view ⇄ editor-view swap + live-chat preview. We are NOT rebuilding it to the Dict/Lore unified-tabbed-detail shape (user decision: "targeted polish, keep shape").
+- **No editor changes** — avatar preview, alternate-greetings UX, validation, dirty-tracking re-arm are **P3b** (the next cycle), not P3a.
+- **No Dictionaries/Lore behavior change** — their lists are tiny; the new controls are gated OFF for those modes.
+- **No new schema, no migration.**
+- **No deterministic Try-it preview** (a separate deferred item; user did not select it).
+
+## Success criteria
+
+- A user with thousands of characters sees a fast, paginated list ("◄ 1–50 of N ►") that mounts only one page of rows at a time.
+- The list can be sorted by Name (A–Z), Recently modified, or Recently created; while searching, results default to relevance and an explicit sort overrides it.
+- The list can be filtered to characters carrying a chosen tag; the count reflects the filtered total.
+- Search preserves the current multi-field FTS matching (name/description/personality/scenario/system_prompt), and now composes with sort + tag + pagination + an accurate count.
+- The Personas (who-you-are) mode gets the same pane controls, implemented over its file-backed backend.
+- Dictionaries/Lore modes are visually and behaviorally unchanged.
+
+---
+
+## Background — current state (verified via source scout, file:line approximate; re-verify at plan time)
+
+**Shared pane** — `tldw_chatbook/Widgets/Persona_Widgets/personas_library_pane.py`
+- The list is a Textual **`ListView`** (`#personas-library-rows`, ~:143). `update_rows(rows, total, noun)` (~:159–259) does a **full rebuild** every render: `await list_view.clear()` then `await list_view.extend(items)`. No virtualization — all `ListItem`s mount at once.
+- A `LibraryRow` dataclass (~:37–45) = `item_id, kind, name, is_unsaved, meta`.
+- Controls today: a search `Input` (`#personas-library-search`, ~:123), toolbar buttons New/Import/Duplicate (~:124–142), a count `Static` (`#personas-library-count`, ~:144). **No sort or filter control exists.**
+- `set_mode(mode)` (~:146–157) toggles which toolbar buttons show per mode. **One pane, one `ListView`, fed different rows per mode** — changing the pane contract affects all four modes, so mode-specific behavior is driven from the screen's per-mode render methods.
+
+**Screen** — `tldw_chatbook/UI/Screens/personas_screen.py`
+- Characters feed: `refresh_character_library_list` (~:625) → cached `self._characters` (id+name only). `_render_library_rows` (~:667–722): `total = len(self._characters)`; small libraries filter in-memory by name substring; at `total >= LIBRARY_FTS_THRESHOLD` (=1000, ~:188) it runs `search_characters_fts` (top-50, `ORDER BY rank`, no offset, count denominator-less).
+- Personas feed: `_refresh_profile_rows_worker` (~:752) → `_render_profile_rows` (~:776–821), in-memory name substring only.
+- Search debounce: `PERSONAS_SEARCH_DEBOUNCE_SECONDS = 0.2` (~:153); `_handle_search_changed` (~:823) → exclusive worker (group `personas-library-search`) → per-mode render, with a stale-snapshot guard (`_library_render_snapshot_is_current`, ~:650). **Every render is a full ListView rebuild.**
+
+**Characters backend**
+- `Character_Chat/Character_Chat_Lib.py`: `fetch_character_names(limit=1000)` (~:457) → `get_character_list_for_ui(db, limit=1000)` (~:415) returns `[{"id","name"}]` sorted by `name.lower()` (~:437). Drops `created_at`/`last_modified`/`tags`.
+- `DB/ChaChaNotes_DB.py`: `list_character_cards(limit=100, offset=0)` (~:3913), query `SELECT * FROM character_cards WHERE deleted = 0 ORDER BY name LIMIT ? OFFSET ?` (~:3932). **No `order_by` param, no include-deleted flag.**
+- Columns on `character_cards` (schema ~:176–198): `name` (UNIQUE), `created_at`, `last_modified`, `version`, `tags` (TEXT, JSON array, in `_CHARACTER_CARD_JSON_FIELDS` ~:3651, deserialized to a Python list), plus creator fields.
+- FTS: `character_cards_fts` covers `name, description, personality, scenario, system_prompt` (schema ~:212–217). `tags` is NOT in FTS. `search_character_cards(search_term, limit=10)` (~:4455) = `... MATCH ? ORDER BY rank LIMIT ?`, no offset.
+- **No COUNT(*) helper for `character_cards` exists.** No query-by-tag helper.
+
+**Handler seam** — `tldw_chatbook/UI/CCP_Modules/ccp_character_handler.py`: `fetch_all_characters` (~:67), `search_characters_fts` (~:45, wraps term as `"term"*` prefix, `db.search_character_cards(..., limit=50)`), `fetch_character_by_id` (~:85), CRUD create/update/delete (~:93/98/115). `CCPCharacterHandler.refresh_character_list` (~:329).
+
+**Personas backend** — separate, **file-backed**: `local_character_persona_service.py` `LocalCharacterPersonaService.list_persona_profiles(mode, limit=100, offset=0)` (~:651) over an in-memory `self._persona_profiles` JSON list (~:36, loaded/persisted as JSON), sorts by `created_at` desc in Python (~:665), slices `[offset:offset+limit]` (~:666). Reached via `app.character_persona_scope_service.list_persona_profiles` (`character_persona_scope_service.py` ~:596). A server backend variant exists (`server_character_persona_service.py`).
+
+**Design-relevant constraints**
+1. The list mounts every row at once → the scale lever is **only page-a-worth of `ListItem`s mounted** (pagination), not virtualization.
+2. No COUNT for `character_cards` → accurate "X of N" needs a new count query.
+3. `list_character_cards` is `ORDER BY name` fixed → sort needs an `order_by` param; non-name sorts also need the extra columns fetched.
+4. Large-library search is FTS (rank, cap 50, no offset, tag-blind) → the FTS path must gain a composable/paged form.
+5. Tags are a JSON array in `character_cards.tags`, unindexed, un-queried, and not loaded into `self._characters`.
+6. Two very different backends (SQL characters, file-backed personas) sit behind one pane → the pane needs one backend-agnostic contract.
+
+---
+
+## Design decisions (resolved with the user)
+
+1. **Direction:** targeted polish, keep the current Characters shape.
+2. **P3 scope:** two sub-projects — **P3a = scale + find** (this doc), **P3b = editor polish** (next cycle).
+3. **Scale mechanism:** **pagination** (page-at-a-time), not virtualization, not raise-the-cap.
+4. **Feature set:** pagination **+ sort + tag filter** (all three).
+5. **Search model:** **preserve FTS** (multi-field relevance), made composable so sort + tag + pagination + count all apply.
+
+---
+
+## Architecture
+
+### A. Characters query seam (`DB/ChaChaNotes_DB.py` + `Character_Chat_Lib.py`)
+
+Introduce one paginated, composable query path plus a count, replacing the split (in-memory substring / capped-FTS) the screen uses today.
+
+**Sort whitelist (no SQL injection).** A fixed mapping from a UI sort key to an exact ORDER BY clause — never interpolate user input into SQL:
+
+```
+CHARACTER_SORT_CLAUSES = {
+    "name_asc":       "ORDER BY name COLLATE NOCASE ASC",
+    "modified_desc":  "ORDER BY last_modified DESC, name COLLATE NOCASE ASC",
+    "created_desc":   "ORDER BY created_at DESC, name COLLATE NOCASE ASC",
+    "relevance":      "ORDER BY rank",   # search mode only (FTS)
+}
+```
+
+**New DB methods** (names indicative; finalize in plan):
+
+- `list_character_cards_page(*, limit, offset, order_by="name_asc", search_term=None, tag=None) -> list[dict]`
+  - **Browse (no `search_term`):** `SELECT <needed cols> FROM character_cards WHERE deleted = 0 [AND <tag predicate>] <order_by clause> LIMIT ? OFFSET ?`.
+  - **Search (`search_term` present):** join FTS —
+    `SELECT c.<cols> FROM character_cards c JOIN character_cards_fts f ON f.rowid = c.rowid WHERE f.character_cards_fts MATCH ? AND c.deleted = 0 [AND <tag predicate>] <order_by clause | ORDER BY rank> LIMIT ? OFFSET ?`.
+    `order_by="relevance"` → `ORDER BY rank`; any explicit sort overrides it. Match term wrapped `"<term>"*` (prefix), preserving current `search_characters_fts` behavior.
+  - Returns the columns the UI needs: at least `id, name, last_modified, created_at, tags` (so rows can carry a meta line and sorting/tag work without a second fetch).
+- `count_character_cards(*, search_term=None, tag=None) -> int`
+  - Same WHERE (and FTS join when searching) as the list query, `SELECT COUNT(*)`. Drives the accurate "X–Y of N".
+- `list_distinct_character_tags() -> list[str]`
+  - `SELECT DISTINCT value FROM character_cards, json_each(character_cards.tags) WHERE character_cards.deleted = 0 ORDER BY value COLLATE NOCASE`. Populates the tag-filter control. (Falls back to a Python distinct pass if `json_each` is unavailable, but SQLite's json1 is compiled in by default and the DB already stores/deserializes JSON here.)
+
+**Tag predicate.** `EXISTS (SELECT 1 FROM json_each(character_cards.tags) WHERE value = ?)` — exact tag membership over the JSON array. `tag=None` omits the clause.
+
+**Keep existing methods intact.** `list_character_cards`, `search_character_cards`, `fetch_character_names`, `get_character_list_for_ui` stay for their other callers; P3a adds new methods and points the *pane's* character path at them. (Plan verifies no other caller depends on the old capped behavior.)
+
+**Lib wrapper.** A thin `Character_Chat_Lib` helper (e.g. `get_character_page_for_ui(db, *, limit, offset, order_by, search_term, tag)` + `count_character_page`) so the screen never talks raw SQL and rows arrive UI-shaped.
+
+### B. Personas backend parity (`local_character_persona_service.py`)
+
+Personas are a Python list — sort/tag/page are pure-Python and require no SQL:
+- Extend `list_persona_profiles` (or add a sibling) to accept `order_by`, `search_term`, and `tag`, applying: substring match over the profile name (and description if present) for `search_term`; membership over the profile's tag field for `tag`; the same sort keys mapped to Python `sorted()` key/reverse; then `[offset:offset+limit]`.
+- A `distinct_persona_tags()` pass over `self._persona_profiles`.
+- Total = count of the filtered (pre-slice) list, so the pane's "X of N" is accurate.
+- The server-backend variant (`server_character_persona_service.py`) mirrors the same public shape (or explicitly no-ops the new params if the server path is out of P3a's runtime — plan confirms which backend the workbench uses today; the local path is primary).
+
+"Relevance" is not meaningful without FTS, so for personas the default sort while searching is **Name A–Z** (documented), and explicit sorts apply as normal.
+
+### C. Pane UI (`personas_library_pane.py`)
+
+Add three backend-agnostic controls the screen drives, **gated to characters + personas modes** via `set_mode` (hidden for dict/lore):
+- **Sort control** — a compact cycle button ("Sort: Name ▾" → Recently modified → Recently created → [Relevance, only while searching]) posting a `PersonaSortChanged(sort_key)` message. (A `Select` is the alternative; the plan picks whichever fits the 2fr rail cleanly — cycle button preferred for width.)
+- **Tag filter** — a "Tag: All ▾" control opening a tag picker (reuse the existing modal-picker pattern from the Lore/Dict attach pickers) populated from the distinct-tags list; selecting posts `PersonaTagFilterChanged(tag | None)`. "All" clears it.
+- **Page bar** — at the list foot: "◄ 1–50 of N ►" with prev/next (disabled at ends), posting `PersonaPageChanged(delta | page)`. Hidden when `N <= page_size`.
+
+**Page size:** `PERSONAS_LIBRARY_PAGE_SIZE = 50` (one constant).
+
+**`update_rows` contract extension:** today `update_rows(rows, total, noun)`; extend to also convey the page window (offset, page_size, filtered_total) so the pane can render the page bar and an accurate count. Keep the signature backward-compatible for dict/lore callers (default page params → no page bar, current behavior).
+
+The pane stays a `ListView` with the same `clear()`+`extend()` rebuild — but each rebuild now receives only one page (≤50) of rows, so mounted-widget count is bounded regardless of library size.
+
+### D. Screen wiring & data flow (`personas_screen.py`)
+
+- Hold the query state per mode: `sort_key`, `tag_filter`, `page_offset`, alongside the existing `search_query` (in `PersonasWorkbenchState`).
+- A single **`_load_character_page` worker** (off-thread via `asyncio.to_thread`, exclusive, group reused from the current search group) that: calls the lib page + count with `(limit=PAGE_SIZE, offset, order_by=sort_key, search_term, tag)`, builds `LibraryRow`s (now with a meta line, e.g. last-modified date), and calls `library.update_rows(rows, filtered_total, page window, noun)`. The existing stale-snapshot guard extends to include `(sort_key, tag, offset)` so a slow page load can't overwrite a newer request.
+- **Reset offset to 0** whenever search / sort / tag changes (a filter change invalidates the current page). Page prev/next only changes offset.
+- **Relevance is search-only:** `sort_key="relevance"` is reachable only while a search term is present. When the search clears while `sort_key=="relevance"`, the screen falls back to the default `name_asc` (and the sort control re-labels to "Name"). Personas never expose Relevance (no FTS).
+- Personas: a parallel `_load_persona_page` path calling the persona service with the same params.
+- Handlers: `@on(PersonaSortChanged)`, `@on(PersonaTagFilterChanged)`, `@on(PersonaPageChanged)` → update state → trigger the load worker for the active mode. All wrapped so a backend error notifies rather than crashing the worker (`run_worker(exit_on_error=…)` discipline — see constraints).
+- `set_mode`/`_apply_mode`: show the new controls only for characters + personas; on entering a mode, reset offset and load page 0.
+
+### Error handling / edge cases
+
+- **Empty results** (search/tag matches nothing): page bar hidden, count "0 of 0", empty ListView (existing empty-state).
+- **Offset past the end** (e.g. tag change shrinks N below current offset): clamp offset into range before fetch; if the page is empty but N>0, snap to the last valid page.
+- **Deleted-during-paging / stale snapshot:** the extended snapshot guard drops results whose `(mode, search, sort, tag, offset)` no longer matches current state (mirrors the P2e/P2g freshness-guard lesson — re-check state after the await before writing to the pane).
+- **Malformed tags JSON** on a row: `json_each` tolerates valid JSON; a row with non-array/NULL tags simply never matches a tag filter and contributes no distinct tags — never raises. The distinct-tags/count queries use `deleted = 0` and the same predicate, so they stay consistent with the list.
+- **FTS unavailable / MATCH syntax error** on odd input: the search path must degrade to no-results-with-notice rather than raise (wrap the FTS query; the current `search_characters_fts` already tolerates this pattern).
+- **`json_each` absence** (hypothetical old SQLite): `list_distinct_character_tags` and the tag predicate fall back to a Python-side pass over loaded rows (documented; not expected to trigger).
+
+### Testing strategy
+
+- **Real-DB tests** (`Tests/…` mirroring existing character-DB tests) for the new DB methods: COUNT matches the list length across pages; `order_by` whitelist produces the three orders + relevance; `json_each` tag predicate returns exactly the tagged rows; offset paging returns disjoint consecutive windows covering the full set; search + tag + sort compose (FTS join returns only matched∧tagged rows in the chosen order); `list_distinct_character_tags` returns sorted uniques; malformed/NULL tags never raise. Seed >2 pages of characters with varied tags/timestamps.
+- **Personas service tests:** pure-Python sort/tag/search/paging parity over a seeded in-memory profile list; accurate filtered total; empty/short-list cases.
+- **Pane widget tests** (host-App mount): page bar renders "X–Y of N", prev/next enable/disable at bounds and post `PersonaPageChanged`; sort cycle posts `PersonaSortChanged` cycling the keys (and includes Relevance only while a search is active); tag control posts `PersonaTagFilterChanged`; controls hidden for dict/lore via `set_mode`; `update_rows` with `N <= page_size` hides the page bar.
+- **Screen integration tests** (real screen + real DB): seed >page-size characters → first page shows PAGE_SIZE rows and "1–50 of N"; next → second page (disjoint); pick a tag → count drops to the tagged subset and rows carry the tag; type a search → FTS-matched paginated subset; change sort → order changes and offset resets to 0; switch to Personas mode → same controls drive the file-backed list. A stale-snapshot regression test (slow page load superseded by a newer sort/tag change does not overwrite).
+
+---
+
+## Task decomposition (for writing-plans → subagent-driven-development)
+
+1. **Characters query + count + tags seam** — `list_character_cards_page`, `count_character_cards`, `list_distinct_character_tags` in `ChaChaNotes_DB.py` + the `Character_Chat_Lib` UI-shaped wrappers, with the sort whitelist and tag predicate. Real-DB tests. (Deliverable: backend can page/sort/tag/count/search characters.)
+2. **Personas backend parity** — extend `LocalCharacterPersonaService.list_persona_profiles` (+ distinct tags) with `order_by`/`search_term`/`tag`; accurate filtered total. Pure-Python tests. (Server variant reconciled or explicitly deferred per which backend is live.)
+3. **Pane controls** — sort cycle button, tag filter control + picker, page bar; new `Persona*Changed` messages; `update_rows` page-window extension; `set_mode` gating. Widget tests.
+4. **Screen wiring + integration** — query state in `PersonasWorkbenchState`; `_load_character_page` / `_load_persona_page` workers (off-thread, extended stale-snapshot guard, offset reset on filter change, clamp); the three `@on` handlers; `_apply_mode` control gating + page-0 load. Screen integration tests.
+
+Four focused tasks → one PR.
+
+---
+
+## Global constraints
+
+- **NO schema migration** — P3a only reads existing `character_cards` columns; ChaChaNotes stays **v22** (NEXT migration v22→v23 reserved for a future change).
+- **Parameterized SQL only** — the ONLY dynamic SQL is the ORDER BY clause, which comes from the fixed `CHARACTER_SORT_CLAUSES` whitelist keyed by an enum; user values (search term, tag) are bound parameters. No string interpolation of user input.
+- **All screen DB I/O off-thread** via `asyncio.to_thread`, wrapped so a backend error notifies (never crashes the worker); reuse the existing exclusive search-worker group; extend the stale-snapshot freshness guard to `(mode, search, sort, tag, offset)`.
+- **Dict/Lore modes unchanged** — new controls gated off; `update_rows` stays backward-compatible for them.
+- **Branch off the LATEST `origin/dev`** (`8f1d2cae8` at spec time — re-verify at plan/merge time). Feature branch `claude/roleplay-p3a-library-scale-find`.
+- **Implementers stage ONLY their task's files** — never `git add -A`, never stage `.superpowers/`.
+- **No background/broad test sweeps; never broad-`pkill` pytest** in this multi-session environment — scope commands to this worktree.
+- **Test env:** `HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest … -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread` (venv in the MAIN checkout; imports resolve to worktree source via cwd; UI tests are slow — generous timeouts).
+
+## Deferred / follow-ups
+
+- **P3b** — editor polish (avatar preview, alternate-greetings UX, validation surface, dirty-tracking re-arm), the next P3 cycle.
+- Consistency-of-feel pass and deterministic Try-it preview (not selected for P3).
+- Adding `tags` to the FTS index (would let search match tags directly) — out of scope; tag filtering is explicit here.
+- Server persona-backend paging parity if/when that path becomes the live workbench backend.

--- a/Docs/superpowers/specs/2026-07-21-roleplay-p3a-library-scale-find-design.md
+++ b/Docs/superpowers/specs/2026-07-21-roleplay-p3a-library-scale-find-design.md
@@ -26,7 +26,7 @@ Make the shared Roleplay library list usable at scale and easier to search. Toda
 - The list can be sorted by Name (A–Z), Recently modified, or Recently created; while searching, results default to relevance and an explicit sort overrides it.
 - The list can be filtered to characters carrying a chosen tag; the count reflects the filtered total.
 - Search preserves the current multi-field FTS matching (name/description/personality/scenario/system_prompt), and now composes with sort + tag + pagination + an accurate count.
-- The Personas (who-you-are) mode gets the same pane controls, implemented over its file-backed backend.
+- The Personas (who-you-are) mode gets pagination + sort + search over its file-backed backend (no tag filter — persona profiles have no tags).
 - Dictionaries/Lore modes are visually and behaviorally unchanged.
 
 ---
@@ -96,37 +96,37 @@ CHARACTER_SORT_CLAUSES = {
 
 - `list_character_cards_page(*, limit, offset, order_by="name_asc", search_term=None, tag=None) -> list[dict]`
   - **Browse (no `search_term`):** `SELECT <needed cols> FROM character_cards WHERE deleted = 0 [AND <tag predicate>] <order_by clause> LIMIT ? OFFSET ?`.
-  - **Search (`search_term` present):** join FTS —
-    `SELECT c.<cols> FROM character_cards c JOIN character_cards_fts f ON f.rowid = c.rowid WHERE f.character_cards_fts MATCH ? AND c.deleted = 0 [AND <tag predicate>] <order_by clause | ORDER BY rank> LIMIT ? OFFSET ?`.
-    `order_by="relevance"` → `ORDER BY rank`; any explicit sort overrides it. Match term wrapped `"<term>"*` (prefix), preserving current `search_characters_fts` behavior.
+  - **Search (`search_term` present):** join FTS — **verified: this mirrors the existing `search_character_cards` exactly** (`ChaChaNotes_DB.py` ~:5136 does `FROM character_cards_fts fts JOIN character_cards cc ON fts.rowid = cc.id WHERE fts.character_cards_fts MATCH ? AND cc.deleted = 0 ORDER BY rank LIMIT ?`). The FTS table is FTS5 **external-content** (`content='character_cards', content_rowid='id'`, ~:223–228), and the AI/AU/AD sync triggers exclude soft-deleted rows — so FTS already contains only non-deleted rows (the `AND c.deleted=0` is redundant-but-harmless in search mode, required in browse mode).
+    `SELECT c.<cols> FROM character_cards c JOIN character_cards_fts f ON f.rowid = c.id WHERE f.character_cards_fts MATCH ? AND c.deleted = 0 [AND <tag predicate>] <order_by clause | ORDER BY rank> LIMIT ? OFFSET ?`.
+    `order_by="relevance"` → `ORDER BY rank`; any explicit sort overrides it. The MATCH term is wrapped `"<term>"*` (prefix) — this wrapping lives in the **handler** (`ccp_character_handler.py` `search_characters_fts` ~:45), NOT the DB method, which passes the term through raw; mirror the handler's wrapping and wrap the MATCH call so an invalid FTS query string degrades to no-results rather than raising.
   - Returns the columns the UI needs: at least `id, name, last_modified, created_at, tags` (so rows can carry a meta line and sorting/tag work without a second fetch).
 - `count_character_cards(*, search_term=None, tag=None) -> int`
   - Same WHERE (and FTS join when searching) as the list query, `SELECT COUNT(*)`. Drives the accurate "X–Y of N".
 - `list_distinct_character_tags() -> list[str]`
-  - `SELECT DISTINCT value FROM character_cards, json_each(character_cards.tags) WHERE character_cards.deleted = 0 ORDER BY value COLLATE NOCASE`. Populates the tag-filter control. (Falls back to a Python distinct pass if `json_each` is unavailable, but SQLite's json1 is compiled in by default and the DB already stores/deserializes JSON here.)
+  - `SELECT DISTINCT je.value FROM character_cards c, json_each(CASE WHEN json_valid(c.tags) THEN c.tags ELSE '[]' END) je WHERE c.deleted = 0 ORDER BY je.value COLLATE NOCASE`. Populates the tag-filter control.
 
-**Tag predicate.** `EXISTS (SELECT 1 FROM json_each(character_cards.tags) WHERE value = ?)` — exact tag membership over the JSON array. `tag=None` omits the clause.
+**Tag predicate.** **⚠ `json_each` must be guarded** — `character_cards.tags` is nullable and the writer (`_ensure_json_string_from_mixed`, `ChaChaNotes_DB.py` ~:4155–4167) **passes a non-JSON string through unchanged** while reads tolerate bad JSON (`_deserialize_row_fields` ~:4116–4127), so a real row can hold `NULL` or an invalid-JSON `tags` value. Bare `json_each(tags)` **RAISES** on those and would crash the entire list/count/distinct query. Use the always-valid form:
+`EXISTS (SELECT 1 FROM json_each(CASE WHEN json_valid(character_cards.tags) THEN character_cards.tags ELSE '[]' END) WHERE value = ?)` — exact tag membership; the `CASE` guarantees `json_each` always receives valid JSON (`'[]'` for NULL/invalid). `tag=None` omits the clause. Requires SQLite JSON1 (default-compiled since 3.9 / 2015; the DB already relies on JSON storage here) — if ever absent, `list_distinct_character_tags` and the predicate fall back to a Python pass over loaded rows.
 
 **Keep existing methods intact.** `list_character_cards`, `search_character_cards`, `fetch_character_names`, `get_character_list_for_ui` stay for their other callers; P3a adds new methods and points the *pane's* character path at them. (Plan verifies no other caller depends on the old capped behavior.)
 
 **Lib wrapper.** A thin `Character_Chat_Lib` helper (e.g. `get_character_page_for_ui(db, *, limit, offset, order_by, search_term, tag)` + `count_character_page`) so the screen never talks raw SQL and rows arrive UI-shaped.
 
-### B. Personas backend parity (`local_character_persona_service.py`)
+### B. Personas: filter/sort/page in the screen layer (no backend edits)
 
-Personas are a Python list — sort/tag/page are pure-Python and require no SQL:
-- Extend `list_persona_profiles` (or add a sibling) to accept `order_by`, `search_term`, and `tag`, applying: substring match over the profile name (and description if present) for `search_term`; membership over the profile's tag field for `tag`; the same sort keys mapped to Python `sorted()` key/reverse; then `[offset:offset+limit]`.
-- A `distinct_persona_tags()` pass over `self._persona_profiles`.
-- Total = count of the filtered (pre-slice) list, so the pane's "X of N" is accurate.
-- The server-backend variant (`server_character_persona_service.py`) mirrors the same public shape (or explicitly no-ops the new params if the server path is out of P3a's runtime — plan confirms which backend the workbench uses today; the local path is primary).
+**Verified:** `app.character_persona_scope_service` is a `CharacterPersonaScopeService` that wraps BOTH a local (file-backed) and a server backend behind a policy enforcer (`app.py` ~:3788–3796) — modifying `list_persona_profiles` on both backends for parity is avoidable. Persona lists are small (local default cap 100), so P3a **applies sort/search/pagination in the screen (or a thin scope-layer helper) over the profile list already returned by `list_persona_profiles(mode)`** — backend-agnostic, works for whichever backend the policy routes to, and needs no dual-backend change.
 
-"Relevance" is not meaningful without FTS, so for personas the default sort while searching is **Name A–Z** (documented), and explicit sorts apply as normal.
+- **Search:** case-insensitive substring over the profile `name` (and `description`) — **verified: persona profiles carry `name` + `description`** (`local_character_persona_service.py` ~:512–534).
+- **Sort:** the same sort keys mapped to Python `sorted()` (Name A–Z; Recently modified/created over the profile timestamps). "Relevance" is not meaningful without FTS, so **personas default to Name A–Z while searching** and never expose the Relevance option.
+- **Tag filter: NOT applicable to personas — verified persona profiles have NO `tags` field.** The tag control is therefore **characters-only** (gated off in personas mode; see §C).
+- **Pagination:** filter → sort → `[offset:offset+page_size]`; total = length of the filtered (pre-slice) list, so "X–Y of N" is accurate.
 
 ### C. Pane UI (`personas_library_pane.py`)
 
-Add three backend-agnostic controls the screen drives, **gated to characters + personas modes** via `set_mode` (hidden for dict/lore):
-- **Sort control** — a compact cycle button ("Sort: Name ▾" → Recently modified → Recently created → [Relevance, only while searching]) posting a `PersonaSortChanged(sort_key)` message. (A `Select` is the alternative; the plan picks whichever fits the 2fr rail cleanly — cycle button preferred for width.)
-- **Tag filter** — a "Tag: All ▾" control opening a tag picker (reuse the existing modal-picker pattern from the Lore/Dict attach pickers) populated from the distinct-tags list; selecting posts `PersonaTagFilterChanged(tag | None)`. "All" clears it.
-- **Page bar** — at the list foot: "◄ 1–50 of N ►" with prev/next (disabled at ends), posting `PersonaPageChanged(delta | page)`. Hidden when `N <= page_size`.
+Add backend-agnostic controls the screen drives, gated by mode via `set_mode` (all hidden for dict/lore):
+- **Sort control** — characters **and** personas. A compact cycle button ("Sort: Name ▾" → Recently modified → Recently created → [Relevance, only while a character search is active]) posting a `PersonaSortChanged(sort_key)` message. (A `Select` is the alternative; the plan picks whichever fits the 2fr rail cleanly — cycle button preferred for width.)
+- **Tag filter** — **characters only** (personas have no tags — §B). A "Tag: All ▾" control opening a tag picker (reuse the existing modal-picker pattern from the Lore/Dict attach pickers) populated from `list_distinct_character_tags()`; selecting posts `PersonaTagFilterChanged(tag | None)`. "All" clears it. Hidden in personas/dict/lore modes.
+- **Page bar** — characters **and** personas. At the list foot: "◄ 1–50 of N ►" with prev/next (disabled at ends), posting `PersonaPageChanged(delta | page)`. Hidden when `N <= page_size`.
 
 **Page size:** `PERSONAS_LIBRARY_PAGE_SIZE = 50` (one constant).
 
@@ -137,19 +137,26 @@ The pane stays a `ListView` with the same `clear()`+`extend()` rebuild — but e
 ### D. Screen wiring & data flow (`personas_screen.py`)
 
 - Hold the query state per mode: `sort_key`, `tag_filter`, `page_offset`, alongside the existing `search_query` (in `PersonasWorkbenchState`).
-- A single **`_load_character_page` worker** (off-thread via `asyncio.to_thread`, exclusive, group reused from the current search group) that: calls the lib page + count with `(limit=PAGE_SIZE, offset, order_by=sort_key, search_term, tag)`, builds `LibraryRow`s (now with a meta line, e.g. last-modified date), and calls `library.update_rows(rows, filtered_total, page window, noun)`. The existing stale-snapshot guard extends to include `(sort_key, tag, offset)` so a slow page load can't overwrite a newer request.
+- A single **`_load_character_page` worker** (off-thread via `asyncio.to_thread`, exclusive, group reused from the current search group) that: calls the lib page with `(limit=PAGE_SIZE, offset, order_by=sort_key, search_term, tag)`, builds `LibraryRow`s (now with a meta line, e.g. last-modified date), and calls `library.update_rows(rows, filtered_total, page window, noun)`. The existing stale-snapshot guard extends to include `(sort_key, tag, offset)` so a slow page load can't overwrite a newer request.
+- **Count caching:** the total `N` depends only on `(search_term, tag)` — not on sort or offset. Run `count_character_cards` only when `(search_term, tag)` changes (cache it keyed by that pair); a prev/next page click or a sort change reuses the cached count and issues just the page query. Avoids a redundant COUNT on every page navigation.
 - **Reset offset to 0** whenever search / sort / tag changes (a filter change invalidates the current page). Page prev/next only changes offset.
 - **Relevance is search-only:** `sort_key="relevance"` is reachable only while a search term is present. When the search clears while `sort_key=="relevance"`, the screen falls back to the default `name_asc` (and the sort control re-labels to "Name"). Personas never expose Relevance (no FTS).
 - Personas: a parallel `_load_persona_page` path calling the persona service with the same params.
 - Handlers: `@on(PersonaSortChanged)`, `@on(PersonaTagFilterChanged)`, `@on(PersonaPageChanged)` → update state → trigger the load worker for the active mode. All wrapped so a backend error notifies rather than crashing the worker (`run_worker(exit_on_error=…)` discipline — see constraints).
-- `set_mode`/`_apply_mode`: show the new controls only for characters + personas; on entering a mode, reset offset and load page 0.
+- `set_mode`/`_apply_mode`: show sort + page controls for characters + personas and the tag control for characters only; on entering a mode, reset offset and load page 0.
+
+**Cache-assumption fixes (verified — `self._characters` becomes one page, not the capped-full library).** Selection is safe (resolved by id via `character_handler.load_character`, not a cache scan), but five sites assume the cache holds the whole (capped) library and must be corrected in this task:
+1. `_render_library_rows` count/filter (~:778 `total = len(self._characters)`, ~:796/801 in-memory substring) → replaced by the paged query + `count_character_cards` (the core change).
+2. Status string (~:1329 `f"Characters: {len(self._characters)} ..."`) → use the COUNT total, not the page length.
+3. Import name-conflict detection (~:3766 `pre_import_ids = {ids in self._characters}` → ~:3803 `if imported_id in pre_import_ids`) → a page-only id set would misclassify an import that collides with an **off-page** existing character as "new". Derive the conflict signal without the full-library cache — e.g. an existence check on `imported_id` before/after, or a return signal from the importer. (Cosmetic: notification wording; no data effect — but a real regression to prevent.)
+4. `_character_record` name resolution after import (~:3797) and after save (~:4565) — the cache scan returns `None` for an off-page character → generic fallback name. Resolve the name by id (handler-loaded record / by-id fetch) instead of scanning the page cache. (Selection itself already uses the id and is unaffected.)
 
 ### Error handling / edge cases
 
 - **Empty results** (search/tag matches nothing): page bar hidden, count "0 of 0", empty ListView (existing empty-state).
 - **Offset past the end** (e.g. tag change shrinks N below current offset): clamp offset into range before fetch; if the page is empty but N>0, snap to the last valid page.
 - **Deleted-during-paging / stale snapshot:** the extended snapshot guard drops results whose `(mode, search, sort, tag, offset)` no longer matches current state (mirrors the P2e/P2g freshness-guard lesson — re-check state after the await before writing to the pane).
-- **Malformed tags JSON** on a row: `json_each` tolerates valid JSON; a row with non-array/NULL tags simply never matches a tag filter and contributes no distinct tags — never raises. The distinct-tags/count queries use `deleted = 0` and the same predicate, so they stay consistent with the list.
+- **Malformed / NULL tags JSON** on a row: handled by the `CASE WHEN json_valid(tags) THEN tags ELSE '[]' END` guard (§A) so `json_each` never sees invalid JSON and never raises; such a row simply never matches a tag filter and contributes no distinct tags. The distinct-tags/count/list queries all use the same `deleted = 0` + guarded predicate, so they stay consistent with each other. **A test must seed a row with NULL and a non-JSON tags value and assert the list/count/distinct queries don't raise.**
 - **FTS unavailable / MATCH syntax error** on odd input: the search path must degrade to no-results-with-notice rather than raise (wrap the FTS query; the current `search_characters_fts` already tolerates this pattern).
 - **`json_each` absence** (hypothetical old SQLite): `list_distinct_character_tags` and the tag predicate fall back to a Python-side pass over loaded rows (documented; not expected to trigger).
 
@@ -165,9 +172,9 @@ The pane stays a `ListView` with the same `clear()`+`extend()` rebuild — but e
 ## Task decomposition (for writing-plans → subagent-driven-development)
 
 1. **Characters query + count + tags seam** — `list_character_cards_page`, `count_character_cards`, `list_distinct_character_tags` in `ChaChaNotes_DB.py` + the `Character_Chat_Lib` UI-shaped wrappers, with the sort whitelist and tag predicate. Real-DB tests. (Deliverable: backend can page/sort/tag/count/search characters.)
-2. **Personas backend parity** — extend `LocalCharacterPersonaService.list_persona_profiles` (+ distinct tags) with `order_by`/`search_term`/`tag`; accurate filtered total. Pure-Python tests. (Server variant reconciled or explicitly deferred per which backend is live.)
+2. **Personas filter/sort/page helper** — a thin screen/scope-layer function that takes the profiles from `list_persona_profiles(mode)` and applies search (name+description substring), sort (Name/Recent), and `[offset:offset+page_size]`, returning `(page_rows, filtered_total)`. **No tag path** (personas have no tags), **no backend edits** (works for whichever backend the scope service routes to). Pure-Python tests over a seeded profile list.
 3. **Pane controls** — sort cycle button, tag filter control + picker, page bar; new `Persona*Changed` messages; `update_rows` page-window extension; `set_mode` gating. Widget tests.
-4. **Screen wiring + integration** — query state in `PersonasWorkbenchState`; `_load_character_page` / `_load_persona_page` workers (off-thread, extended stale-snapshot guard, offset reset on filter change, clamp); the three `@on` handlers; `_apply_mode` control gating + page-0 load. Screen integration tests.
+4. **Screen wiring + integration + cache-assumption fixes** — query state in `PersonasWorkbenchState`; `_load_character_page` / `_load_persona_page` workers (off-thread, extended stale-snapshot guard incl. `(sort, tag, offset)`, offset reset on filter change, offset clamp); the three `@on` handlers; `_apply_mode` control gating (tag = characters only) + page-0 load; **plus the five `self._characters` cache-assumption fixes in §D** (count/filter, status string, import-conflict detection, name resolution after import/save). Screen integration tests including a paged >page-size library, tag-narrows-count, sort resets offset, mode-switch, a stale-snapshot regression, and an import-of-off-page-name-conflict messaging test.
 
 Four focused tasks → one PR.
 

--- a/Tests/Character_Chat/test_persona_list_paging.py
+++ b/Tests/Character_Chat/test_persona_list_paging.py
@@ -1,0 +1,40 @@
+from tldw_chatbook.Character_Chat.persona_list_paging import page_persona_profiles
+
+PROFILES = [
+    {"id": "1", "name": "Alice", "description": "hero", "created_at": "2026-01-01", "last_modified": "2026-01-03"},
+    {"id": "2", "name": "bob", "description": "villain", "created_at": "2026-01-02", "last_modified": "2026-01-02"},
+    {"id": "3", "name": "Carol", "description": "hero mage", "created_at": "2026-01-03", "last_modified": "2026-01-01"},
+]
+
+
+def test_search_matches_name_and_description_case_insensitive():
+    rows, total = page_persona_profiles(PROFILES, search_term="HERO", sort_key="name_asc", offset=0, page_size=50)
+    assert {r["name"] for r in rows} == {"Alice", "Carol"}
+    assert total == 2
+
+
+def test_sort_name_asc_case_insensitive():
+    rows, total = page_persona_profiles(PROFILES, search_term=None, sort_key="name_asc", offset=0, page_size=50)
+    assert [r["name"] for r in rows] == ["Alice", "bob", "Carol"]
+    assert total == 3
+
+
+def test_sort_created_desc():
+    rows, _ = page_persona_profiles(PROFILES, search_term=None, sort_key="created_desc", offset=0, page_size=50)
+    assert [r["name"] for r in rows] == ["Carol", "bob", "Alice"]
+
+
+def test_sort_modified_desc():
+    rows, _ = page_persona_profiles(PROFILES, search_term=None, sort_key="modified_desc", offset=0, page_size=50)
+    assert [r["name"] for r in rows] == ["Alice", "bob", "Carol"]
+
+
+def test_pagination_window_and_total():
+    profiles = [{"id": str(i), "name": f"p{i:03d}", "description": "", "created_at": "x", "last_modified": "x"} for i in range(120)]
+    page2, total = page_persona_profiles(profiles, search_term=None, sort_key="name_asc", offset=50, page_size=50)
+    assert total == 120 and len(page2) == 50 and page2[0]["name"] == "p050"
+
+
+def test_unknown_sort_key_falls_back_to_name():
+    rows, _ = page_persona_profiles(PROFILES, search_term=None, sort_key="relevance", offset=0, page_size=50)
+    assert [r["name"] for r in rows] == ["Alice", "bob", "Carol"]

--- a/Tests/DB/test_character_cards_paging.py
+++ b/Tests/DB/test_character_cards_paging.py
@@ -1,0 +1,143 @@
+# test_character_cards_paging.py
+# Description: RED-first coverage for P3a Task 1 — paged/sorted/tag-filtered
+# character list + count + distinct tags DB seam on CharactersRAGDB, plus the
+# UI-shaping wrappers in Character_Chat_Lib.
+"""
+Adds ``list_character_cards_page`` / ``count_character_cards`` /
+``list_distinct_character_tags`` to ``CharactersRAGDB`` and thin UI wrappers
+in ``Character_Chat_Lib``. These are read-only additions consumed by later
+Roleplay P3a tasks (pane controls, screen wiring) -- nothing consumes them
+yet, so this suite is the sole verification.
+
+Key correctness contracts under test:
+- Pagination windows are disjoint and respect LIMIT/OFFSET.
+- COUNT matches the full unpaginated result set for the same filter.
+- Tag filtering narrows both the list and the count identically.
+- Search composes with tag filter and sort (mirrors the FTS-join pattern of
+  the existing ``search_character_cards``).
+- Sort whitelist: known keys apply the right ORDER BY; unknown keys fall
+  back to name_asc.
+- Distinct tags are case-insensitively sorted and de-duplicated.
+- NULL and non-JSON ``tags`` values never raise (json_each must be
+  json-valid-guarded) across list/count/distinct-tags.
+"""
+
+import time
+
+import pytest
+
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    return CharactersRAGDB(tmp_path / "p3a.db", client_id="test")
+
+
+def _add(db, name, tags, desc=""):
+    return db.add_character_card({"name": name, "description": desc, "tags": tags})
+
+
+def test_page_returns_window_and_disjoint_pages(db):
+    for i in range(120):
+        _add(db, f"char{i:03d}", ["even"] if i % 2 == 0 else ["odd"])
+    page1 = db.list_character_cards_page(limit=50, offset=0, order_by="name_asc")
+    page2 = db.list_character_cards_page(limit=50, offset=50, order_by="name_asc")
+    assert len(page1) == 50 and len(page2) == 50
+    ids1 = {c["id"] for c in page1}
+    ids2 = {c["id"] for c in page2}
+    assert ids1.isdisjoint(ids2)
+    # name_asc order
+    assert [c["name"] for c in page1] == sorted(c["name"] for c in page1)
+
+
+def test_count_matches_full_set(db):
+    for i in range(120):
+        _add(db, f"c{i:03d}", [])
+    # +1 for the pre-seeded Default Assistant (id=1) — assert relative, not absolute:
+    assert db.count_character_cards() == len(
+        db.list_character_cards_page(limit=1000, offset=0)
+    )
+
+
+def test_tag_filter_narrows_list_and_count(db):
+    for i in range(10):
+        _add(db, f"t{i}", ["hero"] if i < 3 else ["villain"])
+    heroes = db.list_character_cards_page(limit=100, offset=0, tag="hero")
+    assert {c["name"] for c in heroes} == {"t0", "t1", "t2"}
+    assert db.count_character_cards(tag="hero") == 3
+
+
+def test_search_composes_with_tag_and_sort(db):
+    _add(db, "Dragon Knight", ["hero"])
+    _add(db, "Dragon Fiend", ["villain"])
+    _add(db, "Wolf", ["hero"])
+    hits = db.list_character_cards_page(
+        limit=100, offset=0, search_term='"Dragon"*', tag="hero", order_by="name_asc"
+    )
+    assert [c["name"] for c in hits] == ["Dragon Knight"]
+    assert db.count_character_cards(search_term='"Dragon"*', tag="hero") == 1
+
+
+def test_sort_by_modified_desc(db):
+    a = _add(db, "alpha", [])
+    # `last_modified` has millisecond precision; a real gap avoids a flaky
+    # tie against alpha's creation timestamp on fast (e.g. in-memory-like)
+    # SQLite round-trips, which would otherwise land beta's update in the
+    # same millisecond as alpha's creation.
+    time.sleep(0.02)
+    b = _add(db, "beta", [])
+    # bump beta's last_modified by updating it
+    rec = db.get_character_card_by_id(b)
+    db.update_character_card(b, {"description": "x"}, int(rec["version"]))
+    rows = db.list_character_cards_page(limit=100, offset=0, order_by="modified_desc")
+    names = [c["name"] for c in rows]
+    assert names.index("beta") < names.index("alpha")
+
+
+def test_distinct_tags_sorted_unique(db):
+    _add(db, "a", ["Zed", "amber"])
+    _add(db, "b", ["amber"])
+    tags = db.list_distinct_character_tags()
+    assert tags == sorted(set(tags), key=str.lower)
+    assert "amber" in tags and "Zed" in tags
+    assert tags.count("amber") == 1
+
+
+def test_malformed_and_null_tags_never_raise(db):
+    good = _add(db, "good", ["ok"])
+    # Force a NULL tags row and a non-JSON tags row directly. Each raw UPDATE
+    # is committed immediately -- the python sqlite3 driver implicitly opens
+    # a transaction on the first DML statement, and `_add` below opens its
+    # own explicit transaction via `db.transaction()`, which would otherwise
+    # collide with the still-open implicit one ("cannot start a transaction
+    # within a transaction").
+    conn = db.get_connection()
+    conn.execute("UPDATE character_cards SET tags = NULL WHERE id = ?", (good,))
+    conn.commit()
+    bad = _add(db, "bad", [])
+    conn.execute("UPDATE character_cards SET tags = 'not,json' WHERE id = ?", (bad,))
+    conn.commit()
+    # None of these may raise:
+    assert isinstance(db.list_character_cards_page(limit=100, offset=0), list)
+    assert isinstance(db.count_character_cards(), int)
+    assert isinstance(db.list_distinct_character_tags(), list)
+    assert isinstance(db.count_character_cards(tag="ok"), int)
+
+
+def test_unknown_order_by_falls_back_to_name(db):
+    _add(db, "b", [])
+    _add(db, "a", [])
+    rows = db.list_character_cards_page(limit=10, offset=0, order_by="bogus")
+    assert [c["name"] for c in rows][:2] == ["a", "b"]
+
+
+def test_lib_wrapper_shapes_rows(db):
+    from tldw_chatbook.Character_Chat.Character_Chat_Lib import (
+        get_character_page_for_ui, count_character_page, list_character_tags,
+    )
+    _add(db, "Zeta", ["x"])
+    rows = get_character_page_for_ui(db, limit=10, offset=0)
+    assert rows and set(rows[0]) == {"id", "name", "last_modified", "created_at", "tags"}
+    assert count_character_page(db) == len(get_character_page_for_ui(db, limit=1000, offset=0))
+    assert "x" in list_character_tags(db)

--- a/Tests/UI/test_personas_character_attach.py
+++ b/Tests/UI/test_personas_character_attach.py
@@ -27,6 +27,7 @@ from Tests.UI.test_personas_dictionaries import (
     FakeDictScopeService,
     PersonasTestApp,
     make_dict_record,
+    patch_character_paging,
 )
 
 pytestmark = pytest.mark.asyncio
@@ -142,6 +143,8 @@ def stub_characters(monkeypatch):
             dict(c) for c in CHARACTERS if str(c["id"]) == str(character_id)
         ),
     )
+    # Task 4: the library pages from the DB seam; feed it the same stub rows.
+    patch_character_paging(monkeypatch)
 
 
 async def _mounted(pilot):

--- a/Tests/UI/test_personas_character_world_books_screen.py
+++ b/Tests/UI/test_personas_character_world_books_screen.py
@@ -45,7 +45,7 @@ from tldw_chatbook.Widgets.Persona_Widgets.personas_character_world_books import
 )
 from tldw_chatbook.Widgets.Persona_Widgets.world_book_picker import WorldBookPicker
 
-from Tests.UI.test_personas_dictionaries import PersonasTestApp
+from Tests.UI.test_personas_dictionaries import PersonasTestApp, patch_character_paging
 
 pytestmark = pytest.mark.asyncio
 
@@ -97,6 +97,8 @@ def stub_characters_for_worldbooks(monkeypatch, seeded_character_with_worldbook)
             dict(record) if str(character_id) == str(char_id) else None
         ),
     )
+    # Task 4: the library pages from the DB seam; mirror fetch_all_characters.
+    patch_character_paging(monkeypatch)
 
 
 async def _mounted(pilot):
@@ -167,6 +169,7 @@ class TestCharacterWorldBooksScreenWiring:
                 dict(record) if str(character_id) == str(char_id) else None
             ),
         )
+        patch_character_paging(monkeypatch)
         mock_app_instance.chachanotes_db = worldbooks_db
         mock_app_instance.chat_dictionary_scope_service = None
 
@@ -223,6 +226,7 @@ def stub_character_for_standalone_worldbook(
             dict(record) if str(character_id) == str(char_id) else None
         ),
     )
+    patch_character_paging(monkeypatch)
 
 
 class TestCharacterWorldBookAttachDetach:

--- a/Tests/UI/test_personas_dictionaries.py
+++ b/Tests/UI/test_personas_dictionaries.py
@@ -23,6 +23,82 @@ from tldw_chatbook.Widgets.Persona_Widgets.personas_library_pane import (
 pytestmark = pytest.mark.asyncio
 
 
+def patch_character_paging(monkeypatch, records=None):
+    """Route the screen's paged character loader over the stubbed character list.
+
+    P3a Task 4 made the character library page from the DB seam
+    (``get_character_page_for_ui``/``count_character_page``/``list_character_tags``,
+    imported into ``personas_screen``). Screen tests that stub ``fetch_all_characters``
+    (rather than seed a real ``CharactersRAGDB``) must also route these three so the
+    library renders their stub rows.
+
+    The source is read LIVE from ``fetch_all_characters()`` each call (unless an
+    explicit ``records`` list is given), so tests that swap ``fetch_all_characters``
+    mid-run (create/delete) stay consistent for free. Mirrors real search (name
+    substring on the FTS-unwrapped term), tag membership, and name_asc sort;
+    ignores the ``db`` arg.
+    """
+    import tldw_chatbook.UI.CCP_Modules.ccp_character_handler as chm
+    import tldw_chatbook.UI.Screens.personas_screen as ps
+
+    def _source():
+        if records is not None:
+            return list(records)
+        try:
+            return list(chm.fetch_all_characters() or [])
+        except Exception:
+            return []
+
+    def _norm(record):
+        return {
+            "id": record.get("id"),
+            "name": record.get("name"),
+            "last_modified": record.get("last_modified"),
+            "created_at": record.get("created_at"),
+            "tags": list(record.get("tags") or []),
+        }
+
+    def _unwrap(search_term):
+        # Reverse _fts_match_query: '"term"*' -> 'term' (trailing * first, then
+        # the surrounding quotes, then unescape doubled quotes).
+        term = str(search_term).strip()
+        if term.endswith("*"):
+            term = term[:-1]
+        return term.strip('"').replace('""', '"').lower()
+
+    def _filtered(search_term, tag):
+        rows = [_norm(r) for r in _source()]
+        if search_term:
+            term = _unwrap(search_term)
+            rows = [r for r in rows if term in str(r["name"] or "").lower()]
+        if tag is not None:
+            rows = [r for r in rows if tag in (r["tags"] or [])]
+        return rows
+
+    def _page(db, *, limit, offset, order_by="name_asc", search_term=None, tag=None):
+        rows = _filtered(search_term, tag)
+        rows.sort(key=lambda r: str(r["name"] or "").lower())
+        return rows[offset : offset + limit]
+
+    def _count(db, *, search_term=None, tag=None):
+        return len(_filtered(search_term, tag))
+
+    def _tags(db):
+        seen: list[str] = []
+        for record in _source():
+            for tag in record.get("tags") or []:
+                if tag not in seen:
+                    seen.append(tag)
+        return sorted(seen, key=str.lower)
+
+    monkeypatch.setattr(ps, "get_character_page_for_ui", _page)
+    monkeypatch.setattr(ps, "count_character_page", _count)
+    monkeypatch.setattr(ps, "list_character_tags", _tags)
+    # Keep the paged loader off the real lazy DB entirely (the patched functions
+    # ignore the db arg, so any non-None sentinel is fine).
+    monkeypatch.setattr(chm, "_default_character_db", lambda: object())
+
+
 def _entry_response(dictionary_id: int, index: int, entry: dict) -> dict:
     """Shape one entry exactly like local _entry_to_response (API naming)."""
     return {
@@ -605,6 +681,7 @@ def stub_characters(monkeypatch):
     monkeypatch.setattr(
         character_handler_module, "fetch_character_by_id", lambda character_id: None
     )
+    patch_character_paging(monkeypatch)
 
 
 class PersonasTestApp(App):

--- a/Tests/UI/test_personas_library_pane_paging.py
+++ b/Tests/UI/test_personas_library_pane_paging.py
@@ -1,0 +1,142 @@
+"""Mounted tests for the Personas library pane sort/tag/page controls (P3a Task 3)."""
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Button, Static
+
+from tldw_chatbook.Widgets.Persona_Widgets.personas_library_pane import (
+    LibraryRow,
+    PersonasLibraryPane,
+)
+from tldw_chatbook.Widgets.Persona_Widgets.personas_messages import (
+    PersonaPageChanged,
+    PersonaSortCycleRequested,
+    PersonaTagFilterRequested,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+class _Host(App):
+    def __init__(self):
+        super().__init__()
+        self.events = []
+
+    def compose(self) -> ComposeResult:
+        yield PersonasLibraryPane(id="pane")
+
+    def on_persona_sort_cycle_requested(self, message: PersonaSortCycleRequested) -> None:
+        self.events.append(("sort", None))
+
+    def on_persona_tag_filter_requested(self, message: PersonaTagFilterRequested) -> None:
+        self.events.append(("tag", None))
+
+    def on_persona_page_changed(self, message: PersonaPageChanged) -> None:
+        self.events.append(("page", message.delta))
+
+
+def _rows(n):
+    return tuple(
+        LibraryRow(item_id=str(i), kind="character", name=f"c{i:03d}") for i in range(n)
+    )
+
+
+async def test_page_bar_shows_when_total_exceeds_page_size():
+    app = _Host()
+    async with app.run_test() as pilot:
+        pane = app.query_one(PersonasLibraryPane)
+        await pane.update_rows(
+            _rows(50), total=130, noun="characters", page_offset=0, page_size=50
+        )
+        await pilot.pause()
+        info = app.query_one("#personas-library-page-info", Static)
+        assert "1-50 of 130" in str(info.renderable)
+        assert app.query_one("#personas-library-prev", Button).disabled is True
+        assert app.query_one("#personas-library-next", Button).disabled is False
+        assert app.query_one("#personas-library-pagebar").display is True
+
+
+async def test_page_bar_hidden_when_fits_one_page():
+    app = _Host()
+    async with app.run_test() as pilot:
+        pane = app.query_one(PersonasLibraryPane)
+        await pane.update_rows(
+            _rows(5), total=5, noun="characters", page_offset=0, page_size=50
+        )
+        await pilot.pause()
+        assert app.query_one("#personas-library-pagebar").display is False
+
+
+async def test_next_prev_post_page_changed():
+    app = _Host()
+    async with app.run_test() as pilot:
+        pane = app.query_one(PersonasLibraryPane)
+        await pane.update_rows(
+            _rows(50), total=130, noun="characters", page_offset=50, page_size=50
+        )
+        await pilot.pause()
+        await pilot.click("#personas-library-next")
+        await pilot.click("#personas-library-prev")
+        await pilot.pause()
+        assert ("page", 1) in app.events and ("page", -1) in app.events
+
+
+async def test_sort_and_tag_buttons_post_intents():
+    app = _Host()
+    async with app.run_test() as pilot:
+        app.query_one(PersonasLibraryPane).set_mode("characters")
+        await pilot.pause()
+        await pilot.click("#personas-library-sort")
+        await pilot.click("#personas-library-tag")
+        await pilot.pause()
+        assert ("sort", None) in app.events and ("tag", None) in app.events
+
+
+async def test_tag_button_hidden_for_personas_visible_for_characters():
+    app = _Host()
+    async with app.run_test() as pilot:
+        pane = app.query_one(PersonasLibraryPane)
+        pane.set_mode("personas")
+        assert app.query_one("#personas-library-tag", Button).display is False
+        assert app.query_one("#personas-library-sort", Button).display is True
+        pane.set_mode("characters")
+        assert app.query_one("#personas-library-tag", Button).display is True
+
+
+async def test_sort_page_hidden_for_lore():
+    app = _Host()
+    async with app.run_test() as pilot:
+        pane = app.query_one(PersonasLibraryPane)
+        pane.set_mode("lore")
+        assert app.query_one("#personas-library-sort", Button).display is False
+        assert app.query_one("#personas-library-tag", Button).display is False
+        # dict/lore call update_rows WITHOUT page kwargs -> no page bar, plain count
+        await pane.update_rows((), total=0, noun="world books")
+        await pilot.pause()
+        assert app.query_one("#personas-library-pagebar").display is False
+
+
+async def test_set_sort_label_and_set_tag_label():
+    app = _Host()
+    async with app.run_test() as pilot:
+        pane = app.query_one(PersonasLibraryPane)
+        pane.set_sort_label("Sort: Recent")
+        pane.set_tag_label("Tag: villain")
+        assert str(app.query_one("#personas-library-sort", Button).label) == "Sort: Recent"
+        assert str(app.query_one("#personas-library-tag", Button).label) == "Tag: villain"
+
+
+async def test_update_rows_without_page_kwargs_keeps_plain_count():
+    """Backward compatibility: dict/lore callers omit page_offset/page_size."""
+    app = _Host()
+    async with app.run_test() as pilot:
+        pane = app.query_one(PersonasLibraryPane)
+        await pane.update_rows(
+            (LibraryRow(item_id="1", kind="dictionary", name="D1"),),
+            total=1,
+            noun="dictionaries",
+        )
+        await pilot.pause()
+        count = app.query_one("#personas-library-count", Static)
+        assert "1 dictionaries" in str(count.renderable)
+        assert app.query_one("#personas-library-pagebar").display is False

--- a/Tests/UI/test_personas_library_scale.py
+++ b/Tests/UI/test_personas_library_scale.py
@@ -1,0 +1,284 @@
+"""P3a Task 4: PersonasScreen library-scale wiring — mounted integration
+against a REAL CharactersRAGDB.
+
+Proves the character library is now page-at-a-time (Task 1 DB seam + Task 3
+pane controls wired through the screen):
+
+- first page shows PERSONAS_LIBRARY_PAGE_SIZE rows + a "1-50 of N" page bar,
+- next page is disjoint from the first,
+- a tag filter narrows the count and resets the page offset,
+- a sort change resets the page offset,
+- importing a card whose name conflicts with an OFF-PAGE character reports
+  "already existed" (drives the count-based pre-import existence check that
+  replaced the page-cache membership snapshot).
+
+Harness: mirrors ``test_personas_character_world_books_screen.py`` — a real
+``CharactersRAGDB`` seeded via ``add_character_card`` and fed to the delegating
+``PersonasTestApp`` from ``test_personas_dictionaries.py``. The screen's paged
+loader (and its import/save paths) resolve the character DB through
+``ccp_character_handler._default_character_db()`` →
+``config.get_chachanotes_db_lazy()``, so the harness points that resolver at the
+seeded DB (and also sets ``chachanotes_db`` on the mock app for good measure).
+"""
+
+import json
+from contextlib import asynccontextmanager
+
+import pytest
+
+import tldw_chatbook.config as config_module
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.UI.Screens.personas_screen import PERSONAS_LIBRARY_PAGE_SIZE
+from tldw_chatbook.Widgets.Persona_Widgets.personas_library_pane import (
+    PersonasLibraryPane,
+)
+
+from Tests.UI.test_personas_dictionaries import PersonasTestApp
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def scaled_db(tmp_path):
+    db = CharactersRAGDB(tmp_path / "p3a_scale.db", "test-client")
+    yield db
+    db.close_connection()
+
+
+def _seed(db, count, *, tags_for=None):
+    """Seed ``count`` characters named c000.. with optional per-index tags."""
+    for i in range(count):
+        db.add_character_card(
+            {
+                "name": f"c{i:03d}",
+                "description": "",
+                "tags": list(tags_for(i)) if tags_for else [],
+            }
+        )
+
+
+def _pane_visible_rows(pane: PersonasLibraryPane) -> int:
+    """Number of selectable library rows currently rendered."""
+    return len(pane._row_lookup)
+
+
+@asynccontextmanager
+async def _personas(mock_app_instance, db, monkeypatch):
+    """Mount PersonasScreen over a real CharactersRAGDB and settle mount work."""
+    # The screen's character DB resolver (import/export/save + the paged loader)
+    # goes through the lazy global getter; route it at the seeded DB.
+    monkeypatch.setattr(config_module, "get_chachanotes_db_lazy", lambda: db)
+    mock_app_instance.chachanotes_db = db
+    mock_app_instance.chat_dictionary_scope_service = None
+    app = PersonasTestApp(mock_app_instance)
+    async with app.run_test(size=(160, 48)) as pilot:
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        yield pilot, pilot.app.screen
+
+
+async def test_first_page_and_next(mock_app_instance, scaled_db, monkeypatch):
+    baseline = scaled_db.count_character_cards()
+    _seed(scaled_db, 130)
+    total = baseline + 130
+    async with _personas(mock_app_instance, scaled_db, monkeypatch) as (
+        pilot,
+        screen,
+    ):
+        pane = screen.query_one(PersonasLibraryPane)
+        assert screen.state.page_offset == 0
+        assert screen._character_total == total
+        # First page: exactly PAGE_SIZE rows + a "1-50 of N" page bar.
+        assert _pane_visible_rows(pane) == PERSONAS_LIBRARY_PAGE_SIZE
+        info = screen.query_one("#personas-library-page-info").renderable
+        assert f"1-{PERSONAS_LIBRARY_PAGE_SIZE} of {total}" in str(info)
+        assert screen.query_one("#personas-library-pagebar").display is True
+
+        first_ids = set(pane._row_lookup and _row_ids(pane))
+        await screen._on_page_changed_delta(1)
+        await pilot.pause()
+        assert screen.state.page_offset == PERSONAS_LIBRARY_PAGE_SIZE
+        second_ids = set(_row_ids(pane))
+        # Next page is a disjoint window.
+        assert first_ids and second_ids and first_ids.isdisjoint(second_ids)
+
+
+def _row_ids(pane: PersonasLibraryPane) -> list[str]:
+    return [row.item_id for row in pane._row_lookup.values()]
+
+
+async def test_tag_filter_narrows_count_and_resets_offset(
+    mock_app_instance, scaled_db, monkeypatch
+):
+    _seed(
+        scaled_db,
+        10,
+        tags_for=lambda i: ["hero"] if i < 3 else ["villain"],
+    )
+    async with _personas(mock_app_instance, scaled_db, monkeypatch) as (
+        pilot,
+        screen,
+    ):
+        screen.state.page_offset = PERSONAS_LIBRARY_PAGE_SIZE  # pretend we paged
+        await screen._apply_tag_filter("hero")
+        await pilot.pause()
+        assert screen._character_total == 3
+        assert screen.state.page_offset == 0
+        assert screen.state.tag_filter == "hero"
+        # Clearing the filter (None) restores the full count.
+        await screen._apply_tag_filter(None)
+        await pilot.pause()
+        assert screen.state.tag_filter is None
+        assert screen._character_total == scaled_db.count_character_cards()
+
+
+async def test_sort_change_resets_offset(mock_app_instance, scaled_db, monkeypatch):
+    _seed(scaled_db, 130)
+    async with _personas(mock_app_instance, scaled_db, monkeypatch) as (
+        pilot,
+        screen,
+    ):
+        assert screen.state.sort_key == "name_asc"
+        screen.state.page_offset = PERSONAS_LIBRARY_PAGE_SIZE
+        await screen._cycle_sort()
+        await pilot.pause()
+        assert screen.state.page_offset == 0
+        # Cycle advanced off the default sort.
+        assert screen.state.sort_key != "name_asc"
+
+
+async def test_character_page_reads_run_off_the_event_loop(
+    mock_app_instance, scaled_db, monkeypatch
+):
+    """The count + page DB reads must be dispatched off the UI event loop."""
+    import asyncio
+
+    import tldw_chatbook.UI.Screens.personas_screen as ps
+
+    _seed(scaled_db, 60)
+    on_loop: list[bool] = []
+    real_page = ps.get_character_page_for_ui
+    real_count = ps.count_character_page
+
+    def _spy_page(*args, **kwargs):
+        try:
+            asyncio.get_running_loop()
+            on_loop.append(True)
+        except RuntimeError:
+            on_loop.append(False)
+        return real_page(*args, **kwargs)
+
+    def _spy_count(*args, **kwargs):
+        try:
+            asyncio.get_running_loop()
+            on_loop.append(True)
+        except RuntimeError:
+            on_loop.append(False)
+        return real_count(*args, **kwargs)
+
+    monkeypatch.setattr(ps, "get_character_page_for_ui", _spy_page)
+    monkeypatch.setattr(ps, "count_character_page", _spy_count)
+    async with _personas(mock_app_instance, scaled_db, monkeypatch) as (pilot, screen):
+        await screen._reload_character_page()
+        await pilot.pause()
+        assert on_loop, "the page/count DB reads must have run"
+        assert all(seen is False for seen in on_loop)
+
+
+async def test_character_search_defaults_to_relevance_sort(
+    mock_app_instance, scaled_db, monkeypatch
+):
+    from tldw_chatbook.Widgets.Persona_Widgets.personas_messages import (
+        PersonaSearchChanged,
+    )
+
+    _seed(scaled_db, 5)
+    async with _personas(mock_app_instance, scaled_db, monkeypatch) as (pilot, screen):
+        assert screen.state.sort_key == "name_asc"
+        screen._handle_search_changed(PersonaSearchChanged(query="c00"))
+        assert screen.state.sort_key == "relevance"
+        assert screen.state.page_offset == 0
+        # Clearing the search reverts relevance (search-only) to name.
+        screen._handle_search_changed(PersonaSearchChanged(query=""))
+        assert screen.state.sort_key == "name_asc"
+        await pilot.pause()
+
+
+async def test_page_nav_reuses_count_cache(mock_app_instance, scaled_db, monkeypatch):
+    """Sort/page navigation must not recompute the count for an unchanged filter."""
+    _seed(scaled_db, 130)
+    async with _personas(mock_app_instance, scaled_db, monkeypatch) as (
+        pilot,
+        screen,
+    ):
+        cache_key = screen._count_cache_key
+        assert cache_key == (None, None)
+        await screen._on_page_changed_delta(1)
+        await pilot.pause()
+        # Page nav within the same (search, tag) keeps the cached key.
+        assert screen._count_cache_key == cache_key
+
+
+async def test_import_offpage_name_conflict_message(
+    mock_app_instance, scaled_db, tmp_path, monkeypatch
+):
+    """A name conflict with an OFF-PAGE character reports 'already existed',
+    not 'imported new' — the page-cache snapshot would have missed it."""
+    # Seed enough alphabetically-earlier characters that the conflict target
+    # ("Zzz Offpage") lands beyond the first page.
+    _seed(scaled_db, 60)
+    conflict_name = "Zzz Offpage"
+    scaled_db.add_character_card({"name": conflict_name, "description": "orig"})
+
+    # A complete V2 card (all required fields) so the real importer parses it and
+    # only the duplicate NAME triggers the conflict path.
+    card_path = tmp_path / "conflict.json"
+    card_path.write_text(
+        json.dumps(
+            {
+                "spec": "chara_card_v2",
+                "spec_version": "2.0",
+                "data": {
+                    "name": conflict_name,
+                    "description": "reimport",
+                    "personality": "",
+                    "scenario": "",
+                    "first_mes": "Hello.",
+                    "mes_example": "",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    async with _personas(mock_app_instance, scaled_db, monkeypatch) as (pilot, screen):
+        # The conflict character is not on page 0 (name_asc), proving the fix
+        # cannot lean on the page cache.
+        pane = screen.query_one(PersonasLibraryPane)
+        assert conflict_name not in {
+            row.name for row in pane._row_lookup.values()
+        }
+
+        notes: list[tuple[str, str]] = []
+        monkeypatch.setattr(
+            screen, "_notify", lambda msg, sev="warning": notes.append((msg, sev))
+        )
+
+        selected: list[str] = []
+
+        async def _fake_select(entity_id, entity_name):
+            selected.append(str(entity_id))
+
+        monkeypatch.setattr(screen, "_select_character", _fake_select)
+
+        before = scaled_db.count_character_cards()
+        await screen._import_character_from_path(str(card_path))
+        await pilot.pause()
+
+        # No new row was created (conflict returned the existing id).
+        assert scaled_db.count_character_cards() == before
+        assert notes, "import must surface a notification"
+        message = notes[-1][0].lower()
+        assert "already existed" in message
+        assert "imported" not in message or "already" in message

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -87,6 +87,8 @@ def stub_scope_service(mock_app_instance):
 
 @pytest.fixture
 def stub_characters(monkeypatch):
+    from Tests.UI.test_personas_dictionaries import patch_character_paging
+
     monkeypatch.setattr(
         character_handler_module,
         "fetch_all_characters",
@@ -99,6 +101,9 @@ def stub_characters(monkeypatch):
             dict(c) for c in CHARACTERS if str(c["id"]) == str(character_id)
         ),
     )
+    # Task 4: the library pages from the DB seam now; mirror fetch_all_characters
+    # (read live so tests that swap it mid-run for create/delete stay consistent).
+    patch_character_paging(monkeypatch)
 
 
 class PersonasTestApp(App):
@@ -1180,7 +1185,9 @@ class TestSearch:
             rows = screen.query(".personas-library-row")
             assert [_row_text(r) for r in rows] == ["Detective Sam"]
             count = str(screen.query_one("#personas-library-count", Static).renderable)
-            assert "1 of 2 characters" in count
+            # Task 4: the library pages from the DB seam, so a search reports the
+            # match count as the page total (no separate "of <library>" copy).
+            assert "1 characters" in count
 
     async def test_clearing_search_restores_all_rows(
         self, mock_app_instance, stub_characters
@@ -1236,7 +1243,8 @@ class TestSearch:
             rows = screen.query(".personas-library-row")
             assert [_row_text(r) for r in rows] == ["Navigator"]
             count = str(screen.query_one("#personas-library-count", Static).renderable)
-            assert "1 of 2 persona profiles" in count
+            # Task 4: personas paginate in-memory; the count is the match total.
+            assert "1 persona profiles" in count
 
     async def test_mode_switch_clears_search(
         self, mock_app_instance, stub_characters, stub_scope_service
@@ -1265,91 +1273,15 @@ class TestSearch:
             # Search input is cleared
             assert screen.query_one("#personas-library-search").value == ""
 
-    async def test_fts_path_used_for_large_libraries(
-        self, mock_app_instance, stub_characters, monkeypatch
-    ):
-        fts_calls: list[str] = []
-
-        def fake_fts(search_term: str, limit: int = 50):
-            fts_calls.append(search_term)
-            return [{"id": 1, "name": "Detective Sam"}]
-
-        monkeypatch.setattr(character_handler_module, "search_characters_fts", fake_fts)
-
-        app = PersonasTestApp(mock_app_instance)
-        async with app.run_test() as pilot:
-            screen = await _mounted(pilot)
-            await pilot.pause()
-            # Lower the threshold so the 2-character stub library triggers FTS
-            screen.LIBRARY_FTS_THRESHOLD = 2
-            search_input = screen.query_one("#personas-library-search")
-            search_input.value = "sam"
-            await self._wait_for_search_render(pilot)
-            assert fts_calls == ["sam"]
-            rows = screen.query(".personas-library-row")
-            assert [_row_text(r) for r in rows] == ["Detective Sam"]
-
-    async def test_fts_search_count_uses_unbounded_full_library_copy(
-        self,
-        mock_app_instance: Any,
-        stub_characters: Any,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """FTS search copy must not use the truncated loaded-page denominator.
-
-        Args:
-            mock_app_instance: Mounted test app fixture.
-            stub_characters: Character-list fixture for the Personas library.
-            monkeypatch: Pytest monkeypatch fixture used to force the FTS path.
-
-        Returns:
-            None.
-        """
-
-        def fake_fts(search_term: str, limit: int = 50) -> list[dict[str, Any]]:
-            return [{"id": 1, "name": "Detective Sam"}]
-
-        monkeypatch.setattr(character_handler_module, "search_characters_fts", fake_fts)
-
-        app = PersonasTestApp(mock_app_instance)
-        async with app.run_test() as pilot:
-            screen = await _mounted(pilot)
-            await pilot.pause()
-            screen.LIBRARY_FTS_THRESHOLD = 2
-            screen.query_one("#personas-library-search").value = "sam"
-            await self._wait_for_search_render(pilot)
-
-            count = str(screen.query_one("#personas-library-count", Static).renderable)
-            assert count == "Showing 1 character match from full library"
-
-    async def test_fts_search_runs_off_the_event_loop(
-        self, mock_app_instance, stub_characters, monkeypatch
-    ):
-        """The FTS query must not run synchronously on the UI loop."""
-        import asyncio
-
-        loop_seen: list[bool] = []
-
-        def fake_fts(search_term: str, limit: int = 50):
-            try:
-                asyncio.get_running_loop()
-                loop_seen.append(True)
-            except RuntimeError:
-                loop_seen.append(False)
-            return [{"id": 1, "name": "Detective Sam"}]
-
-        monkeypatch.setattr(character_handler_module, "search_characters_fts", fake_fts)
-
-        app = PersonasTestApp(mock_app_instance)
-        async with app.run_test() as pilot:
-            screen = await _mounted(pilot)
-            await pilot.pause()
-            screen.LIBRARY_FTS_THRESHOLD = 2
-            screen.query_one("#personas-library-search").value = "sam"
-            await self._wait_for_search_render(pilot)
-            assert loop_seen == [False]
-            rows = screen.query(".personas-library-row")
-            assert [_row_text(r) for r in rows] == ["Detective Sam"]
+    # NOTE (P3a Task 4): the old in-memory-vs-FTS hybrid search (gated on
+    # LIBRARY_FTS_THRESHOLD, using ccp_character_handler.search_characters_fts and
+    # the "Showing N ... from full library" copy) was replaced by a single paged
+    # DB search (get_character_page_for_ui / count_character_page). The former
+    # tests test_fts_path_used_for_large_libraries,
+    # test_fts_search_count_uses_unbounded_full_library_copy, and
+    # test_fts_search_runs_off_the_event_loop covered that removed path; the
+    # off-thread guarantee for the new path is covered in
+    # Tests/UI/test_personas_library_scale.py.
 
     async def test_concurrent_renders_do_not_duplicate_rows(
         self, mock_app_instance, stub_characters

--- a/Tests/UI/test_tag_filter_picker.py
+++ b/Tests/UI/test_tag_filter_picker.py
@@ -1,0 +1,97 @@
+"""Mounted tests for the TagFilterPicker modal (P3a Task 3)."""
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Input, ListView
+
+from tldw_chatbook.Widgets.Persona_Widgets.tag_filter_picker import TagFilterPicker
+
+pytestmark = pytest.mark.asyncio
+
+
+class _PickerHost(App):
+    def __init__(self, tags, current):
+        super().__init__()
+        self._tags = tags
+        self._current = current
+        self.result = "unset"
+
+    def compose(self) -> ComposeResult:
+        yield from ()
+
+    def on_mount(self) -> None:
+        # push_screen_wait requires an active worker (NoActiveWorker otherwise);
+        # mirrors the pattern used by the sibling ConversationAttachPicker test
+        # (Tests/UI/test_conversation_attach_picker.py).
+        self.run_worker(self._drive)
+
+    async def _drive(self) -> None:
+        self.result = await self.push_screen_wait(
+            TagFilterPicker(self._tags, self._current)
+        )
+
+
+def _select(listing: ListView, index: int) -> None:
+    """Highlight ``index`` then select it, mirroring an Enter keypress."""
+    listing.index = index
+    listing.action_select_cursor()
+
+
+async def test_all_row_clears_filter():
+    app = _PickerHost(["hero", "villain"], current="villain")
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        listing = app.screen.query_one("#tag-filter-list", ListView)
+        _select(listing, 0)  # "All (clear filter)"
+        await pilot.pause()
+    assert app.result is None
+
+
+async def test_tag_row_returns_exact_tag_despite_ambiguous_prefix():
+    # "hero" is a text-prefix of "hero mage" - the recovered value must come
+    # from the stored row-index -> tag mapping, not from re-parsing/matching
+    # the rendered label, or picking one could resolve to the other.
+    tags = ["hero", "hero mage"]
+
+    app = _PickerHost(tags, current=None)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        listing = app.screen.query_one("#tag-filter-list", ListView)
+        _select(listing, 1)  # row 0 = All, row 1 = "hero"
+        await pilot.pause()
+    assert app.result == "hero"
+
+    app2 = _PickerHost(tags, current=None)
+    async with app2.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        listing = app2.screen.query_one("#tag-filter-list", ListView)
+        _select(listing, 2)  # row 2 = "hero mage"
+        await pilot.pause()
+    assert app2.result == "hero mage"
+
+
+async def test_escape_cancels_distinct_from_clear_filter():
+    app = _PickerHost(["hero"], current=None)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+    assert app.result is TagFilterPicker.CANCEL
+    assert app.result is not None  # cancel must never be mistaken for clear-filter
+
+
+async def test_search_narrows_rows_then_selects_correct_tag():
+    tags = ["alpha", "beta", "gamma"]
+    app = _PickerHost(tags, current=None)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        screen.query_one("#tag-filter-search", Input).value = "beta"
+        await pilot.pause()
+        listing = screen.query_one("#tag-filter-list", ListView)
+        # "All" + the single matching "beta" row - proves the filter rebuilt
+        # the row set (unfiltered would be 4 rows: All + alpha/beta/gamma).
+        assert len(listing) == 2
+        _select(listing, 1)
+        await pilot.pause()
+    assert app.result == "beta"

--- a/backlog/tasks/task-456 - P3a-follow-up-—-sweep-deferred-library-pagination-minors.md
+++ b/backlog/tasks/task-456 - P3a-follow-up-—-sweep-deferred-library-pagination-minors.md
@@ -1,0 +1,23 @@
+---
+id: task-456
+title: P3a follow-up — sweep deferred library-pagination minors
+status: To Do
+assignee: []
+created_date: '2026-07-22 03:01'
+labels:
+  - tech-debt
+  - personas
+  - p3a
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Cleanup of Minor findings deferred from the P3a whole-branch review (PR #755). None are user-visible bugs; this is hygiene.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Dead _character_record (0 callers) removed from personas_screen.py,Stale LIBRARY_FTS_THRESHOLD constant removed and fetch_character_names docstring reference dropped (search_characters_fts stays — still used by the handler/tests),Count-cache writes (_character_total/_count_cache_key) moved below the freshness guard in _reload_character_page so a superseded reload cannot leave a stale (search,tag) key,personas sort cycle excludes 'relevance' when active_mode != characters (currently harmlessly remapped)
+<!-- AC:END -->

--- a/tldw_chatbook/Character_Chat/Character_Chat_Lib.py
+++ b/tldw_chatbook/Character_Chat/Character_Chat_Lib.py
@@ -594,9 +594,9 @@ def fetch_character_names(
 ) -> List[Dict[str, Any]]:
     """Compatibility wrapper used by older CCP handlers.
 
-    The default ``limit`` must stay in sync with
-    ``PersonasScreen.LIBRARY_FTS_THRESHOLD`` (UI/Screens/personas_screen.py),
-    which switches library search to FTS when the loaded list may be truncated.
+    The default ``limit`` caps the loaded character list; callers that need
+    the full library (e.g. paged/search-backed listings) should pass an
+    explicit ``limit``.
     """
     target_db = db or _get_default_chachanotes_db()
     if target_db is None:

--- a/tldw_chatbook/Character_Chat/Character_Chat_Lib.py
+++ b/tldw_chatbook/Character_Chat/Character_Chat_Lib.py
@@ -525,6 +525,57 @@ def get_character_list_for_ui(
         return []
 
 
+def get_character_page_for_ui(
+    db: CharactersRAGDB,
+    *,
+    limit: int,
+    offset: int,
+    order_by: str = "name_asc",
+    search_term: Optional[str] = None,
+    tag: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """UI-shaped page of characters: id/name/last_modified/created_at/tags."""
+    try:
+        rows = db.list_character_cards_page(
+            limit=limit, offset=offset, order_by=order_by,
+            search_term=search_term, tag=tag,
+        )
+    except Exception as exc:
+        logger.opt(exception=True).error(f"Character page fetch failed: {exc}")
+        return []
+    return [
+        {
+            "id": c.get("id"),
+            "name": c.get("name"),
+            "last_modified": c.get("last_modified"),
+            "created_at": c.get("created_at"),
+            "tags": c.get("tags") if isinstance(c.get("tags"), list) else [],
+        }
+        for c in rows
+        if c.get("id") is not None
+    ]
+
+
+def count_character_page(
+    db: CharactersRAGDB, *, search_term: Optional[str] = None, tag: Optional[str] = None
+) -> int:
+    """Count of characters matching the same search+tag filter as `get_character_page_for_ui`."""
+    try:
+        return db.count_character_cards(search_term=search_term, tag=tag)
+    except Exception as exc:
+        logger.opt(exception=True).error(f"Character count failed: {exc}")
+        return 0
+
+
+def list_character_tags(db: CharactersRAGDB) -> List[str]:
+    """Distinct tag values across non-deleted characters, for UI tag-filter pickers."""
+    try:
+        return db.list_distinct_character_tags()
+    except Exception as exc:
+        logger.opt(exception=True).error(f"Character tag list failed: {exc}")
+        return []
+
+
 def _get_default_chachanotes_db() -> Optional[CharactersRAGDB]:
     """Return the app's default character DB when legacy callers omit one."""
     try:

--- a/tldw_chatbook/Character_Chat/persona_list_paging.py
+++ b/tldw_chatbook/Character_Chat/persona_list_paging.py
@@ -1,0 +1,51 @@
+"""Pure filter/sort/paginate helper for the file-backed persona profile list (P3a).
+
+Personas have no FTS and no tags, so this is a straight in-memory pass over the
+(≤100) profiles the scope service returns — no DB, no backend edit.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _modified_key(p: dict[str, Any]) -> str:
+    for key in ("updated_at", "last_modified", "modified_at"):
+        if p.get(key):
+            return str(p[key])
+    return str(p.get("created_at") or "")
+
+
+_SORTS = {
+    "name_asc": (lambda p: str(p.get("name") or "").lower(), False),
+    "created_desc": (lambda p: str(p.get("created_at") or ""), True),
+    "modified_desc": (_modified_key, True),
+}
+
+
+def page_persona_profiles(
+    profiles: list[dict[str, Any]],
+    *,
+    search_term: str | None,
+    sort_key: str,
+    offset: int,
+    page_size: int,
+) -> tuple[list[dict[str, Any]], int]:
+    """Return ``(page_rows, filtered_total)`` for the persona list.
+
+    Search is a case-insensitive substring over name + description. ``sort_key``
+    outside ``_SORTS`` (e.g. "relevance") falls back to "name_asc".
+    """
+    rows = list(profiles or [])
+    term = (search_term or "").strip().lower()
+    if term:
+        rows = [
+            p for p in rows
+            if term in str(p.get("name") or "").lower()
+            or term in str(p.get("description") or "").lower()
+        ]
+    filtered_total = len(rows)
+    key, reverse = _SORTS.get(sort_key, _SORTS["name_asc"])
+    rows = sorted(rows, key=key, reverse=reverse)
+    start = max(0, offset)
+    return rows[start:start + page_size], filtered_total

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -4129,6 +4129,16 @@ UPDATE db_schema_version
 
     _CHARACTER_CARD_JSON_FIELDS = ["alternate_greetings", "tags", "extensions"]
 
+    # P3a: whitelist of UI sort keys → exact ORDER BY clauses. The ONLY dynamic
+    # SQL fragment; search_term/tag are always bound parameters. "relevance"
+    # is valid only in the search (FTS) branch.
+    _CHARACTER_SORT_CLAUSES = {
+        "name_asc": "ORDER BY name COLLATE NOCASE ASC",
+        "modified_desc": "ORDER BY last_modified DESC, name COLLATE NOCASE ASC",
+        "created_desc": "ORDER BY created_at DESC, name COLLATE NOCASE ASC",
+        "relevance": "ORDER BY rank",
+    }
+
     # --- Character Card Methods ---
     @staticmethod
     def _ensure_json_string_from_mixed(
@@ -4524,6 +4534,105 @@ UPDATE db_schema_version
 
             logger.error(f"Database error listing character cards: {e}")
             raise
+
+    # P3a: json-valid guard so json_each never sees NULL / non-JSON tags.
+    _TAGS_JSON_EACH = "json_each(CASE WHEN json_valid({t}.tags) THEN {t}.tags ELSE '[]' END)"
+
+    def _resolve_sort_clause(self, order_by: str, *, searching: bool) -> str:
+        clause = self._CHARACTER_SORT_CLAUSES.get(order_by)
+        if clause is None or (order_by == "relevance" and not searching):
+            clause = self._CHARACTER_SORT_CLAUSES["name_asc"]
+        return clause
+
+    def list_character_cards_page(
+        self,
+        *,
+        limit: int,
+        offset: int,
+        order_by: str = "name_asc",
+        search_term: str | None = None,
+        tag: str | None = None,
+    ) -> List[Dict[str, Any]]:
+        """Paged, sortable, tag- and search-filterable character list.
+
+        Args:
+            limit: Page size.
+            offset: Rows to skip.
+            order_by: A key of ``_CHARACTER_SORT_CLAUSES``; unknown keys (and
+                "relevance" without a search term) fall back to "name_asc".
+            search_term: FTS5 MATCH query (already prefix-wrapped by the caller,
+                e.g. ``'"dragon"*'``) or None for a browse query.
+            tag: Exact tag membership filter, or None.
+
+        Returns:
+            Deserialized character-card dicts for the page. Never raises on
+            NULL/invalid tags (json_each is json-valid-guarded).
+        """
+        searching = bool(search_term)
+        sort_clause = self._resolve_sort_clause(order_by, searching=searching)
+        params: list[Any] = []
+        where = ["cc.deleted = 0"] if searching else ["deleted = 0"]
+        alias = "cc" if searching else "character_cards"
+        if searching:
+            head = (
+                "SELECT cc.* FROM character_cards_fts fts "
+                "JOIN character_cards cc ON fts.rowid = cc.id"
+            )
+            where.insert(0, "fts.character_cards_fts MATCH ?")
+            params.append(search_term)
+        else:
+            head = "SELECT * FROM character_cards"
+        if tag is not None:
+            where.append(
+                f"EXISTS (SELECT 1 FROM {self._TAGS_JSON_EACH.format(t=alias)} WHERE value = ?)"
+            )
+            params.append(tag)
+        query = f"{head} WHERE {' AND '.join(where)} {sort_clause} LIMIT ? OFFSET ?"
+        params.extend([limit, offset])
+        cursor = self.execute_query(query, tuple(params))
+        return [
+            self._deserialize_row_fields(row, self._CHARACTER_CARD_JSON_FIELDS)
+            for row in cursor.fetchall()
+            if row
+        ]
+
+    def count_character_cards(
+        self, *, search_term: str | None = None, tag: str | None = None
+    ) -> int:
+        """Count non-deleted character cards matching the same search+tag filter."""
+        searching = bool(search_term)
+        params: list[Any] = []
+        alias = "cc" if searching else "character_cards"
+        where = ["cc.deleted = 0"] if searching else ["deleted = 0"]
+        if searching:
+            head = (
+                "SELECT COUNT(*) FROM character_cards_fts fts "
+                "JOIN character_cards cc ON fts.rowid = cc.id"
+            )
+            where.insert(0, "fts.character_cards_fts MATCH ?")
+            params.append(search_term)
+        else:
+            head = "SELECT COUNT(*) FROM character_cards"
+        if tag is not None:
+            where.append(
+                f"EXISTS (SELECT 1 FROM {self._TAGS_JSON_EACH.format(t=alias)} WHERE value = ?)"
+            )
+            params.append(tag)
+        query = f"{head} WHERE {' AND '.join(where)}"
+        cursor = self.execute_query(query, tuple(params))
+        row = cursor.fetchone()
+        return int(row[0]) if row else 0
+
+    def list_distinct_character_tags(self) -> List[str]:
+        """Distinct tag values across non-deleted cards, case-insensitively sorted."""
+        query = (
+            "SELECT DISTINCT je.value "
+            "FROM character_cards cc, "
+            + self._TAGS_JSON_EACH.format(t="cc")
+            + " je WHERE cc.deleted = 0 ORDER BY je.value COLLATE NOCASE"
+        )
+        cursor = self.execute_query(query, ())
+        return [str(r[0]) for r in cursor.fetchall() if r and r[0] is not None]
 
     def update_character_card(
         self, character_id: int, card_data: Dict[str, Any], expected_version: int

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -225,12 +225,6 @@ _CENTER_VIEW_IDS: tuple[str, ...] = (
 class PersonasScreen(BaseAppScreen):
     """Characters, personas, dictionaries, and behavior profiles."""
 
-    #: Page size above which the loaded list may be truncated and FTS is used
-    #: instead of filtering the in-memory list. Must stay in sync with the
-    #: ``fetch_character_names(limit=1000)`` default in
-    #: ``Character_Chat/Character_Chat_Lib.py``, which caps the loaded list.
-    LIBRARY_FTS_THRESHOLD: int = 1000
-
     # Escape/Ctrl+S deliberately do NOT use priority=True: on Textual 8.2.7
     # neither Input nor TextArea (with the default tab_behavior="focus")
     # consumes those keys, so they bubble from the editor fields to this
@@ -501,6 +495,7 @@ class PersonasScreen(BaseAppScreen):
         self._count_cache_key: tuple | None = None
         self._character_tags: list[str] = []
         self._profiles: list[dict] = []
+        self._profile_total: int = 0
         self._dictionaries_cache: list[dict] = []
         self._selected_dictionary_version: int | None = None
         self._lore_books_cache: list[dict] = []
@@ -872,16 +867,17 @@ class PersonasScreen(BaseAppScreen):
             return
         cache_key = (search, tag)
         try:
-            if self._count_cache_key != cache_key:
-                self._character_total = await asyncio.to_thread(
+            if self._count_cache_key == cache_key:
+                total = self._character_total
+            else:
+                total = await asyncio.to_thread(
                     count_character_page, db, search_term=search, tag=tag
                 )
-                self._count_cache_key = cache_key
             # Clamp a now-out-of-range offset back onto the last page.
-            if offset > 0 and offset >= self._character_total:
+            if offset > 0 and offset >= total:
                 offset = max(
                     0,
-                    ((self._character_total - 1) // PERSONAS_LIBRARY_PAGE_SIZE)
+                    ((total - 1) // PERSONAS_LIBRARY_PAGE_SIZE)
                     * PERSONAS_LIBRARY_PAGE_SIZE,
                 )
                 self.state.page_offset = offset
@@ -910,6 +906,10 @@ class PersonasScreen(BaseAppScreen):
             or self.state.page_offset != offset
         ):
             return
+        # Commit shared count state only after the guard passes, so a
+        # superseded reload cannot clobber the winner's cached count.
+        self._character_total = total
+        self._count_cache_key = cache_key
         self._characters = records
         self._update_status_row()
         rows = self._build_library_rows(records, "character")
@@ -922,7 +922,7 @@ class PersonasScreen(BaseAppScreen):
         async with self._render_lock:
             await library.update_rows(
                 rows,
-                total=self._character_total,
+                total=total,
                 noun="characters",
                 page_offset=offset,
                 page_size=PERSONAS_LIBRARY_PAGE_SIZE,
@@ -941,14 +941,6 @@ class PersonasScreen(BaseAppScreen):
             await self._reload_character_page()
         elif self.state.active_mode == "personas":
             await self._render_profile_rows()
-
-    def _character_record(self, item_id: str | None) -> dict | None:
-        if item_id is None:
-            return None
-        for record in self._characters:
-            if str(record.get("id")) == str(item_id):
-                return record
-        return None
 
     def _profile_list_recovery_state(self, exc: Exception) -> DestinationRecoveryState:
         """Build recovery copy when persona profile listing is unavailable."""
@@ -1044,6 +1036,7 @@ class PersonasScreen(BaseAppScreen):
                 expected_mode=expected_mode,
             ):
                 return
+            self._profile_total = total
             rows = self._build_library_rows(page_rows, "persona_profile")
             library = self.query_one(PersonasLibraryPane)
             recovery_state = self._profile_lookup_recovery_state
@@ -1170,7 +1163,7 @@ class PersonasScreen(BaseAppScreen):
         total = (
             self._character_total
             if self.state.active_mode == "characters"
-            else len(self._profiles)
+            else self._profile_total
         )
         if new_offset < 0 or new_offset >= max(1, total):
             return

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -19,10 +19,14 @@ from textual.timer import Timer
 from textual.widgets import Button, Input, ListView, Static, TabbedContent, TextArea
 
 from ...Character_Chat.Character_Chat_Lib import (
+    count_character_page,
     export_character_card_to_json,
     export_character_card_to_png,
+    get_character_page_for_ui,
+    list_character_tags,
     validate_character_book,
 )
+from ...Character_Chat.persona_list_paging import page_persona_profiles
 from ...Character_Chat.world_book_import import normalize_world_book_import
 from ...Character_Chat.world_book_manager import CHARACTER_WORLD_BOOKS_KEY
 from ...Chat.chat_handoff_models import ChatHandoffPayload
@@ -68,8 +72,12 @@ from ...Widgets.Persona_Widgets.personas_library_pane import (
 from ...Widgets.Persona_Widgets.personas_messages import (
     PersonaActionRequested,
     PersonaEntitySelected,
+    PersonaPageChanged,
     PersonaSearchChanged,
+    PersonaSortCycleRequested,
+    PersonaTagFilterRequested,
 )
+from ...Widgets.Persona_Widgets.tag_filter_picker import TagFilterPicker
 from ...Widgets.Persona_Widgets.personas_pane_messages import (
     CharacterEditorCancelled,
     CharacterImageUploadRequested,
@@ -176,6 +184,17 @@ _MODE_PLACEHOLDER_BODY: dict[str, str] = {
 }
 _PLACEHOLDER_FALLBACK = "This mode is coming soon."
 PERSONAS_SEARCH_DEBOUNCE_SECONDS = 0.2
+#: Rows per library page. ``page_offset`` is always kept a multiple of this so
+#: the pane's "start-end of N" label math stays exact.
+PERSONAS_LIBRARY_PAGE_SIZE = 50
+#: Display labels for the library sort keys (shared by the character sort cycle
+#: and the persona render path).
+_LIBRARY_SORT_LABELS: dict[str, str] = {
+    "relevance": "Relevance",
+    "name_asc": "Name",
+    "modified_desc": "Recent edit",
+    "created_desc": "Recent add",
+}
 PERSONAS_AVATAR_IMAGE_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".webp", ".gif"})
 PERSONAS_AVATAR_IMAGE_SUFFIX_COPY = "PNG, JPG, JPEG, WEBP, or GIF"
 PERSONAS_AVATAR_MAX_BYTES = 5 * 1024 * 1024
@@ -472,7 +491,15 @@ class PersonasScreen(BaseAppScreen):
         self._delete_dialog_active: bool = False
         self._character_editor_generation: int = 0
         self._profile_save_inflight: bool = False
+        # ``_characters`` now holds only the CURRENT page of the library, not
+        # the whole (capped) list; ``_character_total`` is the full-library
+        # count for the active (search, tag) filter, cached under
+        # ``_count_cache_key`` so page-nav/sort reuse it and only a filter
+        # change recomputes it.
         self._characters: list[dict] = []
+        self._character_total: int = 0
+        self._count_cache_key: tuple | None = None
+        self._character_tags: list[str] = []
         self._profiles: list[dict] = []
         self._dictionaries_cache: list[dict] = []
         self._selected_dictionary_version: int | None = None
@@ -717,8 +744,16 @@ class PersonasScreen(BaseAppScreen):
     async def refresh_character_library_list(
         self, characters: list[dict] | None
     ) -> None:
-        """Destination-native hook called by ``CCPCharacterHandler``."""
+        """Destination-native hook called by ``CCPCharacterHandler``.
+
+        This fires after character mutations (import/create/save/delete), so the
+        cached count may be stale; invalidate it before re-rendering the page so
+        ``_reload_character_page`` recomputes the total. ``_characters`` is set
+        here from the handler's list for compatibility, but the paged reload
+        below immediately replaces it with the current page only.
+        """
         self._characters = [dict(record) for record in (characters or [])]
+        self._count_cache_key = None
         self._update_status_row()
         if self.state.active_mode != "characters":
             return
@@ -732,16 +767,28 @@ class PersonasScreen(BaseAppScreen):
 
     @staticmethod
     def _build_library_rows(records: list[dict], kind: str) -> tuple[LibraryRow, ...]:
-        """Map id/name records onto library rows, skipping id-less records."""
-        return tuple(
-            LibraryRow(
-                item_id=str(record.get("id")),
-                kind=kind,
-                name=str(record.get("name") or "Unnamed"),
+        """Map id/name records onto library rows, skipping id-less records.
+
+        Character rows carry a ``YYYY-MM-DD`` last-modified meta line; personas
+        (id/name summaries) render without one.
+        """
+        rows: list[LibraryRow] = []
+        for record in records:
+            if record.get("id") is None:
+                continue
+            meta = None
+            if kind == "character":
+                last_modified = str(record.get("last_modified") or "")
+                meta = last_modified[:10] if last_modified else None
+            rows.append(
+                LibraryRow(
+                    item_id=str(record.get("id")),
+                    kind=kind,
+                    name=str(record.get("name") or "Unnamed"),
+                    meta=meta,
+                )
             )
-            for record in records
-            if record.get("id") is not None
-        )
+        return tuple(rows)
 
     def _library_render_snapshot_is_current(
         self,
@@ -766,65 +813,134 @@ class PersonasScreen(BaseAppScreen):
         expected_query: str | None = None,
         expected_mode: str | None = None,
     ) -> None:
-        if not self._library_render_snapshot_is_current(
-            expected_query=expected_query,
-            expected_mode=expected_mode,
-        ):
-            return
+        """Render the character library page.
 
-        query = (
-            expected_query if expected_query is not None else self.state.search_query
-        )
-        total = len(self._characters)
-        filtered_total_unbounded = False
-        if query:
-            if total >= self.LIBRARY_FTS_THRESHOLD:
-                # Large library: use FTS so the full DB corpus is searched
-                # even when the loaded list is a page-size truncation. The
-                # query runs in a thread so the DB call never blocks the UI
-                # loop (the render lock below is only taken afterwards, so
-                # the await cannot deadlock it).
-                matched = await asyncio.to_thread(
-                    ccp_character_handler.search_characters_fts, query
-                )
-                filtered_total_unbounded = True
-            else:
-                # Small library: filter in-memory, case-insensitively on name.
-                q_lower = query.lower()
-                matched = [
-                    r
-                    for r in self._characters
-                    if q_lower in str(r.get("name") or "").lower()
-                ]
-            filtered = True
-        else:
-            matched = self._characters
-            filtered = False
+        Thin wrapper over :meth:`_reload_character_page` (which owns the paged
+        DB query, count cache, and its own post-await freshness re-check). The
+        snapshot args only gate a late debounced call before any DB work; they
+        are why the existing callers (refresh, mode-apply, debounced search)
+        need no changes.
+        """
         if not self._library_render_snapshot_is_current(
             expected_query=expected_query,
             expected_mode=expected_mode,
         ):
             return
-        async with self._render_lock:
-            if not self._library_render_snapshot_is_current(
-                expected_query=expected_query,
-                expected_mode=expected_mode,
-            ):
-                return
-            rows = self._build_library_rows(matched, "character")
+        await self._reload_character_page()
+
+    def _character_sort_cycle(self) -> list[tuple[str, str]]:
+        """Ordered ``(key, label)`` sort options for the character library.
+
+        A "Relevance" option is prepended (and becomes the natural default) only
+        while a search is active, since relevance is search-scored.
+        """
+        base = [
+            ("name_asc", _LIBRARY_SORT_LABELS["name_asc"]),
+            ("modified_desc", _LIBRARY_SORT_LABELS["modified_desc"]),
+            ("created_desc", _LIBRARY_SORT_LABELS["created_desc"]),
+        ]
+        if self.state.search_query:
+            return [("relevance", _LIBRARY_SORT_LABELS["relevance"]), *base]
+        return base
+
+    def _fts_match_query(self) -> str | None:
+        """Wrap the raw search term as a quoted FTS5 prefix query, or None."""
+        term = (self.state.search_query or "").strip()
+        if not term:
+            return None
+        escaped = term.replace('"', '""')
+        return f'"{escaped}"*'
+
+    async def _reload_character_page(self, *, reset_offset: bool = False) -> None:
+        """Load and render one page of characters from the local DB.
+
+        The DB count/list run off-thread; the count is cached under
+        ``(search, tag)`` so page-nav and sort reuse it. After the awaits, a
+        freshness guard re-checks ``(mode, search, sort, tag, offset)`` so a
+        superseded reload never writes stale rows into the pane.
+        """
+        if reset_offset:
+            self.state.page_offset = 0
+        mode = self.state.active_mode
+        query = self.state.search_query
+        sort_key = self.state.sort_key
+        tag = self.state.tag_filter
+        offset = self.state.page_offset
+        search = self._fts_match_query()
+        db = self._character_db()
+        if db is None:
+            return
+        cache_key = (search, tag)
+        try:
+            if self._count_cache_key != cache_key:
+                self._character_total = await asyncio.to_thread(
+                    count_character_page, db, search_term=search, tag=tag
+                )
+                self._count_cache_key = cache_key
+            # Clamp a now-out-of-range offset back onto the last page.
+            if offset > 0 and offset >= self._character_total:
+                offset = max(
+                    0,
+                    ((self._character_total - 1) // PERSONAS_LIBRARY_PAGE_SIZE)
+                    * PERSONAS_LIBRARY_PAGE_SIZE,
+                )
+                self.state.page_offset = offset
+            records = await asyncio.to_thread(
+                get_character_page_for_ui,
+                db,
+                limit=PERSONAS_LIBRARY_PAGE_SIZE,
+                offset=offset,
+                order_by=sort_key,
+                search_term=search,
+                tag=tag,
+            )
+        except Exception as exc:
+            logger.opt(exception=True).warning("Character page load failed.")
+            self._notify(f"Could not load characters: {exc}", "error")
+            return
+        # Freshness guard: a filter/page/mode change during the off-thread reads
+        # supersedes this render. (is_mounted is deliberately NOT checked: it is
+        # still False while the initial on-mount refresh runs; teardown is
+        # tolerated instead by catching the pane QueryError below.)
+        if (
+            self.state.active_mode != mode
+            or self.state.search_query != query
+            or self.state.sort_key != sort_key
+            or self.state.tag_filter != tag
+            or self.state.page_offset != offset
+        ):
+            return
+        self._characters = records
+        self._update_status_row()
+        rows = self._build_library_rows(records, "character")
+        try:
             library = self.query_one(PersonasLibraryPane)
+        except QueryError:
+            # Screen torn down mid-reload; nothing to render.
+            return
+        sort_labels = dict(self._character_sort_cycle())
+        async with self._render_lock:
             await library.update_rows(
                 rows,
-                total=total,
+                total=self._character_total,
                 noun="characters",
-                filtered=filtered,
-                filtered_total_unbounded=filtered_total_unbounded,
+                page_offset=offset,
+                page_size=PERSONAS_LIBRARY_PAGE_SIZE,
             )
+            library.set_sort_label(f"Sort: {sort_labels.get(sort_key, 'Name')}")
+            library.set_tag_label(f"Tag: {tag}" if tag else "Tag: All")
             if (
                 self.state.selected_entity_kind == "character"
                 and self.state.selected_entity_id
             ):
                 library.mark_active_row("character", self.state.selected_entity_id)
+
+    async def _reload_active_library(self) -> None:
+        """Re-render whichever paginated library (characters/personas) is active."""
+        if self.state.active_mode == "characters":
+            await self._reload_character_page()
+        elif self.state.active_mode == "personas":
+            await self._render_profile_rows()
 
     def _character_record(self, item_id: str | None) -> dict | None:
         if item_id is None:
@@ -894,33 +1010,47 @@ class PersonasScreen(BaseAppScreen):
         ):
             return
 
-        query = (
-            expected_query if expected_query is not None else self.state.search_query
+        # Personas load <=100 rows into ``_profiles`` already, so filter, sort,
+        # and page them in-memory (no FTS, no tags). "relevance" is characters-
+        # only; fall back to name_asc for the persona list.
+        sort_key = (
+            self.state.sort_key if self.state.sort_key != "relevance" else "name_asc"
         )
-        total = len(self._profiles)
-        if query:
-            q_lower = query.lower()
-            matched = [
-                r for r in self._profiles if q_lower in str(r.get("name") or "").lower()
-            ]
-            filtered = True
-        else:
-            matched = self._profiles
-            filtered = False
+        offset = self.state.page_offset
+        page_rows, total = page_persona_profiles(
+            self._profiles,
+            search_term=self.state.search_query,
+            sort_key=sort_key,
+            offset=offset,
+            page_size=PERSONAS_LIBRARY_PAGE_SIZE,
+        )
+        # A narrowing filter can strand the offset past the filtered set; fall
+        # back to the last valid page so the list is never blank.
+        if not page_rows and total and offset >= total:
+            offset = (
+                (total - 1) // PERSONAS_LIBRARY_PAGE_SIZE
+            ) * PERSONAS_LIBRARY_PAGE_SIZE
+            self.state.page_offset = offset
+            page_rows, total = page_persona_profiles(
+                self._profiles,
+                search_term=self.state.search_query,
+                sort_key=sort_key,
+                offset=offset,
+                page_size=PERSONAS_LIBRARY_PAGE_SIZE,
+            )
         async with self._render_lock:
             if not self._library_render_snapshot_is_current(
                 expected_query=expected_query,
                 expected_mode=expected_mode,
             ):
                 return
-            rows = self._build_library_rows(matched, "persona_profile")
+            rows = self._build_library_rows(page_rows, "persona_profile")
             library = self.query_one(PersonasLibraryPane)
             recovery_state = self._profile_lookup_recovery_state
             await library.update_rows(
                 rows,
                 total=total,
                 noun="persona profiles",
-                filtered=filtered,
                 recovery_copy=(
                     recovery_state.visible_copy if recovery_state is not None else None
                 ),
@@ -929,7 +1059,13 @@ class PersonasScreen(BaseAppScreen):
                     if recovery_state is not None
                     else "personas-library-recovery"
                 ),
+                page_offset=offset,
+                page_size=PERSONAS_LIBRARY_PAGE_SIZE,
             )
+            if recovery_state is None:
+                library.set_sort_label(
+                    f"Sort: {_LIBRARY_SORT_LABELS.get(sort_key, 'Name')}"
+                )
             if (
                 self.state.selected_entity_kind == "persona_profile"
                 and self.state.selected_entity_id
@@ -942,7 +1078,25 @@ class PersonasScreen(BaseAppScreen):
     def _handle_search_changed(self, message: PersonaSearchChanged) -> None:
         message.stop()
         # Search does not change selection or center pane — no unsaved guard needed.
+        previous_query = self.state.search_query
         self.state.search_query = message.query.strip()
+        now_searching = bool(self.state.search_query)
+        was_searching = bool(previous_query)
+        if (
+            now_searching
+            and not was_searching
+            and self.state.active_mode == "characters"
+        ):
+            # First keystroke of a new character search: relevance ranking is the
+            # natural default (it only exists while a search is active).
+            self.state.sort_key = "relevance"
+        elif not now_searching and self.state.sort_key == "relevance":
+            # Search cleared: relevance is search-only, fall back to name.
+            self.state.sort_key = "name_asc"
+        # A changed search restarts paging and (for characters) invalidates the
+        # count cache so the new (search, tag) pair is recounted.
+        self.state.page_offset = 0
+        self._count_cache_key = None
         self._cancel_search_debounce()
         query = self.state.search_query
         mode = self.state.active_mode
@@ -950,6 +1104,78 @@ class PersonasScreen(BaseAppScreen):
             PERSONAS_SEARCH_DEBOUNCE_SECONDS,
             lambda: self._start_debounced_search_render(query=query, mode=mode),
         )
+
+    @on(PersonaSortCycleRequested)
+    async def _handle_sort_cycle(self, message: PersonaSortCycleRequested) -> None:
+        """Advance the library sort (characters + personas)."""
+        message.stop()
+        if self.state.active_mode not in ("characters", "personas"):
+            return
+        await self._cycle_sort()
+
+    async def _cycle_sort(self) -> None:
+        """Move ``sort_key`` to the next option and reload from page 0."""
+        cycle = [key for key, _ in self._character_sort_cycle()]
+        current = self.state.sort_key if self.state.sort_key in cycle else cycle[0]
+        self.state.sort_key = cycle[(cycle.index(current) + 1) % len(cycle)]
+        self.state.page_offset = 0
+        await self._reload_active_library()
+
+    @on(PersonaTagFilterRequested)
+    async def _handle_tag_filter(self, message: PersonaTagFilterRequested) -> None:
+        """Open the tag-filter picker (characters only)."""
+        message.stop()
+        if self.state.active_mode != "characters" or self._io_dialog_active:
+            return
+        self._io_dialog_active = True
+        self.run_worker(
+            self._tag_filter_worker(), group="personas-io", exit_on_error=False
+        )
+
+    async def _tag_filter_worker(self) -> None:
+        """List tags off-thread, prompt for one, and apply the pick."""
+        try:
+            db = self._character_db()
+            if db is None:
+                return
+            tags = await asyncio.to_thread(list_character_tags, db)
+            picked = await self.app.push_screen_wait(
+                TagFilterPicker(tags, self.state.tag_filter)
+            )
+            if picked is TagFilterPicker.CANCEL:
+                # Escape: leave the current filter untouched.
+                return
+            await self._apply_tag_filter(picked)  # None clears the filter
+        except Exception as exc:
+            logger.opt(exception=True).warning("Tag filter failed.")
+            self._notify(f"Tag filter failed: {exc}", "error")
+        finally:
+            self._io_dialog_active = False
+
+    async def _apply_tag_filter(self, tag: str | None) -> None:
+        """Set the characters tag filter, reset paging, and recount."""
+        self.state.tag_filter = tag
+        self.state.page_offset = 0
+        self._count_cache_key = None  # (search, tag) changed → recount
+        await self._reload_character_page()
+
+    @on(PersonaPageChanged)
+    async def _handle_page_changed(self, message: PersonaPageChanged) -> None:
+        message.stop()
+        await self._on_page_changed_delta(message.delta)
+
+    async def _on_page_changed_delta(self, delta: int) -> None:
+        """Move the page window by ``delta`` pages, clamped to the total."""
+        new_offset = self.state.page_offset + delta * PERSONAS_LIBRARY_PAGE_SIZE
+        total = (
+            self._character_total
+            if self.state.active_mode == "characters"
+            else len(self._profiles)
+        )
+        if new_offset < 0 or new_offset >= max(1, total):
+            return
+        self.state.page_offset = new_offset
+        await self._reload_active_library()
 
     def _cancel_search_debounce(self) -> None:
         """Cancel a pending search render when newer state supersedes it."""
@@ -1215,10 +1441,14 @@ class PersonasScreen(BaseAppScreen):
 
     async def _apply_mode(self, mode: str) -> None:
         self._cancel_search_debounce()
+        # switch_mode resets sort_key/tag_filter/page_offset for a fresh window.
         self.state.switch_mode(mode)
         # switch_mode does not reset search_query; clear it explicitly and
         # reset the Input widget so the library starts unfiltered in the new mode.
         self.state.search_query = ""
+        # The (search, tag) pair changed, so the character count must be
+        # recomputed the next time the characters page loads.
+        self._count_cache_key = None
         try:
             self.query_one("#personas-library-search", Input).value = ""
         except Exception:
@@ -1326,7 +1556,9 @@ class PersonasScreen(BaseAppScreen):
     def _status_row_text(self) -> str:
         mode = self.state.active_mode
         if mode == "characters":
-            return f"Characters: {len(self._characters)} | Source: Local | Attachments: Console"
+            # ``_characters`` is now one page; the full-library count lives in
+            # ``_character_total``.
+            return f"Characters: {self._character_total} | Source: Local | Attachments: Console"
         if mode == "personas":
             return f"Personas: {len(self._profiles)} | Source: Local | Attachments: Console"
         return f"Mode: {MODE_LABELS.get(mode, mode)} | Source: Local | Attachments: Console"
@@ -3761,9 +3993,20 @@ class PersonasScreen(BaseAppScreen):
 
     async def _import_character_from_path(self, path: str) -> None:
         """Import a character card file, then refresh, select, and reveal it."""
-        # On a name conflict the importer returns the EXISTING character's id;
-        # snapshot the pre-import ids so the notification can say so.
-        pre_import_ids = {str(c.get("id")) for c in self._characters}
+        # On a name conflict the importer returns the EXISTING character's id
+        # WITHOUT adding a row; on a new import it creates one. ``_characters``
+        # now holds only one page, so decide "existed vs imported" from the
+        # whole-library count (unfiltered) taken before/after, not a page-cache
+        # id membership check.
+        db = self._character_db()
+        pre_import_count = None
+        if db is not None:
+            try:
+                pre_import_count = await asyncio.to_thread(count_character_page, db)
+            except Exception:
+                logger.opt(exception=True).debug(
+                    "Pre-import character count failed; message will assume new."
+                )
         try:
             # Sync DB call; see the section comment for the threading choice.
             imported_id = await asyncio.to_thread(
@@ -3782,9 +4025,21 @@ class PersonasScreen(BaseAppScreen):
             )
             return
         imported_id = str(imported_id)
-        # Clear any active search (state + Input, as _apply_mode does) so the
-        # imported character is visible in the refreshed list.
+        post_import_count = None
+        if db is not None:
+            try:
+                post_import_count = await asyncio.to_thread(count_character_page, db)
+            except Exception:
+                logger.opt(exception=True).debug("Post-import character count failed.")
+        existed_before = (
+            pre_import_count is not None
+            and post_import_count is not None
+            and post_import_count == pre_import_count
+        )
+        # Clear any active search (state + Input, as _apply_mode does) and reset
+        # paging so the imported character shows on page 0 of the refreshed list.
         self.state.search_query = ""
+        self.state.page_offset = 0
         try:
             self.query_one("#personas-library-search", Input).value = ""
         except Exception:
@@ -3794,13 +4049,22 @@ class PersonasScreen(BaseAppScreen):
             # The user left Characters mode while the import ran; the list is
             # refreshed but selection/center pane belong to the new mode.
             return
-        record = self._character_record(imported_id)
-        name = str((record or {}).get("name") or "Imported character")
+        # Resolve the display name by id (the page cache may not hold this row).
+        loaded = None
+        try:
+            loaded = await asyncio.to_thread(
+                ccp_character_handler.fetch_character_by_id, imported_id
+            )
+        except Exception:
+            logger.opt(exception=True).debug(
+                "Could not resolve imported character name by id."
+            )
+        name = str((loaded or {}).get("name") or "Imported character")
         await self._select_character(imported_id, name)
         # The selection changed outside _run_guarded; refresh the footer hints
         # (attach is now available) and the header state.
         self._sync_title_and_console_actions()
-        if imported_id in pre_import_ids:
+        if existed_before:
             self._notify("Character already existed; selected it.", "information")
         else:
             self._notify("Character imported.", "information")
@@ -4562,8 +4826,11 @@ class PersonasScreen(BaseAppScreen):
         self._edit_mode = "view"
         self._set_active_row_unsaved(False)
         await self.character_handler.refresh_character_list()
-        record = self._character_record(saved_id)
-        name = str((record or {}).get("name") or submitted_name or "Saved character")
+        # ``saved_id`` was just persisted, so it is authoritative; resolve the
+        # name by id (handler-loaded card) or the submitted name rather than
+        # scanning the now-page-only cache, and always load the saved card.
+        loaded = self._full_character_record(saved_id)
+        name = str((loaded or {}).get("name") or submitted_name or "Saved character")
         self.state.select_entity(
             entity_kind="character", entity_id=saved_id, entity_name=name
         )
@@ -4574,8 +4841,7 @@ class PersonasScreen(BaseAppScreen):
         inspector.show_validation(())
         self._sync_inspector_console_actions()
         self.query_one(PersonasLibraryPane).mark_active_row("character", saved_id)
-        if record is not None:
-            await self.character_handler.load_character(saved_id)
+        await self.character_handler.load_character(saved_id)
         self._show_center("#ccp-character-card-view")
         self._sync_title_and_console_actions()
         self.call_after_refresh(self._focus_library_list)

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_library_pane.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_library_pane.py
@@ -14,7 +14,10 @@ from .personas_messages import (
     PersonaActionRequested,
     PersonaEntityKind,
     PersonaEntitySelected,
+    PersonaPageChanged,
     PersonaSearchChanged,
+    PersonaSortCycleRequested,
+    PersonaTagFilterRequested,
 )
 
 _ID_SAFE = re.compile(r"[^a-zA-Z0-9_-]")
@@ -88,6 +91,20 @@ class PersonasLibraryPane(Vertical):
         text-wrap: wrap;
         text-overflow: clip;
     }
+
+    /* The generic Button min-width:16 default would push "next" past the
+       pane's narrow width (2fr of the workbench split); pin the prev/next
+       buttons to a compact width and let the page-info Static fill the rest
+       so the bar never overflows its container. */
+    PersonasLibraryPane #personas-library-pagebar Button {
+        width: 5;
+        min-width: 5;
+    }
+
+    PersonasLibraryPane #personas-library-page-info {
+        width: 1fr;
+        text-align: center;
+    }
     """
 
     def __init__(self, **kwargs) -> None:
@@ -96,8 +113,9 @@ class PersonasLibraryPane(Vertical):
         self._import_visible: bool = True
 
     def on_mount(self) -> None:
-        """Initialize button visibility for default characters mode."""
+        """Initialize control visibility for default characters mode."""
         self.query_one("#personas-library-duplicate", Button).display = False
+        self.query_one("#personas-library-pagebar").display = False
 
     def compose(self) -> ComposeResult:
         """Compose the Library pane header, search controls, and rows.
@@ -140,7 +158,36 @@ class PersonasLibraryPane(Vertical):
                 tooltip="Duplicate the selected item.",
                 classes="console-action-secondary",
             )
+        with Horizontal(id="personas-library-filterbar", classes="ds-toolbar"):
+            yield Button(
+                "Sort: Name",
+                id="personas-library-sort",
+                tooltip="Cycle the list sort order.",
+                classes="console-action-secondary",
+            )
+            yield Button(
+                "Tag: All",
+                id="personas-library-tag",
+                tooltip="Filter characters by tag.",
+                classes="console-action-secondary",
+            )
         yield ListView(id="personas-library-rows")
+        with Horizontal(id="personas-library-pagebar", classes="ds-toolbar"):
+            yield Button(
+                "<",
+                id="personas-library-prev",
+                compact=True,
+                classes="console-action-secondary",
+            )
+            yield Static(
+                "", id="personas-library-page-info", classes="destination-purpose"
+            )
+            yield Button(
+                ">",
+                id="personas-library-next",
+                compact=True,
+                classes="console-action-secondary",
+            )
         yield Static("", id="personas-library-count", classes="destination-purpose")
 
     def set_mode(self, mode: str) -> None:
@@ -158,6 +205,12 @@ class PersonasLibraryPane(Vertical):
             "dictionaries",
             "lore",
         )
+        sort_visible = mode in ("characters", "personas")
+        self.query_one("#personas-library-sort", Button).display = sort_visible
+        self.query_one("#personas-library-tag", Button).display = mode == "characters"
+        if not sort_visible:
+            # dict/lore never paginate - keep the page bar hidden.
+            self.query_one("#personas-library-pagebar").display = False
 
     async def update_rows(
         self,
@@ -169,6 +222,8 @@ class PersonasLibraryPane(Vertical):
         filtered_total_unbounded: bool = False,
         recovery_copy: str | None = None,
         recovery_id: str = "personas-library-recovery",
+        page_offset: int | None = None,
+        page_size: int | None = None,
     ) -> None:
         """Replace the visible rows and count line.
 
@@ -184,6 +239,12 @@ class PersonasLibraryPane(Vertical):
                 pane renders a disabled recovery row instead of list or empty
                 rows.
             recovery_id: Stable DOM id for the recovery copy widget.
+            page_offset: Zero-based offset of ``rows`` within ``total``. When
+                given together with ``page_size``, the pane renders a page bar
+                instead of the plain count line. ``None`` (the default)
+                preserves the pre-paging behavior for callers (dictionaries,
+                lore) that never page.
+            page_size: Page window size paired with ``page_offset``.
 
         Returns:
             None.
@@ -249,17 +310,36 @@ class PersonasLibraryPane(Vertical):
                     ListItem(Static(row.name, markup=False), id=dom_id, classes=classes)
                 )
         await list_view.extend(items)
+        pagebar = self.query_one("#personas-library-pagebar")
+        count_static = self.query_one("#personas-library-count", Static)
+        paginated = page_offset is not None and page_size is not None
         if recovery_copy:
-            count = f"{noun.capitalize()} unavailable"
-        elif filtered and filtered_total_unbounded:
-            match_word = "match" if len(rows) == 1 else "matches"
-            count = (
-                f"Showing {len(rows)} {_singular_noun(noun)} "
-                f"{match_word} from full library"
+            pagebar.display = False
+            count_static.update(f"{noun.capitalize()} unavailable")
+        elif paginated and total > page_size:
+            start = page_offset + 1 if total else 0
+            end = page_offset + len(rows)
+            self.query_one("#personas-library-page-info", Static).update(
+                f"{start}-{end} of {total} {noun}"
             )
+            self.query_one("#personas-library-prev", Button).disabled = page_offset <= 0
+            self.query_one("#personas-library-next", Button).disabled = (
+                page_offset + page_size >= total
+            )
+            pagebar.display = True
+            count_static.update("")
         else:
-            count = f"{len(rows)} of {total} {noun}" if filtered else f"{total} {noun}"
-        self.query_one("#personas-library-count", Static).update(count)
+            pagebar.display = False
+            if filtered and filtered_total_unbounded:
+                match_word = "match" if len(rows) == 1 else "matches"
+                count_static.update(
+                    f"Showing {len(rows)} {_singular_noun(noun)} "
+                    f"{match_word} from full library"
+                )
+            elif filtered:
+                count_static.update(f"{len(rows)} of {total} {noun}")
+            else:
+                count_static.update(f"{total} {noun}")
 
     def mark_active_row(self, kind: str, item_id: str) -> None:
         """Move the list highlight and the .is-active marker to one row."""
@@ -293,6 +373,14 @@ class PersonasLibraryPane(Vertical):
         list_view = self.query_one("#personas-library-rows", ListView)
         for item in list_view.children:
             item.set_class(unsaved and item.id == target, "is-unsaved")
+
+    def set_sort_label(self, text: str) -> None:
+        """Update the sort button's label (the screen owns the sort cycle/copy)."""
+        self.query_one("#personas-library-sort", Button).label = text
+
+    def set_tag_label(self, text: str) -> None:
+        """Update the tag button's label (the screen owns the active tag)."""
+        self.query_one("#personas-library-tag", Button).label = text
 
     @on(Input.Changed, "#personas-library-search")
     def _search_changed(self, event: Input.Changed) -> None:
@@ -335,6 +423,26 @@ class PersonasLibraryPane(Vertical):
     def _duplicate_pressed(self, event: Button.Pressed) -> None:
         event.stop()
         self.post_message(PersonaActionRequested(action="duplicate"))
+
+    @on(Button.Pressed, "#personas-library-sort")
+    def _sort_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.post_message(PersonaSortCycleRequested())
+
+    @on(Button.Pressed, "#personas-library-tag")
+    def _tag_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.post_message(PersonaTagFilterRequested())
+
+    @on(Button.Pressed, "#personas-library-prev")
+    def _prev_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.post_message(PersonaPageChanged(-1))
+
+    @on(Button.Pressed, "#personas-library-next")
+    def _next_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.post_message(PersonaPageChanged(1))
 
     def action_toggle_highlighted(self) -> None:
         """Space on a highlighted dictionary row requests an enable-toggle."""

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_messages.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_messages.py
@@ -87,12 +87,31 @@ class PersonaActionRequested(Message):
         self.entity_id = entity_id
 
 
+class PersonaSortCycleRequested(Message):
+    """The user asked to advance the library sort (screen decides the next key)."""
+
+
+class PersonaTagFilterRequested(Message):
+    """The user asked to open the tag filter (characters only)."""
+
+
+class PersonaPageChanged(Message):
+    """The user asked to move the library page window."""
+
+    def __init__(self, delta: int) -> None:
+        super().__init__()
+        self.delta = delta
+
+
 __all__ = [
     "PersonaAction",
     "PersonaActionRequested",
     "PersonaEntityKind",
     "PersonaEntitySelected",
     "PersonaModeChanged",
+    "PersonaPageChanged",
     "PersonaSearchChanged",
+    "PersonaSortCycleRequested",
+    "PersonaTagFilterRequested",
     "PersonaWorkbenchMode",
 ]

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_state.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_state.py
@@ -40,6 +40,12 @@ class PersonasWorkbenchState:
     runtime_source: str = "local"
     search_query: str = ""
     filter_text: str = ""
+    #: Active library sort key (see ``PersonasScreen._character_sort_cycle``).
+    sort_key: str = "name_asc"
+    #: Active characters-only tag filter (``None`` means "all tags").
+    tag_filter: str | None = None
+    #: Zero-based offset of the visible library page (multiple of page size).
+    page_offset: int = 0
     selected_entity_kind: PersonaEntityKind | None = None
     selected_entity_id: str | None = None
     selected_entity_name: str = ""
@@ -54,6 +60,11 @@ class PersonasWorkbenchState:
             raise ValueError(f"Unsupported Personas mode: {mode}")
         self.active_mode = mode
         self.clear_selection()
+        # Each mode starts with a fresh library window: default sort, no tag
+        # filter, and page 0. Search is cleared by the screen's _apply_mode.
+        self.sort_key = "name_asc"
+        self.tag_filter = None
+        self.page_offset = 0
         self.has_unsaved_changes = False
         self.is_loading = False
         self.status_message = f"Mode: {MODE_LABELS[mode]}"
@@ -90,6 +101,9 @@ class PersonasWorkbenchState:
         self.runtime_source = str(runtime_source or "local")
         self.search_query = ""
         self.filter_text = ""
+        self.sort_key = "name_asc"
+        self.tag_filter = None
+        self.page_offset = 0
         self.clear_selection()
         self.is_loading = False
         self.has_unsaved_changes = False

--- a/tldw_chatbook/Widgets/Persona_Widgets/tag_filter_picker.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/tag_filter_picker.py
@@ -1,0 +1,99 @@
+"""Modal tag picker for the characters library tag filter (P3a).
+
+Mirrors ``ConversationAttachPicker`` (P2e): a ``ModalScreen[str | None]``
+with a search ``Input`` filtering a ``ListView``, and the selected value
+recovered by index (not by re-parsing the rendered label, which is lossy
+for tags containing markup-sensitive characters).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from textual import on
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Input, Label, ListItem, ListView, Static
+
+
+class TagFilterPicker(ModalScreen[str | None]):
+    """Pick one tag (or clear the filter) for the characters library.
+
+    Dismisses with ``None`` when "All (clear filter)" is chosen, the tag
+    string when a tag row is chosen, and ``TagFilterPicker.CANCEL`` when the
+    user backs out with Escape - a sentinel distinct from ``None`` so the
+    caller can tell "clear the filter" apart from "leave it alone".
+
+    Args:
+        tags: Known tags to offer, in display order.
+        current: The currently-active tag (if any), highlighted on mount.
+    """
+
+    CANCEL = object()  # distinct from None ("All") so cancel != clear-filter
+
+    DEFAULT_CSS = """
+    TagFilterPicker { align: center middle; }
+    TagFilterPicker > Vertical {
+        width: 50%; max-width: 60; height: auto; max-height: 80%;
+        padding: 1 2; border: round $panel;
+    }
+    TagFilterPicker #tag-filter-list { height: auto; max-height: 16; }
+    """
+
+    def __init__(self, tags: list[str], current: str | None, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._tags = list(tags)
+        self._current = current
+        self._row_tags: list[str | None] = []
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            yield Label("Filter by tag", markup=False)
+            yield Input(placeholder="Filter tags...", id="tag-filter-search")
+            yield ListView(id="tag-filter-list")
+            yield Static("Enter to pick - Esc to cancel", classes="destination-purpose")
+
+    def on_mount(self) -> None:
+        self._populate(self._tags)
+
+    def _populate(self, tags: list[str]) -> None:
+        listing = self.query_one("#tag-filter-list", ListView)
+        listing.clear()
+        self._row_tags = [None]
+        listing.append(ListItem(Static("All (clear filter)", markup=False)))
+        current_index = 0 if self._current is None else None
+        for index, tag in enumerate(tags, start=1):
+            listing.append(ListItem(Static(tag, markup=False)))
+            self._row_tags.append(tag)
+            if tag == self._current:
+                current_index = index
+        # A filter change must require an explicit re-select: don't let a
+        # previously-highlighted index silently carry over onto a rebuilt,
+        # differently-ordered row set - except on the initial populate,
+        # where we highlight the currently-active tag (or "All").
+        listing.index = current_index
+
+    @on(Input.Changed, "#tag-filter-search")
+    def _filter(self, event: Input.Changed) -> None:
+        event.stop()
+        needle = event.value.strip().lower()
+        tags = [t for t in self._tags if needle in t.lower()] if needle else self._tags
+        self._populate(tags)
+
+    @on(ListView.Selected, "#tag-filter-list")
+    def _selected(self, event: ListView.Selected) -> None:
+        event.stop()
+        listing = self.query_one("#tag-filter-list", ListView)
+        index = listing.index
+        if index is None or not 0 <= index < len(self._row_tags):
+            return
+        self.dismiss(self._row_tags[index])
+
+    def on_key(self, event) -> None:
+        if event.key == "escape":
+            event.stop()
+            self.dismiss(self.CANCEL)
+
+
+__all__ = ["TagFilterPicker"]

--- a/tldw_chatbook/Widgets/Persona_Widgets/tag_filter_picker.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/tag_filter_picker.py
@@ -68,10 +68,12 @@ class TagFilterPicker(ModalScreen[str | None]):
             self._row_tags.append(tag)
             if tag == self._current:
                 current_index = index
-        # A filter change must require an explicit re-select: don't let a
-        # previously-highlighted index silently carry over onto a rebuilt,
-        # differently-ordered row set - except on the initial populate,
-        # where we highlight the currently-active tag (or "All").
+        # Highlight the currently-active tag (or "All" if none) whenever it
+        # appears in the row set being shown - this runs on every populate,
+        # including each search keystroke, not just the initial mount. If
+        # the active tag has been filtered out, current_index stays None and
+        # nothing is pre-highlighted, so a filter change never silently
+        # carries over a stale index onto a rebuilt, differently-ordered set.
         listing.index = current_index
 
     @on(Input.Changed, "#tag-filter-search")


### PR DESCRIPTION
## Roleplay P3a — Characters/Personas library: pagination + sort + tag filter

First sub-project of **P3** (Characters/Personas flow polish), the final phase of the Roleplay redesign. Makes the shared workbench library list scale and easier to search, keeping the current card⇄editor + live-chat-preview shape (targeted polish, not an architectural rebuild).

**No schema migration** — ChaChaNotes stays v22; reads existing `character_cards` columns only.

### What changed
- **Pagination (page-at-a-time, 50/page).** The list previously mounted *every* row at once (no virtualization) and capped at 1,000. Now only one page of `ListView` rows is ever mounted, with an accurate "◄ X–Y of N ►" bar backed by a real `COUNT`.
- **Sort control** — Name A–Z / Recently modified / Recently created (+ Relevance while searching). Whitelisted `ORDER BY` keyed by an enum (no string interpolation).
- **Tag filter (characters only)** — `json_each`-based membership over `character_cards.tags`, json-valid-guarded so NULL/malformed tags never crash the query. Distinct-tags picker modal.
- **Search preserved as FTS** — the existing multi-field relevance match, now composable with tag + sort + pagination + accurate count (browse = plain paged query; search = FTS-join).
- **Two backends behind one pane** — Characters (SQL, full treatment); Personas (file-backed, ≤100) get pagination + sort + search via a pure in-memory helper (no tag; no backend edit). **Dictionaries/Lore modes are gated off and unchanged.**
- **Count cached** by `(search, tag)` so page navigation and sort issue only the page query.
- **Five `self._characters` cache-assumption fixes** — with pagination the cache holds one page, not the whole library, so the status count, import name-conflict detection, and post-import/save name resolution were corrected (selection was already by-id and stays safe).

### Tasks (subagent-driven, spec+quality review each, opus whole-branch review)
1. DB query/count/distinct-tags seam + `Character_Chat_Lib` wrappers — real-DB tests incl. NULL/non-JSON tags never raise.
2. Pure `page_persona_profiles` helper.
3. Pane sort/tag/page controls + intent messages + `TagFilterPicker` + backward-compatible `update_rows`.
4. Screen wiring + count cache + handlers + the 5 cache-assumption fixes + integration tests.

### Verification
- P3a suites: 34 passed (DB paging, persona paging, pane, tag picker, screen integration).
- Reconciled existing suites: `test_personas_workbench.py` + `test_personas_dictionaries.py` — 240 passed.
- `import tldw_chatbook.app` OK.
- Final opus whole-branch review: **Ready to merge — no Critical/Important**; all findings Minor (deferred to a cleanup follow-up: dead `_character_record`, stale `LIBRARY_FTS_THRESHOLD`/docstring, move count-cache writes below the freshness guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds page-at-a-time pagination with sort and tag filter to the Roleplay library, making Characters and Personas faster to browse and search. No schema changes. Adds a backlog task to track deferred cleanup items.

- **New Features**
  - Characters: paged list (50/page) with accurate count, FTS search that composes with tag and sort (Name A–Z, Recently modified, Recently created), and distinct-tag picker.
  - Personas: in-memory paging/sort/search helper for the ≤100 file-backed profiles (no tags).
  - Unified UI: page bar with "X–Y of N", sort cycle button, and tag filter (characters only); Dictionaries/Lore remain unchanged.
  - DB seam: `list_character_cards_page`, `count_character_cards`, `list_distinct_character_tags`; UI wrappers `get_character_page_for_ui`, `count_character_page`, `list_character_tags`. Count results cached by `(search, tag)`.

- **Bug Fixes**
  - Fixed assumptions that the library cache held all characters; status counts, import name-conflict checks, and post-import/save name resolution now work with paged data.
  - Guarded tag filtering so NULL/non-JSON `tags` never crash `json_each`.
  - Sort/tag changes reset page offset; page windows are disjoint and match the counted total.
  - Prevented stale counts by committing the count-cache only after the freshness guard; removed dead `_character_record` and the stale `LIBRARY_FTS_THRESHOLD`, and clamped Personas paging against the filtered total.

<sup>Written for commit 7e29d0593555d1fe61820cadc6567c70b10370ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

