### PR TITLE
Roleplay P3b — Editor polish (avatar preview, alt-greetings list, live validation, save-in-place, persona fields)

### DIFF
--- a/Docs/superpowers/plans/2026-07-22-roleplay-p3b-editor-polish.md
+++ b/Docs/superpowers/plans/2026-07-22-roleplay-p3b-editor-polish.md
@@ -1,0 +1,696 @@
+# Roleplay P3b — Editor Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Polish the character + persona editors — avatar thumbnail, alt-greetings list editor, live per-field validation, save-in-place with dirty re-arm, and the persona `is_active`/`mode`/net-new `personality_traits` fields.
+
+**Architecture:** Five mostly-independent tasks over two widget files (`personas_character_editor_widget.py`, `persona_profile_editor_widget.py`) + their screen seams in `personas_screen.py`, reusing the existing pure image-render primitive (`ConsoleImageRenderCache`) and mirroring the Lore list-editor for greetings. Task 1 (save-in-place) is foundational — it changes the editor lifecycle the others build on.
+
+**Tech Stack:** Python 3.11+, Textual (Container/DataTable/Switch/Select/TextArea), Pydantic DTOs, PIL/rich-pixels/textual-image, pytest.
+
+**Spec:** `Docs/superpowers/specs/2026-07-22-roleplay-p3b-editor-polish-design.md` (committed `a472545a0`).
+
+## Global Constraints
+
+- **NO ChaChaNotes SQLite migration** (stays v22; no new DB tables/columns). The net-new persona `personality_traits` is a **Pydantic DTO + file-backed JSON** field (new key; older profiles default `""`), NOT a DB migration.
+- **Reuse `ConsoleImageRenderCache` + `resolve_default_mode` VERBATIM** (`Chat/console_image_view.py`) — no new decoder. Avatar decode runs **off-thread** (`asyncio.to_thread`), driven from the screen (it has `app.config`), never on the widget.
+- **Preserve alt-greetings multi-line fidelity** — a greeting containing newlines must round-trip byte-identical. The list model replaces the newline-blob + `_loaded_greetings_text` diff rule; it must not regress it.
+- **Save-in-place carries the new optimistic-lock version** — character: re-read the saved record (`load_character(saved_id)` → handler `current_character_data`, or `fetch_character_by_id`) *before* reading its version; persona: the returned `saved` dict already carries the incremented version. Fall back to today's flip-to-card + notify if a character record can't be re-read.
+- **Create → edit transition** after saving a *new* entity: `mark_saved` sets the new id, the finisher flips `_edit_mode` `create`→`edit`, refreshes the list + marks the row active, and stays in the editor.
+- **Apply dirty-re-arm + validation to BOTH editors** (their state machines are duplicated). Extract a shared mixin only if it stays clearly simpler; otherwise mirror the change in both.
+- **Characters-only avatars** — no persona image field.
+- **Save is blocked** (no `*SaveRequested` posted) while an **error**-level validation finding stands; warnings don't block. Validation runs debounced on-change AND authoritatively at Save.
+- All screen DB/decode I/O off-thread, wrapped so errors notify (never crash the worker).
+- **Implementers stage ONLY their task's files** — never `git add -A`, never `.superpowers/`.
+- **No background/broad test sweeps; never broad-`pkill` pytest** — scope to this worktree.
+- **CONCURRENT-SESSION HAZARD:** other sessions are actively editing `personas_screen.py` (RP-UX tasks 425–445, e.g. Start-Chat #754). Keep changes localized to the editor widgets + the save/validation/avatar seams; expect a non-trivial rebase before merge. Branch off the LATEST `origin/dev` (`bf21cfb4b` at plan time — re-verify).
+- **Test command** (prefix every run; run ONLY your task's files):
+  ```bash
+  HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest <targets> \
+  -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+  ```
+  (venv in MAIN checkout; imports resolve to worktree source. UI tests are slow — the 300s timeout is deliberate.)
+
+---
+
+## File Structure
+
+**Modified:**
+- `tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py` — `mark_saved` (T1), avatar thumbnail API + Remove (T2), greetings list editor (T3), live validation (T4), Advanced re-tune (T5).
+- `tldw_chatbook/Widgets/Persona_Widgets/persona_profile_editor_widget.py` — `mark_saved` (T1), live validation (T4), `is_active`/`mode`/`personality_traits` fields (T5).
+- `tldw_chatbook/UI/Screens/personas_screen.py` — save-in-place finishers (T1), avatar render worker (T2), persona save-handler DTO threading (T5).
+- `tldw_chatbook/tldw_api/character_persona_schemas.py` — add `personality_traits` to `PersonaProfileCreate`/`Update` (T5).
+
+**Tests (create/extend under `Tests/UI/` and `Tests/Character_Chat/`):** grep `Tests/` for existing `PersonasCharacterEditorWidget` / `PersonaProfileEditorWidget` / personas-screen host-app fixtures first and mirror them (host `App` that mounts the widget; screen fixture with a real `CharactersRAGDB` + scope service).
+
+---
+
+## Task 1: Dirty re-arm + save-in-place (both editors + finishers)
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py`, `persona_profile_editor_widget.py`
+- Modify: `tldw_chatbook/UI/Screens/personas_screen.py` (`_after_character_save` ~:4804, `_after_profile_save` ~:4913)
+- Test: `Tests/UI/test_personas_editor_save_in_place.py`
+
+**Interfaces:**
+- Produces: `PersonasCharacterEditorWidget.mark_saved(record: dict) -> None`; `PersonaProfileEditorWidget.mark_saved(record: dict) -> None`.
+
+- [ ] **Step 1: Write the failing widget test (re-arm)**
+
+Create `Tests/UI/test_personas_editor_save_in_place.py`. Mirror the existing editor host-app harness (grep `Tests/UI` for `PersonasCharacterEditorWidget`).
+
+```python
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Input
+from tldw_chatbook.Widgets.Persona_Widgets.personas_character_editor_widget import (
+    PersonasCharacterEditorWidget,
+)
+from tldw_chatbook.Widgets.Persona_Widgets.persona_profile_editor_widget import (
+    PersonaProfileEditorWidget,
+)
+from tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages import EditorContentChanged
+
+pytestmark = pytest.mark.asyncio
+
+
+class _CharHost(App):
+    def __init__(self):
+        super().__init__(); self.dirty = 0
+    def compose(self) -> ComposeResult:
+        yield PersonasCharacterEditorWidget()
+    def on_editor_content_changed(self, m): self.dirty += 1
+
+
+async def test_character_mark_saved_rearms_dirty():
+    app = _CharHost()
+    async with app.run_test() as pilot:
+        ed = app.query_one(PersonasCharacterEditorWidget)
+        ed.load_character({"id": 5, "name": "A", "version": 1})
+        await pilot.pause()
+        ed.query_one("#personas-char-editor-name", Input).value = "A2"  # first edit
+        await pilot.pause()
+        assert app.dirty == 1
+        # Simulate a save landing: new version, re-arm.
+        ed.mark_saved({"id": 5, "name": "A2", "version": 2})
+        await pilot.pause()
+        assert ed._dirty_posted is False
+        ed.query_one("#personas-char-editor-name", Input).value = "A3"  # second edit
+        await pilot.pause()
+        assert app.dirty == 2  # re-armed → re-posted
+        assert ed.get_character_data()["version"] == 2  # new optimistic-lock version
+```
+
+Add the persona analog (`PersonaProfileEditorWidget`, ids `#personas-editor-name`, `mark_saved({"id":"p1","name":"B","version":2})`, assert `_dirty_posted is False` and a second edit re-posts, and `collect()["version"] == 2`).
+
+- [ ] **Step 2: Run — verify it fails**
+
+Run the test file. Expected: FAIL — `AttributeError: 'PersonasCharacterEditorWidget' object has no attribute 'mark_saved'`.
+
+- [ ] **Step 3: Implement `mark_saved` on both widgets**
+
+Character editor — add after `load_character` (~:241):
+
+```python
+    def mark_saved(self, record: Dict[str, Any]) -> None:
+        """Re-baseline dirty state to a just-persisted record (save-in-place).
+
+        Adopts the saved record as the new base (so the next Save carries the
+        new ``version`` and any DB-normalized keys), rebaselines the greeting
+        fidelity anchors, resets the dirty snapshot from the CURRENT form (which
+        already shows the saved values), and clears validation. Does NOT
+        repopulate the form — the user's saved edits stay on screen.
+        """
+        self._character_data = dict(record or {})
+        self._loaded_greetings = [
+            str(g) for g in (self._character_data.get("alternate_greetings") or [])
+        ]
+        self._loaded_greetings_text = "\n".join(self._loaded_greetings)
+        self._loaded_snapshot = self._form_snapshot()
+        self._dirty_posted = False
+        self.query_one("#personas-char-editor-validation", Static).update("")
+```
+
+Persona editor — add after `new_persona` (~:109):
+
+```python
+    def mark_saved(self, record: Dict[str, Any]) -> None:
+        """Re-baseline dirty state to a just-persisted persona (save-in-place)."""
+        self._persona_id = str(record.get("id", "")) or self._persona_id
+        self._version = record.get("version", self._version)
+        self._loaded_snapshot = self._form_snapshot()
+        self._dirty_posted = False
+        self.query_one("#personas-editor-validation", Static).update("")
+```
+
+> Note for T3: when the greetings list editor lands, the character `mark_saved` rebaselines `self._greetings` from `record["alternate_greetings"]` instead of `_loaded_greetings*`. T3 updates this method.
+
+- [ ] **Step 4: Run — verify widget tests pass**
+
+Run the test file. Expected: PASS (both widget re-arm tests).
+
+- [ ] **Step 5: Write the failing screen integration test (save-in-place)**
+
+Append a screen test using the personas-screen host-app fixture (grep `Tests/UI` for the fixture that wires a real `CharactersRAGDB`). It should: enter Characters mode, open New editor, type a name, press Save, then assert (a) the editor center (`#ccp-character-editor-view`) is still displayed (NOT the card), (b) `screen.state.has_unsaved_changes is False`, (c) `screen._edit_mode == "edit"` (create→edit), (d) a second field edit re-flags `has_unsaved_changes` True. Shape it to the real fixture's helpers; keep those four assertions.
+
+- [ ] **Step 6: Run — verify it fails**
+
+Expected: FAIL — the editor flips to the card (`#ccp-character-card-view` displayed) and/or `_edit_mode == "view"`.
+
+- [ ] **Step 7: Make the finishers save-in-place**
+
+In `personas_screen.py` `_after_character_save` (~:4804): read the persisted record BEFORE deciding, keep the editor open, transition mode, call `mark_saved`. Replace the tail (from ~:4818 `self._edit_mode = "view"` through ~:4841) with logic equivalent to:
+
+```python
+        # Re-read the just-persisted record (authoritative version). load the
+        # card into the handler so _full_character_record returns fresh data.
+        await self.character_handler.load_character(saved_id)
+        saved_record = self._full_character_record(saved_id)
+        editor = self.query_one(PersonasCharacterEditorWidget)
+        if saved_record is None:
+            # Could not re-read → fall back to today's flip-to-card so we never
+            # leave the editor holding a stale version.
+            self._edit_mode = "view"
+            self._show_center("#ccp-character-card-view")
+        else:
+            self._edit_mode = "edit"          # create→edit stays in the editor
+            editor.mark_saved(saved_record)
+            self._show_center("#ccp-character-editor-view")
+        self._set_active_row_unsaved(False)
+        await self.character_handler.refresh_character_list()
+        name = str((saved_record or {}).get("name") or submitted_name or "Saved character")
+        self.state.select_entity(entity_kind="character", entity_id=saved_id, entity_name=name)
+        self.state.has_unsaved_changes = False
+        inspector = self.query_one(PersonasInspectorPane)
+        inspector.show_selection(name=name, kind="character", authority="Local")
+        inspector.set_unsaved(False)
+        inspector.show_validation(())
+        self._sync_inspector_console_actions()
+        self.query_one(PersonasLibraryPane).mark_active_row("character", saved_id)
+        self._sync_title_and_console_actions()
+        self._notify("Character saved.", severity="information")
+```
+
+(Keep the existing early-return branch at ~:4807 for the "user left the screen" case. Confirm the exact surrounding names when you read the method — `_character_editor_generation` bump, `_focus_library_list` — preserve them where they still apply; the editor now stays focused, so drop the `_focus_library_list` call on the stay-in-editor branch.)
+
+In `_after_profile_save` (~:4913): mirror it — the returned `saved` dict already has the version, so:
+
+```python
+        editor = self.query_one(PersonaProfileEditorWidget)
+        self._edit_mode = "edit"
+        editor.mark_saved(saved)
+        self._show_center("#ccp-persona-editor-view")
+        # ... keep the existing has_unsaved_changes=False / select_entity /
+        #     inspector / _render_profile_rows lines, but REMOVE the
+        #     _show_center("#ccp-persona-card-view") and the card show_persona.
+```
+
+- [ ] **Step 8: Run — verify the screen test passes**
+
+Run the test file. Expected: PASS. Also run the existing personas character + persona editor/screen suites you can name (grep them) to confirm no regression in the save flow.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py tldw_chatbook/Widgets/Persona_Widgets/persona_profile_editor_widget.py tldw_chatbook/UI/Screens/personas_screen.py Tests/UI/test_personas_editor_save_in_place.py
+git commit -m "feat(personas): P3b Task 1 — save-in-place + dirty re-arm (mark_saved, both editors)"
+```
+
+---
+
+## Task 2: Avatar thumbnail preview (character editor)
+
+**Files:**
+- Modify: `personas_character_editor_widget.py` (avatar row ~:200, DEFAULT_CSS ~:89)
+- Modify: `personas_screen.py` (avatar upload chain ~:3841/3889; editor-open path)
+- Test: `Tests/UI/test_personas_character_editor_avatar.py`
+
+**Interfaces:**
+- Produces (widget): `set_avatar_thumbnail(renderable: object | None) -> None` (mounts the renderable, or the text fallback when None); `current_avatar_bytes() -> bytes | None`; a Remove button `#personas-char-editor-avatar-remove` posting a new `CharacterImageRemoveRequested()` message (add to `personas_pane_messages.py`).
+- Consumes (screen): `ConsoleImageRenderCache`, `resolve_default_mode` from `Chat/console_image_view.py`; the graphics-vs-pixels mount from `Widgets/Console/console_transcript.py:_image_row_widget`.
+
+- [ ] **Step 1: Write the failing widget test**
+
+```python
+import pytest
+from textual.app import App, ComposeResult
+from tldw_chatbook.Widgets.Persona_Widgets.personas_character_editor_widget import (
+    PersonasCharacterEditorWidget,
+)
+from tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages import (
+    CharacterImageRemoveRequested,
+)
+from rich_pixels import Pixels
+from PIL import Image
+
+pytestmark = pytest.mark.asyncio
+
+
+class _Host(App):
+    def __init__(self): super().__init__(); self.removed = 0
+    def compose(self) -> ComposeResult: yield PersonasCharacterEditorWidget()
+    def on_character_image_remove_requested(self, m): self.removed += 1
+
+
+async def test_thumbnail_mounts_and_text_fallback():
+    app = _Host()
+    async with app.run_test() as pilot:
+        ed = app.query_one(PersonasCharacterEditorWidget)
+        ed.load_character({"name": "A", "image": b"x"})
+        await pilot.pause()
+        # None → text fallback present, no image widget
+        ed.set_avatar_thumbnail(None)
+        await pilot.pause()
+        assert ed.query("#personas-char-editor-avatar-thumb").is_empty
+        # A pixels renderable → a widget is mounted in the avatar row
+        px = Pixels.from_image(Image.new("RGBA", (8, 8)))
+        ed.set_avatar_thumbnail(px)
+        await pilot.pause()
+        assert not ed.query("#personas-char-editor-avatar-thumb").is_empty
+
+
+async def test_current_avatar_bytes_and_remove():
+    app = _Host()
+    async with app.run_test() as pilot:
+        ed = app.query_one(PersonasCharacterEditorWidget)
+        ed.load_character({"name": "A", "image": b"abc"})
+        await pilot.pause()
+        assert ed.current_avatar_bytes() == b"abc"
+        await pilot.click("#personas-char-editor-avatar-remove")
+        await pilot.pause()
+        assert app.removed == 1
+```
+
+- [ ] **Step 2: Run — verify it fails**
+
+Expected: FAIL (`set_avatar_thumbnail`/`current_avatar_bytes`/`#personas-char-editor-avatar-remove` absent; `CharacterImageRemoveRequested` unimportable).
+
+- [ ] **Step 3: Add the message + widget API**
+
+In `personas_pane_messages.py`, add `class CharacterImageRemoveRequested(Message): ...` (mirror `CharacterImageUploadRequested`). In the character editor:
+- Add a Remove button to the avatar row and a thumbnail mount container. Change the avatar row (compose ~:200) to include a `Static("", id="personas-char-editor-avatar-thumb")` holder and the Remove button:
+
+```python
+            with Horizontal(id="personas-char-editor-avatar-row"):
+                yield Static("Avatar: none", id="personas-char-editor-avatar-status")
+                yield Button("Upload", id="personas-char-editor-avatar-upload", classes="console-action-subdued")
+                yield Button("Remove", id="personas-char-editor-avatar-remove", classes="console-action-subdued")
+            yield Container(id="personas-char-editor-avatar-thumb")
+```
+
+- Grow the CSS: change `#personas-char-editor-avatar-row` off `height: 1` (keep the status/buttons on one line) and give `#personas-char-editor-avatar-thumb` a small box, e.g. `height: 10; max-width: 24; max-height: 10;` (a compact editor thumbnail, smaller than the 80×40 chat box).
+- Methods:
+
+```python
+    def current_avatar_bytes(self) -> bytes | None:
+        data = self._character_data.get("image")
+        return data if isinstance(data, (bytes, bytearray)) else None
+
+    def set_avatar_thumbnail(self, renderable: object | None) -> None:
+        """Mount a prepared avatar renderable (pixels Static or graphics Image),
+        or clear to the text status when None. The screen prepares the
+        renderable off-thread; this only mounts it."""
+        holder = self.query_one("#personas-char-editor-avatar-thumb", Container)
+        holder.remove_children()
+        if renderable is None:
+            return
+        from textual.widgets import Static as _S
+        # A rich renderable (Pixels) mounts inside a Static; a Textual widget
+        # (textual_image Image) mounts directly.
+        from textual.widget import Widget as _W
+        holder.mount(renderable if isinstance(renderable, _W) else _S(renderable))
+
+    @on(Button.Pressed, "#personas-char-editor-avatar-remove")
+    def _remove_avatar_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.post_message(CharacterImageRemoveRequested())
+```
+
+Import `Container` in the widget. Keep `set_avatar_image` (upload staging) as-is; the screen calls the render step after it.
+
+- [ ] **Step 4: Run — verify widget tests pass**
+
+Run the test file. Expected: PASS.
+
+- [ ] **Step 5: Wire the screen render worker + Remove handler**
+
+In `personas_screen.py`, add a screen-owned lazy `ConsoleImageRenderCache` + a render method (mirror `chat_screen.py:2727-2789`):
+
+```python
+    async def _render_character_editor_avatar(self) -> None:
+        try:
+            editor = self.query_one(PersonasCharacterEditorWidget)
+        except QueryError:
+            return
+        data = editor.current_avatar_bytes()
+        editor._set_avatar_status_from_record()  # keep the text status accurate
+        if not data:
+            editor.set_avatar_thumbnail(None)
+            return
+        token = self._character_editor_generation  # session-token guard
+        from tldw_chatbook.Chat.console_image_view import (
+            ConsoleImageRenderCache, resolve_default_mode,
+        )
+        if getattr(self, "_avatar_render_cache", None) is None:
+            self._avatar_render_cache = ConsoleImageRenderCache()
+        cache = self._avatar_render_cache
+        mode = resolve_default_mode(self.app_instance.app_config)  # confirm accessor
+        try:
+            ok = await asyncio.to_thread(cache.prepare, "char-editor-avatar", bytes(data))
+        except Exception:
+            logger.opt(exception=True).debug("avatar decode failed")
+            ok = False
+        if token != self._character_editor_generation or not self.is_mounted:
+            return  # a different editor session started while decoding
+        renderable = None
+        if ok:
+            if mode == "graphics":
+                try:
+                    from textual_image.widget import Image as _Img
+                    pil = cache.get_pil("char-editor-avatar")
+                    renderable = _Img(pil) if pil is not None else None
+                except Exception:
+                    renderable = cache.get_pixels("char-editor-avatar")
+            else:
+                renderable = cache.get_pixels("char-editor-avatar")
+        editor.set_avatar_thumbnail(renderable)
+```
+
+Call `_render_character_editor_avatar()` (via `run_worker(..., exit_on_error=False)` or awaited in an existing async handler) at: (a) the end of `_stage_character_avatar_from_path` (after `set_avatar_image`); (b) when the character editor is shown for edit/new (in the edit-requested / new handler, after `load_character`); and add the Remove handler:
+
+```python
+    @on(CharacterImageRemoveRequested)
+    def _handle_character_image_remove(self, message) -> None:
+        message.stop()
+        try:
+            editor = self.query_one(PersonasCharacterEditorWidget)
+        except QueryError:
+            return
+        editor._character_data.pop("image", None)
+        editor._mark_dirty()
+        self.run_worker(self._render_character_editor_avatar(), exit_on_error=False)
+```
+
+(Confirm the exact app-config accessor — `self.app_instance.app_config` vs `self.app.config`; match what `chat_screen.py` uses for `resolve_default_mode`.)
+
+- [ ] **Step 6: Add a screen render test + run**
+
+Screen integration test (real screen): open the character editor for a character WITH an image → assert a widget mounts under `#personas-char-editor-avatar-thumb`; press Remove → assert it clears + `has_unsaved_changes` True. Run it + the widget tests. Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py tldw_chatbook/UI/Screens/personas_screen.py Tests/UI/test_personas_character_editor_avatar.py
+git commit -m "feat(personas): P3b Task 2 — character avatar thumbnail preview + Remove"
+```
+
+---
+
+## Task 3: Alternate-greetings list editor (character editor)
+
+**Files:**
+- Modify: `personas_character_editor_widget.py` (Advanced section ~:197-199; `_populate_form` ~:266-270; `get_character_data` ~:338-344; `_form_snapshot` ~:405; `mark_saved` from T1)
+- Test: `Tests/UI/test_personas_character_editor_greetings.py`
+
+**Interfaces:** widget-local only (`_greetings: list[str]`); no new messages, no screen changes.
+
+- [ ] **Step 1: Write the failing test (incl. the multi-line fidelity guarantee)**
+
+```python
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import TextArea, DataTable
+from tldw_chatbook.Widgets.Persona_Widgets.personas_character_editor_widget import (
+    PersonasCharacterEditorWidget,
+)
+pytestmark = pytest.mark.asyncio
+
+class _Host(App):
+    def compose(self) -> ComposeResult: yield PersonasCharacterEditorWidget()
+
+async def test_greetings_load_add_delete_reorder_and_multiline_fidelity():
+    app = _Host()
+    async with app.run_test() as pilot:
+        ed = app.query_one(PersonasCharacterEditorWidget)
+        multi = "Hello there.\n\nA second paragraph."   # a greeting WITH newlines
+        ed.load_character({"name": "A", "alternate_greetings": [multi, "Hi!"]})
+        await pilot.pause()
+        # unedited round-trip is byte-identical (the fidelity guarantee)
+        assert ed.get_character_data()["alternate_greetings"] == [multi, "Hi!"]
+        # add
+        ed._greetings_add("Third")
+        assert ed.get_character_data()["alternate_greetings"] == [multi, "Hi!", "Third"]
+        # update index 1
+        ed._greetings_update(1, "Hi again!")
+        assert ed.get_character_data()["alternate_greetings"][1] == "Hi again!"
+        # move index 2 up
+        ed._greetings_move(2, -1)
+        assert ed.get_character_data()["alternate_greetings"] == [multi, "Third", "Hi again!"]
+        # delete index 0 (the multi-line one)
+        ed._greetings_delete(0)
+        assert ed.get_character_data()["alternate_greetings"] == ["Third", "Hi again!"]
+```
+
+(Use the widget-local mutation helpers directly for a deterministic test; add a second test that drives the buttons via `pilot.click` for the Add/Move/Delete ids + `RowHighlighted` selection.)
+
+- [ ] **Step 2: Run — verify it fails**
+
+Expected: FAIL — `_greetings_add`/table absent.
+
+- [ ] **Step 3: Replace the TextArea with the list editor**
+
+In compose, replace the alt-greetings `ds-field-row` (~:197-199) with:
+
+```python
+                with Vertical(classes="ds-field-row"):
+                    yield Label("Alternate greetings")
+                    yield DataTable(id="personas-char-editor-greetings-table", cursor_type="row")
+                    yield TextArea(id="personas-char-editor-greeting-edit")
+                    with Horizontal(classes="ds-toolbar"):
+                        yield Button("Add", id="personas-char-editor-greeting-add", classes="console-action-subdued")
+                        yield Button("Update", id="personas-char-editor-greeting-update", classes="console-action-subdued")
+                        yield Button("Delete", id="personas-char-editor-greeting-delete", classes="console-action-subdued")
+                        yield Button("Move up", id="personas-char-editor-greeting-move-up", classes="console-action-subdued")
+                        yield Button("Move down", id="personas-char-editor-greeting-move-down", classes="console-action-subdued")
+```
+
+Import `DataTable`. Add `_greetings: List[str] = []` in `__init__`, a `_selected_greeting_index: int | None`, and on_mount register the table column (`add_column("Greeting", key="g")`). Implement (mirror `personas_lore_detail.py` for selection tracking):
+
+```python
+    @staticmethod
+    def _greeting_preview(text: str) -> str:
+        first = (text or "").splitlines()[0] if text else ""
+        return (first[:60] + "…") if len(first) > 60 or "\n" in (text or "") else first
+
+    def _render_greetings_table(self) -> None:
+        table = self.query_one("#personas-char-editor-greetings-table", DataTable)
+        table.clear()
+        for i, g in enumerate(self._greetings):
+            table.add_row(self._greeting_preview(g), key=str(i))
+
+    def _greetings_add(self, text: str = "") -> None:
+        self._greetings.append(text)
+        self._render_greetings_table(); self._mark_dirty()
+
+    def _greetings_update(self, index: int, text: str) -> None:
+        if 0 <= index < len(self._greetings):
+            self._greetings[index] = text
+            self._render_greetings_table(); self._mark_dirty()
+
+    def _greetings_delete(self, index: int) -> None:
+        if 0 <= index < len(self._greetings):
+            del self._greetings[index]
+            self._render_greetings_table(); self._mark_dirty()
+
+    def _greetings_move(self, index: int, offset: int) -> None:
+        j = index + offset
+        if 0 <= index < len(self._greetings) and 0 <= j < len(self._greetings):
+            self._greetings[index], self._greetings[j] = self._greetings[j], self._greetings[index]
+            self._render_greetings_table(); self._mark_dirty()
+```
+
+Wire the buttons (Add uses the edit TextArea text; Update/Delete/Move use `_selected_greeting_index`; on `Add`/select, load the greeting into the edit TextArea). Track selection on both `@on(DataTable.RowSelected)` and `@on(DataTable.RowHighlighted)` (set `_selected_greeting_index = int(event.row_key.value)` and load `self._greetings[i]` into the edit TextArea). **The greeting-edit TextArea must NOT feed the dirty `_field_changed` snapshot** (it's a scratch field) — exclude its id there, or gate it.
+
+- [ ] **Step 4: Rewire load/save/snapshot + drop the fidelity-diff**
+
+- `_populate_form` (~:266-270): replace `_loaded_greetings`/`_loaded_greetings_text`/`_area("alt-greetings").text = ...` with `self._greetings = [str(g) for g in (record.get("alternate_greetings") or [])]` then `self._render_greetings_table()`.
+- `get_character_data` (~:338-344): replace the fidelity-diff block with `data["alternate_greetings"] = list(self._greetings)`.
+- `_form_snapshot` (~:405): replace the `_area("alt-greetings").text` element with `tuple(self._greetings)` so dirty detection sees list mutations. (Add/Update/Delete/Move already call `_mark_dirty` directly, so this mainly keeps the snapshot self-consistent for the re-arm comparison.)
+- `mark_saved` (from T1): rebaseline `self._greetings` from `record.get("alternate_greetings")` and drop the `_loaded_greetings*` lines (they no longer exist). Remove the now-dead `_loaded_greetings`/`_loaded_greetings_text` fields from `__init__`.
+
+- [ ] **Step 5: Run — verify it passes**
+
+Run the greetings test file + the T1 save-in-place file (mark_saved changed). Expected: PASS. Grep and run any existing test that asserted the old alt-greetings TextArea behavior and update/replace it (the newline-blob is gone).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py Tests/UI/test_personas_character_editor_greetings.py
+git commit -m "feat(personas): P3b Task 3 — alt-greetings list editor (no newline-corruption)"
+```
+
+---
+
+## Task 4: Live per-field validation (both editors)
+
+**Files:**
+- Modify: `personas_character_editor_widget.py`, `persona_profile_editor_widget.py`
+- Test: extend the two editor test files
+
+**Interfaces:**
+- Produces: `validate() -> list[tuple[str, str, str]]` on both widgets (each item `(field_id, message, level)`, level ∈ `{"error","warning"}`); `_run_validation()` (debounced); `.is-invalid` CSS class toggled on the offending field rows.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+async def test_blank_name_marks_field_and_blocks_save(<char host>):
+    ed.load_character({"name": "A"})
+    ed.query_one("#personas-char-editor-name", Input).value = ""
+    await pilot.pause()  # debounced validation runs
+    row = ed.query_one("#personas-char-editor-name").parent  # the ds-field-row
+    assert row.has_class("is-invalid")
+    # Save is blocked: no CharacterSaveRequested posted
+    saves = []
+    ... capture CharacterSaveRequested on the host ...
+    await pilot.click("#personas-char-editor-save")
+    assert saves == []
+    # fix it → class clears, save posts
+    ed.query_one("#personas-char-editor-name", Input).value = "A"
+    await pilot.pause()
+    assert not row.has_class("is-invalid")
+```
+
+Add: oversized-avatar error (stage `set_avatar_image(b"x"*(PERSONAS_AVATAR_MAX_BYTES+1))` → an error marks the avatar row); persona blank-name analog.
+
+- [ ] **Step 2: Run — verify it fails.** Expected: FAIL (no `.is-invalid`, save still posts).
+
+- [ ] **Step 3: Implement `validate()` + debounced runner + per-field marking**
+
+On each editor: a `validate()` returning `(field_id, message, level)` tuples. Character checks: name required (error); avatar bytes > `PERSONAS_AVATAR_MAX_BYTES` (import the const, error); any greeting blank/whitespace (warning). Persona: name required (error). A `_run_validation()`:
+
+```python
+    _FIELD_ERROR_CLASS = "is-invalid"
+
+    def _run_validation(self) -> list[tuple[str, str, str]]:
+        findings = self.validate()
+        invalid_ids = {fid for fid, _msg, level in findings if level == "error"}
+        for fid in self._validated_field_ids():          # the set of field ids
+            row = self.query_one(f"#{fid}").parent
+            row.set_class(fid in invalid_ids, self._FIELD_ERROR_CLASS)
+        self.show_validation(tuple(f"{fid}: {msg}" for fid, msg, _l in findings))
+        return findings
+```
+
+Call `_run_validation()` from `_field_changed` (debounced via `self.set_timer`, cancel the prior timer) AND at Save. In `_save_pressed`, replace the inline name check with: `if any(l == "error" for _, _, l in self._run_validation()): return` before posting. Add a `.is-invalid` border/color rule to DEFAULT_CSS. Provide `_validated_field_ids()` returning the ids `validate()` can flag.
+
+- [ ] **Step 4: Run — verify it passes.** Run both editor test files. Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py tldw_chatbook/Widgets/Persona_Widgets/persona_profile_editor_widget.py Tests/UI/test_personas_character_editor_avatar.py Tests/UI/test_personas_editor_save_in_place.py
+git commit -m "feat(personas): P3b Task 4 — live per-field validation (both editors)"
+```
+
+---
+
+## Task 5: Persona fields (is_active/mode + net-new personality_traits) + grouping
+
+**Files:**
+- Modify: `tldw_chatbook/tldw_api/character_persona_schemas.py` (`PersonaProfileCreate` ~:556, `PersonaProfileUpdate` ~:570)
+- Modify: `persona_profile_editor_widget.py` (compose/collect/load_persona/_form_snapshot/validate)
+- Modify: `personas_screen.py` (`_handle_profile_save_requested` DTO build ~:4877-4897)
+- Modify: `personas_character_editor_widget.py` (Advanced re-tune — minor)
+- Test: `Tests/Character_Chat/test_persona_personality_traits_roundtrip.py`, extend the persona editor test
+
+**Interfaces:** DTO gains `personality_traits: str`; editor collect/load gain `is_active`/`mode`/`personality_traits`.
+
+**Verified:** the persona service is DTO-driven (`create_persona_profile` validates `PersonaProfileCreate` → `model_dump` → JSON store; `update_persona_profile` uses `model_dump(exclude_none=True)`; `_persona_profile_view` is a passthrough). **So the service methods need NO change** — adding `personality_traits` to the DTO + passing it from the save handler makes it persist and reload automatically. `mode` (`PersonaMode`) values: read the `PersonaMode` literal in `character_persona_schemas.py` for the exact options (default `session_scoped`).
+
+- [ ] **Step 1: Write the failing service/store round-trip test**
+
+```python
+def test_personality_traits_persists_and_reloads(tmp_path):
+    from tldw_chatbook.Character_Chat.local_character_persona_service import LocalCharacterPersonaService
+    from tldw_chatbook.tldw_api.character_persona_schemas import PersonaProfileCreate
+    svc = LocalCharacterPersonaService(<db>, persona_store_path=tmp_path / "p.json")  # match ctor
+    created = svc.create_persona_profile(PersonaProfileCreate(name="P", personality_traits="brave, kind"))
+    assert created["personality_traits"] == "brave, kind"
+    # reload from a fresh service instance (proves the JSON store carries it)
+    svc2 = LocalCharacterPersonaService(<db>, persona_store_path=tmp_path / "p.json")
+    got = svc2.get_persona_profile(created["id"])
+    assert got["personality_traits"] == "brave, kind"
+```
+
+(Confirm the `LocalCharacterPersonaService` ctor + how it reads the store on init; mirror an existing persona-service test.)
+
+- [ ] **Step 2: Run — verify it fails.** Expected: FAIL — `PersonaProfileCreate` has no `personality_traits` (validation error or dropped).
+
+- [ ] **Step 3: Add `personality_traits` to the DTOs**
+
+In `character_persona_schemas.py`: `PersonaProfileCreate` add `personality_traits: str = ""`; `PersonaProfileUpdate` add `personality_traits: str | None = None`. (Freeform string, matching the character `personality` field — NOT the archetype `list[str]`.)
+
+- [ ] **Step 4: Run — verify the round-trip test passes.** Expected: PASS.
+
+- [ ] **Step 5: Surface the fields in the persona editor + thread through save**
+
+Persona editor compose — add (after system-prompt, ~:72), importing `Switch`, `Select`:
+
+```python
+            with Vertical(classes="ds-field-row"):
+                yield Label("Personality traits")
+                yield TextArea(id="personas-editor-personality-traits")
+            with Vertical(classes="ds-field-row"):
+                yield Label("Mode")
+                yield Select([(m, m) for m in PERSONA_MODES], id="personas-editor-mode", allow_blank=False)
+            with Horizontal(classes="ds-field-row"):
+                yield Label("Enabled")
+                yield Switch(id="personas-editor-enabled", value=True)
+```
+
+(`PERSONA_MODES` = the `PersonaMode` literal values — import or inline them from the schema.) Wire:
+- `load_persona`: set `#personas-editor-personality-traits` text = `data.get("personality_traits","")`; `#personas-editor-mode` value = `data.get("mode","session_scoped")`; `#personas-editor-enabled` value = `bool(data.get("is_active", True))`.
+- `collect`: add `"personality_traits"`, `"mode"`, `"is_active"` (from the widgets).
+- `_form_snapshot`: append the three values.
+- `Switch.Changed` also marks dirty (add `@on(Switch.Changed)` → the same `_field_changed` guard path, or include Switch in the change handler).
+
+Screen `_handle_profile_save_requested` (~:4877-4897) — include the fields when building the DTOs:
+
+```python
+                    request = PersonaProfileCreate(
+                        id=data.get("id") or None, name=str(data.get("name") or ""),
+                        description=data.get("description"),
+                        mode=data.get("mode") or "session_scoped",
+                        system_prompt=data.get("system_prompt"),
+                        is_active=bool(data.get("is_active", True)),
+                        personality_traits=str(data.get("personality_traits") or ""),
+                    )
+                    # ... and the Update branch: name/description/mode/system_prompt +
+                    #     is_active=data.get("is_active"), personality_traits=data.get("personality_traits")
+```
+
+- [ ] **Step 6: Character Advanced re-tune (minor)**
+
+Confirm the greetings list editor (T3) reads well inside `#personas-char-editor-advanced`; adjust ordering/labels only if needed. No field removals. (Keep this small — it's the least substantive item.)
+
+- [ ] **Step 7: Add persona editor field tests + run**
+
+Extend the persona editor test: `load_persona({"is_active": False, "mode": "session_scoped", "personality_traits": "x"})` populates the Switch/Select/TextArea; `collect()` returns them; toggling Enabled marks dirty; a persona save-in-place integration test persists + reloads the new fields (drives the handler threading). Run the persona test files + the service round-trip. Expected: PASS. Run `python -c "import tldw_chatbook.app"` (env prefix).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tldw_chatbook/tldw_api/character_persona_schemas.py tldw_chatbook/Widgets/Persona_Widgets/persona_profile_editor_widget.py tldw_chatbook/UI/Screens/personas_screen.py tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py Tests/Character_Chat/test_persona_personality_traits_roundtrip.py Tests/UI/test_personas_editor_save_in_place.py
+git commit -m "feat(personas): P3b Task 5 — persona is_active/mode + net-new personality_traits + field grouping"
+```
+
+*(If Task 5 gets unwieldy, split: 5a = DTO + service round-trip + save-handler threading; 5b = editor fields + grouping.)*
+
+---
+
+## Self-Review Notes (author)
+
+- **Spec coverage:** avatar preview (T2), alt-greetings list (T3), live validation (T4), dirty re-arm + save-in-place incl. create→edit + version-carry (T1), persona is_active/mode + net-new personality_traits (T5), character Advanced re-tune (T5) — all mapped. No SQLite migration; personality_traits is DTO+JSON only.
+- **Type consistency:** `mark_saved(record)` (T1) is updated by T3 (greetings rebaseline); `set_avatar_thumbnail`/`current_avatar_bytes`/`CharacterImageRemoveRequested` (T2); `_greetings` + `_greetings_{add,update,delete,move}` (T3); `validate() -> list[tuple[str,str,str]]` + `_run_validation` + `.is-invalid` (T4); `personality_traits`/`is_active`/`mode` on DTO+editor+handler (T5). Consistent across tasks.
+- **Plan-time confirmations (read fresh):** the exact app-config accessor for `resolve_default_mode`; the `PersonaMode` literal values; the personas-screen host-app test fixture; the `LocalCharacterPersonaService` ctor for the store test; whether `_character_editor_generation`/`_focus_library_list` still apply on the stay-in-editor branch; the greeting-edit TextArea's exclusion from the dirty snapshot.

--- a/Docs/superpowers/specs/2026-07-22-roleplay-p3b-editor-polish-design.md
+++ b/Docs/superpowers/specs/2026-07-22-roleplay-p3b-editor-polish-design.md
@@ -1,0 +1,155 @@
+# Roleplay P3b — Editor polish (character + persona editors)
+
+**Program:** Personas → "Roleplay" workbench redesign. Sub-project **P3b** — second of the **P3 (Characters/Personas flow polish)** phase, and the first cycle of the **"character presence"** theme (P3b editor polish → P3c persistent chat avatar → P3d reaction/expression images). P3a (library pagination/sort/tag-filter) is merged. See the northstar `Docs/superpowers/specs/2026-07-13-roleplay-p0-reframe-northstar-design.md`.
+
+**Date:** 2026-07-22
+**Status:** Design (awaiting user review before writing-plans)
+**Schema:** ChaChaNotes v22 — **P3b adds NO migration** (reads/writes existing `character_cards` columns; personas are file-backed JSON).
+
+---
+
+## Goal
+
+Polish the character and persona editors so authoring is smoother and less error-prone: show the character's avatar as an actual thumbnail (not a text label), edit alternate greetings as a real ordered list (not a fragile newline blob), validate inline and per-field as you type, keep you in the editor after saving (with dirty-tracking correctly re-armed), and surface the persona fields the schema already stores. Also lays the avatar-render groundwork that P3c (persistent chat avatar) reuses.
+
+## Non-goals
+
+- **No persona avatars** (user decision: characters-only for now). Persona profiles gain no image field.
+- **No chat/Console changes** — the persistent chat avatar is P3c; reaction/expression images are P3d.
+- **No schema migration** (v22 stays); no new DB tables/columns.
+- **No new image-rendering engine** — P3b reuses the existing `ConsoleImageRenderCache` + `[chat.images]` mode resolution verbatim.
+
+## Success criteria
+
+- The character editor shows a small rendered thumbnail of the current avatar (honoring `[chat.images]` render mode + terminal capability), updates on upload, and offers a Remove action; a text fallback appears when there's no image or rendering is unavailable.
+- Alternate greetings are edited as an add/update/delete/reorderable list; multi-line greetings survive round-trips (the current newline-corruption hazard is gone).
+- Both editors validate live and per-field (the offending field is marked, plus the existing footer summary), before Save — not only at Save.
+- After a successful Save the editor stays open, the unsaved badge/title clear, and a subsequent edit re-flags dirty (re-arm works).
+- The persona editor exposes `personality_traits` and `enabled` (already stored by the schema/service), grouped sensibly.
+
+---
+
+## Background — current state (verified via source scout; file:line approximate, re-verify at plan time)
+
+**Character editor** — `tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py` (`PersonasCharacterEditorWidget(Container)`, id `ccp-character-editor-view`):
+- compose (~:149–216): `VerticalScroll#personas-char-editor-body` with primary fields name/first-message/description/personality/system-prompt, an **Advanced** collapsible `#personas-char-editor-advanced` (toggle `_set_advanced_open` ~:408) holding scenario/post-history/creator-notes/creator/version/tags/alt-greetings. Then the **avatar row** `Horizontal#personas-char-editor-avatar-row` (~:200, CSS `height:1`), a validation `Static#personas-char-editor-validation` (~:207), and the Save/Cancel toolbar.
+- **Avatar today:** `_set_avatar_status_from_record` (~:415) renders literal text `"Avatar: embedded"`/`"Avatar: none"`; `set_avatar_image(bytes)` (~:279) stages bytes at `self._character_data["image"]` then `_mark_dirty()`. Upload button posts `CharacterImageUploadRequested()`.
+- **Alt-greetings today:** a single `TextArea#personas-char-editor-alt-greetings` (~:199), newline-joined. Load (`_populate_form` ~:266) builds `_loaded_greetings: list[str]` + `_loaded_greetings_text = "\n".join(...)`. Save (`get_character_data` ~:338) applies a **fidelity rule**: if the TextArea text is byte-identical to `_loaded_greetings_text`, return `list(self._loaded_greetings)` verbatim (protects multi-line greetings); only if edited, re-split on `splitlines()`. Stored on the record as `alternate_greetings: list[str]`.
+- **Dirty machinery:** `_loading`, `_loaded_snapshot: tuple | None`, `_dirty_posted: bool`. `_form_snapshot()` (~:391) = raw values of all fields. `load_character` (~:228) populates then **re-arms** (`_loaded_snapshot = _form_snapshot()`, `_dirty_posted = False` at ~:240). `_field_changed` (`@on(Input.Changed)`/`@on(TextArea.Changed)`, ~:433) → `_mark_dirty` (~:425) posts `EditorContentChanged()` **once** (guarded by `_dirty_posted`).
+- **Validation today:** the footer `Static` surface **already exists**. `_save_pressed` (~:464) does an inline name-required check → writes to the Static and returns without posting when blank. `show_validation(errors)` (~:294) is the shared entry the screen calls. **No per-field affordance.** Posts `CharacterSaveRequested(get_character_data())` / `CharacterEditorCancelled()`.
+
+**Persona editor** — `tldw_chatbook/Widgets/Persona_Widgets/persona_profile_editor_widget.py` (`PersonaProfileEditorWidget(Container)`, id `ccp-persona-editor-view`):
+- compose (~:61–78): a **flat 3-field form** — name/description/system-prompt — plus the footer `Static#personas-editor-validation` and Save/Cancel toolbar. **No** `personality_traits`/`enabled` fields, no Advanced split. `_persona_id`/`_version` tracked internally (~:51) for optimistic locking.
+- Same dirty machinery (own copy, ~:57–153); `validate()` (~:155) returns `("name: required",)` when blank; `_save_pressed` (~:171) validates then posts `PersonaProfileSaveRequested(self.collect())`; `collect()` (~:111) returns name/description/system_prompt (+ id/version). `PersonaProfileEditCancelled()` on cancel.
+- **Schema gap:** `PersonaProfileCreate` (`tldw_chatbook/tldw_api/character_persona_schemas.py:53`) supports `personality_traits` + `enabled` — the editor doesn't expose them.
+
+**Both editors** post the same `EditorContentChanged` (`personas_pane_messages.py:75`); the dirty/validation state machines are **duplicated per-widget, not shared**.
+
+**Screen seams** — `tldw_chatbook/UI/Screens/personas_screen.py`:
+- `_handle_editor_content_changed` (~:3750): sets `state.has_unsaved_changes = True`, `inspector.set_unsaved(True)`, badges the row, updates title.
+- **Save finishers (the re-arm site):** `_after_character_save` (~:4804) resets `has_unsaved_changes=False` (~:4830), reloads the card, and **flips to the read-only card** via `_show_center("#ccp-character-card-view")` (~:4838). `_after_profile_save` (~:4913) mirrors it (~:4934, flip at ~:4948). **Neither touches the editor widget's `_dirty_posted`** — the re-arm gap. It's masked today *only because save closes the editor and reopen reloads*.
+- `_validate_character` (~:4748) checks name + (if present) `character_book`; `_handle_save_requested` (~:4760) calls `editor.show_validation(errors)` then `_save_character_worker` (~:4780). Persona `_handle_profile_save_requested` (~:4843) (editor pre-validated) → scope-service create/update (optimistic `expected_version`) → `_after_profile_save`.
+- Unsaved guard: `_run_guarded`/`_confirm_then_run`/`_confirm_discard_unsaved` (~:5063–5116) push `UnsavedChangesDialog`. Cancel routes through it.
+- Avatar upload: `_handle_character_image_upload_requested` (~:3889) → `_avatar_upload_dialog_worker` (`EnhancedFileOpen`, suffixes `PERSONAS_AVATAR_IMAGE_SUFFIXES` ~:198) → `_stage_character_avatar_from_path` (~:3841, `_read_avatar_image_bytes` enforces suffix + `PERSONAS_AVATAR_MAX_BYTES` = 5 MB ~:200) → `editor.set_avatar_image(bytes)`.
+- `_show_center` (~:5006) exclusive-toggles `_CENTER_VIEW_IDS` (~:213). Both editors + both cards are always mounted.
+
+**Render primitive (reuse verbatim)** — `tldw_chatbook/Chat/console_image_view.py` (pure, Textual-free): `ConsoleImageRenderCache.prepare(id, bytes) -> bool` (PIL decode + LANCZOS downscale ≤1024px, LRU-16, **must run off the event loop**), `get_pil(id)`, `get_pixels(id)` (rich-pixels thumbnail). `resolve_default_mode(app_config)` reads `[chat.images].default_render_mode` (+ `terminal_overrides`) → `"pixels"`/`"graphics"`. Mount pattern from `Widgets/Console/console_transcript.py` `_image_row_widget` (~:970): graphics → `textual_image.widget.Image(pil)`; pixels/fallback → `Static(Pixels)`; box capped `max_width:80, max_height:40`.
+
+**List-editor pattern to mirror (alt-greetings)** — `tldw_chatbook/Widgets/Persona_Widgets/personas_lore_detail.py`: a `DataTable` (`cursor_type="row"`) + edit form + Add/Update/Delete/Move-up/Move-down button row; `selected_entry_id` from the cursor, tracked on both `DataTable.RowSelected` and `DataTable.RowHighlighted`; reorder posts the **full reordered id list**. NOTE: lore entries persist via a DB manager; **alt-greetings persist widget-local** (a `list[str]` on the record), so the greetings editor is entirely in-widget — no screen round-trip, no messages to the screen.
+
+---
+
+## Design decisions (resolved with the user)
+
+1. **Sequence:** P3b editor → P3c chat avatar → P3d reactions (deferred to its own program).
+2. **Avatars are characters-only** (personas gain no image).
+3. **Save-in-place:** after Save the editor **stays open** (clears unsaved state, re-arms dirty) rather than flipping to the card.
+4. **Surface persona `personality_traits` + `enabled`** (already schema/service-supported).
+5. All five items: avatar thumbnail preview, alt-greetings list editor, live per-field validation, dirty re-arm + save-in-place, field grouping.
+
+---
+
+## Architecture
+
+### A. Avatar thumbnail preview (character editor)
+
+Reuse the pure render primitive; the editor owns a small render step driven by the screen (which has `app.config` + can run off-thread).
+
+- Replace the avatar row's text-only status with a **thumbnail widget** mounted into `#personas-char-editor-avatar-row` (row height grows from 1 to a small fixed cell box, e.g. `height: 12`, `max_width/max_height` small — a compact editor thumbnail, smaller than the 80×40 chat box). Keep the Upload button; add a **Remove** button that clears `_character_data["image"]`, re-renders the empty state, and marks dirty.
+- **Rendering** goes through a screen worker (the widget can't run `asyncio.to_thread` cleanly and needs `app.config`): on avatar change (upload, remove, or editor open with an image), the screen calls `await asyncio.to_thread(cache.prepare, key, bytes)` on a screen-owned `ConsoleImageRenderCache` (keyed by a stable editor key, e.g. `"char-editor-avatar"`), resolves the mode once via `resolve_default_mode(app.config)`, then hands the editor a ready renderable (a `pil` for graphics or a `Pixels` for pixels) to mount — mirroring `_build_console_image_specs`/`_image_row_widget`. A small editor method `set_avatar_thumbnail(renderable | None, mode)` mounts/replaces the widget (graphics `Image` vs `Static(Pixels)`), or shows the text fallback ("No avatar" / "Preview unavailable") when `None`.
+- **Never blocks / never crashes:** decode is off-thread; a decode failure (`prepare` returns False) or missing `textual_image` falls back to pixels then to text. The editor session-token guard already used for `set_avatar_image` (`_stage_character_avatar_from_path`) extends to the render step so a late render doesn't paint onto a different character's editor.
+
+### B. Alternate-greetings list editor (character editor)
+
+Replace `TextArea#personas-char-editor-alt-greetings` with a compact list editor **inside the Advanced section**, mirroring the lore skeleton but **widget-local** (no screen messages, no DB):
+- A `DataTable#personas-char-editor-greetings-table` (`cursor_type="row"`) showing one row per greeting (a single-line **preview** — first line, truncated), plus an edit `TextArea#personas-char-editor-greeting-edit` for the selected greeting's full (possibly multi-line) text, and a button row **Add / Update / Delete / Move up / Move down** (`#personas-char-editor-greeting-{add,update,delete,move-up,move-down}`).
+- Internal state: `_greetings: list[str]` (the source of truth). Add appends a new (empty or editor-text) greeting; Update writes the edit area back to the selected row; Delete removes it; Move up/down swap with the neighbor (clamped). Every mutation re-renders the table (preview text via a `_greeting_preview(text)` helper) and marks dirty.
+- **Fidelity by construction:** because each greeting is a discrete `str` (edited in its own TextArea, never blob-joined), the multi-line-corruption hazard disappears. `get_character_data` returns `list(self._greetings)` directly (dropping the old `_loaded_greetings_text` diff rule). `load_character` seeds `_greetings` from `record["alternate_greetings"]` (coercing non-str/None safely). Selection tracking mirrors lore (`RowSelected` + `RowHighlighted`).
+
+### C. Live per-field validation (both editors)
+
+Keep the footer `Static` summary; add **live, per-field** validation:
+- A `validate()` method on each editor returns a list of `(field_id, message)` pairs (character extends the current name check; persona extends its `validate()`). Checks: **name required** (both); **oversized avatar** (>`PERSONAS_AVATAR_MAX_BYTES`) and **empty/whitespace-only greeting** (character); (optionally) empty system prompt as a soft warning. The rules live in the widget (pure, testable) — the screen's `_validate_character` `character_book` check stays screen-side and merges into the same surface.
+- **When it runs:** on field change (debounced, reusing the editor's existing `@on(Input.Changed)`/`@on(TextArea.Changed)` path — the same handler that marks dirty also schedules a debounced `_run_validation()`), and always at Save. Results: mark each offending field row with a `.is-invalid` class (CSS border/color) and render the aggregated messages into the footer `Static` (existing `show_validation`, extended to also toggle the per-field classes). Clearing a field's error removes its class live.
+- Save is blocked (no `*SaveRequested` posted) while any **error**-level finding stands; warnings don't block.
+
+### D. Dirty re-arm + save-in-place (both editors + screen finishers)
+
+- Add `mark_saved(saved_record)` to **both** editor widgets: update the internal version/id from `saved_record` (character: version on `_character_data`; persona: `_version`/`_persona_id`), re-baseline dirty (`_loaded_snapshot = _form_snapshot()`, `_dirty_posted = False`, and character also refreshes the greetings baseline), and clear the footer validation. This re-arms **without** re-rendering the form (the form already shows the saved state) and carries the new optimistic-lock version for the next save.
+- **Save-in-place** in the finishers: `_after_character_save` / `_after_profile_save` stop flipping to the card (`_show_center(...card...)` removed from the save path). Instead they keep `_edit_mode` in its edit state, keep the editor center visible, clear `has_unsaved_changes`/`inspector.set_unsaved(False)`/`_set_active_row_unsaved(False)`, obtain the freshly-persisted record (by id) and call `editor.mark_saved(record)`, and notify "Saved". (The read-only card is still reached by selecting the entity in the list, which exits edit mode via the existing guard — unchanged.)
+- **Create → edit transition:** after saving a *new* entity (create), the persisted record gets an id (character) / id+version (persona). `mark_saved(record)` sets that id and the finisher transitions `_edit_mode` from `create` to `edit`, so the editor is now editing the just-created entity in place (subsequent saves are updates with the correct `expected_version`). The library list is refreshed and the new row is marked active/selected, without leaving the editor.
+- The `UnsavedChangesDialog` guard is unaffected: after `mark_saved`, `has_unsaved_changes` is False so navigating away is clean; a fresh edit re-posts `EditorContentChanged` (because `_dirty_posted` was reset) and re-arms the guard.
+
+### E. Field grouping / disclosure (both editors)
+
+- **Character:** re-tune the primary-vs-Advanced split (keep name/first-message/description/personality/system-prompt primary; the greetings list editor lives in Advanced). Minor reordering only — no field removals.
+- **Persona:** add `personality_traits` (a `TextArea` or the same greetings-style list if traits are a list — confirm the schema shape at plan time; `PersonaProfileCreate.personality_traits`) and `enabled` (a `Switch`/checkbox) to `persona_profile_editor_widget.py`, wired through `collect()`/`load_persona`/`_form_snapshot`/`validate`. Group them under the existing form (optionally an Advanced split if the field count warrants). `PersonaProfileCreate`/`PersonaProfileUpdate` and the scope-service round-trip already carry these fields — this is UI surfacing, not schema work.
+
+### Error handling / edge cases
+
+- **No avatar / decode failure / missing `textual_image`:** thumbnail falls back pixels→text; never raises; off-thread decode.
+- **Late avatar render onto a switched editor:** session-token guard drops a stale render (mirrors `_stage_character_avatar_from_path`).
+- **Greetings:** empty list → empty table + empty-state hint; a greeting that is only whitespace → validation warning (or dropped on save per the current strip behavior — keep the strip); multi-line greeting preview shows the first line + "…"; deleting the last row clears the edit area.
+- **Save-in-place version drift:** `mark_saved` must set the new version or the *next* save raises a `ConflictError`; the finisher fetches the persisted record to get it. If the fetch fails, fall back to today's flip-to-card (so we never leave the editor with a stale version) and notify.
+- **Validation debounce vs save:** a Save while a debounced validation is pending still runs the synchronous `validate()` at Save (authoritative), so the debounce can't let an invalid save through.
+- **Persona `enabled`/`personality_traits` absent on older profiles:** default `enabled=True`, `personality_traits=""`/`[]` on load (coerce safely).
+
+### Testing strategy
+
+- **Character editor widget tests:** avatar thumbnail mounts for image bytes (graphics + pixels modes) and shows text fallback for none/decode-fail; Remove clears image + marks dirty; greetings Add/Update/Delete/Move-up/Move-down mutate `_greetings` and re-render; **multi-line greeting round-trips byte-identical** (the fidelity guarantee); `get_character_data` returns the list; `mark_saved` re-arms (`_dirty_posted` False, snapshot rebaselined, version updated) and a subsequent change re-posts `EditorContentChanged`; per-field validation marks the name row invalid on blank + oversized avatar + whitespace greeting, and clears live.
+- **Persona editor widget tests:** `personality_traits` + `enabled` load/collect/round-trip; dirty + `mark_saved` re-arm; validation marks blank name; `enabled` toggle marks dirty.
+- **Screen integration tests (real screen + real DB):** save-in-place keeps the editor open + clears the row/title unsaved state + re-arms so a second edit re-flags dirty (drives the re-arm fix end-to-end); a validation error blocks save and surfaces inline; avatar upload → thumbnail renders; persona save-in-place with the new fields persists + re-arms.
+
+---
+
+## Task decomposition (for writing-plans → subagent-driven-development)
+
+1. **Dirty re-arm + save-in-place** — `mark_saved(record)` on both widgets; `_after_character_save`/`_after_profile_save` stay-in-place + call it; fetch-persisted-record-for-version (fallback to flip-to-card on fetch error). Widget + screen integration tests. *(Foundational — the other items build on the editor staying open.)*
+2. **Avatar thumbnail preview** — screen render worker (reuse `ConsoleImageRenderCache`/`resolve_default_mode`), editor `set_avatar_thumbnail`, grow the row, Remove button, fallbacks + session-token guard. Widget + screen tests.
+3. **Alt-greetings list editor** — replace the TextArea with the DataTable+edit+buttons list editor, `_greetings` state, fidelity-preserving load/save. Widget tests (incl. multi-line round-trip).
+4. **Live per-field validation** — `validate()` rules + debounced runner + `.is-invalid` per-field marking + footer surface, both editors; Save-blocks-on-error. Widget tests.
+5. **Persona fields + field grouping** — surface `personality_traits` + `enabled` in the persona editor (collect/load/snapshot/validate); re-tune character Advanced grouping. Widget + persona save-in-place integration test.
+
+Five focused tasks → one PR.
+
+---
+
+## Global constraints
+
+- **NO schema migration** (ChaChaNotes stays v22); no new DB tables/columns. Persona fields already exist in the schema/service.
+- **Reuse the render primitive verbatim** — `ConsoleImageRenderCache` + `resolve_default_mode` from `Chat/console_image_view.py`; do not build a new decoder. Avatar decode runs **off-thread** (`asyncio.to_thread`), driven from the screen (which has `app.config`).
+- **Preserve the alt-greetings no-corruption guarantee** — multi-line greetings must round-trip byte-identical; the list model replaces the newline-blob + fidelity-diff, it must not regress it.
+- **Save-in-place must carry the new optimistic-lock version** — the next save after a save-in-place must not raise `ConflictError`; fall back to flip-to-card + notify if the persisted record can't be re-read.
+- **Apply dirty-re-arm + validation to BOTH editors** — their state machines are duplicated; keep them consistent (extract a shared mixin only if it's clearly simpler, otherwise mirror the change in both).
+- **Characters-only avatars** — no persona image field.
+- **All screen DB/decode I/O off-thread**, wrapped so errors notify (never crash the worker).
+- **Branch off the LATEST `origin/dev`** (`bf21cfb4b` at spec time — re-verify at plan/merge time; dev is moving fast with concurrent RP-UX work). **Concurrent-session hazard:** other sessions are actively editing `personas_screen.py` (RP-UX-review tasks 425–445, e.g. Start-Chat #754) — expect a non-trivial rebase before merge; keep P3b changes localized to the editor widgets + the save/validation/avatar seams.
+- **Implementers stage ONLY their task's files** — never `git add -A`, never stage `.superpowers/`.
+- **No background/broad test sweeps; never broad-`pkill` pytest** — scope to this worktree.
+- **Test env:** `HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest … -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread` (venv in the MAIN checkout; imports resolve to worktree source; UI tests are slow — generous timeouts).
+
+## Deferred / follow-ups
+
+- **P3c — persistent character avatar in the Console chat** (the next cycle): a docked "Character" panel in the Console left rail rendering the active character's image, resolving `character_id` via `conversations.character_id` (note the Start-Chat handoff is being changed by task-427/#754 — reconcile at P3c time). Reuses P3b's avatar-render step.
+- **P3d — reaction/expression image system** (own future program): net-new image-set data model + authoring + trigger + swap, ported from the tldw_server webui/browser extension (needs the external `../tldw_server` repo).
+- Possible shared editor base/mixin to de-duplicate the dirty/validation machinery (if not done inline in P3b).

--- a/Docs/superpowers/specs/2026-07-22-roleplay-p3b-editor-polish-design.md
+++ b/Docs/superpowers/specs/2026-07-22-roleplay-p3b-editor-polish-design.md
@@ -10,7 +10,7 @@
 
 ## Goal
 
-Polish the character and persona editors so authoring is smoother and less error-prone: show the character's avatar as an actual thumbnail (not a text label), edit alternate greetings as a real ordered list (not a fragile newline blob), validate inline and per-field as you type, keep you in the editor after saving (with dirty-tracking correctly re-armed), and surface the persona fields the schema already stores. Also lays the avatar-render groundwork that P3c (persistent chat avatar) reuses.
+Polish the character and persona editors so authoring is smoother and less error-prone: show the character's avatar as an actual thumbnail (not a text label), edit alternate greetings as a real ordered list (not a fragile newline blob), validate inline and per-field as you type, keep you in the editor after saving (with dirty-tracking correctly re-armed), and round out the persona editor (an Enabled toggle + mode selector + a new personality-traits field). Also lays the avatar-render groundwork that P3c (persistent chat avatar) reuses.
 
 ## Non-goals
 
@@ -25,7 +25,7 @@ Polish the character and persona editors so authoring is smoother and less error
 - Alternate greetings are edited as an add/update/delete/reorderable list; multi-line greetings survive round-trips (the current newline-corruption hazard is gone).
 - Both editors validate live and per-field (the offending field is marked, plus the existing footer summary), before Save — not only at Save.
 - After a successful Save the editor stays open, the unsaved badge/title clear, and a subsequent edit re-flags dirty (re-arm works).
-- The persona editor exposes `personality_traits` and `enabled` (already stored by the schema/service), grouped sensibly.
+- The persona editor exposes an **Enabled** toggle (`is_active`), a **mode** selector, and a new **personality-traits** field — all persisting through save.
 
 ---
 
@@ -41,7 +41,7 @@ Polish the character and persona editors so authoring is smoother and less error
 **Persona editor** — `tldw_chatbook/Widgets/Persona_Widgets/persona_profile_editor_widget.py` (`PersonaProfileEditorWidget(Container)`, id `ccp-persona-editor-view`):
 - compose (~:61–78): a **flat 3-field form** — name/description/system-prompt — plus the footer `Static#personas-editor-validation` and Save/Cancel toolbar. **No** `personality_traits`/`enabled` fields, no Advanced split. `_persona_id`/`_version` tracked internally (~:51) for optimistic locking.
 - Same dirty machinery (own copy, ~:57–153); `validate()` (~:155) returns `("name: required",)` when blank; `_save_pressed` (~:171) validates then posts `PersonaProfileSaveRequested(self.collect())`; `collect()` (~:111) returns name/description/system_prompt (+ id/version). `PersonaProfileEditCancelled()` on cancel.
-- **Schema gap:** `PersonaProfileCreate` (`tldw_chatbook/tldw_api/character_persona_schemas.py:53`) supports `personality_traits` + `enabled` — the editor doesn't expose them.
+- **What the schema actually has (verified):** `PersonaProfileCreate`/`PersonaProfileUpdate` (`tldw_chatbook/tldw_api/character_persona_schemas.py:556/570`) carry `name`, `description`, `system_prompt`, **`is_active: bool`** (the real "enabled" analog), `mode` (`PersonaMode`, e.g. `session_scoped`), `character_card_id`, etc. — but **NO `personality_traits` and no boolean `enabled`** (those `list[str]` fields live in unrelated *archetype* classes, `ArchetypePersonaDefaults`/`ArchetypeMCPConfig` ~:50–62). The editor exposes only name/description/system_prompt, and **the save handler `_handle_profile_save_requested` (personas_screen.py ~:4877–4897) currently drops every field except name/description/mode/system_prompt** when building the DTO. So surfacing `is_active`/`mode` requires plumbing them through `collect()` → the save DTO, and `personality_traits` is **net-new** (add to the DTO + service view + file store + editor).
 
 **Both editors** post the same `EditorContentChanged` (`personas_pane_messages.py:75`); the dirty/validation state machines are **duplicated per-widget, not shared**.
 
@@ -64,7 +64,7 @@ Polish the character and persona editors so authoring is smoother and less error
 1. **Sequence:** P3b editor → P3c chat avatar → P3d reactions (deferred to its own program).
 2. **Avatars are characters-only** (personas gain no image).
 3. **Save-in-place:** after Save the editor **stays open** (clears unsaved state, re-arms dirty) rather than flipping to the card.
-4. **Surface persona `personality_traits` + `enabled`** (already schema/service-supported).
+4. **Persona fields:** surface `is_active` (as an **Enabled** toggle) + a `mode` selector (both exist in the DTO but are dropped by the save handler → plumb through), **and add a net-new `personality_traits` field** (freeform text, matching the character `personality` field) to the persona DTO + service view + file store + editor. (User chose option B — net-new traits, not just surfacing.)
 5. All five items: avatar thumbnail preview, alt-greetings list editor, live per-field validation, dirty re-arm + save-in-place, field grouping.
 
 ---
@@ -96,14 +96,19 @@ Keep the footer `Static` summary; add **live, per-field** validation:
 ### D. Dirty re-arm + save-in-place (both editors + screen finishers)
 
 - Add `mark_saved(saved_record)` to **both** editor widgets: update the internal version/id from `saved_record` (character: version on `_character_data`; persona: `_version`/`_persona_id`), re-baseline dirty (`_loaded_snapshot = _form_snapshot()`, `_dirty_posted = False`, and character also refreshes the greetings baseline), and clear the footer validation. This re-arms **without** re-rendering the form (the form already shows the saved state) and carries the new optimistic-lock version for the next save.
-- **Save-in-place** in the finishers: `_after_character_save` / `_after_profile_save` stop flipping to the card (`_show_center(...card...)` removed from the save path). Instead they keep `_edit_mode` in its edit state, keep the editor center visible, clear `has_unsaved_changes`/`inspector.set_unsaved(False)`/`_set_active_row_unsaved(False)`, obtain the freshly-persisted record (by id) and call `editor.mark_saved(record)`, and notify "Saved". (The read-only card is still reached by selecting the entity in the list, which exits edit mode via the existing guard — unchanged.)
+- **Save-in-place** in the finishers: `_after_character_save` / `_after_profile_save` stop flipping to the card (`_show_center(...card...)` removed from the save path). Instead they keep `_edit_mode` in its edit state, keep the editor center visible, clear `has_unsaved_changes`/`inspector.set_unsaved(False)`/`_set_active_row_unsaved(False)`, obtain the freshly-persisted record and call `editor.mark_saved(record)`, and notify "Saved". (The read-only card is still reached by selecting the entity in the list, which exits edit mode via the existing guard — unchanged.)
+  - **Version-source (verified):** Character — `_after_character_save` already calls `character_handler.load_character(saved_id)` (~:4837); call it (or `fetch_character_by_id(saved_id)`) *before* reading the record so the version is the persisted one — `_full_character_record(saved_id)` can be stale until that load runs. Persona — `_handle_profile_save_requested` already receives the returned saved profile (`result`→`saved` dict) with the incremented version and passes it to `_after_profile_save(saved)`, so `mark_saved(saved)` has the version directly. If the character record can't be re-read, fall back to today's flip-to-card + notify (never leave the editor holding a stale version).
 - **Create → edit transition:** after saving a *new* entity (create), the persisted record gets an id (character) / id+version (persona). `mark_saved(record)` sets that id and the finisher transitions `_edit_mode` from `create` to `edit`, so the editor is now editing the just-created entity in place (subsequent saves are updates with the correct `expected_version`). The library list is refreshed and the new row is marked active/selected, without leaving the editor.
 - The `UnsavedChangesDialog` guard is unaffected: after `mark_saved`, `has_unsaved_changes` is False so navigating away is clean; a fresh edit re-posts `EditorContentChanged` (because `_dirty_posted` was reset) and re-arms the guard.
 
 ### E. Field grouping / disclosure (both editors)
 
 - **Character:** re-tune the primary-vs-Advanced split (keep name/first-message/description/personality/system-prompt primary; the greetings list editor lives in Advanced). Minor reordering only — no field removals.
-- **Persona:** add `personality_traits` (a `TextArea` or the same greetings-style list if traits are a list — confirm the schema shape at plan time; `PersonaProfileCreate.personality_traits`) and `enabled` (a `Switch`/checkbox) to `persona_profile_editor_widget.py`, wired through `collect()`/`load_persona`/`_form_snapshot`/`validate`. Group them under the existing form (optionally an Advanced split if the field count warrants). `PersonaProfileCreate`/`PersonaProfileUpdate` and the scope-service round-trip already carry these fields — this is UI surfacing, not schema work.
+- **Persona:** add three fields to `persona_profile_editor_widget.py`, wired through `collect()`/`load_persona`/`_form_snapshot`/`validate`:
+  1. **Enabled** — a `Switch` bound to `is_active` (exists in the DTO; default `True`).
+  2. **Mode** — a `Select` bound to `mode` (the `PersonaMode` literals; default `session_scoped`).
+  3. **Personality traits** — a **net-new** freeform `TextArea` (`personality_traits: str`, matching the character editor's `personality` field). This is genuinely new persona data: add `personality_traits` to `PersonaProfileCreate`/`PersonaProfileUpdate`, to `LocalCharacterPersonaService` create/update + `_persona_profile_view`, and to the file-backed JSON store (older profiles default to `""` on load — no SQLite migration; personas are JSON). *(Note the codebase's `ArchetypePersonaDefaults.personality_traits` is a `list[str]`; the persona-profile field here is a freeform string for character-parity — keep the names distinct in intent.)*
+  - **Save-handler plumbing (required):** `_handle_profile_save_requested` (~:4877–4897) must include `is_active`, `mode`, and `personality_traits` when building `PersonaProfileCreate`/`Update` (today it drops all but name/description/mode/system_prompt), or the new fields won't persist. Group the three under the form (an Advanced split only if the field count warrants).
 
 ### Error handling / edge cases
 
@@ -112,12 +117,12 @@ Keep the footer `Static` summary; add **live, per-field** validation:
 - **Greetings:** empty list → empty table + empty-state hint; a greeting that is only whitespace → validation warning (or dropped on save per the current strip behavior — keep the strip); multi-line greeting preview shows the first line + "…"; deleting the last row clears the edit area.
 - **Save-in-place version drift:** `mark_saved` must set the new version or the *next* save raises a `ConflictError`; the finisher fetches the persisted record to get it. If the fetch fails, fall back to today's flip-to-card (so we never leave the editor with a stale version) and notify.
 - **Validation debounce vs save:** a Save while a debounced validation is pending still runs the synchronous `validate()` at Save (authoritative), so the debounce can't let an invalid save through.
-- **Persona `enabled`/`personality_traits` absent on older profiles:** default `enabled=True`, `personality_traits=""`/`[]` on load (coerce safely).
+- **`is_active`/`mode`/`personality_traits` absent on older persona profiles:** default `is_active=True`, `mode="session_scoped"`, `personality_traits=""` on load (coerce safely — the JSON store simply lacks the keys for pre-existing profiles).
 
 ### Testing strategy
 
 - **Character editor widget tests:** avatar thumbnail mounts for image bytes (graphics + pixels modes) and shows text fallback for none/decode-fail; Remove clears image + marks dirty; greetings Add/Update/Delete/Move-up/Move-down mutate `_greetings` and re-render; **multi-line greeting round-trips byte-identical** (the fidelity guarantee); `get_character_data` returns the list; `mark_saved` re-arms (`_dirty_posted` False, snapshot rebaselined, version updated) and a subsequent change re-posts `EditorContentChanged`; per-field validation marks the name row invalid on blank + oversized avatar + whitespace greeting, and clears live.
-- **Persona editor widget tests:** `personality_traits` + `enabled` load/collect/round-trip; dirty + `mark_saved` re-arm; validation marks blank name; `enabled` toggle marks dirty.
+- **Persona editor widget tests:** `is_active`/`mode`/`personality_traits` load/collect/round-trip; dirty + `mark_saved` re-arm; validation marks blank name; the Enabled toggle marks dirty. Plus a **service/store test** that the net-new `personality_traits` persists through `create_persona_profile`/`update_persona_profile` and reloads (file-backed round-trip).
 - **Screen integration tests (real screen + real DB):** save-in-place keeps the editor open + clears the row/title unsaved state + re-arms so a second edit re-flags dirty (drives the re-arm fix end-to-end); a validation error blocks save and surfaces inline; avatar upload → thumbnail renders; persona save-in-place with the new fields persists + re-arms.
 
 ---
@@ -128,7 +133,7 @@ Keep the footer `Static` summary; add **live, per-field** validation:
 2. **Avatar thumbnail preview** — screen render worker (reuse `ConsoleImageRenderCache`/`resolve_default_mode`), editor `set_avatar_thumbnail`, grow the row, Remove button, fallbacks + session-token guard. Widget + screen tests.
 3. **Alt-greetings list editor** — replace the TextArea with the DataTable+edit+buttons list editor, `_greetings` state, fidelity-preserving load/save. Widget tests (incl. multi-line round-trip).
 4. **Live per-field validation** — `validate()` rules + debounced runner + `.is-invalid` per-field marking + footer surface, both editors; Save-blocks-on-error. Widget tests.
-5. **Persona fields + field grouping** — surface `personality_traits` + `enabled` in the persona editor (collect/load/snapshot/validate); re-tune character Advanced grouping. Widget + persona save-in-place integration test.
+5. **Persona fields + field grouping** — Enabled (`is_active`) + mode selectors and net-new `personality_traits` (freeform text): add to the persona DTO (`PersonaProfileCreate`/`Update`), `LocalCharacterPersonaService` create/update + `_persona_profile_view`, the JSON store, the editor (collect/load/snapshot/validate), **and the save handler `_handle_profile_save_requested` DTO build** (which currently drops these); re-tune the character Advanced grouping. Widget + service/store round-trip + persona save-in-place integration test. *(Larger than the other tasks — spans schema DTO + service + store + editor + handler; may split into 5a persona-data and 5b field-grouping if it gets unwieldy.)*
 
 Five focused tasks → one PR.
 
@@ -136,7 +141,7 @@ Five focused tasks → one PR.
 
 ## Global constraints
 
-- **NO schema migration** (ChaChaNotes stays v22); no new DB tables/columns. Persona fields already exist in the schema/service.
+- **NO ChaChaNotes (SQLite) schema migration** (stays v22); no new DB tables/columns. The net-new persona `personality_traits` lives in the **Pydantic DTO + file-backed JSON store**, not the SQLite DB — adding it is a new JSON key (older profiles default it), NOT a DB migration.
 - **Reuse the render primitive verbatim** — `ConsoleImageRenderCache` + `resolve_default_mode` from `Chat/console_image_view.py`; do not build a new decoder. Avatar decode runs **off-thread** (`asyncio.to_thread`), driven from the screen (which has `app.config`).
 - **Preserve the alt-greetings no-corruption guarantee** — multi-line greetings must round-trip byte-identical; the list model replaces the newline-blob + fidelity-diff, it must not regress it.
 - **Save-in-place must carry the new optimistic-lock version** — the next save after a save-in-place must not raise `ConflictError`; fall back to flip-to-card + notify if the persisted record can't be re-read.

--- a/Tests/Character_Chat/test_persona_personality_traits_roundtrip.py
+++ b/Tests/Character_Chat/test_persona_personality_traits_roundtrip.py
@@ -1,0 +1,61 @@
+"""Roleplay P3b Task 5: net-new `personality_traits` on the persona profile DTO.
+
+The persona service is DTO-driven (`create_persona_profile` validates
+`PersonaProfileCreate` -> `model_dump` -> JSON store; `_persona_profile_view`
+is a passthrough `dict(record)`), so adding `personality_traits` to the DTO is
+sufficient for it to persist and reload - no service-method change needed.
+Mirrors `test_local_character_persona_service_persists_persona_profile_crud`
+in `test_local_character_persona_service.py` for the ctor/store round-trip
+pattern (db=None: persona-profile CRUD never touches `self.db`).
+"""
+
+from tldw_chatbook.Character_Chat.local_character_persona_service import (
+    LocalCharacterPersonaService,
+)
+from tldw_chatbook.tldw_api.character_persona_schemas import (
+    PersonaProfileCreate,
+    PersonaProfileUpdate,
+)
+
+
+def test_personality_traits_persists_and_reloads(tmp_path):
+    store_path = tmp_path / "personas.json"
+    svc = LocalCharacterPersonaService(None, persona_store_path=store_path)
+
+    created = svc.create_persona_profile(
+        PersonaProfileCreate(
+            id="guide", name="Guide", personality_traits="brave, kind"
+        )
+    )
+    assert created["personality_traits"] == "brave, kind"
+
+    # Reload from a FRESH service instance backed by the same JSON store -
+    # proves the field round-trips through persistence, not just in-memory.
+    svc2 = LocalCharacterPersonaService(None, persona_store_path=store_path)
+    got = svc2.get_persona_profile("guide")
+    assert got["personality_traits"] == "brave, kind"
+
+
+def test_personality_traits_defaults_to_empty_string():
+    svc = LocalCharacterPersonaService(None)
+    created = svc.create_persona_profile(PersonaProfileCreate(name="Blank"))
+    assert created["personality_traits"] == ""
+
+
+def test_personality_traits_updates_and_reloads(tmp_path):
+    store_path = tmp_path / "personas.json"
+    svc = LocalCharacterPersonaService(None, persona_store_path=store_path)
+    created = svc.create_persona_profile(
+        PersonaProfileCreate(id="guide", name="Guide", personality_traits="calm")
+    )
+
+    updated = svc.update_persona_profile(
+        "guide",
+        PersonaProfileUpdate(personality_traits="fierce, loyal"),
+        expected_version=created["version"],
+    )
+    assert updated["personality_traits"] == "fierce, loyal"
+
+    svc2 = LocalCharacterPersonaService(None, persona_store_path=store_path)
+    got = svc2.get_persona_profile("guide")
+    assert got["personality_traits"] == "fierce, loyal"

--- a/Tests/Character_Chat/test_persona_personality_traits_roundtrip.py
+++ b/Tests/Character_Chat/test_persona_personality_traits_roundtrip.py
@@ -59,3 +59,34 @@ def test_personality_traits_updates_and_reloads(tmp_path):
     svc2 = LocalCharacterPersonaService(None, persona_store_path=store_path)
     got = svc2.get_persona_profile("guide")
     assert got["personality_traits"] == "fierce, loyal"
+
+
+def test_personality_traits_update_to_empty_string_clears_and_reloads(tmp_path):
+    """An explicit ``personality_traits=""`` update must persist the empty
+    string, not silently preserve the old value.
+
+    ``update_persona_profile`` builds its patch via
+    ``PersonaProfileUpdate.model_dump(exclude_none=True)`` - which excludes
+    only ``None`` fields, not falsy-but-set ones like ``""`` - so a real
+    clear-to-empty edit round-trips correctly. This pins that behavior.
+    """
+    store_path = tmp_path / "personas.json"
+    svc = LocalCharacterPersonaService(None, persona_store_path=store_path)
+    created = svc.create_persona_profile(
+        PersonaProfileCreate(id="guide", name="Guide", personality_traits="x")
+    )
+    assert created["personality_traits"] == "x"
+
+    updated = svc.update_persona_profile(
+        "guide",
+        PersonaProfileUpdate(personality_traits=""),
+        expected_version=created["version"],
+    )
+    assert updated["personality_traits"] == ""
+
+    # Reload from a FRESH service instance backed by the same JSON store -
+    # proves the cleared value genuinely persisted, not just that the
+    # in-memory record returned by update_persona_profile looks right.
+    svc2 = LocalCharacterPersonaService(None, persona_store_path=store_path)
+    got = svc2.get_persona_profile("guide")
+    assert got["personality_traits"] == ""

--- a/Tests/UI/test_persona_profile_widgets.py
+++ b/Tests/UI/test_persona_profile_widgets.py
@@ -2,7 +2,7 @@
 
 import pytest
 from textual.app import App
-from textual.widgets import Button, Input, Static
+from textual.widgets import Button, Input, Select, Static, Switch, TextArea
 
 from tldw_chatbook.tldw_api import PersonaProfileCreate
 from tldw_chatbook.Widgets.Persona_Widgets.persona_profile_card_widget import (
@@ -12,6 +12,7 @@ from tldw_chatbook.Widgets.Persona_Widgets.persona_profile_editor_widget import 
     PersonaProfileEditorWidget,
 )
 from tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages import (
+    EditorContentChanged,
     EditPersonaRequested,
     PersonaProfileSaveRequested,
 )
@@ -156,6 +157,86 @@ async def test_editor_roundtrips_version():
         editor.new_persona()
         await pilot.pause()
         assert "version" not in editor.collect()
+
+
+async def test_editor_load_collect_roundtrip_new_fields():
+    """Roleplay P3b Task 5: is_active/mode/personality_traits populate on
+    load and round-trip through collect()."""
+    app = WidgetApp()
+    async with app.run_test() as pilot:
+        editor = pilot.app.query_one(PersonaProfileEditorWidget)
+        editor.load_persona(
+            {
+                "id": "p-1",
+                "name": "Archivist",
+                "is_active": False,
+                "mode": "persistent_scoped",
+                "personality_traits": "meticulous, dry wit",
+            }
+        )
+        await pilot.pause()
+        assert pilot.app.query_one("#personas-editor-enabled", Switch).value is False
+        assert (
+            pilot.app.query_one("#personas-editor-mode", Select).value
+            == "persistent_scoped"
+        )
+        assert (
+            pilot.app.query_one(
+                "#personas-editor-personality-traits", TextArea
+            ).text
+            == "meticulous, dry wit"
+        )
+        data = editor.collect()
+        assert data["is_active"] is False
+        assert data["mode"] == "persistent_scoped"
+        assert data["personality_traits"] == "meticulous, dry wit"
+
+
+async def test_editor_new_persona_defaults_enabled_and_session_scoped():
+    """A fresh/new persona defaults Enabled=True, mode=session_scoped, and
+    an empty personality-traits field - matching PersonaProfileCreate's
+    defaults."""
+    app = WidgetApp()
+    async with app.run_test() as pilot:
+        editor = pilot.app.query_one(PersonaProfileEditorWidget)
+        editor.new_persona()
+        await pilot.pause()
+        assert pilot.app.query_one("#personas-editor-enabled", Switch).value is True
+        assert (
+            pilot.app.query_one("#personas-editor-mode", Select).value
+            == "session_scoped"
+        )
+        assert (
+            pilot.app.query_one(
+                "#personas-editor-personality-traits", TextArea
+            ).text
+            == ""
+        )
+        data = editor.collect()
+        assert data["is_active"] is True
+        assert data["mode"] == "session_scoped"
+        assert data["personality_traits"] == ""
+
+
+async def test_toggling_enabled_switch_marks_dirty():
+    """The Enabled Switch participates in dirty tracking exactly like a text
+    field: toggling it after a load posts EditorContentChanged."""
+    received = []
+
+    class CaptureApp(EditorOnlyApp):
+        def on_editor_content_changed(self, message: EditorContentChanged) -> None:
+            received.append(message)
+
+    app = CaptureApp()
+    async with app.run_test() as pilot:
+        editor = pilot.app.query_one(PersonaProfileEditorWidget)
+        editor.load_persona(PROFILE)
+        await pilot.pause()
+        assert received == []
+
+        pilot.app.query_one("#personas-editor-enabled", Switch).value = False
+        await pilot.pause()
+    assert len(received) == 1
 
 
 async def test_persona_profile_create_schema_accepts_description():

--- a/Tests/UI/test_personas_character_editor_avatar.py
+++ b/Tests/UI/test_personas_character_editor_avatar.py
@@ -1,0 +1,192 @@
+"""Roleplay P3b Task 2: character editor avatar thumbnail preview + Remove.
+
+Widget-level coverage mirrors ``test_personas_character_editor_sync.py``'s
+bare-``PersonasCharacterEditorWidget`` host harness; the screen-level coverage
+mirrors ``test_personas_character_world_books_screen.py``'s real-DB
+``PersonasTestApp`` harness (seed a character via ``add_character_card``,
+feed the same id back into the stubbed ``ccp_character_handler`` module
+functions, then drive the editor through the real screen).
+"""
+
+import pytest
+from PIL import Image
+from rich_pixels import Pixels
+from textual.app import App, ComposeResult
+from textual.widgets import Button
+
+import tldw_chatbook.UI.CCP_Modules.ccp_character_handler as character_handler_module
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.Widgets.Persona_Widgets.personas_character_editor_widget import (
+    PersonasCharacterEditorWidget,
+)
+
+from Tests.UI.test_personas_dictionaries import PersonasTestApp, patch_character_paging
+
+pytestmark = pytest.mark.asyncio
+
+
+# ===================================================================
+# Widget-level: set_avatar_thumbnail mount/clear, current_avatar_bytes,
+# Remove button posting the new message.
+# ===================================================================
+
+
+class _Host(App):
+    def __init__(self):
+        super().__init__()
+        self.removed = 0
+
+    def compose(self) -> ComposeResult:
+        yield PersonasCharacterEditorWidget()
+
+    def on_character_image_remove_requested(self, m):
+        self.removed += 1
+
+
+async def test_thumbnail_mounts_and_text_fallback():
+    app = _Host()
+    async with app.run_test() as pilot:
+        ed = app.query_one(PersonasCharacterEditorWidget)
+        ed.load_character({"name": "A", "image": b"x"})
+        await pilot.pause()
+        # None -> text fallback present, no image widget
+        ed.set_avatar_thumbnail(None)
+        await pilot.pause()
+        assert len(ed.query("#personas-char-editor-avatar-thumb > *")) == 0
+        # A pixels renderable -> a widget is mounted in the avatar row
+        px = Pixels.from_image(Image.new("RGBA", (8, 8)))
+        ed.set_avatar_thumbnail(px)
+        await pilot.pause()
+        assert len(ed.query("#personas-char-editor-avatar-thumb > *")) == 1
+
+
+async def test_current_avatar_bytes_and_remove():
+    app = _Host()
+    async with app.run_test() as pilot:
+        ed = app.query_one(PersonasCharacterEditorWidget)
+        ed.load_character({"name": "A", "image": b"abc"})
+        await pilot.pause()
+        assert ed.current_avatar_bytes() == b"abc"
+        # .press() (not pilot.click) - the avatar row sits below the fold of
+        # the scrollable editor body at default pilot size, so a coordinate
+        # click can miss it (see test_upload_button_posts_image_upload_request
+        # in test_personas_character_widgets.py for the same convention).
+        ed.query_one("#personas-char-editor-avatar-remove", Button).press()
+        await pilot.pause()
+        assert app.removed == 1
+
+
+async def test_current_avatar_bytes_none_without_image():
+    app = _Host()
+    async with app.run_test() as pilot:
+        ed = app.query_one(PersonasCharacterEditorWidget)
+        ed.load_character({"name": "A"})
+        await pilot.pause()
+        assert ed.current_avatar_bytes() is None
+
+
+# ===================================================================
+# Screen-level: real PersonasScreen renders the thumbnail off-thread when
+# the editor opens for a character with an embedded image, and Remove
+# clears it + marks the session unsaved.
+# ===================================================================
+
+
+@pytest.fixture
+def avatar_db(tmp_path):
+    db = CharactersRAGDB(tmp_path / "personas_char_avatar.db", "test-client")
+    yield db
+    db.close_connection()
+
+
+@pytest.fixture
+def avatar_image_bytes():
+    """Real PNG-encoded avatar image bytes for a character record."""
+    from io import BytesIO
+
+    buf = BytesIO()
+    Image.new("RGB", (4, 4), color=(200, 40, 40)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+@pytest.fixture
+def seeded_character_with_avatar(avatar_db, avatar_image_bytes):
+    """A real character row, with the SAME id fed back into the stubbed
+    ``ccp_character_handler`` module functions (mirrors
+    ``test_personas_character_world_books_screen.py``'s
+    ``seeded_character_with_worldbook``)."""
+    char_id = avatar_db.add_character_card({"name": "Portraitless"})
+    return {"char_id": char_id, "image": avatar_image_bytes}
+
+
+@pytest.fixture
+def stub_character_with_avatar(monkeypatch, seeded_character_with_avatar):
+    """Feed the screen a character record carrying embedded image bytes."""
+    char_id = seeded_character_with_avatar["char_id"]
+    record = {
+        "id": char_id,
+        "name": "Portraitless",
+        "description": "",
+        "first_message": "Hi.",
+        "version": 1,
+        "image": seeded_character_with_avatar["image"],
+    }
+    monkeypatch.setattr(
+        character_handler_module, "fetch_all_characters", lambda: [dict(record)]
+    )
+    monkeypatch.setattr(
+        character_handler_module,
+        "fetch_character_by_id",
+        lambda character_id: (
+            dict(record) if str(character_id) == str(char_id) else None
+        ),
+    )
+    patch_character_paging(monkeypatch)
+
+
+async def _select_character(pilot, char_id):
+    await pilot.pause()
+    await pilot.click(f"#personas-library-row-character-{char_id}")
+    await pilot.pause()
+    await pilot.app.workers.wait_for_complete()
+    await pilot.pause()
+    return pilot.app.screen
+
+
+class TestCharacterEditorAvatarThumbnailScreen:
+    async def test_editor_with_image_renders_thumbnail(
+        self,
+        mock_app_instance,
+        avatar_db,
+        seeded_character_with_avatar,
+        stub_character_with_avatar,
+    ):
+        mock_app_instance.chachanotes_db = avatar_db
+        mock_app_instance.chat_dictionary_scope_service = None
+        char_id = seeded_character_with_avatar["char_id"]
+
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(200, 60)) as pilot:
+            screen = await _select_character(pilot, char_id)
+            # Open the editor for this character (edit action).
+            from tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages import (
+                EditCharacterRequested,
+            )
+
+            screen.post_message(EditCharacterRequested(str(char_id)))
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            editor = screen.query_one(PersonasCharacterEditorWidget)
+            assert editor.current_avatar_bytes() is not None
+            assert len(editor.query("#personas-char-editor-avatar-thumb > *")) == 1
+
+            editor.query_one("#personas-char-editor-avatar-remove", Button).press()
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            assert editor.current_avatar_bytes() is None
+            assert len(editor.query("#personas-char-editor-avatar-thumb > *")) == 0
+            assert screen.state.has_unsaved_changes is True

--- a/Tests/UI/test_personas_character_editor_avatar.py
+++ b/Tests/UI/test_personas_character_editor_avatar.py
@@ -8,6 +8,7 @@ feed the same id back into the stubbed ``ccp_character_handler`` module
 functions, then drive the editor through the real screen).
 """
 
+import rich_pixels
 import pytest
 from PIL import Image
 from rich_pixels import Pixels
@@ -16,13 +17,22 @@ from textual.widgets import Button
 
 import tldw_chatbook.UI.CCP_Modules.ccp_character_handler as character_handler_module
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.UI.Screens.personas_screen import (
+    AVATAR_THUMB_COLS,
+    AVATAR_THUMB_LINES,
+    PersonasScreen,
+)
 from tldw_chatbook.Widgets.Persona_Widgets.personas_character_editor_widget import (
     PersonasCharacterEditorWidget,
 )
 
 from Tests.UI.test_personas_dictionaries import PersonasTestApp, patch_character_paging
 
-pytestmark = pytest.mark.asyncio
+# Not applied via module-level pytestmark: Tests/UI/pytest.ini sets
+# asyncio_mode = auto, which auto-detects `async def` tests without the
+# explicit marker, and this module also has plain sync unit tests (the
+# _fit_avatar_cell_size coverage below) that pytest-asyncio warns about if
+# the marker is applied to them.
 
 
 # ===================================================================
@@ -86,6 +96,57 @@ async def test_current_avatar_bytes_none_without_image():
 
 
 # ===================================================================
+# Unit-level: PersonasScreen._fit_avatar_cell_size (graphics-mode fitting).
+#
+# Cells are ~2x taller than wide in pixels, so the aspect ratio is compared
+# in "cell units" (pixel_width : pixel_height/2) before fitting into the
+# AVATAR_THUMB_COLS x AVATAR_THUMB_LINES box. Both returned dimensions must
+# stay explicit ints >= 1 - that's what the graphics-mode ``ValueError:
+# height/width must be > 0`` crash this rendering path works around
+# depends on.
+# ===================================================================
+
+
+def test_fit_avatar_cell_size_wide_image_fits_width():
+    # 200x100px -> cell aspect 200:(100/2) = 4.0, wider than the 24:10 = 2.4
+    # box aspect, so it's width-limited.
+    w, h = PersonasScreen._fit_avatar_cell_size(200, 100)
+    assert w == AVATAR_THUMB_COLS
+    assert 1 <= h < AVATAR_THUMB_LINES
+    assert isinstance(w, int) and isinstance(h, int)
+
+
+def test_fit_avatar_cell_size_tall_image_fits_height():
+    # 100x400px -> cell aspect 100:(400/2) = 0.5, narrower than the box
+    # aspect, so it's height-limited.
+    w, h = PersonasScreen._fit_avatar_cell_size(100, 400)
+    assert h == AVATAR_THUMB_LINES
+    assert 1 <= w < AVATAR_THUMB_COLS
+    assert isinstance(w, int) and isinstance(h, int)
+
+
+def test_fit_avatar_cell_size_square_image_stays_in_box():
+    w, h = PersonasScreen._fit_avatar_cell_size(512, 512)
+    assert 1 <= w <= AVATAR_THUMB_COLS
+    assert 1 <= h <= AVATAR_THUMB_LINES
+    # Aspect preserved: a square image is 2:1 in cell units (cells are
+    # ~2x taller than wide), so width should be roughly double height.
+    assert w == pytest.approx(2 * h, abs=1)
+
+
+def test_fit_avatar_cell_size_tiny_image_still_positive():
+    """A tiny (e.g. 4x4) source must still yield a renderable >=1x1 box."""
+    w, h = PersonasScreen._fit_avatar_cell_size(4, 4)
+    assert w >= 1 and h >= 1
+    assert w <= AVATAR_THUMB_COLS and h <= AVATAR_THUMB_LINES
+
+
+def test_fit_avatar_cell_size_degenerate_dimensions_fall_back_to_box():
+    w, h = PersonasScreen._fit_avatar_cell_size(0, 0)
+    assert (w, h) == (AVATAR_THUMB_COLS, AVATAR_THUMB_LINES)
+
+
+# ===================================================================
 # Screen-level: real PersonasScreen renders the thumbnail off-thread when
 # the editor opens for a character with an embedded image, and Remove
 # clears it + marks the session unsaved.
@@ -144,6 +205,49 @@ def stub_character_with_avatar(monkeypatch, seeded_character_with_avatar):
     patch_character_paging(monkeypatch)
 
 
+@pytest.fixture
+def wide_avatar_image_bytes():
+    """A realistic, non-square (2:1) avatar image - wider than tall."""
+    from io import BytesIO
+
+    buf = BytesIO()
+    Image.new("RGBA", (200, 100), color=(10, 120, 200, 255)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+@pytest.fixture
+def seeded_character_with_wide_avatar(avatar_db, wide_avatar_image_bytes):
+    """Same pattern as ``seeded_character_with_avatar``, but with a
+    realistic non-square source image so the fit-not-clip regression test
+    below can't pass by coincidence on a square image."""
+    char_id = avatar_db.add_character_card({"name": "WidePortrait"})
+    return {"char_id": char_id, "image": wide_avatar_image_bytes}
+
+
+@pytest.fixture
+def stub_character_with_wide_avatar(monkeypatch, seeded_character_with_wide_avatar):
+    char_id = seeded_character_with_wide_avatar["char_id"]
+    record = {
+        "id": char_id,
+        "name": "WidePortrait",
+        "description": "",
+        "first_message": "Hi.",
+        "version": 1,
+        "image": seeded_character_with_wide_avatar["image"],
+    }
+    monkeypatch.setattr(
+        character_handler_module, "fetch_all_characters", lambda: [dict(record)]
+    )
+    monkeypatch.setattr(
+        character_handler_module,
+        "fetch_character_by_id",
+        lambda character_id: (
+            dict(record) if str(character_id) == str(char_id) else None
+        ),
+    )
+    patch_character_paging(monkeypatch)
+
+
 async def _select_character(pilot, char_id):
     await pilot.pause()
     await pilot.click(f"#personas-library-row-character-{char_id}")
@@ -151,6 +255,17 @@ async def _select_character(pilot, char_id):
     await pilot.app.workers.wait_for_complete()
     await pilot.pause()
     return pilot.app.screen
+
+
+async def _open_editor_for(pilot, screen, char_id):
+    from tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages import (
+        EditCharacterRequested,
+    )
+
+    screen.post_message(EditCharacterRequested(str(char_id)))
+    await pilot.pause()
+    await pilot.app.workers.wait_for_complete()
+    await pilot.pause()
 
 
 class TestCharacterEditorAvatarThumbnailScreen:
@@ -190,3 +305,101 @@ class TestCharacterEditorAvatarThumbnailScreen:
             assert editor.current_avatar_bytes() is None
             assert len(editor.query("#personas-char-editor-avatar-thumb > *")) == 0
             assert screen.state.has_unsaved_changes is True
+
+
+# ===================================================================
+# Screen-level regression: pixels-mode thumbnail fits the avatar box
+# instead of clipping.
+#
+# ``ConsoleImageRenderCache.get_pixels`` thumbnails to the 80x40
+# chat-transcript box; reusing it for the avatar preview produced an
+# oversized Pixels grid that Rich does not reflow, so the small 24x10
+# thumb container just cropped it to a top-left sliver. These tests drive
+# the real screen render in forced pixels mode with a realistic,
+# non-square avatar and inspect the PIL image actually handed to
+# ``Pixels.from_image`` - proving it was rescaled to the avatar box (not
+# the transcript box) and kept its aspect ratio, rather than merely
+# asserting a widget got mounted (which the clipped version also did).
+# ===================================================================
+
+
+class TestCharacterEditorAvatarThumbnailFit:
+    async def test_wide_avatar_pixels_thumbnail_fits_box_not_clipped(
+        self,
+        monkeypatch,
+        mock_app_instance,
+        avatar_db,
+        seeded_character_with_wide_avatar,
+        stub_character_with_wide_avatar,
+    ):
+        mock_app_instance.chachanotes_db = avatar_db
+        mock_app_instance.chat_dictionary_scope_service = None
+        # Force pixels mode regardless of terminal auto-detection so this
+        # test is deterministic in CI.
+        mock_app_instance.app_config = {
+            "chat": {"images": {"default_render_mode": "pixels"}}
+        }
+        char_id = seeded_character_with_wide_avatar["char_id"]
+
+        captured: list[Image.Image] = []
+        original_from_image = rich_pixels.Pixels.from_image
+
+        def _spy_from_image(image, *args, **kwargs):
+            captured.append(image.copy())
+            return original_from_image(image, *args, **kwargs)
+
+        monkeypatch.setattr(rich_pixels.Pixels, "from_image", _spy_from_image)
+
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(200, 60)) as pilot:
+            screen = await _select_character(pilot, char_id)
+            await _open_editor_for(pilot, screen, char_id)
+
+            editor = screen.query_one(PersonasCharacterEditorWidget)
+            assert editor.current_avatar_bytes() is not None
+            assert len(editor.query("#personas-char-editor-avatar-thumb > *")) == 1
+
+        assert len(captured) == 1, (
+            "Pixels.from_image should be called exactly once building the "
+            "avatar thumbnail"
+        )
+        thumb = captured[0]
+        # Fits the avatar box, in half-block "pixel" units (COLS wide,
+        # LINES*2 tall) - NOT the 80x40 chat-transcript box that
+        # get_pixels() thumbnails to.
+        assert thumb.width <= AVATAR_THUMB_COLS
+        assert thumb.height <= AVATAR_THUMB_LINES * 2
+        # It actually used (not shrunk far below) the box's width - the old
+        # bug's symptom was a sliver, not merely "some image smaller than
+        # the transcript box".
+        assert thumb.width == AVATAR_THUMB_COLS
+        # Aspect preserved (not stretched/cropped to fill the box): the
+        # 200x100 source is 2:1.
+        source_aspect = 200 / 100
+        thumb_aspect = thumb.width / thumb.height
+        assert thumb_aspect == pytest.approx(source_aspect, rel=0.15)
+
+    async def test_tiny_avatar_still_produces_pixels_thumbnail(
+        self,
+        monkeypatch,
+        mock_app_instance,
+        avatar_db,
+        seeded_character_with_avatar,
+        stub_character_with_avatar,
+    ):
+        """A tiny (4x4) avatar must still render a mounted thumbnail."""
+        mock_app_instance.chachanotes_db = avatar_db
+        mock_app_instance.chat_dictionary_scope_service = None
+        mock_app_instance.app_config = {
+            "chat": {"images": {"default_render_mode": "pixels"}}
+        }
+        char_id = seeded_character_with_avatar["char_id"]
+
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(200, 60)) as pilot:
+            screen = await _select_character(pilot, char_id)
+            await _open_editor_for(pilot, screen, char_id)
+
+            editor = screen.query_one(PersonasCharacterEditorWidget)
+            assert editor.current_avatar_bytes() is not None
+            assert len(editor.query("#personas-char-editor-avatar-thumb > *")) == 1

--- a/Tests/UI/test_personas_character_editor_avatar.py
+++ b/Tests/UI/test_personas_character_editor_avatar.py
@@ -28,11 +28,13 @@ from tldw_chatbook.Widgets.Persona_Widgets.personas_character_editor_widget impo
 
 from Tests.UI.test_personas_dictionaries import PersonasTestApp, patch_character_paging
 
-# Not applied via module-level pytestmark: Tests/UI/pytest.ini sets
-# asyncio_mode = auto, which auto-detects `async def` tests without the
-# explicit marker, and this module also has plain sync unit tests (the
-# _fit_avatar_cell_size coverage below) that pytest-asyncio warns about if
-# the marker is applied to them.
+# The async tests below carry an explicit per-function `@pytest.mark.asyncio`
+# decorator rather than a module-level `pytestmark`: this module also has
+# plain sync unit tests (the `_fit_avatar_cell_size` coverage) that
+# pytest-asyncio warns about under a module-level marker, and the explicit
+# per-test decorator keeps the async tests collectable even when the run's
+# rootdir isn't Tests/UI (so Tests/UI/pytest.ini's `asyncio_mode = auto`
+# doesn't apply) — e.g. a run mixing Tests/UI and Tests/Character_Chat.
 
 
 # ===================================================================
@@ -53,6 +55,7 @@ class _Host(App):
         self.removed += 1
 
 
+@pytest.mark.asyncio
 async def test_thumbnail_mounts_and_text_fallback():
     app = _Host()
     async with app.run_test() as pilot:
@@ -70,6 +73,7 @@ async def test_thumbnail_mounts_and_text_fallback():
         assert len(ed.query("#personas-char-editor-avatar-thumb > *")) == 1
 
 
+@pytest.mark.asyncio
 async def test_current_avatar_bytes_and_remove():
     app = _Host()
     async with app.run_test() as pilot:
@@ -86,6 +90,7 @@ async def test_current_avatar_bytes_and_remove():
         assert app.removed == 1
 
 
+@pytest.mark.asyncio
 async def test_current_avatar_bytes_none_without_image():
     app = _Host()
     async with app.run_test() as pilot:
@@ -269,6 +274,7 @@ async def _open_editor_for(pilot, screen, char_id):
 
 
 class TestCharacterEditorAvatarThumbnailScreen:
+    @pytest.mark.asyncio
     async def test_editor_with_image_renders_thumbnail(
         self,
         mock_app_instance,
@@ -324,6 +330,7 @@ class TestCharacterEditorAvatarThumbnailScreen:
 
 
 class TestCharacterEditorAvatarThumbnailFit:
+    @pytest.mark.asyncio
     async def test_wide_avatar_pixels_thumbnail_fits_box_not_clipped(
         self,
         monkeypatch,
@@ -379,6 +386,7 @@ class TestCharacterEditorAvatarThumbnailFit:
         thumb_aspect = thumb.width / thumb.height
         assert thumb_aspect == pytest.approx(source_aspect, rel=0.15)
 
+    @pytest.mark.asyncio
     async def test_tiny_avatar_still_produces_pixels_thumbnail(
         self,
         monkeypatch,

--- a/Tests/UI/test_personas_character_editor_avatar.py
+++ b/Tests/UI/test_personas_character_editor_avatar.py
@@ -314,6 +314,63 @@ class TestCharacterEditorAvatarThumbnailScreen:
 
 
 # ===================================================================
+# Screen-level regression (P3b PR fix - Qodo #3): Remove must not be
+# visually undone by a stale in-flight render.
+#
+# ``_render_character_editor_avatar`` drops its result when its captured
+# ``token`` no longer matches ``_character_editor_generation``. Remove used
+# to leave the generation untouched, so an earlier in-flight render (queued
+# before Remove was clicked, same token) could complete AFTER Remove and
+# re-mount the old avatar bytes. The fix bumps the generation in
+# ``_handle_character_image_remove`` before dispatching its own render, so
+# any prior-token render in flight is dropped instead of winning the race.
+#
+# The exact interleaving (an in-flight decode finishing after Remove) is not
+# reliably forceable in a unit test without invasively faking the asyncio
+# scheduler, so this instead asserts the mechanism the fix relies on: the
+# generation token strictly increases across Remove, which is sufficient to
+# guarantee any earlier-token render is dropped by the guard in
+# ``_render_character_editor_avatar`` regardless of completion order.
+# ===================================================================
+
+
+class TestCharacterEditorAvatarRemoveGenerationBump:
+    @pytest.mark.asyncio
+    async def test_remove_bumps_generation_past_open_time_token(
+        self,
+        mock_app_instance,
+        avatar_db,
+        seeded_character_with_avatar,
+        stub_character_with_avatar,
+    ):
+        mock_app_instance.chachanotes_db = avatar_db
+        mock_app_instance.chat_dictionary_scope_service = None
+        char_id = seeded_character_with_avatar["char_id"]
+
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(200, 60)) as pilot:
+            screen = await _select_character(pilot, char_id)
+            await _open_editor_for(pilot, screen, char_id)
+
+            generation_at_open = screen._character_editor_generation
+
+            editor = screen.query_one(PersonasCharacterEditorWidget)
+            editor.query_one("#personas-char-editor-avatar-remove", Button).press()
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            # The generation strictly advanced past the open-time token, so
+            # a render still carrying that older token (queued before Remove
+            # was clicked) is dropped by _render_character_editor_avatar's
+            # token check even if it completes after Remove's own render.
+            assert screen._character_editor_generation > generation_at_open
+            # And Remove's own effect actually landed: no stale re-mount.
+            assert editor.current_avatar_bytes() is None
+            assert len(editor.query("#personas-char-editor-avatar-thumb > *")) == 0
+
+
+# ===================================================================
 # Screen-level regression: pixels-mode thumbnail fits the avatar box
 # instead of clipping.
 #

--- a/Tests/UI/test_personas_character_editor_greetings.py
+++ b/Tests/UI/test_personas_character_editor_greetings.py
@@ -1,0 +1,155 @@
+"""Roleplay P3b Task 3: alternate-greetings list editor (character editor).
+
+Replaces the single newline-joined alt-greetings ``TextArea`` with a real
+list editor (``DataTable`` + edit area + Add/Update/Delete/Move buttons),
+mirroring ``personas_lore_detail.py``'s entry editor. Each greeting is a
+discrete ``str`` mutated in place - never blob-joined/split - so a greeting
+containing embedded newlines round-trips byte-identical. This is the
+anchor guarantee the old TextArea-splitting approach could not make.
+"""
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Button, DataTable, TextArea
+
+from tldw_chatbook.Widgets.Persona_Widgets.personas_character_editor_widget import (
+    PersonasCharacterEditorWidget,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+class _Host(App):
+    def compose(self) -> ComposeResult:
+        yield PersonasCharacterEditorWidget()
+
+
+async def test_greetings_load_add_delete_reorder_and_multiline_fidelity():
+    app = _Host()
+    async with app.run_test() as pilot:
+        ed = app.query_one(PersonasCharacterEditorWidget)
+        multi = "Hello there.\n\nA second paragraph."  # a greeting WITH newlines
+        ed.load_character({"name": "A", "alternate_greetings": [multi, "Hi!"]})
+        await pilot.pause()
+        # unedited round-trip is byte-identical (the fidelity guarantee)
+        assert ed.get_character_data()["alternate_greetings"] == [multi, "Hi!"]
+        # add
+        ed._greetings_add("Third")
+        assert ed.get_character_data()["alternate_greetings"] == [multi, "Hi!", "Third"]
+        # update index 1
+        ed._greetings_update(1, "Hi again!")
+        assert ed.get_character_data()["alternate_greetings"][1] == "Hi again!"
+        # move index 2 up
+        ed._greetings_move(2, -1)
+        assert ed.get_character_data()["alternate_greetings"] == [
+            multi,
+            "Third",
+            "Hi again!",
+        ]
+        # delete index 0 (the multi-line one)
+        ed._greetings_delete(0)
+        assert ed.get_character_data()["alternate_greetings"] == ["Third", "Hi again!"]
+
+
+async def test_greetings_table_renders_a_row_per_greeting():
+    app = _Host()
+    async with app.run_test() as pilot:
+        ed = app.query_one(PersonasCharacterEditorWidget)
+        ed.load_character({"name": "A", "alternate_greetings": ["One", "Two"]})
+        await pilot.pause()
+        table = ed.query_one("#personas-char-editor-greetings-table", DataTable)
+        assert table.row_count == 2
+
+
+async def test_greetings_edit_textarea_does_not_mark_dirty_on_selection():
+    """Selecting a row loads it into the scratch edit TextArea - that alone
+    must not flip the editor dirty (it isn't a persisted field by itself)."""
+    dirty_events = []
+
+    class CaptureApp(App):
+        def compose(self) -> ComposeResult:
+            yield PersonasCharacterEditorWidget()
+
+        def on_editor_content_changed(self, message) -> None:
+            dirty_events.append(message)
+
+    app = CaptureApp()
+    async with app.run_test() as pilot:
+        ed = app.query_one(PersonasCharacterEditorWidget)
+        ed.load_character({"name": "A", "alternate_greetings": ["One", "Two"]})
+        await pilot.pause()
+        edit_area = ed.query_one("#personas-char-editor-greeting-edit", TextArea)
+        edit_area.text = "Programmatically loaded"
+        await pilot.pause()
+        assert dirty_events == []
+
+
+async def test_greetings_buttons_and_row_highlighted_selection_via_pilot_click():
+    app = _Host()
+    async with app.run_test(size=(120, 60)) as pilot:
+        ed = app.query_one(PersonasCharacterEditorWidget)
+        ed.load_character({"name": "A", "alternate_greetings": ["First", "Second"]})
+        await pilot.pause()
+        # The greetings editor lives in the Advanced section, which loads
+        # collapsed (display: none) - open it so pilot.click can hit it.
+        await pilot.click("#personas-char-editor-advanced-toggle")
+        await pilot.pause()
+
+        table = ed.query_one("#personas-char-editor-greetings-table", DataTable)
+        # Arrow-key navigation only fires RowHighlighted (not RowSelected) -
+        # move the cursor to row 1 ("Second") and confirm selection tracking.
+        table.focus()
+        await pilot.pause()
+        table.move_cursor(row=1)
+        await pilot.pause()
+        assert ed._selected_greeting_index == 1
+        edit_area = ed.query_one("#personas-char-editor-greeting-edit", TextArea)
+        assert edit_area.text == "Second"
+
+        # Update the selected greeting via the Update button.
+        edit_area.text = "Second, edited"
+        await pilot.click("#personas-char-editor-greeting-update")
+        await pilot.pause()
+        assert ed.get_character_data()["alternate_greetings"][1] == "Second, edited"
+
+        # Add a new greeting via the Add button (uses the edit TextArea text).
+        edit_area.text = "Third"
+        await pilot.click("#personas-char-editor-greeting-add")
+        await pilot.pause()
+        assert ed.get_character_data()["alternate_greetings"] == [
+            "First",
+            "Second, edited",
+            "Third",
+        ]
+
+        # Move the newly-selected ("Third", index 2) row up.
+        assert ed._selected_greeting_index == 2
+        await pilot.click("#personas-char-editor-greeting-move-up")
+        await pilot.pause()
+        assert ed.get_character_data()["alternate_greetings"] == [
+            "First",
+            "Third",
+            "Second, edited",
+        ]
+
+        # Delete the currently-selected ("Third", now index 1) row.
+        assert ed._selected_greeting_index == 1
+        await pilot.click("#personas-char-editor-greeting-delete")
+        await pilot.pause()
+        assert ed.get_character_data()["alternate_greetings"] == [
+            "First",
+            "Second, edited",
+        ]
+
+
+async def test_new_character_clears_greetings():
+    app = _Host()
+    async with app.run_test() as pilot:
+        ed = app.query_one(PersonasCharacterEditorWidget)
+        ed.load_character({"name": "A", "alternate_greetings": ["One"]})
+        await pilot.pause()
+        ed.new_character()
+        await pilot.pause()
+        assert ed.get_character_data()["alternate_greetings"] == []
+        table = ed.query_one("#personas-char-editor-greetings-table", DataTable)
+        assert table.row_count == 0

--- a/Tests/UI/test_personas_character_editor_greetings.py
+++ b/Tests/UI/test_personas_character_editor_greetings.py
@@ -142,6 +142,108 @@ async def test_greetings_buttons_and_row_highlighted_selection_via_pilot_click()
         ]
 
 
+async def test_greetings_update_keeps_selection_and_edit_box_in_sync():
+    """Regression: Task 3's cursor-race fix (``_select_greeting_row`` after a
+    mutation's re-render) was applied to Add/Move but NOT to Update. Without
+    it, the async ``RowHighlighted(row=0)`` queued by ``_render_greetings_table``
+    (via ``clear()``/``add_row()``) lands one tick later and silently reverts
+    both ``_selected_greeting_index`` and the scratch edit box to row 0 - so a
+    follow-up Update would commit to the wrong greeting."""
+    app = _Host()
+    async with app.run_test(size=(120, 60)) as pilot:
+        ed = app.query_one(PersonasCharacterEditorWidget)
+        ed.load_character(
+            {"name": "A", "alternate_greetings": ["First", "Second", "Third"]}
+        )
+        await pilot.pause()
+        # The greetings editor lives in the Advanced section, which loads
+        # collapsed (display: none) - open it so pilot.click can hit it.
+        await pilot.click("#personas-char-editor-advanced-toggle")
+        await pilot.pause()
+
+        table = ed.query_one("#personas-char-editor-greetings-table", DataTable)
+        table.focus()
+        await pilot.pause()
+        table.move_cursor(row=1)
+        await pilot.pause()
+        assert ed._selected_greeting_index == 1
+
+        edit_area = ed.query_one("#personas-char-editor-greeting-edit", TextArea)
+        edit_area.text = "Second, edited"
+        await pilot.click("#personas-char-editor-greeting-update")
+        # Let the async RowHighlighted(row=0) queued by the re-render drain -
+        # this is exactly the tick where the pre-fix code reverted to row 0.
+        await pilot.pause()
+
+        assert ed._selected_greeting_index == 1
+        assert edit_area.text == "Second, edited"
+        assert ed.get_character_data()["alternate_greetings"] == [
+            "First",
+            "Second, edited",
+            "Third",
+        ]
+
+
+async def test_greetings_delete_selects_surviving_neighbor():
+    """Regression: same cursor-race gap as Update, but for Delete. Deleting
+    the selected row must leave the surviving neighbor at that position
+    selected (and loaded into the edit box), not silently revert to row 0
+    once the async RowHighlighted(row=0) from the re-render drains."""
+    app = _Host()
+    async with app.run_test(size=(120, 60)) as pilot:
+        ed = app.query_one(PersonasCharacterEditorWidget)
+        ed.load_character(
+            {"name": "A", "alternate_greetings": ["First", "Second", "Third"]}
+        )
+        await pilot.pause()
+        await pilot.click("#personas-char-editor-advanced-toggle")
+        await pilot.pause()
+
+        table = ed.query_one("#personas-char-editor-greetings-table", DataTable)
+        table.focus()
+        await pilot.pause()
+        table.move_cursor(row=1)
+        await pilot.pause()
+        assert ed._selected_greeting_index == 1
+
+        await pilot.click("#personas-char-editor-greeting-delete")
+        await pilot.pause()  # let the async RowHighlighted(row=0) drain
+
+        assert ed.get_character_data()["alternate_greetings"] == ["First", "Third"]
+        # min(1, len-1) == 1: "Third" is now the surviving neighbor at index 1.
+        assert ed._selected_greeting_index == 1
+        edit_area = ed.query_one("#personas-char-editor-greeting-edit", TextArea)
+        assert edit_area.text == "Third"
+
+
+async def test_greetings_delete_last_remaining_clears_selection_and_edit_box():
+    """Deleting the only remaining greeting must land on the documented empty
+    state (no selection, empty edit box) - there is no row left for an async
+    RowHighlighted to fire against, so this must be set directly."""
+    app = _Host()
+    async with app.run_test(size=(120, 60)) as pilot:
+        ed = app.query_one(PersonasCharacterEditorWidget)
+        ed.load_character({"name": "A", "alternate_greetings": ["Only"]})
+        await pilot.pause()
+        await pilot.click("#personas-char-editor-advanced-toggle")
+        await pilot.pause()
+
+        table = ed.query_one("#personas-char-editor-greetings-table", DataTable)
+        table.focus()
+        await pilot.pause()
+        table.move_cursor(row=0)
+        await pilot.pause()
+        assert ed._selected_greeting_index == 0
+
+        await pilot.click("#personas-char-editor-greeting-delete")
+        await pilot.pause()
+
+        assert ed.get_character_data()["alternate_greetings"] == []
+        assert ed._selected_greeting_index is None
+        edit_area = ed.query_one("#personas-char-editor-greeting-edit", TextArea)
+        assert edit_area.text == ""
+
+
 async def test_new_character_clears_greetings():
     app = _Host()
     async with app.run_test() as pilot:

--- a/Tests/UI/test_personas_character_editor_validation.py
+++ b/Tests/UI/test_personas_character_editor_validation.py
@@ -1,0 +1,164 @@
+"""Roleplay P3b Task 4: live per-field validation (character editor).
+
+``validate()`` returns ``(field_id, message, level)`` tuples (``level`` in
+``{"error", "warning"}``). ``_run_validation()`` runs debounced off
+``_field_changed`` (cancelling the prior timer) and authoritatively at Save,
+toggling ``.is-invalid`` on each offending error-level field's enclosing row
+and rendering the aggregated messages into the existing footer ``Static``.
+Warnings never block Save nor mark a row invalid - only errors do.
+
+Mirrors ``Tests/UI/test_personas_character_editor_avatar.py``'s bare-
+``PersonasCharacterEditorWidget`` host harness and
+``Tests/UI/test_personas_workbench.py``'s debounce-settle convention
+(``pilot.pause(DEBOUNCE + margin)``).
+"""
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Button, Input, Static
+
+from tldw_chatbook.UI.Screens.personas_screen import PERSONAS_AVATAR_MAX_BYTES
+from tldw_chatbook.Widgets.Persona_Widgets.personas_character_editor_widget import (
+    PersonasCharacterEditorWidget,
+)
+from tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages import (
+    CharacterSaveRequested,
+)
+
+pytestmark = pytest.mark.asyncio
+
+_DEBOUNCE = PersonasCharacterEditorWidget._VALIDATION_DEBOUNCE_SECONDS
+
+
+class _Host(App):
+    def __init__(self):
+        super().__init__()
+        self.saves = []
+
+    def compose(self) -> ComposeResult:
+        yield PersonasCharacterEditorWidget()
+
+    def on_character_save_requested(self, message: CharacterSaveRequested) -> None:
+        self.saves.append(message.character_data)
+
+
+async def _settle(pilot):
+    """Wait past the validation debounce interval."""
+    await pilot.pause(_DEBOUNCE + 0.05)
+
+
+async def test_blank_name_marks_field_and_blocks_save():
+    app = _Host()
+    async with app.run_test() as pilot:
+        ed = app.query_one(PersonasCharacterEditorWidget)
+        ed.load_character({"name": "A"})
+        await pilot.pause()
+
+        ed.query_one("#personas-char-editor-name", Input).value = ""
+        await pilot.pause()  # not yet - proves this is debounced, not synchronous
+        row = ed.query_one("#personas-char-editor-name").parent
+        assert not row.has_class("is-invalid")
+
+        await _settle(pilot)
+        assert row.has_class("is-invalid")
+
+        # Save is blocked: no CharacterSaveRequested posted.
+        await pilot.click("#personas-char-editor-save")
+        await pilot.pause()
+        assert app.saves == []
+
+        # Fix it -> class clears live, and Save now posts.
+        ed.query_one("#personas-char-editor-name", Input).value = "A"
+        await _settle(pilot)
+        assert not row.has_class("is-invalid")
+
+        await pilot.click("#personas-char-editor-save")
+        await pilot.pause()
+        assert len(app.saves) == 1
+        assert app.saves[0]["name"] == "A"
+
+
+async def test_validate_returns_error_tuple_for_blank_name():
+    app = _Host()
+    async with app.run_test() as pilot:
+        ed = app.query_one(PersonasCharacterEditorWidget)
+        ed.load_character({"name": ""})
+        await pilot.pause()
+        findings = ed.validate()
+        assert ("personas-char-editor-name", "required", "error") in findings
+
+
+async def test_oversized_avatar_marks_field_and_blocks_save():
+    app = _Host()
+    async with app.run_test() as pilot:
+        ed = app.query_one(PersonasCharacterEditorWidget)
+        ed.load_character({"name": "A"})
+        await pilot.pause()
+
+        ed.set_avatar_image(b"x" * (PERSONAS_AVATAR_MAX_BYTES + 1))
+        await _settle(pilot)
+
+        findings = ed.validate()
+        assert any(
+            fid == "personas-char-editor-avatar-status" and level == "error"
+            for fid, _msg, level in findings
+        )
+        row = ed.query_one("#personas-char-editor-avatar-status").parent
+        assert row.has_class("is-invalid")
+
+        await pilot.click("#personas-char-editor-save")
+        await pilot.pause()
+        assert app.saves == []
+
+
+async def test_avatar_within_limit_does_not_mark_field():
+    app = _Host()
+    async with app.run_test() as pilot:
+        ed = app.query_one(PersonasCharacterEditorWidget)
+        ed.load_character({"name": "A"})
+        await pilot.pause()
+
+        ed.set_avatar_image(b"x" * 16)
+        await _settle(pilot)
+
+        row = ed.query_one("#personas-char-editor-avatar-status").parent
+        assert not row.has_class("is-invalid")
+
+        await pilot.click("#personas-char-editor-save")
+        await pilot.pause()
+        assert len(app.saves) == 1
+
+
+async def test_whitespace_greeting_is_warning_and_does_not_block_save():
+    app = _Host()
+    async with app.run_test() as pilot:
+        ed = app.query_one(PersonasCharacterEditorWidget)
+        ed.load_character({"name": "A"})
+        await pilot.pause()
+
+        ed._greetings_add("   ")
+        await pilot.pause()
+
+        findings = ed.validate()
+        assert (
+            "personas-char-editor-greetings-table",
+            "greeting 1 is blank",
+            "warning",
+        ) in findings
+        assert not any(level == "error" for _fid, _msg, level in findings)
+
+        await pilot.click("#personas-char-editor-save")
+        await pilot.pause()
+        assert len(app.saves) == 1
+
+        validation = ed.query_one("#personas-char-editor-validation", Static)
+        assert "greeting 1 is blank" in str(validation.renderable)
+
+
+async def test_validated_field_ids_covers_name_and_avatar():
+    app = _Host()
+    async with app.run_test() as pilot:
+        ed = app.query_one(PersonasCharacterEditorWidget)
+        ids = ed._validated_field_ids()
+        assert "personas-char-editor-name" in ids
+        assert "personas-char-editor-avatar-status" in ids

--- a/Tests/UI/test_personas_character_editor_validation.py
+++ b/Tests/UI/test_personas_character_editor_validation.py
@@ -203,6 +203,33 @@ async def test_blank_new_form_does_not_mark_name_invalid_before_interaction():
         assert "personas-char-editor-name: required" in str(validation.renderable)
 
 
+async def test_reopen_clears_stale_invalid_mark_from_prior_session():
+    """Review fix (Roleplay P3b): a stale ``.is-invalid`` mark left by a
+    prior editing session must not survive reopening the editor onto a new
+    record. The row must clear SYNCHRONOUSLY inside ``load_character`` ->
+    ``_populate_form`` - not rely on the async ``Input.Changed`` event that
+    setting a new value posts (which only arms a fresh debounce timer and
+    would not fire before this assertion, and would not fire at all if the
+    reopened record's value happened to match what was already displayed)."""
+    app = _Host()
+    async with app.run_test() as pilot:
+        ed = app.query_one(PersonasCharacterEditorWidget)
+        ed.load_character({"name": "A"})
+        await pilot.pause()
+
+        ed.query_one("#personas-char-editor-name", Input).value = ""
+        await _settle(pilot)
+        row = ed.query_one("#personas-char-editor-name").parent
+        assert row.has_class("is-invalid")
+
+        ed.load_character({"name": "B"})
+        # Only a bare pause (message-loop churn), never the full debounce
+        # settle - proves the clear is not coming from the async self-heal
+        # path.
+        await pilot.pause()
+        assert not row.has_class("is-invalid")
+
+
 async def test_greeting_add_blank_warns_immediately_without_save():
     """Fix A (review wave): _greetings_add validates directly (no debounce,
     no Save needed) - the warning appears in the footer right after the Add

--- a/Tests/UI/test_personas_character_editor_validation.py
+++ b/Tests/UI/test_personas_character_editor_validation.py
@@ -89,21 +89,33 @@ async def test_validate_returns_error_tuple_for_blank_name():
 
 
 async def test_oversized_avatar_marks_field_and_blocks_save():
+    """Fix A (review wave): set_avatar_image must trigger validation itself,
+    directly and synchronously - not rely on a leftover debounce timer from
+    the preceding load_character call. Proven by fully settling the
+    load-triggered debounce FIRST (so no timer is left pending), then
+    asserting the row is marked invalid after a single pilot.pause() with NO
+    further debounce wait following set_avatar_image."""
     app = _Host()
     async with app.run_test() as pilot:
         ed = app.query_one(PersonasCharacterEditorWidget)
         ed.load_character({"name": "A"})
         await pilot.pause()
+        await _settle(pilot)  # drain any load-triggered debounce fully
+
+        row = ed.query_one("#personas-char-editor-avatar-status").parent
+        assert not row.has_class("is-invalid")
 
         ed.set_avatar_image(b"x" * (PERSONAS_AVATAR_MAX_BYTES + 1))
-        await _settle(pilot)
+        # No settle here: set_avatar_image is a discrete user action that
+        # validates directly (no debounce) - a single pause lets the
+        # class-toggle + footer render land.
+        await pilot.pause()
 
         findings = ed.validate()
         assert any(
             fid == "personas-char-editor-avatar-status" and level == "error"
             for fid, _msg, level in findings
         )
-        row = ed.query_one("#personas-char-editor-avatar-status").parent
         assert row.has_class("is-invalid")
 
         await pilot.click("#personas-char-editor-save")
@@ -162,3 +174,57 @@ async def test_validated_field_ids_covers_name_and_avatar():
         ids = ed._validated_field_ids()
         assert "personas-char-editor-name" in ids
         assert "personas-char-editor-avatar-status" in ids
+
+
+async def test_blank_new_form_does_not_mark_name_invalid_before_interaction():
+    """Fix B (review wave): a freshly-opened blank form must not display
+    validation errors before the user has touched anything, even after the
+    debounce interval elapses (the async Changed events fired by
+    new_character's programmatic population must not surface an error)."""
+    app = _Host()
+    async with app.run_test() as pilot:
+        ed = app.query_one(PersonasCharacterEditorWidget)
+        ed.new_character()
+        await pilot.pause()
+        await _settle(pilot)  # let any load-triggered debounce fire
+
+        row = ed.query_one("#personas-char-editor-name").parent
+        assert not row.has_class("is-invalid")
+        validation = ed.query_one("#personas-char-editor-validation", Static)
+        assert str(validation.renderable) == ""
+
+        # Now a genuine interaction: type then clear -> touched, now invalid.
+        name_input = ed.query_one("#personas-char-editor-name", Input)
+        name_input.value = "X"
+        await pilot.pause()
+        name_input.value = ""
+        await _settle(pilot)
+        assert row.has_class("is-invalid")
+        assert "personas-char-editor-name: required" in str(validation.renderable)
+
+
+async def test_greeting_add_blank_warns_immediately_without_save():
+    """Fix A (review wave): _greetings_add validates directly (no debounce,
+    no Save needed) - the warning appears in the footer right after the Add
+    action, proving the mutator triggers validation itself."""
+    app = _Host()
+    async with app.run_test() as pilot:
+        ed = app.query_one(PersonasCharacterEditorWidget)
+        ed.load_character({"name": "A"})
+        await pilot.pause()
+        await _settle(pilot)  # drain any load-triggered debounce fully
+
+        ed._greetings_add("   ")
+        # No debounce wait: the mutator must validate synchronously.
+        await pilot.pause()
+
+        validation = ed.query_one("#personas-char-editor-validation", Static)
+        assert "greeting 1 is blank" in str(validation.renderable)
+
+        findings = ed.validate()
+        assert not any(level == "error" for _fid, _msg, level in findings)
+
+        # Warning never blocks Save.
+        await pilot.click("#personas-char-editor-save")
+        await pilot.pause()
+        assert len(app.saves) == 1

--- a/Tests/UI/test_personas_character_widgets.py
+++ b/Tests/UI/test_personas_character_widgets.py
@@ -279,8 +279,11 @@ class TestCharacterEditor:
             collected = editor.get_character_data()
             assert collected["alternate_greetings"] == ["para1\n\npara2"]
 
-    async def test_edited_greetings_are_reparsed_per_line(self):
-        """Once the TextArea is edited, greetings re-parse one per line."""
+    async def test_greeting_update_keeps_embedded_newlines_as_one_entry(self):
+        """Updating a single greeting (via the list editor's mutation API,
+        Roleplay P3b Task 3) never re-splits it by line - each greeting is a
+        discrete list entry, not a line-delimited blob, so embedded blank
+        lines within one greeting survive an explicit edit intact."""
         app = WidgetApp()
         async with app.run_test() as pilot:
             editor = pilot.app.query_one(PersonasCharacterEditorWidget)
@@ -288,11 +291,9 @@ class TestCharacterEditor:
             data["alternate_greetings"] = ["para1\n\npara2"]
             editor.load_character(data)
             await pilot.pause()
-            pilot.app.query_one(
-                "#personas-char-editor-alt-greetings", TextArea
-            ).text = "first\n\nsecond"
+            editor._greetings_update(0, "first\n\nsecond")
             collected = editor.get_character_data()
-            assert collected["alternate_greetings"] == ["first", "second"]
+            assert collected["alternate_greetings"] == ["first\n\nsecond"]
 
     async def test_empty_version_defaults_to_1_0(self):
         """Empty/whitespace Version collects as the new-character default."""

--- a/Tests/UI/test_personas_editor_save_in_place.py
+++ b/Tests/UI/test_personas_editor_save_in_place.py
@@ -1,0 +1,183 @@
+"""Roleplay P3b Task 1: save-in-place + dirty re-arm.
+
+After Save, both editors now stay open (instead of flipping to the read-only
+card) with dirty-tracking re-armed against the just-persisted record. Two
+layers of coverage:
+
+- Widget-level: ``mark_saved`` re-baselines the dirty snapshot from the
+  CURRENT form (already showing the saved values) without repopulating it,
+  and adopts the saved record's ``version`` for the next round trip.
+- Screen-level: the character finisher (``_after_character_save``) re-reads
+  the just-persisted record over a REAL ``CharactersRAGDB`` before deciding
+  whether to stay in the editor, so the test proves the optimistic-lock
+  ``version`` genuinely comes from the DB, not a stub.
+
+Mirrors ``Tests/UI/test_personas_character_widgets.py`` /
+``test_persona_profile_widgets.py`` for the bare-widget harness, and
+``Tests/UI/test_personas_character_world_books_screen.py`` /
+``test_personas_dictionaries.py`` for the real-DB screen harness
+(``PersonasTestApp`` + routing ``ccp_character_handler._default_character_db``
+at a real db - the same seam ``create_character``/``update_character``/
+``fetch_character_by_id``/the library-paging loader all read from).
+"""
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Input
+
+import tldw_chatbook.UI.CCP_Modules.ccp_character_handler as character_handler_module
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.Widgets.Persona_Widgets.personas_character_editor_widget import (
+    PersonasCharacterEditorWidget,
+)
+from tldw_chatbook.Widgets.Persona_Widgets.persona_profile_editor_widget import (
+    PersonaProfileEditorWidget,
+)
+from tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages import (
+    EditorContentChanged,
+)
+
+from Tests.UI.test_personas_dictionaries import PersonasTestApp
+
+pytestmark = pytest.mark.asyncio
+
+
+# ===================================================================
+# Widget-level: mark_saved re-arms dirty tracking without repopulating.
+# ===================================================================
+
+
+class _CharHost(App):
+    def __init__(self):
+        super().__init__()
+        self.dirty = 0
+
+    def compose(self) -> ComposeResult:
+        yield PersonasCharacterEditorWidget()
+
+    def on_editor_content_changed(self, message: EditorContentChanged) -> None:
+        self.dirty += 1
+
+
+class _PersonaHost(App):
+    def __init__(self):
+        super().__init__()
+        self.dirty = 0
+
+    def compose(self) -> ComposeResult:
+        yield PersonaProfileEditorWidget()
+
+    def on_editor_content_changed(self, message: EditorContentChanged) -> None:
+        self.dirty += 1
+
+
+async def test_character_mark_saved_rearms_dirty():
+    app = _CharHost()
+    async with app.run_test() as pilot:
+        ed = app.query_one(PersonasCharacterEditorWidget)
+        ed.load_character({"id": 5, "name": "A", "version": 1})
+        await pilot.pause()
+        ed.query_one("#personas-char-editor-name", Input).value = "A2"  # first edit
+        await pilot.pause()
+        assert app.dirty == 1
+
+        # Simulate a save landing: new version, re-arm. mark_saved must NOT
+        # repopulate the form - the user's saved edit ("A2") stays on screen.
+        ed.mark_saved({"id": 5, "name": "A2", "version": 2})
+        await pilot.pause()
+        assert ed._dirty_posted is False
+        assert ed.query_one("#personas-char-editor-name", Input).value == "A2"
+
+        ed.query_one("#personas-char-editor-name", Input).value = "A3"  # second edit
+        await pilot.pause()
+        assert app.dirty == 2  # re-armed -> re-posted
+        assert ed.get_character_data()["version"] == 2  # new optimistic-lock version
+
+
+async def test_persona_mark_saved_rearms_dirty():
+    app = _PersonaHost()
+    async with app.run_test() as pilot:
+        ed = app.query_one(PersonaProfileEditorWidget)
+        ed.load_persona({"id": "p1", "name": "B", "version": 1})
+        await pilot.pause()
+        ed.query_one("#personas-editor-name", Input).value = "B2"  # first edit
+        await pilot.pause()
+        assert app.dirty == 1
+
+        ed.mark_saved({"id": "p1", "name": "B", "version": 2})
+        await pilot.pause()
+        assert ed._dirty_posted is False
+        assert ed.query_one("#personas-editor-name", Input).value == "B2"
+
+        ed.query_one("#personas-editor-name", Input).value = "B3"  # second edit
+        await pilot.pause()
+        assert app.dirty == 2  # re-armed -> re-posted
+        assert ed.collect()["version"] == 2  # new optimistic-lock version
+
+
+# ===================================================================
+# Screen-level: character Save stays in the editor, carrying the fresh
+# optimistic-lock version from a REAL CharactersRAGDB.
+# ===================================================================
+
+
+@pytest.fixture
+def real_char_db(tmp_path):
+    db = CharactersRAGDB(tmp_path / "personas_save_in_place.db", "test-client")
+    yield db
+    db.close_connection()
+
+
+@pytest.fixture
+def route_character_db(monkeypatch, real_char_db):
+    """Route character CRUD + library paging (all read via
+    ``ccp_character_handler._default_character_db``) at a real DB, so a
+    round-tripped Save carries the DB's genuine incremented ``version``."""
+    monkeypatch.setattr(
+        character_handler_module, "_default_character_db", lambda: real_char_db
+    )
+    return real_char_db
+
+
+async def _mounted(pilot):
+    await pilot.pause()
+    return pilot.app.screen
+
+
+class TestCharacterSaveInPlace:
+    async def test_create_save_stays_in_editor_and_rearms_dirty(
+        self, mock_app_instance, route_character_db
+    ):
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await _mounted(pilot)
+            await pilot.press("ctrl+n")
+            await pilot.pause()
+            assert screen._edit_mode == "create"
+
+            screen.query_one("#personas-char-editor-name", Input).value = "New Hero"
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            # (a) the editor center is still displayed - NOT the card.
+            assert screen.query_one("#ccp-character-editor-view").display is True
+            assert screen.query_one("#ccp-character-card-view").display is False
+            # (b) the just-completed save clears the unsaved flag.
+            assert screen.state.has_unsaved_changes is False
+            # (c) create -> edit (a real row now backs the open session).
+            assert screen._edit_mode == "edit"
+            # The persisted row carries a real, DB-assigned optimistic-lock
+            # version (proves the round trip hit the real db, not a stub).
+            saved_id = screen.state.selected_entity_id
+            assert saved_id is not None
+            record = route_character_db.get_character_card_by_id(int(saved_id))
+            assert record is not None
+            assert record["version"] == 1
+
+            # (d) a further field edit re-flags has_unsaved_changes.
+            screen.query_one("#personas-char-editor-name", Input).value = "New Hero 2"
+            await pilot.pause()
+            assert screen.state.has_unsaved_changes is True

--- a/Tests/UI/test_personas_editor_save_in_place.py
+++ b/Tests/UI/test_personas_editor_save_in_place.py
@@ -188,6 +188,68 @@ class TestCharacterSaveInPlace:
             await pilot.pause()
             assert screen.state.has_unsaved_changes is True
 
+    async def test_twice_save_preserves_greeting_and_bumps_version(
+        self, mock_app_instance, route_character_db
+    ):
+        """Edit greeting -> Save -> edit again -> Save, both in the SAME
+        open editor session (save-in-place). Regression coverage for the
+        ``_character_save_inflight`` re-entrant-save guard added alongside
+        this test: a flag left stuck ``True`` after the first save would
+        silently swallow the second Save, so this proves both round trips
+        actually land (distinct greeting text + an advancing optimistic-lock
+        ``version``), not just the first."""
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await _mounted(pilot)
+            await pilot.press("ctrl+n")
+            await pilot.pause()
+            assert screen._edit_mode == "create"
+
+            screen.query_one("#personas-char-editor-name", Input).value = "Twice Saved"
+            screen.query_one(
+                "#personas-char-editor-first-message", TextArea
+            ).text = "Hello there."
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            assert screen._edit_mode == "edit"
+            assert screen.state.has_unsaved_changes is False
+            saved_id = screen.state.selected_entity_id
+            assert saved_id is not None
+            record = route_character_db.get_character_card_by_id(int(saved_id))
+            assert record is not None
+            assert record["version"] == 1
+            assert record["first_message"] == "Hello there."
+
+            # Second edit + save, in the SAME open session (still id
+            # ``saved_id`` - save-in-place never flips to the read-only card
+            # between the two saves).
+            screen.query_one(
+                "#personas-char-editor-first-message", TextArea
+            ).text = "Hello again."
+            await pilot.pause()
+            assert screen.state.has_unsaved_changes is True
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            assert screen.query_one("#ccp-character-editor-view").display is True
+            assert screen.query_one("#ccp-character-card-view").display is False
+            assert screen.state.has_unsaved_changes is False
+            assert screen._edit_mode == "edit"
+            assert screen.state.selected_entity_id == saved_id
+
+            record2 = route_character_db.get_character_card_by_id(int(saved_id))
+            assert record2 is not None
+            # The version advanced (proves the second Save genuinely ran a
+            # persist, not a no-op swallowed by a stuck inflight guard).
+            assert record2["version"] == 2
+            assert record2["first_message"] == "Hello again."
+
 
 # ===================================================================
 # Screen-level (Roleplay P3b Task 5): persona Save threads is_active/mode/

--- a/Tests/UI/test_personas_editor_save_in_place.py
+++ b/Tests/UI/test_personas_editor_save_in_place.py
@@ -23,9 +23,15 @@ at a real db - the same seam ``create_character``/``update_character``/
 
 import pytest
 from textual.app import App, ComposeResult
-from textual.widgets import Input
+from textual.widgets import Input, Select, Switch, TextArea
 
 import tldw_chatbook.UI.CCP_Modules.ccp_character_handler as character_handler_module
+from tldw_chatbook.Character_Chat.character_persona_scope_service import (
+    CharacterPersonaScopeService,
+)
+from tldw_chatbook.Character_Chat.local_character_persona_service import (
+    LocalCharacterPersonaService,
+)
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
 from tldw_chatbook.Widgets.Persona_Widgets.personas_character_editor_widget import (
     PersonasCharacterEditorWidget,
@@ -37,7 +43,7 @@ from tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages import (
     EditorContentChanged,
 )
 
-from Tests.UI.test_personas_dictionaries import PersonasTestApp
+from Tests.UI.test_personas_dictionaries import PersonasTestApp, patch_character_paging
 
 pytestmark = pytest.mark.asyncio
 
@@ -181,3 +187,156 @@ class TestCharacterSaveInPlace:
             screen.query_one("#personas-char-editor-name", Input).value = "New Hero 2"
             await pilot.pause()
             assert screen.state.has_unsaved_changes is True
+
+
+# ===================================================================
+# Screen-level (Roleplay P3b Task 5): persona Save threads is_active/mode/
+# personality_traits through _handle_profile_save_requested into a REAL
+# CharacterPersonaScopeService(local_service=LocalCharacterPersonaService),
+# proving the fields persist (and reload from the JSON store) rather than
+# merely round-tripping through a mock.
+# ===================================================================
+
+
+@pytest.fixture
+def stub_characters(monkeypatch):
+    """Empty character library - only exists so Characters-mode code paths
+    don't explode while this suite drives Personas mode (mirrors the
+    identically-named fixture in test_personas_dictionaries.py)."""
+    monkeypatch.setattr(character_handler_module, "fetch_all_characters", lambda: [])
+    monkeypatch.setattr(
+        character_handler_module, "fetch_character_by_id", lambda character_id: None
+    )
+    patch_character_paging(monkeypatch)
+
+
+@pytest.fixture
+def real_persona_scope_service(tmp_path):
+    """A REAL local persona backend (JSON-file-backed), not a mock - so a
+    round-tripped Save carries genuine persisted values."""
+    local_service = LocalCharacterPersonaService(
+        None, persona_store_path=tmp_path / "personas_save_in_place.json"
+    )
+    return CharacterPersonaScopeService(local_service=local_service, server_service=None)
+
+
+async def _enter_personas_mode(pilot):
+    screen = await _mounted(pilot)
+    await pilot.click("#personas-mode-personas")
+    await pilot.pause()
+    await pilot.app.workers.wait_for_complete()
+    await pilot.pause()
+    return screen
+
+
+class TestPersonaSaveInPlace:
+    async def test_create_save_stays_in_editor_and_persists_new_fields(
+        self, mock_app_instance, stub_characters, real_persona_scope_service
+    ):
+        mock_app_instance.character_persona_scope_service = real_persona_scope_service
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await _enter_personas_mode(pilot)
+            await pilot.click("#personas-library-new")
+            await pilot.pause()
+            assert screen._edit_mode == "create"
+
+            screen.query_one("#personas-editor-name", Input).value = "New Guide"
+            screen.query_one(
+                "#personas-editor-personality-traits", TextArea
+            ).text = "brave, kind"
+            screen.query_one("#personas-editor-mode", Select).value = (
+                "persistent_scoped"
+            )
+            screen.query_one("#personas-editor-enabled", Switch).value = False
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            # (a) the editor center is still displayed - NOT the card.
+            assert screen.query_one("#ccp-persona-editor-view").display is True
+            assert screen.query_one("#ccp-persona-card-view").display is False
+            # (b) the just-completed save clears the unsaved flag.
+            assert screen.state.has_unsaved_changes is False
+            # (c) create -> edit (a real row now backs the open session).
+            assert screen._edit_mode == "edit"
+
+            saved_id = screen.state.selected_entity_id
+            assert saved_id is not None
+
+            # Reload from a FRESH service instance backed by the SAME JSON
+            # store - proves the fields genuinely persisted, not just that
+            # the in-memory record the screen is holding looks right.
+            reloaded_local_service = LocalCharacterPersonaService(
+                None,
+                persona_store_path=(
+                    real_persona_scope_service.local_service.persona_store_path
+                ),
+            )
+            record = reloaded_local_service.get_persona_profile(saved_id)
+            assert record["name"] == "New Guide"
+            assert record["personality_traits"] == "brave, kind"
+            assert record["mode"] == "persistent_scoped"
+            assert record["is_active"] is False
+            assert record["version"] == 1
+
+            # (d) a further field edit re-flags has_unsaved_changes.
+            screen.query_one("#personas-editor-name", Input).value = "New Guide 2"
+            await pilot.pause()
+            assert screen.state.has_unsaved_changes is True
+
+    async def test_edit_save_updates_new_fields_in_place(
+        self, mock_app_instance, stub_characters, real_persona_scope_service
+    ):
+        from tldw_chatbook.tldw_api.character_persona_schemas import (
+            PersonaProfileCreate,
+        )
+
+        local_service = real_persona_scope_service.local_service
+        local_service.create_persona_profile(
+            PersonaProfileCreate(
+                id="p-1",
+                name="Archivist",
+                personality_traits="calm",
+                mode="session_scoped",
+                is_active=True,
+            )
+        )
+        mock_app_instance.character_persona_scope_service = real_persona_scope_service
+        app = PersonasTestApp(mock_app_instance)
+        async with app.run_test(size=(160, 50)) as pilot:
+            screen = await _enter_personas_mode(pilot)
+            await pilot.click("#personas-library-row-persona_profile-p-1")
+            await pilot.pause()
+
+            from tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages import (
+                EditPersonaRequested,
+            )
+
+            screen.post_message(EditPersonaRequested("p-1"))
+            await pilot.pause()
+            assert screen._edit_mode == "edit"
+
+            screen.query_one(
+                "#personas-editor-personality-traits", TextArea
+            ).text = "fierce, loyal"
+            screen.query_one("#personas-editor-enabled", Switch).value = False
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            assert screen.query_one("#ccp-persona-editor-view").display is True
+            assert screen.state.has_unsaved_changes is False
+
+            reloaded_local_service = LocalCharacterPersonaService(
+                None, persona_store_path=local_service.persona_store_path
+            )
+            record = reloaded_local_service.get_persona_profile("p-1")
+            assert record["personality_traits"] == "fierce, loyal"
+            assert record["is_active"] is False
+            assert record["mode"] == "session_scoped"  # untouched field preserved
+            assert record["version"] == 2

--- a/Tests/UI/test_personas_persona_editor_validation.py
+++ b/Tests/UI/test_personas_persona_editor_validation.py
@@ -104,6 +104,33 @@ async def test_validated_field_ids_covers_name():
         assert "personas-editor-name" in ed._validated_field_ids()
 
 
+async def test_reopen_clears_stale_invalid_mark_from_prior_session():
+    """Review fix (Roleplay P3b): a stale ``.is-invalid`` mark left by a
+    prior editing session must not survive reopening the editor onto a new
+    persona. The row must clear SYNCHRONOUSLY inside ``load_persona`` - not
+    rely on the async ``Input.Changed`` event that setting a new value posts
+    (which only arms a fresh debounce timer and would not fire before this
+    assertion, and would not fire at all if the reopened record's value
+    happened to match what was already displayed)."""
+    app = _Host()
+    async with app.run_test() as pilot:
+        ed = app.query_one(PersonaProfileEditorWidget)
+        ed.load_persona({"name": "A"})
+        await pilot.pause()
+
+        ed.query_one("#personas-editor-name", Input).value = ""
+        await _settle(pilot)
+        row = ed.query_one("#personas-editor-name").parent
+        assert row.has_class("is-invalid")
+
+        ed.load_persona({"name": "B"})
+        # Only a bare pause (message-loop churn), never the full debounce
+        # settle - proves the clear is not coming from the async self-heal
+        # path.
+        await pilot.pause()
+        assert not row.has_class("is-invalid")
+
+
 async def test_blank_new_form_does_not_mark_name_invalid_before_interaction():
     """Fix B (review wave): a freshly-opened blank form must not display
     validation errors before the user has touched anything, even after the

--- a/Tests/UI/test_personas_persona_editor_validation.py
+++ b/Tests/UI/test_personas_persona_editor_validation.py
@@ -102,3 +102,30 @@ async def test_validated_field_ids_covers_name():
     async with app.run_test() as pilot:
         ed = app.query_one(PersonaProfileEditorWidget)
         assert "personas-editor-name" in ed._validated_field_ids()
+
+
+async def test_blank_new_form_does_not_mark_name_invalid_before_interaction():
+    """Fix B (review wave): a freshly-opened blank form must not display
+    validation errors before the user has touched anything, even after the
+    debounce interval elapses (the async Changed events fired by
+    new_persona's programmatic population must not surface an error)."""
+    app = _Host()
+    async with app.run_test() as pilot:
+        ed = app.query_one(PersonaProfileEditorWidget)
+        ed.new_persona()
+        await pilot.pause()
+        await _settle(pilot)  # let any load-triggered debounce fire
+
+        row = ed.query_one("#personas-editor-name").parent
+        assert not row.has_class("is-invalid")
+        validation = ed.query_one("#personas-editor-validation", Static)
+        assert str(validation.renderable) == ""
+
+        # Now a genuine interaction: type then clear -> touched, now invalid.
+        name_input = ed.query_one("#personas-editor-name", Input)
+        name_input.value = "X"
+        await pilot.pause()
+        name_input.value = ""
+        await _settle(pilot)
+        assert row.has_class("is-invalid")
+        assert "personas-editor-name: required" in str(validation.renderable)

--- a/Tests/UI/test_personas_persona_editor_validation.py
+++ b/Tests/UI/test_personas_persona_editor_validation.py
@@ -1,0 +1,104 @@
+"""Roleplay P3b Task 4: live per-field validation (persona editor).
+
+Mirrors ``Tests/UI/test_personas_character_editor_validation.py`` for the
+persona profile editor: ``validate()`` now returns typed ``(field_id,
+message, level)`` tuples instead of bare error strings, ``_run_validation()``
+debounces off ``_field_changed`` and runs authoritatively at Save, and the
+name row's ``.is-invalid`` class tracks live as the field is fixed.
+"""
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Input, Static
+
+from tldw_chatbook.Widgets.Persona_Widgets.persona_profile_editor_widget import (
+    PersonaProfileEditorWidget,
+)
+from tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages import (
+    PersonaProfileSaveRequested,
+)
+
+pytestmark = pytest.mark.asyncio
+
+_DEBOUNCE = PersonaProfileEditorWidget._VALIDATION_DEBOUNCE_SECONDS
+
+
+class _Host(App):
+    def __init__(self):
+        super().__init__()
+        self.saves = []
+
+    def compose(self) -> ComposeResult:
+        yield PersonaProfileEditorWidget()
+
+    def on_persona_profile_save_requested(
+        self, message: PersonaProfileSaveRequested
+    ) -> None:
+        self.saves.append(message.data)
+
+
+async def _settle(pilot):
+    """Wait past the validation debounce interval."""
+    await pilot.pause(_DEBOUNCE + 0.05)
+
+
+async def test_blank_name_marks_field_and_blocks_save():
+    app = _Host()
+    async with app.run_test() as pilot:
+        ed = app.query_one(PersonaProfileEditorWidget)
+        ed.load_persona({"name": "A"})
+        await pilot.pause()
+
+        ed.query_one("#personas-editor-name", Input).value = ""
+        await pilot.pause()  # not yet - proves this is debounced
+        row = ed.query_one("#personas-editor-name").parent
+        assert not row.has_class("is-invalid")
+
+        await _settle(pilot)
+        assert row.has_class("is-invalid")
+
+        await pilot.click("#personas-editor-save")
+        await pilot.pause()
+        assert app.saves == []
+
+        ed.query_one("#personas-editor-name", Input).value = "A"
+        await _settle(pilot)
+        assert not row.has_class("is-invalid")
+
+        await pilot.click("#personas-editor-save")
+        await pilot.pause()
+        assert len(app.saves) == 1
+        assert app.saves[0]["name"] == "A"
+
+
+async def test_validate_returns_typed_findings():
+    app = _Host()
+    async with app.run_test() as pilot:
+        ed = app.query_one(PersonaProfileEditorWidget)
+        ed.load_persona({"name": ""})
+        await pilot.pause()
+        findings = ed.validate()
+        assert findings == [("personas-editor-name", "required", "error")]
+
+
+async def test_footer_still_shows_name_required_substring():
+    """Backward-compat: the existing 'name: required' substring assertion in
+    test_persona_profile_widgets.py must keep matching the new
+    '<field_id>: <message>' rendering."""
+    app = _Host()
+    async with app.run_test() as pilot:
+        ed = app.query_one(PersonaProfileEditorWidget)
+        ed.new_persona()
+        await pilot.pause()
+        await pilot.click("#personas-editor-save")
+        await pilot.pause()
+        validation = ed.query_one("#personas-editor-validation", Static)
+        assert "name: required" in str(validation.renderable)
+    assert app.saves == []
+
+
+async def test_validated_field_ids_covers_name():
+    app = _Host()
+    async with app.run_test() as pilot:
+        ed = app.query_one(PersonaProfileEditorWidget)
+        assert "personas-editor-name" in ed._validated_field_ids()

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -937,7 +937,10 @@ class TestPersonasMode:
             await app.workers.wait_for_complete()
             await pilot.pause()
             stub_scope_service.create_persona_profile.assert_awaited_once()
-            assert screen._edit_mode == "view"
+            # Save-in-place: create -> edit, the editor stays open (not the
+            # read-only card).
+            assert screen._edit_mode == "edit"
+            assert screen.query_one("#ccp-persona-editor-view").display is True
 
     async def test_profile_save_refresh_failure_updates_status_row_and_recovery(
         self, mock_app_instance, stub_characters, stub_scope_service
@@ -985,7 +988,9 @@ class TestPersonasMode:
             await pilot.pause()
             stub_scope_service.update_persona_profile.assert_awaited_once()
             assert stub_scope_service.update_persona_profile.await_args.args[0] == "p-1"
-            assert screen._edit_mode == "view"
+            # Save-in-place: the editor stays open after an edit save too.
+            assert screen._edit_mode == "edit"
+            assert screen.query_one("#ccp-persona-editor-view").display is True
 
     async def test_profile_save_failure_keeps_editor_open(
         self, mock_app_instance, stub_characters, stub_scope_service
@@ -4220,9 +4225,10 @@ class TestDirtyTracking:
             await pilot.pause()
             await pilot.app.workers.wait_for_complete()
             await pilot.pause()
-            # Back to the purpose line; "Local" stays out of the header (the
-            # status row already carries "Source: Local").
-            assert str(subtitle.renderable) == "Author the pieces that shape a chat"
+            # Save-in-place: the editor stays open, so the header keeps
+            # showing "Editing <name>" (just without the "- unsaved" suffix
+            # now that the save cleared it).
+            assert str(subtitle.renderable) == "Editing Detective Sam"
             title = screen.query_one("#personas-header #workbench-header-title", Static)
             assert str(title.renderable) == "Roleplay"
 

--- a/backlog/tasks/task-481 - P3b-follow-up-sweep-deferred-editor-polish-minors.md
+++ b/backlog/tasks/task-481 - P3b-follow-up-sweep-deferred-editor-polish-minors.md
@@ -19,10 +19,10 @@ Cleanup of Minor findings deferred from the Roleplay P3b whole-branch review (PR
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] #1 Avatar thumbnail: after opening the character editor and immediately Saving (save-in-place), the thumbnail no longer risks staying blank — re-dispatch `_render_character_editor_avatar()` on the stay-in-editor branch of `_after_character_save` (today the `_character_editor_generation` bump can drop an in-flight open-time render; text status stays correct).
-- [ ] #2 Character editor gains a re-save dedup guard equivalent to the persona `_profile_save_inflight` (save-in-place keeps the Save button live; sequential no-edit Save clicks each run a redundant `update_character` that bumps `version`; no data loss, but wasteful).
-- [ ] #3 `personas_screen.py` `_handle_profile_save_requested`: move the `mode = current_mode()` / `persona_id = ...` lines inside the try/except that resets `_profile_save_inflight`, so a raise there can't latch the flag.
-- [ ] #4 Add a test that editing `personality_traits` to `""` on a persona Update actually clears the stored value (today only non-empty→non-empty is covered; the path is traced-correct but untested).
-- [ ] #5 Add a screen-level test that presses Save twice in one character session (edit greeting → save → edit again → save) to lock in greetings + version preservation across consecutive save-in-place (today only the widget-level `version==2` assertion covers it).
-- [ ] #6 (pre-existing, separate concern) `Widgets/Console/console_transcript.py:_image_row_widget` shares the max-width/height-only `textual_image.Image` sizing that caused a zero-size `ValueError` under a live render in P3b Task 2 — apply the same explicit-size guard there (the avatar path already sidesteps it via `_fit_avatar_cell_size`).
+- [x] #1 Avatar thumbnail re-render on save-in-place — DONE in PR #772 fix wave (cc1c04ad0): `_after_character_save` stay-in-editor branch now re-dispatches `_render_character_editor_avatar()` after `mark_saved`.
+- [x] #2 Character re-save dedup — DONE (cc1c04ad0): `_character_save_inflight` blocks a re-entrant (concurrent double-Ctrl+S) Save; a sequential no-edit re-save (minutes later, fully settled) is still allowed by design (trivial, no data loss).
+- [x] #3 `_profile_save_inflight` try-placement — DONE (cc1c04ad0): `mode`/`persona_id` reads moved inside the try.
+- [x] #4 `personality_traits` clear-to-empty Update test — DONE (cc1c04ad0).
+- [x] #5 twice-save-in-place greeting/version-preservation test — DONE (cc1c04ad0).
+- [ ] #6 (pre-existing, separate concern — the only remaining item) `Widgets/Console/console_transcript.py:_image_row_widget` shares the max-width/height-only `textual_image.Image` sizing that caused a zero-size `ValueError` under a live render in P3b Task 2 — apply the same explicit-size guard there (the avatar path already sidesteps it via `_fit_avatar_cell_size`).
 <!-- AC:END -->

--- a/backlog/tasks/task-481 - P3b-follow-up-sweep-deferred-editor-polish-minors.md
+++ b/backlog/tasks/task-481 - P3b-follow-up-sweep-deferred-editor-polish-minors.md
@@ -1,0 +1,28 @@
+---
+id: task-481
+title: P3b follow-up — sweep deferred editor-polish minors
+status: To Do
+assignee: []
+labels:
+  - tech-debt
+  - personas
+  - p3b
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Cleanup of Minor findings deferred from the Roleplay P3b whole-branch review (PR #772). None are user-visible data bugs; all are cosmetic, self-healing, or coverage/robustness nits.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 Avatar thumbnail: after opening the character editor and immediately Saving (save-in-place), the thumbnail no longer risks staying blank — re-dispatch `_render_character_editor_avatar()` on the stay-in-editor branch of `_after_character_save` (today the `_character_editor_generation` bump can drop an in-flight open-time render; text status stays correct).
+- [ ] #2 Character editor gains a re-save dedup guard equivalent to the persona `_profile_save_inflight` (save-in-place keeps the Save button live; sequential no-edit Save clicks each run a redundant `update_character` that bumps `version`; no data loss, but wasteful).
+- [ ] #3 `personas_screen.py` `_handle_profile_save_requested`: move the `mode = current_mode()` / `persona_id = ...` lines inside the try/except that resets `_profile_save_inflight`, so a raise there can't latch the flag.
+- [ ] #4 Add a test that editing `personality_traits` to `""` on a persona Update actually clears the stored value (today only non-empty→non-empty is covered; the path is traced-correct but untested).
+- [ ] #5 Add a screen-level test that presses Save twice in one character session (edit greeting → save → edit again → save) to lock in greetings + version preservation across consecutive save-in-place (today only the widget-level `version==2` assertion covers it).
+- [ ] #6 (pre-existing, separate concern) `Widgets/Console/console_transcript.py:_image_row_widget` shares the max-width/height-only `textual_image.Image` sizing that caused a zero-size `ValueError` under a live render in P3b Task 2 — apply the same explicit-size guard there (the avatar path already sidesteps it via `_fit_avatar_cell_size`).
+<!-- AC:END -->

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -4065,6 +4065,10 @@ class PersonasScreen(BaseAppScreen):
             return
         editor._character_data.pop("image", None)
         editor._mark_dirty()
+        # A discrete user action (Remove button) - validate immediately, no
+        # debounce, so an avatar-oversize error clears at once on removal.
+        editor._user_touched = True
+        editor._run_validation()
         self.run_worker(
             self._render_character_editor_avatar(),
             group="personas-avatar-render",

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -80,6 +80,7 @@ from ...Widgets.Persona_Widgets.personas_messages import (
 from ...Widgets.Persona_Widgets.tag_filter_picker import TagFilterPicker
 from ...Widgets.Persona_Widgets.personas_pane_messages import (
     CharacterEditorCancelled,
+    CharacterImageRemoveRequested,
     CharacterImageUploadRequested,
     CharacterSaveRequested,
     ConversationRowSelected,
@@ -3446,6 +3447,9 @@ class PersonasScreen(BaseAppScreen):
         # Change-based dirty tracking: the session starts clean; the editor
         # posts EditorContentChanged on the first real modification.
         self.query_one(PersonasCharacterEditorWidget).new_character()
+        # A new character never has an avatar, but a stale thumbnail from
+        # the previous editor session must not linger under the new one.
+        await self._render_character_editor_avatar()
         self._show_center("#ccp-character-editor-view")
         inspector = self.query_one(PersonasInspectorPane)
         # Create mode: the previous selection's identity (and conversation
@@ -3746,6 +3750,13 @@ class PersonasScreen(BaseAppScreen):
         # Change-based dirty tracking: the session starts clean; the editor
         # posts EditorContentChanged on the first real modification.
         self.query_one(PersonasCharacterEditorWidget).load_character(record)
+        # Sync handler: dispatch the (async, off-thread-decoding) thumbnail
+        # render as a worker rather than awaiting it inline.
+        self.run_worker(
+            self._render_character_editor_avatar(),
+            group="personas-avatar-render",
+            exit_on_error=False,
+        )
         self._show_center("#ccp-character-editor-view")
         inspector = self.query_one(PersonasInspectorPane)
         inspector.set_unsaved(False)
@@ -3887,6 +3898,99 @@ class PersonasScreen(BaseAppScreen):
             self._notify(f"Avatar upload failed: {exc}", "error")
             return
         self._notify("Avatar staged. Save the character to persist it.", "information")
+        await self._render_character_editor_avatar()
+
+    async def _render_character_editor_avatar(self) -> None:
+        """Decode and mount the character editor's avatar thumbnail off-thread.
+
+        Also re-syncs the editor's text status Static (``_set_avatar_status_
+        from_record``), since the Remove path clears ``image`` directly
+        without going through ``set_avatar_image``. A session-token guard
+        drops a late render if a different editor session (a new
+        create/edit, a save-in-place, or a cancel) started while the decode
+        was in flight.
+        """
+        try:
+            editor = self.query_one(PersonasCharacterEditorWidget)
+        except QueryError:
+            return
+        editor._set_avatar_status_from_record()
+        data = editor.current_avatar_bytes()
+        if not data:
+            editor.set_avatar_thumbnail(None)
+            return
+        token = self._character_editor_generation
+        from ...Chat.console_image_view import (
+            ConsoleImageRenderCache,
+            resolve_default_mode,
+        )
+
+        if getattr(self, "_avatar_render_cache", None) is None:
+            self._avatar_render_cache = ConsoleImageRenderCache()
+        cache = self._avatar_render_cache
+        # Accessor confirmed against chat_screen.py's own
+        # resolve_default_mode call site and this file's existing
+        # app_config reads (e.g. _provider_readiness_app_config): screen
+        # instances always carry a real app_instance (set in
+        # BaseAppScreen.__init__), so a plain getattr default is enough.
+        app_config = getattr(self.app_instance, "app_config", {}) or {}
+        mode = resolve_default_mode(app_config)
+        # Per-session cache key: avoids one character's decode racing
+        # another's under the same slot if a second editor session opens
+        # before the first's off-thread decode finishes (the fixed-key
+        # alternative would let a slower A-session overwrite a faster
+        # B-session's cache entry after B's own token check already passed).
+        cache_key = f"char-editor-avatar-{token}"
+        try:
+            ok = await asyncio.to_thread(cache.prepare, cache_key, bytes(data))
+        except Exception:
+            logger.opt(exception=True).debug("Character avatar decode failed.")
+            ok = False
+        if token != self._character_editor_generation or not self.is_mounted:
+            return  # a different editor session started while decoding
+        renderable = None
+        if ok:
+            if mode == "graphics":
+                try:
+                    from textual_image.widget import Image as _GraphicsImage
+
+                    pil = cache.get_pil(cache_key)
+                    if pil is not None:
+                        renderable = _GraphicsImage(pil)
+                        # Fixed cell size (matches the thumb box CSS), not
+                        # just max-width/max-height: textual_image's "auto"
+                        # sizing resolves its render region from the parent
+                        # container's settled layout, and mounting a widget
+                        # at runtime (vs. compose-time) can paint one tick
+                        # before that settles, asking the renderer to scale
+                        # to a transient 0-width/height region - which PIL's
+                        # resize() raises on. A fixed size is resolvable
+                        # without waiting on parent layout, so it sidesteps
+                        # the race outright.
+                        renderable.styles.width = 24
+                        renderable.styles.height = 10
+                except Exception:
+                    renderable = cache.get_pixels(cache_key)
+            else:
+                renderable = cache.get_pixels(cache_key)
+        editor.set_avatar_thumbnail(renderable)
+
+    @on(CharacterImageRemoveRequested)
+    def _handle_character_image_remove(
+        self, message: CharacterImageRemoveRequested
+    ) -> None:
+        message.stop()
+        try:
+            editor = self.query_one(PersonasCharacterEditorWidget)
+        except QueryError:
+            return
+        editor._character_data.pop("image", None)
+        editor._mark_dirty()
+        self.run_worker(
+            self._render_character_editor_avatar(),
+            group="personas-avatar-render",
+            exit_on_error=False,
+        )
 
     # ===== Import / export =====
     #

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -492,6 +492,10 @@ class PersonasScreen(BaseAppScreen):
         self._delete_dialog_active: bool = False
         self._character_editor_generation: int = 0
         self._profile_save_inflight: bool = False
+        # Mirrors _profile_save_inflight for the character editor: guards
+        # against a re-entrant Save (double-click/Ctrl+S) while an earlier
+        # save for this session is still persisting.
+        self._character_save_inflight: bool = False
         # ``_characters`` now holds only the CURRENT page of the library, not
         # the whole (capped) list; ``_character_total`` is the full-library
         # count for the active (search, tag) filter, cached under
@@ -3450,6 +3454,10 @@ class PersonasScreen(BaseAppScreen):
         self._character_editor_generation += 1
         self._edit_mode = "create"
         self.state.clear_selection()
+        # A new session starts unclaimed - re-arms the save-in-place dedup
+        # guard (see _handle_save_requested) even if the previous session
+        # ended on a successful save.
+        self._character_save_inflight = False
         # Change-based dirty tracking: the session starts clean; the editor
         # posts EditorContentChanged on the first real modification.
         self.query_one(PersonasCharacterEditorWidget).new_character()
@@ -3753,6 +3761,8 @@ class PersonasScreen(BaseAppScreen):
             return
         self._character_editor_generation += 1
         self._edit_mode = "edit"
+        # A new session starts unclaimed (see _begin_create_character).
+        self._character_save_inflight = False
         # Change-based dirty tracking: the session starts clean; the editor
         # posts EditorContentChanged on the first real modification.
         self.query_one(PersonasCharacterEditorWidget).load_character(record)
@@ -4069,6 +4079,15 @@ class PersonasScreen(BaseAppScreen):
         # debounce, so an avatar-oversize error clears at once on removal.
         editor._user_touched = True
         editor._run_validation()
+        # Bump the generation BEFORE dispatching this render (rather than
+        # relying on the render below to be the last word): an earlier
+        # in-flight render from before Remove was clicked shares this
+        # session's token and would otherwise complete afterwards and
+        # re-mount the just-removed image, visually undoing Remove. Bumping
+        # first makes that stale render's token mismatch (dropped), while
+        # this dispatch below captures the NEW token and correctly clears
+        # the thumbnail (image is now None).
+        self._character_editor_generation += 1
         self.run_worker(
             self._render_character_editor_avatar(),
             group="personas-avatar-render",
@@ -4957,6 +4976,14 @@ class PersonasScreen(BaseAppScreen):
     @on(CharacterSaveRequested)
     def _handle_save_requested(self, message: CharacterSaveRequested) -> None:
         message.stop()
+        if self._character_save_inflight:
+            # A save for this session is already persisting (re-entrant
+            # Save click / Ctrl+S); ignore the duplicate rather than firing
+            # a second redundant persist (mirrors _profile_save_inflight).
+            logger.debug(
+                "Character save already in flight; ignoring duplicate request."
+            )
+            return
         data = dict(message.character_data or {})
         errors = self._validate_character(data)
         # The editor footer is the single in-editor validation surface: the
@@ -4968,6 +4995,7 @@ class PersonasScreen(BaseAppScreen):
             # editing state instead of duplicating the error detail.
             self.query_one(PersonasInspectorPane).show_validation_editing()
             return
+        self._character_save_inflight = True
         # Snapshot UI-thread state here; the background persistence call must
         # not read mutable screen state.
         self._save_character_worker(
@@ -4995,6 +5023,9 @@ class PersonasScreen(BaseAppScreen):
         except Exception as exc:
             logger.opt(exception=True).error(f"Error saving character: {exc}")
             self._notify(f"Save failed: {exc}", "error")
+            # Allow an immediate retry - _after_character_save (the success
+            # path) resets this same flag itself.
+            self._character_save_inflight = False
             return
         await self._after_character_save(saved_id, str(data.get("name") or ""))
 
@@ -5004,7 +5035,11 @@ class PersonasScreen(BaseAppScreen):
         if not self.is_mounted or self.state.active_mode != "characters":
             # The save completed after the user left the screen or switched
             # modes; refresh the cached list but leave the selection,
-            # inspector, and center pane alone.
+            # inspector, and center pane alone. The persist itself finished,
+            # so release the guard here too - a later new session
+            # (_begin_create_character / _handle_edit_requested) would also
+            # re-arm it, but there is no reason to leave it latched.
+            self._character_save_inflight = False
             try:
                 await self.character_handler.refresh_character_list()
             except Exception:
@@ -5068,6 +5103,13 @@ class PersonasScreen(BaseAppScreen):
             self._edit_mode = "edit"  # create -> edit stays in the editor
             editor.mark_saved(saved_record)
             self._show_center("#ccp-character-editor-view")
+            # This method already bumped _character_editor_generation above,
+            # which invalidates (drops) any render still in flight from
+            # before the save - so re-render now with the new token or the
+            # thumbnail can be left blank/stale until the next unrelated
+            # avatar action.
+            await self._render_character_editor_avatar()
+        self._character_save_inflight = False
         self._sync_title_and_console_actions()
         self._notify("Character saved.", severity="information")
 
@@ -5109,9 +5151,18 @@ class PersonasScreen(BaseAppScreen):
             self._notify("Save failed: persona profiles are unavailable.", "error")
             return
         self._profile_save_inflight = True
-        mode = self.persona_handler.current_mode()
-        persona_id = str(data.get("id") or "")
+        # mode/persona_id are read INSIDE the try (rather than before it) so
+        # a raise from either (e.g. current_mode()) is caught below, which
+        # resets the inflight flag; reading them ahead of the try would let
+        # such a raise propagate uncaught, latching the flag True forever
+        # and silently no-opping every future save via the guard above.
+        # Placeholder defaults keep both names bound for the except block's
+        # log line even if the raise happens before either assignment runs.
+        mode: str | None = None
+        persona_id: str = ""
         try:
+            mode = self.persona_handler.current_mode()
+            persona_id = str(data.get("id") or "")
             if self._edit_mode == "create" or not persona_id:
                 request = PersonaProfileCreate(
                     id=data.get("id") or None,
@@ -5139,7 +5190,10 @@ class PersonasScreen(BaseAppScreen):
                     mode=mode,
                 )
         except Exception as exc:
-            logger.opt(exception=True).error(f"Error saving persona profile: {exc}")
+            logger.opt(exception=True).error(
+                f"Error saving persona profile: persona_id={persona_id!r}, "
+                f"mode={mode!r}, expected_version={data.get('version')!r}: {exc}"
+            )
             self._notify(f"Save failed: {exc}", "error")
             # Allow an immediate retry - only a real DB round trip (or a
             # fresh edit) may claim this flag again.

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -5119,6 +5119,8 @@ class PersonasScreen(BaseAppScreen):
                     description=data.get("description"),
                     mode=data.get("mode") or "session_scoped",
                     system_prompt=data.get("system_prompt"),
+                    is_active=bool(data.get("is_active", True)),
+                    personality_traits=str(data.get("personality_traits") or ""),
                 )
                 result = await service.create_persona_profile(request, mode=mode)
             else:
@@ -5127,6 +5129,8 @@ class PersonasScreen(BaseAppScreen):
                     description=data.get("description"),
                     mode=data.get("mode"),
                     system_prompt=data.get("system_prompt"),
+                    is_active=data.get("is_active"),
+                    personality_traits=data.get("personality_traits"),
                 )
                 result = await service.update_persona_profile(
                     persona_id,

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -3460,6 +3460,10 @@ class PersonasScreen(BaseAppScreen):
     async def _begin_create_profile(self) -> None:
         self._edit_mode = "create"
         self.state.clear_selection()
+        # A new session starts unclaimed - re-arms the save-in-place dedup
+        # guard (see _handle_profile_save_requested) even if the previous
+        # session ended on a successful save.
+        self._profile_save_inflight = False
         # Change-based dirty tracking: the session starts clean (see
         # _begin_create_character).
         self.query_one(PersonaProfileEditorWidget).new_persona()
@@ -3715,6 +3719,8 @@ class PersonasScreen(BaseAppScreen):
             return
         record = await self._fetch_profile_record(str(message.persona_id))
         self._edit_mode = "edit"
+        # A new session starts unclaimed (see _begin_create_profile).
+        self._profile_save_inflight = False
         # Change-based dirty tracking: the session starts clean; the editor
         # posts EditorContentChanged on the first real modification.
         self.query_one(PersonaProfileEditorWidget).load_persona(record)
@@ -3760,6 +3766,10 @@ class PersonasScreen(BaseAppScreen):
             # A stray Changed outside an editing session (e.g. racing a
             # save/cancel finisher) must not resurrect the dirty flag.
             return
+        # A genuinely new edit re-arms the save-in-place dedup guard (see
+        # _handle_profile_save_requested) - harmless no-op for a character
+        # edit, which does not use this flag.
+        self._profile_save_inflight = False
         if self.state.has_unsaved_changes:
             return
         self.state.has_unsaved_changes = True
@@ -4816,14 +4826,39 @@ class PersonasScreen(BaseAppScreen):
                 )
             return
         self._character_editor_generation += 1
-        self._edit_mode = "view"
         self._set_active_row_unsaved(False)
         await self.character_handler.refresh_character_list()
+        # Re-read the just-persisted record (authoritative version - carries
+        # the incremented optimistic-lock version) directly off the UI
+        # thread. character_handler.load_character() below only SCHEDULES a
+        # background worker and cannot be awaited for completion (see
+        # _select_character's note on the same pattern), so a direct
+        # to_thread fetch is required here to reliably decide whether the
+        # editor can stay open before the rest of this method proceeds.
+        try:
+            saved_record = await asyncio.to_thread(
+                ccp_character_handler.fetch_character_by_id, saved_id
+            )
+        except Exception:
+            logger.opt(exception=True).warning(
+                f"Could not re-read saved character {saved_id!r}; falling back "
+                "to the card view."
+            )
+            saved_record = None
+        if saved_record:
+            # Keep the handler's cache in sync so other _full_character_record
+            # readers (Edit-again, world-book/dictionary refreshes) see the
+            # fresh record too, ahead of load_character's own async refresh.
+            self.character_handler.current_character_id = saved_id
+            self.character_handler.current_character_data = dict(saved_record)
+        else:
+            saved_record = None
         # ``saved_id`` was just persisted, so it is authoritative; resolve the
-        # name by id (handler-loaded card) or the submitted name rather than
-        # scanning the now-page-only cache, and always load the saved card.
-        loaded = self._full_character_record(saved_id)
-        name = str((loaded or {}).get("name") or submitted_name or "Saved character")
+        # name by the re-read record or the submitted name rather than
+        # scanning the now-page-only cache.
+        name = str(
+            (saved_record or {}).get("name") or submitted_name or "Saved character"
+        )
         self.state.select_entity(
             entity_kind="character", entity_id=saved_id, entity_name=name
         )
@@ -4835,9 +4870,18 @@ class PersonasScreen(BaseAppScreen):
         self._sync_inspector_console_actions()
         self.query_one(PersonasLibraryPane).mark_active_row("character", saved_id)
         await self.character_handler.load_character(saved_id)
-        self._show_center("#ccp-character-card-view")
+        editor = self.query_one(PersonasCharacterEditorWidget)
+        if saved_record is None:
+            # Could not re-read -> fall back to today's flip-to-card so we
+            # never leave the editor holding a stale version.
+            self._edit_mode = "view"
+            self._show_center("#ccp-character-card-view")
+            self.call_after_refresh(self._focus_library_list)
+        else:
+            self._edit_mode = "edit"  # create -> edit stays in the editor
+            editor.mark_saved(saved_record)
+            self._show_center("#ccp-character-editor-view")
         self._sync_title_and_console_actions()
-        self.call_after_refresh(self._focus_library_list)
         self._notify("Character saved.", severity="information")
 
     @on(PersonaProfileSaveRequested)
@@ -4852,12 +4896,21 @@ class PersonasScreen(BaseAppScreen):
         """
         message.stop()
         if self._profile_save_inflight:
-            logger.debug("Persona save already in flight; ignoring duplicate request.")
+            # Save-in-place keeps ``_edit_mode`` at "edit" after a successful
+            # save (it no longer flips back to "view"), so this flag is now
+            # the sole guard against a stale duplicate: it is claimed here
+            # and, on success, stays claimed until a genuinely NEW edit
+            # (_handle_editor_content_changed) or a new session
+            # (_begin_create_profile / edit-load) re-arms it. A failed save
+            # clears it immediately below so the user can retry at once.
+            logger.debug(
+                "Persona save already in flight or already fulfilled for this "
+                "baseline; ignoring duplicate request."
+            )
             return
         if self._edit_mode not in ("create", "edit"):
-            # Message dispatch is serial, so a double-posted Save arrives after
-            # the first save already finished and returned to view mode; a save
-            # without an open edit session is a stale duplicate.
+            # A save without an open edit session (e.g. arriving after the
+            # user cancelled or left the screen) is stale.
             logger.debug("Persona save without an open edit session; ignoring.")
             return
         data = dict(message.data or {})
@@ -4869,46 +4922,46 @@ class PersonasScreen(BaseAppScreen):
             self._notify("Save failed: persona profiles are unavailable.", "error")
             return
         self._profile_save_inflight = True
+        mode = self.persona_handler.current_mode()
+        persona_id = str(data.get("id") or "")
         try:
-            mode = self.persona_handler.current_mode()
-            persona_id = str(data.get("id") or "")
-            try:
-                if self._edit_mode == "create" or not persona_id:
-                    request = PersonaProfileCreate(
-                        id=data.get("id") or None,
-                        name=str(data.get("name") or ""),
-                        description=data.get("description"),
-                        mode=data.get("mode") or "session_scoped",
-                        system_prompt=data.get("system_prompt"),
-                    )
-                    result = await service.create_persona_profile(request, mode=mode)
-                else:
-                    request = PersonaProfileUpdate(
-                        name=str(data.get("name") or ""),
-                        description=data.get("description"),
-                        mode=data.get("mode"),
-                        system_prompt=data.get("system_prompt"),
-                    )
-                    result = await service.update_persona_profile(
-                        persona_id,
-                        request,
-                        expected_version=data.get("version"),
-                        mode=mode,
-                    )
-            except Exception as exc:
-                logger.opt(exception=True).error(f"Error saving persona profile: {exc}")
-                self._notify(f"Save failed: {exc}", "error")
-                return
-            if hasattr(result, "model_dump"):
-                result = result.model_dump(mode="json")
-            if not isinstance(result, dict):
-                # Tolerate backends that return ids/None: keep the submitted data.
-                result = dict(data)
-            saved = dict(result)
-            saved.setdefault("id", persona_id)
-            await self._after_profile_save(saved)
-        finally:
+            if self._edit_mode == "create" or not persona_id:
+                request = PersonaProfileCreate(
+                    id=data.get("id") or None,
+                    name=str(data.get("name") or ""),
+                    description=data.get("description"),
+                    mode=data.get("mode") or "session_scoped",
+                    system_prompt=data.get("system_prompt"),
+                )
+                result = await service.create_persona_profile(request, mode=mode)
+            else:
+                request = PersonaProfileUpdate(
+                    name=str(data.get("name") or ""),
+                    description=data.get("description"),
+                    mode=data.get("mode"),
+                    system_prompt=data.get("system_prompt"),
+                )
+                result = await service.update_persona_profile(
+                    persona_id,
+                    request,
+                    expected_version=data.get("version"),
+                    mode=mode,
+                )
+        except Exception as exc:
+            logger.opt(exception=True).error(f"Error saving persona profile: {exc}")
+            self._notify(f"Save failed: {exc}", "error")
+            # Allow an immediate retry - only a real DB round trip (or a
+            # fresh edit) may claim this flag again.
             self._profile_save_inflight = False
+            return
+        if hasattr(result, "model_dump"):
+            result = result.model_dump(mode="json")
+        if not isinstance(result, dict):
+            # Tolerate backends that return ids/None: keep the submitted data.
+            result = dict(data)
+        saved = dict(result)
+        saved.setdefault("id", persona_id)
+        await self._after_profile_save(saved)
 
     async def _after_profile_save(self, saved: dict) -> None:
         # Refresh the cached profile list tolerantly even when the user has
@@ -4930,7 +4983,7 @@ class PersonasScreen(BaseAppScreen):
         if not self.is_mounted or self.state.active_mode != "personas":
             # Leave the selection, inspector, and center pane alone.
             return
-        self._edit_mode = "view"
+        self._edit_mode = "edit"  # create -> edit stays in the editor
         self.state.has_unsaved_changes = False
         self._set_active_row_unsaved(False)
         saved_id = str(saved.get("id") or "")
@@ -4944,10 +4997,15 @@ class PersonasScreen(BaseAppScreen):
         inspector.show_validation(())
         self._sync_inspector_console_actions()
         await self._render_profile_rows()
-        self.query_one(PersonaProfileCardWidget).show_persona(saved)
-        self._show_center("#ccp-persona-card-view")
+        # Save-in-place: the returned ``saved`` dict already carries the
+        # incremented optimistic-lock version, so the editor (which stays
+        # open) re-baselines dirty tracking straight from it - no re-read
+        # needed (unlike the character finisher, which reads a stale handler
+        # cache and must go back to the DB).
+        editor = self.query_one(PersonaProfileEditorWidget)
+        editor.mark_saved(saved)
+        self._show_center("#ccp-persona-editor-view")
         self._sync_title_and_console_actions()
-        self.call_after_refresh(self._focus_library_list)
         self._notify("Persona saved.", "information")
 
     # ===== Cancel =====

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -203,6 +203,12 @@ PERSONAS_AVATAR_MAX_SIZE_COPY = "5 MB"
 PERSONAS_DICTIONARY_IMPORT_MAX_BYTES = 10 * 1024 * 1024
 PERSONAS_WORLDBOOK_IMPORT_MAX_BYTES = 10 * 1024 * 1024
 
+# Character editor avatar thumbnail box, in character cells. Must stay in
+# sync with #personas-char-editor-avatar-thumb's CSS max-width/max-height in
+# personas_character_editor_widget.py - change one, change both.
+AVATAR_THUMB_COLS = 24
+AVATAR_THUMB_LINES = 10
+
 # 80-column terminals need a tighter three-pane split than the default
 # 2:4:2 workbench minimums. Keep this screen-owned so a later rail-collapse
 # task can replace it without changing pane widgets.
@@ -3966,14 +3972,87 @@ class PersonasScreen(BaseAppScreen):
                         # to a transient 0-width/height region - which PIL's
                         # resize() raises on. A fixed size is resolvable
                         # without waiting on parent layout, so it sidesteps
-                        # the race outright.
-                        renderable.styles.width = 24
-                        renderable.styles.height = 10
+                        # the race outright. Both dims must stay explicit
+                        # ints (not "auto") to avoid reintroducing that
+                        # crash, so the fit below is computed in cells
+                        # rather than left to the renderer.
+                        w_cells, h_cells = self._fit_avatar_cell_size(
+                            pil.width, pil.height
+                        )
+                        renderable.styles.width = w_cells
+                        renderable.styles.height = h_cells
                 except Exception:
-                    renderable = cache.get_pixels(cache_key)
+                    renderable = self._build_avatar_pixels(cache, cache_key)
             else:
-                renderable = cache.get_pixels(cache_key)
+                renderable = self._build_avatar_pixels(cache, cache_key)
         editor.set_avatar_thumbnail(renderable)
+
+    @staticmethod
+    def _fit_avatar_cell_size(pixel_width: int, pixel_height: int) -> tuple[int, int]:
+        """Fit a PIL image's pixel size into the avatar thumb box, in cells.
+
+        Terminal cells are roughly twice as tall (in pixels) as they are
+        wide, so the image's aspect ratio is first converted from pixels to
+        "cell units" (halving the height) before fitting it into the
+        ``AVATAR_THUMB_COLS`` x ``AVATAR_THUMB_LINES`` box. Both returned
+        dimensions are explicit ints >= 1 - leaving either as "auto" is what
+        reintroduced the 0-size ``ValueError`` this rendering path already
+        works around (see the caller's comment).
+
+        Args:
+            pixel_width: Source image width in pixels.
+            pixel_height: Source image height in pixels.
+
+        Returns:
+            ``(width_cells, height_cells)``, each clamped to
+            ``[1, AVATAR_THUMB_COLS]`` / ``[1, AVATAR_THUMB_LINES]``.
+        """
+        if pixel_width <= 0 or pixel_height <= 0:
+            return AVATAR_THUMB_COLS, AVATAR_THUMB_LINES
+        # Aspect ratio expressed in cell units (width-cells : height-cells).
+        cell_aspect = pixel_width / (pixel_height / 2)
+        box_aspect = AVATAR_THUMB_COLS / AVATAR_THUMB_LINES
+        if cell_aspect >= box_aspect:
+            # Image is relatively wider than the box - fit to width.
+            w_cells = AVATAR_THUMB_COLS
+            h_cells = max(1, round(AVATAR_THUMB_COLS / cell_aspect))
+        else:
+            # Image is relatively taller than the box - fit to height.
+            h_cells = AVATAR_THUMB_LINES
+            w_cells = max(1, round(AVATAR_THUMB_LINES * cell_aspect))
+        w_cells = max(1, min(AVATAR_THUMB_COLS, w_cells))
+        h_cells = max(1, min(AVATAR_THUMB_LINES, h_cells))
+        return w_cells, h_cells
+
+    @staticmethod
+    def _build_avatar_pixels(cache: "ConsoleImageRenderCache", cache_key: str):
+        """Build a ``rich_pixels.Pixels`` sized to the avatar thumb box.
+
+        ``cache.get_pixels`` thumbnails to the 80x40 chat-transcript box,
+        which is far larger than the character editor's compact avatar
+        preview; reusing it produces an oversized Pixels grid that Rich does
+        not reflow, so the small thumb container just crops it to a
+        top-left sliver. This instead pulls the cached full-size PIL image
+        and thumbnails a private copy to the avatar box (in half-block
+        "pixel" units: one character column is ~1px wide, one character
+        line is ~2px tall).
+
+        Args:
+            cache: The render cache holding the decoded avatar image.
+            cache_key: The per-session cache key ``prepare`` was called with.
+
+        Returns:
+            A ``Pixels`` renderable fitted to the avatar box, or ``None``
+            when the image is not (or no longer) cached.
+        """
+        import rich_pixels
+
+        pil = cache.get_pil(cache_key)
+        if pil is None:
+            return None
+        thumb = pil.copy()
+        thumb.thumbnail((AVATAR_THUMB_COLS, AVATAR_THUMB_LINES * 2))
+        return rich_pixels.Pixels.from_image(thumb)
 
     @on(CharacterImageRemoveRequested)
     def _handle_character_image_remove(

--- a/tldw_chatbook/Widgets/Persona_Widgets/persona_profile_editor_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/persona_profile_editor_widget.py
@@ -2,23 +2,30 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, get_args
 
 from textual import on
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal, Vertical, VerticalScroll
 from textual.timer import Timer
-from textual.widgets import Button, Input, Label, Static, TextArea
+from textual.widgets import Button, Input, Label, Select, Static, Switch, TextArea
 
+from ...tldw_api.character_persona_schemas import PersonaMode
 from .personas_pane_messages import (
     EditorContentChanged,
     PersonaProfileEditCancelled,
     PersonaProfileSaveRequested,
 )
 
+#: The `PersonaMode` literal's values, for the editor's mode `Select` options.
+PERSONA_MODES: tuple[str, ...] = get_args(PersonaMode)
+#: Default mode for a persona with none set, matching `PersonaProfileCreate`.
+_DEFAULT_MODE = "session_scoped"
+
 
 class PersonaProfileEditorWidget(Container):
-    """ds-field-row form: name, description, system prompt."""
+    """ds-field-row form: name, description, system prompt, personality
+    traits, mode, and enabled toggle."""
 
     DEFAULT_CSS = """
     PersonaProfileEditorWidget {
@@ -93,6 +100,20 @@ class PersonaProfileEditorWidget(Container):
             with Vertical(classes="ds-field-row"):
                 yield Label("System prompt")
                 yield TextArea(id="personas-editor-system-prompt")
+            with Vertical(classes="ds-field-row"):
+                yield Label("Personality traits")
+                yield TextArea(id="personas-editor-personality-traits")
+            with Vertical(classes="ds-field-row"):
+                yield Label("Mode")
+                yield Select(
+                    [(m, m) for m in PERSONA_MODES],
+                    id="personas-editor-mode",
+                    allow_blank=False,
+                    value=_DEFAULT_MODE,
+                )
+            with Horizontal(classes="ds-field-row"):
+                yield Label("Enabled")
+                yield Switch(id="personas-editor-enabled", value=True)
         # Validation stays outside the scroll body so it is always visible
         # next to Save (anchored-footer principle, same as the character editor).
         yield Static("", id="personas-editor-validation")
@@ -120,6 +141,16 @@ class PersonaProfileEditorWidget(Container):
             )
             self.query_one("#personas-editor-system-prompt", TextArea).text = str(
                 data.get("system_prompt", "")
+            )
+            self.query_one(
+                "#personas-editor-personality-traits", TextArea
+            ).text = str(data.get("personality_traits", "") or "")
+            mode = data.get("mode") or _DEFAULT_MODE
+            self.query_one("#personas-editor-mode", Select).value = (
+                mode if mode in PERSONA_MODES else _DEFAULT_MODE
+            )
+            self.query_one("#personas-editor-enabled", Switch).value = bool(
+                data.get("is_active", True)
             )
             self.query_one("#personas-editor-validation", Static).update("")
         finally:
@@ -165,6 +196,11 @@ class PersonaProfileEditorWidget(Container):
             "system_prompt": self.query_one(
                 "#personas-editor-system-prompt", TextArea
             ).text,
+            "personality_traits": self.query_one(
+                "#personas-editor-personality-traits", TextArea
+            ).text,
+            "mode": self.query_one("#personas-editor-mode", Select).value,
+            "is_active": self.query_one("#personas-editor-enabled", Switch).value,
         }
         if self._persona_id is not None:
             data["id"] = self._persona_id
@@ -178,15 +214,26 @@ class PersonaProfileEditorWidget(Container):
             self.query_one("#personas-editor-name", Input).value,
             self.query_one("#personas-editor-description", TextArea).text,
             self.query_one("#personas-editor-system-prompt", TextArea).text,
+            self.query_one("#personas-editor-personality-traits", TextArea).text,
+            self.query_one("#personas-editor-mode", Select).value,
+            self.query_one("#personas-editor-enabled", Switch).value,
         )
 
     @on(Input.Changed)
     @on(TextArea.Changed)
-    def _field_changed(self, event: Input.Changed | TextArea.Changed) -> None:
+    @on(Select.Changed)
+    @on(Switch.Changed)
+    def _field_changed(
+        self,
+        event: Input.Changed | TextArea.Changed | Select.Changed | Switch.Changed,
+    ) -> None:
         """Announce the first real user modification of the session.
 
         See PersonasCharacterEditorWidget._field_changed for the suppression
-        mechanism (loading flag + loaded-snapshot comparison).
+        mechanism (loading flag + loaded-snapshot comparison). ``Select`` and
+        ``Switch`` (the mode/enabled fields) route through the same handler
+        as ``Input``/``TextArea`` so a mode change or an Enabled toggle
+        participates in dirty tracking identically to a text edit.
         """
         # Same condition the dirty-post below ultimately gates on (minus
         # _dirty_posted, which only suppresses the once-per-session

--- a/tldw_chatbook/Widgets/Persona_Widgets/persona_profile_editor_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/persona_profile_editor_widget.py
@@ -108,6 +108,25 @@ class PersonaProfileEditorWidget(Container):
         """Clear the form for a new (unsaved) persona."""
         self.load_persona({})
 
+    def mark_saved(self, record: Dict[str, Any]) -> None:
+        """Re-baseline dirty state to a just-persisted persona (save-in-place).
+
+        Adopts the saved ``id``/``version`` as the new base (so the next Save
+        carries the incremented optimistic-lock version) and resets the dirty
+        snapshot from the CURRENT form (which already shows the saved
+        values). Does NOT repopulate the form - the user's saved edits stay
+        on screen.
+
+        Args:
+            record: The just-persisted persona record (carries the
+                incremented optimistic-lock ``version``).
+        """
+        self._persona_id = str(record.get("id", "")) or self._persona_id
+        self._version = record.get("version", self._version)
+        self._loaded_snapshot = self._form_snapshot()
+        self._dirty_posted = False
+        self.query_one("#personas-editor-validation", Static).update("")
+
     def collect(self) -> Dict[str, Any]:
         """Return the current form values as a dict.
 

--- a/tldw_chatbook/Widgets/Persona_Widgets/persona_profile_editor_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/persona_profile_editor_widget.py
@@ -7,6 +7,7 @@ from typing import Any, Dict
 from textual import on
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal, Vertical, VerticalScroll
+from textual.timer import Timer
 from textual.widgets import Button, Input, Label, Static, TextArea
 
 from .personas_pane_messages import (
@@ -43,7 +44,21 @@ class PersonaProfileEditorWidget(Container):
         border: none;
         margin-right: 1;
     }
+
+    /* Live per-field validation (Roleplay P3b Task 4): a literal color, not
+       a $ds-* token - DEFAULT_CSS must resolve in bare-App test harnesses
+       that never load the app stylesheet. */
+    PersonaProfileEditorWidget .is-invalid {
+        border: round red;
+    }
     """
+
+    #: CSS class toggled on an offending error-level field's enclosing row
+    #: by ``_run_validation``.
+    _FIELD_ERROR_CLASS = "is-invalid"
+    #: Delay before a field-change-triggered validation pass runs, matching
+    #: PersonasCharacterEditorWidget's debounce.
+    _VALIDATION_DEBOUNCE_SECONDS = 0.2
 
     def __init__(self, **kwargs) -> None:
         kwargs.setdefault("id", "ccp-persona-editor-view")
@@ -57,6 +72,9 @@ class PersonaProfileEditorWidget(Container):
         self._loading: bool = False
         self._loaded_snapshot: tuple | None = None
         self._dirty_posted: bool = False
+        # Live validation (Roleplay P3b Task 4): see
+        # PersonasCharacterEditorWidget._validation_timer for the mechanism.
+        self._validation_timer: Timer | None = None
 
     def compose(self) -> ComposeResult:
         yield Static("Persona Editor", classes="destination-section")
@@ -164,6 +182,7 @@ class PersonaProfileEditorWidget(Container):
         See PersonasCharacterEditorWidget._field_changed for the suppression
         mechanism (loading flag + loaded-snapshot comparison).
         """
+        self._schedule_validation()
         if self._loading or self._dirty_posted or self._loaded_snapshot is None:
             return
         if self._form_snapshot() == self._loaded_snapshot:
@@ -171,12 +190,47 @@ class PersonaProfileEditorWidget(Container):
         self._dirty_posted = True
         self.post_message(EditorContentChanged())
 
-    def validate(self) -> tuple[str, ...]:
-        """Return a tuple of validation error strings, empty if valid."""
-        errors: list[str] = []
+    def validate(self) -> list[tuple[str, str, str]]:
+        """Live per-field checks: name required.
+
+        Returns:
+            ``(field_id, message, level)`` tuples, ``level`` in
+            ``{"error", "warning"}``.
+        """
+        findings: list[tuple[str, str, str]] = []
         if not self.query_one("#personas-editor-name", Input).value.strip():
-            errors.append("name: required")
-        return tuple(errors)
+            findings.append(("personas-editor-name", "required", "error"))
+        return findings
+
+    def _validated_field_ids(self) -> set[str]:
+        """Field ids ``validate()`` can flag at ``error`` level."""
+        return {"personas-editor-name"}
+
+    def _run_validation(self) -> list[tuple[str, str, str]]:
+        """Compute findings, mark/un-mark offending rows, render the footer.
+
+        Runs debounced on field change (``_schedule_validation``, wired into
+        ``_field_changed``) and authoritatively at Save (``_save_pressed``),
+        which blocks when any finding is ``level == "error"``.
+
+        Returns:
+            The findings just computed and rendered.
+        """
+        findings = self.validate()
+        invalid_ids = {fid for fid, _msg, level in findings if level == "error"}
+        for fid in self._validated_field_ids():
+            row = self.query_one(f"#{fid}").parent
+            row.set_class(fid in invalid_ids, self._FIELD_ERROR_CLASS)
+        self.show_validation(tuple(f"{fid}: {msg}" for fid, msg, _level in findings))
+        return findings
+
+    def _schedule_validation(self) -> None:
+        """Debounce ``_run_validation`` so a burst of typing validates once."""
+        if self._validation_timer is not None:
+            self._validation_timer.stop()
+        self._validation_timer = self.set_timer(
+            self._VALIDATION_DEBOUNCE_SECONDS, self._run_validation
+        )
 
     def show_validation(self, errors: tuple[str, ...]) -> None:
         """Render validation errors in the editor footer (the single
@@ -190,9 +244,7 @@ class PersonaProfileEditorWidget(Container):
     @on(Button.Pressed, "#personas-editor-save")
     def _save_pressed(self, event: Button.Pressed) -> None:
         event.stop()
-        errors = self.validate()
-        self.show_validation(errors)
-        if errors:
+        if any(level == "error" for _fid, _msg, level in self._run_validation()):
             return
         self.post_message(PersonaProfileSaveRequested(self.collect()))
 

--- a/tldw_chatbook/Widgets/Persona_Widgets/persona_profile_editor_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/persona_profile_editor_widget.py
@@ -75,6 +75,11 @@ class PersonaProfileEditorWidget(Container):
         # Live validation (Roleplay P3b Task 4): see
         # PersonasCharacterEditorWidget._validation_timer for the mechanism.
         self._validation_timer: Timer | None = None
+        # Fix-wave gate: a freshly-opened form (load_persona/new_persona)
+        # must not display validation errors before the user has actually
+        # interacted with it. Set True on a genuine field edit or a Save
+        # click; reset on every load.
+        self._user_touched: bool = False
 
     def compose(self) -> ComposeResult:
         yield Static("Persona Editor", classes="destination-section")
@@ -121,6 +126,7 @@ class PersonaProfileEditorWidget(Container):
             self._loading = False
         self._loaded_snapshot = self._form_snapshot()
         self._dirty_posted = False
+        self._user_touched = False
 
     def new_persona(self) -> None:
         """Clear the form for a new (unsaved) persona."""
@@ -182,6 +188,17 @@ class PersonaProfileEditorWidget(Container):
         See PersonasCharacterEditorWidget._field_changed for the suppression
         mechanism (loading flag + loaded-snapshot comparison).
         """
+        # Same condition the dirty-post below ultimately gates on (minus
+        # _dirty_posted, which only suppresses the once-per-session
+        # announcement, not the touched flag): a genuine edit, not the
+        # programmatic-population Changed events load_persona/new_persona
+        # trigger.
+        if (
+            not self._loading
+            and self._loaded_snapshot is not None
+            and self._form_snapshot() != self._loaded_snapshot
+        ):
+            self._user_touched = True
         self._schedule_validation()
         if self._loading or self._dirty_posted or self._loaded_snapshot is None:
             return
@@ -213,9 +230,21 @@ class PersonaProfileEditorWidget(Container):
         ``_field_changed``) and authoritatively at Save (``_save_pressed``),
         which blocks when any finding is ``level == "error"``.
 
+        Display is gated on ``_user_touched``: a freshly-opened form
+        (``load_persona``/``new_persona``) must not show errors before the
+        user has actually interacted with it, so while untouched no row is
+        marked invalid and the footer stays clear.
+
         Returns:
-            The findings just computed and rendered.
+            The findings actually rendered - empty when gated by
+            ``_user_touched`` (not the raw ``validate()`` output, since
+            nothing was displayed in that case).
         """
+        if not self._user_touched:
+            for fid in self._validated_field_ids():
+                self.query_one(f"#{fid}").parent.remove_class(self._FIELD_ERROR_CLASS)
+            self.show_validation(())
+            return []
         findings = self.validate()
         invalid_ids = {fid for fid, _msg, level in findings if level == "error"}
         for fid in self._validated_field_ids():
@@ -244,6 +273,10 @@ class PersonaProfileEditorWidget(Container):
     @on(Button.Pressed, "#personas-editor-save")
     def _save_pressed(self, event: Button.Pressed) -> None:
         event.stop()
+        # Save is itself a user action: authoritatively validate even an
+        # untouched blank form (clicking Save with nothing else edited must
+        # still block + mark the offending field).
+        self._user_touched = True
         if any(level == "error" for _fid, _msg, level in self._run_validation()):
             return
         self.post_message(PersonaProfileSaveRequested(self.collect()))

--- a/tldw_chatbook/Widgets/Persona_Widgets/persona_profile_editor_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/persona_profile_editor_widget.py
@@ -153,6 +153,13 @@ class PersonaProfileEditorWidget(Container):
                 data.get("is_active", True)
             )
             self.query_one("#personas-editor-validation", Static).update("")
+            # Clear any stale per-field invalid marks left by a prior session:
+            # if the reopened record's values are byte-identical to what's
+            # already displayed, no Changed event fires and _run_validation
+            # never runs to self-heal a previously-marked row (Roleplay P3b
+            # review fix).
+            for fid in self._validated_field_ids():
+                self.query_one(f"#{fid}").parent.remove_class(self._FIELD_ERROR_CLASS)
         finally:
             self._loading = False
         self._loaded_snapshot = self._form_snapshot()

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, List
 from textual import on
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal, Vertical, VerticalScroll
+from textual.timer import Timer
 from textual.widgets import Button, DataTable, Input, Label, Static, TextArea
 
 from ...Character_Chat.world_book_manager import CHARACTER_WORLD_BOOKS_KEY
@@ -137,7 +138,22 @@ class PersonasCharacterEditorWidget(Container):
         border: none;
         margin-right: 1;
     }
+
+    /* Live per-field validation (Roleplay P3b Task 4): a literal color, not
+       a $ds-* token - DEFAULT_CSS must resolve in bare-App test harnesses
+       that never load the app stylesheet. */
+    PersonasCharacterEditorWidget .is-invalid {
+        border: round red;
+    }
     """
+
+    #: CSS class toggled on an offending error-level field's enclosing row
+    #: by ``_run_validation``.
+    _FIELD_ERROR_CLASS = "is-invalid"
+    #: Delay before a field-change-triggered validation pass runs, matching
+    #: the library search debounce (``PERSONAS_SEARCH_DEBOUNCE_SECONDS`` in
+    #: personas_screen.py).
+    _VALIDATION_DEBOUNCE_SECONDS = 0.2
 
     def __init__(self, **kwargs: Any) -> None:
         kwargs.setdefault("id", "ccp-character-editor-view")
@@ -163,6 +179,10 @@ class PersonasCharacterEditorWidget(Container):
         self._loading: bool = False
         self._loaded_snapshot: tuple | None = None
         self._dirty_posted: bool = False
+        # Live validation (Roleplay P3b Task 4): the pending debounce timer
+        # scheduled by _field_changed, cancelled and re-armed on every real
+        # field change so only the last edit in a typing burst validates.
+        self._validation_timer: Timer | None = None
 
     def compose(self) -> ComposeResult:
         yield Static("Character Editor", classes="destination-section")
@@ -406,6 +426,81 @@ class PersonasCharacterEditorWidget(Container):
 
         holder.mount(renderable if isinstance(renderable, _W) else _S(renderable))
 
+    def validate(self) -> list[tuple[str, str, str]]:
+        """Live per-field checks: name required, oversized avatar, blank greetings.
+
+        Returns:
+            ``(field_id, message, level)`` tuples, ``level`` in
+            ``{"error", "warning"}``. Errors block Save (see
+            ``_save_pressed``); warnings are informational only and never
+            mark a row invalid.
+        """
+        findings: list[tuple[str, str, str]] = []
+        if not self._input("name").value.strip():
+            findings.append(("personas-char-editor-name", "required", "error"))
+        avatar_bytes = self.current_avatar_bytes()
+        if avatar_bytes is not None:
+            # Local import: this widget module is itself imported by
+            # personas_screen at module-load time, so a top-level import of
+            # its constants back here would deadlock as a circular import.
+            from ...UI.Screens.personas_screen import (
+                PERSONAS_AVATAR_MAX_BYTES,
+                PERSONAS_AVATAR_MAX_SIZE_COPY,
+            )
+
+            if len(avatar_bytes) > PERSONAS_AVATAR_MAX_BYTES:
+                findings.append(
+                    (
+                        "personas-char-editor-avatar-status",
+                        f"image exceeds {PERSONAS_AVATAR_MAX_SIZE_COPY}",
+                        "error",
+                    )
+                )
+        for index, greeting in enumerate(self._greetings, start=1):
+            if not greeting.strip():
+                findings.append(
+                    (
+                        "personas-char-editor-greetings-table",
+                        f"greeting {index} is blank",
+                        "warning",
+                    )
+                )
+        return findings
+
+    def _validated_field_ids(self) -> set[str]:
+        """Field ids ``validate()`` can flag at ``error`` level.
+
+        Only these are reconciled (marked/un-marked) by ``_run_validation``;
+        greetings are warning-only and never toggle ``.is-invalid``.
+        """
+        return {"personas-char-editor-name", "personas-char-editor-avatar-status"}
+
+    def _run_validation(self) -> list[tuple[str, str, str]]:
+        """Compute findings, mark/un-mark offending rows, render the footer.
+
+        Runs debounced on field change (``_schedule_validation``, wired into
+        ``_field_changed``) and authoritatively at Save (``_save_pressed``),
+        which blocks when any finding is ``level == "error"``.
+
+        Returns:
+            The findings just computed and rendered.
+        """
+        findings = self.validate()
+        invalid_ids = {fid for fid, _msg, level in findings if level == "error"}
+        for fid in self._validated_field_ids():
+            row = self.query_one(f"#{fid}").parent
+            row.set_class(fid in invalid_ids, self._FIELD_ERROR_CLASS)
+        self.show_validation(tuple(f"{fid}: {msg}" for fid, msg, _level in findings))
+        return findings
+
+    def _schedule_validation(self) -> None:
+        """Debounce ``_run_validation`` so a burst of typing validates once."""
+        if self._validation_timer is not None:
+            self._validation_timer.stop()
+        self._validation_timer = self.set_timer(
+            self._VALIDATION_DEBOUNCE_SECONDS, self._run_validation
+        )
+
     def show_validation(self, errors: tuple[str, ...]) -> None:
         """Render screen-side validation errors in the editor footer.
 
@@ -641,6 +736,7 @@ class PersonasCharacterEditorWidget(Container):
             and event.text_area.id == "personas-char-editor-greeting-edit"
         ):
             return
+        self._schedule_validation()
         if self._loading or self._dirty_posted or self._loaded_snapshot is None:
             return
         if self._form_snapshot() == self._loaded_snapshot:
@@ -729,11 +825,8 @@ class PersonasCharacterEditorWidget(Container):
     @on(Button.Pressed, "#personas-char-editor-save")
     def _save_pressed(self, event: Button.Pressed) -> None:
         event.stop()
-        validation = self.query_one("#personas-char-editor-validation", Static)
-        if not self._input("name").value.strip():
-            validation.update("Validation errors:\nname: required")
+        if any(level == "error" for _fid, _msg, level in self._run_validation()):
             return
-        validation.update("")
         self.post_message(CharacterSaveRequested(self.get_character_data()))
 
     @on(Button.Pressed, "#personas-char-editor-cancel")

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
@@ -578,12 +578,31 @@ class PersonasCharacterEditorWidget(Container):
         if 0 <= index < len(self._greetings):
             self._greetings[index] = text
             self._render_greetings_table()
+            # Same race as Add/Move: re-render resets the DataTable cursor and
+            # queues an async RowHighlighted(row=0). Re-select the row that was
+            # actually updated so the edit box keeps showing it (not row 0's
+            # text), and so a follow-up Update commits to the right entry.
+            self._select_greeting_row(index)
             self._mark_dirty()
 
     def _greetings_delete(self, index: int) -> None:
         if 0 <= index < len(self._greetings):
             del self._greetings[index]
             self._render_greetings_table()
+            if self._greetings:
+                # Select the surviving neighbor at the same position (or the
+                # new last row if we deleted the tail) so the async
+                # RowHighlighted(row=0) queued by the re-render above doesn't
+                # silently revert the selection/edit box to row 0.
+                new_index = min(index, len(self._greetings) - 1)
+                self._select_greeting_row(new_index)
+            else:
+                # No rows left means no async RowHighlighted will ever fire to
+                # clobber this, so it's safe to set the empty state directly.
+                self._selected_greeting_index = None
+                self.query_one(
+                    "#personas-char-editor-greeting-edit", TextArea
+                ).text = ""
             self._mark_dirty()
 
     def _greetings_move(self, index: int, offset: int) -> None:
@@ -665,9 +684,10 @@ class PersonasCharacterEditorWidget(Container):
         event.stop()
         if self._selected_greeting_index is None:
             return
+        # _greetings_delete now selects the surviving neighbor (or clears the
+        # edit box if the list is empty) itself, so it must not be
+        # unconditionally overwritten here afterward.
         self._greetings_delete(self._selected_greeting_index)
-        self._selected_greeting_index = None
-        self.query_one("#personas-char-editor-greeting-edit", TextArea).text = ""
 
     @on(Button.Pressed, "#personas-char-editor-greeting-move-up")
     def _greeting_move_up_pressed(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
@@ -183,6 +183,11 @@ class PersonasCharacterEditorWidget(Container):
         # scheduled by _field_changed, cancelled and re-armed on every real
         # field change so only the last edit in a typing burst validates.
         self._validation_timer: Timer | None = None
+        # Fix-wave gate: a freshly-opened form (load_character/new_character)
+        # must not display validation errors before the user has actually
+        # interacted with it. Set True on a genuine field edit, an avatar
+        # action, a greeting mutation, or a Save click; reset on every load.
+        self._user_touched: bool = False
 
     def compose(self) -> ComposeResult:
         yield Static("Character Editor", classes="destination-section")
@@ -317,6 +322,7 @@ class PersonasCharacterEditorWidget(Container):
         # the just-populated form) and ignores events that match it.
         self._loaded_snapshot = self._form_snapshot()
         self._dirty_posted = False
+        self._user_touched = False
 
     def mark_saved(self, record: Dict[str, Any]) -> None:
         """Re-baseline dirty state to a just-persisted record (save-in-place).
@@ -391,6 +397,10 @@ class PersonasCharacterEditorWidget(Container):
         self._character_data["image"] = image_data
         self._set_avatar_status_from_record()
         self._mark_dirty()
+        # A discrete user action (upload flow) - validate immediately, no
+        # debounce needed, so an oversized avatar's error appears at once.
+        self._user_touched = True
+        self._run_validation()
 
     def current_avatar_bytes(self) -> bytes | None:
         """Return the loaded record's embedded avatar bytes, if any.
@@ -479,12 +489,26 @@ class PersonasCharacterEditorWidget(Container):
         """Compute findings, mark/un-mark offending rows, render the footer.
 
         Runs debounced on field change (``_schedule_validation``, wired into
-        ``_field_changed``) and authoritatively at Save (``_save_pressed``),
-        which blocks when any finding is ``level == "error"``.
+        ``_field_changed``) and directly off discrete actions (avatar
+        upload/remove, greeting mutations) and authoritatively at Save
+        (``_save_pressed``), which blocks when any finding is
+        ``level == "error"``.
+
+        Display is gated on ``_user_touched``: a freshly-opened form
+        (``load_character``/``new_character``) must not show errors before
+        the user has actually interacted with it, so while untouched no row
+        is marked invalid and the footer stays clear.
 
         Returns:
-            The findings just computed and rendered.
+            The findings actually rendered - empty when gated by
+            ``_user_touched`` (not the raw ``validate()`` output, since
+            nothing was displayed in that case).
         """
+        if not self._user_touched:
+            for fid in self._validated_field_ids():
+                self.query_one(f"#{fid}").parent.remove_class(self._FIELD_ERROR_CLASS)
+            self.show_validation(())
+            return []
         findings = self.validate()
         invalid_ids = {fid for fid, _msg, level in findings if level == "error"}
         for fid in self._validated_field_ids():
@@ -668,6 +692,10 @@ class PersonasCharacterEditorWidget(Container):
         self._greetings.append(text)
         self._render_greetings_table()
         self._mark_dirty()
+        # A discrete user action (Add button) - validate immediately, no
+        # debounce, so a blank-greeting warning appears at once.
+        self._user_touched = True
+        self._run_validation()
 
     def _greetings_update(self, index: int, text: str) -> None:
         if 0 <= index < len(self._greetings):
@@ -679,6 +707,8 @@ class PersonasCharacterEditorWidget(Container):
             # text), and so a follow-up Update commits to the right entry.
             self._select_greeting_row(index)
             self._mark_dirty()
+            self._user_touched = True
+            self._run_validation()
 
     def _greetings_delete(self, index: int) -> None:
         if 0 <= index < len(self._greetings):
@@ -699,6 +729,8 @@ class PersonasCharacterEditorWidget(Container):
                     "#personas-char-editor-greeting-edit", TextArea
                 ).text = ""
             self._mark_dirty()
+            self._user_touched = True
+            self._run_validation()
 
     def _greetings_move(self, index: int, offset: int) -> None:
         j = index + offset
@@ -709,6 +741,8 @@ class PersonasCharacterEditorWidget(Container):
             )
             self._render_greetings_table()
             self._mark_dirty()
+            self._user_touched = True
+            self._run_validation()
 
     # ===== Events =====
 
@@ -736,6 +770,16 @@ class PersonasCharacterEditorWidget(Container):
             and event.text_area.id == "personas-char-editor-greeting-edit"
         ):
             return
+        # Same condition _mark_dirty ultimately gates on (minus _dirty_posted,
+        # which only suppresses the once-per-session announcement, not the
+        # touched flag): a genuine edit, not the programmatic-population
+        # Changed events load_character/new_character trigger.
+        if (
+            not self._loading
+            and self._loaded_snapshot is not None
+            and self._form_snapshot() != self._loaded_snapshot
+        ):
+            self._user_touched = True
         self._schedule_validation()
         if self._loading or self._dirty_posted or self._loaded_snapshot is None:
             return
@@ -825,6 +869,10 @@ class PersonasCharacterEditorWidget(Container):
     @on(Button.Pressed, "#personas-char-editor-save")
     def _save_pressed(self, event: Button.Pressed) -> None:
         event.stop()
+        # Save is itself a user action: authoritatively validate even an
+        # untouched blank form (clicking Save with nothing else edited must
+        # still block + mark the offending field).
+        self._user_touched = True
         if any(level == "error" for _fid, _msg, level in self._run_validation()):
             return
         self.post_message(CharacterSaveRequested(self.get_character_data()))

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, List
 from textual import on
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal, Vertical, VerticalScroll
-from textual.widgets import Button, Input, Label, Static, TextArea
+from textual.widgets import Button, DataTable, Input, Label, Static, TextArea
 
 from ...Character_Chat.world_book_manager import CHARACTER_WORLD_BOOKS_KEY
 from .personas_pane_messages import (
@@ -74,7 +74,12 @@ class PersonasCharacterEditorWidget(Container):
         height: 2;
     }
 
-    PersonasCharacterEditorWidget #personas-char-editor-alt-greetings {
+    PersonasCharacterEditorWidget #personas-char-editor-greetings-table {
+        min-height: 4;
+        max-height: 8;
+    }
+
+    PersonasCharacterEditorWidget #personas-char-editor-greeting-edit {
         height: 3;
     }
 
@@ -141,12 +146,13 @@ class PersonasCharacterEditorWidget(Container):
         # id/version (and any keys the form does not edit, e.g.
         # character_book) survive a load -> save round trip.
         self._character_data: Dict[str, Any] = {}
-        # Greeting fidelity: the loaded greetings list and its joined TextArea
-        # form. An untouched save must return the original list verbatim —
-        # re-splitting the joined text would corrupt any greeting that itself
-        # contains newlines (one multi-paragraph greeting becomes N greetings).
-        self._loaded_greetings: List[str] = []
-        self._loaded_greetings_text: str = ""
+        # Alternate greetings: a real list editor (DataTable + scratch edit
+        # TextArea), not a newline-joined blob. Each greeting is a discrete
+        # str mutated in place via _greetings_add/_update/_delete/_move, so a
+        # greeting containing embedded newlines round-trips byte-identical —
+        # there is no join/split step to corrupt it.
+        self._greetings: List[str] = []
+        self._selected_greeting_index: int | None = None
         # Dirty tracking (UX-E3): ``_loading`` suppresses Changed events that
         # are dispatched while a programmatic population is in progress;
         # ``_loaded_snapshot`` is the authoritative suppressor for the ones
@@ -207,8 +213,37 @@ class PersonasCharacterEditorWidget(Container):
                         id="personas-char-editor-tags", placeholder="tag, another tag"
                     )
                 with Vertical(classes="ds-field-row"):
-                    yield Label("Alternate greetings (one per line)")
-                    yield TextArea(id="personas-char-editor-alt-greetings")
+                    yield Label("Alternate greetings")
+                    yield DataTable(
+                        id="personas-char-editor-greetings-table", cursor_type="row"
+                    )
+                    yield TextArea(id="personas-char-editor-greeting-edit")
+                    with Horizontal(classes="ds-toolbar"):
+                        yield Button(
+                            "Add",
+                            id="personas-char-editor-greeting-add",
+                            classes="console-action-subdued",
+                        )
+                        yield Button(
+                            "Update",
+                            id="personas-char-editor-greeting-update",
+                            classes="console-action-subdued",
+                        )
+                        yield Button(
+                            "Delete",
+                            id="personas-char-editor-greeting-delete",
+                            classes="console-action-subdued",
+                        )
+                        yield Button(
+                            "Move up",
+                            id="personas-char-editor-greeting-move-up",
+                            classes="console-action-subdued",
+                        )
+                        yield Button(
+                            "Move down",
+                            id="personas-char-editor-greeting-move-down",
+                            classes="console-action-subdued",
+                        )
             with Horizontal(id="personas-char-editor-avatar-row"):
                 yield Static("Avatar: none", id="personas-char-editor-avatar-status")
                 yield Button(
@@ -232,6 +267,12 @@ class PersonasCharacterEditorWidget(Container):
                 id="personas-char-editor-cancel",
                 classes="console-action-secondary",
             )
+
+    def on_mount(self) -> None:
+        """Register the alternate-greetings table's single column."""
+        self.query_one(
+            "#personas-char-editor-greetings-table", DataTable
+        ).add_column("Greeting", key="g")
 
     # ===== Field accessors =====
 
@@ -261,20 +302,19 @@ class PersonasCharacterEditorWidget(Container):
         """Re-baseline dirty state to a just-persisted record (save-in-place).
 
         Adopts the saved record as the new base (so the next Save carries the
-        new ``version`` and any DB-normalized keys), rebaselines the greeting
-        fidelity anchors, resets the dirty snapshot from the CURRENT form
-        (which already shows the saved values), and clears validation. Does
-        NOT repopulate the form - the user's saved edits stay on screen.
+        new ``version`` and any DB-normalized keys), rebaselines the greetings
+        list, resets the dirty snapshot from the CURRENT form (which already
+        shows the saved values), and clears validation. Does NOT repopulate
+        the form - the user's saved edits stay on screen.
 
         Args:
             record: The just-persisted character record (carries the
                 incremented optimistic-lock ``version``).
         """
         self._character_data = dict(record or {})
-        self._loaded_greetings = [
+        self._greetings = [
             str(g) for g in (self._character_data.get("alternate_greetings") or [])
         ]
-        self._loaded_greetings_text = "\n".join(self._loaded_greetings)
         self._loaded_snapshot = self._form_snapshot()
         self._dirty_posted = False
         self.query_one("#personas-char-editor-validation", Static).update("")
@@ -303,11 +343,12 @@ class PersonasCharacterEditorWidget(Container):
         self._input("tags").value = ", ".join(
             str(tag) for tag in (record.get("tags") or [])
         )
-        self._loaded_greetings = [
+        self._greetings = [
             str(greeting) for greeting in (record.get("alternate_greetings") or [])
         ]
-        self._loaded_greetings_text = "\n".join(self._loaded_greetings)
-        self._area("alt-greetings").text = self._loaded_greetings_text
+        self._selected_greeting_index = None
+        self.query_one("#personas-char-editor-greeting-edit", TextArea).text = ""
+        self._render_greetings_table()
         self._set_avatar_status_from_record()
         self.query_one("#personas-char-editor-validation", Static).update("")
         self._set_advanced_open(False)
@@ -404,18 +445,10 @@ class PersonasCharacterEditorWidget(Container):
         # Empty/whitespace Version falls back to the new_character default.
         version = self._input("version").value
         data["character_version"] = version if version.strip() else "1.0"
-        # Greeting fidelity rule: if the TextArea text is exactly the joined
-        # form of the loaded list, the user did not edit it — return the
-        # ORIGINAL list verbatim so multi-line greetings survive the round
-        # trip. Only when the text was edited do we re-parse one greeting per
-        # non-blank line.
-        greetings_text = self._area("alt-greetings").text
-        if greetings_text == self._loaded_greetings_text:
-            data["alternate_greetings"] = list(self._loaded_greetings)
-        else:
-            data["alternate_greetings"] = [
-                line.strip() for line in greetings_text.splitlines() if line.strip()
-            ]
+        # Each greeting is a discrete list entry (never blob-joined/split), so
+        # this is always the exact, byte-identical list - including any
+        # embedded newlines within a single greeting.
+        data["alternate_greetings"] = list(self._greetings)
         data["tags"] = [
             tag.strip() for tag in self._input("tags").value.split(",") if tag.strip()
         ]
@@ -476,7 +509,7 @@ class PersonasCharacterEditorWidget(Container):
             self._input("creator").value,
             self._input("version").value,
             self._input("tags").value,
-            self._area("alt-greetings").text,
+            tuple(self._greetings),
         )
 
     def _set_advanced_open(self, open_: bool) -> None:
@@ -502,6 +535,67 @@ class PersonasCharacterEditorWidget(Container):
         self._dirty_posted = True
         self.post_message(EditorContentChanged())
 
+    # ===== Alternate greetings (widget-local list editor) =====
+
+    @staticmethod
+    def _greeting_preview(text: str) -> str:
+        """First-line, truncated preview for the greetings table row."""
+        first = (text or "").splitlines()[0] if text else ""
+        return (first[:60] + "…") if len(first) > 60 or "\n" in (text or "") else first
+
+    def _render_greetings_table(self) -> None:
+        table = self.query_one("#personas-char-editor-greetings-table", DataTable)
+        table.clear()
+        for i, greeting in enumerate(self._greetings):
+            table.add_row(self._greeting_preview(greeting), key=str(i))
+
+    def _load_greeting_into_edit(self, index: int) -> None:
+        if 0 <= index < len(self._greetings):
+            self.query_one(
+                "#personas-char-editor-greeting-edit", TextArea
+            ).text = self._greetings[index]
+
+    def _select_greeting_row(self, index: int) -> None:
+        """Move the table cursor to ``index`` after a mutation's re-render.
+
+        ``_render_greetings_table`` clears and rebuilds the table, which
+        resets DataTable's own cursor to row 0 and posts an async
+        ``RowHighlighted(row=0)`` that would otherwise clobber the intended
+        selection once the message queue drains. Explicitly re-issuing
+        ``move_cursor`` here posts a second, later message that wins.
+        """
+        if 0 <= index < len(self._greetings):
+            self.query_one(
+                "#personas-char-editor-greetings-table", DataTable
+            ).move_cursor(row=index)
+
+    def _greetings_add(self, text: str = "") -> None:
+        self._greetings.append(text)
+        self._render_greetings_table()
+        self._mark_dirty()
+
+    def _greetings_update(self, index: int, text: str) -> None:
+        if 0 <= index < len(self._greetings):
+            self._greetings[index] = text
+            self._render_greetings_table()
+            self._mark_dirty()
+
+    def _greetings_delete(self, index: int) -> None:
+        if 0 <= index < len(self._greetings):
+            del self._greetings[index]
+            self._render_greetings_table()
+            self._mark_dirty()
+
+    def _greetings_move(self, index: int, offset: int) -> None:
+        j = index + offset
+        if 0 <= index < len(self._greetings) and 0 <= j < len(self._greetings):
+            self._greetings[index], self._greetings[j] = (
+                self._greetings[j],
+                self._greetings[index],
+            )
+            self._render_greetings_table()
+            self._mark_dirty()
+
     # ===== Events =====
 
     @on(Input.Changed)
@@ -509,7 +603,13 @@ class PersonasCharacterEditorWidget(Container):
     def _field_changed(self, event: Input.Changed | TextArea.Changed) -> None:
         """Announce the first real user modification of the session.
 
-        All Inputs/TextAreas that bubble here are this editor's own fields.
+        All Inputs/TextAreas that bubble here are this editor's own fields,
+        EXCEPT the alternate-greetings edit TextArea: that one is a scratch
+        field for staging a single greeting's text (populated on row
+        selection, committed via the Add/Update buttons which call
+        ``_mark_dirty`` directly) and must not itself feed dirty detection -
+        merely selecting a row would otherwise spuriously dirty the editor.
+
         Programmatic population also fires Changed; those events either land
         while ``_loading`` is set or (the usual case, since Textual posts them
         asynchronously) after ``load_character`` returned, where the snapshot
@@ -517,11 +617,77 @@ class PersonasCharacterEditorWidget(Container):
         loaded. Paste and undo also fire Changed, so the comparison covers
         them too.
         """
+        if (
+            isinstance(event, TextArea.Changed)
+            and event.text_area.id == "personas-char-editor-greeting-edit"
+        ):
+            return
         if self._loading or self._dirty_posted or self._loaded_snapshot is None:
             return
         if self._form_snapshot() == self._loaded_snapshot:
             return
         self._mark_dirty()
+
+    @on(DataTable.RowSelected, "#personas-char-editor-greetings-table")
+    def _greeting_row_selected(self, event: DataTable.RowSelected) -> None:
+        event.stop()
+        if event.row_key is not None and event.row_key.value is not None:
+            self._selected_greeting_index = int(event.row_key.value)
+            self._load_greeting_into_edit(self._selected_greeting_index)
+
+    @on(DataTable.RowHighlighted, "#personas-char-editor-greetings-table")
+    def _greeting_row_highlighted(self, event: DataTable.RowHighlighted) -> None:
+        # Arrow-key navigation only fires RowHighlighted (not RowSelected), so
+        # without this the edit TextArea would silently keep stale content
+        # from a prior row while _selected_greeting_index tracks the cursor.
+        event.stop()
+        if event.row_key is not None and event.row_key.value is not None:
+            self._selected_greeting_index = int(event.row_key.value)
+            self._load_greeting_into_edit(self._selected_greeting_index)
+
+    @on(Button.Pressed, "#personas-char-editor-greeting-add")
+    def _greeting_add_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        text = self.query_one("#personas-char-editor-greeting-edit", TextArea).text
+        self._greetings_add(text)
+        self._select_greeting_row(len(self._greetings) - 1)
+
+    @on(Button.Pressed, "#personas-char-editor-greeting-update")
+    def _greeting_update_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        if self._selected_greeting_index is None:
+            return
+        text = self.query_one("#personas-char-editor-greeting-edit", TextArea).text
+        self._greetings_update(self._selected_greeting_index, text)
+
+    @on(Button.Pressed, "#personas-char-editor-greeting-delete")
+    def _greeting_delete_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        if self._selected_greeting_index is None:
+            return
+        self._greetings_delete(self._selected_greeting_index)
+        self._selected_greeting_index = None
+        self.query_one("#personas-char-editor-greeting-edit", TextArea).text = ""
+
+    @on(Button.Pressed, "#personas-char-editor-greeting-move-up")
+    def _greeting_move_up_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        if self._selected_greeting_index is None:
+            return
+        target = self._selected_greeting_index - 1
+        if 0 <= target < len(self._greetings):
+            self._greetings_move(self._selected_greeting_index, -1)
+            self._select_greeting_row(target)
+
+    @on(Button.Pressed, "#personas-char-editor-greeting-move-down")
+    def _greeting_move_down_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        if self._selected_greeting_index is None:
+            return
+        target = self._selected_greeting_index + 1
+        if 0 <= target < len(self._greetings):
+            self._greetings_move(self._selected_greeting_index, 1)
+            self._select_greeting_row(target)
 
     @on(Button.Pressed, "#personas-char-editor-advanced-toggle")
     def _toggle_advanced(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
@@ -21,6 +21,7 @@ from textual.widgets import Button, Input, Label, Static, TextArea
 from ...Character_Chat.world_book_manager import CHARACTER_WORLD_BOOKS_KEY
 from .personas_pane_messages import (
     CharacterEditorCancelled,
+    CharacterImageRemoveRequested,
     CharacterImageUploadRequested,
     CharacterSaveRequested,
     EditorContentChanged,
@@ -87,7 +88,7 @@ class PersonasCharacterEditorWidget(Container):
     }
 
     PersonasCharacterEditorWidget #personas-char-editor-avatar-row {
-        height: 1;
+        height: auto;
         min-height: 1;
         padding: 0 1;
     }
@@ -97,13 +98,24 @@ class PersonasCharacterEditorWidget(Container):
         margin-right: 2;
     }
 
-    PersonasCharacterEditorWidget #personas-char-editor-avatar-upload {
+    PersonasCharacterEditorWidget #personas-char-editor-avatar-upload,
+    PersonasCharacterEditorWidget #personas-char-editor-avatar-remove {
         width: auto;
         min-width: 0;
         height: 1;
         min-height: 1;
         padding: 0 1;
         border: none;
+    }
+
+    /* A compact editor thumbnail box - smaller than the 80x40 chat
+       transcript image box, since this is a single always-visible avatar
+       preview rather than a scrolling message history. */
+    PersonasCharacterEditorWidget #personas-char-editor-avatar-thumb {
+        height: 10;
+        max-width: 24;
+        max-height: 10;
+        padding: 0 1;
     }
 
     PersonasCharacterEditorWidget .ds-toolbar {
@@ -204,6 +216,12 @@ class PersonasCharacterEditorWidget(Container):
                     id="personas-char-editor-avatar-upload",
                     classes="console-action-subdued",
                 )
+                yield Button(
+                    "Remove",
+                    id="personas-char-editor-avatar-remove",
+                    classes="console-action-subdued",
+                )
+            yield Container(id="personas-char-editor-avatar-thumb")
         yield Static("", id="personas-char-editor-validation")
         with Horizontal(classes="ds-toolbar"):
             yield Button(
@@ -312,6 +330,40 @@ class PersonasCharacterEditorWidget(Container):
         self._character_data["image"] = image_data
         self._set_avatar_status_from_record()
         self._mark_dirty()
+
+    def current_avatar_bytes(self) -> bytes | None:
+        """Return the loaded record's embedded avatar bytes, if any.
+
+        Returns:
+            The ``image`` key's bytes, or ``None`` when absent or not a
+            bytes-like value (e.g. the legacy ``avatar`` URL/path string,
+            which this editor does not decode as an image).
+        """
+        data = self._character_data.get("image")
+        return data if isinstance(data, (bytes, bytearray)) else None
+
+    def set_avatar_thumbnail(self, renderable: object | None) -> None:
+        """Mount a prepared avatar renderable, or clear to the text status.
+
+        The screen owns decoding (off-thread, via ``ConsoleImageRenderCache``)
+        and passes the finished renderable here; this method only mounts it -
+        a rich renderable (e.g. ``rich_pixels.Pixels``) mounts inside a
+        ``Static``, while a Textual widget (e.g. a ``textual_image`` graphics
+        ``Image``) mounts directly.
+
+        Args:
+            renderable: The prepared renderable to display, or ``None`` to
+                clear the thumbnail (leaving the text status as the sole
+                avatar indicator).
+        """
+        holder = self.query_one("#personas-char-editor-avatar-thumb", Container)
+        holder.remove_children()
+        if renderable is None:
+            return
+        from textual.widget import Widget as _W
+        from textual.widgets import Static as _S
+
+        holder.mount(renderable if isinstance(renderable, _W) else _S(renderable))
 
     def show_validation(self, errors: tuple[str, ...]) -> None:
         """Render screen-side validation errors in the editor footer.
@@ -482,6 +534,11 @@ class PersonasCharacterEditorWidget(Container):
     def _upload_avatar_pressed(self, event: Button.Pressed) -> None:
         event.stop()
         self.post_message(CharacterImageUploadRequested())
+
+    @on(Button.Pressed, "#personas-char-editor-avatar-remove")
+    def _remove_avatar_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.post_message(CharacterImageRemoveRequested())
 
     @on(Button.Pressed, "#personas-char-editor-save")
     def _save_pressed(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
@@ -239,6 +239,28 @@ class PersonasCharacterEditorWidget(Container):
         self._loaded_snapshot = self._form_snapshot()
         self._dirty_posted = False
 
+    def mark_saved(self, record: Dict[str, Any]) -> None:
+        """Re-baseline dirty state to a just-persisted record (save-in-place).
+
+        Adopts the saved record as the new base (so the next Save carries the
+        new ``version`` and any DB-normalized keys), rebaselines the greeting
+        fidelity anchors, resets the dirty snapshot from the CURRENT form
+        (which already shows the saved values), and clears validation. Does
+        NOT repopulate the form - the user's saved edits stay on screen.
+
+        Args:
+            record: The just-persisted character record (carries the
+                incremented optimistic-lock ``version``).
+        """
+        self._character_data = dict(record or {})
+        self._loaded_greetings = [
+            str(g) for g in (self._character_data.get("alternate_greetings") or [])
+        ]
+        self._loaded_greetings_text = "\n".join(self._loaded_greetings)
+        self._loaded_snapshot = self._form_snapshot()
+        self._dirty_posted = False
+        self.query_one("#personas-char-editor-validation", Static).update("")
+
     def _populate_form(self, data: Dict[str, Any]) -> None:
         self._character_data = dict(data or {})
         record = self._character_data

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
@@ -383,6 +383,12 @@ class PersonasCharacterEditorWidget(Container):
         self._render_greetings_table()
         self._set_avatar_status_from_record()
         self.query_one("#personas-char-editor-validation", Static).update("")
+        # Clear any stale per-field invalid marks left by a prior session: if
+        # the reopened record's values are byte-identical to what's already
+        # displayed, no Changed event fires and _run_validation never runs to
+        # self-heal a previously-marked row (Roleplay P3b review fix).
+        for fid in self._validated_field_ids():
+            self.query_one(f"#{fid}").parent.remove_class(self._FIELD_ERROR_CLASS)
         self._set_advanced_open(False)
 
     def new_character(self) -> None:

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
@@ -215,6 +215,12 @@ class PersonasCharacterEditorWidget(Container):
                 classes="console-action-subdued",
             )
             with Vertical(id="personas-char-editor-advanced"):
+                # Long-form content fields first (grouped with the alternate-
+                # greetings list editor, itself content), then the short
+                # single-line bookkeeping inputs (Creator/Version/Tags) as a
+                # trailing cluster - keeps similar-weight widgets together
+                # rather than sandwiching the DataTable+toolbar list editor
+                # between unrelated one-line Inputs (Roleplay P3b Task 5).
                 with Vertical(classes="ds-field-row"):
                     yield Label("Scenario")
                     yield TextArea(id="personas-char-editor-scenario")
@@ -224,19 +230,6 @@ class PersonasCharacterEditorWidget(Container):
                 with Vertical(classes="ds-field-row"):
                     yield Label("Creator notes")
                     yield TextArea(id="personas-char-editor-creator-notes")
-                with Vertical(classes="ds-field-row"):
-                    yield Label("Creator")
-                    yield Input(
-                        id="personas-char-editor-creator", placeholder="Creator name"
-                    )
-                with Vertical(classes="ds-field-row"):
-                    yield Label("Version")
-                    yield Input(id="personas-char-editor-version", value="1.0")
-                with Vertical(classes="ds-field-row"):
-                    yield Label("Tags (comma-separated)")
-                    yield Input(
-                        id="personas-char-editor-tags", placeholder="tag, another tag"
-                    )
                 with Vertical(classes="ds-field-row"):
                     yield Label("Alternate greetings")
                     yield DataTable(
@@ -269,6 +262,19 @@ class PersonasCharacterEditorWidget(Container):
                             id="personas-char-editor-greeting-move-down",
                             classes="console-action-subdued",
                         )
+                with Vertical(classes="ds-field-row"):
+                    yield Label("Creator")
+                    yield Input(
+                        id="personas-char-editor-creator", placeholder="Creator name"
+                    )
+                with Vertical(classes="ds-field-row"):
+                    yield Label("Version")
+                    yield Input(id="personas-char-editor-version", value="1.0")
+                with Vertical(classes="ds-field-row"):
+                    yield Label("Tags (comma-separated)")
+                    yield Input(
+                        id="personas-char-editor-tags", placeholder="tag, another tag"
+                    )
             with Horizontal(id="personas-char-editor-avatar-row"):
                 yield Static("Avatar: none", id="personas-char-editor-avatar-status")
                 yield Button(

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py
@@ -52,6 +52,10 @@ class CharacterImageUploadRequested(Message):
     """User requested to choose an image for the active character editor."""
 
 
+class CharacterImageRemoveRequested(Message):
+    """User requested to remove the avatar image from the active character editor."""
+
+
 class EditPersonaRequested(Message):
     """Edit was requested for the displayed persona profile."""
 

--- a/tldw_chatbook/tldw_api/character_persona_schemas.py
+++ b/tldw_chatbook/tldw_api/character_persona_schemas.py
@@ -562,6 +562,9 @@ class PersonaProfileCreate(BaseModel):
     mode: PersonaMode = "session_scoped"
     system_prompt: str | None = None
     is_active: bool = True
+    # Freeform trait description, matching the character-side `personality`
+    # field (NOT the structured archetype `personality_traits: list[str]`).
+    personality_traits: str = ""
     use_persona_state_context_default: bool = True
     voice_defaults: PersonaVoiceDefaults = Field(default_factory=PersonaVoiceDefaults)
     setup: PersonaSetupState = Field(default_factory=PersonaSetupState)
@@ -574,6 +577,7 @@ class PersonaProfileUpdate(BaseModel):
     mode: PersonaMode | None = None
     system_prompt: str | None = None
     is_active: bool | None = None
+    personality_traits: str | None = None
     use_persona_state_context_default: bool | None = None
     voice_defaults: PersonaVoiceDefaults | None = None
     setup: PersonaSetupState | None = None


### PR DESCRIPTION
## Roleplay P3b — Editor polish (character + persona editors)

Second sub-project of **P3** (Characters/Personas flow polish) and the first cycle of the **character-presence** theme (P3b editor polish → P3c persistent chat avatar → P3d reaction images). **No schema migration** — ChaChaNotes stays v22; the new persona `personality_traits` lives in the Pydantic DTO + file-backed JSON store (a new key, not a DB column).

### What changed (5 tasks)
1. **Save-in-place + dirty re-arm** — after Save the editor stays open (clears the unsaved badge, re-arms dirty via `mark_saved()`), including the create→edit transition and carrying the new optimistic-lock version (with a flip-to-card fallback if the record can't be re-read).
2. **Avatar thumbnail preview** (character) — the text "Avatar: embedded" line becomes a real rendered thumbnail, reusing the existing `ConsoleImageRenderCache` + `[chat.images]` mode resolution (off-thread decode, graphics/pixels/text fallback), fitted to its box (`_fit_avatar_cell_size`), plus a Remove action.
3. **Alt-greetings list editor** (character) — the fragile newline blob becomes a DataTable + edit area + Add/Update/Delete/Move; each greeting is a discrete string, so **multi-line greetings round-trip byte-identical** (the old corruption hazard is gone).
4. **Live per-field validation** (both) — validates as you type (debounced) and authoritatively at Save, marks the offending field, and blocks Save on errors (warnings don't block); a `_user_touched` gate means a blank new form isn't marked invalid before you interact.
5. **Persona fields** — an **Enabled** toggle (`is_active`) + a **mode** selector (both were dropped by the save handler) and a **net-new `personality_traits`** freeform field (DTO + save handler + file-store); plus a character Advanced re-tune.

### Process & verification
- Subagent-driven, 5 tasks, spec+quality review after each (4 fix-waves applied for real defects: avatar pixels-clipping, greeting cursor-race on Update/Delete, validation not firing on avatar/greeting actions + blank-form over-marking), plus an **opus whole-branch review: Ready to merge, no Critical/Important**.
- One user-visible Minor folded in (stale `.is-invalid` border on editor reopen).
- **328 passed** across all P3b editor suites + the reconciled workbench/dictionaries suites; `import tldw_chatbook.app` OK.

### Deferred (follow-up backlog)
Cosmetic/self-healing minors: avatar blank on open-then-immediate-save; character re-save dedup; `_profile_save_inflight` try-placement; a `personality_traits`-clear-to-empty test; and the pre-existing `console_transcript.py` shared `textual_image` sizing risk.

**Rebase note:** concurrent RP-UX sessions edit `personas_screen.py`; on merge-go I'll rebase onto the latest `dev`, re-verify the `_profile_save_inflight` re-arm sites survive, and re-gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the character and persona editors with save-in-place, avatar preview, a real greetings list, live validation, and new persona fields. No schema changes; `personality_traits` persists via DTO/JSON; deferred polish minors are tracked in backlog task 481.

- New Features
  - Save-in-place with dirty re-arm for character and persona editors; adopts the saved record’s optimistic-lock version and stays in edit, with a safe fallback to view if re-read fails.
  - Character avatar thumbnail preview sized to its box with a Remove action; uses `ConsoleImageRenderCache` and respects `AVATAR_THUMB_COLS`/`AVATAR_THUMB_LINES`.
  - Alternate greetings list editor (DataTable + edit area + Add/Update/Delete/Move); multi-line greetings round-trip exactly.
  - Live per-field validation (debounced) and on Save; errors block Save, warnings don’t; blank forms aren’t marked invalid until touched.
  - Persona fields: `is_active` toggle, mode selector (`PersonaMode` options), and new freeform `personality_traits` persisted via DTO and JSON store.

- Bug Fixes
  - Avatar rendering fits the box and preserves aspect; fixes prior pixels-cropping, 0-size crash, and the remove/render race, with a re-render after save-in-place when needed.
  - Greetings selection race fixed after Update/Delete; selection stays on the intended row.
  - Validation runs on avatar/greeting actions; stale `.is-invalid` borders clear on editor reopen.
  - Save dedup no longer relies on `_edit_mode` flips; guards on whether the current baseline was already claimed by a save and blocks re-entrant Save clicks.

<sup>Written for commit 5c1dda8c57b5747c6864515d7acb43ea4b4e3a3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

