### PR TITLE
fix(console): disclose rail conversations hidden by the per-group cap (task 354)

### DIFF
--- a/Tests/UI/test_console_rail_sections.py
+++ b/Tests/UI/test_console_rail_sections.py
@@ -36,6 +36,11 @@ from tldw_chatbook.Widgets.Console.console_workspace_context import (
 from tldw_chatbook.Widgets.Console.console_workspace_details import (
     ConsoleWorkspaceDetailsTray,
 )
+from tldw_chatbook.Workspaces.conversation_browser_state import (
+    CONSOLE_CONVERSATION_BROWSER_GROUP_ROW_LIMIT,
+    ConsoleConversationBrowserInputRow,
+    build_console_conversation_browser_state,
+)
 from tldw_chatbook.Workspaces.display_state import ConsoleWorkspaceContextState
 
 
@@ -509,11 +514,6 @@ from tldw_chatbook.Widgets.Console.console_session_switcher_modal import (  # no
     ConsoleSessionSwitcherModal,
     ConsoleSwitcherChoice,
 )
-from tldw_chatbook.Workspaces.conversation_browser_state import (  # noqa: E402
-    ConsoleConversationBrowserInputRow,
-)
-
-
 def _switcher_rows() -> tuple[ConsoleConversationBrowserInputRow, ...]:
     def row(key, title, native=None, **kw):
         return ConsoleConversationBrowserInputRow(
@@ -873,3 +873,46 @@ async def test_switcher_result_shows_saved_chat_vocabulary_not_in_progress():
         label = str(result.label)
         assert "saved chat" in label
         assert "in-progress" not in label
+
+
+def _overflow_conversation_browser():
+    rows = tuple(
+        ConsoleConversationBrowserInputRow(
+            row_key=f"c{i}",
+            conversation_id=f"c{i}",
+            native_session_id=None,
+            title=f"Chat {i}",
+            scope_type="global",
+            workspace_id=None,
+            workspace_label="Chats",
+            status="workspace-thread",
+            updated_label="1d",
+        )
+        for i in range(CONSOLE_CONVERSATION_BROWSER_GROUP_ROW_LIMIT + 3)
+    )
+    return build_console_conversation_browser_state(rows=rows, active_workspace_id="ws-a")
+
+
+class _OverflowTrayApp(App):
+    def compose(self):
+        import dataclasses
+
+        state = dataclasses.replace(
+            _workspace_state(), conversation_browser=_overflow_conversation_browser()
+        )
+        yield ConsoleWorkspaceContextTray(state, id="overflow-tray")
+
+
+@pytest.mark.asyncio
+async def test_rail_discloses_conversations_hidden_by_the_cap_in_no_query_view():
+    """TASK-354: with more conversations than the per-group cap and no search
+    active, the rail must render an explicit overflow disclosure pointing at
+    Ctrl+K, instead of silently dropping the oldest with no affordance."""
+    app = _OverflowTrayApp()
+    async with app.run_test(size=(70, 40)):
+        status = app.query_one(
+            "#console-workspace-conversation-search-status", Static
+        )
+        text = str(getattr(status.renderable, "plain", status.renderable))
+        assert "3 more" in text
+        assert "Ctrl+K" in text

--- a/Tests/Workspaces/test_console_conversation_browser_state.py
+++ b/Tests/Workspaces/test_console_conversation_browser_state.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 from tldw_chatbook.Workspaces.conversation_browser_state import (
+    CONSOLE_CONVERSATION_BROWSER_GROUP_ROW_LIMIT,
     ConsoleConversationBrowserInputRow,
     build_console_conversation_browser_state,
     console_persisted_row_updated_sort,
@@ -713,3 +714,49 @@ def test_normalized_conversation_row_recency_flows_through_helper():
     assert (
         console_persisted_row_updated_sort(normalized) == "2026-07-21T13:19:00+00:00"
     )
+
+
+def _chat_rows(n):
+    return tuple(
+        _row(
+            f"c{i}",
+            f"Chat {i}",
+            scope_type="global",
+            workspace_id=None,
+            workspace_label="Chats",
+        )
+        for i in range(n)
+    )
+
+
+def test_no_query_view_discloses_conversations_hidden_by_the_cap():
+    """TASK-354: the rail silently caps each group at
+    CONSOLE_CONVERSATION_BROWSER_GROUP_ROW_LIMIT; with no search active the
+    overflow was dropped with zero disclosure, so the oldest conversations
+    looked deleted. The no-query view must announce the hidden rows and how to
+    reach them."""
+    rows = _chat_rows(CONSOLE_CONVERSATION_BROWSER_GROUP_ROW_LIMIT + 3)
+    state = build_console_conversation_browser_state(
+        rows=rows, active_workspace_id="ws-a"
+    )
+    assert "3 more" in state.status_copy
+    assert "Ctrl+K" in state.status_copy
+
+
+def test_no_query_view_has_no_disclosure_when_nothing_is_capped():
+    state = build_console_conversation_browser_state(
+        rows=_chat_rows(3), active_workspace_id="ws-a"
+    )
+    assert state.status_copy == ""
+
+
+def test_cap_disclosure_excludes_user_collapsed_sections():
+    """A collapsed section shows its own count in the header — its rows are not
+    'silently' hidden, so they must not inflate the cap disclosure."""
+    rows = _chat_rows(CONSOLE_CONVERSATION_BROWSER_GROUP_ROW_LIMIT + 5)
+    state = build_console_conversation_browser_state(
+        rows=rows,
+        active_workspace_id="ws-a",
+        group_collapse_preferences={"section:chats": True},
+    )
+    assert state.status_copy == ""

--- a/backlog/tasks/task-354 - Fix-rail-Chats-list-silently-capping-at-11-conversations-with-no-overflow-affordance.md
+++ b/backlog/tasks/task-354 - Fix-rail-Chats-list-silently-capping-at-11-conversations-with-no-overflow-affordance.md
@@ -1,10 +1,16 @@
 ---
 id: TASK-354
-title: Fix rail Chats list silently capping at 11 conversations with no overflow affordance
-status: To Do
-assignee: []
+title: >-
+  Fix rail Chats list silently capping at 11 conversations with no overflow
+  affordance
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-20 14:21'
-labels: [console, ux]
+updated_date: '2026-07-22 05:18'
+labels:
+  - console
+  - ux
 dependencies: []
 priority: medium
 ---
@@ -23,5 +29,38 @@ With 12 seeded conversations, the rail's Chats section listed 11 (Websocket...De
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Either list all conversations (scrollable), or show an explicit 'N more — search with Ctrl+K / Show all' disclosure row at the section end
+- [x] #1 Either list all conversations (scrollable), or show an explicit 'N more — search with Ctrl+K / Show all' disclosure row at the section end
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Root cause (code-verified): the grouped browser caps each group at
+`CONSOLE_CONVERSATION_BROWSER_GROUP_ROW_LIMIT` (12); `_visible_rows` drops the
+overflow and computes `hidden_count`, but `_build_status_copy` returned `""`
+unless a search query was active, so the default no-query view had ZERO
+disclosure — the oldest conversation was simply gone with no hint (only Ctrl+K
+fuzzy-search could still reach it). task-138 covered the OLD rail's searchable
+subsection; the newer grouped browser's no-query view was uncovered.
+
+Fix (chose the AC's "explicit disclosure" option, not "list all"): compute the
+silently-capped count and surface it as the existing `status_copy` line (which
+the tray already renders unconditionally, right under the always-present search
+box). `_build_status_copy` now, when no query is active and rows were capped,
+returns `"{n} more conversation(s) — search with Ctrl+K"`. The count comes from
+a new `_capped_hidden_count(sections)` = `sum(section.hidden_count for
+non-collapsed sections)`: `_visible_rows` reports `hidden_count=0` for collapsed
+groups, so a non-collapsed section's `hidden_count` is PURE cap overflow —
+user-collapsed sections (which show their own header count) are correctly
+excluded and never inflate the disclosure. The search-mode "Showing X of Y" copy
+is unchanged.
+
+Verified: 3 state unit tests (discloses when capped; no disclosure when nothing
+capped; excludes user-collapsed sections) + 1 tray render test mounting the real
+`ConsoleWorkspaceContextTray` with 15 conversations and asserting the
+`#console-workspace-conversation-search-status` static shows "3 more … Ctrl+K"
+in the no-query view. Files:
+`tldw_chatbook/Workspaces/conversation_browser_state.py`,
+`Tests/Workspaces/test_console_conversation_browser_state.py`,
+`Tests/UI/test_console_rail_sections.py`.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Workspaces/conversation_browser_state.py
+++ b/tldw_chatbook/Workspaces/conversation_browser_state.py
@@ -420,6 +420,7 @@ def build_console_conversation_browser_state(
         query_active=query_active,
         total_count=effective_total_count,
         displayed_count=_displayed_row_count(sections),
+        capped_hidden_count=_capped_hidden_count(sections),
     )
 
     return ConsoleConversationBrowserState(
@@ -684,20 +685,43 @@ def _selected_summary(rows: tuple[ConsoleConversationBrowserInputRow, ...]) -> s
     return selected.title or selected.workspace_label
 
 
+def _capped_hidden_count(
+    sections: tuple[ConsoleConversationBrowserSection, ...],
+) -> int:
+    """Return the rows hidden by the per-group cap in the current render.
+
+    TASK-354: excludes collapsed sections — their rows are hidden by an explicit
+    user collapse that already shows its own header count, not by silent
+    capping. A non-collapsed section's ``hidden_count`` is pure cap overflow
+    (``_visible_rows`` reports 0 for collapsed groups), so summing it across
+    expanded sections yields exactly the silently-dropped total.
+    """
+    return sum(
+        section.hidden_count for section in sections if not section.collapsed
+    )
+
+
 def _build_status_copy(
     *,
     query_active: bool,
     total_count: int,
     displayed_count: int,
+    capped_hidden_count: int = 0,
 ) -> str:
-    if not query_active:
-        return ""
-    match_label = "match" if total_count == 1 else "matches"
-    status = f"{total_count} {match_label}"
-    shown_count = min(total_count, displayed_count)
-    if total_count > shown_count:
-        status = f"{status}. Showing {shown_count} of {total_count}"
-    return status
+    if query_active:
+        match_label = "match" if total_count == 1 else "matches"
+        status = f"{total_count} {match_label}"
+        shown_count = min(total_count, displayed_count)
+        if total_count > shown_count:
+            status = f"{status}. Showing {shown_count} of {total_count}"
+        return status
+    # TASK-354: with no search active the per-group cap can silently drop the
+    # oldest conversations, so they read as deleted. Disclose the count and point
+    # at the search that reaches them (Ctrl+K fuzzy-finds capped rows).
+    if capped_hidden_count > 0:
+        row_label = "conversation" if capped_hidden_count == 1 else "conversations"
+        return f"{capped_hidden_count} more {row_label} — search with Ctrl+K"
+    return ""
 
 
 def _displayed_row_count(

--- a/tldw_chatbook/Workspaces/conversation_browser_state.py
+++ b/tldw_chatbook/Workspaces/conversation_browser_state.py
@@ -691,10 +691,12 @@ def _capped_hidden_count(
     """Return the rows hidden by the per-group cap in the current render.
 
     TASK-354: excludes collapsed sections — their rows are hidden by an explicit
-    user collapse that already shows its own header count, not by silent
-    capping. A non-collapsed section's ``hidden_count`` is pure cap overflow
-    (``_visible_rows`` reports 0 for collapsed groups), so summing it across
-    expanded sections yields exactly the silently-dropped total.
+    user collapse (reversible by expanding the section, which the toggle in the
+    section header invites), not by the silent cap, so they are not "silently"
+    lost and must not inflate the disclosure. A non-collapsed section's
+    ``hidden_count`` is pure cap overflow (``_visible_rows`` reports 0 for
+    collapsed groups), so summing it across expanded sections yields exactly the
+    silently-dropped total.
     """
     return sum(
         section.hidden_count for section in sections if not section.collapsed


### PR DESCRIPTION
## Summary

Console UX review task **354** (P2, high confidence, J2 returning-power-user journey). With 12 seeded conversations plus native sessions, the rail's Chats section listed only 11 in every state — the oldest was silently dropped with **no overflow affordance**. A user scanning the rail would reasonably conclude the conversation was deleted; it's only reachable via Ctrl+K fuzzy-search, which nothing discloses.

## Root cause (code-verified)

The grouped browser caps each group at `CONSOLE_CONVERSATION_BROWSER_GROUP_ROW_LIMIT` (12). `_visible_rows` drops the overflow and computes `hidden_count`, but `_build_status_copy` returned `""` unless a search query was active — so the default no-query view had **zero disclosure** ("Showing X of Y" only ever appeared mid-search). task-138 shipped cap-state copy for the *old* rail's searchable subsection; the newer grouped browser's no-query view was an uncovered gap.

## Change

Chose the AC's **explicit-disclosure** option (over "list all"): surface the silently-capped count as the existing `status_copy` line, which the tray already renders unconditionally right under the always-present search box. When no query is active and rows were capped:

```
"{n} more conversation(s) — search with Ctrl+K"
```

The count comes from a new `_capped_hidden_count(sections)` = `sum(section.hidden_count for non-collapsed sections)`. `_visible_rows` reports `hidden_count=0` for collapsed groups, so a **non-collapsed** section's `hidden_count` is *pure cap overflow* — user-collapsed sections (which already show their own header count) are excluded and never inflate the disclosure. The search-mode "Showing X of Y" copy is unchanged.

Single production file touched (`conversation_browser_state.py`) — the `status_copy` already flows through `state.conversation_browser` to the tray.

## Verification

- 3 state unit tests: discloses when capped; **no** disclosure when nothing is capped; excludes user-collapsed sections.
- 1 tray **render** test: mounts the real `ConsoleWorkspaceContextTray` with 15 conversations and asserts `#console-workspace-conversation-search-status` shows "3 more … Ctrl+K" in the no-query view.
- Full Console sweep: **1230 passed / 15 failed — all 15 within the known baseline, 0 outside**.

Files: `tldw_chatbook/Workspaces/conversation_browser_state.py`, `Tests/Workspaces/test_console_conversation_browser_state.py`, `Tests/UI/test_console_rail_sections.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Console rail to disclose conversations hidden by the per-group cap. In the no-search view, the tray now shows “N more conversations — search with Ctrl+K” so overflow items aren’t silently dropped. Addresses Task 354’s explicit-disclosure acceptance criteria.

- **Bug Fixes**
  - Implementation: added `_capped_hidden_count` and passed it to `_build_status_copy`; when `query_active` is false it returns “N more … Ctrl+K”; excludes collapsed sections (hidden by explicit user collapse, not the cap); search-mode “Showing X of Y” unchanged.
  - Expanded tests: state tests for capped/uncapped/collapsed cases, plus a tray render test asserting the disclosure (“3 more … Ctrl+K”) appears in the no-query view.

<sup>Written for commit 64463db5a8be1147c52187f3aa8b0d3fdf93079d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

