### PR TITLE
feat(console): Roleplay P3c — persistent character avatar in Console chat

### DIFF
--- a/Docs/superpowers/plans/2026-07-22-roleplay-p3c-console-character-avatar.md
+++ b/Docs/superpowers/plans/2026-07-22-roleplay-p3c-console-character-avatar.md
@@ -378,7 +378,9 @@ Fetch wrapper (synchronous, run off-thread; a seam the test can spy):
 
 ```python
     def _fetch_character_card_for_avatar(self, character_id: int):
-        db = getattr(self, "chachanotes_db", None) or getattr(self.app_instance, "chachanotes_db", None)
+        # Canonical DB accessor used throughout chat_screen.py (e.g. the resume
+        # path `_resolve_resumed_character_name`); there is no `self.chachanotes_db`.
+        db = getattr(self.app_instance, "chachanotes_db", None)
         if db is None:
             return None
         try:
@@ -388,7 +390,7 @@ Fetch wrapper (synchronous, run off-thread; a seam the test can spy):
             return None
 ```
 
-(Confirm the DB accessor the Console uses — grep chat_screen for `chachanotes_db` / `get_character_card_by_id` and match it.)
+(Verified: `getattr(self.app_instance, "chachanotes_db", None)` is the accessor used everywhere in `chat_screen.py`; the resume path mirrors this exact off-thread fetch.)
 
 The refresh (mirror `_refresh_active_dictionaries_summary_if_scope_changed`, but decode off-thread and build a spec):
 
@@ -404,7 +406,7 @@ The refresh (mirror `_refresh_active_dictionaries_summary_if_scope_changed`, but
         self._active_character_avatar_name = name
         if character_id is None:
             self._active_character_avatar = None
-            self._render_character_avatar_into_section()
+            await self._render_character_avatar_into_section()
             return
         _, cache = self._ensure_console_image_view()
         mode = getattr(self, "_console_image_default_mode", "pixels")
@@ -426,16 +428,21 @@ The refresh (mirror `_refresh_active_dictionaries_summary_if_scope_changed`, but
         if (self._current_console_rail_character_id(),) != scope or not self.is_mounted:
             return
         self._active_character_avatar = spec
-        self._render_character_avatar_into_section()
+        await self._render_character_avatar_into_section()
 
-    def _render_character_avatar_into_section(self) -> None:
-        """Re-mount the avatar widget + name into the (already-composed) section."""
+    async def _render_character_avatar_into_section(self) -> None:
+        """Re-mount the avatar widget + name into the (already-composed) section.
+
+        Async because Textual `Widget.mount()` returns an `AwaitMount` that
+        must be awaited so the widget is present before the caller returns
+        (the integration test asserts the mounted state right after the tick).
+        """
         try:
             holder = self.query_one("#console-character-avatar", Container)
         except QueryError:
             return  # section not composed (config off / not mounted)
-        holder.remove_children()
-        holder.mount(self._build_character_avatar_widget(self._active_character_avatar))
+        await holder.remove_children()
+        await holder.mount(self._build_character_avatar_widget(self._active_character_avatar))
         try:
             self.query_one("#console-character-name", Static).update(
                 self._active_character_avatar_name or "No character in this chat"

--- a/Docs/superpowers/plans/2026-07-22-roleplay-p3c-console-character-avatar.md
+++ b/Docs/superpowers/plans/2026-07-22-roleplay-p3c-console-character-avatar.md
@@ -1,0 +1,555 @@
+# Roleplay P3c — Console Character Avatar Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show the active character's avatar + name persistently in a new collapsible "Character" section of the native Console left rail, following the session and reusing the existing image renderer.
+
+**Architecture:** Read the active character off the live `ConsoleChatSession` (#754); render its `image` BLOB via the chat screen's existing `ConsoleImageRenderCache` + `resolve_default_mode` + the shared `fit_image_cell_size` (#775), off-thread; cache the decoded spec + refresh it only when `(character_id,)` changes, hooked into `_sync_native_console_chat_ui` (mirroring the dictionary "what's in play" pattern); a config-gated 5th rail section mounts it.
+
+**Tech Stack:** Python 3.11+, Textual, PIL/rich-pixels/textual-image, pytest.
+
+**Spec:** `Docs/superpowers/specs/2026-07-22-roleplay-p3c-console-character-avatar-design.md` (committed `2fb0d0d81`).
+
+## Global Constraints
+
+- **NO ChaChaNotes migration** (v22) — reads existing `character_cards.image` + `conversations.character_id` (already written by #754).
+- **Resolve the active character ONLY off the live `ConsoleChatSession`** (`_active_native_console_session().character_id`/`.character_name`); never read legacy `app.current_chat_*` reactives (split-brain).
+- **Reuse `self._console_image_cache`** (via `_ensure_console_image_view()` — do NOT create a second cache), `resolve_default_mode`, and `fit_image_cell_size`; avatar decode runs **off-thread** (`asyncio.to_thread`).
+- **Zero-DB-on-recompose:** the DB fetch/decode happens only in the scope-changed refresh; compose reads only the cache; **the cache holds a SPEC (data), not a live widget** (each mount builds a fresh widget). Re-check the `(character_id,)` scope AFTER the await to drop a stale render.
+- **The refresh must NEVER raise into `_sync_native_console_chat_ui`** — wrap; failure → text/empty fallback.
+- **Config-gated** on `[chat.images].show_character_avatar` (default **True**); the section is not composed when off.
+- **Characters-only** (no persona image).
+- **DO NOT modify `_active_console_dictionary_scope_ids`** — it is NOT inert (feeds the dictionary/world-book "what's in play" summarize via `character_id`); leave it `(conversation_id, None)`. Add a pin-test.
+- **Rail adds ONLY** `character_open` (to `ConsoleRailPreferences` + `ConsoleRailState` dataclasses AND both construction sites in `console_rail_state.py`) + one compose block; the section toggle + requery are generic and auto-handle it.
+- **Narrow-rail avatar box** sized to the rail (`CHARACTER_AVATAR_COLS = 16`, `CHARACTER_AVATAR_LINES = 8` — adjust at implementation if it overflows the rail); pixels is the safe fallback; don't rebuild the graphics widget every sync tick.
+- **Branch off the LATEST `origin/dev`** (`dc21e3f04` at plan time — has #754 + #775; re-verify at merge). **Concurrent-session hazard:** `chat_screen.py` is heavily edited by other sessions — keep changes localized to the new accessor/section/refresh; expect a non-trivial rebase.
+- **Implementers stage ONLY their task's files** — never `git add -A`, never `.superpowers/`.
+- **No background/broad test sweeps; never broad-`pkill` pytest** — scope to this worktree.
+- **`Tests/UI/pytest.ini` sets `asyncio_mode = auto`** → keep async tests in `Tests/UI/` and do NOT mix `Tests/UI/` with another directory in ONE pytest invocation (rootdir shift drops auto-mode), OR add explicit `@pytest.mark.asyncio` per async test.
+- **Test command** (prefix every run; run ONLY your task's files):
+  ```bash
+  HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest <targets> \
+  -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread
+  ```
+
+---
+
+## File Structure
+
+**Modified:**
+- `tldw_chatbook/Chat/console_image_view.py` — add pure `resolve_show_character_avatar` (Task 1).
+- `tldw_chatbook/Config.py` — document `show_character_avatar` in the `[chat.images]` block (Task 1).
+- `tldw_chatbook/UI/Screens/chat_screen.py` — accessors (T1), the "Character" compose block (T2), the avatar cache + refresh + build (T3), the sync-tick wire (T4).
+- `tldw_chatbook/Chat/console_rail_state.py` — `character_open` field (2 dataclasses + 2 construction sites) (Task 2).
+
+**Tests (`Tests/UI/` — asyncio auto-mode):** grep `Tests/UI/` for the existing Console chat-screen harness (e.g. `ConsoleHarness` in `test_product_maturity_gate1_core_loop_screen_adaptation.py`, and the console-left-rail section tests) and mirror them for real-screen tests. Pure helpers can be tested under `Tests/Chat/`.
+
+---
+
+## Task 1: Config helper + resolution accessors
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_image_view.py` (near `resolve_default_mode`)
+- Modify: `tldw_chatbook/Config.py` (`[chat.images]` block, ~:2740-2754 — comment/doc only)
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py` (near `_current_console_rail_conversation_id`, ~:3866)
+- Test: `Tests/Chat/test_console_image_view.py` (config helper), `Tests/UI/test_console_character_avatar.py` (accessors)
+
+**Interfaces:**
+- Produces: `resolve_show_character_avatar(app_config) -> bool` (console_image_view.py); `PersonasScreen`… no — `ChatScreen._current_console_rail_character_id() -> int | None`, `ChatScreen._current_console_rail_character_name() -> str | None`.
+
+- [ ] **Step 1: Write the failing config-helper test**
+
+Append to `Tests/Chat/test_console_image_view.py` (import `resolve_show_character_avatar`):
+
+```python
+def test_resolve_show_character_avatar_defaults_true():
+    from tldw_chatbook.Chat.console_image_view import resolve_show_character_avatar
+    assert resolve_show_character_avatar({}) is True
+    assert resolve_show_character_avatar({"chat": {"images": {}}}) is True
+
+
+def test_resolve_show_character_avatar_explicit_false():
+    from tldw_chatbook.Chat.console_image_view import resolve_show_character_avatar
+    assert resolve_show_character_avatar(
+        {"chat": {"images": {"show_character_avatar": False}}}
+    ) is False
+
+
+def test_resolve_show_character_avatar_live_shape():
+    from tldw_chatbook.Chat.console_image_view import resolve_show_character_avatar
+    assert resolve_show_character_avatar(
+        {"COMPREHENSIVE_CONFIG_RAW": {"chat": {"images": {"show_character_avatar": False}}}}
+    ) is False
+```
+
+- [ ] **Step 2: Run — verify it fails**
+
+Run `Tests/Chat/test_console_image_view.py -k resolve_show_character_avatar`. Expected: FAIL — `ImportError`.
+
+- [ ] **Step 3: Implement the config helper**
+
+In `console_image_view.py`, right after `resolve_default_mode` (or near `_chat_images_config`):
+
+```python
+def resolve_show_character_avatar(app_config: Mapping[str, Any]) -> bool:
+    """Whether the Console shows the active character's avatar (default True).
+
+    Reads ``[chat.images].show_character_avatar`` via the same both-shapes
+    accessor as ``resolve_default_mode`` (raw TOML or the live
+    ``COMPREHENSIVE_CONFIG_RAW`` nesting).
+    """
+    value = _chat_images_config(app_config).get("show_character_avatar", True)
+    return bool(value)
+```
+
+In `Config.py`'s `[chat.images]` documentation block (~:2740-2754), add a `# show_character_avatar = true  # show the active character's avatar in the Console left rail` comment alongside the other keys (documentation only — the default lives in the resolver).
+
+- [ ] **Step 4: Run — verify config-helper tests pass**
+
+Run `Tests/Chat/test_console_image_view.py -k resolve_show_character_avatar`. Expected: PASS (3).
+
+- [ ] **Step 5: Write the failing accessor test**
+
+Create `Tests/UI/test_console_character_avatar.py`. Mirror the existing Console chat-screen harness (grep `Tests/UI` for `ConsoleHarness`; it builds a `ChatScreen` with a real store). Sketch:
+
+```python
+import pytest
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_current_console_rail_character_id_reads_active_session(console_screen_with_character):
+    # console_screen_with_character: a ChatScreen whose active native session has
+    # character_id=7, character_name="Ada" (shape it to the real harness).
+    screen = console_screen_with_character
+    assert screen._current_console_rail_character_id() == 7
+    assert screen._current_console_rail_character_name() == "Ada"
+
+
+async def test_current_console_rail_character_id_none_for_generic_session(console_screen_generic):
+    screen = console_screen_generic
+    assert screen._current_console_rail_character_id() is None
+    assert screen._current_console_rail_character_name() is None
+
+
+async def test_p3c_leaves_dictionary_scope_ids_unchanged(console_screen_with_character):
+    # Pin: P3c must NOT make _active_console_dictionary_scope_ids character-aware
+    # (that would change the dictionary/world-book "what's in play" content).
+    screen = console_screen_with_character
+    conv_id, char_id = screen._active_console_dictionary_scope_ids()
+    assert char_id is None
+```
+
+(Shape the two fixtures to the real harness: an active `ConsoleChatSession` with `character_id`/`character_name` set vs a generic one. If the harness makes constructing an active session awkward, set the fields on the store's active session directly.)
+
+- [ ] **Step 6: Run — verify it fails**
+
+Run `Tests/UI/test_console_character_avatar.py`. Expected: FAIL — `_current_console_rail_character_id` missing.
+
+- [ ] **Step 7: Implement the accessors**
+
+In `chat_screen.py`, right after `_current_console_rail_conversation_id` (~:3876), add (NO legacy fallback — resolve only off the live session):
+
+```python
+    def _current_console_rail_character_id(self) -> Optional[int]:
+        """Active native Console session's character id (int), or None.
+
+        Resolved ONLY off the live session (#754 sets it at Start-Chat, on
+        DB-resume, and on screen-state restore); never from legacy
+        ``app.current_chat_*`` reactives. None for a generic session.
+        """
+        native_session = self._active_native_console_session()
+        if native_session is None:
+            return None
+        character_id = getattr(native_session, "character_id", None)
+        try:
+            return int(character_id) if character_id is not None else None
+        except (TypeError, ValueError):
+            return None
+
+    def _current_console_rail_character_name(self) -> Optional[str]:
+        """Active native Console session's character name, or None."""
+        native_session = self._active_native_console_session()
+        if native_session is None:
+            return None
+        name = getattr(native_session, "character_name", None)
+        return str(name) if name else None
+```
+
+- [ ] **Step 8: Run — verify accessor tests pass**
+
+Run `Tests/UI/test_console_character_avatar.py`. Expected: PASS (3, incl. the dictionary-scope pin).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_image_view.py tldw_chatbook/Config.py tldw_chatbook/UI/Screens/chat_screen.py Tests/Chat/test_console_image_view.py Tests/UI/test_console_character_avatar.py
+git commit -m "feat(console): P3c Task 1 — show_character_avatar config + active-character rail accessors"
+```
+
+---
+
+## Task 2: The "Character" collapsible rail section
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_rail_state.py` (`ConsoleRailPreferences` ~:76, `ConsoleRailState` ~:106, raw-dict construction ~:244-247, preferences construction ~:519-522)
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py` (compose_content left-rail body, after the Details section ~:8658)
+- Test: `Tests/UI/test_console_character_avatar.py` (extend)
+
+**Interfaces:**
+- Consumes: `resolve_show_character_avatar` (T1), `_current_console_rail_character_id`/`_name` (T1), and (T3) `self._active_character_avatar` (spec | None) + `self._active_character_avatar_name` + `_build_character_avatar_widget(spec)`.
+- Produces: the `#console-rail-section-body-character` section + `#console-character-avatar` container + `#console-character-name` Static; `ConsoleRailState.character_open`.
+
+**Note:** the section is composed reading only the cache (`self._active_character_avatar`); T3 fills that cache. For this task, initialize `self._active_character_avatar = None` and `self._active_character_avatar_name = None` in `__init__` so the section composes an empty state, and add a temporary `_build_character_avatar_widget` stub that renders the empty/text state (T3 extends it to real images).
+
+- [ ] **Step 1: Add `character_open` to the rail-state dataclasses + both construction sites**
+
+In `console_rail_state.py`:
+- `ConsoleRailPreferences` (after `agent_open` ~:76): `character_open: bool = True`
+- `ConsoleRailState` (after `agent_open` ~:106): `character_open: bool = True`
+- Raw-dict construction (~:244-247, after the `agent_open=` line): `character_open=_coerce_bool(raw.get("character_open"), defaults.character_open),`
+- Preferences construction (~:519-522, after the `agent_open=` line): `character_open=preferences.character_open,`
+
+- [ ] **Step 2: Write the failing rail-section test**
+
+Extend `Tests/UI/test_console_character_avatar.py`:
+
+```python
+async def test_character_section_composes_when_config_on(console_screen_with_character):
+    screen = console_screen_with_character  # config default → show_character_avatar True
+    assert screen.query("#console-rail-section-body-character")   # section present
+    assert screen.query("#console-character-name")
+
+
+async def test_character_section_absent_when_config_off(console_screen_avatar_off):
+    # console_screen_avatar_off: app_config has chat.images.show_character_avatar = False
+    screen = console_screen_avatar_off
+    assert not screen.query("#console-rail-section-body-character")
+
+
+async def test_character_section_empty_state_for_generic_session(console_screen_generic):
+    screen = console_screen_generic
+    name = screen.query_one("#console-character-name")
+    assert "No character" in str(name.renderable)  # empty-state copy
+```
+
+- [ ] **Step 3: Run — verify it fails**
+
+Run `Tests/UI/test_console_character_avatar.py`. Expected: FAIL — no `#console-rail-section-body-character`.
+
+- [ ] **Step 4: Add the cache fields + a build stub + the compose block**
+
+In `chat_screen.py` `__init__` (near the other `_active_*_summary` fields, ~:1911): `self._active_character_avatar = None` (spec | None), `self._active_character_avatar_name = None`, `self._last_console_avatar_scope = None`.
+
+Add the build helper (T3 will extend the image branches; for now it renders the text/empty state):
+
+```python
+    def _build_character_avatar_widget(self, spec) -> Widget:
+        """Build a fresh avatar widget from the cached spec (data, not a widget).
+
+        T3 fills `spec` with {character_id, name, mode, pil, pixels}. With no
+        spec / no image, render a compact text placeholder.
+        """
+        from textual.widgets import Static as _S
+        if not spec or (spec.get("pil") is None and spec.get("pixels") is None):
+            hint = "no avatar" if spec else "No character in this chat"
+            return _S(hint, id="console-character-avatar-empty")
+        # T3 extends: graphics -> textual_image Image(pil) with fit dims;
+        # pixels -> Static(Pixels). Placeholder until then:
+        return _S("", id="console-character-avatar-empty")
+```
+
+In `compose_content`, after the Details section (~:8658), gated on config:
+
+```python
+                        # Section 5: Character (avatar of the active character).
+                        if resolve_show_character_avatar(
+                            getattr(getattr(self, "app_instance", None), "app_config", {}) or {}
+                        ):
+                            yield ConsoleRailSectionHeader(
+                                "Character",
+                                section_id="character",
+                                open=rail_state.character_open,
+                                id="console-rail-section-header-character",
+                            )
+                            character_body = Vertical(
+                                id="console-rail-section-body-character",
+                                classes="console-rail-section-body",
+                            )
+                            character_body.styles.height = "auto"
+                            if not rail_state.character_open:
+                                character_body.styles.display = "none"
+                            with character_body:
+                                avatar_holder = Container(id="console-character-avatar")
+                                with avatar_holder:
+                                    yield self._build_character_avatar_widget(
+                                        self._active_character_avatar
+                                    )
+                                yield Static(
+                                    self._active_character_avatar_name or "No character in this chat",
+                                    id="console-character-name",
+                                )
+```
+
+(Import `resolve_show_character_avatar` at the top of `chat_screen.py`; `Container`/`Static`/`Vertical`/`ConsoleRailSectionHeader` are already imported.)
+
+- [ ] **Step 5: Run — verify it passes**
+
+Run `Tests/UI/test_console_character_avatar.py`. Expected: PASS. Confirm the generic empty-state copy and the config-off absence. Also toggle the section via the existing rail toggle in a test if the harness supports it (the generic toggle handles `character` automatically).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_rail_state.py tldw_chatbook/UI/Screens/chat_screen.py Tests/UI/test_console_character_avatar.py
+git commit -m "feat(console): P3c Task 2 — Character rail section (config-gated, empty state)"
+```
+
+---
+
+## Task 3: Avatar cache + scope-guarded off-thread refresh + render
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py` (extend `_build_character_avatar_widget`; add `_refresh_active_character_avatar_if_scope_changed` + `_render_character_avatar_into_section`; constants)
+- Test: `Tests/UI/test_console_character_avatar.py` (extend, real-screen + real-DB)
+
+**Interfaces:**
+- Consumes: `_current_console_rail_character_id` (T1); `_ensure_console_image_view()` → `(_, cache)`; `self._console_image_default_mode`; `fit_image_cell_size`; `get_character_card_by_id`.
+- Produces: `_refresh_active_character_avatar_if_scope_changed()` (async), consumed by T4; the filled `self._active_character_avatar` spec.
+
+- [ ] **Step 1: Write the failing refresh test (real screen + real DB)**
+
+Extend `Tests/UI/test_console_character_avatar.py`. Seed a character WITH an image in the screen's real `CharactersRAGDB`, set the active session's `character_id` to it:
+
+```python
+async def test_refresh_populates_avatar_cache_and_mounts(console_screen_with_db):
+    app, screen, db = console_screen_with_db
+    from PIL import Image as PILImage
+    from io import BytesIO
+    buf = BytesIO(); PILImage.new("RGB", (32, 32), (200, 10, 10)).save(buf, format="PNG")
+    char_id = db.add_character_card({"name": "Ada", "image": buf.getvalue()})
+    _set_active_console_character(screen, char_id, "Ada")   # harness helper
+
+    await screen._refresh_active_character_avatar_if_scope_changed()
+    assert screen._active_character_avatar is not None
+    assert screen._active_character_avatar.get("character_id") == char_id
+    assert screen._active_character_avatar.get("pil") is not None or \
+           screen._active_character_avatar.get("pixels") is not None
+
+    # unchanged scope → no re-fetch (spy the DB fetch)
+    calls = []
+    orig = screen._fetch_character_card_for_avatar   # the off-thread fetch wrapper
+    screen._fetch_character_card_for_avatar = lambda cid: (calls.append(cid), orig(cid))[1]
+    await screen._refresh_active_character_avatar_if_scope_changed()
+    assert calls == []   # scope guard short-circuits before any fetch
+
+
+async def test_refresh_clears_avatar_for_generic_session(console_screen_with_db):
+    app, screen, db = console_screen_with_db
+    _set_active_console_character(screen, None, None)
+    await screen._refresh_active_character_avatar_if_scope_changed()
+    assert screen._active_character_avatar is None
+
+
+async def test_refresh_never_raises_on_bad_image(console_screen_with_db):
+    app, screen, db = console_screen_with_db
+    char_id = db.add_character_card({"name": "Bad", "image": b"not-an-image"})
+    _set_active_console_character(screen, char_id, "Bad")
+    await screen._refresh_active_character_avatar_if_scope_changed()  # must not raise
+    # decode failed → empty/text spec, name still set
+    assert screen._active_character_avatar_name == "Bad"
+```
+
+- [ ] **Step 2: Run — verify it fails**
+
+Expected: FAIL — `_refresh_active_character_avatar_if_scope_changed` missing.
+
+- [ ] **Step 3: Add constants + the fetch wrapper + the refresh + extend the build**
+
+Constants (module level, near the other Console constants):
+
+```python
+CHARACTER_AVATAR_COLS = 16
+CHARACTER_AVATAR_LINES = 8
+```
+
+Fetch wrapper (synchronous, run off-thread; a seam the test can spy):
+
+```python
+    def _fetch_character_card_for_avatar(self, character_id: int):
+        db = getattr(self, "chachanotes_db", None) or getattr(self.app_instance, "chachanotes_db", None)
+        if db is None:
+            return None
+        try:
+            return db.get_character_card_by_id(int(character_id))
+        except Exception:
+            logger.opt(exception=True).debug("avatar: character fetch failed")
+            return None
+```
+
+(Confirm the DB accessor the Console uses — grep chat_screen for `chachanotes_db` / `get_character_card_by_id` and match it.)
+
+The refresh (mirror `_refresh_active_dictionaries_summary_if_scope_changed`, but decode off-thread and build a spec):
+
+```python
+    async def _refresh_active_character_avatar_if_scope_changed(self) -> None:
+        """Refresh the cached character avatar only when the active character changed."""
+        character_id = self._current_console_rail_character_id()
+        scope = (character_id,)
+        if scope == self._last_console_avatar_scope:
+            return
+        self._last_console_avatar_scope = scope
+        name = self._current_console_rail_character_name()
+        self._active_character_avatar_name = name
+        if character_id is None:
+            self._active_character_avatar = None
+            self._render_character_avatar_into_section()
+            return
+        _, cache = self._ensure_console_image_view()
+        mode = getattr(self, "_console_image_default_mode", "pixels")
+        key = f"character:{character_id}"
+        spec = {"character_id": character_id, "name": name, "mode": mode, "pil": None, "pixels": None}
+        try:
+            card = await asyncio.to_thread(self._fetch_character_card_for_avatar, character_id)
+            image = (card or {}).get("image")
+            if isinstance(image, (bytes, bytearray)) and image:
+                ok = await asyncio.to_thread(cache.prepare, key, bytes(image))
+                if ok:
+                    if mode == "graphics":
+                        spec["pil"] = cache.get_pil(key)
+                    else:
+                        spec["pixels"] = cache.get_pixels(key)
+        except Exception:
+            logger.opt(exception=True).debug("avatar: refresh failed")
+        # Drop a stale render if the active character changed during decode.
+        if (self._current_console_rail_character_id(),) != scope or not self.is_mounted:
+            return
+        self._active_character_avatar = spec
+        self._render_character_avatar_into_section()
+
+    def _render_character_avatar_into_section(self) -> None:
+        """Re-mount the avatar widget + name into the (already-composed) section."""
+        try:
+            holder = self.query_one("#console-character-avatar", Container)
+        except QueryError:
+            return  # section not composed (config off / not mounted)
+        holder.remove_children()
+        holder.mount(self._build_character_avatar_widget(self._active_character_avatar))
+        try:
+            self.query_one("#console-character-name", Static).update(
+                self._active_character_avatar_name or "No character in this chat"
+            )
+        except QueryError:
+            pass
+```
+
+Extend `_build_character_avatar_widget` to mount real images (mirror `console_transcript._image_row_widget`):
+
+```python
+    def _build_character_avatar_widget(self, spec) -> Widget:
+        if not spec or (spec.get("pil") is None and spec.get("pixels") is None):
+            hint = "no avatar" if (spec and spec.get("character_id") is not None) else "No character in this chat"
+            return Static(hint, id="console-character-avatar-empty")
+        if spec.get("mode") == "graphics" and spec.get("pil") is not None:
+            try:
+                from textual_image.widget import Image as _GraphicsImage
+                widget = _GraphicsImage(spec["pil"], id="console-character-avatar-image")
+                w, h = fit_image_cell_size(spec["pil"].width, spec["pil"].height,
+                                           CHARACTER_AVATAR_COLS, CHARACTER_AVATAR_LINES)
+                widget.styles.width = w
+                widget.styles.height = h
+                return widget
+            except Exception:
+                logger.opt(exception=True).debug("avatar: graphics mount failed")
+        pixels = spec.get("pixels")
+        if pixels is None and spec.get("pil") is not None:
+            scaled = spec["pil"].copy()
+            scaled.thumbnail((CHARACTER_AVATAR_COLS, CHARACTER_AVATAR_LINES * 2))
+            from rich_pixels import Pixels
+            pixels = Pixels.from_image(scaled)
+        widget = Static(pixels if pixels is not None else "", id="console-character-avatar-image")
+        widget.styles.max_width = CHARACTER_AVATAR_COLS
+        widget.styles.max_height = CHARACTER_AVATAR_LINES
+        return widget
+```
+
+(Import `fit_image_cell_size` at the top; `Static`/`Container`/`QueryError`/`asyncio`/`logger` already imported. Confirm imports.)
+
+- [ ] **Step 4: Run — verify it passes**
+
+Run `Tests/UI/test_console_character_avatar.py`. Expected: PASS (incl. scope-guard no-refetch, generic-clear, bad-image never-raises).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/UI/Screens/chat_screen.py Tests/UI/test_console_character_avatar.py
+git commit -m "feat(console): P3c Task 3 — avatar cache + scope-guarded off-thread refresh + render"
+```
+
+---
+
+## Task 4: Wire into the sync tick + integration
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py` (`_sync_native_console_chat_ui` ~:10129)
+- Test: `Tests/UI/test_console_character_avatar.py` (integration)
+
+**Interfaces:**
+- Consumes: `_refresh_active_character_avatar_if_scope_changed` (T3).
+
+- [ ] **Step 1: Write the failing integration test**
+
+```python
+async def test_sync_tick_refreshes_avatar(console_screen_with_db):
+    app, screen, db = console_screen_with_db
+    from PIL import Image as PILImage
+    from io import BytesIO
+    buf = BytesIO(); PILImage.new("RGB", (32, 32)).save(buf, format="PNG")
+    char_id = db.add_character_card({"name": "Ada", "image": buf.getvalue()})
+    _set_active_console_character(screen, char_id, "Ada")
+
+    await screen._sync_native_console_chat_ui()   # the central sync entrypoint
+
+    assert screen._active_character_avatar is not None
+    assert screen._active_character_avatar_name == "Ada"
+    name = screen.query_one("#console-character-name")
+    assert "Ada" in str(name.renderable)
+```
+
+- [ ] **Step 2: Run — verify it fails**
+
+Expected: FAIL — the sync tick doesn't refresh the avatar yet.
+
+- [ ] **Step 3: Wire the refresh into the sync tick**
+
+In `_sync_native_console_chat_ui` (~:10129), after the dictionary/world-book refreshes, add:
+
+```python
+            await self._refresh_active_character_avatar_if_scope_changed()
+```
+
+(Match the surrounding `try`/guard structure — the refresh already never raises, but keep it inside whatever guard wraps the dictionary refreshes.)
+
+- [ ] **Step 4: Run — verify it passes**
+
+Run `Tests/UI/test_console_character_avatar.py`. Expected: PASS.
+
+- [ ] **Step 5: Run the focused suite + app import**
+
+Run `Tests/UI/test_console_character_avatar.py` + the existing Console rail/chat-screen test modules you touched or mirrored (name them explicitly — grep `Tests/UI` for console-left-rail / `ConsoleHarness` tests). Also `python -c "import tldw_chatbook.app"` (env prefix). Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/UI/Screens/chat_screen.py Tests/UI/test_console_character_avatar.py
+git commit -m "feat(console): P3c Task 4 — refresh avatar from the Console sync tick + integration"
+```
+
+---
+
+## Self-Review Notes (author)
+
+- **Spec coverage:** config helper (T1), accessors (T1), the dictionary-scope pin (T1), the rail section + `character_open` + empty state + config gate (T2), the cache-as-spec + scope-guarded off-thread refresh + never-raise + post-await re-check + narrow-rail fit (T3), the sync-tick wire + integration (T4) — all mapped. No migration; `_active_console_dictionary_scope_ids` untouched (pinned).
+- **Type consistency:** `resolve_show_character_avatar` (T1) → used in T2 compose; `_current_console_rail_character_id`/`_name` (T1) → used in T2/T3; `self._active_character_avatar` (spec dict) + `_active_character_avatar_name` + `_last_console_avatar_scope` + `_build_character_avatar_widget` (T2 stub → T3 real) + `_refresh_active_character_avatar_if_scope_changed` + `_render_character_avatar_into_section` + `_fetch_character_card_for_avatar` (T3) → consumed by T4. `CHARACTER_AVATAR_COLS/LINES`, cache key `f"character:{id}"` consistent.
+- **Plan-time confirmations (read fresh):** the Console DB accessor (`self.chachanotes_db` vs `self.app_instance.chachanotes_db`); the real Console chat-screen test harness + how to set an active session's `character_id` (`_set_active_console_character` helper); the exact `try`/guard wrapping the dictionary refreshes in `_sync_native_console_chat_ui`; whether the graphics avatar renders cleanly in the rail `VerticalScroll` (fall back to pixels if not); the narrow-rail box constants against the real rail width.

--- a/Docs/superpowers/specs/2026-07-22-roleplay-p3c-console-character-avatar-design.md
+++ b/Docs/superpowers/specs/2026-07-22-roleplay-p3c-console-character-avatar-design.md
@@ -106,6 +106,12 @@ Mirror the dictionary "what's in play" machinery:
 - **Deleted character:** `get_character_card_by_id` returns None (`deleted = 0` filter) → empty state.
 - **Zero-DB-on-recompose:** rail recompose reads only `_active_character_avatar`/`_name`; the DB fetch happens only in the scope-changed refresh.
 
+### Risks & plan-time considerations (from spec review)
+
+- **Rail machinery is clean (verified):** `ConsoleRailState` uses per-section `*_open` fields; the section toggle (`changes[f"{section_id}_open"]`) and requery (`#console-rail-section-body-{section_id}`) are string-driven with no hardcoded section list/count anywhere. Adding `character_open` + a 5th compose block is minimal — no other enumeration site to update.
+- **Narrow-rail avatar box:** the left rail is a fraction of screen width, far narrower than the transcript's 80×40 image box. `CHARACTER_AVATAR_COLS`/`CHARACTER_AVATAR_LINES` must be sized to fit the rail (e.g. ~16 cols) so a graphics/pixels avatar doesn't overflow or clip; `fit_image_cell_size` then fits within that. Pick the constants against the actual rail width at plan time.
+- **Graphics image in a scrolling rail:** `textual_image` graphics images can have redraw/artifact quirks inside a `VerticalScroll` that recomposes often. Verify the graphics path renders cleanly in the rail (P3b proved it in the editor's scroll); the pixels fallback is the safer default. Do NOT rebuild the graphics widget on every sync tick — the scope-guard means the refresh only re-mounts on a character change, and a full rail recompose rebuilds the widget from the cached PIL (no re-decode); confirm the 0.2s streaming poll does not force a rail recompose (it drives the transcript, not the rail).
+
 ### Testing strategy
 
 - **Config helper:** `resolve_show_character_avatar` default True; explicit False/True; live-config-shape (COMPREHENSIVE_CONFIG_RAW).

--- a/Docs/superpowers/specs/2026-07-22-roleplay-p3c-console-character-avatar-design.md
+++ b/Docs/superpowers/specs/2026-07-22-roleplay-p3c-console-character-avatar-design.md
@@ -58,7 +58,7 @@ Show the active character's profile image persistently in the native Console cha
 1. **Panel form:** a **collapsible "Character" section** (a 5th rail section, matching Session/Model/Agent/Details).
 2. **Config default:** `show_character_avatar` **on** by default.
 3. **Characters-only** (no persona image).
-4. **Include the adjacent fix:** source the real `character_id` in `_active_console_dictionary_scope_ids` (closes the leftover `None` hole so the dictionary/world-book scope becomes character-aware).
+4. **Do NOT touch `_active_console_dictionary_scope_ids`** (reversed after review). Verification showed the `None` there is **not an inert hole**: that tuple flows into `refresh_active_dictionaries_summary` → `_run_dictionary_summary_off_thread(service, conversation_id, character_id)` → `Chat_Dictionary_Lib._resolve_active_dictionaries(db, conversation_id, char_data)`, which **uses the character id to include character-embedded dictionaries** in the "what's in play" summary (same for world-books). Sourcing the real id would change what those inspectors show and could **break the "shown=applied" invariant** if the native send does not apply character dicts (character-dicts-on-native-send was deferred pre-#754; whether #754 changed that needs its own analysis). So the `None` is arguably the *correct* current behavior, and this is a separate feature question — **deferred to its own follow-up**, out of P3c scope. P3c adds only its OWN independent `_current_console_rail_character_id()` accessor for the avatar; it does not read or change `_active_console_dictionary_scope_ids`.
 
 ---
 
@@ -66,8 +66,8 @@ Show the active character's profile image persistently in the native Console cha
 
 ### A. Resolution accessor + adjacent scope fix (`chat_screen.py`)
 
-- Add `_current_console_rail_character_id() -> int | None` and `_current_console_rail_character_name() -> str | None`, mirroring `_current_console_rail_conversation_id`: read the live session via `_active_native_console_session()` and return `session.character_id` / `session.character_name` (or `None`).
-- **Adjacent fix:** change `_active_console_dictionary_scope_ids()` to return `(self._current_console_rail_conversation_id(), self._current_console_rail_character_id())` instead of `(..., None)`, and drop the stale "once it lands" comment. This makes the existing dictionary/world-book "what's in play" scope guard character-aware (a latent correctness improvement; no behavior regression since character was previously always `None`).
+- Add `_current_console_rail_character_id() -> int | None` and `_current_console_rail_character_name() -> str | None`, mirroring `_current_console_rail_conversation_id`: read the live session via `_active_native_console_session()` and return `session.character_id` / `session.character_name` (or `None`). This accessor is **used only by the avatar** (§C–E); it is independent of `_active_console_dictionary_scope_ids`.
+- **Do NOT modify `_active_console_dictionary_scope_ids`** — see design decision 4: sourcing the real id there changes the dictionary/world-book "what's in play" content (character-embedded dicts) and touches the shown=applied invariant; it's a separate feature question, deferred.
 
 ### B. Config helper (`console_image_view.py`)
 
@@ -109,7 +109,7 @@ Mirror the dictionary "what's in play" machinery:
 ### Testing strategy
 
 - **Config helper:** `resolve_show_character_avatar` default True; explicit False/True; live-config-shape (COMPREHENSIVE_CONFIG_RAW).
-- **Accessor:** `_current_console_rail_character_id`/`_name` return the active session's fields; `None` when no session/character. `_active_console_dictionary_scope_ids` now returns the real character id (regression pin: the dictionary scope tuple includes it).
+- **Accessor:** `_current_console_rail_character_id`/`_name` return the active session's fields; `None` when no session/character. (A pin that P3c leaves `_active_console_dictionary_scope_ids` unchanged — still `(conversation_id, None)` — so the dictionary/world-book summaries are unaffected.)
 - **Refresh scope-guard (real screen + real DB):** seed a character with an image; set the active session's `character_id`; run the sync tick → the panel mounts the avatar + name; unchanged scope → the DB fetch does NOT run again (spy the fetch); change `character_id` → it re-fetches and updates; set `character_id=None` → empty state; character with no image → name + placeholder. Assert off-thread (the fetch runs off the event loop) and that a stale post-await render is dropped when the scope changed during decode.
 - **Rail section:** the "Character" section composes when config on, absent when off; the `character_open` toggle collapses/expands it like the others; empty state renders for a generic session.
 - **Integration:** Start-Chat with a character → avatar shows; resume a persisted character conversation → avatar shows; generic session → empty state.
@@ -118,7 +118,7 @@ Mirror the dictionary "what's in play" machinery:
 
 ## Task decomposition (for writing-plans → subagent-driven-development)
 
-1. **Config helper + resolution accessors + adjacent scope fix** — `resolve_show_character_avatar` (console_image_view.py) + `_current_console_rail_character_id`/`_name` + fix `_active_console_dictionary_scope_ids` to source the real id (chat_screen.py). Unit + a dictionary-scope regression test. *(Foundational, isolated.)*
+1. **Config helper + resolution accessors** — `resolve_show_character_avatar` (console_image_view.py) + `_current_console_rail_character_id`/`_name` (chat_screen.py). Unit tests. *(Foundational, isolated; does NOT touch `_active_console_dictionary_scope_ids`.)*
 2. **The "Character" rail section** — `ConsoleRailState.character_open` + compose the 5th `ConsoleRailSectionHeader` + body (config-gated) + empty state + toggle wiring. Rail widget tests.
 3. **Avatar cache + scope-guarded off-thread refresh + render** — the cache fields, `_refresh_active_character_avatar_if_scope_changed` (reuse `_console_image_cache` + `resolve_default_mode` + `fit_image_cell_size`, compact rail box), mount into the section, never-raise. Real-screen + real-DB refresh tests.
 4. **Wire into `_sync_native_console_chat_ui` + integration** — call the refresh from the sync tick; Start-Chat / resume / generic / character-change integration tests.
@@ -144,5 +144,6 @@ Four focused tasks → one PR.
 ## Deferred / follow-ups
 
 - **P3d — reaction/expression image system** (own future program): a net-new image-set data model + authoring + trigger + swap, ported from the tldw_server webui/browser extension (needs the external `../tldw_server` repo). Renders into P3c's panel.
+- **Character-aware "what's in play" (separate concern, pulled out of P3c):** decide whether the native Console dictionary/world-book summaries should include character-embedded dicts/books now that #754 gives sessions a real `character_id` — i.e. whether `_active_console_dictionary_scope_ids` (and its world-book twin) should source `session.character_id`. This requires verifying the native **send** path applies character dicts/books post-#754 first (to preserve "shown=applied"); if it doesn't, either wire that too or leave the summary conversation-only. File as its own task.
 - Migrate the personas editor's `_fit_avatar_cell_size`/`_build_avatar_pixels` to the shared `fit_image_cell_size` (partly done by #775 for the transcript; the personas editor still has its own copy).
 - A live config-toggle recompose (if `show_character_avatar` is toggled mid-session) — P3c composes on the config at compose time; a mid-session toggle picks up on the next natural recompose.

--- a/Docs/superpowers/specs/2026-07-22-roleplay-p3c-console-character-avatar-design.md
+++ b/Docs/superpowers/specs/2026-07-22-roleplay-p3c-console-character-avatar-design.md
@@ -1,0 +1,148 @@
+# Roleplay P3c — Persistent character avatar in the Console chat
+
+**Program:** Personas → "Roleplay" workbench redesign. Sub-project **P3c** — the second cycle of the **"character-presence"** theme (P3b editor polish → **P3c persistent chat avatar** → P3d reaction/expression images). P3a, P3b, and the enabling task-427/#754 (character-on-Console-session) are all merged to dev.
+
+**Date:** 2026-07-22
+**Status:** Design (awaiting user review before writing-plans)
+**Schema:** ChaChaNotes v22 — **P3c adds NO migration** (reads existing `character_cards.image` + `conversations.character_id`, both already present/written by #754).
+
+---
+
+## Goal
+
+Show the active character's profile image persistently in the native Console chat, so you can see who you're talking to. A new collapsible **"Character"** section in the Console left rail renders the active character's avatar + name, following the session as it changes (Start-Chat, resume, tab switch) and reusing the image renderer P3b/P3a built.
+
+## Non-goals
+
+- **No reaction/expression images** (that's P3d — a net-new image-set model + trigger + swap, ported from the tldw_server webui).
+- **No persona avatars** (personas have no image — characters-only, consistent with P3b).
+- **No new image decoder / renderer** — reuse `ConsoleImageRenderCache` + `resolve_default_mode` + the shared `fit_image_cell_size` (from #775).
+- **No schema migration** — `conversations.character_id` is already written by #754; `character_cards.image` already exists.
+- **No change to how the character is set** — #754 owns that; P3c only reads it.
+
+## Success criteria
+
+- Starting a chat with a character (Start-Chat) shows that character's avatar + name in the Console left rail's "Character" section.
+- Resuming a persisted character conversation repopulates the panel (the session's `character_id` is restored from `conversations.character_id` by #754).
+- A generic (no-character) Console session shows a clean empty state, not a broken/blank panel.
+- Switching the active session/tab updates the panel to the new session's character.
+- The avatar honors `[chat.images]` render mode (graphics/pixels) with a text fallback, and never blocks the UI (off-thread decode) or crashes the sync tick.
+- `[chat.images].show_character_avatar` (default **on**) gates the whole feature.
+
+---
+
+## Background — current state (verified via source scout at dev `dc21e3f04`; file:line approximate, re-verify at plan time)
+
+**Active-character resolution (post-#754).** The live session object is `ConsoleChatSession` (`Chat/console_chat_store.py`), which now carries `character_id: int | None` (~:181) + `character_name: str | None` (~:182). Set at three sites: Start-Chat native handoff `_start_character_console_session` (`chat_screen.py` ~:9724-9730, id/name from `_character_session_identity_from_handoff` ~:472-505); DB-resume `_resume_console_workspace_conversation` (~:4212-4237, reads `conversation["character_id"]` → `session.character_id`, resolves name via `_resolve_resumed_character_name` → `get_character_card_by_id`); screen-state serialize/restore (~:9153/9212). **`None` for a never-character generic session.**
+- Active session accessor: `_active_native_console_session()` (`chat_screen.py` ~:3853) → the live `ConsoleChatSession | None`.
+- Conversation-id accessor: `_current_console_rail_conversation_id()` (~:3866). **There is NO character-id accessor yet** — P3c adds one.
+- **Leftover hole:** `_active_console_dictionary_scope_ids()` (~:6756-6772) still `return self._current_console_rail_conversation_id(), None` — the `character_id` is hardcoded `None` with a "once it lands, source a real character id here" note. #754 did not update it.
+- **Split-brain guard:** the native Console must NOT read legacy `app.current_chat_*` reactives — resolve only off the live session.
+
+**Durable persistence (already written by #754).** `persist_session_if_needed` (`console_chat_store.py` ~:1035-1055) writes `character_id`/`character_name`/`assistant_kind="character"` into `create_conversation` (`chat_persistence_service.py` ~:70-72) → `conversations.character_id` (`ChaChaNotes_DB.py` :268, index `idx_conv_char` :280). The resume path already reads it back, so a resumed session's `session.character_id` is repopulated — **P3c reads the session field and needs no separate fallback query.**
+
+**Character image.** `get_character_card_by_id(character_id: int)` (`ChaChaNotes_DB.py` ~:4336, `SELECT *`) returns the row dict with `"image"` as raw `bytes` (schema `image BLOB` :194). No lighter image-only fetch exists — `SELECT *` is the path. `character_id` is INT.
+
+**Renderer (reuse verbatim).** `chat_screen.py` already owns `self._console_image_cache: ConsoleImageRenderCache | None` (~:1873, lazily created in `_ensure_console_image_view` ~:2945, which also sets `_console_image_default_mode = resolve_default_mode(app_config)` ~:2956). `ConsoleImageRenderCache.prepare(id: str, bytes) -> bool` (`console_image_view.py` ~:257) is keyed by an arbitrary string and does PIL decode off the event loop. `fit_image_cell_size(pixel_w, pixel_h, box_cols, box_lines)` (`console_image_view.py`, added in #775) returns explicit aspect-preserving cell dims. The graphics-vs-pixels mount is `console_transcript._image_row_widget` (a copyable pattern) — graphics → `textual_image.widget.Image(pil)` with explicit `fit_image_cell_size` dims, pixels/fallback → `Static(Pixels)`.
+
+**Left rail (mount point).** `compose_content` (~:8285); `#console-left-rail` (~:8399) → `#console-left-rail-body` (VerticalScroll ~:8437) holds four collapsible sections, each a `ConsoleRailSectionHeader` (imported ~:292) + `Vertical(id="console-rail-section-body-<id>")`: Session (~:8441/8447), Model (~:8472/8478), Agent (~:8603/8610), Details (~:8650/8657). A new **Character** section mounts as a 5th pair here. Section open/closed state is threaded through `ConsoleRailState` (toggle list built ~:6222; header/body requery pattern ~:6346-6349) — P3c adds a `character_open` flag.
+
+**Refresh hook + the pattern to mirror.** Central re-sync `_sync_native_console_chat_ui` (~:10102) runs on tab/session switch, Start-Chat, resume, setup changes, and a 0.2s poll. The proven "what's in play" pattern: a cache field (`_active_dictionaries_summary` ~:1911) + a scope-guard field (`_last_console_dictionary_scope_ids` ~:1918) + a change-gated refresh (`_refresh_active_dictionaries_summary_if_scope_changed` ~:6808-6824, early-returns when the scope tuple is unchanged, else runs the DB work `asyncio.to_thread`) called from the sync tick; compose/recompose reads ONLY the cache (zero-DB-on-recompose).
+
+**Config.** `[chat.images]` (`Config.py` ~:2740-2754: `enabled`, `show_attach_button`, `default_render_mode`, `max_size_mb`, `terminal_overrides`). Read via `_chat_images_config(app_config)` (`console_image_view.py`). A `show_character_avatar` toggle joins here.
+
+---
+
+## Design decisions (resolved with the user)
+
+1. **Panel form:** a **collapsible "Character" section** (a 5th rail section, matching Session/Model/Agent/Details).
+2. **Config default:** `show_character_avatar` **on** by default.
+3. **Characters-only** (no persona image).
+4. **Include the adjacent fix:** source the real `character_id` in `_active_console_dictionary_scope_ids` (closes the leftover `None` hole so the dictionary/world-book scope becomes character-aware).
+
+---
+
+## Architecture
+
+### A. Resolution accessor + adjacent scope fix (`chat_screen.py`)
+
+- Add `_current_console_rail_character_id() -> int | None` and `_current_console_rail_character_name() -> str | None`, mirroring `_current_console_rail_conversation_id`: read the live session via `_active_native_console_session()` and return `session.character_id` / `session.character_name` (or `None`).
+- **Adjacent fix:** change `_active_console_dictionary_scope_ids()` to return `(self._current_console_rail_conversation_id(), self._current_console_rail_character_id())` instead of `(..., None)`, and drop the stale "once it lands" comment. This makes the existing dictionary/world-book "what's in play" scope guard character-aware (a latent correctness improvement; no behavior regression since character was previously always `None`).
+
+### B. Config helper (`console_image_view.py`)
+
+- Add a pure `resolve_show_character_avatar(app_config) -> bool` mirroring `resolve_default_mode`: `_chat_images_config(app_config).get("show_character_avatar", True)` coerced to bool (default **True**). Document the new key in the `[chat.images]` config section (`Config.py`) alongside the others.
+
+### C. The "Character" rail section (`chat_screen.py` compose + `ConsoleRailState`)
+
+- Add a `character_open: bool` field to `ConsoleRailState` (default open) and thread it through the toggle list (~:6222) + header/body requery (~:6346-6349), exactly like the other four sections.
+- In `compose_content`, when `resolve_show_character_avatar(app_config)` is True, compose a 5th `ConsoleRailSectionHeader("Character", section_id="character", …)` + `Vertical(id="console-rail-section-body-character")` inside `#console-left-rail-body` (after Details, or positioned per the rail's ordering). When the config is off, the section is not composed.
+- The section body holds: a thumbnail container (`#console-character-avatar`) + a name `Static` (`#console-character-name`). The body reads only the cached rendered avatar + name — **no DB/decode in compose**.
+- **Empty state:** when there's no active character (`character_id is None` — generic session), show a compact placeholder ("No character in this chat") and no image.
+
+### D. Avatar cache + scope-guarded off-thread refresh (`chat_screen.py`)
+
+Mirror the dictionary "what's in play" machinery:
+- Cache fields: `self._active_character_avatar` = a small **spec (data, NOT a live widget)** — e.g. `{character_id, name, mode, pil | pixels}` — enough to build a fresh mount widget without re-decoding. (A Textual widget can't be re-mounted on recompose, so the cache holds the decoded PIL/Pixels + mode, and each mount builds a new `Image`/`Static`, exactly like the transcript's `ConsoleImageRowSpec` → `_image_row_widget`.) Plus `self._active_character_avatar_name`.
+- Scope-guard: `self._last_console_avatar_scope: tuple | None` = `(character_id,)`.
+- `_refresh_active_character_avatar_if_scope_changed()`:
+  - Compute `scope = (self._current_console_rail_character_id(),)`. If `scope == self._last_console_avatar_scope`, return (zero DB).
+  - Set `self._last_console_avatar_scope = scope`. If `character_id is None`: clear the cache (empty state) + update the section, return.
+  - Otherwise run off-thread (`asyncio.to_thread`): `card = get_character_card_by_id(character_id)`; `image = card.get("image")`; if bytes, `self._console_image_cache.prepare(f"character:{character_id}", image)`; build the renderable via `resolve_default_mode`/`fit_image_cell_size` sized to a compact rail box (new `CHARACTER_AVATAR_COLS`/`CHARACTER_AVATAR_LINES` constants). Wrap so any failure → text fallback / empty (never raises in the sync tick).
+  - After the await, re-check the scope is still current (a session switch mid-decode supersedes), then update the cache + mount into `#console-character-avatar` + set `#console-character-name`.
+- Reuse `self._console_image_cache` (do NOT create a second cache).
+
+### E. Wire the refresh into the sync tick (`chat_screen.py`)
+
+- Call `_refresh_active_character_avatar_if_scope_changed()` from `_sync_native_console_chat_ui` (~:10102), alongside `_refresh_active_dictionaries_summary_if_scope_changed()` (~:10129). The scope-guard makes it a cheap no-op when the character is unchanged; it only fetches/decodes when the active character changes.
+
+### Error handling / edge cases
+
+- **No active session / generic session:** `character_id is None` → empty-state placeholder, cache cleared, no DB.
+- **Character has no image** (`image` is None/empty): show the name + a text "no avatar" placeholder (not a blank box).
+- **Decode failure / missing `textual_image`:** graphics → pixels → text fallback (same as P3b); off-thread; the refresh never raises into the sync tick (wrapped).
+- **Session switch mid-decode:** the post-await scope re-check drops a stale render (mirrors the P3b avatar session-token guard and the dictionary summary's scope re-check).
+- **Config off:** section not composed; refresh early-returns (guard on `resolve_show_character_avatar`).
+- **Deleted character:** `get_character_card_by_id` returns None (`deleted = 0` filter) → empty state.
+- **Zero-DB-on-recompose:** rail recompose reads only `_active_character_avatar`/`_name`; the DB fetch happens only in the scope-changed refresh.
+
+### Testing strategy
+
+- **Config helper:** `resolve_show_character_avatar` default True; explicit False/True; live-config-shape (COMPREHENSIVE_CONFIG_RAW).
+- **Accessor:** `_current_console_rail_character_id`/`_name` return the active session's fields; `None` when no session/character. `_active_console_dictionary_scope_ids` now returns the real character id (regression pin: the dictionary scope tuple includes it).
+- **Refresh scope-guard (real screen + real DB):** seed a character with an image; set the active session's `character_id`; run the sync tick → the panel mounts the avatar + name; unchanged scope → the DB fetch does NOT run again (spy the fetch); change `character_id` → it re-fetches and updates; set `character_id=None` → empty state; character with no image → name + placeholder. Assert off-thread (the fetch runs off the event loop) and that a stale post-await render is dropped when the scope changed during decode.
+- **Rail section:** the "Character" section composes when config on, absent when off; the `character_open` toggle collapses/expands it like the others; empty state renders for a generic session.
+- **Integration:** Start-Chat with a character → avatar shows; resume a persisted character conversation → avatar shows; generic session → empty state.
+
+---
+
+## Task decomposition (for writing-plans → subagent-driven-development)
+
+1. **Config helper + resolution accessors + adjacent scope fix** — `resolve_show_character_avatar` (console_image_view.py) + `_current_console_rail_character_id`/`_name` + fix `_active_console_dictionary_scope_ids` to source the real id (chat_screen.py). Unit + a dictionary-scope regression test. *(Foundational, isolated.)*
+2. **The "Character" rail section** — `ConsoleRailState.character_open` + compose the 5th `ConsoleRailSectionHeader` + body (config-gated) + empty state + toggle wiring. Rail widget tests.
+3. **Avatar cache + scope-guarded off-thread refresh + render** — the cache fields, `_refresh_active_character_avatar_if_scope_changed` (reuse `_console_image_cache` + `resolve_default_mode` + `fit_image_cell_size`, compact rail box), mount into the section, never-raise. Real-screen + real-DB refresh tests.
+4. **Wire into `_sync_native_console_chat_ui` + integration** — call the refresh from the sync tick; Start-Chat / resume / generic / character-change integration tests.
+
+Four focused tasks → one PR.
+
+---
+
+## Global constraints
+
+- **NO schema migration** (ChaChaNotes stays v22); reads existing `character_cards.image` + `conversations.character_id` (already written by #754).
+- **Resolve the active character ONLY off the live `ConsoleChatSession`** (`_active_native_console_session().character_id`/`.character_name`); never read legacy `app.current_chat_*` reactives (split-brain).
+- **Reuse the renderer verbatim** — `self._console_image_cache` (do not create a second cache), `resolve_default_mode`, and `fit_image_cell_size` (#775); avatar decode runs **off-thread** (`asyncio.to_thread`).
+- **Zero-DB-on-recompose** — the DB fetch/decode happens only in the scope-changed refresh (mirror `_refresh_active_dictionaries_summary_if_scope_changed`); compose reads only the cache. Re-check the `(character_id,)` scope after the await to drop a stale render.
+- **The refresh must never raise into `_sync_native_console_chat_ui`** (wrap; failure → text/empty fallback).
+- **Config-gated** on `[chat.images].show_character_avatar` (default True); section not composed when off.
+- **Characters-only** (no persona image).
+- **Branch off the LATEST `origin/dev`** (`dc21e3f04` at spec time — has #754 + #775; re-verify at plan/merge time). **Concurrent-session hazard:** `chat_screen.py` and `personas_screen.py` are heavily edited by other sessions — keep P3c localized to the new accessor/section/refresh + the one `_active_console_dictionary_scope_ids` line; expect a rebase before merge.
+- **Implementers stage ONLY their task's files** — never `git add -A`, never `.superpowers/`.
+- **No background/broad test sweeps; never broad-`pkill` pytest** — scope to this worktree.
+- **Test env:** `HOME=/private/tmp/tldw-chatbook-test-home XDG_DATA_HOME=/private/tmp/tldw-chatbook-test-home/.local/share /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest … -q -p no:cacheprovider -o addopts="" --timeout=300 --timeout-method=thread` (venv in MAIN checkout; imports resolve to worktree; UI tests slow — generous timeouts). Note `Tests/UI/pytest.ini` sets `asyncio_mode = auto`; a run that mixes `Tests/UI/` with another dir drops that (rootdir shift) — keep async tests in `Tests/UI/` and run them without cross-dir mixing, or add explicit `@pytest.mark.asyncio`.
+
+## Deferred / follow-ups
+
+- **P3d — reaction/expression image system** (own future program): a net-new image-set data model + authoring + trigger + swap, ported from the tldw_server webui/browser extension (needs the external `../tldw_server` repo). Renders into P3c's panel.
+- Migrate the personas editor's `_fit_avatar_cell_size`/`_build_avatar_pixels` to the shared `fit_image_cell_size` (partly done by #775 for the transcript; the personas editor still has its own copy).
+- A live config-toggle recompose (if `show_character_avatar` is toggled mid-session) — P3c composes on the config at compose time; a mid-session toggle picks up on the next natural recompose.

--- a/Tests/Chat/test_console_image_view.py
+++ b/Tests/Chat/test_console_image_view.py
@@ -257,3 +257,29 @@ def test_fit_image_cell_size_respects_arbitrary_box():
     # The avatar box (24x10) still works through the same helper.
     cw, ch = fit_image_cell_size(1000, 1000, 24, 10)
     assert 1 <= cw <= 24 and 1 <= ch <= 10
+
+
+# --- resolve_show_character_avatar (P3c) -------------------------------------
+
+
+def test_resolve_show_character_avatar_defaults_true():
+    from tldw_chatbook.Chat.console_image_view import resolve_show_character_avatar
+
+    assert resolve_show_character_avatar({}) is True
+    assert resolve_show_character_avatar({"chat": {"images": {}}}) is True
+
+
+def test_resolve_show_character_avatar_explicit_false():
+    from tldw_chatbook.Chat.console_image_view import resolve_show_character_avatar
+
+    assert resolve_show_character_avatar(
+        {"chat": {"images": {"show_character_avatar": False}}}
+    ) is False
+
+
+def test_resolve_show_character_avatar_live_shape():
+    from tldw_chatbook.Chat.console_image_view import resolve_show_character_avatar
+
+    assert resolve_show_character_avatar(
+        {"COMPREHENSIVE_CONFIG_RAW": {"chat": {"images": {"show_character_avatar": False}}}}
+    ) is False

--- a/Tests/Chat/test_console_rail_state.py
+++ b/Tests/Chat/test_console_rail_state.py
@@ -449,6 +449,7 @@ def test_console_rail_preferences_serialize_to_public_dict_shape():
         "model_open": True,
         "details_open": False,
         "agent_open": False,
+        "character_open": True,
     }
 
 
@@ -514,16 +515,18 @@ def test_console_rail_section_defaults():
 
     prefs = ConsoleRailPreferences()
     # Task-400: "context" (staged sources) is no longer a left-rail section;
-    # it renders in the Inspector rail instead.
+    # it renders in the Inspector rail instead. P3c added "character".
     assert CONSOLE_RAIL_SECTION_IDS == (
         "session",
         "model",
         "details",
         "agent",
+        "character",
     )
     assert prefs.session_open is True
     assert prefs.model_open is True
     assert prefs.details_open is False
+    assert prefs.character_open is True
 
 
 def test_coerce_console_rail_preferences_reads_section_fields():

--- a/Tests/UI/test_console_character_avatar.py
+++ b/Tests/UI/test_console_character_avatar.py
@@ -18,6 +18,7 @@ import pytest
 import pytest_asyncio
 
 from tldw_chatbook.Chat.console_chat_store import ConsoleChatSession, ConsoleChatStore
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
 from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 
 from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
@@ -173,3 +174,82 @@ async def test_character_section_empty_state_for_generic_session(
     screen = console_screen_generic
     name = screen.query_one("#console-character-name")
     assert "No character" in str(name.renderable)  # empty-state copy
+
+
+# --- P3c Task 3: avatar cache + scope-guarded off-thread refresh + render ---
+#
+# Real screen + real ``CharactersRAGDB``: only a real DB round-trip proves
+# `_refresh_active_character_avatar_if_scope_changed` genuinely decodes the
+# stored character-card image bytes into the cache (a fake DB can't catch a
+# broken `get_character_card_by_id(...)["image"]` read, and a fake cache
+# can't catch a broken `ConsoleImageRenderCache.prepare` call).
+
+
+@pytest.fixture
+def avatar_db(tmp_path):
+    db = CharactersRAGDB(tmp_path / "console_character_avatar.db", "test-client")
+    yield db
+    db.close_connection()
+
+
+@pytest_asyncio.fixture
+async def console_screen_with_db(avatar_db):
+    """Mounted Console screen wired to a real ``CharactersRAGDB``."""
+    app = _build_test_app()
+    app.chachanotes_db = avatar_db
+    host = ConsoleHarness(app)
+    async with host.run_test(size=(180, 48)) as pilot:
+        screen = host.screen_stack[-1]
+        await _wait_for_selector(
+            screen, pilot, "#console-rail-section-header-details"
+        )
+        yield app, screen, avatar_db
+
+
+def _set_active_console_character(screen, character_id, character_name) -> None:
+    """Bind the active native Console session to a character (or clear it)."""
+    session = screen._active_native_console_session()
+    assert session is not None, "no active native Console session"
+    session.character_id = character_id
+    session.character_name = character_name
+
+
+@pytest.mark.asyncio
+async def test_refresh_populates_avatar_cache_and_mounts(console_screen_with_db):
+    app, screen, db = console_screen_with_db
+    from PIL import Image as PILImage
+    from io import BytesIO
+    buf = BytesIO(); PILImage.new("RGB", (32, 32), (200, 10, 10)).save(buf, format="PNG")
+    char_id = db.add_character_card({"name": "Ada", "image": buf.getvalue()})
+    _set_active_console_character(screen, char_id, "Ada")
+
+    await screen._refresh_active_character_avatar_if_scope_changed()
+    assert screen._active_character_avatar is not None
+    assert screen._active_character_avatar.get("character_id") == char_id
+    assert screen._active_character_avatar.get("pil") is not None or \
+           screen._active_character_avatar.get("pixels") is not None
+
+    # unchanged scope -> no re-fetch (spy the DB fetch)
+    calls = []
+    orig = screen._fetch_character_card_for_avatar   # the off-thread fetch wrapper
+    screen._fetch_character_card_for_avatar = lambda cid: (calls.append(cid), orig(cid))[1]
+    await screen._refresh_active_character_avatar_if_scope_changed()
+    assert calls == []   # scope guard short-circuits before any fetch
+
+
+@pytest.mark.asyncio
+async def test_refresh_clears_avatar_for_generic_session(console_screen_with_db):
+    app, screen, db = console_screen_with_db
+    _set_active_console_character(screen, None, None)
+    await screen._refresh_active_character_avatar_if_scope_changed()
+    assert screen._active_character_avatar is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_never_raises_on_bad_image(console_screen_with_db):
+    app, screen, db = console_screen_with_db
+    char_id = db.add_character_card({"name": "Bad", "image": b"not-an-image"})
+    _set_active_console_character(screen, char_id, "Bad")
+    await screen._refresh_active_character_avatar_if_scope_changed()  # must not raise
+    # decode failed -> empty/text spec, name still set
+    assert screen._active_character_avatar_name == "Bad"

--- a/Tests/UI/test_console_character_avatar.py
+++ b/Tests/UI/test_console_character_avatar.py
@@ -1,0 +1,76 @@
+"""P3c Task 1: active-character rail accessors on ``ChatScreen``.
+
+Resolves the active character ONLY off the live native Console session
+(``_active_native_console_session().character_id`` / ``.character_name`` --
+#754 sets these at Start-Chat, on DB-resume, and on screen-state restore);
+never from the legacy ``app.current_chat_*`` reactives (the documented
+Console<->Library split-brain -- see
+``Tests/UI/test_console_dictionaries_attach.py``).
+
+Uses the same ``_bare_console_screen`` pattern as
+``Tests/UI/test_console_native_chat_flow.py``: builds a native-console
+screen shell directly (bypassing ``ChatScreen.__init__``, which requires a
+mounted Textual app), so these are plain, fast unit-level checks rather than
+a full pilot-driven screen.
+"""
+
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatSession, ConsoleChatStore
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+
+def _bare_console_screen(store: ConsoleChatStore) -> ChatScreen:
+    """Build a native-console screen shell for direct accessor calls.
+
+    See ``Tests/UI/test_console_native_chat_flow.py::_bare_console_screen``
+    for the rationale (bypasses ``ChatScreen.__init__``).
+    """
+    screen = ChatScreen.__new__(ChatScreen)
+    screen._console_chat_store = store
+    screen._console_visible_draft_session_id = None
+    screen._console_composer_or_none = lambda: None
+    return screen
+
+
+def _store_with_session(session: ConsoleChatSession) -> ConsoleChatStore:
+    store = ConsoleChatStore()
+    store.restore_state(
+        sessions=[session],
+        messages_by_session={session.id: []},
+        active_session_id=session.id,
+    )
+    return store
+
+
+def test_current_console_rail_character_id_reads_active_session():
+    session = ConsoleChatSession(id="session-a", character_id=7, character_name="Ada")
+    screen = _bare_console_screen(_store_with_session(session))
+
+    assert screen._current_console_rail_character_id() == 7
+    assert screen._current_console_rail_character_name() == "Ada"
+
+
+def test_current_console_rail_character_id_none_for_generic_session():
+    session = ConsoleChatSession(id="session-a")
+    screen = _bare_console_screen(_store_with_session(session))
+
+    assert screen._current_console_rail_character_id() is None
+    assert screen._current_console_rail_character_name() is None
+
+
+def test_p3c_leaves_dictionary_scope_ids_unchanged():
+    """Pin: P3c must NOT make ``_active_console_dictionary_scope_ids``
+    character-aware -- that would change the dictionary/world-book "what's
+    in play" content it feeds. ``character_id`` stays ``None`` there even
+    for a character-bound native session.
+    """
+    session = ConsoleChatSession(
+        id="session-a",
+        character_id=7,
+        character_name="Ada",
+        persisted_conversation_id="conv-1",
+    )
+    screen = _bare_console_screen(_store_with_session(session))
+
+    conversation_id, character_id = screen._active_console_dictionary_scope_ids()
+    assert conversation_id == "conv-1"
+    assert character_id is None

--- a/Tests/UI/test_console_character_avatar.py
+++ b/Tests/UI/test_console_character_avatar.py
@@ -16,6 +16,7 @@ a full pilot-driven screen.
 
 import pytest
 import pytest_asyncio
+from textual.widgets import Static
 
 from tldw_chatbook.Chat.console_chat_store import ConsoleChatSession, ConsoleChatStore
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
@@ -108,6 +109,38 @@ def test_build_character_avatar_widget_spec_without_image():
     widget = screen._build_character_avatar_widget(
         {"character_id": 7, "name": "Ada", "pil": None, "pixels": None}
     )
+    assert str(widget.renderable) == "no avatar"
+
+
+def test_build_character_avatar_widget_pixels_failure_falls_back_to_text(monkeypatch):
+    """FIX A: `_build_character_avatar_widget` must NEVER raise, even when the
+    ``rich_pixels`` build fails. It is reached from
+    ``_render_character_avatar_into_section``, which runs outside
+    ``_refresh_active_character_avatar_if_scope_changed``'s try/except -- and
+    that refresh itself must never raise into the 0.2s Console sync poll. A
+    decode/build failure here must degrade to the same text placeholder as
+    the no-image case, not propagate.
+    """
+    from PIL import Image as PILImage
+    import rich_pixels
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(rich_pixels.Pixels, "from_image", staticmethod(_boom))
+
+    screen = _bare_console_screen(ConsoleChatStore())
+    spec = {
+        "character_id": 7,
+        "name": "Ada",
+        "mode": "pixels",  # skip the graphics branch, hit the pixels fallback
+        "pil": PILImage.new("RGB", (32, 32), (200, 10, 10)),
+        "pixels": None,
+    }
+
+    widget = screen._build_character_avatar_widget(spec)  # must not raise
+
+    assert isinstance(widget, Static)
     assert str(widget.renderable) == "no avatar"
 
 
@@ -228,6 +261,12 @@ async def test_refresh_populates_avatar_cache_and_mounts(console_screen_with_db)
     assert screen._active_character_avatar.get("character_id") == char_id
     assert screen._active_character_avatar.get("pil") is not None or \
            screen._active_character_avatar.get("pixels") is not None
+
+    # FIX B: prove the widget actually landed in the DOM (not just the
+    # cached spec dict) right after the refresh awaits the mount.
+    holder = screen.query_one("#console-character-avatar")
+    mounted_ids = {child.id for child in holder.children}
+    assert "console-character-avatar-image" in mounted_ids
 
     # unchanged scope -> no re-fetch (spy the DB fetch)
     calls = []

--- a/Tests/UI/test_console_character_avatar.py
+++ b/Tests/UI/test_console_character_avatar.py
@@ -239,6 +239,23 @@ async def console_screen_with_db(avatar_db):
         yield app, screen, avatar_db
 
 
+@pytest_asyncio.fixture
+async def console_screen_with_db_avatar_off(avatar_db):
+    """Mounted Console screen wired to a real DB, with the avatar rail
+    section config-off (``chat.images.show_character_avatar = False``).
+    """
+    app = _build_test_app()
+    app.chachanotes_db = avatar_db
+    app.app_config["chat"] = {"images": {"show_character_avatar": False}}
+    host = ConsoleHarness(app)
+    async with host.run_test(size=(180, 48)) as pilot:
+        screen = host.screen_stack[-1]
+        await _wait_for_selector(
+            screen, pilot, "#console-rail-section-header-details"
+        )
+        yield app, screen, avatar_db
+
+
 def _set_active_console_character(screen, character_id, character_name) -> None:
     """Bind the active native Console session to a character (or clear it)."""
     session = screen._active_native_console_session()
@@ -294,6 +311,33 @@ async def test_refresh_never_raises_on_bad_image(console_screen_with_db):
     assert screen._active_character_avatar_name == "Bad"
 
 
+@pytest.mark.asyncio
+async def test_refresh_never_raises_when_mount_fails(console_screen_with_db, monkeypatch):
+    """Whole-branch review, FIX 1: `_render_character_avatar_into_section`'s
+    ``holder.mount(...)`` runs outside `_refresh_active_character_avatar_if_
+    scope_changed`'s own try/except, at two call sites, and that refresh runs
+    unconditionally on every 0.2s Console sync tick -- some worker dispatch
+    sites run with ``exit_on_error=True``, so an escaping mount failure (e.g.
+    a transient layout race on a session-switch/resume tick) could crash the
+    app. The refresh must never raise even when the mount itself blows up.
+    """
+    app, screen, db = console_screen_with_db
+    from PIL import Image as PILImage
+    from io import BytesIO
+    buf = BytesIO(); PILImage.new("RGB", (32, 32), (200, 10, 10)).save(buf, format="PNG")
+    char_id = db.add_character_card({"name": "Ada", "image": buf.getvalue()})
+    _set_active_console_character(screen, char_id, "Ada")
+
+    holder = screen.query_one("#console-character-avatar")
+
+    async def _boom(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(holder, "mount", _boom)
+
+    await screen._refresh_active_character_avatar_if_scope_changed()  # must not raise
+
+
 # --- P3c Task 4: wire the refresh into the Console sync tick -----------------
 #
 # Unlike `test_refresh_populates_avatar_cache_and_mounts` above (which calls
@@ -318,3 +362,31 @@ async def test_sync_tick_refreshes_avatar(console_screen_with_db):
     assert screen._active_character_avatar_name == "Ada"
     name = screen.query_one("#console-character-name")
     assert "Ada" in str(name.renderable)
+
+
+# --- Whole-branch review fixes (P3c) -----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_skips_db_fetch_when_config_off(console_screen_with_db_avatar_off):
+    """Whole-branch review, FIX 2: per the spec's Error-handling section,
+    `_refresh_active_character_avatar_if_scope_changed` must early-return
+    when `resolve_show_character_avatar(...)` is False -- the rail section
+    isn't even composed in that case, so the off-thread DB fetch + PIL
+    decode must not run at all.
+    """
+    app, screen, db = console_screen_with_db_avatar_off
+    from PIL import Image as PILImage
+    from io import BytesIO
+    buf = BytesIO(); PILImage.new("RGB", (32, 32), (200, 10, 10)).save(buf, format="PNG")
+    char_id = db.add_character_card({"name": "Ada", "image": buf.getvalue()})
+    _set_active_console_character(screen, char_id, "Ada")
+
+    calls = []
+    orig = screen._fetch_character_card_for_avatar
+    screen._fetch_character_card_for_avatar = lambda cid: (calls.append(cid), orig(cid))[1]
+
+    await screen._refresh_active_character_avatar_if_scope_changed()
+
+    assert calls == []  # config-off short-circuits before any DB fetch
+    assert screen._active_character_avatar is None

--- a/Tests/UI/test_console_character_avatar.py
+++ b/Tests/UI/test_console_character_avatar.py
@@ -390,3 +390,34 @@ async def test_refresh_skips_db_fetch_when_config_off(console_screen_with_db_ava
 
     assert calls == []  # config-off short-circuits before any DB fetch
     assert screen._active_character_avatar is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_repopulates_after_config_toggle_off_then_on(console_screen_with_db):
+    """Qodo #782-3 regression: the config-off branch clears the cache AND must
+    invalidate the scope guard, otherwise re-enabling the feature without
+    changing the active character hits the scope-equality early-return and the
+    Character section sticks in the empty state forever.
+    """
+    app, screen, db = console_screen_with_db
+    from PIL import Image as PILImage
+    from io import BytesIO
+    buf = BytesIO(); PILImage.new("RGB", (32, 32), (10, 180, 60)).save(buf, format="PNG")
+    char_id = db.add_character_card({"name": "Ada", "image": buf.getvalue()})
+    _set_active_console_character(screen, char_id, "Ada")
+
+    # (1) feature on (default): populates + records scope (char_id,)
+    await screen._refresh_active_character_avatar_if_scope_changed()
+    assert screen._active_character_avatar is not None
+
+    # (2) toggle off: clears the cache AND invalidates the scope guard
+    app.app_config["chat"] = {"images": {"show_character_avatar": False}}
+    await screen._refresh_active_character_avatar_if_scope_changed()
+    assert screen._active_character_avatar is None
+    assert screen._last_console_avatar_scope is None  # guard invalidated
+
+    # (3) toggle back on, SAME character: must repopulate (was stuck empty pre-fix)
+    app.app_config["chat"] = {"images": {"show_character_avatar": True}}
+    await screen._refresh_active_character_avatar_if_scope_changed()
+    assert screen._active_character_avatar is not None
+    assert screen._active_character_avatar.get("character_id") == char_id

--- a/Tests/UI/test_console_character_avatar.py
+++ b/Tests/UI/test_console_character_avatar.py
@@ -292,3 +292,29 @@ async def test_refresh_never_raises_on_bad_image(console_screen_with_db):
     await screen._refresh_active_character_avatar_if_scope_changed()  # must not raise
     # decode failed -> empty/text spec, name still set
     assert screen._active_character_avatar_name == "Bad"
+
+
+# --- P3c Task 4: wire the refresh into the Console sync tick -----------------
+#
+# Unlike `test_refresh_populates_avatar_cache_and_mounts` above (which calls
+# `_refresh_active_character_avatar_if_scope_changed` directly), this proves
+# the wire: the real Console sync entrypoint `_sync_native_console_chat_ui`
+# -- the same tick that already refreshes the dictionary/world-book "what's
+# in play" summaries -- also refreshes the character avatar.
+
+
+@pytest.mark.asyncio
+async def test_sync_tick_refreshes_avatar(console_screen_with_db):
+    app, screen, db = console_screen_with_db
+    from PIL import Image as PILImage
+    from io import BytesIO
+    buf = BytesIO(); PILImage.new("RGB", (32, 32), (200, 10, 10)).save(buf, format="PNG")
+    char_id = db.add_character_card({"name": "Ada", "image": buf.getvalue()})
+    _set_active_console_character(screen, char_id, "Ada")
+
+    await screen._sync_native_console_chat_ui()  # the real sync entrypoint, not the refresh directly
+
+    assert screen._active_character_avatar is not None
+    assert screen._active_character_avatar_name == "Ada"
+    name = screen.query_one("#console-character-name")
+    assert "Ada" in str(name.renderable)

--- a/Tests/UI/test_console_character_avatar.py
+++ b/Tests/UI/test_console_character_avatar.py
@@ -14,8 +14,16 @@ mounted Textual app), so these are plain, fast unit-level checks rather than
 a full pilot-driven screen.
 """
 
+import pytest
+import pytest_asyncio
+
 from tldw_chatbook.Chat.console_chat_store import ConsoleChatSession, ConsoleChatStore
 from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+    ConsoleHarness,
+)
 
 
 def _bare_console_screen(store: ConsoleChatStore) -> ChatScreen:
@@ -74,3 +82,94 @@ def test_p3c_leaves_dictionary_scope_ids_unchanged():
     conversation_id, character_id = screen._active_console_dictionary_scope_ids()
     assert conversation_id == "conv-1"
     assert character_id is None
+
+
+# --- P3c Task 2: config-gated "Character" rail section ----------------------
+#
+# `_build_character_avatar_widget` is a T2 stub -- it only renders the
+# text/empty state from a cache spec; T3 extends it with real image
+# rendering. The rail section itself composes reading only
+# `self._active_character_avatar` / `_active_character_avatar_name`, which
+# T2 always seeds empty in `__init__` -- T3 wires the real active-character
+# lookup that fills them. So the "with character" fixture below only needs
+# to exercise the default-config (`show_character_avatar` True) path, not an
+# actually character-bound session.
+
+
+def test_build_character_avatar_widget_empty_state_no_spec():
+    screen = _bare_console_screen(ConsoleChatStore())
+    widget = screen._build_character_avatar_widget(None)
+    assert str(widget.renderable) == "No character in this chat"
+
+
+def test_build_character_avatar_widget_spec_without_image():
+    screen = _bare_console_screen(ConsoleChatStore())
+    widget = screen._build_character_avatar_widget(
+        {"character_id": 7, "name": "Ada", "pil": None, "pixels": None}
+    )
+    assert str(widget.renderable) == "no avatar"
+
+
+@pytest_asyncio.fixture
+async def console_screen_with_character():
+    """Mounted Console screen under the default config (avatar rail on)."""
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+    async with host.run_test(size=(180, 48)) as pilot:
+        screen = host.screen_stack[-1]
+        await _wait_for_selector(
+            screen, pilot, "#console-rail-section-header-details"
+        )
+        yield screen
+
+
+@pytest_asyncio.fixture
+async def console_screen_avatar_off():
+    """Mounted Console screen with ``chat.images.show_character_avatar`` off."""
+    app = _build_test_app()
+    app.app_config["chat"] = {"images": {"show_character_avatar": False}}
+    host = ConsoleHarness(app)
+    async with host.run_test(size=(180, 48)) as pilot:
+        screen = host.screen_stack[-1]
+        await _wait_for_selector(
+            screen, pilot, "#console-rail-section-header-details"
+        )
+        yield screen
+
+
+@pytest_asyncio.fixture
+async def console_screen_generic():
+    """Mounted Console screen, default config, generic (no-character) session."""
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+    async with host.run_test(size=(180, 48)) as pilot:
+        screen = host.screen_stack[-1]
+        await _wait_for_selector(
+            screen, pilot, "#console-rail-section-header-details"
+        )
+        yield screen
+
+
+@pytest.mark.asyncio
+async def test_character_section_composes_when_config_on(
+    console_screen_with_character,
+):
+    screen = console_screen_with_character  # config default -> show_character_avatar True
+    assert screen.query("#console-rail-section-body-character")  # section present
+    assert screen.query("#console-character-name")
+
+
+@pytest.mark.asyncio
+async def test_character_section_absent_when_config_off(console_screen_avatar_off):
+    # console_screen_avatar_off: app_config has chat.images.show_character_avatar = False
+    screen = console_screen_avatar_off
+    assert not screen.query("#console-rail-section-body-character")
+
+
+@pytest.mark.asyncio
+async def test_character_section_empty_state_for_generic_session(
+    console_screen_generic,
+):
+    screen = console_screen_generic
+    name = screen.query_one("#console-character-name")
+    assert "No character" in str(name.renderable)  # empty-state copy

--- a/Tests/UI/test_console_persistent_rails.py
+++ b/Tests/UI/test_console_persistent_rails.py
@@ -224,14 +224,16 @@ def _rail_prefs(
     model_open: bool = True,
     details_open: bool = False,
     agent_open: bool = False,
+    character_open: bool = True,
 ) -> dict[str, bool]:
-    """Full serialized rail-preference shape (left/right rails + four sections).
+    """Full serialized rail-preference shape (left/right rails + five sections).
 
-    The persisted shape carries the four collapsible left-rail section states
+    The persisted shape carries the five collapsible left-rail section states
     alongside the left/right rail openness. Section states default to the
-    first-run layout (Session/Model open, Details/Agent collapsed). Task-400
-    dropped the Context section (staged sources moved to the Inspector), so
-    serialized payloads no longer carry a ``context_open`` key.
+    first-run layout (Session/Model/Character open, Details/Agent collapsed).
+    Task-400 dropped the Context section (staged sources moved to the
+    Inspector), so serialized payloads no longer carry a ``context_open`` key.
+    P3c added the Character section (``character_open``).
     """
     return {
         "left_open": left_open,
@@ -240,6 +242,7 @@ def _rail_prefs(
         "model_open": model_open,
         "details_open": details_open,
         "agent_open": agent_open,
+        "character_open": character_open,
     }
 
 

--- a/tldw_chatbook/Chat/console_image_view.py
+++ b/tldw_chatbook/Chat/console_image_view.py
@@ -106,6 +106,24 @@ def _chat_images_config(app_config: Mapping[str, Any]) -> Mapping[str, Any]:
     return images if isinstance(images, Mapping) else {}
 
 
+def resolve_show_character_avatar(app_config: Mapping[str, Any]) -> bool:
+    """Whether the Console shows the active character's avatar (default True).
+
+    Reads ``[chat.images].show_character_avatar`` via the same both-shapes
+    accessor as ``resolve_default_mode`` (raw TOML or the live
+    ``COMPREHENSIVE_CONFIG_RAW`` nesting).
+
+    Args:
+        app_config: The application config mapping (``[chat.images]``
+            section is read; missing sections are tolerated).
+
+    Returns:
+        True unless explicitly disabled via ``show_character_avatar = false``.
+    """
+    value = _chat_images_config(app_config).get("show_character_avatar", True)
+    return bool(value)
+
+
 def resolve_default_mode(
     app_config: Mapping[str, Any],
 ) -> Literal["pixels", "graphics"]:

--- a/tldw_chatbook/Chat/console_rail_state.py
+++ b/tldw_chatbook/Chat/console_rail_state.py
@@ -13,7 +13,7 @@ CONSOLE_RAIL_LEFT_DEFAULT_OPEN = True
 CONSOLE_RAIL_RIGHT_DEFAULT_OPEN = False
 # Task-400: the "context" (staged sources) section moved from the left rail
 # into the Inspector rail, so it is no longer a collapsible left-rail section.
-CONSOLE_RAIL_SECTION_IDS = ("session", "model", "details", "agent")
+CONSOLE_RAIL_SECTION_IDS = ("session", "model", "details", "agent", "character")
 CONSOLE_RAIL_RIGHT_COMPACT_COLLAPSE_COLUMNS = 150
 CONSOLE_RAIL_CONTEXT_LABEL = f"Context {GLYPH_COLLAPSED}"
 CONSOLE_RAIL_INSPECTOR_LABEL = f"{GLYPH_COLLAPSE_LEFT} Inspector"
@@ -74,6 +74,7 @@ class ConsoleRailPreferences:
     model_open: bool = True
     details_open: bool = False
     agent_open: bool = False
+    character_open: bool = True
 
 
 @dataclass(frozen=True)
@@ -104,6 +105,7 @@ class ConsoleRailState:
     model_open: bool = True
     details_open: bool = False
     agent_open: bool = False
+    character_open: bool = True
 
 
 def _sanitize_key_part(value: Any) -> str:
@@ -245,6 +247,7 @@ def coerce_console_rail_preferences(raw: Any) -> ConsoleRailPreferences:
         model_open=_coerce_bool(raw.get("model_open"), defaults.model_open),
         details_open=_coerce_bool(raw.get("details_open"), defaults.details_open),
         agent_open=_coerce_bool(raw.get("agent_open"), defaults.agent_open),
+        character_open=_coerce_bool(raw.get("character_open"), defaults.character_open),
     )
 
 
@@ -257,8 +260,9 @@ def serialize_console_rail_preferences(
         preferences: Rail preferences to serialize.
 
     Returns:
-        Persistence dict with the left/right rail flags and the four
-        left-rail section flags (task-400 dropped ``context_open``).
+        Persistence dict with the left/right rail flags and the five
+        left-rail section flags (task-400 dropped ``context_open``; P3c
+        added ``character_open``).
     """
     return {
         "left_open": bool(preferences.left_open),
@@ -267,6 +271,7 @@ def serialize_console_rail_preferences(
         "model_open": bool(preferences.model_open),
         "details_open": bool(preferences.details_open),
         "agent_open": bool(preferences.agent_open),
+        "character_open": bool(preferences.character_open),
     }
 
 
@@ -520,4 +525,5 @@ def build_console_rail_state(
         model_open=preferences.model_open,
         details_open=preferences.details_open,
         agent_open=preferences.agent_open,
+        character_open=preferences.character_open,
     )

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -26,6 +26,7 @@ from textual.color import Color
 from textual.events import Click, DescendantFocus, Key, MouseUp, Paste, Resize
 from textual.message_pump import NoActiveAppError
 from textual.reactive import reactive
+from textual.widget import Widget
 from textual.widgets import Button, Static, TextArea, Select, Collapsible, Input
 
 from ..Navigation.base_app_screen import BaseAppScreen
@@ -187,6 +188,7 @@ from ...Chat.console_image_view import (
     ConsoleImageViewState,
     next_view_mode,
     resolve_default_mode,
+    resolve_show_character_avatar,
 )
 from ...Chat.console_paste_attach import (
     extract_dropped_path,
@@ -1934,6 +1936,15 @@ class ChatScreen(BaseAppScreen):
         # P2g-2 Task 4: same double-open guard, for the World Books
         # inspector block's Attach/Detach picker flow.
         self._console_worldbook_dialog_active = False
+        # P3c: cached avatar spec (dict | None) for the active character in
+        # the "Character" rail section, plus its display name and the
+        # scope (conversation/character) it was last computed for. Mirrors
+        # the dictionaries/world-books caches above -- the compose path
+        # reads only this cache, never doing I/O on recompose. T3 fills
+        # `_active_character_avatar`; this task only seeds the empty state.
+        self._active_character_avatar: dict | None = None
+        self._active_character_avatar_name: str | None = None
+        self._last_console_avatar_scope: Any | None = None
         self.ui_state = UIState()
         self._load_sidebar_state()
 
@@ -3898,6 +3909,20 @@ class ChatScreen(BaseAppScreen):
             return None
         name = getattr(native_session, "character_name", None)
         return str(name) if name else None
+
+    def _build_character_avatar_widget(self, spec: dict | None) -> Widget:
+        """Build a fresh avatar widget from the cached spec (data, not a widget).
+
+        T3 fills `spec` with {character_id, name, mode, pil, pixels}. With no
+        spec / no image, render a compact text placeholder.
+        """
+        from textual.widgets import Static as _S
+        if not spec or (spec.get("pil") is None and spec.get("pixels") is None):
+            hint = "no avatar" if spec else "No character in this chat"
+            return _S(hint, id="console-character-avatar-empty")
+        # T3 extends: graphics -> textual_image Image(pil) with fit dims;
+        # pixels -> Static(Pixels). Placeholder until then:
+        return _S("", id="console-character-avatar-empty")
 
     def _console_session_id_for_workspace_conversation(
         self,
@@ -8693,6 +8718,35 @@ class ChatScreen(BaseAppScreen):
                             details_tray.styles.width = "100%"
                             details_tray.styles.min_width = 0
                             yield details_tray
+
+                        # Section 5: Character (avatar of the active character).
+                        if resolve_show_character_avatar(
+                            getattr(getattr(self, "app_instance", None), "app_config", {}) or {}
+                        ):
+                            yield ConsoleRailSectionHeader(
+                                "Character",
+                                section_id="character",
+                                open=rail_state.character_open,
+                                id="console-rail-section-header-character",
+                            )
+                            character_body = Vertical(
+                                id="console-rail-section-body-character",
+                                classes="console-rail-section-body",
+                            )
+                            character_body.styles.height = "auto"
+                            if not rail_state.character_open:
+                                character_body.styles.display = "none"
+                            with character_body:
+                                avatar_holder = Container(id="console-character-avatar")
+                                with avatar_holder:
+                                    yield self._build_character_avatar_widget(
+                                        self._active_character_avatar
+                                    )
+                                yield Static(
+                                    self._active_character_avatar_name
+                                    or "No character in this chat",
+                                    id="console-character-name",
+                                )
 
                 main_column = Vertical(id="console-main-column")
                 main_column.styles.width = "13fr"

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -186,6 +186,7 @@ from ...Chat.console_image_view import (
     ConsoleImageRenderCache,
     ConsoleImageRowSpec,
     ConsoleImageViewState,
+    fit_image_cell_size,
     next_view_mode,
     resolve_default_mode,
     resolve_show_character_avatar,
@@ -423,6 +424,11 @@ CONSOLE_SUBAGENT_COUNTS_CACHE_TTL_SECONDS = 2.0
 # bound, same "explicit invalidation is a nice-to-have, the TTL is the
 # correctness backstop" philosophy).
 CONSOLE_PERSISTED_ROWS_CACHE_TTL_SECONDS = 2.0
+# P3c Task 3: the "Character" rail avatar box's fitted cell size (mirrors
+# the transcript inline-image row's `fit_image_cell_size` usage, sized
+# smaller for the rail's narrower column).
+CHARACTER_AVATAR_COLS = 16
+CHARACTER_AVATAR_LINES = 8
 CONSOLE_FOCUS_REGISTRY = WorkbenchFocusRegistry(
     (
         "console-left-rail",
@@ -3910,19 +3916,118 @@ class ChatScreen(BaseAppScreen):
         name = getattr(native_session, "character_name", None)
         return str(name) if name else None
 
+    def _fetch_character_card_for_avatar(self, character_id: int) -> dict | None:
+        """Synchronous character-card fetch for the avatar refresh (off-thread).
+
+        Canonical DB accessor used throughout `chat_screen.py` (e.g. the
+        resume path `_resolve_resumed_character_name`); there is no
+        `self.chachanotes_db`.
+        """
+        db = getattr(self.app_instance, "chachanotes_db", None)
+        if db is None:
+            return None
+        try:
+            return db.get_character_card_by_id(int(character_id))
+        except Exception:
+            logger.opt(exception=True).debug("avatar: character fetch failed")
+            return None
+
+    async def _refresh_active_character_avatar_if_scope_changed(self) -> None:
+        """Refresh the cached character avatar only when the active character changed."""
+        character_id = self._current_console_rail_character_id()
+        scope = (character_id,)
+        if scope == self._last_console_avatar_scope:
+            return
+        self._last_console_avatar_scope = scope
+        name = self._current_console_rail_character_name()
+        self._active_character_avatar_name = name
+        if character_id is None:
+            self._active_character_avatar = None
+            await self._render_character_avatar_into_section()
+            return
+        _, cache = self._ensure_console_image_view()
+        mode = getattr(self, "_console_image_default_mode", "pixels")
+        key = f"character:{character_id}"
+        spec = {"character_id": character_id, "name": name, "mode": mode, "pil": None, "pixels": None}
+        try:
+            card = await asyncio.to_thread(self._fetch_character_card_for_avatar, character_id)
+            image = (card or {}).get("image")
+            if isinstance(image, (bytes, bytearray)) and image:
+                ok = await asyncio.to_thread(cache.prepare, key, bytes(image))
+                if ok:
+                    if mode == "graphics":
+                        spec["pil"] = cache.get_pil(key)
+                    else:
+                        spec["pixels"] = cache.get_pixels(key)
+        except Exception:
+            logger.opt(exception=True).debug("avatar: refresh failed")
+        # Drop a stale render if the active character changed during decode.
+        if (self._current_console_rail_character_id(),) != scope or not self.is_mounted:
+            return
+        self._active_character_avatar = spec
+        await self._render_character_avatar_into_section()
+
+    async def _render_character_avatar_into_section(self) -> None:
+        """Re-mount the avatar widget + name into the (already-composed) section.
+
+        Async because Textual `Widget.mount()` returns an `AwaitMount` that
+        must be awaited so the widget is present before the caller returns
+        (the integration test asserts the mounted state right after the tick).
+        """
+        try:
+            holder = self.query_one("#console-character-avatar", Container)
+        except QueryError:
+            return  # section not composed (config off / not mounted)
+        await holder.remove_children()
+        await holder.mount(self._build_character_avatar_widget(self._active_character_avatar))
+        try:
+            self.query_one("#console-character-name", Static).update(
+                self._active_character_avatar_name or "No character in this chat"
+            )
+        except QueryError:
+            pass
+
     def _build_character_avatar_widget(self, spec: dict | None) -> Widget:
         """Build a fresh avatar widget from the cached spec (data, not a widget).
 
-        T3 fills `spec` with {character_id, name, mode, pil, pixels}. With no
-        spec / no image, render a compact text placeholder.
+        `spec` is `{character_id, name, mode, pil, pixels}` (T3 fills it via
+        `_refresh_active_character_avatar_if_scope_changed`). With no spec,
+        or a spec whose image decode failed/is pending, render a compact
+        text placeholder. The cache holds this spec (data), not a live
+        widget -- every (re)mount builds a fresh widget from it.
         """
         from textual.widgets import Static as _S
         if not spec or (spec.get("pil") is None and spec.get("pixels") is None):
-            hint = "no avatar" if spec else "No character in this chat"
+            hint = "no avatar" if (spec and spec.get("character_id") is not None) else "No character in this chat"
             return _S(hint, id="console-character-avatar-empty")
-        # T3 extends: graphics -> textual_image Image(pil) with fit dims;
-        # pixels -> Static(Pixels). Placeholder until then:
-        return _S("", id="console-character-avatar-empty")
+        if spec.get("mode") == "graphics" and spec.get("pil") is not None:
+            try:
+                from textual_image.widget import Image as _GraphicsImage
+                widget = _GraphicsImage(spec["pil"], id="console-character-avatar-image")
+                # Explicit fitted cell size, not just max-width/max-height --
+                # see `console_transcript._image_row_widget`'s identical
+                # guard: textual_image's "auto" sizing resolves its render
+                # region from the parent's settled layout, and mounting a
+                # tick before that settles can ask the renderer to scale
+                # into a transient 0-width/height region, which PIL's
+                # resize() raises on.
+                w, h = fit_image_cell_size(spec["pil"].width, spec["pil"].height,
+                                           CHARACTER_AVATAR_COLS, CHARACTER_AVATAR_LINES)
+                widget.styles.width = w
+                widget.styles.height = h
+                return widget
+            except Exception:
+                logger.opt(exception=True).debug("avatar: graphics mount failed")
+        pixels = spec.get("pixels")
+        if pixels is None and spec.get("pil") is not None:
+            scaled = spec["pil"].copy()
+            scaled.thumbnail((CHARACTER_AVATAR_COLS, CHARACTER_AVATAR_LINES * 2))
+            from rich_pixels import Pixels
+            pixels = Pixels.from_image(scaled)
+        widget = Static(pixels if pixels is not None else "", id="console-character-avatar-image")
+        widget.styles.max_width = CHARACTER_AVATAR_COLS
+        widget.styles.max_height = CHARACTER_AVATAR_LINES
+        return widget
 
     def _console_session_id_for_workspace_conversation(
         self,

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -3875,6 +3875,30 @@ class ChatScreen(BaseAppScreen):
             return str(conversation_id) if conversation_id else None
         return self._current_console_conversation_id()
 
+    def _current_console_rail_character_id(self) -> Optional[int]:
+        """Active native Console session's character id (int), or None.
+
+        Resolved ONLY off the live session (#754 sets it at Start-Chat, on
+        DB-resume, and on screen-state restore); never from legacy
+        ``app.current_chat_*`` reactives. None for a generic session.
+        """
+        native_session = self._active_native_console_session()
+        if native_session is None:
+            return None
+        character_id = getattr(native_session, "character_id", None)
+        try:
+            return int(character_id) if character_id is not None else None
+        except (TypeError, ValueError):
+            return None
+
+    def _current_console_rail_character_name(self) -> Optional[str]:
+        """Active native Console session's character name, or None."""
+        native_session = self._active_native_console_session()
+        if native_session is None:
+            return None
+        name = getattr(native_session, "character_name", None)
+        return str(name) if name else None
+
     def _console_session_id_for_workspace_conversation(
         self,
         conversation_id: str,

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -3971,8 +3971,10 @@ class ChatScreen(BaseAppScreen):
         """Re-mount the avatar widget + name into the (already-composed) section.
 
         Async because Textual `Widget.mount()` returns an `AwaitMount` that
-        must be awaited so the widget is present before the caller returns
-        (the integration test asserts the mounted state right after the tick).
+        must be awaited so the widget is present before the caller returns.
+        `test_refresh_populates_avatar_cache_and_mounts` asserts the mounted
+        DOM state (not just the cached spec dict) right after the refresh
+        awaits this.
         """
         try:
             holder = self.query_one("#console-character-avatar", Container)
@@ -3995,6 +3997,14 @@ class ChatScreen(BaseAppScreen):
         or a spec whose image decode failed/is pending, render a compact
         text placeholder. The cache holds this spec (data), not a live
         widget -- every (re)mount builds a fresh widget from it.
+
+        This method must NEVER raise: it is reached from
+        `_render_character_avatar_into_section`, which runs outside
+        `_refresh_active_character_avatar_if_scope_changed`'s try/except (and
+        that refresh itself must never raise into the 0.2s Console sync
+        poll). Any image-build failure -- graphics mount OR the rich_pixels
+        fallback -- degrades to the same text placeholder used for the
+        no-image case.
         """
         from textual.widgets import Static as _S
         if not spec or (spec.get("pil") is None and spec.get("pixels") is None):
@@ -4018,16 +4028,20 @@ class ChatScreen(BaseAppScreen):
                 return widget
             except Exception:
                 logger.opt(exception=True).debug("avatar: graphics mount failed")
-        pixels = spec.get("pixels")
-        if pixels is None and spec.get("pil") is not None:
-            scaled = spec["pil"].copy()
-            scaled.thumbnail((CHARACTER_AVATAR_COLS, CHARACTER_AVATAR_LINES * 2))
-            from rich_pixels import Pixels
-            pixels = Pixels.from_image(scaled)
-        widget = Static(pixels if pixels is not None else "", id="console-character-avatar-image")
-        widget.styles.max_width = CHARACTER_AVATAR_COLS
-        widget.styles.max_height = CHARACTER_AVATAR_LINES
-        return widget
+        try:
+            pixels = spec.get("pixels")
+            if pixels is None and spec.get("pil") is not None:
+                scaled = spec["pil"].copy()
+                scaled.thumbnail((CHARACTER_AVATAR_COLS, CHARACTER_AVATAR_LINES * 2))
+                from rich_pixels import Pixels
+                pixels = Pixels.from_image(scaled)
+            widget = Static(pixels if pixels is not None else "", id="console-character-avatar-image")
+            widget.styles.max_width = CHARACTER_AVATAR_COLS
+            widget.styles.max_height = CHARACTER_AVATAR_LINES
+            return widget
+        except Exception:
+            logger.opt(exception=True).debug("avatar: pixels build failed")
+            return _S("no avatar", id="console-character-avatar-empty")
 
     def _console_session_id_for_workspace_conversation(
         self,

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -10325,6 +10325,13 @@ class ChatScreen(BaseAppScreen):
             # stale frame behind.
             await self._refresh_active_dictionaries_summary_if_scope_changed()
             await self._refresh_active_world_books_summary_if_scope_changed()
+            # P3c Task 4: mirrors the dictionary/world-book scope-guarded
+            # refresh pattern immediately above -- safe to call unconditionally
+            # on every sync tick because the refresh is itself scope-guarded
+            # (no-op when the active character hasn't changed) and never
+            # raises (see `_refresh_active_character_avatar_if_scope_changed`
+            # docstring, T3).
+            await self._refresh_active_character_avatar_if_scope_changed()
             # task-280: hand the control bar a pre-await snapshot (its own
             # pre-existing timing). The rail-VISIBILITY call below must NOT
             # reuse this snapshot: `_sync_console_native_session_tabs` can

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -3934,6 +3934,15 @@ class ChatScreen(BaseAppScreen):
 
     async def _refresh_active_character_avatar_if_scope_changed(self) -> None:
         """Refresh the cached character avatar only when the active character changed."""
+        if not resolve_show_character_avatar(
+            getattr(getattr(self, "app_instance", None), "app_config", {}) or {}
+        ):
+            # Feature is config-off: the rail section isn't composed, so
+            # skip the off-thread DB fetch + PIL decode below entirely and
+            # keep the cache empty for when the section is next shown.
+            self._active_character_avatar = None
+            self._active_character_avatar_name = None
+            return
         character_id = self._current_console_rail_character_id()
         scope = (character_id,)
         if scope == self._last_console_avatar_scope:
@@ -3980,14 +3989,24 @@ class ChatScreen(BaseAppScreen):
             holder = self.query_one("#console-character-avatar", Container)
         except QueryError:
             return  # section not composed (config off / not mounted)
-        await holder.remove_children()
-        await holder.mount(self._build_character_avatar_widget(self._active_character_avatar))
         try:
-            self.query_one("#console-character-name", Static).update(
-                self._active_character_avatar_name or "No character in this chat"
-            )
-        except QueryError:
-            pass
+            await holder.remove_children()
+            await holder.mount(self._build_character_avatar_widget(self._active_character_avatar))
+            try:
+                self.query_one("#console-character-name", Static).update(
+                    self._active_character_avatar_name or "No character in this chat"
+                )
+            except QueryError:
+                pass
+        except Exception:
+            # Must never raise: called from `_refresh_active_character_avatar_
+            # if_scope_changed` at two sites outside that method's own
+            # try/except, which is itself invoked unconditionally on every
+            # 0.2s Console sync tick (`_sync_native_console_chat_ui`) -- some
+            # worker dispatch sites run with `exit_on_error=True`, so an
+            # escaping mount failure (e.g. a session-switch/resume tick
+            # racing a transient layout state) could crash the app.
+            logger.opt(exception=True).debug("avatar: render into section failed")
 
     def _build_character_avatar_widget(self, spec: dict | None) -> Widget:
         """Build a fresh avatar widget from the cached spec (data, not a widget).
@@ -4006,10 +4025,9 @@ class ChatScreen(BaseAppScreen):
         fallback -- degrades to the same text placeholder used for the
         no-image case.
         """
-        from textual.widgets import Static as _S
         if not spec or (spec.get("pil") is None and spec.get("pixels") is None):
             hint = "no avatar" if (spec and spec.get("character_id") is not None) else "No character in this chat"
-            return _S(hint, id="console-character-avatar-empty")
+            return Static(hint, id="console-character-avatar-empty")
         if spec.get("mode") == "graphics" and spec.get("pil") is not None:
             try:
                 from textual_image.widget import Image as _GraphicsImage
@@ -4041,7 +4059,7 @@ class ChatScreen(BaseAppScreen):
             return widget
         except Exception:
             logger.opt(exception=True).debug("avatar: pixels build failed")
-            return _S("no avatar", id="console-character-avatar-empty")
+            return Static("no avatar", id="console-character-avatar-empty")
 
     def _console_session_id_for_workspace_conversation(
         self,

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -3942,6 +3942,12 @@ class ChatScreen(BaseAppScreen):
             # keep the cache empty for when the section is next shown.
             self._active_character_avatar = None
             self._active_character_avatar_name = None
+            # Invalidate the scope guard too: otherwise, if the feature is
+            # re-enabled while character_id is unchanged, the equality check
+            # below would early-return and the section would stay stuck in
+            # the empty state (Qodo #782-3). Resetting forces a repopulate on
+            # the next config-on tick.
+            self._last_console_avatar_scope = None
             return
         character_id = self._current_console_rail_character_id()
         scope = (character_id,)

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -2740,6 +2740,7 @@ max_tabs = 10  # Maximum number of chat tabs allowed
 [chat.images]
 enabled = true
 show_attach_button = true  # Show/hide the attach file button in chat
+# show_character_avatar = true  # show the active character's avatar in the Console left rail
 default_render_mode = "auto"  # auto, pixels, regular
 max_size_mb = 10.0
 auto_resize = true


### PR DESCRIPTION
## Roleplay P3c — persistent character avatar in the Console chat

Second cycle of the character-presence theme (P3b editor polish shipped in #772). Docks a live, always-visible avatar of the active character in a new **Character** section of the Console left rail, so "who am I talking to" is shown, not just a text chip.

### What it does
- Reads the active character **only** off the live `ConsoleChatSession` (`character_id`/`character_name`, set by #754 at Start-Chat / DB-resume / screen-state restore) — never legacy `app.current_chat_*` reactives (split-brain-safe).
- New config-gated (`[chat.images] show_character_avatar`, default **True**) collapsible **Character** rail section with an empty state ("No character in this chat") and a name label.
- Renders via the existing single `_console_image_cache` (`resolve_default_mode` + `fit_image_cell_size`) — graphics → pixels → text fallback, sized to the narrow rail.
- Refresh is **scope-guarded + off-thread** (`asyncio.to_thread` decode), caches a **spec dict** (not a live widget, so recompose can rebuild), re-checks scope after the await (drops a stale render on mid-decode session switch), and **never raises** into the ~0.2s Console sync tick.

### Constraints honored
- **No DB migration** (schema stays v22 — reads existing `character_cards.image` + `conversations.character_id`).
- `_active_console_dictionary_scope_ids` left **untouched** (it is not inert — it feeds the "what's in play" dictionary/world-book summaries; a non-tautological pin-test guards it).
- Zero-DB-on-recompose; characters-only; single render cache reused; config-off composes nothing.

### Tasks (SDD)
1. `resolve_show_character_avatar` config helper + `_current_console_rail_character_id/_name` accessors + dict-scope pin-test.
2. Config-gated "Character" rail section (`character_open` threaded through both `ConsoleRailState` dataclasses + construction sites + `CONSOLE_RAIL_SECTION_IDS` + serialize) + empty state.
3. Avatar cache-as-spec + scope-guarded off-thread refresh + async-awaited render + never-raise build.
4. Wire into `_sync_native_console_chat_ui` + integration.

### Review
Whole-branch review (opus): **APPROVE-WITH-NITS**, 0 Critical/Important, all 10 global constraints verified, 105/105 tests green. Both Minor findings fixed before this PR: render mount-path now wrapped so it never raises into the sync tick (plan-mandated invariant); refresh early-returns (skips DB fetch + PIL decode) when the feature is config-off (spec §Error-handling).

### Tests
`Tests/UI/test_console_character_avatar.py`, `Tests/UI/test_console_persistent_rails.py`, `Tests/Chat/test_console_image_view.py`, `Tests/Chat/test_console_rail_state.py` — all green; `import tldw_chatbook.app` clean.

Follow-ups (deferred): the identical unguarded `Pixels.from_image` pattern in `console_transcript._image_row_widget`; migrate the personas editor `_fit_avatar_cell_size` to the shared `fit_image_cell_size`; P3d (reaction/expression images from the tldw_server webui).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a persistent “Character” section to the Console left rail that shows the active character’s avatar and name, so it’s clear who you’re talking to. The avatar follows the session, uses the existing image pipeline, and never blocks or crashes the sync tick.

- **New Features**
  - New config-gated `[chat.images].show_character_avatar` (default true) to show a Character rail section with avatar + name.
  - Reads `character_id`/`character_name` only from the live `ConsoleChatSession` (no legacy reactives).
  - Reuses `ConsoleImageRenderCache`, respects `resolve_default_mode` (`graphics`/`pixels`) with text fallback; rail-fit via `fit_image_cell_size`.
  - Scope-guarded, off-thread decode; caches a spec (not a widget); zero DB on recompose; wired into `_sync_native_console_chat_ui`.
  - Adds `character_open` to `ConsoleRailState` and preference serialization; no DB migration (uses existing `character_cards.image` and `conversations.character_id`).

- **Bug Fixes**
  - Render/build and mount paths never raise; bad images or missing graphics path degrade to text.
  - Config-off path early-returns, skips DB fetch/PIL decode, and invalidates the scope guard so re-enabling repopulates without a character change.
  - Post-await scope check drops stale renders on mid-decode session switches.

<sup>Written for commit 44ed5478a23223c79b63101b795f7af9ca49799d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

