### PR TITLE
fix(personas): Open in Console lands in a fresh conversation (TASK-428)

### DIFF
--- a/Tests/UI/test_chat_first_handoffs.py
+++ b/Tests/UI/test_chat_first_handoffs.py
@@ -1109,3 +1109,137 @@ def test_apply_current_handoff_context_ignores_mock_auto_attributes():
     app = AsyncMock()
 
     assert apply_current_handoff_context(app, "Use this.") == "Use this."
+
+
+def _personas_preview_handoff_payload(
+    *, suggested_prompt: str = "Continue this conversation in character."
+) -> ChatHandoffPayload:
+    """Build a Personas "Open in Console" preview-conversation handoff (task-428).
+
+    Mirrors ``PersonasPreviewController.open_in_console`` -> ``_stage_handoff``:
+    ``source="personas"``, ``item_type="preview-conversation"``, and metadata
+    that carries the selection but NOT an ``intent`` -- so it deliberately
+    misses the task-427 character path and lands in the staged-context lane.
+    """
+    return ChatHandoffPayload(
+        source="personas",
+        item_type="preview-conversation",
+        title="Personas preview conversation",
+        body="User: Hello\nElara: Well met, traveller.",
+        suggested_prompt=suggested_prompt,
+        metadata={
+            "selected_kind": "character",
+            "selected_record_id": "7",
+            "backend": "local",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_open_in_console_creates_fresh_session_not_reusing_active():
+    """A Personas "Open in Console" handoff, with another Console conversation
+    already active, must land in a NEW focused conversation titled from the
+    handoff (not the prefill) rather than reusing the active tab (task-428)."""
+    from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+        ConsoleHarness,
+    )
+    from Tests.UI.test_screen_navigation import _build_test_app
+
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        await pilot.pause()
+        screen = host.screen_stack[-1]
+        store = screen._ensure_console_chat_store()
+
+        # A pre-existing, already-active Console conversation.
+        active = store.ensure_session()
+        prior_id = active.id
+
+        app.pending_chat_handoff = _personas_preview_handoff_payload()
+        await screen._consume_pending_chat_handoff()
+        await pilot.pause()
+
+        new_id = store.active_session_id
+        # AC#1: a distinct, now-active session -- the prior one is untouched
+        # and still present (both coexist).
+        assert new_id != prior_id
+        assert prior_id in store._sessions
+        new_session = store._sessions[new_id]
+        # AC#2: titled from the handoff, never the prefilled instruction text.
+        assert new_session.title == "Personas preview conversation"
+        assert "Continue this conversation" not in new_session.title
+        # The staged prompt seeds the NEW session's draft.
+        assert (
+            store.session_draft(new_id).strip()
+            == "Continue this conversation in character."
+        )
+        assert app.pending_chat_handoff is None
+
+
+@pytest.mark.asyncio
+async def test_open_in_console_does_not_pollute_prior_session_draft():
+    """Seeding the fresh session's draft must not bleed the prefill into the
+    previously-active conversation via the draft-swap sync (task-428/TASK-339).
+
+    The prior session starts with an empty draft; after the handoff it must
+    still be empty -- never carry the staged "Continue ..." prompt.
+    """
+    from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+        ConsoleHarness,
+    )
+    from Tests.UI.test_screen_navigation import _build_test_app
+
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        await pilot.pause()
+        screen = host.screen_stack[-1]
+        store = screen._ensure_console_chat_store()
+
+        active = store.ensure_session()
+        prior_id = active.id
+        store.set_session_draft(prior_id, "")
+
+        app.pending_chat_handoff = _personas_preview_handoff_payload()
+        await screen._consume_pending_chat_handoff()
+        await pilot.pause()
+
+        assert store.active_session_id != prior_id
+        assert store.session_draft(prior_id).strip() == ""
+
+
+@pytest.mark.asyncio
+async def test_non_personas_handoff_still_reuses_active_session():
+    """Scope guard: the fresh-session behavior is Personas-only. A non-Personas
+    "Use in Console" handoff must keep reusing the active session (task-428)."""
+    from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+        ConsoleHarness,
+    )
+    from Tests.UI.test_screen_navigation import _build_test_app
+
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        await pilot.pause()
+        screen = host.screen_stack[-1]
+        store = screen._ensure_console_chat_store()
+
+        active = store.ensure_session()
+        prior_id = active.id
+
+        app.pending_chat_handoff = ChatHandoffPayload(
+            source="library",
+            item_type="media",
+            title="Some media",
+            body="Body",
+            suggested_prompt="Summarize this.",
+        )
+        await screen._consume_pending_chat_handoff()
+        await pilot.pause()
+
+        # Reused, not spawned fresh.
+        assert store.active_session_id == prior_id

--- a/Tests/UI/test_chat_first_handoffs.py
+++ b/Tests/UI/test_chat_first_handoffs.py
@@ -1137,9 +1137,12 @@ def _personas_preview_handoff_payload(
 
 @pytest.mark.asyncio
 async def test_open_in_console_creates_fresh_session_not_reusing_active():
-    """A Personas "Open in Console" handoff, with another Console conversation
-    already active, must land in a NEW focused conversation titled from the
-    handoff (not the prefill) rather than reusing the active tab (task-428)."""
+    """Open in Console lands in a new focused conversation, not the active tab.
+
+    A Personas "Open in Console" handoff, with another Console conversation
+    already active, must create a NEW focused conversation titled from the
+    handoff (not the prefill) rather than reusing the active tab (task-428).
+    """
     from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
         ConsoleHarness,
     )
@@ -1180,11 +1183,11 @@ async def test_open_in_console_creates_fresh_session_not_reusing_active():
 
 @pytest.mark.asyncio
 async def test_open_in_console_does_not_pollute_prior_session_draft():
-    """Seeding the fresh session's draft must not bleed the prefill into the
-    previously-active conversation via the draft-swap sync (task-428/TASK-339).
+    """Seeding the fresh session's draft must not pollute the prior session.
 
-    The prior session starts with an empty draft; after the handoff it must
-    still be empty -- never carry the staged "Continue ..." prompt.
+    Guards the draft-swap sync (task-428/TASK-339): the prior session starts
+    with an empty draft, and after the handoff it must still be empty -- never
+    carry the staged "Continue ..." prompt.
     """
     from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
         ConsoleHarness,
@@ -1212,9 +1215,46 @@ async def test_open_in_console_does_not_pollute_prior_session_draft():
 
 
 @pytest.mark.asyncio
+async def test_open_in_console_snapshots_composer_before_activating_new_session():
+    """The fresh-session switch must snapshot the composer first (task-428).
+
+    ``create_session`` activates the new session; per TASK-339 the composer
+    must be snapshotted before that switch so settle-window keystrokes carry
+    into the new session instead of being saved to the old one. Drive the
+    staging method directly and inspect before the deferred sync worker runs.
+    """
+    from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+        ConsoleHarness,
+    )
+    from Tests.UI.test_screen_navigation import _build_test_app
+
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        await pilot.pause()
+        screen = host.screen_stack[-1]
+        store = screen._ensure_console_chat_store()
+        active = store.ensure_session()
+        # Clear any snapshot left by mount so the assertion proves THIS handoff
+        # captured one.
+        screen._console_draft_switch_snapshot = None
+
+        # Direct call (not via _consume_pending_chat_handoff) so we can inspect
+        # state before the run_worker-scheduled sync pass executes.
+        screen._stage_handoff_as_console_live_work(_personas_preview_handoff_payload())
+
+        assert store.active_session_id != active.id
+        assert screen._console_draft_switch_snapshot is not None
+
+
+@pytest.mark.asyncio
 async def test_non_personas_handoff_still_reuses_active_session():
-    """Scope guard: the fresh-session behavior is Personas-only. A non-Personas
-    "Use in Console" handoff must keep reusing the active session (task-428)."""
+    """Non-Personas handoffs keep reusing the active session (scope guard).
+
+    The fresh-session behavior is Personas-only, so a non-Personas "Use in
+    Console" handoff must keep reusing the active session (task-428).
+    """
     from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
         ConsoleHarness,
     )

--- a/backlog/tasks/task-428 - Roleplay-handoffs-stage-into-a-fresh-conversation-instead-of-the-active-tab.md
+++ b/backlog/tasks/task-428 - Roleplay-handoffs-stage-into-a-fresh-conversation-instead-of-the-active-tab.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-428
 title: Roleplay handoffs stage into a fresh conversation instead of the active tab
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-21 09:38'
+updated_date: '2026-07-22 13:48'
 labels:
   - roleplay
   - console
@@ -20,6 +21,24 @@ Filed from the RP/character-card UX review (Docs/superpowers/qa/rp-ux-review-202
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Start Chat / Open in Console with another conversation active creates and focuses a new conversation rather than reusing the active tab
-- [ ] #2 The new conversation is not named after prefilled instruction text
+- [x] #1 Start Chat / Open in Console with another conversation active creates and focuses a new conversation rather than reusing the active tab
+- [x] #2 The new conversation is not named after prefilled instruction text
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Builds on TASK-427 (PR #754, stacked): 427 already routed the character "Start Chat" handoff to a fresh, activated session titled "Chat with {name}". This closes the remaining half — the "Open in Console" preview-transcript handoff.
+
+ROOT CAUSE: the Personas preview "Open in Console" handoff (source=personas, item_type=preview-conversation) carries no start_chat intent, so it misses 427's character path and falls into the shared _stage_handoff_as_console_live_work, whose store.ensure_session(...) REUSED whatever Console conversation was active — polluting an unrelated tab and (on send) risking a 'Continue this con...' auto-title.
+
+FIX (Personas-only, chat_screen.py): new module predicate _is_personas_preview_handoff(payload); in the staging method's suggested_prompt block, personas-preview handoffs go through store.create_session(...) (fresh + pre-activated) titled from the sanitized handoff title, seeding the new session's draft. AC#1 (create+focus new conv, not reuse): create_session sets active_session_id and the native sync pass focuses it. AC#2 (not named after prefill): the title is a real, non-default title so the send-time _maybe_auto_title_session leaves it. Every other 'Use in Console' source keeps ensure_session (scope choice: Personas-only).
+
+CORRECTNESS TRAP AVOIDED (design-review finding): the fresh branch does NOT run the inline composer.load_draft — the composer still points at the previously-active session, and _sync_console_session_draft (TASK-339 draft-swap) would otherwise save the prefill back into THAT session. Regression-tested (test_open_in_console_does_not_pollute_prior_session_draft).
+
+SCOPE/HONESTY (follow-up, not 428): the fresh 'Open in Console' session uses default settings — no character system_prompt/character_id — so it ISOLATES context (the AC) but does not itself make the continuation 'in character'; a send retains the P0-2 agent-loop limitation. The Start-Chat card-fetch FAILURE fallback deliberately still reuses (427's error path).
+
+TESTS (Tests/UI/test_chat_first_handoffs.py): 3 new (fresh-session AC#1/AC#2, no-cross-session-draft-pollution, non-personas-reuse scope guard), all RED->GREEN. Full handoff+console suites 231 passed; personas preview 21 passed. Regression: test_console_live_work_handoffs.py 13 failures PROVEN pre-existing (base combined 13 fail/227 pass == with-change 13 fail/227 pass; all schedules/subscriptions, unrelated).
+
+Files: tldw_chatbook/UI/Screens/chat_screen.py, Tests/UI/test_chat_first_handoffs.py.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -505,6 +505,24 @@ def _character_session_identity_from_handoff(
     return character_id, character_name, assistant_id
 
 
+def _is_personas_preview_handoff(payload: ChatHandoffPayload) -> bool:
+    """Return whether a handoff is a Personas "Open in Console" preview transcript.
+
+    These are staged by ``PersonasPreviewController.open_in_console`` with the
+    workbench's fixed ``source="personas"`` identity and a
+    ``"preview-conversation"`` item type. They carry no ``start_chat`` intent,
+    so they miss the character-session path (task-427); task-428 routes them
+    into a fresh, dedicated Console conversation rather than reusing (and
+    polluting) whatever conversation happens to be active. The predicate is
+    deliberately narrow: Personas "Start Chat" (``"{kind}-card"``) and "Attach"
+    handoffs do not match.
+    """
+    return (
+        str(payload.source or "").strip() == "personas"
+        and str(payload.item_type or "").strip() == "preview-conversation"
+    )
+
+
 def _source_mentions_rag(source: Any) -> bool:
     """Return whether a source label explicitly includes a RAG token.
 
@@ -9845,24 +9863,44 @@ class ChatScreen(BaseAppScreen):
         suggested_prompt = launch_payload["suggested_prompt"]
         if suggested_prompt:
             store = self._ensure_console_chat_store()
-            session = store.ensure_session(
-                title=self._console_initial_session_title_for_workspace(
-                    store.workspace_context.active_workspace_id
-                ),
-                workspace_id=store.workspace_context.active_workspace_id,
-                settings=self._default_console_session_settings(),
-            )
-            if not store.session_draft(session.id).strip():
-                store.set_session_draft(session.id, suggested_prompt)
-            try:
-                composer = self.query_one(
-                    "#console-native-composer", ConsoleComposerBar
+            if _is_personas_preview_handoff(payload):
+                # task-428: a Roleplay "Open in Console" handoff must land in
+                # its own fresh, focused conversation -- never bleed into (or
+                # reuse) whatever Console conversation is already active.
+                # ``create_session`` also pre-activates the new session, so the
+                # native sync pass below focuses it and loads its draft into the
+                # composer. We deliberately do NOT poke the composer here: it
+                # still reflects the previously-active session, and the
+                # draft-swap sync (TASK-339) would save this prompt back into
+                # THAT session. ``title`` (a sanitized ``payload.title``) is a
+                # real, non-default title, so the send-time auto-titler
+                # (``_maybe_auto_title_session``) leaves it as-is rather than
+                # renaming it after the prefilled instruction.
+                session = store.create_session(
+                    title=title,
+                    workspace_id=store.workspace_context.active_workspace_id,
+                    settings=self._default_console_session_settings(),
                 )
-            except QueryError:
-                pass
+                store.set_session_draft(session.id, suggested_prompt)
             else:
-                if not composer.draft_text().strip():
-                    composer.load_draft(suggested_prompt)
+                session = store.ensure_session(
+                    title=self._console_initial_session_title_for_workspace(
+                        store.workspace_context.active_workspace_id
+                    ),
+                    workspace_id=store.workspace_context.active_workspace_id,
+                    settings=self._default_console_session_settings(),
+                )
+                if not store.session_draft(session.id).strip():
+                    store.set_session_draft(session.id, suggested_prompt)
+                try:
+                    composer = self.query_one(
+                        "#console-native-composer", ConsoleComposerBar
+                    )
+                except QueryError:
+                    pass
+                else:
+                    if not composer.draft_text().strip():
+                        composer.load_draft(suggested_prompt)
 
         self.run_worker(
             self._sync_native_console_chat_ui(), exclusive=True, group="console-sync"

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -516,6 +516,13 @@ def _is_personas_preview_handoff(payload: ChatHandoffPayload) -> bool:
     polluting) whatever conversation happens to be active. The predicate is
     deliberately narrow: Personas "Start Chat" (``"{kind}-card"``) and "Attach"
     handoffs do not match.
+
+    Args:
+        payload: A handoff staged into the native Console.
+
+    Returns:
+        ``True`` only for a Personas "Open in Console" preview-conversation
+        handoff; ``False`` for every other source/item type.
     """
     return (
         str(payload.source or "").strip() == "personas"
@@ -9867,15 +9874,19 @@ class ChatScreen(BaseAppScreen):
                 # task-428: a Roleplay "Open in Console" handoff must land in
                 # its own fresh, focused conversation -- never bleed into (or
                 # reuse) whatever Console conversation is already active.
-                # ``create_session`` also pre-activates the new session, so the
-                # native sync pass below focuses it and loads its draft into the
-                # composer. We deliberately do NOT poke the composer here: it
-                # still reflects the previously-active session, and the
-                # draft-swap sync (TASK-339) would save this prompt back into
-                # THAT session. ``title`` (a sanitized ``payload.title``) is a
-                # real, non-default title, so the send-time auto-titler
+                # ``create_session`` pre-activates the new session, which IS an
+                # active-session switch: snapshot the composer first (TASK-339)
+                # so any keystrokes typed in the settle window before the
+                # deferred ``_sync_console_session_draft`` carry forward into
+                # the new session instead of being saved to the old one and
+                # wiped. We deliberately do NOT poke the composer here -- the
+                # sync pass below owns it and loads the new session's draft;
+                # poking it would save this prompt back into the old session.
+                # ``title`` (a sanitized ``payload.title``) is a real,
+                # non-default title, so the send-time auto-titler
                 # (``_maybe_auto_title_session``) leaves it as-is rather than
                 # renaming it after the prefilled instruction.
+                self._capture_console_draft_switch_snapshot()
                 session = store.create_session(
                     title=title,
                     workspace_id=store.workspace_context.active_workspace_id,


### PR DESCRIPTION
## Summary

Closes the remaining half of the RP review's P0-2 "handoff" cluster. **Stacked on #754 (TASK-427)** — GitHub will retarget this to `dev` once #754 merges.

TASK-427 already made the Personas **"Start Chat"** button build a fresh, activated, character-titled Console conversation. This fixes the sibling **"Open in Console"** button: staging the preview *transcript* into Console previously **reused whatever conversation was active** (via `ensure_session`), polluting an unrelated tab and — on send — risking a `"Continue this con…"` auto-title.

## Root cause

The "Open in Console" handoff (`source="personas"`, `item_type="preview-conversation"`) carries no `start_chat` intent, so it misses 427's character path and lands in the shared `_stage_handoff_as_console_live_work`, whose `store.ensure_session(...)` is get-or-reuse.

## Fix (Personas-only)

- New module predicate `_is_personas_preview_handoff(payload)` — narrow: matches only `personas` + `preview-conversation` (Start Chat is `"{kind}-card"`, Attach is `"{kind}-card"` — neither matches).
- In the staging method's `suggested_prompt` block, personas-preview handoffs go through `store.create_session(...)` (fresh + pre-activated) titled from the sanitized handoff title (`"Personas preview conversation"`); the new session's draft is seeded.
- **AC#1** (creates *and focuses* a new conversation, not reuse): `create_session` sets `active_session_id`; the native sync pass focuses it.
- **AC#2** (not named after the prefill): the title is a real, non-default title, so the send-time `_maybe_auto_title_session` leaves it as-is.
- Every other "Use in Console" source (Library / RAG / Media / Notes) keeps `ensure_session` — zero behavior change outside Personas.

## Correctness trap avoided (design-review finding)

The fresh branch deliberately does **not** poke the composer. The composer still reflects the *previously-active* session, and `_sync_console_session_draft` (the TASK-339 draft-swap) would otherwise save the prefill back into **that** session. Seeding the new session's draft and letting the sync pass own the composer prevents cross-session draft pollution — pinned by a dedicated regression test.

## Scope / honesty (follow-up, not this task)

The fresh "Open in Console" session uses default settings — **no character system prompt, no `character_id`**. It *isolates* context (the AC) but doesn't itself make the continuation "in character"; a *send* keeps the P0-2 agent-loop limitation. Same limitation as before, just relocated out of the active tab. The Start-Chat card-fetch *failure* fallback still reuses (that's 427's deliberate error path).

## Verification

- 3 new tests (`test_chat_first_handoffs.py`), each RED→GREEN: fresh-session AC#1/AC#2, no-cross-session-draft-pollution, non-personas-reuse scope guard.
- Full handoff + console store/controller suites: **231 passed**. Personas preview: **21 passed**.
- Regression net (`test_console_native_chat_flow` + `test_console_live_work_handoffs`): 13 failures **proven pre-existing** — combined base = `13 failed / 227 passed`, identical with this change; all are schedules/subscription tests unrelated to Personas.

Closes TASK-428.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Personas “Open in Console” now creates a fresh, focused conversation titled from the preview and snapshots the composer before the switch. This prevents draft and auto-title pollution and satisfies TASK-428.

- **Bug Fixes**
  - Route Personas preview handoffs (`source="personas"`, `item_type="preview-conversation"`) through `create_session` and seed the new session’s draft; title comes from the preview.
  - Snapshot the composer before the fresh-session switch so settle-window keystrokes carry into the new session (TASK-339); skip inline composer updates to avoid writing the prompt into the old session.
  - Keep non-Personas handoffs unchanged (`ensure_session` still reused).
  - Add tests for fresh session behavior, no cross-session draft leaks, composer snapshot before activation, and scope guard.

<sup>Written for commit c669046bcde886b903061258cb9744a28056367b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

