### PR TITLE
fix(console): explicit-fit graphics image size in transcript (task-481 #6)

### DIFF
--- a/Tests/Chat/test_console_image_view.py
+++ b/Tests/Chat/test_console_image_view.py
@@ -7,6 +7,7 @@ from tldw_chatbook.Chat.console_image_view import (
     IMAGE_DECODE_MAX_DIMENSION,
     ConsoleImageRenderCache,
     ConsoleImageViewState,
+    fit_image_cell_size,
     next_view_mode,
     resolve_default_mode,
 )
@@ -214,3 +215,45 @@ def test_resolve_default_mode_live_shape_terminal_override(monkeypatch):
         }
     }
     assert resolve_default_mode(live_shape) == "graphics"
+
+
+# --- fit_image_cell_size (P3b avatar guard, generalized for the transcript) ---
+
+
+def test_fit_image_cell_size_returns_explicit_positive_ints_within_box():
+    # The whole point: never "auto" (0-size crash) - always explicit >=1 ints
+    # clamped to the box, for any realistic image.
+    for w, h in [(512, 512), (1024, 256), (100, 900), (7, 3), (1, 1)]:
+        cw, ch = fit_image_cell_size(w, h, 80, 40)
+        assert isinstance(cw, int) and isinstance(ch, int)
+        assert 1 <= cw <= 80 and 1 <= ch <= 40
+
+
+def test_fit_image_cell_size_wide_image_fits_width():
+    # A very wide image is width-bound: full 80 cols, fewer lines.
+    cw, ch = fit_image_cell_size(1600, 200, 80, 40)
+    assert cw == 80 and ch < 40
+
+
+def test_fit_image_cell_size_tall_image_fits_height():
+    # A very tall image is height-bound: full 40 lines, fewer cols.
+    cw, ch = fit_image_cell_size(100, 1600, 80, 40)
+    assert ch == 40 and cw < 80
+
+
+def test_fit_image_cell_size_preserves_aspect_within_box():
+    # Square pixels -> ~2:1 cell aspect (cells are ~2x taller than wide);
+    # fitting into 80x40 should be width-bound at 80 with height ~ 80/2 = 40.
+    cw, ch = fit_image_cell_size(400, 400, 80, 40)
+    assert cw == 80 and ch == 40
+
+
+def test_fit_image_cell_size_degenerate_returns_full_box():
+    assert fit_image_cell_size(0, 100, 80, 40) == (80, 40)
+    assert fit_image_cell_size(100, 0, 24, 10) == (24, 10)
+
+
+def test_fit_image_cell_size_respects_arbitrary_box():
+    # The avatar box (24x10) still works through the same helper.
+    cw, ch = fit_image_cell_size(1000, 1000, 24, 10)
+    assert 1 <= cw <= 24 and 1 <= ch <= 10

--- a/Tests/UI/test_console_native_transcript.py
+++ b/Tests/UI/test_console_native_transcript.py
@@ -983,8 +983,12 @@ def test_image_row_widget_builds_for_both_modes():
     graphics_row = next(r for r in transcript._transcript_rows() if r.kind == "image")
     graphics_widget = transcript._build_row_widget(graphics_row, track=False)
     assert graphics_widget.id == f"console-image-{message.id}"
-    assert graphics_widget.styles.max_width.value == 80
-    assert graphics_widget.styles.max_height.value == 40
+    # Graphics images now carry an EXPLICIT fitted cell size (not just
+    # max-width/max-height): textual_image's "auto" sizing could resolve to a
+    # transient 0-region mid-mount and crash PIL.resize(). A 16x16 square fits
+    # the 80x40 box exactly at (80, 40).
+    assert graphics_widget.styles.width.value == 80
+    assert graphics_widget.styles.height.value == 40
 
 
 def test_image_row_rebuild_tracked_on_mode_change():

--- a/backlog/tasks/task-481 - P3b-follow-up-sweep-deferred-editor-polish-minors.md
+++ b/backlog/tasks/task-481 - P3b-follow-up-sweep-deferred-editor-polish-minors.md
@@ -1,7 +1,7 @@
 ---
 id: task-481
 title: P3b follow-up — sweep deferred editor-polish minors
-status: To Do
+status: Done
 assignee: []
 labels:
   - tech-debt
@@ -24,5 +24,5 @@ Cleanup of Minor findings deferred from the Roleplay P3b whole-branch review (PR
 - [x] #3 `_profile_save_inflight` try-placement — DONE (cc1c04ad0): `mode`/`persona_id` reads moved inside the try.
 - [x] #4 `personality_traits` clear-to-empty Update test — DONE (cc1c04ad0).
 - [x] #5 twice-save-in-place greeting/version-preservation test — DONE (cc1c04ad0).
-- [ ] #6 (pre-existing, separate concern — the only remaining item) `Widgets/Console/console_transcript.py:_image_row_widget` shares the max-width/height-only `textual_image.Image` sizing that caused a zero-size `ValueError` under a live render in P3b Task 2 — apply the same explicit-size guard there (the avatar path already sidesteps it via `_fit_avatar_cell_size`).
+- [x] #6 `console_transcript.py:_image_row_widget` explicit-size guard — DONE in PR #775 (cf8d69c63): extracted `fit_image_cell_size` pure helper into `console_image_view.py`, set explicit fitted cell dims on the graphics image (pixels Static keeps its safe max-* cap).
 <!-- AC:END -->

--- a/tldw_chatbook/Chat/console_image_view.py
+++ b/tldw_chatbook/Chat/console_image_view.py
@@ -36,6 +36,49 @@ _RENDER_MODES: tuple[ConsoleImageViewMode, ...] = ("pixels", "graphics", "hidden
 _LEGACY_TO_MODE = {"pixels": "pixels", "regular": "graphics"}
 
 
+def fit_image_cell_size(
+    pixel_width: int, pixel_height: int, box_cols: int, box_lines: int
+) -> tuple[int, int]:
+    """Fit a PIL image's pixel size into a cell box, preserving aspect ratio.
+
+    A ``textual_image.widget.Image`` sized with only ``max-width``/``max-height``
+    resolves its render region from the parent container's *settled* layout;
+    mounting at runtime (vs. compose time) can paint one tick before that
+    settles, asking the renderer to scale into a transient 0-width/height region
+    -- which PIL's ``resize()`` raises ``ValueError`` on. Setting BOTH cell
+    dimensions to explicit ints sidesteps that race (a fixed size resolves
+    without waiting on parent layout). Terminal cells are ~2x taller than wide
+    in pixels, so the image aspect is converted to "cell units" (halving the
+    height) before fitting.
+
+    Args:
+        pixel_width: Source image width in pixels.
+        pixel_height: Source image height in pixels.
+        box_cols: Target box width in character columns.
+        box_lines: Target box height in character lines.
+
+    Returns:
+        ``(width_cells, height_cells)``, each an int clamped to
+        ``[1, box_cols]`` / ``[1, box_lines]``. Degenerate input returns the
+        full box.
+    """
+    if pixel_width <= 0 or pixel_height <= 0:
+        return box_cols, box_lines
+    cell_aspect = pixel_width / (pixel_height / 2)
+    box_aspect = box_cols / box_lines
+    if cell_aspect >= box_aspect:
+        # Relatively wider than the box -> fit to width.
+        w_cells = box_cols
+        h_cells = max(1, round(box_cols / cell_aspect))
+    else:
+        # Relatively taller than the box -> fit to height.
+        h_cells = box_lines
+        w_cells = max(1, round(box_lines * cell_aspect))
+    w_cells = max(1, min(box_cols, w_cells))
+    h_cells = max(1, min(box_lines, h_cells))
+    return w_cells, h_cells
+
+
 def next_view_mode(current: ConsoleImageViewMode) -> ConsoleImageViewMode:
     """Return the next mode in the pixels -> graphics -> hidden cycle.
 

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -27,6 +27,7 @@ from tldw_chatbook.Chat.console_image_view import (
     PIXELS_MAX_COLS,
     PIXELS_MAX_LINES,
     ConsoleImageRowSpec,
+    fit_image_cell_size,
 )
 from tldw_chatbook.Chat.console_message_actions import (
     ConsoleMessageAction,
@@ -975,6 +976,18 @@ class ConsoleTranscript(VerticalScroll):
                 from textual_image.widget import Image as _GraphicsImage
 
                 widget = _GraphicsImage(spec.pil, id=f"console-image-{spec.message_id}")
+                # Explicit fitted cell size, not just max-width/max-height:
+                # textual_image's "auto" sizing resolves its render region
+                # from the parent's settled layout, and mounting a tick before
+                # that settles can ask the renderer to scale into a transient
+                # 0-width/height region - which PIL's resize() raises on. Fixed
+                # ints resolve without waiting on layout, sidestepping the race
+                # (the personas avatar preview uses the same guard).
+                w_cells, h_cells = fit_image_cell_size(
+                    spec.pil.width, spec.pil.height, PIXELS_MAX_COLS, PIXELS_MAX_LINES
+                )
+                widget.styles.width = w_cells
+                widget.styles.height = h_cells
             except Exception:
                 logger.opt(exception=True).warning(
                     "textual-image unavailable; falling back to pixels row."
@@ -996,9 +1009,11 @@ class ConsoleTranscript(VerticalScroll):
                 pixels if pixels is not None else "",
                 id=f"console-image-{spec.message_id}",
             )
+            # Pixels render at their baked half-block size; a max cap is safe
+            # here (no textual_image auto-sizing race).
+            widget.styles.max_width = PIXELS_MAX_COLS
+            widget.styles.max_height = PIXELS_MAX_LINES
         widget.add_class("console-transcript-image")
-        widget.styles.max_width = 80
-        widget.styles.max_height = 40
         return widget
 
     def _update_row_widget(self, widget: Widget, row: _TranscriptRow) -> Widget:


### PR DESCRIPTION
## Console transcript — explicit-fit graphics image size (task-481 #6)

`Widgets/Console/console_transcript.py:_image_row_widget` mounted graphics-mode message images (`textual_image.widget.Image`) with only `max-width`/`max-height` set. That's the same **auto-sizing race** P3b Task 2 already fixed for the character-avatar preview: `textual_image` resolves its render region from the parent's *settled* layout, so mounting a tick before layout settles can ask the renderer to scale into a transient 0-width/height region — which `PIL.resize()` raises `ValueError` on.

### Fix
- Extract P3b's `_fit_avatar_cell_size` into a reusable **pure helper** `fit_image_cell_size(pixel_width, pixel_height, box_cols, box_lines)` in `Chat/console_image_view.py` (parameterized by box dims; aspect-preserving; returns explicit ints ≥ 1 clamped to the box).
- Set **explicit fitted cell dims** (`styles.width`/`styles.height`) on the graphics widget (box = the transcript's 80×40), instead of relying on `max-*` auto-sizing.
- The pixels `Static` fallback keeps its safe `max-width`/`max-height` cap (Pixels render at their baked half-block size — no auto-sizing race).

### Notes
- The pure helper is a natural shared seam for the upcoming P3c character-avatar panel too; the personas editor's `_fit_avatar_cell_size` can migrate to it later (left as-is here to avoid touching the concurrently-edited `personas_screen.py`).
- Updated the one existing transcript test that asserted the old `max_width`/`max_height` on the graphics widget (a 16×16 square fits the 80×40 box exactly at `(80, 40)`, now via explicit `width`/`height`).

### Verification
6 new `fit_image_cell_size` unit tests + **261 passed** across `test_console_image_view.py` + `test_console_native_transcript.py` + `test_console_native_chat_flow.py`; `import tldw_chatbook.app` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash when rendering graphics images in the console transcript by setting explicit cell width/height, avoiding `textual_image` auto-sizing races that caused `PIL.resize()` errors. Closes task-481 #6.

- **Bug Fixes**
  - Added `fit_image_cell_size(pixel_width, pixel_height, box_cols, box_lines)` in `Chat/console_image_view.py` to compute explicit, aspect-preserving cell sizes within the box.
  - Set explicit `styles.width`/`styles.height` on graphics images (80×40), replacing `max-*` auto-sizing that could resolve to 0-size in `textual_image.widget.Image`.
  - Kept the pixels fallback with `max-width`/`max-height` caps.
  - Updated tests and added unit coverage for `fit_image_cell_size`.

<sup>Written for commit 85a92ebe8e90958b028c97de5419d6ae6be7fc79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

