### PR TITLE
chore(backlog): record pilot-measured diagnosis for task-353 (transcript image-row gap)

### DIFF
--- a/backlog/tasks/task-353 - Fix-transcript-spreading-messages-to-pane-extremes-with-a-dead-gap-between-them.md
+++ b/backlog/tasks/task-353 - Fix-transcript-spreading-messages-to-pane-extremes-with-a-dead-gap-between-them.md
@@ -1,10 +1,16 @@
 ---
 id: TASK-353
-title: Fix transcript spreading messages to pane extremes with a dead gap between them
+title: >-
+  Fix transcript spreading messages to pane extremes with a dead gap between
+  them
 status: To Do
-assignee: []
+assignee:
+  - '@claude'
 created_date: '2026-07-20 14:21'
-labels: [console, ux]
+updated_date: '2026-07-22 05:34'
+labels:
+  - console
+  - ux
 dependencies: []
 priority: medium
 ---
@@ -25,3 +31,32 @@ After the first send, the user message renders at the very top of the transcript
 <!-- AC:BEGIN -->
 - [ ] #1 Messages should stack contiguously (top-anchored or bottom-anchored), so the conversation reads as a chronological flow
 <!-- AC:END -->
+
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+DIAGNOSIS (pilot-measured, not yet fixed): the giant gap is the inline-image
+row's height, not scroll/anchoring. `_image_row_widget`
+(console_transcript.py ~970) sets `max_width=80, max_height=40` on the row
+widget. PIXELS mode (rich_pixels Static, styles.height=auto) is correctly
+CONTENT-SIZED — an 80x8 image → 4 rows, 16x16 → 8 rows, no void. GRAPHICS mode
+(textual_image `Image`, styles.height=None) FILLS to max_height=40 for EVERY
+aspect ratio (wide/square/tall all measured region.height=40); it renders the
+image at correct aspect INSIDE the 40-row box and letterboxes the rest → the
+~36-40 row void. `height="auto"` does NOT help (textual_image still fills 40).
+Default render mode is "auto" (config.py:2743), which resolves to graphics when
+the terminal claims support (xterm.js does), so the void is the default
+experience with images.
+
+FIX OPTIONS (need served-app + real-image verification): (a) compute the
+aspect-correct display height for the graphics widget (H/W × display_cols ×
+cell-aspect, capped 40) and set styles.height explicitly so the box matches the
+image (risk: cell-aspect is terminal-dependent — textual_image is meant to own
+this, so probe its API for a natural-size/sizing option first); (b) constrain
+graphics like pixels; (c) if graphics letterboxing can't be tamed cleanly,
+consider defaulting the served/limited path to pixels (content-sized, no void) —
+a product decision. Pixels mode already correct, so the target is graphics-mode
+height. Repro needs the textual-serve harness with a real image (graphics
+protocol) — pilots fall back to synthetic sizing.
+<!-- SECTION:PLAN:END -->


### PR DESCRIPTION
## Summary

Investigated Console UX review **task-353** (transcript "giant gap") and pilot-measured the mechanism, but did not land a fix — the clean fix is nuanced and needs served-app + real-image verification, so this PR just records the diagnosis in the task's Implementation Plan (task left **To Do**).

## What I found (pilot-measured)

The gap is the **inline-image row's height**, not scroll/anchoring:

- **Pixels mode** (`rich_pixels` Static, `styles.height=auto`) is correctly **content-sized** — an 80×8 image → 4 rows, 16×16 → 8 rows. No void.
- **Graphics mode** (`textual_image.Image`, `styles.height=None`) **fills to `max_height=40` for every aspect ratio** (wide/square/tall all measured `region.height=40`). It renders the image at correct aspect *inside* that 40-row box and letterboxes the rest → the ~36-40 row void. `height="auto"` does **not** help (textual_image still fills 40).
- Default render mode is `"auto"` (`config.py:2743`), which resolves to **graphics** when the terminal claims support (xterm.js does) — so the void is the default experience with images.

## Fix options (recorded in the task)

(a) Compute the aspect-correct display height for the graphics widget and set `styles.height` explicitly so the box matches the image — but cell-aspect is terminal-dependent and textual_image is meant to own this, so probe its sizing API first; (b) constrain graphics like pixels; (c) if graphics letterboxing can't be tamed cleanly, consider defaulting the served/limited path to pixels (already content-sized, no void) — a product decision. Repro needs the textual-serve harness with a real image (graphics protocol); pilots fall back to synthetic sizing.

No code change — backlog only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recorded the root cause for TASK-353: the transcript gap is from the inline-image row in `graphics` (`textual_image`) filling `max_height=40` by default (render mode `auto` resolves to graphics; `pixels`/`rich_pixels` is content-sized). Added fix options and repro notes to the task’s Implementation Plan; no app or UI changes in this PR.

<sup>Written for commit 49e2f06d1e30eab7464c1e912cc167e26934c350. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

