### PR TITLE
Internal Prompts: file follow-up + deferred-scope backlog tasks (466-475)

### DIFF
--- a/backlog/tasks/task-466 - Internal-Prompts-editor-real-click-integration-test.md
+++ b/backlog/tasks/task-466 - Internal-Prompts-editor-real-click-integration-test.md
@@ -1,0 +1,24 @@
+---
+id: TASK-466
+title: 'Internal Prompts editor: real-click integration test for Save/Reset/Cancel'
+status: To Do
+assignee: []
+created_date: '2026-07-22 22:10'
+labels:
+  - internal-prompts
+  - test-coverage
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The InternalPromptEditorModal's Save/Reset/Cancel are exercised via the `_save_from_test` seam and the panel's `_apply_editor_result` entry point, but no test drives the real Button.Pressed -> push_screen -> callback -> run_worker chain. A wrong `@on` selector (e.g. on Reset) would go undetected. Add a pilot-driven integration test that clicks the actual buttons.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A pilot test clicks the modal's Save button and asserts the override persists + the row badge updates
+- [ ] #2 A pilot test clicks Reset and asserts the override is cleared
+- [ ] #3 A pilot test clicks Cancel (and presses Escape) and asserts no change
+<!-- AC:END -->

--- a/backlog/tasks/task-467 - Internal-Prompts-panel-group-header-hide-test.md
+++ b/backlog/tasks/task-467 - Internal-Prompts-panel-group-header-hide-test.md
@@ -1,0 +1,23 @@
+---
+id: TASK-467
+title: 'Internal Prompts panel: test that a subsystem header hides when search filters all its rows'
+status: To Do
+assignee: []
+created_date: '2026-07-22 22:10'
+labels:
+  - internal-prompts
+  - test-coverage
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+InternalPromptsPanel._on_search hides a subsystem's group header when all its rows are filtered out (any_visible flag). The behavior is correct by inspection but has no direct test. Add one.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A test searches for a term matching only one subsystem and asserts the non-matching subsystems' group headers have display=False
+- [ ] #2 The matching subsystem's header remains visible
+<!-- AC:END -->

--- a/backlog/tasks/task-468 - Internal-Prompts-editor-unknown-action-debug-log.md
+++ b/backlog/tasks/task-468 - Internal-Prompts-editor-unknown-action-debug-log.md
@@ -1,0 +1,23 @@
+---
+id: TASK-468
+title: 'Internal Prompts editor: debug-log the modal's unknown-action branch'
+status: To Do
+assignee: []
+created_date: '2026-07-22 22:10'
+labels:
+  - internal-prompts
+  - polish
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+InternalPromptsPanel._apply_editor_result has a silent `else: return` for a result action other than save/reset/None. It is currently unreachable (the modal's dismiss contract is closed), but a future modal change could hit it silently. Add a one-line debug log for defense-in-depth.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The unknown-action branch logs at debug level with the unexpected action value
+- [ ] #2 No behavior change for the save/reset/None paths
+<!-- AC:END -->

--- a/backlog/tasks/task-469 - Internal-Prompts-editor-disable-reset-when-uncustomized.md
+++ b/backlog/tasks/task-469 - Internal-Prompts-editor-disable-reset-when-uncustomized.md
@@ -1,0 +1,24 @@
+---
+id: TASK-469
+title: 'Internal Prompts editor: disable Reset button when the prompt is not customized'
+status: To Do
+assignee: []
+created_date: '2026-07-22 22:10'
+labels:
+  - internal-prompts
+  - polish
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The editor modal's Reset button is always enabled. Reset on an uncustomized prompt is a harmless no-op (delete_settings_from_cli_config no-ops), but the spec intended Reset to be disabled/no-op when there is nothing to reset. Disable the button when override_state.customized is False for the prompt.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Reset is disabled (or clearly inert) when the prompt has no override / is not customized
+- [ ] #2 Reset is enabled when the prompt is customized
+- [ ] #3 A test covers both states
+<!-- AC:END -->

--- a/backlog/tasks/task-470 - Onboard-per-provider-system-prompt-fallbacks-to-registry.md
+++ b/backlog/tasks/task-470 - Onboard-per-provider-system-prompt-fallbacks-to-registry.md
@@ -1,0 +1,24 @@
+---
+id: TASK-470
+title: 'Onboard per-provider system_prompt fallbacks to the Internal Prompts registry'
+status: To Do
+assignee: []
+created_date: '2026-07-22 22:10'
+labels:
+  - internal-prompts
+  - enhancement
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Deferred from the Internal Prompts program. The per-provider 'You are a helpful AI assistant' style system_prompt fallbacks in Summarization_General_Lib / Local_Summarization_Lib and the [api_settings.<provider>].system_prompt defaults are not yet registry-backed. Onboard them as PromptSpecs (one-liners) so they are user-editable, following the established byte-parity + transport-boundary-test pattern.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The provider system_prompt fallbacks are registered as PromptSpecs with byte-identical defaults (golden-parity tests)
+- [ ] #2 Call sites resolve via the registry; existing programmatic overrides still win
+- [ ] #3 A transport-boundary test proves an override reaches the payload
+<!-- AC:END -->

--- a/backlog/tasks/task-471 - Onboard-OCR-transcription-prompts-to-registry.md
+++ b/backlog/tasks/task-471 - Onboard-OCR-transcription-prompts-to-registry.md
@@ -1,0 +1,24 @@
+---
+id: TASK-471
+title: 'Onboard OCR / transcription prompts to the Internal Prompts registry'
+status: To Do
+assignee: []
+created_date: '2026-07-22 22:10'
+labels:
+  - internal-prompts
+  - enhancement
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Deferred from the program (flagged model-specific/brittle). The docext VLM extraction prompt, image-analysis prompt, and Qwen2Audio transcription chat-template prompts in Local_Ingestion are hardcoded. Evaluate whether they can be safely registry-backed (some are model-specific chat templates) and onboard the ones that can.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Onboardable OCR/image/transcription prompts are registered with byte-identical defaults
+- [ ] #2 Model-specific chat-template prompts that cannot be safely edited are documented as intentionally excluded
+- [ ] #3 Call sites resolve via the registry where onboarded
+<!-- AC:END -->

--- a/backlog/tasks/task-472 - Onboard-prompt-selector-UI-analysis-templates-to-registry.md
+++ b/backlog/tasks/task-472 - Onboard-prompt-selector-UI-analysis-templates-to-registry.md
@@ -1,0 +1,24 @@
+---
+id: TASK-472
+title: 'Onboard prompt_selector UI analysis-prompt templates to the Internal Prompts registry'
+status: To Do
+assignee: []
+created_date: '2026-07-22 22:10'
+labels:
+  - internal-prompts
+  - enhancement
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Deferred from the program (picker UX, different feature). Widgets/prompt_selector.py holds ~30 hardcoded system+user analysis-prompt templates keyed by media type. Decide whether these belong in the Internal Prompts registry or remain a separate picker concern; if onboarded, they need a UX that fits a keyed template set rather than the single-prompt editor.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A decision is recorded on whether prompt_selector templates join the registry or stay separate
+- [ ] #2 If onboarded: templates are registry-backed with parity tests and a suitable editing UX
+- [ ] #3 If not: the rationale is documented and the templates left as-is
+<!-- AC:END -->

--- a/backlog/tasks/task-473 - Onboard-MCP-prompt-templates-to-registry.md
+++ b/backlog/tasks/task-473 - Onboard-MCP-prompt-templates-to-registry.md
@@ -1,0 +1,24 @@
+---
+id: TASK-473
+title: 'Onboard MCP-exposed prompt templates to the Internal Prompts registry'
+status: To Do
+assignee: []
+created_date: '2026-07-22 22:10'
+labels:
+  - internal-prompts
+  - enhancement
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Deferred from the program. MCP/prompts.py exposes conversation-analysis, document-generation, media-analysis, search-synthesis and character-interaction prompt templates over MCP as hardcoded f-strings. Onboard them to the registry so they are user-editable and consistent with the app's own prompts.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The MCP prompt templates are registered with byte-identical defaults (parity tests)
+- [ ] #2 The MCP server resolves them via the registry
+- [ ] #3 An override reaches the MCP-exposed template output (integration test)
+<!-- AC:END -->

--- a/backlog/tasks/task-474 - Onboard-prompt-engineering-metaprompt-to-registry.md
+++ b/backlog/tasks/task-474 - Onboard-prompt-engineering-metaprompt-to-registry.md
@@ -1,0 +1,24 @@
+---
+id: TASK-474
+title: 'Onboard the prompt-engineering metaprompt to the Internal Prompts registry'
+status: To Do
+assignee: []
+created_date: '2026-07-22 22:10'
+labels:
+  - internal-prompts
+  - enhancement
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Deferred from the program. Prompt_Management/Prompt_Engineering.py contains the large Anthropic 'metaprompt' used by generate_prompt(). Onboard it as a single PromptSpec so it is user-editable, preserving its exact text and its function-calling example blocks.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The metaprompt is registered with a byte-identical default (parity test)
+- [ ] #2 generate_prompt() resolves it via the registry
+- [ ] #3 Its placeholder/token contract is captured so edits cannot break generate_prompt()
+<!-- AC:END -->

--- a/backlog/tasks/task-475 - Onboard-media-ingestion-one-liner-prompts-to-registry.md
+++ b/backlog/tasks/task-475 - Onboard-media-ingestion-one-liner-prompts-to-registry.md
@@ -1,0 +1,24 @@
+---
+id: TASK-475
+title: 'Onboard media-ingestion one-liner prompts to the Internal Prompts registry'
+status: To Do
+assignee: []
+created_date: '2026-07-22 22:10'
+labels:
+  - internal-prompts
+  - enhancement
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Deferred from the program. Local_Ingestion Document_Processing / Image_Processing / audio_processing hold one-liner default prompts ('Please provide a comprehensive summary of this {type}.', image-analysis, chunk-summarize/combine). Onboard the stable ones to the registry.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The onboardable media-ingestion one-liners are registered with byte-identical defaults (parity tests)
+- [ ] #2 Call sites resolve via the registry; existing custom_prompt overrides still win
+- [ ] #3 A transport-boundary or call-site test proves an override is honored
+<!-- AC:END -->


### PR DESCRIPTION
## Summary

Backlog-only PR (no code) filing the remaining Internal Prompts work items so the record is accurate after the program (#741 / #748 / #758) and its follow-ups (#763) closed out.

**P3 review polish (466-469)** — small, non-correctness items surfaced by the P3 whole-branch review:
- 466: real-click integration test for the editor modal's Save/Reset/Cancel chain (currently tested via a seam)
- 467: test that a subsystem's group header hides when search filters all its rows
- 468: debug-log the modal's (currently unreachable) unknown-action branch
- 469: disable the modal's Reset button when a prompt isn't customized

**Deferred prompt-onboarding scope (470-475)** — the prompt groups the program intentionally left out ("onboard later, one spec each"):
- 470: per-provider `system_prompt` fallbacks
- 471: OCR / transcription prompts
- 472: `prompt_selector` UI analysis templates (picker UX)
- 473: MCP-exposed prompt templates
- 474: the prompt-engineering metaprompt
- 475: media-ingestion one-liner prompts

## ID assignment

Highest existing task on dev is 463. IDs 464/465 were already claimed on in-flight branches, so this uses **466-475**, re-verified free across every origin branch at commit time (the repo's recurring ID-collision pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filed backlog tasks 466–475 to capture Internal Prompts follow-ups and deferred onboarding so tracking stays accurate after the program closed. No code changes; adds task specs for P3 polish (integration tests, header-visibility test, unknown-action debug log, disable Reset) and future onboarding of per-provider system prompts, OCR/transcription prompts, `prompt_selector` templates, MCP templates, the prompt-engineering metaprompt, and media-ingestion one-liners.

<sup>Written for commit 3287d28f77e600522d5990403393c4b21c575291. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

