### PR TITLE
Token & context accuracy: per-model window, real estimator, config cleanup (TASK-320/321/325)

### DIFF
--- a/Docs/superpowers/plans/2026-07-22-token-context-accuracy.md
+++ b/Docs/superpowers/plans/2026-07-22-token-context-accuracy.md
@@ -1,0 +1,794 @@
+# Token & Context Accuracy Implementation Plan (TASK-320 / 321 / 325)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the model context window authoritative/config-overridable, replace all `.split()` token estimates with one consistent estimator, fix the token gauge's denominator, and remove the dead `chat_context_limit` config key — all through the existing `token_counter` seam so task-322's trimmer sharpens with no change to its code.
+
+**Architecture:** `model_capabilities.py` gains a `context_window` capability (pattern + direct, case-insensitive provider lookup); `token_counter.get_model_token_limit` consults it first then a refreshed table; a single `token_counter.estimate_tokens` (custom-gated → tiktoken → CJK-weighted chars floor) replaces every word-count path and both `count_tokens_*` functions delegate to it; the enhanced-chat gauge divides by the input window; `chat_context_limit` is deleted.
+
+**Tech Stack:** Python ≥3.11, pytest. tiktoken and the HF `tokenizers` lib are **absent** in the venv (estimator tests target the chars path).
+
+## Global Constraints
+
+- **Worktree:** all work happens in `/Users/macbook-dev/Documents/GitHub/tldw_chatbook-token-accuracy` (branch `feat/token-context-accuracy`, off `origin/dev @ dc21e3f04`, which contains task-322). Never touch the main checkout.
+- **Test command (venv lives in the main checkout):**
+  `cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook-token-accuracy && /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest <path> -v`
+- **Do NOT modify** `tldw_chatbook/Chat/console_history_budget.py` (task-322); it inherits improvements through `count_tokens_messages`/`get_model_token_limit`.
+- **Preserve these exact window values** (pinned by `Tests/Chat/test_token_counter.py`): `gpt-4`→8192, `gpt-4-32k`→32768, `gpt-4-turbo`→128000, `claude-3-opus-20240229`→200000, `claude-2`→100000, `"default"`→4096, unknown-openai-model→4096. The **only** intended value change: `gpt-3.5-turbo` 4096→16385.
+- **Fallback windows stay conservative.** Over-estimating a window is the only way to 400 the 322 budget; only bump the `anthropic` provider default (100000→200000). Keep `openai` 4096, `google` 30720, `mistral` 32000, `"default"` 4096.
+- **Capability patterns must be anchored and agree with the table** (a `context_window` a pattern returns must equal any table entry the same model would hit).
+- **Estimator constants:** `base_ratio` = `TOKENS_PER_CHAR_ESTIMATES.get(provider, default 0.25)`, `CJK_TOKENS_PER_CHAR = 1.0`, `ESTIMATE_HEADROOM = 1.2`. A 100-ASCII-char string must estimate in `(25, 50)` (keeps `test_character_estimation_fallback` green). Never use `.split()` for a token estimate.
+- **Signatures:** `estimate_tokens(text, model="gpt-3.5-turbo", provider="") -> int`; `count_tokens_messages(messages, model="gpt-3.5-turbo", provider="") -> int` (new trailing optional `provider`, so 322's `count_tokens_messages(flattened, model)` call is unchanged); `get_context_window(provider, model) -> int | None`.
+
+---
+
+## Task 1: `context_window` capability + case-insensitive provider lookup
+
+**Files:**
+- Modify: `tldw_chatbook/model_capabilities.py`
+- Test: `Tests/test_model_capabilities.py`
+
+**Interfaces:**
+- Produces: `ModelCapabilities.get_context_window(self, provider: str, model: str) -> int | None`; module `get_context_window(provider: str, model: str) -> int | None`. Direct mappings and the OpenAI/Anthropic family patterns carry a `context_window` int. Provider matching is case-insensitive.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `Tests/test_model_capabilities.py`:
+
+```python
+from tldw_chatbook.model_capabilities import ModelCapabilities, get_context_window
+
+
+def test_get_context_window_direct_mapping():
+    caps = ModelCapabilities({})  # uses DEFAULT_MODEL_* (no config file)
+    assert caps.get_context_window("OpenAI", "gpt-4o") == 128000
+    assert caps.get_context_window("Anthropic", "claude-3-opus-20240229") == 200000
+    assert caps.get_context_window("Google", "gemini-1.5-pro") == 2097152
+
+
+def test_get_context_window_via_family_pattern():
+    caps = ModelCapabilities({})
+    # A novel dated variant not in direct mappings resolves via the anchored pattern.
+    assert caps.get_context_window("OpenAI", "gpt-4o-2099-12-31") == 128000
+    assert caps.get_context_window("Anthropic", "claude-3-5-haiku-20991231") == 200000
+
+
+def test_get_context_window_unknown_is_none():
+    caps = ModelCapabilities({})
+    assert caps.get_context_window("OpenAI", "totally-unknown-model") is None
+    # Generic gpt-4 variant must NOT match a pattern (so the table's gpt-4 wins later).
+    assert caps.get_context_window("OpenAI", "gpt-4-some-variant") is None
+
+
+def test_provider_lookup_is_case_insensitive():
+    caps = ModelCapabilities({})
+    assert caps.is_vision_capable("openai", "gpt-4o") is True
+    assert caps.is_vision_capable("OpenAI", "gpt-4o") is True
+    assert caps.get_context_window("anthropic", "claude-3-opus-20240229") == \
+        caps.get_context_window("Anthropic", "claude-3-opus-20240229") == 200000
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook-token-accuracy && /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/test_model_capabilities.py -v -k "context_window or case_insensitive"`
+Expected: FAIL (`AttributeError: 'ModelCapabilities' object has no attribute 'get_context_window'`).
+
+- [ ] **Step 3: Add `context_window` to `DEFAULT_MODEL_CAPABILITIES`**
+
+In `tldw_chatbook/model_capabilities.py`, add a `"context_window"` key to these existing entries (leave all other keys/entries as-is):
+
+```python
+    # OpenAI
+    "gpt-4-vision-preview": {"vision": True, "max_images": 1, "context_window": 128000},
+    "gpt-4-turbo": {"vision": True, "max_images": 10, "context_window": 128000},
+    "gpt-4-turbo-2024-04-09": {"vision": True, "max_images": 10, "context_window": 128000},
+    "gpt-4o": {"vision": True, "max_images": 10, "context_window": 128000},
+    "gpt-4o-mini": {"vision": True, "max_images": 10, "context_window": 128000},
+    "gpt-4.1-2025-04-14": {"vision": True, "max_images": 10, "context_window": 1047576},
+    "o4-mini-2025-04-16": {"vision": True, "max_images": 10, "context_window": 200000},
+    "o3-2025-04-16": {"vision": True, "max_images": 10, "context_window": 200000},
+    "o3-mini-2025-01-31": {"vision": True, "max_images": 10, "context_window": 200000},
+    "gpt-4.1-mini-2025-04-14": {"vision": True, "max_images": 10, "context_window": 1047576},
+    "gpt-4.1-nano-2025-04-14": {"vision": True, "max_images": 10, "context_window": 1047576},
+    # Anthropic
+    "claude-3-opus-20240229": {"vision": True, "max_images": 5, "context_window": 200000},
+    "claude-3-sonnet-20240229": {"vision": True, "max_images": 5, "context_window": 200000},
+    "claude-3-haiku-20240307": {"vision": True, "max_images": 5, "context_window": 200000},
+    "claude-3-5-sonnet-20240620": {"vision": True, "max_images": 5, "context_window": 200000},
+    "claude-3-5-sonnet-20241022": {"vision": True, "max_images": 5, "context_window": 200000},
+    # Google
+    "gemini-pro-vision": {"vision": True, "max_images": 1, "context_window": 12288},
+    "gemini-1.5-pro": {"vision": True, "max_images": 10, "context_window": 2097152},
+    "gemini-1.5-flash": {"vision": True, "max_images": 10, "context_window": 1048576},
+    "gemini-2.0-flash": {"vision": True, "max_images": 10, "context_window": 1048576},
+```
+
+- [ ] **Step 4: Add `context_window` to OpenAI + Anthropic family patterns**
+
+In `DEFAULT_MODEL_PATTERNS`, add `"context_window"` to these entries (keep `vision` and every other pattern unchanged; do NOT add `context_window` to Google patterns — their `(pro|flash)` pattern spans non-uniform windows, so Google windows resolve via direct mappings + table):
+
+```python
+    "OpenAI": [
+        {"pattern": r"^gpt-4.*vision", "vision": True, "context_window": 128000},
+        {"pattern": r"^gpt-4[o0](?:-mini)?", "vision": True, "context_window": 128000},
+        {"pattern": r"^gpt-4.*turbo", "vision": True, "context_window": 128000},
+        {"pattern": r"^gpt-4\.1", "vision": True, "context_window": 1047576},
+        {"pattern": r"^o[34](?:-mini)?", "vision": True, "context_window": 200000},
+        {"pattern": r"^dall-e", "vision": True, "image_generation": True},
+    ],
+    "Anthropic": [
+        {"pattern": r"^claude-3", "vision": True, "context_window": 200000},
+        {"pattern": r"^claude.*opus-4", "vision": True, "context_window": 200000},
+        {"pattern": r"^claude.*sonnet-4", "vision": True, "context_window": 200000},
+    ],
+```
+
+- [ ] **Step 5: Make the provider pattern lookup case-insensitive**
+
+In `ModelCapabilities.__init__`, after `self._compiled_patterns = self._compile_patterns()` (currently line ~166), add a lower-cased index:
+
+```python
+        self._compiled_patterns = self._compile_patterns()
+        # Case-insensitive provider index: callers pass mixed/lowercase provider
+        # names ("openai") while pattern keys are title-case ("OpenAI").
+        self._provider_key_by_lower = {
+            provider.lower(): provider for provider in self._compiled_patterns
+        }
+```
+
+In `get_model_capabilities`, replace the pattern-block branch (currently `elif provider in self._compiled_patterns:` ... loop) with a case-insensitive resolve:
+
+```python
+        # 2. Check provider-specific patterns (case-insensitive provider match)
+        else:
+            provider_key = self._provider_key_by_lower.get((provider or "").lower())
+            if provider_key is not None:
+                for pattern, pattern_capabilities in self._compiled_patterns[provider_key]:
+                    if pattern.match(model):
+                        capabilities = pattern_capabilities.copy()
+                        logger.debug(
+                            f"Pattern matched for {provider}/{model}: {capabilities}"
+                        )
+                        break
+```
+
+- [ ] **Step 6: Add `get_context_window` (method + module function)**
+
+Add the method to `ModelCapabilities` (e.g. after `is_vision_capable`):
+
+```python
+    def get_context_window(self, provider: str, model: str) -> Optional[int]:
+        """Return the model's input context window, or None if unknown."""
+        return self.get_model_capabilities(provider, model).get("context_window")
+```
+
+Add the module convenience function near `is_vision_capable` (module level):
+
+```python
+def get_context_window(provider: str, model: str) -> Optional[int]:
+    """Convenience function to resolve a model's input context window."""
+    return get_model_capabilities().get_context_window(provider, model)
+```
+
+- [ ] **Step 7: Run the tests to verify pass**
+
+Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook-token-accuracy && /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/test_model_capabilities.py -v`
+Expected: PASS (new tests + all pre-existing capability tests still green).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tldw_chatbook/model_capabilities.py Tests/test_model_capabilities.py
+git commit -m "feat(capabilities): per-model context_window + case-insensitive provider lookup (TASK-320)"
+```
+
+---
+
+## Task 2: refreshed table + capabilities-first `get_model_token_limit`
+
+**Files:**
+- Modify: `tldw_chatbook/Utils/token_counter.py` (`MODEL_TOKEN_LIMITS`, `get_model_token_limit`)
+- Test: `Tests/Chat/test_token_counter.py`
+
+**Interfaces:**
+- Consumes: `model_capabilities.get_context_window(provider, model)` (Task 1).
+- Produces: `get_model_token_limit(model, provider="openai") -> int` resolving capabilities → exact table → longest-prefix table → provider default.
+
+- [ ] **Step 1: Update/extend the failing tests**
+
+In `Tests/Chat/test_token_counter.py`, change the one pinned value and add current-model + capabilities-override + longest-prefix tests:
+
+```python
+    def test_estimate_remaining_tokens(self):
+        """Test estimating remaining tokens"""
+        history = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there"},
+        ]
+        used, limit, remaining = estimate_remaining_tokens(
+            history, model="gpt-3.5-turbo", max_tokens_response=1000
+        )
+        assert used > 0
+        assert limit == 16385  # gpt-3.5-turbo refreshed input window
+        assert remaining < limit - 1000
+```
+
+```python
+    def test_get_model_token_limit_current_models(self):
+        assert get_model_token_limit("gpt-4o", "openai") == 128000
+        assert get_model_token_limit("claude-3-5-sonnet-20241022", "anthropic") == 200000
+        assert get_model_token_limit("gemini-1.5-pro", "google") == 2097152
+        assert get_model_token_limit("mistral-large", "mistral") == 128000
+
+    def test_get_model_token_limit_prefers_capabilities_over_table(self):
+        # A novel dated gpt-4o variant is not a table key; capabilities resolves it.
+        assert get_model_token_limit("gpt-4o-2099-12-31", "openai") == 128000
+
+    def test_get_model_token_limit_longest_prefix_wins(self):
+        # "gpt-4" (8192) must not shadow a more specific match; a bare gpt-4 variant
+        # with no capability pattern falls to the gpt-4 table prefix.
+        assert get_model_token_limit("gpt-4-some-variant", "openai") == 8192
+
+    def test_get_model_token_limit_anthropic_default_bumped(self):
+        # Unknown modern Claude falls back to the 200k floor, not the stale 100k.
+        assert get_model_token_limit("claude-99-future", "anthropic") == 200000
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `... -m pytest Tests/Chat/test_token_counter.py -v -k "current_models or capabilities or longest_prefix or anthropic_default or estimate_remaining"`
+Expected: FAIL (`test_estimate_remaining_tokens` asserts 16385 vs current 4096; new tests fail on stale values).
+
+- [ ] **Step 3: Refresh `MODEL_TOKEN_LIMITS`**
+
+Replace the `MODEL_TOKEN_LIMITS` dict body in `token_counter.py` with (keys stay full-length; preserved values unchanged except gpt-3.5-turbo):
+
+```python
+MODEL_TOKEN_LIMITS = {
+    # OpenAI
+    "gpt-4": 8192,
+    "gpt-4-32k": 32768,
+    "gpt-4-turbo": 128000,
+    "gpt-4-turbo-preview": 128000,
+    "gpt-4o": 128000,
+    "gpt-4o-mini": 128000,
+    "gpt-4.1": 1047576,
+    "gpt-3.5-turbo": 16385,
+    "gpt-3.5-turbo-16k": 16384,
+    "o1": 200000,
+    "o1-mini": 128000,
+    "o3": 200000,
+    "o3-mini": 200000,
+    "o4-mini": 200000,
+    # Anthropic
+    "claude-3-opus-20240229": 200000,
+    "claude-3-sonnet-20240229": 200000,
+    "claude-3-haiku-20240307": 200000,
+    "claude-3-5-sonnet-20240620": 200000,
+    "claude-3-5-sonnet-20241022": 200000,
+    "claude-2.1": 200000,
+    "claude-2": 100000,
+    "claude-instant-1.2": 100000,
+    # Google
+    "gemini-1.5-pro": 2097152,
+    "gemini-1.5-flash": 1048576,
+    "gemini-2.0-flash": 1048576,
+    "gemini-pro": 30720,
+    "gemini-pro-vision": 12288,
+    # Others
+    "mistral-large": 128000,
+    "mistral-medium": 32000,
+    "mistral-small": 32000,
+    "mixtral-8x7b": 32000,
+    # Default for unknown models
+    "default": 4096,
+}
+```
+
+- [ ] **Step 4: Rewrite `get_model_token_limit`**
+
+Replace the whole function body:
+
+```python
+def get_model_token_limit(model: str, provider: str = "openai") -> int:
+    """
+    Get the input context-window token limit for a specific model.
+
+    Resolves in priority order: the per-model capability `context_window`
+    (config-overridable), an exact table entry, the longest matching table
+    prefix, then a conservative provider default. Fallbacks lean conservative
+    on purpose: under-estimating the window degrades gracefully (more trimming),
+    while over-estimating is the only way to overflow the model on dispatch.
+    """
+    # 1. Per-model capability context window (authoritative, config-overridable).
+    try:
+        from tldw_chatbook.model_capabilities import get_context_window
+
+        window = get_context_window(provider, model)
+        if window is not None:
+            return window
+    except Exception as e:  # never let capability resolution break token limits
+        logger.debug(f"context_window lookup failed for {provider}/{model}: {e}")
+
+    # 2. Exact table match.
+    if model in MODEL_TOKEN_LIMITS:
+        return MODEL_TOKEN_LIMITS[model]
+
+    # 3. Longest matching table prefix (so "gpt-4" can't shadow "gpt-4-turbo").
+    best_limit = None
+    best_len = -1
+    for model_prefix, limit in MODEL_TOKEN_LIMITS.items():
+        if model_prefix == "default":
+            continue
+        if model.startswith(model_prefix) and len(model_prefix) > best_len:
+            best_limit = limit
+            best_len = len(model_prefix)
+    if best_limit is not None:
+        return best_limit
+
+    # 4. Conservative provider default.
+    provider_defaults = {
+        "anthropic": 200000,  # every modern Claude is >= 200k; safe floor
+        "google": 30720,
+        "openai": 4096,
+        "mistral": 32000,
+    }
+    return provider_defaults.get(provider, MODEL_TOKEN_LIMITS["default"])
+```
+
+- [ ] **Step 5: Run the pinned + new tests to verify pass**
+
+Run: `... -m pytest Tests/Chat/test_token_counter.py -v`
+Expected: PASS — including the pinned `test_get_model_token_limit_known_model`, `..._unknown_model` (4096), `..._by_prefix` (gpt-4-some-variant 8192, claude-3-opus-custom 4096), and the new tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/Utils/token_counter.py Tests/Chat/test_token_counter.py
+git commit -m "feat(tokens): capabilities-first get_model_token_limit + refreshed window table (TASK-320)"
+```
+
+---
+
+## Task 3: one `estimate_tokens`, delegate both counters, delete dead word-count
+
+**Files:**
+- Modify: `tldw_chatbook/Utils/custom_tokenizers.py` (add `has_tokenizers` + `custom_tokenizers_available`)
+- Modify: `tldw_chatbook/Utils/token_counter.py` (`estimate_tokens`, CJK helpers, `count_tokens_messages`, `count_tokens_chat_history`, import)
+- Modify: `tldw_chatbook/Chat/Chat_Functions.py` (delete `approximate_token_count`)
+- Test: `Tests/Chat/test_token_counter.py`
+
+**Interfaces:**
+- Produces: `estimate_tokens(text, model="gpt-3.5-turbo", provider="") -> int`; `count_tokens_messages(messages, model="gpt-3.5-turbo", provider="") -> int`; `CustomTokenizerManager.has_tokenizers() -> bool`; `custom_tokenizers_available() -> bool`.
+
+- [ ] **Step 1: Write the failing estimator tests**
+
+Add to `Tests/Chat/test_token_counter.py`:
+
+```python
+from tldw_chatbook.Utils.token_counter import estimate_tokens, count_tokens_messages
+
+
+class TestEstimator:
+    def test_empty_text_is_zero(self):
+        assert estimate_tokens("", "gpt-4o", "openai") == 0
+
+    def test_cjk_floor_at_least_one_token_per_char(self):
+        # CJK code points are >= ~1 token each; a conservative floor never under-counts.
+        cjk = "你好世界" * 10  # 40 CJK chars
+        assert estimate_tokens(cjk, "gemini-1.5-pro", "google") >= len(cjk)
+
+    def test_code_sample_exceeds_word_count(self):
+        code = "def f(x):\n    return [i*i for i in range(x) if i % 2 == 0]\n" * 3
+        assert estimate_tokens(code, "claude-3-5-sonnet-20241022", "anthropic") > len(code.split())
+
+    def test_ascii_100_chars_in_band(self):
+        # Keeps the pinned test_character_estimation_fallback assumptions valid.
+        assert 25 < estimate_tokens("A" * 100, "unknown", "unknown") < 50
+
+    def test_messages_and_chat_history_agree_for_one_message(self):
+        msg = [{"role": "user", "content": "hello world foo bar"}]
+        assert count_tokens_chat_history(msg, model="claude-3-5-sonnet-20241022",
+                                         provider="anthropic") == \
+            count_tokens_messages(msg, "claude-3-5-sonnet-20241022", "anthropic")
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `... -m pytest Tests/Chat/test_token_counter.py::TestEstimator -v`
+Expected: FAIL (`cannot import name 'estimate_tokens'`).
+
+- [ ] **Step 3: Add the availability gate to `custom_tokenizers.py`**
+
+Add a method to `CustomTokenizerManager` (near `count_tokens`):
+
+```python
+    def has_tokenizers(self) -> bool:
+        """Cheap availability check (no metrics, no I/O) — are any mappings loaded?"""
+        return bool(self._model_mappings)
+```
+
+Add a module function next to `count_tokens_with_custom`:
+
+```python
+def custom_tokenizers_available() -> bool:
+    """True only when a custom tokenizer could actually resolve (mappings loaded)."""
+    return get_tokenizer_manager().has_tokenizers()
+```
+
+- [ ] **Step 4: Extend the token_counter import to include the gate**
+
+In `token_counter.py`, replace the custom-tokenizers import block:
+
+```python
+try:
+    from .custom_tokenizers import (
+        count_tokens_with_custom,
+        count_messages_with_custom,
+        custom_tokenizers_available,
+    )
+
+    CUSTOM_TOKENIZERS_AVAILABLE = True
+except ImportError:
+    CUSTOM_TOKENIZERS_AVAILABLE = False
+    count_tokens_with_custom = None
+    count_messages_with_custom = None
+    custom_tokenizers_available = None
+```
+
+- [ ] **Step 5: Add the CJK constants + helpers + `estimate_tokens`**
+
+In `token_counter.py`, after `TOKENS_PER_CHAR_ESTIMATES` add:
+
+```python
+# Conservative chars-based estimate constants (used when no tokenizer is available).
+CJK_TOKENS_PER_CHAR = 1.0   # each CJK code point is >= ~1 token
+ESTIMATE_HEADROOM = 1.2     # documented headroom so estimates lean high (safe)
+
+_CJK_RANGES = (
+    (0x3040, 0x30FF),  # Hiragana + Katakana
+    (0x3400, 0x4DBF),  # CJK Unified Ext-A
+    (0x4E00, 0x9FFF),  # CJK Unified Ideographs
+    (0xAC00, 0xD7AF),  # Hangul syllables
+    (0xF900, 0xFAFF),  # CJK Compatibility Ideographs
+    (0xFF00, 0xFFEF),  # Fullwidth / halfwidth (CJK punctuation)
+)
+
+
+def _is_cjk(ch: str) -> bool:
+    cp = ord(ch)
+    return any(lo <= cp <= hi for lo, hi in _CJK_RANGES)
+
+
+def _chars_estimate(text: str, provider: str) -> int:
+    """Conservative chars-based token floor; weights CJK higher, applies headroom."""
+    cjk = sum(1 for ch in text if _is_cjk(ch))
+    other = len(text) - cjk
+    base_ratio = TOKENS_PER_CHAR_ESTIMATES.get(
+        provider or "default", TOKENS_PER_CHAR_ESTIMATES["default"]
+    )
+    return int((other * base_ratio + cjk * CJK_TOKENS_PER_CHAR) * ESTIMATE_HEADROOM)
+
+
+def estimate_tokens(text: str, model: str = "gpt-3.5-turbo", provider: str = "") -> int:
+    """Single text token estimator: custom tokenizer (gated) -> tiktoken -> chars floor.
+
+    Never uses whitespace word counts. `provider` only selects the chars-path
+    ratio; CJK weighting and the tiktoken/custom tiers are provider-independent.
+    """
+    if not text:
+        return 0
+    if CUSTOM_TOKENIZERS_AVAILABLE and custom_tokenizers_available():
+        custom = count_tokens_with_custom(text, model, provider)
+        if custom is not None:
+            return custom
+    if TIKTOKEN_AVAILABLE:
+        return count_tokens_tiktoken(text, model)
+    return _chars_estimate(text, provider)
+```
+
+- [ ] **Step 6: Delegate `count_tokens_messages` and `count_tokens_chat_history`**
+
+Replace `count_tokens_messages` (keep the per-message framing overhead; swap text counting to `estimate_tokens`; add the optional trailing `provider`):
+
+```python
+def count_tokens_messages(
+    messages: List[Dict[str, Any]], model: str = "gpt-3.5-turbo", provider: str = ""
+) -> int:
+    """Count tokens for OpenAI-format messages (framing overhead + estimate_tokens)."""
+    if not messages:
+        return 0
+
+    if model.startswith("gpt-3.5") or model.startswith("gpt-4"):
+        tokens_per_message = 3
+        tokens_per_name = 1
+        base_tokens = 3
+    else:
+        tokens_per_message = 2
+        tokens_per_name = 1
+        base_tokens = 2
+
+    total_tokens = base_tokens
+    for message in messages:
+        total_tokens += tokens_per_message
+        role = message.get("role", "")
+        if role:
+            total_tokens += estimate_tokens(role, model, provider)
+        content = message.get("content", "")
+        if content:
+            total_tokens += estimate_tokens(content, model, provider)
+        name = message.get("name", "")
+        if name:
+            total_tokens += tokens_per_name
+            total_tokens += estimate_tokens(name, model, provider)
+    return total_tokens
+```
+
+Also unify the `system_prompt` branch of `estimate_remaining_tokens` (so every count feeding that budget uses the one estimator). Replace its `if system_prompt:` block:
+
+```python
+    # Add system prompt if present
+    if system_prompt:
+        current_tokens += estimate_tokens(system_prompt, model, provider)
+```
+
+Replace `count_tokens_chat_history` so it converts formats and delegates (drop its custom/tiktoken/chars branches):
+
+```python
+def count_tokens_chat_history(
+    history: List[Union[Tuple[Optional[str], Optional[str]], Dict[str, Any]]],
+    model: str = "gpt-3.5-turbo",
+    provider: str = "openai",
+) -> int:
+    """Count tokens in chat-history format (tuples or message dicts) via the one estimator."""
+    if not history:
+        return 0
+
+    messages: List[Dict[str, Any]] = []
+    for item in history:
+        if isinstance(item, tuple) and len(item) == 2:
+            user_msg, bot_msg = item
+            if user_msg:
+                messages.append({"role": "user", "content": user_msg})
+            if bot_msg:
+                messages.append({"role": "assistant", "content": bot_msg})
+        elif isinstance(item, dict) and "role" in item and "content" in item:
+            messages.append(item)
+        else:
+            logger.warning(f"Unknown history format: {type(item)}")
+
+    return count_tokens_messages(messages, model, provider)
+```
+
+- [ ] **Step 7: Delete the dead `approximate_token_count`**
+
+In `tldw_chatbook/Chat/Chat_Functions.py`, delete the entire `approximate_token_count` function (the `def approximate_token_count(history): ...` block, ~lines 100-113). It has zero callers.
+
+- [ ] **Step 8: Run estimator + existing token tests + the 322 suite**
+
+Run: `... -m pytest Tests/Chat/test_token_counter.py Tests/Chat/test_console_history_budget.py -v`
+Expected: PASS — `TestEstimator`, the pre-existing `TestTokenCounter` (incl. `test_character_estimation_fallback` in (25,50) and `test_provider_specific_ratios`), and all task-322 tests (322's real-counter test asserts a *relative* image cost, so it stays green).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add tldw_chatbook/Utils/custom_tokenizers.py tldw_chatbook/Utils/token_counter.py tldw_chatbook/Chat/Chat_Functions.py Tests/Chat/test_token_counter.py
+git commit -m "feat(tokens): one estimate_tokens (custom/tiktoken/CJK-chars), delegate counters, drop dead word-count (TASK-321)"
+```
+
+---
+
+## Task 4: route the Console draft estimate through `estimate_tokens`
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py` (`_estimate_tokens`, import at line ~234)
+- Test: `Tests/Chat/test_chat_screen_token_estimate.py` (new)
+
+**Interfaces:**
+- Consumes: `estimate_tokens` (Task 3).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/Chat/test_chat_screen_token_estimate.py`:
+
+```python
+from types import SimpleNamespace
+
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+from tldw_chatbook.Utils.token_counter import estimate_tokens
+
+
+def test_estimate_tokens_uses_shared_estimator_no_split():
+    # Call the unbound method with a minimal self; it must delegate to estimate_tokens,
+    # never a .split() word count.
+    self_stub = SimpleNamespace()
+    text = "def f(x): return x*x  # a code-ish draft with symbols"
+    result = ChatScreen._estimate_tokens(self_stub, {"draft": text})
+    assert result == estimate_tokens(text, "", "")
+    # A word-count would be far lower than the chars-based estimate.
+    assert result != len(text.split())
+
+
+def test_estimate_tokens_none_for_empty_draft():
+    self_stub = SimpleNamespace()
+    assert ChatScreen._estimate_tokens(self_stub, {"draft": ""}) is None
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `... -m pytest Tests/Chat/test_chat_screen_token_estimate.py -v`
+Expected: FAIL (`result` uses `count_tokens_tiktoken`/`.split()`, not `estimate_tokens`).
+
+- [ ] **Step 3: Update the import and `_estimate_tokens`**
+
+In `tldw_chatbook/UI/Screens/chat_screen.py`, change the import at line ~234 from:
+
+```python
+from ...Utils.token_counter import count_tokens_tiktoken
+```
+
+to:
+
+```python
+from ...Utils.token_counter import estimate_tokens
+```
+
+Replace the `_estimate_tokens` method body (currently uses `count_tokens_tiktoken(text)` with a `.split()*1.3` except-fallback):
+
+```python
+    def _estimate_tokens(self, payload: dict[str, Any]) -> int | None:
+        """Return a token estimate for the current draft text."""
+        text = payload.get("draft", "")
+        if not text:
+            return None
+        return estimate_tokens(text, "", "")
+```
+
+`count_tokens_tiktoken` has exactly one use in this file (inside `_estimate_tokens`), so replacing the import is safe; if a grep shows another use, keep both imports.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `... -m pytest Tests/Chat/test_chat_screen_token_estimate.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/UI/Screens/chat_screen.py Tests/Chat/test_chat_screen_token_estimate.py
+git commit -m "feat(console): route draft token estimate through estimate_tokens (TASK-321)"
+```
+
+---
+
+## Task 5: gauge input-window denominator + remove `chat_context_limit`
+
+**Files:**
+- Modify: `tldw_chatbook/Event_Handlers/Chat_Events/chat_token_events.py` (add helper; both fix sites, lines ~155 & ~281)
+- Modify: `tldw_chatbook/config.py` (remove `chat_context_limit` at lines 84 & 3034)
+- Test: `Tests/Chat/test_token_display_limit.py` (new), `Tests/Chat/test_config_no_chat_context_limit.py` (new)
+
+**Interfaces:**
+- Produces: `chat_token_events._resolve_token_display_limit(total_limit: int, custom_limit: int) -> int`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/Chat/test_token_display_limit.py`:
+
+```python
+from tldw_chatbook.Event_Handlers.Chat_Events.chat_token_events import (
+    _resolve_token_display_limit,
+)
+
+
+def test_display_limit_is_input_window_by_default():
+    # AC#3: the gauge denominator is the model input window, not the output budget.
+    assert _resolve_token_display_limit(total_limit=128000, custom_limit=0) == 128000
+
+
+def test_display_limit_honors_custom_override():
+    assert _resolve_token_display_limit(total_limit=128000, custom_limit=5000) == 5000
+
+
+def test_display_limit_ignores_nonpositive_custom():
+    assert _resolve_token_display_limit(total_limit=200000, custom_limit=0) == 200000
+    assert _resolve_token_display_limit(total_limit=200000, custom_limit=-3) == 200000
+```
+
+Create `Tests/Chat/test_config_no_chat_context_limit.py`:
+
+```python
+from pathlib import Path
+
+import tldw_chatbook.config as config_mod
+from tldw_chatbook.config import DEFAULT_RAG_SEARCH_CONFIG
+
+
+def test_chat_context_limit_removed_from_defaults():
+    assert "chat_context_limit" not in DEFAULT_RAG_SEARCH_CONFIG
+
+
+def test_chat_context_limit_absent_from_config_source():
+    # 325 AC#2: no references remain (dict default + sample TOML both gone).
+    source = Path(config_mod.__file__).read_text(encoding="utf-8")
+    assert "chat_context_limit" not in source
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `... -m pytest Tests/Chat/test_token_display_limit.py Tests/Chat/test_config_no_chat_context_limit.py -v`
+Expected: FAIL (`cannot import name '_resolve_token_display_limit'`; `chat_context_limit` still present).
+
+- [ ] **Step 3: Add the display-limit helper**
+
+In `tldw_chatbook/Event_Handlers/Chat_Events/chat_token_events.py`, add a module-level helper (near the top, after imports):
+
+```python
+def _resolve_token_display_limit(total_limit: int, custom_limit: int) -> int:
+    """Gauge denominator: the model input window, unless a positive custom limit is set.
+
+    task-320 AC#3: usage is measured against the model *input* context window,
+    not the ~2048-token output-response budget.
+    """
+    return custom_limit if custom_limit > 0 else total_limit
+```
+
+- [ ] **Step 4: Use the helper at both gauge sites**
+
+At **both** occurrences (lines ~153-162 and ~279-288), replace this block:
+
+```python
+        # Use max_tokens_response as the display limit instead of model's total limit
+        # This allows users to see how their conversation measures against their configured limit
+        display_limit = max_tokens_response
+
+        # Check if there's a custom token limit setting (we'll add this later)
+        try:
+            custom_limit_widget = app.query_one("#chat-custom-token-limit", Input)
+            custom_limit = int(custom_limit_widget.value or "0")
+            if custom_limit > 0:
+                display_limit = custom_limit
+        except (QueryError, ValueError):
+            # No custom limit widget or invalid value, use max_tokens_response
+            pass
+```
+
+with:
+
+```python
+        # task-320 AC#3: measure usage against the model input window (total_limit),
+        # not the output-response budget. A positive custom-limit widget still wins.
+        try:
+            custom_limit_widget = app.query_one("#chat-custom-token-limit", Input)
+            custom_limit = int(custom_limit_widget.value or "0")
+        except (QueryError, ValueError):
+            custom_limit = 0
+        display_limit = _resolve_token_display_limit(total_limit, custom_limit)
+```
+
+(`total_limit` is already unpacked from `_estimate_tokens_cached(...)` above each site.)
+
+- [ ] **Step 5: Remove `chat_context_limit` from config**
+
+In `tldw_chatbook/config.py`, delete the line `"chat_context_limit": 10,` inside `DEFAULT_RAG_SEARCH_CONFIG` (line 84), and delete the line `chat_context_limit = 10` in the sample TOML under `[rag_search]` (line 3034). After this, `grep -c chat_context_limit tldw_chatbook/config.py` returns 0.
+
+- [ ] **Step 6: Run to verify pass**
+
+Run: `... -m pytest Tests/Chat/test_token_display_limit.py Tests/Chat/test_config_no_chat_context_limit.py Tests/Chat/test_footer_token_dirty_gate.py -v`
+Expected: PASS (new tests green; the footer dirty-gate suite — caching behavior — still green).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tldw_chatbook/Event_Handlers/Chat_Events/chat_token_events.py tldw_chatbook/config.py Tests/Chat/test_token_display_limit.py Tests/Chat/test_config_no_chat_context_limit.py
+git commit -m "fix(tokens): gauge divides by input window; remove dead chat_context_limit (TASK-320/325)"
+```
+
+---
+
+## Final verification (after all tasks)
+
+- [ ] Run the full affected suite:
+  `... -m pytest Tests/test_model_capabilities.py Tests/Chat/test_token_counter.py Tests/Chat/test_console_history_budget.py Tests/Chat/test_console_chat_controller.py Tests/Chat/test_footer_token_dirty_gate.py Tests/Chat/test_chat_screen_token_estimate.py Tests/Chat/test_token_display_limit.py Tests/Chat/test_config_no_chat_context_limit.py -v`
+  Expected: all pass (baseline non-related failures — the pre-existing `test_anthropic_native_tools` failure and the `mocker`-fixture errors in `test_chat_functions.py` — are unaffected by this branch).
+- [ ] Confirm `git grep -n "\.split()" tldw_chatbook/Utils/token_counter.py tldw_chatbook/Chat/Chat_Functions.py tldw_chatbook/UI/Screens/chat_screen.py` shows no `.split()` token estimate remains.
+- [ ] Update the three backlog task files (`task-320`, `task-321`, `task-325`) — check ACs, add Implementation Notes — as the final step before finishing the branch.

--- a/Docs/superpowers/specs/2026-07-22-token-context-accuracy-design.md
+++ b/Docs/superpowers/specs/2026-07-22-token-context-accuracy-design.md
@@ -1,0 +1,204 @@
+# Token & context accuracy: per-model window, real estimator, config cleanup (TASK-320 / 321 / 325)
+
+**Date**: 2026-07-22
+**Status**: Approved design, pending implementation plan
+**Base**: origin/dev @ `dc21e3f04` (contains task-322, PR #778)
+**Backlog**: TASK-320, TASK-321, TASK-325 (all "To Do", no listed deps)
+
+## Why
+
+The token/window numbers behind every budget and gauge are wrong or stale, and
+task-322's Console history trimmer consumes them through the `token_counter`
+seam, so its correctness is capped by theirs.
+
+- **No authoritative per-model window (320).** `MODEL_TOKEN_LIMITS`
+  (`token_counter.py`) predates current models (no gpt-4o, gpt-4.1, o1/o3,
+  claude-3.5/3.7/4, gemini-1.5/2), so `get_model_token_limit` falls back to
+  wrong conservative defaults (Anthropic 100k vs real 200k). No `context_window`
+  exists in `model_capabilities.py` (only `vision`/`max_images`). The token
+  gauge (`chat_token_events.py`) divides usage by the ~2048-token *output*
+  budget instead of the model *input* window.
+- **Word-count token estimation (321).** When tiktoken is absent,
+  `count_tokens_messages` counts whitespace words (`content.split()`);
+  `count_tokens_chat_history` uses a chars estimate for non-OpenAI even with
+  tiktoken; and `approximate_token_count` (`Chat_Functions.py`) is a dead
+  whitespace word count. Word counts under-count real tokens (~1.3–1.5× for
+  English, far more for code/CJK), so any budget built on them still overflows.
+- **Dead config key (325).** `chat_context_limit = 10` sits under `[rag_search]`,
+  is never read anywhere, and silently no-ops for a user who sets it.
+
+This makes the window authoritative and config-overridable, makes token
+estimates a real conservative floor everywhere, and removes the dead key —
+without changing task-322's code (it sharpens through the shared seam).
+
+## Decisions (user-approved)
+
+1. **Remove `chat_context_limit`** (not wire it). It is superseded by 322's
+   model-aware token bound; adding an overlapping message-count cap under the
+   wrong config section is confusing. Satisfies 325 AC#1's "or is removed".
+2. **Fix the token gauge in place.** The gauge lives in the deprecated-but-still-
+   scheduled enhanced-chat path (`chat_token_events.py`); the Console has none.
+   Swap its denominator to the model input window (a ~1-line correctness fix on
+   still-shipped code) rather than descoping 320 AC#3.
+
+## Architecture
+
+Three well-bounded units plus one deletion. All flow through the existing
+`token_counter` seam; `console_history_budget` (322) is untouched and inherits
+the improvements.
+
+### Unit A — Per-model context window (320 AC#1/#2)
+
+**`model_capabilities.py`:** add a `context_window` capability, exactly parallel
+to `vision`/`max_images`.
+
+- Extend `DEFAULT_MODEL_PATTERNS` entries and `DEFAULT_MODEL_CAPABILITIES` with
+  a `context_window` (int) field for current families/models. `context_window`
+  is the model **input** window and is distinct from the existing `max_tokens`
+  (output cap) key already present on some entries — do not conflate them.
+- Add `ModelCapabilities.get_context_window(provider, model) -> int | None`
+  (reads `get_model_capabilities(provider, model).get("context_window")`) and a
+  module convenience `get_context_window(provider, model)`.
+- **Case-insensitive provider lookup (review finding — real latent bug).**
+  `DEFAULT_MODEL_PATTERNS` keys providers title-case (`"OpenAI"`,`"Anthropic"`)
+  and `get_model_capabilities` matches `provider in self._compiled_patterns`
+  case-sensitively, but callers pass mixed/lowercase (`get_model_token_limit`'s
+  own defaults use `"openai"`; 322 passes `resolution.provider`). A lowercase
+  caller silently misses the pattern block. Fix by resolving the provider
+  key case-insensitively (build `self._compiled_patterns` lookups against a
+  lower-cased provider, or normalize both sides at match time). This also
+  hardens the existing `is_vision_capable` path; a regression test asserts
+  vision resolves for both `"openai"` and `"OpenAI"`.
+
+**`token_counter.py`:** rewrite `get_model_token_limit(model, provider)` to
+resolve in priority order:
+1. `model_capabilities.get_context_window(provider, model)` if not `None`
+   (lazy import inside the function to avoid the config circular import, the
+   same pattern `ModelCapabilities.__init__` uses).
+2. Exact match in a **refreshed** `MODEL_TOKEN_LIMITS`.
+3. **Longest-prefix** match in `MODEL_TOKEN_LIMITS` (review finding: the current
+   arbitrary-order `startswith` lets `"gpt-4"` (8192) shadow `"gpt-4o"`; iterate
+   candidates and pick the longest matching prefix so specific entries win).
+4. Provider default, else `MODEL_TOKEN_LIMITS["default"]`.
+
+Refreshed `MODEL_TOKEN_LIMITS` (current published **input** windows; concrete
+values, verify at implementation): gpt-4o/gpt-4o-mini 128000, gpt-4-turbo
+128000, gpt-4.1* 1047576, gpt-4 8192, gpt-3.5-turbo 16385, o1 200000, o1-mini
+128000, o3/o3-mini/o4-mini 200000; claude-3-opus/haiku/sonnet 200000,
+claude-3-5-* 200000, claude-3-7-* 200000, claude-opus-4-*/sonnet-4-* 200000,
+claude-2.1 200000, claude-2 100000; gemini-1.5-pro 2097152, gemini-1.5-flash
+1048576, gemini-2.* 1048576, gemini-pro 30720; mistral-large 128000,
+mistral-small/medium 32000, mixtral-8x7b 32000; `"default"` 8192. Provider
+defaults lean to the provider's common current window but stay a conservative
+floor (anthropic 200000, google 1048576, openai 128000, mistral 32000).
+**Safety note:** for the 322 budget, under-estimating the window is safe (it
+trims more, never 400s); over-estimating an unknown model is the only risk, so
+truly-unknown models keep the conservative `"default"`.
+
+### Unit B — One consistent estimator, no `.split()` (321 AC#1/#2/#3)
+
+**`token_counter.py`:** add `estimate_tokens(text, model, provider) -> int`, the
+single text-token estimator, tiered:
+
+1. **Custom tokenizer** — `count_tokens_with_custom(text, model, provider)`,
+   only behind a cheap availability gate. The `CustomTokenizerManager` singleton
+   (`get_tokenizer_manager()`) logs metrics on every `count_tokens` call even
+   when it will return `None`, so calling it per trim iteration adds overhead to
+   322's hot path (review finding). Add `CustomTokenizerManager.has_tokenizers()
+   -> bool` returning `bool(self._model_mappings)` (no metrics, no I/O) and a
+   module `custom_tokenizers_available() -> bool` (`CUSTOM_TOKENIZERS_AVAILABLE
+   and get_tokenizer_manager().has_tokenizers()`). Enter the custom tier only
+   when that is true — the default install (no `mappings.json`) pays nothing.
+2. **tiktoken** — `count_tokens_tiktoken(text, model)` when `TIKTOKEN_AVAILABLE`.
+3. **Chars-based conservative estimate** (always available), replacing every
+   `.split()`:
+   ```
+   estimate = int((non_cjk_chars * base_ratio + cjk_chars * CJK_TOKENS_PER_CHAR)
+                   * ESTIMATE_HEADROOM)
+   ```
+   where `base_ratio = TOKENS_PER_CHAR_ESTIMATES.get(provider, 0.25)`,
+   `CJK_TOKENS_PER_CHAR = 1.0` (each CJK code point is ≥ ~1 token — a floor),
+   `ESTIMATE_HEADROOM = 1.2` (documented headroom so English/code lean high, the
+   safe direction). CJK detection covers Hiragana/Katakana (U+3040–30FF), CJK
+   Unified + Ext-A (U+3400–4DBF, U+4E00–9FFF), Hangul (U+AC00–D7AF), CJK compat
+   (U+F900–FAFF), and fullwidth/CJK punctuation (U+FF00–FFEF).
+
+**Delegation (single chain, no double-counting).**
+- `estimate_tokens(text, model, provider: str = "")` — the one estimator.
+  `provider` is optional and only selects the chars-path `base_ratio`
+  (`""`/unknown → 0.25); the CJK weighting, tiktoken tier, and custom-gate are
+  provider-independent (the custom tier resolves by `model`+`provider` when
+  available).
+- `count_tokens_messages(messages, model, provider: str = "")` — gains an
+  optional trailing `provider`; sums `estimate_tokens` over role/content/name
+  and keeps its per-message framing overhead (`tokens_per_message`,
+  `base_tokens`) unchanged. The new param is trailing and optional, so 322's
+  existing `count_tokens_messages(flattened, model)` call is unchanged (it
+  resolves `provider=""` → generic ratio, which is fine — CJK weighting, the
+  dominant factor, is provider-independent).
+- `count_tokens_chat_history(history, model, provider)` — converts its
+  tuple/dict history to messages and returns
+  `count_tokens_messages(messages, model, provider)`. Its bespoke branches (the
+  message-level `count_messages_with_custom` tier, the OpenAI-only tiktoken
+  gate, and the divergent chars branch) are **removed** — all custom/tiktoken/
+  chars logic now lives once, inside `estimate_tokens`, so there is exactly one
+  estimator and no double custom-counting.
+- Delete the dead `approximate_token_count` (`Chat_Functions.py`; zero callers
+  dev-wide).
+
+`console_history_budget` (322) is untouched: its `count_tokens_messages(
+flattened, model)` call keeps working and now routes through `estimate_tokens`.
+
+**Documented behavior shift:** non-OpenAI users *with* tiktoken installed now
+get tiktoken-based counts (higher, more accurate) instead of the old chars
+estimate; without tiktoken they get the improved chars floor instead of word
+counts. Both directions lean higher (safer for budgets).
+
+### Unit C — Gauge ceiling fix + config cleanup (320 AC#3, 325)
+
+- **`chat_token_events.py`:** set the gauge denominator to the model input
+  window (`total_limit`, already returned by `estimate_remaining_tokens`)
+  instead of `max_tokens_response`, preserving the existing
+  `#chat-custom-token-limit` manual override that follows. Remove the stale
+  "measures against configured limit" comment.
+- **`config.py`:** remove `chat_context_limit` from `DEFAULT_RAG_SEARCH_CONFIG`
+  and from the sample TOML under `[rag_search]`. Verified zero references
+  dev-wide outside `config.py`, so no consumer breaks; the loader merges over
+  defaults, so a leftover key in an existing user file is a harmless no-op
+  (no migration needed).
+
+## Testing
+
+- **Window lookup (320 AC#4):** `get_model_token_limit` returns the correct
+  current window for ≥1 current model per major provider (gpt-4o→128000,
+  claude-3-5-sonnet→200000, gemini-1.5-pro→2097152, mistral-large→128000);
+  a `[model_capabilities]`-configured `context_window` pattern overrides the
+  table; longest-prefix beats a shorter shadowing prefix (`gpt-4o` ≠ `gpt-4`);
+  truly-unknown model → conservative default.
+- **Case-insensitivity (Unit A):** `is_vision_capable` and `get_context_window`
+  resolve identically for `"openai"` and `"OpenAI"`.
+- **Estimator floors (321 AC#3), property-based (tiktoken absent, so no
+  reference tokenizer):** a pure-CJK string estimates `>= len(text)` (CJK floor);
+  a code sample estimates strictly greater than its whitespace word count
+  (`> len(sample.split())`, proving it is not the old `.split()` and leans
+  high); an empty string → 0; `count_tokens_messages` with the chars path
+  returns a value strictly greater than the summed word counts of its contents.
+- **Consistency:** for a single `{role, content}` message,
+  `count_tokens_chat_history([...], model, provider)` equals
+  `count_tokens_messages([...], model, provider)` (chat_history now delegates),
+  and both are `> 0` for non-empty content with tiktoken absent (chars path).
+- **Gauge (320 AC#3):** the display limit passed to `format_token_display`
+  equals `get_model_token_limit(model, provider)` (not `max_tokens_response`)
+  when no custom-limit widget value is set; a custom value still overrides.
+- **Removal (325 AC#2):** a test asserts `chat_context_limit` is absent from the
+  loaded default config and the generated sample TOML.
+
+## Out of scope
+
+- task-322 trimmer logic (unchanged; it only benefits).
+- Per-provider `per_image_tokens` calibration (322's flat estimate stays).
+- A Console token gauge (Console has none today; not added here).
+- Downloading/bundling real provider tokenizer files (the custom tier stays
+  opt-in via user-installed `~/.config/tldw_cli/tokenizers/mappings.json`).
+- Migrating existing user configs that still contain `chat_context_limit`
+  (harmless unknown key).

--- a/Docs/superpowers/specs/2026-07-22-token-context-accuracy-design.md
+++ b/Docs/superpowers/specs/2026-07-22-token-context-accuracy-design.md
@@ -161,8 +161,24 @@ single text-token estimator, tiered:
   gate, and the divergent chars branch) are **removed** — all custom/tiktoken/
   chars logic now lives once, inside `estimate_tokens`, so there is exactly one
   estimator and no double custom-counting.
+- **`chat_screen._estimate_tokens`** (`UI/Screens/chat_screen.py`) — the
+  Console draft token estimate shown in `ConsoleContextModal` — currently does
+  `count_tokens_tiktoken(text)` with an `except` fallback of
+  `int(len(text.split()) * 1.3)` (a `.split()` token estimate, AC#1 violation;
+  a UI count, AC#2 scope). Replace its body with
+  `estimate_tokens(text, model, provider)` using the active session's model/
+  provider when readily available, else `""` (generic ratio) — removing the
+  last `.split()` token estimate and unifying it onto the one estimator.
 - Delete the dead `approximate_token_count` (`Chat_Functions.py`; zero callers
   dev-wide).
+
+**AC#1 completeness.** A dev-wide sweep for `.split()` token estimates found
+exactly these three in-scope sites (`count_tokens_messages`,
+`approximate_token_count`, `chat_screen._estimate_tokens`). The remaining
+`.split()` uses are intentionally **out of scope**: `local_writing_service.
+_word_count` (a literal word count), the Evals `metrics_calculator` /
+`DEVELOPER_GUIDE` (BLEU/ROUGE/F1 token-overlap scoring, not context budgeting),
+and dictation/STTS/wizard display word counts.
 
 `console_history_budget` (322) is untouched: its `count_tokens_messages(
 flattened, model)` call keeps working and now routes through `estimate_tokens`.

--- a/Docs/superpowers/specs/2026-07-22-token-context-accuracy-design.md
+++ b/Docs/superpowers/specs/2026-07-22-token-context-accuracy-design.md
@@ -81,19 +81,37 @@ resolve in priority order:
    candidates and pick the longest matching prefix so specific entries win).
 4. Provider default, else `MODEL_TOKEN_LIMITS["default"]`.
 
-Refreshed `MODEL_TOKEN_LIMITS` (current published **input** windows; concrete
-values, verify at implementation): gpt-4o/gpt-4o-mini 128000, gpt-4-turbo
-128000, gpt-4.1* 1047576, gpt-4 8192, gpt-3.5-turbo 16385, o1 200000, o1-mini
-128000, o3/o3-mini/o4-mini 200000; claude-3-opus/haiku/sonnet 200000,
-claude-3-5-* 200000, claude-3-7-* 200000, claude-opus-4-*/sonnet-4-* 200000,
-claude-2.1 200000, claude-2 100000; gemini-1.5-pro 2097152, gemini-1.5-flash
-1048576, gemini-2.* 1048576, gemini-pro 30720; mistral-large 128000,
-mistral-small/medium 32000, mixtral-8x7b 32000; `"default"` 8192. Provider
-defaults lean to the provider's common current window but stay a conservative
-floor (anthropic 200000, google 1048576, openai 128000, mistral 32000).
-**Safety note:** for the 322 budget, under-estimating the window is safe (it
-trims more, never 400s); over-estimating an unknown model is the only risk, so
-truly-unknown models keep the conservative `"default"`.
+Refreshed `MODEL_TOKEN_LIMITS` (current published **input** windows; verify at
+implementation). **ADD** current models: gpt-4o/gpt-4o-mini 128000, gpt-4.1*
+1047576, o1 200000, o1-mini 128000, o3/o3-mini/o4-mini 200000, claude-3-5-*
+200000, claude-3-7-* 200000, claude-opus-4-*/sonnet-4-* 200000, gemini-1.5-pro
+2097152, gemini-1.5-flash 1048576, gemini-2.* 1048576, mistral-large 128000.
+**PRESERVE exactly** (pinned by existing tests): gpt-4 8192, gpt-4-32k 32768,
+gpt-4-turbo 128000, claude-3-opus-20240229 200000, claude-2 100000,
+`"default"` **4096**. **The one value correction:** gpt-3.5-turbo 4096 → 16385
+(current real window; requires updating one existing test assertion, below).
+Table keys stay **full-length** (e.g. `claude-3-opus-20240229`, not a bare
+`claude-3-opus`) so the longest-prefix fallback can't shadow a shorter key.
+
+**Provider defaults — keep conservative; one bump.** Bump `anthropic`
+100000 → 200000 only (task-named, and the safe floor since every modern Claude
+is ≥ 200k). Keep `openai` 4096, `google` 30720, `mistral` 32000, and
+`"default"` 4096. **Safety principle:** for the 322 budget, under-estimating the
+window is safe (it trims more, never 400s); over-estimating an unknown model is
+the only way to cause a provider 400, so fallback/unknown defaults stay
+conservative and accuracy comes from the per-model capability patterns and
+full table entries — never from raising the fallbacks.
+
+**Capability-pattern anchoring & agreement.** Because `get_model_token_limit`
+consults capabilities **before** the table, `context_window` patterns must be
+specific/anchored (e.g. `^gpt-4o`, `^gpt-4\.1`, `^o[134]`, `^claude-3-5`,
+`^claude.*sonnet-4`, `gemini-1\.5`, `gemini-2\.`) so they do not match generic
+synthetic variants (`gpt-4-some-variant` must still fall through to the table's
+`gpt-4` → 8192, and bare `gpt-4`/`gpt-4-32k` must match no pattern). Where a
+pattern *can* also match a preserved-value model, its `context_window` must
+**agree** with the table (e.g. the `claude-3` pattern's `context_window` =
+200000 = table `claude-3-opus-20240229`), so capabilities-first never returns a
+number the pinned tests don't expect.
 
 ### Unit B — One consistent estimator, no `.split()` (321 AC#1/#2/#3)
 
@@ -192,6 +210,30 @@ counts. Both directions lean higher (safer for budgets).
   when no custom-limit widget value is set; a custom value still overrides.
 - **Removal (325 AC#2):** a test asserts `chat_context_limit` is absent from the
   loaded default config and the generated sample TOML.
+
+**Existing tests (`Tests/Chat/test_token_counter.py`) — update / keep green.**
+This suite pins the exact values above; the design deliberately keeps almost all
+of it passing:
+- **Update (intended):** `test_estimate_remaining_tokens` asserts
+  `limit == 4096` for `gpt-3.5-turbo`; change to `16385` (the refreshed window).
+- **Kept green by the value choices above:**
+  `test_get_model_token_limit_known_model` (gpt-4 8192 / gpt-4-32k 32768 /
+  gpt-4-turbo 128000 / claude-3-opus-20240229 200000 preserved);
+  `test_get_model_token_limit_unknown_model` (`"default"` stays 4096);
+  `test_get_model_token_limit_by_prefix` (full-length claude keys + anchored
+  patterns keep `claude-3-opus-custom` → openai default 4096, and
+  `gpt-4-some-variant` → `gpt-4` 8192).
+- **Chars-constant constraint:** `test_character_estimation_fallback` asserts a
+  100-ASCII-char message estimates in `(25, 50)`. With `base_ratio 0.25 ×
+  HEADROOM 1.2 = 0.30` plus message overhead this lands ~35 — the constants
+  must keep a 100-char ASCII string in that band (i.e. `base_ratio × headroom`
+  well under 0.5).
+- `test_tiktoken_counting` is `skipif(not TIKTOKEN_AVAILABLE)` → skipped in the
+  venv; the estimator tests target the chars path deterministically.
+- `Tests/Chat/test_footer_token_dirty_gate.py` asserts caching behavior
+  (re-tokenize counts, `cached == direct`) and relative sums, not exact token
+  values or the gauge denominator, so it survives; confirm its `tokenizer_spy`
+  fixture still patches the kept `count_tokens_chat_history` boundary.
 
 ## Out of scope
 

--- a/Tests/Chat/test_chat_screen_token_estimate.py
+++ b/Tests/Chat/test_chat_screen_token_estimate.py
@@ -1,0 +1,20 @@
+from types import SimpleNamespace
+
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+from tldw_chatbook.Utils.token_counter import estimate_tokens
+
+
+def test_estimate_tokens_uses_shared_estimator_no_split():
+    # Call the unbound method with a minimal self; it must delegate to estimate_tokens,
+    # never a .split() word count.
+    self_stub = SimpleNamespace()
+    text = "def f(x): return x*x  # a code-ish draft with symbols"
+    result = ChatScreen._estimate_tokens(self_stub, {"draft": text})
+    assert result == estimate_tokens(text, "", "")
+    # A word-count would be far lower than the chars-based estimate.
+    assert result != len(text.split())
+
+
+def test_estimate_tokens_none_for_empty_draft():
+    self_stub = SimpleNamespace()
+    assert ChatScreen._estimate_tokens(self_stub, {"draft": ""}) is None

--- a/Tests/Chat/test_config_no_chat_context_limit.py
+++ b/Tests/Chat/test_config_no_chat_context_limit.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+import tldw_chatbook.config as config_mod
+from tldw_chatbook.config import DEFAULT_RAG_SEARCH_CONFIG
+
+
+def test_chat_context_limit_removed_from_defaults():
+    assert "chat_context_limit" not in DEFAULT_RAG_SEARCH_CONFIG
+
+
+def test_chat_context_limit_absent_from_config_source():
+    # 325 AC#2: no references remain (dict default + sample TOML both gone).
+    source = Path(config_mod.__file__).read_text(encoding="utf-8")
+    assert "chat_context_limit" not in source

--- a/Tests/Chat/test_token_counter.py
+++ b/Tests/Chat/test_token_counter.py
@@ -77,14 +77,17 @@ class TestTokenCounter:
         assert get_model_token_limit("gemini-1.5-pro", "google") == 2097152
         assert get_model_token_limit("mistral-large", "mistral") == 128000
 
-    def test_get_model_token_limit_prefers_capabilities_over_table(self):
-        # A novel dated gpt-4o variant is not a table key; capabilities resolves it.
-        assert get_model_token_limit("gpt-4o-2099-12-31", "openai") == 128000
+    def test_get_model_token_limit_prefers_capabilities_over_table(self, monkeypatch):
+        # Capabilities must be consulted before the table: patch get_context_window
+        # to a sentinel and confirm even a model WITH a table entry returns it.
+        import tldw_chatbook.model_capabilities as mc
+        monkeypatch.setattr(mc, "get_context_window", lambda provider, model: 999999)
+        assert get_model_token_limit("gpt-4", "openai") == 999999  # table would say 8192
 
     def test_get_model_token_limit_longest_prefix_wins(self):
-        # "gpt-4" (8192) must not shadow a more specific match; a bare gpt-4 variant
-        # with no capability pattern falls to the gpt-4 table prefix.
-        assert get_model_token_limit("gpt-4-some-variant", "openai") == 8192
+        # No capability pattern matches "gpt-4-32k-custom"; both "gpt-4" (8192) and
+        # "gpt-4-32k" (32768) are table prefixes, so the LONGEST must win.
+        assert get_model_token_limit("gpt-4-32k-custom", "openai") == 32768
 
     def test_get_model_token_limit_anthropic_default_bumped(self):
         # Unknown modern Claude falls back to the 200k floor, not the stale 100k.

--- a/Tests/Chat/test_token_counter.py
+++ b/Tests/Chat/test_token_counter.py
@@ -218,6 +218,12 @@ class TestEstimator:
         cjk = "你好世界" * 10  # 40 CJK chars
         assert estimate_tokens(cjk, "gemini-1.5-pro", "google") >= len(cjk)
 
+    def test_cjk_punctuation_floor(self):
+        # CJK Symbols & Punctuation (U+3000-303F) must be weighted as CJK, not ASCII,
+        # so punctuation-heavy CJK text still meets the conservative floor.
+        punct = "、。" * 20  # 40 CJK-punctuation chars
+        assert estimate_tokens(punct, "gemini-1.5-pro", "google") >= len(punct)
+
     def test_code_sample_exceeds_word_count(self):
         code = "def f(x):\n    return [i*i for i in range(x) if i % 2 == 0]\n" * 3
         assert estimate_tokens(code, "claude-3-5-sonnet-20241022", "anthropic") > len(code.split())

--- a/Tests/Chat/test_token_counter.py
+++ b/Tests/Chat/test_token_counter.py
@@ -67,10 +67,28 @@ class TestTokenCounter:
         used, limit, remaining = estimate_remaining_tokens(
             history, model="gpt-3.5-turbo", max_tokens_response=1000
         )
-
         assert used > 0
-        assert limit == 4096  # GPT-3.5 default
-        assert remaining < limit - 1000  # Less than limit minus response reservation
+        assert limit == 16385  # gpt-3.5-turbo refreshed input window
+        assert remaining < limit - 1000
+
+    def test_get_model_token_limit_current_models(self):
+        assert get_model_token_limit("gpt-4o", "openai") == 128000
+        assert get_model_token_limit("claude-3-5-sonnet-20241022", "anthropic") == 200000
+        assert get_model_token_limit("gemini-1.5-pro", "google") == 2097152
+        assert get_model_token_limit("mistral-large", "mistral") == 128000
+
+    def test_get_model_token_limit_prefers_capabilities_over_table(self):
+        # A novel dated gpt-4o variant is not a table key; capabilities resolves it.
+        assert get_model_token_limit("gpt-4o-2099-12-31", "openai") == 128000
+
+    def test_get_model_token_limit_longest_prefix_wins(self):
+        # "gpt-4" (8192) must not shadow a more specific match; a bare gpt-4 variant
+        # with no capability pattern falls to the gpt-4 table prefix.
+        assert get_model_token_limit("gpt-4-some-variant", "openai") == 8192
+
+    def test_get_model_token_limit_anthropic_default_bumped(self):
+        # Unknown modern Claude falls back to the 200k floor, not the stale 100k.
+        assert get_model_token_limit("claude-99-future", "anthropic") == 200000
 
     def test_format_token_display_green(self):
         """Test token display formatting - green indicator"""

--- a/Tests/Chat/test_token_counter.py
+++ b/Tests/Chat/test_token_counter.py
@@ -13,6 +13,7 @@ from tldw_chatbook.Utils.token_counter import (
     format_token_display,
     TIKTOKEN_AVAILABLE,
 )
+from tldw_chatbook.Utils.token_counter import estimate_tokens, count_tokens_messages
 #
 ########################################################################################################################
 #
@@ -176,6 +177,30 @@ class TestTokenCounter:
 
         result = count_tokens_chat_history(history)
         assert result > 0  # Should handle mixed formats gracefully
+
+
+class TestEstimator:
+    def test_empty_text_is_zero(self):
+        assert estimate_tokens("", "gpt-4o", "openai") == 0
+
+    def test_cjk_floor_at_least_one_token_per_char(self):
+        # CJK code points are >= ~1 token each; a conservative floor never under-counts.
+        cjk = "你好世界" * 10  # 40 CJK chars
+        assert estimate_tokens(cjk, "gemini-1.5-pro", "google") >= len(cjk)
+
+    def test_code_sample_exceeds_word_count(self):
+        code = "def f(x):\n    return [i*i for i in range(x) if i % 2 == 0]\n" * 3
+        assert estimate_tokens(code, "claude-3-5-sonnet-20241022", "anthropic") > len(code.split())
+
+    def test_ascii_100_chars_in_band(self):
+        # Keeps the pinned test_character_estimation_fallback assumptions valid.
+        assert 25 < estimate_tokens("A" * 100, "unknown", "unknown") < 50
+
+    def test_messages_and_chat_history_agree_for_one_message(self):
+        msg = [{"role": "user", "content": "hello world foo bar"}]
+        assert count_tokens_chat_history(msg, model="claude-3-5-sonnet-20241022",
+                                         provider="anthropic") == \
+            count_tokens_messages(msg, "claude-3-5-sonnet-20241022", "anthropic")
 
 
 #

--- a/Tests/Chat/test_token_counter.py
+++ b/Tests/Chat/test_token_counter.py
@@ -94,6 +94,22 @@ class TestTokenCounter:
         # Unknown modern Claude falls back to the 200k floor, not the stale 100k.
         assert get_model_token_limit("claude-99-future", "anthropic") == 200000
 
+    def test_get_model_token_limit_openrouter_resolves_upstream(self):
+        # OpenRouter IDs are "upstream_provider/model"; resolve the upstream window
+        # instead of the generic 4096 default. (Qodo review #5.)
+        assert get_model_token_limit("openai/gpt-4o-mini", "openrouter") == 128000
+        assert get_model_token_limit("openai/gpt-4o-mini", "OpenRouter") == 128000
+        assert get_model_token_limit("anthropic/claude-3.7-sonnet", "openrouter") == 200000
+        assert get_model_token_limit("google/gemini-2.0-flash-001", "openrouter") == 1048576
+
+    def test_get_model_token_limit_provider_casing_insensitive(self):
+        # TitleCase provider must resolve the same conservative default as lowercase.
+        # (Qodo review #6 — provider_defaults lookup was case-sensitive.)
+        assert get_model_token_limit("unknown-model", "Anthropic") == \
+            get_model_token_limit("unknown-model", "anthropic") == 200000
+        assert get_model_token_limit("unknown-model", "OpenAI") == \
+            get_model_token_limit("unknown-model", "openai") == 4096
+
     def test_format_token_display_green(self):
         """Test token display formatting - green indicator"""
         result = format_token_display(100, 1000)
@@ -201,6 +217,16 @@ class TestEstimator:
         assert count_tokens_chat_history(msg, model="claude-3-5-sonnet-20241022",
                                          provider="anthropic") == \
             count_tokens_messages(msg, "claude-3-5-sonnet-20241022", "anthropic")
+
+    def test_chars_estimate_provider_casing_insensitive(self):
+        # The chars-path ratio lookup must be case-insensitive: "Google" (0.3)
+        # must not silently fall back to the default ratio. (Qodo review #6.)
+        text = "some plain english text " * 4
+        assert estimate_tokens(text, "gemini-1.5-pro", "Google") == \
+            estimate_tokens(text, "gemini-1.5-pro", "google")
+        # And Google's higher ratio genuinely differs from the default bucket.
+        assert estimate_tokens(text, "gemini-1.5-pro", "Google") > \
+            estimate_tokens(text, "m", "openai")
 
 
 #

--- a/Tests/Chat/test_token_counter.py
+++ b/Tests/Chat/test_token_counter.py
@@ -196,8 +196,22 @@ class TestTokenCounter:
 
 
 class TestEstimator:
+    @pytest.fixture(autouse=True)
+    def _force_chars_path(self, monkeypatch):
+        # These tests assert the chars-floor behavior; force that path so they
+        # are deterministic regardless of whether tiktoken / a custom tokenizer
+        # happens to be installed in the running environment.
+        import tldw_chatbook.Utils.token_counter as tc
+        monkeypatch.setattr(tc, "TIKTOKEN_AVAILABLE", False)
+        monkeypatch.setattr(tc, "custom_tokenizers_available", lambda: False)
+
     def test_empty_text_is_zero(self):
         assert estimate_tokens("", "gpt-4o", "openai") == 0
+
+    def test_short_nonempty_text_floors_at_one(self):
+        # int() truncation must not round a short non-empty string down to 0.
+        assert estimate_tokens("hi", "gpt-4o", "openai") >= 1
+        assert estimate_tokens("a", "gpt-4o", "openai") >= 1
 
     def test_cjk_floor_at_least_one_token_per_char(self):
         # CJK code points are >= ~1 token each; a conservative floor never under-counts.

--- a/Tests/Chat/test_token_display_limit.py
+++ b/Tests/Chat/test_token_display_limit.py
@@ -1,0 +1,17 @@
+from tldw_chatbook.Event_Handlers.Chat_Events.chat_token_events import (
+    _resolve_token_display_limit,
+)
+
+
+def test_display_limit_is_input_window_by_default():
+    # AC#3: the gauge denominator is the model input window, not the output budget.
+    assert _resolve_token_display_limit(total_limit=128000, custom_limit=0) == 128000
+
+
+def test_display_limit_honors_custom_override():
+    assert _resolve_token_display_limit(total_limit=128000, custom_limit=5000) == 5000
+
+
+def test_display_limit_ignores_nonpositive_custom():
+    assert _resolve_token_display_limit(total_limit=200000, custom_limit=0) == 200000
+    assert _resolve_token_display_limit(total_limit=200000, custom_limit=-3) == 200000

--- a/Tests/test_model_capabilities.py
+++ b/Tests/test_model_capabilities.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 from tldw_chatbook.model_capabilities import (
     ModelCapabilities,
     get_model_capabilities,
+    get_context_window,
     is_vision_capable,
     reload_capabilities,
 )
@@ -514,6 +515,42 @@ class TestEdgeCases:
 
         # Should be sorted
         assert vision_models == sorted(vision_models)
+
+
+#
+#######################################################################################################################
+#
+# Context Window Tests
+#
+
+
+def test_get_context_window_direct_mapping():
+    caps = ModelCapabilities({})  # uses DEFAULT_MODEL_* (no config file)
+    assert caps.get_context_window("OpenAI", "gpt-4o") == 128000
+    assert caps.get_context_window("Anthropic", "claude-3-opus-20240229") == 200000
+    assert caps.get_context_window("Google", "gemini-1.5-pro") == 2097152
+
+
+def test_get_context_window_via_family_pattern():
+    caps = ModelCapabilities({})
+    # A novel dated variant not in direct mappings resolves via the anchored pattern.
+    assert caps.get_context_window("OpenAI", "gpt-4o-2099-12-31") == 128000
+    assert caps.get_context_window("Anthropic", "claude-3-5-haiku-20991231") == 200000
+
+
+def test_get_context_window_unknown_is_none():
+    caps = ModelCapabilities({})
+    assert caps.get_context_window("OpenAI", "totally-unknown-model") is None
+    # Generic gpt-4 variant must NOT match a pattern (so the table's gpt-4 wins later).
+    assert caps.get_context_window("OpenAI", "gpt-4-some-variant") is None
+
+
+def test_provider_lookup_is_case_insensitive():
+    caps = ModelCapabilities({})
+    assert caps.is_vision_capable("openai", "gpt-4o") is True
+    assert caps.is_vision_capable("OpenAI", "gpt-4o") is True
+    assert caps.get_context_window("anthropic", "claude-3-opus-20240229") == \
+        caps.get_context_window("Anthropic", "claude-3-opus-20240229") == 200000
 
 
 #

--- a/Tests/test_model_capabilities.py
+++ b/Tests/test_model_capabilities.py
@@ -543,14 +543,22 @@ def test_get_context_window_unknown_is_none():
     assert caps.get_context_window("OpenAI", "totally-unknown-model") is None
     # Generic gpt-4 variant must NOT match a pattern (so the table's gpt-4 wins later).
     assert caps.get_context_window("OpenAI", "gpt-4-some-variant") is None
+    # Bare gpt-4 / gpt-4-32k must match no pattern (so the table's gpt-4->8192 wins later).
+    assert caps.get_context_window("OpenAI", "gpt-4") is None
+    assert caps.get_context_window("OpenAI", "gpt-4-32k") is None
 
 
 def test_provider_lookup_is_case_insensitive():
     caps = ModelCapabilities({})
-    assert caps.is_vision_capable("openai", "gpt-4o") is True
-    assert caps.is_vision_capable("OpenAI", "gpt-4o") is True
-    assert caps.get_context_window("anthropic", "claude-3-opus-20240229") == \
-        caps.get_context_window("Anthropic", "claude-3-opus-20240229") == 200000
+    # Use a PATTERN-only model (NOT in DEFAULT_MODEL_CAPABILITIES direct maps) so the
+    # provider-keyed pattern branch is actually exercised — direct mappings ignore provider.
+    assert caps.is_vision_capable("openai", "gpt-4o-2099-12-31") is True
+    assert caps.is_vision_capable("OpenAI", "gpt-4o-2099-12-31") is True
+    assert (
+        caps.get_context_window("openai", "gpt-4o-2099-12-31")
+        == caps.get_context_window("OpenAI", "gpt-4o-2099-12-31")
+        == 128000
+    )
 
 
 #

--- a/backlog/tasks/task-320 - Add-per-model-context-window-and-refresh-token-limit-table.md
+++ b/backlog/tasks/task-320 - Add-per-model-context-window-and-refresh-token-limit-table.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-320
 title: Add per-model context_window and refresh the stale token-limit table
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-20 18:45'
 labels: [llm, tech-debt]
@@ -17,8 +17,23 @@ There is no authoritative per-model context window anywhere in the codebase, whi
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A per-model `context_window` is resolvable (pattern-based, like the vision capability) for the providers/models the app supports
-- [ ] #2 The hardcoded token-limit table reflects current model windows, or is derived from the capabilities config
-- [ ] #3 Token-usage percentage/threshold logic (`token_counter.py:330` and its callers) is computed against the model input context window, not the output-token budget
-- [ ] #4 Unit tests cover limit lookup for at least one current model per major provider
+- [x] #1 A per-model `context_window` is resolvable (pattern-based, like the vision capability) for the providers/models the app supports
+- [x] #2 The hardcoded token-limit table reflects current model windows, or is derived from the capabilities config
+- [x] #3 Token-usage percentage/threshold logic (`token_counter.py:330` and its callers) is computed against the model input context window, not the output-token budget
+- [x] #4 Unit tests cover limit lookup for at least one current model per major provider
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Made the model context window authoritative and config-overridable, and fixed the token gauge's denominator. Part of the token/context-accuracy sub-project (with task-321/325); feeds the task-322 Console history trimmer through the shared `token_counter` seam with no change to 322's code.
+
+Approach:
+- **`model_capabilities.py`**: added a per-model `context_window` capability parallel to `vision`/`max_images` — on the direct mappings (`DEFAULT_MODEL_CAPABILITIES`) and on anchored OpenAI/Anthropic family patterns (`DEFAULT_MODEL_PATTERNS`); Google windows resolve via direct mappings + table since its `(pro|flash)` pattern spans non-uniform windows. Added `get_context_window(provider, model)` (method + module fn). Fixed a **latent case-sensitivity bug**: the provider→pattern lookup was case-sensitive while callers pass mixed/lowercase — now case-insensitive via a lower-cased provider index (hardens the existing `is_vision_capable` path too).
+- **`token_counter.py`**: rewrote `get_model_token_limit` to resolve capability `context_window` FIRST, then an exact table match, then the **longest** table prefix (fixes `gpt-4` shadowing `gpt-4-turbo`), then a conservative provider default. Refreshed `MODEL_TOKEN_LIMITS` with current models (gpt-4o/4.1, o1/o3/o4, claude-3.5/3.7/4, gemini-1.5/2, mistral-large) while preserving every test-pinned value; the only value correction is `gpt-3.5-turbo` 4096→16385. Provider defaults stay conservative (only `anthropic` bumped 100000→200000, the safe floor for modern Claude) because over-estimating a window is the only way to overflow the 322 budget on dispatch.
+- **`chat_token_events.py`** (AC#3): both gauge sites now divide usage by the model **input** window (`total_limit`) via a small `_resolve_token_display_limit(total_limit, custom_limit)` helper, not the ~2048-token output reservation; the manual custom-limit override is preserved.
+
+Testing: capability resolution incl. case-insensitivity + anchored-pattern/table agreement; `get_model_token_limit` per major provider + capabilities-first (monkeypatched sentinel) + discriminating longest-prefix (`gpt-4-32k-custom`→32768); gauge helper (input-window default / custom override). tiktoken is absent in the venv so estimator tests target the chars path.
+
+Files: `tldw_chatbook/model_capabilities.py`, `tldw_chatbook/Utils/token_counter.py`, `tldw_chatbook/Event_Handlers/Chat_Events/chat_token_events.py`, `Tests/test_model_capabilities.py`, `Tests/Chat/test_token_counter.py`, `Tests/Chat/test_token_display_limit.py`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-321 - Replace-word-char-token-estimation-with-real-tokenizer.md
+++ b/backlog/tasks/task-321 - Replace-word-char-token-estimation-with-real-tokenizer.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-321
 title: Replace word/char token estimation with a real tokenizer estimate
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-20 18:45'
 labels: [llm, tech-debt]
@@ -17,7 +17,23 @@ Token counting is only accurate for OpenAI (tiktoken). For every other provider,
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Non-OpenAI token estimates no longer use whitespace word counts (`.split()`)
-- [ ] #2 A consistent estimator (provider tokenizer where available, else a chars-based estimate with documented headroom) is used everywhere token counts feed a budget or a UI limit
-- [ ] #3 Tests assert the estimate is at least a conservative floor for representative code and CJK samples
+- [x] #1 Non-OpenAI token estimates no longer use whitespace word counts (`.split()`)
+- [x] #2 A consistent estimator (provider tokenizer where available, else a chars-based estimate with documented headroom) is used everywhere token counts feed a budget or a UI limit
+- [x] #3 Tests assert the estimate is at least a conservative floor for representative code and CJK samples
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Replaced every `.split()` token estimate with a single consistent estimator. Part of the token/context-accuracy sub-project (with task-320/325).
+
+Approach: added `estimate_tokens(text, model, provider="") -> int` in `token_counter.py` with a tiered strategy — **custom tokenizer** (only behind a cheap `custom_tokenizers_available()` / `has_tokenizers()` gate so the default install pays no per-call metric overhead) → **tiktoken** (when installed) → **chars-based conservative floor**. The chars floor weights CJK code points higher than ASCII (`int((non_cjk*0.25 + cjk*1.0) * 1.2)` with a documented 1.2 headroom) so it never under-counts code or CJK — the safe direction for a budget. `count_tokens_messages` (now with a trailing optional `provider`), `count_tokens_chat_history`, and `estimate_remaining_tokens`'s system-prompt branch all delegate to `estimate_tokens`, so there is exactly one estimator and no double custom-counting. Deleted the dead `approximate_token_count` (zero callers). Routed the Console draft estimate `chat_screen._estimate_tokens` through `estimate_tokens`, removing its `.split()*1.3` fallback (the last in-scope `.split()` token estimate).
+
+task-322's `console_history_budget.py` is untouched — its `count_tokens_messages(flattened, model)` call keeps working (trailing-optional `provider`) and now routes through the improved estimator.
+
+Testing (property-based, tiktoken absent): pure-CJK string estimates ≥ its char count; a code sample exceeds its whitespace word count; a 100-ASCII-char string lands in (25,50) (keeps the pre-existing `test_character_estimation_fallback` green); empty→0; `count_tokens_chat_history` == `count_tokens_messages` for one message.
+
+Deferred follow-up minors (non-blocking, from final review): `_CJK_RANGES` omits CJK punctuation U+3000–303F; `count_messages_with_custom` is now an unused import in `token_counter.py`; the new estimator tests aren't `skipif(TIKTOKEN_AVAILABLE)`-guarded (matches the repo's existing unguarded convention; would need guarding only to run green in a tiktoken-present env).
+
+Files: `tldw_chatbook/Utils/token_counter.py`, `tldw_chatbook/Utils/custom_tokenizers.py`, `tldw_chatbook/Chat/Chat_Functions.py`, `tldw_chatbook/UI/Screens/chat_screen.py`, `Tests/Chat/test_token_counter.py`, `Tests/Chat/test_chat_screen_token_estimate.py`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-325 - Wire-or-remove-dead-chat-context-limit-config-key.md
+++ b/backlog/tasks/task-325 - Wire-or-remove-dead-chat-context-limit-config-key.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-325
 title: Wire or remove the dead chat_context_limit config key
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-07-20 18:45'
 labels: [config, tech-debt]
@@ -17,6 +17,18 @@ priority: medium
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 `chat_context_limit` either drives a real message-count fallback cap in the Console history builder, or is removed from config and the sample TOML
-- [ ] #2 If kept, its effect is covered by a test; if removed, no references remain
+- [x] #1 `chat_context_limit` either drives a real message-count fallback cap in the Console history builder, or is removed from config and the sample TOML
+- [x] #2 If kept, its effect is covered by a test; if removed, no references remain
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+**Removed** `chat_context_limit` (chose removal over wiring, user-approved). It was a message-count value misplaced under `[rag_search]` and never read anywhere; it is superseded by task-322's model-aware token bound (strictly better than a fixed turn cap), and wiring a second overlapping cap under the wrong config section would be confusing.
+
+Deleted the key from `DEFAULT_RAG_SEARCH_CONFIG` and from the sample TOML `[rag_search]` block in `config.py`. Verified zero references remain dev-wide (only `config.py` contained it; no runtime consumer, no tests). No migration needed — the config loader merges over defaults, so a leftover key in an existing user file is a harmless no-op.
+
+Testing: asserts `chat_context_limit` is absent from both the loaded `DEFAULT_RAG_SEARCH_CONFIG` dict and the `config.py` source text (catches the sample TOML too).
+
+Files: `tldw_chatbook/config.py`, `Tests/Chat/test_config_no_chat_context_limit.py`.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/Chat_Functions.py
+++ b/tldw_chatbook/Chat/Chat_Functions.py
@@ -97,21 +97,6 @@ class ResponseFormat(BaseModel):
     )
 
 
-def approximate_token_count(history):
-    try:
-        total_text = ""
-        for user_msg, bot_msg in history:
-            if user_msg:
-                total_text += user_msg + " "
-            if bot_msg:
-                total_text += bot_msg + " "
-        total_tokens = len(total_text.split())
-        return total_tokens
-    except Exception as e:
-        logger.error(f"Error calculating token count: {str(e)}")
-        return 0
-
-
 # 1. Dispatch table for handler functions
 API_CALL_HANDLERS = {
     "openai": chat_with_openai,

--- a/tldw_chatbook/Event_Handlers/Chat_Events/chat_token_events.py
+++ b/tldw_chatbook/Event_Handlers/Chat_Events/chat_token_events.py
@@ -25,6 +25,15 @@ if TYPE_CHECKING:
 # Functions:
 
 
+def _resolve_token_display_limit(total_limit: int, custom_limit: int) -> int:
+    """Gauge denominator: the model input window, unless a positive custom limit is set.
+
+    task-320 AC#3: usage is measured against the model *input* context window,
+    not the ~2048-token output-response budget.
+    """
+    return custom_limit if custom_limit > 0 else total_limit
+
+
 def _estimate_tokens_cached(
     app: "TldwCli",
     chat_history: list,
@@ -150,19 +159,14 @@ async def update_chat_token_counter(app: "TldwCli") -> None:
             system_prompt=system_prompt,
         )
 
-        # Use max_tokens_response as the display limit instead of model's total limit
-        # This allows users to see how their conversation measures against their configured limit
-        display_limit = max_tokens_response
-
-        # Check if there's a custom token limit setting (we'll add this later)
+        # task-320 AC#3: measure usage against the model input window (total_limit),
+        # not the output-response budget. A positive custom-limit widget still wins.
         try:
             custom_limit_widget = app.query_one("#chat-custom-token-limit", Input)
             custom_limit = int(custom_limit_widget.value or "0")
-            if custom_limit > 0:
-                display_limit = custom_limit
         except (QueryError, ValueError):
-            # No custom limit widget or invalid value, use max_tokens_response
-            pass
+            custom_limit = 0
+        display_limit = _resolve_token_display_limit(total_limit, custom_limit)
 
         # Update the display in footer
         try:
@@ -277,17 +281,14 @@ async def update_chat_token_counter_with_pending(
             system_prompt=system_prompt,
         )
 
-        # Use max_tokens_response as the display limit instead of model's total limit
-        display_limit = max_tokens_response
-
-        # Check if there's a custom token limit setting
+        # task-320 AC#3: measure usage against the model input window (total_limit),
+        # not the output-response budget. A positive custom-limit widget still wins.
         try:
             custom_limit_widget = app.query_one("#chat-custom-token-limit", Input)
             custom_limit = int(custom_limit_widget.value or "0")
-            if custom_limit > 0:
-                display_limit = custom_limit
         except (QueryError, ValueError):
-            pass
+            custom_limit = 0
+        display_limit = _resolve_token_display_limit(total_limit, custom_limit)
 
         # Update the display in footer with a pending indicator
         try:

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -234,7 +234,7 @@ from ...Utils.console_background_effects import (
     normalize_console_background_effects,
 )
 from ...Utils.input_validation import sanitize_string, validate_text_input
-from ...Utils.token_counter import count_tokens_tiktoken
+from ...Utils.token_counter import estimate_tokens
 from ...UI.Workbench import (
     CommandStrip,
     DestinationHeader,
@@ -1401,10 +1401,7 @@ class ChatScreen(BaseAppScreen):
         text = payload.get("draft", "")
         if not text:
             return None
-        try:
-            return count_tokens_tiktoken(text)
-        except Exception:
-            return int(len(text.split()) * 1.3)
+        return estimate_tokens(text, "", "")
 
     async def action_jump_console_tab(self, number: int) -> None:
         """Jump directly to the Nth native Console session tab (Alt+1..9).

--- a/tldw_chatbook/Utils/custom_tokenizers.py
+++ b/tldw_chatbook/Utils/custom_tokenizers.py
@@ -191,6 +191,10 @@ class CustomTokenizerManager:
 
         return None
 
+    def has_tokenizers(self) -> bool:
+        """Cheap availability check (no metrics, no I/O) — are any mappings loaded?"""
+        return bool(self._model_mappings)
+
     def count_tokens(self, text: str, model: str, provider: str) -> Optional[int]:
         """
         Count tokens using a custom tokenizer if available.
@@ -419,6 +423,11 @@ def get_tokenizer_manager() -> CustomTokenizerManager:
     if _tokenizer_manager is None:
         _tokenizer_manager = CustomTokenizerManager()
     return _tokenizer_manager
+
+
+def custom_tokenizers_available() -> bool:
+    """True only when a custom tokenizer could actually resolve (mappings loaded)."""
+    return get_tokenizer_manager().has_tokenizers()
 
 
 def count_tokens_with_custom(text: str, model: str, provider: str) -> Optional[int]:

--- a/tldw_chatbook/Utils/custom_tokenizers.py
+++ b/tldw_chatbook/Utils/custom_tokenizers.py
@@ -426,7 +426,14 @@ def get_tokenizer_manager() -> CustomTokenizerManager:
 
 
 def custom_tokenizers_available() -> bool:
-    """True only when a custom tokenizer could actually resolve (mappings loaded)."""
+    """Report whether a custom tokenizer could actually resolve a model.
+
+    Cheap gate for the token estimator: avoids invoking the metrics-logging
+    count path when no tokenizer mappings are installed.
+
+    Returns:
+        ``True`` only when tokenizer mappings are loaded, else ``False``.
+    """
     return get_tokenizer_manager().has_tokenizers()
 
 

--- a/tldw_chatbook/Utils/custom_tokenizers.py
+++ b/tldw_chatbook/Utils/custom_tokenizers.py
@@ -429,12 +429,14 @@ def custom_tokenizers_available() -> bool:
     """Report whether a custom tokenizer could actually resolve a model.
 
     Cheap gate for the token estimator: avoids invoking the metrics-logging
-    count path when no tokenizer mappings are installed.
+    count path unless BOTH the ``tokenizers`` library is importable AND tokenizer
+    mappings are installed. Either one missing means the custom tier can only
+    return ``None``, so it is skipped.
 
     Returns:
-        ``True`` only when tokenizer mappings are loaded, else ``False``.
+        ``True`` only when the library is present and mappings are loaded.
     """
-    return get_tokenizer_manager().has_tokenizers()
+    return TOKENIZERS_AVAILABLE and get_tokenizer_manager().has_tokenizers()
 
 
 def count_tokens_with_custom(text: str, model: str, provider: str) -> Optional[int]:

--- a/tldw_chatbook/Utils/token_counter.py
+++ b/tldw_chatbook/Utils/token_counter.py
@@ -11,13 +11,18 @@ from loguru import logger
 #
 # Local Imports - Import with error handling to avoid circular imports
 try:
-    from .custom_tokenizers import count_tokens_with_custom, count_messages_with_custom
+    from .custom_tokenizers import (
+        count_tokens_with_custom,
+        count_messages_with_custom,
+        custom_tokenizers_available,
+    )
 
     CUSTOM_TOKENIZERS_AVAILABLE = True
 except ImportError:
     CUSTOM_TOKENIZERS_AVAILABLE = False
     count_tokens_with_custom = None
     count_messages_with_custom = None
+    custom_tokenizers_available = None
 #
 ########################################################################################################################
 #
@@ -79,6 +84,52 @@ TOKENS_PER_CHAR_ESTIMATES = {
     "openrouter": 0.25,  # Depends on underlying model
     "default": 0.25,  # Default fallback
 }
+
+# Conservative chars-based estimate constants (used when no tokenizer is available).
+CJK_TOKENS_PER_CHAR = 1.0   # each CJK code point is >= ~1 token
+ESTIMATE_HEADROOM = 1.2     # documented headroom so estimates lean high (safe)
+
+_CJK_RANGES = (
+    (0x3040, 0x30FF),  # Hiragana + Katakana
+    (0x3400, 0x4DBF),  # CJK Unified Ext-A
+    (0x4E00, 0x9FFF),  # CJK Unified Ideographs
+    (0xAC00, 0xD7AF),  # Hangul syllables
+    (0xF900, 0xFAFF),  # CJK Compatibility Ideographs
+    (0xFF00, 0xFFEF),  # Fullwidth / halfwidth (CJK punctuation)
+)
+
+
+def _is_cjk(ch: str) -> bool:
+    cp = ord(ch)
+    return any(lo <= cp <= hi for lo, hi in _CJK_RANGES)
+
+
+def _chars_estimate(text: str, provider: str) -> int:
+    """Conservative chars-based token floor; weights CJK higher, applies headroom."""
+    cjk = sum(1 for ch in text if _is_cjk(ch))
+    other = len(text) - cjk
+    base_ratio = TOKENS_PER_CHAR_ESTIMATES.get(
+        provider or "default", TOKENS_PER_CHAR_ESTIMATES["default"]
+    )
+    return int((other * base_ratio + cjk * CJK_TOKENS_PER_CHAR) * ESTIMATE_HEADROOM)
+
+
+def estimate_tokens(text: str, model: str = "gpt-3.5-turbo", provider: str = "") -> int:
+    """Single text token estimator: custom tokenizer (gated) -> tiktoken -> chars floor.
+
+    Never uses whitespace word counts. `provider` only selects the chars-path
+    ratio; CJK weighting and the tiktoken/custom tiers are provider-independent.
+    """
+    if not text:
+        return 0
+    if CUSTOM_TOKENIZERS_AVAILABLE and custom_tokenizers_available():
+        custom = count_tokens_with_custom(text, model, provider)
+        if custom is not None:
+            return custom
+    if TIKTOKEN_AVAILABLE:
+        return count_tokens_tiktoken(text, model)
+    return _chars_estimate(text, provider)
+
 
 # Token limits per model (approximate)
 MODEL_TOKEN_LIMITS = {
@@ -158,66 +209,34 @@ def count_tokens_tiktoken(text: str, model: str = "gpt-3.5-turbo") -> int:
 
 
 def count_tokens_messages(
-    messages: List[Dict[str, Any]], model: str = "gpt-3.5-turbo"
+    messages: List[Dict[str, Any]], model: str = "gpt-3.5-turbo", provider: str = ""
 ) -> int:
-    """
-    Count tokens for a list of messages in OpenAI format.
-
-    Args:
-        messages: List of message dicts with 'role' and 'content' keys
-        model: The model name for accurate token counting
-
-    Returns:
-        Total token count including message formatting overhead
-    """
+    """Count tokens for OpenAI-format messages (framing overhead + estimate_tokens)."""
     if not messages:
         return 0
 
-    # Different models have different message formatting overhead
     if model.startswith("gpt-3.5") or model.startswith("gpt-4"):
-        # Each message has overhead: <|start|>role<|end|>content<|end|>
         tokens_per_message = 3
-        tokens_per_name = 1  # If name is present
-        base_tokens = 3  # Every reply is primed with <|start|>assistant<|message|>
+        tokens_per_name = 1
+        base_tokens = 3
     else:
-        # Conservative estimate for other models
         tokens_per_message = 2
         tokens_per_name = 1
         base_tokens = 2
 
     total_tokens = base_tokens
-
     for message in messages:
         total_tokens += tokens_per_message
-
-        # Count tokens in role
         role = message.get("role", "")
         if role:
-            total_tokens += (
-                count_tokens_tiktoken(role, model)
-                if TIKTOKEN_AVAILABLE
-                else len(role.split())
-            )
-
-        # Count tokens in content
+            total_tokens += estimate_tokens(role, model, provider)
         content = message.get("content", "")
         if content:
-            total_tokens += (
-                count_tokens_tiktoken(content, model)
-                if TIKTOKEN_AVAILABLE
-                else len(content.split())
-            )
-
-        # Count tokens in name if present
+            total_tokens += estimate_tokens(content, model, provider)
         name = message.get("name", "")
         if name:
             total_tokens += tokens_per_name
-            total_tokens += (
-                count_tokens_tiktoken(name, model)
-                if TIKTOKEN_AVAILABLE
-                else len(name.split())
-            )
-
+            total_tokens += estimate_tokens(name, model, provider)
     return total_tokens
 
 
@@ -226,64 +245,24 @@ def count_tokens_chat_history(
     model: str = "gpt-3.5-turbo",
     provider: str = "openai",
 ) -> int:
-    """
-    Count tokens in chat history format (list of tuples or message dicts).
-
-    Args:
-        history: Chat history in various formats
-        model: The model name for accurate counting
-        provider: The LLM provider name
-
-    Returns:
-        Total estimated token count
-    """
+    """Count tokens in chat-history format (tuples or message dicts) via the one estimator."""
     if not history:
         return 0
 
-    # Convert history to message format
-    messages = []
-
+    messages: List[Dict[str, Any]] = []
     for item in history:
         if isinstance(item, tuple) and len(item) == 2:
-            # (user_msg, bot_msg) format
             user_msg, bot_msg = item
             if user_msg:
                 messages.append({"role": "user", "content": user_msg})
             if bot_msg:
                 messages.append({"role": "assistant", "content": bot_msg})
         elif isinstance(item, dict) and "role" in item and "content" in item:
-            # Already in message format
             messages.append(item)
         else:
             logger.warning(f"Unknown history format: {type(item)}")
 
-    # Try custom tokenizers first
-    if CUSTOM_TOKENIZERS_AVAILABLE and count_messages_with_custom:
-        custom_count = count_messages_with_custom(messages, model, provider)
-        if custom_count is not None:
-            logger.debug(
-                f"Using custom tokenizer for {model} ({provider}): {custom_count} tokens"
-            )
-            return custom_count
-
-    # Use provider-specific counting if available
-    if provider == "openai" and TIKTOKEN_AVAILABLE:
-        return count_tokens_messages(messages, model)
-    else:
-        # Fallback to character-based estimation
-        total_chars = 0
-        for msg in messages:
-            content = msg.get("content", "")
-            total_chars += len(content)
-
-        # Add some overhead for message formatting
-        total_chars += len(messages) * 10  # Rough estimate for role and formatting
-
-        # Use provider-specific ratio
-        ratio = TOKENS_PER_CHAR_ESTIMATES.get(
-            provider, TOKENS_PER_CHAR_ESTIMATES["default"]
-        )
-        return int(total_chars * ratio)
+    return count_tokens_messages(messages, model, provider)
 
 
 def get_model_token_limit(model: str, provider: str = "openai") -> int:
@@ -357,12 +336,7 @@ def estimate_remaining_tokens(
 
     # Add system prompt if present
     if system_prompt:
-        if provider == "openai" and TIKTOKEN_AVAILABLE:
-            current_tokens += count_tokens_tiktoken(system_prompt, model)
-        else:
-            current_tokens += int(
-                len(system_prompt) * TOKENS_PER_CHAR_ESTIMATES.get(provider, 0.25)
-            )
+        current_tokens += estimate_tokens(system_prompt, model, provider)
 
     # Get model limit
     total_limit = get_model_token_limit(model, provider)

--- a/tldw_chatbook/Utils/token_counter.py
+++ b/tldw_chatbook/Utils/token_counter.py
@@ -87,20 +87,33 @@ MODEL_TOKEN_LIMITS = {
     "gpt-4-32k": 32768,
     "gpt-4-turbo": 128000,
     "gpt-4-turbo-preview": 128000,
-    "gpt-3.5-turbo": 4096,
+    "gpt-4o": 128000,
+    "gpt-4o-mini": 128000,
+    "gpt-4.1": 1047576,
+    "gpt-3.5-turbo": 16385,
     "gpt-3.5-turbo-16k": 16384,
+    "o1": 200000,
+    "o1-mini": 128000,
+    "o3": 200000,
+    "o3-mini": 200000,
+    "o4-mini": 200000,
     # Anthropic
     "claude-3-opus-20240229": 200000,
     "claude-3-sonnet-20240229": 200000,
     "claude-3-haiku-20240307": 200000,
+    "claude-3-5-sonnet-20240620": 200000,
+    "claude-3-5-sonnet-20241022": 200000,
     "claude-2.1": 200000,
     "claude-2": 100000,
     "claude-instant-1.2": 100000,
     # Google
+    "gemini-1.5-pro": 2097152,
+    "gemini-1.5-flash": 1048576,
+    "gemini-2.0-flash": 1048576,
     "gemini-pro": 30720,
     "gemini-pro-vision": 12288,
     # Others
-    "mistral-large": 32000,
+    "mistral-large": 128000,
     "mistral-medium": 32000,
     "mistral-small": 32000,
     "mixtral-8x7b": 32000,
@@ -275,32 +288,47 @@ def count_tokens_chat_history(
 
 def get_model_token_limit(model: str, provider: str = "openai") -> int:
     """
-    Get the token limit for a specific model.
+    Get the input context-window token limit for a specific model.
 
-    Args:
-        model: The model name
-        provider: The LLM provider
-
-    Returns:
-        Maximum token limit for the model
+    Resolves in priority order: the per-model capability `context_window`
+    (config-overridable), an exact table entry, the longest matching table
+    prefix, then a conservative provider default. Fallbacks lean conservative
+    on purpose: under-estimating the window degrades gracefully (more trimming),
+    while over-estimating is the only way to overflow the model on dispatch.
     """
-    # Check specific model limits
+    # 1. Per-model capability context window (authoritative, config-overridable).
+    try:
+        from tldw_chatbook.model_capabilities import get_context_window
+
+        window = get_context_window(provider, model)
+        if window is not None:
+            return window
+    except Exception as e:  # never let capability resolution break token limits
+        logger.debug(f"context_window lookup failed for {provider}/{model}: {e}")
+
+    # 2. Exact table match.
     if model in MODEL_TOKEN_LIMITS:
         return MODEL_TOKEN_LIMITS[model]
 
-    # Check by model prefix
+    # 3. Longest matching table prefix (so "gpt-4" can't shadow "gpt-4-turbo").
+    best_limit = None
+    best_len = -1
     for model_prefix, limit in MODEL_TOKEN_LIMITS.items():
-        if model.startswith(model_prefix):
-            return limit
+        if model_prefix == "default":
+            continue
+        if model.startswith(model_prefix) and len(model_prefix) > best_len:
+            best_limit = limit
+            best_len = len(model_prefix)
+    if best_limit is not None:
+        return best_limit
 
-    # Provider-specific defaults
+    # 4. Conservative provider default.
     provider_defaults = {
-        "anthropic": 100000,  # Conservative for Claude
-        "google": 30720,  # Gemini default
-        "openai": 4096,  # GPT-3.5 default
-        "mistral": 32000,  # Mistral default
+        "anthropic": 200000,  # every modern Claude is >= 200k; safe floor
+        "google": 30720,
+        "openai": 4096,
+        "mistral": 32000,
     }
-
     return provider_defaults.get(provider, MODEL_TOKEN_LIMITS["default"])
 
 

--- a/tldw_chatbook/Utils/token_counter.py
+++ b/tldw_chatbook/Utils/token_counter.py
@@ -90,6 +90,7 @@ CJK_TOKENS_PER_CHAR = 1.0   # each CJK code point is >= ~1 token
 ESTIMATE_HEADROOM = 1.2     # documented headroom so estimates lean high (safe)
 
 _CJK_RANGES = (
+    (0x3000, 0x303F),  # CJK Symbols and Punctuation (。、「」etc.)
     (0x3040, 0x30FF),  # Hiragana + Katakana
     (0x3400, 0x4DBF),  # CJK Unified Ext-A
     (0x4E00, 0x9FFF),  # CJK Unified Ideographs

--- a/tldw_chatbook/Utils/token_counter.py
+++ b/tldw_chatbook/Utils/token_counter.py
@@ -117,13 +117,20 @@ def _norm_provider(provider: str) -> str:
 
 
 def _chars_estimate(text: str, provider: str) -> int:
-    """Conservative chars-based token floor; weights CJK higher, applies headroom."""
+    """Conservative chars-based token floor; weights CJK higher, applies headroom.
+
+    Non-empty text always estimates to at least 1 token — ``int()`` truncation
+    would otherwise round very short strings (e.g. "hi") down to 0, which would
+    under-count and defeat the conservative-floor guarantee.
+    """
+    if not text:
+        return 0
     cjk = sum(1 for ch in text if _is_cjk(ch))
     other = len(text) - cjk
     base_ratio = TOKENS_PER_CHAR_ESTIMATES.get(
         _norm_provider(provider) or "default", TOKENS_PER_CHAR_ESTIMATES["default"]
     )
-    return int((other * base_ratio + cjk * CJK_TOKENS_PER_CHAR) * ESTIMATE_HEADROOM)
+    return max(1, int((other * base_ratio + cjk * CJK_TOKENS_PER_CHAR) * ESTIMATE_HEADROOM))
 
 
 def estimate_tokens(text: str, model: str = "gpt-3.5-turbo", provider: str = "") -> int:

--- a/tldw_chatbook/Utils/token_counter.py
+++ b/tldw_chatbook/Utils/token_counter.py
@@ -104,26 +104,48 @@ def _is_cjk(ch: str) -> bool:
     return any(lo <= cp <= hi for lo, hi in _CJK_RANGES)
 
 
+def _norm_provider(provider: str) -> str:
+    """Normalize a provider name for case-insensitive dict lookups.
+
+    Args:
+        provider: Provider name in any casing (e.g. ``"OpenAI"``, ``"google"``).
+
+    Returns:
+        The lower-cased, stripped provider name (``""`` for ``None``/blank).
+    """
+    return str(provider or "").strip().lower()
+
+
 def _chars_estimate(text: str, provider: str) -> int:
     """Conservative chars-based token floor; weights CJK higher, applies headroom."""
     cjk = sum(1 for ch in text if _is_cjk(ch))
     other = len(text) - cjk
     base_ratio = TOKENS_PER_CHAR_ESTIMATES.get(
-        provider or "default", TOKENS_PER_CHAR_ESTIMATES["default"]
+        _norm_provider(provider) or "default", TOKENS_PER_CHAR_ESTIMATES["default"]
     )
     return int((other * base_ratio + cjk * CJK_TOKENS_PER_CHAR) * ESTIMATE_HEADROOM)
 
 
 def estimate_tokens(text: str, model: str = "gpt-3.5-turbo", provider: str = "") -> int:
-    """Single text token estimator: custom tokenizer (gated) -> tiktoken -> chars floor.
+    """Estimate the token count of a text string with one consistent strategy.
 
-    Never uses whitespace word counts. `provider` only selects the chars-path
-    ratio; CJK weighting and the tiktoken/custom tiers are provider-independent.
+    Tiers: a custom tokenizer (only when one is actually installed), else
+    tiktoken (when available), else a conservative chars-based floor. Never uses
+    a whitespace word count.
+
+    Args:
+        text: The text to estimate.
+        model: Model name (selects the tiktoken encoding / custom tokenizer).
+        provider: Provider name (case-insensitive); selects the chars-path ratio
+            and the custom tokenizer's provider patterns.
+
+    Returns:
+        Estimated token count (0 for empty text).
     """
     if not text:
         return 0
     if CUSTOM_TOKENIZERS_AVAILABLE and custom_tokenizers_available():
-        custom = count_tokens_with_custom(text, model, provider)
+        custom = count_tokens_with_custom(text, model, _norm_provider(provider))
         if custom is not None:
             return custom
     if TIKTOKEN_AVAILABLE:
@@ -275,6 +297,16 @@ def get_model_token_limit(model: str, provider: str = "openai") -> int:
     on purpose: under-estimating the window degrades gracefully (more trimming),
     while over-estimating is the only way to overflow the model on dispatch.
     """
+    provider_key = _norm_provider(provider)
+
+    # OpenRouter model IDs are "upstream_provider/model" (e.g. "openai/gpt-4o-mini");
+    # resolve against the upstream provider/model so they don't fall through to the
+    # generic default. Split once and re-dispatch -- the re-dispatch provider is the
+    # upstream (never "openrouter"), so this cannot recurse indefinitely.
+    if provider_key == "openrouter" and "/" in model:
+        upstream_provider, upstream_model = model.split("/", 1)
+        return get_model_token_limit(upstream_model, upstream_provider)
+
     # 1. Per-model capability context window (authoritative, config-overridable).
     try:
         from tldw_chatbook.model_capabilities import get_context_window
@@ -308,7 +340,7 @@ def get_model_token_limit(model: str, provider: str = "openai") -> int:
         "openai": 4096,
         "mistral": 32000,
     }
-    return provider_defaults.get(provider, MODEL_TOKEN_LIMITS["default"])
+    return provider_defaults.get(provider_key, MODEL_TOKEN_LIMITS["default"])
 
 
 def estimate_remaining_tokens(

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -81,7 +81,6 @@ DEFAULT_RAG_SEARCH_CONFIG = {
     "vector_top_k": 10,
     "web_vector_top_k": 10,
     "llm_context_document_limit": 10,
-    "chat_context_limit": 10,
     # New comprehensive RAG settings
     "retriever": {
         "fts_top_k": 10,
@@ -3032,7 +3031,6 @@ fts_top_k = 10
 vector_top_k = 10
 web_vector_top_k = 10
 llm_context_document_limit = 10
-chat_context_limit = 10
 
 
 # --- Model Capabilities Configuration ---

--- a/tldw_chatbook/model_capabilities.py
+++ b/tldw_chatbook/model_capabilities.py
@@ -223,7 +223,15 @@ class ModelCapabilities:
         return capabilities.get("vision", False)
 
     def get_context_window(self, provider: str, model: str) -> Optional[int]:
-        """Return the model's input context window, or None if unknown."""
+        """Return the model's input context window.
+
+        Args:
+            provider: The provider name (case-insensitive).
+            model: The model identifier.
+
+        Returns:
+            The input context window in tokens, or ``None`` if unknown.
+        """
         return self.get_model_capabilities(provider, model).get("context_window")
 
     def get_model_capabilities(self, provider: str, model: str) -> Dict[str, Any]:
@@ -354,7 +362,15 @@ def is_vision_capable(provider: str, model: str) -> bool:
 
 
 def get_context_window(provider: str, model: str) -> Optional[int]:
-    """Convenience function to resolve a model's input context window."""
+    """Resolve a model's input context window from the global capabilities.
+
+    Args:
+        provider: The provider name (case-insensitive).
+        model: The model identifier.
+
+    Returns:
+        The input context window in tokens, or ``None`` if unknown.
+    """
     return get_model_capabilities().get_context_window(provider, model)
 
 

--- a/tldw_chatbook/model_capabilities.py
+++ b/tldw_chatbook/model_capabilities.py
@@ -26,23 +26,25 @@ logger = logging.getLogger(__name__)
 # Users can override or extend these in their config.toml file.
 DEFAULT_MODEL_PATTERNS = {
     "OpenAI": [
-        {"pattern": r"^gpt-4.*vision", "vision": True},
+        {"pattern": r"^gpt-4.*vision", "vision": True, "context_window": 128000},
         {
             "pattern": r"^gpt-4[o0](?:-mini)?",
             "vision": True,
+            "context_window": 128000,
         },  # gpt-4o, gpt-40, gpt-4o-mini
-        {"pattern": r"^gpt-4.*turbo", "vision": True},
-        {"pattern": r"^gpt-4\.1", "vision": True},  # gpt-4.1 series
+        {"pattern": r"^gpt-4.*turbo", "vision": True, "context_window": 128000},
+        {"pattern": r"^gpt-4\.1", "vision": True, "context_window": 1047576},  # gpt-4.1 series
         {
             "pattern": r"^o[34](?:-mini)?",
             "vision": True,
+            "context_window": 200000,
         },  # o3, o4, o3-mini, o4-mini series
         {"pattern": r"^dall-e", "vision": True, "image_generation": True},
     ],
     "Anthropic": [
-        {"pattern": r"^claude-3", "vision": True},  # All Claude 3 models have vision
-        {"pattern": r"^claude.*opus-4", "vision": True},  # Claude Opus 4 series
-        {"pattern": r"^claude.*sonnet-4", "vision": True},  # Claude Sonnet 4 series
+        {"pattern": r"^claude-3", "vision": True, "context_window": 200000},  # All Claude 3 models have vision
+        {"pattern": r"^claude.*opus-4", "vision": True, "context_window": 200000},  # Claude Opus 4 series
+        {"pattern": r"^claude.*sonnet-4", "vision": True, "context_window": 200000},  # Claude Sonnet 4 series
     ],
     "Google": [
         {"pattern": r"gemini.*vision", "vision": True},
@@ -84,28 +86,28 @@ DEFAULT_MODEL_PATTERNS = {
 # Known models with direct capabilities (for common models)
 DEFAULT_MODEL_CAPABILITIES = {
     # OpenAI
-    "gpt-4-vision-preview": {"vision": True, "max_images": 1},
-    "gpt-4-turbo": {"vision": True, "max_images": 10},
-    "gpt-4-turbo-2024-04-09": {"vision": True, "max_images": 10},
-    "gpt-4o": {"vision": True, "max_images": 10},
-    "gpt-4o-mini": {"vision": True, "max_images": 10},
-    "gpt-4.1-2025-04-14": {"vision": True, "max_images": 10},
-    "o4-mini-2025-04-16": {"vision": True, "max_images": 10},
-    "o3-2025-04-16": {"vision": True, "max_images": 10},
-    "o3-mini-2025-01-31": {"vision": True, "max_images": 10},
-    "gpt-4.1-mini-2025-04-14": {"vision": True, "max_images": 10},
-    "gpt-4.1-nano-2025-04-14": {"vision": True, "max_images": 10},
+    "gpt-4-vision-preview": {"vision": True, "max_images": 1, "context_window": 128000},
+    "gpt-4-turbo": {"vision": True, "max_images": 10, "context_window": 128000},
+    "gpt-4-turbo-2024-04-09": {"vision": True, "max_images": 10, "context_window": 128000},
+    "gpt-4o": {"vision": True, "max_images": 10, "context_window": 128000},
+    "gpt-4o-mini": {"vision": True, "max_images": 10, "context_window": 128000},
+    "gpt-4.1-2025-04-14": {"vision": True, "max_images": 10, "context_window": 1047576},
+    "o4-mini-2025-04-16": {"vision": True, "max_images": 10, "context_window": 200000},
+    "o3-2025-04-16": {"vision": True, "max_images": 10, "context_window": 200000},
+    "o3-mini-2025-01-31": {"vision": True, "max_images": 10, "context_window": 200000},
+    "gpt-4.1-mini-2025-04-14": {"vision": True, "max_images": 10, "context_window": 1047576},
+    "gpt-4.1-nano-2025-04-14": {"vision": True, "max_images": 10, "context_window": 1047576},
     # Anthropic
-    "claude-3-opus-20240229": {"vision": True, "max_images": 5},
-    "claude-3-sonnet-20240229": {"vision": True, "max_images": 5},
-    "claude-3-haiku-20240307": {"vision": True, "max_images": 5},
-    "claude-3-5-sonnet-20240620": {"vision": True, "max_images": 5},
-    "claude-3-5-sonnet-20241022": {"vision": True, "max_images": 5},
+    "claude-3-opus-20240229": {"vision": True, "max_images": 5, "context_window": 200000},
+    "claude-3-sonnet-20240229": {"vision": True, "max_images": 5, "context_window": 200000},
+    "claude-3-haiku-20240307": {"vision": True, "max_images": 5, "context_window": 200000},
+    "claude-3-5-sonnet-20240620": {"vision": True, "max_images": 5, "context_window": 200000},
+    "claude-3-5-sonnet-20241022": {"vision": True, "max_images": 5, "context_window": 200000},
     # Google
-    "gemini-pro-vision": {"vision": True, "max_images": 1},
-    "gemini-1.5-pro": {"vision": True, "max_images": 10},
-    "gemini-1.5-flash": {"vision": True, "max_images": 10},
-    "gemini-2.0-flash": {"vision": True, "max_images": 10},
+    "gemini-pro-vision": {"vision": True, "max_images": 1, "context_window": 12288},
+    "gemini-1.5-pro": {"vision": True, "max_images": 10, "context_window": 2097152},
+    "gemini-1.5-flash": {"vision": True, "max_images": 10, "context_window": 1048576},
+    "gemini-2.0-flash": {"vision": True, "max_images": 10, "context_window": 1048576},
     # Moonshot
     "moonshot-v1-8k-vision-preview": {"vision": True, "max_images": 1},
     "moonshot-v1-32k-vision-preview": {"vision": True, "max_images": 1},
@@ -164,6 +166,11 @@ class ModelCapabilities:
 
         # Compile patterns for efficiency
         self._compiled_patterns = self._compile_patterns()
+        # Case-insensitive provider index: callers pass mixed/lowercase provider
+        # names ("openai") while pattern keys are title-case ("OpenAI").
+        self._provider_key_by_lower = {
+            provider.lower(): provider for provider in self._compiled_patterns
+        }
 
         # Cache for resolved capabilities
         self._capability_cache: Dict[Tuple[str, str], Dict[str, Any]] = {}
@@ -215,6 +222,10 @@ class ModelCapabilities:
         capabilities = self.get_model_capabilities(provider, model)
         return capabilities.get("vision", False)
 
+    def get_context_window(self, provider: str, model: str) -> Optional[int]:
+        """Return the model's input context window, or None if unknown."""
+        return self.get_model_capabilities(provider, model).get("context_window")
+
     def get_model_capabilities(self, provider: str, model: str) -> Dict[str, Any]:
         """
         Get all capabilities for a model.
@@ -239,15 +250,17 @@ class ModelCapabilities:
             capabilities = self.direct_mappings[model].copy()
             logger.debug(f"Found direct mapping for {model}: {capabilities}")
 
-        # 2. Check provider-specific patterns
-        elif provider in self._compiled_patterns:
-            for pattern, pattern_capabilities in self._compiled_patterns[provider]:
-                if pattern.match(model):
-                    capabilities = pattern_capabilities.copy()
-                    logger.debug(
-                        f"Pattern matched for {provider}/{model}: {capabilities}"
-                    )
-                    break
+        # 2. Check provider-specific patterns (case-insensitive provider match)
+        else:
+            provider_key = self._provider_key_by_lower.get((provider or "").lower())
+            if provider_key is not None:
+                for pattern, pattern_capabilities in self._compiled_patterns[provider_key]:
+                    if pattern.match(model):
+                        capabilities = pattern_capabilities.copy()
+                        logger.debug(
+                            f"Pattern matched for {provider}/{model}: {capabilities}"
+                        )
+                        break
 
         # 3. If no match found, use defaults
         if not capabilities:
@@ -338,6 +351,11 @@ def is_vision_capable(provider: str, model: str) -> bool:
         True if the model supports vision input
     """
     return get_model_capabilities().is_vision_capable(provider, model)
+
+
+def get_context_window(provider: str, model: str) -> Optional[int]:
+    """Convenience function to resolve a model's input context window."""
+    return get_model_capabilities().get_context_window(provider, model)
 
 
 def reload_capabilities():


### PR DESCRIPTION
Implements the token/context-accuracy sub-project (**TASK-320 / 321 / 325**) — the numbers behind every budget and gauge, which the task-322 Console history trimmer consumes through the shared `token_counter` seam. **task-322's `console_history_budget.py` is untouched** and inherits the improvements.

## What changed

**TASK-320 — per-model context window**
- Added a `context_window` capability to `model_capabilities.py` (direct maps + anchored OpenAI/Anthropic family patterns), plus `get_context_window(provider, model)`. Fixed a **latent case-sensitivity bug** in the provider→pattern lookup (callers pass `"openai"`, keys were `"OpenAI"`) — now case-insensitive, which also hardens the existing `is_vision_capable` path.
- Rewrote `get_model_token_limit`: capability `context_window` first → exact table → **longest**-prefix (fixes `gpt-4` shadowing `gpt-4-turbo`) → conservative provider default. Refreshed `MODEL_TOKEN_LIMITS` with current models; preserved every test-pinned value; only `gpt-3.5-turbo` 4096→16385. Fallbacks stay conservative (only `anthropic` 100k→200k) — over-estimating a window is the only way to overflow the 322 budget on dispatch.
- Token gauge (`chat_token_events.py`) now divides usage by the model **input** window at both sites, not the ~2048-token output reservation (via `_resolve_token_display_limit`).

**TASK-321 — one real estimator, no `.split()`**
- New `estimate_tokens(text, model, provider="")`: custom tokenizer (behind a cheap `has_tokenizers()` gate so the default install pays no per-call metrics) → tiktoken → CJK-weighted chars floor (`int((non_cjk*0.25 + cjk*1.0) * 1.2)`, conservative so it never under-counts code/CJK). `count_tokens_messages` (trailing-optional `provider`), `count_tokens_chat_history`, and `estimate_remaining_tokens` all delegate to it. Deleted the dead `approximate_token_count`; routed the Console draft estimate (`chat_screen._estimate_tokens`) through it, removing the last `.split()*1.3` fallback.

**TASK-325 — dead config key**
- Removed `chat_context_limit` (a message-count misplaced under `[rag_search]`, never read; superseded by 322's model-aware token bound) from the default config + sample TOML. Zero references remain.

## Testing
- Full affected suite: **191 passed, 1 skipped** (tiktoken absent → estimator tests target the chars path). Property-based floors (pure-CJK ≥ len, 100-ASCII in (25,50), code > word-count), discriminating capabilities-first + longest-prefix tests, case-insensitive pattern lookup, gauge denominator, config absence.
- Executed via subagent-driven development (implementer + reviewer per task, whole-branch opus review = **Ready to merge**, 0 Critical/Important).

## Deferred follow-up minors (non-blocking, from final review)
- `_CJK_RANGES` omits CJK punctuation U+3000–303F (pure-Han floor still holds).
- `count_messages_with_custom` is now an unused import in `token_counter.py`.
- New estimator tests aren't `skipif(TIKTOKEN_AVAILABLE)`-guarded (matches the repo's existing convention; only matters in a tiktoken-present env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-model context windows, a single accurate token estimator, and fixes the token gauge to use the input window. Addresses TASK-320, TASK-321, and TASK-325; the Console history trimmer inherits improvements via the shared `token_counter`.

- **New Features**
  - Per-model context windows via `model_capabilities.get_context_window(provider, model)` with anchored patterns and case-insensitive provider matching.
  - Refreshed token limits and lookup order in `get_model_token_limit`: capability → exact table → longest-prefix → conservative default; OpenRouter IDs like `openai/gpt-4o-mini` resolve upstream; `gpt-3.5-turbo` set to 16385; Anthropic default 200000.
  - One estimator: `estimate_tokens(text, model, provider)` tiers to custom tokenizer (only if `tokenizers` and mappings exist) → `tiktoken` → CJK‑weighted chars floor; floors any non-empty text at ≥1; all counters delegate; `.split()` paths removed, including Console draft via `ChatScreen._estimate_tokens`.

- **Bug Fixes**
  - Token gauge uses the model input window via `_resolve_token_display_limit`, honoring a positive custom override.
  - Provider handling hardened: case-insensitive across lookups; OpenRouter upstream resolution; custom-tokenizer gating requires both the `tokenizers` library and model mappings; removed `chat_context_limit` config key.
  - Estimator counts CJK Symbols & Punctuation (U+3000–303F) as CJK to avoid undercounting punctuation-heavy CJK text.

<sup>Written for commit 9f70535bb067b2c090b6bb061ecb4ad494fd0e41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

