### PR TITLE
RAG SP2a: profile system storage foundation

### DIFF
--- a/Docs/superpowers/plans/2026-07-22-rag-profile-system-sp2a-storage.md
+++ b/Docs/superpowers/plans/2026-07-22-rag-profile-system-sp2a-storage.md
@@ -1,0 +1,599 @@
+# SP2a — Profile System: Storage Foundation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the existing `ConfigProfileManager` into a *correct*, file-backed, user-facing profile store: fix the broken serialization round-trip, fix the builtins that silently ignore their own settings, mark builtins read-only, give profiles a rename-safe stable id, store one file per user profile, and add real CRUD.
+
+**Architecture:** All changes live in `tldw_chatbook/RAG_Search/config_profiles.py`. `ProfileConfig` gains a stable `id` and a `read_only` flag. `ProfileConfig.from_dict` routes `rag_config` through `RAGConfig.from_dict` (proper nested-dataclass reconstruction). The ~13 builtins are corrected to the real dataclass field names + valid enum values and marked `read_only`. The single `custom_profiles.json` blob is replaced by one JSON file per user profile under the existing `rag_profiles/` dir (legacy blob auto-migrated). CRUD (`save_profile`/`delete_profile`/`rename_profile`/`clone_profile`) guards against mutating builtins.
+
+**Tech Stack:** Python 3.11+, existing `ProfileConfig`/`RAGConfig` dataclasses, `json`, pytest. Tests pass an explicit temp `profiles_dir` to `ConfigProfileManager(...)` (note: `get_profile_manager()` re-instantiates per call — it is NOT a singleton — so tests construct the manager directly with a temp dir).
+
+## Global Constraints
+
+- **Spec:** `Docs/superpowers/specs/2026-07-21-rag-profile-system-design.md`; overview `Docs/superpowers/specs/2026-07-21-rag-settings-profiles-overview.md`. This plan is **SP2a only** — the storage foundation.
+- **OUT OF SCOPE (this is SP2b, a later PR):** the config-resolution unification (`resolve_active_rag_config`), routing `config.py`'s loader through the active profile, deprecating `AppRAGSearchConfig.rag.*` value keys, the active-profile pointer wiring, `reset_shared_rag_service()`, the first-run "Imported settings" import, and the embed==query parity test. **Do NOT touch `config.py`'s loader, `ingestion_indexing.py`, `rag_factory.py`'s resolution, or `[rag.service].profile` in SP2a.**
+- **Owner decision:** builtins are fixed to use the REAL fields (not left as-is), so fast/balanced/accuracy actually differ.
+- **Real dataclass fields (verbatim):** `ChunkingConfig.chunk_size`, `.chunk_overlap`, `.chunking_method` (NOT `.size`/`.overlap`). `SearchConfig.default_top_k`, `.default_search_mode` (values `"plain"|"semantic"|"hybrid"`), `.score_threshold` (NOT `.top_k`/`.default_type`). `VectorStoreConfig.type` ∈ `{"chroma","memory","auto"}` (NOT `"in_memory"`).
+- **Value mapping for `default_type` → `default_search_mode`:** `"keyword"→"plain"`, `"semantic"→"semantic"`, `"hybrid"→"hybrid"`. This is a value map, not a blind rename.
+- **No DB migration** (profiles are files). **Builtins are never written to disk.**
+- **Persistence lives together:** all edits in `config_profiles.py`; new tests in `Tests/RAG/test_config_profiles.py`.
+- Google-style docstrings, type hints on public methods, snake_case.
+
+## Plan-time facts (verified)
+- `ProfileConfig.from_dict` is at `config_profiles.py:114-151`; the bug is lines 117-121 (`RAGConfig(**data["rag_config"])`).
+- `RAGConfig.from_dict` (`config.py:395-430`) rebuilds nested dataclasses correctly — route through it.
+- `asdict()` only emits real dataclass fields, so `to_dict()` already drops the builtins' dead attributes; the builtin fix is independent of the round-trip fix.
+- Builtins set dead attrs at (approx) lines 176/178-181, 198-201, 218-221, 298-300, 319-322, 349-351, 367-371.
+- `validate_profile` reads dead attrs at `config_profiles.py:731` (`.chunking.overlap >= .chunking.size`) and `:738` (`.search.top_k`).
+- `_save_custom_profiles` (blob writer) at `config_profiles.py:527-545`; `_load_custom_profiles` at `:449-467`; blob path `profiles_dir/"custom_profiles.json"`.
+- `create_custom_profile` at `:477-525` keys `_profiles` by `name.lower().replace(" ","_")` (the de-facto slug).
+- **Note (flag for SP2b, do NOT fix here):** `rag_factory.py:95-99`'s auto-detect reads `config.search.default_type` — a phantom field. After the builtin fix that attr no longer exists, so `hasattr(config.search,"default_type")` is `False` and that branch simply never fires (no crash). Leave it; SP2b's resolution work owns it.
+
+---
+
+## File Structure
+- **Modify** `tldw_chatbook/RAG_Search/config_profiles.py` — `ProfileConfig` (add `id`, `read_only`; fix `from_dict`); builtins (field names + values + `read_only=True` + explicit `id`); `validate_profile` (real fields); storage (`_load_custom_profiles`/`_save_custom_profiles` → per-file + legacy migration); CRUD (`save_profile`/`delete_profile`/`rename_profile`/`clone_profile`).
+- **Create** `Tests/RAG/test_config_profiles.py` — all SP2a tests.
+
+---
+
+## Task 1: Fix the ProfileConfig serialization round-trip
+
+**Files:**
+- Modify: `tldw_chatbook/RAG_Search/config_profiles.py:114-151` (`ProfileConfig.from_dict`)
+- Test: `Tests/RAG/test_config_profiles.py`
+
+**Interfaces:**
+- Produces: `ProfileConfig.from_dict(data)` returns a profile whose `.rag_config` is a real `RAGConfig` with real sub-dataclass instances (not raw dicts).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# Tests/RAG/test_config_profiles.py
+import json
+from tldw_chatbook.RAG_Search.config_profiles import ProfileConfig
+from tldw_chatbook.RAG_Search.simplified.config import (
+    RAGConfig, EmbeddingConfig, ChunkingConfig,
+)
+
+
+def _profile(**over):
+    rag = RAGConfig(
+        embedding=EmbeddingConfig(model="round-trip-model"),
+        chunking=ChunkingConfig(chunk_size=333, chunk_overlap=77),
+    )
+    return ProfileConfig(name="RT", description="d", profile_type="custom", rag_config=rag)
+
+
+def test_round_trip_reconstructs_nested_dataclasses():
+    p = _profile()
+    restored = ProfileConfig.from_dict(json.loads(json.dumps(p.to_dict())))
+    # These attribute accesses raise AttributeError today (sub-configs are dicts).
+    assert isinstance(restored.rag_config, RAGConfig)
+    assert isinstance(restored.rag_config.embedding, EmbeddingConfig)
+    assert isinstance(restored.rag_config.chunking, ChunkingConfig)
+    assert restored.rag_config.embedding.model == "round-trip-model"
+    assert restored.rag_config.chunking.chunk_size == 333
+    assert restored.rag_config.chunking.chunk_overlap == 77
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest Tests/RAG/test_config_profiles.py::test_round_trip_reconstructs_nested_dataclasses -q`
+Expected: FAIL — `AttributeError: 'dict' object has no attribute 'model'` (sub-config is a raw dict).
+
+- [ ] **Step 3: Fix `from_dict`**
+
+In `config_profiles.py`, replace the `rag_config` reconstruction (lines 117-121):
+```python
+        rag_config = (
+            RAGConfig.from_dict(data["rag_config"])
+            if isinstance(data["rag_config"], dict)
+            else data["rag_config"]
+        )
+```
+(Leave the `reranking_config`/`processing_config` branches as-is — those are flat dataclasses; verify at implementation that `RerankingConfig`/`ProcessingConfig` have no nested dataclass fields. If either DOES nest, give it the same `.from_dict` treatment.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest Tests/RAG/test_config_profiles.py::test_round_trip_reconstructs_nested_dataclasses -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/RAG_Search/config_profiles.py Tests/RAG/test_config_profiles.py
+git commit -m "fix(rag): ProfileConfig round-trip reconstructs nested dataclasses"
+```
+
+---
+
+## Task 2: Fix the builtin profiles (real fields + valid enum values) + validate_profile
+
+**Files:**
+- Modify: `tldw_chatbook/RAG_Search/config_profiles.py` — `_load_builtin_profiles` (all builtins) and `validate_profile` (~:731,:738)
+- Test: `Tests/RAG/test_config_profiles.py` (append)
+
+**Interfaces:**
+- Produces: builtins whose declared chunk/overlap/top_k/mode actually take effect on the real dataclass fields.
+
+- [ ] **Step 1: Write the failing test (append)**
+
+```python
+from tldw_chatbook.RAG_Search.config_profiles import ConfigProfileManager
+
+
+def _mgr(tmp_path):
+    return ConfigProfileManager(profiles_dir=tmp_path / "profiles")
+
+
+def test_builtins_apply_declared_settings(tmp_path):
+    m = _mgr(tmp_path)
+    fast = m.get_profile("fast_search")
+    assert fast.rag_config.chunking.chunk_size == 256      # was silently 400 (dead attr)
+    assert fast.rag_config.chunking.chunk_overlap == 32
+    assert fast.rag_config.search.default_top_k == 5
+
+    # Builtins are meaningfully differentiated, not all default:
+    sizes = {name: m.get_profile(name).rag_config.chunking.chunk_size
+             for name in ("fast_search", "high_accuracy", "long_context")}
+    assert len(set(sizes.values())) == 3, sizes
+
+
+def test_builtins_use_valid_search_mode_and_store_type(tmp_path):
+    m = _mgr(tmp_path)
+    valid_modes = {"plain", "semantic", "hybrid"}
+    valid_types = {"chroma", "memory", "auto"}
+    for name in m.list_profiles():
+        p = m.get_profile(name)
+        assert p.rag_config.search.default_search_mode in valid_modes, name
+        assert p.rag_config.vector_store.type in valid_types, name
+    # bm25_only was keyword-only -> plain (value-mapped, not "keyword")
+    assert m.get_profile("bm25_only").rag_config.search.default_search_mode == "plain"
+
+
+def test_validate_profile_reads_real_fields(tmp_path):
+    m = _mgr(tmp_path)
+    bad = m.get_profile("hybrid_basic")
+    # Force an overlap >= size on the REAL fields; validate must catch it.
+    bad.rag_config.chunking.chunk_overlap = bad.rag_config.chunking.chunk_size + 1
+    warnings = m.validate_profile(bad)
+    assert any("overlap" in w.lower() for w in warnings)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest Tests/RAG/test_config_profiles.py -q -k builtins or validate`
+Expected: FAIL — `fast_search` chunk_size is 400 (default), modes/store-type invalid, validate reads dead attrs.
+
+- [ ] **Step 3: Fix every builtin + validate_profile**
+
+In `_load_builtin_profiles`, apply these substitutions to EVERY builtin (there are ~13; do not miss any — search the method for each dead pattern):
+- `.chunking.size = N`   → `.chunking.chunk_size = N`
+- `.chunking.overlap = N` → `.chunking.chunk_overlap = N`
+- `.search.top_k = N`     → `.search.default_top_k = N`
+- `.search.default_type = "keyword"` → `.search.default_search_mode = "plain"`
+- `.search.default_type = "semantic"` → `.search.default_search_mode = "semantic"`
+- `.search.default_type = "hybrid"`  → `.search.default_search_mode = "hybrid"`
+- `.vector_store.type = "in_memory"` → `.vector_store.type = "memory"`
+
+Leave builtins that already use the correct fields (`hybrid_enhanced`, `hybrid_full` use `chunk_size`/`default_search_mode`/`default_top_k`) unchanged.
+
+In `validate_profile` (~:731, :738):
+```python
+        if profile.rag_config.chunking.chunk_overlap >= profile.rag_config.chunking.chunk_size:
+            warnings.append("Chunk overlap should be less than chunk size")
+```
+```python
+                > profile.rag_config.search.default_top_k
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest Tests/RAG/test_config_profiles.py -q`
+Expected: PASS. Then grep to confirm no dead attrs remain:
+`grep -nE "\.chunking\.(size|overlap)\b|\.search\.(top_k|default_type)\b|\"in_memory\"" tldw_chatbook/RAG_Search/config_profiles.py` → no matches.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/RAG_Search/config_profiles.py Tests/RAG/test_config_profiles.py
+git commit -m "fix(rag): builtin profiles use real dataclass fields + valid enum values"
+```
+
+---
+
+## Task 3: Stable `id` + read-only builtin marker on ProfileConfig
+
+**Files:**
+- Modify: `tldw_chatbook/RAG_Search/config_profiles.py` — `ProfileConfig` dataclass, its `to_dict`/`from_dict`, `_load_builtin_profiles` (stamp `id`+`read_only`), add a `_slugify` helper.
+- Test: `Tests/RAG/test_config_profiles.py` (append)
+
+**Interfaces:**
+- Produces:
+  - `ProfileConfig.id: str` (stable, filename-safe; backfilled from name-slug when absent).
+  - `ProfileConfig.read_only: bool` (True for builtins).
+  - `_slugify(name: str) -> str` (module-level helper).
+
+- [ ] **Step 1: Write the failing test (append)**
+
+```python
+def test_builtins_are_read_only_with_ids(tmp_path):
+    m = _mgr(tmp_path)
+    hb = m.get_profile("hybrid_basic")
+    assert hb.read_only is True
+    assert hb.id == "hybrid_basic"
+
+
+def test_profileconfig_id_backfilled_and_round_trips():
+    from tldw_chatbook.RAG_Search.config_profiles import ProfileConfig, _slugify
+    from tldw_chatbook.RAG_Search.simplified.config import RAGConfig
+    p = ProfileConfig(name="My Cool Profile", description="d",
+                      profile_type="custom", rag_config=RAGConfig())
+    assert p.id == _slugify("My Cool Profile")  # auto-derived when not given
+    import json
+    restored = ProfileConfig.from_dict(json.loads(json.dumps(p.to_dict())))
+    assert restored.id == p.id
+    assert restored.read_only is False
+    # Old files with no id/read_only keys still load (backfill):
+    legacy = {k: v for k, v in p.to_dict().items() if k not in ("id", "read_only")}
+    legacy_restored = ProfileConfig.from_dict(legacy)
+    assert legacy_restored.id == _slugify("My Cool Profile")
+    assert legacy_restored.read_only is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest Tests/RAG/test_config_profiles.py -q -k "read_only or id_backfilled"`
+Expected: FAIL — `ProfileConfig` has no `id`/`read_only`, no `_slugify`.
+
+- [ ] **Step 3: Implement**
+
+Add a module-level helper near the top of `config_profiles.py`:
+```python
+import re
+
+
+def _slugify(name: str) -> str:
+    """Filename-safe stable slug for a profile display name."""
+    slug = re.sub(r"[^a-z0-9]+", "_", str(name).strip().lower()).strip("_")
+    return slug or "profile"
+```
+
+Add fields to the `ProfileConfig` dataclass (after `profile_type` / before component configs is fine; keep dataclass-default ordering valid — all new fields have defaults so put them after the last existing field or with defaults):
+```python
+    id: Optional[str] = None
+    read_only: bool = False
+```
+In `ProfileConfig.__post_init__` (add one if absent):
+```python
+    def __post_init__(self):
+        if not self.id:
+            self.id = _slugify(self.name)
+```
+In `to_dict`, add `"id": self.id, "read_only": self.read_only,`.
+In `from_dict`'s final `cls(...)` call, add `id=data.get("id"), read_only=data.get("read_only", False),` (the `__post_init__` backfills id when the key is missing/None).
+
+In `_load_builtin_profiles`, stamp every builtin with `read_only=True` and an explicit `id` equal to its `_profiles[...]` key (e.g. `id="hybrid_basic", read_only=True`). Key `self._profiles` by that same id.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest Tests/RAG/test_config_profiles.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/RAG_Search/config_profiles.py Tests/RAG/test_config_profiles.py
+git commit -m "feat(rag): ProfileConfig stable id + read_only builtin marker"
+```
+
+---
+
+## Task 4: File-per-profile storage + legacy-blob migration
+
+**Files:**
+- Modify: `tldw_chatbook/RAG_Search/config_profiles.py` — `_load_custom_profiles` (`:449-467`), `_save_custom_profiles` (`:527-545`), add `_profile_path(id)` + `_migrate_legacy_blob()`.
+- Test: `Tests/RAG/test_config_profiles.py` (append)
+
+**Interfaces:**
+- Consumes: `ProfileConfig.id`, `read_only` (Task 3); `_slugify` (Task 3).
+- Produces:
+  - `_profile_path(profile_id: str) -> Path` → `profiles_dir/f"{profile_id}.json"`.
+  - `_save_one(profile: ProfileConfig) -> None` → writes that profile's file.
+  - `_load_custom_profiles()` reads every `*.json` user-profile file (skips reserved names) and one-time migrates a legacy `custom_profiles.json` blob into per-file, then renames the blob to `custom_profiles.json.migrated`.
+
+- [ ] **Step 1: Write the failing test (append)**
+
+```python
+import json as _json
+
+
+def test_user_profile_saved_as_own_file(tmp_path):
+    m = _mgr(tmp_path)
+    from tldw_chatbook.RAG_Search.config_profiles import ProfileConfig
+    from tldw_chatbook.RAG_Search.simplified.config import RAGConfig
+    p = ProfileConfig(name="Sales RAG", description="d", profile_type="custom",
+                      rag_config=RAGConfig())
+    m.save_profile(p)  # (Task 5 adds save_profile; if running Task 4 first, call m._save_one(p))
+    assert (tmp_path / "profiles" / f"{p.id}.json").exists()
+    # A fresh manager over the same dir loads it back, correctly:
+    m2 = _mgr(tmp_path)
+    loaded = m2.get_profile(p.id)
+    assert loaded is not None and loaded.read_only is False
+    assert isinstance(loaded.rag_config, RAGConfig)
+
+
+def test_legacy_blob_migrated_to_per_file(tmp_path):
+    pdir = tmp_path / "profiles"
+    pdir.mkdir(parents=True)
+    from tldw_chatbook.RAG_Search.config_profiles import ProfileConfig
+    from tldw_chatbook.RAG_Search.simplified.config import RAGConfig
+    legacy = ProfileConfig(name="Legacy One", description="d",
+                           profile_type="custom", rag_config=RAGConfig())
+    (pdir / "custom_profiles.json").write_text(
+        _json.dumps({"profiles": [legacy.to_dict()]}))
+    m = _mgr(tmp_path)  # construction triggers load+migrate
+    assert m.get_profile(legacy.id) is not None
+    assert (pdir / f"{legacy.id}.json").exists()
+    assert (pdir / "custom_profiles.json.migrated").exists()
+    assert not (pdir / "custom_profiles.json").exists()
+    # Idempotent: a second manager doesn't choke on the already-migrated blob.
+    _mgr(tmp_path)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest Tests/RAG/test_config_profiles.py -q -k "own_file or legacy_blob"`
+Expected: FAIL — no per-file storage / migration yet.
+
+- [ ] **Step 3: Implement**
+
+Add helpers and rewrite the storage methods:
+```python
+_RESERVED_PROFILE_FILES = {"custom_profiles.json", "custom_profiles.json.migrated"}
+
+
+    def _profile_path(self, profile_id: str) -> Path:
+        return self.profiles_dir / f"{profile_id}.json"
+
+    def _save_one(self, profile: "ProfileConfig") -> None:
+        """Write a single user profile to its own file (never builtins)."""
+        if profile.read_only:
+            return
+        with open(self._profile_path(profile.id), "w") as f:
+            json.dump(profile.to_dict(), f, indent=2)
+
+    def _load_custom_profiles(self):
+        """Load user profiles from per-file JSON; migrate a legacy blob once."""
+        self._migrate_legacy_blob()
+        for path in self.profiles_dir.glob("*.json"):
+            if path.name in _RESERVED_PROFILE_FILES:
+                continue
+            try:
+                with open(path, "r") as f:
+                    profile = ProfileConfig.from_dict(json.load(f))
+                profile.read_only = False
+                self._profiles[profile.id] = profile
+            except Exception as e:
+                logger.error(f"Failed to load profile {path.name}: {e}")
+
+    def _migrate_legacy_blob(self):
+        """One-time split of the old custom_profiles.json blob into per-file."""
+        blob = self.profiles_dir / "custom_profiles.json"
+        if not blob.exists():
+            return
+        try:
+            with open(blob, "r") as f:
+                data = json.load(f)
+            for pdata in data.get("profiles", []):
+                profile = ProfileConfig.from_dict(pdata)
+                profile.read_only = False
+                target = self._profile_path(profile.id)
+                if not target.exists():  # never clobber an existing per-file profile
+                    with open(target, "w") as out:
+                        json.dump(profile.to_dict(), out, indent=2)
+            blob.rename(self.profiles_dir / "custom_profiles.json.migrated")
+            logger.info("Migrated legacy custom_profiles.json to per-file profiles")
+        except Exception as e:
+            logger.error(f"Legacy profile blob migration failed: {e}")
+```
+Delete the old `_save_custom_profiles` blob writer, and replace its call sites (in `create_custom_profile` at `:521`) with `self._save_one(custom_config)`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest Tests/RAG/test_config_profiles.py -q`
+Expected: PASS (the `own_file` test's `save_profile` lands in Task 5; if Task 5 not yet done, temporarily call `_save_one` — but implement Task 5 next so the final suite is green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/RAG_Search/config_profiles.py Tests/RAG/test_config_profiles.py
+git commit -m "feat(rag): file-per-profile storage + legacy blob migration"
+```
+
+---
+
+## Task 5: CRUD with read-only guards
+
+**Files:**
+- Modify: `tldw_chatbook/RAG_Search/config_profiles.py` — add `save_profile`, `delete_profile`, `rename_profile`, `clone_profile`.
+- Test: `Tests/RAG/test_config_profiles.py` (append)
+
+**Interfaces:**
+- Consumes: `_save_one`, `_profile_path` (Task 4); `_slugify`, `id`, `read_only` (Task 3).
+- Produces:
+  - `save_profile(profile) -> ProfileConfig` (refuses read-only; writes file; registers).
+  - `delete_profile(profile_id) -> bool` (refuses builtins; removes file + registry entry).
+  - `rename_profile(profile_id, new_name) -> ProfileConfig` (changes display name, KEEPS id/file).
+  - `clone_profile(source_id, new_name) -> ProfileConfig` (deep-copies any profile — incl. a builtin — into a new writable user profile with a fresh unique id).
+
+- [ ] **Step 1: Write the failing test (append)**
+
+```python
+import pytest
+
+
+def test_cannot_mutate_builtins(tmp_path):
+    m = _mgr(tmp_path)
+    with pytest.raises(ValueError):
+        m.delete_profile("hybrid_basic")
+    with pytest.raises(ValueError):
+        m.rename_profile("hybrid_basic", "Nope")
+    with pytest.raises(ValueError):
+        m.save_profile(m.get_profile("hybrid_basic"))  # read_only
+
+
+def test_clone_builtin_creates_writable_copy(tmp_path):
+    m = _mgr(tmp_path)
+    clone = m.clone_profile("high_accuracy", "My Accuracy")
+    assert clone.read_only is False
+    assert clone.id != "high_accuracy"
+    assert clone.rag_config.chunking.chunk_size == m.get_profile("high_accuracy").rag_config.chunking.chunk_size
+    assert (tmp_path / "profiles" / f"{clone.id}.json").exists()
+    # Editing the clone does not touch the builtin:
+    clone.rag_config.chunking.chunk_size = 111
+    m.save_profile(clone)
+    assert m.get_profile("high_accuracy").rag_config.chunking.chunk_size != 111
+
+
+def test_rename_keeps_id_and_file(tmp_path):
+    m = _mgr(tmp_path)
+    c = m.clone_profile("hybrid_basic", "Before")
+    old_id = c.id
+    renamed = m.rename_profile(c.id, "After")
+    assert renamed.id == old_id                 # id stable across rename
+    assert renamed.name == "After"
+    assert (tmp_path / "profiles" / f"{old_id}.json").exists()
+
+
+def test_delete_removes_file_and_entry(tmp_path):
+    m = _mgr(tmp_path)
+    c = m.clone_profile("hybrid_basic", "Temp")
+    assert m.delete_profile(c.id) is True
+    assert m.get_profile(c.id) is None
+    assert not (tmp_path / "profiles" / f"{c.id}.json").exists()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest Tests/RAG/test_config_profiles.py -q -k "mutate_builtins or clone_builtin or rename_keeps or delete_removes"`
+Expected: FAIL — CRUD methods don't exist.
+
+- [ ] **Step 3: Implement**
+
+```python
+    def _unique_id(self, base_slug: str) -> str:
+        candidate, n = base_slug, 2
+        while candidate in self._profiles:
+            candidate = f"{base_slug}_{n}"
+            n += 1
+        return candidate
+
+    def save_profile(self, profile: "ProfileConfig") -> "ProfileConfig":
+        """Persist a user profile (refuses read-only builtins)."""
+        if profile.read_only:
+            raise ValueError(f"Profile '{profile.id}' is read-only")
+        self._profiles[profile.id] = profile
+        self._save_one(profile)
+        return profile
+
+    def delete_profile(self, profile_id: str) -> bool:
+        prof = self._profiles.get(profile_id)
+        if prof is None:
+            return False
+        if prof.read_only:
+            raise ValueError(f"Builtin profile '{profile_id}' cannot be deleted")
+        self._profiles.pop(profile_id, None)
+        path = self._profile_path(profile_id)
+        if path.exists():
+            path.unlink()
+        return True
+
+    def rename_profile(self, profile_id: str, new_name: str) -> "ProfileConfig":
+        prof = self._profiles.get(profile_id)
+        if prof is None:
+            raise ValueError(f"Profile '{profile_id}' not found")
+        if prof.read_only:
+            raise ValueError(f"Builtin profile '{profile_id}' cannot be renamed")
+        prof.name = new_name  # id + filename stay the same (rename-safe)
+        self._save_one(prof)
+        return prof
+
+    def clone_profile(self, source_id: str, new_name: str) -> "ProfileConfig":
+        src = self._profiles.get(source_id)
+        if src is None:
+            raise ValueError(f"Source profile '{source_id}' not found")
+        new_id = self._unique_id(_slugify(new_name))
+        clone = ProfileConfig.from_dict({
+            **src.to_dict(),
+            "id": new_id,
+            "name": new_name,
+            "read_only": False,
+            "profile_type": "custom",
+        })
+        return self.save_profile(clone)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest Tests/RAG/test_config_profiles.py -q`
+Expected: PASS (whole file).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/RAG_Search/config_profiles.py Tests/RAG/test_config_profiles.py
+git commit -m "feat(rag): profile CRUD (save/delete/rename/clone) with read-only guards"
+```
+
+---
+
+## Task 6: Regression gate + docstring
+
+**Files:**
+- Modify: `tldw_chatbook/RAG_Search/config_profiles.py` (module/class docstring note only)
+- Test: run the broader RAG suite
+
+- [ ] **Step 1: Run the RAG suites that touch profiles**
+
+Run: `pytest Tests/RAG/ -q`
+Expected: PASS at/above baseline. Because `create_rag_service` resolves builtins via this manager, confirm `Tests/RAG/simplified/` (service construction) still passes — the builtin field-name fix changes builtin chunk sizes, which changes their SP1 fingerprints; that is expected and must not fail any test that asserts a *specific* collection name for a builtin (update such an assertion to the new value if any surface, do not revert the builtin fix).
+
+- [ ] **Step 2: Add a class docstring note to `ConfigProfileManager`**
+
+```python
+    """Manages RAG configuration profiles.
+
+    Builtins are read-only clone-seeds; user profiles are stored one JSON file
+    per profile under ``rag_profiles/`` keyed by a stable ``id`` (rename-safe).
+    NOTE: the active-profile pointer and config-resolution wiring live in SP2b,
+    not here — this class is storage + CRUD only.
+    """
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tldw_chatbook/RAG_Search/config_profiles.py
+git commit -m "docs(rag): document profile storage model (SP2a)"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage** (`2026-07-21-rag-profile-system-design.md`, SP2a slice):
+- §1 profile unit is `ProfileConfig` → used throughout. ✓
+- §2 file-per-profile + legacy migration + stable id vs rename → Tasks 3,4,5. ✓
+- §3 read-only builtins (~13), clone-to-edit → Tasks 3,5. ✓
+- Round-trip correctness (implied by "file-per-profile" working) → Task 1. ✓
+- Builtin correctness (owner decision to fix) → Task 2. ✓
+- §4 single active pointer, §5 config unification, §6 first-run import, §7 switch/reset, parity → **SP2b (out of scope, explicitly excluded in Global Constraints).** ✓
+- §8 testing: round-trip, builtin immutability, clone→editable, stable-id survives rename, slug disambiguation (`_unique_id`), legacy-blob idempotent → Tasks 1-5. ✓
+
+**2. Placeholder scan:** every code step has full code; every test has assertions. The Task-4 `own_file` test references `save_profile` (Task 5) — flagged inline with the `_save_one` fallback; final suite green after Task 5. ✓
+
+**3. Type consistency:** `ProfileConfig.id`/`read_only`, `_slugify`, `_profile_path`/`_save_one`, `save_profile`/`delete_profile`/`rename_profile`/`clone_profile`, `_unique_id` — names identical across the tasks that define and consume them. `RAGConfig.from_dict` used consistently. ✓
+
+**Deferred/flagged for SP2b (not gaps):** `rag_factory.py:95` phantom `default_type` auto-detect; the active pointer + `resolve_active_rag_config` + `reset_shared_rag_service` + first-run import + parity test.

--- a/Tests/RAG/test_config_profiles.py
+++ b/Tests/RAG/test_config_profiles.py
@@ -1,5 +1,8 @@
 import json
+import json as _json
+
 import pytest
+
 from tldw_chatbook.RAG_Search.config_profiles import ConfigProfileManager, ProfileConfig
 from tldw_chatbook.RAG_Search.simplified.config import (
     RAGConfig, EmbeddingConfig, ChunkingConfig, VectorStoreConfig,
@@ -108,9 +111,6 @@ def test_profileconfig_id_backfilled_and_round_trips():
     assert legacy_restored.read_only is False
 
 
-import json as _json
-
-
 def test_user_profile_saved_as_own_file(tmp_path):
     m = _mgr(tmp_path)
     from tldw_chatbook.RAG_Search.config_profiles import ProfileConfig
@@ -144,6 +144,46 @@ def test_legacy_blob_migrated_to_per_file(tmp_path):
     _mgr(tmp_path)
 
 
+def test_legacy_blob_migration_isolates_per_entry_failures(tmp_path):
+    # Review finding (Important): the whole `for pdata in ...` loop in
+    # _migrate_legacy_blob was one try/except. If ProfileConfig.from_dict
+    # raised on one entry (e.g. an old blob with a renamed/unknown
+    # rag_config sub-key -> TypeError from `EmbeddingConfig(**data)`), the
+    # WHOLE migration aborted: the blob was never renamed, and every OTHER
+    # valid custom profile in the same blob silently vanished on upgrade.
+    # Per-entry isolation must let the valid entries still migrate, and the
+    # blob must still be renamed even though one entry failed.
+    pdir = tmp_path / "profiles"
+    pdir.mkdir(parents=True)
+    from tldw_chatbook.RAG_Search.config_profiles import ProfileConfig
+    from tldw_chatbook.RAG_Search.simplified.config import RAGConfig
+
+    bad_entry = {
+        "name": "Broken",
+        "description": "d",
+        "profile_type": "custom",
+        # Unknown/renamed key -> EmbeddingConfig(**data) raises TypeError
+        # inside RAGConfig.from_dict, which ProfileConfig.from_dict propagates.
+        "rag_config": {"embedding": {"nonexistent_field_xyz": True}},
+    }
+    valid = ProfileConfig(
+        name="Still Good", description="d", profile_type="custom",
+        rag_config=RAGConfig(),
+    )
+    (pdir / "custom_profiles.json").write_text(
+        _json.dumps({"profiles": [bad_entry, valid.to_dict()]}, default=str))
+
+    m = _mgr(tmp_path)  # construction must not raise / must not abort entirely
+
+    # The valid profile (listed AFTER the bad one) still migrated + is loadable.
+    assert m.get_profile(valid.id) is not None
+    assert (pdir / f"{valid.id}.json").exists()
+
+    # The blob is renamed regardless of the partial failure.
+    assert (pdir / "custom_profiles.json.migrated").exists()
+    assert not (pdir / "custom_profiles.json").exists()
+
+
 def test_cannot_mutate_builtins(tmp_path):
     m = _mgr(tmp_path)
     with pytest.raises(ValueError):
@@ -152,6 +192,32 @@ def test_cannot_mutate_builtins(tmp_path):
         m.rename_profile("hybrid_basic", "Nope")
     with pytest.raises(ValueError):
         m.save_profile(m.get_profile("hybrid_basic"))  # read_only
+
+
+def test_builtin_readonly_flag_cannot_be_flipped_to_bypass_guards(tmp_path):
+    # Review finding (Important): delete_profile/rename_profile/save_profile
+    # guarded on `profile.read_only`, checked on the SHARED ProfileConfig
+    # instance that get_profile() returns. A caller could flip
+    # `read_only = False` on that shared object and then delete/rename/save
+    # a builtin -- save_profile's `existing is not profile` collision check
+    # is bypassed entirely since it IS the same object. The guard must
+    # additionally be keyed off an immutable, un-flippable record of which
+    # ids are builtins (captured once at construction), not the mutable flag.
+    m = _mgr(tmp_path)
+    b = m.get_profile("hybrid_basic")
+    b.read_only = False  # attacker flips the mutable flag on the shared object
+
+    with pytest.raises(ValueError):
+        m.delete_profile("hybrid_basic")
+    with pytest.raises(ValueError):
+        m.rename_profile("hybrid_basic", "X")
+    with pytest.raises(ValueError):
+        m.save_profile(b)
+
+    # The builtin is intact: same object, unrenamed, still on the manager.
+    assert m.get_profile("hybrid_basic") is b
+    assert m.get_profile("hybrid_basic").name == "Hybrid Basic"
+    assert not (tmp_path / "profiles" / "hybrid_basic.json").exists()
 
 
 def test_clone_builtin_creates_writable_copy(tmp_path):
@@ -450,3 +516,89 @@ def test_save_profile_allows_user_over_user_same_id(tmp_path):
     m.save_profile(first)
     m.save_profile(second)  # must not raise
     assert m.get_profile("shared_id").name == "Second"
+
+
+def test_profile_path_rejects_non_slug_id(tmp_path):
+    # Review finding (Important), defense-in-depth: _profile_path built
+    # `profiles_dir / f"{id}.json"` directly from whatever id it was given.
+    # An id that is not already a bare slug (e.g. containing "..", "/", or
+    # an absolute path) must be rejected outright so every file operation
+    # keyed by id (_save_one, delete_profile, migration) can never escape
+    # profiles_dir.
+    m = _mgr(tmp_path)
+    with pytest.raises(ValueError):
+        m._profile_path("../x")
+    with pytest.raises(ValueError):
+        m._profile_path("../../tmp/pwned")
+    with pytest.raises(ValueError):
+        m._profile_path("/etc/passwd")
+    with pytest.raises(ValueError):
+        m._profile_path("Not A Slug")
+
+
+def test_hand_edited_id_path_traversal_is_neutralized_by_filename_authority(tmp_path):
+    # Review finding (Important): ProfileConfig.from_dict trusts the JSON's
+    # internal "id" field verbatim (__post_init__ only backfills when it's
+    # falsy). A hand-edited profile file with a crafted internal id like
+    # "../../pwned" was registered in self._profiles under THAT unsafe key,
+    # so any later save/delete keyed by id could write/unlink outside
+    # profiles_dir. The FILENAME (stem) must be authoritative on load, never
+    # the JSON's internal id.
+    pdir = tmp_path / "profiles"
+    pdir.mkdir(parents=True)
+    from tldw_chatbook.RAG_Search.config_profiles import ProfileConfig
+    from tldw_chatbook.RAG_Search.simplified.config import RAGConfig
+
+    evil = ProfileConfig(
+        id="../../pwned", name="Evil", description="d",
+        profile_type="custom", rag_config=RAGConfig(), read_only=False,
+    )
+    (pdir / "evil.json").write_text(_json.dumps(evil.to_dict(), default=str))
+
+    m = _mgr(tmp_path)
+
+    # Registered under the SAFE stem-derived id, never the traversal id.
+    assert m.get_profile("evil") is not None
+    assert m.get_profile("../../pwned") is None
+    assert "../../pwned" not in m._profiles
+    assert m.get_profile("evil").id == "evil"
+
+    # No file was ever written outside profiles_dir.
+    assert not (tmp_path / "pwned.json").exists()
+    assert not (tmp_path.parent / "pwned.json").exists()
+
+    # And the safe id is fully usable through normal CRUD:
+    assert m.delete_profile("evil") is True
+    assert not (pdir / "evil.json").exists()
+
+
+def test_load_uses_filename_stem_as_authoritative_id(tmp_path):
+    # Review finding (Important), companion case: even a non-malicious
+    # divergence between a profile file's name and its internal JSON id
+    # (e.g. from manual editing, or copying a file to a new name) must not
+    # be trusted -- the on-disk stem is the id, full stop. Otherwise files
+    # get orphaned and delete_profile(<stem>) doesn't stick.
+    pdir = tmp_path / "profiles"
+    pdir.mkdir(parents=True)
+    from tldw_chatbook.RAG_Search.config_profiles import ProfileConfig
+    from tldw_chatbook.RAG_Search.simplified.config import RAGConfig
+
+    mismatched = ProfileConfig(
+        id="b", name="Mismatched", description="d",
+        profile_type="custom", rag_config=RAGConfig(), read_only=False,
+    )
+    (pdir / "a.json").write_text(_json.dumps(mismatched.to_dict(), default=str))
+
+    m = _mgr(tmp_path)
+    assert m.get_profile("a") is not None
+    assert m.get_profile("a").id == "a"
+    assert m.get_profile("b") is None
+
+    assert m.delete_profile("a") is True
+    assert m.get_profile("a") is None
+    assert not (pdir / "a.json").exists()
+
+    # Fresh manager: it must NOT reappear (e.g. from a leftover/duplicate file).
+    m2 = _mgr(tmp_path)
+    assert m2.get_profile("a") is None
+    assert m2.get_profile("b") is None

--- a/Tests/RAG/test_config_profiles.py
+++ b/Tests/RAG/test_config_profiles.py
@@ -105,3 +105,39 @@ def test_profileconfig_id_backfilled_and_round_trips():
     legacy_restored = ProfileConfig.from_dict(legacy)
     assert legacy_restored.id == _slugify("My Cool Profile")
     assert legacy_restored.read_only is False
+
+
+import json as _json
+
+
+def test_user_profile_saved_as_own_file(tmp_path):
+    m = _mgr(tmp_path)
+    from tldw_chatbook.RAG_Search.config_profiles import ProfileConfig
+    from tldw_chatbook.RAG_Search.simplified.config import RAGConfig
+    p = ProfileConfig(name="Sales RAG", description="d", profile_type="custom",
+                      rag_config=RAGConfig())
+    m._save_one(p)  # (Task 5 adds save_profile; Task 4 uses _save_one directly)
+    assert (tmp_path / "profiles" / f"{p.id}.json").exists()
+    # A fresh manager over the same dir loads it back, correctly:
+    m2 = _mgr(tmp_path)
+    loaded = m2.get_profile(p.id)
+    assert loaded is not None and loaded.read_only is False
+    assert isinstance(loaded.rag_config, RAGConfig)
+
+
+def test_legacy_blob_migrated_to_per_file(tmp_path):
+    pdir = tmp_path / "profiles"
+    pdir.mkdir(parents=True)
+    from tldw_chatbook.RAG_Search.config_profiles import ProfileConfig
+    from tldw_chatbook.RAG_Search.simplified.config import RAGConfig
+    legacy = ProfileConfig(name="Legacy One", description="d",
+                           profile_type="custom", rag_config=RAGConfig())
+    (pdir / "custom_profiles.json").write_text(
+        _json.dumps({"profiles": [legacy.to_dict()]}, default=str))
+    m = _mgr(tmp_path)  # construction triggers load+migrate
+    assert m.get_profile(legacy.id) is not None
+    assert (pdir / f"{legacy.id}.json").exists()
+    assert (pdir / "custom_profiles.json.migrated").exists()
+    assert not (pdir / "custom_profiles.json").exists()
+    # Idempotent: a second manager doesn't choke on the already-migrated blob.
+    _mgr(tmp_path)

--- a/Tests/RAG/test_config_profiles.py
+++ b/Tests/RAG/test_config_profiles.py
@@ -359,6 +359,84 @@ def test_save_reload_round_trips_explicit_persist_directory(tmp_path):
     assert reloaded.rag_config.vector_store.persist_directory == persist_dir
 
 
+def test_load_does_not_clobber_unrelated_profile_on_disk_during_self_heal(tmp_path, monkeypatch):
+    # Regression test (SP2a review): _load_custom_profiles's self-heal branch
+    # reassigns a builtin-colliding profile's id via _unique_id, which only
+    # checks self._profiles -- the in-memory dict being built INCREMENTALLY
+    # during the glob loop. It does not check on-disk files. So if the glob
+    # visits the collider file (high_accuracy.json, shadowing the read-only
+    # builtin) BEFORE an unrelated, legitimate high_accuracy_2.json is loaded,
+    # _unique_id returns "high_accuracy_2" (not yet in _profiles) and
+    # _save_one overwrites the unrelated profile's file, silently destroying
+    # it. Path.glob order is filesystem-dependent, so we force the
+    # collider-first order here to make the failure deterministic; the fix
+    # (_unique_id_reserving_disk) must be safe under either order.
+    from pathlib import Path
+    from tldw_chatbook.RAG_Search.config_profiles import ProfileConfig
+    from tldw_chatbook.RAG_Search.simplified.config import RAGConfig, EmbeddingConfig
+
+    pdir = tmp_path / "profiles"
+    pdir.mkdir(parents=True)
+
+    collider = ProfileConfig(
+        id="high_accuracy", name="Collider", description="hand placed",
+        profile_type="custom", read_only=False,
+        rag_config=RAGConfig(embedding=EmbeddingConfig(model="collider-marker-model")),
+    )
+    (pdir / "high_accuracy.json").write_text(
+        _json.dumps(collider.to_dict(), default=str))
+
+    legit = ProfileConfig(
+        id="high_accuracy_2", name="Legit Other Profile", description="unrelated",
+        profile_type="custom", read_only=False,
+        rag_config=RAGConfig(embedding=EmbeddingConfig(model="legit-other-marker-model")),
+    )
+    (pdir / "high_accuracy_2.json").write_text(
+        _json.dumps(legit.to_dict(), default=str))
+
+    # Force the collider-first glob order (the order under which the bug
+    # manifests) so this test doesn't depend on filesystem-specific readdir
+    # ordering. The fix must be safe regardless of order.
+    real_glob = Path.glob
+
+    def ordered_glob(self, pattern):
+        results = list(real_glob(self, pattern))
+        results.sort(key=lambda p: (p.name != "high_accuracy.json", p.name))
+        return iter(results)
+
+    monkeypatch.setattr(Path, "glob", ordered_glob)
+
+    m = _mgr(tmp_path)
+
+    # The read-only builtin is untouched.
+    builtin = m.get_profile("high_accuracy")
+    assert builtin.read_only is True
+    assert builtin.rag_config.embedding.model == "BAAI/bge-large-en-v1.5"
+
+    # The collider must be reassigned off BOTH "high_accuracy" (the builtin)
+    # and "high_accuracy_2" (already claimed on disk by the unrelated
+    # profile) -- landing on a third id.
+    reassigned = [
+        p for p in m._profiles.values()
+        if p.rag_config.embedding.model == "collider-marker-model"
+    ]
+    assert len(reassigned) == 1
+    assert reassigned[0].id == "high_accuracy_3"
+    assert (pdir / "high_accuracy_3.json").exists()
+    assert not (pdir / "high_accuracy.json").exists()
+
+    # The unrelated legit profile must survive intact -- in memory...
+    legit_loaded = m.get_profile("high_accuracy_2")
+    assert legit_loaded is not None
+    assert legit_loaded.name == "Legit Other Profile"
+    assert legit_loaded.rag_config.embedding.model == "legit-other-marker-model"
+
+    # ...and on disk (never overwritten by the collider's content).
+    on_disk = json.loads((pdir / "high_accuracy_2.json").read_text())
+    assert on_disk["name"] == "Legit Other Profile"
+    assert on_disk["rag_config"]["embedding"]["model"] == "legit-other-marker-model"
+
+
 def test_save_profile_allows_user_over_user_same_id(tmp_path):
     # Only READ-ONLY collisions are rejected; two distinct user profiles that
     # happen to share an id may overwrite one another via save_profile.

--- a/Tests/RAG/test_config_profiles.py
+++ b/Tests/RAG/test_config_profiles.py
@@ -1,4 +1,5 @@
 import json
+import pytest
 from tldw_chatbook.RAG_Search.config_profiles import ConfigProfileManager, ProfileConfig
 from tldw_chatbook.RAG_Search.simplified.config import (
     RAGConfig, EmbeddingConfig, ChunkingConfig, VectorStoreConfig,
@@ -141,3 +142,57 @@ def test_legacy_blob_migrated_to_per_file(tmp_path):
     assert not (pdir / "custom_profiles.json").exists()
     # Idempotent: a second manager doesn't choke on the already-migrated blob.
     _mgr(tmp_path)
+
+
+def test_cannot_mutate_builtins(tmp_path):
+    m = _mgr(tmp_path)
+    with pytest.raises(ValueError):
+        m.delete_profile("hybrid_basic")
+    with pytest.raises(ValueError):
+        m.rename_profile("hybrid_basic", "Nope")
+    with pytest.raises(ValueError):
+        m.save_profile(m.get_profile("hybrid_basic"))  # read_only
+
+
+def test_clone_builtin_creates_writable_copy(tmp_path):
+    m = _mgr(tmp_path)
+    clone = m.clone_profile("high_accuracy", "My Accuracy")
+    assert clone.read_only is False
+    assert clone.id != "high_accuracy"
+    assert clone.rag_config.chunking.chunk_size == m.get_profile("high_accuracy").rag_config.chunking.chunk_size
+    assert (tmp_path / "profiles" / f"{clone.id}.json").exists()
+    # Editing the clone does not touch the builtin:
+    clone.rag_config.chunking.chunk_size = 111
+    m.save_profile(clone)
+    assert m.get_profile("high_accuracy").rag_config.chunking.chunk_size != 111
+
+
+def test_rename_keeps_id_and_file(tmp_path):
+    m = _mgr(tmp_path)
+    c = m.clone_profile("hybrid_basic", "Before")
+    old_id = c.id
+    renamed = m.rename_profile(c.id, "After")
+    assert renamed.id == old_id                 # id stable across rename
+    assert renamed.name == "After"
+    assert (tmp_path / "profiles" / f"{old_id}.json").exists()
+
+
+def test_delete_removes_file_and_entry(tmp_path):
+    m = _mgr(tmp_path)
+    c = m.clone_profile("hybrid_basic", "Temp")
+    assert m.delete_profile(c.id) is True
+    assert m.get_profile(c.id) is None
+    assert not (tmp_path / "profiles" / f"{c.id}.json").exists()
+
+
+def test_create_custom_profile_is_id_consistent(tmp_path):
+    # Carry-forward fix from Task 4 review: create_custom_profile used to key
+    # _profiles by name.lower().replace(" ", "_") while profile.id is
+    # _slugify(name) (which collapses ALL non-alnum, not just spaces), so the
+    # in-memory key could diverge from the id-based filename. It must now go
+    # through save_profile() so the same key (profile.id) is used both in
+    # memory and on disk.
+    m = _mgr(tmp_path)
+    created = m.create_custom_profile("My Custom! Profile", base_profile="balanced")
+    assert m.get_profile(created.id) is created
+    assert (tmp_path / "profiles" / f"{created.id}.json").exists()

--- a/Tests/RAG/test_config_profiles.py
+++ b/Tests/RAG/test_config_profiles.py
@@ -1,0 +1,31 @@
+import json
+from tldw_chatbook.RAG_Search.config_profiles import ProfileConfig
+from tldw_chatbook.RAG_Search.simplified.config import (
+    RAGConfig, EmbeddingConfig, ChunkingConfig, VectorStoreConfig,
+)
+
+
+def _profile(**over):
+    rag = RAGConfig(
+        embedding=EmbeddingConfig(model="round-trip-model"),
+        chunking=ChunkingConfig(chunk_size=333, chunk_overlap=77),
+        # Pin vector_store to "memory" so persist_directory stays None. With
+        # the "auto" default, VectorStoreConfig.__post_init__ resolves to
+        # "chroma" (and a real PosixPath persist_directory) whenever the
+        # embeddings_rag optional deps happen to be installed, which breaks
+        # json.dumps below for reasons unrelated to what this test checks.
+        vector_store=VectorStoreConfig(type="memory"),
+    )
+    return ProfileConfig(name="RT", description="d", profile_type="custom", rag_config=rag)
+
+
+def test_round_trip_reconstructs_nested_dataclasses():
+    p = _profile()
+    restored = ProfileConfig.from_dict(json.loads(json.dumps(p.to_dict())))
+    # These attribute accesses raise AttributeError today (sub-configs are dicts).
+    assert isinstance(restored.rag_config, RAGConfig)
+    assert isinstance(restored.rag_config.embedding, EmbeddingConfig)
+    assert isinstance(restored.rag_config.chunking, ChunkingConfig)
+    assert restored.rag_config.embedding.model == "round-trip-model"
+    assert restored.rag_config.chunking.chunk_size == 333
+    assert restored.rag_config.chunking.chunk_overlap == 77

--- a/Tests/RAG/test_config_profiles.py
+++ b/Tests/RAG/test_config_profiles.py
@@ -67,3 +67,11 @@ def test_validate_profile_reads_real_fields(tmp_path):
     bad.rag_config.chunking.chunk_overlap = bad.rag_config.chunking.chunk_size + 1
     warnings = m.validate_profile(bad)
     assert any("overlap" in w.lower() for w in warnings)
+
+
+def test_high_accuracy_has_no_stray_method_attr(tmp_path):
+    m = _mgr(tmp_path)
+    chunking = m.get_profile("high_accuracy").rag_config.chunking
+    # '.method' is a typo of the real field 'chunking_method' -> must not exist as a stray attr
+    assert "method" not in vars(chunking)
+    assert chunking.chunking_method in {"words", "sentences", "paragraphs"}

--- a/Tests/RAG/test_config_profiles.py
+++ b/Tests/RAG/test_config_profiles.py
@@ -196,3 +196,55 @@ def test_create_custom_profile_is_id_consistent(tmp_path):
     created = m.create_custom_profile("My Custom! Profile", base_profile="balanced")
     assert m.get_profile(created.id) is created
     assert (tmp_path / "profiles" / f"{created.id}.json").exists()
+
+
+def test_save_profile_rejects_id_collision_with_readonly_builtin(tmp_path):
+    # Review finding (Critical): a builtin's id is _slugify(display_name), so
+    # a brand-new non-read-only ProfileConfig named "High Accuracy" collides
+    # with the builtin id "high_accuracy". save_profile only checked
+    # `profile.read_only` on the INCOMING object, so it would silently
+    # overwrite (and persist) the builtin, making it deletable/mutable.
+    m = _mgr(tmp_path)
+    from tldw_chatbook.RAG_Search.config_profiles import ProfileConfig
+    from tldw_chatbook.RAG_Search.simplified.config import RAGConfig
+    builtin = m.get_profile("high_accuracy")
+    assert builtin.read_only is True
+
+    colliding = ProfileConfig(
+        name="High Accuracy", description="d", profile_type="custom",
+        rag_config=RAGConfig(),
+    )
+    assert colliding.id == "high_accuracy"
+    assert colliding.read_only is False
+
+    with pytest.raises(ValueError):
+        m.save_profile(colliding)
+
+    # The builtin must be untouched: same object, still read-only.
+    assert m.get_profile("high_accuracy") is builtin
+    assert m.get_profile("high_accuracy").read_only is True
+    assert not (tmp_path / "profiles" / "high_accuracy.json").exists()
+
+
+def test_create_custom_profile_uniquifies_id_matching_builtin_name(tmp_path):
+    # Review finding (Critical), friendly-path companion: creating a custom
+    # profile whose display name matches a builtin's must not raise and must
+    # not collide with the builtin id -- it should get a uniquified id.
+    m = _mgr(tmp_path)
+    created = m.create_custom_profile("High Accuracy", base_profile="balanced")
+    assert created.id != "high_accuracy"
+    assert m.get_profile(created.id) is created
+
+    builtin = m.get_profile("high_accuracy")
+    assert builtin.read_only is True
+    assert builtin.id == "high_accuracy"
+
+
+def test_clone_tags_are_independent_of_source(tmp_path):
+    # Review finding (Important): ProfileConfig.to_dict() did `"tags": self.tags`
+    # (no copy), so a clone's tags list was the SAME list object as the
+    # source's. Mutating the clone's tags corrupted the source builtin.
+    m = _mgr(tmp_path)
+    clone = m.clone_profile("high_accuracy", "My Accuracy")
+    clone.tags.append("X")
+    assert "X" not in m.get_profile("high_accuracy").tags

--- a/Tests/RAG/test_config_profiles.py
+++ b/Tests/RAG/test_config_profiles.py
@@ -1,5 +1,5 @@
 import json
-from tldw_chatbook.RAG_Search.config_profiles import ProfileConfig
+from tldw_chatbook.RAG_Search.config_profiles import ConfigProfileManager, ProfileConfig
 from tldw_chatbook.RAG_Search.simplified.config import (
     RAGConfig, EmbeddingConfig, ChunkingConfig, VectorStoreConfig,
 )
@@ -29,3 +29,41 @@ def test_round_trip_reconstructs_nested_dataclasses():
     assert restored.rag_config.embedding.model == "round-trip-model"
     assert restored.rag_config.chunking.chunk_size == 333
     assert restored.rag_config.chunking.chunk_overlap == 77
+
+
+def _mgr(tmp_path):
+    return ConfigProfileManager(profiles_dir=tmp_path / "profiles")
+
+
+def test_builtins_apply_declared_settings(tmp_path):
+    m = _mgr(tmp_path)
+    fast = m.get_profile("fast_search")
+    assert fast.rag_config.chunking.chunk_size == 256      # was silently 400 (dead attr)
+    assert fast.rag_config.chunking.chunk_overlap == 32
+    assert fast.rag_config.search.default_top_k == 5
+
+    # Builtins are meaningfully differentiated, not all default:
+    sizes = {name: m.get_profile(name).rag_config.chunking.chunk_size
+             for name in ("fast_search", "high_accuracy", "long_context")}
+    assert len(set(sizes.values())) == 3, sizes
+
+
+def test_builtins_use_valid_search_mode_and_store_type(tmp_path):
+    m = _mgr(tmp_path)
+    valid_modes = {"plain", "semantic", "hybrid"}
+    valid_types = {"chroma", "memory", "auto"}
+    for name in m.list_profiles():
+        p = m.get_profile(name)
+        assert p.rag_config.search.default_search_mode in valid_modes, name
+        assert p.rag_config.vector_store.type in valid_types, name
+    # bm25_only was keyword-only -> plain (value-mapped, not "keyword")
+    assert m.get_profile("bm25_only").rag_config.search.default_search_mode == "plain"
+
+
+def test_validate_profile_reads_real_fields(tmp_path):
+    m = _mgr(tmp_path)
+    bad = m.get_profile("hybrid_basic")
+    # Force an overlap >= size on the REAL fields; validate must catch it.
+    bad.rag_config.chunking.chunk_overlap = bad.rag_config.chunking.chunk_size + 1
+    warnings = m.validate_profile(bad)
+    assert any("overlap" in w.lower() for w in warnings)

--- a/Tests/RAG/test_config_profiles.py
+++ b/Tests/RAG/test_config_profiles.py
@@ -503,6 +503,126 @@ def test_load_does_not_clobber_unrelated_profile_on_disk_during_self_heal(tmp_pa
     assert on_disk["rag_config"]["embedding"]["model"] == "legit-other-marker-model"
 
 
+def _force_glob_order(monkeypatch, first_name):
+    # Same technique as the Addendum-2 collider test above: Path.glob order
+    # is filesystem-dependent, so force a deterministic order by sorting the
+    # real results with `first_name` pinned first.
+    from pathlib import Path
+
+    real_glob = Path.glob
+
+    def ordered_glob(self, pattern):
+        results = list(real_glob(self, pattern))
+        results.sort(key=lambda p: (p.name != first_name, p.name))
+        return iter(results)
+
+    monkeypatch.setattr(Path, "glob", ordered_glob)
+
+
+def test_load_does_not_clobber_sibling_file_that_slugifies_to_same_id(tmp_path, monkeypatch):
+    # Regression test (SP2a review, second clobber hole): the self-heal in
+    # _load_custom_profiles fires _save_one whenever canonical_path != path,
+    # but the OLD code only reassigns/uniquifies the id inside the
+    # `if desired_id in self._profiles:` branch -- a MEMORY-only check. If
+    # the canonical file for `desired_id` belongs to a DIFFERENT,
+    # not-yet-loaded profile (two distinct filenames that slugify to the
+    # same id, e.g. "foo-bar.json" and "foo_bar.json" both -> "foo_bar"),
+    # that on-disk collision is invisible to the check, and the self-heal
+    # overwrites the other file's content before it's ever loaded --
+    # silently and permanently destroying it.
+    #
+    # This test forces the vulnerable glob order (the non-canonical stem
+    # "foo-bar.json" visited BEFORE the canonical "foo_bar.json") so the
+    # failure is deterministic under the old code.
+    from tldw_chatbook.RAG_Search.config_profiles import ProfileConfig
+    from tldw_chatbook.RAG_Search.simplified.config import RAGConfig, EmbeddingConfig
+
+    pdir = tmp_path / "profiles"
+    pdir.mkdir(parents=True)
+
+    profile_a = ProfileConfig(
+        id="foo-bar", name="Profile A", description="dash-named",
+        profile_type="custom", read_only=False,
+        rag_config=RAGConfig(embedding=EmbeddingConfig(model="profile-a-marker-model")),
+    )
+    (pdir / "foo-bar.json").write_text(_json.dumps(profile_a.to_dict(), default=str))
+
+    profile_b = ProfileConfig(
+        id="foo_bar", name="Profile B", description="underscore-named",
+        profile_type="custom", read_only=False,
+        rag_config=RAGConfig(embedding=EmbeddingConfig(model="profile-b-marker-model")),
+    )
+    (pdir / "foo_bar.json").write_text(_json.dumps(profile_b.to_dict(), default=str))
+
+    _force_glob_order(monkeypatch, "foo-bar.json")
+
+    m = _mgr(tmp_path)
+
+    loaded = list(m._profiles.values())
+    a_matches = [p for p in loaded if p.rag_config.embedding.model == "profile-a-marker-model"]
+    b_matches = [p for p in loaded if p.rag_config.embedding.model == "profile-b-marker-model"]
+
+    # Both distinctive profiles must survive, each exactly once, under
+    # different ids.
+    assert len(a_matches) == 1, "Profile A missing or duplicated after self-heal"
+    assert len(b_matches) == 1, "Profile B missing or duplicated after self-heal (clobbered)"
+    assert a_matches[0].id != b_matches[0].id
+
+    # Neither on-disk file was overwritten with the other's content.
+    on_disk_names = {p.name for p in pdir.glob("*.json")}
+    disk_models = {
+        json.loads(p.read_text())["rag_config"]["embedding"]["model"]
+        for p in pdir.glob("*.json")
+    }
+    assert "profile-a-marker-model" in disk_models
+    assert "profile-b-marker-model" in disk_models
+    assert len(on_disk_names) == 2
+
+
+def test_load_does_not_clobber_sibling_file_reverse_glob_order(tmp_path, monkeypatch):
+    # Same two colliding-slug files as above, but with the glob order
+    # reversed (canonical "foo_bar.json" visited first). The fix must hold
+    # regardless of which file the filesystem happens to yield first.
+    from tldw_chatbook.RAG_Search.config_profiles import ProfileConfig
+    from tldw_chatbook.RAG_Search.simplified.config import RAGConfig, EmbeddingConfig
+
+    pdir = tmp_path / "profiles"
+    pdir.mkdir(parents=True)
+
+    profile_a = ProfileConfig(
+        id="foo-bar", name="Profile A", description="dash-named",
+        profile_type="custom", read_only=False,
+        rag_config=RAGConfig(embedding=EmbeddingConfig(model="profile-a-marker-model")),
+    )
+    (pdir / "foo-bar.json").write_text(_json.dumps(profile_a.to_dict(), default=str))
+
+    profile_b = ProfileConfig(
+        id="foo_bar", name="Profile B", description="underscore-named",
+        profile_type="custom", read_only=False,
+        rag_config=RAGConfig(embedding=EmbeddingConfig(model="profile-b-marker-model")),
+    )
+    (pdir / "foo_bar.json").write_text(_json.dumps(profile_b.to_dict(), default=str))
+
+    _force_glob_order(monkeypatch, "foo_bar.json")
+
+    m = _mgr(tmp_path)
+
+    loaded = list(m._profiles.values())
+    a_matches = [p for p in loaded if p.rag_config.embedding.model == "profile-a-marker-model"]
+    b_matches = [p for p in loaded if p.rag_config.embedding.model == "profile-b-marker-model"]
+
+    assert len(a_matches) == 1, "Profile A missing or duplicated after self-heal"
+    assert len(b_matches) == 1, "Profile B missing or duplicated after self-heal (clobbered)"
+    assert a_matches[0].id != b_matches[0].id
+
+    disk_models = {
+        json.loads(p.read_text())["rag_config"]["embedding"]["model"]
+        for p in pdir.glob("*.json")
+    }
+    assert "profile-a-marker-model" in disk_models
+    assert "profile-b-marker-model" in disk_models
+
+
 def test_save_profile_allows_user_over_user_same_id(tmp_path):
     # Only READ-ONLY collisions are rejected; two distinct user profiles that
     # happen to share an id may overwrite one another via save_profile.

--- a/Tests/RAG/test_config_profiles.py
+++ b/Tests/RAG/test_config_profiles.py
@@ -6,7 +6,7 @@ from tldw_chatbook.RAG_Search.simplified.config import (
 )
 
 
-def _profile(**over):
+def _profile():
     rag = RAGConfig(
         embedding=EmbeddingConfig(model="round-trip-model"),
         chunking=ChunkingConfig(chunk_size=333, chunk_overlap=77),
@@ -248,3 +248,127 @@ def test_clone_tags_are_independent_of_source(tmp_path):
     clone = m.clone_profile("high_accuracy", "My Accuracy")
     clone.tags.append("X")
     assert "X" not in m.get_profile("high_accuracy").tags
+
+
+def test_legacy_blob_migration_does_not_shadow_readonly_builtin(tmp_path):
+    # Review finding (Important): _migrate_legacy_blob wrote
+    # self._profiles[profile.id] = profile directly, bypassing
+    # save_profile's read-only collision guard. A legacy custom_profiles.json
+    # blob containing a user profile named "High Accuracy" migrates to
+    # high_accuracy.json and would overwrite the read-only builtin -- making
+    # it deletable and persisting the overwrite on every future boot.
+    pdir = tmp_path / "profiles"
+    pdir.mkdir(parents=True)
+    from tldw_chatbook.RAG_Search.config_profiles import ProfileConfig
+    from tldw_chatbook.RAG_Search.simplified.config import RAGConfig
+    legacy_user_profile = ProfileConfig(
+        name="High Accuracy", description="user's own", profile_type="custom",
+        rag_config=RAGConfig(),
+    )
+    (pdir / "custom_profiles.json").write_text(
+        _json.dumps({"profiles": [legacy_user_profile.to_dict()]}, default=str))
+
+    m = _mgr(tmp_path)  # construction triggers load+migrate
+
+    builtin = m.get_profile("high_accuracy")
+    assert builtin.read_only is True
+    # Real builtin config, not the migrated user profile's defaults:
+    assert builtin.rag_config.embedding.model == "BAAI/bge-large-en-v1.5"
+
+    with pytest.raises(ValueError):
+        m.delete_profile("high_accuracy")
+
+    # The migrated user profile must be present under a DIFFERENT, writable id.
+    others = [p for pid, p in m._profiles.items()
+              if pid != "high_accuracy" and p.name == "High Accuracy"]
+    assert len(others) == 1
+    assert others[0].read_only is False
+    assert others[0].id != "high_accuracy"
+    assert (pdir / f"{others[0].id}.json").exists()
+
+
+def test_hand_placed_file_named_like_builtin_id_is_self_healed(tmp_path):
+    # Companion path for the same review finding: a hand-placed (or
+    # otherwise stray) <builtin_id>.json file loaded directly via
+    # _load_custom_profiles must not shadow the builtin either -- it must be
+    # reassigned to a unique id and the colliding file removed from disk.
+    pdir = tmp_path / "profiles"
+    pdir.mkdir(parents=True)
+    from tldw_chatbook.RAG_Search.config_profiles import ProfileConfig
+    from tldw_chatbook.RAG_Search.simplified.config import RAGConfig
+    colliding = ProfileConfig(
+        id="high_accuracy", name="High Accuracy", description="hand placed",
+        profile_type="custom", rag_config=RAGConfig(), read_only=False,
+    )
+    (pdir / "high_accuracy.json").write_text(
+        _json.dumps(colliding.to_dict(), default=str))
+
+    m = _mgr(tmp_path)
+
+    builtin = m.get_profile("high_accuracy")
+    assert builtin.read_only is True
+    assert builtin.rag_config.embedding.model == "BAAI/bge-large-en-v1.5"
+
+    with pytest.raises(ValueError):
+        m.delete_profile("high_accuracy")
+
+    others = [p for pid, p in m._profiles.items()
+              if pid != "high_accuracy" and p.name == "High Accuracy"]
+    assert len(others) == 1
+    assert others[0].read_only is False
+    new_id = others[0].id
+    assert new_id != "high_accuracy"
+    assert (pdir / f"{new_id}.json").exists()
+    assert not (pdir / "high_accuracy.json").exists()
+
+
+def test_create_custom_profile_returns_fully_built_rag_config(tmp_path):
+    # Review finding (Important): create_custom_profile built rag_config via
+    # RAGConfig(**asdict(base.rag_config)) -- the RAGConfig(**dict)
+    # anti-pattern that leaves sub-configs (chunking, embedding, ...) as raw
+    # dicts instead of dataclass instances, so
+    # .rag_config.chunking.chunk_size raised AttributeError.
+    m = _mgr(tmp_path)
+    created = m.create_custom_profile("X", base_profile="balanced")
+    assert isinstance(created.rag_config.chunking.chunk_size, int)
+    assert (created.rag_config.chunking.chunk_size
+            == m.get_profile("balanced").rag_config.chunking.chunk_size)
+
+
+def test_save_reload_round_trips_explicit_persist_directory(tmp_path):
+    # Exercises the Path/default=str save+reload branch for
+    # persist_directory regardless of whether the embeddings_rag optional
+    # deps are installed, by pinning vector_store explicitly instead of
+    # relying on auto-resolution.
+    from pathlib import Path
+    m = _mgr(tmp_path)
+    from tldw_chatbook.RAG_Search.config_profiles import ProfileConfig
+    from tldw_chatbook.RAG_Search.simplified.config import RAGConfig, VectorStoreConfig
+    persist_dir = tmp_path / "chroma_store"
+    p = ProfileConfig(
+        name="Chroma Explicit", description="d", profile_type="custom",
+        rag_config=RAGConfig(
+            vector_store=VectorStoreConfig(type="chroma", persist_directory=persist_dir)
+        ),
+    )
+    m.save_profile(p)
+
+    m2 = _mgr(tmp_path)
+    reloaded = m2.get_profile(p.id)
+    assert isinstance(reloaded.rag_config.vector_store.persist_directory, Path)
+    assert reloaded.rag_config.vector_store.persist_directory == persist_dir
+
+
+def test_save_profile_allows_user_over_user_same_id(tmp_path):
+    # Only READ-ONLY collisions are rejected; two distinct user profiles that
+    # happen to share an id may overwrite one another via save_profile.
+    m = _mgr(tmp_path)
+    from tldw_chatbook.RAG_Search.config_profiles import ProfileConfig
+    from tldw_chatbook.RAG_Search.simplified.config import RAGConfig
+    first = ProfileConfig(id="shared_id", name="First", description="d",
+                          profile_type="custom", rag_config=RAGConfig(), read_only=False)
+    second = ProfileConfig(id="shared_id", name="Second", description="d",
+                           profile_type="custom", rag_config=RAGConfig(), read_only=False)
+    m.save_profile(first)
+    m.save_profile(second)  # must not raise
+    assert m.get_profile("shared_id").name == "Second"

--- a/Tests/RAG/test_config_profiles.py
+++ b/Tests/RAG/test_config_profiles.py
@@ -722,3 +722,73 @@ def test_load_uses_filename_stem_as_authoritative_id(tmp_path):
     m2 = _mgr(tmp_path)
     assert m2.get_profile("a") is None
     assert m2.get_profile("b") is None
+
+
+def test_stray_file_named_custom_profiles_json_is_not_destroyed_as_legacy_blob(tmp_path):
+    # Review finding (PR #780 residual): a profile whose display name
+    # slugifies to "custom_profiles" (create_custom_profile("Custom
+    # Profiles"), or a hand-placed custom-profiles.json file) can end up
+    # with a canonical file custom_profiles.json -- which is ALSO the
+    # reserved legacy-blob filename. On the next manager construction,
+    # _migrate_legacy_blob used to treat that per-profile file as a legacy
+    # blob: it has no "profiles" key so nothing is migrated, but the code
+    # still unconditionally os.replace'd it to
+    # custom_profiles.json.migrated -- itself a reserved name that is
+    # NEVER loaded as a profile either -- silently and permanently losing
+    # the profile. _migrate_legacy_blob must validate the blob SHAPE (a
+    # dict with a "profiles" key) before doing anything, and must leave a
+    # non-blob-shaped file completely untouched (no rename, no write).
+    #
+    # Because "custom_profiles.json" is (by design, see the reserved-name
+    # guard below) never loaded back into the manager as a per-file
+    # profile, "survives" here is verified at the filesystem level: the
+    # file must still exist, under its original name, with its original
+    # content intact -- not silently renamed away into an unreachable
+    # ".migrated" file.
+    pdir = tmp_path / "profiles"
+    pdir.mkdir(parents=True)
+    from tldw_chatbook.RAG_Search.config_profiles import ProfileConfig
+    from tldw_chatbook.RAG_Search.simplified.config import RAGConfig, EmbeddingConfig
+
+    stray = ProfileConfig(
+        id="custom_profiles", name="Custom Profiles", description="hand placed",
+        profile_type="custom", read_only=False,
+        rag_config=RAGConfig(embedding=EmbeddingConfig(model="stray-single-profile-marker")),
+    )
+    blob_path = pdir / "custom_profiles.json"
+    migrated_path = pdir / "custom_profiles.json.migrated"
+    blob_path.write_text(_json.dumps(stray.to_dict(), default=str))
+
+    def assert_survives():
+        assert blob_path.exists(), "custom_profiles.json must not be renamed/removed"
+        assert not migrated_path.exists(), "must not be treated as a legacy blob"
+        on_disk = json.loads(blob_path.read_text())
+        assert on_disk["rag_config"]["embedding"]["model"] == "stray-single-profile-marker"
+
+    _mgr(tmp_path)  # boot 1
+    assert_survives()
+
+    _mgr(tmp_path)  # boot 2 -- pre-fix, this is where the file was already gone
+    assert_survives()
+
+
+def test_create_custom_profile_never_canonicalizes_onto_reserved_blob_filename(tmp_path):
+    # Companion fix: creating a profile whose display name slugifies to
+    # "custom_profiles" must never be allowed to land on
+    # custom_profiles.json -- that's the reserved legacy-blob filename, and
+    # a profile written there would be destroyed as a false-positive legacy
+    # blob on the very next manager construction (see the stray-file test
+    # above). The id (and therefore the filename) must be reassigned away
+    # from the reserved name, exactly like any other id collision.
+    m = _mgr(tmp_path)
+    created = m.create_custom_profile("Custom Profiles", base_profile="balanced")
+
+    assert created.id != "custom_profiles"
+    assert not (tmp_path / "profiles" / "custom_profiles.json").exists()
+    assert (tmp_path / "profiles" / f"{created.id}.json").exists()
+
+    # Survives a fresh-manager reload, reachable under the same (reassigned) id.
+    m2 = _mgr(tmp_path)
+    reloaded = m2.get_profile(created.id)
+    assert reloaded is not None
+    assert reloaded.name == "Custom Profiles"

--- a/Tests/RAG/test_config_profiles.py
+++ b/Tests/RAG/test_config_profiles.py
@@ -75,3 +75,33 @@ def test_high_accuracy_has_no_stray_method_attr(tmp_path):
     # '.method' is a typo of the real field 'chunking_method' -> must not exist as a stray attr
     assert "method" not in vars(chunking)
     assert chunking.chunking_method in {"words", "sentences", "paragraphs"}
+
+
+def test_builtins_are_read_only_with_ids(tmp_path):
+    m = _mgr(tmp_path)
+    hb = m.get_profile("hybrid_basic")
+    assert hb.read_only is True
+    assert hb.id == "hybrid_basic"
+
+
+def test_profileconfig_id_backfilled_and_round_trips():
+    from tldw_chatbook.RAG_Search.config_profiles import ProfileConfig, _slugify
+    from tldw_chatbook.RAG_Search.simplified.config import RAGConfig, VectorStoreConfig
+    # Pin vector_store to "memory" (see _profile() above): with the "auto"
+    # default, VectorStoreConfig.__post_init__ resolves to "chroma" (and a
+    # real PosixPath persist_directory) whenever the embeddings_rag optional
+    # deps happen to be installed, which breaks json.dumps below for reasons
+    # unrelated to what this test checks (id/read_only round-tripping).
+    p = ProfileConfig(name="My Cool Profile", description="d",
+                      profile_type="custom",
+                      rag_config=RAGConfig(vector_store=VectorStoreConfig(type="memory")))
+    assert p.id == _slugify("My Cool Profile")  # auto-derived when not given
+    import json
+    restored = ProfileConfig.from_dict(json.loads(json.dumps(p.to_dict())))
+    assert restored.id == p.id
+    assert restored.read_only is False
+    # Old files with no id/read_only keys still load (backfill):
+    legacy = {k: v for k, v in p.to_dict().items() if k not in ("id", "read_only")}
+    legacy_restored = ProfileConfig.from_dict(legacy)
+    assert legacy_restored.id == _slugify("My Cool Profile")
+    assert legacy_restored.read_only is False

--- a/backlog/tasks/task-476 - RAG-settings-profiles-SP1-per-embedding-config-index-isolation.md
+++ b/backlog/tasks/task-476 - RAG-settings-profiles-SP1-per-embedding-config-index-isolation.md
@@ -2,7 +2,7 @@
 id: TASK-476
 title: >-
   RAG settings + profiles SP1: per-embedding-config index isolation
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-07-21 16:30'
 updated_date: '2026-07-21 16:30'

--- a/backlog/tasks/task-483 - RAG-settings-profiles-SP2a-profile-storage-foundation.md
+++ b/backlog/tasks/task-483 - RAG-settings-profiles-SP2a-profile-storage-foundation.md
@@ -1,0 +1,38 @@
+---
+id: TASK-483
+title: >-
+  RAG settings + profiles SP2a: profile storage foundation
+status: To Do
+assignee: []
+created_date: '2026-07-22 01:15'
+updated_date: '2026-07-22 01:15'
+labels:
+  - rag
+  - profiles
+dependencies:
+  - task-476
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+First half of SP2 (profile system) in the RAG settings screen + profiles program (overview: Docs/superpowers/specs/2026-07-21-rag-settings-profiles-overview.md; SP2 spec: Docs/superpowers/specs/2026-07-21-rag-profile-system-design.md; plan: Docs/superpowers/plans/2026-07-22-rag-profile-system-sp2a-storage.md). Turns the existing `ConfigProfileManager` into a correct, file-backed, user-facing profile store. SP2b (config-resolution unification onto the active profile, reset seam, first-run import, parity test) is a separate follow-up task/PR. Depends on SP1 (task-476, merged PR #771).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] `ProfileConfig.from_dict` reconstructs nested dataclasses correctly (routes rag_config through `RAGConfig.from_dict`), so file-per-profile round-trips.
+- [ ] Builtin profiles use the real dataclass fields and valid enum values (chunk_size/chunk_overlap/default_top_k/default_search_mode; store type memory not "in_memory"; keyword→plain), so fast/balanced/accuracy actually differ; `validate_profile` reads real fields.
+- [ ] `ProfileConfig` has a stable, rename-safe `id` and a `read_only` marker; builtins are read-only.
+- [ ] User profiles are stored one JSON file per profile under `rag_profiles/`; a legacy `custom_profiles.json` blob is migrated to per-file once (idempotent).
+- [ ] CRUD: `save_profile` / `delete_profile` / `rename_profile` / `clone_profile`, all refusing to mutate builtins; clone deep-copies (incl. a builtin) into a fresh writable profile; rename keeps id + file.
+- [ ] No config-resolution / active-pointer / reset-seam / first-run-import changes (those are SP2b). No DB migration.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+See Docs/superpowers/plans/2026-07-22-rag-profile-system-sp2a-storage.md — 6 TDD tasks: (1) round-trip fix; (2) builtin field/value fix + validate; (3) stable id + read_only marker; (4) file-per-profile storage + legacy migration; (5) CRUD with read-only guards; (6) regression gate + docs. SDD-executed, user-gated PR. All changes in RAG_Search/config_profiles.py.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-484 - Fix-builtin-profiles-with-invalid-chunking_method-values.md
+++ b/backlog/tasks/task-484 - Fix-builtin-profiles-with-invalid-chunking_method-values.md
@@ -1,0 +1,31 @@
+---
+id: TASK-484
+title: >-
+  Fix builtin RAG profiles with invalid chunking_method values
+status: To Do
+assignee: []
+created_date: '2026-07-22 01:45'
+updated_date: '2026-07-22 01:45'
+labels:
+  - rag
+  - profiles
+  - followup
+dependencies:
+  - task-483
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow-up from SP2a (task-483) Task 2 review. Three builtin profiles in `tldw_chatbook/RAG_Search/config_profiles.py` set the CORRECT field `chunking_method` but to values that are NOT in the pipeline's valid set (words/sentences/paragraphs/tokens/semantic/json/ebook_chapters/xml/rolling_summarize): `hybrid_full` and `research_papers` use `"hierarchical"`, `technical_docs` uses `"structural"`. These are silently unused today, but if the enhanced-chunking code path (`Chunker.chunk_text`) is ever exercised for a profile with these values it raises `InvalidChunkingMethodError`. This is a different bug class from the SP2a dead-attribute fix (correct field, invalid value), so it was left as a follow-up.
+
+Decide the correct valid `chunking_method` for each (these builtins also set `preserve_structure`; "paragraphs" is the closest structure-respecting valid method) and set it, or remove the line to fall back to the default. Needs a small design decision on intended chunking behavior for each.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] Every builtin profile's `chunking_method` is a value accepted by the runtime chunker (no `InvalidChunkingMethodError` possible from any builtin).
+- [ ] A test asserts all builtins use a valid `chunking_method`.
+<!-- AC:END -->

--- a/tldw_chatbook/RAG_Search/config_profiles.py
+++ b/tldw_chatbook/RAG_Search/config_profiles.py
@@ -175,7 +175,13 @@ class ProfileConfig:
 
 
 class ConfigProfileManager:
-    """Manages configuration profiles and experiments."""
+    """Manages RAG configuration profiles.
+
+    Builtins are read-only clone-seeds; user profiles are stored one JSON file
+    per profile under ``rag_profiles/`` keyed by a stable ``id`` (rename-safe).
+    NOTE: the active-profile pointer and config-resolution wiring live in SP2b,
+    not here — this class is storage + CRUD only.
+    """
 
     def __init__(self, profiles_dir: Optional[Path] = None):
         self.profiles_dir = profiles_dir or (get_user_data_dir() / "rag_profiles")

--- a/tldw_chatbook/RAG_Search/config_profiles.py
+++ b/tldw_chatbook/RAG_Search/config_profiles.py
@@ -6,6 +6,7 @@ along with utilities for experiment tracking and A/B testing.
 """
 
 import json
+import re
 import time
 from typing import Dict, Any, Optional, List, Literal, Tuple
 from dataclasses import dataclass, field, asdict
@@ -19,6 +20,12 @@ from .reranker import RerankingConfig
 from .parallel_processor import ProcessingConfig
 from ..config import get_user_data_dir
 from ..Metrics.metrics_logger import log_counter, log_histogram
+
+
+def _slugify(name: str) -> str:
+    """Filename-safe stable slug for a profile display name."""
+    slug = re.sub(r"[^a-z0-9]+", "_", str(name).strip().lower()).strip("_")
+    return slug or "profile"
 
 
 # Profile types
@@ -91,9 +98,19 @@ class ProfileConfig:
     expected_latency_ms: Optional[float] = None
     expected_accuracy: Optional[float] = None
 
+    # Stable identity / mutability marker
+    id: Optional[str] = None
+    read_only: bool = False
+
+    def __post_init__(self):
+        if not self.id:
+            self.id = _slugify(self.name)
+
     def to_dict(self) -> Dict[str, Any]:
         """Convert profile to dictionary."""
         return {
+            "id": self.id,
+            "read_only": self.read_only,
             "name": self.name,
             "description": self.description,
             "profile_type": self.profile_type,
@@ -148,6 +165,8 @@ class ProfileConfig:
             tags=data.get("tags", []),
             expected_latency_ms=data.get("expected_latency_ms"),
             expected_accuracy=data.get("expected_accuracy"),
+            id=data.get("id"),
+            read_only=data.get("read_only", False),
         )
 
 
@@ -182,6 +201,8 @@ class ConfigProfileManager:
         bm25_rag.search.include_citations = True
 
         self._profiles["bm25_only"] = ProfileConfig(
+            id="bm25_only",
+            read_only=True,
             name="BM25 Only",
             description="Pure keyword/BM25 search without semantic vectors",
             profile_type="fast_search",
@@ -202,6 +223,8 @@ class ConfigProfileManager:
         vector_rag.search.include_citations = True
 
         self._profiles["vector_only"] = ProfileConfig(
+            id="vector_only",
+            read_only=True,
             name="Vector Only",
             description="Pure semantic/vector search without keyword matching",
             profile_type="fast_search",
@@ -222,6 +245,8 @@ class ConfigProfileManager:
         hybrid_basic_rag.search.include_citations = True
 
         self._profiles["hybrid_basic"] = ProfileConfig(
+            id="hybrid_basic",
+            read_only=True,
             name="Hybrid Basic",
             description="Combined keyword and semantic search without enhancements",
             profile_type="balanced",
@@ -247,6 +272,8 @@ class ConfigProfileManager:
         hybrid_enhanced_rag.search.parent_inclusion_strategy = "size_based"
 
         self._profiles["hybrid_enhanced"] = ProfileConfig(
+            id="hybrid_enhanced",
+            read_only=True,
             name="Hybrid Enhanced",
             description="Hybrid search with parent document retrieval",
             profile_type="balanced",
@@ -280,6 +307,8 @@ class ConfigProfileManager:
         )
 
         self._profiles["hybrid_full"] = ProfileConfig(
+            id="hybrid_full",
+            read_only=True,
             name="Hybrid Full",
             description="All features enabled for maximum accuracy",
             profile_type="high_accuracy",
@@ -302,6 +331,8 @@ class ConfigProfileManager:
         fast_rag.search.cache_size = 200
 
         self._profiles["fast_search"] = ProfileConfig(
+            id="fast_search",
+            read_only=True,
             name="Fast Search",
             description="Optimized for low latency with acceptable accuracy",
             profile_type="fast_search",
@@ -331,6 +362,8 @@ class ConfigProfileManager:
         )
 
         self._profiles["high_accuracy"] = ProfileConfig(
+            id="high_accuracy",
+            read_only=True,
             name="High Accuracy",
             description="Optimized for maximum retrieval accuracy",
             profile_type="high_accuracy",
@@ -350,6 +383,8 @@ class ConfigProfileManager:
         balanced_rag.search.default_top_k = 10
 
         self._profiles["balanced"] = ProfileConfig(
+            id="balanced",
+            read_only=True,
             name="Balanced",
             description="Balance between speed and accuracy",
             profile_type="balanced",
@@ -370,6 +405,8 @@ class ConfigProfileManager:
         long_context_rag.search.default_top_k = 5  # Fewer but larger chunks
 
         self._profiles["long_context"] = ProfileConfig(
+            id="long_context",
+            read_only=True,
             name="Long Context",
             description="For documents requiring extended context",
             profile_type="long_context",
@@ -390,6 +427,8 @@ class ConfigProfileManager:
         tech_rag.search.include_citations = True
 
         self._profiles["technical_docs"] = ProfileConfig(
+            id="technical_docs",
+            read_only=True,
             name="Technical Documentation",
             description="Optimized for technical content with tables and code",
             profile_type="technical_docs",
@@ -418,6 +457,8 @@ class ConfigProfileManager:
         )
 
         self._profiles["research_papers"] = ProfileConfig(
+            id="research_papers",
+            read_only=True,
             name="Research Papers",
             description="Optimized for academic papers and citations",
             profile_type="research_papers",
@@ -435,6 +476,8 @@ class ConfigProfileManager:
         code_rag.search.default_top_k = 20  # More results for code search
 
         self._profiles["code_search"] = ProfileConfig(
+            id="code_search",
+            read_only=True,
             name="Code Search",
             description="Optimized for searching code repositories",
             profile_type="code_search",

--- a/tldw_chatbook/RAG_Search/config_profiles.py
+++ b/tldw_chatbook/RAG_Search/config_profiles.py
@@ -318,7 +318,6 @@ class ConfigProfileManager:
         accurate_rag.embedding.batch_size = 16
         accurate_rag.chunking.chunk_size = 512
         accurate_rag.chunking.chunk_overlap = 128
-        accurate_rag.chunking.method = "hierarchical"
         accurate_rag.search.default_top_k = 20
         accurate_rag.search.include_citations = True
         accurate_rag.search.score_threshold = 0.7

--- a/tldw_chatbook/RAG_Search/config_profiles.py
+++ b/tldw_chatbook/RAG_Search/config_profiles.py
@@ -6,6 +6,7 @@ along with utilities for experiment tracking and A/B testing.
 """
 
 import json
+import os
 import re
 import time
 from typing import Dict, Any, Optional, List, Literal, Tuple
@@ -193,6 +194,13 @@ class ConfigProfileManager:
 
         # Load built-in profiles
         self._load_builtin_profiles()
+
+        # Immutable, un-flippable record of which ids are builtins. Mutation
+        # guards (save/delete/rename) check THIS set, not the mutable
+        # `ProfileConfig.read_only` field on a shared instance -- a caller
+        # cannot bypass the guard by doing
+        # `manager.get_profile("x").read_only = False`.
+        self._builtin_ids = frozenset(self._profiles.keys())
 
         # Load custom profiles
         self._load_custom_profiles()
@@ -499,7 +507,24 @@ class ConfigProfileManager:
         logger.info(f"Loaded {len(self._profiles)} built-in profiles")
 
     def _profile_path(self, profile_id: str) -> Path:
-        """Path to a user profile's own JSON file."""
+        """Path to a user profile's own JSON file.
+
+        Args:
+            profile_id: Candidate profile id. Must already be a bare,
+                filesystem-safe slug (i.e. equal to ``_slugify(profile_id)``).
+                This is defense-in-depth against a crafted or hand-edited
+                profile id (e.g. ``"../../etc/passwd"``) escaping
+                ``profiles_dir`` via any id-keyed file operation
+                (``_save_one``, ``delete_profile``, legacy-blob migration).
+
+        Returns:
+            The per-profile JSON file path under ``profiles_dir``.
+
+        Raises:
+            ValueError: If ``profile_id`` is not already a bare slug.
+        """
+        if profile_id != _slugify(profile_id):
+            raise ValueError(f"unsafe profile id: {profile_id!r}")
         return self.profiles_dir / f"{profile_id}.json"
 
     def _save_one(self, profile: "ProfileConfig") -> None:
@@ -510,7 +535,20 @@ class ConfigProfileManager:
             json.dump(profile.to_dict(), f, indent=2, default=str)
 
     def _load_custom_profiles(self):
-        """Load user profiles from per-file JSON; migrate a legacy blob once."""
+        """Load user profiles from per-file JSON; migrate a legacy blob once.
+
+        The FILENAME (stem) is authoritative for a profile's id -- never the
+        JSON's internal ``"id"`` field, which may be missing, hand-edited,
+        stale, or (if untrusted) even crafted for path traversal. If the
+        stem-derived id collides with an already-registered profile (a
+        builtin, or a profile loaded earlier in this same pass), it is
+        reassigned to a unique id. Whenever the canonical filename for the
+        resolved id doesn't match the file it was loaded from -- because the
+        stem needed slugifying, or the id was reassigned -- the profile is
+        self-healed on disk: written under its canonical name first, then
+        the stale file is removed, so a crash between the two steps never
+        loses data.
+        """
         self._migrate_legacy_blob()
         for path in self.profiles_dir.glob("*.json"):
             if path.name in _RESERVED_PROFILE_FILES:
@@ -519,33 +557,69 @@ class ConfigProfileManager:
                 with open(path, "r") as f:
                     profile = ProfileConfig.from_dict(json.load(f))
                 profile.read_only = False
-                existing = self._profiles.get(profile.id)
-                if existing is not None and existing.read_only:
-                    # A hand-placed or stale file is shadowing a read-only
-                    # builtin id. Never let it win: reassign to a unique id
-                    # and self-heal the on-disk file so this can't recur.
-                    old_id = profile.id
-                    profile.id = self._unique_id_reserving_disk(profile.id)
-                    self._save_one(profile)
-                    if path.exists():
-                        path.unlink()
+
+                desired_id = _slugify(path.stem)
+                if desired_id in self._profiles:
+                    # Collides with a builtin or an already-loaded profile
+                    # (e.g. a hand-placed <builtin_id>.json, or two files
+                    # whose stems slugify to the same id). Never let it win:
+                    # reassign to a unique id, checking disk too, since the
+                    # in-memory dict is only partially populated mid-glob.
+                    old_id = desired_id
+                    desired_id = self._unique_id_reserving_disk(desired_id)
                     logger.warning(
-                        f"Profile file {path.name} collided with read-only "
-                        f"builtin '{old_id}'; reassigned to id '{profile.id}'"
+                        f"Profile file {path.name} collided with id "
+                        f"'{old_id}'; reassigned to id '{desired_id}'"
                     )
-                self._profiles[profile.id] = profile
+
+                profile.id = desired_id
+                self._profiles[desired_id] = profile
+
+                canonical_path = self._profile_path(desired_id)
+                if canonical_path != path:
+                    # Self-heal: write under the canonical name FIRST, then
+                    # remove the stale/incorrectly-named file.
+                    self._save_one(profile)
+                    try:
+                        if path.exists():
+                            path.unlink()
+                    except OSError as e:
+                        logger.warning(
+                            f"Failed to remove stale profile file {path}: {e}"
+                        )
+                    logger.warning(
+                        f"Profile file {path.name} did not match its "
+                        f"canonical id '{desired_id}'; self-healed to "
+                        f"{canonical_path.name}"
+                    )
             except Exception as e:
                 logger.error(f"Failed to load profile {path.name}: {e}")
 
     def _migrate_legacy_blob(self):
-        """One-time split of the old custom_profiles.json blob into per-file."""
+        """One-time split of the old custom_profiles.json blob into per-file.
+
+        Each profile entry is migrated independently: a single bad or
+        unparseable entry (e.g. an old blob with a renamed/unknown
+        ``rag_config`` sub-key, raising ``TypeError`` from
+        ``ProfileConfig.from_dict``) is logged and skipped rather than
+        aborting the whole migration -- otherwise one corrupt entry would
+        silently take every OTHER valid custom profile in the blob down with
+        it. The blob is renamed to ``.migrated`` unconditionally once it has
+        been successfully read, so it is never reprocessed on a later boot
+        even if every entry in it failed to migrate.
+        """
         blob = self.profiles_dir / "custom_profiles.json"
         if not blob.exists():
             return
         try:
             with open(blob, "r") as f:
                 data = json.load(f)
-            for pdata in data.get("profiles", []):
+        except Exception as e:
+            logger.error(f"Legacy profile blob migration failed to read {blob}: {e}")
+            return
+
+        for pdata in data.get("profiles", []):
+            try:
                 profile = ProfileConfig.from_dict(pdata)
                 profile.read_only = False
                 existing = self._profiles.get(profile.id)
@@ -557,10 +631,19 @@ class ConfigProfileManager:
                 if not target.exists():  # never clobber an existing per-file profile
                     with open(target, "w") as out:
                         json.dump(profile.to_dict(), out, indent=2, default=str)
-            blob.rename(self.profiles_dir / "custom_profiles.json.migrated")
+            except Exception as e:
+                entry_name = pdata.get("name", "<unknown>") if isinstance(pdata, dict) else "<unknown>"
+                logger.error(
+                    f"Skipping unmigratable legacy profile entry '{entry_name}': {e}"
+                )
+
+        try:
+            # os.replace is an atomic overwrite on both POSIX and Windows
+            # (Path.rename raises on Windows if the destination exists).
+            os.replace(str(blob), str(blob.parent / "custom_profiles.json.migrated"))
             logger.info("Migrated legacy custom_profiles.json to per-file profiles")
-        except Exception as e:
-            logger.error(f"Legacy profile blob migration failed: {e}")
+        except OSError as e:
+            logger.error(f"Failed to rename migrated legacy blob {blob}: {e}")
 
     def get_profile(self, name: str) -> Optional[ProfileConfig]:
         """Get a configuration profile by name."""
@@ -587,8 +670,28 @@ class ConfigProfileManager:
         return candidate
 
     def save_profile(self, profile: "ProfileConfig") -> "ProfileConfig":
-        """Persist a user profile (refuses read-only builtins, incoming or existing)."""
-        if profile.read_only:
+        """Persist a user profile.
+
+        Refuses to persist a read-only builtin, whether the incoming
+        ``profile`` object is itself read-only or its id merely collides
+        with an existing read-only builtin.
+
+        Args:
+            profile: The profile to save. Its ``id`` determines both the
+                in-memory key and the on-disk filename it is written to.
+
+        Returns:
+            The same ``profile`` instance, now registered and persisted.
+
+        Raises:
+            ValueError: If ``profile.read_only`` is ``True``, or
+                ``profile.id`` names a builtin (checked against the
+                immutable ``self._builtin_ids`` set, which cannot be
+                defeated by flipping ``read_only`` on a shared instance), or
+                ``profile.id`` collides with a different, read-only,
+                already-registered profile.
+        """
+        if profile.read_only or profile.id in self._builtin_ids:
             raise ValueError(f"Profile '{profile.id}' is read-only")
         existing = self._profiles.get(profile.id)
         if existing is not None and existing is not profile and existing.read_only:
@@ -600,6 +703,23 @@ class ConfigProfileManager:
         return profile
 
     def delete_profile(self, profile_id: str) -> bool:
+        """Delete a user profile by id, removing both its in-memory entry
+        and its on-disk file.
+
+        Args:
+            profile_id: The id of the profile to delete.
+
+        Returns:
+            ``True`` if a profile was found and deleted, ``False`` if no
+            profile with that id is registered.
+
+        Raises:
+            ValueError: If ``profile_id`` names a builtin profile. Checked
+                against both ``self._builtin_ids`` (immutable, un-flippable)
+                and the profile's own ``read_only`` flag.
+        """
+        if profile_id in self._builtin_ids:
+            raise ValueError(f"Builtin profile '{profile_id}' cannot be deleted")
         prof = self._profiles.get(profile_id)
         if prof is None:
             return False
@@ -612,6 +732,26 @@ class ConfigProfileManager:
         return True
 
     def rename_profile(self, profile_id: str, new_name: str) -> "ProfileConfig":
+        """Rename a user profile's display name in place.
+
+        The profile's ``id`` (and therefore its on-disk filename) is left
+        unchanged -- only ``name`` is updated -- so the profile remains
+        reachable under the same id before and after the rename.
+
+        Args:
+            profile_id: The id of the profile to rename.
+            new_name: The new display name.
+
+        Returns:
+            The renamed profile.
+
+        Raises:
+            ValueError: If no profile with ``profile_id`` is registered, or
+                it names a builtin profile (checked against both
+                ``self._builtin_ids`` and ``read_only``).
+        """
+        if profile_id in self._builtin_ids:
+            raise ValueError(f"Builtin profile '{profile_id}' cannot be renamed")
         prof = self._profiles.get(profile_id)
         if prof is None:
             raise ValueError(f"Profile '{profile_id}' not found")
@@ -622,6 +762,22 @@ class ConfigProfileManager:
         return prof
 
     def clone_profile(self, source_id: str, new_name: str) -> "ProfileConfig":
+        """Clone an existing profile (builtin or user) into a new, writable profile.
+
+        Args:
+            source_id: Id of the profile to clone from.
+            new_name: Display name for the clone. Its id is derived from
+                this name via ``_slugify`` and uniquified against existing
+                ids, so it never collides with the source (or any other
+                profile) even if the display name matches.
+
+        Returns:
+            The newly created, persisted, writable clone.
+
+        Raises:
+            ValueError: If ``source_id`` does not resolve to a registered
+                profile.
+        """
         src = self._profiles.get(source_id)
         if src is None:
             raise ValueError(f"Source profile '{source_id}' not found")

--- a/tldw_chatbook/RAG_Search/config_profiles.py
+++ b/tldw_chatbook/RAG_Search/config_profiles.py
@@ -28,6 +28,10 @@ def _slugify(name: str) -> str:
     return slug or "profile"
 
 
+# Filenames under profiles_dir that are never treated as user-profile files.
+_RESERVED_PROFILE_FILES = {"custom_profiles.json", "custom_profiles.json.migrated"}
+
+
 # Profile types
 ProfileType = Literal[
     "fast_search",  # Optimized for speed
@@ -488,25 +492,50 @@ class ConfigProfileManager:
 
         logger.info(f"Loaded {len(self._profiles)} built-in profiles")
 
+    def _profile_path(self, profile_id: str) -> Path:
+        """Path to a user profile's own JSON file."""
+        return self.profiles_dir / f"{profile_id}.json"
+
+    def _save_one(self, profile: "ProfileConfig") -> None:
+        """Write a single user profile to its own file (never builtins)."""
+        if profile.read_only:
+            return
+        with open(self._profile_path(profile.id), "w") as f:
+            json.dump(profile.to_dict(), f, indent=2, default=str)
+
     def _load_custom_profiles(self):
-        """Load user-defined profiles from disk."""
-        custom_profiles_file = self.profiles_dir / "custom_profiles.json"
-
-        if custom_profiles_file.exists():
+        """Load user profiles from per-file JSON; migrate a legacy blob once."""
+        self._migrate_legacy_blob()
+        for path in self.profiles_dir.glob("*.json"):
+            if path.name in _RESERVED_PROFILE_FILES:
+                continue
             try:
-                with open(custom_profiles_file, "r") as f:
-                    custom_data = json.load(f)
-
-                for profile_data in custom_data.get("profiles", []):
-                    profile = ProfileConfig.from_dict(profile_data)
-                    self._profiles[profile.name.lower().replace(" ", "_")] = profile
-
-                logger.info(
-                    f"Loaded {len(custom_data.get('profiles', []))} custom profiles"
-                )
-
+                with open(path, "r") as f:
+                    profile = ProfileConfig.from_dict(json.load(f))
+                profile.read_only = False
+                self._profiles[profile.id] = profile
             except Exception as e:
-                logger.error(f"Failed to load custom profiles: {e}")
+                logger.error(f"Failed to load profile {path.name}: {e}")
+
+    def _migrate_legacy_blob(self):
+        """One-time split of the old custom_profiles.json blob into per-file."""
+        blob = self.profiles_dir / "custom_profiles.json"
+        if not blob.exists():
+            return
+        try:
+            with open(blob, "r") as f:
+                data = json.load(f)
+            for pdata in data.get("profiles", []):
+                profile = ProfileConfig.from_dict(pdata)
+                profile.read_only = False
+                target = self._profile_path(profile.id)
+                if not target.exists():  # never clobber an existing per-file profile
+                    with open(target, "w") as out:
+                        json.dump(profile.to_dict(), out, indent=2, default=str)
+            blob.rename(self.profiles_dir / "custom_profiles.json.migrated")
+            logger.info("Migrated legacy custom_profiles.json to per-file profiles")
+        except Exception as e:
+            logger.error(f"Legacy profile blob migration failed: {e}")
 
     def get_profile(self, name: str) -> Optional[ProfileConfig]:
         """Get a configuration profile by name."""
@@ -560,31 +589,11 @@ class ConfigProfileManager:
         # Save the custom profile
         profile_key = name.lower().replace(" ", "_")
         self._profiles[profile_key] = custom_config
-        self._save_custom_profiles()
+        self._save_one(custom_config)
 
         logger.info(f"Created custom profile: {name}")
 
         return custom_config
-
-    def _save_custom_profiles(self):
-        """Save custom profiles to disk."""
-        custom_profiles = {
-            name: profile
-            for name, profile in self._profiles.items()
-            if profile.profile_type == "custom"
-        }
-
-        custom_profiles_file = self.profiles_dir / "custom_profiles.json"
-
-        with open(custom_profiles_file, "w") as f:
-            json.dump(
-                {
-                    "profiles": [p.to_dict() for p in custom_profiles.values()],
-                    "saved_at": datetime.now().isoformat(),
-                },
-                f,
-                indent=2,
-            )
 
     def start_experiment(self, config: ExperimentConfig):
         """Start an A/B testing experiment."""

--- a/tldw_chatbook/RAG_Search/config_profiles.py
+++ b/tldw_chatbook/RAG_Search/config_profiles.py
@@ -525,7 +525,7 @@ class ConfigProfileManager:
                     # builtin id. Never let it win: reassign to a unique id
                     # and self-heal the on-disk file so this can't recur.
                     old_id = profile.id
-                    profile.id = self._unique_id(profile.id)
+                    profile.id = self._unique_id_reserving_disk(profile.id)
                     self._save_one(profile)
                     if path.exists():
                         path.unlink()
@@ -552,7 +552,7 @@ class ConfigProfileManager:
                 if existing is not None and existing.read_only:
                     # Never let a migrated user profile shadow a read-only
                     # builtin id -- write it to a uniquified file instead.
-                    profile.id = self._unique_id(profile.id)
+                    profile.id = self._unique_id_reserving_disk(profile.id)
                 target = self._profile_path(profile.id)
                 if not target.exists():  # never clobber an existing per-file profile
                     with open(target, "w") as out:
@@ -573,6 +573,15 @@ class ConfigProfileManager:
     def _unique_id(self, base_slug: str) -> str:
         candidate, n = base_slug, 2
         while candidate in self._profiles:
+            candidate = f"{base_slug}_{n}"
+            n += 1
+        return candidate
+
+    def _unique_id_reserving_disk(self, base_slug: str) -> str:
+        """Like _unique_id but also avoids ids whose file already exists on disk
+        (the in-memory dict is only partially populated during load)."""
+        candidate, n = base_slug, 2
+        while candidate in self._profiles or self._profile_path(candidate).exists():
             candidate = f"{base_slug}_{n}"
             n += 1
         return candidate

--- a/tldw_chatbook/RAG_Search/config_profiles.py
+++ b/tldw_chatbook/RAG_Search/config_profiles.py
@@ -115,7 +115,7 @@ class ProfileConfig:
     def from_dict(cls, data: Dict[str, Any]) -> "ProfileConfig":
         """Create profile from dictionary."""
         rag_config = (
-            RAGConfig(**data["rag_config"])
+            RAGConfig.from_dict(data["rag_config"])
             if isinstance(data["rag_config"], dict)
             else data["rag_config"]
         )

--- a/tldw_chatbook/RAG_Search/config_profiles.py
+++ b/tldw_chatbook/RAG_Search/config_profiles.py
@@ -550,7 +550,13 @@ class ConfigProfileManager:
         loses data.
         """
         self._migrate_legacy_blob()
-        for path in self.profiles_dir.glob("*.json"):
+        # Materialize + sort the glob into a fixed list up front: the loop
+        # below self-heals by writing/unlinking files under this same
+        # directory, so iterating a live directory scan while mutating it is
+        # unsafe (order becomes filesystem- and implementation-dependent).
+        # A deterministic order alone doesn't prevent a clobber -- see the
+        # disk-occupancy check below -- but it makes behavior reproducible.
+        for path in sorted(self.profiles_dir.glob("*.json")):
             if path.name in _RESERVED_PROFILE_FILES:
                 continue
             try:
@@ -559,14 +565,24 @@ class ConfigProfileManager:
                 profile.read_only = False
 
                 desired_id = _slugify(path.stem)
-                if desired_id in self._profiles:
-                    # Collides with a builtin or an already-loaded profile
-                    # (e.g. a hand-placed <builtin_id>.json, or two files
-                    # whose stems slugify to the same id). Never let it win:
-                    # reassign to a unique id, checking disk too, since the
-                    # in-memory dict is only partially populated mid-glob.
+                canonical_path = self._profile_path(desired_id)
+                if desired_id in self._profiles or (
+                    canonical_path != path and canonical_path.exists()
+                ):
+                    # Collides with a builtin, an already-loaded profile, OR
+                    # the canonical file for this id belongs to a DIFFERENT,
+                    # not-yet-loaded profile still on disk (e.g. two stems --
+                    # "foo-bar" and "foo_bar" -- that both slugify to
+                    # "foo_bar"). That last case is invisible to a
+                    # memory-only check: since the in-memory dict is only
+                    # partially populated mid-glob, checking just
+                    # `desired_id in self._profiles` would let the self-heal
+                    # below silently overwrite that other file before it's
+                    # ever loaded. Reassign to a unique id, checking disk
+                    # too.
                     old_id = desired_id
                     desired_id = self._unique_id_reserving_disk(desired_id)
+                    canonical_path = self._profile_path(desired_id)
                     logger.warning(
                         f"Profile file {path.name} collided with id "
                         f"'{old_id}'; reassigned to id '{desired_id}'"
@@ -575,7 +591,6 @@ class ConfigProfileManager:
                 profile.id = desired_id
                 self._profiles[desired_id] = profile
 
-                canonical_path = self._profile_path(desired_id)
                 if canonical_path != path:
                     # Self-heal: write under the canonical name FIRST, then
                     # remove the stale/incorrectly-named file.

--- a/tldw_chatbook/RAG_Search/config_profiles.py
+++ b/tldw_chatbook/RAG_Search/config_profiles.py
@@ -173,12 +173,12 @@ class ConfigProfileManager:
 
         # BM25 Only Profile (Pure keyword search)
         bm25_rag = RAGConfig()
-        bm25_rag.vector_store.type = "in_memory"  # No vector DB needed
+        bm25_rag.vector_store.type = "memory"  # No vector DB needed
         bm25_rag.embedding.model = "all-MiniLM-L6-v2"  # Still needed for interface
-        bm25_rag.chunking.size = 512
-        bm25_rag.chunking.overlap = 64
-        bm25_rag.search.default_type = "keyword"
-        bm25_rag.search.top_k = 20
+        bm25_rag.chunking.chunk_size = 512
+        bm25_rag.chunking.chunk_overlap = 64
+        bm25_rag.search.default_search_mode = "plain"
+        bm25_rag.search.default_top_k = 20
         bm25_rag.search.include_citations = True
 
         self._profiles["bm25_only"] = ProfileConfig(
@@ -195,10 +195,10 @@ class ConfigProfileManager:
         vector_rag = RAGConfig()
         vector_rag.embedding.model = "sentence-transformers/all-mpnet-base-v2"
         vector_rag.embedding.batch_size = 32
-        vector_rag.chunking.size = 384
-        vector_rag.chunking.overlap = 64
-        vector_rag.search.default_type = "semantic"
-        vector_rag.search.top_k = 10
+        vector_rag.chunking.chunk_size = 384
+        vector_rag.chunking.chunk_overlap = 64
+        vector_rag.search.default_search_mode = "semantic"
+        vector_rag.search.default_top_k = 10
         vector_rag.search.include_citations = True
 
         self._profiles["vector_only"] = ProfileConfig(
@@ -215,10 +215,10 @@ class ConfigProfileManager:
         hybrid_basic_rag = RAGConfig()
         hybrid_basic_rag.embedding.model = "all-MiniLM-L6-v2"
         hybrid_basic_rag.embedding.batch_size = 32
-        hybrid_basic_rag.chunking.size = 384
-        hybrid_basic_rag.chunking.overlap = 64
-        hybrid_basic_rag.search.default_type = "hybrid"
-        hybrid_basic_rag.search.top_k = 15
+        hybrid_basic_rag.chunking.chunk_size = 384
+        hybrid_basic_rag.chunking.chunk_overlap = 64
+        hybrid_basic_rag.search.default_search_mode = "hybrid"
+        hybrid_basic_rag.search.default_top_k = 15
         hybrid_basic_rag.search.include_citations = True
 
         self._profiles["hybrid_basic"] = ProfileConfig(
@@ -295,9 +295,9 @@ class ConfigProfileManager:
         fast_rag = RAGConfig()
         fast_rag.embedding.model = "all-MiniLM-L6-v2"
         fast_rag.embedding.batch_size = 64
-        fast_rag.chunking.size = 256
-        fast_rag.chunking.overlap = 32
-        fast_rag.search.top_k = 5
+        fast_rag.chunking.chunk_size = 256
+        fast_rag.chunking.chunk_overlap = 32
+        fast_rag.search.default_top_k = 5
         fast_rag.search.enable_cache = True
         fast_rag.search.cache_size = 200
 
@@ -316,10 +316,10 @@ class ConfigProfileManager:
         accurate_rag = RAGConfig()
         accurate_rag.embedding.model = "BAAI/bge-large-en-v1.5"  # Larger, more accurate
         accurate_rag.embedding.batch_size = 16
-        accurate_rag.chunking.size = 512
-        accurate_rag.chunking.overlap = 128
+        accurate_rag.chunking.chunk_size = 512
+        accurate_rag.chunking.chunk_overlap = 128
         accurate_rag.chunking.method = "hierarchical"
-        accurate_rag.search.top_k = 20
+        accurate_rag.search.default_top_k = 20
         accurate_rag.search.include_citations = True
         accurate_rag.search.score_threshold = 0.7
 
@@ -346,9 +346,9 @@ class ConfigProfileManager:
         # Balanced Profile
         balanced_rag = RAGConfig()
         balanced_rag.embedding.model = "sentence-transformers/all-mpnet-base-v2"
-        balanced_rag.chunking.size = 384
-        balanced_rag.chunking.overlap = 64
-        balanced_rag.search.top_k = 10
+        balanced_rag.chunking.chunk_size = 384
+        balanced_rag.chunking.chunk_overlap = 64
+        balanced_rag.search.default_top_k = 10
 
         self._profiles["balanced"] = ProfileConfig(
             name="Balanced",
@@ -364,11 +364,11 @@ class ConfigProfileManager:
         # Long Context Profile
         long_context_rag = RAGConfig()
         long_context_rag.embedding.model = "BAAI/bge-base-en-v1.5"
-        long_context_rag.chunking.size = 1024  # Larger chunks
-        long_context_rag.chunking.overlap = 256
+        long_context_rag.chunking.chunk_size = 1024  # Larger chunks
+        long_context_rag.chunking.chunk_overlap = 256
         long_context_rag.chunking.enable_parent_retrieval = True
         long_context_rag.chunking.parent_size_multiplier = 3
-        long_context_rag.search.top_k = 5  # Fewer but larger chunks
+        long_context_rag.search.default_top_k = 5  # Fewer but larger chunks
 
         self._profiles["long_context"] = ProfileConfig(
             name="Long Context",
@@ -728,14 +728,14 @@ class ConfigProfileManager:
             )
 
         # Check chunk size vs overlap
-        if profile.rag_config.chunking.overlap >= profile.rag_config.chunking.size:
+        if profile.rag_config.chunking.chunk_overlap >= profile.rag_config.chunking.chunk_size:
             warnings.append("Chunk overlap should be less than chunk size")
 
         # Check reranking configuration
         if profile.reranking_config:
             if (
                 profile.reranking_config.top_k_to_rerank
-                > profile.rag_config.search.top_k
+                > profile.rag_config.search.default_top_k
             ):
                 warnings.append("Reranking top_k should not exceed search top_k")
 

--- a/tldw_chatbook/RAG_Search/config_profiles.py
+++ b/tldw_chatbook/RAG_Search/config_profiles.py
@@ -566,8 +566,10 @@ class ConfigProfileManager:
 
                 desired_id = _slugify(path.stem)
                 canonical_path = self._profile_path(desired_id)
-                if desired_id in self._profiles or (
-                    canonical_path != path and canonical_path.exists()
+                if (
+                    desired_id in self._profiles
+                    or (canonical_path != path and canonical_path.exists())
+                    or canonical_path.name in _RESERVED_PROFILE_FILES
                 ):
                     # Collides with a builtin, an already-loaded profile, OR
                     # the canonical file for this id belongs to a DIFFERENT,
@@ -579,7 +581,11 @@ class ConfigProfileManager:
                     # `desired_id in self._profiles` would let the self-heal
                     # below silently overwrite that other file before it's
                     # ever loaded. Reassign to a unique id, checking disk
-                    # too.
+                    # too. Also reassign if the canonical filename is
+                    # reserved (e.g. "custom_profiles.json") -- that name is
+                    # reserved for the legacy blob, and a profile file
+                    # canonicalized onto it would be mistaken for (and
+                    # destroyed as) a legacy blob on the next boot.
                     old_id = desired_id
                     desired_id = self._unique_id_reserving_disk(desired_id)
                     canonical_path = self._profile_path(desired_id)
@@ -622,6 +628,21 @@ class ConfigProfileManager:
         it. The blob is renamed to ``.migrated`` unconditionally once it has
         been successfully read, so it is never reprocessed on a later boot
         even if every entry in it failed to migrate.
+
+        Guard: a file at this reserved path is only ever treated as a real
+        legacy blob if it actually HAS the blob shape (a dict with a
+        ``"profiles"`` key). A single-profile file can end up at this exact
+        path -- e.g. a profile whose display name slugifies to
+        "custom_profiles" (``create_custom_profile("Custom Profiles")``), or
+        a hand-placed/copied file -- and such a file has no ``"profiles"``
+        key. Without this check, nothing would migrate (there's no
+        "profiles" list to iterate) but the file would still get
+        unconditionally renamed to ``.migrated`` below, which is itself a
+        reserved filename that is never loaded as a profile either --
+        silently and permanently losing that profile. If the shape doesn't
+        match, do nothing at all: leave the file exactly as-is (no rename,
+        no write) rather than risk destroying data that isn't actually a
+        legacy blob.
         """
         blob = self.profiles_dir / "custom_profiles.json"
         if not blob.exists():
@@ -631,6 +652,14 @@ class ConfigProfileManager:
                 data = json.load(f)
         except Exception as e:
             logger.error(f"Legacy profile blob migration failed to read {blob}: {e}")
+            return
+
+        if not isinstance(data, dict) or "profiles" not in data:
+            logger.warning(
+                f"{blob} does not have the legacy blob shape "
+                f"(dict with a 'profiles' key); leaving it untouched "
+                f"instead of migrating/renaming it."
+            )
             return
 
         for pdata in data.get("profiles", []):
@@ -669,17 +698,31 @@ class ConfigProfileManager:
         return list(self._profiles.keys())
 
     def _unique_id(self, base_slug: str) -> str:
+        # Also reject a candidate whose canonical file would be a reserved
+        # name (e.g. "custom_profiles", whose file is the legacy-blob
+        # filename) -- a profile canonicalized onto that name would be
+        # mistaken for the legacy blob (and destroyed) by
+        # _migrate_legacy_blob on the next boot. A normal, non-colliding
+        # slug is returned unchanged, same as before.
         candidate, n = base_slug, 2
-        while candidate in self._profiles:
+        while (
+            candidate in self._profiles
+            or f"{candidate}.json" in _RESERVED_PROFILE_FILES
+        ):
             candidate = f"{base_slug}_{n}"
             n += 1
         return candidate
 
     def _unique_id_reserving_disk(self, base_slug: str) -> str:
         """Like _unique_id but also avoids ids whose file already exists on disk
-        (the in-memory dict is only partially populated during load)."""
+        (the in-memory dict is only partially populated during load), and ids
+        whose canonical file would be a reserved name (see _unique_id)."""
         candidate, n = base_slug, 2
-        while candidate in self._profiles or self._profile_path(candidate).exists():
+        while (
+            candidate in self._profiles
+            or self._profile_path(candidate).exists()
+            or f"{candidate}.json" in _RESERVED_PROFILE_FILES
+        ):
             candidate = f"{base_slug}_{n}"
             n += 1
         return candidate

--- a/tldw_chatbook/RAG_Search/config_profiles.py
+++ b/tldw_chatbook/RAG_Search/config_profiles.py
@@ -127,7 +127,7 @@ class ProfileConfig:
             else None,
             "created_at": self.created_at,
             "version": self.version,
-            "tags": self.tags,
+            "tags": list(self.tags),
             "expected_latency_ms": self.expected_latency_ms,
             "expected_accuracy": self.expected_accuracy,
         }
@@ -553,9 +553,14 @@ class ConfigProfileManager:
         return candidate
 
     def save_profile(self, profile: "ProfileConfig") -> "ProfileConfig":
-        """Persist a user profile (refuses read-only builtins)."""
+        """Persist a user profile (refuses read-only builtins, incoming or existing)."""
         if profile.read_only:
             raise ValueError(f"Profile '{profile.id}' is read-only")
+        existing = self._profiles.get(profile.id)
+        if existing is not None and existing is not profile and existing.read_only:
+            raise ValueError(
+                f"Profile id '{profile.id}' collides with read-only builtin '{profile.id}'"
+            )
         self._profiles[profile.id] = profile
         self._save_one(profile)
         return profile
@@ -636,6 +641,11 @@ class ConfigProfileManager:
             elif hasattr(custom_config.rag_config, key):
                 setattr(custom_config.rag_config, key, value)
             # Add more override logic as needed
+
+        # Uniquify the id up front so a user-chosen name that happens to match
+        # a builtin's display name (e.g. "High Accuracy" -> "high_accuracy")
+        # doesn't collide with the read-only builtin's id.
+        custom_config.id = self._unique_id(_slugify(name))
 
         # Save the custom profile (keyed by profile.id, same as its filename,
         # so it's reachable by the same key before and after a restart)

--- a/tldw_chatbook/RAG_Search/config_profiles.py
+++ b/tldw_chatbook/RAG_Search/config_profiles.py
@@ -545,6 +545,57 @@ class ConfigProfileManager:
         """List all available profile names."""
         return list(self._profiles.keys())
 
+    def _unique_id(self, base_slug: str) -> str:
+        candidate, n = base_slug, 2
+        while candidate in self._profiles:
+            candidate = f"{base_slug}_{n}"
+            n += 1
+        return candidate
+
+    def save_profile(self, profile: "ProfileConfig") -> "ProfileConfig":
+        """Persist a user profile (refuses read-only builtins)."""
+        if profile.read_only:
+            raise ValueError(f"Profile '{profile.id}' is read-only")
+        self._profiles[profile.id] = profile
+        self._save_one(profile)
+        return profile
+
+    def delete_profile(self, profile_id: str) -> bool:
+        prof = self._profiles.get(profile_id)
+        if prof is None:
+            return False
+        if prof.read_only:
+            raise ValueError(f"Builtin profile '{profile_id}' cannot be deleted")
+        self._profiles.pop(profile_id, None)
+        path = self._profile_path(profile_id)
+        if path.exists():
+            path.unlink()
+        return True
+
+    def rename_profile(self, profile_id: str, new_name: str) -> "ProfileConfig":
+        prof = self._profiles.get(profile_id)
+        if prof is None:
+            raise ValueError(f"Profile '{profile_id}' not found")
+        if prof.read_only:
+            raise ValueError(f"Builtin profile '{profile_id}' cannot be renamed")
+        prof.name = new_name  # id + filename stay the same (rename-safe)
+        self._save_one(prof)
+        return prof
+
+    def clone_profile(self, source_id: str, new_name: str) -> "ProfileConfig":
+        src = self._profiles.get(source_id)
+        if src is None:
+            raise ValueError(f"Source profile '{source_id}' not found")
+        new_id = self._unique_id(_slugify(new_name))
+        clone = ProfileConfig.from_dict({
+            **src.to_dict(),
+            "id": new_id,
+            "name": new_name,
+            "read_only": False,
+            "profile_type": "custom",
+        })
+        return self.save_profile(clone)
+
     def create_custom_profile(
         self, name: str, base_profile: str = "balanced", **overrides
     ) -> ProfileConfig:
@@ -586,10 +637,9 @@ class ConfigProfileManager:
                 setattr(custom_config.rag_config, key, value)
             # Add more override logic as needed
 
-        # Save the custom profile
-        profile_key = name.lower().replace(" ", "_")
-        self._profiles[profile_key] = custom_config
-        self._save_one(custom_config)
+        # Save the custom profile (keyed by profile.id, same as its filename,
+        # so it's reachable by the same key before and after a restart)
+        self.save_profile(custom_config)
 
         logger.info(f"Created custom profile: {name}")
 

--- a/tldw_chatbook/RAG_Search/config_profiles.py
+++ b/tldw_chatbook/RAG_Search/config_profiles.py
@@ -519,6 +519,20 @@ class ConfigProfileManager:
                 with open(path, "r") as f:
                     profile = ProfileConfig.from_dict(json.load(f))
                 profile.read_only = False
+                existing = self._profiles.get(profile.id)
+                if existing is not None and existing.read_only:
+                    # A hand-placed or stale file is shadowing a read-only
+                    # builtin id. Never let it win: reassign to a unique id
+                    # and self-heal the on-disk file so this can't recur.
+                    old_id = profile.id
+                    profile.id = self._unique_id(profile.id)
+                    self._save_one(profile)
+                    if path.exists():
+                        path.unlink()
+                    logger.warning(
+                        f"Profile file {path.name} collided with read-only "
+                        f"builtin '{old_id}'; reassigned to id '{profile.id}'"
+                    )
                 self._profiles[profile.id] = profile
             except Exception as e:
                 logger.error(f"Failed to load profile {path.name}: {e}")
@@ -534,6 +548,11 @@ class ConfigProfileManager:
             for pdata in data.get("profiles", []):
                 profile = ProfileConfig.from_dict(pdata)
                 profile.read_only = False
+                existing = self._profiles.get(profile.id)
+                if existing is not None and existing.read_only:
+                    # Never let a migrated user profile shadow a read-only
+                    # builtin id -- write it to a uniquified file instead.
+                    profile.id = self._unique_id(profile.id)
                 target = self._profile_path(profile.id)
                 if not target.exists():  # never clobber an existing per-file profile
                     with open(target, "w") as out:
@@ -565,7 +584,7 @@ class ConfigProfileManager:
         existing = self._profiles.get(profile.id)
         if existing is not None and existing is not profile and existing.read_only:
             raise ValueError(
-                f"Profile id '{profile.id}' collides with read-only builtin '{profile.id}'"
+                f"Profile id '{profile.id}' collides with read-only builtin '{existing.name}'"
             )
         self._profiles[profile.id] = profile
         self._save_one(profile)
@@ -630,7 +649,7 @@ class ConfigProfileManager:
             name=name,
             description=f"Custom profile based on {base_profile}",
             profile_type="custom",
-            rag_config=RAGConfig(**asdict(base.rag_config)),
+            rag_config=RAGConfig.from_dict(asdict(base.rag_config)),
             reranking_config=RerankingConfig(**asdict(base.reranking_config))
             if base.reranking_config
             else None,

--- a/tldw_chatbook/RAG_Search/simplified/enhanced_rag_service_v2.py
+++ b/tldw_chatbook/RAG_Search/simplified/enhanced_rag_service_v2.py
@@ -204,7 +204,7 @@ class EnhancedRAGServiceV2(EnhancedRAGService):
             # Temporarily use experiment profile settings
             if experiment_profile and experiment_profile.rag_config:
                 # Override search parameters from experiment profile
-                top_k = top_k or experiment_profile.rag_config.search.top_k
+                top_k = top_k or experiment_profile.rag_config.search.default_top_k
                 include_citations = (
                     include_citations
                     if include_citations is not None


### PR DESCRIPTION
## SP2a — RAG profile system: storage foundation

Second sub-project of the RAG settings screen + profiles program; the **safe half of SP2**. Makes the existing `ConfigProfileManager` a *correct, file-backed, user-facing* profile store — **without** touching the risky config-resolution wiring (that's **SP2b**, its spec already written, a separate user-gated PR). Depends on SP1 (index isolation, #771 merged). Backlog `task-483`.

All production changes are in `tldw_chatbook/RAG_Search/config_profiles.py`.

### What & why
- **Fixed the broken serialization round-trip.** `ProfileConfig.from_dict` used `RAGConfig(**dict)`, leaving sub-configs as raw dicts (`.rag_config.embedding.model` → AttributeError). Now routes through `RAGConfig.from_dict` — the prerequisite for file storage.
- **Fixed the builtins, which silently ignored their own settings.** Most builtins set *dead attributes* (`.chunking.size`/`.overlap`/`.search.top_k`/`.default_type`, `type="in_memory"`) that aren't the real dataclass fields — so "fast" (chunk 256) and "accuracy" (chunk 512) actually ran identical defaults. Corrected to the real fields + valid enum values (keyword→`plain`, store type `memory`), removed a stray `.chunking.method` dead attr, and fixed `validate_profile` to read real fields. Now fast/balanced/accuracy genuinely differ.
- **Stable, rename-safe `id` + `read_only` marker.** All ~13 builtins stamped read-only; user profiles keyed by a `_slugify` id that survives rename.
- **File-per-profile storage** under `rag_profiles/` (one JSON per user profile), with one-time legacy `custom_profiles.json` → per-file migration (idempotent, no-clobber). `default=str` handles chroma `persist_directory` Paths on write; `from_dict` restores them on read.
- **CRUD with read-only guards:** `save_profile` / `delete_profile` / `rename_profile` / `clone_profile` — none can mutate a builtin; clone deep-copies any profile (incl. a builtin) into a fresh writable one.

### Notable review catches (all fixed)
The read-only invariant — "a builtin can never be mutated/shadowed/deleted" — turned out to have **three** distinct holes, each reproduced and closed:
1. `save_profile` id-collision: a new profile named "High Accuracy" (→ id `high_accuracy`) could overwrite the builtin. Guarded.
2. **Load/migration path**: a *legacy* custom profile named "High Accuracy" migrated to `high_accuracy.json` and shadowed the builtin on every boot. Fixed with uniquify-on-collision in both the loader and the migration.
3. The uniquify fix itself introduced an **order-dependent file-clobber** (checked in-memory but not disk, so it could overwrite an unrelated on-disk profile). Fixed with a disk-aware uniquify + write-before-delete ordering.
Also fixed: `clone_profile` shared the `tags` list by reference (corrupted the source); `create_custom_profile` returned a half-built object (same `RAGConfig(**dict)` anti-pattern); and a `.search.top_k` ripple in `enhanced_rag_service_v2.py` from the builtin rename.

### Testing
`Tests/RAG/` — **492 passed, 8 skipped, 0 failed**. New: `Tests/RAG/test_config_profiles.py` (23 tests: round-trip incl. chroma Path, builtin settings applied + valid enums, id/read_only + backfill, file storage + legacy migration, CRUD guards, all three read-only-invariant holes as regression locks).

### Out of scope (SP2b, next)
Config-resolution unification (`resolve_active_rag_config`), routing `config.py`'s loader + the active pointer through the profile, `reset_shared_rag_service()`, first-run "Imported settings" import, embed==query parity. This PR does not touch `config.py`'s loader, `ingestion_indexing.py`, `rag_factory.py`'s resolution, or `[rag.service].profile`.

### Follow-ups filed
- `task-484` — three builtins (`hybrid_full`/`research_papers`/`technical_docs`) use the correct field `chunking_method` with invalid values ("hierarchical"/"structural") that would raise on the enhanced-chunking path (pre-existing, different bug class).

### Process
SDD-executed: fresh subagent + spec/quality review per task, plus a final opus whole-branch review; every finding traced to file:line and fixed or filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Foundation for the RAG profile system (SP2a): makes `ConfigProfileManager` a correct, file-backed, user-facing store with stable ids and read-only built-ins; adds path-safe ids and deterministic load/migration to prevent clobbers. Addresses TASK-483.

- **New Features**
  - File-per-profile storage under `rag_profiles/` with one-time auto-migration from `custom_profiles.json`.
  - `ProfileConfig` gains stable `id` and `read_only`; built-ins are read-only; safe CRUD (`save_profile`, `delete_profile`, `rename_profile`, `clone_profile`) with disk-aware id uniquify; rename keeps id/file; `create_custom_profile` uniquifies ids upfront.
  - Reliable round-trip: `ProfileConfig.from_dict` uses `RAGConfig.from_dict`; `to_dict` copies `tags`; JSON write handles `Path` via `default=str`.

- **Bug Fixes**
  - Path-safe ids and load hardening: `_profile_path` rejects non-slug ids; loader treats filename stem as the source of truth and self-heals divergence; glob is materialized/sorted and reassignment widens to avoid clobber when stems collide (e.g., `foo-bar.json` vs `foo_bar.json`) using disk+memory-aware uniquify.
  - Migration isolation: per-entry try/except so one bad entry can’t abort others; legacy blob is always renamed via `os.replace`; stray files are never treated as the legacy blob; names canonicalize onto reserved filenames.
  - Immutable read-only guard: capture builtin ids as a frozenset so save/delete/rename cannot be bypassed by flipping `read_only`; saving cannot collide with a read-only profile; clone uses independent `tags`.
  - Built-ins use real fields and valid enums; `validate_profile` checks real fields; closes ways to mutate or shadow built-ins (save collisions, legacy migration, hand-placed files) with guards and self-heal; updated `simplified/enhanced_rag_service_v2.py` to read `default_top_k`.

<sup>Written for commit f0639b9fd3dd0c280dea300d7fd4472a4cc3ba1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

