### PR TITLE
fix(console): order the rail by last activity, not creation time (task 355)

### DIFF
--- a/Tests/Workspaces/test_console_conversation_browser_state.py
+++ b/Tests/Workspaces/test_console_conversation_browser_state.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from tldw_chatbook.Workspaces.conversation_browser_state import (
     ConsoleConversationBrowserInputRow,
     build_console_conversation_browser_state,
+    console_persisted_row_updated_sort,
     format_console_relative_age,
 )
 from tldw_chatbook.Workspaces.models import DEFAULT_WORKSPACE_ID
@@ -653,3 +654,62 @@ def test_rows_sorted_recent_first_regression():
     workspaces = next(s for s in state.sections if s.section_id == "workspaces")
     titles = [row.title for row in workspaces.groups[0].rows]
     assert titles == ["New", "Old"]
+
+
+def test_persisted_updated_sort_prefers_last_modified_over_created_at():
+    """TASK-355: normalize_conversation_row exposes last_modified/created_at but
+    NO updated_at key, so the rail's recency ordering + age labels must derive
+    from last_modified. Falling through to created_at orders the rail by
+    creation time, so a just-used conversation looks stale and sorts wrong."""
+    row = {
+        "last_modified": "2026-07-21T13:19:00+00:00",
+        "created_at": "2026-07-21T13:04:00+00:00",
+    }
+    assert console_persisted_row_updated_sort(row) == "2026-07-21T13:19:00+00:00"
+
+
+def test_persisted_updated_sort_fallback_chain():
+    # explicit updated_at still wins when present (back-compat).
+    assert (
+        console_persisted_row_updated_sort(
+            {"updated_at": "U", "last_modified": "M", "created_at": "C"}
+        )
+        == "U"
+    )
+    # last_modified beats created_at (the recency fix).
+    assert (
+        console_persisted_row_updated_sort({"last_modified": "M", "created_at": "C"})
+        == "M"
+    )
+    # created_at / last_updated remain the fallbacks when no recency field.
+    assert console_persisted_row_updated_sort({"created_at": "C"}) == "C"
+    assert console_persisted_row_updated_sort({"last_updated": "L"}) == "L"
+    # empty and None-bearing rows never raise and collapse to "".
+    assert console_persisted_row_updated_sort({}) == ""
+    assert (
+        console_persisted_row_updated_sort({"last_modified": None, "created_at": "C"})
+        == "C"
+    )
+
+
+def test_normalized_conversation_row_recency_flows_through_helper():
+    """Integration for TASK-355: persisted rail rows are built from
+    normalize_conversation_row's output, which emits last_modified but NO
+    updated_at — so the helper must source recency from last_modified end-to-end,
+    reproducing the exact data shape the rail sees."""
+    from tldw_chatbook.Chat.chat_conversation_service import normalize_conversation_row
+
+    normalized = normalize_conversation_row(
+        {
+            "id": "conv-1",
+            "title": "Long conversation about embeddings",
+            "last_modified": "2026-07-21T13:19:00+00:00",
+            "created_at": "2026-07-21T13:04:00+00:00",
+        }
+    )
+    # The root cause: the normalized payload carries no updated_at key.
+    assert "updated_at" not in normalized
+    # The fix: recency is sourced from last_modified, not creation time.
+    assert (
+        console_persisted_row_updated_sort(normalized) == "2026-07-21T13:19:00+00:00"
+    )

--- a/backlog/tasks/task-355 - Order-rail-conversations-by-last-activity-instead-of-creation-time.md
+++ b/backlog/tasks/task-355 - Order-rail-conversations-by-last-activity-instead-of-creation-time.md
@@ -1,10 +1,14 @@
 ---
 id: TASK-355
 title: Order rail conversations by last activity instead of creation time
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-20 14:21'
-labels: [console, ux]
+updated_date: '2026-07-22 04:54'
+labels:
+  - console
+  - ux
 dependencies: []
 priority: medium
 ---
@@ -23,5 +27,37 @@ After sending a message into 'Long conversation about embeddings...' at 13:19, a
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Most-recently-active ordering (or a clear 'Recent' grouping) and age = last activity
+- [x] #1 Most-recently-active ordering (or a clear 'Recent' grouping) and age = last activity
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Root cause (code-verified): persisted rail rows populated `updated_sort` from
+`item.get("updated_at") or created_at or last_updated`, but the payload comes
+from `normalize_conversation_row`, which emits `last_modified`/`created_at` and
+has NO `updated_at` key — so every persisted row silently degraded to its
+creation time. Both the rail's recency-first sort (`_sort_normal_rows`) and its
+age labels (`format_console_relative_age`) read `updated_sort`, and the Ctrl+K
+switcher shares the same rows, so a just-used conversation sorted/labelled as if
+it had never been touched. Latent since the browser's introduction (995a3f9ae),
+not a regression.
+
+Fix: DRY the two identical inline fallback chains (chat_screen.py, the two
+persisted-row builders) into one pure helper `console_persisted_row_updated_sort`
+in `Workspaces/conversation_browser_state` that inserts `last_modified` into the
+chain (`updated_at → last_modified → created_at → last_updated → ""`, None-safe).
+`last_modified` is bumped to now() on every conversation write, so it is the
+recency field; an explicit `updated_at` still wins for any caller that supplies
+one. Native-session rows already sort by the real `session.updated_at` attribute
+and are untouched.
+
+Verified: 2 helper unit tests (last_modified beats created_at; full fallback
+order incl. None-safety) + 1 integration test that runs a real
+`normalize_conversation_row` payload through the helper and asserts both the root
+cause (`"updated_at" not in normalized`) and the fix. Pure-data change with a
+clear testable seam, so no served capture needed. Files:
+`tldw_chatbook/Workspaces/conversation_browser_state.py`,
+`tldw_chatbook/Workspaces/__init__.py`, `tldw_chatbook/UI/Screens/chat_screen.py`,
+`Tests/Workspaces/test_console_conversation_browser_state.py`.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -314,6 +314,7 @@ from ...Workspaces import (
     DEFAULT_WORKSPACE_ID,
     WorkspaceRecord,
     build_console_conversation_browser_state,
+    console_persisted_row_updated_sort,
 )
 from ...Widgets.compact_model_bar import CompactModelBar
 from ...Widgets.Persona_Widgets.dictionary_picker import DictionaryPicker
@@ -4775,12 +4776,10 @@ class ChatScreen(BaseAppScreen):
                             and current_conversation == conversation_id
                         ),
                         source_kind="persisted",
-                        updated_sort=str(
-                            item.get("updated_at")
-                            or item.get("created_at")
-                            or item.get("last_updated")
-                            or ""
-                        ),
+                        # TASK-355: recency-first ordering / age labels must come
+                        # from last_modified (normalize_conversation_row exposes
+                        # no updated_at) or the rail degrades to creation order.
+                        updated_sort=console_persisted_row_updated_sort(item),
                     )
                     rows.append(
                         self._apply_console_browser_star_state(row, starred_ids)
@@ -4974,12 +4973,10 @@ class ChatScreen(BaseAppScreen):
                             and current_conversation == conversation_id
                         ),
                         source_kind="persisted",
-                        updated_sort=str(
-                            item.get("updated_at")
-                            or item.get("created_at")
-                            or item.get("last_updated")
-                            or ""
-                        ),
+                        # TASK-355: recency-first ordering / age labels must come
+                        # from last_modified (normalize_conversation_row exposes
+                        # no updated_at) or the rail degrades to creation order.
+                        updated_sort=console_persisted_row_updated_sort(item),
                     )
                     rows.append(
                         self._apply_console_browser_star_state(row, starred_ids)

--- a/tldw_chatbook/Workspaces/__init__.py
+++ b/tldw_chatbook/Workspaces/__init__.py
@@ -9,6 +9,7 @@ from .conversation_browser_state import (
     ConsoleConversationBrowserSection,
     ConsoleConversationBrowserState,
     build_console_conversation_browser_state,
+    console_persisted_row_updated_sort,
 )
 from .display_state import (
     CONSOLE_WORKSPACE_CONVERSATION_RESULT_LIMIT,
@@ -75,6 +76,7 @@ __all__ = [
     "build_console_conversation_browser_state",
     "build_library_workspace_depth_state",
     "build_console_workspace_state",
+    "console_persisted_row_updated_sort",
     "console_workspace_conversation_result_copy",
     "console_workspace_conversation_visible_rows",
     "evaluate_workspace_eligibility",

--- a/tldw_chatbook/Workspaces/conversation_browser_state.py
+++ b/tldw_chatbook/Workspaces/conversation_browser_state.py
@@ -98,6 +98,33 @@ def format_console_relative_age(value: str, *, now: datetime) -> str:
     return f"{days // 365}y"
 
 
+def console_persisted_row_updated_sort(item: Mapping[str, object]) -> str:
+    """Return the recency timestamp for a persisted conversation browser row.
+
+    The rail orders conversations recency-first and derives their age labels
+    from this value, so it must reflect last *activity*. TASK-355: the persisted
+    payload comes from ``normalize_conversation_row``, which exposes
+    ``last_modified``/``created_at`` but NO ``updated_at`` key — so reading only
+    ``updated_at`` silently degraded every persisted row to its creation time
+    (a just-used conversation looked stale and sorted wrong). ``last_modified``
+    (bumped to now on every conversation write) is the recency field; it is
+    preferred over ``created_at`` while an explicit ``updated_at`` still wins for
+    any caller that does provide one.
+
+    Args:
+        item: Normalized conversation row mapping.
+
+    Returns:
+        The best available recency timestamp as a string, or ``""`` when none is
+        present. ``None`` values in any field are skipped, never stringified.
+    """
+    for key in ("updated_at", "last_modified", "created_at", "last_updated"):
+        value = item.get(key)
+        if value:
+            return str(value)
+    return ""
+
+
 @dataclass(frozen=True)
 class ConsoleConversationBrowserInputRow:
     """Input row used to build the grouped Console conversation browser.


### PR DESCRIPTION
## Summary

Console UX review task **355** (P2, high confidence, J2 returning-power-user journey). After sending a message into an old conversation and restarting, the rail still listed it in **creation order** with a creation-age label — a returning user scanning for "the chat I was just in" can't find it, and the age misrepresents recency of use.

## Root cause (code-verified)

Persisted rail rows populated `updated_sort` from:

```python
item.get("updated_at") or item.get("created_at") or item.get("last_updated") or ""
```

but the payload comes from `normalize_conversation_row`, which emits `last_modified`/`created_at` and has **no `updated_at` key**. So `updated_at` was always `None` and every persisted row silently fell through to its **creation time**. Both the rail's recency-first sort (`_sort_normal_rows`) and its age labels (`format_console_relative_age`) read `updated_sort`, and the Ctrl+K switcher shares the same rows — so a just-used conversation sorted and labelled as if it had never been touched. Latent since the browser's introduction (`995a3f9ae`), not a regression.

## Change

DRY the two identical inline fallback chains (the two persisted-row builders in `chat_screen.py`) into one pure, `None`-safe helper `console_persisted_row_updated_sort` in `conversation_browser_state`, inserting `last_modified` into the chain:

```
updated_at → last_modified → created_at → last_updated → ""
```

`last_modified` is bumped to `now()` on every conversation write, so it's the recency field; an explicit `updated_at` still wins for any caller that supplies one. Native-session rows already sort by the real `session.updated_at` attribute and are untouched.

## Verification

- 2 helper unit tests (last_modified beats created_at; full fallback order incl. `None`-safety).
- 1 **integration** test that runs a real `normalize_conversation_row` payload through the helper and asserts both the root cause (`"updated_at" not in normalized`) and the fix — reproducing the exact data shape the rail sees.
- Full Console sweep: **1228 passed / 15 failed — all 15 within the known baseline, 0 outside** (one collapse-persist contention flake passes 4/4 in isolation).

Pure-data change with a clear testable seam, so no served capture needed.

Files: `tldw_chatbook/Workspaces/conversation_browser_state.py`, `tldw_chatbook/Workspaces/__init__.py`, `tldw_chatbook/UI/Screens/chat_screen.py`, `Tests/Workspaces/test_console_conversation_browser_state.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Orders the Console conversation rail by last activity (`last_modified`) instead of creation time so recent chats show first and display the correct age. Addresses TASK-355; Ctrl+K switcher now follows the same recency ordering.

- **Bug Fixes**
  - Root cause: persisted rows computed `updated_sort` from `updated_at/created_at/last_updated`, but normalized rows don’t include `updated_at`, so sorting fell back to creation time.
  - Added `console_persisted_row_updated_sort` with fallback `updated_at → last_modified → created_at → last_updated` (None-safe); exported via `tldw_chatbook/Workspaces/__init__.py`.
  - Replaced two inline chains in `tldw_chatbook/UI/Screens/chat_screen.py`; native session rows unchanged.
  - Tests: 2 unit tests for fallback behavior + 1 integration test using a real `normalize_conversation_row` payload.

<sup>Written for commit 390d69fbeb247800b99b15d178b0cd0b8b634659. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

