### PR TITLE
chore(backlog): task-457 (c) Inspector toggle already resolved by #745; split AC + record (a)/(b) plan

### DIFF
--- a/backlog/tasks/task-457 - Console-first-feedback-cluster-follow-ups-cold-send-optimistic-echo-rail-pressed-state-inspector-during-run.md
+++ b/backlog/tasks/task-457 - Console-first-feedback-cluster-follow-ups-cold-send-optimistic-echo-rail-pressed-state-inspector-during-run.md
@@ -21,5 +21,38 @@ Remaining pieces of the task-351 first-feedback finding (Console UX review j4-fi
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Cold-provider first send echoes the user's message before the readiness probe resolves; a not-ready provider shows an honest block/error row instead of a silently-dropped message,Rail conversation rows show a pressed/loading acknowledgment on click,Inspector toggle acknowledges immediately (within ~100ms) even during an active run
+- [ ] #1 (a) Cold-provider first send echoes the user's message before the readiness probe resolves; a not-ready provider shows an honest block/error row instead of a silently-dropped message
+- [ ] #2 (b) Rail conversation rows show a pressed/loading acknowledgment on click
+- [x] #3 (c) Inspector toggle acknowledges immediately (within ~100ms) even during an active run
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+(c) DONE — no code change needed; already resolved by PR #745 (task-344/349,
+the run-scoped workspace-context guard). The ~0.7s lag in the review (dev
+cad9e271d, pre-#745) was the ~5x/sec workspace-context `sync_state` recompose
+during a run blocking the event loop and delaying the click; #745's guard
+(chat_screen.py ~6328: skip `sync_state` when `run_active and already_synced and
+not state_changed`) removed that churn. The toggle handler itself
+(`on_console_inspector_rail_open` → `_set_console_rail_preference(right_open)` →
+`_sync_console_rail_visibility_if_changed`, a synchronous `styles.display` flip)
+was always immediate. Served-app measured (llama live, mid-run): Inspector-open
+latency 18–54ms during a run vs 6ms idle — well under the ~100ms AC. Regression-
+protected by `Tests/UI/test_console_tick_gating.py::test_console_workspace_
+context_fresh_tray_still_synced_mid_run`.
+
+(a) COLD ECHO — remaining, a real behaviour change: append the USER message in
+`submit_draft` after validation but BEFORE `resolve_for_send`. On a not-ready
+provider the USER row + SYSTEM block-row both persist. Open UX decision (needs
+sign-off): the draft is currently kept on block (`should_clear_draft=False`,
+task-340 draft-preservation), so echoing before resolve would make each blocked
+retry echo a NEW duplicate USER row — the coherent model is clear-draft-on-block
++ retry-by-retype, which changes task-340 behaviour and every "blocked send →
+no user message" test. Verify cold latency with a genuinely slow/cold provider.
+
+(b) RAIL LOADING FEEDBACK — remaining: on a conversation-row click, mark the row
+loading (spinner/dim) until `_resume_console_workspace_conversation` completes or
+errors, so a slow/failed open no longer reads as a dead click. Needs load-state
+tracking on the row + served-app verification.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-457 - Console-first-feedback-cluster-follow-ups-cold-send-optimistic-echo-rail-pressed-state-inspector-during-run.md
+++ b/backlog/tasks/task-457 - Console-first-feedback-cluster-follow-ups-cold-send-optimistic-echo-rail-pressed-state-inspector-during-run.md
@@ -38,9 +38,12 @@ not state_changed`) removed that churn. The toggle handler itself
 (`on_console_inspector_rail_open` → `_set_console_rail_preference(right_open)` →
 `_sync_console_rail_visibility_if_changed`, a synchronous `styles.display` flip)
 was always immediate. Served-app measured (llama live, mid-run): Inspector-open
-latency 18–54ms during a run vs 6ms idle — well under the ~100ms AC. Regression-
-protected by `Tests/UI/test_console_tick_gating.py::test_console_workspace_
-context_fresh_tray_still_synced_mid_run`.
+latency 18–54ms during a run vs 6ms idle — well under the ~100ms AC. Regression
+test (kept on one line so it copies cleanly):
+
+```
+Tests/UI/test_console_tick_gating.py::test_console_workspace_context_fresh_tray_still_synced_mid_run
+```
 
 (a) COLD ECHO — remaining, a real behaviour change: append the USER message in
 `submit_draft` after validation but BEFORE `resolve_for_send`. On a not-ready


### PR DESCRIPTION
## Summary

Investigated sub-symptom **(c)** of the task-457 first-feedback cluster (the Inspector toggle showing no response for ~0.7s during a run) and found it is **already resolved on dev** — no code change needed. This PR is backlog-only: it splits the bundled AC, checks (c), and records the plans for the remaining (a)/(b).

## Why (c) is already fixed

The ~0.7s lag in the review (dev `cad9e271d`, before #745) was the **~5×/sec workspace-context `sync_state` recompose** during a run blocking the event loop and delaying the click. **PR #745 (task-344/349)** added a run-scoped guard (`chat_screen.py` ~6328: skip `sync_state` when `run_active and already_synced and not state_changed`) that removed exactly that churn. The toggle handler itself was always immediate (a synchronous `styles.display` flip via `_sync_console_rail_visibility_if_changed`).

**Served-app measurement** (llama live, `home351` provider home, mid-run):

| condition | Inspector-open latency |
|---|---|
| idle | 6 ms |
| during a run | 18 ms |
| during a run (again) | 54 ms |

All well under the ~100ms AC (and far under the finding's 0.7s). Regression-protected by `Tests/UI/test_console_tick_gating.py::test_console_workspace_context_fresh_tray_still_synced_mid_run`.

## Remaining (recorded in the task's Implementation Plan)

- **(a) cold optimistic echo** — a real behaviour change (append the USER message before `resolve_for_send`) with an open UX decision on the block/retry model (echoing before resolve makes each blocked retry duplicate the USER row under the current `should_clear_draft=False` / task-340 draft-preservation).
- **(b) rail-row loading feedback** — loading indicator on a clicked conversation row until the open completes/errors.

Backlog only — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Verified task-457(c) Inspector toggle lag is already fixed on `dev` by #745; no product code changes. Split the task’s AC into (a) cold optimistic echo, (b) rail-row loading feedback, and (c) inspector toggle; marked (c) done and recorded plans for (a)/(b).

- **Refactors**
  - Split bundled AC in the backlog doc; checked off (c) and captured plan for (a)/(b).
  - Captured rationale: #745’s run-scoped `sync_state` guard removed the churn; measured 18–54 ms during runs (under 100 ms); covered by `Tests/UI/test_console_tick_gating.py`.
  - Kept the regression-test selector on one line in a fenced block to copy cleanly.

<sup>Written for commit e75b5a2adb43afc4a04149798b8ec64f5e588d8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

