### PR TITLE
feat(console): task-457(b) rail loading feedback + (a) code-review hardening

### DIFF
--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -371,6 +371,49 @@ async def test_probe_exception_after_optimistic_echo_marks_row_blocked():
 
 
 @pytest.mark.asyncio
+async def test_skill_refuse_after_optimistic_echo_marks_row_blocked():
+    """TASK-457(a) (code-review finding 1): a skill-substitution refusal after
+    the optimistic echo is a block outcome like the not-ready / probe-raise
+    paths — the echoed USER row must be failed so the refused command cannot
+    leak into the next send's provider context (skip_failed only drops failed)."""
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+
+    async def _refuse(messages):
+        return messages, "Refused: untrusted skill."
+
+    controller._apply_skill_substitution = _refuse
+
+    result = await controller.submit_draft("run /evil")
+
+    assert result.accepted is False
+    messages = store.messages_for_session(store.active_session_id)
+    assert messages[0].role.value == "user"
+    assert messages[0].status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_dictionary_apply_raise_after_optimistic_echo_marks_row_blocked():
+    """TASK-457(a) (code-review finding 1): a raise from chat-dictionary / world-
+    info application (or prefill) after the optimistic echo must also fail the
+    echoed row so a never-sent message cannot leak into the next send."""
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+
+    async def _boom(messages, session_id):
+        raise RuntimeError("dict boom")
+
+    controller._apply_chat_dictionaries = _boom
+
+    with pytest.raises(RuntimeError):
+        await controller.submit_draft("hello")
+
+    messages = store.messages_for_session(store.active_session_id)
+    assert messages[0].role.value == "user"
+    assert messages[0].status == "failed"
+
+
+@pytest.mark.asyncio
 async def test_blocked_workspace_source_preserves_draft_and_skips_provider_call():
     class RecordingGateway(BlockedGateway):
         calls = 0
@@ -1554,6 +1597,63 @@ def test_submit_stages_all_pendings_and_clears(monkeypatch):
     user_message = [m for m in messages if m.role is ConsoleMessageRole.USER][-1]
     assert len(user_message.attachments) == 2
     assert user_message.image_data is not None  # mirror holds
+
+
+def test_image_budget_excludes_failed_send_blocked_echo(monkeypatch):
+    """TASK-457(a) (code-review finding 2): a send-blocked USER echo persists as
+    a `failed` row that KEEPS its attachment data but is dropped from the emitted
+    payload by skip_failed. The image-budget RESERVATION loop must skip it too —
+    otherwise the reserved-but-never-emitted slots starve a real older image
+    message (silent wrong payload)."""
+    monkeypatch.setattr(controller_module, "is_vision_capable", lambda p, m: True)
+    monkeypatch.setattr(controller_module, "max_history_images", lambda p, m: 1)
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(
+        store=store, provider_gateway=StreamingGateway(), model="vision-model"
+    )
+    session = store.ensure_session()
+    from tldw_chatbook.Chat.console_chat_models import MessageAttachment
+
+    def _att(tag):
+        return (
+            MessageAttachment(
+                data=tag.encode(),
+                mime_type="image/png",
+                display_name=f"{tag}.png",
+                position=0,
+            ),
+        )
+
+    store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content="real",
+        attachments=_att("real"),
+    )
+    blocked = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content="blocked",
+        attachments=_att("blocked"),
+    )
+    # Newer than the real message, failed, but still carrying its image bytes.
+    store.mark_message_send_blocked(blocked.id)
+
+    messages = store.messages_for_session(session.id)
+    payloads = controller._provider_message_payloads(messages, skip_failed=True)
+
+    user_payloads = [m for m in payloads if m["role"] == "user"]
+    assert len(user_payloads) == 1
+    images = (
+        [p for p in user_payloads[0]["content"] if p["type"] == "image_url"]
+        if isinstance(user_payloads[0]["content"], list)
+        else []
+    )
+    assert len(images) == 1
+    import base64
+
+    decoded = base64.b64decode(images[0]["image_url"]["url"].split(",", 1)[1])
+    assert decoded == b"real"
 
 
 def test_image_budget_counts_images_newest_first(monkeypatch):

--- a/Tests/UI/test_console_workspace_context_rail.py
+++ b/Tests/UI/test_console_workspace_context_rail.py
@@ -1788,3 +1788,86 @@ async def test_console_rail_wrap_budget_tracks_terminal_width() -> None:
             name_lines = _first_row_name_lines(console)
             assert all(cell_len(line) <= budget for line in name_lines)
     assert budgets["narrow"] < budgets["wide"]
+
+
+@pytest.mark.asyncio
+async def test_console_conversation_row_loading_toggles_on_matching_row() -> None:
+    """task-457(b): the rail must be able to flag a conversation row as loading
+    (spinner) so a slow open reads as acknowledged, and clear it, matching by
+    conversation id; an unknown id is a no-op that never raises."""
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 44)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-workspace-context")
+        tray = console.query_one(
+            "#console-workspace-context", ConsoleWorkspaceContextTray
+        )
+        tray.sync_state(
+            _base_grouped_workspace_state(rows=(_browser_row("conv-x", "Saved chat"),))
+        )
+        await pilot.pause()
+
+        row = console.query_one("#console-workspace-conversation-0", Button)
+        assert getattr(row, "conversation_id", "") == "conv-x"
+        assert row.loading is False
+
+        console._set_console_conversation_row_loading("conv-x", True)
+        assert row.loading is True
+
+        console._set_console_conversation_row_loading("conv-x", False)
+        assert row.loading is False
+
+        # Unknown id must not raise or touch the row.
+        console._set_console_conversation_row_loading("nope", True)
+        assert row.loading is False
+
+
+@pytest.mark.asyncio
+async def test_console_conversation_row_click_shows_loading_until_resume_finishes() -> None:
+    """task-457(b): clicking a not-yet-open persisted conversation awaits the
+    resume inline; the pressed row must show a loading acknowledgment for the
+    duration and clear it once the resume settles, so a slow/failed open no
+    longer reads as a dead click."""
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 44)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-workspace-context")
+        tray = console.query_one(
+            "#console-workspace-context", ConsoleWorkspaceContextTray
+        )
+        tray.sync_state(
+            _base_grouped_workspace_state(rows=(_browser_row("conv-y", "Saved chat"),))
+        )
+        await pilot.pause()
+
+        row = console.query_one("#console-workspace-conversation-0", Button)
+        assert getattr(row, "conversation_id", "") == "conv-y"
+
+        loading_during_resume: list[bool] = []
+
+        async def _fake_resume(conversation_id, **kwargs):
+            # The pressed row must already read as loading before the slow
+            # resume work runs, and match the clicked conversation.
+            assert conversation_id == "conv-y"
+            loading_during_resume.append(
+                console.query_one(
+                    "#console-workspace-conversation-0", Button
+                ).loading
+            )
+            return False
+
+        console._resume_console_workspace_conversation = _fake_resume
+
+        await console.on_button_pressed(Button.Pressed(row))
+
+        assert loading_during_resume == [True]
+        # Once the resume settles (here: not resumable) the row is not left
+        # stuck spinning.
+        assert (
+            console.query_one("#console-workspace-conversation-0", Button).loading
+            is False
+        )

--- a/Tests/UI/test_console_workspace_context_rail.py
+++ b/Tests/UI/test_console_workspace_context_rail.py
@@ -1871,3 +1871,39 @@ async def test_console_conversation_row_click_shows_loading_until_resume_finishe
             console.query_one("#console-workspace-conversation-0", Button).loading
             is False
         )
+
+
+@pytest.mark.asyncio
+async def test_console_conversation_row_loading_cleared_when_resume_raises() -> None:
+    """task-457(b): if the inline resume RAISES, the `finally` must still clear
+    the row's loading spinner so a failed open never leaves it stuck (the error
+    itself still propagates out of the handler)."""
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 44)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-workspace-context")
+        tray = console.query_one(
+            "#console-workspace-context", ConsoleWorkspaceContextTray
+        )
+        tray.sync_state(
+            _base_grouped_workspace_state(rows=(_browser_row("conv-z", "Saved chat"),))
+        )
+        await pilot.pause()
+
+        row = console.query_one("#console-workspace-conversation-0", Button)
+        assert getattr(row, "conversation_id", "") == "conv-z"
+
+        async def _raising_resume(conversation_id, **kwargs):
+            raise RuntimeError("resume boom")
+
+        console._resume_console_workspace_conversation = _raising_resume
+
+        with pytest.raises(RuntimeError):
+            await console.on_button_pressed(Button.Pressed(row))
+
+        assert (
+            console.query_one("#console-workspace-conversation-0", Button).loading
+            is False
+        )

--- a/backlog/tasks/task-457 - Console-first-feedback-cluster-follow-ups-cold-send-optimistic-echo-rail-pressed-state-inspector-during-run.md
+++ b/backlog/tasks/task-457 - Console-first-feedback-cluster-follow-ups-cold-send-optimistic-echo-rail-pressed-state-inspector-during-run.md
@@ -24,7 +24,7 @@ Remaining pieces of the task-351 first-feedback finding (Console UX review j4-fi
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
 - [x] #1 (a) Cold-provider first send echoes the user's message before the readiness probe resolves; a not-ready provider shows an honest block/error row instead of a silently-dropped message
-- [ ] #2 (b) Rail conversation rows show a pressed/loading acknowledgment on click
+- [x] #2 (b) Rail conversation rows show a pressed/loading acknowledgment on click
 - [x] #3 (c) Inspector toggle acknowledges immediately (within ~100ms) even during an active run
 <!-- AC:END -->
 
@@ -116,4 +116,26 @@ assistant/system row to `"failed"` and bypass the assistant terminal guards.
 Both covered by new RED→GREEN tests (`..._rejects_non_user_rows`,
 `test_probe_exception_after_optimistic_echo_marks_row_blocked`); 276 Chat-suite
 green.
+
+(b) DONE. A rail conversation-row click that opens a not-yet-loaded persisted
+conversation awaits `_resume_console_workspace_conversation` inline; a slow or
+failing open used to read as a dead click. The pressed row is now flagged
+`loading` (Textual's built-in spinner overlay) for the duration of the resume
+and always cleared afterwards. New screen helper
+`_set_console_conversation_row_loading(conversation_id, loading)` matches the row
+by its `conversation_id` attribute and no-ops when the row is gone (a successful
+resume recomposes the rail, which already drops the flag; the `finally` covers
+the not-resumable/error return so the row never stays stuck spinning). Only the
+slow `session_id is None` resume branch is wrapped — the already-open
+`switch_session` path is instant and needs no spinner.
+
+Verified RED->GREEN in `Tests/UI/test_console_workspace_context_rail.py`:
+`test_console_conversation_row_loading_toggles_on_matching_row` (helper toggles
+`.loading` on the matching row; unknown id is a no-op) and
+`test_console_conversation_row_click_shows_loading_until_resume_finishes` (a row
+press flags the row loading before the awaited resume runs and clears it once the
+resume settles). Full rail + scope-row + handoffs suites green.
+
+PR map: (c) shipped via PR #745; (a) cold-send optimistic echo via PR #777;
+(b) rail loading feedback via PR #779 — all three ACs met.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-457 - Console-first-feedback-cluster-follow-ups-cold-send-optimistic-echo-rail-pressed-state-inspector-during-run.md
+++ b/backlog/tasks/task-457 - Console-first-feedback-cluster-follow-ups-cold-send-optimistic-echo-rail-pressed-state-inspector-during-run.md
@@ -136,6 +136,18 @@ Verified RED->GREEN in `Tests/UI/test_console_workspace_context_rail.py`:
 press flags the row loading before the awaited resume runs and clears it once the
 resume settles). Full rail + scope-row + handoffs suites green.
 
-PR map: (c) shipped via PR #745; (a) cold-send optimistic echo via PR #777;
-(b) rail loading feedback via PR #779 — all three ACs met.
+Code-review follow-up (findings 1+2 folded into PR #779, RED→GREEN): (1) the
+optimistic echo now marks the row send-blocked on EVERY non-accepted exit after
+the append, not just the not-ready/probe-raise ones — a skill-substitution
+refusal and any raise from dictionary/world-info/prefill application are wrapped
+so the echoed row can't leak into the next send's context; (2) the image-budget
+RESERVATION loop now honors `skip_failed`, so a send-blocked echo (which keeps
+its attachment data but is dropped from the payload) no longer reserves image
+slots a real message would lose. Finding 3 (blocked echo persists a durable
+`failed` row whose status is lost on reload → re-leak + orphan block row) filed
+as task-485 (needs a design call).
+
+PR map: (c) shipped via PR #745; (a) cold-send optimistic echo via PR #777
+(+ findings 1+2 hardening in #779); (b) rail loading feedback via PR #779 —
+all three ACs met.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-485 - Console-blocked-send-echo-persistence-failed-status-lost-on-reload-and-orphan-block-row.md
+++ b/backlog/tasks/task-485 - Console-blocked-send-echo-persistence-failed-status-lost-on-reload-and-orphan-block-row.md
@@ -1,0 +1,70 @@
+---
+id: TASK-485
+title: >-
+  Console blocked-send echo persistence: failed status lost on reload +
+  orphan block row
+status: To Do
+assignee: []
+created_date: '2026-07-22 12:19'
+labels:
+  - console
+  - ux
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow-up from the task-457(a) code review (finding 3). The cold-send optimistic
+echo appends the USER row with `persist=self.store.persistence is not None`
+BEFORE the readiness probe, so a blocked first send now creates a durable
+persisted conversation (auto-titled from the first attempt) containing a
+`failed` USER row — while the honest SYSTEM block-row explaining it is NOT
+persisted. Two problems follow:
+
+1. **Status lost on reload (correctness).** When a persisted conversation is
+   resumed, `_resume_console_workspace_conversation` reconstructs each message
+   with a HARDCODED `status="complete"` (`chat_screen.py:3969`). A row that was
+   `failed` (send-blocked) therefore comes back as `complete`, so
+   `_provider_messages_for_session(skip_failed=True)` no longer excludes it — the
+   never-sent message re-enters the next send's provider context after a
+   restart/resume. This defeats the context-exclusion guarantee that
+   `mark_message_send_blocked` + `skip_failed` enforce in-session.
+2. **Orphan block row (UX).** The `failed` USER row persists but the SYSTEM
+   block-row does not, so on reload the user sees a lonely clean-rendered
+   "hello" (the `[failed]` suffix is suppressed for USER rows) with no
+   explanation; repeated blocked retries accumulate persisted duplicate USER
+   rows.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A send that never reached the provider does not leave a durable record that, on resume, re-enters the next send's provider context (the never-sent row is either not persisted, or its non-sent state round-trips and is still excluded)
+- [ ] #2 Resuming a conversation whose first send was blocked does not show an unexplained lonely user message (no orphan)
+- [ ] #3 A successful first send still persists correctly and appears in the workspace rail with its derived title (no regression to task-457(a))
+- [ ] #4 Regression coverage for the resume/round-trip path of a blocked send
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Candidate approaches (pick one, needs a UX/design call):
+
+- **Defer echo persistence to the accepted path (recommended).** Append the
+  optimistic echo with `persist=False` (in-memory echo still gives the immediate
+  cold-send feedback), and persist the USER row + session only once the turn is
+  confirmed to proceed (the `_notify_submission_accepted` / assistant-append
+  point). A blocked send then persists nothing → no orphan, no reload re-leak.
+  Verify the workspace rail still shows a SUCCESSFUL send (rail-refresh depends
+  on the session being persisted on accept) and that auto-title (already moved
+  before the append in 457(a)) still lands the derived title on the persisted
+  conversation.
+- **Persist the SYSTEM block-row too + round-trip the failed status.** Keep
+  persisting the echo, additionally persist the block-row, and stop hardcoding
+  `status="complete"` on reload (`chat_screen.py:3969`) — requires the durable
+  message store to carry a per-message failed/blocked flag (schema check).
+
+The first avoids a schema change and removes both problems at once; prefer it
+unless there's a product reason to keep blocked attempts in durable history.
+<!-- SECTION:PLAN:END -->

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -453,19 +453,31 @@ class ConsoleChatController:
 
         if pendings:
             self.store.clear_pending_attachments(session.id)
-        provider_messages = self._provider_messages_for_session(session.id)
-        provider_messages, refuse = await self._apply_skill_substitution(
-            provider_messages
-        )
-        if refuse is not None:
-            return self._block(session.id, refuse)
-        provider_messages = await self._apply_chat_dictionaries(
-            provider_messages, session.id
-        )
-        provider_messages = await self._apply_world_info(
-            provider_messages, session.id
-        )
-        prefill, prefill_from_one_shot = self._resolve_submit_prefill(session.id)
+        try:
+            provider_messages = self._provider_messages_for_session(session.id)
+            provider_messages, refuse = await self._apply_skill_substitution(
+                provider_messages
+            )
+            if refuse is not None:
+                # A substitution refusal is a block outcome like any other
+                # (provider not ready, probe raise): fail the echoed row so the
+                # refused command never enters the next send's provider context.
+                self.store.mark_message_send_blocked(echoed_user.id)
+                return self._block(session.id, refuse)
+            provider_messages = await self._apply_chat_dictionaries(
+                provider_messages, session.id
+            )
+            provider_messages = await self._apply_world_info(
+                provider_messages, session.id
+            )
+            prefill, prefill_from_one_shot = self._resolve_submit_prefill(session.id)
+        except BaseException:
+            # Any failure between the optimistic echo and the confirmed turn
+            # (dictionary/world-info application, prefill resolution) must also
+            # fail the echoed row, or a never-sent message leaks into the next
+            # send's provider context (`skip_failed` only drops "failed" rows).
+            self.store.mark_message_send_blocked(echoed_user.id)
+            raise
         # The accepted-hook fires only once the turn is confirmed to
         # actually proceed (Qodo finding 3, PR #636 bot review): it used to
         # fire right after the USER row was appended, BEFORE this skill
@@ -2761,6 +2773,12 @@ class ConsoleChatController:
             if budget <= 0:
                 break
             if message.role is not ConsoleMessageRole.USER:
+                continue
+            if skip_failed and message.status == "failed":
+                # A send-blocked echo keeps its attachment data but is dropped
+                # from the emitted payload below (skip_failed); it must not
+                # reserve image budget a real message would then lose (TASK-457
+                # code-review finding 2).
                 continue
             usable = [
                 attachment

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -4324,6 +4324,12 @@ class ChatScreen(BaseAppScreen):
         (the caller clears it in a ``finally``). Matches on the row's
         ``conversation_id`` attribute and no-ops when the row is no longer
         mounted, e.g. a recompose already replaced it.
+
+        Args:
+            conversation_id: The row's ``conversation_id`` attribute to match;
+                a blank value is a no-op.
+            loading: ``True`` to show the row's loading spinner, ``False`` to
+                clear it.
         """
         target = str(conversation_id or "").strip()
         if not target:

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -4311,6 +4311,28 @@ class ChatScreen(BaseAppScreen):
             return ""
         return str(card.get("name") or "").strip()
 
+    def _set_console_conversation_row_loading(
+        self, conversation_id: str, loading: bool
+    ) -> None:
+        """Toggle a loading indicator on the matching workspace rail row.
+
+        task-457(b): clicking a not-yet-open persisted conversation awaits
+        ``_resume_console_workspace_conversation`` inline, so a slow or failing
+        open otherwise reads as a dead click. Flagging the pressed row
+        ``loading`` gives immediate feedback until the resume completes (the
+        post-resume rail recompose rebuilds the row without the flag) or errors
+        (the caller clears it in a ``finally``). Matches on the row's
+        ``conversation_id`` attribute and no-ops when the row is no longer
+        mounted, e.g. a recompose already replaced it.
+        """
+        target = str(conversation_id or "").strip()
+        if not target:
+            return
+        for row in self.query(".console-workspace-conversation-row"):
+            if str(getattr(row, "conversation_id", "") or "").strip() == target:
+                row.loading = loading
+                return
+
     async def _resume_console_workspace_conversation(
         self,
         conversation_id: str,
@@ -14622,15 +14644,28 @@ class ChatScreen(BaseAppScreen):
                         severity="warning",
                     )
                     return
-                resumed = await self._resume_console_workspace_conversation(
-                    row_conversation_id,
-                    target_scope_type=(
-                        browser_row.scope_type if browser_row is not None else None
-                    ),
-                    target_workspace_id=(
-                        browser_row.workspace_id if browser_row is not None else None
-                    ),
-                )
+                # task-457(b): the resume is awaited inline and can be slow or
+                # fail; flag the pressed row loading for the duration so it does
+                # not read as a dead click, and always clear it afterwards (a
+                # successful resume also recomposes the rail, which drops the
+                # flag; the finally covers the not-resumable/error return).
+                self._set_console_conversation_row_loading(row_conversation_id, True)
+                try:
+                    resumed = await self._resume_console_workspace_conversation(
+                        row_conversation_id,
+                        target_scope_type=(
+                            browser_row.scope_type if browser_row is not None else None
+                        ),
+                        target_workspace_id=(
+                            browser_row.workspace_id
+                            if browser_row is not None
+                            else None
+                        ),
+                    )
+                finally:
+                    self._set_console_conversation_row_loading(
+                        row_conversation_id, False
+                    )
                 if resumed:
                     await self._refresh_console_conversation_browser_after_selection()
                     return


### PR DESCRIPTION
## What

Completes **task-457**: (b) rail conversation-row loading feedback, plus the (a) hardening surfaced by the task-457 code review (findings 1 & 2). (a) cold-send optimistic echo itself shipped in PR #777 (merged); this PR carries the follow-up fixes to it.

## (b) Rail conversation-row loading feedback

Clicking a rail row that opens a **not-yet-loaded persisted conversation** awaits `_resume_console_workspace_conversation` inline (the `session_id is None` branch); a slow/failing open read as a dead click. New helper `_set_console_conversation_row_loading(conversation_id, loading)` flags the pressed row `loading` (Textual spinner); the handler wraps the inline resume in loading-on / `finally`-off. The rail recomposes only after the resume completes, so the flag survives the load and the recompose clears it; the `finally` covers the not-resumable/error return (never stuck spinning). Only the slow branch is wrapped — the instant `switch_session` path is untouched.

Tests: helper-toggle, click-shows-loading-until-resume-settles, and loading-cleared-when-resume-raises.

## (a) Code-review hardening (findings 1 & 2)

**Finding 1 — context leak on non-accepted exits.** The echoed USER row was only marked send-blocked on the not-ready and probe-raise exits. A skill-substitution refusal returned `_block` without marking it, and `_apply_chat_dictionaries`/`_apply_world_info`/prefill could raise unwrapped — leaving the echo `"complete"` so the never-sent message leaked into the next send's provider context (`skip_failed` only drops `"failed"`). Now the whole post-echo / pre-accept region is wrapped: the refusal marks-blocked before returning, and any raise marks-blocked then re-raises.

**Finding 2 — silent image drop.** The image-budget RESERVATION loop had no `skip_failed` guard while the emit loop did, so a send-blocked echo (keeps its attachment data, dropped from the payload) reserved image slots a real older image message then lost. The reservation loop now skips `failed` rows too.

Tests (RED→GREEN): `test_skill_refuse_after_optimistic_echo_marks_row_blocked`, `test_dictionary_apply_raise_after_optimistic_echo_marks_row_blocked`, `test_image_budget_excludes_failed_send_blocked_echo`.

## Filed, not fixed here

**Finding 3 → task-485.** The blocked echo persists a durable `"failed"` USER row, but resume hardcodes `status="complete"` (`chat_screen.py:3969`) so the failed state is lost on reload (re-leak after restart) and the SYSTEM block-row isn't persisted (orphan "hello" on reload). The fix is a persistence design decision (defer echo persistence to the accepted path, recommended; or persist the block-row + round-trip the status) — filed for a separate change.

## Verification

211 controller+store green (incl. the 3 new (a) tests) + send-path native-flow green + full rail/scope-row/handoffs green. Qodo review addressed: docstring `Args` fixed; "inline resume blocks UI" pushed back in-thread (a Textual `await` yields to the event loop, pre-existing code, worker refactor out of scope for a feedback task).

🤖 Generated with [Claude Code](https://claude.com/claude-code)