### PR TITLE
chore(backlog): resolve five duplicate task-ID collisions (448/449/450/451/456)

### DIFF
--- a/backlog/tasks/task-459 - Internal-prompts-warn-once-on-wrong-typed-override-values.md
+++ b/backlog/tasks/task-459 - Internal-prompts-warn-once-on-wrong-typed-override-values.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-448
+id: TASK-459
 title: 'Internal prompts: warn once on wrong-typed override values'
 status: To Do
 assignee: []

--- a/backlog/tasks/task-460 - Internal-prompts-transport-boundary-tests-for-websearch-sites-2-4.md
+++ b/backlog/tasks/task-460 - Internal-prompts-transport-boundary-tests-for-websearch-sites-2-4.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-449
+id: TASK-460
 title: 'Internal prompts: transport-boundary tests for websearch sites 2-4'
 status: To Do
 assignee: []

--- a/backlog/tasks/task-461 - RAG-reranker-remove-unreachable-literal-fallback.md
+++ b/backlog/tasks/task-461 - RAG-reranker-remove-unreachable-literal-fallback.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-450
+id: TASK-461
 title: 'RAG reranker: remove unreachable literal fallback in _call_llm_impl'
 status: To Do
 assignee: []

--- a/backlog/tasks/task-462 - Internal-prompts-dead-key-hygiene-after-full-migration.md
+++ b/backlog/tasks/task-462 - Internal-prompts-dead-key-hygiene-after-full-migration.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-451
+id: TASK-462
 title: 'Internal prompts: dead-key hygiene after full migration'
 status: To Do
 assignee: []

--- a/backlog/tasks/task-463 - P3a-follow-up-—-sweep-deferred-library-pagination-minors.md
+++ b/backlog/tasks/task-463 - P3a-follow-up-—-sweep-deferred-library-pagination-minors.md
@@ -1,5 +1,5 @@
 ---
-id: task-456
+id: TASK-463
 title: P3a follow-up — sweep deferred library-pagination minors
 status: To Do
 assignee: []


### PR DESCRIPTION
## Summary

Five task IDs were each claimed by two different tasks on `dev` — concurrent sessions minting the same numbers without seeing each other. This trips the `No duplicate backlog task IDs` guard and makes the IDs ambiguous.

For each collision the **Done** (or earlier-created) task keeps the number; the **To Do** task is renumbered to the next free IDs (max on dev was 458):

| # | Keeps the number | Renumbered → |
|---|---|---|
| 448 | Skills-editor-guard-dirty-edits *(Done)* | Internal-prompts-warn-once → **459** |
| 449 | Skills-editor-visible-unsaved-changes *(Done)* | Internal-prompts-transport-boundary → **460** |
| 450 | Console-rail-flush-left *(Done)* | RAG-reranker-remove-unreachable-literal-fallback → **461** |
| 451 | Footer-key-hints *(older)* | Internal-prompts-dead-key-hygiene → **462** |
| 456 | RAG-scope-narrowing-Phase-3 *(Done)* | P3a-follow-up-sweep-deferred-library-pagination-minors → **463** |

All movers are To Do (safe to renumber), and 459–463 were verified free across every worktree and remote branch.

## Notes

- The **456** pair had slipped an earlier scan because one filename carries an em-dash that `git ls-tree` quotes; a robust scan caught it. That file also had a malformed lowercase `id: task-456` — corrected to `id: TASK-463` on the move.
- No cross-references change: the only two body references (task-415 → "task-449's Discard", task-346 → "task-451" footer) already point at the **retained keepers**.
- After this, no task keeps a duplicate filename number or frontmatter id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renumbered five duplicate backlog task IDs to restore uniqueness across filenames and frontmatter. Also fixed a malformed lowercase id and an em‑dash filename that earlier scans missed.

- **Bug Fixes**
  - Renumbered To Do tasks: 448→459, 449→460, 450→461, 451→462, 456→463.
  - Verified 459–463 are free across all worktrees and remote branches.
  - Corrected `id: task-456` → `id: TASK-463` and handled the quoted em‑dash filename in scans.

<sup>Written for commit d8e504b8d2bbf98d2bf9294e66c075975a782e0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

