### PR TITLE
fix(console): collapse sub-agent tool provenance, mark truncation, count MCP tools in the chip (task 350)

### DIFF
--- a/Tests/Chat/test_console_agent_bridge.py
+++ b/Tests/Chat/test_console_agent_bridge.py
@@ -557,6 +557,42 @@ def test_format_agent_step_marker_matches_each_live_marker_shape():
     assert format_agent_step_marker(STEP_MODEL, summary="The answer is 42.") is None
 
 
+def test_long_tool_result_marker_is_collapsed_with_truncation_affordance():
+    """TASK-350: a spawn_subagent whose result IS the full answer must not be
+    dumped verbatim into the TOOL marker — it duplicated the assistant bubble
+    word-for-word. Collapse it to a preview and mark the truncation plus how much
+    is hidden, so the marker reads as provenance, not a second copy."""
+    answer = "### Understanding SQLite WAL. " + "word " * 300  # long answer
+    marker = format_agent_step_marker(
+        STEP_TOOL_RESULT, tool_name="spawn_subagent", result=answer
+    )
+    assert marker.startswith("\u2699 spawn_subagent \u2192 ### Understanding SQLite")
+    assert "\u2026" in marker  # ellipsis marks the cut
+    assert "chars)" in marker  # explicit "how much more" affordance
+    assert len(marker) < len(answer) // 2  # collapsed, not a full duplicate
+
+
+def test_short_tool_result_marker_is_unchanged():
+    # Short results stay verbatim — no ellipsis, no affordance.
+    marker = format_agent_step_marker(
+        STEP_TOOL_RESULT, tool_name="calculator", result="42"
+    )
+    assert marker == "\u2699 calculator \u2192 42"
+    assert "\u2026" not in marker
+
+
+def test_step_truncation_cuts_on_word_boundary_with_ellipsis():
+    from tldw_chatbook.Chat.console_agent_bridge import _truncate_step_text
+
+    text = "alpha beta gamma delta epsilon zeta eta theta iota kappa"
+    out = _truncate_step_text(text, limit=24)
+    assert "\u2026" in out and "(+" in out and "chars)" in out
+    preview = out.split("\u2026", 1)[0].strip()
+    # every token shown is a whole word from the source — never a mid-word clip
+    assert preview
+    assert all(tok in text.split() for tok in preview.split())
+
+
 def test_resume_marker_messages_reproduces_live_markers_after_simulated_restart(
     tmp_path,
 ):

--- a/Tests/Chat/test_console_agent_bridge.py
+++ b/Tests/Chat/test_console_agent_bridge.py
@@ -593,6 +593,17 @@ def test_step_truncation_cuts_on_word_boundary_with_ellipsis():
     assert all(tok in text.split() for tok in preview.split())
 
 
+def test_step_truncation_cuts_on_newline_and_tab_boundaries():
+    """Qodo #3: markdown/structured results split on newlines/tabs, not just
+    spaces — the boundary search must treat any whitespace as a token break so a
+    fenced/heading result is not clipped mid-token."""
+    from tldw_chatbook.Chat.console_agent_bridge import _truncate_step_text
+
+    text = "### Heading\n\nsome body text that keeps going well past the limit here"
+    out = _truncate_step_text(text, limit=15)
+    assert out.split("\u2026", 1)[0] == "### Heading"  # cut at the newline, not "so"
+
+
 def test_resume_marker_messages_reproduces_live_markers_after_simulated_restart(
     tmp_path,
 ):

--- a/Tests/Chat/test_console_display_state.py
+++ b/Tests/Chat/test_console_display_state.py
@@ -61,6 +61,27 @@ def test_console_control_state_counter_activity_flags():
     )
 
 
+def test_console_control_state_tools_chip_includes_mcp_tools():
+    """TASK-350: the header Tools chip must count the tools that can actually run
+    — built-in AND MCP — not just built-in. It read 'Tools: 0 ready' while the
+    inspector showed 'MCP: 10 tools ready'."""
+    state = ConsoleControlState.from_values(tool_count=0, mcp_tool_count=10)
+    assert state.tools_label == "Tools: 10 ready"
+    assert state.tools_active is True
+
+
+def test_console_control_state_tools_chip_sums_builtin_and_mcp():
+    state = ConsoleControlState.from_values(tool_count=2, mcp_tool_count=10)
+    assert state.tools_label == "Tools: 12 ready"
+
+
+def test_console_control_state_tools_chip_without_mcp_seam_counts_builtin_only():
+    # No MCP seam wired (mcp_tool_count default None) — chip is unchanged.
+    state = ConsoleControlState.from_values(tool_count=3)
+    assert state.tools_label == "Tools: 3 ready"
+    assert state.tools_active is True
+
+
 def test_console_staged_context_state_preserves_live_work_payload_provenance():
     launch = ConsoleLiveWorkLaunch.from_values(
         source="Library Search/RAG",

--- a/backlog/tasks/task-350 - Fix-sub-agent-run-rendering-duplicated-answer-text-and-mid-word-truncated-tool-entries.md
+++ b/backlog/tasks/task-350 - Fix-sub-agent-run-rendering-duplicated-answer-text-and-mid-word-truncated-tool-entries.md
@@ -1,10 +1,16 @@
 ---
 id: TASK-350
-title: Fix sub-agent run rendering - duplicated answer text and mid-word truncated tool entries
-status: To Do
-assignee: []
+title: >-
+  Fix sub-agent run rendering - duplicated answer text and mid-word truncated
+  tool entries
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-07-20 14:21'
-labels: [console, ux]
+updated_date: '2026-07-22 06:02'
+labels:
+  - console
+  - ux
 dependencies: []
 priority: medium
 ---
@@ -23,5 +29,37 @@ The first ordinary prompt was routed through a 'spawn_subagent' tool call. Conse
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Tool provenance should be collapsed/summarized (not duplicate the full answer), truncation should be marked with an expand affordance, and the Tools chip should reflect the tools that can actually run
+- [x] #1 Tool provenance should be collapsed/summarized (not duplicate the full answer), truncation should be marked with an expand affordance, and the Tools chip should reflect the tools that can actually run
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Three localized fixes for the three sub-symptoms:
+
+1. DUPLICATE ANSWER (collapse tool provenance): `format_agent_step_marker`
+   rendered `⚙ {tool_name} → {result}` with the UNtruncated result, so a
+   spawn_subagent whose result IS the 600-word answer printed it verbatim in the
+   TOOL marker AND streamed it into the assistant bubble. Now the result is run
+   through a new shared `_truncate_step_text(text, limit)` (limit 160) so the
+   marker is a concise provenance preview, not a second copy.
+
+2. MID-WORD TRUNCATION (affordance): `_truncate_step_text` cuts on a word
+   boundary near the limit, then appends `…` + a `(+N chars)` hint — replacing
+   both the marker collapse above and `_summarize`'s old silent `str(raw)[:200]`
+   mid-word clip (the inspector's live-step lines). Deterministic, so the shared
+   live/resume marker formatter stays byte-identical.
+
+3. TOOLS CHIP counts runnable tools: `ConsoleControlState.from_values` gained
+   `mcp_tool_count`; the header chip is now `Tools: {built-in + MCP} ready`
+   (`mcp_tool_count is None` → built-in only, no seam). Fixes the chip reading
+   "Tools: 0 ready" while the inspector showed "MCP: 10 tools ready". The rail
+   badge's `tool_count` is a distinct pending-tool-call count and was left alone.
+
+Verified: RED→GREEN — 3 marker/truncation tests (collapse w/ affordance,
+short-result unchanged, word-boundary cut) + 3 chip tests (includes MCP, sums
+built-in+MCP, no-seam unchanged); full Chat console suite (696) + agent-bridge/
+display-state green. Files: `tldw_chatbook/Chat/console_agent_bridge.py`,
+`tldw_chatbook/Chat/console_display_state.py`,
+`tldw_chatbook/UI/Screens/chat_screen.py`, + the two Chat test files.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -142,7 +142,10 @@ def _truncate_step_text(text: str, *, limit: int) -> str:
     if len(text) <= limit:
         return text
     cut = text[:limit].rstrip()
-    boundary = cut.rfind(" ")
+    # Cut on any whitespace boundary (space/newline/tab/CR), not just a literal
+    # space — markdown and structured tool output split on newlines/tabs, so a
+    # space-only search would still clip those mid-token (Qodo #3).
+    boundary = max(cut.rfind(ws) for ws in (" ", "\n", "\t", "\r"))
     if boundary >= limit // 2:
         cut = cut[:boundary].rstrip()
     hidden = len(text) - len(cut)

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -123,6 +123,32 @@ def compose_agent_system_prompt(session_prompt: str) -> str:
     return f"{session_prompt}\n\n{operating}"
 
 
+_STEP_MARKER_RESULT_LIMIT = 160
+_STEP_SUMMARY_LIMIT = 200
+
+
+def _truncate_step_text(text: str, *, limit: int) -> str:
+    """Collapse long step text to a preview with an explicit truncation affordance.
+
+    TASK-350: a tool result that IS the full answer must not be dumped verbatim
+    into a transcript marker (it duplicated the assistant bubble word-for-word),
+    and a truncated summary must never be a silent mid-word clip ("the traditional
+    rollba"). Cuts on a word boundary when one sits reasonably close to ``limit``,
+    then appends an ellipsis and a ``(+N chars)`` hint so the reader can see it was
+    collapsed and by how much. Deterministic, so the shared live/resume marker
+    formatter stays byte-identical.
+    """
+    text = str(text if text is not None else "")
+    if len(text) <= limit:
+        return text
+    cut = text[:limit].rstrip()
+    boundary = cut.rfind(" ")
+    if boundary >= limit // 2:
+        cut = cut[:boundary].rstrip()
+    hidden = len(text) - len(cut)
+    return f"{cut}… (+{hidden} chars)"
+
+
 def format_agent_step_marker(
     kind: str,
     *,
@@ -152,7 +178,13 @@ def format_agent_step_marker(
     if kind == STEP_SPAWN:
         return f"⤷ spawned sub-agent: {summary}"
     if kind == STEP_TOOL_RESULT and tool_name not in _QUIET_STEP_TOOLS:
-        return f"⚙ {tool_name} → {result}"
+        # Collapse the result to a preview: a spawn_subagent result IS the full
+        # answer, and dumping it verbatim duplicated the assistant bubble (task-350).
+        preview = _truncate_step_text(
+            str(result if result is not None else ""),
+            limit=_STEP_MARKER_RESULT_LIMIT,
+        )
+        return f"⚙ {tool_name} → {preview}"
     if kind == STEP_ERROR:
         return f"⚠ {summary}"
     return None
@@ -1159,7 +1191,9 @@ class ConsoleAgentBridge:
         # TOOL marker path (_append_marker) is also raw, since its consumers
         # never parse the text as markup either.
         raw = step.summary or step.result or step.tool_name or step.kind
-        return str(raw)[:200]
+        # task-350: mark truncation with an ellipsis + affordance instead of a
+        # silent mid-word clip for the run inspector's live-step lines.
+        return _truncate_step_text(str(raw), limit=_STEP_SUMMARY_LIMIT)
 
     def _previous_primary_run_id(self, conversation_id: str) -> str | None:
         for record in self._db.list_runs(conversation_id, include_superseded=False):

--- a/tldw_chatbook/Chat/console_display_state.py
+++ b/tldw_chatbook/Chat/console_display_state.py
@@ -308,22 +308,28 @@ class ConsoleControlState:
         rag_enabled: bool = False,
         staged_source_count: int = 0,
         tool_count: int = 0,
+        mcp_tool_count: int | None = None,
         approval_count: int = 0,
     ) -> "ConsoleControlState":
         persona_text = _clean(persona, "")
         persona_label = (
             f"Persona: {persona_text}" if persona_text else "Assistant: General"
         )
+        # TASK-350: the chip must reflect the tools that can ACTUALLY run — built-in
+        # AND MCP. Counting only built-in read "Tools: 0 ready" while the inspector
+        # showed "MCP: 10 tools ready". `mcp_tool_count is None` means no MCP seam
+        # wired, so the chip falls back to built-in only.
+        effective_tool_count = tool_count + (mcp_tool_count or 0)
         return cls(
             provider_label=f"Provider: {_clean(provider, 'not selected')}",
             model_label=f"Model: {_clean(model, 'not selected')}",
             persona_label=persona_label,
             rag_label=f"RAG: {'on' if rag_enabled else 'off'}",
             sources_label=f"Sources: {staged_source_count} staged",
-            tools_label=f"Tools: {tool_count} ready",
+            tools_label=f"Tools: {effective_tool_count} ready",
             approvals_label=f"Approvals: {approval_count} pending",
             sources_active=staged_source_count > 0,
-            tools_active=tool_count > 0,
+            tools_active=effective_tool_count > 0,
             approvals_active=approval_count > 0,
         )
 

--- a/tldw_chatbook/Chat/console_display_state.py
+++ b/tldw_chatbook/Chat/console_display_state.py
@@ -311,6 +311,24 @@ class ConsoleControlState:
         mcp_tool_count: int | None = None,
         approval_count: int = 0,
     ) -> "ConsoleControlState":
+        """Build the Console control-bar chip state from raw run values.
+
+        Args:
+            provider: Active provider name, or falsy for "not selected".
+            model: Active model name, or falsy for "not selected".
+            persona: Persona/assistant label; falsy falls back to "General".
+            rag_enabled: Whether RAG is on for this send.
+            staged_source_count: Number of staged context sources.
+            tool_count: Built-in tools that can run.
+            mcp_tool_count: MCP catalog size that can run, or ``None`` when no MCP
+                seam is wired (chip then reflects built-in tools only).
+            approval_count: Pending MCP approvals.
+
+        Returns:
+            A ``ConsoleControlState`` whose ``tools_label`` counts the tools that
+            can actually run (built-in + MCP) and whose ``*_active`` flags drive
+            chip emphasis.
+        """
         persona_text = _clean(persona, "")
         persona_label = (
             f"Persona: {persona_text}" if persona_text else "Assistant: General"

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -3326,6 +3326,7 @@ class ChatScreen(BaseAppScreen):
             rag_enabled=_source_mentions_rag(source),
             staged_source_count=1 if pending_launch else 0,
             tool_count=self._console_tool_count(),
+            mcp_tool_count=self._console_mcp_tool_count(),
             approval_count=self._console_pending_approval_count(),
         )
 


### PR DESCRIPTION
## Summary

Console UX review **task-350** (P2, high confidence, J4 streaming journey). When the model routes the first prompt through a `spawn_subagent` tool call, the transcript rendered it badly in three ways — all fixed here.

## The three sub-symptoms

**1. Duplicate answer.** `format_agent_step_marker` rendered `⚙ {tool_name} → {result}` with the **untruncated** result, so a `spawn_subagent` whose result *is* the 600-word answer printed it verbatim in the TOOL marker **and** streamed it into the assistant bubble — the same answer twice. The result now runs through a shared `_truncate_step_text` (limit 160), so the marker is a concise provenance preview, not a second copy.

**2. Silent mid-word truncation.** `_truncate_step_text` cuts on a **word boundary** near the limit and appends `…` + a `(+N chars)` affordance, replacing `_summarize`'s old silent `str(raw)[:200]` mid-word clip (`the traditional rollba`) on the inspector's live-step lines. Deterministic, so the shared live/resume marker formatter stays byte-identical.

**3. Tools chip hid MCP tools.** `ConsoleControlState.from_values` gained `mcp_tool_count`; the header chip is now `Tools: {built-in + MCP} ready` (`None` → built-in only when no MCP seam is wired). Fixes the chip reading **"Tools: 0 ready"** while the inspector showed **"MCP: 10 tools ready"**. The rail badge's `tool_count` is a distinct *pending tool-call* count and was left alone.

## Verification

- **RED→GREEN**: 3 marker/truncation tests (collapse with affordance; short result unchanged; word-boundary cut) + 3 chip tests (includes MCP; sums built-in+MCP; no-seam unchanged).
- Full Chat console suite (**696**) + agent-bridge/display-state green.
- Full UI Console sweep: **1229 passed / 15 failed — all 15 within the known baseline, 0 outside** (one background-effect contention flake passes 3/3 in isolation).

Files: `tldw_chatbook/Chat/console_agent_bridge.py`, `tldw_chatbook/Chat/console_display_state.py`, `tldw_chatbook/UI/Screens/chat_screen.py`, `Tests/Chat/test_console_agent_bridge.py`, `Tests/Chat/test_console_display_state.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three console UX issues: collapses long sub-agent tool results in step markers, adds clear whitespace-aware truncation, and updates the Tools chip to include MCP tools. Resolves TASK-350 by removing duplicate answers, improving readability, and showing accurate tool availability.

- Bug Fixes
  - Step marker for tool results now shows a short preview (160 chars) with a truncation affordance, instead of the full result, to prevent duplicate assistant messages.
  - Truncation now cuts on whitespace boundaries (spaces/newlines/tabs) and appends "…" with "(+N chars)" for clarity.
  - Tools chip now totals built-in + MCP tools via mcp_tool_count, and its active state reflects the combined count.

<sup>Written for commit 74aa11d20b82564ff7a72d4ab626c5f9fc2d5926. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

