### PR TITLE
fix(console): dock feedback toasts to the top so they don't cover/swallow composer clicks (task 352)

### DIFF
--- a/Tests/UI/test_console_toast_placement.py
+++ b/Tests/UI/test_console_toast_placement.py
@@ -1,6 +1,12 @@
 """Console feedback toasts must not sit over the composer action cluster (task-352)."""
 
 import pytest
+
+# Textual does not export ToastRack publicly (it is not in `textual.widgets`),
+# and the headless notification system does not mount one, so the test reaches
+# into the private module to construct one directly and assert the Console
+# screen's CSS docks it. Mirrors the existing `textual.widgets._markdown`
+# private import already used under Tests/.
 from textual.widgets._toast import ToastRack
 
 from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
@@ -10,7 +16,7 @@ from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
 
 
 @pytest.mark.asyncio
-async def test_console_toast_rack_docks_top_not_over_composer():
+async def test_console_toast_rack_docks_top_not_over_composer() -> None:
     """Textual docks notification toasts bottom-right by default — directly over
     the Console composer's Send/Attach/Save cluster and staged-chip strip — and
     toasts capture clicks, so a click aimed at those controls during a toast

--- a/Tests/UI/test_console_toast_placement.py
+++ b/Tests/UI/test_console_toast_placement.py
@@ -1,0 +1,40 @@
+"""Console feedback toasts must not sit over the composer action cluster (task-352)."""
+
+import pytest
+from textual.widgets._toast import ToastRack
+
+from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+    ConsoleHarness,
+)
+
+
+@pytest.mark.asyncio
+async def test_console_toast_rack_docks_top_not_over_composer():
+    """Textual docks notification toasts bottom-right by default — directly over
+    the Console composer's Send/Attach/Save cluster and staged-chip strip — and
+    toasts capture clicks, so a click aimed at those controls during a toast
+    hits the toast instead. The Console screen must dock its toast rack to the
+    TOP so feedback never obscures, or swallows clicks aimed at, the composer
+    controls (task-352).
+    """
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+
+        # Toasts are not rendered by the headless notification system, so mount a
+        # ToastRack directly under the Console screen and assert the screen's CSS
+        # docks it to the top (Textual's own default is bottom-right).
+        rack = ToastRack()
+        await console.mount(rack)
+        await pilot.pause()
+
+        assert rack.styles.align_vertical == "top", (
+            "Console toast rack aligns "
+            f"{rack.styles.align_vertical!r} — it would sit over the composer"
+        )
+        assert str(rack.styles.dock) == "top", (
+            f"Console toast rack docks {rack.styles.dock!r}, expected 'top'"
+        )

--- a/backlog/tasks/task-352 - Reposition-feedback-toasts-off-the-composer-action-cluster-and-stop-them-swallowing-clicks.md
+++ b/backlog/tasks/task-352 - Reposition-feedback-toasts-off-the-composer-action-cluster-and-stop-them-swallowing-clicks.md
@@ -1,10 +1,16 @@
 ---
 id: TASK-352
-title: Reposition feedback toasts off the composer action cluster and stop them swallowing clicks
-status: To Do
-assignee: []
+title: >-
+  Reposition feedback toasts off the composer action cluster and stop them
+  swallowing clicks
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-20 14:21'
-labels: [console, ux]
+updated_date: '2026-07-22 04:18'
+labels:
+  - console
+  - ux
 dependencies: []
 priority: medium
 ---
@@ -27,5 +33,40 @@ Also observed independently in J6 keyboard-only/small-terminal as `j6-boot-toast
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Feedback must not obscure the primary controls it reports on. Place toasts above the composer or in the status bar, keep them short-lived, and never let them intercept clicks aimed at controls beneath
+- [x] #1 Feedback must not obscure the primary controls it reports on. Place toasts above the composer or in the status bar, keep them short-lived, and never let them intercept clicks aimed at controls beneath
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Root cause: Textual docks notification toasts bottom-right by default
+(`ToastRack { dock: bottom; align: right bottom }`) — directly over the Console
+composer's Send/Attach/Save cluster and the staged-chip strip — and toasts
+intercept clicks (click-to-dismiss), so a click aimed at those controls during a
+~5s toast dismisses the toast instead of pressing the button. The app had no
+toast override.
+
+Fix: a one-rule `ChatScreen.DEFAULT_CSS` docks the Console screen's toast rack to
+the TOP-right (`dock: top; align: right top`). A top-docked rack can never
+overlap the bottom composer cluster, so feedback no longer obscures — nor
+swallows clicks aimed at — the composer controls; the only thing beneath a
+top-right toast is the header status chips (read-only). Kept in `DEFAULT_CSS`
+rather than the CSS bundle so it applies in BOTH the real app (which loads the
+bundle + widget DEFAULT_CSS) and test harnesses (which load DEFAULT_CSS but not
+the built bundle) — this is what makes it regression-testable. Scoped to
+`ChatScreen` (2-type selector beats Textual's 1-type `ToastRack` default);
+additive to `BaseAppScreen.DEFAULT_CSS` via the MRO (44 layout tests confirm
+BaseAppScreen styling intact). Toast duration left at Textual's short default —
+with the occlusion removed, the ~5s lifetime is no longer harmful; changing the
+global notify timeout across ~95 sites is out of scope.
+
+Verified: RED→GREEN regression test `test_console_toast_rack_docks_top_not_over_
+composer` (mounts a ToastRack under the Console screen and asserts the CSS docks
+it top — the headless notification system doesn't render toasts, so the style is
+asserted directly). Served-app capture confirms the composer region is clean at
+boot (previously the boot "Model catalog" toast sat over it); the boot
+catalog-refresh toast can't be re-triggered live because the capture harness
+aborts outbound https, but the top-dock mechanism is deterministic and proven by
+the test. Files: `tldw_chatbook/UI/Screens/chat_screen.py`,
+`Tests/UI/test_console_toast_placement.py`.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -601,6 +601,23 @@ class ChatScreen(BaseAppScreen):
     input text, and UI preferences when navigating away and returning.
     """
 
+    # TASK-352: Textual docks notification toasts bottom-right by default —
+    # directly over the Console composer's Send/Attach/Save cluster and the
+    # staged-chip strip — and toasts intercept clicks, so a click aimed at those
+    # controls during a ~5s toast dismisses the toast instead of pressing the
+    # button. Dock the Console screen's toast rack to the TOP-right so feedback
+    # never obscures, or swallows clicks aimed at, the composer's controls.
+    # Kept in DEFAULT_CSS (not the bundle) so it applies in both the real app
+    # and test harnesses, which load widget DEFAULT_CSS but not the built bundle.
+    DEFAULT_CSS = """
+    ChatScreen ToastRack {
+        dock: top;
+        align: right top;
+        margin-top: 1;
+        margin-bottom: 0;
+    }
+    """
+
     BINDINGS = [
         # Textual's Screen base class binds tab/shift+tab to the "app."-namespaced
         # focus_next/focus_previous actions, which always dispatch to App.action_focus_next


### PR DESCRIPTION
## Summary

Console UX review task **352** (P2, high confidence). Textual docks notification toasts **bottom-right** by default — directly over the Console composer's **Send/Attach/Save** cluster and the staged-chip strip. Because toasts capture clicks (click-to-dismiss), a click aimed at those controls during a ~5s toast dismisses the toast instead of pressing the button. The finding measured this across three journeys: every attach/clear/limit toast (J3), the boot "Model catalog" toast (J4), and the small-terminal boot toast (J6). The app had no toast override.

## Change

A one-rule `ChatScreen.DEFAULT_CSS` docks the Console screen's toast rack to the **top-right**:

```css
ChatScreen ToastRack {
    dock: top;
    align: right top;
    margin-top: 1;
    margin-bottom: 0;
}
```

A top-docked rack can never overlap the bottom composer cluster, so feedback no longer obscures — nor swallows clicks aimed at — the composer controls. The only thing beneath a top-right toast is the header's read-only status chips.

**Why `DEFAULT_CSS`, not the CSS bundle:** the bundle isn't loaded by the test harnesses (they use widget `DEFAULT_CSS` only). Keeping the rule in `ChatScreen.DEFAULT_CSS` means it applies in **both** the real app and the harness — which is what makes the fix regression-testable. Scoped to `ChatScreen` (2-type selector beats Textual's 1-type `ToastRack` default) and additive to `BaseAppScreen.DEFAULT_CSS` via the MRO.

Toast duration is left at Textual's short default — with the occlusion removed the ~5s lifetime is no longer harmful, and changing the global notify timeout across ~95 `notify()` sites is out of scope.

## Verification

- **RED→GREEN** test `test_console_toast_rack_docks_top_not_over_composer`: mounts a `ToastRack` under the Console screen and asserts the CSS docks it top (the headless notification system doesn't render toasts, so the computed `dock`/`align` style is asserted directly). Was `bottom` before, `top` after.
- 44 layout tests confirm the added `DEFAULT_CSS` is additive (BaseAppScreen styling intact).
- Served-app capture: the composer region is clean at boot (previously the "Model catalog" toast sat over it). The boot catalog-refresh toast can't be re-triggered live because the capture harness aborts outbound https, but the top-dock mechanism is deterministic and proven by the test.
- Full Console sweep: **1218 passed / 15 failed — all 15 within the known baseline, 0 outside**.

Files: `tldw_chatbook/UI/Screens/chat_screen.py`, `Tests/UI/test_console_toast_placement.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move Console feedback toasts to the top-right so they no longer cover the composer or intercept clicks. Satisfies TASK-352 acceptance criteria.

- **Bug Fixes**
  - Override `ToastRack` placement via `ChatScreen.DEFAULT_CSS` (`dock: top; align: right top`), scoped to `ChatScreen`.
  - Keep the rule in widget `DEFAULT_CSS` (not the CSS bundle) so it applies in both the app and test harness.
  - Add regression test `test_console_toast_rack_docks_top_not_over_composer` that mounts a `ToastRack` and asserts the top dock; uses a private `textual.widgets._toast` import since `ToastRack` isn’t publicly exported in headless mode.

<sup>Written for commit 6414fe1f6ba24a74605b23125328476ae73d798b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

